### PR TITLE
fix(tls): wire TLSConfig.AllowedCiphers into HTTP + gRPC cipher suites (#333)

### DIFF
--- a/configs/keyorix.yaml.tpl
+++ b/configs/keyorix.yaml.tpl
@@ -26,7 +26,12 @@ server:
       enabled: false
       cert_file: "certs/server.crt"     # Path to TLS certificate
       key_file: "certs/server.key"      # Path to TLS key
-      allowed_ciphers: []               # Optional cipher list
+      # Optional TLS 1.2 cipher suite allowlist, by name (e.g.
+      # "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"). Empty/unset keeps the built-in secure
+      # AEAD-only default. Only modern AEAD suites are accepted (RC4/3DES/CBC-mode
+      # suites are rejected at startup); TLS 1.3 negotiates its own suites and is
+      # unaffected by this list.
+      allowed_ciphers: []
     ratelimit:
       # Enable rate limiting
       enabled: false
@@ -42,6 +47,7 @@ server:
       enabled: false
       cert_file: "certs/server.crt"
       key_file: "certs/server.key"
+      # See server.http.tls.allowed_ciphers above — same semantics for gRPC.
       allowed_ciphers: []
     ratelimit:
       enabled: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -313,11 +313,19 @@ func (s ServerInstanceConfig) EffectiveMaxRequestBodyBytes() int64 {
 }
 
 type TLSConfig struct {
-	Enabled        bool     `yaml:"enabled"`
-	AutoCert       bool     `yaml:"auto_cert,omitempty"`
-	Domains        []string `yaml:"domains,omitempty"`
-	CertFile       string   `yaml:"cert_file"`
-	KeyFile        string   `yaml:"key_file"`
+	Enabled  bool     `yaml:"enabled"`
+	AutoCert bool     `yaml:"auto_cert,omitempty"`
+	Domains  []string `yaml:"domains,omitempty"`
+	CertFile string   `yaml:"cert_file"`
+	KeyFile  string   `yaml:"key_file"`
+	// AllowedCiphers optionally restricts the TLS 1.2 cipher suites offered to
+	// SecureCipherSuiteNames' names (e.g. "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384").
+	// Left empty/unset, the caller's own hardcoded secure AEAD-only default applies
+	// unchanged (see ResolveCipherSuites, and server/main.go's + server/grpc/server.go's
+	// applyTLSHardening, which wire this in — #333). Any name outside
+	// SecureCipherSuiteNames — including weak/deprecated suites (RC4, 3DES, CBC-mode)
+	// and TLS 1.3 suite names, which don't apply to CipherSuites at all — is rejected
+	// at startup rather than silently ignored or accepted.
 	AllowedCiphers []string `yaml:"allowed_ciphers"`
 }
 

--- a/internal/config/tls_ciphers.go
+++ b/internal/config/tls_ciphers.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"crypto/tls"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SecureCipherSuiteNames is the allowlist of TLS 1.2 cipher-suite names an operator may
+// list under tls.allowed_ciphers. It is deliberately restricted to modern AEAD suites
+// (AES-GCM and ChaCha20-Poly1305) — RC4, 3DES, and CBC-mode suites are excluded outright
+// because they're cryptographically weak/deprecated (RC4/3DES are broken; CBC-mode TLS
+// suites are Lucky-13/padding-oracle-adjacent) and must never be selectable via config,
+// even by a misinformed operator.
+//
+// TLS 1.3 is intentionally NOT represented here: crypto/tls negotiates its (always-AEAD)
+// suite set automatically and tls.Config.CipherSuites has no effect on TLS 1.3
+// connections, so there is nothing for an "allowed_ciphers" list to select among on 1.3.
+var SecureCipherSuiteNames = map[string]uint16{
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+}
+
+// ResolveCipherSuites turns the operator-configured tls.allowed_ciphers list (a list of
+// cipher-suite NAMES, e.g. "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384") into the resolved
+// []uint16 IDs the standard library's tls.Config.CipherSuites expects (#333).
+//
+// When AllowedCiphers is empty/unset, defaultSuites is returned unchanged — an operator
+// who has never touched this field keeps exactly the same hardened default posture as
+// before, so this cannot make an existing deployment's TLS weaker by omission.
+//
+// When AllowedCiphers is set, every entry must name a suite in SecureCipherSuiteNames;
+// any unknown, misspelled, or deliberately weak/deprecated suite (RC4, 3DES, CBC-mode,
+// etc.) fails closed with a descriptive error rather than being silently dropped or
+// silently accepted, so a typo or a weak choice is caught at startup instead of quietly
+// producing a different (possibly weaker, possibly merely wrong) posture at runtime.
+func (t TLSConfig) ResolveCipherSuites(defaultSuites []uint16) ([]uint16, error) {
+	if len(t.AllowedCiphers) == 0 {
+		return defaultSuites, nil
+	}
+	resolved := make([]uint16, 0, len(t.AllowedCiphers))
+	for _, name := range t.AllowedCiphers {
+		id, ok := SecureCipherSuiteNames[strings.TrimSpace(name)]
+		if !ok {
+			return nil, fmt.Errorf(
+				"tls.allowed_ciphers: %q is not a recognized, secure TLS 1.2 cipher suite (allowed: %s) — "+
+					"weak/deprecated suites (RC4, 3DES, CBC-mode) are rejected outright",
+				name, strings.Join(sortedCipherSuiteNames(), ", "),
+			)
+		}
+		resolved = append(resolved, id)
+	}
+	return resolved, nil
+}
+
+// sortedCipherSuiteNames returns SecureCipherSuiteNames' keys sorted, for stable,
+// readable error messages.
+func sortedCipherSuiteNames() []string {
+	names := make([]string, 0, len(SecureCipherSuiteNames))
+	for name := range SecureCipherSuiteNames {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/config/tls_ciphers_test.go
+++ b/internal/config/tls_ciphers_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #333: when AllowedCiphers is empty/unset, ResolveCipherSuites must return the caller's
+// default unchanged — an operator who never touched tls.allowed_ciphers must see no
+// change in TLS posture.
+func TestTLSConfig_ResolveCipherSuites_DefaultWhenUnset(t *testing.T) {
+	def := []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}
+
+	got, err := TLSConfig{}.ResolveCipherSuites(def)
+	require.NoError(t, err)
+	assert.Equal(t, def, got)
+}
+
+// #333: a configured, valid TLS 1.2 AEAD suite list must be resolved to the matching
+// []uint16 IDs, in the order given, ignoring the caller's default entirely.
+func TestTLSConfig_ResolveCipherSuites_HonorsConfiguredCiphers(t *testing.T) {
+	def := []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384}
+	cfg := TLSConfig{AllowedCiphers: []string{
+		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+	}}
+
+	got, err := cfg.ResolveCipherSuites(def)
+	require.NoError(t, err)
+	assert.Equal(t, []uint16{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+	}, got)
+}
+
+// #333: every entry in SecureCipherSuiteNames must resolve individually — sanity check
+// that the allowlist and the resolver agree with each other.
+func TestTLSConfig_ResolveCipherSuites_AllAllowlistedNamesResolve(t *testing.T) {
+	for name, id := range SecureCipherSuiteNames {
+		got, err := TLSConfig{AllowedCiphers: []string{name}}.ResolveCipherSuites(nil)
+		require.NoErrorf(t, err, "name %q should resolve", name)
+		assert.Equalf(t, []uint16{id}, got, "name %q", name)
+	}
+}
+
+// #333: unrecognized, weak, or deprecated cipher suite names (RC4, 3DES, CBC-mode, plain
+// typos, and TLS 1.3-only suite names — which don't apply to tls.Config.CipherSuites at
+// all) must be rejected with an error rather than silently ignored or accepted.
+func TestTLSConfig_ResolveCipherSuites_RejectsWeakOrUnknownCiphers(t *testing.T) {
+	for _, name := range []string{
+		"TLS_RSA_WITH_RC4_128_SHA",
+		"TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+		"TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+		"TLS_AES_128_GCM_SHA256", // TLS 1.3 suite name; not selectable via CipherSuites
+		"not-a-real-cipher-suite",
+		"",
+	} {
+		_, err := TLSConfig{AllowedCiphers: []string{name}}.ResolveCipherSuites(nil)
+		assert.Errorf(t, err, "expected an error for cipher suite name %q", name)
+	}
+}
+
+// A mix of one valid and one invalid name must still fail closed — a single bad entry
+// must not be silently dropped while the rest is accepted.
+func TestTLSConfig_ResolveCipherSuites_OneBadEntryFailsTheWholeList(t *testing.T) {
+	cfg := TLSConfig{AllowedCiphers: []string{
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		"TLS_RSA_WITH_RC4_128_SHA",
+	}}
+	_, err := cfg.ResolveCipherSuites(nil)
+	assert.Error(t, err)
+}

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -160,22 +160,35 @@ func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server,
 }
 
 // hardenedCipherSuites is the explicit AEAD-only cipher suite allowlist applied to
