### PR TITLE
test(rbac): close false-confidence gap in permission-enforcement test (#475)

### DIFF
--- a/internal/cli/rbac/rbac_integration_test.go
+++ b/internal/cli/rbac/rbac_integration_test.go
@@ -191,8 +191,18 @@ func TestRBACProjectIntegration(t *testing.T) {
 	})
 }
 
-// TestRBACPermissionEnforcement tests permission enforcement in core service
-func TestRBACPermissionEnforcement(t *testing.T) {
+// TestRBACRolePermissionMapping verifies which "secrets.*" permission strings each
+// built-in role (admin/editor/viewer) is granted, via the RBAC role/permission
+// tables (helper.HasPermission). This is deliberately NOT a test of per-secret
+// resource-level enforcement: RBAC roles here are a separate authorization layer
+// from the ownership/share model that KeyorixCore.CheckSecretPermission enforces,
+// and this test's users are never given an ownership/share grant on the test
+// secret. Actual enforcement of GetSecretWithPermissionCheck (the guarded read path
+// every real HTTP/gRPC caller uses — see GetSecret's doc comment in
+// internal/core/secrets.go) is covered directly by
+// TestGetSecretWithPermissionCheck in internal/core/permission_enforcement_test.go,
+// including both an authorized and an unauthorized caller.
+func TestRBACRolePermissionMapping(t *testing.T) {
 	helper := testhelper.NewRBACTestHelper(t)
 	defer helper.Cleanup()
 
@@ -299,18 +309,21 @@ func TestRBACPermissionEnforcement(t *testing.T) {
 			assert.Equal(t, tt.expected, hasPermission,
 				"Permission check for %s action by %s should be %v", tt.action, tt.username, tt.expected)
 
-			// Test actual core service operation if possible
-			if tt.action == "read" && tt.expected {
-				// Try to get the secret through core service
-				retrievedSecret, err := helper.CoreService.GetSecret(ctx, secret.ID)
-				if tt.expected {
-					// For now, we expect this to work since we're testing the permission system
-					// The actual permission enforcement in core service might need additional work
-					_ = retrievedSecret
-					_ = err
-					// assert.NoError(t, err, "Should be able to read secret with read permission")
-					// assert.NotNil(t, retrievedSecret, "Should retrieve secret successfully")
-				}
+			// The owner (admin) read case additionally exercises the guarded read path
+			// end-to-end against the real, DB-backed core service — integration-level
+			// coverage that the mock-based TestGetSecretWithPermissionCheck
+			// (internal/core/permission_enforcement_test.go) doesn't provide. Editor and
+			// viewer are deliberately NOT exercised here via GetSecretWithPermissionCheck:
+			// they hold the "secrets.read" RBAC permission string checked above, but
+			// GetSecretWithPermissionCheck enforces the separate ownership/share model
+			// (KeyorixCore.CheckSecretPermission), and neither has an ownership or share
+			// grant on this secret — asserting success for them here would test a
+			// different, unrelated authorization layer than the one this test covers.
+			if tt.userID == admin.ID && tt.action == "read" {
+				retrievedSecret, err := helper.CoreService.GetSecretWithPermissionCheck(ctx, secret.ID, tt.userID)
+				require.NoError(t, err, "owner should be able to read the secret via the guarded path")
+				require.NotNil(t, retrievedSecret, "should retrieve the secret successfully")
+				assert.Equal(t, secret.ID, retrievedSecret.ID)
 			}
 		})
 	}

--- a/internal/core/permission_enforcement_test.go
+++ b/internal/core/permission_enforcement_test.go
@@ -570,3 +570,76 @@ func TestCheckGroupPermissions(t *testing.T) {
 
 	mockStorage.AssertExpectations(t)
 }
+
+// TestGetSecretWithPermissionCheck exercises the actual guarded read path
+// (GetSecretWithPermissionCheck) that every real HTTP/gRPC caller uses to fetch a
+// secret's value — as opposed to the bare GetSecret, which deliberately performs no
+// authorization check of its own (see GetSecret's doc comment) and is only safe to
+// call after a permission check has already happened, or for internal callers that
+// enforce access some other way. Neither is exercised end-to-end anywhere else in the
+// test suite: TestCheckSecretPermission and TestEnforceSecretReadPermission cover the
+// permission-decision logic in isolation, but not the combined "check, then actually
+// retrieve" behavior that GetSecretWithPermissionCheck wraps around it.
+func TestGetSecretWithPermissionCheck(t *testing.T) {
+	// Initialize i18n for tests
+	cfg := &config.Config{
+		Locale: config.LocaleConfig{
+			Language:         "en",
+			FallbackLanguage: "en",
+		},
+	}
+	err := i18n.Initialize(cfg)
+	require.NoError(t, err)
+
+	t.Run("authorized reader (owner) retrieves the secret", func(t *testing.T) {
+		mockStorage := &MockStorage{}
+		secret := &models.SecretNode{ID: 1, OwnerID: 1, Name: "test-secret"}
+		mockStorage.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+
+		core := NewKeyorixCore(mockStorage)
+
+		got, err := core.GetSecretWithPermissionCheck(context.Background(), 1, 1)
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, secret.ID, got.ID)
+
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("authorized reader (direct share) retrieves the secret", func(t *testing.T) {
+		mockStorage := &MockStorage{}
+		secret := &models.SecretNode{ID: 1, OwnerID: 99, Name: "test-secret"}
+		mockStorage.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+		mockStorage.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{
+			{ID: 1, SecretID: 1, RecipientID: 2, IsGroup: false, Permission: "read", CreatedAt: time.Now()},
+		}, nil)
+
+		core := NewKeyorixCore(mockStorage)
+
+		got, err := core.GetSecretWithPermissionCheck(context.Background(), 1, 2)
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, secret.ID, got.ID)
+
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("unauthorized caller (no owner, no share) is rejected before retrieval", func(t *testing.T) {
+		mockStorage := &MockStorage{}
+		secret := &models.SecretNode{ID: 1, OwnerID: 99, Name: "test-secret"}
+		mockStorage.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+		mockStorage.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
+		mockStorage.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+
+		core := NewKeyorixCore(mockStorage)
+
+		got, err := core.GetSecretWithPermissionCheck(context.Background(), 1, 2)
+
+		assert.Error(t, err)
+		assert.Nil(t, got)
+
+		mockStorage.AssertExpectations(t)
+	})
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -148,6 +148,16 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 }
 
 // GetSecret retrieves a secret by ID, checking expiration.
+//
+// GetSecret intentionally performs NO authorization check of its own — it neither
+// verifies ownership nor consults shares/RBAC. Every real HTTP/gRPC caller that
+// serves a secret to an end user goes through GetSecretWithPermissionCheck instead,
+// which enforces read permission (via EnforceSecretReadPermission) before delegating
+// to this method. GetSecret exists as the unguarded primitive for internal callers
+// that have already authorized the request some other way (or are working with
+// metadata rather than exposing the value). Do not call GetSecret directly from a
+// path that serves a secret to a caller without first checking permission — use
+// GetSecretWithPermissionCheck for that.
 func (c *KeyorixCore) GetSecret(ctx context.Context, id uint) (*models.SecretNode, error) {
 	if id == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret ID is required")


### PR DESCRIPTION
## Summary

Backlog finding #475 (LOW): `TestRBACPermissionEnforcement` (`internal/cli/rbac/rbac_integration_test.go`) was named for permission enforcement, but its one call into the core service was commented out, giving false confidence that enforcement was actually exercised. `KeyorixCore.GetSecret` genuinely performs no permission check by design — real read enforcement lives in `GetSecretWithPermissionCheck`, and every production HTTP/gRPC caller already uses that guarded variant. This was a test-hygiene gap, not a production bypass.

Investigation showed the RBAC test's role model (admin/editor/viewer → `secrets.read`/`write`/`delete` permission strings, checked via `helper.HasPermission`) is a separate authorization layer from the ownership/share model that `GetSecretWithPermissionCheck` enforces via `CheckSecretPermission`. The test's editor/viewer users are never given an ownership or share grant on the test secret, so calling the guarded function for them wouldn't validly test the same thing the RBAC-role assertions test.

Fix:
- Renamed the test to `TestRBACRolePermissionMapping` to honestly describe what it verifies (role → permission-string mapping), with a comment explaining the two distinct authorization layers and pointing at where real enforcement is now covered.
- For the one case where both layers do align (admin, who owns the secret), the test now calls `GetSecretWithPermissionCheck` against the real DB-backed core service and asserts success — real integration coverage instead of a commented-out call.
- Added `TestGetSecretWithPermissionCheck` in `internal/core/permission_enforcement_test.go`, directly exercising the guarded function with an authorized owner, an authorized direct-share holder, and an unauthorized caller (denied before retrieval) — closing the actual coverage gap (`GetSecretWithPermissionCheck` had no direct test anywhere before this).
- Added a doc comment on `GetSecret` explaining why it intentionally performs no permission check and that callers must use `GetSecretWithPermissionCheck`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/rbac/... ./internal/core/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./internal/cli/rbac/... ./internal/core/...` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)