### PR TITLE
fix(catalog): cascade-revoke project secret shares on project delete (#119)

### DIFF
--- a/internal/core/catalog_delete_project_test.go
+++ b/internal/core/catalog_delete_project_test.go
@@ -130,7 +130,7 @@ func TestDeleteProject_ForceSkipsGuardButStaysTransactional(t *testing.T) {
 func TestDeleteProject_RealStorage_RejectsWhenSecretsExist(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}))
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
 
@@ -149,7 +149,7 @@ func TestDeleteProject_RealStorage_RejectsWhenSecretsExist(t *testing.T) {
 func TestDeleteProject_RealStorage_EmptyProjectSucceeds(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}))
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
 
@@ -165,7 +165,7 @@ func TestDeleteProject_RealStorage_EmptyProjectSucceeds(t *testing.T) {
 func TestDeleteProject_RealStorage_ForceCascadesOverSecrets(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}))
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
 
@@ -188,7 +188,7 @@ func TestDeleteProject_RealStorage_ForceCascadesOverSecrets(t *testing.T) {
 func TestDeleteProject_RealStorage_DisablesDynamicSecretConfigsAndRevokesLeases(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}, &models.Role{}, &models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}, &models.AuditEvent{}, &models.Role{}, &models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
 
 	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
 	require.NoError(t, enc.Initialize("test-passphrase"))

