### PR TITLE
fix(rbac): add a grant-time separation-of-duties preventive gate (#419)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,6 +18,8 @@ description = "Demo / docs / scripts / test fixtures — non-real sample credent
 regexes = [
   '''keyorix-audit-checkpoint-v1''',
   '''keyorix-evidence-signature-v1''',
+  '''keyorix-evidence-signature-kek-v2''',
+  '''keyorix-evidence-signature-kek-id-v2''',
 ]
 paths = [
   '''demo/.*''',

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -33,7 +33,7 @@ func newBootstrappedCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 		&models.PersonalAccessToken{}, &models.Session{}, &models.ShareRecord{},
 		&models.AuditEvent{},
 		&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.ProjectMembership{},
-		&models.SecretNode{}, &models.DynamicSecretConfig{},
+		&models.SecretNode{}, &models.DynamicSecretConfig{}, &models.SoDPolicy{},
 	))
 
 	st := store.NewLocalStorage(db)

--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -181,7 +181,13 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 	// access was actually granted — reconcile it to revoked rather than leaving a
 	// phantom "active" record with no corresponding role, and free the slot so the
 	// user can retry.
-	if err := c.AssignUserRoleWithExpiry(ctx, userID, userID, role.ID, scope, expiresAt); err != nil {
+	//
+	// Deliberately calls assignUserRoleWithExpirySkipSoD, not AssignUserRoleWithExpiry:
+	// break-glass is un-gated by design (the whole point is access the user does NOT
+	// already have), so it must not be refused by the #419 separation-of-duties
+	// preventive gate during a genuine incident — see that function's doc comment
+	// (jit_access.go).
+	if err := c.assignUserRoleWithExpirySkipSoD(ctx, userID, userID, role.ID, scope, expiresAt); err != nil {
 		activation.State = BreakGlassRevoked
 		activation.RevokedAt = &now
 		_ = c.storage.UpdateBreakGlassActivation(ctx, activation)

--- a/internal/core/jit_access.go
+++ b/internal/core/jit_access.go
@@ -28,7 +28,35 @@ import (
 // permissions (that's break-glass's entire purpose) — closing this gap needs a
 // break-glass-aware carve-out, which is its own follow-up, not a mechanical mirror
 // of AssignUserRole's fix.
+//
+// #419: the separation-of-duties preventive gate (requireNoSoDViolation) DOES
+// apply here by default, unlike the ceiling check above — this is precisely the
+// JIT-timing-evasion vector the finding describes ("a toxic-permission overlap
+// that both starts and fully expires between two SoD digest runs ... concretely
+// constructible by arranging two overlapping short-lived grants"). Break-glass
+// is the one caller that legitimately cannot be blocked by it (same reasoning as
+// the ceiling-check gap above): see assignUserRoleWithExpirySkipSoD, which
+// break_glass.go calls instead.
 func (c *KeyorixCore) AssignUserRoleWithExpiry(ctx context.Context, actorID, userID, roleID uint, scope Scope, expiresAt time.Time) error {
+	if err := c.requireNoSoDViolation(ctx, userID, roleID); err != nil {
+		return err
+	}
+	return c.assignUserRoleWithExpirySkipSoD(ctx, actorID, userID, roleID, scope, expiresAt)
+}
+
+// assignUserRoleWithExpirySkipSoD performs the identical time-bound grant as
+// AssignUserRoleWithExpiry but deliberately SKIPS the #419 separation-of-duties
+// preventive check. Use it ONLY where the action is break-glass's self-service
+// emergency access (break_glass.go's ActivateBreakGlass): break-glass is
+// documented as "Deliberately un-gated by RBAC — the whole point is access the
+// user does NOT already have", so a false-positive SoD block during a genuine
+// incident is an unacceptable failure mode for the control that exists to
+// remediate incidents — mirroring the exact reasoning already established above
+// for the escalation-by-proxy ceiling check this function also (deliberately)
+// skips. Never call this from any other path — the HTTP JIT-assign endpoint and
+// the access-request TTL-approval path must go through AssignUserRoleWithExpiry
+// so the SoD gate applies.
+func (c *KeyorixCore) assignUserRoleWithExpirySkipSoD(ctx context.Context, actorID, userID, roleID uint, scope Scope, expiresAt time.Time) error {
 	if err := c.storage.AssignRoleWithExpiry(ctx, userID, roleID, scope, expiresAt); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
@@ -39,13 +67,19 @@ func (c *KeyorixCore) AssignUserRoleWithExpiry(ctx context.Context, actorID, use
 // AssignGroupRoleWithExpiry assigns a time-bound role to a group at scope, gated by
 // the same escalation-by-proxy ceiling as the permanent grant (AssignRoleToGroup —
 // a JIT admin grant to a group is just as much a self-escalation vector as a
-// permanent one); see AssignUserRoleWithExpiry.
+// permanent one); see AssignUserRoleWithExpiry. Also gated by the #419
+// separation-of-duties preventive check (requireGroupGrantNoSoDViolation) — no
+// caller of this function needs a break-glass-style carve-out, unlike the direct
+// user grant above.
 func (c *KeyorixCore) AssignGroupRoleWithExpiry(ctx context.Context, actorID, groupID, roleID uint, scope Scope, expiresAt time.Time) error {
 	role, err := c.storage.GetRole(ctx, roleID)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
 	if err := c.requireAuthorityForRole(ctx, actorID, scope.ProjectID, role.Name); err != nil {
+		return err
+	}
+	if err := c.requireGroupGrantNoSoDViolation(ctx, groupID, roleID); err != nil {
 		return err
 	}
 	if err := c.storage.AssignRoleToGroupWithExpiry(ctx, groupID, roleID, scope, expiresAt); err != nil {

--- a/internal/core/machine_token.go
+++ b/internal/core/machine_token.go
@@ -209,7 +209,10 @@ func (c *KeyorixCore) ValidateMachineToken(ctx context.Context, raw string) (*mo
 // must not be reachable through this path. Granting an admin role is additionally
 // gated by requireAuthorityForRole (the same escalation-by-proxy ceiling
 // AddProjectMember applies) — an admin-credentialed machine identity is just as
-// much a self-escalation vector as an admin user grant.
+// much a self-escalation vector as an admin user grant. Also gated by the #419
+// separation-of-duties preventive check (requireMachineGrantNoSoDViolation,
+// sod.go) — a machine identity holds real permissions too and Authorize
+// authorizes it, so the same toxic-permission-pair concern applies.
 func (c *KeyorixCore) AssignMachineRole(ctx context.Context, machineID, roleID uint, scope Scope, actorID uint) error {
 	m, err := c.machineInProject(ctx, scope.ProjectID, machineID)
 	if err != nil {
@@ -220,6 +223,9 @@ func (c *KeyorixCore) AssignMachineRole(ctx context.Context, machineID, roleID u
 		return err
 	}
 	if err := c.requireAuthorityForRole(ctx, actorID, scope.ProjectID, role.Name); err != nil {
+		return err
+	}
+	if err := c.requireMachineGrantNoSoDViolation(ctx, machineID, roleID); err != nil {
 		return err
 	}
 	if err := c.storage.AssignMachineRole(ctx, machineID, roleID, scope); err != nil {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -330,12 +330,22 @@ func (m *MockStorage) GetSoDPolicy(ctx context.Context, id uint) (*models.SoDPol
 	return args.Get(0).(*models.SoDPolicy), args.Error(1)
 }
 
+// ListSoDPolicies defaults to "no policies configured" when a test hasn't set up
+// an expectation for it (mirrors GetProject/ListEnvironmentsByProject above) —
+// #419 wired a ListSoDPolicies call into every role-grant choke point
+// (requireNoSoDViolation and friends, sod.go), so any grant-path test that
+// doesn't care about SoD would otherwise need to stub this out too.
 func (m *MockStorage) ListSoDPolicies(ctx context.Context) ([]*models.SoDPolicy, error) {
-	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
+	for _, c := range m.ExpectedCalls {
+		if c.Method == "ListSoDPolicies" {
+			args := m.Called(ctx)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).([]*models.SoDPolicy), args.Error(1)
+		}
 	}
-	return args.Get(0).([]*models.SoDPolicy), args.Error(1)
+	return nil, nil
 }
 
 func (m *MockStorage) DeleteSoDPolicy(ctx context.Context, id uint) error {

--- a/internal/core/rbac_audit_test.go
+++ b/internal/core/rbac_audit_test.go
@@ -19,7 +19,7 @@ func newRBACAuditCore(t *testing.T) *KeyorixCore {
 	require.NoError(t, db.AutoMigrate(
 		&models.AuditEvent{}, &models.UserRole{}, &models.Role{}, &models.Permission{},
 		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.Project{}, &models.Environment{},
+		&models.Project{}, &models.Environment{}, &models.SoDPolicy{},
 	))
 	return NewKeyorixCore(store.NewLocalStorage(db))
 }
@@ -80,7 +80,7 @@ func TestRBACAuditTrail_GroupRole(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
-		&models.AuditEvent{}, &models.Group{}, &models.Role{}, &models.GroupRole{},
+		&models.AuditEvent{}, &models.Group{}, &models.Role{}, &models.GroupRole{}, &models.SoDPolicy{},
 	))
 	require.NoError(t, db.Create(&models.Group{ID: 7, Name: "platform"}).Error)
 	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "editor"}).Error)

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -137,6 +137,9 @@ func (c *KeyorixCore) AssignRoleToGroup(ctx context.Context, actorID, groupID, r
 	if err := c.requireAuthorityForRole(ctx, actorID, scope.ProjectID, role.Name); err != nil {
 		return err
 	}
+	if err := c.requireGroupGrantNoSoDViolation(ctx, groupID, roleID); err != nil {
+		return err
+	}
 	if err := c.storage.AssignRoleToGroup(ctx, groupID, roleID, scope); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
@@ -279,9 +282,13 @@ func (c *KeyorixCore) SetUserRoles(ctx context.Context, actorID, userID uint, ro
 // audit event. actorID is the acting principal (0 when unauthenticated, e.g. a
 // local CLI invocation). This is the audited choke point all role-assignment
 // paths funnel through. See requireGranterHoldsRolePermissions for the
-// admin-rank-ceiling check on the grant (#93/#107/#141).
+// admin-rank-ceiling check on the grant (#93/#107/#141), and requireNoSoDViolation
+// (sod.go) for the separation-of-duties preventive gate (#419).
 func (c *KeyorixCore) AssignUserRole(ctx context.Context, actorID, userID, roleID uint, scope Scope) error {
 	if err := c.requireGranterHoldsRolePermissions(ctx, actorID, roleID, scope); err != nil {
+		return err
+	}
+	if err := c.requireNoSoDViolation(ctx, userID, roleID); err != nil {
 		return err
 	}
 	if err := c.storage.AssignRole(ctx, userID, roleID, scope); err != nil {
@@ -307,7 +314,20 @@ func (c *KeyorixCore) AssignUserRole(ctx context.Context, actorID, userID, roleI
 // actorID is still recorded as the audit actor. Never call this from a path
 // reachable by an ordinary authenticated request exercising roles.assign — that
 // path must go through AssignUserRole so the ceiling check applies.
+//
+// #419: the separation-of-duties preventive gate (requireNoSoDViolation) IS
+// still applied here, unlike the ceiling check above — this is a distinct
+// concern (whether the grant creates a toxic-permission overlap, not whether the
+// granter's own authority covers it) and its only caller, reconcileSSOGroups
+// (sso.go), already treats any error from this call as "role not added, sync the
+// rest, retry next login" rather than failing the login — so blocking here is
+// safe and closes an SSO-group-mapping-driven instance of the same #419 gap
+// (IdP group membership can change on every login, which is at least as fast a
+// grant/revoke cycle as an explicit JIT grant).
 func (c *KeyorixCore) assignUserRoleSystemGrant(ctx context.Context, actorID, userID, roleID uint, scope Scope) error {
+	if err := c.requireNoSoDViolation(ctx, userID, roleID); err != nil {
+		return err
+	}
 	if err := c.storage.AssignRole(ctx, userID, roleID, scope); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}

--- a/internal/core/rbac_management_test.go
+++ b/internal/core/rbac_management_test.go
@@ -19,7 +19,7 @@ func newRBACManagementCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	require.NoError(t, db.AutoMigrate(
 		&models.AuditEvent{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.Project{}, &models.Environment{},
+		&models.Project{}, &models.Environment{}, &models.SoDPolicy{},
 	))
 	return NewKeyorixCore(store.NewLocalStorage(db)), db
 }

--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -197,20 +197,9 @@ func (c *KeyorixCore) userSoDViolations(ctx context.Context, u *models.User, pol
 		return out, nil
 	}
 
-	perms, err := c.storage.GetUserPermissions(ctx, u.ID)
+	held, err := c.userHeldPermissionSet(ctx, u.ID)
 	if err != nil {
 		return nil, err
-	}
-	groupPerms, err := c.storage.GetUserGroupPermissions(ctx, u.ID)
-	if err != nil {
-		return nil, err
-	}
-	held := make(map[string]bool, len(perms)+len(groupPerms))
-	for _, p := range perms {
-		held[p.Name] = true
-	}
-	for _, p := range groupPerms {
-		held[p.Name] = true
 	}
 	var out []SoDViolation
 	for _, pol := range policies {
@@ -224,6 +213,32 @@ func (c *KeyorixCore) userSoDViolations(ctx context.Context, u *models.User, pol
 		}
 	}
 	return out, nil
+}
+
+// userHeldPermissionSet returns the set of permission names userID holds via
+// DIRECT role assignments and GROUP-inherited roles — NOT the admin-bypass
+// (callers that need bypass-awareness check adminRoleName separately, exactly as
+// userSoDViolations already does above). Shared by the periodic scan
+// (userSoDViolations) and the grant-time preventive check (requireNoSoDViolation
+// and friends, #419) so both compute "what does this principal effectively hold"
+// identically — one policy-matching rule, not two.
+func (c *KeyorixCore) userHeldPermissionSet(ctx context.Context, userID uint) (map[string]bool, error) {
+	perms, err := c.storage.GetUserPermissions(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	groupPerms, err := c.storage.GetUserGroupPermissions(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	held := make(map[string]bool, len(perms)+len(groupPerms))
+	for _, p := range perms {
+		held[p.Name] = true
+	}
+	for _, p := range groupPerms {
+		held[p.Name] = true
+	}
+	return held, nil
 }
 
 // machineSoDViolations scans active machine identities, appending any violations
@@ -311,4 +326,264 @@ func actorPtr(id uint) *uint {
 	}
 	a := id
 	return &a
+}
+
+// ── Preventive gate (#419) ───────────────────────────────────────────────────
+//
+// DetectSoDViolations above is a purely periodic/on-demand DETECTIVE control — it
+// only catches a toxic-permission overlap when someone runs it (a scheduled
+// digest or an on-demand call). Combined with this codebase's JIT/time-bound
+// role grants (UserRole.ExpiresAt and friends), a toxic overlap that both STARTS
+// and FULLY EXPIRES between two scans is genuinely exercisable through the live
+// Authorize() path — real access is granted and can be used during that window —
+// but never appears in any SoD violation report: a timing-based evasion of the
+// control, concretely constructible by arranging two overlapping short-lived
+// grants.
+//
+// The functions below are the PREVENTIVE counterpart. Called from every direct
+// role-grant choke point, before a new grant lands, they reuse the exact same
+// policy-matching rule the periodic scan uses (sodPolicyNewlyCompletedBy) to ask
+// a narrower, single-principal (or single-grant-set) question — "would THIS
+// grant, together with what the principal ALREADY holds, complete a policy that
+// isn't already complete?" — and BLOCK the grant if so (fail closed, matching
+// this codebase's established posture for every other grant-time ceiling check:
+// requireGranterHoldsRolePermissions, requireAuthorityForRole).
+//
+// Deliberately out of scope below: a principal who ALREADY holds (or is being
+// granted) an admin permission-bypass role (isAdminRoleName). An admin holds
+// every permission and so trivially "violates" every SoD policy the instant one
+// is defined — exactly the case userSoDViolations' own admin-bypass branch flags
+// on the periodic scan. Applying that same rule as a hard PREVENTIVE block would
+// refuse ALL further admin-role provisioning the moment any SoD policy exists —
+// an availability regression far outside what this fix is meant to close.
+// Admin-role grants are separately, adequately gated by their own
+// escalation-by-proxy ceiling (requireAuthorityForRole/requireAdminAuthorityAt:
+// only an existing admin may grant one).
+//
+// Also deliberately NOT wired into break_glass.go's self-service emergency
+// activation: break-glass is documented as "Deliberately un-gated by RBAC — the
+// whole point is access the user does NOT already have", and a false-positive
+// SoD block during a genuine incident would be a severe, unacceptable failure
+// mode for the control that exists to remediate incidents. See
+// assignUserRoleWithExpirySkipSoD (jit_access.go) for the carve-out, which
+// mirrors the SAME reasoning this codebase already applies to the ceiling check
+// AssignUserRoleWithExpiry also (deliberately) skips.
+
+// sodPolicyNewlyCompletedBy returns the first policy in policies that becomes
+// satisfied (both permission sides held) once adding is unioned into held, but
+// was NOT already satisfied by held alone — i.e. a violation this specific
+// change would newly create, not one that already existed. nil when nothing
+// newly completes. The one shared predicate every preventive check below (and,
+// via userSoDViolations, the periodic scan) evaluates a policy with.
+func sodPolicyNewlyCompletedBy(policies []*models.SoDPolicy, held, adding map[string]bool) *models.SoDPolicy {
+	for _, pol := range policies {
+		if held[pol.PermissionA] && held[pol.PermissionB] {
+			continue // already violated before this change — not created by it
+		}
+		hasA := held[pol.PermissionA] || adding[pol.PermissionA]
+		hasB := held[pol.PermissionB] || adding[pol.PermissionB]
+		if hasA && hasB {
+			return pol
+		}
+	}
+	return nil
+}
+
+// rolePermissionNameSet returns the permission names roleID's role_permissions
+// rows carry.
+func (c *KeyorixCore) rolePermissionNameSet(ctx context.Context, roleID uint) (map[string]bool, error) {
+	perms, err := c.storage.GetRolePermissions(ctx, roleID)
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]bool, len(perms))
+	for _, p := range perms {
+		set[p.Name] = true
+	}
+	return set, nil
+}
+
+// sodBlockedErr formats the blocking error a preventive check returns when a
+// grant would newly complete pol.
+func sodBlockedErr(pol *models.SoDPolicy, detail string) error {
+	return fmt.Errorf("cannot %s: it would create a separation-of-duties violation with policy %q (%s + %s)",
+		detail, pol.Name, pol.PermissionA, pol.PermissionB)
+}
+
+// requireNoSoDViolation is the preventive gate for a DIRECT user role grant: it
+// blocks granting roleID to userID if doing so would newly complete an SoD
+// policy given userID's OTHER current permissions (direct + group,
+// scope-agnostic — SoD policies are principal-level, exactly like the periodic
+// scan, not scope-restricted; a user must never hold both sides ANYWHERE, not
+// merely "not in the same project"). This is the choke point AssignUserRole and
+// AssignUserRoleWithExpiry both call.
+func (c *KeyorixCore) requireNoSoDViolation(ctx context.Context, userID, roleID uint) error {
+	policies, err := c.storage.ListSoDPolicies(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if len(policies) == 0 {
+		return nil
+	}
+	if c.adminRoleName(ctx, userID) != "" {
+		return nil // already holds admin-bypass — see package doc above
+	}
+	role, err := c.storage.GetRole(ctx, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if isAdminRoleName(role.Name) {
+		return nil // granting admin-bypass — see package doc above
+	}
+	adding, err := c.rolePermissionNameSet(ctx, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if len(adding) == 0 {
+		return nil
+	}
+	held, err := c.userHeldPermissionSet(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if pol := sodPolicyNewlyCompletedBy(policies, held, adding); pol != nil {
+		return sodBlockedErr(pol, "grant this role")
+	}
+	return nil
+}
+
+// requireGroupGrantNoSoDViolation is requireNoSoDViolation's GROUP-grant
+// counterpart: a role assigned to a group is inherited by every member, so it
+// can complete a policy for a member exactly as a direct grant would. Checks
+// each active, non-admin-bypass member (a group's membership is a small,
+// bounded set — unlike DetectSoDViolations' full-deployment scan — so this
+// stays cheap even run synchronously on every group-role assignment). A member
+// who already holds admin-bypass is skipped, not treated as a block (see
+// package doc above).
+func (c *KeyorixCore) requireGroupGrantNoSoDViolation(ctx context.Context, groupID, roleID uint) error {
+	policies, err := c.storage.ListSoDPolicies(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if len(policies) == 0 {
+		return nil
+	}
+	role, err := c.storage.GetRole(ctx, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if isAdminRoleName(role.Name) {
+		return nil
+	}
+	adding, err := c.rolePermissionNameSet(ctx, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if len(adding) == 0 {
+		return nil
+	}
+	members, err := c.storage.ListGroupMembers(ctx, groupID)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	for _, m := range members {
+		if !m.IsActive || c.adminRoleName(ctx, m.ID) != "" {
+			continue
+		}
+		held, err := c.userHeldPermissionSet(ctx, m.ID)
+		if err != nil {
+			return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+		}
+		if pol := sodPolicyNewlyCompletedBy(policies, held, adding); pol != nil {
+			return fmt.Errorf("cannot assign this role to the group: it would create a separation-of-duties violation for member %d with policy %q (%s + %s)",
+				m.ID, pol.Name, pol.PermissionA, pol.PermissionB)
+		}
+	}
+	return nil
+}
+
+// requireMachineGrantNoSoDViolation is requireNoSoDViolation's machine-identity
+// counterpart: a machine holds permissions only through its explicit role
+// grants (machineSoDViolations — no admin-bypass ever applies to a machine, a
+// leaked token is bounded to its explicit grants), so "held" is simply the
+// union of its OTHER current roles' permissions.
+func (c *KeyorixCore) requireMachineGrantNoSoDViolation(ctx context.Context, machineID, roleID uint) error {
+	policies, err := c.storage.ListSoDPolicies(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if len(policies) == 0 {
+		return nil
+	}
+	role, err := c.storage.GetRole(ctx, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if isAdminRoleName(role.Name) {
+		return nil
+	}
+	adding, err := c.rolePermissionNameSet(ctx, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if len(adding) == 0 {
+		return nil
+	}
+	roles, err := c.storage.GetMachineRoles(ctx, machineID)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	held := make(map[string]bool)
+	for _, r := range roles {
+		perms, err := c.rolePermissionNameSet(ctx, r.ID)
+		if err != nil {
+			return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+		}
+		for name := range perms {
+			held[name] = true
+		}
+	}
+	if pol := sodPolicyNewlyCompletedBy(policies, held, adding); pol != nil {
+		return sodBlockedErr(pol, "assign this role")
+	}
+	return nil
+}
+
+// requireGrantSetNoSoDViolation is requireNoSoDViolation's counterpart for a set
+// of roles granted ATOMICALLY to one principal with NO prior grants — e.g.
+// CreateUserWithAssignments minting a brand-new user's system role plus project
+// assignments in one call, where there is no user ID yet to look up existing
+// permissions against, so every role in the set is evaluated together instead.
+// Any role in the set that is itself admin-bypass exempts the whole set (see
+// package doc above).
+func (c *KeyorixCore) requireGrantSetNoSoDViolation(ctx context.Context, roleIDs []uint) error {
+	policies, err := c.storage.ListSoDPolicies(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if len(policies) == 0 {
+		return nil
+	}
+	held := make(map[string]bool)
+	for _, rid := range roleIDs {
+		role, err := c.storage.GetRole(ctx, rid)
+		if err != nil {
+			return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+		}
+		if isAdminRoleName(role.Name) {
+			return nil
+		}
+		perms, err := c.rolePermissionNameSet(ctx, rid)
+		if err != nil {
+			return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+		}
+		for name := range perms {
+			held[name] = true
+		}
+	}
+	if pol := sodPolicyNewlyCompletedBy(policies, map[string]bool{}, held); pol != nil {
+		return fmt.Errorf("cannot create user: the combined role assignments would create a separation-of-duties violation with policy %q (%s + %s)",
+			pol.Name, pol.PermissionA, pol.PermissionB)
+	}
+	return nil
 }

--- a/internal/core/sod_preventive_gate_external_test.go
+++ b/internal/core/sod_preventive_gate_external_test.go
@@ -1,0 +1,292 @@
+package core_test
+
+// sod_preventive_gate_external_test.go — #419: DetectSoDViolations (sod.go) is a
+// purely periodic/on-demand DETECTIVE control; combined with JIT/time-bound role
+// grants, a toxic-permission overlap that both starts and fully expires between two
+// scans is exercisable through Authorize() but never appears in any report. These
+// tests prove the grant-time PREVENTIVE gate (requireNoSoDViolation and friends,
+// sod.go) closes that window: a grant that would newly complete an SoD policy is
+// blocked at every direct role-grant choke point, a grant that does NOT is
+// unaffected (non-regression), and break-glass's self-service emergency access is
+// deliberately exempt (it is documented as un-gated by RBAC by design).
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// role/permission fixture reminder (testhelper.seedTestData): role 2 = admin
+// (bypass), role 3 = editor (secrets.read, secrets.write, users.read), role 4 =
+// viewer (secrets.read, users.read), role 5 = auditor (audit.read, audit.admin,
+// system.read, users.read, roles.read).
+
+// AssignUserRole must BLOCK a grant that would newly complete an SoD policy given
+// the target user's OTHER current permissions — the direct-grant half of #419.
+func TestAssignUserRole_BlocksNewSoDViolation(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 4, nil) // viewer (global) → secrets.read, users.read
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	// editor adds secrets.write — combined with alice's existing secrets.read this
+	// newly completes the policy, so the grant must be refused. actorID 0 is the
+	// system pseudo-actor (bypasses the unrelated grant-ceiling check — #93/#107/
+	// #141 — so only the SoD gate under test is exercised).
+	err = h.CoreService.AssignUserRole(ctx, 0, 10, 3, core.Scope{})
+	require.Error(t, err, "granting editor must be blocked: it would create a new SoD violation")
+	assert.Contains(t, err.Error(), "separation-of-duties")
+
+	ids, gerr := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{})
+	require.NoError(t, gerr)
+	assert.NotContains(t, ids, uint(3), "the blocked grant must not have been persisted")
+}
+
+// A grant that does NOT complete any SoD policy must still succeed normally —
+// critical non-regression, since this gate now runs on every role-grant path.
+func TestAssignUserRole_AllowsNonViolatingGrant(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "bob", 11)
+	h.AssignUserRole(t, 11, 4, nil) // viewer → secrets.read, users.read
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	// auditor (audit.read, audit.admin, system.read, users.read, roles.read) shares
+	// no permission with either side of the policy beyond what bob already holds
+	// alone — granting it completes nothing.
+	err = h.CoreService.AssignUserRole(ctx, 0, 11, 5, core.Scope{})
+	require.NoError(t, err, "a non-violating grant must succeed unimpeded")
+
+	ids, gerr := h.Storage.GetUserRoleIDsAt(ctx, 11, storage.Scope{})
+	require.NoError(t, gerr)
+	assert.Contains(t, ids, uint(5), "the auditor role must have been granted")
+}
+
+// AssignUserRoleWithExpiry (the JIT/time-bound grant path) must ALSO block a
+// newly-completing SoD violation — this is the exact timing-evasion vector #419
+// describes: without this, a toxic overlap granted with an expiry could start and
+// fully expire between two DetectSoDViolations runs, invisible to the periodic
+// scan, while still genuinely authorizing access for its whole (short) lifetime.
+func TestAssignUserRoleWithExpiry_BlocksJITSoDViolation(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "carol", 12)
+	h.AssignUserRole(t, 12, 4, nil) // viewer → secrets.read
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	expiresAt := time.Now().Add(1 * time.Hour)
+	err = h.CoreService.AssignUserRoleWithExpiry(ctx, 1, 12, 3, core.Scope{}, expiresAt)
+	require.Error(t, err, "a short-lived JIT grant that would create a toxic overlap must be blocked too, closing the timing-evasion window")
+	assert.Contains(t, err.Error(), "separation-of-duties")
+
+	ids, gerr := h.Storage.GetUserRoleIDsAt(ctx, 12, storage.Scope{})
+	require.NoError(t, gerr)
+	assert.NotContains(t, ids, uint(3), "the blocked time-bound grant must not have been persisted")
+}
+
+// The JIT path's non-regression counterpart: a time-bound grant that does not
+// complete any policy must still succeed and actually authorize.
+func TestAssignUserRoleWithExpiry_AllowsNonViolatingGrant(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "dave", 13)
+	h.AssignUserRole(t, 13, 4, nil) // viewer
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	expiresAt := time.Now().Add(1 * time.Hour)
+	err = h.CoreService.AssignUserRoleWithExpiry(ctx, 1, 13, 5, core.Scope{}, expiresAt) // auditor
+	require.NoError(t, err, "a non-violating time-bound grant must succeed unimpeded")
+
+	ids, gerr := h.Storage.GetUserRoleIDsAt(ctx, 13, storage.Scope{})
+	require.NoError(t, gerr)
+	assert.Contains(t, ids, uint(5))
+}
+
+// Granting a role to a GROUP is inherited by every member exactly like a direct
+// grant, so it must be checked the same way — a member who would newly complete a
+// policy blocks the whole group-role assignment.
+func TestAssignRoleToGroup_BlocksNewSoDViolationForMember(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "erin", 14)
+	h.AssignUserRole(t, 14, 4, nil) // viewer directly → secrets.read
+	h.CreateTestGroup(t, "writers", "", 30)
+	h.AssignUserToGroup(t, 14, 30)
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	// Granting editor (secrets.write) to the GROUP would complete the policy for
+	// erin, its member.
+	err = h.CoreService.AssignRoleToGroup(ctx, 1, 30, 3, core.Scope{})
+	require.Error(t, err, "the group grant must be blocked on behalf of the member it would newly violate for")
+	assert.Contains(t, err.Error(), "separation-of-duties")
+
+	roles, gerr := h.CoreService.GetGroupRoles(ctx, 30)
+	require.NoError(t, gerr)
+	for _, r := range roles {
+		assert.NotEqual(t, uint(3), r.ID, "the blocked group role must not have been persisted")
+	}
+}
+
+// A group-role grant that violates nothing for any current member must still
+// succeed normally.
+func TestAssignRoleToGroup_AllowsNonViolatingGrant(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "frank", 15)
+	h.AssignUserRole(t, 15, 4, nil) // viewer
+	h.CreateTestGroup(t, "auditors", "", 31)
+	h.AssignUserToGroup(t, 15, 31)
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	err = h.CoreService.AssignRoleToGroup(ctx, 1, 31, 5, core.Scope{}) // auditor: no conflict
+	require.NoError(t, err, "a non-violating group grant must succeed unimpeded")
+
+	roles, gerr := h.CoreService.GetGroupRoles(ctx, 31)
+	require.NoError(t, gerr)
+	var found bool
+	for _, r := range roles {
+		if r.ID == 5 {
+			found = true
+		}
+	}
+	assert.True(t, found, "the auditor role must have been granted to the group")
+}
+
+// CreateUserWithAssignments mints a BRAND-NEW user's roles atomically, so there is
+// no existing user ID to check "other current grants" against — the preventive
+// gate instead evaluates whether the FULL set of role grants landing together
+// would complete a policy (requireGrantSetNoSoDViolation).
+func TestCreateUserWithAssignments_BlocksNewSoDViolationAcrossGrantSet(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	// The global system role is "viewer" (secrets.read) and the lone project
+	// assignment is "editor" (secrets.write) — together, in one atomic call, they
+	// complete the policy for a user who a moment ago didn't exist at all. Project 1
+	// ("default") is already seeded by testhelper.seedTestData.
+	_, err = h.CoreService.CreateUserWithAssignments(ctx, &core.CreateUserRequest{
+		Username: "grace", Email: "grace@test.com", DisplayName: "Grace", Password: "Sup3rS3cret!Pass",
+	}, "viewer", []core.ProjectAssignment{{ProjectID: 1, Role: "editor"}}, 0)
+	require.Error(t, err, "the combined grant set must be refused for completing an SoD policy")
+	assert.Contains(t, err.Error(), "separation-of-duties")
+
+	_, gerr := h.CoreService.GetUserByEmail(ctx, "grace@test.com")
+	assert.Error(t, gerr, "no user must have been created")
+}
+
+// A brand-new user's combined role grants that do NOT complete any policy must
+// still succeed normally.
+func TestCreateUserWithAssignments_AllowsNonViolatingGrantSet(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	// Project 1 ("default") is already seeded by testhelper.seedTestData.
+	created, err := h.CoreService.CreateUserWithAssignments(ctx, &core.CreateUserRequest{
+		Username: "heidi", Email: "heidi@test.com", DisplayName: "Heidi", Password: "Sup3rS3cret!Pass",
+	}, "viewer", []core.ProjectAssignment{{ProjectID: 1, Role: "auditor"}}, 0)
+	require.NoError(t, err, "a non-violating grant set must succeed unimpeded")
+	assert.NotZero(t, created.ID)
+}
+
+// Break-glass self-service emergency access must NOT be blocked by the #419
+// preventive gate, even when the emergency role would (by the ordinary rule)
+// newly complete an SoD policy — break-glass is documented as deliberately
+// un-gated by RBAC (its whole point is access the user does not already have),
+// and a false-positive SoD block during a genuine incident would be an
+// unacceptable failure mode. See assignUserRoleWithExpirySkipSoD (jit_access.go).
+func TestActivateBreakGlass_NotBlockedBySoD(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}, &models.BreakGlassActivation{}))
+	ctx := context.Background()
+
+	h.CoreService.SetBreakGlassPolicy(core.BreakGlassPolicy{
+		Enabled: true, EmergencyRole: "editor", DefaultTTL: 4 * time.Hour, MaxTTL: 24 * time.Hour,
+	})
+
+	const proj = uint(2)
+	h.CreateTestUser(t, "ivan", 16)
+	pid := proj
+	h.AssignUserRole(t, 16, 4, &pid) // viewer at the project → secrets.read
+
+	// This policy would ordinarily block granting "editor" (secrets.write) to a
+	// principal who already holds secrets.read.
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 16, "prod incident requiring editor access", "")
+	require.NoError(t, err, "break-glass must not be blocked by the SoD preventive gate")
+	assert.Equal(t, core.BreakGlassActive, act.State)
+
+	ids, gerr := h.Storage.GetUserRoleIDsAt(ctx, 16, storage.Scope{ProjectID: proj})
+	require.NoError(t, gerr)
+	assert.Contains(t, ids, uint(3), "the emergency role was actually granted despite the SoD policy")
+}
+
+// A principal who already holds an admin permission-bypass role is out of scope
+// for the preventive gate (see sod.go's package doc): they trivially "violate"
+// every policy already, and blocking further grants to them would refuse ALL
+// admin-role-holder provisioning the moment any SoD policy exists.
+func TestAssignUserRole_AdminBypassNotBlockedBySoD(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "judy", 17)
+	h.AssignUserRole(t, 17, 2, nil) // admin (permission-bypass)
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	err = h.CoreService.AssignUserRole(ctx, 0, 17, 3, core.Scope{}) // editor
+	require.NoError(t, err, "granting a role to an existing admin-bypass holder must not be refused by the SoD gate")
+}

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -510,7 +510,7 @@ func TestReconcileSSORoles_IsRBACAudited(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{}, &models.AuditEvent{}, &models.SoDPolicy{}))
 	ls := store.NewLocalStorage(db)
 	c := NewKeyorixCore(ls)
 	ctx := context.Background()

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -190,6 +190,21 @@ func (c *KeyorixCore) CreateUserWithAssignments(ctx context.Context, req *Create
 		addGrant(r.ID, a.ProjectID)
 	}
 
+	// #419: the separation-of-duties preventive gate. A brand-new user has no
+	// prior grants to check against (requireNoSoDViolation needs a user ID that
+	// doesn't exist yet), so requireGrantSetNoSoDViolation instead evaluates
+	// whether the FULL set of role grants landing atomically below would together
+	// complete a policy — the same evasion this closes for an existing user's
+	// individual grants, applied to "many roles minted for one brand-new user in
+	// one call" instead.
+	roleIDs := make([]uint, 0, len(grants))
+	for _, g := range grants {
+		roleIDs = append(roleIDs, g.RoleID)
+	}
+	if err := c.requireGrantSetNoSoDViolation(ctx, roleIDs); err != nil {
+		return nil, err
+	}
+
 	created, err := c.storage.CreateUserWithRoleGrants(ctx, user, grants)
 	if err != nil {
 		// #117: same race/translation as CreateUser above — see its comment.

--- a/internal/testhelper/rbac_test_helper.go
+++ b/internal/testhelper/rbac_test_helper.go
@@ -68,6 +68,11 @@ func NewRBACTestHelper(t *testing.T) *RBACTestHelper {
 		&models.PersonalAccessToken{},
 		&models.Session{},
 		&models.SystemMetadata{},
+		// #419: every role-grant choke point now calls ListSoDPolicies (the
+		// separation-of-duties preventive gate, sod.go) — migrated unconditionally
+		// here so any test exercising a grant path gets a real (empty-by-default)
+		// sod_policies table instead of a "no such table" storage error.
+		&models.SoDPolicy{},
 	)
 	require.NoError(t, err)
 

--- a/server/grpc/services/audit_service_test.go
+++ b/server/grpc/services/audit_service_test.go
@@ -127,7 +127,7 @@ func TestAuditService_GetRBACAuditLogs_ReturnsRoleChanges(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.UserRole{},
 		&models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.Project{}, &models.Environment{}))
+		&models.Project{}, &models.Environment{}, &models.SoDPolicy{}))
 	// auditCtx() is user 1 — grant it super_admin (global) so the audit.read check passes.
 	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "super_admin"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 0}).Error)

--- a/server/http/deployment_disclosure_family_test.go
+++ b/server/http/deployment_disclosure_family_test.go
@@ -180,9 +180,17 @@ func TestDeploymentDisclosureFamily_BaselineDeniedAuditorAllowed(t *testing.T) {
 	defer server.Close()
 
 	createTestToken(t, testCore) // bootstrap admin + seed roles/permissions
-	seedFamilyFixtures(t, testCore)
+	// Tokens are created BEFORE seedFamilyFixtures: it plants an SoD policy
+	// ("family-test-policy", system.read + audit.read) that system_auditor itself
+	// violates, by design, so /sod/violations has a real row to disclose. Since
+	// #419, minting a NEW system_auditor account after that policy exists would be
+	// correctly BLOCKED by the grant-time preventive gate — creating the account
+	// first (no policy yet) and defining the policy afterward instead reproduces
+	// the intended "grandfathered/pre-existing violation" scenario, exactly what
+	// the periodic scan is meant to still catch.
 	baselineToken := createLimitedToken(t, testCore) // system_viewer only (system.read)
 	auditorToken := createAuditorToken(t, testCore)  // system_auditor (audit.read, global)
+	seedFamilyFixtures(t, testCore)
 
 	// Plant a non-conforming secret BEFORE the naming policy is enabled (naming policy
 	// is only enforced at create time — a policy tightened afterward leaves existing
@@ -378,10 +386,14 @@ func TestDashboardStats_PermissionTiers(t *testing.T) {
 	defer server.Close()
 
 	createTestToken(t, testCore)
-	seedFamilyFixtures(t, testCore)
+	// Tokens created BEFORE seedFamilyFixtures — see the identical comment in
+	// TestDeploymentDisclosureFamily_BaselineDeniedAuditorAllowed above (#419: the
+	// grant-time SoD preventive gate would otherwise block minting system_auditor
+	// after the fixture's SoD policy already exists).
 	noPermToken := createNoPermissionToken(t, testCore)
 	baselineToken := createLimitedToken(t, testCore)
 	auditorToken := createAuditorToken(t, testCore)
+	seedFamilyFixtures(t, testCore)
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	get := func(token, path string) (*http.Response, []byte) {

--- a/server/http/handlers/create_user_assignments_test.go
+++ b/server/http/handlers/create_user_assignments_test.go
@@ -27,7 +27,7 @@ func setupCreateUserAssignmentsTest(t *testing.T) (*UserHandler, *gorm.DB) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.UserRole{}, &models.Role{}, &models.Project{},
-		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Environment{}))
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Environment{}, &models.SoDPolicy{}))
 	require.NoError(t, db.Create(&models.Role{Name: "system_viewer"}).Error)
 	require.NoError(t, db.Create(&models.Role{Name: "project_developer"}).Error)
 	require.NoError(t, db.Create(&models.Project{Name: "default"}).Error)

--- a/server/http/handlers/rbac_real_test.go
+++ b/server/http/handlers/rbac_real_test.go
@@ -62,6 +62,7 @@ func openTestDB(t *testing.T) *gorm.DB {
 		&models.User{},
 		&models.Project{},
 		&models.Environment{},
+		&models.SoDPolicy{},
 	))
 	// A distinct name from any role individual tests create via mustCreateRole (some
 	// create their own role literally named "admin" for unrelated purposes) — Role.Name

--- a/server/http/user_roles_scope_test.go
+++ b/server/http/user_roles_scope_test.go
@@ -34,7 +34,7 @@ func setupUserRolesScopeCore(t *testing.T) *core.KeyorixCore {
 		&models.Project{}, &models.Environment{}, &models.User{},
 		&models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.AuditEvent{}, &models.Session{},
+		&models.AuditEvent{}, &models.Session{}, &models.SoDPolicy{},
 	))
 
 	now := time.Now()


