### PR TITLE
fix(rotation): batch the rotation planner's per-candidate risk scoring (#409)

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -506,6 +506,14 @@ func (m *MockStorage) GetSecret(ctx context.Context, id uint) (*models.SecretNod
 	return args.Get(0).(*models.SecretNode), args.Error(1)
 }
 
+func (m *MockStorage) GetSecretsByIDs(ctx context.Context, ids []uint) ([]*models.SecretNode, error) {
+	args := m.Called(ctx, ids)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.SecretNode), args.Error(1)
+}
+
 func (m *MockStorage) GetSecretByName(ctx context.Context, name string, projectID, environmentID uint) (*models.SecretNode, error) {
 	args := m.Called(ctx, name, projectID, environmentID)
 	if args.Get(0) == nil {
@@ -694,6 +702,14 @@ func (m *MockStorage) DeleteShareRecord(ctx context.Context, shareID uint) error
 
 func (m *MockStorage) ListSharesBySecret(ctx context.Context, secretID uint) ([]*models.ShareRecord, error) {
 	args := m.Called(ctx, secretID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.ShareRecord), args.Error(1)
+}
+
+func (m *MockStorage) ListSharesBySecretIDs(ctx context.Context, secretIDs []uint) ([]*models.ShareRecord, error) {
+	args := m.Called(ctx, secretIDs)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -963,6 +979,14 @@ func (m *MockStorage) ListGroupMembers(ctx context.Context, groupID uint) ([]*mo
 	return args.Get(0).([]*models.User), args.Error(1)
 }
 
+func (m *MockStorage) ListGroupMembersByGroupIDs(ctx context.Context, groupIDs []uint) (map[uint][]*models.User, error) {
+	args := m.Called(ctx, groupIDs)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[uint][]*models.User), args.Error(1)
+}
+
 // Role Management
 
 func (m *MockStorage) CreateRole(ctx context.Context, role *models.Role) (*models.Role, error) {
@@ -1129,6 +1153,14 @@ func (m *MockStorage) ListSecretAccessLogs(ctx context.Context, secretID uint, s
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]models.SecretAccessLog), args.Error(1)
+}
+
+func (m *MockStorage) CountSecretReadsBySecretIDs(ctx context.Context, secretIDs []uint, since time.Time) (map[uint]int, error) {
+	args := m.Called(ctx, secretIDs, since)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[uint]int), args.Error(1)
 }
 
 func (m *MockStorage) PrincipalSecretFirstSeen(ctx context.Context, since time.Time) (map[string]map[uint]time.Time, error) {

--- a/internal/core/rotation_planner.go
+++ b/internal/core/rotation_planner.go
@@ -93,9 +93,18 @@ func (c *KeyorixCore) GenerateRotationPlan(ctx context.Context, projectID uint) 
 	}
 
 	candidateSet := make(map[uint]bool, len(candidates))
+	candidateIDs := make([]uint, 0, len(candidates))
 	for id := range candidates {
 		candidateSet[id] = true
+		candidateIDs = append(candidateIDs, id)
 	}