-// every gRPC TLS listener, regardless of how its certificate is sourced.
+// every gRPC TLS listener, regardless of how its certificate is sourced, UNLESS the
+// operator has explicitly configured tls.allowed_ciphers (#333) — in which case that
+// configured list is honored instead (see applyTLSHardening).
 var hardenedCipherSuites = []uint16{
 	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 }
 
-// applyTLSHardening layers the deliberately hardened MinVersion/CipherSuites onto
-// tlsConfig in place. The protocol-version floor and cipher-suite allowlist are
-// independent of how the certificate itself is sourced, so this must be applied
-// uniformly on both the AutoCert and non-AutoCert paths below — AutoCert should only
-// supply the certificate, not silently determine the rest of the TLS posture too
-// (#172).
-func applyTLSHardening(tlsConfig *tls.Config) {
+// applyTLSHardening layers the hardened MinVersion/CipherSuites onto tlsConfig in
+// place. The protocol-version floor and cipher-suite allowlist are independent of how
+// the certificate itself is sourced, so this must be applied uniformly on both the
+// AutoCert and non-AutoCert paths below — AutoCert should only supply the certificate,
+// not silently determine the rest of the TLS posture too (#172).
+//
+// CipherSuites is resolved from tlsCfg.AllowedCiphers (#333): unset means the hardcoded
+// hardenedCipherSuites default above applies unchanged (no regression for existing
+// deployments); set means the operator's configured suite list is honored instead,
+// validated against config.SecureCipherSuiteNames so a weak/deprecated/misspelled
+// suite name fails closed rather than being silently ignored or accepted. MinVersion
+// stays fixed at TLS 1.2 — TLS 1.3 has no equivalent per-suite selection.
+func applyTLSHardening(tlsConfig *tls.Config, tlsCfg config.TLSConfig) error {
 	tlsConfig.MinVersion = tls.VersionTLS12
-	tlsConfig.CipherSuites = hardenedCipherSuites
+	suites, err := tlsCfg.ResolveCipherSuites(hardenedCipherSuites)
+	if err != nil {
+		return fmt.Errorf("invalid gRPC TLS configuration: %w", err)
+	}
+	tlsConfig.CipherSuites = suites
+	return nil
 }
 
 // createGRPCTLSConfig creates TLS configuration for gRPC server
@@ -185,7 +198,9 @@ func createGRPCTLSConfig(cfg *config.Config) (*tls.Config, error) {
 		// not wired up here — but the hardened MinVersion/CipherSuites below must
 		// still apply, matching the non-AutoCert path's posture (#172).
 		tlsConfig := &tls.Config{}
-		applyTLSHardening(tlsConfig)
+		if err := applyTLSHardening(tlsConfig, cfg.Server.GRPC.TLS); err != nil {
+			return nil, err
+		}
 		return tlsConfig, nil
 	}
 
@@ -196,6 +211,8 @@ func createGRPCTLSConfig(cfg *config.Config) (*tls.Config, error) {
 	}
 
 	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
-	applyTLSHardening(tlsConfig)
+	if err := applyTLSHardening(tlsConfig, cfg.Server.GRPC.TLS); err != nil {
+		return nil, err
+	}
 	return tlsConfig, nil
 }

