### PR TITLE
harden(validation): wire the identifier validator to Project/Group/Role names (#189)

### DIFF
--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/keyorixhq/keyorix/server/validation"
 )
 
 // actorID returns the acting user's ID from the request context (0 when absent).
@@ -24,11 +25,12 @@ func actorID(r *http.Request) uint {
 // CatalogHandler handles project and environment endpoints.
 type CatalogHandler struct {
 	coreService *core.KeyorixCore
+	validator   *validation.Validator
 }
 
 // NewCatalogHandler creates a new CatalogHandler.
 func NewCatalogHandler(svc *core.KeyorixCore) *CatalogHandler {
-	return &CatalogHandler{coreService: svc}
+	return &CatalogHandler{coreService: svc, validator: validation.NewValidator()}
 }
 
 // ListProjects handles GET /api/v1/projects — returns projects with secret and
@@ -110,7 +112,14 @@ func (h *CatalogHandler) GetProjectDrift(w http.ResponseWriter, r *http.Request)
 // CreateProject handles POST /api/v1/projects
 func (h *CatalogHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Name        string `json:"name"`
+		// #189: a Project name is a plain human-readable identifier (no existing
+		// naming-policy mechanism, unlike SecretNode.Name's dedicated conformance
+		// check), and it's routinely shown to higher-trust approvers in access-review
+		// UIs, audit logs, and CLI confirmation prompts — so it's restricted to the
+		// `identifier` charset (letters/digits/space/`-`/`_`) to block zero-width,
+		// RTL-override, and homograph-lookalike characters that could otherwise make
+		// a malicious project visually indistinguishable from a legitimate one.
+		Name        string `json:"name" validate:"required,max=200,identifier"`
 		Description string `json:"description"`
 		// Environments, when non-empty, seeds the project with exactly these
 		// environments instead of the default development/staging/production set —
@@ -119,6 +128,10 @@ func (h *CatalogHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.validator.Validate(&body); err != nil {
+		sendError(w, "ValidationError", "Invalid request data", http.StatusBadRequest, err)
 		return
 	}
 
@@ -165,12 +178,17 @@ func (h *CatalogHandler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		Name        string `json:"name"`
+		// See CreateProject's Name field comment for why `identifier` is applied here.
+		Name        string `json:"name" validate:"required,max=200,identifier"`
 		Description string `json:"description"`
 		RequireMFA  *bool  `json:"require_mfa"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.validator.Validate(&body); err != nil {
+		sendError(w, "ValidationError", "Invalid request data", http.StatusBadRequest, err)
 		return
 	}
 	// require_mfa is a per-project SECURITY-POLICY control (ADR-037), not ordinary content.

--- a/server/http/handlers/catalog_create_project_test.go
+++ b/server/http/handlers/catalog_create_project_test.go
@@ -87,8 +87,8 @@ func TestCreateProject_BlankEnvironmentsFallBackToDefaults(t *testing.T) {
 // accepted and later shown, apparently-legitimate, in an access-review UI or audit log.
 func TestCreateProject_RejectsDangerousNames(t *testing.T) {
 	cases := map[string]string{
-		"zero-width space":        "prod​team", // U+200B ZERO WIDTH SPACE
-		"RTL override":            "prod‮team", // U+202E RIGHT-TO-LEFT OVERRIDE
+		"zero-width space":        "prod\u200bteam", // U+200B ZERO WIDTH SPACE
+		"RTL override":            "prod\u202eteam", // U+202E RIGHT-TO-LEFT OVERRIDE
 		"non-breaking space":      "prod team", // U+00A0 NO-BREAK SPACE (not in allowlist)
 		"cyrillic homograph 'a'":  "prodаpi",   // U+0430 CYRILLIC SMALL LETTER A looks like Latin "a"
 		"CSV-formula-like prefix": "=cmd|'/calc'",

--- a/server/http/handlers/catalog_create_project_test.go
+++ b/server/http/handlers/catalog_create_project_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -79,4 +80,43 @@ func TestCreateProject_BlankEnvironmentsFallBackToDefaults(t *testing.T) {
 	var p models.Project
 	require.NoError(t, db.Where("name = ?", "svc").First(&p).Error)
 	assert.ElementsMatch(t, []string{"development", "staging", "production"}, envNames(t, db, p.ID))
+}
+
+// #189: Project.Name is wired to the `identifier` validator so a name carrying an
+// invisible or visually-deceptive character is rejected, rather than silently
+// accepted and later shown, apparently-legitimate, in an access-review UI or audit log.
+func TestCreateProject_RejectsDangerousNames(t *testing.T) {
+	cases := map[string]string{
+		"zero-width space":        "prod​team", // U+200B ZERO WIDTH SPACE
+		"RTL override":            "prod‮team", // U+202E RIGHT-TO-LEFT OVERRIDE
+		"non-breaking space":      "prod team", // U+00A0 NO-BREAK SPACE (not in allowlist)
+		"cyrillic homograph 'a'":  "prodаpi",   // U+0430 CYRILLIC SMALL LETTER A looks like Latin "a"
+		"CSV-formula-like prefix": "=cmd|'/calc'",
+	}
+	for name, dangerous := range cases {
+		t.Run(name, func(t *testing.T) {
+			h, _ := newCreateProjectHandler(t)
+			body, err := json.Marshal(map[string]string{"name": dangerous})
+			require.NoError(t, err)
+			w := postCreateProject(t, h, string(body))
+			assert.Equal(t, http.StatusBadRequest, w.Code, "response body: %s", w.Body.String())
+		})
+	}
+}
+
+// Non-regression: ordinary alphanumeric/space/hyphen/underscore names — the vast
+// majority of real project names — must keep working.
+func TestCreateProject_AcceptsLegitimateNames(t *testing.T) {
+	legit := []string{"web", "api-gateway", "Payments_2026", "team one"}
+	for _, name := range legit {
+		t.Run(name, func(t *testing.T) {
+			h, db := newCreateProjectHandler(t)
+			body, err := json.Marshal(map[string]string{"name": name})
+			require.NoError(t, err)
+			w := postCreateProject(t, h, string(body))
+			require.Equal(t, http.StatusCreated, w.Code, "response body: %s", w.Body.String())
+			var p models.Project
+			require.NoError(t, db.Where("name = ?", name).First(&p).Error)
+		})
+	}
 }

--- a/server/http/handlers/groups_handler.go
+++ b/server/http/handlers/groups_handler.go
@@ -69,7 +69,12 @@ func (h *GroupHandler) CreateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		Name        string `json:"name" validate:"required,min=1,max=255"`
+		// #189: a Group name has no dedicated naming-policy mechanism (unlike
+		// SecretNode.Name) and is human-visible in access-review UIs, audit logs, and
+		// CLI confirmation prompts — restrict it to the `identifier` charset so a
+		// zero-width, RTL-override, or homograph-lookalike character can't be used to
+		// visually disguise the group.
+		Name        string `json:"name" validate:"required,min=1,max=255,identifier"`
 		Description string `json:"description"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -137,7 +142,8 @@ func (h *GroupHandler) UpdateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		Name        string `json:"name" validate:"omitempty,min=1,max=255"`
+		// See CreateGroup's Name field comment for why `identifier` is applied here.
+		Name        string `json:"name" validate:"omitempty,min=1,max=255,identifier"`
 		Description string `json:"description"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {

--- a/server/http/handlers/groups_handler_identifier_test.go
+++ b/server/http/handlers/groups_handler_identifier_test.go
@@ -45,8 +45,8 @@ func postCreateGroup(t *testing.T, h *GroupHandler, name string) *httptest.Respo
 
 func TestCreateGroup_RejectsDangerousNames(t *testing.T) {
 	cases := map[string]string{
-		"zero-width space": "prod​team", // U+200B ZERO WIDTH SPACE
-		"RTL override":     "prod‮team", // U+202E RIGHT-TO-LEFT OVERRIDE
+		"zero-width space": "prod\u200bteam", // U+200B ZERO WIDTH SPACE
+		"RTL override":     "prod\u202eteam", // U+202E RIGHT-TO-LEFT OVERRIDE
 		"cyrillic homograph 'a'": "prodаpi", // U+0430 CYRILLIC SMALL LETTER A
 	}
 	for name, dangerous := range cases {
@@ -76,7 +76,7 @@ func TestUpdateGroup_RejectsDangerousName(t *testing.T) {
 	createW := postCreateGroup(t, h, "ops")
 	require.Equal(t, http.StatusCreated, createW.Code)
 
-	body, err := json.Marshal(map[string]string{"name": "prod​team"}) // zero-width space
+	body, err := json.Marshal(map[string]string{"name": "prod\u200bteam"}) // zero-width space
 	require.NoError(t, err)
 	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPut, "/api/v1/groups/1", bytes.NewReader(body)), "id", "1"))
 	req.Header.Set("Content-Type", "application/json")

--- a/server/http/handlers/groups_handler_identifier_test.go
+++ b/server/http/handlers/groups_handler_identifier_test.go
@@ -1,0 +1,86 @@
+// groups_handler_identifier_test.go — regression tests for #189: Group.Name is
+// wired to the `identifier` validator so a name carrying an invisible or
+// visually-deceptive character is rejected rather than silently accepted and
+// later shown, apparently-legitimate, in an access-review UI or audit log.
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newGroupHandlerForTest(t *testing.T) *GroupHandler {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.AuditEvent{}, &models.Role{}))
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h, err := NewGroupHandler(c)
+	require.NoError(t, err)
+	return h
+}
+
+func postCreateGroup(t *testing.T, h *GroupHandler, name string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"name": name})
+	require.NoError(t, err)
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/groups", bytes.NewReader(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateGroup(w, req)
+	return w
+}
+
+func TestCreateGroup_RejectsDangerousNames(t *testing.T) {
+	cases := map[string]string{
+		"zero-width space": "prod​team", // U+200B ZERO WIDTH SPACE
+		"RTL override":     "prod‮team", // U+202E RIGHT-TO-LEFT OVERRIDE
+		"cyrillic homograph 'a'": "prodаpi", // U+0430 CYRILLIC SMALL LETTER A
+	}
+	for name, dangerous := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := newGroupHandlerForTest(t)
+			w := postCreateGroup(t, h, dangerous)
+			require.Equal(t, http.StatusBadRequest, w.Code, "response body: %s", w.Body.String())
+		})
+	}
+}
+
+func TestCreateGroup_AcceptsLegitimateNames(t *testing.T) {
+	legit := []string{"ops", "platform-admins", "Group_One", "sales team"}
+	for _, name := range legit {
+		t.Run(name, func(t *testing.T) {
+			h := newGroupHandlerForTest(t)
+			w := postCreateGroup(t, h, name)
+			require.Equal(t, http.StatusCreated, w.Code, "response body: %s", w.Body.String())
+		})
+	}
+}
+
+// UpdateGroup's Name is optional (omitempty) but must still reject a dangerous
+// value when one is supplied.
+func TestUpdateGroup_RejectsDangerousName(t *testing.T) {
+	h := newGroupHandlerForTest(t)
+	createW := postCreateGroup(t, h, "ops")
+	require.Equal(t, http.StatusCreated, createW.Code)
+
+	body, err := json.Marshal(map[string]string{"name": "prod​team"}) // zero-width space
+	require.NoError(t, err)
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPut, "/api/v1/groups/1", bytes.NewReader(body)), "id", "1"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.UpdateGroup(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, "response body: %s", w.Body.String())
+}

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -63,8 +63,16 @@ type UserRole struct {
 }
 
 // CreateRoleRequest is the request body for role creation.
+//
+// #189: Name is restricted to the `identifier` charset (letters/digits/space/`-`/`_`)
+// so a zero-width, RTL-override, or homograph-lookalike character can't be used to
+// visually disguise a custom role in an access-review UI or audit log. This only
+// constrains roles created through this API — the bootstrap-seeded system/builtin
+// roles (admin, viewer, ...; see internal/core/auth_bootstrap.go) are written
+// directly via storage.CreateRole and never pass through this validated request type,
+// so they're unaffected.
 type CreateRoleRequest struct {
-	Name        string   `json:"name"        validate:"required,min=3,max=50"`
+	Name        string   `json:"name"        validate:"required,min=3,max=50,identifier"`
 	Description string   `json:"description" validate:"required,min=1,max=200"`
 	Permissions []string `json:"permissions" validate:"required,min=1"`
 }

--- a/server/http/handlers/rbac_test.go
+++ b/server/http/handlers/rbac_test.go
@@ -543,7 +543,7 @@ func TestCreateRole(t *testing.T) {
 			name:      "name with zero-width space is rejected",
 			authToken: "valid-token",
 			requestBody: map[string]interface{}{
-				"name":        "dev​team",
+				"name":        "dev\u200bteam",
 				"description": "Developer role with limited access",
 				"permissions": []string{"secrets.read", "secrets.write"},
 			},
@@ -554,7 +554,7 @@ func TestCreateRole(t *testing.T) {
 			name:      "name with RTL override is rejected",
 			authToken: "valid-token",
 			requestBody: map[string]interface{}{
-				"name":        "dev‮team",
+				"name":        "dev\u202eteam",
 				"description": "Developer role with limited access",
 				"permissions": []string{"secrets.read", "secrets.write"},
 			},

--- a/server/http/handlers/rbac_test.go
+++ b/server/http/handlers/rbac_test.go
@@ -539,6 +539,28 @@ func TestCreateRole(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
+			// #189: a zero-width space (U+200B) can't be used to disguise a role name.
+			name:      "name with zero-width space is rejected",
+			authToken: "valid-token",
+			requestBody: map[string]interface{}{
+				"name":        "dev​team",
+				"description": "Developer role with limited access",
+				"permissions": []string{"secrets.read", "secrets.write"},
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			// #189: an RTL override (U+202E) can't be used to disguise a role name.
+			name:      "name with RTL override is rejected",
+			authToken: "valid-token",
+			requestBody: map[string]interface{}{
+				"name":        "dev‮team",
+				"description": "Developer role with limited access",
+				"permissions": []string{"secrets.read", "secrets.write"},
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
 			name:           "unauthorized",
 			authToken:      "",
 			requestBody:    map[string]interface{}{},


### PR DESCRIPTION
## Summary

Closes the residual half of backlog #189. The blank/zero-width `required`
check and the `identifier` charset rule were both added in an earlier round
(#632), but the `identifier` rule was opt-in and, per that PR's own comment,
never actually wired to a single struct field. That meant nothing stopped a
Project, Group, or custom Role from being created with a name containing
invisible Unicode (zero-width space), an RTL override, or a homograph
lookalike character — which could visually fool a higher-trust approver
reading an access-review UI, audit log, or CLI confirmation prompt into
thinking it's a different, legitimate resource.

## Changes

- `server/http/handlers/catalog.go`: `CatalogHandler` had no validator wired
  at all for Project create/update. Added one and tagged `Name` with
  `validate:"required,max=200,identifier"` on both `CreateProject` and
  `UpdateProject`.
- `server/http/handlers/groups_handler.go`: added `,identifier` to
  `CreateGroup`'s (required) and `UpdateGroup`'s (omitempty) `Name` tag.
- `server/http/handlers/rbac.go`: added `,identifier` to
  `CreateRoleRequest.Name`. This only affects roles created through this API
  — bootstrap-seeded system/builtin roles (admin, viewer, ...) are written
  directly via `storage.CreateRole` and never pass through this validated
  request type.

`SecretNode.Name` is intentionally **not** touched: it already has its own
dedicated naming-policy/conformance mechanism (#385/#389), and adding the
generic `identifier` charset rule there would conflict with that mechanism
rather than complement it.

The `identifier` regex (`^[a-zA-Z0-9 _-]+$`) is unchanged from #632 — this PR
is purely about wiring the existing, already-audited rule to fields that had
zero protection.

## Test plan
- [x] Added regression tests rejecting a zero-width space, RTL override, and
  Cyrillic homograph 'a' on Project create, Group create/update, and Role
  create.
- [x] Added non-regression tests confirming ordinary alphanumeric/space/
  hyphen/underscore names (the existing convention across this codebase's
  fixtures) are still accepted.
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./server/... ./internal/core/... -count=1` — all pass
- [x] `gosec -severity medium -exclude-generated ./server/... ./internal/core/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)