### PR TITLE
fix(encryption): local CLI key-ops join the #92 exclusive-DEK-lock coordination (#196)

### DIFF
--- a/internal/cli/encryption/encryption.go
+++ b/internal/cli/encryption/encryption.go
@@ -117,6 +117,35 @@ func loadConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
+// initLocalKeyOpService constructs and initializes the encryption.Service for a
+// short-lived, LOCAL key-management CLI operation — status/validate/fix-perms/
+// upgrade-aad/init — and has it participate in the same cross-process lock
+// coordination the server (held for its whole lifetime) and rotate/migrate-
+// provider (held for the duration of their write) already use (#92/#195/#196).
+// None of these commands rotate the DEK themselves, so they take the SHARED
+// side of the lock: any number of them can run concurrently with each other,
+// but every one is refused while a live server or an in-progress rotation/
+// migrate-provider holds the lock exclusively — instead of silently reading
+// (or, for upgrade-aad, writing under) a DEK that's concurrently being
+// replaced. cleanPendingDEK matches upgrade-aad/rotate's existing convention of
+// clearing a leftover dek.key.pending from an interrupted rotation before
+// initializing. Callers must `defer service.Shutdown()` on success to release
+// the lock.
+func initLocalKeyOpService(cfg *config.Config, baseDir, passphrase string, cleanPendingDEK bool) (*encryption.Service, error) {
+	service := encryption.NewService(&cfg.Storage.Encryption, baseDir)
+	if cleanPendingDEK {
+		service.CleanPendingDEK()
+	}
+	if err := service.Initialize(passphrase); err != nil {
+		return nil, fmt.Errorf("failed to initialize encryption: %w", err)
+	}
+	if err := service.AcquireSharedKeyLock(); err != nil {
+		service.Shutdown()
+		return nil, fmt.Errorf("%w — a live server or an in-progress rotation/migrate-provider is using this key directory; stop it or wait for it to finish, then retry", err)
+	}
+	return service, nil
+}
+
 func runInit(cmd *cobra.Command, args []string) error {
 	cfg, err := loadConfig()
 	if err != nil {
@@ -129,17 +158,17 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	baseDir, _ := os.Getwd()
-	service := encryption.NewService(&cfg.Storage.Encryption, baseDir)
-
 	passphrase, err := masterPassphrase(cfg)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("🔐 Initializing encryption...")
-	if err := service.Initialize(passphrase); err != nil {
-		return fmt.Errorf("failed to initialize encryption: %w", err)
+	service, err := initLocalKeyOpService(cfg, baseDir, passphrase, false)
+	if err != nil {
+		return err
 	}
+	defer service.Shutdown()
 
 	fmt.Println("✅ Encryption initialized successfully")
 	fmt.Printf("📋 Key version: %s\n", service.GetKeyVersion())
@@ -163,17 +192,18 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	baseDir, _ := os.Getwd()
-	service := encryption.NewService(&cfg.Storage.Encryption, baseDir)
-
 	passphrase, err := masterPassphrase(cfg)
 	if err != nil {
 		fmt.Printf("⚠️  %v\n", err)
 		return nil
 	}
-	if err := service.Initialize(passphrase); err != nil {
-		fmt.Printf("❌ Initialization failed: %v\n", err)
+
+	service, err := initLocalKeyOpService(cfg, baseDir, passphrase, false)
+	if err != nil {
+		fmt.Printf("❌ %v\n", err)
 		return nil
 	}
+	defer service.Shutdown()
 
 	fmt.Printf("Initialized: ✅\n")
 	fmt.Printf("Key Version: %s\n", service.GetKeyVersion())
@@ -262,15 +292,14 @@ func upgradeAADWithConfig(cfg *config.Config) error {
 	}
 
 	baseDir, _ := os.Getwd()
-	service := encryption.NewService(&cfg.Storage.Encryption, baseDir)
-
 	passphrase, err := masterPassphrase(cfg)
 	if err != nil {
 		return err
 	}
-	service.CleanPendingDEK()
-	if err := service.Initialize(passphrase); err != nil {
-		return fmt.Errorf("failed to initialize encryption: %w", err)
+
+	service, err := initLocalKeyOpService(cfg, baseDir, passphrase, true)
+	if err != nil {
+		return err
 	}
 	defer service.Shutdown()
 
@@ -306,14 +335,17 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	return validateWithConfig(cfg)
+}
 
+// validateWithConfig is the testable core of runValidate.
+func validateWithConfig(cfg *config.Config) error {
 	if !cfg.Storage.Encryption.Enabled {
 		fmt.Println("ℹ️  Encryption is disabled - nothing to validate")
 		return nil
 	}
 
 	baseDir, _ := os.Getwd()
-	service := encryption.NewService(&cfg.Storage.Encryption, baseDir)
 
 	fmt.Println("🔍 Validating encryption setup...")
 
@@ -321,10 +353,13 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := service.Initialize(passphrase); err != nil {
-		fmt.Printf("❌ Initialization failed: %v\n", err)
+
+	service, err := initLocalKeyOpService(cfg, baseDir, passphrase, false)
+	if err != nil {
+		fmt.Printf("❌ %v\n", err)
 		return err
 	}
+	defer service.Shutdown()
 
 	if err := service.ValidateKeyFiles(); err != nil {
 		fmt.Printf("❌ Key file validation failed: %v\n", err)
@@ -341,21 +376,26 @@ func runFixPerms(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	return fixPermsWithConfig(cfg)
+}
 
+// fixPermsWithConfig is the testable core of runFixPerms.
+func fixPermsWithConfig(cfg *config.Config) error {
 	if !cfg.Storage.Encryption.Enabled {
 		return fmt.Errorf("encryption is disabled in configuration")
 	}
 
 	baseDir, _ := os.Getwd()
-	service := encryption.NewService(&cfg.Storage.Encryption, baseDir)
-
 	passphrase, err := masterPassphrase(cfg)
 	if err != nil {
 		return err
 	}
-	if err := service.Initialize(passphrase); err != nil {
-		return fmt.Errorf("failed to initialize encryption: %w", err)
+
+	service, err := initLocalKeyOpService(cfg, baseDir, passphrase, false)
+	if err != nil {
+		return err
 	}
+	defer service.Shutdown()
 
 	fmt.Println("🔧 Fixing key file permissions...")
 	if err := service.FixKeyFilePermissions(); err != nil {

--- a/internal/cli/encryption/local_key_lock_test.go
+++ b/internal/cli/encryption/local_key_lock_test.go
@@ -1,0 +1,97 @@
+package encryption
+
+// local_key_lock_test.go — end-to-end pin for #196: local, short-lived
+// key-management CLI commands (status/validate/fix-perms/upgrade-aad/init)
+// now participate in the same dek.lock coordination the server and
+// RotateDEKWithSweep already use, via initLocalKeyOpService's
+// AcquireSharedKeyLock call. Exercised here through validateWithConfig, the
+// simplest of the wired commands (no database dependency).
+//
+// The unit-level lock-primitive tests (AcquireSharedKeyLock's own mutual-
+// exclusion/refusal semantics) live in internal/encryption/exclusive_lock_test.go;
+// this test proves the CLI entry point actually reaches that primitive and
+// surfaces a clear, actionable error.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	enc "github.com/keyorixhq/keyorix/internal/encryption"
+)
+
+const localLockTestPassphrase = "local-key-lock-test-passphrase-123"
+
+// newLocalLockTestConfig points cfg at a throwaway key directory (validateWithConfig
+// resolves it from os.Getwd(), so the caller must t.Chdir into workDir first) and
+// sets KEYORIX_MASTER_PASSWORD so masterPassphrase() succeeds.
+func newLocalLockTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	t.Setenv("KEYORIX_MASTER_PASSWORD", localLockTestPassphrase)
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Encryption = config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "kek.salt",
+	}
+	return cfg
+}
+
+// TestValidateWithConfig_RefusedWhileServerHoldsLock proves requirement (1):
+// a local CLI operation (here, `keyorix encryption validate`) fails fast with
+// a clear, actionable error when a live server (or, equally, an in-progress
+// RotateDEKWithSweep — both hold the exact same exclusive dek.lock) already
+// holds the key directory.
+func TestValidateWithConfig_RefusedWhileServerHoldsLock(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	cfg := newLocalLockTestConfig(t)
+
+	// Provision the key material once, up front (mirrors `keyorix encryption
+	// init` having already run against this directory).
+	setup := enc.NewService(&cfg.Storage.Encryption, workDir)
+	if err := setup.Initialize(localLockTestPassphrase); err != nil {
+		t.Fatalf("failed to provision key material: %v", err)
+	}
+	setup.Shutdown()
+
+	// Simulate a live server (or an in-progress rotation sweep — both use
+	// AcquireExclusiveKeyLock) holding the key directory exclusively.
+	serverSvc := enc.NewService(&cfg.Storage.Encryption, workDir)
+	if err := serverSvc.Initialize(localLockTestPassphrase); err != nil {
+		t.Fatalf("failed to initialize simulated server: %v", err)
+	}
+	if err := serverSvc.AcquireExclusiveKeyLock(); err != nil {
+		t.Fatalf("simulated server failed to acquire the exclusive key lock: %v", err)
+	}
+	defer serverSvc.Shutdown()
+
+	err := validateWithConfig(cfg)
+	if err == nil {
+		t.Fatal("expected validate to be refused while a live server/rotation holds the exclusive key lock")
+	}
+	if !strings.Contains(err.Error(), "exclusively") {
+		t.Errorf("expected a clear, actionable error mentioning the exclusive holder, got: %v", err)
+	}
+}
+
+// TestValidateWithConfig_SucceedsWithNoServerOrRotationRunning is the
+// non-regression control for requirement (2): ordinary, single-invocation CLI
+// usage (the common case — no server running, no rotation in progress) must
+// not be broken by requiring a lock that's never held in that scenario.
+func TestValidateWithConfig_SucceedsWithNoServerOrRotationRunning(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	cfg := newLocalLockTestConfig(t)
+
+	setup := enc.NewService(&cfg.Storage.Encryption, workDir)
+	if err := setup.Initialize(localLockTestPassphrase); err != nil {
+		t.Fatalf("failed to provision key material: %v", err)
+	}
+	setup.Shutdown()
+
+	if err := validateWithConfig(cfg); err != nil {
+		t.Fatalf("expected validate to succeed with no server/rotation running, got: %v", err)
+	}
+}

--- a/internal/encryption/exclusive_lock.go
+++ b/internal/encryption/exclusive_lock.go
@@ -1,4 +1,4 @@
-// exclusive_lock.go — single-live-DEK-holder coordination (ADR-010 / #92).
+// exclusive_lock.go — single-live-DEK-holder coordination (ADR-010 / #92/#196).
 //
 // The DEK rotation CLI is a separate OS process from the running server: without
 // coordination, it can promote a new DEK to disk while the server still holds the
@@ -10,6 +10,18 @@
 // sweep) take an exclusive, non-blocking flock on the same file — whichever runs
 // first blocks the other, so rotation simply refuses to run against a live
 // server instead of racing it.
+//
+// #196: that exclusive lock alone leaves every OTHER short-lived, local key-
+// management CLI command (status/validate/fix-perms/upgrade-aad/init) with no
+// coordination at all — none of them acquire anything today, so one can read (or,
+// for upgrade-aad, write under) the DEK while a rotation sweep or a live server is
+// concurrently replacing it. Since these commands don't themselves rotate the
+// DEK, they don't need to exclude EACH OTHER — only the actual writer (server or
+// rotation/migrate-provider). acquireSharedKeyLock takes the same lock file in
+// flock's SHARED mode: any number of shared holders can coexist, but flock
+// refuses a shared request while another process holds the file exclusively
+// (and vice versa), so this still refuses to run while a live server or an
+// in-progress rotation/migrate-provider holds the lock.
 package encryption
 
 import (
@@ -40,9 +52,32 @@ func acquireExclusiveKeyLock(baseDir string) (*os.File, error) {
 	return f, nil
 }
 
-// releaseExclusiveKeyLock releases a lock taken by acquireExclusiveKeyLock. Nil is
-// a safe no-op (nothing was held).
-func releaseExclusiveKeyLock(f *os.File) {
+// acquireSharedKeyLock takes a non-blocking SHARED advisory lock on the SAME
+// dek.lock file acquireExclusiveKeyLock uses (#196). Any number of processes can
+// hold the shared lock at once — concurrent local CLI commands never contend
+// with each other over it — but a shared request is refused outright while
+// another process holds the file EXCLUSIVELY, which is exactly what a live
+// server (from startup) or an in-progress rotation/migrate-provider (for the
+// duration of its write) does. That refusal is the whole point: it stops a
+// local, non-rotating CLI command from reading (or writing under) a DEK that's
+// concurrently being replaced.
+func acquireSharedKeyLock(baseDir string) (*os.File, error) {
+	path := filepath.Join(baseDir, serverLockFileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600) // #nosec G304 -- operator-configured key directory, not user input
+	if err != nil {
+		return nil, fmt.Errorf("open DEK lock file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_SH|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("another process holds the DEK lock exclusively (a live server, or an in-progress rotation/migrate-provider): %w", err)
+	}
+	return f, nil
+}
+
+// releaseKeyLock releases a lock taken by acquireExclusiveKeyLock or
+// acquireSharedKeyLock — flock's LOCK_UN releases whichever mode is held on the
+// fd, so one release path serves both. Nil is a safe no-op (nothing was held).
+func releaseKeyLock(f *os.File) {
 	if f == nil {
 		return
 	}

--- a/internal/encryption/exclusive_lock_test.go
+++ b/internal/encryption/exclusive_lock_test.go
@@ -85,3 +85,110 @@ func TestAcquireExclusiveKeyLock_SecondServerRefused(t *testing.T) {
 		t.Fatal("expected a second server instance to be refused the key lock")
 	}
 }
+
+// The tests below pin #196: local, short-lived CLI commands (status/validate/
+// fix-perms/upgrade-aad/init) now participate in the SAME dek.lock coordination
+// via AcquireSharedKeyLock, so they can no longer read (or write under) a DEK
+// that a live server or an in-progress rotation sweep is concurrently
+// replacing — while still never contending with each other.
+
+// TestAcquireSharedKeyLock_RefusedWhileServerHoldsLock proves requirement (1):
+// a local CLI operation taking the shared lock must be refused, with a clear
+// error, while a live server (simulated exactly as
+// TestRotateDEKWithSweep_RefusesWhileServerHoldsLock does, by a Service that
+// has acquired the exclusive lock) holds the key directory.
+func TestAcquireSharedKeyLock_RefusedWhileServerHoldsLock(t *testing.T) {
+	serverSvc, dir := newTestService(t, lockTestPassphrase)
+	if err := serverSvc.AcquireExclusiveKeyLock(); err != nil {
+		t.Fatalf("server failed to acquire its own key lock: %v", err)
+	}
+	defer serverSvc.Shutdown()
+
+	cliSvc := newTestServiceAtDir(t, dir, lockTestPassphrase)
+	defer cliSvc.Shutdown()
+
+	err := cliSvc.AcquireSharedKeyLock()
+	if err == nil {
+		t.Fatal("expected the local CLI operation to be refused the shared lock while the server holds it exclusively")
+	}
+	if !strings.Contains(err.Error(), "exclusively") {
+		t.Fatalf("expected an error explaining the key directory is held exclusively, got: %v", err)
+	}
+}
+
+// TestAcquireSharedKeyLock_RefusedWhileRotationSweepInProgress proves the other
+// half of requirement (1): the exact scenario in the bug report — a CLI
+// command reading/writing key material while RotateDEKWithSweep is mid-flight
+// on a different process. RotateDEKWithSweep holds the exclusive dek.lock for
+// the duration of its sweep (AcquireExclusiveKeyLock, called at the top of
+// RotateDEKWithSweep) — simulated here the same way, by a Service holding that
+// same exclusive lock — so a concurrent local CLI operation must be refused.
+func TestAcquireSharedKeyLock_RefusedWhileRotationSweepInProgress(t *testing.T) {
+	rotatingSvc, dir := newTestService(t, lockTestPassphrase)
+	if err := rotatingSvc.AcquireExclusiveKeyLock(); err != nil {
+		t.Fatalf("rotation failed to acquire the exclusive key lock: %v", err)
+	}
+	defer rotatingSvc.Shutdown()
+
+	cliSvc := newTestServiceAtDir(t, dir, lockTestPassphrase)
+	defer cliSvc.Shutdown()
+
+	err := cliSvc.AcquireSharedKeyLock()
+	if err == nil {
+		t.Fatal("expected the local CLI operation to be refused the shared lock while a rotation sweep holds it exclusively")
+	}
+	if !strings.Contains(err.Error(), "rotation") {
+		t.Fatalf("expected the error to mention the in-progress rotation, got: %v", err)
+	}
+}
+
+// TestAcquireSharedKeyLock_SucceedsWhenNoServerOrRotationHoldsLock is the
+// non-regression control for requirement (2): ordinary CLI usage — no server
+// running, no rotation in progress — must not be broken by requiring a lock
+// that would never be granted in that scenario.
+func TestAcquireSharedKeyLock_SucceedsWhenNoServerOrRotationHoldsLock(t *testing.T) {
+	svc, _ := newTestService(t, lockTestPassphrase)
+	defer svc.Shutdown()
+
+	if err := svc.AcquireSharedKeyLock(); err != nil {
+		t.Fatalf("expected the shared lock to be granted when nothing else holds it, got: %v", err)
+	}
+}
+
+// TestAcquireSharedKeyLock_SucceedsAfterExclusiveLockReleased is the positive
+// control mirroring TestRotateDEKWithSweep_SucceedsAfterServerLockReleased:
+// once the server/rotation releases the exclusive lock, a local CLI operation
+// against the same key directory proceeds normally.
+func TestAcquireSharedKeyLock_SucceedsAfterExclusiveLockReleased(t *testing.T) {
+	serverSvc, dir := newTestService(t, lockTestPassphrase)
+	if err := serverSvc.AcquireExclusiveKeyLock(); err != nil {
+		t.Fatalf("server failed to acquire its own key lock: %v", err)
+	}
+	serverSvc.Shutdown() // releases the lock
+
+	cliSvc := newTestServiceAtDir(t, dir, lockTestPassphrase)
+	defer cliSvc.Shutdown()
+
+	if err := cliSvc.AcquireSharedKeyLock(); err != nil {
+		t.Fatalf("shared lock should be granted once the exclusive holder's lock is released: %v", err)
+	}
+}
+
+// TestAcquireSharedKeyLock_MultipleReadersDoNotBlockEachOther proves shared
+// locks are, as the name implies, shared: several concurrent local CLI
+// operations against the same key directory (e.g. two operators independently
+// running `status`) must not contend with each other, unlike the exclusive
+// lock the server/rotation use.
+func TestAcquireSharedKeyLock_MultipleReadersDoNotBlockEachOther(t *testing.T) {
+	first, dir := newTestService(t, lockTestPassphrase)
+	defer first.Shutdown()
+	if err := first.AcquireSharedKeyLock(); err != nil {
+		t.Fatalf("first reader failed to acquire the shared lock: %v", err)
+	}
+
+	second := newTestServiceAtDir(t, dir, lockTestPassphrase)
+	defer second.Shutdown()
+	if err := second.AcquireSharedKeyLock(); err != nil {
+		t.Fatalf("second concurrent reader should not be blocked by the first, got: %v", err)
+	}
+}

--- a/internal/encryption/service_rotation.go
+++ b/internal/encryption/service_rotation.go
@@ -232,6 +232,35 @@ func (s *Service) AcquireExclusiveKeyLock() error {
 	return nil
 }
 
+// AcquireSharedKeyLock takes a shared, non-blocking OS advisory lock on the same
+// key-directory lock file AcquireExclusiveKeyLock uses (#196). It is for local,
+// short-lived CLI commands that read (or, for upgrade-aad, write under) the
+// CURRENT DEK without themselves rotating it — status/validate/fix-perms/
+// upgrade-aad/init. Unlike AcquireExclusiveKeyLock, any number of Services can
+// hold the shared lock at the same time, so ordinary concurrent CLI invocations
+// never contend with each other over it — but it is refused outright while a
+// live server or an in-progress rotation/migrate-provider holds the lock
+// exclusively, so those commands fail fast instead of racing a DEK that's
+// concurrently being replaced. Released by Shutdown, same as the exclusive
+// lock. Idempotent: a second call while this Service already holds either kind
+// of lock is a no-op.
+func (s *Service) AcquireSharedKeyLock() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.initialized {
+		return fmt.Errorf("encryption service not initialized")
+	}
+	if s.serverLock != nil {
+		return nil
+	}
+	f, err := acquireSharedKeyLock(s.keyManager.baseDir)
+	if err != nil {
+		return err
+	}
+	s.serverLock = f
+	return nil
+}
+
 // Shutdown cleanly wipes the DEK from memory and releases the exclusive key
 // lock, if this Service was holding one.
 func (s *Service) Shutdown() {
@@ -240,7 +269,7 @@ func (s *Service) Shutdown() {
 	if s.keyManager != nil {
 		s.keyManager.Wipe()
 	}
-	releaseExclusiveKeyLock(s.serverLock)
+	releaseKeyLock(s.serverLock)
 	s.serverLock = nil
 	s.initialized = false
 }


### PR DESCRIPTION
## Summary

- `internal/cli/encryption/encryption.go`'s `status`, `validate`, `fix-perms`, `upgrade-aad`, and `init` each construct their own `encryption.Service` and call `Initialize()` — reading (or, for `upgrade-aad`, writing under) the DEK — with **no** cross-process coordination at all, unlike the server (holds `AcquireExclusiveKeyLock` for its whole lifetime) and `rotate`/`migrate-provider` (already locked, #92/#195). One of these commands can therefore run concurrently with a live server or an in-progress `RotateDEKWithSweep` and read stale key material, or (for `upgrade-aad`) write rows under a DEK that's mid-replacement.
- Adds `Service.AcquireSharedKeyLock()` — a shared (`flock LOCK_SH`) advisory lock on the exact same `dek.lock` file `AcquireExclusiveKeyLock` already uses. Any number of these local, non-rotating commands can hold the shared lock concurrently (they never need to exclude each other), but the shared request is refused outright while a live server or an in-progress rotation holds the file **exclusively** — so they now fail fast with a clear, actionable error instead of racing the DEK swap.
- Wired through one new `initLocalKeyOpService` helper in `internal/cli/encryption/encryption.go`, so every affected command gets this automatically rather than each remembering to call it individually.
- Deliberately scoped to the #92 `dek.lock` mechanism (the lock the bug report and `rotate`/the server already use) — `migrate-provider`'s separate `dek.key.lock` (added by #195, guarding only rotate-vs-rewrap) is out of scope here; extending that too would be a distinct, narrower follow-up if wanted.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/... ./internal/encryption/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./internal/cli/... ./internal/encryption/...` — 0 issues
- [x] `golangci-lint run ./internal/cli/encryption/... ./internal/encryption/...` — 0 issues
- New regression tests (mirroring the #92 `TestRotateDEKWithSweep_RefusesWhileServerHoldsLock` template):
  - `internal/encryption/exclusive_lock_test.go`: `TestAcquireSharedKeyLock_RefusedWhileServerHoldsLock`, `TestAcquireSharedKeyLock_RefusedWhileRotationSweepInProgress`, `TestAcquireSharedKeyLock_SucceedsWhenNoServerOrRotationHoldsLock`, `TestAcquireSharedKeyLock_SucceedsAfterExclusiveLockReleased`, `TestAcquireSharedKeyLock_MultipleReadersDoNotBlockEachOther`
  - `internal/cli/encryption/local_key_lock_test.go`: `TestValidateWithConfig_RefusedWhileServerHoldsLock`, `TestValidateWithConfig_SucceedsWithNoServerOrRotationRunning` (end-to-end through the wired `validateWithConfig` CLI entry point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)