### PR TITLE
fix(compliance): count write-tier activity toward dormant-grant detection (#424)

### DIFF
--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -717,12 +717,15 @@ func (c *KeyorixCore) accessGovernancePostureFromSnapshot(ctx context.Context, p
 // flagged even though the same user is actively reading secrets elsewhere.
 //
 // The activity signal used per grant depends on the role's tier (roleIsAdminTier):
-//   - A plain read/write-tier role is "used" by ANY entry in LastUserSecretActivity
-//     (a secret read is exactly what such a role exists to enable).
+//   - A plain read/write-tier role is "used" by ANY entry in LastUserSecretActivity —
+//     a read OR a create/update/rotate (#424), since a write-tier grant (e.g. a
+//     CI/CD pipeline operator or secret-provisioning admin) may legitimately never
+//     read a secret's value back at all.
 //   - An admin-tier role (secrets.delete/admin, or a role-management permission
 //     like roles.assign) additionally requires an entry in
 //     LastUserElevatedActivity — an actually-observed elevated action — since
-//     ordinary secret reads don't attest to the ADMIN capability being used at all.
+//     ordinary secret reads/writes don't attest to the ADMIN capability being used
+//     at all.
 //
 // This is an approximation, not a perfect per-grant attribution: the audit trail
 // doesn't record which specific grant authorized a given action, only that SOME

--- a/internal/core/compliance_posture_external_test.go
+++ b/internal/core/compliance_posture_external_test.go
@@ -162,6 +162,41 @@ func TestCompliancePosture_RecentActivityNotDormant(t *testing.T) {
 	assert.Equal(t, 0, p.AccessGovernance.DormantRoleGrants, "alice accessed a secret recently — not dormant")
 }
 
+// #424: a write-tier grant (e.g. "editor": secrets.read + secrets.write) held by a
+// user who only ever creates/updates/rotates secrets — never reads one back, a
+// legitimate pattern for a CI/CD pipeline operator or secret-provisioning admin —
+// must not be flagged dormant purely because "read" isn't part of their workflow.
+// accessActivityEventTypes now also matches secret.created/updated/rotated, not
+// just secret.read.
+func TestCompliancePosture_WriteOnlyActivityNotDormant(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.AuditEvent{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.RotationPolicy{},
+	))
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj)) // editor: secrets.read + secrets.write
+
+	aid := uint(10)
+	pid := proj
+	// Zero secret.read events anywhere in the project — only write/rotate/create
+	// activity, exactly the write-only usage pattern this fix targets.
+	require.NoError(t, h.DB.Create(&models.AuditEvent{
+		EventType: "secret.created", UserID: &aid, ProjectID: &pid, EventTime: time.Now().Add(-72 * time.Hour),
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.AuditEvent{
+		EventType: "secret.rotated", UserID: &aid, ProjectID: &pid, EventTime: time.Now().Add(-time.Hour),
+	}).Error)
+
+	p, err := h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, p.AccessGovernance.DormantRoleGrants,
+		"alice's editor grant has recent write/rotate activity — a write-tier grant must not require a read to count as used")
+}
+
 // #258: role grants must be assessed per grant, not per user — an admin-tier grant
 // (secrets.delete + roles.assign, like the seeded "admin" role) must be flagged
 // dormant even when the SAME user has recent, ordinary read activity under a

--- a/internal/storage/store/local_access_activity.go
+++ b/internal/storage/store/local_access_activity.go
@@ -17,11 +17,28 @@ import (
 // Every secret read — whether the reader is the owner or a share recipient — is
 // audited generically as "secret.read" (see LogSecretReadWithProject); there is
 // currently no separate event type for a share-sourced read, so only "secret.read"
-// is listed here. A prior "shared_secret_accessed" entry was removed (#418): the
-// writer that would have produced it was dead code with no caller other than its
-// own unit test, so the event never actually occurred and this list never matched
-// it in practice.
-var accessActivityEventTypes = []string{"secret.read"}
+// is listed here for reads. A prior "shared_secret_accessed" entry was removed
+// (#418): the writer that would have produced it was dead code with no caller
+// other than its own unit test, so the event never actually occurred and this list
+// never matched it in practice.
+//
+// "secret.created" / "secret.updated" / "secret.rotated" (LogSecretCreatedWithProject
+// / LogSecretUpdatedWithProject / LogSecretRotatedWithProject, internal/core/audit.go)
+// are also included (#424): a plain secrets.write-tier grant (create/update/rotate,
+// no read) exists to enable exactly these actions — e.g. a CI/CD pipeline operator
+// or a secret-provisioning admin who writes secrets but never reads their values
+// back. Before this, such a holder's genuinely-active grant was misclassified as
+// dormant purely because "read" wasn't part of their workflow.
+//
+// Deliberately NOT included: "secret.deleted". Holding secrets.delete/admin makes a
+// role admin-tier (see roleIsAdminTier, internal/core/access_review.go) and its
+// grant is instead assessed against elevatedActivityEventTypes below — folding
+// "secret.deleted" into this plain-tier list would let an admin-tier grant's
+// destructive action satisfy the WRONG activity check for countDormantRoleGrants'
+// per-grant-tier split (#258).
+var accessActivityEventTypes = []string{
+	"secret.read", "secret.created", "secret.updated", "secret.rotated",
+}
 
 // elevatedActivityEventTypes are the audit event types that count as exercising an
 // administrative-tier capability, for the admin-tier half of dormant-role-grant


### PR DESCRIPTION
## Summary

- `accessActivityEventTypes` (`internal/storage/store/local_access_activity.go`) drove `countDormantRoleGrants`'s plain-tier "used" check (and the access review's `LastUsedAt` annotation) from `secret.read` alone.
- A write-tier grant holder who only creates/updates/rotates secrets and never reads one back — e.g. a CI/CD pipeline operator or a secret-provisioning admin — was misclassified as dormant, risking revocation of a genuinely-active grant during an access review.
- Extended the list with `secret.created` / `secret.updated` / `secret.rotated` — the exact audit event-type strings written by `LogSecretCreatedWithProject` / `LogSecretUpdatedWithProject` / `LogSecretRotatedWithProject` (`internal/core/audit.go`) — so a grant is "used" by either a read OR a write/management action.
- `secret.deleted` is deliberately **not** added here: it stays exclusive to `elevatedActivityEventTypes`, since holding `secrets.delete`/`secrets.admin` makes a role admin-tier (`roleIsAdminTier`), and folding it into the plain-tier list would let a destructive action satisfy the wrong tier's activity check (#258's per-grant-tier split).

## Test plan

- [x] Added `TestCompliancePosture_WriteOnlyActivityNotDormant`: an editor-role grant with only `secret.created`/`secret.rotated` events (zero reads) is no longer flagged dormant.
- [x] Confirmed the existing zero-activity dormant case (`TestGetCompliancePosture_RollsUpControls`) and the admin-tier masking tests still pass — no regression.
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `go test ./internal/core/... ./internal/storage/... -run 'Dormant|Compliance|Activity' -v` — all pass.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.

🤖 Generated with Claude Code