### PR TITLE
fix(remote-storage): add missing "success" key to sendSuccess (storage.type: remote was fully broken)

### DIFF
--- a/server/http/handlers/helpers.go
+++ b/server/http/handlers/helpers.go
@@ -7,12 +7,24 @@ import (
 )
 
 // sendSuccess sends a successful JSON response
+//
+// The envelope always carries "success": true (in addition to the implicit 2xx
+// status code). Every internal/storage/store/remote_*.go method backing
+// storage.type: remote decodes the upstream body into
+// internal/storage/remote.APIResponse and branches on its Success field, NOT
+// the HTTP status — before this field was added, that field silently defaulted
+// to Go's zero value (false) for every genuinely successful response from a
+// real (non-test-mock) production server, so the entire storage.type: remote
+// deployment mode misreported every successful proxied read/write as a
+// failure. This is a purely additive JSON key: existing consumers of the
+// "data"/"message" keys are unaffected.
 func sendSuccess(w http.ResponseWriter, data interface{}, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 
 	response := map[string]interface{}{
-		"data": data,
+		"success": true,
+		"data":    data,
 	}
 	if message != "" {
 		response["message"] = message
@@ -65,12 +77,23 @@ func goSafe(fn func()) {
 }
 
 // sendError sends an error JSON response
+//
+// Explicitly carries "success": false. This is not strictly load-bearing for
+// internal/storage/remote.HTTPClient today: this body's "error" key is a bare
+// string, which doesn't unmarshal into APIResponse.Error's *APIError struct
+// type, so json.Unmarshal already fails and makeRequest's parse-failure branch
+// synthesizes its own Success:false/Error response instead of ever reading
+// this body's fields. That's an accidental, fragile safety net (it would stop
+// working the moment this "error" key were ever reshaped into an object to
+// match APIError) — writing the field explicitly here means the error path no
+// longer depends on that coincidence.
 func sendError(w http.ResponseWriter, errorType, message string, statusCode int, details interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(statusCode)
 
 	response := map[string]interface{}{
+		"success": false,
 		"error":   errorType,
 		"message": message,
 		"code":    statusCode,

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -16,7 +16,8 @@ info:
     setup-token flow, health, and Prometheus metrics) need no token.
 
     ## Response envelope
-    Unless noted, success responses wrap the payload as `{ "data": <…>, "message": "<…>" }`.
+    Unless noted, success responses wrap the payload as
+    `{ "success": true, "data": <…>, "message": "<…>" }`.
     Errors use `{ "error": { "code": <int>, "message": <string>, "type": <string> } }`.
 
     ## Authorization

--- a/server/http/handlers/rotation_policies_handler.go
+++ b/server/http/handlers/rotation_policies_handler.go
@@ -40,7 +40,7 @@ func NewRotationPolicyHandler(coreService *core.KeyorixCore) *RotationPolicyHand
 func (h *RotationPolicyHandler) sendSuccess(w http.ResponseWriter, data interface{}, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	if err := json.NewEncoder(w).Encode(SuccessResponse{Data: data, Message: message}); err != nil {
+	if err := json.NewEncoder(w).Encode(SuccessResponse{Success: true, Data: data, Message: message}); err != nil {
 		log.Printf("Error encoding JSON response: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}

--- a/server/http/handlers/secrets_handler.go
+++ b/server/http/handlers/secrets_handler.go
@@ -38,7 +38,14 @@ func NewSecretHandler(coreService *core.KeyorixCore) (*SecretHandler, error) {
 }
 
 // ErrorResponse is the standard error envelope returned on all 4xx/5xx responses.
+//
+// Success is always false here — the zero value already gives that for free,
+// but it's written out explicitly for symmetry with SuccessResponse and so it
+// doesn't rely on internal/storage/remote.HTTPClient's incidental
+// parse-failure fallback (see helpers.go's sendError doc comment) to end up
+// correct.
 type ErrorResponse struct {
+	Success bool        `json:"success"`
 	Error   string      `json:"error"`
 	Message string      `json:"message"`
 	Code    int         `json:"code"`
@@ -46,7 +53,15 @@ type ErrorResponse struct {
 }
 
 // SuccessResponse is the standard success envelope returned on 2xx responses.
+//
+// Success must always be true here: internal/storage/store/remote_*.go (the
+// storage.type: remote backend) decodes this body into
+// internal/storage/remote.APIResponse and branches on its Success field, not
+// the HTTP status — omitting this field left it at Go's zero value (false)
+// for every genuinely successful response, misreporting every proxied
+// read/write as a failure.
 type SuccessResponse struct {
+	Success bool        `json:"success"`
 	Data    interface{} `json:"data"`
 	Message string      `json:"message,omitempty"`
 }
@@ -55,7 +70,7 @@ type SuccessResponse struct {
 func (h *SecretHandler) sendSuccess(w http.ResponseWriter, data interface{}, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	if err := json.NewEncoder(w).Encode(SuccessResponse{Data: data, Message: message}); err != nil {
+	if err := json.NewEncoder(w).Encode(SuccessResponse{Success: true, Data: data, Message: message}); err != nil {
 		log.Printf("Error encoding JSON response: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}

--- a/server/http/handlers/shares_handler.go
+++ b/server/http/handlers/shares_handler.go
@@ -32,7 +32,7 @@ func NewShareHandler(coreService *core.KeyorixCore) (*ShareHandler, error) {
 func (h *ShareHandler) sendSuccess(w http.ResponseWriter, data interface{}, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	if err := json.NewEncoder(w).Encode(SuccessResponse{Data: data, Message: message}); err != nil {
+	if err := json.NewEncoder(w).Encode(SuccessResponse{Success: true, Data: data, Message: message}); err != nil {
 		log.Printf("Error encoding JSON response: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}

--- a/server/http/remote_storage_success_field_test.go
+++ b/server/http/remote_storage_success_field_test.go
@@ -1,0 +1,171 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteStorage_SuccessFieldFix_RealServerRoundTrip proves the fix for the
+// missing "success" key in the shared HTTP success envelope (server/http/handlers/
+// helpers.go's sendSuccess, plus the three per-handler duplicates in
+// secrets_handler.go/rotation_policies_handler.go/shares_handler.go) end-to-end
+// against a REAL, production server — not a hand-rolled mock.
+//
+// Before the fix: internal/storage/remote.APIResponse.Success (the field every
+// internal/storage/store/remote_*.go method branches on to decide success/failure)
+// silently defaulted to Go's zero value, false, for EVERY genuinely successful 2xx
+// response from a real server, because sendSuccess never wrote a "success" key into
+// the JSON body at all. That made storage.type: remote non-functional against a
+// real upstream: every read and write was misreported as a failure, even though it
+// had genuinely succeeded server-side.
+//
+// This test builds two independent *core.KeyorixCore instances, each with its own
+// SQLite-backed storage:
+//
+//   - "upstream": a normal Keyorix server, exercised through the ACTUAL
+//     NewRouter(...)/handlers this package registers (the real production code
+//     path, not a synthetic stand-in of the wire protocol).
+//   - "downstream": a store.RemoteStorage pointed at "upstream" over real HTTP —
+//     exactly the storage.type: remote deployment mode (ADR-049) describes.
+//
+// It drives several distinct real operations (single-resource GET, filtered
+// LIST, and a mutating PUT) through the downstream RemoteStorage client and
+// asserts each one is read back as success (not misreported as an error) AND
+// that the data returned is the real data that lives in the upstream's own
+// storage — proving the round trip, not just "the call didn't error".
+func TestRemoteStorage_SuccessFieldFix_RealServerRoundTrip(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	// --- upstream: a real Keyorix server ---
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	ctx := context.Background()
+
+	// Seed real data directly against the upstream's own core (bypassing the wire
+	// entirely for setup, so the test's assertions are only about the read/write
+	// paths this fix touches, not about unrelated wire-DTO shape mismatches between
+	// RemoteStorage's raw-model POST bodies and the REST handlers' own request DTOs).
+	adminUser, err := upstreamCore.Storage().GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+
+	project, err := upstreamCore.CreateProject(ctx, "e2e-success-field-project", "seeded for the sendSuccess fix e2e test")
+	require.NoError(t, err)
+	envs, err := upstreamCore.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs, "CreateProject must seed default environments")
+	envID := envs[0].ID
+
+	secret, err := upstreamCore.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name:          "e2e-success-field-secret",
+		Value:         []byte("s3cr3t-value"),
+		ProjectID:     project.ID,
+		EnvironmentID: envID,
+		Type:          "generic",
+		CreatedBy:     adminUser.Username,
+		OwnerID:       adminUser.ID,
+	})
+	require.NoError(t, err)
+
+	// --- downstream: storage.type: remote, pointed at the upstream ---
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+
+	// --- GET a single user ---
+	// Before the fix, GET /api/v1/users/{id} genuinely returns 200 with the real
+	// user, but RemoteStorage.GetUser saw Success==false (the zero value) and
+	// returned an error instead — the read that DID succeed server-side was
+	// reported as a failure to the caller.
+	gotUser, err := rs.GetUser(ctx, adminUser.ID)
+	require.NoError(t, err, "GetUser must not be misreported as a failure for a genuinely successful upstream response")
+	assert.Equal(t, adminUser.Username, gotUser.Username)
+	assert.Equal(t, adminUser.Email, gotUser.Email)
+
+	// --- LIST users (filtered) ---
+	users, total, err := rs.ListUsers(ctx, &coreStorage.UserFilter{Page: 1, PageSize: 50})
+	require.NoError(t, err, "ListUsers must not be misreported as a failure for a genuinely successful upstream response")
+	assert.GreaterOrEqual(t, total, int64(1))
+	found := false
+	for _, u := range users {
+		if u.ID == adminUser.ID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "the seeded admin user must be present in the real upstream's own ListUsers result")
+
+	// --- GET a single secret ---
+	gotSecret, err := rs.GetSecret(ctx, secret.ID)
+	require.NoError(t, err, "GetSecret must not be misreported as a failure for a genuinely successful upstream response")
+	assert.Equal(t, secret.Name, gotSecret.Name)
+	assert.Equal(t, secret.ProjectID, gotSecret.ProjectID)
+
+	// NOTE: GetSecretByName is deliberately not exercised here — it targets
+	// /api/v1/secrets/by-name/{name}, a route that server/http/router.go never
+	// registers at all (confirmed: no "by-name" route exists), so it 404s for an
+	// unrelated, pre-existing reason having nothing to do with this fix. Left as a
+	// separate follow-up finding rather than folded into this fix's scope.
+
+	// --- LIST secrets (filtered by project) ---
+	secrets, secTotal, err := rs.ListSecrets(ctx, &coreStorage.SecretFilter{ProjectID: &project.ID, Page: 1, PageSize: 50})
+	require.NoError(t, err, "ListSecrets must not be misreported as a failure for a genuinely successful upstream response")
+	assert.Equal(t, int64(1), secTotal)
+	require.Len(t, secrets, 1)
+	assert.Equal(t, secret.ID, secrets[0].ID)
+
+	// --- a genuine mutating write (PUT) ---
+	// Exercises the mutating-response path (not just GET), which goes through the
+	// exact same sendSuccess helper. Before the fix this also always looked like a
+	// failure even though the upstream had genuinely applied the update and
+	// returned 200.
+	//
+	// NOTE: models.SecretNode carries no JSON tags (its fields serialize as plain
+	// Go field names, e.g. "MaxReads"), while UpdateSecret's handler decodes a
+	// snake_case DTO (e.g. "max_reads") — a separate, pre-existing wire-shape
+	// mismatch (same class of issue as CreateUser's DisplayName/display_name
+	// mismatch found during investigation) that silently no-ops any field-level
+	// change sent this way. That's out of this fix's scope, so this step proves
+	// the PUT round-trip genuinely reached and re-persisted the row server-side —
+	// via UpdatedAt, which core.UpdateSecret always bumps — rather than asserting
+	// a specific field value changed.
+	beforeUpdatedAt := secret.UpdatedAt
+	newMaxReads := 7
+	updated, err := rs.UpdateSecret(ctx, &models.SecretNode{ID: secret.ID, MaxReads: &newMaxReads})
+	require.NoError(t, err, "UpdateSecret must not be misreported as a failure for a genuinely successful upstream response")
+	require.NotNil(t, updated)
+
+	// Confirm the write genuinely landed by reading it back directly from the
+	// upstream's OWN storage (not just "the client call didn't error").
+	directRead, err := upstreamCore.Storage().GetSecret(ctx, secret.ID)
+	require.NoError(t, err)
+	assert.True(t, directRead.UpdatedAt.After(beforeUpdatedAt),
+		"the downstream's forwarded PUT must be a real row-level write reaching the upstream's own secret_nodes table, not a call that merely didn't error")
+}


### PR DESCRIPTION
## Summary

`sendSuccess` (`server/http/handlers/helpers.go`) — the shared response-envelope helper nearly every production HTTP handler uses to send a 2xx response — never wrote a `"success"` key into its JSON body. It only relied on the implicit HTTP status code to signal success.

`internal/storage/remote.APIResponse.Success` is exactly the field every method in `internal/storage/store/remote_*.go` (the `storage.type: remote` backend — a Keyorix server configured to treat *another* Keyorix server's ordinary REST API as its storage backend, per ADR-049) branches on via `if !resp.Success { return error }` — **not** the HTTP status code.

With no `"success"` key in the body, `Success` silently defaulted to Go's zero value (`false`) for **every genuinely successful response** from a real (non-test-mock) upstream server. Confirmed via `internal/storage/remote/client.go`'s `makeRequest`: on a 2xx response with `Success == false` and no `Error`, it synthesizes a generic `UPSTREAM_UNSUCCESSFUL` error — meaning **every single read/write via `storage.type: remote` against a real upstream server was being misreported as a failure**, even though the operation genuinely succeeded server-side. This made the entire `storage.type: remote` deployment mode non-functional. The existing `remote_storage_test.go` suite never caught this because it only exercises hand-rolled mock servers that manually set `Success: true`.

## Blast radius

`sendSuccess` is used at ~256 call sites across `server/http/handlers/*.go`. In addition, three handler types (`SecretHandler`, `RotationPolicyHandler`, `ShareHandler`) had their own duplicate `sendSuccess`/`SuccessResponse` implementations with the identical bug — fixed at the shared `SuccessResponse` struct so all three are covered by one change.

Confirmed via `#452`'s follow-up fix (PR #793, currently open) that this was already known and deliberately worked around: its new endpoints "construct the exact `{success, data, error}` envelope … rather than the generic `sendSuccess`/`sendError` helpers" specifically because of this bug. This PR fixes the shared helper directly instead — the correct, minimal, blast-radius-covering fix, rather than continuing to hand-roll per-endpoint envelopes.

## Changes

- **`server/http/handlers/helpers.go`** — `sendSuccess` now writes `"success": true`. `sendError` now also writes `"success": false` explicitly, for defense-in-depth: `RemoteStorage`'s client happens to work correctly for the error path *today* (its `"error"` key is a bare string, which fails to unmarshal into `APIResponse.Error`'s struct type, so the client's parse-failure fallback already synthesizes `Success:false`) — but that was a fragile coincidence, not a designed invariant, so it's made explicit rather than left to rely on it.
- **`server/http/handlers/secrets_handler.go`** — `SuccessResponse`/`ErrorResponse` (shared by `SecretHandler`, `RotationPolicyHandler`, `ShareHandler`) gain an explicit `Success bool` field, set `true` at all three call sites.
- **`server/http/handlers/openapi.yaml`** — doc-only update reflecting the new `"success"` key in the response envelope description.
- **`server/http/remote_storage_success_field_test.go`** (new) — end-to-end proof, not a unit test on the helper in isolation: builds a real "upstream" server via the actual production `NewRouter`, points a real `store.RemoteStorage` "downstream" client at it over real HTTP, and drives GetUser/ListUsers/GetSecret/ListSecrets/UpdateSecret through it, asserting each succeeds and that the data is genuinely read from / written to the upstream's own storage. **Confirmed this test fails against the pre-fix code** with the exact predicted symptom (`UPSTREAM_UNSUCCESSFUL: upstream returned an unsuccessful response with no error detail` on a literal HTTP 200), and passes once the fix is restored.

## Compatibility

Purely additive JSON key — existing consumers of `.data`/`.message` (web UI, CLI) are unaffected. Grepped this repo for JSON schema validation on API responses; found none (the OpenAPI spec is documentation-only, no `additionalProperties: false` near the envelope). `internal/cli/system/init.go` already declares a `Success bool` field on its own response struct (never wired into control flow), so it tolerates the field's prior absence and gains nothing but consistency now. Not able to check `keyorix-web` directly (separate repo) — worth a quick sanity check there, though an added key on an already-loosely-typed envelope is very unlikely to break anything.

## Related, out-of-scope findings surfaced during investigation

- `internal/storage/store/remote_users.go`'s `CreateUser` and `remote_secrets.go`'s `CreateSecret`/`UpdateSecret` POST/PUT the raw `models.User`/`models.SecretNode` structs (no JSON tags, so they serialize as `Username`/`DisplayName`/`MaxReads` etc.), but the real REST handlers decode snake_case DTOs (`username`, `display_name`, `max_reads`). Case-insensitive JSON matching bridges same-spelling keys but not the underscore difference, so e.g. `display_name` never actually arrives — a separate, pre-existing wire-shape mismatch that silently no-ops or fails these calls under `storage.type: remote`, independent of this fix.
- `GetSecretByName` (`remote_secrets.go`) targets `/api/v1/secrets/by-name/{name}`, a route `server/http/router.go` never registers at all — a 404 for this call under `storage.type: remote`.
- `DeleteUser`/`DeleteSecret` return `204 No Content` with no body, but their `RemoteStorage` callers still gate on `resp.Success` from parsing that (empty) body — a third, distinct pre-existing issue.

None of these are touched here; flagging them for separate follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` — full suite passes except one pre-existing, unrelated flake (`TestConcurrency_RequestPasswordReset_BurstIsThrottled`), independently confirmed flaky on this same tree by rerunning 3x, unrelated to any file this PR touches (also previously noted as a known flake in PR #793's own test plan).
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run ./server/http/... ./internal/storage/store/... ./internal/storage/remote/...` — 0 issues
- [x] New end-to-end test verified to fail against the pre-fix code and pass against the fix (regression-proof, not just "code reads right")

🤖 Generated with [Claude Code](https://claude.com/claude-code)