### PR TITLE
fix(remote-storage): treat a 204/empty-body 2xx response as success (#498)

### DIFF
--- a/internal/storage/remote/client.go
+++ b/internal/storage/remote/client.go
@@ -244,6 +244,20 @@ func (c *HTTPClient) makeRequest(ctx context.Context, method, path string, body 
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
+	// A 2xx response with a genuinely empty body (the canonical shape of a 204
+	// No Content, e.g. DeleteUser/DeleteSecret) is an unambiguous success, not
+	// a parse failure (#498). json.Unmarshal on zero bytes errors with
+	// "unexpected end of JSON input", which — before this check — fell into
+	// the generic parse-error branch below and synthesized Success:false,
+	// silently misreporting every genuinely successful delete as failed. Only
+	// short-circuit for a truly empty body on a 2xx status; a malformed/
+	// truncated JSON body (non-empty) still falls through to the real parse
+	// error below, so a corrupted response on a 200 that was SUPPOSED to
+	// carry content is still correctly surfaced as an error.
+	if len(respBody) == 0 && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return &APIResponse{Success: true}, nil
+	}
+
 	var apiResp APIResponse
 	if err := json.Unmarshal(respBody, &apiResp); err != nil {
 		// If we can't parse as API response, create a generic error

--- a/internal/storage/remote/client_test.go
+++ b/internal/storage/remote/client_test.go
@@ -303,6 +303,93 @@ func TestHTTPClient_MalformedSuccessResponse_NoPanic(t *testing.T) {
 	})
 }
 
+// TestHTTPClient_204NoContent_Success pins #498: a 204 No Content response (the
+// real shape DeleteUser/DeleteSecret's handlers return — an empty body, no JSON
+// at all) must be treated as an unambiguous success, not a parse failure. Before
+// the fix, json.Unmarshal on the zero-byte body errored with "unexpected end of
+// JSON input", and makeRequest's parse-error branch synthesized Success:false —
+// silently misreporting every genuinely successful delete as a failure.
+func TestHTTPClient_204NoContent_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	config := &Config{
+		BaseURL:        server.URL,
+		APIKey:         "test-key",
+		TimeoutSeconds: 30,
+		RetryAttempts:  0,
+		TLSVerify:      false,
+	}
+	client, err := NewHTTPClient(config)
+	require.NoError(t, err)
+
+	resp, err := client.Delete(context.Background(), "/users/1")
+	require.NoError(t, err, "a 204 No Content must not be misreported as a request failure")
+	require.NotNil(t, resp)
+	assert.True(t, resp.Success, "a 204 No Content must be treated as success, not the zero-value Success:false")
+	assert.Nil(t, resp.Error)
+}
+
+// TestHTTPClient_2xxEmptyBody_Success generalizes the #498 fix beyond a literal
+// 204: any 2xx status with a genuinely empty body (not just 204) must also be
+// treated as success, since the mechanism (an empty body can't be unmarshaled)
+// is identical regardless of the exact 2xx code used.
+func TestHTTPClient_2xxEmptyBody_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// deliberately write nothing
+	}))
+	defer server.Close()
+
+	config := &Config{
+		BaseURL:        server.URL,
+		APIKey:         "test-key",
+		TimeoutSeconds: 30,
+		RetryAttempts:  0,
+		TLSVerify:      false,
+	}
+	client, err := NewHTTPClient(config)
+	require.NoError(t, err)
+
+	resp, err := client.Get(context.Background(), "/whatever")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Success)
+}
+
+// TestHTTPClient_MalformedNonEmptyBody_StillReportsFailure is the non-regression
+// half of the #498 fix: the empty-body special case must NOT be broadened into
+// "any unparseable body is success". A 200 that was supposed to carry a JSON
+// body but instead sends truncated/malformed (non-empty) bytes must still
+// surface as a genuine parse failure (Success:false with the raw body captured
+// in Error.Details), exactly as before this fix.
+func TestHTTPClient_MalformedNonEmptyBody_StillReportsFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success": tru`)) // truncated, non-empty, malformed JSON
+	}))
+	defer server.Close()
+
+	config := &Config{
+		BaseURL:        server.URL,
+		APIKey:         "test-key",
+		TimeoutSeconds: 30,
+		RetryAttempts:  0,
+		TLSVerify:      false,
+	}
+	client, err := NewHTTPClient(config)
+	require.NoError(t, err)
+
+	resp, err := client.Get(context.Background(), "/whatever")
+	require.NoError(t, err, "a parse failure is reported via Success:false/Error, not a Go error")
+	require.NotNil(t, resp)
+	assert.False(t, resp.Success, "a genuinely malformed non-empty body must still be reported as a failure")
+	require.NotNil(t, resp.Error)
+	assert.Contains(t, resp.Error.Details, `{"success": tru`)
+}
+
 // TestAPIError_ErrorMethod_NilSafe pins the nil-receiver guard directly: any
 // existing or future caller doing (*APIError)(nil).Error() must not panic.
 func TestAPIError_ErrorMethod_NilSafe(t *testing.T) {

--- a/server/http/remote_storage_delete_204_test.go
+++ b/server/http/remote_storage_delete_204_test.go
@@ -1,0 +1,109 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteStorage_DeleteUserAndDeleteSecret_204NoContent_RealServerRoundTrip
+// pins the fix for #498: RemoteStorage.DeleteUser/DeleteSecret gate on
+// resp.Success, which internal/storage/remote/client.go's makeRequest derives
+// from JSON-unmarshaling the response body. The REAL handlers
+// (server/http/handlers/users_crud.go's DeleteUser, secrets_crud.go's
+// DeleteSecret) return 204 No Content with a genuinely empty body — the
+// idiomatic REST shape for a successful delete with nothing to return.
+//
+// Before the fix: json.Unmarshal on the zero-byte body errored with "unexpected
+// end of JSON input", and makeRequest's parse-error branch synthesized
+// APIResponse{Success: false, Error: {Code: "HTTP_204", ...}} — so a delete that
+// genuinely succeeded server-side (confirmed via a direct read against the
+// upstream's own storage) was reported back to the caller as a failure.
+//
+// This test builds a real upstream Keyorix server via NewRouter and a real
+// store.RemoteStorage client pointed at it over HTTP — not a hand-rolled mock
+// that could mask the bug by returning Success: true directly.
+func TestRemoteStorage_DeleteUserAndDeleteSecret_204NoContent_RealServerRoundTrip(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	// --- upstream: a real Keyorix server ---
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	ctx := context.Background()
+
+	// A second, non-admin user to delete — DeleteUser refuses to delete the
+	// last install administrator, so the seeded bootstrap admin can't be used
+	// for this test.
+	victimUser, err := upstreamCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "delete-me",
+		Email:    "delete-me@example.com",
+		Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+
+	adminUser, err := upstreamCore.Storage().GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+
+	project, err := upstreamCore.CreateProject(ctx, "e2e-delete-204-project", "seeded for the #498 delete/204 e2e test")
+	require.NoError(t, err)
+	envs, err := upstreamCore.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs, "CreateProject must seed default environments")
+	envID := envs[0].ID
+
+	secret, err := upstreamCore.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name:          "e2e-delete-204-secret",
+		Value:         []byte("s3cr3t-value"),
+		ProjectID:     project.ID,
+		EnvironmentID: envID,
+		Type:          "generic",
+		CreatedBy:     adminUser.Username,
+		OwnerID:       adminUser.ID,
+	})
+	require.NoError(t, err)
+
+	// --- downstream: storage.type: remote, pointed at the upstream ---
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+
+	// --- DeleteUser: the real handler returns 204 No Content, empty body ---
+	err = rs.DeleteUser(ctx, victimUser.ID)
+	require.NoError(t, err, "DeleteUser must not be misreported as a failure for a genuine 204 No Content success")
+
+	// Confirm the delete genuinely landed server-side, not just "the call
+	// didn't error".
+	_, err = upstreamCore.Storage().GetUserByEmail(ctx, "delete-me@example.com")
+	require.Error(t, err, "the user must actually be gone from the upstream's own storage")
+
+	// --- DeleteSecret: same 204/empty-body shape ---
+	err = rs.DeleteSecret(ctx, secret.ID)
+	require.NoError(t, err, "DeleteSecret must not be misreported as a failure for a genuine 204 No Content success")
+
+	_, err = upstreamCore.Storage().GetSecret(ctx, secret.ID)
+	require.Error(t, err, "the secret must actually be gone (soft-deleted) from the upstream's own storage")
+}


