### PR TITLE
fix(notifychan): route broadcast alerts to email + stop false success audit (#221)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1018,6 +1018,15 @@ type NotificationEmailConfig struct {
 	Password string `yaml:"password"` // use KEYORIX_NOTIFY_SMTP_PASSWORD env var instead
 	From     string `yaml:"from"`
 	TLS      string `yaml:"tls"` // starttls | implicit | none(dev-only)
+	// BroadcastTo is the destination address for BROADCAST notifications — the
+	// scheduled compliance digest and auto-rotation-failure alerts (#221) — when
+	// email is the channel carrying them. Unlike a per-user notification (whose
+	// recipient is resolved from the user's account), a broadcast has no single
+	// addressee, so without this the email channel has nowhere to route it and the
+	// broadcast silently never sends. Optional: leave unset if Slack/Teams/webhook
+	// already covers deployment-wide broadcasts, or if email-only broadcast alerting
+	// isn't wanted.
+	BroadcastTo string `yaml:"broadcast_to"`
 }
 
 // GetPassword returns the resolved SMTP password, preferring the environment variable.

--- a/internal/core/compliance_digest.go
+++ b/internal/core/compliance_digest.go
@@ -10,6 +10,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -90,9 +91,12 @@ func plural(n int) string {
 }
 
 // SendComplianceDigest builds the digest and broadcasts it to the configured
