### PR TITLE
test: add native Go fuzz tests for Shamir, JWT, and rotation-ref parsing

### DIFF
--- a/internal/core/oidc_fuzz_test.go
+++ b/internal/core/oidc_fuzz_test.go
@@ -1,0 +1,124 @@
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// FuzzOIDCVerifierVerify fuzzes OIDCVerifier.Verify, the JWT parsing entry point
+// for machine-identity federation (ADR-031): an external workload presents this
+// raw string as a Bearer credential on every authenticated request once OIDC
+// federation is enabled, which makes it the single most attacker-exposed
+// token-parsing boundary in the codebase — unlike the opaque session/PAT/machine
+// tokens (server/middleware/auth.go), which are validated by a DB lookup rather
+// than decoded/parsed.
+//
+// This asserts Verify (a) never panics on arbitrary input, and (b) never returns
+// a partially-populated success — a non-empty issuer/subject together with a nil
+// error — for malformed input; on any failure it must return a clean error with
+// issuer/subject left empty, mirroring how every rejection path in oidc.go already
+// returns ("", "", err).
+func FuzzOIDCVerifierVerify(f *testing.F) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		f.Fatal(err)
+	}
+	other, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		f.Fatal(err)
+	}
+	v, err := NewOIDCVerifier(
+		[]OIDCTrustedIssuer{{Issuer: "https://k8s.local", Audiences: []string{"keyorix"}}},
+		staticResolver{kid: "kid-1", key: &key.PublicKey},
+	)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	sign := func(signKey *rsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+		tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tok.Header["kid"] = kid
+		s, serr := tok.SignedString(signKey)
+		if serr != nil {
+			f.Fatal(serr)
+		}
+		return s
+	}
+	base := func() jwt.MapClaims {
+		return jwt.MapClaims{
+			"iss": "https://k8s.local", "sub": "sa", "aud": []string{"keyorix"},
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}
+	}
+
+	// --- Seed corpus, harvested from oidc_test.go's TestOIDCVerify_* table -----
+	f.Add("") // empty string
+
+	valid := sign(key, "kid-1", base())
+	f.Add(valid)                // genuinely valid token
+	f.Add(valid[:len(valid)-5]) // truncated (end cut off)
+	f.Add(valid[5:])            // corrupted (front cut off)
+	f.Add(valid + "x")          // trailing garbage appended
+
+	untrustedIss := base()
+	untrustedIss["iss"] = "https://evil.local"
+	f.Add(sign(key, "kid-1", untrustedIss))
+
+	wrongAud := base()
+	wrongAud["aud"] = []string{"some-other-service"}
+	f.Add(sign(key, "kid-1", wrongAud))
+
+	expired := base()
+	expired["exp"] = time.Now().Add(-2 * time.Hour).Unix()
+	f.Add(sign(key, "kid-1", expired))
+
+	f.Add(sign(other, "kid-1", base()))     // signed by an untrusted key, wrong kid claimed
+	f.Add(sign(key, "kid-unknown", base())) // unknown kid
+
+	noSub := base()
+	delete(noSub, "sub")
+	f.Add(sign(key, "kid-1", noSub))
+
+	// HMAC algorithm confusion — must be rejected (asymmetric algorithms only).
+	hmacTok := jwt.NewWithClaims(jwt.SigningMethodHS256, base())
+	hmacTok.Header["kid"] = "kid-1"
+	if hs, herr := hmacTok.SignedString([]byte("secret")); herr == nil {
+		f.Add(hs)
+	}
+
+	noIat := base()
+	delete(noIat, "iat")
+	f.Add(sign(key, "kid-1", noIat))
+
+	staleIat := base()
+	staleIat["iat"] = time.Now().Add(-48 * time.Hour).Unix()
+	staleIat["exp"] = time.Now().Add(10 * 365 * 24 * time.Hour).Unix()
+	f.Add(sign(key, "kid-1", staleIat))
+
+	multiAudNoAzp := base()
+	multiAudNoAzp["aud"] = []string{"keyorix", "some-other-trusted-service"}
+	f.Add(sign(key, "kid-1", multiAudNoAzp))
+
+	f.Add("not.a.jwt")
+	f.Add("...")
+	f.Add("a.b.c.d") // wrong number of dot-separated segments
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		issuer, subject, verr := v.Verify(context.Background(), raw)
+		if verr != nil {
+			if issuer != "" || subject != "" {
+				t.Fatalf("Verify returned an error but a non-empty issuer/subject: issuer=%q subject=%q err=%v raw=%q", issuer, subject, verr, raw)
+			}
+			return
+		}
+		if issuer == "" || subject == "" {
+			t.Fatalf("Verify returned success (nil error) with an empty issuer/subject: issuer=%q subject=%q raw=%q", issuer, subject, raw)
+		}
+	})
+}

