### PR TITLE
fix(helm): pin the main chart's default image tag to appVersion (#137)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,49 @@ jobs:
             --set externalDatabase.host=db.example.com --set externalDatabase.password=ci \
             | ./kubeconform -strict -summary -kubernetes-version 1.29.0
 
+      - name: Pinned default image tag + Secret-sourced passwords (#137)
+        run: |
+          # #137 residual: server/web images used to default to the mutable
+          # `latest` tag, and this asserts the default render instead pins to
+          # the chart's own appVersion (matching keyorix-operator/
+          # keyorix-k8s-sync's already-hardened `default .Chart.AppVersion .tag`
+          # convention) -- no `latest` anywhere in the default render.
+          APP_VERSION="$(sed -n 's/^appVersion: *"\{0,1\}\([^"]*\)"\{0,1\}$/\1/p' deploy/helm/keyorix/Chart.yaml)"
+          helm template kx deploy/helm/keyorix \
+            --set auth.masterPassword=ci --set postgresql.auth.password=ci \
+            --set auth.adminPassword=ci > default-render.yaml
+          if grep -q ':latest' default-render.yaml; then
+            echo "expected no ':latest' image tag in the default render"; exit 1
+          fi
+          if ! grep -q "image: ghcr.io/keyorixhq/keyorix-server:${APP_VERSION}\$" default-render.yaml; then
+            echo "expected the server image pinned to appVersion ${APP_VERSION}"; exit 1
+          fi
+          if ! grep -q "image: \"ghcr.io/keyorixhq/keyorix-web:${APP_VERSION}\"\$" default-render.yaml; then
+            echo "expected the web image pinned to appVersion ${APP_VERSION}"; exit 1
+          fi
+          # An explicit tag/digest override must still work (non-regression for
+          # existing values.yaml overrides set before this fix).
+          helm template kx deploy/helm/keyorix \
+            --set auth.masterPassword=ci --set postgresql.auth.password=ci \
+            --set server.image.tag=v1.2.3 --set web.image.digest=sha256:deadbeef \
+            > override-render.yaml
+          if ! grep -q 'image: ghcr.io/keyorixhq/keyorix-server:v1.2.3$' override-render.yaml; then
+            echo "expected an explicit server.image.tag override to still apply"; exit 1
+          fi
+          if ! grep -q 'image: "ghcr.io/keyorixhq/keyorix-web@sha256:deadbeef"$' override-render.yaml; then
+            echo "expected web.image.digest to still take precedence over tag"; exit 1
+          fi
+          # #137 residual: the master/db/admin passwords must be sourced from
+          # the Secret via secretKeyRef, never a literal env var value.
+          for key in KEYORIX_MASTER_PASSWORD KEYORIX_DB_PASSWORD KEYORIX_ADMIN_PASSWORD; do
+            if ! grep -A2 "name: $key\$" default-render.yaml | grep -q 'secretKeyRef'; then
+              echo "expected $key to be sourced via secretKeyRef, not a literal value"; exit 1
+            fi
+          done
+          if ! grep -A2 'name: POSTGRES_PASSWORD$' default-render.yaml | grep -q 'secretKeyRef'; then
+            echo "expected POSTGRES_PASSWORD to be sourced via secretKeyRef, not a literal value"; exit 1
+          fi
+
       - name: Lint + render keyorix-k8s-sync chart
         run: |
           K8S_SYNC_SET="--set keyorix.url=https://k --set keyorix.tokenSecret.name=tok \

--- a/deploy/helm/keyorix/README.md
+++ b/deploy/helm/keyorix/README.md
@@ -38,7 +38,8 @@ helm test keyorix
 | `auth.masterPassword` | — | **Required** (or `auth.existingSecret`). KEK passphrase. |
 | `auth.existingSecret` | — | Bring your own Secret (`KEYORIX_MASTER_PASSWORD`, `KEYORIX_DB_PASSWORD`, opt. `KEYORIX_ADMIN_PASSWORD`). |
 | `auth.adminPassword` | — | Optional first-boot admin bootstrap (idempotent). |
-| `server.image.tag` | chart `appVersion` | Server image tag. |
+| `server.image.tag` | chart `appVersion` | Server image tag (empty pins to the chart's own `appVersion`; `server.image.digest` takes precedence if set). |
+| `web.image.tag` | chart `appVersion` | Web UI image tag (same default/precedence as `server.image.tag`). |
 | `server.keysPersistence.*` | 1Gi RWO | The encryption-keys PVC (`resource-policy: keep`). |
 | `web.enabled` | `true` | Deploy the UI (with a k8s-adapted nginx that proxies to the server Service). |
 | `ingress.*` | disabled | Ingress for the web UI. |

--- a/deploy/helm/keyorix/templates/_helpers.tpl
+++ b/deploy/helm/keyorix/templates/_helpers.tpl
@@ -45,6 +45,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.web.image.digest -}}
 {{- printf "%s@%s" .Values.web.image.repository .Values.web.image.digest -}}
 {{- else -}}
-{{- printf "%s:%s" .Values.web.image.repository .Values.web.image.tag -}}
+{{- printf "%s:%s" .Values.web.image.repository (default .Chart.AppVersion .Values.web.image.tag) -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/keyorix/values.yaml
+++ b/deploy/helm/keyorix/values.yaml
@@ -21,12 +21,13 @@ auth:
 server:
   image:
     repository: ghcr.io/keyorixhq/keyorix-server
-    # `latest`/`main` are MUTABLE — the exact same tag can point at a different
-    # image tomorrow, defeating "what did I actually deploy" and any image-scan
-    # attestation pinned to this value. Pin to an immutable `sha-<commit>` tag, a
-    # `vX.Y.Z` release tag, or (strongest) a digest via `digest:` below for
-    # production.
-    tag: "latest"
+    # Empty defaults to this chart's own appVersion (a pinned `vX.Y.Z`), matching
+    # the keyorix-operator/keyorix-k8s-sync charts. `latest`/`main` are MUTABLE —
+    # the exact same tag can point at a different image tomorrow, defeating "what
+    # did I actually deploy" and any image-scan attestation pinned to this value —
+    # only set this to a floating tag if you understand that tradeoff. A digest
+    # via `digest:` below (strongest pin) takes precedence over either.
+    tag: ""
     # digest, when set (e.g. "sha256:abc123..."), pins the exact image content —
     # immune to a tag being retargeted after the fact — and takes precedence over
     # tag.
@@ -60,8 +61,9 @@ web:
   enabled: true
   image:
     repository: ghcr.io/keyorixhq/keyorix-web
-    # See server.image.tag — the same mutable-tag caveat applies here.
-    tag: latest
+    # See server.image.tag — same appVersion-pinned default, same mutable-tag
+    # caveat if you override it.
+    tag: ""
     # digest, when set, takes precedence over tag (see server.image.digest).
     digest: ""
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

PR #662 hardened pod securityContext/NetworkPolicy/resource limits on the
main `keyorix` chart's server/web/postgres pods but explicitly left two
residuals as documented deferrals: a mutable `latest` default image tag,
and a "master password via plain env var" concern. This closes the first
residual and clarifies the second was already resolved before #662 ever
landed.

### 1. Mutable `latest` image tag — fixed

- `values.yaml`: `server.image.tag` / `web.image.tag` now default to `""`
  instead of `"latest"`/`latest`.
- `templates/_helpers.tpl`: `keyorix.web.image` now falls back to
  `.Chart.AppVersion` when `tag` is empty — `keyorix.server.image` already
  had this fallback wired up, but `values.yaml`'s explicit `"latest"`
  always short-circuited it before `default` could apply.
- Mirrors the exact `default .Chart.AppVersion .Values.image.tag` pattern
  the already-hardened `keyorix-operator`/`keyorix-k8s-sync` charts use.
- `image.digest` still takes precedence over `tag` for both images,
  unchanged. Explicit `tag`/`digest` overrides continue to render exactly
  as before (verified) — non-regression for any existing values.yaml that
  already pins a tag.
- README updated to match (it already documented `server.image.tag`'s
  default as "chart `appVersion`" — this was a docs/code mismatch until
  now).

### 2. Master password via plain env var — investigated, already fixed

I traced `templates/secret.yaml` + `server-deployment.yaml` +
`postgresql.yaml`: `KEYORIX_MASTER_PASSWORD`, `KEYORIX_DB_PASSWORD`,
`KEYORIX_ADMIN_PASSWORD`, and `POSTGRES_PASSWORD` are all already sourced
via `valueFrom.secretKeyRef` against a chart-generated (or
`auth.existingSecret`-supplied) `Secret` — confirmed present since this
chart's very first commit, predating #662. There is no literal password
`value:` anywhere in this chart today. Left this untouched rather than
force an unnecessary change to the deliberately fail-fast (no
auto-generation) master-password handling, where a hasty "improvement"
(e.g. Helm-side auto-generation) risks bricking the KEK-derived,
already-stored secrets on upgrade if it ever silently rotated the value.

### CI

Added a step to the `helm-chart` job that renders the default chart and
asserts: no `:latest` image tag appears anywhere, both images render
pinned to the chart's `appVersion`, an explicit `tag`/`digest` override
still applies (non-regression), and the master/db/admin/postgres
passwords are still `secretKeyRef`-sourced (regression guard for the
already-correct pattern).

## Test plan

- [x] `helm lint --strict deploy/helm/keyorix`
- [x] `helm template deploy/helm/keyorix | kubeconform -strict` for both
      the bundled-DB and external-DB paths (matching CI exactly)
- [x] Confirmed default render pins `ghcr.io/keyorixhq/keyorix-server` and
      `keyorix-web` to the chart's `appVersion` (`0.85.0`), no `latest`
- [x] Confirmed an explicit `server.image.tag`/`web.image.digest`
      override still renders correctly
- [x] Confirmed `KEYORIX_MASTER_PASSWORD`/`KEYORIX_DB_PASSWORD`/
      `KEYORIX_ADMIN_PASSWORD`/`POSTGRES_PASSWORD` render via
      `secretKeyRef`, not a literal value
- [x] New CI assertions run locally and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)