### PR TITLE
test(storage): pin RBAC Phase 2 project_id NULL backfill on SQLite

### DIFF
--- a/internal/storage/factory_rbac_project_id_backfill_test.go
+++ b/internal/storage/factory_rbac_project_id_backfill_test.go
@@ -1,0 +1,83 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRBACPhase2Backfill_NullProjectIDNormalisedToZero pins the RBAC Phase 2
+// backfill loop in migrateDatabase (the `for _, tbl := range []string{
+// "user_roles", "group_roles"} { ... UPDATE %s SET project_id = 0 WHERE
+// project_id IS NULL ... }` block): it never actually ran on SQLite until the
+// #490/#761 columnExists/tableExists dialect fix, because tableExists(db,
+// tbl) always returned false on SQLite before that fix, so the loop body's
+// `continue` fired unconditionally and the UPDATE was unreachable code on
+// every SQLite boot.
+//
+// Simulate a genuinely pre-008 legacy install: user_roles/group_roles tables
+// created directly via raw SQL in the old nullable-project_id shape (no
+// environment_id column at all, project_id with no NOT NULL/default), with a
+// row seeded with project_id IS NULL via a raw INSERT — GORM's own
+// model-based Create can never produce that NULL today, since
+// models.UserRole/GroupRole now declare ProjectID as `uint` with
+// `not null;default:0`. Re-running migrateDatabase directly (the same entry
+// point a real process boot calls) must both add the missing environment_id
+// column and normalise the NULL project_id row to the 0 = global sentinel the
+// authorization queries expect — verified via a raw column scan (not a GORM
+// struct scan, which would mask a NULL by coercing it into a zero uint
+// regardless of what is actually stored).
+func TestRBACPhase2Backfill_NullProjectIDNormalisedToZero(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "rbac-phase2-backfill.db")
+	db, err := gormOpenForTest(t, dbPath)
+	require.NoError(t, err)
+
+	// Legacy pre-008 shape: no environment_id column, project_id nullable.
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id INTEGER NOT NULL,
+		role_id INTEGER NOT NULL,
+		project_id INTEGER,
+		PRIMARY KEY (user_id, role_id, project_id)
+	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE group_roles (
+		group_id INTEGER NOT NULL,
+		role_id INTEGER NOT NULL,
+		project_id INTEGER,
+		PRIMARY KEY (group_id, role_id, project_id)
+	)`).Error)
+
+	// A legacy NULL-project_id row (the exact pre-008 shape) plus an
+	// already-scoped row that must be left untouched by the backfill.
+	require.NoError(t, db.Exec(`INSERT INTO user_roles (user_id, role_id, project_id) VALUES (1, 1, NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO user_roles (user_id, role_id, project_id) VALUES (2, 1, 5)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO group_roles (group_id, role_id, project_id) VALUES (1, 1, NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO group_roles (group_id, role_id, project_id) VALUES (2, 1, 5)`).Error)
+
+	f := &DefaultStorageFactory{}
+	require.NoError(t, f.migrateDatabase(db))
+
+	assert.True(t, columnExists(db, "user_roles", "environment_id"), "environment_id must be backfilled onto user_roles")
+	assert.True(t, columnExists(db, "group_roles", "environment_id"), "environment_id must be backfilled onto group_roles")
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	var userRoleProjectID int
+	require.NoError(t, sqlDB.QueryRow(`SELECT project_id FROM user_roles WHERE user_id = 1 AND role_id = 1`).Scan(&userRoleProjectID))
+	assert.Equal(t, 0, userRoleProjectID, "legacy NULL project_id on user_roles must be normalised to the 0 = global sentinel")
+
+	var groupRoleProjectID int
+	require.NoError(t, sqlDB.QueryRow(`SELECT project_id FROM group_roles WHERE group_id = 1 AND role_id = 1`).Scan(&groupRoleProjectID))
+	assert.Equal(t, 0, groupRoleProjectID, "legacy NULL project_id on group_roles must be normalised to the 0 = global sentinel")
+
+	// The already-scoped rows must be left exactly as they were.
+	var scopedUserRoleProjectID int
+	require.NoError(t, sqlDB.QueryRow(`SELECT project_id FROM user_roles WHERE user_id = 2 AND role_id = 1`).Scan(&scopedUserRoleProjectID))
+	assert.Equal(t, 5, scopedUserRoleProjectID, "an already-scoped user_roles row must not be touched by the backfill")
+
+	var scopedGroupRoleProjectID int
+	require.NoError(t, sqlDB.QueryRow(`SELECT project_id FROM group_roles WHERE group_id = 2 AND role_id = 1`).Scan(&scopedGroupRoleProjectID))
+	assert.Equal(t, 5, scopedGroupRoleProjectID, "an already-scoped group_roles row must not be touched by the backfill")
+}


### PR DESCRIPTION
## Summary

Closes out a low-severity follow-up from the security-hardening campaign's audit of `internal/storage/factory.go`.

`migrateDatabase`'s RBAC Phase 2 loop (around line 552) backfills `project_id` from `NULL` to `0` for legacy `user_roles`/`group_roles` rows:

```go
for _, tbl := range []string{"user_roles", "group_roles"} {
    if !tableExists(db, tbl) { continue }
    ...
    if columnExists(db, tbl, "project_id") {
        db.Exec(fmt.Sprintf("UPDATE %s SET project_id = 0 WHERE project_id IS NULL", tbl))
    }
}
```

This backfill never actually ran on SQLite until the recent `columnExists`/`tableExists` dialect fix — `tableExists(db, tbl)` always returned `false` on SQLite, so the loop body's `continue` fired unconditionally and the `UPDATE` was unreachable code on every SQLite boot. Now that the dialect bug is fixed, this backfill will finally execute on any future boot against a legacy database, but it had no regression test proving it works.

This PR adds `TestRBACPhase2Backfill_NullProjectIDNormalisedToZero`:

- Seeds a pre-008-shaped `user_roles`/`group_roles` table (no `environment_id` column, nullable `project_id`, no default) directly via raw SQL, with one row's `project_id` set to `NULL` via a raw `INSERT` — GORM's own model-based `Create` can never produce that NULL today, since `models.UserRole`/`GroupRole` now declare `ProjectID` as `uint` with `not null;default:0`.
- Runs `migrateDatabase` directly (the same real entry point a process boot calls, matching this package's existing `factory_companion_index_test.go` convention).
- Asserts, via a raw `sqlDB.QueryRow` column scan (not a GORM struct scan, which would mask a NULL by coercing it to a zero `uint` regardless of what's actually stored), that the previously-NULL `project_id` is now `0` for both tables, and that an already-scoped row is left untouched.

Not itself a security bug — the pre-fix behavior failed closed (a NULL `project_id` in a `uint` GORM scan typically errors the query rather than silently granting access), and the blast radius is narrow (only very old SQLite installs bootstrapped before GORM AutoMigrate existed would have NULL `project_id` rows in the first place). This is coverage for a previously-untested code path.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./internal/storage/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)