### PR TITLE
fix(compliance): don't let a forced-incomplete close reset the recertification cadence (#237)

### DIFF
--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -324,6 +324,14 @@ func (c *KeyorixCore) CloseAccessReviewCampaign(ctx context.Context, actorID, pr
 	campaign.State = CampaignStateClosed
 	campaign.ClosedBy = actorID
 	campaign.ClosedAt = &now
+	// #237: a forced close with items still pending freezes the campaign as
+	// evidence, but it is NOT a genuine, fully-decided recertification cycle —
+	// some access was never reviewed. Without this signal, ClosedAt alone makes
+	// this close indistinguishable from an on-time, fully-completed one, and
+	// RunScheduledRecertification's cadence check (recertification.go) would
+	// silently treat it as satisfying the FULL cadence window, resetting the
+	// clock as if every grant had just been recertified.
+	campaign.ForcedIncomplete = force && progress.Pending > 0
 	// The "already closed" check above is a plain read, so two concurrent close calls
 	// (or a close racing another close) can both observe "open" before either write
 	// lands. UpdateAccessReviewCampaign's WHERE-state='open' conditional UPDATE is the

--- a/internal/core/access_review_campaign_external_test.go
+++ b/internal/core/access_review_campaign_external_test.go
@@ -239,6 +239,10 @@ func TestCloseAccessReviewCampaign_PendingGuardAndForce(t *testing.T) {
 	closed, err := h.CoreService.CloseAccessReviewCampaign(ctx, 1, proj, res.Campaign.ID, true)
 	require.NoError(t, err)
 	assert.Equal(t, core.CampaignStateClosed, closed.Campaign.State)
+	// #237: a force-close performed while items are still pending must be marked
+	// ForcedIncomplete so the recertification cadence doesn't treat it as a
+	// genuine, fully-decided review.
+	assert.True(t, closed.Campaign.ForcedIncomplete, "a force-close with pending items must be flagged incomplete")
 
 	// A closed campaign rejects further decisions.
 	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
@@ -249,6 +253,35 @@ func TestCloseAccessReviewCampaign_PendingGuardAndForce(t *testing.T) {
 	// Re-closing is rejected.
 	_, err = h.CoreService.CloseAccessReviewCampaign(ctx, 1, proj, res.Campaign.ID, true)
 	require.Error(t, err)
+}
+
+// #237: a close with every item already decided (no pending items left) is a
+// genuine, fully-completed recertification — even when the caller happens to pass
+// force=true, it must NOT be flagged ForcedIncomplete, so it isn't penalized by the
+// recertification cadence the way a genuinely abandoned/rushed close is.
+func TestCloseAccessReviewCampaign_FullyDecidedIsNotForcedIncomplete(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	require.NoError(t, err)
+	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
+	require.NoError(t, err)
+	require.Len(t, detail.Items, 1)
+	require.NoError(t, h.CoreService.DecideAccessReviewItem(ctx, 1, proj, res.Campaign.ID, detail.Items[0].ID, "attest", ""))
+
+	// Nothing pending, so this close (whether force is true or false) is a genuine
+	// completed review.
+	closed, err := h.CoreService.CloseAccessReviewCampaign(ctx, 1, proj, res.Campaign.ID, true)
+	require.NoError(t, err)
+	assert.Equal(t, core.CampaignStateClosed, closed.Campaign.State)
+	assert.False(t, closed.Campaign.ForcedIncomplete, "a fully-decided close must not be flagged incomplete")
 }
 
 // A campaign id from another project is not reachable through this project's scope.

--- a/internal/core/recertification.go
+++ b/internal/core/recertification.go
@@ -82,7 +82,20 @@ func (c *KeyorixCore) RunScheduledRecertification(ctx context.Context, cadenceDa
 		// No open campaign — is the project due for one?
 		due := lastClosed == nil // never reviewed
 		if lastClosed != nil && lastClosed.Campaign.ClosedAt != nil {
-			due = lastClosed.Campaign.ClosedAt.Before(cutoff)
+			anchor := lastClosed.Campaign.ClosedAt
+			// #237: a force-close performed while items were still pending
+			// (ForcedIncomplete) is evidence of an ABANDONED cycle, not a
+			// completed recertification — some access was never reviewed. Anchor
+			// the cadence to when the campaign was OPENED instead of when it was
+			// hastily force-closed, so an admin can't silently reset the full
+			// cadence window (and thus how long stale access goes unexamined) by
+			// force-closing early; the next campaign becomes due sooner,
+			// proportional to how little of the cadence window the abandoned
+			// cycle actually covered.
+			if lastClosed.Campaign.ForcedIncomplete {
+				anchor = &lastClosed.Campaign.CreatedAt
+			}
+			due = anchor.Before(cutoff)
 		}
 		if !due {
 			continue

--- a/internal/core/recertification_external_test.go
+++ b/internal/core/recertification_external_test.go
@@ -86,3 +86,48 @@ func TestRunScheduledRecertification_AutoOpensOverdueNotRecent(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, hasOpenCampaign(camps3), "recently-reviewed project 3 is left alone")
 }
+
+// #237: a campaign that was force-closed with pending items (ForcedIncomplete) must
+// not let a recent ClosedAt hide how stale the review actually is — the cadence
+// anchors to when the campaign was OPENED, not when it was hastily closed. A
+// genuinely completed close (ForcedIncomplete=false) with the same old open time but
+// a recent close is, by contrast, a real completed review and must NOT be due.
+func TestRunScheduledRecertification_ForcedIncompleteAnchorsToOpenTime(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+	require.NoError(t, h.DB.AutoMigrate(&models.Notification{}))
+
+	ctx := context.Background()
+	now := time.Now()
+	openedLongAgo := now.AddDate(0, 0, -200) // opened well outside a 90-day cadence
+	closedRecently := now.AddDate(0, 0, -5)  // but closed just now
+
+	// Project 2: opened long ago, force-closed recently while items were still
+	// pending — an abandoned/rushed cycle. Despite the recent ClosedAt, it must
+	// still be treated as overdue.
+	require.NoError(t, h.DB.Create(&models.AccessReviewCampaign{
+		ProjectID: 2, Name: "abandoned", State: core.CampaignStateClosed,
+		CreatedAt: openedLongAgo, ClosedAt: &closedRecently, ForcedIncomplete: true,
+	}).Error)
+
+	// Project 3: same open/close timestamps, but every item was actually decided
+	// (ForcedIncomplete=false) — a genuine, if belated, completed review. The
+	// recent ClosedAt legitimately resets the cadence clock.
+	require.NoError(t, h.DB.Create(&models.AccessReviewCampaign{
+		ProjectID: 3, Name: "completed", State: core.CampaignStateClosed,
+		CreatedAt: openedLongAgo, ClosedAt: &closedRecently, ForcedIncomplete: false,
+	}).Error)
+
+	res, err := h.CoreService.RunScheduledRecertification(ctx, 90, true)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, res.Opened, 1)
+
+	camps2, err := h.CoreService.ListAccessReviewCampaigns(ctx, 2)
+	require.NoError(t, err)
+	assert.True(t, hasOpenCampaign(camps2), "an abandoned force-close doesn't hide behind a recent ClosedAt")
+
+	camps3, err := h.CoreService.ListAccessReviewCampaigns(ctx, 3)
+	require.NoError(t, err)
+	assert.False(t, hasOpenCampaign(camps3), "a genuinely completed close resets the cadence clock at ClosedAt")
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -768,12 +768,16 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 			return fmt.Errorf("failed to migrate access_review_campaign tables: %w", err)
 		}
 	} else {
-		// #483: Degraded/DegradedReasons were added to AccessReviewCampaign after this
-		// table could already exist in the field (same pgx hazard as project_invitations
-		// above — never full-AutoMigrate an existing table here); add the new columns
-		// via the Migrator so an existing deployment's campaigns table picks them up.
+		// #483/#237: Degraded/DegradedReasons/ForcedIncomplete were each added to
+		// AccessReviewCampaign after this table could already exist in the field (same
+		// pgx hazard as project_invitations above — never full-AutoMigrate an existing
+		// table here); add the new columns via the Migrator so an existing deployment's
+		// campaigns table picks them up. UpdateAccessReviewCampaign does a full-column
+		// Select("*").Updates, so a missing column here isn't just a silently-unused
+		// field — it hard-fails every subsequent campaign create/update on an upgraded
+		// install that predates whichever field was added.
 		m := db.Migrator()
-		for _, col := range []string{"Degraded", "DegradedReasons"} {
+		for _, col := range []string{"Degraded", "DegradedReasons", "ForcedIncomplete"} {
 			if !m.HasColumn(&models.AccessReviewCampaign{}, col) {
 				if err := m.AddColumn(&models.AccessReviewCampaign{}, col); err != nil {
 					return fmt.Errorf("failed to add access_review_campaigns.%s column: %w", col, err)

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -221,6 +221,14 @@ type AccessReviewCampaign struct {
 	// DegradedReasons is JSON-serialized (gorm serializer) so it round-trips as a
 	// native []string, mirroring AccessReviewReport.DegradedReasons.
 	DegradedReasons []string `gorm:"serializer:json" json:"degraded_reasons,omitempty"`
+	// ForcedIncomplete marks a close performed with `force` while items were still
+	// pending (#237): the campaign was frozen as evidence, but it is NOT a genuine
+	// completed recertification — some access was never reviewed. Mirrors the
+	// Degraded pattern above: without a durable signal, this close is otherwise
+	// indistinguishable from a fully-decided one, so the recertification cadence
+	// (recertification.go) would silently treat a rushed, incomplete force-close as
+	// satisfying a full review cycle and push the next-due date out just as far.
+	ForcedIncomplete bool `gorm:"default:false" json:"forced_incomplete"`
 }
 
 // AccessReviewItem is one access grant captured in a campaign at open time, plus


### PR DESCRIPTION
## Summary
- `CloseAccessReviewCampaign`'s forced close (items still pending) unconditionally stamped `ClosedAt`, and `RunScheduledRecertification` computes the next due date purely from `ClosedAt` — so an admin force-closing a campaign with unreviewed items silently reset the cadence clock exactly like a genuine, fully-completed recertification, extending how long stale/unreviewed access goes unexamined.
- Adds `AccessReviewCampaign.ForcedIncomplete` (mirrors the existing `Degraded`/`DegradedReasons` durable-signal pattern on this model), set when `force=true` closes a campaign that still has pending items.
- `RunScheduledRecertification`'s due-date check now anchors to the campaign's `CreatedAt` (open time) instead of `ClosedAt` when `ForcedIncomplete` is set, so an abandoned/rushed cycle can't hide behind a recent close timestamp — the next campaign becomes due sooner, proportional to the actual elapsed time since the cycle was opened. A genuinely completed close (no pending items) is unaffected and still resets the clock at `ClosedAt`.

## Test plan
- [x] Extended `TestCloseAccessReviewCampaign_PendingGuardAndForce` to assert `ForcedIncomplete=true` on a forced close with pending items.
- [x] Added `TestCloseAccessReviewCampaign_FullyDecidedIsNotForcedIncomplete` — a close with everything decided (even with `force=true`) is NOT flagged incomplete.
- [x] Added `TestRunScheduledRecertification_ForcedIncompleteAnchorsToOpenTime` — same open/close timestamps, but `ForcedIncomplete=true` is treated as overdue while `ForcedIncomplete=false` (genuine completed review) is not.
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `go test ./internal/core/... -run 'AccessReview|Campaign|Recert' -v` — all pass.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.

🤖 Generated with Claude Code