### PR TITLE
fix(compliance): compute the deployment-wide hygiene rollup with O(1) queries (#393)

### DIFF
--- a/internal/core/deployment_hygiene.go
+++ b/internal/core/deployment_hygiene.go
@@ -6,12 +6,16 @@
 // zero-membership account has no other route to see, so the route requires audit.read
 // (not the universal system_viewer baseline system.read; see #273). Parallels the
 // deployment-wide PAT ([[pat_hygiene]]) and machine-token hygiene views; built on the
-// per-project [[project_hygiene]] summary.
+// per-project [[project_hygiene]] summary. Each signal is computed via a single
+// deployment-wide (grouped) query rather than one call per project — see the #393
+// fix note on DeploymentHygieneSummary.
 package core
 
 import (
 	"context"
 	"fmt"
+	"sort"
+	"time"
 )
 
 // DeploymentHygiene is the install-wide hygiene rollup: summed totals across all
@@ -32,32 +36,108 @@ type ProjectHygieneBreakdown struct {
 // lists the projects with at least one outstanding signal. Healthy projects are
 // omitted from the breakdown but contribute their (zero) counts to the totals. The
 // windows (in days) default when non-positive, matching ProjectHygieneSummary.
+//
+// #393: this used to call ProjectHygieneSummary once PER PROJECT — five separate DB
+// round trips (orphaned/unused/expiring/stale-MI/rotation-overdue), repeated for
+// every project in the deployment, with no pagination or cap anywhere in the chain.
+// A deployment with many projects made a single call to this route (reachable well
+// below system_admin) take arbitrarily long and issue an arbitrarily large number of
+// queries — a DoS-adjacent cost with no relationship to what the caller asked for.
+// Each signal is now computed ONCE, deployment-wide, either via a dedicated grouped
+// (`GROUP BY project_id`) storage query, or — for rotation-overdue, which was
+// already exposed as a single deployment-wide call (see compliance_posture.go) — by
+// grouping its one deployment-wide result in memory. Total DB round trips is now a
+// small constant regardless of project count: this endpoint's whole purpose is a
+// cross-project aggregate, so a set-based query is both the natural and the cheap
+// shape for it, matching the #238 fix's targeted-query pattern for the same family
+// of bug.
 func (c *KeyorixCore) DeploymentHygieneSummary(ctx context.Context, unusedDays, expiringDays, staleMIDays int) (*DeploymentHygiene, error) {
+	if unusedDays <= 0 {
+		unusedDays = defaultHygieneUnusedDays
+	}
+	if expiringDays <= 0 {
+		expiringDays = defaultHygieneExpiringDays
+	}
+	if staleMIDays <= 0 {
+		staleMIDays = defaultHygieneStaleMIDays
+	}
+
 	projects, err := c.ListProjects(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list projects: %w", err)
 	}
+	projectIDs := make([]uint, len(projects))
+	names := make(map[uint]string, len(projects))
+	for i, p := range projects {
+		projectIDs[i] = p.ID
+		names[p.ID] = p.Name
+	}
 
-	out := &DeploymentHygiene{Projects: make([]ProjectHygieneBreakdown, 0)}
-	for _, p := range projects {
-		summary, err := c.ProjectHygieneSummary(ctx, p.ID, unusedDays, expiringDays, staleMIDays)
-		if err != nil {
-			return nil, fmt.Errorf("project %d hygiene: %w", p.ID, err)
-		}
-		out.Totals.OrphanedSecrets += summary.OrphanedSecrets
-		out.Totals.UnusedSecrets += summary.UnusedSecrets
-		out.Totals.ExpiringSecrets += summary.ExpiringSecrets
-		out.Totals.StaleMachineIdentities += summary.StaleMachineIdentities
-		out.Totals.RotationOverdue += summary.RotationOverdue
+	orphaned, err := c.storage.CountOrphanedSecretsByProject(ctx, projectIDs)
+	if err != nil {
+		return nil, fmt.Errorf("orphaned secrets: %w", err)
+	}
+	unused, err := c.storage.CountUnusedSecretsByProject(ctx, projectIDs, c.now().Add(-time.Duration(unusedDays)*24*time.Hour))
+	if err != nil {
+		return nil, fmt.Errorf("unused secrets: %w", err)
+	}
+	expiringCutoff := c.now().Add(time.Duration(expiringDays) * 24 * time.Hour)
+	expiring, err := c.storage.CountExpiringSecretsByProject(ctx, projectIDs, expiringCutoff)
+	if err != nil {
+		return nil, fmt.Errorf("expiring secrets: %w", err)
+	}
+	staleMI, err := c.storage.CountStaleMachineIdentitiesByProject(ctx, projectIDs, c.now().Add(-time.Duration(staleMIDays)*24*time.Hour))
+	if err != nil {
+		return nil, fmt.Errorf("stale machine identities: %w", err)
+	}
 
-		if summary.OrphanedSecrets+summary.UnusedSecrets+summary.ExpiringSecrets+
-			summary.StaleMachineIdentities+summary.RotationOverdue > 0 {
-			out.Projects = append(out.Projects, ProjectHygieneBreakdown{
-				ProjectID:      p.ID,
-				ProjectName:    p.Name,
-				ProjectHygiene: *summary,
-			})
+	// GetRotationStatus(nil, nil) is already the established deployment-wide call
+	// (compliance_posture.go uses it the same way) — a single ListRotationPolicies
+	// query plus a per-POLICY (not per-project) scan of that policy's covered
+	// secrets, so its cost is bounded by the deployment's policy/secret count, not
+	// multiplied again by project count the way calling it once per project was.
+	statuses, err := c.GetRotationStatus(ctx, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("rotation status: %w", err)
+	}
+	rotationOverdue := make(map[uint]int)
+	for _, s := range statuses {
+		if s.Status == RotationStatusOverdue {
+			rotationOverdue[s.ProjectID]++
 		}
 	}
+
+	// Union of every project ID carrying at least one outstanding signal.
+	flagged := make(map[uint]struct{})
+	for _, m := range []map[uint]int{orphaned, unused, expiring, staleMI, rotationOverdue} {
+		for pid := range m {
+			flagged[pid] = struct{}{}
+		}
+	}
+
+	out := &DeploymentHygiene{Projects: make([]ProjectHygieneBreakdown, 0, len(flagged))}
+	for pid := range flagged {
+		ph := ProjectHygiene{
+			OrphanedSecrets:        orphaned[pid],
+			UnusedSecrets:          unused[pid],
+			ExpiringSecrets:        expiring[pid],
+			StaleMachineIdentities: staleMI[pid],
+			RotationOverdue:        rotationOverdue[pid],
+		}
+		out.Totals.OrphanedSecrets += ph.OrphanedSecrets
+		out.Totals.UnusedSecrets += ph.UnusedSecrets
+		out.Totals.ExpiringSecrets += ph.ExpiringSecrets
+		out.Totals.StaleMachineIdentities += ph.StaleMachineIdentities
+		out.Totals.RotationOverdue += ph.RotationOverdue
+		out.Projects = append(out.Projects, ProjectHygieneBreakdown{
+			ProjectID:      pid,
+			ProjectName:    names[pid],
+			ProjectHygiene: ph,
+		})
+	}
+	// Grouped-query results and a map iteration order are both otherwise
+	// nondeterministic; sort by ID so the response is stable across calls.
+	sort.Slice(out.Projects, func(i, j int) bool { return out.Projects[i].ProjectID < out.Projects[j].ProjectID })
+
 	return out, nil
 }

--- a/internal/core/deployment_hygiene_test.go
+++ b/internal/core/deployment_hygiene_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -82,4 +84,91 @@ func TestDeploymentHygieneSummary(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, h.Totals.OrphanedSecrets)
 	})
+}
+
+// totalQueryCounter tallies every SELECT GORM executes, via the same "gorm:query"
+// callback hook GORM itself uses to run queries — a precise, non-flaky substitute
+// for a timing-based assertion (mirrors the #238 fix's queryCounter).
+type totalQueryCounter struct {
+	mu    sync.Mutex
+	total int
+}
+
+func attachTotalQueryCounter(t *testing.T, db *gorm.DB) *totalQueryCounter {
+	qc := &totalQueryCounter{}
+	err := db.Callback().Query().After("gorm:query").Register("test:count_total_queries", func(_ *gorm.DB) {
+		qc.mu.Lock()
+		defer qc.mu.Unlock()
+		qc.total++
+	})
+	require.NoError(t, err)
+	return qc
+}
+
+// #393: DeploymentHygieneSummary used to call ProjectHygieneSummary once PER
+// PROJECT — five separate DB round trips (orphaned/unused/expiring/stale-MI/
+// rotation-overdue), repeated for every project in the deployment, with no bound.
+// That made the endpoint's query count (and so its latency/DB load) grow linearly,
+// unboundedly, with the number of projects in the deployment — reachable well below
+// system_admin. Each signal is now computed once, deployment-wide, via a grouped
+// query. This proves the query count issued by a single call is the SAME whether
+// the deployment has 5 or 60 projects — a query COUNT assertion, not a timing one,
+// so it can't flake under load.
+func TestDeploymentHygieneSummary_QueryCostDoesNotScaleWithProjectCount(t *testing.T) {
+	runWithNProjects := func(n int) int {
+		require.NoError(t, i18n.InitializeForTesting())
+		db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+		require.NoError(t, err)
+		sqlDB, _ := db.DB()
+		sqlDB.SetMaxOpenConns(1)
+		require.NoError(t, db.AutoMigrate(
+			&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{},
+			&models.Environment{}, &models.SecretAccessLog{}, &models.MachineIdentity{}, &models.AuditEvent{},
+			&models.RotationPolicy{},
+		))
+		require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+		require.NoError(t, db.Create(&models.User{ID: 2, Username: "leaver", Email: "l@t.com"}).Error)
+
+		c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+		ctx := context.Background()
+		now := time.Now()
+
+		for i := 0; i < n; i++ {
+			p, err := c.storage.CreateProject(ctx, &models.Project{Name: fmt.Sprintf("p%d", i)})
+			require.NoError(t, err)
+			e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+			require.NoError(t, err)
+			// Every third project carries debt (orphaned secret + stale machine
+			// identity), so the breakdown is non-trivial — the QUERY COUNT must stay
+			// flat regardless of how many projects (or how many carry debt) exist.
+			ownerID := uint(1)
+			if i%3 == 0 {
+				ownerID = 2
+			}
+			_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+				Name: "s", ProjectID: p.ID, EnvironmentID: e.ID, Type: "password", OwnerID: ownerID,
+				IsSecret: true, CreatedAt: now, UpdatedAt: now,
+			})
+			require.NoError(t, err)
+			_, err = c.storage.CreateMachineIdentity(ctx, &models.MachineIdentity{
+				ProjectID: p.ID, Name: "svc", IdentityType: "service", State: MachineActive,
+				CreatedAt: now.Add(-200 * 24 * time.Hour),
+			})
+			require.NoError(t, err)
+		}
+		require.NoError(t, c.storage.DeleteUser(ctx, 2)) // offboard → every "%3==0" secret is orphaned
+
+		qc := attachTotalQueryCounter(t, db)
+		_, err = c.DeploymentHygieneSummary(ctx, 90, 30, 90)
+		require.NoError(t, err)
+		return qc.total
+	}
+
+	small := runWithNProjects(5)
+	large := runWithNProjects(60)
+
+	assert.Equal(t, small, large,
+		"DeploymentHygieneSummary's query count must not scale with the number of projects in the deployment")
+	assert.Less(t, small, 20,
+		"expected a small constant number of grouped/deployment-wide queries, not one set of queries per project")
 }

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -581,6 +581,22 @@ func (m *MockStorage) ListOrphanedSecrets(ctx context.Context, projectID uint) (
 	return args.Get(0).([]*models.SecretNode), args.Error(1)
 }
 