+
+	// #409: risk-score every candidate secret with a small constant number of
+	// batched storage queries (see ComputeSecretRiskScoresBatch), not by calling
+	// ComputeSecretRiskScore fresh — with its own several queries — once per
+	// candidate. planSecret below never touches storage itself; it only reads
+	// from riskScores/riskErr computed here, once, for the whole project.
+	riskScores, riskErr := c.ComputeSecretRiskScoresBatch(ctx, candidateIDs)
 
 	edges, err := c.storage.ListSecretDependenciesForProject(ctx, projectID)
 	if err != nil {
@@ -119,7 +128,7 @@ func (c *KeyorixCore) GenerateRotationPlan(ctx context.Context, projectID uint) 
 		wave := RotationWave{Index: wi, Secrets: make([]PlannedRotation, 0, len(ids))}
 		for _, id := range ids {
 			entry := candidates[id]
-			pr := c.planSecret(ctx, entry, dependsOnInPlan[id], candidates)
+			pr := c.planSecret(entry, dependsOnInPlan[id], candidates, riskScores, riskErr)
 			wave.Secrets = append(wave.Secrets, pr)
 			if entry.Status == RotationStatusOverdue {
 				plan.OverdueCount++
@@ -221,25 +230,38 @@ func (c *KeyorixCore) GenerateDeploymentRotationPlan(ctx context.Context) (*Depl
 	return dp, nil
 }
 
-// planSecret turns a candidate entry into a PlannedRotation with urgency and reasons.
-func (c *KeyorixCore) planSecret(ctx context.Context, e *RotationStatusEntry, deps []uint, candidates map[uint]*RotationStatusEntry) PlannedRotation {
+// planSecret turns a candidate entry into a PlannedRotation with urgency and
+// reasons. It never touches storage itself — riskScores/riskErr are computed once
+// for every candidate in the project by ComputeSecretRiskScoresBatch (#409), not
+// freshly per secret here.
+func (c *KeyorixCore) planSecret(e *RotationStatusEntry, deps []uint, candidates map[uint]*RotationStatusEntry, riskScores map[uint]*SecretRiskScore, riskErr error) PlannedRotation {
 	riskScore, riskBand := 0, ""
 	riskDegraded := false
 	riskDegradedReason := "risk score based on incomplete exposure data (treated as worst-case, not deprioritized)"
-	if r, err := c.ComputeSecretRiskScore(ctx, e.SecretID); err != nil {
-		// #486: an outright failure to compute the risk score (e.g. a storage
-		// flake on the secret lookup) must NOT read the same as a genuine,
+	switch {
+	case riskErr != nil:
+		// #486: an outright failure to compute risk scores (e.g. a storage flake
+		// on the batched secret lookup) must NOT read the same as a genuine,
 		// fully-resolved zero-risk score — that would silently under-rank an
 		// actually-risky overdue secret, since rotationUrgency shifts intra-wave
 		// ordering by risk score. Degrade the same way ComputeSecretRiskScore's
 		// own incomplete-exposure case does below, so callers can't tell the two
 		// "the score is 0" cases apart from a real, verified low-risk secret.
-		log.Printf("rotation plan: risk score for secret %d (%s): %v — treating as degraded, not silently zero", e.SecretID, e.SecretName, err)
+		log.Printf("rotation plan: risk score for secret %d (%s): %v — treating as degraded, not silently zero", e.SecretID, e.SecretName, riskErr)
 		riskDegraded = true
-		riskDegradedReason = fmt.Sprintf("risk score: %v (treated as worst-case, not deprioritized)", err)
-	} else if r != nil {
+		riskDegradedReason = fmt.Sprintf("risk score: %v (treated as worst-case, not deprioritized)", riskErr)
+	case riskScores[e.SecretID] != nil:
+		r := riskScores[e.SecretID]
 		riskScore, riskBand = r.Score, r.Band
 		riskDegraded = r.Degraded
+	default:
+		// The secret is a candidate (it exists in RotationStatusEntry form) but has
+		// no entry in the batch result — e.g. deleted between candidate listing and
+		// the risk-score batch call. Same #486 treatment as an outright per-secret
+		// error: never silently zero.
+		log.Printf("rotation plan: risk score for secret %d (%s): not found in batch result — treating as degraded, not silently zero", e.SecretID, e.SecretName)
+		riskDegraded = true
+		riskDegradedReason = "risk score: secret not found (treated as worst-case, not deprioritized)"
 	}
 
 	pr := PlannedRotation{

--- a/internal/core/rotation_planner_test.go
+++ b/internal/core/rotation_planner_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -162,13 +164,11 @@ func TestGenerateRotationPlanEmptyWhenNothingDue(t *testing.T) {
 // risky overdue secret in rotationUrgency's intra-wave ordering, and the API
 // response's RiskDegraded:false would give callers no hint anything failed.
 func TestPlanSecretRiskScoreErrorDegrades(t *testing.T) {
-	ctx := context.Background()
 	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
 	c, _ := newPlannerCore(t, now)
 
-	// No SecretNode row exists for this ID, so ComputeSecretRiskScore's
-	// underlying c.storage.GetSecret call fails outright (not a degraded
-	// result — an error).
+	// This secret ID has no entry in the batch risk-score result (e.g. its
+	// underlying secret row is gone by the time ComputeSecretRiskScoresBatch ran).
 	e := &RotationStatusEntry{
 		SecretID:    999,
 		SecretName:  "ghost-secret",
@@ -176,12 +176,34 @@ func TestPlanSecretRiskScoreErrorDegrades(t *testing.T) {
 		DaysOverdue: 10,
 	}
 
-	pr := c.planSecret(ctx, e, nil, map[uint]*RotationStatusEntry{})
+	pr := c.planSecret(e, nil, map[uint]*RotationStatusEntry{}, map[uint]*SecretRiskScore{}, nil)
 
 	assert.True(t, pr.RiskDegraded, "a risk-score computation error must degrade the plan entry, not silently zero it")
 	assert.Equal(t, 0, pr.RiskScore, "an errored risk score is a floor of 0, not an inflated guess")
 	assert.Empty(t, pr.RiskBand)
 	assert.Contains(t, joinReasons(pr.Reasons), "risk score", "the reason must surface that the risk score itself could not be computed")
+}
+
+// A genuine batch-wide risk-score computation failure (riskErr != nil, e.g. the
+// batched secret lookup itself errored) must degrade the entry the same way a
+// missing-from-result secret does (#486, #409).
+func TestPlanSecretRiskScoreBatchErrorDegrades(t *testing.T) {
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	c, _ := newPlannerCore(t, now)
+
+	e := &RotationStatusEntry{
+		SecretID:    1,
+		SecretName:  "some-secret",
+		Status:      RotationStatusOverdue,
+		DaysOverdue: 10,
+	}
+
+	pr := c.planSecret(e, nil, map[uint]*RotationStatusEntry{}, nil, errors.New("batch lookup failed"))
+
+	assert.True(t, pr.RiskDegraded)
+	assert.Equal(t, 0, pr.RiskScore)
+	assert.Empty(t, pr.RiskBand)
+	assert.Contains(t, joinReasons(pr.Reasons), "risk score")
 }
 
 func joinReasons(rs []string) string {
@@ -295,6 +317,82 @@ func TestGenerateDeploymentRotationPlan_CyclicProjectIsSkippedNotFatal(t *testin
 	assert.Equal(t, 1, dp.OverdueCount)
 	require.Len(t, dp.Projects, 1)
 	assert.Equal(t, uint(2), dp.Projects[0].ProjectID)
+}
+
+// #409: GenerateDeploymentRotationPlan (via GenerateRotationPlan → planSecret) used
+// to call ComputeSecretRiskScore fresh — with its own several queries — once per
+// candidate secret, per project: an O(projects × candidates × groups-per-secret)
+// unbounded fan-out on a single request. ComputeSecretRiskScoresBatch now fetches
+// every input (secrets, read counts, shares, group memberships) once PER PROJECT
+// via batched (GROUP BY / IN) queries, so a project's risk-scoring query count no
+// longer grows with its candidate-secret count. This proves the total query count
+// issued by a single GenerateDeploymentRotationPlan call is the SAME whether each of
+// a fixed number of projects has 5 or 50 always-overdue candidate secrets — mixing
+// direct-user and group shares, so both ListSharesBySecretIDs and
+// ListGroupMembersByGroupIDs are actually exercised — a query COUNT assertion, not a
+// timing one, so it can't flake under load.
+func TestGenerateDeploymentRotationPlan_RiskScoringQueryCostDoesNotScaleWithCandidateCount(t *testing.T) {
+	const numProjects = 3
+
+	runWithCandidatesPerProject := func(perProject int) int {
+		now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+		db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+		require.NoError(t, err)
+		sqlDB, _ := db.DB()
+		sqlDB.SetMaxOpenConns(1)
+		require.NoError(t, db.AutoMigrate(
+			&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.RotationPolicy{},
+			&models.SecretDependency{}, &models.ShareRecord{}, &models.SecretAccessLog{}, &models.AuditEvent{},
+			&models.User{}, &models.Group{}, &models.UserGroup{},
+		))
+		c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+		ctx := context.Background()
+
+		require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@t.com"}).Error)
+		require.NoError(t, db.Create(&models.User{ID: 2, Username: "direct-recipient", Email: "d@t.com"}).Error)
+		require.NoError(t, db.Create(&models.User{ID: 3, Username: "group-member", Email: "g@t.com"}).Error)
+		require.NoError(t, db.Create(&models.Group{ID: 1, Name: "team-a"}).Error)
+		require.NoError(t, db.Create(&models.UserGroup{UserID: 3, GroupID: 1}).Error)
+
+		overdue := now.Add(-200 * 24 * time.Hour) // well past a 90-day cadence
+		secretID := uint(1)
+		for p := uint(1); p <= numProjects; p++ {
+			require.NoError(t, db.Create(&models.Project{ID: p, Name: fmt.Sprintf("proj-%d", p)}).Error)
+			require.NoError(t, db.Create(&models.Environment{ID: p, ProjectID: p, Name: "env"}).Error)
+			require.NoError(t, db.Create(&models.RotationPolicy{
+				Name: fmt.Sprintf("90d-%d", p), Scope: "project", ProjectID: &p, IntervalDays: 90, AlertDaysBefore: 14, IsActive: true,
+			}).Error)
+			for i := 0; i < perProject; i++ {
+				require.NoError(t, db.Create(&models.SecretNode{
+					ID: secretID, Name: fmt.Sprintf("s-%d", secretID), ProjectID: p, EnvironmentID: p,
+					IsSecret: true, Status: "active", OwnerID: 1, LastRotatedAt: &overdue,
+				}).Error)
+				// Alternate direct-user and group shares so both ListSharesBySecretIDs
+				// and ListGroupMembersByGroupIDs are actually exercised, not just the
+				// no-shares-at-all path.
+				if i%2 == 0 {
+					require.NoError(t, db.Create(&models.ShareRecord{SecretID: secretID, OwnerID: 1, RecipientID: 2, IsGroup: false}).Error)
+				} else {
+					require.NoError(t, db.Create(&models.ShareRecord{SecretID: secretID, OwnerID: 1, RecipientID: 1, IsGroup: true}).Error)
+				}
+				secretID++
+			}
+		}
+
+		qc := attachTotalQueryCounter(t, db)
+		dp, err := c.GenerateDeploymentRotationPlan(ctx)
+		require.NoError(t, err)
+		require.Equal(t, numProjects*perProject, dp.TotalSecrets)
+		return qc.total
+	}
+
+	small := runWithCandidatesPerProject(5)
+	large := runWithCandidatesPerProject(50)
+
+	assert.Equal(t, small, large,
+		"query count must not scale with the number of candidate secrets per project")
+	assert.Less(t, small, 40,
+		"expected a small constant number of batched queries per project, not one set of queries per candidate secret")
 }
 
 func TestGenerateDeploymentRotationPlan_NothingDueAnywhere(t *testing.T) {

--- a/internal/core/secret_risk.go
+++ b/internal/core/secret_risk.go
@@ -70,11 +70,22 @@ func (c *KeyorixCore) ComputeSecretRiskScore(ctx context.Context, secretID uint)
 	}
 	now := c.now()
 
+	reads := c.countReads(ctx, secretID, now.AddDate(0, 0, -30))
+	principalCount, expoDegraded, expoReasons := c.countPrincipals(ctx, secret)
+	return scoreSecret(secret, now, reads, principalCount, expoDegraded, expoReasons), nil
+}
+
+// scoreSecret builds a SecretRiskScore from a secret row plus its already-resolved
+// usage (read count) and exposure (principal count) inputs — the pure composite-
+// scoring logic shared by ComputeSecretRiskScore (which resolves those inputs one
+// secret at a time) and ComputeSecretRiskScoresBatch (which resolves them for many
+// secrets at once via batched queries, #409), so both produce byte-for-byte the
+// same score for the same inputs.
+func scoreSecret(secret *models.SecretNode, now time.Time, reads, principalCount int, expoDegraded bool, expoReasons []string) *SecretRiskScore {
 	expScore, expDetail := expiryRisk(secret.Expiration, now)
 	rotScore, rotDetail := rotationRisk(secret.LastRotatedAt, secret.CreatedAt, now)
-	usageScore, usageDetail := usageRisk(c.countReads(ctx, secretID, now.AddDate(0, 0, -30)))
+	usageScore, usageDetail := usageRisk(reads)
 
-	principalCount, expoDegraded, expoReasons := c.countPrincipals(ctx, secret)
 	expoScore, expoDetail := exposureRisk(principalCount)
 	if expoDegraded {
 		// #407: a share/group-membership lookup failed, so principalCount is an
@@ -113,7 +124,139 @@ func (c *KeyorixCore) ComputeSecretRiskScore(ctx context.Context, secretID uint)
 			out.DegradedReasons = append(out.DegradedReasons, "exposure:"+r)
 		}
 	}
+	return out
+}
+
+// ComputeSecretRiskScoresBatch computes the risk score for every secret in
+// secretIDs with a small, constant number of storage queries regardless of how
+// many secrets are being scored — instead of ComputeSecretRiskScore's ~3+ queries
+// called fresh for each one.
+//
+// #409: GenerateDeploymentRotationPlan called ComputeSecretRiskScore once per
+// candidate secret, per project — an O(projects × candidates × groups-per-secret)
+// unbounded fan-out on a single request (the same bug family as #238/#393). Each
+// input ComputeSecretRiskScore needs is now fetched once for the whole batch: one
+// GetSecretsByIDs, one CountSecretReadsBySecretIDs (GROUP BY), one
+// ListSharesBySecretIDs, and (only if any share is a group share) one
+// ListGroupMembersByGroupIDs — four queries total, not up to 3+N.
+//
+// Returns a map from secret ID to its score; a secretID with no matching row
+// (e.g. deleted between candidate listing and this call) is simply absent from
+// the result — callers must treat a missing entry the same as ComputeSecretRiskScore
+// returning a "secret not found" error for that one ID.
+//
+// Batching changes failure GRANULARITY, not the scoring logic or the worst-case
+// degrade bias (#407): a single failed grouped query now affects every secret in
+// the batch whose score depends on that data, instead of only the one secret whose
+// individual per-secret query happened to fail — strictly more conservative than
+// before, never less:
+//   - GetSecretsByIDs failing outright fails the whole batch (returns an error) —
+//     mirrors ComputeSecretRiskScore's own GetSecret failure, just widened from one
+//     secret to every secret requested in this call.
+//   - CountSecretReadsBySecretIDs failing falls back to zero reads for every
+//     secret, same as countReads' own per-secret fallback (never an error, never a
+//     Degraded flag — usage was never part of the exposure-degrade contract).
+//   - ListSharesBySecretIDs failing degrades every secret's exposure factor to the
+//     worst case, same as countPrincipals' own per-secret "shares:" failure.
+//   - ListGroupMembersByGroupIDs failing degrades only the secrets that actually
+//     have a group share (secrets with only direct-user shares, or no shares, are
+//     unaffected) — the query covers every group referenced by any candidate, so a
+//     failure there means every one of those groups' membership is unresolved.
+func (c *KeyorixCore) ComputeSecretRiskScoresBatch(ctx context.Context, secretIDs []uint) (map[uint]*SecretRiskScore, error) {
+	out := make(map[uint]*SecretRiskScore, len(secretIDs))
+	if len(secretIDs) == 0 {
+		return out, nil
+	}
+
+	secrets, err := c.storage.GetSecretsByIDs(ctx, secretIDs)
+	if err != nil {
+		return nil, fmt.Errorf("get secrets: %w", err)
+	}
+	now := c.now()
+
+	readCounts, err := c.storage.CountSecretReadsBySecretIDs(ctx, secretIDs, now.AddDate(0, 0, -30))
+	if err != nil {
+		// Same fallback as countReads: an unreadable read count is treated as zero
+		// reads, not an error and not a Degraded flag.
+		readCounts = map[uint]int{}
+	}
+
+	sharesBySecret := map[uint][]*models.ShareRecord{}
+	sharesFailed := false
+	var sharesErr error
+	if shares, err := c.storage.ListSharesBySecretIDs(ctx, secretIDs); err != nil {
+		sharesFailed = true
+		sharesErr = err
+	} else {
+		for _, sh := range shares {
+			sharesBySecret[sh.SecretID] = append(sharesBySecret[sh.SecretID], sh)
+		}
+	}
+
+	groupIDSet := map[uint]struct{}{}
+	for _, shares := range sharesBySecret {
+		for _, sh := range shares {
+			if sh.IsGroup {
+				groupIDSet[sh.RecipientID] = struct{}{}
+			}
+		}
+	}
+	membersByGroup := map[uint][]*models.User{}
+	groupsFailed := false
+	var groupsErr error
+	if len(groupIDSet) > 0 {
+		groupIDs := make([]uint, 0, len(groupIDSet))
+		for id := range groupIDSet {
+			groupIDs = append(groupIDs, id)
+		}
+		if m, err := c.storage.ListGroupMembersByGroupIDs(ctx, groupIDs); err != nil {
+			groupsFailed = true
+			groupsErr = err
+		} else {
+			membersByGroup = m
+		}
+	}
+
+	for _, secret := range secrets {
+		principalCount, expoDegraded, expoReasons := principalsFromBatch(
+			secret, sharesBySecret[secret.ID], membersByGroup, sharesFailed, sharesErr, groupsFailed, groupsErr,
+		)
+		out[secret.ID] = scoreSecret(secret, now, readCounts[secret.ID], principalCount, expoDegraded, expoReasons)
+	}
 	return out, nil
+}
+
+// principalsFromBatch is the batch-friendly equivalent of countPrincipals: same
+// owner+shares+group-members counting logic, but reading from data already
+// fetched for the whole candidate batch instead of issuing its own per-secret
+// queries. See ComputeSecretRiskScoresBatch for how sharesFailed/groupsFailed
+// (batch-wide) map onto countPrincipals' original per-secret failure reasons.
+func principalsFromBatch(
+	secret *models.SecretNode, shares []*models.ShareRecord, membersByGroup map[uint][]*models.User,
+	sharesFailed bool, sharesErr error, groupsFailed bool, groupsErr error,
+) (count int, degraded bool, reasons []string) {
+	principals := map[uint]struct{}{}
+	if secret.OwnerID != 0 {
+		principals[secret.OwnerID] = struct{}{}
+	}
+	if sharesFailed {
+		return len(principals), true, []string{fmt.Sprintf("shares: %v", sharesErr)}
+	}
+	for _, sh := range shares {
+		if sh.IsGroup {
+			if groupsFailed {
+				degraded = true
+				reasons = append(reasons, fmt.Sprintf("group_members:group=%d: %v", sh.RecipientID, groupsErr))
+				continue
+			}
+			for _, m := range membersByGroup[sh.RecipientID] {
+				principals[m.ID] = struct{}{}
+			}
+		} else {
+			principals[sh.RecipientID] = struct{}{}
+		}
+	}
+	return len(principals), degraded, reasons
 }
 
 func expiryRisk(exp *time.Time, now time.Time) (int, string) {

--- a/internal/core/secret_risk_test.go
+++ b/internal/core/secret_risk_test.go
@@ -138,3 +138,121 @@ func TestComputeSecretRiskScore_DegradedOnListGroupMembersError(t *testing.T) {
 	assert.Contains(t, got.DegradedReasons[0], "exposure:group_members:group=7")
 	assert.Equal(t, 90, factorByKey(got, "exposure").Score, "an incomplete exposure count must fail toward the worst-case score")
 }
+
+// #409: ComputeSecretRiskScoresBatch must produce byte-for-byte the same score as
+// ComputeSecretRiskScore for the same underlying data — batching how the inputs
+// are fetched must not change the scoring logic.
+func TestComputeSecretRiskScoresBatch_MatchesSingleSecretScore(t *testing.T) {
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	expired := now.AddDate(0, 0, -3)
+	store := new(MockStorage)
+
+	secret := &models.SecretNode{ID: 1, Name: "stripe-key", OwnerID: 9, Expiration: &expired, CreatedAt: now.AddDate(0, 0, -400)}
+	store.On("GetSecretsByIDs", mock.Anything, []uint{1}).Return([]*models.SecretNode{secret}, nil)
+	store.On("CountSecretReadsBySecretIDs", mock.Anything, []uint{1}, mock.Anything).Return(map[uint]int{}, nil)
+	store.On("ListSharesBySecretIDs", mock.Anything, []uint{1}).Return([]*models.ShareRecord{{SecretID: 1, IsGroup: true, RecipientID: 5}}, nil)
+	members := make([]*models.User, 20)
+	for i := range members {
+		members[i] = &models.User{ID: uint(100 + i)}
+	}
+	store.On("ListGroupMembersByGroupIDs", mock.Anything, []uint{5}).Return(map[uint][]*models.User{5: members}, nil)
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return now }
+
+	got, err := c.ComputeSecretRiskScoresBatch(context.Background(), []uint{1})
+	require.NoError(t, err)
+	require.Contains(t, got, uint(1))
+	require.Equal(t, RiskBandHigh, got[1].Band)
+	require.Equal(t, 100, factorByKey(got[1], "expiry").Score)
+	require.Equal(t, 100, factorByKey(got[1], "rotation").Score)
+	require.Equal(t, 80, factorByKey(got[1], "usage").Score)
+	require.Equal(t, 90, factorByKey(got[1], "exposure").Score)
+	require.GreaterOrEqual(t, got[1].Score, 90)
+	assert.False(t, got[1].Degraded)
+}
+
+// A batch-wide ListSharesBySecretIDs failure must degrade EVERY secret in the
+// batch's exposure factor to the worst case (#407's "never under-count" invariant,
+// widened from one secret to the whole batch — never the other direction).
+func TestComputeSecretRiskScoresBatch_DegradedOnSharesErrorAffectsWholeBatch(t *testing.T) {
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	future := now.AddDate(0, 0, 200)
+	rotated := now.AddDate(0, 0, -5)
+	store := new(MockStorage)
+
+	secrets := []*models.SecretNode{
+		{ID: 1, Name: "a", OwnerID: 9, Expiration: &future, LastRotatedAt: &rotated, CreatedAt: now.AddDate(0, 0, -10)},
+		{ID: 2, Name: "b", OwnerID: 9, Expiration: &future, LastRotatedAt: &rotated, CreatedAt: now.AddDate(0, 0, -10)},
+	}
+	store.On("GetSecretsByIDs", mock.Anything, []uint{1, 2}).Return(secrets, nil)
+	store.On("CountSecretReadsBySecretIDs", mock.Anything, []uint{1, 2}, mock.Anything).Return(map[uint]int{}, nil)
+	store.On("ListSharesBySecretIDs", mock.Anything, []uint{1, 2}).Return(nil, errors.New("simulated shares query failure"))
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return now }
+
+	got, err := c.ComputeSecretRiskScoresBatch(context.Background(), []uint{1, 2})
+	require.NoError(t, err)
+	for _, id := range []uint{1, 2} {
+		require.Contains(t, got, id)
+		assert.True(t, got[id].Degraded, "secret %d must degrade on a batch-wide shares failure", id)
+		assert.Equal(t, 90, factorByKey(got[id], "exposure").Score)
+	}
+}
+
+// A batch-wide ListGroupMembersByGroupIDs failure degrades only the secrets that
+// actually have a group share — a secret with only a direct-user share (or no
+// shares at all) is unaffected, since it never depended on that failed lookup.
+func TestComputeSecretRiskScoresBatch_GroupMembersErrorOnlyAffectsGroupSharedSecrets(t *testing.T) {
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	future := now.AddDate(0, 0, 200)
+	rotated := now.AddDate(0, 0, -5)
+	store := new(MockStorage)
+
+	secrets := []*models.SecretNode{
+		{ID: 1, Name: "group-shared", OwnerID: 9, Expiration: &future, LastRotatedAt: &rotated, CreatedAt: now.AddDate(0, 0, -10)},
+		{ID: 2, Name: "user-shared-only", OwnerID: 9, Expiration: &future, LastRotatedAt: &rotated, CreatedAt: now.AddDate(0, 0, -10)},
+	}
+	store.On("GetSecretsByIDs", mock.Anything, []uint{1, 2}).Return(secrets, nil)
+	store.On("CountSecretReadsBySecretIDs", mock.Anything, []uint{1, 2}, mock.Anything).Return(map[uint]int{}, nil)
+	store.On("ListSharesBySecretIDs", mock.Anything, []uint{1, 2}).Return([]*models.ShareRecord{
+		{SecretID: 1, IsGroup: true, RecipientID: 7},
+		{SecretID: 2, IsGroup: false, RecipientID: 42},
+	}, nil)
+	store.On("ListGroupMembersByGroupIDs", mock.Anything, []uint{7}).Return(nil, errors.New("simulated group-members query failure"))
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return now }
+
+	got, err := c.ComputeSecretRiskScoresBatch(context.Background(), []uint{1, 2})
+	require.NoError(t, err)
+	require.Contains(t, got, uint(1))
+	require.Contains(t, got, uint(2))
+	assert.True(t, got[1].Degraded, "the group-shared secret must degrade on the failed group lookup")
+	assert.False(t, got[2].Degraded, "the direct-user-only-shared secret never depended on the failed group lookup")
+}
+
+// A secretID missing from GetSecretsByIDs' result (e.g. deleted concurrently) is
+// simply absent from ComputeSecretRiskScoresBatch's result — callers must treat
+// that the same as ComputeSecretRiskScore's own "secret not found" error for that
+// one ID (see planSecret's #486 handling), not crash or silently zero the whole
+// batch.
+func TestComputeSecretRiskScoresBatch_MissingSecretIsAbsentFromResult(t *testing.T) {
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	store := new(MockStorage)
+
+	store.On("GetSecretsByIDs", mock.Anything, []uint{1, 999}).Return([]*models.SecretNode{
+		{ID: 1, Name: "a", OwnerID: 9, CreatedAt: now.AddDate(0, 0, -10)},
+	}, nil)
+	store.On("CountSecretReadsBySecretIDs", mock.Anything, []uint{1, 999}, mock.Anything).Return(map[uint]int{}, nil)
+	store.On("ListSharesBySecretIDs", mock.Anything, []uint{1, 999}).Return([]*models.ShareRecord{}, nil)
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return now }
+
+	got, err := c.ComputeSecretRiskScoresBatch(context.Background(), []uint{1, 999})
+	require.NoError(t, err)
+	assert.Contains(t, got, uint(1))
+	assert.NotContains(t, got, uint(999), "a secretID with no matching row must be absent, not a zero-value entry")
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -338,6 +338,13 @@ type Storage interface {
 	// Secret Management
 	CreateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error)
 	GetSecret(ctx context.Context, id uint) (*models.SecretNode, error)
+	// GetSecretsByIDs is the batch form of GetSecret: every secret in ids, in one
+	// query, instead of one GetSecret call per ID. IDs with no matching row are
+	// simply absent from the result (no error) — same as GetSecret's own
+	// not-found case, just without the per-ID error wrapping. Used by the rotation
+	// planner's risk-scoring batch (#409) so scoring N candidate secrets costs a
+	// small constant number of queries, not N.
+	GetSecretsByIDs(ctx context.Context, ids []uint) ([]*models.SecretNode, error)
 	GetSecretByName(ctx context.Context, name string, projectID, environmentID uint) (*models.SecretNode, error)
 	UpdateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error)
 	DeleteSecret(ctx context.Context, id uint) error
@@ -401,6 +408,11 @@ type Storage interface {
 	UpdateShareRecord(ctx context.Context, share *models.ShareRecord) (*models.ShareRecord, error)
 	DeleteShareRecord(ctx context.Context, shareID uint) error
 	ListSharesBySecret(ctx context.Context, secretID uint) ([]*models.ShareRecord, error)
+	// ListSharesBySecretIDs is the batch form of ListSharesBySecret: currently-active
+	// share records for every secret in secretIDs, in one query — used by the
+	// rotation planner's risk-scoring batch (#409) instead of one ListSharesBySecret
+	// call per candidate secret.
+	ListSharesBySecretIDs(ctx context.Context, secretIDs []uint) ([]*models.ShareRecord, error)
 	ListSharesByUser(ctx context.Context, userID uint) ([]*models.ShareRecord, error)
 	ListSharesByOwner(ctx context.Context, ownerID uint) ([]*models.ShareRecord, error)
 	ListSharesByGroup(ctx context.Context, groupID uint) ([]*models.ShareRecord, error)
@@ -534,6 +546,11 @@ type Storage interface {
 	AddUserToGroup(ctx context.Context, userID, groupID uint) error
 	RemoveUserFromGroup(ctx context.Context, userID, groupID uint) error
 	ListGroupMembers(ctx context.Context, groupID uint) ([]*models.User, error)
+	// ListGroupMembersByGroupIDs is the batch form of ListGroupMembers: the members
+	// of every group in groupIDs, keyed by group ID, in one query — used by the
+	// rotation planner's risk-scoring batch (#409) instead of one ListGroupMembers
+	// call per group share, per candidate secret.
+	ListGroupMembersByGroupIDs(ctx context.Context, groupIDs []uint) (map[uint][]*models.User, error)
 
 	// Permission Management
 	CreatePermission(ctx context.Context, permission *models.Permission) (*models.Permission, error)
@@ -637,6 +654,13 @@ type Storage interface {
 	LogAuditEvent(ctx context.Context, event *models.AuditEvent) error
 	CreateSecretAccessLog(ctx context.Context, log *models.SecretAccessLog) error
 	ListSecretAccessLogs(ctx context.Context, secretID uint, since time.Time) ([]models.SecretAccessLog, error)
+	// CountSecretReadsBySecretIDs returns, for every secret in secretIDs with at
+	// least one qualifying row, the number of "read" access-log entries at or
+	// after since — aggregated in SQL (GROUP BY + COUNT), not one
+	// ListSecretAccessLogs call per secret. Used by the rotation planner's
+	// risk-scoring batch (#409); a secret absent from the result had zero
+	// qualifying reads, same as ListSecretAccessLogs returning an empty slice.
+	CountSecretReadsBySecretIDs(ctx context.Context, secretIDs []uint, since time.Time) (map[uint]int, error)
 	// PrincipalSecretFirstSeen returns, for every non-empty accessed_by with at least
 	// one access log row at or after `since`, the earliest access time per secret it
 	// touched in that range — aggregated in SQL (GROUP BY + MIN), not loaded as full

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -39,6 +40,36 @@ func (ls *LocalStorage) ListSecretAccessLogs(ctx context.Context, secretID uint,
 		Limit(maxSecretAccessLogRows).
 		Find(&logs)
 	return logs, result.Error
+}
+
+// CountSecretReadsBySecretIDs returns, for every secret in secretIDs with at least
+// one qualifying row, the number of "read" access-log entries at or after since —
+// aggregated in SQL (GROUP BY + COUNT), not one ListSecretAccessLogs call (plus a
+// Go-side action=="read" filter) per secret. Used by the rotation planner's
+// risk-scoring batch (#409) instead of one such call per candidate secret. A
+// secret absent from the result had zero qualifying reads.
+func (ls *LocalStorage) CountSecretReadsBySecretIDs(ctx context.Context, secretIDs []uint, since time.Time) (map[uint]int, error) {
+	out := make(map[uint]int, len(secretIDs))
+	if len(secretIDs) == 0 {
+		return out, nil
+	}
+	type row struct {
+		SecretNodeID uint
+		Count        int
+	}
+	var rows []row
+	err := ls.db.WithContext(ctx).Model(&models.SecretAccessLog{}).
+		Select("secret_node_id, COUNT(*) AS count").
+		Where("secret_node_id IN ? AND access_time >= ? AND action = ?", secretIDs, since, "read").
+		Group("secret_node_id").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
+	}
+	for _, r := range rows {
+		out[r.SecretNodeID] = r.Count
+	}
+	return out, nil
 }
 
 // PrincipalSecretFirstSeen returns, for every (principal, secret) pair with at least one

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -343,6 +343,22 @@ func (ls *LocalStorage) GetSecret(ctx context.Context, id uint) (*models.SecretN
 	return &secret, nil
 }
 
+// GetSecretsByIDs batch-fetches secrets by ID in one query — the batch form of
+// GetSecret. IDs with no matching (non-deleted) row are simply absent from the
+// result, in whatever order GORM returns them (callers needing a specific order
+// must sort/index by ID themselves). Used by the rotation planner's risk-scoring
+// batch (#409) so scoring N candidate secrets costs one query, not N.
+func (ls *LocalStorage) GetSecretsByIDs(ctx context.Context, ids []uint) ([]*models.SecretNode, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var secrets []*models.SecretNode
+	if err := ls.db.WithContext(ctx).Where("id IN ?", ids).Find(&secrets).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return secrets, nil
+}
+
 // GetSecretByName retrieves a secret by name and scope.
 func (ls *LocalStorage) GetSecretByName(ctx context.Context, name string, projectID, environmentID uint) (*models.SecretNode, error) {
 	var secret models.SecretNode

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -194,6 +194,24 @@ func (ls *LocalStorage) ListSharesBySecret(ctx context.Context, secretID uint) (
 	return shares, nil
 }
 
+// ListSharesBySecretIDs is the batch form of ListSharesBySecret: currently-active
+// share records (same soft-delete/expiry filter, #402) for every secret in
+// secretIDs, in one query. Used by the rotation planner's risk-scoring batch
+// (#409) instead of one ListSharesBySecret call per candidate secret.
+func (ls *LocalStorage) ListSharesBySecretIDs(ctx context.Context, secretIDs []uint) ([]*models.ShareRecord, error) {
+	if len(secretIDs) == 0 {
+		return nil, nil
+	}
+	var shares []*models.ShareRecord
+	if err := ls.db.WithContext(ctx).Where(
+		"secret_id IN ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
+		secretIDs, time.Now(),
+	).Find(&shares).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
+	}
+	return shares, nil
+}
+
 // ListSharesByUser lists currently-active share records where userID is the direct
 // recipient. See ListSharesBySecret for why expired shares are excluded (#402).
 func (ls *LocalStorage) ListSharesByUser(ctx context.Context, userID uint) ([]*models.ShareRecord, error) {

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -474,6 +474,38 @@ func (ls *LocalStorage) ListGroupMembers(ctx context.Context, groupID uint) ([]*
 	return users, nil
 }
 
+// ListGroupMembersByGroupIDs is the batch form of ListGroupMembers: the members of
+// every group in groupIDs, keyed by group ID, in one query. Unlike ListGroupMembers
+// this does not verify each group ID actually exists — callers already know the
+// IDs are real (e.g. they came from existing share records) and want the member
+// lookup batched, not a per-group existence check. Used by the rotation planner's
+// risk-scoring batch (#409) instead of one ListGroupMembers call per group share,
+// per candidate secret.
+func (ls *LocalStorage) ListGroupMembersByGroupIDs(ctx context.Context, groupIDs []uint) (map[uint][]*models.User, error) {
+	out := make(map[uint][]*models.User, len(groupIDs))
+	if len(groupIDs) == 0 {
+		return out, nil
+	}
+	type row struct {
+		models.User
+		GroupID uint
+	}
+	var rows []row
+	err := ls.db.WithContext(ctx).Table("users").
+		Select("users.*, user_groups.group_id AS group_id").
+		Joins("JOIN user_groups ON user_groups.user_id = users.id").
+		Where("user_groups.group_id IN ?", groupIDs).
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for i := range rows {
+		u := rows[i].User
+		out[rows[i].GroupID] = append(out[rows[i].GroupID], &u)
+	}
+	return out, nil
+}
+
 // --- Password history (ADR-025) ---
 
 // AddPasswordHistory records a bcrypt hash for the user.

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -124,6 +124,15 @@ func (rs *RemoteStorage) ListSecretAccessLogs(_ context.Context, _ uint, _ time.
 	return nil, fmt.Errorf("ListSecretAccessLogs not available in remote mode")
 }
 
+// CountSecretReadsBySecretIDs is the batch form of ListSecretAccessLogs' read
+// tally, which is itself not available in remote mode — so is this, for the same
+// reason. A caller (the rotation planner's risk-scoring batch, #409) already falls
+// back to treating this as zero reads for every secret on this error, exactly what
+// ListSecretAccessLogs' own error already causes today via countReads' fallback.
+func (rs *RemoteStorage) CountSecretReadsBySecretIDs(_ context.Context, _ []uint, _ time.Time) (map[uint]int, error) {
+	return nil, fmt.Errorf("CountSecretReadsBySecretIDs not available in remote mode")
+}
+
 // PrincipalSecretFirstSeen is not available in remote mode; anomaly detection is server-side.
 func (rs *RemoteStorage) PrincipalSecretFirstSeen(_ context.Context, _ time.Time) (map[string]map[uint]time.Time, error) {
 	return nil, fmt.Errorf("PrincipalSecretFirstSeen not available in remote mode")

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -53,6 +53,26 @@ func (rs *RemoteStorage) GetSecret(ctx context.Context, id uint) (*models.Secret
 	return &result, nil
 }
 
+// GetSecretsByIDs is the batch form of GetSecret. There is no bulk by-ID REST
+// endpoint, so this issues one GetSecret call per ID (the same per-secret network
+// cost remote mode already pays today) rather than adding a new one — it only lets
+// callers batch at the Go-API level. An ID whose lookup fails is skipped rather
+// than failing the whole batch: the caller (the rotation planner's risk-scoring
+// batch, #409) already treats an ID missing from the result the same conservative
+// way GetSecret's own error is treated for a single secret — never a silent
+// zero-risk score, so skipping here loses no safety margin.
+func (rs *RemoteStorage) GetSecretsByIDs(ctx context.Context, ids []uint) ([]*models.SecretNode, error) {
+	out := make([]*models.SecretNode, 0, len(ids))
+	for _, id := range ids {
+		secret, err := rs.GetSecret(ctx, id)
+		if err != nil {
+			continue
+		}
+		out = append(out, secret)
+	}
+	return out, nil
+}
+
 // GetSecretByName retrieves a secret by name and scope context via remote API.
 func (rs *RemoteStorage) GetSecretByName(ctx context.Context, name string, projectID, environmentID uint) (*models.SecretNode, error) {
 	path := fmt.Sprintf("/api/v1/secrets/by-name/%s?project_id=%d&environment_id=%d",

--- a/internal/storage/store/remote_sharing.go
+++ b/internal/storage/store/remote_sharing.go
@@ -97,6 +97,27 @@ func (rs *RemoteStorage) ListSharesBySecret(ctx context.Context, secretID uint) 
 	return result, nil
 }
 
+// ListSharesBySecretIDs is the batch form of ListSharesBySecret. There is no bulk
+// by-secret-IDs REST endpoint, so this issues one ListSharesBySecret call per
+// secret — but unlike GetSecretsByIDs, a failure here fails the WHOLE batch
+// (returns immediately) rather than skipping the affected secret: silently
+// treating a failed shares lookup as "no shares" would under-count that secret's
+// exposure, exactly the #407 bug (a widely-shared secret incorrectly reading as
+// low-exposure) this method must not reintroduce. Failing the batch degrades
+// every secret's exposure factor to the worst case instead — never fewer
+// principals than reality, only ever more caution than strictly necessary.
+func (rs *RemoteStorage) ListSharesBySecretIDs(ctx context.Context, secretIDs []uint) ([]*models.ShareRecord, error) {
+	var out []*models.ShareRecord
+	for _, id := range secretIDs {
+		shares, err := rs.ListSharesBySecret(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("list shares by secret %d: %w", id, err)
+		}
+		out = append(out, shares...)
+	}
+	return out, nil
+}
+
 // ListSharesByUser lists all share records where userID is the recipient via remote API.
 func (rs *RemoteStorage) ListSharesByUser(ctx context.Context, userID uint) ([]*models.ShareRecord, error) {
 	path := fmt.Sprintf("/api/v1/users/%d/shares", userID)

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -278,6 +278,16 @@ func (rs *RemoteStorage) ListGroupMembers(_ context.Context, _ uint) ([]*models.
 	return nil, remoteUnsupported("ListGroupMembers")
 }
 
+// ListGroupMembersByGroupIDs is the batch form of ListGroupMembers, which is itself
+// unsupported in remote mode — so is this, for the same reason (group membership is
+// server-side only). Matches ListGroupMembers' existing per-group unsupported error:
+// a caller (the rotation planner's risk-scoring batch, #409) already degrades a
+// secret's exposure factor to the worst case on this error, exactly as it already
+// does today when a group share's ListGroupMembers call fails in remote mode.
+func (rs *RemoteStorage) ListGroupMembersByGroupIDs(_ context.Context, _ []uint) (map[uint][]*models.User, error) {
+	return nil, remoteUnsupported("ListGroupMembersByGroupIDs")
+}
+
 // --- Password history (ADR-025) ---
 // Password changes are processed server-side in remote mode, so history is
 // recorded and checked there; these are stubs.

--- a/internal/storage/store/rotation_risk_batch_test.go
+++ b/internal/storage/store/rotation_risk_batch_test.go
@@ -1,0 +1,139 @@
+// rotation_risk_batch_test.go — LocalStorage tests for the batched storage methods
+// added to fix #409 (GenerateDeploymentRotationPlan's per-candidate-secret risk
+// score fan-out): GetSecretsByIDs, CountSecretReadsBySecretIDs,
+// ListSharesBySecretIDs, ListGroupMembersByGroupIDs.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newRotationRiskBatchTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.Environment{}, &models.ShareRecord{},
+		&models.SecretAccessLog{}, &models.User{}, &models.Group{}, &models.UserGroup{},
+	))
+	return NewLocalStorage(db)
+}
+
+func TestGetSecretsByIDs(t *testing.T) {
+	ls := newRotationRiskBatchTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env"}).Error)
+	require.NoError(t, ls.db.Create(&models.SecretNode{ID: 1, Name: "a", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active"}).Error)
+	require.NoError(t, ls.db.Create(&models.SecretNode{ID: 2, Name: "b", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active"}).Error)
+	require.NoError(t, ls.db.Create(&models.SecretNode{ID: 3, Name: "c", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active"}).Error)
+
+	got, err := ls.GetSecretsByIDs(ctx, []uint{1, 3, 999})
+	require.NoError(t, err)
+	names := map[uint]string{}
+	for _, s := range got {
+		names[s.ID] = s.Name
+	}
+	assert.Equal(t, map[uint]string{1: "a", 3: "c"}, names, "returns only the matching IDs, silently omitting the nonexistent one")
+
+	empty, err := ls.GetSecretsByIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}
+
+func TestCountSecretReadsBySecretIDs(t *testing.T) {
+	ls := newRotationRiskBatchTestStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	since := now.Add(-30 * 24 * time.Hour)
+
+	mkLog := func(secretID uint, action string, at time.Time) {
+		require.NoError(t, ls.db.Create(&models.SecretAccessLog{
+			SecretNodeID: secretID, Action: action, AccessTime: at, AccessedBy: "u",
+		}).Error)
+	}
+	// Secret 1: 3 reads in-window, 1 out-of-window read, 1 in-window update (not counted).
+	mkLog(1, "read", now.Add(-time.Hour))
+	mkLog(1, "read", now.Add(-2*time.Hour))
+	mkLog(1, "read", now.Add(-3*time.Hour))
+	mkLog(1, "read", now.Add(-40*24*time.Hour)) // before the window
+	mkLog(1, "update", now.Add(-time.Hour))
+	// Secret 2: no reads at all.
+	mkLog(2, "update", now.Add(-time.Hour))
+	// Secret 3: 1 read in-window.
+	mkLog(3, "read", now.Add(-time.Hour))
+
+	got, err := ls.CountSecretReadsBySecretIDs(ctx, []uint{1, 2, 3, 999}, since)
+	require.NoError(t, err)
+	assert.Equal(t, 3, got[1])
+	assert.NotContains(t, got, uint(2), "a secret with zero qualifying reads is absent, not a zero entry")
+	assert.Equal(t, 1, got[3])
+	assert.NotContains(t, got, uint(999))
+}
+
+func TestListSharesBySecretIDs(t *testing.T) {
+	ls := newRotationRiskBatchTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 9, Username: "owner", Email: "owner@x.io"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 2, Username: "u2", Email: "u2@x.io"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 3, Username: "u3", Email: "u3@x.io"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 4, Username: "u4", Email: "u4@x.io"}).Error)
+	require.NoError(t, ls.db.Create(&models.SecretNode{ID: 1, Name: "a", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active", OwnerID: 9}).Error)
+	require.NoError(t, ls.db.Create(&models.SecretNode{ID: 2, Name: "b", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active", OwnerID: 9}).Error)
+
+	_, err := ls.CreateShareRecord(ctx, &models.ShareRecord{SecretID: 1, OwnerID: 9, RecipientID: 2, IsGroup: false})
+	require.NoError(t, err)
+	_, err = ls.CreateShareRecord(ctx, &models.ShareRecord{SecretID: 2, OwnerID: 9, RecipientID: 3, IsGroup: false})
+	require.NoError(t, err)
+	past := time.Now().Add(-time.Hour)
+	expired, err := ls.CreateShareRecord(ctx, &models.ShareRecord{SecretID: 1, OwnerID: 9, RecipientID: 4, IsGroup: false})
+	require.NoError(t, err)
+	require.NoError(t, ls.db.Model(&models.ShareRecord{}).Where("id = ?", expired.ID).Update("expires_at", past).Error)
+
+	got, err := ls.ListSharesBySecretIDs(ctx, []uint{1, 2})
+	require.NoError(t, err)
+	bySecret := map[uint][]uint{}
+	for _, sh := range got {
+		bySecret[sh.SecretID] = append(bySecret[sh.SecretID], sh.RecipientID)
+	}
+	assert.ElementsMatch(t, []uint{2}, bySecret[1], "excludes the expired share")
+	assert.ElementsMatch(t, []uint{3}, bySecret[2])
+}
+
+func TestListGroupMembersByGroupIDs(t *testing.T) {
+	ls := newRotationRiskBatchTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.Group{ID: 1, Name: "team-a"}).Error)
+	require.NoError(t, ls.db.Create(&models.Group{ID: 2, Name: "team-b"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 10, Username: "alice", Email: "a@x.io"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 11, Username: "bob", Email: "b@x.io"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 12, Username: "carol", Email: "c@x.io"}).Error)
+	require.NoError(t, ls.db.Create(&models.UserGroup{UserID: 10, GroupID: 1}).Error)
+	require.NoError(t, ls.db.Create(&models.UserGroup{UserID: 11, GroupID: 1}).Error)
+	require.NoError(t, ls.db.Create(&models.UserGroup{UserID: 12, GroupID: 2}).Error)
+
+	got, err := ls.ListGroupMembersByGroupIDs(ctx, []uint{1, 2})
+	require.NoError(t, err)
+
+	idsOf := func(users []*models.User) []uint {
+		ids := make([]uint, len(users))
+		for i, u := range users {
+			ids[i] = u.ID
+		}
+		return ids
+	}
+	assert.ElementsMatch(t, []uint{10, 11}, idsOf(got[1]))
+	assert.ElementsMatch(t, []uint{12}, idsOf(got[2]))
+
+	empty, err := ls.ListGroupMembersByGroupIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}


### PR DESCRIPTION
## Summary

- `planSecret` (`internal/core/rotation_planner.go`) called `ComputeSecretRiskScore` fresh — with its own `GetSecret`, `ListSecretAccessLogs`, `ListSharesBySecret`, and one `ListGroupMembers` per group share — once per candidate secret, per project, on every `GenerateDeploymentRotationPlan` call: an `O(projects × candidates × groups-per-secret)` unbounded fan-out on a single request (backlog #409, same bug family as #238/#393).
- Adds `ComputeSecretRiskScoresBatch` (`internal/core/secret_risk.go`), which fetches every input `ComputeSecretRiskScore` needs — secrets, read counts, shares, group memberships — once per project via four new batched storage methods (`GetSecretsByIDs`, `CountSecretReadsBySecretIDs` (`GROUP BY`), `ListSharesBySecretIDs`, `ListGroupMembersByGroupIDs`), then scores each candidate in memory using the same `scoreSecret` composite logic `ComputeSecretRiskScore` already used (now shared, so both produce byte-for-byte identical scores for identical inputs).
- `planSecret` no longer touches storage at all — `GenerateRotationPlan` calls the batch once per project and passes the precomputed score map (plus a batch-level error) down to every candidate.
- Batching necessarily coarsens failure *granularity*, not the scoring logic or the #407 worst-case degrade bias: a failed grouped query now degrades every secret in the batch whose score depends on that data (e.g. every secret with a group share, if `ListGroupMembersByGroupIDs` fails) instead of only the one secret whose individual per-secret query happened to fail — always more conservative, never less.
- Local (GORM) storage gets real grouped/`IN` queries. Remote storage gets either a per-ID loop (`GetSecretsByIDs`, `ListSharesBySecretIDs`, tolerant of/fail-fast on per-ID issues respectively) or an "unsupported" stub matching that method's existing per-item remote behavior (`ListGroupMembersByGroupIDs`, `CountSecretReadsBySecretIDs` — both already unsupported per-secret today), so remote-mode behavior is unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./internal/core/... ./internal/storage/...` — 0 issues
- [x] `golangci-lint run ./internal/core/... ./internal/storage/...` — 0 issues
- [x] New query-count regression test (`TestGenerateDeploymentRotationPlan_RiskScoringQueryCostDoesNotScaleWithCandidateCount`) proves the query count for a fixed number of projects stays flat whether each project has 5 or 50 candidate secrets (mixing direct-user and group shares)
- [x] New unit tests for `ComputeSecretRiskScoresBatch` (matches-single-secret-score, partial-failure granularity, missing-secret handling) and storage-level tests for the four new batched methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)