### PR TITLE
fix(encryption): add rotate --dry-run and full sweep-result reporting (#425)

### DIFF
--- a/internal/cli/encryption/encryption.go
+++ b/internal/cli/encryption/encryption.go
@@ -54,7 +54,10 @@ var rotateCmd = &cobra.Command{
 the database within a single transaction (ADR-010).
 
 This is a write-locking operation. Stop write traffic to the database before
-running. Requires --confirm.`,
+running. Requires --confirm.
+
+Pass --dry-run to preview which tables/rows a rotation would re-encrypt WITHOUT
+making any changes to the database or the DEK — no --confirm needed for a dry run.`,
 	RunE: runRotate,
 }
 
@@ -75,6 +78,7 @@ for the duration of the sweep (typically brief; they are not high-row-count tabl
 }
 
 var rotateConfirm bool
+var rotateDryRun bool
 
 func init() {
 	EncryptionCmd.AddCommand(initCmd)
@@ -93,6 +97,8 @@ func init() {
 
 	rotateCmd.Flags().BoolVar(&rotateConfirm, "confirm", false,
 		"required acknowledgement that the database will be write-locked during the sweep")
+	rotateCmd.Flags().BoolVar(&rotateDryRun, "dry-run", false,
+		"preview which tables/rows a rotation would re-encrypt, without making any changes to the database or the DEK (does not require --confirm)")
 }
 
 var validateCmd = &cobra.Command{
@@ -216,20 +222,24 @@ func runRotate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return rotateWithConfig(cfg, rotateConfirm)
+	return rotateWithConfig(cfg, rotateConfirm, rotateDryRun)
 }
 
 // rotateWithConfig is the testable core of runRotate. It does no config loading
-// and no flag parsing — callers pass an explicit confirm bool. Returns early
+// and no flag parsing — callers pass explicit confirm/dryRun bools. Returns early
 // (before any DB or encryption work) on the validation gates so tests don't
 // need a real database or key files.
-func rotateWithConfig(cfg *config.Config, confirm bool) error {
+func rotateWithConfig(cfg *config.Config, confirm bool, dryRun bool) error {
 	if !cfg.Storage.Encryption.Enabled {
 		return fmt.Errorf("encryption is disabled in configuration")
 	}
 
 	if cfg.Storage.Type == "remote" {
 		return fmt.Errorf("DEK rotation must run on the server host. Current storage type is 'remote' — connect to the server and run this command there")
+	}
+
+	if dryRun {
+		return dryRunRotation(cfg)
 	}
 
 	if !confirm {
@@ -263,13 +273,66 @@ func rotateWithConfig(cfg *config.Config, confirm bool) error {
 	defer closeDB(db)
 
 	fmt.Println("🔄 Rotating DEK with full re-encryption sweep...")
-	if err := service.RotateDEKWithSweep(passphrase, db); err != nil {
+	result, err := service.RotateDEKWithSweep(passphrase, db)
+	if err != nil {
 		return fmt.Errorf("DEK rotation failed: %w", err)
 	}
 
 	fmt.Println("✅ DEK rotated successfully")
 	fmt.Printf("📋 New key version: %s\n", service.GetKeyVersion())
+	printSweepResult(result)
 	return nil
+}
+
+// dryRunRotation previews what a real "rotate" would touch — table names and row
+// counts — WITHOUT making any changes to the database or the DEK, and without
+// requiring --confirm. It uses the SAME shared-key-lock local-CLI-op pattern as
+// status/validate/fix-perms/upgrade-aad (refused only while a live server or an
+// in-progress rotation/migrate-provider holds the key directory exclusively), not
+// the exclusive lock a real rotation takes — a dry run never writes the DEK, so it
+// does not need to exclude a live server the way an actual rotation does.
+func dryRunRotation(cfg *config.Config) error {
+	baseDir, _ := os.Getwd()
+	passphrase, err := masterPassphrase(cfg)
+	if err != nil {
+		return err
+	}
+
+	service, err := initLocalKeyOpService(cfg, baseDir, passphrase, false)
+	if err != nil {
+		return err
+	}
+	defer service.Shutdown()
+
+	db, err := storage.OpenGormDB(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to open database for dry-run rotation preview: %w", err)
+	}
+	defer closeDB(db)
+
+	fmt.Println("🔍 Dry run: previewing what a DEK rotation would re-encrypt — no changes will be made to the database or the DEK...")
+	result, err := service.PreviewRotationSweep(db)
+	if err != nil {
+		return fmt.Errorf("dry-run rotation preview failed: %w", err)
+	}
+
+	fmt.Println("✅ Dry run complete — no changes were made")
+	printSweepResult(result)
+	return nil
+}
+
+// printSweepResult prints every field of a SweepResult — all 8 per-table "Swept"
+// counts plus LegacyAADUpgraded — so an operator sees the FULL sweep outcome
+// (real or previewed), not a partial one. Before this, the CLI printed no
+// per-table detail from a rotation at all, and even the underlying service log
+// line covered only 5 of these 8 fields — silently omitting mfa_secrets,
+// dynamic_secret_configs, and dynamic_secret_leases, the exact three tables
+// #422's sweep-gap fix added.
+func printSweepResult(result *encryption.SweepResult) {
+	fmt.Printf("📋 secret_versions: %d, sessions: %d, api_tokens: %d, api_clients: %d, password_resets: %d, mfa_secrets: %d, dynamic_secret_configs: %d, dynamic_secret_leases: %d (legacy AAD upgraded: %d)\n",
+		result.SecretVersionsSwept, result.SessionsSwept, result.APITokensSwept, result.APIClientsSwept,
+		result.PasswordResetsSwept, result.MFASecretsSwept, result.DynamicSecretConfigsSwept, result.DynamicSecretLeasesSwept,
+		result.LegacyAADUpgraded)
 }
 
 func runUpgradeAAD(cmd *cobra.Command, args []string) error {

--- a/internal/cli/encryption/encryption_test.go
+++ b/internal/cli/encryption/encryption_test.go
@@ -21,7 +21,7 @@ func TestRotateWithConfig_RequiresConfirm(t *testing.T) {
 		},
 	}
 
-	err := rotateWithConfig(cfg, false)
+	err := rotateWithConfig(cfg, false, false)
 	if err == nil {
 		t.Fatal("expected error when --confirm is not passed, got nil")
 	}
@@ -43,7 +43,7 @@ func TestRotateWithConfig_RejectsRemoteStorage(t *testing.T) {
 		},
 	}
 
-	err := rotateWithConfig(cfg, true)
+	err := rotateWithConfig(cfg, true, false)
 	if err == nil {
 		t.Fatal("expected error for remote storage type, got nil")
 	}
@@ -65,7 +65,7 @@ func TestRotateWithConfig_RejectsDisabledEncryption(t *testing.T) {
 		},
 	}
 
-	err := rotateWithConfig(cfg, true)
+	err := rotateWithConfig(cfg, true, false)
 	if err == nil {
 		t.Fatal("expected error when encryption is disabled, got nil")
 	}

--- a/internal/cli/encryption/rotate_dry_run_test.go
+++ b/internal/cli/encryption/rotate_dry_run_test.go
@@ -1,0 +1,342 @@
+package encryption
+
+// rotate_dry_run_test.go — regression tests for backlog #425: `keyorix encryption
+// rotate --dry-run` and the expanded post-rotation summary.
+//
+// Covers:
+//  1. TestRotateWithConfig_DryRun_AccuratePreviewNoChanges — a --dry-run reports
+//     an accurate per-table preview (one row seeded per DEK-encrypted table) and
+//     makes NO changes: the seeded ciphertext is byte-for-byte unchanged and the
+//     DEK/key version is unchanged, verified by re-initialising a fresh Service
+//     from the on-disk key material after the dry run.
+//  2. TestRotateWithConfig_DryRun_DoesNotRequireConfirm — --dry-run succeeds
+//     without --confirm (a preview isn't the irreversible operation --confirm
+//     guards).
+//  3. TestRotateWithConfig_RealRotation_PrintsAllSweepResultFields — a real
+//     (non-dry-run) rotation's printed summary now includes all 8 SweepResult
+//     "Swept" fields, not just the original 5 — closing the operator-visibility
+//     gap where mfa_secrets/dynamic_secret_configs/dynamic_secret_leases (the
+//     exact 3 tables #422's sweep-gap fix added) were silently omitted.
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	enc "github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+const dryRunTestPassphrase = "dry-run-test-passphrase-correct-horse-battery"
+
+// captureStdout redirects os.Stdout for the duration of fn and returns everything
+// written to it, so tests can assert on the operator-facing CLI output.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("io.Copy: %v", err)
+	}
+	return buf.String()
+}
+
+// seedOneRowPerTable seeds exactly one row into every one of the 8 DEK-encrypted
+// tables SweepResult tracks, each with a distinguishable plaintext, so a test can
+// assert on the per-table counts a preview or a real rotation reports.
+func seedOneRowPerTable(t *testing.T, db *gorm.DB, svc *enc.Service) {
+	t.Helper()
+
+	node := &models.SecretNode{ProjectID: 1, Name: "dry-run-node", IsSecret: true}
+	mustCreate(t, db, node)
+	aad := enc.SecretAAD(node.ID, 1, 1)
+	val, meta := mustEncryptAAD(t, svc, "dry-run-secret-value", aad)
+	mustCreate(t, db, &models.SecretVersion{SecretNodeID: node.ID, VersionNumber: 1, EncryptedValue: val, EncryptionMetadata: models.JSON(meta)})
+
+	sVal, sMeta := mustEncrypt(t, svc, "dry-run-session-token")
+	mustCreate(t, db, &models.Session{UserID: 1, SessionToken: "dry-run-session", EncryptedSessionToken: sVal, SessionTokenMetadata: models.JSON(sMeta)})
+
+	tVal, tMeta := mustEncrypt(t, svc, "dry-run-api-token")
+	mustCreate(t, db, &models.APIToken{ClientID: 1, Token: "dry-run-token", EncryptedToken: tVal, TokenMetadata: models.JSON(tMeta)})
+
+	cVal, cMeta := mustEncrypt(t, svc, "dry-run-client-secret")
+	mustCreate(t, db, &models.APIClient{Name: "dry-run-client", ClientID: "dry-run-client-id", EncryptedClientSecret: cVal, ClientSecretMetadata: models.JSON(cMeta)})
+
+	prVal, prMeta := mustEncrypt(t, svc, "dry-run-reset-token")
+	mustCreate(t, db, &models.PasswordReset{UserID: 1, Token: "dry-run-reset", EncryptedToken: prVal, TokenMetadata: models.JSON(prMeta)})
+
+	mfaVal, mfaMeta := mustEncrypt(t, svc, "dry-run-totp-seed")
+	mustCreate(t, db, &models.MFASecret{UserID: 1, SecretEnc: mfaVal, SecretMeta: mfaMeta})
+
+	dsnVal, dsnMeta := mustEncrypt(t, svc, "postgres://dry-run@db/app")
+	mustCreate(t, db, &models.DynamicSecretConfig{Name: "dry-run-pg", ProjectID: 1, EnvironmentID: 1, AdminDSNEnc: dsnVal, AdminDSNMeta: dsnMeta})
+
+	credVal, credMeta := mustEncrypt(t, svc, `{"user":"dry-run","pass":"run"}`)
+	mustCreate(t, db, &models.DynamicSecretLease{LeaseID: "dry-run-lease", ConfigID: 1, CredentialEnc: credVal, CredentialMeta: credMeta})
+}
+
+// setupDryRunTest wires a throwaway on-disk sqlite DB + key directory, seeds one
+// row per DEK-encrypted table, and returns the config plus the still-live seeding
+// Service (so the caller can decrypt seeded rows with the pre-rotation DEK).
+func setupDryRunTest(t *testing.T) (*config.Config, *enc.Service, string) {
+	t.Helper()
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	t.Setenv("KEYORIX_MASTER_PASSWORD", dryRunTestPassphrase)
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Encryption = config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "kek.salt",
+	}
+	dbPath := filepath.Join(workDir, "secrets.db")
+	cfg.Storage.Database.Path = dbPath
+
+	svc := enc.NewService(&cfg.Storage.Encryption, workDir)
+	if err := svc.Initialize(dryRunTestPassphrase); err != nil {
+		t.Fatalf("initialise encryption: %v", err)
+	}
+	t.Cleanup(svc.Shutdown)
+
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{Logger: logger.Discard})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.Session{},
+		&models.APIToken{}, &models.APIClient{}, &models.PasswordReset{},
+		&models.MFASecret{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
+	); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	seedOneRowPerTable(t, db, svc)
+	closeGorm(db)
+
+	return cfg, svc, workDir
+}
+
+// assertAllEightFieldsReported checks the CLI's printed summary surfaces every one
+// of the 8 SweepResult "Swept" fields (plus LegacyAADUpgraded) with the expected
+// count — the core regression this fix closes: previously only 5 of 8 were ever
+// logged, and the CLI printed none of them at all.
+func assertAllEightFieldsReported(t *testing.T, output string, wantCount int) {
+	t.Helper()
+	for _, field := range []string{
+		"secret_versions", "sessions", "api_tokens", "api_clients",
+		"password_resets", "mfa_secrets", "dynamic_secret_configs", "dynamic_secret_leases",
+	} {
+		if !strings.Contains(output, field) {
+			t.Errorf("expected summary output to mention %q, got:\n%s", field, output)
+		}
+	}
+	if !strings.Contains(output, "legacy AAD upgraded") {
+		t.Errorf("expected summary output to mention legacy AAD upgraded count, got:\n%s", output)
+	}
+	_ = wantCount // counts are checked precisely by the callers below via fmt.Sprintf assertions
+}
+
+// TestRotateWithConfig_DryRun_AccuratePreviewNoChanges is the core --dry-run
+// regression: the preview must report the correct row count for every table AND
+// must not change a single byte of ciphertext or rotate the DEK.
+func TestRotateWithConfig_DryRun_AccuratePreviewNoChanges(t *testing.T) {
+	cfg, seedSvc, workDir := setupDryRunTest(t)
+
+	preRotateKeyVersion := seedSvc.GetKeyVersion()
+
+	// Snapshot every seeded row's raw ciphertext before the dry run.
+	dbBefore, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{Logger: logger.Discard})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	var (
+		verBefore   models.SecretVersion
+		sessBefore  models.Session
+		tokBefore   models.APIToken
+		cliBefore   models.APIClient
+		rstBefore   models.PasswordReset
+		mfaBefore   models.MFASecret
+		dsnBefore   models.DynamicSecretConfig
+		leaseBefore models.DynamicSecretLease
+	)
+	mustFirst(t, dbBefore, &verBefore, 1)
+	mustFirst(t, dbBefore, &sessBefore, 1)
+	mustFirst(t, dbBefore, &tokBefore, 1)
+	mustFirst(t, dbBefore, &cliBefore, 1)
+	mustFirst(t, dbBefore, &rstBefore, 1)
+	mustFirst(t, dbBefore, &mfaBefore, 1)
+	mustFirst(t, dbBefore, &dsnBefore, 1)
+	mustFirst(t, dbBefore, &leaseBefore, 1)
+	closeGorm(dbBefore)
+
+	var rotErr error
+	output := captureStdout(t, func() {
+		// confirm=false, dryRun=true: a dry run must succeed WITHOUT --confirm.
+		rotErr = rotateWithConfig(cfg, false, true)
+	})
+	if rotErr != nil {
+		t.Fatalf("dry-run rotateWithConfig failed: %v", rotErr)
+	}
+
+	if !strings.Contains(output, "Dry run") {
+		t.Errorf("expected dry-run output to announce itself as a dry run, got:\n%s", output)
+	}
+	for _, want := range []string{
+		"secret_versions: 1", "sessions: 1", "api_tokens: 1", "api_clients: 1",
+		"password_resets: 1", "mfa_secrets: 1", "dynamic_secret_configs: 1",
+		// seedOneRowPerTable encrypts the mfa_secrets/dynamic_secret_configs/
+		// dynamic_secret_leases rows via the legacy (no-AAD) path — those 3
+		// sweepers always reconstruct AAD and upgrade a legacy row in place, so 3
+		// legacy upgrades are expected (secret_versions was seeded already
+		// AAD-bound, and the other 4 tables have no AAD binding to upgrade to).
+		"dynamic_secret_leases: 1", "legacy AAD upgraded: 3",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected dry-run preview to report %q, got:\n%s", want, output)
+		}
+	}
+
+	// No pending-DEK or promoted-DEK-related file activity: a dry run must never
+	// touch the key directory at all.
+	if _, err := os.Stat(filepath.Join(workDir, "dek.key.pending")); !os.IsNotExist(err) {
+		t.Errorf("dry run must not create a pending DEK file (stat err: %v)", err)
+	}
+
+	// The DEK/key version must be completely unchanged: re-initialise a FRESH
+	// Service straight from the on-disk key material and confirm it reports the
+	// exact same key version the pre-dry-run Service had.
+	freshSvc := enc.NewService(&cfg.Storage.Encryption, workDir)
+	if err := freshSvc.Initialize(dryRunTestPassphrase); err != nil {
+		t.Fatalf("re-initialise from on-disk key after dry run: %v", err)
+	}
+	defer freshSvc.Shutdown()
+	if got := freshSvc.GetKeyVersion(); got != preRotateKeyVersion {
+		t.Errorf("DEK/key version changed by a --dry-run: before=%q after=%q", preRotateKeyVersion, got)
+	}
+
+	// Every seeded row's ciphertext must be byte-for-byte unchanged.
+	dbAfter, err := gorm.Open(sqlite.Open(cfg.Storage.Database.Path), &gorm.Config{Logger: logger.Discard})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer closeGorm(dbAfter)
+
+	var verAfter models.SecretVersion
+	mustFirst(t, dbAfter, &verAfter, 1)
+	if !bytes.Equal(verBefore.EncryptedValue, verAfter.EncryptedValue) {
+		t.Error("secret_versions ciphertext changed by a --dry-run")
+	}
+	var sessAfter models.Session
+	mustFirst(t, dbAfter, &sessAfter, 1)
+	if !bytes.Equal(sessBefore.EncryptedSessionToken, sessAfter.EncryptedSessionToken) {
+		t.Error("sessions ciphertext changed by a --dry-run")
+	}
+	var tokAfter models.APIToken
+	mustFirst(t, dbAfter, &tokAfter, 1)
+	if !bytes.Equal(tokBefore.EncryptedToken, tokAfter.EncryptedToken) {
+		t.Error("api_tokens ciphertext changed by a --dry-run")
+	}
+	var cliAfter models.APIClient
+	mustFirst(t, dbAfter, &cliAfter, 1)
+	if !bytes.Equal(cliBefore.EncryptedClientSecret, cliAfter.EncryptedClientSecret) {
+		t.Error("api_clients ciphertext changed by a --dry-run")
+	}
+	var rstAfter models.PasswordReset
+	mustFirst(t, dbAfter, &rstAfter, 1)
+	if !bytes.Equal(rstBefore.EncryptedToken, rstAfter.EncryptedToken) {
+		t.Error("password_resets ciphertext changed by a --dry-run")
+	}
+	var mfaAfter models.MFASecret
+	mustFirst(t, dbAfter, &mfaAfter, 1)
+	if !bytes.Equal(mfaBefore.SecretEnc, mfaAfter.SecretEnc) {
+		t.Error("mfa_secrets ciphertext changed by a --dry-run")
+	}
+	var dsnAfter models.DynamicSecretConfig
+	mustFirst(t, dbAfter, &dsnAfter, 1)
+	if !bytes.Equal(dsnBefore.AdminDSNEnc, dsnAfter.AdminDSNEnc) {
+		t.Error("dynamic_secret_configs ciphertext changed by a --dry-run")
+	}
+	var leaseAfter models.DynamicSecretLease
+	mustFirst(t, dbAfter, &leaseAfter, 1)
+	if !bytes.Equal(leaseBefore.CredentialEnc, leaseAfter.CredentialEnc) {
+		t.Error("dynamic_secret_leases ciphertext changed by a --dry-run")
+	}
+
+	// The seeded ciphertext must still decrypt under the ORIGINAL (never-rotated)
+	// DEK — the strongest possible proof nothing was re-encrypted.
+	aad := enc.SecretAAD(1, 1, 1)
+	if pt, err := seedSvc.DecryptSecretWithAAD(verAfter.EncryptedValue, aad); err != nil {
+		t.Errorf("seeded secret no longer decrypts under the original DEK after a dry run: %v", err)
+	} else if string(pt) != "dry-run-secret-value" {
+		t.Errorf("unexpected plaintext after dry run: %q", pt)
+	}
+}
+
+// TestRotateWithConfig_DryRun_DoesNotRequireConfirm proves --dry-run does not
+// need --confirm: unlike a real rotation, previewing what would happen is not the
+// irreversible operation --confirm guards.
+func TestRotateWithConfig_DryRun_DoesNotRequireConfirm(t *testing.T) {
+	cfg, _, _ := setupDryRunTest(t)
+
+	var rotErr error
+	_ = captureStdout(t, func() {
+		rotErr = rotateWithConfig(cfg, false, true)
+	})
+	if rotErr != nil {
+		t.Fatalf("dry-run should succeed without --confirm, got: %v", rotErr)
+	}
+}
+
+// TestRotateWithConfig_RealRotation_PrintsAllSweepResultFields proves the
+// post-rotation summary a REAL rotation prints now surfaces all 8 SweepResult
+// "Swept" fields (plus LegacyAADUpgraded) — not just the original 5, which
+// silently omitted mfa_secrets, dynamic_secret_configs, and
+// dynamic_secret_leases (the exact 3 tables #422's own sweep-gap fix added).
+func TestRotateWithConfig_RealRotation_PrintsAllSweepResultFields(t *testing.T) {
+	cfg, _, _ := setupDryRunTest(t)
+
+	var rotErr error
+	output := captureStdout(t, func() {
+		rotErr = rotateWithConfig(cfg, true, false)
+	})
+	if rotErr != nil {
+		t.Fatalf("real rotation failed: %v", rotErr)
+	}
+
+	if !strings.Contains(output, "DEK rotated successfully") {
+		t.Errorf("expected the usual real-rotation success message, got:\n%s", output)
+	}
+	for _, want := range []string{
+		"secret_versions: 1", "sessions: 1", "api_tokens: 1", "api_clients: 1",
+		"password_resets: 1", "mfa_secrets: 1", "dynamic_secret_configs: 1",
+		// seedOneRowPerTable encrypts the mfa_secrets/dynamic_secret_configs/
+		// dynamic_secret_leases rows via the legacy (no-AAD) path — those 3
+		// sweepers always reconstruct AAD and upgrade a legacy row in place, so 3
+		// legacy upgrades are expected (secret_versions was seeded already
+		// AAD-bound, and the other 4 tables have no AAD binding to upgrade to).
+		"dynamic_secret_leases: 1", "legacy AAD upgraded: 3",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected post-rotation summary to report %q, got:\n%s", want, output)
+		}
+	}
+	assertAllEightFieldsReported(t, output, 1)
+}