--- a/internal/crypto/shamir_fuzz_test.go
+++ b/internal/crypto/shamir_fuzz_test.go
@@ -1,0 +1,101 @@
+package crypto
+
+import (
+	"crypto/hmac"
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzCombineKEK fuzzes the Shamir share-parsing/reconstruction boundary — the
+// most security-critical parser in the codebase, since it turns untrusted-shape
+// input (an operator-configured share file or env var, see ShamirKeyProvider.KEK)
+// into the master KEK. decodeShare is the actual byte-payload parser (raw / hex /
+// base64), and combineKEK is where a bad reconstruction must fail closed (#429).
+//
+// This does not just fuzz for crashes: it also asserts the #429 security
+// invariant survives arbitrary fuzzed input — combineKEK must never return a
+// "success" whose reconstructed KEK fails the HMAC commitment check when a
+// commitment is configured (mirroring TestShamir_ForgedShare_FoolsMagicOnlyCheck_
+// ButCommitmentCatchesIt / TestShamir_CombineKEK_CommitmentRoundTrip in
+// shamir_test.go, which construct the same genuine-shares + commitment setup by
+// hand for a fixed table of forged inputs instead of a fuzzed input space).
+func FuzzCombineKEK(f *testing.F) {
+	kek := testKEK()
+	threshold := 3
+	shares, err := SplitKEK(kek, 5, threshold)
+	require.NoError(f, err)
+	commitment := CommitKEK(kek)
+
+	// The attacker/fuzzer is modeled as controlling ONE of the threshold-many
+	// share sources; genuine holds the other threshold-1 real shares (mirrors
+	// TestShamirKeyProvider_ForgedShareRejectedWithCommitment's setup).
+	genuine := append([][]byte{}, shares[:threshold-1]...)
+
+	// --- Seed corpus, harvested from shamir_provider_test.go / shamir_test.go ---
+	f.Add([]byte{})              // empty payload
+	f.Add([]byte("a"))           // too short (1 byte) to even be a share
+	f.Add([]byte("!"))           // garbage share (TestShamirKeyProvider_Errors)
+	f.Add([]byte(kekShareMagic)) // legacy magic-only format, no threshold/KEK bytes
+
+	// A genuinely valid share (raw bytes) for the SAME split/KEK — completing the
+	// threshold, this must actually succeed and match the commitment.
+	f.Add(append([]byte{}, shares[threshold-1]...))
+	// The same genuine share, but as hex/base64 TEXT — decodeShare must transparently
+	// decode either encoding, exactly as a share file/env var may contain.
+	f.Add([]byte(hex.EncodeToString(shares[threshold-1])))
+	f.Add([]byte(base64.StdEncoding.EncodeToString(shares[threshold-1])))
+
+	// A duplicate of an already-genuine share (same x-coordinate) — Combine must
+	// reject this as a duplicate rather than silently accepting it.
+	f.Add(append([]byte{}, genuine[0]...))
+
+	// A share from Split (not SplitKEK) — unframed, wrong length relative to the
+	// framed shares (TestShamirKeyProvider_UnframedSharesRejected).
+	unframedShares, uerr := Split(kek, 3, 2)
+	require.NoError(f, uerr)
+	f.Add(append([]byte{}, unframedShares[0]...))
+
+	// A valid share for a DIFFERENT KEK (correct length/framing, wrong content) —
+	// must reconstruct to something that does not satisfy this commitment.
+	otherKEK := make([]byte, KEKSize)
+	for i := range otherKEK {
+		otherKEK[i] = byte(255 - i)
+	}
+	otherShares, oerr := SplitKEK(otherKEK, 5, threshold)
+	require.NoError(f, oerr)
+	f.Add(append([]byte{}, otherShares[threshold-1]...))
+
+	// A forged share (#429 construction): an attacker holding threshold-1 genuine
+	// shares picks an arbitrary x-coordinate and solves for the y-values that make
+	// the WHOLE payload (magic, threshold, and a chosen fake KEK) interpolate
+	// exactly — the exact attack combineKEK's commitment check must catch.
+	fakeKEK := make([]byte, KEKSize)
+	for i := range fakeKEK {
+		fakeKEK[i] = 0x77
+	}
+	targetPayload := append(append([]byte{}, kekShareMagic...), byte(threshold))
+	targetPayload = append(targetPayload, fakeKEK...)
+	forged := forgeShare(genuine, 210, targetPayload)
+	f.Add(append([]byte{}, forged...))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		thirdShare, derr := decodeShare(data)
+		if derr != nil {
+			// Too short to be any kind of share (decodeShare's only failure mode) —
+			// nothing meaningful to combine, and decodeShare itself must not panic
+			// getting here, which the fuzz harness already enforces.
+			return
+		}
+		attackerShares := append(append([][]byte{}, genuine...), thirdShare)
+		kek, cerr := combineKEK(attackerShares, commitment)
+		if cerr != nil {
+			return
+		}
+		if !hmac.Equal(CommitKEK(kek), commitment) {
+			t.Fatalf("combineKEK returned success (no error) for a reconstructed KEK that fails its own HMAC commitment check — commitment bypass; data=%x kek=%x", data, kek)
+		}
+	})
+}

