### PR TITLE
fix(compliance): compute the deployment-wide name-conformance scan with O(1) queries (#416)

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -597,6 +597,14 @@ func (m *MockStorage) CountExpiringSecretsByProject(ctx context.Context, project
 	return args.Get(0).(map[uint]int), args.Error(1)
 }
 
+func (m *MockStorage) ListLiveSecretNamesByProject(ctx context.Context, projectIDs []uint, limit int) ([]storage.SecretNameRow, bool, error) {
+	args := m.Called(ctx, projectIDs, limit)
+	if args.Get(0) == nil {
+		return nil, args.Bool(1), args.Error(2)
+	}
+	return args.Get(0).([]storage.SecretNameRow), args.Bool(1), args.Error(2)
+}
+
 func (m *MockStorage) ListProjectSecretsForDrift(ctx context.Context, projectID uint) ([]storage.DriftSecretRow, error) {
 	args := m.Called(ctx, projectID)
 	if args.Get(0) == nil {

--- a/internal/core/secret_name_conformance_deployment.go
+++ b/internal/core/secret_name_conformance_deployment.go
@@ -12,7 +12,16 @@ package core
 import (
 	"context"
 	"fmt"
+	"sort"
 )
+
+// deploymentSecretNameConformanceMaxRows bounds the single deployment-wide query the
+// conformance scan issues (#416) — analogous to secretInventoryMaxRows/
+// secretListingMaxRows, but a larger ceiling since this one query covers every
+// project in the deployment rather than a single project at a time. Truncated on
+// the report signals the (rare) case a deployment actually has more live secrets
+// than this, instead of silently dropping the rest.
+const deploymentSecretNameConformanceMaxRows = 100000
 
 // DeploymentSecretNameViolation is one naming-policy violation plus its project.
 type DeploymentSecretNameViolation struct {
@@ -29,13 +38,30 @@ type DeploymentSecretNameConformanceReport struct {
 	Pattern       string                          `json:"pattern,omitempty"`
 	MaxLength     int                             `json:"max_length,omitempty"`
 	TotalSecrets  int                             `json:"total_secrets"`
-	Violations    []DeploymentSecretNameViolation `json:"violations"`
+	// Truncated reports whether deploymentSecretNameConformanceMaxRows was hit, i.e.
+	// the deployment has more live secrets than this scan pulled in a single query —
+	// the result above is then a (possibly incomplete) sample, not the full set.
+	Truncated  bool                            `json:"truncated,omitempty"`
+	Violations []DeploymentSecretNameViolation `json:"violations"`
 }
 
-// DeploymentSecretNameConformance scans every live secret across all projects (each via
-// the per-project SecretNameConformance) and returns those whose name violates the
-// current naming policy, each tagged with its project, ordered by project then name.
-// Skips the scan entirely when no policy is configured. Never reads a value.
+// DeploymentSecretNameConformance returns every live secret across all projects whose
+// name violates the current naming policy, each tagged with its project, ordered by
+// project then name. Skips the scan entirely when no policy is configured. Never
+// reads a value.
+//
+// #416: this used to call SecretNameConformance once PER PROJECT — a full
+// ListSecrets query per project, repeated for every project in the deployment, with
+// no bound on project count — the same N+1/unbounded fan-out family as #238/#393. A
+// deployment with many projects made a single call to this route take arbitrarily
+// long and issue an arbitrarily large number of queries. Naming-policy conformance
+// can't be pushed into SQL as a pure aggregate (matching a caller-configured regex
+// isn't a database concern), so the fix here is narrower than #393's grouped-COUNT
+// approach: fetch every project's live secret names in ONE bounded query
+// (ListLiveSecretNamesByProject) and run the regex check in memory, exactly as
+// SecretNameConformance already does per-project — only the N+1 QUERY pattern is
+// eliminated, not the in-memory regex work (which was never the bottleneck). Total
+// DB round trips is now a small constant regardless of project count.
 func (c *KeyorixCore) DeploymentSecretNameConformance(ctx context.Context) (*DeploymentSecretNameConformanceReport, error) {
 	report := &DeploymentSecretNameConformanceReport{
 		PolicyEnabled: c.secretNamePolicy.Enabled,
@@ -52,20 +78,46 @@ func (c *KeyorixCore) DeploymentSecretNameConformance(ctx context.Context) (*Dep
 	if err != nil {
 		return nil, fmt.Errorf("list projects: %w", err)
 	}
+	if len(projects) == 0 {
+		return report, nil
+	}
 
-	for _, p := range projects {
-		sub, err := c.SecretNameConformance(ctx, p.ID)
-		if err != nil {
-			return nil, fmt.Errorf("project %d conformance: %w", p.ID, err)
-		}
-		report.TotalSecrets += sub.TotalSecrets
-		for _, v := range sub.Violations {
+	projectIDs := make([]uint, len(projects))
+	projectName := make(map[uint]string, len(projects))
+	for i, p := range projects {
+		projectIDs[i] = p.ID
+		projectName[p.ID] = p.Name
+	}
+
+	rows, truncated, err := c.storage.ListLiveSecretNamesByProject(ctx, projectIDs, deploymentSecretNameConformanceMaxRows)
+	if err != nil {
+		return nil, fmt.Errorf("list secret names: %w", err)
+	}
+	report.Truncated = truncated
+	report.TotalSecrets = len(rows)
+
+	for _, r := range rows {
+		if verr := c.validateSecretName(r.Name); verr != nil {
 			report.Violations = append(report.Violations, DeploymentSecretNameViolation{
-				ProjectID:           p.ID,
-				ProjectName:         p.Name,
-				SecretNameViolation: v,
+				ProjectID:   r.ProjectID,
+				ProjectName: projectName[r.ProjectID],
+				SecretNameViolation: SecretNameViolation{
+					ID:             r.ID,
+					Name:           r.Name,
+					Type:           r.Type,
+					Classification: r.Classification,
+					EnvironmentID:  r.EnvironmentID,
+					Reason:         verr.Error(),
+				},
 			})
 		}
 	}
+
+	sort.Slice(report.Violations, func(i, j int) bool {
+		if report.Violations[i].ProjectID != report.Violations[j].ProjectID {
+			return report.Violations[i].ProjectID < report.Violations[j].ProjectID
+		}
+		return report.Violations[i].Name < report.Violations[j].Name
+	})
 	return report, nil
 }

--- a/internal/core/secret_name_conformance_deployment_test.go
+++ b/internal/core/secret_name_conformance_deployment_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -81,4 +82,69 @@ func TestDeploymentSecretNameConformance(t *testing.T) {
 		assert.Equal(t, 4, rep.TotalSecrets)
 		assert.Empty(t, rep.Violations)
 	})
+}
+
+// #416: DeploymentSecretNameConformance used to call SecretNameConformance once PER
+// PROJECT — a full ListSecrets query per project, repeated for every project in the
+// deployment, with no bound on project count. That made the endpoint's query count
+// (and so its latency/DB load) grow linearly, unboundedly, with the number of
+// projects in the deployment — reachable well below system_admin, the same
+// N+1/unbounded fan-out family as #238/#393. Every project's live secret names are
+// now fetched in a single bounded query (ListLiveSecretNamesByProject) and checked
+// against the naming policy in memory. This proves the query count issued by a
+// single call is the SAME whether the deployment has 5 or 50 projects — a query
+// COUNT assertion (attachTotalQueryCounter, defined in deployment_hygiene_test.go),
+// not a timing one, so it can't flake under load.
+func TestDeploymentSecretNameConformance_QueryCostDoesNotScaleWithProjectCount(t *testing.T) {
+	runWithNProjects := func(n int) int {
+		require.NoError(t, i18n.InitializeForTesting())
+		db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+		require.NoError(t, err)
+		sqlDB, _ := db.DB()
+		sqlDB.SetMaxOpenConns(1)
+		require.NoError(t, db.AutoMigrate(
+			&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
+		))
+
+		c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+		ctx := context.Background()
+		now := time.Now()
+		require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{Enabled: true, Pattern: "^[A-Z][A-Z0-9_]*$"}))
+
+		for i := 0; i < n; i++ {
+			p, err := c.storage.CreateProject(ctx, &models.Project{Name: fmt.Sprintf("p%d", i)})
+			require.NoError(t, err)
+			e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+			require.NoError(t, err)
+			// One conforming and one violating name per project, so the breakdown is
+			// non-trivial — the QUERY COUNT must stay flat regardless of how many
+			// projects (or how many carry violations) exist.
+			_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+				Name: "DB_PASSWORD", ProjectID: p.ID, EnvironmentID: e.ID, Type: "password", OwnerID: 1,
+				IsSecret: true, CreatedAt: now, UpdatedAt: now,
+			})
+			require.NoError(t, err)
+			_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+				Name: fmt.Sprintf("bad-key-%d", i), ProjectID: p.ID, EnvironmentID: e.ID, Type: "password", OwnerID: 1,
+				IsSecret: true, CreatedAt: now, UpdatedAt: now,
+			})
+			require.NoError(t, err)
+		}
+
+		qc := attachTotalQueryCounter(t, db)
+		rep, err := c.DeploymentSecretNameConformance(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 2*n, rep.TotalSecrets)
+		assert.Len(t, rep.Violations, n)
+		assert.False(t, rep.Truncated)
+		return qc.total
+	}
+
+	small := runWithNProjects(5)
+	large := runWithNProjects(50)
+
+	assert.Equal(t, small, large,
+		"DeploymentSecretNameConformance's query count must not scale with the number of projects in the deployment")
+	assert.Less(t, small, 10,
+		"expected a small constant number of queries (list projects + one bounded secret-name scan), not one set of queries per project")
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -363,6 +363,16 @@ type Storage interface {
 	// ListSecrets(ExpiresBefore) count ProjectHygieneSummary uses per-project
 	// (#393). A project absent from the result has zero expiring secrets.
 	CountExpiringSecretsByProject(ctx context.Context, projectIDs []uint, expiresBefore time.Time) (map[uint]int, error)
+	// ListLiveSecretNamesByProject returns every live secret (folders excluded)
+	// across every project in projectIDs — id/name/type/classification/environment
+	// plus its project ID — in a SINGLE query ordered by project then name, capped at
+	// limit total rows. This is the deployment-wide counterpart to the per-project
+	// ListSecrets call SecretNameConformance uses (#416): naming-policy regex
+	// matching is not a SQL concern, so this intentionally returns raw rows for the
+	// caller to check against the policy in memory — only the N+1 QUERY pattern
+	// (one ListSecrets call per project) is eliminated, not the in-memory regex
+	// work. The returned bool reports whether limit was hit (result truncated).
+	ListLiveSecretNamesByProject(ctx context.Context, projectIDs []uint, limit int) ([]SecretNameRow, bool, error)
 	// GetSecretTags returns a secret's tag names (sorted). SetSecretTags replaces a
 	// secret's tags wholesale, upserting Tag rows by name — secret organization/search.
 	GetSecretTags(ctx context.Context, secretID uint) ([]string, error)
@@ -904,6 +914,20 @@ type DriftSecretRow struct {
 	Type          string
 	HasExpiration bool
 	HasMaxReads   bool
+}
+
+// SecretNameRow is one live secret's naming-conformance-relevant projection plus its
+// project ID — the row shape ListLiveSecretNamesByProject returns for the
+// deployment-wide naming-policy conformance scan (#416). Mirrors the fields
+// SecretNameViolation already carries per-project, so the deployment-wide caller can
+// build a DeploymentSecretNameViolation directly without a second lookup.
+type SecretNameRow struct {
+	ProjectID      uint
+	ID             uint
+	Name           string
+	Type           string
+	Classification string
+	EnvironmentID  uint
 }
 
 // UserFilter defines filtering options for user queries

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -620,6 +620,35 @@ func (ls *LocalStorage) CountExpiringSecretsByProject(ctx context.Context, proje
 	return counts, nil
 }
 
+// ListLiveSecretNamesByProject returns every live secret (folders excluded) across
+// every project in projectIDs — id/name/type/classification/environment plus its
+// project ID — in a SINGLE query ordered by project then name, instead of one
+// ListSecrets call per project (#416, the deployment-wide name-conformance scan's
+// N+1 fix). Fetches one row beyond limit so truncation can be reported without a
+// separate COUNT query.
+func (ls *LocalStorage) ListLiveSecretNamesByProject(ctx context.Context, projectIDs []uint, limit int) ([]storage.SecretNameRow, bool, error) {
+	if len(projectIDs) == 0 {
+		return nil, false, nil
+	}
+	var rows []storage.SecretNameRow
+	err := ls.db.WithContext(ctx).Model(&models.SecretNode{}).
+		Select("project_id, id, name, type, classification, environment_id").
+		Where("project_id IN ?", projectIDs).
+		Where("is_secret = ?", true).
+		Order("project_id ASC, name ASC").
+		Limit(limit + 1).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, false, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	truncated := false
+	if len(rows) > limit {
+		truncated = true
+		rows = rows[:limit]
+	}
+	return rows, truncated, nil
+}
+
 // GetSecretTags returns the secret's tag names, sorted.
 func (ls *LocalStorage) GetSecretTags(ctx context.Context, secretID uint) ([]string, error) {
 	var names []string

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -183,6 +183,12 @@ func (rs *RemoteStorage) CountExpiringSecretsByProject(_ context.Context, _ []ui
 	return nil, fmt.Errorf("CountExpiringSecretsByProject not available in remote mode")
 }
 
+// ListLiveSecretNamesByProject is not available in remote mode; the grouped
+// deployment-wide name-conformance scan (#416) runs server-side.
+func (rs *RemoteStorage) ListLiveSecretNamesByProject(_ context.Context, _ []uint, _ int) ([]storage.SecretNameRow, bool, error) {
+	return nil, false, fmt.Errorf("ListLiveSecretNamesByProject not available in remote mode")
+}
+
 // GetSecretTags / SetSecretTags are not available in remote mode; tag storage is server-side.
 func (rs *RemoteStorage) GetSecretTags(_ context.Context, _ uint) ([]string, error) {
 	return nil, fmt.Errorf("GetSecretTags not available in remote mode")


### PR DESCRIPTION
## Summary

- `DeploymentSecretNameConformance` called `SecretNameConformance` once **per project** — a full `ListSecrets` query per project, repeated for every project in the deployment, with no bound on project count. A deployment with many projects made a single call to this route (reachable well below `system_admin`) take arbitrarily long and issue an arbitrarily large number of queries — the same N+1/unbounded fan-out family as #393.
- Naming-policy conformance can't be pushed into SQL as a pure aggregate the way #393's grouped `COUNT`s were (matching a caller-configured regex isn't a database concern), so the fix here is narrower: fetch every project's live secret names in **one** bounded query (new `ListLiveSecretNamesByProject` storage method) and run the same `validateSecretName` regex check in memory, exactly as `SecretNameConformance` already does per-project. Only the N+1 **query** pattern is eliminated, not the in-memory regex work, which was never the bottleneck.
- `ListLiveSecretNamesByProject` is capped at `deploymentSecretNameConformanceMaxRows` (100000) total across all projects, mirroring the `secretInventoryMaxRows`/`secretListingMaxRows` convention this feature family already uses; the report now carries a `Truncated` flag so hitting the cap is signaled rather than silently dropping rows.
- New storage method added to the `Storage` interface, implemented on `LocalStorage` (a real single GORM query, ordered by project then name) and `RemoteStorage` (unsupported, matching this feature's existing local-only convention).

Conformance-checking logic (what counts as a violation) is unchanged — this is a data-fetching refactor only.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./internal/core/... ./internal/storage/...` — 0 issues
- [x] `golangci-lint run ./internal/core/... ./internal/storage/...` — 0 issues
- [x] New regression test `TestDeploymentSecretNameConformance_QueryCostDoesNotScaleWithProjectCount` (GORM query-counting callback, mirrors the #393 fix's test) proves the scan's total query count is the same whether the deployment has 5 or 50 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)