### PR TITLE
fix(certificates): enforce per-secret permission on certificate inspection (#239)

### DIFF
--- a/internal/core/certificate.go
+++ b/internal/core/certificate.go
@@ -42,9 +42,15 @@ type CertificateInfo struct {
 
 // InspectCertificate decrypts the secret's current value, parses the leaf X.509
 // certificate, and returns its public metadata. actorID is the inspecting principal.
-// Authorization (scoped secrets.read) is enforced at the transport layer, mirroring
-// the other per-secret read endpoints.
+// Authorization is enforced here via EnforceSecretReadPermission — the same
+// ownership/share-aware permission check every other per-secret value-derived read
+// goes through — on top of whatever project-scoped secrets.read the transport layer
+// already required. Holding project-wide secrets.read is not enough on its own: the
+// actor must also own the secret or hold an active share on it.
 func (c *KeyorixCore) InspectCertificate(ctx context.Context, actorID, secretID uint) (*CertificateInfo, error) {
+	if _, err := c.EnforceSecretReadPermission(ctx, secretID, actorID); err != nil {
+		return nil, err
+	}
 	secret, err := c.storage.GetSecret(ctx, secretID)
 	if err != nil {
 		return nil, fmt.Errorf("%s: secret %d not found", i18n.T("ErrorNotFound", nil), secretID)

--- a/internal/core/certificate_test.go
+++ b/internal/core/certificate_test.go
@@ -105,10 +105,13 @@ func newCertCore(t *testing.T, now time.Time) (*KeyorixCore, *gorm.DB) {
 	return &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}, db
 }
 
-// mkCertSecret stores a secret (no encryption → value lives in the version row).
+// mkCertSecret stores a secret (no encryption → value lives in the version row), owned
+// by user 9 — the actor ID every InspectCertificate call in this file uses — so the
+// EnforceSecretReadPermission check InspectCertificate now performs is satisfied via
+// ownership without needing the shares/groups tables migrated.
 func mkCertSecret(t *testing.T, db *gorm.DB, id uint, name, status string, value []byte) {
 	t.Helper()
-	require.NoError(t, db.Create(&models.SecretNode{ID: id, Name: name, IsSecret: true, Status: status, Type: "certificate"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: id, Name: name, IsSecret: true, Status: status, Type: "certificate", OwnerID: 9}).Error)
 	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: id, VersionNumber: 1, EncryptedValue: value}).Error)
 }
 
@@ -213,4 +216,39 @@ func TestInspectCertificateSuspended(t *testing.T) {
 	_, err := c.InspectCertificate(ctx, 9, 1)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "suspended")
+}
+
+// TestInspectCertificateEnforcesPerSecretPermission guards #239: InspectCertificate
+// used to call storage.GetSecret directly and rely solely on the caller's HTTP route
+// being gated by scoped secrets.read, skipping the ownership/share-aware permission
+// check every other per-secret value-derived read goes through (GetSecretWithPermissionCheck,
+// GetSecretTags, GetSecretAccessStats, …). That let any actor holding project-wide
+// secrets.read see a certificate's Subject/Issuer/SANs/serial number, even for a
+// certificate they neither own nor were shared — a real information disclosure. This
+// proves both directions: a non-owner/non-shared actor is now refused, and a share
+// recipient still succeeds — no regression for the legitimate path.
+func TestInspectCertificateEnforcesPerSecretPermission(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+
+	certPEM, _ := selfSignedPEM(t, "restricted.example.com", now.Add(30*24*time.Hour))
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "restricted-cert", IsSecret: true, Status: "active", Type: "certificate", OwnerID: 9}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: 1, VersionNumber: 1, EncryptedValue: certPEM}).Error)
+
+	t.Run("actor with no ownership/share is refused, despite the HTTP route already gating project-scoped secrets.read", func(t *testing.T) {
+		_, err := c.InspectCertificate(ctx, 42, 1) // actor 42: no owner/share grant on secret 1
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "insufficient permissions")
+	})
+
+	t.Run("actor with an active share on the secret still succeeds — no regression", func(t *testing.T) {
+		require.NoError(t, db.Create(&models.ShareRecord{ID: 1, SecretID: 1, OwnerID: 9, RecipientID: 7, IsGroup: false, Permission: "read"}).Error)
+		info, err := c.InspectCertificate(ctx, 7, 1)
+		require.NoError(t, err)
+		assert.Contains(t, info.Subject, "restricted.example.com")
+	})
 }

--- a/server/http/handlers/secret_certificate.go
+++ b/server/http/handlers/secret_certificate.go
@@ -35,6 +35,8 @@ func (h *SecretHandler) GetSecretCertificate(w http.ResponseWriter, r *http.Requ
 			status = http.StatusNotFound
 		case strings.Contains(msg, "not a parseable"), strings.Contains(msg, "suspended"):
 			status = http.StatusBadRequest
+		case strings.Contains(msg, "permission") || strings.Contains(msg, "not authorized"):
+			status = http.StatusForbidden
 		}
 		h.sendError(w, "Error", msg, status, nil)
 		return


### PR DESCRIPTION
## Summary
- `InspectCertificate` called `storage.GetSecret` directly and relied solely on the
  HTTP route's project-scoped `secrets.read` RBAC gate, unlike every other
  per-secret value-derived read in the codebase (`GetSecretWithPermissionCheck`,
  `GetSecretTags`, `GetSecretAccessStats`, `GetSecretAccessHistory`, `GetSecretAuditTrail`,
  ...), which layer `EnforceSecretReadPermission`'s ownership/share check on top of the
  plain project-scoped permission.
- This meant an actor holding project-wide `secrets.read` — but with no owner or
  share grant on a *specific* certificate secret — could still see that certificate's
  Subject/Issuer DN, SANs, and serial number: an information disclosure inconsistent
  with every other per-secret read path.
- `InspectCertificate` now calls `EnforceSecretReadPermission(ctx, secretID, actorID)`
  first, the same ownership/share-aware check the rest of the codebase uses. The HTTP
  handler (its only caller — confirmed no gRPC caller exists) now also maps a
  permission-denied error to 403 Forbidden, matching the pattern used by sibling
  handlers like `GetSecretAccessStats`.

## Test plan
- [x] Added `TestInspectCertificateEnforcesPerSecretPermission` in
      `internal/core/certificate_test.go`: an actor with no ownership/share is
      refused, and a share recipient still succeeds (no regression).
- [x] Updated `mkCertSecret` test helper to set `OwnerID: 9` (matching the actor ID
      every existing `InspectCertificate` test in the file already used) so the
      pre-existing tests keep passing under the new enforcement.
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `go test ./internal/core/... ./server/...` — all pass (full packages, not just
      the certificate-scoped subset).
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.

🤖 Generated with Claude Code