### PR TITLE
feat(compliance): add access-request hygiene control for stale lapses

### DIFF
--- a/internal/core/control_framework.go
+++ b/internal/core/control_framework.go
@@ -180,6 +180,21 @@ func EvaluateControls(p *CompliancePosture) []ControlState {
 			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.15"}, SOC2: []string{"CC6.1"}, DORA: []string{"Art.9"}, ENS: []string{"op.acc.4", "op.exp.7"}},
 		},
 		{
+			ID: "access-request-hygiene", Name: "Access-request approval hygiene (no stale, unresolved lapses)", Area: "Access governance",
+			// A pending access request (ADR-024's dual-control workflow, #257) that
+			// lapses with no explicit approve/reject/withdraw decision is the same
+			// shape of gap as #395's stale risk exceptions: an access decision that was
+			// supposed to be made never was — it just silently expired. RequiredApprovals
+			// (the configured N-of-M dual-control threshold; ApproveAccessRequestWithExpiry
+			// already enforces maker != checker) is surfaced in Detail for auditor
+			// context, but only Expired drives the verdict — a deployment with zero
+			// requests, or requests that were all explicitly resolved, must stay Pass
+			// rather than gapping on an unconfigured/default posture.
+			Status:     controlStatus(p.DegradedArea("access_requests:"), p.AccessRequests.Expired > 0),
+			Detail:     fmt.Sprintf("%d expired without resolution, %d pending of %d total request(s); required approvers=%d", p.AccessRequests.Expired, p.AccessRequests.Pending, p.AccessRequests.TotalRequests, p.AccessRequests.RequiredApprovals),
+			Frameworks: FrameworkRefs{ISO27001: []string{"A.5.3"}, SOC2: []string{"CC6.2", "CC5.1"}, ENS: []string{"op.acc.3"}},
+		},
+		{
 			ID: "data-retention", Name: "Data-retention / storage limitation", Area: "Data governance",
 			Status:     statusFromBool(p.Retention.Enabled),
 			Detail:     retentionDetail(p.Retention),

--- a/internal/core/control_framework_test.go
+++ b/internal/core/control_framework_test.go
@@ -207,6 +207,41 @@ func TestEvaluateControls_RiskExceptionHygiene(t *testing.T) {
 	assert.Equal(t, ControlStatusUnknown, rd.Status)
 }
 
+// #767 added AccessRequestPosture (dual-control access-request/approval workflow,
+// ADR-024/#257) to the posture, but nothing evaluated it as a control. A request
+// that lapses (expires) with no explicit approve/reject/withdraw decision is the
+// same shape of gap as #395's stale risk exceptions: zero requests, or requests that
+// were all explicitly resolved, must pass; any expired-but-unresolved request must
+// surface as a gap naming the count.
+func TestEvaluateControls_AccessRequestHygiene(t *testing.T) {
+	none := EvaluateControls(&CompliancePosture{})
+	an := findControl(t, none, "access-request-hygiene")
+	assert.Equal(t, ControlStatusPass, an.Status)
+
+	resolved := EvaluateControls(&CompliancePosture{
+		AccessRequests: AccessRequestPosture{TotalRequests: 5, Approved: 3, Rejected: 1, Withdrawn: 1, RequiredApprovals: 2},
+	})
+	ar := findControl(t, resolved, "access-request-hygiene")
+	assert.Equal(t, ControlStatusPass, ar.Status, "all-resolved requests must not gap the control")
+
+	lapsed := EvaluateControls(&CompliancePosture{
+		AccessRequests: AccessRequestPosture{TotalRequests: 4, Pending: 1, Expired: 3, RequiredApprovals: 1},
+	})
+	al := findControl(t, lapsed, "access-request-hygiene")
+	assert.Equal(t, ControlStatusGap, al.Status)
+	assert.Contains(t, al.Detail, "3 expired without resolution")
+	assert.Contains(t, al.Detail, "1 pending of 4 total request(s)")
+	assert.Contains(t, al.Detail, "required approvers=1")
+
+	// A degraded access-request collection must surface as unknown, never a false
+	// pass just because Expired's zero value looks clean (#136).
+	degraded := EvaluateControls(&CompliancePosture{
+		DegradedReasons: []string{"access_requests:project=1: simulated db failure"},
+	})
+	ad := findControl(t, degraded, "access-request-hygiene")
+	assert.Equal(t, ControlStatusUnknown, ad.Status)
+}
+
 // Once the scan has evaluated at least one certificate, the control reflects the real
 // data: pass when none are expired, gap when at least one is.
 func TestEvaluateControls_CertificateHygiene_ScanningEnabled(t *testing.T) {


### PR DESCRIPTION
## Summary
- PR #767 added `AccessRequestPosture` (dual-control access-request/approval workflow, ADR-024) to `CompliancePosture` and the evidence pack, but `EvaluateControls` (the auditor-facing pass/gap control matrix in `internal/core/control_framework.go`) had no entry consulting this data at all — the same "data collected but no control evaluates it" gap this campaign has fixed before (#395 risk-exceptions, #396 classification).
- Add a new `access-request-hygiene` control: **Gap** when `p.AccessRequests.Expired > 0` (a pending request lapsed with no explicit approve/reject/withdraw decision — the exact same "expired but not cleaned up" framing as the `risk-exception-hygiene` control added for #395), **Pass** otherwise (including the default zero-request/all-resolved state), **Unknown** when the underlying `access_requests:` sub-rollup failed to collect this run (mirrors the `#136` degraded-collection pattern used throughout this file).
- The control's `Detail` also surfaces `RequiredApprovals` (the configured N-of-M dual-control threshold) and `Pending`/`TotalRequests` for auditor context, even though only `Expired` drives the pass/fail verdict — a `RequiredApprovals < 2` (single-approver) signal was considered but rejected as the primary gate because the workflow floors the threshold at 1 by default, which would gap every ordinary/unconfigured deployment.
- Mapped to ISO 27001 A.5.3 (segregation of duties — dual control enforces maker != checker), SOC2 CC6.2/CC5.1, and ENS op.acc.3, matching this file's existing framework-reference conventions for related access-governance controls.

## Test plan
- [x] Added `TestEvaluateControls_AccessRequestHygiene` mirroring `TestEvaluateControls_RiskExceptionHygiene`'s style: zero-request and all-resolved postures pass, an expired-lapse posture gaps naming the count, and a degraded `access_requests:` collection reports Unknown (not a false Pass).
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... -run 'Compliance|Control|AccessRequest' -v` — all pass
- [x] `go test ./internal/core/...` — full package suite passes
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with Claude Code