--- a/internal/rotation/azure_fuzz_test.go
+++ b/internal/rotation/azure_fuzz_test.go
@@ -1,0 +1,62 @@
+package rotation
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// FuzzAzureGenerateUpstreamRef fuzzes the ref interpolated into the Microsoft
+// Graph URL path by AzureAppSecretExecutor.GenerateUpstream (azure.go), the
+// executor whose own doc comment documents the exact bug this campaign already
+// found and fixed here: "ref is interpolated into the Graph URL path... a
+// crafted ref that begins with an allowed prefix (e.g.
+// '<allowed-guid>/../<victim-guid>') could path-traverse to a different
+// application and defeat allowed_refs." GenerateUpstream now rejects any
+// path/query metacharacter up front (strings.ContainsAny(ref, "/?#%")) before
+// the ref ever reaches url.PathEscape / the Graph client.
+//
+// This fuzzes the same invariant the existing regression test
+// (TestAzure_GenerateUpstream_Errors/"ref with path metacharacters rejected")
+// checks for one fixed malicious ref, but over the whole input space: (a)
+// GenerateUpstream must never panic, and (b) it must never let a ref containing
+// one of those metacharacters reach the Graph client (fake.addedFor) — i.e.
+// every ref that reaches the upstream call must be metacharacter-free.
+func FuzzAzureGenerateUpstreamRef(f *testing.F) {
+	// Seed corpus: a legitimate GUID-shaped ref, the exact path-traversal string
+	// the existing regression test uses, and a handful of other metacharacter
+	// shapes an attacker might try against the prefix allowlist.
+	f.Add("app-123")
+	f.Add("app-1/../victim-2")
+	f.Add("app-1/../../etc/passwd")
+	f.Add("app-1?x=1")
+	f.Add("app-1#frag")
+	f.Add("app-1%2e%2e%2fvictim")
+	f.Add("")
+	f.Add("app-")
+	f.Add(strings.Repeat("app-1/", 50) + "victim")
+
+	f.Fuzz(func(t *testing.T, ref string) {
+		fake := &fakeAzure{newSecret: "n3w-secret"}
+		e := azureWith(fake, "app-") // prefix allowlist an attacker might try to defeat
+
+		_, err := e.GenerateUpstream(context.Background(), ref)
+
+		if strings.ContainsAny(ref, "/?#%") {
+			if err == nil {
+				t.Fatalf("GenerateUpstream accepted a ref containing a path/query metacharacter: %q", ref)
+			}
+			if fake.addedFor != "" {
+				t.Fatalf("a metacharacter-bearing ref reached the Graph client: ref=%q addedFor=%q", ref, fake.addedFor)
+			}
+			return
+		}
+		// No metacharacters: it may still be rejected by the allowed_refs prefix
+		// check or the empty-ref check, but if it DID reach the upstream client,
+		// the exact ref (unmodified) must be what was sent — never a mangled or
+		// differently-scoped value.
+		if fake.addedFor != "" && fake.addedFor != ref {
+			t.Fatalf("Graph client received a different ref than was requested: requested=%q sent=%q", ref, fake.addedFor)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Gap analysis found zero `func Fuzz*` tests anywhere in the codebase. Adds three native Go fuzz targets (`testing.F`/`go test -fuzz`, no third-party fuzzing lib) at the highest-value parser/decoder boundaries handling attacker-influenceable or previously-buggy input:
  - `internal/crypto/shamir_fuzz_test.go` — `FuzzCombineKEK`: fuzzes the Shamir share-parsing/reconstruction path (`decodeShare` + `combineKEK`) behind the #429 KEK-reconstruction-forgery finding. Asserts no panic AND that `combineKEK` never returns success for a KEK that fails its own HMAC commitment check.
  - `internal/core/oidc_fuzz_test.go` — `FuzzOIDCVerifierVerify`: fuzzes `OIDCVerifier.Verify`, the JWT parsing entry point for machine-identity federation (ADR-031) — a raw Bearer token presented on every authenticated request once OIDC federation is enabled, unlike the opaque session/PAT/machine tokens which are validated by DB lookup rather than decoded. Asserts no panic and no partially-populated success (non-empty issuer/subject with a nil error) on malformed input.
  - `internal/rotation/azure_fuzz_test.go` — `FuzzAzureGenerateUpstreamRef`: fuzzes the rotation ref interpolated into the Microsoft Graph URL in `AzureAppSecretExecutor.GenerateUpstream` — the exact path-traversal bug this campaign already found and fixed (`allowed_refs` prefix check is start-only; a crafted `<allowed-guid>/../<victim-guid>` ref could escape scope). Asserts no panic and that no metacharacter-bearing ref ever reaches the upstream Graph client.
- Each target seeds a regression corpus (`f.Add(...)`) harvested from the existing test suites (`shamir_provider_test.go`/`shamir_test.go`, `oidc_test.go`, `azure_test.go`), so `go test ./...` (no `-fuzz` flag) still exercises them as a regression suite even without a live fuzzing session.
- Ran each for a 30s local burst (`go test -fuzz=FuzzXxx -fuzztime=30s`): all three clean, no crash or invariant violation found (Shamir: 5.2M execs, OIDC: 633K execs, Azure ref: 693K execs).

## Follow-up (not in this PR)
- CI should add a short `-fuzz -fuzztime=30s`-style smoke pass per target as a lightweight regression gate.
- Extended (hours-long) fuzzing should run on separate long-lived infrastructure, not CI.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, no `-fuzz`)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `go test -fuzz=FuzzCombineKEK -fuzztime=30s ./internal/crypto` — clean
- [x] `go test -fuzz=FuzzOIDCVerifierVerify -fuzztime=30s ./internal/core` — clean
- [x] `go test -fuzz=FuzzAzureGenerateUpstreamRef -fuzztime=30s ./internal/rotation` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)