-// notification channels (Slack/Teams/webhook). It is a single broadcast (no
-// per-user fan-out), so a chat channel gets one message. Returns whether a digest
-// was delivered (false when no notification channel is wired). Audited.
+// notification channels (Slack/Teams/webhook/email). It is a single broadcast (no
+// per-user fan-out), so a chat channel gets one message. Returns whether the digest
+// was actually attempted (false when no notification channel is wired at all, OR
+// every wired channel was a no-op — e.g. an email-only deployment with no
+// email.broadcast_to destination configured, #221). Audited either way, but the
+// audit event only claims success when delivery was actually attempted.
 func (c *KeyorixCore) SendComplianceDigest(ctx context.Context) (bool, error) {
 	if c.notificationSink == nil {
 		return false, nil // nowhere to deliver — no channel configured
@@ -101,13 +105,18 @@ func (c *KeyorixCore) SendComplianceDigest(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	c.notificationSink.Deliver(NotificationEvent{
+	attempted := c.notificationSink.Deliver(NotificationEvent{
 		Type:    "compliance.digest",
 		Title:   title,
 		Message: body,
 		Link:    "/compliance",
 	})
 	sysCtx := WithActorType(ctx, ActorTypeSystem)
+	if !attempted {
+		log.Printf("compliance digest: notification channel(s) configured but none accepted the broadcast (e.g. email-only with no broadcast destination) — digest was NOT delivered")
+		c.writeAuditEventFailed(sysCtx, EventComplianceDigestSent, nil, "", "compliance digest broadcast attempted but no configured channel could accept it")
+		return false, nil
+	}
 	c.writeAuditEvent(sysCtx, EventComplianceDigestSent, nil, nil, "compliance digest broadcast to notification channels")
 	return true, nil
 }

--- a/internal/core/compliance_digest_test.go
+++ b/internal/core/compliance_digest_test.go
@@ -60,7 +60,40 @@ func TestSendComplianceDigest_Broadcasts(t *testing.T) {
 	assert.Equal(t, "compliance.digest", sink.events[0].Type)
 	assert.Contains(t, sink.events[0].Title, "compliance digest")
 
-	var n int64
-	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "compliance.digest_sent").Count(&n).Error)
-	assert.Equal(t, int64(1), n)
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", "compliance.digest_sent").Find(&events).Error)
+	require.Len(t, events, 1)
+	require.NotNil(t, events[0].Success)
+	assert.True(t, *events[0].Success, "the digest genuinely was delivered — the audit event must say so")
+}
+
+// TestSendComplianceDigest_NoChannelAcceptsIt is a regression test for #221: an
+// email-only deployment with no configured broadcast destination used to have
+// Deliver() silently drop the event AND still get an audit event claiming
+// "compliance digest broadcast to notification channels" — a false positive an
+// operator could never distinguish from an actual, successful send. The sink here
+// stands in for exactly that case (fakeSink.refuse mirrors EmailSink.Deliver
+// returning false with no recipient/no broadcast_to configured): the audit event
+// must now say the broadcast was NOT delivered, and a log line must make the gap
+// discoverable.
+func TestSendComplianceDigest_NoChannelAcceptsIt(t *testing.T) {
+	c, db, _ := newEvidenceExportCore(t) // real store, empty deployment
+	sink := &fakeSink{refuse: true}
+	c.SetNotificationSink(sink)
+
+	var sent bool
+	var err error
+	logged := captureLog(t, func() {
+		sent, err = c.SendComplianceDigest(context.Background())
+	})
+	require.NoError(t, err)
+	assert.False(t, sent, "no channel accepted the broadcast — the caller must be told delivery did not happen")
+	assert.Empty(t, sink.events, "the sink never actually accepted the event")
+	assert.Contains(t, logged, "compliance digest", "a no-op broadcast must be logged, not silent")
+
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", "compliance.digest_sent").Find(&events).Error)
+	require.Len(t, events, 1, "the attempt is still audited")
+	require.NotNil(t, events[0].Success)
+	assert.False(t, *events[0].Success, "delivery never happened — the audit event must not claim success (#221)")
 }

--- a/internal/core/notification_dispatch_test.go
+++ b/internal/core/notification_dispatch_test.go
@@ -10,9 +10,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type fakeSink struct{ events []NotificationEvent }
+// fakeSink is a NotificationSink test double. refuse, when true, simulates a sink
+// that cannot accept the event at all (e.g. the email channel with no recipient and
+// no configured broadcast destination, #221): Deliver still records nothing was
+// attempted, and returns false so callers can assert on the accurate signal.
+type fakeSink struct {
+	events []NotificationEvent
+	refuse bool
+}
 
-func (f *fakeSink) Deliver(ev NotificationEvent) { f.events = append(f.events, ev) }
+func (f *fakeSink) Deliver(ev NotificationEvent) bool {
+	if f.refuse {
+		return false
+	}
+	f.events = append(f.events, ev)
+	return true
+}
 
 func TestNotify_DispatchesToSinkWithResolvedEmail(t *testing.T) {
 	store := new(MockStorage)

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -43,7 +43,12 @@ const (
 // deployment-wide channel is still an appropriate destination for this event (unlike
 // the per-user events in notifications.go), it just must not cross project
 // boundaries within a single message. No-op when nothing failed for this project;
-// the sink is non-blocking.
+// the sink is non-blocking. If every configured channel is a no-op for this event
+// (e.g. an email-only deployment with no broadcast destination configured, #221),
+// that is logged so the gap is discoverable — this alert is the only signal an
+// operator gets that auto-rotation is silently failing, separate from the
+// EventAutoRotationFailures audit row the caller writes for the rotation failure
+// itself (which is accurate regardless of whether this alert lands).
 func (c *KeyorixCore) notifyRotationFailures(ctx context.Context, projectID uint, failed map[uint]string) {
 	if len(failed) == 0 || c.notificationSink == nil {
 		return
@@ -54,13 +59,16 @@ func (c *KeyorixCore) notifyRotationFailures(ctx context.Context, projectID uint
 	}
 	sort.Strings(lines) // stable, deterministic ordering
 	pid := projectID
-	c.notificationSink.Deliver(NotificationEvent{
+	attempted := c.notificationSink.Deliver(NotificationEvent{
 		Type:      "rotation.failed",
 		Title:     fmt.Sprintf("Auto-rotation: %d secret(s) failed to rotate in %s", len(failed), c.projectLabel(ctx, projectID)),
 		Message:   "The following secrets could not be auto-rotated:\n" + strings.Join(lines, "\n"),
 		ProjectID: &pid,
 		Link:      fmt.Sprintf("/projects/%d/secrets", projectID),
 	})
+	if !attempted {
+		log.Printf("rotation: %d secret(s) failed to rotate in project %d, but no configured notification channel could accept the alert (e.g. email-only with no broadcast destination) — the alert was NOT delivered", len(failed), projectID)
+	}
 }
 
 // SetRotationManager wires the configured backend rotation executors (ADR-047) that

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -542,6 +542,36 @@ func TestRunAutoRotation_NotifiesFailures(t *testing.T) {
 	assert.Contains(t, sink.events[0].Message, "connection refused")
 }
 
+// TestRunAutoRotation_NotifiesFailures_LogsWhenNoChannelAccepts is a regression test
+// for #221: when no configured notification channel could accept the rotation-
+// failure broadcast (e.g. an email-only deployment with no broadcast destination —
+// fakeSink.refuse stands in for that), the run must still succeed and the rotation-
+// failure audit event (EventAutoRotationFailures) must still be written accurately —
+// but the alert-delivery gap itself must be logged, not silently swallowed.
+func TestRunAutoRotation_NotifiesFailures_LogsWhenNoChannelAccepts(t *testing.T) {
+	fake := &fakeExecutor{name: "pg", err: errors.New("connection refused")}
+	c, db, fixed := backendPolicyCore(t, fake)
+	sink := &fakeSink{refuse: true}
+	c.SetNotificationSink(sink)
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-60*24*time.Hour))
+
+	var rotated int
+	var err error
+	logged := captureLog(t, func() {
+		rotated, err = c.RunAutoRotation(context.Background())
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, rotated)
+	assert.Empty(t, sink.events, "no channel accepted the alert")
+	assert.Contains(t, logged, "no configured notification channel could accept the alert", "the delivery gap must be discoverable")
+
+	// The rotation-failure audit event is about the rotation failing, not about
+	// whether the alert was delivered — it must still be written and still accurate.
+	var n int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", EventAutoRotationFailures).Count(&n).Error)
+	assert.Equal(t, int64(1), n)
+}
+
 // A clean run (no failures) sends nothing.
 func TestRunAutoRotation_NoFailuresNoNotify(t *testing.T) {
 	c, db, fixed := rotationExecCore(t)

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -389,8 +389,19 @@ type NotificationEvent struct {
 // best-effort: Deliver runs on the notification path and must never block or fail
 // the triggering operation. Defined here (not in the channel package) so core has
 // no dependency on the channel implementations.
+//
+// Deliver reports whether the event was actually handed off to the channel's
+// delivery pipeline (true) or was a no-op (false) — e.g. a broadcast event with no
+// per-user recipient and no configured destination for the channel to route it to.
+// This is a synchronous, best-effort signal about whether an attempt was even
+// queued; it does NOT confirm the remote destination accepted it (that outcome
+// stays opaque to the caller by design and is tracked only in the per-channel
+// Prometheus counters — see notify_metrics.go). Callers that broadcast to a
+// deployment-wide audience (SendComplianceDigest, notifyRotationFailures) use the
+// return value so their audit trail doesn't claim success when nothing was ever
+// attempted (#221).
 type NotificationSink interface {
-	Deliver(ev NotificationEvent)
+	Deliver(ev NotificationEvent) bool
 }
 
 // SetNotificationSink wires the broadcast (deployment-wide, aggregate) notification

--- a/internal/notifychan/chat.go
+++ b/internal/notifychan/chat.go
@@ -71,12 +71,16 @@ func newChat(cfg ChatConfig, baseBackoff time.Duration) (*ChatSink, error) {
 	return s, nil
 }
 
-// Deliver enqueues the event. Non-blocking; a full queue drops and counts it.
-func (s *ChatSink) Deliver(ev core.NotificationEvent) {
+// Deliver enqueues the event. Non-blocking; a full queue drops and counts it. Like
+// the webhook channel, the Slack/Teams incoming-webhook is one fixed destination —
+// not a per-user address — so every event (including a broadcast) is always
+// attempted; Deliver only reports false when the sink itself is nil.
+func (s *ChatSink) Deliver(ev core.NotificationEvent) bool {
 	if s == nil {
-		return
+		return false
 	}
 	s.d.enqueue(ev)
+	return true
 }
 
 // send POSTs the platform payload once. retryable reports whether a non-nil err is

--- a/internal/notifychan/email.go
+++ b/internal/notifychan/email.go
@@ -1,7 +1,17 @@
 // email.go — the SMTP notification channel. Like the credential-delivery mailer
 // (ADR-028) it delegates TLS correctness to wneessen/go-mail rather than hand-
 // rolling net/smtp. Delivery, retry, and metrics are handled by the shared engine
-// (delivery.go); events without a recipient email are dropped before they enqueue.
+// (delivery.go).
+//
+// A per-user event (ev.Email resolved by the caller, e.g. dispatchNotification)
+// always has somewhere to go. A BROADCAST event (SendComplianceDigest,
+// notifyRotationFailures) has no such per-user address — a broadcast is meant for
+// whoever is configured to receive it, not one specific mailbox — so it is routed
+// to cfg.BroadcastTo, the operator-configured digest/admin destination, exactly the
+// way the webhook/chat channels always route a broadcast to their one fixed
+// endpoint. With neither an event Email nor a configured BroadcastTo there is
+// nowhere to send it; that drop is counted and logged like any other channel
+// failure rather than silently discarded (#221).
 package notifychan
 
 import (
@@ -48,6 +58,14 @@ type EmailConfig struct {
 	Password string
 	From     string
 	TLS      string // starttls | implicit | none(dev-only)
+	// BroadcastTo is the destination address for BROADCAST notifications (the
+	// scheduled compliance digest, auto-rotation-failure alerts) — the address a
+	// deployment-wide alert goes to when email is the channel handling it. Optional:
+	// leave empty when a non-email channel (Slack/Teams/webhook) already receives
+	// broadcasts, or when email-only broadcast alerting isn't wanted. Without it, a
+	// broadcast event has no recipient to route to and is dropped (counted/logged,
+	// not silently, #221).
+	BroadcastTo string
 }
 
 // EmailSink delivers notifications as plaintext email via the operator's SMTP relay.
@@ -85,13 +103,29 @@ func newEmail(cfg EmailConfig, baseBackoff time.Duration) (*EmailSink, error) {
 	return s, nil
 }
 
-// Deliver enqueues the event. Non-blocking; a full queue drops and counts it. Events
-// without a recipient address are dropped here (nothing to send), not enqueued.
-func (s *EmailSink) Deliver(ev core.NotificationEvent) {
-	if s == nil || ev.Email == "" {
-		return
+// Deliver enqueues the event and reports whether it was actually handed off for
+// sending. Non-blocking; a full queue drops and counts it (see delivery.go).
+//
+// An event with no per-user Email is a BROADCAST (compliance digest, rotation-
+// failure alert): it is routed to the configured BroadcastTo address rather than
+// being dropped for lacking a per-user recipient (#221). With no Email and no
+// BroadcastTo configured there is genuinely nowhere to send it — that is still
+// counted and logged as a dropped delivery, not silently discarded, so an operator
+// running email-only can see a broadcast channel that never has anywhere to go.
+func (s *EmailSink) Deliver(ev core.NotificationEvent) bool {
+	if s == nil {
+		return false
+	}
+	if ev.Email == "" {
+		if s.cfg.BroadcastTo == "" {
+			notifyDeliveries.WithLabelValues(s.d.channel, outcomeDropped).Inc()
+			log.Printf("notifychan: email dropped a broadcast notification (type=%q) — no recipient and no email.broadcast_to destination configured", ev.Type)
+			return false
+		}
+		ev.Email = s.cfg.BroadcastTo
 	}
 	s.d.enqueue(ev)
+	return true
 }
 
 // send mails the event once. retryable reports whether a non-nil err is transient: a

--- a/internal/notifychan/email_test.go
+++ b/internal/notifychan/email_test.go
@@ -61,14 +61,40 @@ func TestNewEmail_TLSNoneRequiresExplicitOptIn(t *testing.T) {
 	s.Close()
 }
 
-func TestEmailSink_SkipsEventsWithoutRecipient(t *testing.T) {
+// TestEmailSink_BroadcastWithNoDestinationConfiguredIsDroppedAndCounted is a
+// regression test for #221: an event with no per-user Email and no configured
+// BroadcastTo (an email-only deployment with the compliance digest / rotation-
+// failure alerts and nothing else configured) has genuinely nowhere to go. It must
+// still be dropped before it ever enqueues (the worker never dials SMTP for it) —
+// but unlike before the fix, the drop is no longer silent: Deliver reports it was
+// NOT attempted, and it produces a "dropped" delivery outcome an operator can alert
+// on, instead of leaving zero trace anywhere.
+func TestEmailSink_BroadcastWithNoDestinationConfiguredIsDroppedAndCounted(t *testing.T) {
 	t.Setenv(envAllowInsecureSMTP, "true")
 	before := emailOutcomeTotal(t)
 	sink, err := NewEmail(EmailConfig{Host: "smtp.invalid", From: "ops@x.io", TLS: "none"})
 	require.NoError(t, err)
-	// Email == "" — nothing to send to. It must be dropped before it ever enqueues,
-	// so the worker never dials SMTP and no delivery outcome is recorded.
-	sink.Deliver(core.NotificationEvent{Title: "no recipient", Message: "x"})
+	attempted := sink.Deliver(core.NotificationEvent{Type: "compliance.digest", Title: "no recipient, no broadcast_to", Message: "x"})
 	sink.Close()
-	assert.Equal(t, 0.0, emailOutcomeTotal(t)-before, "recipient-less events must not produce a delivery outcome")
+	assert.False(t, attempted, "no recipient and no broadcast_to means genuinely nowhere to send")
+	assert.Equal(t, 1.0, emailOutcomeTotal(t)-before, "the drop must be counted, not silent (#221)")
+}
+
+// TestEmailSink_BroadcastRoutesToConfiguredDestination is a regression test for
+// #221: a broadcast event (no per-user Email — compliance digest / rotation-failure
+// alert) must be routed to the operator-configured BroadcastTo address rather than
+// dropped, when email is the channel carrying it. The SMTP host here is an
+// immediately-refusing closed port (mirrors internal/delivery's smtp_test.go
+// pattern) so the send fails fast and deterministically; the point of this test is
+// that delivery was ATTEMPTED (and the resulting failure counted), not that it
+// succeeded.
+func TestEmailSink_BroadcastRoutesToConfiguredDestination(t *testing.T) {
+	t.Setenv(envAllowInsecureSMTP, "true")
+	before := emailOutcomeTotal(t)
+	sink, err := NewEmail(EmailConfig{Host: "127.0.0.1", Port: 1, From: "ops@x.io", TLS: "none", BroadcastTo: "admin@x.io"})
+	require.NoError(t, err)
+	attempted := sink.Deliver(core.NotificationEvent{Type: "compliance.digest", Title: "digest", Message: "x"})
+	assert.True(t, attempted, "a broadcast event must be routed to the configured destination, not dropped")
+	sink.Close()
+	assert.Equal(t, 1.0, emailOutcomeTotal(t)-before, "the attempted send (here, a failure) must be counted — not silent")
 }

--- a/internal/notifychan/multi.go
+++ b/internal/notifychan/multi.go
@@ -30,9 +30,17 @@ func NewMulti(sinks ...core.NotificationSink) core.NotificationSink {
 	}
 }
 
-// Deliver fans the event out to every wrapped sink.
-func (m *MultiSink) Deliver(ev core.NotificationEvent) {
+// Deliver fans the event out to every wrapped sink. It reports whether ANY wrapped
+// sink actually attempted delivery — so a caller broadcasting across several
+// channels only sees false when every single one of them was a no-op (e.g. an
+// email-only deployment with no configured broadcast destination, #221), not merely
+// when one of several channels couldn't take it.
+func (m *MultiSink) Deliver(ev core.NotificationEvent) bool {
+	attempted := false
 	for _, s := range m.sinks {
-		s.Deliver(ev)
+		if s.Deliver(ev) {
+			attempted = true
+		}
 	}
+	return attempted
 }

--- a/internal/notifychan/multi_test.go
+++ b/internal/notifychan/multi_test.go
@@ -7,16 +7,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type countingSink struct{ n int }
+type countingSink struct {
+	n      int
+	refuse bool // simulates a sink that has nowhere to route the event (#221)
+}
 
-func (c *countingSink) Deliver(core.NotificationEvent) { c.n++ }
+func (c *countingSink) Deliver(core.NotificationEvent) bool {
+	if c.refuse {
+		return false
+	}
+	c.n++
+	return true
+}
 
 func TestNewMulti_FansOutToAll(t *testing.T) {
 	a, b := &countingSink{}, &countingSink{}
 	sink := NewMulti(a, b)
-	sink.Deliver(core.NotificationEvent{UserID: 1})
+	attempted := sink.Deliver(core.NotificationEvent{UserID: 1})
 	assert.Equal(t, 1, a.n)
 	assert.Equal(t, 1, b.n)
+	assert.True(t, attempted)
+}
+
+// TestNewMulti_AttemptedTrueIfAnySinkAccepts is a regression test for #221: a
+// broadcast must not be reported as failed just because ONE of several channels
+// couldn't take it — only when NONE of them could.
+func TestNewMulti_AttemptedTrueIfAnySinkAccepts(t *testing.T) {
+	accepts, refuses := &countingSink{}, &countingSink{refuse: true}
+	sink := NewMulti(refuses, accepts)
+	attempted := sink.Deliver(core.NotificationEvent{UserID: 1})
+	assert.True(t, attempted, "at least one sink accepted the event")
+	assert.Equal(t, 1, accepts.n)
+	assert.Equal(t, 0, refuses.n)
+}
+
+// TestNewMulti_AttemptedFalseIfEverySinkRefuses is a regression test for #221: when
+// every wrapped sink is a no-op for this event, the fan-out must say so rather than
+// silently claim success.
+func TestNewMulti_AttemptedFalseIfEverySinkRefuses(t *testing.T) {
+	a, b := &countingSink{refuse: true}, &countingSink{refuse: true}
+	sink := NewMulti(a, b)
+	attempted := sink.Deliver(core.NotificationEvent{UserID: 1})
+	assert.False(t, attempted, "no sink accepted the event — must not claim success")
 }
 
 func TestNewMulti_NilWhenNoLiveSinks(t *testing.T) {

--- a/internal/notifychan/webhook.go
+++ b/internal/notifychan/webhook.go
@@ -85,12 +85,16 @@ func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*WebhookSink, err
 }
 
 // Deliver enqueues the event for asynchronous POST. Non-blocking: a full queue (a
-// wedged endpoint) drops and counts the event rather than stalling the caller.
-func (s *WebhookSink) Deliver(ev core.NotificationEvent) {
+// wedged endpoint) drops and counts the event rather than stalling the caller. The
+// webhook endpoint is one fixed, operator-configured destination — not a per-user
+// address — so every event (including a broadcast) is always attempted; Deliver
+// only reports false when the sink itself is nil.
+func (s *WebhookSink) Deliver(ev core.NotificationEvent) bool {
 	if s == nil {
-		return
+		return false
 	}
 	s.d.enqueue(ev)
+	return true
 }
 
 // send POSTs the event once. retryable reports whether a non-nil err is transient

--- a/server/main.go
+++ b/server/main.go
@@ -448,12 +448,13 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	}
 	if ec := cfg.Notifications.Email; ec.Enabled {
 		sink, eerr := notifychan.NewEmail(notifychan.EmailConfig{
-			Host:     ec.Host,
-			Port:     ec.Port,
-			Username: ec.Username,
-			Password: ec.GetPassword(),
-			From:     ec.From,
-			TLS:      ec.TLS,
+			Host:        ec.Host,
+			Port:        ec.Port,
+			Username:    ec.Username,
+			Password:    ec.GetPassword(),
+			From:        ec.From,
+			TLS:         ec.TLS,
+			BroadcastTo: ec.BroadcastTo,
 		})
 		if eerr != nil {
 			return nil, nil, fmt.Errorf("failed to init notification email channel: %w", eerr)
@@ -477,6 +478,15 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		}
 		broadcastSinks = append(broadcastSinks, sink)
 		log.Printf("Notification Teams channel enabled")
+	}
+	// #221: email-only, with no email.broadcast_to configured, has no destination
+	// for a deployment-wide broadcast (compliance digest, auto-rotation-failure
+	// alert) to route to — it will keep no-op'ing every time one fires. Warn at
+	// startup rather than let an operator discover it only from the (also newly
+	// added, #221) dropped-delivery metric/log after the fact.
+	if cfg.Notifications.Email.Enabled && cfg.Notifications.Email.BroadcastTo == "" &&
+		!cfg.Notifications.Webhook.Enabled && !cfg.Notifications.Slack.Enabled && !cfg.Notifications.Teams.Enabled {
+		log.Printf("WARNING: notifications.email is the only enabled notification channel and notifications.email.broadcast_to is not set — the compliance digest and auto-rotation-failure alerts have no destination to broadcast to and will silently no-op every time they fire; set notifications.email.broadcast_to to an admin/ops address to receive them")
 	}
 	if sink := notifychan.NewMulti(broadcastSinks...); sink != nil {
 		coreService.SetNotificationSink(sink)


### PR DESCRIPTION
## Summary

An email-only notification configuration (only the email delivery channel configured, no webhook/Slack/Teams) silently black-holed the scheduled compliance digest and rotation-failure broadcasts — with zero metric/log trace, while the compliance-digest audit event falsely claimed delivery succeeded.

**Root cause:** `EmailSink.Deliver` dropped any event with no per-user `Email` field *before it ever enqueued*, so no delivery outcome was ever recorded. `SendComplianceDigest`/`notifyRotationFailures` build BROADCAST events (meant for whoever is configured to receive them, not one specific mailbox) with no per-user `Email` set — unlike the webhook/chat channels, which always route a broadcast to their one fixed, operator-configured endpoint regardless of recipient. `SendComplianceDigest` then wrote its `compliance.digest_sent` audit event unconditionally, regardless of whether anything was actually delivered.

**Fix:**
- Added `EmailConfig`/`NotificationEmailConfig.BroadcastTo` (`notifications.email.broadcast_to` in config) — an operator-configured destination address for broadcast events, mirroring how webhook/chat already route a broadcast to one fixed endpoint.
- `EmailSink.Deliver` now routes a no-recipient event to `BroadcastTo` instead of dropping it. With neither a recipient nor `BroadcastTo` configured, the event is still dropped — but the drop is now counted (`keyorix_notify_deliveries_total{channel="email",outcome="dropped"}`) and logged, not silent.
- `NotificationSink.Deliver` now returns whether the event was actually handed off to a delivery channel (vs. a no-op). `SendComplianceDigest` uses this to log the gap and write the audit event as **failed** (`writeAuditEventFailed`) rather than claiming success when nothing was delivered. `notifyRotationFailures` logs the same gap (its separate rotation-failure audit event, which is about the rotation itself, was already accurate and is untouched).
- Added a startup warning when email is the only enabled notification channel and `broadcast_to` is unset, so the gap is visible before it silently no-ops in production.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/notifychan/... ./internal/core/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./internal/notifychan/... ./internal/core/...` (0 issues)
- [x] New regression tests:
  - `TestEmailSink_BroadcastRoutesToConfiguredDestination` — a broadcast event is routed to the configured email destination, not dropped
  - `TestEmailSink_BroadcastWithNoDestinationConfiguredIsDroppedAndCounted` — with no destination, the drop is counted/logged, not silent
  - `TestSendComplianceDigest_NoChannelAcceptsIt` — when no channel accepts the broadcast, the audit event now records `Success=false` (previously always `true`) and the gap is logged
  - `TestRunAutoRotation_NotifiesFailures_LogsWhenNoChannelAccepts` — same gap logged for the rotation-failure alert path, while the (separate, already-accurate) rotation-failure audit event is preserved
  - `TestNewMulti_AttemptedTrueIfAnySinkAccepts` / `TestNewMulti_AttemptedFalseIfEverySinkRefuses` — the fan-out sink only reports "not attempted" when *every* wrapped channel was a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)