### PR TITLE
feat(dynamic-secrets): real Kubernetes bound-token revocation (#97 residual)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,6 +18,8 @@ description = "Demo / docs / scripts / test fixtures — non-real sample credent
 regexes = [
   '''keyorix-audit-checkpoint-v1''',
   '''keyorix-evidence-signature-v1''',
+  '''keyorix-evidence-signature-kek-v2''',
+  '''keyorix-evidence-signature-kek-id-v2''',
 ]
 paths = [
   '''demo/.*''',

--- a/docs/adr-058-kubernetes-dynamic-secrets.md
+++ b/docs/adr-058-kubernetes-dynamic-secrets.md
@@ -26,15 +26,27 @@ Kubernetes **TokenRequest** API (`POST …/serviceaccounts/{sa}/token`).
 
 - **Ephemeral, like the cloud backends.** The API server enforces the token's
   `expirationTimestamp`, so `SupportsNativeExpiry` and `IsEphemeralBackend` are both
-  true; `Revoke` is a no-op and `Renew` is refused (issue a fresh lease). The lease TTL
-  is floored at the Kubernetes 10-minute minimum so the lease's stated TTL matches what
-  the API server actually mints.
+  true; `Renew` is refused (issue a fresh lease). The lease TTL is floored at the
+  Kubernetes 10-minute minimum so the lease's stated TTL matches what the API server
+  actually mints.
+- **`Revoke` is opt-in, not always a no-op (#97 follow-up).** Unlike AWS STS / Azure /
+  GCP — which genuinely have no safe early-revoke mechanism (see "Cross-backend
+  revocation survey" below) — Kubernetes TokenRequest tokens support
+  `spec.boundObjectRef`: the API server checks the bound object's live existence + UID
+  on every request, independent of the token's own `exp` claim. Setting
+  `"revocable":true` in the config makes `Issue` create a dedicated, per-lease `Secret`
+  and bind the token to it; `Revoke` then deletes that `Secret`, which invalidates the
+  token immediately. This is **off by default**: it requires the calling identity to
+  also hold `create`+`delete` on `secrets` in the namespace (on top of `create` on
+  `serviceaccounts/token`), so it must be a deliberate per-config choice, not a silent
+  new requirement for every existing deployment. The bound object is scoped to one
+  lease, so revoking it has no effect on other leases or on the ServiceAccount itself.
 - **JSON "admin DSN".** The encrypted config carries
-  `{"namespace","service_account","audiences"?}`. When `api_server`/`ca_cert`/`token`
-  are omitted the engine uses the standard **in-cluster** configuration (the mounted
-  service-account token and CA) — so no credentials live in Keyorix config when the
-  server runs in the cluster. The calling identity must hold `create` on the
-  `serviceaccounts/token` subresource for the target ServiceAccount.
+  `{"namespace","service_account","audiences"?,"revocable"?}`. When
+  `api_server`/`ca_cert`/`token` are omitted the engine uses the standard **in-cluster**
+  configuration (the mounted service-account token and CA) — so no credentials live in
+  Keyorix config when the server runs in the cluster. The calling identity must hold
+  `create` on the `serviceaccounts/token` subresource for the target ServiceAccount.
 - **Dependency-free.** The TokenRequest is a small REST call over `net/http` with the
   cluster CA pinned, mirroring the Kubernetes sync agent's REST sink — no `client-go`.
 - **Credential shape.** The issued credential carries `token`, `namespace`,
@@ -48,6 +60,33 @@ Kubernetes **TokenRequest** API (`POST …/serviceaccounts/{sa}/token`).
 - **Path-segment guard.** The namespace and service-account name are validated (DNS-label
   charset) before being placed into the request path, rejecting traversal/injection
   rather than escaping.
+
+### Cross-backend revocation survey (#97 residual)
+
+Every cloud-IAM backend previously documented its no-op `Revoke` as "inherent to
+self-expiring token types." Re-investigated per-backend, that turned out to be true
+for three of the four, but not for Kubernetes:
+
+- **AWS STS** (`sts:AssumeRole`): AWS has no "revoke this one session" API. The
+  documented workaround (the IAM console's "Revoke active sessions," an
+  `aws:TokenIssueTime`-conditioned `Deny` policy) is scoped to the *role*, not a
+  session — it would deny every concurrent session on that role, not just the one
+  being revoked. Left as a no-op; the blast radius is unacceptable to automate.
+- **Azure** (`DefaultAzureCredential.GetToken`): a client-credentials-style flow with
+  no refresh token and no per-token revoke API; Microsoft's session/refresh-token
+  revocation mechanisms apply to delegated user-session flows, not this one. Left as
+  a no-op.
+- **GCP** (`iamcredentials.generateAccessToken`): mints a short-lived OAuth2 token,
+  not a downloadable service-account key (keys CAN be deleted for immediate effect,
+  but this backend never creates one). Google's IAM Credentials API documentation is
+  explicit that these tokens cannot be revoked before natural expiry. Left as a no-op.
+- **Kubernetes** (`TokenRequest`): supports `spec.boundObjectRef`, which the API
+  server enforces live on every request — see above. Fixed via the opt-in
+  `"revocable":true` config, scoped to one lease at a time.
+
+`CredentialEngine.RevokeInvalidatesCredential(adminDSN)` lets `RevokeLease`'s audit
+trail distinguish "this specific lease's `Revoke` was a real provider-side kill" from
+"self-expiring, still live" instead of assuming every ephemeral backend is a no-op.
 
 ## Alternatives considered
 
@@ -64,4 +103,5 @@ Kubernetes **TokenRequest** API (`POST …/serviceaccounts/{sa}/token`).
 - Operators can register a `kubernetes` dynamic-secret config and issue short-lived SA
   tokens through the same CLI/API/gRPC as every other backend.
 - The Keyorix server (or its ambient identity) needs RBAC to create tokens for the target
-  ServiceAccounts — an operator concern, documented in the CLI help.
+  ServiceAccounts — an operator concern, documented in the CLI help. Opting a config into
+  `"revocable":true` additionally needs `create`+`delete` on `secrets` in that namespace.

--- a/internal/cli/dynamic/config_create.go
+++ b/internal/cli/dynamic/config_create.go
@@ -46,10 +46,17 @@ not a username/password:
   azure:      {"scopes":["https://management.azure.com/.default"]}
   kubernetes: {"namespace":"app","service_account":"my-app","audiences":["https://svc"]}
               (mints a ServiceAccount token via TokenRequest; add
-              "api_server"/"ca_cert"/"token" to target an out-of-cluster API server)
+              "api_server"/"ca_cert"/"token" to target an out-of-cluster API server;
+              add "revocable":true to let Revoke genuinely invalidate the token
+              early instead of waiting for its natural expiry — this binds each
+              token to a dedicated per-lease Secret and requires the calling
+              identity to also hold create+delete on secrets in the namespace,
+              on top of create on serviceaccounts/token)
 Cloud credentials for the mint call come from the ambient identity (AWS chain /
 GCP ADC / Azure DefaultAzureCredential / in-cluster ServiceAccount), never from
-Keyorix config.
+Keyorix config. AWS STS, Azure, and GCP tokens have no safe early-revoke
+mechanism and always self-expire — see internal/dynamic's per-backend file
+header comments for why.
 
 Examples:
   keyorix dynamic-secret create --name app-db --project-id 1 --backend postgres \

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -429,14 +429,18 @@ func (c *KeyorixCore) RevokeLease(ctx context.Context, leaseID string, userID ui
 	if err := c.storage.UpdateDynamicSecretLease(ctx, lease); err != nil {
 		return err
 	}
-	// #97: for an ephemeral backend (AWS STS, Kubernetes) engine.Revoke above is a
-	// documented no-op — the credential cannot be invalidated early at the provider,
-	// only marked dead in Keyorix's own bookkeeping. Saying "revoked" outright would
+	// #97: for most ephemeral backends (AWS STS, Azure, GCP, and Kubernetes unless
+	// opted into bound-token revocation) engine.Revoke above is a documented no-op
+	// — the credential cannot be invalidated early at the provider, only marked
+	// dead in Keyorix's own bookkeeping. Saying "revoked" outright would
 	// misleadingly imply the credential is dead; it remains live until its own
 	// provider-enforced expiry (lease.ExpiresAt, corrected to the actual granted
-	// expiry at issue — see IssueLease).
+	// expiry at issue — see IssueLease). RevokeInvalidatesCredential tells us
+	// whether THIS lease's specific adminDSN actually got a real revoke (e.g. a
+	// Kubernetes config with "revocable":true), so that case is audited honestly
+	// as a genuine revoke rather than lumped in with the no-op backends.
 	msg := fmt.Sprintf("revoked dynamic lease %s (reason=%s)", lease.LeaseID, reason)
-	if engine.IsEphemeralBackend() {
+	if engine.IsEphemeralBackend() && !engine.RevokeInvalidatesCredential(adminDSN) {
 		msg = fmt.Sprintf("marked dynamic lease %s revoked locally (reason=%s); the %s credential cannot be invalidated early and remains live until its provider-enforced expiry at %s",
 			lease.LeaseID, reason, cfg.BackendType, lease.ExpiresAt.UTC().Format(time.RFC3339))
 	}

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -551,6 +551,31 @@ func TestDynamicSecrets_RevokeEphemeralBackendAuditsHonestly(t *testing.T) {
 	assert.Contains(t, ev.Description, "cannot be invalidated early", "the audit trail must not claim a full provider-side revoke for an ephemeral backend")
 }
 
+// #97: the flip side of the test above — an ephemeral backend whose Revoke DID
+// genuinely invalidate the credential early (e.g. Kubernetes with
+// "revocable":true — see kubernetes.go) must NOT be lumped in with the no-op
+// backends' misleading "cannot be invalidated early" message.
+func TestDynamicSecrets_RevokeEffectiveEphemeralBackendAuditsAsGenuineRevoke(t *testing.T) {
+	c, db, fake, _ := newDynamicTestCore(t)
+	fake.Ephemeral = true
+	effective := true
+	fake.RevokeEffective = &effective
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+
+	issued, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+	require.NoError(t, c.RevokeLease(ctx, issued.LeaseID, 7, "manual"))
+
+	lease, err := c.storage.GetDynamicSecretLease(ctx, issued.LeaseID)
+	require.NoError(t, err)
+	assert.Equal(t, "revoked", lease.Status)
+
+	var ev models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", "dynamic_lease.revoked").Order("id DESC").First(&ev).Error)
+	assert.NotContains(t, ev.Description, "cannot be invalidated early", "a backend that genuinely revoked the credential must not be audited as a no-op")
+}
+
 func TestDynamicSecrets_CreateRejectsDefaultOverMax(t *testing.T) {
 	c, _, _, _ := newDynamicTestCore(t)
 	_, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{

--- a/internal/dynamic/awssts.go
+++ b/internal/dynamic/awssts.go
@@ -4,6 +4,20 @@
 // AWS enforces their expiry and they cannot be revoked or renewed, so Revoke is a
 // no-op and Renew is refused (issue a fresh lease instead).
 //
+// #97 residual (investigated, not fixed here): AWS has no "revoke this one
+// AssumeRole session" API. The one documented workaround — the IAM console's
+// "Revoke active sessions" action, which attaches/updates a Deny statement
+// conditioned on aws:TokenIssueTime <= <revocation timestamp> — is scoped to the
+// ROLE, not to a single session: it denies EVERY session (from every principal)
+// assumed before that timestamp, including other concurrent, unrelated leases
+// issued from this same role_arn. Automating that from a single-lease Revoke()
+// call would revoke sessions this call was never asked to touch — an
+// unacceptable, uncontrolled blast radius — so it is not wired up here. This
+// backend also never calls GetFederationToken or creates a per-lease IAM
+// user/role (only AssumeRole, see Issue below), so there is no per-lease IAM
+// object to delete either. Revoke remains a documented no-op;
+// RevokeInvalidatesCredential always returns false.
+//
 // The encrypted "admin DSN" carries this backend's JSON config instead of a database
 // connection string:
 //
@@ -134,8 +148,13 @@ func (e *AWSSTSEngine) Issue(ctx context.Context, adminDSN, creationTemplate str
 	return Credential{Fields: fields}, sessionName, nil
 }
 
-// Revoke is a no-op: STS credentials self-expire and cannot be invalidated early.
+// Revoke is a no-op: STS credentials self-expire and cannot be invalidated early
+// without denying every other concurrent session on the same role (see the file
+// header for the specific mechanism investigated and rejected).
 func (e *AWSSTSEngine) Revoke(_ context.Context, _, _ string) error { return nil }
+
+// RevokeInvalidatesCredential is always false: see the file header.
+func (e *AWSSTSEngine) RevokeInvalidatesCredential(_ string) bool { return false }
 
 // Renew is refused: an STS credential's lifetime is fixed at issue. core.RenewLease
 // guards on IsEphemeralBackend before reaching here; this is a defensive backstop.

--- a/internal/dynamic/awssts_test.go
+++ b/internal/dynamic/awssts_test.go
@@ -60,6 +60,7 @@ func TestAWSSTSEngine_Issue(t *testing.T) {
 	assert.Equal(t, "aws-sts", eng.BackendType())
 	require.NoError(t, eng.Revoke(context.Background(), "", role)) // no-op
 	require.Error(t, eng.Renew(context.Background(), "", role, time.Now()))
+	assert.False(t, eng.RevokeInvalidatesCredential(""), "AWS has no per-session revoke API for AssumeRole credentials")
 }
 
 func TestAWSSTSEngine_DurationClampedToMin(t *testing.T) {

--- a/internal/dynamic/azure.go
+++ b/internal/dynamic/azure.go
@@ -4,6 +4,21 @@
 // expiry and the token cannot be revoked or renewed, so Revoke is a no-op and Renew
 // is refused (issue a fresh lease).
 //
+// #97 residual (investigated, not fixed here): this backend acquires the token via
+// DefaultAzureCredential.GetToken — a client-credentials-style flow (managed
+// identity / workload identity / client secret), never an interactive/delegated
+// flow. Access tokens minted this way carry no refresh token and are not tracked
+// against a revocable session, so there is no "revoke this token" Entra ID/Graph
+// API call for them — Microsoft's documented token-revocation mechanisms
+// (revokeSignInSessions, invalidating refresh tokens) apply to delegated
+// user-session flows, not to this one. Disabling/deleting the underlying identity
+// (the managed identity or the service principal's credential) only stops FUTURE
+// token acquisitions — Azure AD's token cache/propagation model means already-
+// issued access tokens for that identity can remain valid at resource providers
+// until they expire on their own, and doing so would in any case revoke every
+// other concurrent lease using the same identity, not just this one. Revoke
+// remains a documented no-op; RevokeInvalidatesCredential always returns false.
+//
 // The encrypted "admin DSN" carries this backend's JSON config:
 //
 //	{"scopes":["https://management.azure.com/.default"]}
@@ -79,8 +94,12 @@ func (e *AzureEngine) Issue(ctx context.Context, adminDSN, _ string, _ time.Dura
 	return Credential{Fields: fields}, "keyorix-dyn-" + suffix, nil
 }
 
-// Revoke is a no-op: Azure AD tokens self-expire and cannot be invalidated early.
+// Revoke is a no-op: Azure AD tokens self-expire and cannot be invalidated early
+// (see the file header for the specific mechanism investigated and rejected).
 func (e *AzureEngine) Revoke(_ context.Context, _, _ string) error { return nil }
+
+// RevokeInvalidatesCredential is always false: see the file header.
+func (e *AzureEngine) RevokeInvalidatesCredential(_ string) bool { return false }
 
 // Renew is refused: an Azure token's lifetime is fixed at issue. core.RenewLease
 // guards on IsEphemeralBackend before reaching here; this is a defensive backstop.

--- a/internal/dynamic/cloud_token_test.go
+++ b/internal/dynamic/cloud_token_test.go
@@ -51,6 +51,7 @@ func TestGCPEngine_Issue(t *testing.T) {
 	assert.Equal(t, "gcp", eng.BackendType())
 	require.NoError(t, eng.Revoke(context.Background(), "", role))
 	require.Error(t, eng.Renew(context.Background(), "", role, time.Now()))
+	assert.False(t, eng.RevokeInvalidatesCredential(""), "GCP generateAccessToken tokens can't be revoked before natural expiry")
 }
 
 func TestGCPEngine_Defaults(t *testing.T) {
@@ -103,6 +104,7 @@ func TestAzureEngine_Issue(t *testing.T) {
 	assert.Equal(t, "azure", eng.BackendType())
 	require.NoError(t, eng.Revoke(context.Background(), "", role))
 	require.Error(t, eng.Renew(context.Background(), "", role, time.Now()))
+	assert.False(t, eng.RevokeInvalidatesCredential(""), "Azure client-credential access tokens can't be revoked before natural expiry")
 }
 
 func TestAzureEngine_ConfigValidation(t *testing.T) {

--- a/internal/dynamic/engine.go
+++ b/internal/dynamic/engine.go
@@ -41,12 +41,25 @@ type CredentialEngine interface {
 	// the sweeper disabled would mint a credential whose TTL is never enforced.
 	SupportsNativeExpiry() bool
 	BackendType() string
-	// IsEphemeralBackend reports whether the backend mints self-expiring,
-	// non-revocable credentials (e.g. AWS STS) rather than a persistent role on a
-	// target. For such backends Revoke is a no-op (nothing to drop) and Renew is
-	// refused — the credential's lifetime is fixed by the cloud provider at issue,
-	// so a new lease must be issued instead of extending an existing one.
+	// IsEphemeralBackend reports whether the backend mints self-expiring
+	// credentials (e.g. AWS STS) rather than a persistent role on a target. Renew
+	// is refused for such backends — the credential's lifetime is fixed by the
+	// cloud provider at issue, so a new lease must be issued instead of extending
+	// an existing one. It does NOT by itself mean Revoke is a no-op: see
+	// RevokeInvalidatesCredential.
 	IsEphemeralBackend() bool
+	// RevokeInvalidatesCredential reports whether calling Revoke for this specific
+	// adminDSN actually invalidates the credential at the provider before its
+	// natural expiry (true), or is only local Keyorix bookkeeping that leaves the
+	// credential live until it self-expires (false). Persistent-role backends
+	// (Postgres/MySQL/MongoDB/Redis) always return true — DROP/DELETE really
+	// removes the account. Most cloud-IAM backends (AWS STS, Azure, GCP) always
+	// return false — see each file's header comment for the provider-specific
+	// reason a real revoke isn't safely automatable. Kubernetes returns true only
+	// when the specific lease's adminDSN config opted into bound-token revocation
+	// (see kubernetes.go); otherwise false. Callers use this to render an accurate
+	// audit message instead of assuming every ephemeral backend is a no-op.
+	RevokeInvalidatesCredential(adminDSN string) bool
 }
 
 // New returns the engine for a backend type.
@@ -103,13 +116,25 @@ type FakeEngine struct {
 	FailRevoke   bool
 	FailRenew    bool
 	NativeExpiry bool              // when true, mimics a backend with DB-level TTL (e.g. Postgres)
-	Ephemeral    bool              // when true, mimics a cloud-IAM backend (no revoke, no renew)
+	Ephemeral    bool              // when true, mimics a cloud-IAM backend (no renew)
 	IssueFields  map[string]string // when set, returned in the issued Credential.Fields
+	// RevokeEffective overrides RevokeInvalidatesCredential's result when non-nil,
+	// for tests simulating a backend (like Kubernetes' opt-in bound-token mode)
+	// whose Revoke genuinely invalidates the credential despite being ephemeral.
+	// When nil, it defaults to !Ephemeral (matching every real non-ephemeral
+	// engine, and AWS STS/Azure/GCP's always-false ephemeral no-op).
+	RevokeEffective *bool
 }
 
 func (f *FakeEngine) BackendType() string        { return "fake" }
 func (f *FakeEngine) SupportsNativeExpiry() bool { return f.NativeExpiry }
 func (f *FakeEngine) IsEphemeralBackend() bool   { return f.Ephemeral }
+func (f *FakeEngine) RevokeInvalidatesCredential(_ string) bool {
+	if f.RevokeEffective != nil {
+		return *f.RevokeEffective
+	}
+	return !f.Ephemeral
+}
 
 func (f *FakeEngine) Issue(_ context.Context, _, _ string, _ time.Duration) (Credential, string, error) {
 	f.mu.Lock()

--- a/internal/dynamic/gcp.go
+++ b/internal/dynamic/gcp.go
@@ -4,6 +4,16 @@
 // expiry and the token cannot be revoked or renewed, so Revoke is a no-op and Renew
 // is refused (issue a fresh lease).
 //
+// #97 residual (investigated, not fixed here): this backend calls
+// iamcredentials.projects.serviceAccounts.generateAccessToken, which mints a
+// short-lived OAuth2 access token (not a downloadable/long-lived service-account
+// KEY). Google's IAM Credentials API documentation is explicit that tokens minted
+// this way cannot be revoked before their natural expiry — there is no
+// provider-side "kill this specific generateAccessToken token" call, unlike a
+// service-account key (which CAN be deleted for immediate effect, but this
+// backend never creates one — see Issue below). Revoke remains a documented
+// no-op; RevokeInvalidatesCredential always returns false.
+//
 // The encrypted "admin DSN" carries this backend's JSON config:
 //
 //	{"service_account":"sa@project.iam.gserviceaccount.com",
@@ -93,8 +103,12 @@ func (e *GCPEngine) Issue(ctx context.Context, adminDSN, _ string, ttl time.Dura
 	return Credential{Fields: fields}, "keyorix-dyn-" + suffix, nil
 }
 
-// Revoke is a no-op: GCP access tokens self-expire and cannot be invalidated early.
+// Revoke is a no-op: GCP access tokens self-expire and cannot be invalidated early
+// (see the file header for the specific mechanism investigated and rejected).
 func (e *GCPEngine) Revoke(_ context.Context, _, _ string) error { return nil }
+
+// RevokeInvalidatesCredential is always false: see the file header.
+func (e *GCPEngine) RevokeInvalidatesCredential(_ string) bool { return false }
 
 // Renew is refused: a GCP token's lifetime is fixed at issue. core.RenewLease guards
 // on IsEphemeralBackend before reaching here; this is a defensive backstop.

--- a/internal/dynamic/kubernetes.go
+++ b/internal/dynamic/kubernetes.go
@@ -1,13 +1,35 @@
 // kubernetes.go — the Kubernetes dynamic-secret backend (ADR-035, cloud-IAM): mints a
 // short-lived ServiceAccount token via the Kubernetes TokenRequest API
 // (POST …/serviceaccounts/{sa}/token). Like AWS STS and GCP these are ephemeral —
-// Kubernetes enforces the token's expiry and it cannot be revoked or renewed, so Revoke
-// is a no-op and Renew is refused (issue a fresh lease instead).
+// Kubernetes enforces the token's expiry, so Renew is refused (issue a fresh lease
+// instead) — but unlike AWS/Azure/GCP, Revoke is NOT always a no-op here (#97
+// residual, investigated):
+//
+// Kubernetes TokenRequest tokens can be bound to a live Kubernetes object via
+// spec.boundObjectRef (this is exactly the documented mechanism `kubectl create
+// token --bound-object-kind=Secret` uses, and how kubelet's projected-volume
+// tokens are bound to their Pod). The API server's ServiceAccount token
+// authenticator checks the bound object's live existence + UID on EVERY request,
+// independent of the token's own exp claim — so deleting the bound object
+// invalidates the token immediately, before its natural expiry.
+//
+// This is opt-in per config ("revocable":true — see below), OFF by default, for
+// two reasons: (1) it requires the calling identity to also hold create/delete on
+// `secrets` in the target namespace, on top of the `create` on
+// `serviceaccounts/token` every config already needs — a real permission
+// expansion that must be a deliberate operator choice, not a silent new
+// requirement for every existing deployment; (2) the bound object is scoped to
+// THIS ONE lease (a dedicated, empty per-lease Secret named after the lease's
+// role label), so revoking it has no blast radius on other leases or on the
+// ServiceAccount itself — unlike AWS/Azure's only revocation workarounds, which
+// would deny/invalidate every concurrent session on the shared role/identity
+// (see awssts.go / azure.go for why those remain no-ops).
 //
 // The encrypted "admin DSN" carries this backend's JSON config:
 //
 //	{"namespace":"default","service_account":"my-app",
 //	 "audiences":["https://my-service"],   // optional; omit for the API-server audience
+//	 "revocable":true,                     // optional; see header above (default false)
 //	 "api_server":"https://10.0.0.1:443",  // optional; omit to use in-cluster config
 //	 "ca_cert":"<PEM>","token":"<bearer>"} // required when api_server is set
 //
@@ -16,8 +38,9 @@
 // service-account token and CA) — so no credentials live in Keyorix config when the
 // server runs in the cluster. The identity making the call (in-cluster SA or the
 // configured token) must hold `create` on the `serviceaccounts/token` subresource for
-// the target ServiceAccount. To stay dependency-free (no client-go) the TokenRequest is
-// a small REST call over net/http, mirroring the Kubernetes sync agent's REST sink.
+// the target ServiceAccount, plus `create`+`delete` on `secrets` in the namespace when
+// revocable is true. To stay dependency-free (no client-go) every call is a small REST
+// request over net/http, mirroring the Kubernetes sync agent's REST sink.
 package dynamic
 
 import (
@@ -43,10 +66,25 @@ const (
 	k8sSACAPath    = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )
 
+// boundObjectRef identifies the per-lease Secret a revocable token's
+// spec.boundObjectRef points to (see the file header).
+type boundObjectRef struct {
+	Name string
+	UID  string
+}
+
 // k8sTokenMinter is the slice of Kubernetes the engine uses — an interface seam so the
 // engine is unit-tested with a fake and the REST/TLS plumbing stays contained here.
 type k8sTokenMinter interface {
-	mintToken(ctx context.Context, namespace, serviceAccount string, audiences []string, expiration time.Duration) (token string, expiry time.Time, err error)
+	mintToken(ctx context.Context, namespace, serviceAccount string, audiences []string, expiration time.Duration, bound *boundObjectRef) (token string, expiry time.Time, err error)
+	// createBoundSecret creates an empty, per-lease Secret used only as a
+	// TokenRequest boundObjectRef target, returning its UID. Only called when the
+	// lease's config sets "revocable":true.
+	createBoundSecret(ctx context.Context, namespace, name string) (uid string, err error)
+	// deleteBoundSecret deletes the Secret created by createBoundSecret,
+	// immediately invalidating any token bound to it. Idempotent: deleting an
+	// already-gone Secret is not an error.
+	deleteBoundSecret(ctx context.Context, namespace, name string) error
 }
 
 // KubernetesEngine mints short-lived ServiceAccount tokens via the TokenRequest API.
@@ -62,13 +100,20 @@ type k8sConfig struct {
 	Namespace      string   `json:"namespace"`
 	ServiceAccount string   `json:"service_account"`
 	Audiences      []string `json:"audiences,omitempty"`
-	APIServer      string   `json:"api_server,omitempty"`
-	CACert         string   `json:"ca_cert,omitempty"`
-	Token          string   `json:"token,omitempty"`
+	// Revocable opts this config into bound-token revocation (see the file
+	// header): Issue creates a dedicated per-lease Secret and binds the token to
+	// it, so Revoke can delete that Secret to invalidate the token early. Default
+	// false preserves the original no-op behavior and requires no extra RBAC.
+	Revocable bool   `json:"revocable,omitempty"`
+	APIServer string `json:"api_server,omitempty"`
+	CACert    string `json:"ca_cert,omitempty"`
+	Token     string `json:"token,omitempty"`
 }
 
-// Issue mints a token for the configured ServiceAccount. roleName is a label only —
-// there is nothing to drop on revoke. creationTemplate is unused.
+// Issue mints a token for the configured ServiceAccount. roleName is the lease
+// label; when Revocable is set it is also the name of the per-lease bound Secret
+// created below (needed by Revoke to find and delete it later). creationTemplate
+// is unused.
 func (e *KubernetesEngine) Issue(ctx context.Context, adminDSN, _ string, ttl time.Duration) (Credential, string, error) {
 	var cfg k8sConfig
 	if err := json.Unmarshal([]byte(adminDSN), &cfg); err != nil {
@@ -94,15 +139,35 @@ func (e *KubernetesEngine) Issue(ctx context.Context, adminDSN, _ string, ttl ti
 		}
 		minter = m
 	}
-	token, expiry, err := minter.mintToken(ctx, cfg.Namespace, cfg.ServiceAccount, cfg.Audiences, expiration)
-	if err != nil {
-		return Credential{}, "", fmt.Errorf("kubernetes: request token: %w", err)
-	}
 
+	// Generated up front (rather than after minting) so it can double as the
+	// per-lease bound Secret's name when revocable is set.
 	suffix, err := randString(12)
 	if err != nil {
 		return Credential{}, "", err
 	}
+	label := "keyorix-dyn-" + suffix
+
+	var bound *boundObjectRef
+	if cfg.Revocable {
+		uid, err := minter.createBoundSecret(ctx, cfg.Namespace, label)
+		if err != nil {
+			return Credential{}, "", fmt.Errorf("kubernetes: create bound secret for revocation: %w", err)
+		}
+		bound = &boundObjectRef{Name: label, UID: uid}
+	}
+
+	token, expiry, err := minter.mintToken(ctx, cfg.Namespace, cfg.ServiceAccount, cfg.Audiences, expiration, bound)
+	if err != nil {
+		if bound != nil {
+			// The TokenRequest failed after the Secret was created — clean it up
+			// (best-effort) rather than leave an orphaned bound object nothing was
+			// ever minted against.
+			_ = minter.deleteBoundSecret(ctx, cfg.Namespace, bound.Name)
+		}
+		return Credential{}, "", fmt.Errorf("kubernetes: request token: %w", err)
+	}
+
 	fields := map[string]string{
 		"token":           token,
 		"namespace":       cfg.Namespace,
@@ -111,11 +176,50 @@ func (e *KubernetesEngine) Issue(ctx context.Context, adminDSN, _ string, ttl ti
 	if !expiry.IsZero() {
 		fields["expiration"] = expiry.UTC().Format(time.RFC3339)
 	}
-	return Credential{Fields: fields}, "keyorix-dyn-" + suffix, nil
+	return Credential{Fields: fields}, label, nil
 }
 
-// Revoke is a no-op: ServiceAccount tokens self-expire and cannot be invalidated early.
-func (e *KubernetesEngine) Revoke(_ context.Context, _, _ string) error { return nil }
+// Revoke is a no-op unless the lease's config set "revocable":true, in which case
+// roleName is also the name of the per-lease Secret created at Issue and bound
+// into the token's spec.boundObjectRef — deleting it here immediately invalidates
+// the token (see the file header for why this is safe: it is scoped to this one
+// lease). Deleting an already-gone Secret is treated as success, so a retried or
+// double revoke doesn't fail.
+func (e *KubernetesEngine) Revoke(ctx context.Context, adminDSN, roleName string) error {
+	var cfg k8sConfig
+	if err := json.Unmarshal([]byte(adminDSN), &cfg); err != nil {
+		return fmt.Errorf("kubernetes: config must be JSON ({\"namespace\":...,\"service_account\":...}): %w", err)
+	}
+	if !cfg.Revocable {
+		return nil // no bound object was created for this lease — self-expiring, nothing to drop
+	}
+
+	minter := e.minter
+	if minter == nil {
+		m, err := newRealK8sMinter(cfg)
+		if err != nil {
+			return err
+		}
+		minter = m
+	}
+	if err := minter.deleteBoundSecret(ctx, cfg.Namespace, roleName); err != nil {
+		return fmt.Errorf("kubernetes: delete bound secret %s/%s: %w", cfg.Namespace, roleName, err)
+	}
+	return nil
+}
+
+// RevokeInvalidatesCredential reports whether this lease's config opted into
+// bound-token revocation ("revocable":true — see the file header). A malformed
+// adminDSN fails closed to false: understating a genuine revoke (rare — Issue
+// would already have failed on the same malformed config) is far safer than an
+// audit trail overclaiming that a credential was killed when it wasn't.
+func (e *KubernetesEngine) RevokeInvalidatesCredential(adminDSN string) bool {
+	var cfg k8sConfig
+	if err := json.Unmarshal([]byte(adminDSN), &cfg); err != nil {
+		return false
+	}
+	return cfg.Revocable
+}
 
 // Renew is refused: a token's lifetime is fixed at issue. core.RenewLease guards on
 // IsEphemeralBackend before reaching here; this is a defensive backstop.
@@ -181,17 +285,29 @@ func newRealK8sMinter(cfg k8sConfig) (*realK8sMinter, error) {
 	}, nil
 }
 
-func (m *realK8sMinter) mintToken(ctx context.Context, namespace, serviceAccount string, audiences []string, expiration time.Duration) (string, time.Time, error) {
+func (m *realK8sMinter) mintToken(ctx context.Context, namespace, serviceAccount string, audiences []string, expiration time.Duration, bound *boundObjectRef) (string, time.Time, error) {
 	expSeconds := int64(expiration.Seconds())
+	spec := map[string]interface{}{
+		"expirationSeconds": expSeconds,
+	}
+	if len(audiences) > 0 {
+		spec["audiences"] = audiences
+	}
+	if bound != nil {
+		// Binds the token's validity to this Secret's live existence + UID (see
+		// the file header) — this is what makes Revoke's delete an immediate,
+		// real invalidation instead of local bookkeeping.
+		spec["boundObjectRef"] = map[string]interface{}{
+			"kind":       "Secret",
+			"apiVersion": "v1",
+			"name":       bound.Name,
+			"uid":        bound.UID,
+		}
+	}
 	reqBody := map[string]interface{}{
 		"apiVersion": "authentication.k8s.io/v1",
 		"kind":       "TokenRequest",
-		"spec": map[string]interface{}{
-			"expirationSeconds": expSeconds,
-		},
-	}
-	if len(audiences) > 0 {
-		reqBody["spec"].(map[string]interface{})["audiences"] = audiences
+		"spec":       spec,
 	}
 	raw, err := json.Marshal(reqBody)
 	if err != nil {
@@ -237,6 +353,91 @@ func (m *realK8sMinter) mintToken(ctx context.Context, namespace, serviceAccount
 		expiry, _ = time.Parse(time.RFC3339, out.Status.ExpirationTimestamp)
 	}
 	return out.Status.Token, expiry, nil
+}
+
+// createBoundSecret creates an empty, labeled Secret used only as a TokenRequest
+// boundObjectRef target (see the file header), returning its UID so it can be
+// embedded in that boundObjectRef.
+func (m *realK8sMinter) createBoundSecret(ctx context.Context, namespace, name string) (string, error) {
+	reqBody := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name": name,
+			"labels": map[string]interface{}{
+				"app.kubernetes.io/managed-by": "keyorix",
+				"keyorix.io/purpose":           "dynamic-secret-token-binding",
+			},
+		},
+		"type": "Opaque",
+	}
+	raw, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshal Secret: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/namespaces/%s/secrets", m.host, pathSegment(namespace))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw)) // #nosec G107 -- host is operator-configured/in-cluster
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := m.hc.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return "", fmt.Errorf("not authorized (HTTP %d) — the caller needs create on secrets in %s (required when revocable is true)", resp.StatusCode, namespace)
+	}
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("create Secret returned HTTP %d", resp.StatusCode)
+	}
+
+	var out struct {
+		Metadata struct {
+			UID string `json:"uid"`
+		} `json:"metadata"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("decode Secret response: %w", err)
+	}
+	if out.Metadata.UID == "" {
+		return "", fmt.Errorf("create Secret returned no uid")
+	}
+	return out.Metadata.UID, nil
+}
+
+// deleteBoundSecret deletes the Secret created by createBoundSecret, immediately
+// invalidating any token bound to it. A 404 is treated as success so Revoke stays
+// idempotent (a retried, or already-cleaned-up, revoke must not fail).
+func (m *realK8sMinter) deleteBoundSecret(ctx context.Context, namespace, name string) error {
+	url := fmt.Sprintf("%s/api/v1/namespaces/%s/secrets/%s", m.host, pathSegment(namespace), pathSegment(name))
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil) // #nosec G107 -- host is operator-configured/in-cluster
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := m.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode == http.StatusNotFound {
+		return nil // already gone — revoke is idempotent
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("not authorized (HTTP %d) — the caller needs delete on secrets in %s (required when revocable is true)", resp.StatusCode, namespace)
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("delete Secret returned HTTP %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // pathSegment guards a namespace/service-account name placed into the request path: K8s

--- a/internal/dynamic/kubernetes_test.go
+++ b/internal/dynamic/kubernetes_test.go
@@ -9,7 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeK8sMinter records what Issue passed and returns a canned token.
+// fakeK8sMinter records what Issue/Revoke passed and returns canned results. It
+// implements k8sTokenMinter without touching a real cluster — this is the same
+// fake-seam convention every other dynamic-secret engine's tests use (see e.g.
+// fakeSTS in awssts_test.go). It proves the engine issues the correct API calls
+// with the correct parameters (namespace/name/boundObjectRef), NOT that a real
+// Kubernetes API server actually rejects a token after its bound Secret is
+// deleted — that would require a live cluster, which this test environment
+// doesn't have.
 type fakeK8sMinter struct {
 	token  string
 	expiry time.Time
@@ -18,11 +25,39 @@ type fakeK8sMinter struct {
 	gotNamespace, gotServiceAccount string
 	gotAudiences                    []string
 	gotExpiration                   time.Duration
+	gotBound                        *boundObjectRef
+
+	createSecretErr   error
+	createSecretUID   string
+	createdSecretNS   string
+	createdSecretName string
+
+	deleteSecretErr    error
+	deleteSecretCalled bool
+	deletedSecretNS    string
+	deletedSecretName  string
 }
 
-func (f *fakeK8sMinter) mintToken(_ context.Context, ns, sa string, aud []string, exp time.Duration) (string, time.Time, error) {
-	f.gotNamespace, f.gotServiceAccount, f.gotAudiences, f.gotExpiration = ns, sa, aud, exp
+func (f *fakeK8sMinter) mintToken(_ context.Context, ns, sa string, aud []string, exp time.Duration, bound *boundObjectRef) (string, time.Time, error) {
+	f.gotNamespace, f.gotServiceAccount, f.gotAudiences, f.gotExpiration, f.gotBound = ns, sa, aud, exp, bound
 	return f.token, f.expiry, f.err
+}
+
+func (f *fakeK8sMinter) createBoundSecret(_ context.Context, ns, name string) (string, error) {
+	f.createdSecretNS, f.createdSecretName = ns, name
+	if f.createSecretErr != nil {
+		return "", f.createSecretErr
+	}
+	if f.createSecretUID == "" {
+		return "fake-secret-uid", nil
+	}
+	return f.createSecretUID, nil
+}
+
+func (f *fakeK8sMinter) deleteBoundSecret(_ context.Context, ns, name string) error {
+	f.deleteSecretCalled = true
+	f.deletedSecretNS, f.deletedSecretName = ns, name
+	return f.deleteSecretErr
 }
 
 func TestKubernetesEngine_Metadata(t *testing.T) {
@@ -46,6 +81,7 @@ func TestKubernetesEngine_IssueMintsToken(t *testing.T) {
 	assert.Equal(t, "my-app", fake.gotServiceAccount)
 	assert.Equal(t, []string{"https://svc"}, fake.gotAudiences)
 	assert.Equal(t, 30*time.Minute, fake.gotExpiration)
+	assert.Nil(t, fake.gotBound, "revocable defaults to false — no boundObjectRef")
 
 	// Returned as fields (no username/password — an ephemeral token backend).
 	assert.Empty(t, cred.Username)
@@ -90,9 +126,98 @@ func TestKubernetesEngine_IssuePropagatesMintError(t *testing.T) {
 	assert.Contains(t, err.Error(), "request token")
 }
 
-func TestKubernetesEngine_RevokeIsNoOpRenewRefused(t *testing.T) {
+// --- #97: opt-in bound-token revocation ---
+
+func TestKubernetesEngine_RevocableIssueBindsTokenToPerLeaseSecret(t *testing.T) {
+	fake := &fakeK8sMinter{token: "tok", createSecretUID: "secret-uid-123"}
+	e := &KubernetesEngine{minter: fake}
+
+	cfg := `{"namespace":"app","service_account":"my-app","revocable":true}`
+	_, role, err := e.Issue(context.Background(), cfg, "", time.Hour)
+	require.NoError(t, err)
+
+	// The bound Secret is created in the lease's namespace, named after the
+	// returned lease label — Revoke later uses that same name to find it again.
+	assert.Equal(t, "app", fake.createdSecretNS)
+	assert.Equal(t, role, fake.createdSecretName)
+
+	// The TokenRequest carried that Secret's name+uid as spec.boundObjectRef.
+	require.NotNil(t, fake.gotBound)
+	assert.Equal(t, role, fake.gotBound.Name)
+	assert.Equal(t, "secret-uid-123", fake.gotBound.UID)
+}
+
+func TestKubernetesEngine_NonRevocableIssueCreatesNoBoundSecret(t *testing.T) {
+	fake := &fakeK8sMinter{token: "tok"}
+	e := &KubernetesEngine{minter: fake}
+
+	_, _, err := e.Issue(context.Background(), `{"namespace":"app","service_account":"sa"}`, "", time.Hour)
+	require.NoError(t, err)
+	assert.Empty(t, fake.createdSecretName, "revocable defaults to false — no Secret should be created")
+	assert.Nil(t, fake.gotBound)
+}
+
+func TestKubernetesEngine_RevocableIssuePropagatesCreateSecretError(t *testing.T) {
+	fake := &fakeK8sMinter{token: "tok", createSecretErr: assert.AnError}
+	e := &KubernetesEngine{minter: fake}
+
+	_, _, err := e.Issue(context.Background(), `{"namespace":"app","service_account":"sa","revocable":true}`, "", time.Hour)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create bound secret")
+}
+
+func TestKubernetesEngine_RevocableIssueCleansUpSecretOnMintFailure(t *testing.T) {
+	fake := &fakeK8sMinter{err: assert.AnError, createSecretUID: "uid-x"}
+	e := &KubernetesEngine{minter: fake}
+
+	_, _, err := e.Issue(context.Background(), `{"namespace":"app","service_account":"sa","revocable":true}`, "", time.Hour)
+	require.Error(t, err)
+	assert.True(t, fake.deleteSecretCalled, "a failed mint must not leave an orphaned bound Secret behind")
+	assert.Equal(t, "app", fake.deletedSecretNS)
+	assert.Equal(t, fake.createdSecretName, fake.deletedSecretName)
+}
+
+func TestKubernetesEngine_RevokeIsNoOpWhenNotRevocable(t *testing.T) {
+	fake := &fakeK8sMinter{}
+	e := &KubernetesEngine{minter: fake}
+	require.NoError(t, e.Revoke(context.Background(), `{"namespace":"app","service_account":"sa"}`, "keyorix-dyn-x"))
+	assert.False(t, fake.deleteSecretCalled, "revocable defaults to false — Revoke must not touch the target")
+}
+
+func TestKubernetesEngine_RevokeDeletesBoundSecretWhenRevocable(t *testing.T) {
+	fake := &fakeK8sMinter{}
+	e := &KubernetesEngine{minter: fake}
+	err := e.Revoke(context.Background(), `{"namespace":"app","service_account":"sa","revocable":true}`, "keyorix-dyn-x")
+	require.NoError(t, err)
+	assert.True(t, fake.deleteSecretCalled)
+	assert.Equal(t, "app", fake.deletedSecretNS)
+	assert.Equal(t, "keyorix-dyn-x", fake.deletedSecretName, "the lease's role name is the bound Secret's name")
+}
+
+func TestKubernetesEngine_RevokePropagatesDeleteError(t *testing.T) {
+	fake := &fakeK8sMinter{deleteSecretErr: assert.AnError}
+	e := &KubernetesEngine{minter: fake}
+	err := e.Revoke(context.Background(), `{"namespace":"app","service_account":"sa","revocable":true}`, "keyorix-dyn-x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete bound secret")
+}
+
+func TestKubernetesEngine_RevokeRejectsMalformedConfig(t *testing.T) {
+	e := &KubernetesEngine{minter: &fakeK8sMinter{}}
+	err := e.Revoke(context.Background(), "not-json", "keyorix-dyn-x")
+	require.Error(t, err)
+}
+
+func TestKubernetesEngine_RevokeInvalidatesCredential(t *testing.T) {
 	e := &KubernetesEngine{}
-	require.NoError(t, e.Revoke(context.Background(), "{}", "keyorix-dyn-x"))
+	assert.False(t, e.RevokeInvalidatesCredential(`{"namespace":"app","service_account":"sa"}`), "default (revocable absent) is false")
+	assert.False(t, e.RevokeInvalidatesCredential(`{"namespace":"app","service_account":"sa","revocable":false}`))
+	assert.True(t, e.RevokeInvalidatesCredential(`{"namespace":"app","service_account":"sa","revocable":true}`))
+	assert.False(t, e.RevokeInvalidatesCredential("not-json"), "a malformed config fails closed to false, never overclaims a real revoke")
+}
+
+func TestKubernetesEngine_RenewRefused(t *testing.T) {
+	e := &KubernetesEngine{}
 	err := e.Renew(context.Background(), "{}", "keyorix-dyn-x", time.Now())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not renewable")

--- a/internal/dynamic/mongodb.go
+++ b/internal/dynamic/mongodb.go
@@ -35,6 +35,10 @@ type MongoEngine struct{}
 func (e *MongoEngine) BackendType() string      { return "mongodb" }
 func (e *MongoEngine) IsEphemeralBackend() bool { return false }
 
+// RevokeInvalidatesCredential is always true: dropUser really removes the
+// account, so a subsequent auth attempt with it fails immediately.
+func (e *MongoEngine) RevokeInvalidatesCredential(_ string) bool { return true }
+
 // SupportsNativeExpiry is false: MongoDB users have no native expiry, so lease
 // expiry is enforced only by the auto-revoke sweeper (which must be enabled).
 func (e *MongoEngine) SupportsNativeExpiry() bool { return false }

--- a/internal/dynamic/mysql.go
+++ b/internal/dynamic/mysql.go
@@ -27,6 +27,10 @@ type MySQLEngine struct{}
 func (e *MySQLEngine) BackendType() string      { return "mysql" }
 func (e *MySQLEngine) IsEphemeralBackend() bool { return false }
 
+// RevokeInvalidatesCredential is always true: DROP USER really removes the
+// account, so a subsequent connection attempt with it fails immediately.
+func (e *MySQLEngine) RevokeInvalidatesCredential(_ string) bool { return true }
+
 // SupportsNativeExpiry is false: MySQL users have no VALID UNTIL, so lease expiry
 // is enforced only by the auto-revoke sweeper (which must be enabled).
 func (e *MySQLEngine) SupportsNativeExpiry() bool { return false }

--- a/internal/dynamic/postgres.go
+++ b/internal/dynamic/postgres.go
@@ -16,6 +16,10 @@ type PostgresEngine struct{}
 func (e *PostgresEngine) BackendType() string      { return "postgres" }
 func (e *PostgresEngine) IsEphemeralBackend() bool { return false }
 
+// RevokeInvalidatesCredential is always true: DROP ROLE really removes the
+// account, so a subsequent connection attempt with it fails immediately.
+func (e *PostgresEngine) RevokeInvalidatesCredential(_ string) bool { return true }
+
 // SupportsNativeExpiry is true: PostgreSQL roles carry a VALID UNTIL, so the
 // credential disables itself at expiry even without the auto-revoke sweeper.
 func (e *PostgresEngine) SupportsNativeExpiry() bool { return true }

--- a/internal/dynamic/redis.go
+++ b/internal/dynamic/redis.go
@@ -33,6 +33,10 @@ type RedisEngine struct{}
 func (e *RedisEngine) BackendType() string      { return "redis" }
 func (e *RedisEngine) IsEphemeralBackend() bool { return false }
 
+// RevokeInvalidatesCredential is always true: ACL DELUSER really removes the
+// account, so a subsequent auth attempt with it fails immediately.
+func (e *RedisEngine) RevokeInvalidatesCredential(_ string) bool { return true }
+
 // SupportsNativeExpiry is false: Redis ACL users have no native expiry, so lease
 // expiry is enforced only by the auto-revoke sweeper (which must be enabled).
 func (e *RedisEngine) SupportsNativeExpiry() bool { return false }


### PR DESCRIPTION
## Summary

Follow-up to the #97 hardening round (install-wide max-lease-TTL for dynamic
secrets). That round left `Revoke()` as a no-op for every cloud-IAM dynamic
secret backend (AWS STS, Azure, GCP, Kubernetes), documented generically as
"inherent to self-expiring token types." This PR re-investigates that claim
per backend and fixes the one backend where it turned out not to be true.

### Investigated, left as a documented no-op (genuinely no safe mechanism)

- **AWS STS** (`sts:AssumeRole`): AWS has no "revoke this one session" API.
  The only documented workaround — the IAM console's "Revoke active
  sessions," an `aws:TokenIssueTime`-conditioned `Deny` policy — is scoped to
  the **role**, not a session: it would deny every concurrent session on that
  role, including leases this call was never asked to touch. Automating that
  from a single-lease `Revoke()` is an unacceptable blast radius.
- **Azure** (`DefaultAzureCredential.GetToken`): a client-credentials-style
  flow (managed/workload identity) with no refresh token and no per-token
  revoke API. Azure AD's session/refresh-token revocation mechanisms apply to
  delegated user-session flows, not this one.
- **GCP** (`iamcredentials.generateAccessToken`): mints a short-lived OAuth2
  token, not a downloadable service-account key (keys *can* be deleted for
  immediate effect, but this backend never creates one). Google's IAM
  Credentials API docs are explicit that these tokens can't be revoked before
  natural expiry.

Each file's header comment now states the specific reason instead of a
generic "inherent to self-expiring tokens" line, and each engine's new
`RevokeInvalidatesCredential` always returns `false`.

### Fixed: Kubernetes (`internal/dynamic/kubernetes.go`)

Kubernetes `TokenRequest` tokens support `spec.boundObjectRef`: the API
server checks the bound object's live existence + UID on **every** request,
independent of the token's own `exp` claim — this is the same mechanism
`kubectl create token --bound-object-kind=Secret` and kubelet's projected
Pod-bound tokens rely on.

Added an opt-in `"revocable":true` config field:
- `Issue` creates a dedicated, per-lease `Secret` and binds the token to it
  via `spec.boundObjectRef`.
- `Revoke` deletes that `Secret`, immediately invalidating the token — idempotent
  (a 404 on delete is treated as success).
- Off by default, so no existing deployment's behavior or required RBAC
  changes silently. Turning it on requires the calling identity to also hold
  `create`+`delete` on `secrets` in the target namespace (on top of `create`
  on `serviceaccounts/token`, already required).
- Scoped to exactly one lease: deleting the bound `Secret` has no effect on
  any other lease or on the ServiceAccount itself — unlike the AWS/Azure
  workarounds above, there's no shared-identity blast radius here.

### Audit-trail correctness

Added `CredentialEngine.RevokeInvalidatesCredential(adminDSN) bool` to the
interface (implemented by every engine) so `RevokeLease`'s audit message can
tell a genuine per-lease revoke (Kubernetes with `revocable:true`) apart from
the no-op backends, instead of assuming every `IsEphemeralBackend() == true`
engine's `Revoke` is cosmetic.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/dynamic/... -count=1` (new tests cover: revocable
      Issue creates the bound Secret and passes its name/uid into
      `boundObjectRef`; a failed mint cleans up the orphaned Secret; Revoke
      deletes the bound Secret only when `revocable` is set and is a no-op
      otherwise; malformed config fails closed; `RevokeInvalidatesCredential`
      for all four cloud backends)
- [x] `go test ./internal/core/...` (new test proves `RevokeLease`'s audit
      message reports a genuine revoke, not "cannot be invalidated early,"
      for an ephemeral engine whose `RevokeInvalidatesCredential` is true)
- [x] `gosec -severity medium -exclude-generated ./internal/dynamic/...` — 0 issues

**Scope of what the tests prove:** these are fake-minter unit tests (the same
convention every other dynamic-secret engine test in this repo uses) proving
the engine issues the correct API calls with the correct parameters
(create-Secret → TokenRequest with `boundObjectRef` → delete-Secret on
revoke). They do **not** prove a real Kubernetes API server actually rejects
a token after its bound Secret is deleted — that would need a live cluster,
which this environment doesn't have. The mechanism itself (`boundObjectRef`
live-checking) is a documented, stable Kubernetes API server behavior, not a
new invention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)