--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -26,3 +26,70 @@ func TestCreateGRPCTLSConfig_AutoCertAppliesHardening(t *testing.T) {
 		t.Fatal("CipherSuites must not be empty on the AutoCert branch")
 	}
 }
+
+// #333: when tls.allowed_ciphers is unset, createGRPCTLSConfig must keep the existing
+// hardcoded secure default CipherSuites unchanged (no regression).
+func TestCreateGRPCTLSConfig_DefaultPreservedWhenAllowedCiphersUnset(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Server.GRPC.TLS.Enabled = true
+	cfg.Server.GRPC.TLS.AutoCert = true
+
+	tlsConfig, err := createGRPCTLSConfig(cfg)
+	if err != nil {
+		t.Fatalf("createGRPCTLSConfig: %v", err)
+	}
+	if !grpcCipherSuitesEqual(tlsConfig.CipherSuites, hardenedCipherSuites) {
+		t.Errorf("CipherSuites = %v, want the unchanged hardcoded default %v", tlsConfig.CipherSuites, hardenedCipherSuites)
+	}
+}
+
+// #333: when tls.allowed_ciphers names a valid, specific TLS 1.2 AEAD suite list, the
+// resulting tls.Config must reflect exactly that list, not the hardcoded default.
+func TestCreateGRPCTLSConfig_HonorsConfiguredAllowedCiphers(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Server.GRPC.TLS.Enabled = true
+	cfg.Server.GRPC.TLS.AutoCert = true
+	cfg.Server.GRPC.TLS.AllowedCiphers = []string{"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"}
+	want := []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256}
+
+	tlsConfig, err := createGRPCTLSConfig(cfg)
+	if err != nil {
+		t.Fatalf("createGRPCTLSConfig: %v", err)
+	}
+	if !grpcCipherSuitesEqual(tlsConfig.CipherSuites, want) {
+		t.Errorf("CipherSuites = %v, want the configured %v (not the hardcoded default %v)", tlsConfig.CipherSuites, want, hardenedCipherSuites)
+	}
+}
+
+// #333: an invalid/weak/deprecated cipher suite name must be rejected, not silently
+// accepted, by createGRPCTLSConfig.
+func TestCreateGRPCTLSConfig_RejectsWeakOrUnknownCipher(t *testing.T) {
+	for _, name := range []string{
+		"TLS_RSA_WITH_RC4_128_SHA",
+		"TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+		"not-a-real-cipher-suite",
+	} {
+		cfg := &config.Config{}
+		cfg.Server.GRPC.TLS.Enabled = true
+		cfg.Server.GRPC.TLS.AutoCert = true
+		cfg.Server.GRPC.TLS.AllowedCiphers = []string{name}
+
+		if _, err := createGRPCTLSConfig(cfg); err == nil {
+			t.Errorf("createGRPCTLSConfig must reject weak/unknown cipher suite %q", name)
+		}
+	}
+}
+
+// grpcCipherSuitesEqual reports whether two ordered cipher-suite ID slices are identical.
+func grpcCipherSuitesEqual(a, b []uint16) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/server/main.go
+++ b/server/main.go
@@ -1305,7 +1305,14 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 		var serveErr error
 		if cfg.Server.HTTP.TLS.Enabled {
 			if cfg.Server.HTTP.TLS.AutoCert {
-				server.TLSConfig = buildAutoCertTLSConfig(cfg.Server.HTTP.TLS.Domains)
+				// checkTransportTLSPosture already validated tls.allowed_ciphers at boot,
+				// so this should never fail in practice; handled defensively anyway.
+				autoCertTLSConfig, err := buildAutoCertTLSConfig(cfg.Server.HTTP.TLS.Domains, cfg.Server.HTTP.TLS)
+				if err != nil {
+					log.Printf("HTTP server error: %v", err)
+					return
+				}
+				server.TLSConfig = autoCertTLSConfig
 				serveErr = server.ServeTLS(ln, "", "")
 			} else {
 				serveErr = server.ServeTLS(ln, cfg.Server.HTTP.TLS.CertFile, cfg.Server.HTTP.TLS.KeyFile)
@@ -1331,20 +1338,35 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 
 // checkTransportTLSPosture guards against silently serving credentials/secret values in
 // cleartext. For each enabled listener without TLS it either fails closed (when
-// security.require_transport_tls is set) or logs a prominent warning. It also warns when
-// the allowed_ciphers / protocol_versions tuning is set, since those fields are not
-// currently honored (the suite list + TLS 1.2 minimum are fixed) and would otherwise give
-// a false sense of control.
+// security.require_transport_tls is set) or logs a prominent warning.
+//
+// It also fails closed when tls.allowed_ciphers names a cipher suite that isn't a
+// recognized, secure TLS 1.2 suite (weak/deprecated suites like RC4/3DES/CBC-mode, or a
+// plain typo) — allowed_ciphers is now genuinely wired into the HTTP and gRPC TLS
+// builders (#333, applyTLSHardening in server/main.go and server/grpc/server.go), so a
+// bad value here would otherwise only surface as a confusing runtime TLS handshake
+// failure instead of a clear startup error.
+//
+// protocol_versions remains a separate, still-unwired tuning field (out of scope for
+// #333 — the TLS 1.2 floor stays fixed in code) — it still only warns, not fails, so an
+// operator isn't misled into thinking it took effect.
 func checkTransportTLSPosture(cfg *config.Config) error {
 	require := cfg.Security.RequireTransportTLS
 	check := func(name string, inst config.ServerInstanceConfig) error {
 		if !inst.Enabled {
 			return nil
 		}
-		// The tuning fields are not wired into the TLS builders — warn whenever they are
-		// set (TLS on or off) so an operator isn't misled into thinking they took effect.
-		if len(inst.TLS.AllowedCiphers) > 0 || len(inst.ProtocolVersions) > 0 {
-			log.Printf("WARNING: %s tls.allowed_ciphers / protocol_versions are set but NOT honored — the cipher suite list and TLS 1.2 minimum are fixed in code.", name)
+		// allowed_ciphers is honored now (#333) — validate it up front so a
+		// misspelled/weak/deprecated cipher name fails closed at startup instead of
+		// only surfacing when a client fails to negotiate a TLS connection.
+		if _, err := inst.TLS.ResolveCipherSuites(nil); err != nil {
+			return fmt.Errorf("%s %w", name, err)
+		}
+		// protocol_versions is parsed but still not wired into the TLS builders — warn
+		// whenever it's set (TLS on or off) so an operator isn't misled into thinking it
+		// took effect.
+		if len(inst.ProtocolVersions) > 0 {
+			log.Printf("WARNING: %s protocol_versions is set but NOT honored — the TLS 1.2 minimum is fixed in code.", name)
 		}
 		if inst.TLS.Enabled {
 			return nil
@@ -1503,44 +1525,64 @@ func createTLSConfig(cfg *config.Config) (*tls.Config, error) {
 	}
 
 	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
-	applyTLSHardening(tlsConfig)
+	if err := applyTLSHardening(tlsConfig, cfg.Server.HTTP.TLS); err != nil {
+		return nil, err
+	}
 	return tlsConfig, nil
 }
 
 // hardenedCipherSuites is the explicit AEAD-only cipher suite allowlist applied to
-// every HTTP TLS listener, regardless of how its certificate is sourced.
+// every HTTP TLS listener, regardless of how its certificate is sourced, UNLESS the
+// operator has explicitly configured tls.allowed_ciphers (#333) — in which case that
+// configured list is honored instead (see applyTLSHardening).
 var hardenedCipherSuites = []uint16{
 	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 }
 
-// applyTLSHardening layers the deliberately hardened MinVersion/CipherSuites onto
-// tlsConfig in place. The protocol-version floor and cipher-suite allowlist are
-// independent of how the certificate itself is sourced, so this must be applied
-// uniformly whether tlsConfig came from a manually configured cert/key pair
-// (createTLSConfig) or from an autocert.Manager (buildAutoCertTLSConfig) — AutoCert
-// should only supply the certificate, not silently determine the rest of the TLS
-// posture too (#172).
-func applyTLSHardening(tlsConfig *tls.Config) {
+// applyTLSHardening layers the hardened MinVersion/CipherSuites onto tlsConfig in
+// place. The protocol-version floor and cipher-suite allowlist are independent of how
+// the certificate itself is sourced, so this must be applied uniformly whether
+// tlsConfig came from a manually configured cert/key pair (createTLSConfig) or from an
+// autocert.Manager (buildAutoCertTLSConfig) — AutoCert should only supply the
+// certificate, not silently determine the rest of the TLS posture too (#172).
+//
+// CipherSuites is resolved from tlsCfg.AllowedCiphers (#333): when the operator has
+// left tls.allowed_ciphers unset, the hardcoded hardenedCipherSuites default above
+// applies unchanged (no regression for existing deployments); when they've set it,
+// their configured suite list is honored instead — validated against
+// config.SecureCipherSuiteNames, so a weak/deprecated/misspelled suite name fails
+// closed at startup rather than being silently ignored (the previous behavior) or
+// silently accepted. MinVersion stays fixed at TLS 1.2: TLS 1.3 has no equivalent
+// per-suite selection, so there is nothing for allowed_ciphers to configure there.
+func applyTLSHardening(tlsConfig *tls.Config, tlsCfg config.TLSConfig) error {
 	tlsConfig.MinVersion = tls.VersionTLS12
-	tlsConfig.CipherSuites = hardenedCipherSuites
+	suites, err := tlsCfg.ResolveCipherSuites(hardenedCipherSuites)
+	if err != nil {
+		return fmt.Errorf("invalid TLS configuration: %w", err)
+	}
+	tlsConfig.CipherSuites = suites
+	return nil
 }
 
 // buildAutoCertTLSConfig builds the tls.Config for HTTP AutoCert (Let's Encrypt-style
 // automatic certificate management) mode: the autocert.Manager supplies the
 // certificate (via GetCertificate/NextProtos), and the same hardened
 // MinVersion/CipherSuites as the non-AutoCert path (createTLSConfig) are layered on
-// top instead of being silently discarded (#172).
-func buildAutoCertTLSConfig(domains []string) *tls.Config {
+// top instead of being silently discarded (#172), honoring tls.allowed_ciphers the
+// same way createTLSConfig does (#333).
+func buildAutoCertTLSConfig(domains []string, tlsCfg config.TLSConfig) (*tls.Config, error) {
 	m := &autocert.Manager{
 		Cache:      autocert.DirCache("certs"),
 		Prompt:     autocert.AcceptTOS,
 		HostPolicy: autocert.HostWhitelist(domains...),
 	}
 	tlsConfig := m.TLSConfig()
-	applyTLSHardening(tlsConfig)
-	return tlsConfig
+	if err := applyTLSHardening(tlsConfig, tlsCfg); err != nil {
+		return nil, err
+	}
+	return tlsConfig, nil
 }
 
 // resolveOutboundIP returns the machine's preferred outbound IP address.

--- a/server/transport_tls_test.go
+++ b/server/transport_tls_test.go
@@ -148,13 +148,29 @@ func TestCheckTransportTLSPosture(t *testing.T) {
 	}
 }
 
-// #333: TLSConfig.AllowedCiphers is parsed but never wired into the hardcoded
-// AEAD-only CipherSuites list (server/main.go, server/grpc/server.go). An operator who
-// sets it must get a clear warning, not silent no-op — never a hard failure, since the
-// hardcoded list it can't affect is already AEAD-only.
-func TestCheckTransportTLSPosture_WarnsOnDeadAllowedCiphers(t *testing.T) {
+// #333: TLSConfig.AllowedCiphers is now wired into the HTTP/gRPC CipherSuites
+// (server/main.go's applyTLSHardening, server/grpc/server.go's applyTLSHardening) — an
+// operator who sets a valid TLS 1.2 AEAD suite name gets it honored; a bad
+// (unrecognized/weak/deprecated) suite name fails closed at startup instead of being
+// silently ignored (the old behavior) or silently accepted.
+func TestCheckTransportTLSPosture_RejectsInvalidAllowedCiphers(t *testing.T) {
 	c := cfgWith(true, true, false, false, false)
+	// TLS_AES_128_GCM_SHA256 is a TLS 1.3 suite name — TLS 1.3 doesn't support
+	// per-suite selection via tls.Config.CipherSuites, so it's not in the TLS 1.2
+	// allowlist and must be rejected, not silently accepted.
 	c.Server.HTTP.TLS.AllowedCiphers = []string{"TLS_AES_128_GCM_SHA256"}
+
+	if err := checkTransportTLSPosture(c); err == nil {
+		t.Fatal("an unrecognized/TLS-1.3-only cipher suite name must fail closed at startup")
+	}
+}
+
+// protocol_versions remains a separate, still-unwired tuning field (out of scope for
+// #333) — setting it must still only warn, not fail, and must not mention
+// allowed_ciphers (which is no longer a dead setting).
+func TestCheckTransportTLSPosture_ProtocolVersionsStillWarns(t *testing.T) {
+	c := cfgWith(true, true, false, false, false)
+	c.Server.HTTP.ProtocolVersions = []string{"TLS1.3"}
 
 	var buf bytes.Buffer
 	orig := log.Writer()
@@ -162,10 +178,10 @@ func TestCheckTransportTLSPosture_WarnsOnDeadAllowedCiphers(t *testing.T) {
 	defer log.SetOutput(orig)
 
 	if err := checkTransportTLSPosture(c); err != nil {
-		t.Fatalf("a dead allowed_ciphers setting must warn, not fail: %v", err)
+		t.Fatalf("a set protocol_versions must warn, not fail: %v", err)
 	}
-	if !strings.Contains(buf.String(), "tls.allowed_ciphers") {
-		t.Errorf("expected a warning mentioning tls.allowed_ciphers, got log output: %q", buf.String())
+	if !strings.Contains(buf.String(), "protocol_versions") {
+		t.Errorf("expected a warning mentioning protocol_versions, got log output: %q", buf.String())
 	}
 }
 
@@ -173,7 +189,10 @@ func TestCheckTransportTLSPosture_WarnsOnDeadAllowedCiphers(t *testing.T) {
 // — buildAutoCertTLSConfig (the AutoCert-mode config builder) must apply the same
 // hardening as the non-AutoCert path (createTLSConfig).
 func TestBuildAutoCertTLSConfig_AppliesHardening(t *testing.T) {
-	tlsConfig := buildAutoCertTLSConfig([]string{"example.com"})
+	tlsConfig, err := buildAutoCertTLSConfig([]string{"example.com"}, config.TLSConfig{})
+	if err != nil {
+		t.Fatalf("buildAutoCertTLSConfig: %v", err)
+	}
 	if tlsConfig == nil {
 		t.Fatal("buildAutoCertTLSConfig must not return nil")
 	}
@@ -210,4 +229,107 @@ func TestCreateTLSConfig_NonAutoCertAppliesHardening(t *testing.T) {
 	if len(tlsConfig.CipherSuites) == 0 {
 		t.Fatal("CipherSuites must not be empty")
 	}
+}
+
+// #333 regression: when AllowedCiphers is unset, both createTLSConfig (non-AutoCert)
+// and buildAutoCertTLSConfig (AutoCert) must keep the existing hardcoded secure default
+// — an operator who has never touched tls.allowed_ciphers must see no change in TLS
+// posture.
+func TestApplyTLSHardening_DefaultPreservedWhenAllowedCiphersUnset(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeSelfSignedCert(t, dir)
+
+	cfg := &config.Config{}
+	cfg.Server.HTTP.TLS.Enabled = true
+	cfg.Server.HTTP.TLS.CertFile = certFile
+	cfg.Server.HTTP.TLS.KeyFile = keyFile
+
+	tlsConfig, err := createTLSConfig(cfg)
+	if err != nil {
+		t.Fatalf("createTLSConfig: %v", err)
+	}
+	if !cipherSuitesEqual(tlsConfig.CipherSuites, hardenedCipherSuites) {
+		t.Errorf("CipherSuites = %v, want the unchanged hardcoded default %v", tlsConfig.CipherSuites, hardenedCipherSuites)
+	}
+
+	autoCertTLSConfig, err := buildAutoCertTLSConfig([]string{"example.com"}, config.TLSConfig{})
+	if err != nil {
+		t.Fatalf("buildAutoCertTLSConfig: %v", err)
+	}
+	if !cipherSuitesEqual(autoCertTLSConfig.CipherSuites, hardenedCipherSuites) {
+		t.Errorf("AutoCert CipherSuites = %v, want the unchanged hardcoded default %v", autoCertTLSConfig.CipherSuites, hardenedCipherSuites)
+	}
+}
+
+// #333: when AllowedCiphers is configured with a valid, specific TLS 1.2 AEAD suite
+// list, the resulting tls.Config must reflect exactly that list — not the hardcoded
+// default — on both the non-AutoCert and AutoCert HTTP paths.
+func TestApplyTLSHardening_HonorsConfiguredAllowedCiphers(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeSelfSignedCert(t, dir)
+
+	configured := []string{"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"}
+	want := []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256}
+
+	cfg := &config.Config{}
+	cfg.Server.HTTP.TLS.Enabled = true
+	cfg.Server.HTTP.TLS.CertFile = certFile
+	cfg.Server.HTTP.TLS.KeyFile = keyFile
+	cfg.Server.HTTP.TLS.AllowedCiphers = configured
+
+	tlsConfig, err := createTLSConfig(cfg)
+	if err != nil {
+		t.Fatalf("createTLSConfig: %v", err)
+	}
+	if !cipherSuitesEqual(tlsConfig.CipherSuites, want) {
+		t.Errorf("CipherSuites = %v, want the configured %v (not the hardcoded default %v)", tlsConfig.CipherSuites, want, hardenedCipherSuites)
+	}
+
+	autoCertTLSConfig, err := buildAutoCertTLSConfig([]string{"example.com"}, cfg.Server.HTTP.TLS)
+	if err != nil {
+		t.Fatalf("buildAutoCertTLSConfig: %v", err)
+	}
+	if !cipherSuitesEqual(autoCertTLSConfig.CipherSuites, want) {
+		t.Errorf("AutoCert CipherSuites = %v, want the configured %v", autoCertTLSConfig.CipherSuites, want)
+	}
+}
+
+// #333: an invalid/weak/deprecated cipher suite name must be rejected, not silently
+// accepted, by both createTLSConfig and buildAutoCertTLSConfig.
+func TestApplyTLSHardening_RejectsWeakOrUnknownCipher(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeSelfSignedCert(t, dir)
+
+	for _, name := range []string{
+		"TLS_RSA_WITH_RC4_128_SHA",              // RC4: broken
+		"TLS_RSA_WITH_3DES_EDE_CBC_SHA",         // 3DES: broken
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", // CBC-mode: deprecated
+		"not-a-real-cipher-suite",               // plain typo
+	} {
+		cfg := &config.Config{}
+		cfg.Server.HTTP.TLS.Enabled = true
+		cfg.Server.HTTP.TLS.CertFile = certFile
+		cfg.Server.HTTP.TLS.KeyFile = keyFile
+		cfg.Server.HTTP.TLS.AllowedCiphers = []string{name}
+
+		if _, err := createTLSConfig(cfg); err == nil {
+			t.Errorf("createTLSConfig must reject weak/unknown cipher suite %q", name)
+		}
+		if _, err := buildAutoCertTLSConfig([]string{"example.com"}, cfg.Server.HTTP.TLS); err == nil {
+			t.Errorf("buildAutoCertTLSConfig must reject weak/unknown cipher suite %q", name)
+		}
+	}
+}
+
+// cipherSuitesEqual reports whether two ordered cipher-suite ID slices are identical.
+func cipherSuitesEqual(a, b []uint16) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary

Closes the residual half of backlog finding #333 (LOW). An earlier round
added `checkTransportTLSPosture` to loudly warn when `tls.allowed_ciphers`
was set, since the setting was parsed but never actually applied — both
the HTTP server (`server/main.go`) and the gRPC server
(`server/grpc/server.go`) always hardcoded the same AEAD-only cipher
suite list regardless of the operator's config. That warning is no
longer needed for `allowed_ciphers` — this PR actually wires it in.

- Added `internal/config/tls_ciphers.go`: a curated
  `SecureCipherSuiteNames` allowlist (TLS 1.2 AES-GCM / ChaCha20-Poly1305
  suites only) and `TLSConfig.ResolveCipherSuites(default)`, which:
  - returns the caller's default unchanged when `AllowedCiphers` is
    empty/unset (no regression for existing deployments),
  - resolves a configured list to the matching `[]uint16` IDs when set,
  - rejects (with a descriptive error) any name that isn't in the
    allowlist — including RC4/3DES/CBC-mode suites and TLS 1.3 suite
    names (TLS 1.3 negotiates its own suites; `CipherSuites` has no
    effect on it).
- `server/main.go`'s `applyTLSHardening` and `server/grpc/server.go`'s
  `applyTLSHardening` now call `ResolveCipherSuites` instead of always
  assigning the hardcoded `hardenedCipherSuites` list. `MinVersion` stays
  fixed at TLS 1.2 (unaffected by this fix; `protocol_versions` is a
  separate, still-unwired field, out of scope here).
- `checkTransportTLSPosture` now validates `allowed_ciphers` at boot
  (fail closed on an invalid/weak name) instead of only warning that it's
  dead, and its `protocol_versions`-only warning message is updated to
  reflect that `allowed_ciphers` is no longer a no-op.
- Updated `configs/keyorix.yaml.tpl` comments to document the new
  semantics.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/config/... ./server/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./internal/config/... ./server/...` (0 issues)
- [x] `gofmt -l` clean on all changed files
- [x] `golangci-lint run ./internal/config/... ./server/...` (0 issues)
- New/updated tests cover: default preserved when unset (both HTTP +
  gRPC, AutoCert + non-AutoCert), configured list honored (both
  transports), and invalid/weak/unknown cipher names rejected at both the
  `internal/config.ResolveCipherSuites` level and the
  `checkTransportTLSPosture` startup-gate level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)