### PR TITLE
fix(compliance): scope the recertification scheduler tick's campaign lookup (#238)

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -246,6 +246,22 @@ func (m *MockStorage) ListAccessReviewCampaigns(ctx context.Context, projectID u
 	return args.Get(0).([]*models.AccessReviewCampaign), args.Error(1)
 }
 
+func (m *MockStorage) GetOpenAccessReviewCampaign(ctx context.Context, projectID uint) (*models.AccessReviewCampaign, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AccessReviewCampaign), args.Error(1)
+}
+
+func (m *MockStorage) GetLatestClosedAccessReviewCampaign(ctx context.Context, projectID uint) (*models.AccessReviewCampaign, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AccessReviewCampaign), args.Error(1)
+}
+
 func (m *MockStorage) UpdateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (bool, error) {
 	args := m.Called(ctx, c)
 	return args.Bool(0), args.Error(1)
@@ -262,6 +278,11 @@ func (m *MockStorage) ListAccessReviewItems(ctx context.Context, campaignID uint
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]*models.AccessReviewItem), args.Error(1)
+}
+
+func (m *MockStorage) CountPendingAccessReviewItems(ctx context.Context, campaignID uint) (int, error) {
+	args := m.Called(ctx, campaignID)
+	return args.Int(0), args.Error(1)
 }
 
 func (m *MockStorage) GetAccessReviewItem(ctx context.Context, id uint) (*models.AccessReviewItem, error) {

--- a/internal/core/recertification.go
+++ b/internal/core/recertification.go
@@ -63,26 +63,43 @@ func (c *KeyorixCore) RunScheduledRecertification(ctx context.Context, cadenceDa
 
 	for _, proj := range projects {
 		pid := proj.ID
-		campaigns, err := c.ListAccessReviewCampaigns(ctx, pid)
+
+		// #238: this used to call ListAccessReviewCampaigns, which loads the
+		// project's ENTIRE historical campaign+item corpus (every campaign the
+		// project has ever had, plus every item within each, just to tally
+		// progress) on every single tick, for every project. That cost grows
+		// unboundedly with a deployment's accumulated campaign history, not with
+		// what a tick actually needs to decide. The tick only needs two targeted
+		// facts: (1) is a campaign already open, and if so how much of it is still
+		// pending; (2) if not, when did the most recent one close. Both are now
+		// single-row, indexed lookups instead of a full per-project reload.
+		open, err := c.storage.GetOpenAccessReviewCampaign(ctx, pid)
 		if err != nil {
 			continue // a per-project read error must not abort the whole sweep
 		}
-		open, lastClosed := splitCampaigns(campaigns)
 
 		// A review is already in progress — nudge admins only if items remain.
 		if open != nil {
-			if open.Progress.Pending > 0 {
+			pending, err := c.storage.CountPendingAccessReviewItems(ctx, open.ID)
+			if err != nil {
+				continue
+			}
+			if pending > 0 {
 				res.Reminded += c.remindRecertificationAdmins(ctx, pid,
 					fmt.Sprintf("Access recertification for %s has %d item(s) still pending review.",
-						c.projectLabel(ctx, pid), open.Progress.Pending))
+						c.projectLabel(ctx, pid), pending))
 			}
 			continue
 		}
 
 		// No open campaign — is the project due for one?
+		lastClosed, err := c.storage.GetLatestClosedAccessReviewCampaign(ctx, pid)
+		if err != nil {
+			continue
+		}
 		due := lastClosed == nil // never reviewed
-		if lastClosed != nil && lastClosed.Campaign.ClosedAt != nil {
-			anchor := lastClosed.Campaign.ClosedAt
+		if lastClosed != nil && lastClosed.ClosedAt != nil {
+			anchor := lastClosed.ClosedAt
 			// #237: a force-close performed while items were still pending
 			// (ForcedIncomplete) is evidence of an ABANDONED cycle, not a
 			// completed recertification — some access was never reviewed. Anchor
@@ -92,8 +109,8 @@ func (c *KeyorixCore) RunScheduledRecertification(ctx context.Context, cadenceDa
 			// force-closing early; the next campaign becomes due sooner,
 			// proportional to how little of the cadence window the abandoned
 			// cycle actually covered.
-			if lastClosed.Campaign.ForcedIncomplete {
-				anchor = &lastClosed.Campaign.CreatedAt
+			if lastClosed.ForcedIncomplete {
+				anchor = &lastClosed.CreatedAt
 			}
 			due = anchor.Before(cutoff)
 		}
@@ -120,7 +137,11 @@ func (c *KeyorixCore) RunScheduledRecertification(ctx context.Context, cadenceDa
 }
 
 // splitCampaigns returns the open campaign (if any) and the most-recent closed one.
-// The list is newest-first, so the first match in each case is the latest.
+// The list is newest-first, so the first match in each case is the latest. Used by
+// the compliance-posture snapshot (compliance_posture.go), which — unlike the
+// recertification scheduler tick above — genuinely needs the full per-project
+// campaign list for its dashboard tallies (e.g. counting every open campaign's
+// pending items across the deployment); it is not part of the #238 fix.
 func splitCampaigns(campaigns []*CampaignWithProgress) (open *CampaignWithProgress, lastClosed *CampaignWithProgress) {
 	for _, cw := range campaigns {
 		if cw.Campaign.State == CampaignStateOpen {

--- a/internal/core/recertification_external_test.go
+++ b/internal/core/recertification_external_test.go
@@ -2,6 +2,8 @@ package core_test
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func hasOpenCampaign(campaigns []*core.CampaignWithProgress) bool {
@@ -130,4 +133,90 @@ func TestRunScheduledRecertification_ForcedIncompleteAnchorsToOpenTime(t *testin
 	camps3, err := h.CoreService.ListAccessReviewCampaigns(ctx, 3)
 	require.NoError(t, err)
 	assert.False(t, hasOpenCampaign(camps3), "a genuinely completed close resets the cadence clock at ClosedAt")
+}
+
+// queryCounter tallies the SELECT queries GORM executes against each table, via the
+// same "gorm:query" callback hook GORM itself uses to run queries — a precise,
+// non-flaky substitute for a timing-based assertion.
+type queryCounter struct {
+	mu      sync.Mutex
+	byTable map[string]int
+}
+
+func attachQueryCounter(t *testing.T, db *gorm.DB) *queryCounter {
+	qc := &queryCounter{byTable: map[string]int{}}
+	err := db.Callback().Query().After("gorm:query").Register("test:count_queries", func(tx *gorm.DB) {
+		qc.mu.Lock()
+		defer qc.mu.Unlock()
+		table := ""
+		if tx.Statement != nil {
+			table = tx.Statement.Table
+		}
+		qc.byTable[table]++
+	})
+	require.NoError(t, err)
+	return qc
+}
+
+func (qc *queryCounter) count(table string) int {
+	qc.mu.Lock()
+	defer qc.mu.Unlock()
+	return qc.byTable[table]
+}
+
+// #238: RunScheduledRecertification used to fetch a project's ENTIRE historical
+// campaign+item corpus (ListAccessReviewCampaigns, then ListAccessReviewItems for
+// EVERY campaign returned) on every scheduler tick, for every project — cost that
+// grew unboundedly with a deployment's accumulated campaign history rather than with
+// what a tick actually needs to decide. This proves the fixed tick's campaign lookup
+// executes the same number of queries against access_review_campaigns/
+// access_review_items whether a project has 5 or 100 historical (closed) campaigns —
+// a query COUNT assertion, not a timing one, so it can't flake under load.
+func TestRunScheduledRecertification_CampaignQueryCostDoesNotScaleWithHistory(t *testing.T) {
+	runTickAndCountCampaignQueries := func(historicalCampaigns int) (campaignQueries, itemQueries int) {
+		h := testhelper.NewRBACTestHelper(t)
+		defer h.Cleanup()
+		migrateCampaignTables(t, h)
+		require.NoError(t, h.DB.AutoMigrate(&models.Notification{}))
+
+		ctx := context.Background()
+		now := time.Now()
+
+		// A pile of ancient, irrelevant history for project 2 — the deeper past a
+		// correctly-scoped scheduler tick has no reason to ever reload.
+		for i := 0; i < historicalCampaigns; i++ {
+			closedAt := now.AddDate(0, 0, -1000-i)
+			require.NoError(t, h.DB.Create(&models.AccessReviewCampaign{
+				ProjectID: 2, Name: fmt.Sprintf("historical-%d", i),
+				State: core.CampaignStateClosed, CreatedAt: closedAt, ClosedAt: &closedAt,
+			}).Error)
+		}
+		// The one campaign that's actually relevant to this tick's decision: recent
+		// enough that project 2 is not overdue.
+		recent := now.AddDate(0, 0, -10)
+		require.NoError(t, h.DB.Create(&models.AccessReviewCampaign{
+			ProjectID: 2, Name: "recent", State: core.CampaignStateClosed,
+			CreatedAt: recent, ClosedAt: &recent,
+		}).Error)
+
+		qc := attachQueryCounter(t, h.DB)
+		_, err := h.CoreService.RunScheduledRecertification(ctx, 90, true)
+		require.NoError(t, err)
+		return qc.count("access_review_campaigns"), qc.count("access_review_items")
+	}
+
+	smallCampaignQueries, smallItemQueries := runTickAndCountCampaignQueries(5)
+	largeCampaignQueries, largeItemQueries := runTickAndCountCampaignQueries(100)
+
+	assert.Equal(t, smallCampaignQueries, largeCampaignQueries,
+		"campaign-table query count must not scale with a project's historical campaign count")
+	assert.Equal(t, smallItemQueries, largeItemQueries,
+		"item-table query count must not scale with a project's historical campaign count")
+
+	// 3 seeded projects x 2 targeted single-row lookups each (GetOpenAccessReviewCampaign
+	// + GetLatestClosedAccessReviewCampaign) = 6 — not the old N+1 shape, where the
+	// campaign-table query count would stay small but the item-table query count
+	// would grow by one per historical campaign returned.
+	assert.Equal(t, 6, smallCampaignQueries, "expected exactly two targeted campaign lookups per project")
+	assert.Equal(t, 0, smallItemQueries, "no open campaign exists, so no item query should run at all")
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -149,6 +149,16 @@ type Storage interface {
 	CreateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (*models.AccessReviewCampaign, error)
 	GetAccessReviewCampaign(ctx context.Context, id uint) (*models.AccessReviewCampaign, error)
 	ListAccessReviewCampaigns(ctx context.Context, projectID uint) ([]*models.AccessReviewCampaign, error)
+	// GetOpenAccessReviewCampaign returns the project's currently open campaign, or
+	// nil if none is open — a targeted single-row lookup for callers (e.g. the
+	// recertification scheduler tick, #238) that only need to know whether a review
+	// is already in flight, not the project's full historical campaign list.
+	GetOpenAccessReviewCampaign(ctx context.Context, projectID uint) (*models.AccessReviewCampaign, error)
+	// GetLatestClosedAccessReviewCampaign returns the project's most recently closed
+	// campaign (by CreatedAt), or nil if it has never had one. A targeted
+	// ORDER BY ... LIMIT 1 lookup for callers that only need the anchor point for the
+	// next recertification due-date, not the entire historical corpus (#238).
+	GetLatestClosedAccessReviewCampaign(ctx context.Context, projectID uint) (*models.AccessReviewCampaign, error)
 	// UpdateAccessReviewCampaign persists a campaign state transition with a
 	// conditional UPDATE (only a campaign whose CURRENT stored state is still "open"
 	// may be transitioned). The bool reports whether the row matched and was updated;
@@ -157,6 +167,11 @@ type Storage interface {
 	UpdateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (bool, error)
 	CreateAccessReviewItems(ctx context.Context, items []*models.AccessReviewItem) error
 	ListAccessReviewItems(ctx context.Context, campaignID uint) ([]*models.AccessReviewItem, error)
+	// CountPendingAccessReviewItems returns the number of items in a campaign still
+	// awaiting a decision (decision = "pending"), without loading the item rows
+	// themselves — used by the recertification scheduler tick (#238) to size an
+	// in-flight campaign's remaining work for a reminder.
+	CountPendingAccessReviewItems(ctx context.Context, campaignID uint) (int, error)
 	GetAccessReviewItem(ctx context.Context, id uint) (*models.AccessReviewItem, error)
 	// UpdateAccessReviewItem persists a decision with a conditional UPDATE (only an
 	// item whose CURRENT stored decision is still "pending", in a campaign whose

--- a/internal/storage/store/local_access_review_campaigns.go
+++ b/internal/storage/store/local_access_review_campaigns.go
@@ -5,10 +5,12 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
 )
 
 // --- Campaigns ---
@@ -38,6 +40,49 @@ func (ls *LocalStorage) ListAccessReviewCampaigns(ctx context.Context, projectID
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return rows, nil
+}
+
+// GetOpenAccessReviewCampaign returns the project's open campaign (nil if none is
+// open) via a targeted `WHERE project_id = ? AND state = 'open'` lookup — not by
+// loading and filtering the project's full campaign history. #238: the
+// recertification scheduler tick used to call ListAccessReviewCampaigns (which
+// returns EVERY campaign the project has ever had, oldest to newest) on every tick
+// for every project just to answer "is one open right now"; the cost of that grew
+// unboundedly with a deployment's accumulated campaign history. This query costs the
+// same whether the project has 1 or 10,000 historical campaigns.
+func (ls *LocalStorage) GetOpenAccessReviewCampaign(ctx context.Context, projectID uint) (*models.AccessReviewCampaign, error) {
+	var c models.AccessReviewCampaign
+	err := ls.db.WithContext(ctx).
+		Where("project_id = ? AND state = ?", projectID, accessReviewCampaignOpen).
+		Order("created_at DESC").
+		First(&c).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return &c, nil
+}
+
+// GetLatestClosedAccessReviewCampaign returns the project's most recently created
+// non-open campaign (nil if it has never had one) via a targeted
+// `ORDER BY created_at DESC LIMIT 1` lookup, so the recertification scheduler tick
+// (#238) can anchor the next-due date without loading the project's entire
+// historical campaign corpus just to find the newest closed row.
+func (ls *LocalStorage) GetLatestClosedAccessReviewCampaign(ctx context.Context, projectID uint) (*models.AccessReviewCampaign, error) {
+	var c models.AccessReviewCampaign
+	err := ls.db.WithContext(ctx).
+		Where("project_id = ? AND state <> ?", projectID, accessReviewCampaignOpen).
+		Order("created_at DESC").
+		First(&c).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return &c, nil
 }
 
 // accessReviewCampaignOpen mirrors core.CampaignStateOpen (the store package cannot
@@ -88,6 +133,21 @@ func (ls *LocalStorage) ListAccessReviewItems(ctx context.Context, campaignID ui
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return rows, nil
+}
+
+// CountPendingAccessReviewItems returns the number of items still awaiting a
+// decision for a campaign via a single `COUNT(*) WHERE decision = 'pending'`, not by
+// loading every item row and tallying in Go — used by the recertification scheduler
+// tick (#238) to size an in-flight campaign's remaining work for a reminder.
+func (ls *LocalStorage) CountPendingAccessReviewItems(ctx context.Context, campaignID uint) (int, error) {
+	var n int64
+	err := ls.db.WithContext(ctx).Model(&models.AccessReviewItem{}).
+		Where("campaign_id = ? AND decision = ?", campaignID, accessReviewItemPending).
+		Count(&n).Error
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return int(n), nil
 }
 
 func (ls *LocalStorage) GetAccessReviewItem(ctx context.Context, id uint) (*models.AccessReviewItem, error) {

--- a/internal/storage/store/remote_access_review_campaigns.go
+++ b/internal/storage/store/remote_access_review_campaigns.go
@@ -21,6 +21,14 @@ func (rs *RemoteStorage) ListAccessReviewCampaigns(_ context.Context, _ uint) ([
 	return nil, remoteUnsupported("ListAccessReviewCampaigns")
 }
 
+func (rs *RemoteStorage) GetOpenAccessReviewCampaign(_ context.Context, _ uint) (*models.AccessReviewCampaign, error) {
+	return nil, remoteUnsupported("GetOpenAccessReviewCampaign")
+}
+
+func (rs *RemoteStorage) GetLatestClosedAccessReviewCampaign(_ context.Context, _ uint) (*models.AccessReviewCampaign, error) {
+	return nil, remoteUnsupported("GetLatestClosedAccessReviewCampaign")
+}
+
 func (rs *RemoteStorage) UpdateAccessReviewCampaign(_ context.Context, _ *models.AccessReviewCampaign) (bool, error) {
 	return false, remoteUnsupported("UpdateAccessReviewCampaign")
 }
@@ -31,6 +39,10 @@ func (rs *RemoteStorage) CreateAccessReviewItems(_ context.Context, _ []*models.
 
 func (rs *RemoteStorage) ListAccessReviewItems(_ context.Context, _ uint) ([]*models.AccessReviewItem, error) {
 	return nil, remoteUnsupported("ListAccessReviewItems")
+}
+
+func (rs *RemoteStorage) CountPendingAccessReviewItems(_ context.Context, _ uint) (int, error) {
+	return 0, remoteUnsupported("CountPendingAccessReviewItems")
 }
 
 func (rs *RemoteStorage) GetAccessReviewItem(_ context.Context, _ uint) (*models.AccessReviewItem, error) {


### PR DESCRIPTION
## Summary

MEDIUM backlog finding #238: `RunScheduledRecertification` — the recertification
scheduler tick — called `ListAccessReviewCampaigns` for every project on every tick.
That call loads the project's ENTIRE historical campaign list and then, per campaign
returned, every one of its items just to tally progress (an N+1 inside the loop). The
cost of a single tick grew unboundedly with a deployment's accumulated
campaign/item history, not with what the tick actually needs to decide — a
deployment that's been running recertification for a long time would see the tick
get progressively slower and more resource-intensive purely from irrelevant history.

Per-project, the tick only needs two facts:
- Is a campaign currently open, and if so how many of its items are still pending
  (to decide whether to nudge admins)?
- If not, when did the most recent one close (to compute whether the project is
  overdue)?

## Fix

Added three targeted storage methods (mirroring the existing
storage-interface + Local + Remote pattern) instead of reusing the
full-list-then-filter-in-Go shape:

- `GetOpenAccessReviewCampaign` — `WHERE project_id = ? AND state = 'open' LIMIT 1`
- `GetLatestClosedAccessReviewCampaign` — `WHERE project_id = ? AND state <> 'open' ORDER BY created_at DESC LIMIT 1`
- `CountPendingAccessReviewItems` — `COUNT(*) WHERE campaign_id = ? AND decision = 'pending'`

`RunScheduledRecertification` now calls these directly instead of
`ListAccessReviewCampaigns` + `ListAccessReviewItems`. Cost per project is now
constant regardless of the project's historical campaign count. Remote storage
gets the usual `remoteUnsupported` stubs (access-review campaigns are
server-side-only, matching the existing `ListAccessReviewCampaigns` stub).

`compliance_posture.go` has the same `ListAccessReviewCampaigns`-based shape (it's
part of the same family as backlog #386/#393/#409/#416) but genuinely needs the
full per-project campaign list for its dashboard tallies (counting every open
campaign's pending items across the deployment, "never reviewed" counts, etc.) —
left alone here, out of scope for this fix. Worth a shared helper in a future round
if that pattern keeps recurring.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./internal/core/... ./internal/storage/...` — 0 issues
- [x] New regression test `TestRunScheduledRecertification_CampaignQueryCostDoesNotScaleWithHistory`:
      seeds 5 vs. 100 historical closed campaigns for a project, runs the scheduler
      tick with a GORM query-counting callback attached, and asserts the
      campaign-table and item-table query counts are identical in both cases (a
      precise query-count assertion, not timing-based) — 6 targeted single-row
      lookups total (3 seeded projects × 2 each), 0 item queries, regardless of N.
- [x] Existing recertification tests (reminders/dedupe, auto-open overdue-vs-recent,
      #237 forced-incomplete anchor) still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)