--- a/internal/core/restore_admin_ceiling_test.go
+++ b/internal/core/restore_admin_ceiling_test.go
@@ -28,7 +28,7 @@ func newRestoreCeilingCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.Project{}, &models.Environment{}, &models.AuditEvent{},
-		&models.SecretNode{}, &models.SecretVersion{},
+		&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{},
 		&models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
 	))
 	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -168,6 +168,36 @@ func (ls *LocalStorage) DeleteProject(ctx context.Context, id uint) error {
 			Where("project_id = ?", id).Update("deleted_at", deletedAt).Error; err != nil {
 			return fmt.Errorf("failed to soft-delete project secrets: %w", err)
 		}
+		// Revoke every still-active share for every secret in this project (#119
+		// residual): the bulk update above is a raw UPDATE on secret_nodes, unlike
+		// DeleteSecret's per-secret path, which also revokes that secret's ShareRecord
+		// rows (#370) — so a project-cascade delete used to skip that step entirely,
+		// leaving shares for the project's secrets live. Left alone, a share would
+		// silently reactivate (via CheckSharePermission) the instant the project (and
+		// its secrets) is later restored, with zero re-authorization — exactly the
+		// hazard #370 closed for a single secret delete. The subquery is raw SQL,
+		// deliberately bypassing GORM's default deleted_at IS NULL scope on
+		// SecretNode, so it also reaches the secrets just soft-deleted above. Mirrors
+		// #370: like RestoreSecret, RestoreProject does NOT bring these shares back —
+		// "delete means gone" for sharing, whether the secret was deleted directly or
+		// via a project cascade.
+		if err := tx.Where("secret_id IN (SELECT id FROM secret_nodes WHERE project_id = ?) AND deleted_at IS NULL", id).
+			Delete(&models.ShareRecord{}).Error; err != nil {
+			return fmt.Errorf("failed to revoke project secret shares: %w", err)
+		}
+		// UserRole/GroupRole grants scoped to this project are deliberately left
+		// untouched here, unlike ShareRecord above. Both are plain composite-primary-key
+		// join rows (UserID/GroupID, RoleID, ProjectID, EnvironmentID) with no DeletedAt
+		// column of their own — soft-deleting them isn't possible without a schema
+		// migration that also reworks their primary key (a soft-deleted grant would
+		// collide with a later re-grant of the identical scope under today's PK), and
+		// RestoreProject's design (see requireAuthorityToReinstateProjectRoles / #161)
+		// depends on these rows surviving the soft-delete window unchanged so a restore
+		// fully reinstates the project's prior grants, gated by the actor's own
+		// authority. PurgeDeletedProjectsBefore already hard-deletes them once the
+		// project passes its retention window and can no longer be restored — the same
+		// cascade, just necessarily deferred until undo is off the table.
+		//
 		// Soft-delete all currently-live environments in the project.
 		if err := tx.Model(&models.Environment{}).
 			Where("project_id = ?", id).Update("deleted_at", deletedAt).Error; err != nil {

--- a/internal/storage/store/local_sharing_test.go
+++ b/internal/storage/store/local_sharing_test.go
@@ -169,6 +169,88 @@ func TestDeleteSecret_RevokesActiveShares(t *testing.T) {
 	assert.Equal(t, "", perm)
 }
 
+// #119 residual: DeleteProject's secret cascade is a raw bulk UPDATE on secret_nodes,
+// unlike DeleteSecret's per-secret path — before the fix it never revoked each
+// project secret's ShareRecord rows, leaving them live even though the project (and its
+// secrets) had just been deleted. Mirrors TestDeleteSecret_RevokesActiveShares, but
+// through the project-delete cascade instead of a single secret delete, and additionally
+// confirms RestoreProject does not silently reinstate the revoked share — "delete means
+// gone" for sharing, whether the secret went via a direct delete or a project cascade.
+func TestDeleteProject_RevokesActiveSharesForProjectSecrets(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.DynamicSecretConfig{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "grantee", Email: "g@x.io"}).Error)
+	proj, err := ls.CreateProject(ctx, &models.Project{Name: "app"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: proj.ID})
+	require.NoError(t, err)
+	sec, err := ls.CreateSecret(ctx, &models.SecretNode{
+		ProjectID: proj.ID, EnvironmentID: env.ID, Name: "db-pw", IsSecret: true, Type: "text",
+		Status: "active", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	share, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: sec.ID, RecipientID: 2, IsGroup: false, OwnerID: 1, Permission: "read",
+	})
+	require.NoError(t, err)
+
+	// Sanity: the grantee has access before the project delete.
+	perm, err := ls.CheckSharePermission(ctx, sec.ID, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "read", perm)
+
+	// Delete the whole project (not the secret directly) — the cascade path this test
+	// pins, as distinct from TestDeleteSecret_RevokesActiveShares above.
+	require.NoError(t, ls.DeleteProject(ctx, proj.ID))
+
+	var deletedShare models.ShareRecord
+	require.NoError(t, db.Unscoped().First(&deletedShare, share.ID).Error)
+	assert.True(t, deletedShare.DeletedAt.Valid,
+		"the share must be revoked (soft-deleted) when the project holding its secret is deleted")
+
+	// Restoring the project brings the secret back, but must NOT resurrect the share
+	// that the project's delete cascade already revoked.
+	_, restoredSecrets, err := ls.RestoreProject(ctx, proj.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, restoredSecrets, "the project restore must bring the secret back")
+
+	perm, err = ls.CheckSharePermission(ctx, sec.ID, 2)
+	require.Error(t, err, "a share revoked by project delete must not resurrect when the project is restored")
+	assert.Equal(t, "", perm)
+}
+
+// TestDeleteProject_LeavesRoleGrantsUntouched pins the DeleteProject side of the #119
+// residual: UserRole/GroupRole (unlike ShareRecord) have no DeletedAt column of their
+// own and cannot be soft-deleted without a schema change to their composite primary
+// key, and RestoreProject's existing role-reinstatement design (#161,
+// requireAuthorityToReinstateProjectRoles) depends on these rows surviving the
+// soft-delete window unchanged. They are cleaned up permanently, instead, once the
+// project passes its retention window and is no longer restorable
+// (PurgeDeletedProjectsBefore, see TestPurgeDeletedProjectsBefore_CascadesRoleGrants).
+func TestDeleteProject_LeavesRoleGrantsUntouched(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.UserRole{}, &models.GroupRole{}, &models.DynamicSecretConfig{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	proj, err := ls.CreateProject(ctx, &models.Project{Name: "app"})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: proj.ID}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 1, ProjectID: proj.ID}).Error)
+
+	require.NoError(t, ls.DeleteProject(ctx, proj.ID))
+
+	var userRoleCount, groupRoleCount int64
+	require.NoError(t, db.Model(&models.UserRole{}).Where("project_id = ?", proj.ID).Count(&userRoleCount).Error)
+	assert.Equal(t, int64(1), userRoleCount, "UserRole grants must survive a project soft-delete so restore can reinstate them")
+	require.NoError(t, db.Model(&models.GroupRole{}).Where("project_id = ?", proj.ID).Count(&groupRoleCount).Error)
+	assert.Equal(t, int64(1), groupRoleCount, "GroupRole grants must survive a project soft-delete so restore can reinstate them")
+}
+
 // #136: CheckSharePermission's OwnerID==userID check must not match when both are the
 // zero value. A machine actor's ID is also 0, so an unguarded equality would grant it
 // owner-level "write" on every ownerless (machine-created) secret.