### PR DESCRIPTION
## Summary

Fixes backlog finding #498 (MEDIUM): under `storage.type: remote`, `RemoteStorage.DeleteUser`/`DeleteSecret` gate on `APIResponse.Success`, which `internal/storage/remote/client.go`'s `makeRequest` derives from JSON-unmarshaling the HTTP response body. The real handlers (`server/http/handlers/users_crud.go`'s `DeleteUser`, `secrets_crud.go`'s `DeleteSecret`) correctly return `204 No Content` with a genuinely empty body — the idiomatic REST convention for a successful delete with nothing to return.

`json.Unmarshal` on a zero-byte body errors with `"unexpected end of JSON input"`, which — before this fix — fell into `makeRequest`'s generic parse-error branch and synthesized `APIResponse{Success: false, Error: {Code: "HTTP_204", ...}}`. That meant every genuinely successful delete against a real upstream server was silently misreported to the caller as a failure.

This is the same underlying shape as the recently-fixed #452/`sendSuccess` bug (PR #794), but for a different response convention that fix didn't cover.

## Fix

`makeRequest` now checks, before attempting to unmarshal: if the response body is genuinely empty AND the status is 2xx, synthesize `APIResponse{Success: true}` directly rather than attempting to parse nothing as JSON. Any other combination (non-2xx status, or a non-empty-but-malformed body on a 200 that was supposed to carry content) still falls through to the existing parse-error path unchanged — a genuine parse failure is still surfaced as an error, not silently treated as success.

## Testing

- `TestHTTPClient_204NoContent_Success` / `TestHTTPClient_2xxEmptyBody_Success` — unit tests pinning the empty-body-is-success behavior directly against `makeRequest`.
- `TestHTTPClient_MalformedNonEmptyBody_StillReportsFailure` — non-regression test proving a genuinely malformed, non-empty JSON body on a 200 still reports `Success: false` with the raw body captured in `Error.Details`.
- `TestRemoteStorage_DeleteUserAndDeleteSecret_204NoContent_RealServerRoundTrip` — end-to-end test (following the #452/#794 pattern) driving `RemoteStorage.DeleteUser`/`DeleteSecret` through a real `store.RemoteStorage` client against a real `NewRouter`-backed server, confirming the deletes both report success AND genuinely land server-side (verified via a direct read against the upstream's own storage).
- Confirmed non-tautological: reverted the fix, re-ran the new tests, and observed both the unit test and the e2e test fail with the exact predicted symptom (`delete user failed: HTTP_204: HTTP 204: 204 No Content`) before restoring the fix and confirming it passes.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/storage/... ./server/http/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./internal/storage/... ./server/http/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)