### PR TITLE
fix(grpc): reject empty ref on ConnectService.ReadSecret (#400)

### DIFF
--- a/server/grpc/services/connect_service.go
+++ b/server/grpc/services/connect_service.go
@@ -48,6 +48,9 @@ func (s *ConnectGRPCService) ReadSecret(ctx context.Context, req *pb.ReadFederat
 	if err := authorizeGlobal(ctx, s.core, actor, "connect.read"); err != nil {
 		return nil, err
 	}
+	if req.GetRef() == "" {
+		return nil, status.Error(codes.InvalidArgument, "ref is required")
+	}
 	value, err := s.core.ReadFederatedSecret(ctx, actor.ActorKind(), actor.PrincipalID(), req.GetConnector(), req.GetRef())
 	if err != nil {
 		msg := err.Error()

--- a/server/grpc/services/connect_service_test.go
+++ b/server/grpc/services/connect_service_test.go
@@ -72,6 +72,17 @@ func TestConnectService_ReadSecret_UnknownConnector(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestConnectService_ReadSecret_EmptyRefRejected regression-tests backlog #400:
+// ReadSecret must reject an empty ref with codes.InvalidArgument before ever
+// calling core.ReadFederatedSecret, matching the HTTP GetSecret handler's
+// `ref query parameter is required` 400 (server/http/handlers/connect.go).
+func TestConnectService_ReadSecret_EmptyRefRejected(t *testing.T) {
+	svc := newConnectService(t)
+	_, err := svc.ReadSecret(connCtx(), readReq("aws", ""))
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
 func TestConnectService_Unauthenticated(t *testing.T) {
 	svc := newConnectService(t)
 	_, err := svc.ListConnectors(context.Background(), &emptypb.Empty{})


### PR DESCRIPTION
## Summary
- `ConnectGRPCService.ReadSecret` (`server/grpc/services/connect_service.go`) skipped the empty-`ref` validation its HTTP sibling `GetSecret` (`server/http/handlers/connect.go`) already performs, so an empty ref was forwarded straight into `core.ReadFederatedSecret` instead of failing fast with a client error (backlog #400, LOW — cosmetic/error-shape gap, no authorization bypass).
- Add the equivalent check — `req.GetRef() == ""` → `status.Error(codes.InvalidArgument, "ref is required")` — right after the `connect.read` authorization check and before the core call, matching this file's existing validation conventions used elsewhere in the gRPC services package (e.g. `"id is required"`, `"project_id is required"`).

## Test plan
- [x] Added `TestConnectService_ReadSecret_EmptyRefRejected` in `connect_service_test.go`, asserting `codes.InvalidArgument` for an empty ref (mirrors the HTTP path's 400 behavior for the same input).
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./server/grpc/... ./internal/connect/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./server/grpc/... ./internal/connect/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)