### PR TITLE
fix(encryption): derive the evidence-signing key from the KEK, not the DEK (#268)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,6 +18,8 @@ description = "Demo / docs / scripts / test fixtures — non-real sample credent
 regexes = [
   '''keyorix-audit-checkpoint-v1''',
   '''keyorix-evidence-signature-v1''',
+  '''keyorix-evidence-signature-kek-v2''',
+  '''keyorix-evidence-signature-kek-id-v2''',
 ]
 paths = [
   '''demo/.*''',

--- a/internal/cli/encryption/migrate_provider.go
+++ b/internal/cli/encryption/migrate_provider.go
@@ -506,4 +506,11 @@ func printMigrateSummary(tgt config.EncryptionConfig, backupRel string) {
 		fmt.Printf("      # salt_path: %s (set storage.encryption.salt_path)\n", tgt.SaltPath)
 		fmt.Printf("      # the master passphrase is now %s — set KEYORIX_MASTER_PASSWORD to it\n", newMasterPasswordEnv)
 	}
+	fmt.Println()
+	fmt.Println("⚠️  Unlike a `rotate`, this changes the KEK — and with it, the compliance-")
+	fmt.Println("   evidence-pack signing key (#268). Any evidence pack signed BEFORE this")
+	fmt.Println("   migration will report as \"superseded key version\" (not tampered) under")
+	fmt.Println("   `keyorix compliance verify` from now on; a routine `encryption rotate`")
+	fmt.Println("   does NOT have this effect. Run `compliance verify` on any outstanding")
+	fmt.Println("   packs before this step if you need to confirm they're still valid.")
 }

--- a/internal/core/evidence_signing.go
+++ b/internal/core/evidence_signing.go
@@ -1,10 +1,13 @@
 // evidence_signing.go — authenticity signatures for exported compliance-evidence
 // packs (ISO 27001 / SOC 2). The scheduled export HMAC-signs the exact bytes it
-// writes with a DEK-derived key the database/DBA does not hold (see
+// writes with a KEK-derived key the database/DBA does not hold (see
 // encryption.Service.EvidenceSignKey), so an archived pack's integrity is provable
-// on the server off-box. A signature is "<keyVersion>:<hmac-hex>"; a signature made
-// under a DEK version superseded by a rotation is reported as unverifiable rather
-// than a generic mismatch (mirrors the audit-checkpoint key-version handling).
+// on the server off-box. Deriving from the KEK rather than the DEK means a routine
+// DEK rotation does NOT invalidate previously-signed packs — the KEK is unaffected
+// by it, only by a KEK-provider migration (#268). A signature is
+// "<keyVersion>:<hmac-hex>"; a signature made under a key version superseded by a
+// KEK change is reported as unverifiable rather than a generic mismatch (mirrors
+// the audit-checkpoint key-version handling).
 package core
 
 import (
@@ -14,9 +17,10 @@ import (
 	"strings"
 )
 
-// SetEvidenceSignKey wires the DEK-derived HMAC key (and its DEK key version) used to
-// sign and verify evidence packs. Called at startup when encryption is enabled; with
-// no key set, packs are exported unsigned and verification is unavailable.
+// SetEvidenceSignKey wires the KEK-derived HMAC key (and its key-version fingerprint)
+// used to sign and verify evidence packs. Called at startup when encryption is
+// enabled; with no key set, packs are exported unsigned and verification is
+// unavailable.
 func (c *KeyorixCore) SetEvidenceSignKey(key []byte, keyVersion string) {
 	c.evidenceSignKey = key
 	c.evidenceSignKeyVersion = keyVersion
@@ -41,15 +45,16 @@ func (c *KeyorixCore) signEvidence(data []byte) (string, bool) {
 // EvidenceVerifyResult reports the outcome of verifying a pack's signature.
 type EvidenceVerifyResult struct {
 	Valid          bool   `json:"valid"`
-	KeyVersion     string `json:"key_version,omitempty"`     // DEK version the signature was made under
-	CurrentVersion string `json:"current_version,omitempty"` // current signing-key (DEK) version
+	KeyVersion     string `json:"key_version,omitempty"`     // key version the signature was made under
+	CurrentVersion string `json:"current_version,omitempty"` // current signing-key (KEK) fingerprint
 	Reason         string `json:"reason,omitempty"`
 }
 
 // VerifyEvidenceSignature recomputes the HMAC over data and compares it to signature
-// in constant time. A signature made under a superseded DEK version is reported
-// unverifiable (not just invalid), so a post-rotation false alarm is distinguishable
-// from real tampering.
+// in constant time. A signature made under a superseded key version — i.e. a KEK
+// change, since a routine DEK rotation no longer affects this key at all (#268) — is
+// reported unverifiable (not just invalid), so a false alarm is distinguishable from
+// real tampering.
 func (c *KeyorixCore) VerifyEvidenceSignature(data []byte, signature string) *EvidenceVerifyResult {
 	if !c.EvidenceSigningAvailable() {
 		return &EvidenceVerifyResult{Reason: "evidence signing is unavailable (encryption disabled)"}
@@ -60,7 +65,7 @@ func (c *KeyorixCore) VerifyEvidenceSignature(data []byte, signature string) *Ev
 	}
 	res := &EvidenceVerifyResult{KeyVersion: version, CurrentVersion: c.evidenceSignKeyVersion}
 	if version != c.evidenceSignKeyVersion {
-		res.Reason = "signature was made under a superseded key version (the DEK has rotated since); cannot verify"
+		res.Reason = "signature was made under a superseded key version (the signing key has changed since); cannot verify"
 		return res
 	}
 	want, err := hex.DecodeString(sigHex)

--- a/internal/core/evidence_signing_test.go
+++ b/internal/core/evidence_signing_test.go
@@ -64,6 +64,41 @@ func TestEvidenceSignature_WrongKeySameVersionRejected(t *testing.T) {
 	assert.NotContains(t, res.Reason, "superseded", "the version matched — the HMAC check, not version handling, must reject it")
 }
 
+// TestEvidenceSignature_PreFixPackReportedSupersededNotTampered pins the
+// non-regression the #268 fix depends on: switching the evidence-signing key's
+// derivation source (DEK -> KEK, so a routine DEK rotation stops invalidating
+// signatures — see encryption.Service.EvidenceSignKey) also changes the "key
+// version" label's format going forward (old scheme: the DEK's own rotation
+// version, e.g. "v1700000000"; new scheme: an "esk-<hex>" KEK fingerprint). An old
+// pack signed before this fix shipped, under the old scheme's version label, must
+// still be reported as made under a SUPERSEDED key version — exactly the existing,
+// honest, non-misleading outcome documented at the top of this file — never as
+// freshly "tampered" just because the fix changed the label format.
+func TestEvidenceSignature_PreFixPackReportedSupersededNotTampered(t *testing.T) {
+	data := []byte(`{"generated_at":"2026-01-01T00:00:00Z"}`)
+
+	// Simulate the pack as it would have been signed BEFORE this fix, under the
+	// old DEK-rotation-version-derived label.
+	oldPackCore := &KeyorixCore{}
+	oldPackCore.SetEvidenceSignKey([]byte("0123456789abcdef0123456789abcdef"), "v1700000000")
+	sig, ok := oldPackCore.signEvidence(data)
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(sig, "v1700000000:"))
+
+	// The running deployment now uses the NEW (KEK-derived) key and its
+	// "esk-<hex>"-style version label, wired exactly as SetEvidenceSignKey is
+	// called from server/main.go after this fix.
+	c := &KeyorixCore{}
+	c.SetEvidenceSignKey([]byte("ffffffffffffffffffffffffffffffff"), "esk-0123456789abcdef0123456789abcd")
+
+	res := c.VerifyEvidenceSignature(data, sig)
+	assert.False(t, res.Valid)
+	assert.Contains(t, res.Reason, "superseded")
+	assert.NotContains(t, res.Reason, "does not match", "an old-scheme pack must be reported as superseded, not tampered")
+	assert.Equal(t, "v1700000000", res.KeyVersion)
+	assert.Equal(t, "esk-0123456789abcdef0123456789abcd", res.CurrentVersion)
+}
+
 func TestEvidenceSignature_UnavailableWithoutKey(t *testing.T) {
 	c := &KeyorixCore{}
 	assert.False(t, c.EvidenceSigningAvailable())

--- a/internal/encryption/evidence_sign_key_test.go
+++ b/internal/encryption/evidence_sign_key_test.go
@@ -1,0 +1,132 @@
+package encryption
+
+// evidence_sign_key_test.go — regression tests for #268: the evidence-signing key
+// (used to sign exported compliance-evidence packs, see
+// internal/core/evidence_signing.go) must be derived from the KEK, not the DEK, so
+// a routine DEK rotation does not silently and permanently invalidate every
+// previously-signed pack. It should only change on a genuine KEK change (a
+// KEK-provider migration, ADR-041 — a far rarer, deliberate operator action).
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/crypto"
+)
+
+// TestEvidenceSignKey_StableAcrossDEKRotation is the core regression test for
+// #268: signing key and version must be BYTE-IDENTICAL before and after a full
+// RotateDEKWithSweep, even though the DEK itself (and its own key version) changes.
+// This is what makes an evidence pack signed before a DEK rotation still verifiable
+// after one.
+func TestEvidenceSignKey_StableAcrossDEKRotation(t *testing.T) {
+	db := newTestDB(t)
+	svc, _ := newTestService(t, "test-passphrase")
+
+	keyBefore, verBefore, ok := svc.EvidenceSignKey()
+	if !ok {
+		t.Fatal("EvidenceSignKey unavailable before rotation")
+	}
+	if len(keyBefore) != 32 {
+		t.Fatalf("expected a 32-byte key, got %d bytes", len(keyBefore))
+	}
+
+	dekBefore := captureCurrentDEK(t, svc)
+	dekVerBefore := svc.GetKeyVersion()
+
+	if _, err := svc.RotateDEKWithSweep("test-passphrase", db); err != nil {
+		t.Fatalf("RotateDEKWithSweep failed: %v", err)
+	}
+
+	// Sanity: the DEK and its own version DID change (that's the whole point of
+	// rotation) — otherwise this test would be vacuous.
+	dekAfter := captureCurrentDEK(t, svc)
+	if bytes.Equal(dekBefore, dekAfter) {
+		t.Fatal("DEK did not change after rotation — test setup is broken")
+	}
+	if svc.GetKeyVersion() == dekVerBefore {
+		t.Fatal("DEK key version did not change after rotation — test setup is broken")
+	}
+
+	keyAfter, verAfter, ok := svc.EvidenceSignKey()
+	if !ok {
+		t.Fatal("EvidenceSignKey unavailable after rotation")
+	}
+	if !bytes.Equal(keyBefore, keyAfter) {
+		t.Fatalf("evidence-signing key changed across a DEK rotation: before=%x after=%x", keyBefore, keyAfter)
+	}
+	if verBefore != verAfter {
+		t.Fatalf("evidence-signing key version changed across a DEK rotation: before=%q after=%q", verBefore, verAfter)
+	}
+}
+
+// TestEvidenceSignKey_ChangesAcrossKEKMigration proves the corresponding negative:
+// a genuine KEK change (KEK-provider migration, ADR-041) DOES change the
+// evidence-signing key and its version. This is expected and correctly reported by
+// VerifyEvidenceSignature as "superseded key version", not silently accepted and
+// not reported as tampering — the same non-regression the #268 fix preserves.
+func TestEvidenceSignKey_ChangesAcrossKEKMigration(t *testing.T) {
+	dir := t.TempDir()
+	oldKEK := filepath.Join(dir, "old.kek")
+	newKEK := filepath.Join(dir, "new.kek")
+	writeHexKEK(t, oldKEK)
+	writeHexKEK(t, newKEK)
+
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	km.SetKeyProvider(crypto.NewFileKeyProvider(oldKEK))
+	if err := km.Initialize(""); err != nil {
+		t.Fatalf("initialize old: %v", err)
+	}
+	keyBefore, verBefore, ok := km.GetEvidenceSignKey()
+	if !ok {
+		t.Fatal("GetEvidenceSignKey unavailable after initialize")
+	}
+
+	if err := km.RewrapDEK(crypto.NewFileKeyProvider(newKEK)); err != nil {
+		t.Fatalf("rewrap: %v", err)
+	}
+
+	// A fresh manager loading under the NEW provider (mirroring a server restart
+	// after migrate-provider, since RewrapDEK itself doesn't live-update an
+	// already-running process) must derive a DIFFERENT evidence-signing key/version.
+	kmNew := NewKeyManager(dir, "dek.key", "kek.salt")
+	kmNew.SetKeyProvider(crypto.NewFileKeyProvider(newKEK))
+	if err := kmNew.Initialize(""); err != nil {
+		t.Fatalf("initialize new: %v", err)
+	}
+	keyAfter, verAfter, ok := kmNew.GetEvidenceSignKey()
+	if !ok {
+		t.Fatal("GetEvidenceSignKey unavailable after re-initialize with new provider")
+	}
+
+	if bytes.Equal(keyBefore, keyAfter) {
+		t.Fatal("evidence-signing key did NOT change across a KEK-provider migration — it should have")
+	}
+	if verBefore == verAfter {
+		t.Fatalf("evidence-signing key version did NOT change across a KEK-provider migration — it should have (got %q both times)", verBefore)
+	}
+}
+
+// TestEvidenceSignKey_UnavailableWhenUninitialized mirrors the existing DEK/audit-
+// checkpoint-key behavior: no KEK has been derived yet, so no signing key exists.
+func TestEvidenceSignKey_UnavailableWhenUninitialized(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	if _, _, ok := km.GetEvidenceSignKey(); ok {
+		t.Fatal("expected GetEvidenceSignKey to report unavailable before Initialize")
+	}
+}
+
+// TestEvidenceSignKey_WipedOnShutdown proves Wipe() zeroes the evidence-signing
+// key alongside the DEK, so neither lingers in memory after shutdown.
+func TestEvidenceSignKey_WipedOnShutdown(t *testing.T) {
+	svc, _ := newTestService(t, "test-passphrase")
+	if _, _, ok := svc.EvidenceSignKey(); !ok {
+		t.Fatal("EvidenceSignKey unavailable before shutdown")
+	}
+	svc.keyManager.Wipe()
+	if _, _, ok := svc.keyManager.GetEvidenceSignKey(); ok {
+		t.Fatal("expected the evidence-signing key to be gone after Wipe()")
+	}
+}

--- a/internal/encryption/keymanager_io.go
+++ b/internal/encryption/keymanager_io.go
@@ -1,6 +1,6 @@
 // keymanager_io.go — Key access, validation, and memory wipe.
 //
-// GetDEK, GetKeyVersion, ValidateKeyFiles, FixKeyFilePermissions, Wipe.
+// GetDEK, GetKeyVersion, GetEvidenceSignKey, ValidateKeyFiles, FixKeyFilePermissions, Wipe.
 // For initialisation see keymanager_lifecycle.go. For rotation see keymanager_rotation.go.
 package encryption
 
@@ -27,6 +27,20 @@ func (km *KeyManager) GetKeyVersion() string {
 	return km.keyVersion
 }
 
+// GetEvidenceSignKey returns a copy of the KEK-derived evidence-signing key and its
+// fingerprint ("key version"), or ok=false if the manager has not been initialized
+// (no KEK has been derived yet, so no evidence-signing key exists).
+func (km *KeyManager) GetEvidenceSignKey() (key []byte, keyID string, ok bool) {
+	km.mu.RLock()
+	defer km.mu.RUnlock()
+	if len(km.evidenceSignKey) == 0 {
+		return nil, "", false
+	}
+	key = make([]byte, len(km.evidenceSignKey))
+	copy(key, km.evidenceSignKey)
+	return key, km.evidenceSignKeyID, true
+}
+
 // ValidateKeyFiles checks that key files exist and have correct permissions (0600).
 func (km *KeyManager) ValidateKeyFiles() error {
 	files := []securefiles.FilePermSpec{
@@ -45,7 +59,7 @@ func (km *KeyManager) FixKeyFilePermissions() error {
 	return securefiles.FixFilePerms(files, true)
 }
 
-// Wipe securely removes the DEK from memory.
+// Wipe securely removes the DEK and the evidence-signing key from memory.
 func (km *KeyManager) Wipe() {
 	km.mu.Lock()
 	defer km.mu.Unlock()
@@ -53,5 +67,9 @@ func (km *KeyManager) Wipe() {
 	if km.currentDEK != nil {
 		wipeBytes(km.currentDEK)
 		km.currentDEK = nil
+	}
+	if km.evidenceSignKey != nil {
+		wipeBytes(km.evidenceSignKey)
+		km.evidenceSignKey = nil
 	}
 }

--- a/internal/encryption/keymanager_lifecycle.go
+++ b/internal/encryption/keymanager_lifecycle.go
@@ -22,12 +22,16 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"golang.org/x/crypto/hkdf"
 
 	"github.com/keyorixhq/keyorix/internal/crypto"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
@@ -51,7 +55,51 @@ type KeyManager struct {
 	// Service to obtain the KEK from elsewhere. Either way the KEK still wraps the
 	// same on-disk DEK, so the data path is unchanged.
 	keyProvider crypto.KeyProvider
-	mu          sync.RWMutex
+	// evidenceSignKey/evidenceSignKeyID are a 32-byte HMAC key and its public
+	// fingerprint, derived from the KEK (NOT the DEK) via HKDF-SHA256 at
+	// Initialize time — before the KEK is wiped below. Used to sign/verify
+	// exported compliance-evidence packs (internal/core/evidence_signing.go).
+	// Deriving from the KEK rather than the DEK is the point (#268): a routine
+	// DEK rotation (RotateDEKWithSweep, ADR-010) re-wraps a brand-new DEK under
+	// the SAME KEK, so this key — and its fingerprint — is completely unaffected
+	// by it, and a previously-signed evidence pack stays verifiable across a DEK
+	// rotation. Only a genuine KEK change (KEK-provider migration, RewrapDEK /
+	// ADR-041 — a far rarer, deliberate operator action) changes it; when that
+	// happens VerifyEvidenceSignature correctly reports an older signature as
+	// made under a superseded key version rather than as tampered, same as
+	// before. Never persisted to disk — held only in memory, like currentDEK.
+	evidenceSignKey   []byte
+	evidenceSignKeyID string
+	mu                sync.RWMutex
+}
+
+// evidenceSignKeyInfo/evidenceSignKeyIDInfo domain-separate the evidence-signing
+// key (and its public fingerprint) from any other use of the KEK (HKDF info
+// parameter). Bump the suffix only if the derivation scheme changes.
+const (
+	evidenceSignKeyInfo   = "keyorix-evidence-signature-kek-v2"
+	evidenceSignKeyIDInfo = "keyorix-evidence-signature-kek-id-v2"
+)
+
+// deriveEvidenceSignKey derives the 32-byte evidence-signing HMAC key and its
+// 16-byte public key-ID fingerprint from kek via HKDF-SHA256 (two independently
+// domain-separated outputs of the same KEK, so the fingerprint reveals nothing
+// about the key itself). Both are pure, deterministic functions of the KEK alone,
+// so they are stable across a DEK rotation (same KEK) and only change when the KEK
+// itself does (KEK-provider migration).
+func deriveEvidenceSignKey(kek []byte) (key []byte, keyID string, err error) {
+	keyR := hkdf.New(sha256.New, kek, nil, []byte(evidenceSignKeyInfo))
+	key = make([]byte, 32)
+	if _, err = io.ReadFull(keyR, key); err != nil {
+		return nil, "", fmt.Errorf("derive evidence-signing key: %w", err)
+	}
+	idR := hkdf.New(sha256.New, kek, nil, []byte(evidenceSignKeyIDInfo))
+	idBytes := make([]byte, 16)
+	if _, err = io.ReadFull(idR, idBytes); err != nil {
+		wipeBytes(key)
+		return nil, "", fmt.Errorf("derive evidence-signing key id: %w", err)
+	}
+	return key, "esk-" + hex.EncodeToString(idBytes), nil
 }
 
 // SetKeyProvider configures where the KEK comes from. Must be called before
@@ -119,7 +167,17 @@ func (km *KeyManager) Initialize(passphrase string) error {
 		return fmt.Errorf("failed to unwrap DEK: %w", err)
 	}
 
+	// Derive the evidence-signing key from the KEK (still in scope here, before the
+	// deferred wipe above runs) — NOT from dek, so it survives a later DEK rotation
+	// unchanged (#268).
+	esk, eskID, err := deriveEvidenceSignKey(kek)
+	if err != nil {
+		return fmt.Errorf("failed to derive evidence-signing key: %w", err)
+	}
+
 	km.currentDEK = dek
+	km.evidenceSignKey = esk
+	km.evidenceSignKeyID = eskID
 	return nil
 }
 

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -186,33 +186,24 @@ func (s *Service) AuditCheckpointKey() (key []byte, keyVersion string, ok bool) 
 	return out, s.keyManager.GetKeyVersion(), true
 }
 
-// evidenceSignKeyInfo domain-separates the evidence-signing key from the DEK's
-// other uses (HKDF info parameter).
-const evidenceSignKeyInfo = "keyorix-evidence-signature-v1"
-
-// EvidenceSignKey derives a 32-byte HMAC key for signing exported compliance-
-// evidence packs from the current DEK via HKDF-SHA256, alongside the current key
-// version. Like AuditCheckpointKey it is DEK-bound but domain-separated and held
-// only in application memory — so an archived evidence pack's authenticity is
-// provable on the server without the key ever touching the database or the export.
-// Returns ok=false when encryption is disabled or uninitialised.
+// EvidenceSignKey returns the 32-byte HMAC key used to sign exported compliance-
+// evidence packs, alongside its fingerprint ("key version"). Unlike
+// AuditCheckpointKey, this key is derived from the KEK, not the DEK (see
+// KeyManager.evidenceSignKey and #268): a routine DEK rotation
+// (RotateDEKWithSweep, ADR-010) re-wraps a brand-new DEK under the SAME KEK, so
+// this key is completely unaffected by it, and a previously-signed evidence pack
+// stays verifiable across a DEK rotation. Held only in application memory, never
+// persisted, exactly like the DEK — so an archived evidence pack's authenticity
+// is provable on the server without the key ever touching the database or the
+// export. Returns ok=false when encryption is disabled or uninitialised (no KEK
+// has been derived).
 func (s *Service) EvidenceSignKey() (key []byte, keyVersion string, ok bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if !s.config.Enabled || !s.initialized {
 		return nil, "", false
 	}
-	dek := s.keyManager.GetDEK()
-	defer wipeBytes(dek)
-	if len(dek) == 0 {
-		return nil, "", false
-	}
-	r := hkdf.New(sha256.New, dek, nil, []byte(evidenceSignKeyInfo))
-	out := make([]byte, 32)
-	if _, err := io.ReadFull(r, out); err != nil {
-		return nil, "", false
-	}
-	return out, s.keyManager.GetKeyVersion(), true
+	return s.keyManager.GetEvidenceSignKey()
 }
 
 // EncryptSecret encrypts plaintext and returns (encryptedBytes, metadataBytes, error).

--- a/server/main.go
+++ b/server/main.go
@@ -309,8 +309,10 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			// mark so a process restart cannot reset it to zero (ADR-029).
 			coreService.SeedAuditWatermark(context.Background())
 		}
-		// Derive the evidence-pack signing key from the DEK so scheduled evidence
-		// exports are signed (and verifiable). Unavailable when encryption is off.
+		// Derive the evidence-pack signing key from the KEK (not the DEK — #268, so a
+		// routine DEK rotation does not invalidate previously-signed packs) so
+		// scheduled evidence exports are signed (and verifiable). Unavailable when
+		// encryption is off.
 		if key, keyVer, ok := encSvc.EvidenceSignKey(); ok {
 			coreService.SetEvidenceSignKey(key, keyVer)
 		}


### PR DESCRIPTION
## Summary

Closes backlog #268's residual gap: **DEK rotation permanently and silently invalidated the cryptographic verifiability of every previously-signed compliance-evidence pack.**

`EvidenceSignKey` (`internal/encryption/service.go`) derived the HMAC evidence-signing key via HKDF-SHA256 over the *live DEK*. Since `RotateDEKWithSweep` zeroizes the old DEK on every rotation with no keyring/version history retained, any evidence pack signed under a DEK version that has since rotated became **permanently** unverifiable — even though the earlier fix (`VerifyEvidenceSignature`) already correctly reports this as "superseded key version — cannot verify" rather than falsely flagging it as tampered. A routine, product-encouraged operational action (DEK rotation, nudged by NIS2/ISO controls) silently degraded a *different* compliance guarantee (long-term evidence-pack authenticity) as a side effect.

## Root cause / design insight

Tracing `RotateDEKWithSweep` (`internal/encryption/keymanager_rotation.go`) and `RewrapDEK` (`internal/encryption/keymanager_rewrap.go`) end-to-end: a routine DEK rotation re-derives the **same KEK** (from the same passphrase/salt, or the same configured KEK provider) and only replaces/re-wraps the DEK it wraps. The KEK itself only changes on a **KEK-provider migration** (`RewrapDEK`, `keyorix encryption migrate-provider`) — a far rarer, deliberate, operator-initiated action, run offline with the server stopped.

That means a genuinely separate, much-longer-lived "Evidence Signing Key" doesn't need any new persisted state, keyring, or migration surface — it falls out for free by deriving it from the **KEK** instead of the DEK, captured once (before the KEK is wiped) at `KeyManager.Initialize()` time, exactly like `currentDEK` already is.

## Fix

- `KeyManager` now derives a 32-byte evidence-signing key **and** a 16-byte public fingerprint ("key version", `"esk-<hex>"`) from the KEK via two independently domain-separated HKDF-SHA256 outputs, at `Initialize()` time, held only in memory (never persisted), wiped on `Shutdown`/`Wipe()` alongside the DEK.
- `Service.EvidenceSignKey()` now delegates to `KeyManager.GetEvidenceSignKey()` instead of doing its own DEK-based HKDF.
- No changes needed in `internal/core/evidence_signing.go`'s actual signing/verification logic — `VerifyEvidenceSignature` already treats the "key version" as an opaque comparison, so the honest superseded-vs-tampered distinction is preserved automatically; only doc comments were updated for accuracy.
- Added an advisory note to `encryption migrate-provider`'s summary output: it is now the *one* operation that still affects evidence-pack signature continuity (a routine `encryption rotate` no longer does).

## Non-goals / scope

- Does **not** attempt to retroactively make already-signed packs (under the old, DEK-derived scheme) verifiable — that key material is gone by design. Those packs correctly report as signed under a superseded key version, same honest behavior as before.
- Does **not** touch `AuditCheckpointKey` (a different mechanism/use case, ADR-029, out of scope for #268) — worth a follow-up look given the same architectural pattern, but audit checkpoints have different, continuously-re-verified-against-a-chain semantics.
- Does **not** add continuity across a KEK-provider migration — that operation is rare, deliberate, and already correctly reported as "superseded, not tampered."

## Testing

- `internal/encryption/evidence_sign_key_test.go` (new): proves the evidence-signing key/version is **byte-identical** before and after a full `RotateDEKWithSweep` (the core #268 regression), proves it correctly **changes** across a KEK-provider migration, plus uninitialized/wipe-on-shutdown coverage.
- `internal/core/evidence_signing_test.go`: added `TestEvidenceSignature_PreFixPackReportedSupersededNotTampered`, pinning the non-regression — an old pack signed under the pre-fix (DEK-rotation-version) label is still reported as superseded, never as tampered, once wired with the new KEK-derived key/label.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/encryption/... -count=1` — all pass
- `go test ./internal/core/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./internal/encryption/...` — 0 issues
- `gosec -severity medium -exclude-generated ./internal/core/... ./internal/cli/encryption/... ./server/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)