### PR DESCRIPTION
## Summary

Backlog #419 (MEDIUM): `DetectSoDViolations` (`internal/core/sod.go`) is a purely
periodic/on-demand DETECTIVE control — it scans for toxic-permission overlaps
only when explicitly run (a scheduled digest or an on-demand CLI/API call), with
zero preventive gate at grant time. Combined with this codebase's JIT/time-bound
role grants (`UserRole.ExpiresAt`), a toxic-permission overlap that both **starts**
and **fully expires** between two SoD digest runs is genuinely exercisable through
the live `Authorize()` path (real access is granted and can be used during that
window) but never appears in any SoD violation report — a timing-based evasion of
the control.

This PR adds the missing preventive counterpart: a grant-time check, reusing the
periodic scan's own policy-matching rule, wired into every direct role-grant choke
point in the codebase.

## Design

- **Core reusable logic** (`internal/core/sod.go`): `sodPolicyNewlyCompletedBy`
  is the one shared predicate — "does unioning `adding` into `held` complete a
  policy that wasn't already complete?" — used by every preventive check below.
  `userSoDViolations` (the periodic scan) is refactored to share
  `userHeldPermissionSet` with the new preventive checks, rather than duplicating
  the held-permission computation.
- **Direct user grant**: `requireNoSoDViolation(ctx, userID, roleID)` — wired into
  `AssignUserRole` (the audited choke point `AddProjectMember`,
  `SetProjectMemberRole`, `ApproveAccessRequest`, and `applyInvitationGrants` all
  funnel through) and `AssignUserRoleWithExpiry` (the JIT/time-bound path — this is
  the literal timing-evasion vector the finding describes, reached by the direct
  HTTP JIT-assign endpoint and `ApproveAccessRequestWithExpiry`'s TTL grant).
- **SSO group-role sync**: `assignUserRoleSystemGrant` (the sole caller,
  `reconcileSSOGroups`, already treats any error as "not added, retry next
  login" — never fails the login) also gets the check, closing an
  IdP-group-membership-driven instance of the same gap.
- **Group grant**: `requireGroupGrantNoSoDViolation(ctx, groupID, roleID)` — a
  role granted to a group is inherited by every member, so it's checked against
  each active member's current permissions (a group's membership is a small,
  bounded set, unlike the periodic scan's full-deployment sweep). Wired into
  `AssignRoleToGroup` and `AssignGroupRoleWithExpiry`.
- **Machine identity grant**: `requireMachineGrantNoSoDViolation` — a machine
  holds real permissions and is authorized too (`AuthorizePrincipal`), so the
  same concern applies. Wired into `AssignMachineRole`.
- **Atomic multi-grant for a brand-new user**: `requireGrantSetNoSoDViolation` —
  `CreateUserWithAssignments` mints a system role + project assignments in one
  call for a user with no ID yet, so there's nothing to look up "existing grants"
  against; instead the full set of roles landing together is evaluated as one.

## Deliberate carve-outs (both scoped and documented in `sod.go`/`jit_access.go`)

- **Admin-permission-bypass roles are out of scope.** A principal who already
  holds (or is being granted) an admin role (`isAdminRoleName`) trivially "holds"
  every permission and so "violates" every SoD policy the instant one is defined
  — exactly what the periodic scan's own admin-bypass branch already flags.
  Applying that as a hard preventive block would refuse **all** further
  admin-role provisioning the moment any SoD policy exists — a severe
  availability regression well outside this fix's scope. Admin-role grants are
  separately gated by their own escalation-by-proxy ceiling
  (`requireAuthorityForRole`/`requireAdminAuthorityAt`).
- **Break-glass is exempt.** `break_glass.go`'s `ActivateBreakGlass` is
  documented as "Deliberately un-gated by RBAC — the whole point is access the
  user does NOT already have." A false-positive SoD block during a genuine
  incident would be an unacceptable failure mode for the control that exists to
  remediate incidents — the same reasoning this codebase already applies to the
  ceiling check `AssignUserRoleWithExpiry` also (deliberately) skips for
  break-glass. It now calls a new sibling, `assignUserRoleWithExpirySkipSoD`,
  instead of `AssignUserRoleWithExpiry`; every other JIT caller (the HTTP
  endpoint, access-request approval) is unaffected and still gated.

## Behavior: block, not warn

Granting a role that would newly complete an SoD policy is **blocked outright**
(fail closed), matching this campaign's established posture for every other
grant-time ceiling check in this file (`requireGranterHoldsRolePermissions`,
`requireAuthorityForRole`) — there is no existing "hard vs. warn-only" severity
tier in the SoD policy model to mirror, so blocking is the consistent default.

## Test-infrastructure fallout

Every ad-hoc in-memory test schema that exercises a grant path now needs the
`sod_policies` table (production always migrates it unconditionally at boot —
`internal/storage/factory.go:834` — this was purely a test-fixture gap). Fixed by
adding `models.SoDPolicy{}` to the shared `AutoMigrate` lists
(`testhelper.NewRBACTestHelper`, `newBootstrappedCore`, `newRBACManagementCore`,
`newRBACAuditCore`, and a handful of one-off `server/http`/`server/grpc/services`
setups) and to `MockStorage.ListSoDPolicies` (defaults to "no policies" when a
test hasn't set up an expectation, mirroring the existing `GetProject` pattern).
Also reordered two `server/http` deployment-disclosure-family tests so the
fixture's SoD policy is created *after* the test mints its `system_auditor`
account, reproducing the intended "grandfathered/pre-existing violation" scenario
the periodic-scan assertion needs, instead of the new gate correctly blocking the
mint.

## Test plan

- [x] `internal/core/sod_preventive_gate_external_test.go` — new regression
      tests: a grant that would newly complete a policy is blocked (direct user,
      JIT/time-bound, group, and atomic multi-grant paths) and a non-violating
      grant still succeeds on every one of those paths (non-regression);
      break-glass is proven NOT blocked even when its emergency role would
      otherwise trip the policy; an existing admin-bypass holder is proven NOT
      blocked either.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... -count=1`
- [x] `go test ./... -count=1` (one pre-existing, unrelated flake —
      `TestConcurrency_RequestPasswordReset_BurstIsThrottled` — reproduces
      identically on unmodified `main`)
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)