+func (m *MockStorage) CountOrphanedSecretsByProject(ctx context.Context, projectIDs []uint) (map[uint]int, error) {
+	args := m.Called(ctx, projectIDs)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[uint]int), args.Error(1)
+}
+
+func (m *MockStorage) CountExpiringSecretsByProject(ctx context.Context, projectIDs []uint, expiresBefore time.Time) (map[uint]int, error) {
+	args := m.Called(ctx, projectIDs, expiresBefore)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[uint]int), args.Error(1)
+}
+
 func (m *MockStorage) ListProjectSecretsForDrift(ctx context.Context, projectID uint) ([]storage.DriftSecretRow, error) {
 	args := m.Called(ctx, projectID)
 	if args.Get(0) == nil {
@@ -1188,6 +1204,14 @@ func (m *MockStorage) UnusedSecrets(ctx context.Context, projectID *uint, notRea
 	return args.Get(0).([]storage.UnusedSecretStat), args.Error(1)
 }
 
+func (m *MockStorage) CountUnusedSecretsByProject(ctx context.Context, projectIDs []uint, notReadSince time.Time) (map[uint]int, error) {
+	args := m.Called(ctx, projectIDs, notReadSince)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[uint]int), args.Error(1)
+}
+
 func (m *MockStorage) CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error {
 	args := m.Called(ctx, alert)
 	return args.Error(0)
@@ -1592,6 +1616,14 @@ func (m *MockStorage) CountMachineIdentitiesByClassification(ctx context.Context
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(map[string]int), args.Error(1)
+}
+
+func (m *MockStorage) CountStaleMachineIdentitiesByProject(ctx context.Context, projectIDs []uint, olderThan time.Time) (map[uint]int, error) {
+	args := m.Called(ctx, projectIDs, olderThan)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[uint]int), args.Error(1)
 }
 
 func (m *MockStorage) CreateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) (*models.MachineIdentityCredential, error) {

--- a/internal/core/rotation_policies.go
+++ b/internal/core/rotation_policies.go
@@ -160,12 +160,17 @@ const (
 // GetRotationStatus returns every policy-covered secret with an explicit status,
 // so the dashboard can render a full inspector and a rotation health score.
 type RotationStatusEntry struct {
-	PolicyID          uint       `json:"policy_id"`
-	PolicyName        string     `json:"policy_name"`
-	IntervalDays      int        `json:"interval_days"`
-	AlertDaysBefore   int        `json:"alert_days_before"`
-	SecretID          uint       `json:"secret_id"`
-	SecretName        string     `json:"secret_name"`
+	PolicyID        uint   `json:"policy_id"`
+	PolicyName      string `json:"policy_name"`
+	IntervalDays    int    `json:"interval_days"`
+	AlertDaysBefore int    `json:"alert_days_before"`
+	SecretID        uint   `json:"secret_id"`
+	SecretName      string `json:"secret_name"`
+	// ProjectID is the covered secret's project — always populated from the secret
+	// row itself (no extra query), regardless of whether GetRotationStatus was
+	// called project-scoped or deployment-wide. Lets a deployment-wide caller (the
+	// hygiene rollup, #393) group entries by project without a per-project call.
+	ProjectID         uint       `json:"project_id"`
 	EnvironmentID     uint       `json:"environment_id"`
 	LastRotatedAt     *time.Time `json:"last_rotated_at"`
 	DaysSinceRotation int        `json:"days_since_rotation"`
@@ -282,6 +287,7 @@ func (c *KeyorixCore) GetRotationStatus(ctx context.Context, projectID, environm
 				AlertDaysBefore:   policy.AlertDaysBefore,
 				SecretID:          secret.ID,
 				SecretName:        secret.Name,
+				ProjectID:         secret.ProjectID,
 				EnvironmentID:     secret.EnvironmentID,
 				LastRotatedAt:     secret.LastRotatedAt,
 				DaysSinceRotation: daysSince,

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -252,6 +252,13 @@ type Storage interface {
 	// CountMachineIdentitiesByClassification returns install-wide counts keyed by
 	// classification label ("" = unclassified) for the compliance posture.
 	CountMachineIdentitiesByClassification(ctx context.Context) (map[string]int, error)
+	// CountStaleMachineIdentitiesByProject returns, for every project in
+	// projectIDs in a single grouped query, the count of ACTIVE machine identities
+	// not seen since olderThan (never-seen counts from creation) — the same
+	// definition as ListStaleMachineIdentities, but deployment-wide in one query
+	// instead of one call per project. Used by the hygiene rollup (#393). A
+	// project absent from the result has zero stale machine identities.
+	CountStaleMachineIdentitiesByProject(ctx context.Context, projectIDs []uint, olderThan time.Time) (map[uint]int, error)
 
 	// Machine-token credentials (ADR-030) — opaque bearer tokens, hashed at rest.
 	CreateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) (*models.MachineIdentityCredential, error)
@@ -344,6 +351,18 @@ type Storage interface {
 	// a live user (the owner was deleted/soft-deleted) — offboarding hygiene, so an
 	// admin can re-assign ownership. Scoped to the project via the environment JOIN.
 	ListOrphanedSecrets(ctx context.Context, projectID uint) ([]*models.SecretNode, error)
+	// CountOrphanedSecretsByProject returns the orphaned-secret count (same
+	// definition as ListOrphanedSecrets) for every project in projectIDs, in a
+	// single grouped query keyed by project ID — the deployment-wide counterpart
+	// used by the hygiene rollup (#393) instead of calling ListOrphanedSecrets once
+	// per project. A project absent from the result has zero orphaned secrets.
+	CountOrphanedSecretsByProject(ctx context.Context, projectIDs []uint) (map[uint]int, error)
+	// CountExpiringSecretsByProject returns, for every project in projectIDs in a
+	// single grouped query, the count of live secrets with a non-null expiration
+	// before expiresBefore — the deployment-wide counterpart to the
+	// ListSecrets(ExpiresBefore) count ProjectHygieneSummary uses per-project
+	// (#393). A project absent from the result has zero expiring secrets.
+	CountExpiringSecretsByProject(ctx context.Context, projectIDs []uint, expiresBefore time.Time) (map[uint]int, error)
 	// GetSecretTags returns a secret's tag names (sorted). SetSecretTags replaces a
 	// secret's tags wholesale, upserting Tag rows by name — secret organization/search.
 	GetSecretTags(ctx context.Context, secretID uint) ([]string, error)
@@ -637,6 +656,12 @@ type Storage interface {
 	// access since `notReadSince` — including never-read secrets — ordered
 	// never-read first, then oldest last read.
 	UnusedSecrets(ctx context.Context, projectID *uint, notReadSince time.Time) ([]UnusedSecretStat, error)
+	// CountUnusedSecretsByProject returns, for every project in projectIDs in a
+	// single grouped query, the count of secrets not read since notReadSince (or
+	// never read) — the deployment-wide counterpart to UnusedSecrets, used by the
+	// hygiene rollup (#393) instead of calling UnusedSecrets once per project. A
+	// project absent from the result has zero unused secrets.
+	CountUnusedSecretsByProject(ctx context.Context, projectIDs []uint, notReadSince time.Time) (map[uint]int, error)
 	CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error
 	ListAnomalyAlerts(ctx context.Context, acknowledged *bool) ([]models.AnomalyAlert, error)
 	// AcknowledgeAnomalyAlert marks an alert acknowledged and stamps who did it and

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -214,6 +214,49 @@ func (ls *LocalStorage) UnusedSecrets(ctx context.Context, projectID *uint, notR
 	return stats, nil
 }
 
+// CountUnusedSecretsByProject returns, for every project in projectIDs, the count
+// of secrets qualifying under the same "not read since notReadSince (or never
+// read)" definition UnusedSecrets uses, via a single grouped query — the
+// deployment-wide counterpart used by the hygiene rollup (#393) instead of calling
+// UnusedSecrets once per project. Two aggregation levels are needed (UnusedSecrets'
+// own per-secret MAX(access_time)/HAVING, then a COUNT(*) of the qualifying secrets
+// per project), so the per-secret query runs as a FROM subquery. A project with no
+// unused secrets is simply absent from the returned map.
+func (ls *LocalStorage) CountUnusedSecretsByProject(ctx context.Context, projectIDs []uint, notReadSince time.Time) (map[uint]int, error) {
+	counts := make(map[uint]int)
+	if len(projectIDs) == 0 {
+		return counts, nil
+	}
+
+	perSecret := ls.db.WithContext(ctx).
+		Table("secret_nodes AS s").
+		Select("s.project_id AS project_id").
+		Joins("LEFT JOIN secret_access_logs l ON l.secret_node_id = s.id AND l.action = ?", "read").
+		Where("s.is_secret = ?", true).
+		Where("s.deleted_at IS NULL").
+		Where("s.project_id IN ?", projectIDs).
+		Group("s.id, s.project_id").
+		Having("MAX(l.access_time) IS NULL OR MAX(l.access_time) < ?", notReadSince)
+
+	type row struct {
+		ProjectID uint
+		N         int64
+	}
+	var rows []row
+	err := ls.db.WithContext(ctx).
+		Table("(?) AS unused", perSecret).
+		Select("project_id, COUNT(*) AS n").
+		Group("project_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		counts[r.ProjectID] = int(r.N)
+	}
+	return counts, nil
+}
+
 // AuditRetentionStats returns the total audit event count plus the oldest and
 // newest event_time in a single aggregate query. Keyorix applies no retention
 // cap, so MIN(event_time) is the true start of the trail — the basis for the

--- a/internal/storage/store/local_machine_identities.go
+++ b/internal/storage/store/local_machine_identities.go
@@ -6,6 +6,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"gorm.io/gorm/clause"
 
@@ -77,4 +78,43 @@ func (ls *LocalStorage) ListAllMachineIdentities(ctx context.Context) ([]*models
 
 func (ls *LocalStorage) CountMachineIdentitiesByClassification(ctx context.Context) (map[string]int, error) {
 	return countByClassification(ctx, ls.db, &models.MachineIdentity{})
+}
+
+// machineIdentityStateActive mirrors core.MachineActive (the store package cannot
+// import core: core already imports storage/store). Keeps
+// CountStaleMachineIdentitiesByProject's "only ACTIVE identities count as stale"
+// rule in lockstep with ListStaleMachineIdentities's in-memory filter.
+const machineIdentityStateActive = "active"
+
+// CountStaleMachineIdentitiesByProject returns, for every project in projectIDs,
+// the count of ACTIVE machine identities not seen since olderThan (an identity
+// never seen counts from its creation time) — the same definition
+// ListStaleMachineIdentities uses, but as a single grouped query instead of one
+// ListMachineIdentities call per project. Used by the deployment-wide hygiene
+// rollup (#393) instead of fanning out one call per project. A project with no
+// stale machine identities is simply absent from the returned map.
+func (ls *LocalStorage) CountStaleMachineIdentitiesByProject(ctx context.Context, projectIDs []uint, olderThan time.Time) (map[uint]int, error) {
+	counts := make(map[uint]int)
+	if len(projectIDs) == 0 {
+		return counts, nil
+	}
+	type row struct {
+		ProjectID uint
+		N         int64
+	}
+	var rows []row
+	err := ls.db.WithContext(ctx).Model(&models.MachineIdentity{}).
+		Select("project_id, COUNT(*) AS n").
+		Where("project_id IN ?", projectIDs).
+		Where("state = ?", machineIdentityStateActive).
+		Where("(last_seen_at IS NULL AND created_at < ?) OR last_seen_at < ?", olderThan, olderThan).
+		Group("project_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, r := range rows {
+		counts[r.ProjectID] = int(r.N)
+	}
+	return counts, nil
 }

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -557,6 +557,69 @@ func (ls *LocalStorage) ListOrphanedSecrets(ctx context.Context, projectID uint)
 	return secrets, nil
 }
 
+// CountOrphanedSecretsByProject returns the same "owner no longer live" count as
+// ListOrphanedSecrets, for every project in projectIDs, via a single
+// `GROUP BY secret_nodes.project_id` query — the deployment-wide counterpart used
+// by the hygiene rollup (#393) instead of calling ListOrphanedSecrets once per
+// project (which turned "every project" into a per-project round trip). A project
+// with no orphaned secrets is simply absent from the returned map.
+func (ls *LocalStorage) CountOrphanedSecretsByProject(ctx context.Context, projectIDs []uint) (map[uint]int, error) {
+	counts := make(map[uint]int)
+	if len(projectIDs) == 0 {
+		return counts, nil
+	}
+	type row struct {
+		ProjectID uint
+		N         int64
+	}
+	var rows []row
+	err := ls.db.WithContext(ctx).Model(&models.SecretNode{}).
+		Select("secret_nodes.project_id AS project_id, COUNT(*) AS n").
+		Joins("JOIN environments ON environments.id = secret_nodes.environment_id AND environments.project_id = secret_nodes.project_id").
+		Joins("LEFT JOIN users ON users.id = secret_nodes.owner_id AND users.deleted_at IS NULL").
+		Where("secret_nodes.project_id IN ?", projectIDs).
+		Where("users.id IS NULL").
+		Group("secret_nodes.project_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, r := range rows {
+		counts[r.ProjectID] = int(r.N)
+	}
+	return counts, nil
+}
+
+// CountExpiringSecretsByProject returns, for every project in projectIDs, the
+// count of live secrets with a non-null expiration before expiresBefore — the
+// same definition ListSecrets(ExpiresBefore) uses per-project, but grouped into a
+// single deployment-wide query for the hygiene rollup (#393). A project with no
+// expiring secrets is simply absent from the returned map.
+func (ls *LocalStorage) CountExpiringSecretsByProject(ctx context.Context, projectIDs []uint, expiresBefore time.Time) (map[uint]int, error) {
+	counts := make(map[uint]int)
+	if len(projectIDs) == 0 {
+		return counts, nil
+	}
+	type row struct {
+		ProjectID uint
+		N         int64
+	}
+	var rows []row
+	err := ls.db.WithContext(ctx).Model(&models.SecretNode{}).
+		Select("project_id, COUNT(*) AS n").
+		Where("project_id IN ?", projectIDs).
+		Where("expiration IS NOT NULL AND expiration < ?", expiresBefore).
+		Group("project_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, r := range rows {
+		counts[r.ProjectID] = int(r.N)
+	}
+	return counts, nil
+}
+
 // GetSecretTags returns the secret's tag names, sorted.
 func (ls *LocalStorage) GetSecretTags(ctx context.Context, secretID uint) ([]string, error) {
 	var names []string

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -139,6 +139,12 @@ func (rs *RemoteStorage) UnusedSecrets(_ context.Context, _ *uint, _ time.Time) 
 	return nil, fmt.Errorf("UnusedSecrets not available in remote mode")
 }
 
+// CountUnusedSecretsByProject is not available in remote mode; the grouped
+// hygiene-rollup query (#393) runs server-side.
+func (rs *RemoteStorage) CountUnusedSecretsByProject(_ context.Context, _ []uint, _ time.Time) (map[uint]int, error) {
+	return nil, fmt.Errorf("CountUnusedSecretsByProject not available in remote mode")
+}
+
 // AuditRetentionStats is not available in remote mode; retention coverage aggregates server-side.
 func (rs *RemoteStorage) AuditRetentionStats(_ context.Context) (*storage.AuditRetentionStats, error) {
 	return nil, fmt.Errorf("AuditRetentionStats not available in remote mode")

--- a/internal/storage/store/remote_machine_identities.go
+++ b/internal/storage/store/remote_machine_identities.go
@@ -40,6 +40,12 @@ func (rs *RemoteStorage) CountMachineIdentitiesByClassification(_ context.Contex
 	return nil, remoteUnsupported("CountMachineIdentitiesByClassification")
 }
 
+// CountStaleMachineIdentitiesByProject is not available in remote mode; the
+// grouped hygiene-rollup query (#393) runs server-side.
+func (rs *RemoteStorage) CountStaleMachineIdentitiesByProject(_ context.Context, _ []uint, _ time.Time) (map[uint]int, error) {
+	return nil, remoteUnsupported("CountStaleMachineIdentitiesByProject")
+}
+
 func (rs *RemoteStorage) CreateMachineIdentityCredential(_ context.Context, _ *models.MachineIdentityCredential) (*models.MachineIdentityCredential, error) {
 	return nil, remoteUnsupported("CreateMachineIdentityCredential")
 }

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -171,6 +171,18 @@ func (rs *RemoteStorage) ListOrphanedSecrets(_ context.Context, _ uint) ([]*mode
 	return nil, fmt.Errorf("ListOrphanedSecrets not available in remote mode")
 }
 
+// CountOrphanedSecretsByProject is not available in remote mode; the grouped
+// hygiene-rollup query (#393) runs server-side.
+func (rs *RemoteStorage) CountOrphanedSecretsByProject(_ context.Context, _ []uint) (map[uint]int, error) {
+	return nil, fmt.Errorf("CountOrphanedSecretsByProject not available in remote mode")
+}
+
+// CountExpiringSecretsByProject is not available in remote mode; the grouped
+// hygiene-rollup query (#393) runs server-side.
+func (rs *RemoteStorage) CountExpiringSecretsByProject(_ context.Context, _ []uint, _ time.Time) (map[uint]int, error) {
+	return nil, fmt.Errorf("CountExpiringSecretsByProject not available in remote mode")
+}
+
 // GetSecretTags / SetSecretTags are not available in remote mode; tag storage is server-side.
 func (rs *RemoteStorage) GetSecretTags(_ context.Context, _ uint) ([]string, error) {
 	return nil, fmt.Errorf("GetSecretTags not available in remote mode")


### PR DESCRIPTION
## Summary

`DeploymentHygieneSummary` (`internal/core/deployment_hygiene.go`) called `ProjectHygieneSummary` once **per project** — five separate DB round trips (orphaned secrets, unused secrets, expiring secrets, stale machine identities, rotation-overdue), repeated for every project in the deployment, with no pagination or cap anywhere in the chain. A deployment with many projects made a single call to this route (gated on `audit.read`, reachable well below `system_admin`) take arbitrarily long and issue an arbitrarily large number of queries — the same N+1/unbounded-fan-out family as #238/#386, but multiplicative (projects × per-project unbounded queries), per backlog finding **#393 (MEDIUM)**.

## Fix

Each signal is now computed once, deployment-wide, instead of once per project:

- **Orphaned / expiring secrets / stale machine identities**: three new targeted storage methods (`CountOrphanedSecretsByProject`, `CountExpiringSecretsByProject`, `CountStaleMachineIdentitiesByProject`) each run a single `GROUP BY project_id` query across the deployment's project IDs, instead of one call per project.
- **Unused secrets**: `CountUnusedSecretsByProject` reuses `UnusedSecrets`'s existing per-secret aggregation as a FROM subquery, so the "never read, or not read since X" definition stays identical to the per-project version — just grouped by project in one query.
- **Rotation-overdue**: reuses `GetRotationStatus`'s existing deployment-wide call (`GetRotationStatus(ctx, nil, nil)` — already used this way by `compliance_posture.go`) instead of calling it once per project. `RotationStatusEntry` now carries `ProjectID`, populated from the already-loaded secret row (no extra query), so the deployment-wide result can be grouped by project in memory.

Total DB round trips for the rollup is now a small constant regardless of project count — the endpoint's whole purpose is a cross-project aggregate, so a set-based query is both the natural and the cheap shape for it, matching the #238 fix's targeted-query pattern for the same bug family.

New storage methods are added to the `Storage` interface and implemented on both `LocalStorage` (real grouped queries) and `RemoteStorage` (unsupported, matching the existing convention — this hygiene rollup was already local-storage-only: `ListOrphanedSecrets` already returns "not available in remote mode" today).

## Testing

Adds `TestDeploymentHygieneSummary_QueryCostDoesNotScaleWithProjectCount`: a GORM query-counting callback (not a timing assertion, mirroring the #238 fix's test helper) proving the rollup's total query count is identical whether the deployment has 5 or 60 projects, and stays well under 20 queries (versus the old shape, which would issue roughly `1 + 5×N` queries for `N` projects).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./internal/core/... ./internal/storage/...` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)