### PR TITLE
fix(grpc): reorder unary chain so MetricsInterceptor wraps AuthInterceptor (#223)

### DIFF
--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -36,12 +36,26 @@ func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server,
 		// order listed: the first is OUTERMOST (executes first on the way in, last on
 		// the way out), wrapping every interceptor listed after it. RecoveryInterceptor
 		// / StreamRecoveryInterceptor are listed FIRST so a panic in ANY later
-		// interceptor — logging, timeout, auth, metrics, or the handler itself — is
+		// interceptor — metrics, logging, timeout, auth, or the handler itself — is
 		// caught, instead of only panics inside the handler. A panic that unwound past
 		// an inner (non-outermost) recovery interceptor would otherwise crash the
 		// request with none of Recovery's clean INTERNAL status + logged stack trace.
+		//
+		// MetricsInterceptor is listed SECOND — inside Recovery but wrapping everything
+		// after it, including AuthInterceptor — for parity with the HTTP API, where
+		// PrometheusMiddleware is registered before the Authentication middleware
+		// (server/http/router.go) and so records every request regardless of auth
+		// outcome. Metrics used to run last, after Auth, so an auth-rejected gRPC call
+		// (bad/expired token, IP-allowlist miss, MFA required) never reached it and was
+		// invisible to keyorix_grpc_requests_total — a credential-stuffing campaign
+		// against the gRPC endpoint produced zero movement in Prometheus-based
+		// alerting, even though LoggingInterceptor (also outermost) still logged every
+		// attempt. Metrics sits just inside Recovery (not outside it) so a panic is
+		// still caught and turned into a clean INTERNAL status before Metrics' own
+		// deferred bookkeeping runs on the way out.
 		grpc.ChainUnaryInterceptor(
 			interceptors.RecoveryInterceptor(),
+			interceptors.MetricsInterceptor(),
 			interceptors.LoggingInterceptor(),
 			// Cap each unary RPC at the same 60s the HTTP API's Timeout middleware
 			// enforces, so a hung handler can't tie up resources over gRPC when it would
@@ -49,8 +63,18 @@ func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server,
 			// long-lived), so the stream chain carries no timeout.
 			interceptors.TimeoutInterceptor(grpcUnaryTimeout),
 			interceptors.AuthInterceptor(coreService, cfg.Security.RequireMFA),
-			interceptors.MetricsInterceptor(),
 		),
+		// The stream chain intentionally carries no metrics interceptor: MetricsInterceptor
+		// (and the keyorix_grpc_requests_total / _duration_seconds_total series it feeds)
+		// times a single request/response round trip, and grpcMetrics.TotalDuration backs
+		// an average-latency figure. A streaming call's "handler" blocks for the entire
+		// life of the stream (StreamAuditLogs can run for hours), so folding stream call
+		// establishment into the same counters/duration total would both misrepresent unary
+		// latency (one long-lived stream would dominate the average) and conflate two
+		// different things under one metric name. Auth-rejected stream opens are still
+		// visible via StreamLoggingInterceptor (also outermost here). A correct fix — a
+		// separate, stream-specific metric — is tracked as its own follow-up rather than
+		// folded into this reordering.
 		grpc.ChainStreamInterceptor(
 			interceptors.StreamRecoveryInterceptor(),
 			interceptors.StreamLoggingInterceptor(),

--- a/server/grpc/server_integration_test.go
+++ b/server/grpc/server_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	keyorixgrpc "github.com/keyorixhq/keyorix/server/grpc"
+	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -258,4 +259,49 @@ func TestGRPCServer_KeepaliveReclaimsAbandonedConnection(t *testing.T) {
 	}
 	assert.False(t, errors.Is(readErr, os.ErrDeadlineExceeded),
 		"the read must unblock because the SERVER closed the connection, not because our own read deadline fired first (got: %v)", readErr)
+}
+
+// TestGRPCServer_MetricsRecordAuthRejectedRequest is the regression guard for #223:
+// MetricsInterceptor must sit outside (wrap) AuthInterceptor in the real chain
+// NewServer builds, so an auth-rejected call is still counted — mirroring the HTTP
+// API, where PrometheusMiddleware is registered ahead of the Authentication
+// middleware and so records every request regardless of auth outcome. Before the
+// fix, MetricsInterceptor ran last (after AuthInterceptor), so a request AuthInterceptor
+// rejected never reached it and was invisible to keyorix_grpc_requests_total — a
+// credential-stuffing campaign against the gRPC endpoint produced zero movement in
+// Prometheus-based alerting.
+func TestGRPCServer_MetricsRecordAuthRejectedRequest(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+
+	srv, err := keyorixgrpc.NewServer(&config.Config{}, h.CoreService)
+	require.NoError(t, err)
+	lis := bufconn.Listen(1024 * 1024)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	before := interceptors.GetGRPCMetrics()
+
+	// No authorization metadata at all — AuthInterceptor rejects this with
+	// Unauthenticated before the handler ever runs.
+	_, err = pb.NewSecretServiceClient(conn).GetSecret(ctx, &pb.GetSecretRequest{Id: 1})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	after := interceptors.GetGRPCMetrics()
+	assert.Greater(t, after.TotalRequests, before.TotalRequests,
+		"an auth-rejected request must still be counted in TotalRequests")
+	assert.Greater(t, after.ErrorRequests, before.ErrorRequests,
+		"an auth-rejected request must be recorded as an error outcome")
 }


### PR DESCRIPTION
## Summary

Fixes backlog finding **#223 (LOW)**: `server/grpc/server.go`'s unary interceptor
chain ran `Recovery -> Logging -> Timeout -> Auth -> Metrics`. Since
`grpc.ChainUnaryInterceptor` wraps in listed order (first = outermost), any request
`AuthInterceptor` rejected (bad/expired token, IP-allowlist miss, MFA required)
never reached `MetricsInterceptor` — invisible to `keyorix_grpc_requests_total`.
The HTTP API doesn't have this gap: `PrometheusMiddleware` is registered ahead of
the `Authentication` middleware in `server/http/router.go`, so it records every
request regardless of auth outcome. A credential-stuffing campaign against the
gRPC endpoint produced zero movement in Prometheus-based alerting, even though
`LoggingInterceptor` (already outermost) still logged every attempt.

## Fix

- Reordered the unary chain to `Recovery -> Metrics -> Logging -> Timeout -> Auth`,
  so `MetricsInterceptor` now wraps `AuthInterceptor` (parity with HTTP) while
  `RecoveryInterceptor` stays truly outermost — a panic anywhere downstream is
  still caught and turned into a clean `INTERNAL` status before `Metrics`' own
  bookkeeping runs on the way out.
- Extended the existing chain-ordering comment to explain the new placement and
  why it matters.
- `interceptors.MetricsInterceptor()` itself is untouched — it already just wraps
  `handler(ctx, req)` and records the returned error, so it works correctly
  wherever it sits in the chain.
- Investigated whether the stream chain (`grpc.ChainStreamInterceptor`, which has
  no metrics interceptor at all today) needs the same fix for parity. Concluded no:
  `MetricsInterceptor`'s duration bookkeeping assumes a single request/response
  round trip, and a streaming RPC's "handler" blocks for the entire life of the
  stream (`StreamAuditLogs` can run for hours) — folding stream call establishment
  into the same counters would both misrepresent the average unary latency (one
  long stream would dominate it) and conflate two different things under one
  metric name. Auth-rejected stream opens are still visible via
  `StreamLoggingInterceptor` (already outermost). Documented this in-line as a
  distinct follow-up rather than bolting a mismatched metric onto this reordering.

## Testing

Added `TestGRPCServer_MetricsRecordAuthRejectedRequest` in
`server/grpc/server_integration_test.go`, which drives an unauthenticated
`GetSecret` call through the real `NewServer` chain over bufconn and asserts the
shared Prometheus-backed counters (`interceptors.GetGRPCMetrics()`) increment.
Manually verified it fails against the old (pre-fix) ordering and passes with the
fix, confirming it's a genuine regression guard.

## Verification

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./server/grpc/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./server/grpc/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)