### PR TITLE
fix(remote-storage): route GetSecretByName to a real registered endpoint (#497)

### DIFF
--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -180,6 +180,35 @@ func (c *KeyorixCore) GetSecretWithPermissionCheck(ctx context.Context, id, user
 	return c.GetSecret(ctx, id)
 }
 
+// GetSecretByName resolves a secret by its name within a project/environment. Like
+// GetSecret, it performs NO authorization check of its own — callers that serve the
+// result to an end user must go through GetSecretByNameWithPermissionCheck instead.
+func (c *KeyorixCore) GetSecretByName(ctx context.Context, name string, projectID, environmentID uint) (*models.SecretNode, error) {
+	secret, err := c.storage.GetSecretByName(ctx, name, projectID, environmentID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
+	}
+	if secret.Expiration != nil && time.Now().After(*secret.Expiration) {
+		return nil, fmt.Errorf("%s", i18n.T("ErrorSecretExpired", nil))
+	}
+	return secret, nil
+}
+
+// GetSecretByNameWithPermissionCheck retrieves a secret by name/project/environment
+// with read permission enforcement — the name-lookup counterpart to
+// GetSecretWithPermissionCheck, mirroring the resolve-then-authorize-by-id pattern
+// ResolveSecretRef/GetSecretValueByRef already use for the ref-based value read.
+func (c *KeyorixCore) GetSecretByNameWithPermissionCheck(ctx context.Context, name string, projectID, environmentID, userID uint) (*models.SecretNode, error) {
+	secret, err := c.storage.GetSecretByName(ctx, name, projectID, environmentID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
+	}
+	if _, err := c.EnforceSecretReadPermission(ctx, secret.ID, userID); err != nil {
+		return nil, err
+	}
+	return c.GetSecret(ctx, secret.ID)
+}
+
 // UpdateSecret updates an existing secret.
 func (c *KeyorixCore) UpdateSecret(ctx context.Context, req *UpdateSecretRequest) (*models.SecretNode, error) {
 	if err := c.validateUpdateSecretRequest(req); err != nil {

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -74,9 +74,16 @@ func (rs *RemoteStorage) GetSecretsByIDs(ctx context.Context, ids []uint) ([]*mo
 }
 
 // GetSecretByName retrieves a secret by name and scope context via remote API.
+//
+// The server registers this lookup as GET /api/v1/secrets/by-name with the name as
+// a query parameter (mirroring ListSecrets' project_id/environment_id query-scoped
+// convention), not as a path segment (#497: an earlier version of this method
+// requested /api/v1/secrets/by-name/{name}, a route server/http/router.go never
+// registered, so every call 404'd against a real server regardless of whether the
+// secret existed).
 func (rs *RemoteStorage) GetSecretByName(ctx context.Context, name string, projectID, environmentID uint) (*models.SecretNode, error) {
-	path := fmt.Sprintf("/api/v1/secrets/by-name/%s?project_id=%d&environment_id=%d",
-		url.PathEscape(name), projectID, environmentID)
+	path := fmt.Sprintf("/api/v1/secrets/by-name?name=%s&project_id=%d&environment_id=%d",
+		url.QueryEscape(name), projectID, environmentID)
 	resp, err := rs.client.Get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret by name: %w", err)

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -263,6 +263,69 @@ func (h *SecretHandler) GetSecret(w http.ResponseWriter, r *http.Request) {
 	h.sendSuccess(w, response, "")
 }
 
+// GetSecretByName handles GET /api/v1/secrets/by-name?name=X&project_id=Y&environment_id=Z
+// — looks up a secret's metadata by its name scoped to a project/environment, for
+// callers (e.g. RemoteStorage) that only have the name rather than the numeric ID.
+// The route's scoped-permission gate (ScopeFromQuery) authorizes the caller against
+// the project_id/environment_id query params, matching ListSecrets' convention; the
+// per-user ownership/sharing check then runs against the resolved secret's own ID,
+// the same belt-and-suspenders pattern GetSecret (by id) uses.
+func (h *SecretHandler) GetSecretByName(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	name := strings.TrimSpace(r.URL.Query().Get("name"))
+	if name == "" {
+		h.sendError(w, "InvalidParameter", "name is required", http.StatusBadRequest, nil)
+		return
+	}
+	projectID, err := strconv.ParseUint(r.URL.Query().Get("project_id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "project_id is required", http.StatusBadRequest, nil)
+		return
+	}
+	environmentID, err := strconv.ParseUint(r.URL.Query().Get("environment_id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "environment_id is required", http.StatusBadRequest, nil)
+		return
+	}
+
+	// Machine principals (ADR-030) are already authorized at the query-param scope by
+	// the route gate; the per-user owner/sharing check does not apply to them, so
+	// resolve directly (same split GetSecret uses for the by-id route).
+	isMachine := userCtx.MachineIdentityID != nil
+
+	var secret *models.SecretNode
+	if isMachine {
+		secret, err = h.coreService.GetSecretByName(r.Context(), name, uint(projectID), uint(environmentID))
+	} else {
+		secret, err = h.coreService.GetSecretByNameWithPermissionCheck(r.Context(), name, uint(projectID), uint(environmentID), userCtx.UserID)
+	}
+	if err != nil {
+		log.Printf("Error getting secret by name: %v", err)
+		if strings.Contains(err.Error(), "not found") {
+			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
+		} else if strings.Contains(err.Error(), "permission denied") {
+			h.sendError(w, "Forbidden", "Access denied", http.StatusForbidden, nil)
+		} else {
+			h.sendError(w, "InternalError", "Failed to get secret", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+
+	uid, sID, uname, sname := userCtx.UserID, secret.ID, userCtx.Username, secret.Name
+	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
+	auditCtx := core.DetachedAuditContext(r.Context())
+	goSafe(func() {
+		h.coreService.LogSecretReadWithProject(auditCtx, uid, sID, secret.ProjectID, uname, sname, ip, ua)
+	}) // #nosec G118
+
+	h.sendSuccess(w, secret, "")
+}
+
 // GetSecretValueByRef handles GET /api/v1/secrets/value?ref=project/environment/name —
 // reads a secret's value resolved by a human-readable reference instead of a numeric
 // ID, for integrations (e.g. the External Secrets Operator) that template a key string.

--- a/server/http/remote_storage_get_secret_by_name_test.go
+++ b/server/http/remote_storage_get_secret_by_name_test.go
@@ -1,0 +1,106 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteStorage_GetSecretByName_RealServerRoundTrip proves the fix for #497:
+// RemoteStorage.GetSecretByName targeted /api/v1/secrets/by-name/{name}, a route
+// server/http/router.go never registered, so every call 404'd against a real
+// production server regardless of whether the secret actually existed.
+//
+// The fix adds GET /api/v1/secrets/by-name (query-parameter scoped, mirroring
+// ListSecrets' project_id/environment_id convention rather than a path segment)
+// and points RemoteStorage.GetSecretByName's client-side URL construction at it.
+//
+// Like TestRemoteStorage_SuccessFieldFix_RealServerRoundTrip, this drives the
+// method through a REAL running server (NewRouter) via a REAL RemoteStorage
+// client over real HTTP — not a hand-rolled mock — so the test would have failed
+// against the pre-fix code with a 404, not just against a synthetic stand-in of
+// the route.
+func TestRemoteStorage_GetSecretByName_RealServerRoundTrip(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	// --- upstream: a real Keyorix server ---
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	ctx := context.Background()
+
+	adminUser, err := upstreamCore.Storage().GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+
+	project, err := upstreamCore.CreateProject(ctx, "e2e-get-by-name-project", "seeded for the GetSecretByName route fix e2e test (#497)")
+	require.NoError(t, err)
+	envs, err := upstreamCore.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs, "CreateProject must seed default environments")
+	envID := envs[0].ID
+
+	secret, err := upstreamCore.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name:          "e2e-get-by-name-secret",
+		Value:         []byte("s3cr3t-value"),
+		ProjectID:     project.ID,
+		EnvironmentID: envID,
+		Type:          "generic",
+		CreatedBy:     adminUser.Username,
+		OwnerID:       adminUser.ID,
+	})
+	require.NoError(t, err)
+
+	// --- downstream: storage.type: remote, pointed at the upstream ---
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+
+	// --- the secret genuinely exists: must be found, not 404 ---
+	got, err := rs.GetSecretByName(ctx, secret.Name, project.ID, envID)
+	require.NoError(t, err, "GetSecretByName must reach the real /api/v1/secrets/by-name route and succeed for a secret that genuinely exists (#497)")
+	require.NotNil(t, got)
+	assert.Equal(t, secret.ID, got.ID)
+	assert.Equal(t, secret.Name, got.Name)
+	assert.Equal(t, project.ID, got.ProjectID)
+	assert.Equal(t, envID, got.EnvironmentID)
+
+	// --- the secret genuinely does NOT exist: must be a real not-found, not a
+	// routing 404 confused with "found nothing" ---
+	_, err = rs.GetSecretByName(ctx, "does-not-exist-at-all", project.ID, envID)
+	require.Error(t, err, "a name that genuinely doesn't exist must still return an error")
+
+	// --- a name that IS registered, but scoped to the wrong project/environment,
+	// must also fail closed rather than leaking across scope ---
+	otherProject, err := upstreamCore.CreateProject(ctx, "e2e-get-by-name-other-project", "a second project the secret does not belong to")
+	require.NoError(t, err)
+	otherEnvs, err := upstreamCore.ListEnvironmentsByProject(ctx, otherProject.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, otherEnvs)
+
+	_, err = rs.GetSecretByName(ctx, secret.Name, otherProject.ID, otherEnvs[0].ID)
+	require.Error(t, err, "the same secret name must not resolve under a different project/environment scope")
+}

--- a/server/http/remote_storage_success_field_test.go
+++ b/server/http/remote_storage_success_field_test.go
@@ -128,11 +128,9 @@ func TestRemoteStorage_SuccessFieldFix_RealServerRoundTrip(t *testing.T) {
 	assert.Equal(t, secret.Name, gotSecret.Name)
 	assert.Equal(t, secret.ProjectID, gotSecret.ProjectID)
 
-	// NOTE: GetSecretByName is deliberately not exercised here — it targets
-	// /api/v1/secrets/by-name/{name}, a route that server/http/router.go never
-	// registers at all (confirmed: no "by-name" route exists), so it 404s for an
-	// unrelated, pre-existing reason having nothing to do with this fix. Left as a
-	// separate follow-up finding rather than folded into this fix's scope.
+	// NOTE: GetSecretByName is not exercised here — it is covered by its own
+	// dedicated end-to-end fix/regression test (#497),
+	// remote_storage_get_secret_by_name_test.go, once the missing route was added.
 
 	// --- LIST secrets (filtered by project) ---
 	secrets, secTotal, err := rs.ListSecrets(ctx, &coreStorage.SecretFilter{ProjectID: &project.ID, Page: 1, PageSize: 50})

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -473,6 +473,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// By-reference value read (ESO etc.): resolve project/environment/name → the
 			// secret's value. Scoped to the resolved secret; static path, before /{id}.
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromRefQuery)).Get("/value", secretHandler.GetSecretValueByRef)
+			// By-name metadata lookup, scoped by project_id/environment_id query params
+			// (same gate/convention as ListSecrets above) — the server-side counterpart
+			// RemoteStorage.GetSecretByName (#497) needs; a caller with only a secret's
+			// name (not its numeric ID) resolves it here. Static path, before /{id}.
+			r.With(customMiddleware.RequireScopedPermission("secrets.read", customMiddleware.ScopeFromQuery)).Get("/by-name", secretHandler.GetSecretByName)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}", secretHandler.GetSecret)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/versions", secretHandler.GetSecretVersions)
 			r.With(customMiddleware.RequireScopedPermission("secrets.read", secretScope)).Get("/{id}/risk", secretHandler.GetSecretRisk)


### PR DESCRIPTION
## Summary

Fixes backlog finding #497 (MEDIUM): `RemoteStorage.GetSecretByName` (`internal/storage/store/remote_secrets.go`) requested `GET /api/v1/secrets/by-name/{name}`, a route `server/http/router.go` never registered. Every call through this method returned a 404 against a real production server, regardless of whether the secret actually existed — `storage.type: remote` deployments could never look up a secret by name.

## Investigation (which case applies)

Confirmed by reading the actual router registrations, not assuming:

- `RemoteStorage.GetSecretByName` requested `/api/v1/secrets/by-name/{name}?project_id=...&environment_id=...` — a path-segment name with query-param scope.
- `server/http/router.go`'s `/secrets` group has no `by-name` route at all (grep-confirmed; a pre-existing test comment in `remote_storage_success_field_test.go` had already noted this and deliberately skipped exercising the method).
- No *equivalent* lookup exists under a different path either:
  - `ListSecrets` (`GET /secrets/`) supports only a fuzzy `search` param, no exact-name filter, and its filter type (`models.SecretListFilter`) has no `Name` field at all.
  - The `/secrets/value?ref=project/environment/name` route (`GetSecretValueByRef` / `ResolveSecretRef`) resolves by **project and environment name strings**, not numeric IDs — a different addressing scheme built for a different caller (human/CLI refs), and it also does a value read (with read-count/audit side effects), not a plain metadata get.

Conclusion: this is the "genuinely missing route" case, not a path-mismatch fix. Added a new server-side route rather than repointing the client at something that already covers this exact (name, project ID, environment ID) lookup.

## Fix

- Added `GET /api/v1/secrets/by-name?name=X&project_id=Y&environment_id=Z` in `server/http/router.go`, as a static path registered before `/{id}` (same ordering convention as the other static paths in this group), gated by `secrets.read` via `ScopeFromQuery` — the exact same scope-resolution convention `ListSecrets`/`UsageMostAccessed` already use for query-param-scoped reads.
- Added the handler `SecretHandler.GetSecretByName` (`server/http/handlers/secrets_crud.go`), following the same machine-principal vs. per-user-permission-check split `GetSecret` (by ID) already uses.
- Added `KeyorixCore.GetSecretByName` / `GetSecretByNameWithPermissionCheck` (`internal/core/secrets.go`), mirroring the existing `GetSecret`/`GetSecretWithPermissionCheck` pair and the resolve-then-authorize-by-id pattern `ResolveSecretRef` + `GetSecretValueByRef` already establish.
- Repointed `RemoteStorage.GetSecretByName`'s client-side URL construction at the new query-parameter route (`url.QueryEscape` instead of a path segment).
- Updated the stale "deliberately not exercised" note in `remote_storage_success_field_test.go` now that the route exists.

## Known pre-existing limitation (not introduced by this fix)

The shared remote HTTP client (`internal/storage/remote/client.go`) discards the JSON error envelope for any `>= 400` status and returns a generic `httpStatusError{StatusCode, Status}` instead (e.g. `"HTTP 404: 404 Not Found"`). This means a genuine "secret not found" 404 and a routing 404 already produce an identical error shape at the `RemoteStorage` call site — for *every* method on this client, not something this fix introduces. Flagging it here since the task explicitly asked to check for it; treating a real fix (surfacing the parsed `APIError` on 4xx) as a separate, follow-up finding, out of this fix's scope.

## Test plan

- [x] New end-to-end test `TestRemoteStorage_GetSecretByName_RealServerRoundTrip` (`server/http/remote_storage_get_secret_by_name_test.go`), following the established `NewRouter` + real `RemoteStorage`-over-HTTP pattern from the #452/#794 fixes:
  - A secret that genuinely exists is found by name/project/environment (would 404 pre-fix).
  - A name that genuinely doesn't exist returns an error.
  - The same name scoped to a *different* project/environment also fails closed (no cross-scope leak).
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/... ./server/http/... -count=1` — all green
- [x] `gosec -severity medium -exclude-generated ./internal/storage/... ./server/http/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)