--- a/internal/cli/encryption/rotate_e2e_test.go
+++ b/internal/cli/encryption/rotate_e2e_test.go
@@ -162,7 +162,7 @@ func runRotationE2E(t *testing.T, kind string) {
 	}
 
 	// 4. Rotate through the real CLI entry point.
-	if err := rotateWithConfig(cfg, true); err != nil {
+	if err := rotateWithConfig(cfg, true, false); err != nil {
 		t.Fatalf("rotateWithConfig: %v", err)
 	}
 

--- a/internal/encryption/auth_encryption_rotate.go
+++ b/internal/encryption/auth_encryption_rotate.go
@@ -22,7 +22,7 @@ func (ae *AuthEncryption) RotateAuthEncryption(passphrase string) error {
 	if !ae.service.IsEnabled() {
 		return fmt.Errorf("encryption is disabled")
 	}
-	if err := ae.service.RotateDEKWithSweep(passphrase, ae.db); err != nil {
+	if _, err := ae.service.RotateDEKWithSweep(passphrase, ae.db); err != nil {
 		return fmt.Errorf("failed to rotate auth encryption keys: %w", err)
 	}
 	return nil

--- a/internal/encryption/exclusive_lock_test.go
+++ b/internal/encryption/exclusive_lock_test.go
@@ -42,7 +42,7 @@ func TestRotateDEKWithSweep_RefusesWhileServerHoldsLock(t *testing.T) {
 	rotSvc := newTestServiceAtDir(t, dir, lockTestPassphrase)
 	defer rotSvc.Shutdown()
 
-	err := rotSvc.RotateDEKWithSweep(lockTestPassphrase, db)
+	_, err := rotSvc.RotateDEKWithSweep(lockTestPassphrase, db)
 	if err == nil {
 		t.Fatal("expected rotation to be refused while the server holds the key lock")
 	}
@@ -64,7 +64,7 @@ func TestRotateDEKWithSweep_SucceedsAfterServerLockReleased(t *testing.T) {
 	rotSvc := newTestServiceAtDir(t, dir, lockTestPassphrase)
 	defer rotSvc.Shutdown()
 
-	if err := rotSvc.RotateDEKWithSweep(lockTestPassphrase, db); err != nil {
+	if _, err := rotSvc.RotateDEKWithSweep(lockTestPassphrase, db); err != nil {
 		t.Fatalf("rotation should succeed once the server's lock is released: %v", err)
 	}
 }

--- a/internal/encryption/keymanager_lock_test.go
+++ b/internal/encryption/keymanager_lock_test.go
@@ -123,7 +123,7 @@ func TestRewrapAndRotate_ConcurrentRace_FinalDEKMatchesDB(t *testing.T) {
 	var rotateErr, rewrapErr error
 	go func() {
 		defer wg.Done()
-		rotateErr = svcA.RotateDEKWithSweep("test-passphrase", db)
+		_, rotateErr = svcA.RotateDEKWithSweep("test-passphrase", db)
 	}()
 	go func() {
 		defer wg.Done()

--- a/internal/encryption/service_rotation.go
+++ b/internal/encryption/service_rotation.go
@@ -19,11 +19,14 @@ import (
 // The DB transaction is owned here: committed on sweep success, rolled back on
 // any failure. The old DEK remains active if anything fails. This is a
 // write-locking operation — avoid accepting write traffic during the sweep.
-func (s *Service) RotateDEKWithSweep(passphrase string, db *gorm.DB) error {
+//
+// Returns the completed SweepResult so callers (the rotate CLI) can report every
+// field of it to the operator, not just the subset logged below.
+func (s *Service) RotateDEKWithSweep(passphrase string, db *gorm.DB) (*SweepResult, error) {
 	s.mu.RLock()
 	if !s.initialized {
 		s.mu.RUnlock()
-		return fmt.Errorf("encryption service not initialized")
+		return nil, fmt.Errorf("encryption service not initialized")
 	}
 	s.mu.RUnlock()
 
@@ -34,9 +37,10 @@ func (s *Service) RotateDEKWithSweep(passphrase string, db *gorm.DB) error {
 	// or never happens. AcquireExclusiveKeyLock is released by the deferred
 	// Shutdown() the CLI already calls after this function returns.
 	if err := s.AcquireExclusiveKeyLock(); err != nil {
-		return fmt.Errorf("refusing to rotate: %w — stop the running server before rotating", err)
+		return nil, fmt.Errorf("refusing to rotate: %w — stop the running server before rotating", err)
 	}
 
+	var sweepResult *SweepResult
 	sweepFn := func(oldSvc, newSvc *EncryptionService, newKeyVersion string) error {
 		tx := db.Begin()
 		if tx.Error != nil {
@@ -48,7 +52,7 @@ func (s *Service) RotateDEKWithSweep(passphrase string, db *gorm.DB) error {
 			}
 		}()
 
-		result, err := SweepAllTables(tx, oldSvc, newSvc, newKeyVersion)
+		result, err := SweepAllTables(tx, oldSvc, newSvc, newKeyVersion, false)
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("sweep failed: %w", err)
@@ -57,14 +61,22 @@ func (s *Service) RotateDEKWithSweep(passphrase string, db *gorm.DB) error {
 			return fmt.Errorf("failed to commit sweep transaction: %w", err)
 		}
 
-		log.Printf("✅ Sweep committed: %d secret_versions, %d sessions, %d api_tokens, %d api_clients, %d password_resets re-encrypted (%d legacy AAD upgraded)",
+		// Log (and, via the returned SweepResult, report to the CLI operator) every
+		// field of the result — not just the original 5 of 8 "Swept" counts. The 3
+		// previously-omitted fields here (mfa_secrets, dynamic_secret_configs,
+		// dynamic_secret_leases) are exactly the tables #422's sweep-gap fix added;
+		// silently under-reporting them left an operator with no visibility into
+		// whether that fix's own sweeps ran, even after the data itself was safe.
+		log.Printf("✅ Sweep committed: %d secret_versions, %d sessions, %d api_tokens, %d api_clients, %d password_resets, %d mfa_secrets, %d dynamic_secret_configs, %d dynamic_secret_leases re-encrypted (%d legacy AAD upgraded)",
 			result.SecretVersionsSwept, result.SessionsSwept, result.APITokensSwept,
-			result.APIClientsSwept, result.PasswordResetsSwept, result.LegacyAADUpgraded)
+			result.APIClientsSwept, result.PasswordResetsSwept, result.MFASecretsSwept,
+			result.DynamicSecretConfigsSwept, result.DynamicSecretLeasesSwept, result.LegacyAADUpgraded)
+		sweepResult = result
 		return nil
 	}
 
 	if err := s.keyManager.RotateDEKWithSweep(passphrase, sweepFn); err != nil {
-		return fmt.Errorf("DEK rotation with sweep failed: %w", err)
+		return nil, fmt.Errorf("DEK rotation with sweep failed: %w", err)
 	}
 
 	s.mu.Lock()
@@ -72,10 +84,51 @@ func (s *Service) RotateDEKWithSweep(passphrase string, db *gorm.DB) error {
 	dek := s.keyManager.GetDEK()
 	encSvc, err := NewEncryptionService(dek)
 	if err != nil {
-		return fmt.Errorf("failed to recreate encryption service after rotation: %w", err)
+		return nil, fmt.Errorf("failed to recreate encryption service after rotation: %w", err)
 	}
 	s.encryptionService = encSvc
-	return nil
+	return sweepResult, nil
+}
+
+// PreviewRotationSweep performs a READ-ONLY dry run of the same table/row
+// traversal RotateDEKWithSweep's sweep uses, so an operator can see exactly what a
+// real rotation would touch — table names and row counts — before committing to
+// that write-locking, irreversible operation.
+//
+// It makes NO changes whatsoever: the current encryption service is used as BOTH
+// oldSvc and newSvc (no new DEK is generated, nothing is written to the key
+// directory), SweepAllTables is invoked with dryRun=true (which skips every
+// per-row Updates() write while still performing every SELECT/decrypt/re-encrypt/
+// count step, so the preview is accurate and would surface a row that couldn't be
+// decrypted), and the wrapping transaction is unconditionally rolled back —
+// never committed — regardless of outcome.
+func (s *Service) PreviewRotationSweep(db *gorm.DB) (*SweepResult, error) {
+	s.mu.RLock()
+	if !s.initialized {
+		s.mu.RUnlock()
+		return nil, fmt.Errorf("encryption service not initialized")
+	}
+	svc := s.encryptionService
+	keyVersion := s.keyManager.GetKeyVersion()
+	s.mu.RUnlock()
+
+	tx := db.Begin()
+	if tx.Error != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", tx.Error)
+	}
+	// Always rolled back — a dry run must never persist anything, no matter what.
+	defer tx.Rollback()
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+		}
+	}()
+
+	result, err := SweepAllTables(tx, svc, svc, keyVersion, true)
+	if err != nil {
+		return nil, fmt.Errorf("dry-run sweep preview failed: %w", err)
+	}
+	return result, nil
 }
 
 // UpgradeAuthAAD re-encrypts every legacy (pre-#94), no-AAD row in the AAD-bound auth
@@ -113,7 +166,7 @@ func (s *Service) UpgradeAuthAAD(db *gorm.DB) (*SweepResult, error) {
 	}()
 
 	result := &SweepResult{}
-	sweptMFA, legacyMFA, err := sweepMFASecrets(tx, svc, svc, keyVersion)
+	sweptMFA, legacyMFA, err := sweepMFASecrets(tx, svc, svc, keyVersion, false)
 	if err != nil {
 		tx.Rollback()
 		return nil, fmt.Errorf("mfa_secrets AAD upgrade failed: %w", err)
@@ -121,7 +174,7 @@ func (s *Service) UpgradeAuthAAD(db *gorm.DB) (*SweepResult, error) {
 	result.MFASecretsSwept = sweptMFA
 	result.LegacyAADUpgraded += legacyMFA
 
-	sweptDynConfigs, legacyDynConfigs, err := sweepDynamicSecretConfigs(tx, svc, svc, keyVersion)
+	sweptDynConfigs, legacyDynConfigs, err := sweepDynamicSecretConfigs(tx, svc, svc, keyVersion, false)
 	if err != nil {
 		tx.Rollback()
 		return nil, fmt.Errorf("dynamic_secret_configs AAD upgrade failed: %w", err)
@@ -129,7 +182,7 @@ func (s *Service) UpgradeAuthAAD(db *gorm.DB) (*SweepResult, error) {
 	result.DynamicSecretConfigsSwept = sweptDynConfigs
 	result.LegacyAADUpgraded += legacyDynConfigs
 
-	sweptDynLeases, legacyDynLeases, err := sweepDynamicSecretLeases(tx, svc, svc, keyVersion)
+	sweptDynLeases, legacyDynLeases, err := sweepDynamicSecretLeases(tx, svc, svc, keyVersion, false)
 	if err != nil {
 		tx.Rollback()
 		return nil, fmt.Errorf("dynamic_secret_leases AAD upgrade failed: %w", err)

--- a/internal/encryption/sweep.go
+++ b/internal/encryption/sweep.go
@@ -39,35 +39,42 @@ type SweepResult struct {
 
 // SweepAllTables re-encrypts every DEK-encrypted row within a single DB transaction.
 // oldSvc decrypts; newSvc re-encrypts. Called while both DEK services are live in memory.
-func SweepAllTables(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (*SweepResult, error) {
+//
+// dryRun gates ONLY the final per-row write (tx.Model(...).Updates(...)) in each
+// sweeper: every SELECT, decrypt, re-encrypt, and count still runs exactly as a real
+// sweep would, so the returned SweepResult is an accurate preview of what a real
+// rotation would touch (including catching any row that would fail to decrypt), but
+// nothing here is ever persisted — the caller is expected to always roll back the
+// transaction when dryRun is true (see Service.PreviewRotationSweep).
+func SweepAllTables(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string, dryRun bool) (*SweepResult, error) {
 	result := &SweepResult{}
 
-	sweptVersions, legacyUpgraded, err := sweepSecretVersions(tx, oldSvc, newSvc, newKeyVersion)
+	sweptVersions, legacyUpgraded, err := sweepSecretVersions(tx, oldSvc, newSvc, newKeyVersion, dryRun)
 	if err != nil {
 		return nil, fmt.Errorf("secret_versions sweep failed: %w", err)
 	}
 	result.SecretVersionsSwept = sweptVersions
 	result.LegacyAADUpgraded = legacyUpgraded
 
-	sweptSessions, err := sweepSessions(tx, oldSvc, newSvc, newKeyVersion)
+	sweptSessions, err := sweepSessions(tx, oldSvc, newSvc, newKeyVersion, dryRun)
 	if err != nil {
 		return nil, fmt.Errorf("sessions sweep failed: %w", err)
 	}
 	result.SessionsSwept = sweptSessions
 
-	sweptAPITokens, err := sweepAPITokens(tx, oldSvc, newSvc, newKeyVersion)
+	sweptAPITokens, err := sweepAPITokens(tx, oldSvc, newSvc, newKeyVersion, dryRun)
 	if err != nil {
 		return nil, fmt.Errorf("api_tokens sweep failed: %w", err)
 	}
 	result.APITokensSwept = sweptAPITokens
 
-	sweptClients, err := sweepAPIClients(tx, oldSvc, newSvc, newKeyVersion)
+	sweptClients, err := sweepAPIClients(tx, oldSvc, newSvc, newKeyVersion, dryRun)
 	if err != nil {
 		return nil, fmt.Errorf("api_clients sweep failed: %w", err)
 	}
 	result.APIClientsSwept = sweptClients
 
-	sweptResets, err := sweepPasswordResets(tx, oldSvc, newSvc, newKeyVersion)
+	sweptResets, err := sweepPasswordResets(tx, oldSvc, newSvc, newKeyVersion, dryRun)
 	if err != nil {
 		return nil, fmt.Errorf("password_resets sweep failed: %w", err)
 	}
@@ -79,21 +86,21 @@ func SweepAllTables(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionSe
 	// MFA login and dynamic-secret access irrecoverably. They are also AAD-bound
 	// (#94) as of this fix, so — like sweepSecretVersions — each also upgrades any
 	// still-legacy (no-AAD) row it encounters, contributing to LegacyAADUpgraded.
-	sweptMFA, legacyMFA, err := sweepMFASecrets(tx, oldSvc, newSvc, newKeyVersion)
+	sweptMFA, legacyMFA, err := sweepMFASecrets(tx, oldSvc, newSvc, newKeyVersion, dryRun)
 	if err != nil {
 		return nil, fmt.Errorf("mfa_secrets sweep failed: %w", err)
 	}
 	result.MFASecretsSwept = sweptMFA
 	result.LegacyAADUpgraded += legacyMFA
 
-	sweptDynConfigs, legacyDynConfigs, err := sweepDynamicSecretConfigs(tx, oldSvc, newSvc, newKeyVersion)
+	sweptDynConfigs, legacyDynConfigs, err := sweepDynamicSecretConfigs(tx, oldSvc, newSvc, newKeyVersion, dryRun)
 	if err != nil {
 		return nil, fmt.Errorf("dynamic_secret_configs sweep failed: %w", err)
 	}
 	result.DynamicSecretConfigsSwept = sweptDynConfigs
 	result.LegacyAADUpgraded += legacyDynConfigs
 
-	sweptDynLeases, legacyDynLeases, err := sweepDynamicSecretLeases(tx, oldSvc, newSvc, newKeyVersion)
+	sweptDynLeases, legacyDynLeases, err := sweepDynamicSecretLeases(tx, oldSvc, newSvc, newKeyVersion, dryRun)
 	if err != nil {
 		return nil, fmt.Errorf("dynamic_secret_leases sweep failed: %w", err)
 	}
@@ -111,8 +118,10 @@ func SweepAllTables(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionSe
 //   - Legacy rows (no aad_version): decrypt without AAD, re-encrypt with new
 //     DEK + correct AAD (completes the M2 AAD migration).
 //
+// dryRun skips the final Updates() write only — every other step (fetch, decrypt,
+// re-encrypt, counting) still runs, so callers get an accurate preview.
 // Returns (rowsSwept, legacyRowsUpgraded, error).
-func sweepSecretVersions(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, int, error) {
+func sweepSecretVersions(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string, dryRun bool) (int, int, error) {
 	var offset int
 	var totalSwept, totalLegacyUpgraded int
 
@@ -188,11 +197,13 @@ func sweepSecretVersions(tx *gorm.DB, oldSvc *EncryptionService, newSvc *Encrypt
 				return totalSwept, totalLegacyUpgraded, fmt.Errorf("failed to marshal metadata for secret_version id=%d: %w", version.ID, err)
 			}
 
-			if err := tx.Model(&models.SecretVersion{}).Where("id = ?", version.ID).Updates(map[string]interface{}{
-				"encrypted_value":     newEncryptedBytes,
-				"encryption_metadata": models.JSON(metadataBytes),
-			}).Error; err != nil {
-				return totalSwept, totalLegacyUpgraded, fmt.Errorf("failed to update re-encrypted secret_version id=%d: %w", version.ID, err)
+			if !dryRun {
+				if err := tx.Model(&models.SecretVersion{}).Where("id = ?", version.ID).Updates(map[string]interface{}{
+					"encrypted_value":     newEncryptedBytes,
+					"encryption_metadata": models.JSON(metadataBytes),
+				}).Error; err != nil {
+					return totalSwept, totalLegacyUpgraded, fmt.Errorf("failed to update re-encrypted secret_version id=%d: %w", version.ID, err)
+				}
 			}
 
 			totalSwept++

--- a/internal/encryption/sweep_aad_binding_test.go
+++ b/internal/encryption/sweep_aad_binding_test.go
@@ -29,7 +29,8 @@ func TestRotateDEKWithSweep_PreservesAADBinding(t *testing.T) {
 	nodeID := seedSecretNode(t, db, projectID)
 	versionID := seedSecretVersion(t, db, svc, nodeID, projectID, versionNumber, "super-secret-value")
 
-	require.NoError(t, svc.RotateDEKWithSweep("test-passphrase", db))
+	_, rotErr := svc.RotateDEKWithSweep("test-passphrase", db)
+	require.NoError(t, rotErr)
 
 	var v models.SecretVersion
 	require.NoError(t, db.First(&v, versionID).Error)

--- a/internal/encryption/sweep_auth.go
+++ b/internal/encryption/sweep_auth.go
@@ -21,7 +21,8 @@ import (
 	"gorm.io/gorm"
 )
 
-func sweepSessions(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, error) {
+// dryRun skips the final Updates() write only; every other step still runs.
+func sweepSessions(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string, dryRun bool) (int, error) {
 	var sessions []models.Session
 	if err := tx.Find(&sessions).Error; err != nil {
 		return 0, fmt.Errorf("failed to fetch sessions: %w", err)
@@ -52,18 +53,21 @@ func sweepSessions(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionSer
 		if err != nil {
 			return swept, fmt.Errorf("failed to marshal session metadata id=%d: %w", session.ID, err)
 		}
-		if err := tx.Model(&models.Session{}).Where("id = ?", session.ID).Updates(map[string]interface{}{
-			"encrypted_session_token": newBytes,
-			"session_token_metadata":  models.JSON(metaBytes),
-		}).Error; err != nil {
-			return swept, fmt.Errorf("failed to update session id=%d: %w", session.ID, err)
+		if !dryRun {
+			if err := tx.Model(&models.Session{}).Where("id = ?", session.ID).Updates(map[string]interface{}{
+				"encrypted_session_token": newBytes,
+				"session_token_metadata":  models.JSON(metaBytes),
+			}).Error; err != nil {
+				return swept, fmt.Errorf("failed to update session id=%d: %w", session.ID, err)
+			}
 		}
 		swept++
 	}
 	return swept, nil
 }
 
-func sweepAPITokens(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, error) {
+// dryRun skips the final Updates() write only; every other step still runs.
+func sweepAPITokens(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string, dryRun bool) (int, error) {
 	var tokens []models.APIToken
 	if err := tx.Find(&tokens).Error; err != nil {
 		return 0, fmt.Errorf("failed to fetch api_tokens: %w", err)
@@ -94,18 +98,21 @@ func sweepAPITokens(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionSe
 		if err != nil {
 			return swept, fmt.Errorf("failed to marshal api_token metadata id=%d: %w", token.ID, err)
 		}
-		if err := tx.Model(&models.APIToken{}).Where("id = ?", token.ID).Updates(map[string]interface{}{
-			"encrypted_token": newBytes,
-			"token_metadata":  models.JSON(metaBytes),
-		}).Error; err != nil {
-			return swept, fmt.Errorf("failed to update api_token id=%d: %w", token.ID, err)
+		if !dryRun {
+			if err := tx.Model(&models.APIToken{}).Where("id = ?", token.ID).Updates(map[string]interface{}{
+				"encrypted_token": newBytes,
+				"token_metadata":  models.JSON(metaBytes),
+			}).Error; err != nil {
+				return swept, fmt.Errorf("failed to update api_token id=%d: %w", token.ID, err)
+			}
 		}
 		swept++
 	}
 	return swept, nil
 }
 
-func sweepAPIClients(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, error) {
+// dryRun skips the final Updates() write only; every other step still runs.
+func sweepAPIClients(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string, dryRun bool) (int, error) {
 	var clients []models.APIClient
 	if err := tx.Find(&clients).Error; err != nil {
 		return 0, fmt.Errorf("failed to fetch api_clients: %w", err)
@@ -136,11 +143,13 @@ func sweepAPIClients(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionS
 		if err != nil {
 			return swept, fmt.Errorf("failed to marshal api_client metadata id=%d: %w", client.ID, err)
 		}
-		if err := tx.Model(&models.APIClient{}).Where("id = ?", client.ID).Updates(map[string]interface{}{
-			"encrypted_client_secret": newBytes,
-			"client_secret_metadata":  models.JSON(metaBytes),
-		}).Error; err != nil {
-			return swept, fmt.Errorf("failed to update api_client id=%d: %w", client.ID, err)
+		if !dryRun {
+			if err := tx.Model(&models.APIClient{}).Where("id = ?", client.ID).Updates(map[string]interface{}{
+				"encrypted_client_secret": newBytes,
+				"client_secret_metadata":  models.JSON(metaBytes),
+			}).Error; err != nil {
+				return swept, fmt.Errorf("failed to update api_client id=%d: %w", client.ID, err)
+			}
 		}
 		swept++
 	}
@@ -153,8 +162,9 @@ func sweepAPIClients(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionS
 // sweepSecretVersions's legacy-branch pattern. Missing this sweeper's re-encryption
 // step entirely (the original gap, ADR-010) meant a DEK rotation left every enrolled
 // TOTP secret encrypted under the wiped old DEK — permanently breaking MFA login.
+// dryRun skips the final Updates() write only; every other step still runs.
 // Returns (rowsSwept, legacyRowsUpgraded, error).
-func sweepMFASecrets(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, int, error) {
+func sweepMFASecrets(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string, dryRun bool) (int, int, error) {
 	var rows []models.MFASecret
 	if err := tx.Find(&rows).Error; err != nil {
 		return 0, 0, fmt.Errorf("failed to fetch mfa_secrets: %w", err)
@@ -192,11 +202,13 @@ func sweepMFASecrets(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionS
 		if err != nil {
 			return swept, legacyUpgraded, fmt.Errorf("failed to marshal mfa_secret metadata id=%d: %w", row.ID, err)
 		}
-		if err := tx.Model(&models.MFASecret{}).Where("id = ?", row.ID).Updates(map[string]interface{}{
-			"secret_enc":  newBytes,
-			"secret_meta": metaBytes,
-		}).Error; err != nil {
-			return swept, legacyUpgraded, fmt.Errorf("failed to update mfa_secret id=%d: %w", row.ID, err)
+		if !dryRun {
+			if err := tx.Model(&models.MFASecret{}).Where("id = ?", row.ID).Updates(map[string]interface{}{
+				"secret_enc":  newBytes,
+				"secret_meta": metaBytes,
+			}).Error; err != nil {
+				return swept, legacyUpgraded, fmt.Errorf("failed to update mfa_secret id=%d: %w", row.ID, err)
+			}
 		}
 		swept++
 		if isLegacy {
@@ -212,8 +224,9 @@ func sweepMFASecrets(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionS
 // upgraded to AAD in place — see sweepMFASecrets. Missing this sweeper's
 // re-encryption step entirely (the original gap, ADR-010) left the admin connection
 // string undecryptable after a DEK rotation — the backend could no longer be reached
-// or its leases revoked. Returns (rowsSwept, legacyRowsUpgraded, error).
-func sweepDynamicSecretConfigs(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, int, error) {
+// or its leases revoked. dryRun skips the final Updates() write only; every other
+// step still runs. Returns (rowsSwept, legacyRowsUpgraded, error).
+func sweepDynamicSecretConfigs(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string, dryRun bool) (int, int, error) {
 	var rows []models.DynamicSecretConfig
 	if err := tx.Find(&rows).Error; err != nil {
 		return 0, 0, fmt.Errorf("failed to fetch dynamic_secret_configs: %w", err)
@@ -251,11 +264,13 @@ func sweepDynamicSecretConfigs(tx *gorm.DB, oldSvc *EncryptionService, newSvc *E
 		if err != nil {
 			return swept, legacyUpgraded, fmt.Errorf("failed to marshal dynamic_secret_config metadata id=%d: %w", row.ID, err)
 		}
-		if err := tx.Model(&models.DynamicSecretConfig{}).Where("id = ?", row.ID).Updates(map[string]interface{}{
-			"admin_dsn_enc":  newBytes,
-			"admin_dsn_meta": metaBytes,
-		}).Error; err != nil {
-			return swept, legacyUpgraded, fmt.Errorf("failed to update dynamic_secret_config id=%d: %w", row.ID, err)
+		if !dryRun {
+			if err := tx.Model(&models.DynamicSecretConfig{}).Where("id = ?", row.ID).Updates(map[string]interface{}{
+				"admin_dsn_enc":  newBytes,
+				"admin_dsn_meta": metaBytes,
+			}).Error; err != nil {
+				return swept, legacyUpgraded, fmt.Errorf("failed to update dynamic_secret_config id=%d: %w", row.ID, err)
+			}
 		}
 		swept++
 		if isLegacy {
@@ -270,8 +285,9 @@ func sweepDynamicSecretConfigs(tx *gorm.DB, oldSvc *EncryptionService, newSvc *E
 // DynamicSecretLeaseAAD(LeaseID, ConfigID) (#94). Legacy rows are upgraded to AAD in
 // place — see sweepMFASecrets. Missing this sweeper's re-encryption step entirely
 // (the original gap, ADR-010) left active lease credentials undecryptable after a DEK
-// rotation. Returns (rowsSwept, legacyRowsUpgraded, error).
-func sweepDynamicSecretLeases(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, int, error) {
+// rotation. dryRun skips the final Updates() write only; every other step still
+// runs. Returns (rowsSwept, legacyRowsUpgraded, error).
+func sweepDynamicSecretLeases(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string, dryRun bool) (int, int, error) {
 	var rows []models.DynamicSecretLease
 	if err := tx.Find(&rows).Error; err != nil {
 		return 0, 0, fmt.Errorf("failed to fetch dynamic_secret_leases: %w", err)
@@ -309,11 +325,13 @@ func sweepDynamicSecretLeases(tx *gorm.DB, oldSvc *EncryptionService, newSvc *En
 		if err != nil {
 			return swept, legacyUpgraded, fmt.Errorf("failed to marshal dynamic_secret_lease metadata id=%d: %w", row.ID, err)
 		}
-		if err := tx.Model(&models.DynamicSecretLease{}).Where("id = ?", row.ID).Updates(map[string]interface{}{
-			"credential_enc":  newBytes,
-			"credential_meta": metaBytes,
-		}).Error; err != nil {
-			return swept, legacyUpgraded, fmt.Errorf("failed to update dynamic_secret_lease id=%d: %w", row.ID, err)
+		if !dryRun {
+			if err := tx.Model(&models.DynamicSecretLease{}).Where("id = ?", row.ID).Updates(map[string]interface{}{
+				"credential_enc":  newBytes,
+				"credential_meta": metaBytes,
+			}).Error; err != nil {
+				return swept, legacyUpgraded, fmt.Errorf("failed to update dynamic_secret_lease id=%d: %w", row.ID, err)
+			}
 		}
 		swept++
 		if isLegacy {
@@ -323,7 +341,8 @@ func sweepDynamicSecretLeases(tx *gorm.DB, oldSvc *EncryptionService, newSvc *En
 	return swept, legacyUpgraded, nil
 }
 
-func sweepPasswordResets(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string) (int, error) {
+// dryRun skips the final Updates() write only; every other step still runs.
+func sweepPasswordResets(tx *gorm.DB, oldSvc *EncryptionService, newSvc *EncryptionService, newKeyVersion string, dryRun bool) (int, error) {
 	var resets []models.PasswordReset
 	if err := tx.Find(&resets).Error; err != nil {
 		return 0, fmt.Errorf("failed to fetch password_resets: %w", err)
@@ -354,11 +373,13 @@ func sweepPasswordResets(tx *gorm.DB, oldSvc *EncryptionService, newSvc *Encrypt
 		if err != nil {
 			return swept, fmt.Errorf("failed to marshal password_reset metadata id=%d: %w", reset.ID, err)
 		}
-		if err := tx.Model(&models.PasswordReset{}).Where("id = ?", reset.ID).Updates(map[string]interface{}{
-			"encrypted_token": newBytes,
-			"token_metadata":  models.JSON(metaBytes),
-		}).Error; err != nil {
-			return swept, fmt.Errorf("failed to update password_reset id=%d: %w", reset.ID, err)
+		if !dryRun {
+			if err := tx.Model(&models.PasswordReset{}).Where("id = ?", reset.ID).Updates(map[string]interface{}{
+				"encrypted_token": newBytes,
+				"token_metadata":  models.JSON(metaBytes),
+			}).Error; err != nil {
+				return swept, fmt.Errorf("failed to update password_reset id=%d: %w", reset.ID, err)
+			}
 		}
 		swept++
 	}

--- a/internal/encryption/sweep_completeness_test.go
+++ b/internal/encryption/sweep_completeness_test.go
@@ -1,0 +1,160 @@
+package encryption
+
+// sweep_completeness_test.go — regression test for backlog #425's structural
+// concern: SweepAllTables (sweep.go/sweep_auth.go) is a hand-maintained list of
+// individual sweepXxx calls, and nothing prevents a future developer from adding
+// a new DEK-encrypted column to internal/storage/models WITHOUT also adding a
+// corresponding sweep — silently re-introducing the exact shape of #422 (a
+// DEK-rotation sweep gap that caused permanent, irrecoverable data loss for the
+// tables it missed).
+//
+// There is no way to make Go statically verify "every DEK-encrypted column has a
+// sweep" — encryption happens at the application layer, not via any type the
+// compiler could check. Instead, this test parses every non-test .go file in
+// internal/storage/models via go/ast (NOT a hardcoded list of model types, so a
+// brand-new model struct is picked up automatically — only the discovered FIELD
+// still has to match the naming convention below) for struct fields matching the
+// naming convention every one of today's 8 DEK-encrypted columns follows: type
+// []byte, name either "Encrypted*" or "*Enc". It then diffs that discovered set
+// against expectedSweptFields, a hand-maintained map mirroring exactly what
+// SweepAllTables sweeps today.
+//
+// This only catches a NEW column that follows the existing naming convention —
+// it can't catch one that doesn't, or a coincidentally-named non-encrypted field
+// (there are none today; see the exhaustive grep this test's PR description
+// documents). Within that scope, though, it turns "a future developer forgot to
+// add a sweep" from a silent, discovered-in-production data-loss bug into a
+// failing test, at test time, with an actionable message pointing at exactly
+// which field is unaccounted for.
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// modelField identifies one struct field in internal/storage/models.
+type modelField struct {
+	Struct string
+	Field  string
+}
+
+func (f modelField) String() string { return f.Struct + "." + f.Field }
+
+// expectedSweptFields mirrors exactly what SweepAllTables (sweep.go's
+// sweepSecretVersions + sweep_auth.go's sweepSessions/sweepAPITokens/
+// sweepAPIClients/sweepPasswordResets/sweepMFASecrets/sweepDynamicSecretConfigs/
+// sweepDynamicSecretLeases) re-encrypts today. Keep this in lockstep with
+// SweepAllTables — that's the entire point of this test.
+var expectedSweptFields = map[modelField]bool{
+	{"SecretVersion", "EncryptedValue"}:     true,
+	{"Session", "EncryptedSessionToken"}:    true,
+	{"APIToken", "EncryptedToken"}:          true,
+	{"APIClient", "EncryptedClientSecret"}:  true,
+	{"PasswordReset", "EncryptedToken"}:     true,
+	{"MFASecret", "SecretEnc"}:              true,
+	{"DynamicSecretConfig", "AdminDSNEnc"}:  true,
+	{"DynamicSecretLease", "CredentialEnc"}: true,
+}
+
+// TestSweepCompleteness_EveryEncryptedModelFieldHasASweep is the regression test
+// described above.
+func TestSweepCompleteness_EveryEncryptedModelFieldHasASweep(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed — cannot locate internal/storage/models relative to this test file")
+	}
+	modelsDir := filepath.Join(filepath.Dir(thisFile), "..", "storage", "models")
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, modelsDir, func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("failed to parse %s: %v", modelsDir, err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatalf("no packages found under %s — did the models package move?", modelsDir)
+	}
+
+	discovered := map[modelField]bool{}
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				ts, ok := n.(*ast.TypeSpec)
+				if !ok {
+					return true
+				}
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok || st.Fields == nil {
+					return true
+				}
+				for _, f := range st.Fields.List {
+					if !isByteSliceType(f.Type) {
+						continue
+					}
+					for _, name := range f.Names {
+						if looksLikeEncryptedFieldName(name.Name) {
+							discovered[modelField{ts.Name.Name, name.Name}] = true
+						}
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	if len(discovered) == 0 {
+		t.Fatal("discovered zero Encrypted*/*Enc []byte fields in internal/storage/models — the AST walk is almost certainly broken (models.go alone has several), not that encryption was removed")
+	}
+
+	var missing []modelField
+	for f := range discovered {
+		if !expectedSweptFields[f] {
+			missing = append(missing, f)
+		}
+	}
+	var stale []modelField
+	for f := range expectedSweptFields {
+		if !discovered[f] {
+			stale = append(stale, f)
+		}
+	}
+	sort.Slice(missing, func(i, j int) bool { return missing[i].String() < missing[j].String() })
+	sort.Slice(stale, func(i, j int) bool { return stale[i].String() < stale[j].String() })
+
+	if len(missing) > 0 {
+		t.Errorf("found DEK-encrypted-looking field(s) in internal/storage/models NOT accounted for by this test's expectedSweptFields map: %v\n"+
+			"Verify each one is actually re-encrypted by SweepAllTables (internal/encryption/sweep.go + sweep_auth.go) — if it's a genuinely new "+
+			"DEK-encrypted column, add a sweepXxx call for it there (see #422 for what happens if you don't), then add it to expectedSweptFields "+
+			"here. If it's a false positive (a []byte field that happens to match the naming convention but isn't DEK-encrypted), narrow the "+
+			"looksLikeEncryptedFieldName heuristic instead.", missing)
+	}
+	if len(stale) > 0 {
+		t.Errorf("expectedSweptFields lists field(s) no longer found (by name+type) in internal/storage/models — update this test's expected map: %v", stale)
+	}
+}
+
+// isByteSliceType reports whether expr is exactly `[]byte` (an unsized array/slice
+// of the builtin identifier "byte").
+func isByteSliceType(expr ast.Expr) bool {
+	arr, ok := expr.(*ast.ArrayType)
+	if !ok || arr.Len != nil {
+		return false
+	}
+	ident, ok := arr.Elt.(*ast.Ident)
+	return ok && ident.Name == "byte"
+}
+
+// looksLikeEncryptedFieldName reports whether name follows the DEK-encrypted
+// column naming convention every one of today's 8 tracked fields uses:
+// EncryptedValue, EncryptedSessionToken, EncryptedToken (x2), EncryptedClientSecret,
+// SecretEnc, AdminDSNEnc, CredentialEnc.
+func looksLikeEncryptedFieldName(name string) bool {
+	return strings.HasPrefix(name, "Encrypted") || strings.HasSuffix(name, "Enc")
+}

--- a/internal/encryption/sweep_completeness_test.go
+++ b/internal/encryption/sweep_completeness_test.go
@@ -30,7 +30,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/fs"
+	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -71,42 +71,49 @@ func TestSweepCompleteness_EveryEncryptedModelFieldHasASweep(t *testing.T) {
 	}
 	modelsDir := filepath.Join(filepath.Dir(thisFile), "..", "storage", "models")
 
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, modelsDir, func(fi fs.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
+	entries, err := os.ReadDir(modelsDir)
 	if err != nil {
-		t.Fatalf("failed to parse %s: %v", modelsDir, err)
+		t.Fatalf("failed to read %s: %v", modelsDir, err)
 	}
-	if len(pkgs) == 0 {
-		t.Fatalf("no packages found under %s — did the models package move?", modelsDir)
+	var goFiles []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		goFiles = append(goFiles, filepath.Join(modelsDir, e.Name()))
+	}
+	if len(goFiles) == 0 {
+		t.Fatalf("no .go files found under %s — did the models package move?", modelsDir)
 	}
 
+	fset := token.NewFileSet()
 	discovered := map[modelField]bool{}
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
-			ast.Inspect(file, func(n ast.Node) bool {
-				ts, ok := n.(*ast.TypeSpec)
-				if !ok {
-					return true
-				}
-				st, ok := ts.Type.(*ast.StructType)
-				if !ok || st.Fields == nil {
-					return true
-				}
-				for _, f := range st.Fields.List {
-					if !isByteSliceType(f.Type) {
-						continue
-					}
-					for _, name := range f.Names {
-						if looksLikeEncryptedFieldName(name.Name) {
-							discovered[modelField{ts.Name.Name, name.Name}] = true
-						}
-					}
-				}
-				return true
-			})
+	for _, path := range goFiles {
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("failed to parse %s: %v", path, err)
 		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			ts, ok := n.(*ast.TypeSpec)
+			if !ok {
+				return true
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok || st.Fields == nil {
+				return true
+			}
+			for _, f := range st.Fields.List {
+				if !isByteSliceType(f.Type) {
+					continue
+				}
+				for _, name := range f.Names {
+					if looksLikeEncryptedFieldName(name.Name) {
+						discovered[modelField{ts.Name.Name, name.Name}] = true
+					}
+				}
+			}
+			return true
+		})
 	}
 
 	if len(discovered) == 0 {

--- a/internal/encryption/sweep_test.go
+++ b/internal/encryption/sweep_test.go
@@ -154,7 +154,7 @@ func TestRotateDEKWithSweep_ReEncryptsAllRows(t *testing.T) {
 	oldDEK := captureCurrentDEK(t, svc)
 
 	// Run rotation with sweep
-	if err := svc.RotateDEKWithSweep("test-passphrase", db); err != nil {
+	if _, err := svc.RotateDEKWithSweep("test-passphrase", db); err != nil {
 		t.Fatalf("RotateDEKWithSweep failed: %v", err)
 	}
 
@@ -216,7 +216,7 @@ func TestRotateDEKWithSweep_MultipleBatches(t *testing.T) {
 	}
 
 	oldDEK := captureCurrentDEK(t, svc)
-	if err := svc.RotateDEKWithSweep("test-passphrase", db); err != nil {
+	if _, err := svc.RotateDEKWithSweep("test-passphrase", db); err != nil {
 		t.Fatalf("RotateDEKWithSweep failed: %v", err)
 	}
 	if string(oldDEK) == string(captureCurrentDEK(t, svc)) {
@@ -271,7 +271,7 @@ func TestRotateDEKWithSweep_ReEncryptsAuthSecretTables(t *testing.T) {
 	require.NoError(t, db.Create(&models.DynamicSecretLease{LeaseID: "l-1", ConfigID: 9, CredentialEnc: credEnc, CredentialMeta: credMeta}).Error)
 
 	oldDEK := captureCurrentDEK(t, svc)
-	if err := svc.RotateDEKWithSweep("test-passphrase", db); err != nil {
+	if _, err := svc.RotateDEKWithSweep("test-passphrase", db); err != nil {
 		t.Fatalf("RotateDEKWithSweep failed: %v", err)
 	}
 	oldEncSvc, err := NewEncryptionService(oldDEK)
@@ -316,7 +316,8 @@ func TestRotateDEKWithSweep_SoftDeletedSecretDoesNotBlock(t *testing.T) {
 	require.NoError(t, db.Delete(&models.SecretNode{}, nodeID).Error)
 
 	// Rotation must still succeed (previously aborted with "no project found").
-	require.NoError(t, svc.RotateDEKWithSweep("test-passphrase", db))
+	_, rotErr := svc.RotateDEKWithSweep("test-passphrase", db)
+	require.NoError(t, rotErr)
 
 	var v models.SecretVersion
 	require.NoError(t, db.First(&v, versionID).Error)
@@ -350,7 +351,7 @@ func TestRotateDEKWithSweep_UpgradesLegacyAAD(t *testing.T) {
 	}
 
 	// Run sweep
-	if err := svc.RotateDEKWithSweep("test-passphrase", db); err != nil {
+	if _, err := svc.RotateDEKWithSweep("test-passphrase", db); err != nil {
 		t.Fatalf("RotateDEKWithSweep failed: %v", err)
 	}
 
@@ -403,7 +404,7 @@ func TestRotateDEKWithSweep_RollbackOnError(t *testing.T) {
 		t.Fatalf("failed to drop table: %v", err)
 	}
 
-	err := svc.RotateDEKWithSweep("test-passphrase", db)
+	_, err := svc.RotateDEKWithSweep("test-passphrase", db)
 	if err == nil {
 		t.Fatal("expected RotateDEKWithSweep to fail, but it succeeded")
 	}


### PR DESCRIPTION
## Summary

Backlog #425 (MEDIUM): `keyorix encryption rotate` had no `--dry-run` flag and no way for an operator to preview what a DEK rotation would touch before committing to the write-locking, irreversible operation. Separately, the post-rotation summary silently surfaced only 5 of `SweepResult`'s 8 fields — and the 3 it dropped (`mfa_secrets`, `dynamic_secret_configs`, `dynamic_secret_leases`) are exactly the tables #422's sweep-gap fix added, meaning an operator running a rotation today has no visibility into whether that earlier fix's own sweeps actually ran.

- Threaded a `dryRun bool` through `SweepAllTables` and every `sweepXxx` function. `dryRun` gates *only* the final per-row `tx.Model(...).Updates(...)` write — every SELECT/decrypt/re-encrypt/count step still runs, so the preview is accurate and would surface a row that couldn't decrypt, exactly like a real rotation would.
- Added `Service.PreviewRotationSweep`: a genuinely read-only dry run that uses the *current* encryption service as both "old" and "new" (no new DEK is generated, nothing is written to the key directory) inside a transaction that is unconditionally rolled back.
- Added `rotate --dry-run`: does not require `--confirm` (a preview isn't the irreversible operation `--confirm` guards), takes the same shared-key-lock as the other read-only CLI ops (status/validate/fix-perms/upgrade-aad), and prints the same full per-table summary a real rotation now does.
- `Service.RotateDEKWithSweep` now returns the completed `SweepResult` so the CLI can print all 8 "Swept" fields plus `LegacyAADUpgraded`, not just 5 — closing real operator-visibility value independent of `--dry-run`.
- Added a regression test (`TestSweepCompleteness_EveryEncryptedModelFieldHasASweep`) that parses every model struct in `internal/storage/models` via `go/ast` (not a hardcoded list of models — a brand-new model is picked up automatically) for fields matching the DEK-encrypted-column naming convention every one of today's 8 fields follows (`Encrypted*` / `*Enc`, `[]byte`), and fails if `SweepAllTables`'s hand-maintained coverage drifts from what's actually discovered.

**Scoped out / follow-up:** the structural "nothing forces a future developer to update `SweepAllTables`'s hand-maintained list" concern is only partially closed by the new completeness test — it only catches a new encrypted field that follows the existing naming convention. Making it fully automatic (e.g. a runtime registry or codegen keyed off a struct tag) felt like more design work than this fix warranted.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/encryption/... ./internal/encryption/... -count=1` (all pass, including 3 new tests: dry-run accurate preview + no DB/DEK changes, dry-run doesn't require `--confirm`, real rotation prints all 8 `SweepResult` fields, plus the AST-based completeness test)
- [x] `gosec -severity medium -exclude-generated ./internal/cli/encryption/... ./internal/encryption/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)