### PR TITLE
harden(operator): opt-in namespace-scoped RBAC binding (#327/#427)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,38 @@ jobs:
       - name: Lint + render keyorix-operator chart
         run: |
           helm lint deploy/helm/keyorix-operator
-          # CRDs ship under crds/ (not templated); validate the rendered controller
-          # resources. -skip the CRD-defined kind is unnecessary here (none rendered).
+          helm lint deploy/helm/keyorix-operator --set 'watchNamespaces={team-a,team-b}'
+
+          # Default (cluster-wide) mode: kubeconform-validate the rendered controller
+          # resources (CRDs ship under crds/, not templated, so none rendered here), and
+          # prove the Secret/KeyorixSecret RBAC is still bound via the existing
+          # cluster-wide ClusterRoleBinding — the #327/#427 backward-compatibility
+          # guarantee for deployments that don't opt into namespace scoping.
           helm template kx deploy/helm/keyorix-operator --set leaderElection=true \
-            | ./kubeconform -strict -summary -kubernetes-version 1.29.0
+            > default-render.yaml
+          ./kubeconform -strict -summary -kubernetes-version 1.29.0 < default-render.yaml
+          if ! grep -q '^kind: ClusterRoleBinding$' default-render.yaml; then
+            echo "expected a ClusterRoleBinding in the default (unscoped) render"; exit 1
+          fi
+          if grep -A2 '^kind: RoleBinding$' default-render.yaml | grep -q 'name: kx-keyorix-operator$'; then
+            echo "unexpected namespace-scoped RoleBinding for the main Secret/CRD grant in the default render"
+            exit 1
+          fi
+
+          # Namespace-scoped mode (opt-in, #327/#427): prove the same RBAC is instead
+          # bound via a RoleBinding in each watchNamespaces entry, with NO cluster-wide
+          # ClusterRoleBinding — least privilege for a per-namespace deployment model.
+          helm template kx deploy/helm/keyorix-operator --set 'watchNamespaces={team-a,team-b}' \
+            > scoped-render.yaml
+          ./kubeconform -strict -summary -kubernetes-version 1.29.0 < scoped-render.yaml
+          if grep -q '^kind: ClusterRoleBinding$' scoped-render.yaml; then
+            echo "did not expect a ClusterRoleBinding when watchNamespaces is set"; exit 1
+          fi
+          for ns in team-a team-b; do
+            if ! grep -B2 "  namespace: $ns\$" scoped-render.yaml | grep -q 'name: kx-keyorix-operator$'; then
+              echo "expected a RoleBinding named kx-keyorix-operator in namespace $ns"; exit 1
+            fi
+          done
+          if ! grep -q -- '-watch-namespaces=team-a,team-b' scoped-render.yaml; then
+            echo "expected the -watch-namespaces flag on the manager Deployment"; exit 1
+          fi

--- a/deploy/helm/keyorix-operator/README.md
+++ b/deploy/helm/keyorix-operator/README.md
@@ -21,14 +21,33 @@ helm install keyorix-operator deploy/helm/keyorix-operator -n keyorix-system --c
 | `leaderElection` | Run >1 replica safely via a lease in the release namespace (default `false`) |
 | `metricsPort` / `healthPort` | Manager metrics (`/metrics`) and probe (`/healthz`,`/readyz`) ports |
 | `serviceAccount.create` / `serviceAccount.name` | ServiceAccount control |
+| `watchNamespaces` | Restrict this instance (and its RBAC) to these namespaces instead of the whole cluster — see [RBAC](#rbac) |
 | `resources`, `nodeSelector`, `tolerations`, `affinity`, `podAnnotations` | Standard pod scheduling/resourcing |
 
 ## RBAC
 
 A `ClusterRole` grants read on `keyorixsecrets` (+ status/finalizers) and
-get/list/watch/create/update/patch on `secrets`. A namespaced `Role` grants the lease +
-event access leader election needs. The operator reads secret **values** only through the
-Keyorix API (with each `KeyorixSecret`'s machine token) — never from the cluster.
+get/list/watch/create/update/patch/delete on `secrets` (`delete` is used only to remove the
+target Secret once the upstream Keyorix reference is confirmed gone). A namespaced `Role`
+grants the lease + event access leader election needs. The operator reads secret **values**
+only through the Keyorix API (with each `KeyorixSecret`'s machine token) — never from the
+cluster.
+
+By default a single operator instance watches `KeyorixSecret` CRs across every namespace in
+the cluster, so the `ClusterRole` above is bound cluster-wide via a `ClusterRoleBinding`. If
+you instead run one operator instance per namespace (or per bounded tenant set), set
+`watchNamespaces` to that instance's namespace(s):
+
+```sh
+helm install keyorix-operator-team-a deploy/helm/keyorix-operator -n team-a \
+  --set 'watchNamespaces={team-a}'
+```
+
+This passes `-watch-namespaces` to the manager (restricting its own watch/cache to those
+namespaces too) and swaps the cluster-wide `ClusterRoleBinding` for a namespace-scoped
+`RoleBinding` in each listed namespace — the same `ClusterRole` stays cluster-scoped (a
+Kubernetes RBAC object type), but its granted access is limited to the bound namespaces. Do
+not deploy more than one instance watching the same namespace with different configs.
 
 ## Uninstalling
 

--- a/deploy/helm/keyorix-operator/templates/deployment.yaml
+++ b/deploy/helm/keyorix-operator/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
             - "-health-probe-bind-address=:{{ .Values.healthPort | default 8081 }}"
             - "-metrics-bind-address=:{{ .Values.metricsPort | default 8080 }}"
             - "-leader-elect={{ .Values.leaderElection | default false }}"
+            {{- if .Values.watchNamespaces }}
+            - "-watch-namespaces={{ join "," .Values.watchNamespaces }}"
+            {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.metricsPort | default 8080 }}

--- a/deploy/helm/keyorix-operator/templates/rbac.yaml
+++ b/deploy/helm/keyorix-operator/templates/rbac.yaml
@@ -1,22 +1,32 @@
 {{/*
-The operator needs cluster-wide read on KeyorixSecrets and read/write on the Secrets it
-materialises, plus a namespaced lease for leader election. The Secret verbs match the
-controller's generated RBAC (operator/config/rbac/role.yaml).
+The operator needs read on KeyorixSecrets and read/write on the Secrets it materialises,
+plus a namespaced lease for leader election. The Secret verbs match the controller's
+generated RBAC (operator/config/rbac/role.yaml) -- including `delete`, which
+`wipeTargetSecret` uses to remove the target Secret once the upstream Keyorix reference is
+confirmed gone (#428).
 
-NOTE (#327): this ClusterRole/ClusterRoleBinding (rather than a per-namespace Role/
-RoleBinding) reflects the operator's actual deployment model -- a single cluster-wide
-instance watching KeyorixSecret CRs (a namespaced CRD) across every namespace, with no
---watch-namespaces flag or other dynamic-namespace-discovery mechanism. It genuinely cannot
-predict ahead of time which namespace the next CR (and its TokenSecretRef/target Secret)
-will land in, and Kubernetes RBAC has no way to scope list/watch by resourceNames or to a
-dynamically changing namespace set -- so per-managed-namespace RoleBindings aren't possible
-without also adding namespace-scoping to the operator's deployment model.
+NOTE (#327/#427): a single ClusterRole definition is always used (for manifest
+reusability), but how it's BOUND depends on `watchNamespaces`:
 
-To bound the blast radius of this necessarily cluster-wide Secret grant (e.g. if the
-operator process is ever compromised via #184/#240), operator/cmd/main.go scopes the
-manager's Secret informer cache to only Secrets carrying the operator's managed-by label, so
-the operator does not hold an in-memory cache of every Secret in the cluster -- only the
-ones it already owns via this same RBAC.
+  - Default (`watchNamespaces` empty): bound cluster-wide via a `ClusterRoleBinding`. This
+    matches the operator's default deployment model -- a single cluster-wide instance
+    watching KeyorixSecret CRs (a namespaced CRD) across every namespace, with no static
+    namespace list configured, so it genuinely cannot predict ahead of time which namespace
+    the next CR (and its TokenSecretRef/target Secret) will land in. Kubernetes RBAC has no
+    way to scope list/watch by resourceNames or to a dynamically changing namespace set, so
+    per-namespace RoleBindings aren't possible in this mode.
+
+  - `watchNamespaces` set: bound via a namespace-scoped `RoleBinding` in each listed
+    namespace instead -- least privilege for deployments that run one operator instance per
+    namespace/tenant set (matching the corresponding `-watch-namespaces` flag passed to the
+    manager in deployment.yaml, which restricts the manager's own watch/cache to the same
+    namespaces).
+
+To further bound the blast radius of this (in the default mode, necessarily cluster-wide)
+Secret grant (e.g. if the operator process is ever compromised via #184/#240),
+operator/cmd/main.go also scopes the manager's Secret informer cache to only Secrets
+carrying the operator's managed-by label, so the operator does not hold an in-memory cache
+of every Secret it can see -- only the ones it already owns via this same RBAC.
 */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -27,7 +37,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["secrets.keyorix.io"]
     resources: ["keyorixsecrets"]
     verbs: ["get", "list", "watch"]
@@ -38,6 +48,27 @@ rules:
     resources: ["keyorixsecrets/finalizers"]
     verbs: ["update"]
 ---
+{{- if .Values.watchNamespaces }}
+{{- $root := . }}
+{{- range .Values.watchNamespaces }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kxop.fullname" $root }}
+  namespace: {{ . }}
+  labels:
+    {{- include "kxop.labels" $root | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kxop.fullname" $root }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kxop.serviceAccountName" $root }}
+    namespace: {{ $root.Release.Namespace }}
+---
+{{- end }}
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -53,6 +84,7 @@ subjects:
     name: {{ include "kxop.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 ---
+{{- end }}
 # Leader election (used when replicas > 1 / leaderElection=true) and event emission.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deploy/helm/keyorix-operator/values.yaml
+++ b/deploy/helm/keyorix-operator/values.yaml
@@ -21,6 +21,16 @@ leaderElection: false
 metricsPort: 8080
 healthPort: 8081
 
+# watchNamespaces (OPTIONAL, #327/#427): restricts this operator instance to reconciling
+# KeyorixSecret CRs (and their target Secrets) in only the listed namespaces, instead of
+# the default cluster-wide behavior. When set, RBAC is scoped accordingly: the chart's
+# ClusterRole is bound via a namespace-scoped RoleBinding in each listed namespace instead
+# of a cluster-wide ClusterRoleBinding -- least privilege for deployments that run one
+# operator instance per namespace/tenant set. When empty (the default), a single instance
+# watches every namespace and needs the broader ClusterRoleBinding to do so.
+#   watchNamespaces: [team-a, team-b]
+watchNamespaces: []
+
 serviceAccount:
   create: true
   # name overrides the generated ServiceAccount name.

--- a/docs/k8s-operator.md
+++ b/docs/k8s-operator.md
@@ -43,6 +43,20 @@ helm upgrade keyorix-operator deploy/helm/keyorix-operator -n keyorix-system \
   --set replicas=2 --set leaderElection=true
 ```
 
+By default a single operator instance watches `KeyorixSecret` CRs across every namespace in
+the cluster, so its RBAC (`ClusterRole`) is bound cluster-wide via a `ClusterRoleBinding` —
+the only way to grant access to a namespace it can't predict ahead of time. If your
+deployment instead runs one operator instance per namespace (or per bounded tenant set), set
+`watchNamespaces` to scope both the manager's watch and its RBAC binding down to a
+namespace-scoped `RoleBinding` per listed namespace:
+
+```sh
+helm install keyorix-operator-team-a deploy/helm/keyorix-operator -n team-a \
+  --set 'watchNamespaces={team-a}'
+```
+
+See the chart's [README](../deploy/helm/keyorix-operator/README.md#rbac) for details.
+
 ## Usage
 
 1. Create a least-privilege machine-identity token (ADR-030) Secret in your app

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -34,45 +34,66 @@ func init() {
 // itself manages, and routes every other Secret read straight to the API server instead
 // of through that (now-restricted) cache.
 //
-// The operator is deployed as a single cluster-wide instance: it watches KeyorixSecret CRs
-// (a namespaced CRD) across every namespace, with no --watch-namespaces flag or other
-// dynamic-namespace-discovery mechanism, so its ClusterRole necessarily grants Secret
-// get/list/watch/create/update/patch cluster-wide too — the operator genuinely cannot
-// predict which namespace the next CR (and its TokenSecretRef/target Secret) will land in,
-// and Kubernetes RBAC has no way to scope list/watch by resourceNames or to a dynamically
-// changing namespace set. See #327 and operator/config/rbac/role.yaml /
+// By DEFAULT the operator is deployed as a single cluster-wide instance: it watches
+// KeyorixSecret CRs (a namespaced CRD) across every namespace, so its ClusterRole
+// necessarily grants Secret get/list/watch/create/update/patch/delete cluster-wide too —
+// with no static namespace list configured, the operator genuinely cannot predict which
+// namespace the next CR (and its TokenSecretRef/target Secret) will land in, and
+// Kubernetes RBAC has no way to scope list/watch by resourceNames or to a dynamically
+// changing namespace set. See #327/#427 and operator/config/rbac/role.yaml /
 // deploy/helm/keyorix-operator/templates/rbac.yaml for the fuller writeup.
 //
-// What IS avoidable is controller-runtime's default behavior of caching every Secret in
-// the cluster in the operator's own process memory just because SetupWithManager calls
-// Owns(&corev1.Secret{}) to watch the Secrets it owns. That default cache would hold the
-// full contents of every Secret in the cluster — including ones this operator has no
-// relationship to — turning a compromise of the operator process (e.g. the SSRF/dependency
-// findings #184/#240) into a trivial in-memory dump of the entire cluster's Secrets instead
-// of just the ones it manages. Restricting the informer to controller.ManagedByLabel closes
-// that gap: only Secrets this operator previously created (and therefore already has full
-// read/write RBAC over anyway) are ever resident in its cache.
+// Operators who instead run one instance PER namespace (or per bounded tenant set) can
+// opt into the -watch-namespaces flag: it restricts every cached type (KeyorixSecret CRs
+// AND Secrets) to just those namespaces via cache.Options.DefaultNamespaces, and the Helm
+// chart's watchNamespaces value correspondingly swaps the cluster-wide ClusterRoleBinding
+// for a namespace-scoped RoleBinding per watched namespace (still against the same
+// ClusterRole definition, for manifest reusability) — the least-privilege choice for that
+// deployment model, without forcing it on the default multi-tenant one.
+//
+// What IS always avoidable, regardless of namespace scoping, is controller-runtime's
+// default behavior of caching every Secret in the cluster in the operator's own process
+// memory just because SetupWithManager calls Owns(&corev1.Secret{}) to watch the Secrets
+// it owns. That default cache would hold the full contents of every Secret it can see —
+// including ones this operator has no relationship to — turning a compromise of the
+// operator process (e.g. the SSRF/dependency findings #184/#240) into a trivial in-memory
+// dump of Secrets instead of just the ones it manages. Restricting the informer to
+// controller.ManagedByLabel closes that gap: only Secrets this operator previously created
+// (and therefore already has full read/write RBAC over anyway) are ever resident in its
+// cache.
 //
 // Token Secrets (read via TokenSecretRef) and not-yet-adopted target Secrets never carry
 // that label, so DisableFor routes their reads around the label-restricted cache to a live
 // API call — they stay correctly readable on every reconcile, just uncached.
-func secretCacheOptions() (cache.Options, client.Options) {
+func secretCacheOptions(watchNamespaces []string) (cache.Options, client.Options) {
 	managedByThisOperator := labels.SelectorFromSet(map[string]string{
 		controller.ManagedByLabel: controller.ManagedByValue,
 	})
-	return cache.Options{
-			ByObject: map[client.Object]cache.ByObject{
-				&corev1.Secret{}: {Label: managedByThisOperator},
-			},
-		}, client.Options{
-			Cache: &client.CacheOptions{
-				DisableFor: []client.Object{&corev1.Secret{}},
-			},
+	opts := cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Secret{}: {Label: managedByThisOperator},
+		},
+	}
+	if len(watchNamespaces) > 0 {
+		defaultNamespaces := make(map[string]cache.Config, len(watchNamespaces))
+		for _, ns := range watchNamespaces {
+			defaultNamespaces[ns] = cache.Config{}
 		}
+		// Left unset on the Secret ByObject entry above so it defaults from
+		// DefaultNamespaces (controller-runtime's precedence rule): the label
+		// restriction and the namespace restriction combine, rather than one
+		// overriding the other.
+		opts.DefaultNamespaces = defaultNamespaces
+	}
+	return opts, client.Options{
+		Cache: &client.CacheOptions{
+			DisableFor: []client.Object{&corev1.Secret{}},
+		},
+	}
 }
 
 func main() {
-	var metricsAddr, probeAddr, allowedServers string
+	var metricsAddr, probeAddr, allowedServers, watchNamespaces string
 	var enableLeaderElection bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "address the metric endpoint binds to")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "address the probe endpoint binds to")
@@ -81,6 +102,11 @@ func main() {
 	flag.StringVar(&allowedServers, "allowed-servers", os.Getenv("KEYORIX_ALLOWED_SERVERS"),
 		"comma-separated list of trusted Keyorix base URLs (https://host) a KeyorixSecret's spec.server must match. "+
 			"REQUIRED: without it every CR is rejected, so the operator never sends a token to a CR-chosen destination.")
+	flag.StringVar(&watchNamespaces, "watch-namespaces", os.Getenv("KEYORIX_WATCH_NAMESPACES"),
+		"OPTIONAL comma-separated list of namespaces this instance manages KeyorixSecret CRs and their target "+
+			"Secrets in. Leave empty (the default) to watch every namespace in the cluster, which requires a "+
+			"cluster-wide RBAC grant (#327/#427). Set this to run one operator instance per namespace/tenant set "+
+			"with a namespace-scoped RBAC grant instead — see deploy/helm/keyorix-operator's watchNamespaces value.")
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
@@ -88,7 +114,17 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	setupLog := ctrl.Log.WithName("setup")
 
-	secretCache, secretClient := secretCacheOptions()
+	var watchNS []string
+	for _, ns := range strings.Split(watchNamespaces, ",") {
+		if ns = strings.TrimSpace(ns); ns != "" {
+			watchNS = append(watchNS, ns)
+		}
+	}
+	if len(watchNS) > 0 {
+		setupLog.Info("restricting watched namespaces", "namespaces", watchNS)
+	}
+
+	secretCache, secretClient := secretCacheOptions(watchNS)
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},

--- a/operator/cmd/main_test.go
+++ b/operator/cmd/main_test.go
@@ -30,7 +30,7 @@ func secretByObject(opts cache.Options) (cache.ByObject, bool) {
 // because this is a single cluster-wide operator instance, see cmd/main.go's doc comment)
 // grants access far beyond what any one reconcile touches.
 func TestSecretCacheOptions_ScopesInformerToManagedSecrets(t *testing.T) {
-	cacheOpts, _ := secretCacheOptions()
+	cacheOpts, _ := secretCacheOptions(nil)
 
 	byObj, ok := secretByObject(cacheOpts)
 	require.True(t, ok, "the Secret informer must have an explicit ByObject scope, not the cluster-wide default")
@@ -53,7 +53,7 @@ func TestSecretCacheOptions_ScopesInformerToManagedSecrets(t *testing.T) {
 // Secrets, which never carry the managed-by label) unreadable: direct client reads for
 // Secrets must bypass that cache and go live to the API server instead.
 func TestSecretCacheOptions_DisablesCacheForDirectSecretReads(t *testing.T) {
-	_, clientOpts := secretCacheOptions()
+	_, clientOpts := secretCacheOptions(nil)
 
 	require.NotNil(t, clientOpts.Cache, "direct Secret reads must be excluded from the label-restricted cache")
 	found := false
@@ -68,6 +68,37 @@ func TestSecretCacheOptions_DisablesCacheForDirectSecretReads(t *testing.T) {
 // Guard against the cache options silently reverting to controller-runtime's cluster-wide
 // default (a nil/empty ByObject map caches everything with no restriction at all).
 func TestSecretCacheOptions_IsNotClusterWideDefault(t *testing.T) {
-	cacheOpts, _ := secretCacheOptions()
+	cacheOpts, _ := secretCacheOptions(nil)
 	assert.NotEmpty(t, cacheOpts.ByObject, "cache.Options.ByObject must not be empty, or Secret caching silently reverts to the cluster-wide default")
+}
+
+// #327/#427: when the operator is configured (via -watch-namespaces, wired from the Helm
+// chart's watchNamespaces value) to manage only a bounded set of namespaces, the manager's
+// cache — and therefore, in practice via the corresponding RBAC RoleBinding, its real
+// access — must be limited to exactly those namespaces, not silently fall back to
+// cluster-wide.
+func TestSecretCacheOptions_RestrictsToWatchNamespacesWhenSet(t *testing.T) {
+	cacheOpts, _ := secretCacheOptions([]string{"team-a", "team-b"})
+
+	require.NotNil(t, cacheOpts.DefaultNamespaces, "DefaultNamespaces must be set when watch namespaces are configured")
+	assert.Len(t, cacheOpts.DefaultNamespaces, 2)
+	_, hasA := cacheOpts.DefaultNamespaces["team-a"]
+	_, hasB := cacheOpts.DefaultNamespaces["team-b"]
+	assert.True(t, hasA)
+	assert.True(t, hasB)
+
+	// The label restriction on Secrets must still apply — namespace-scoping and
+	// label-scoping combine rather than one replacing the other.
+	byObj, ok := secretByObject(cacheOpts)
+	require.True(t, ok)
+	managed := labels.Set{controller.ManagedByLabel: controller.ManagedByValue}
+	assert.True(t, byObj.Label.Matches(managed))
+}
+
+// The default (cluster-wide) behavior must be preserved when no namespaces are configured —
+// this is what the existing default Helm chart install (and existing deployments upgrading
+// without setting watchNamespaces) rely on.
+func TestSecretCacheOptions_DefaultsToClusterWideWhenUnset(t *testing.T) {
+	cacheOpts, _ := secretCacheOptions(nil)
+	assert.Empty(t, cacheOpts.DefaultNamespaces, "DefaultNamespaces must be unset by default, preserving cluster-wide watch behavior")
 }

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -1,18 +1,31 @@
 ---
-# NOTE (#327): this is a ClusterRole/ClusterRoleBinding, not a namespaced Role, because the
-# operator is deployed as a single cluster-wide instance that watches KeyorixSecret CRs (a
-# namespaced CRD) across every namespace -- there is no --watch-namespaces flag or other
-# dynamic-namespace-discovery mechanism (see operator/cmd/main.go), so it genuinely cannot
-# predict ahead of time which namespace the next CR (and its TokenSecretRef/target Secret)
-# will land in. Kubernetes RBAC also has no way to scope `list`/`watch` by resourceNames or
-# to a dynamically changing namespace set, so narrowing this to per-namespace RoleBindings
-# isn't possible without also adding namespace-scoping to the operator's deployment model.
+# NOTE (#327/#427): this is a ClusterRole/ClusterRoleBinding, not a namespaced Role, because
+# by DEFAULT the operator is deployed as a single cluster-wide instance that watches
+# KeyorixSecret CRs (a namespaced CRD) across every namespace -- with no static namespace
+# list configured it genuinely cannot predict ahead of time which namespace the next CR
+# (and its TokenSecretRef/target Secret) will land in. Kubernetes RBAC also has no way to
+# scope `list`/`watch` by resourceNames or to a dynamically changing namespace set, so
+# narrowing this to per-namespace RoleBindings isn't possible for that deployment model.
 #
-# What operator/cmd/main.go DOES do to bound the blast radius of this necessarily cluster-
-# wide grant: it scopes the manager's Secret informer cache to only Secrets carrying the
-# operator's managed-by label (see secretCacheOptions in operator/cmd/main.go), so a
-# compromised operator process can't trivially dump every cluster Secret straight out of its
-# own in-memory cache -- only ones it already owns via this same RBAC.
+# Operators who instead run one instance PER namespace (or per bounded tenant set) can opt
+# into least-privilege, namespace-scoped RBAC: see the `watchNamespaces` value in
+# deploy/helm/keyorix-operator, which passes the corresponding `-watch-namespaces` flag
+# (operator/cmd/main.go) and swaps this same ClusterRole's binding from a cluster-wide
+# ClusterRoleBinding to a namespace-scoped RoleBinding per watched namespace -- the
+# ClusterRole definition here stays reusable across both modes.
+#
+# The verbs below are the minimum the reconcile logic actually uses: `create`/`update`/
+# `patch`/`get`/`list`/`watch` to materialise and refresh the target Secret, and `delete`
+# for `wipeTargetSecret` (keyorixsecret_controller.go), which removes the target Secret when
+# the upstream Keyorix reference is confirmed gone (#428) -- no broader verb (e.g.
+# deletecollection) is granted.
+#
+# What operator/cmd/main.go ALSO does to bound the blast radius of this (in the default
+# cluster-wide mode, necessarily cluster-wide) grant: it scopes the manager's Secret
+# informer cache to only Secrets carrying the operator's managed-by label (see
+# secretCacheOptions in operator/cmd/main.go), so a compromised operator process can't
+# trivially dump every cluster Secret straight out of its own in-memory cache -- only ones
+# it already owns via this same RBAC.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -24,6 +37,7 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/operator/internal/controller/keyorixsecret_controller.go
+++ b/operator/internal/controller/keyorixsecret_controller.go
@@ -123,7 +123,7 @@ type valueFetcher interface {
 // +kubebuilder:rbac:groups=secrets.keyorix.io,resources=keyorixsecrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=secrets.keyorix.io,resources=keyorixsecrets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=secrets.keyorix.io,resources=keyorixsecrets/finalizers,verbs=update
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reads the referenced Keyorix values and writes them into the target Secret.
 func (r *KeyorixSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
## Summary

- The operator's `ClusterRole` (`operator/config/rbac/role.yaml`, mirrored in `deploy/helm/keyorix-operator/templates/rbac.yaml`) grants cluster-wide Secret create/get/list/watch/update/patch, bound via a cluster-wide `ClusterRoleBinding` — even though the reconcile logic only ever touches Secrets in the same namespace as the triggering `KeyorixSecret` CR (#327, and #427's near-duplicate of the same claim). If the operator's ServiceAccount token is ever exfiltrated, that grant lets an attacker read/write Secrets in every namespace, not just the ones it legitimately manages.
- Investigated the operator's actual deployment model (`operator/cmd/main.go`, `keyorixsecret_controller.go`, ADR-060): today it's genuinely a single cluster-wide instance watching `KeyorixSecret` CRs across every namespace with no static namespace list, so the cluster-wide grant is required in that mode — Kubernetes RBAC can't scope `list`/`watch` to a dynamically changing namespace set. Forcing a namespace-scoped model onto that default would break it.
- Instead, added an **opt-in** `-watch-namespaces` flag (`operator/cmd/main.go`) and a matching Helm `watchNamespaces` value: when set, the manager's cache/watch is restricted to those namespaces (`cache.Options.DefaultNamespaces`), and the chart swaps the cluster-wide `ClusterRoleBinding` for a namespace-scoped `RoleBinding` per watched namespace — least privilege for operators who run one instance per namespace/tenant set. This mirrors the existing `targetNamespaces` pattern already used by the `keyorix-k8s-sync` chart. The default (unset) behavior and rendered manifests are unchanged, so this is fully backward compatible.
- **Found in passing:** the #428 fix (wipe the target Secret when the upstream reference is confirmed gone) added a real `Delete` call on the target Secret, but the RBAC grant was never updated with the `delete` verb — so that cleanup path has been silently failing RBAC checks in any real cluster since it shipped. Added `delete` to the kubebuilder marker (regenerated `role.yaml` via `make manifests`) and the Helm chart's `ClusterRole`.
- Updated `docs/k8s-operator.md` and the chart README with the new `watchNamespaces` option.

## Test plan

- [x] `cd operator && GOWORK=off go build ./... && GOWORK=off go vet ./... && GOWORK=off go test ./... -count=1` — clean, plus new tests covering `secretCacheOptions` with/without `watchNamespaces`
- [x] `gofmt -l .` clean, `golangci-lint run ./...` — 0 issues
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `helm lint deploy/helm/keyorix-operator` (default and `--set 'watchNamespaces={team-a,team-b}'`) — both clean
- [x] `helm template` + `kubeconform -strict` for both modes — both valid
- [x] Manually confirmed rendered RBAC: default mode → `ClusterRoleBinding` (no per-namespace `RoleBinding`); `watchNamespaces` set → per-namespace `RoleBinding`s, no `ClusterRoleBinding`, and `-watch-namespaces` flag present on the Deployment
- [x] Added these same assertions to the `helm-chart` CI job so both modes stay proven going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)