--- a/server/http/restore_route_authz_test.go
+++ b/server/http/restore_route_authz_test.go
@@ -107,7 +107,7 @@ func TestRestoreProjectAndEnvironmentRoutesRequireRolesAssign(t *testing.T) {
 		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.AuditEvent{}, &models.Session{}, &models.Project{}, &models.Environment{},
-		&models.SecretNode{}, &models.SecretVersion{},
+		&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{},
 		&models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
 	))
 	now := time.Now()


### PR DESCRIPTION
## Summary

Closes the still-open residual of backlog finding #119 (LOW): `DeleteProject` (`internal/core/catalog.go`, `internal/storage/store/local_secrets.go`) had no cascade cleanup of project-scoped `share_records` rows.

### What was actually happening

`DeleteProject`'s secret cascade is a raw bulk `UPDATE secret_nodes SET deleted_at = ...`, unlike `DeleteSecret`'s per-secret path, which also revokes that secret's `ShareRecord` rows (#370). The project-cascade path skipped this step entirely, so a share for a secret that lived in a deleted project stayed fully active — and would silently reactivate (via `CheckSharePermission`) the instant the project was later restored, with zero re-authorization step. This is exactly the hazard #370 closed for a direct single-secret delete, just missing on the project-cascade path.

### Fix

`DeleteProject` now also soft-deletes every still-active `ShareRecord` for every secret in the project, in the same transaction as the secrets/environments/project soft-delete. Mirroring `RestoreSecret`'s existing "delete means gone" behavior for sharing, `RestoreProject` deliberately does **not** bring these shares back — restoring a project resurrects its secrets/environments, but a share revoked by the delete stays revoked.

### `UserRole`/`GroupRole` — investigated, deliberately left untouched

The backlog note also called out `user_roles` as orphaned. After reading the schema and the existing restore design, cascading these the same way would be wrong:

- `UserRole`/`GroupRole` have **no `DeletedAt` column** — they're plain composite-primary-key join rows (`UserID/GroupID, RoleID, ProjectID, EnvironmentID`), so a soft-delete cascade for them isn't possible without a schema migration that also reworks the primary key (a soft-deleted grant would collide with a later re-grant of the identical scope).
- `RestoreProject`'s existing design (`requireAuthorityToReinstateProjectRoles`, #161) explicitly depends on these rows surviving the soft-delete window **unchanged**, so a restore fully reinstates the project's prior grants, gated by the actor's own authority ceiling check. Hard-deleting them at `DeleteProject` time (mirroring the purge cascade, just moved earlier) would silently defeat that restore-reinstatement contract — a regression, not a fix.
- `PurgeDeletedProjectsBefore` already hard-deletes these rows once the project passes its retention window and is no longer restorable — the same cleanup, just correctly deferred until undo is off the table.

A regression test (`TestDeleteProject_LeavesRoleGrantsUntouched`) pins this as intentional so it isn't mistaken for a gap again.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/... -count=1`
- [x] `go test ./... -count=1` (full repo, including a few unrelated test files whose `AutoMigrate` lists needed `models.ShareRecord{}` added now that `DeleteProject` touches that table)
- [x] `gosec -severity medium -exclude-generated ./internal/core/... ./internal/storage/...` — 0 issues
- [x] New tests: `TestDeleteProject_RevokesActiveSharesForProjectSecrets` (share revoked on project delete, confirmed NOT to resurrect on `RestoreProject`) and `TestDeleteProject_LeavesRoleGrantsUntouched` (role grants intentionally survive)
- [x] Verified the new share-revoke test actually catches the regression (fails without the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)