### PR TITLE
chore: add self-hosted continuous-fuzzing tooling

### DIFF
--- a/scripts/fuzzing/README.md
+++ b/scripts/fuzzing/README.md
@@ -1,0 +1,123 @@
+# Continuous fuzzing (self-hosted)
+
+Runs the repo's `func Fuzz*` targets (`internal/crypto`, `internal/core`,
+`internal/rotation` as of this writing — see `targets.conf`) continuously on a
+dedicated box, rotating between them for hours at a time. CI only runs these
+as a quick regression pass over the seed corpus; deep fuzzing needs far more
+wall-clock time than a CI job's budget affords, so it belongs on separate,
+long-lived infrastructure — a small home-lab VM/LXC is a good fit.
+
+## What you get
+
+- A systemd service that cycles through every target in `targets.conf`,
+  forever, pulling `main` fresh once per full cycle.
+- A push notification (via [ntfy.sh](https://ntfy.sh), no account needed) the
+  moment a target crashes — deduped, so a target that keeps re-failing
+  against an already-known crasher doesn't re-alert every cycle.
+- A daily heartbeat notification, so silence itself tells you the service (or
+  the box) died, without you needing to check in manually.
+- Any new corpus file (a crash reproduction, or a coverage-expanding
+  "interesting" input the fuzzer found) gets committed and pushed to a
+  dedicated `fuzz-corpus` branch automatically — review/merge what's
+  interesting from there.
+
+## One-time setup (on the LXC/VM)
+
+Debian or Alpine, ~512MB RAM is plenty for a single-target-at-a-time rotation
+(bump `MemoryMax` in `systemd/keyorix-fuzz.service` if you widen
+`targets.conf` to run more in parallel — this setup deliberately runs targets
+one at a time, not concurrently).
+
+1. **Install Go** (same version as `go.mod` — check the repo's current
+   `go.mod`/CI config for the exact version) and `git`, `rsync`, `curl`.
+
+2. **Create a dedicated user** to run the service as (never run this as
+   root):
+   ```
+   useradd -m -s /bin/bash fuzzer
+   mkdir -p /opt/keyorix-fuzz /etc/keyorix-fuzz
+   chown fuzzer:fuzzer /opt/keyorix-fuzz
+   ```
+
+3. **Generate an SSH deploy key** for this box, as the `fuzzer` user:
+   ```
+   sudo -u fuzzer ssh-keygen -t ed25519 -f /home/fuzzer/.ssh/id_ed25519 -N ""
+   cat /home/fuzzer/.ssh/id_ed25519.pub
+   ```
+   Add the printed public key to the repo's GitHub settings under **Settings
+   → Deploy keys → Add deploy key**, with **"Allow write access"** checked
+   (needed to push the `fuzz-corpus` branch). Scope this key to *this repo
+   only* — deploy keys are always single-repo, which is exactly the
+   least-privilege shape you want here (unlike a personal PAT, which this
+   setup deliberately avoids).
+
+4. **Clone the repo twice** as the `fuzzer` user — once for fuzzing (stays on
+   `main`), once as a worktree for the corpus branch:
+   ```
+   sudo -u fuzzer git clone git@github.com:keyorixhq/keyorix.git /opt/keyorix-fuzz/keyorix
+   cd /opt/keyorix-fuzz/keyorix
+   sudo -u fuzzer git worktree add ../keyorix-fuzz-corpus -b fuzz-corpus
+   sudo -u fuzzer git -C ../keyorix-fuzz-corpus push -u origin fuzz-corpus
+   ```
+
+5. **Pick an ntfy.sh topic.** Topics are unauthenticated by default (anyone
+   who guesses the name can read/publish to it), so generate something long
+   and random rather than anything guessable:
+   ```
+   openssl rand -hex 16
+   ```
+   Subscribe to `https://ntfy.sh/<that-topic>` in the
+   [ntfy app](https://ntfy.sh/#getting-started) (iOS/Android/web) so you
+   actually see the pushes.
+
+6. **Write the config file:**
+   ```
+   cp scripts/fuzzing/config.env.example /etc/keyorix-fuzz/config.env
+   $EDITOR /etc/keyorix-fuzz/config.env   # fill in NTFY_TOPIC at minimum
+   chmod 600 /etc/keyorix-fuzz/config.env
+   chown fuzzer:fuzzer /etc/keyorix-fuzz/config.env
+   ```
+
+7. **Install the systemd units:**
+   ```
+   cp scripts/fuzzing/systemd/*.service scripts/fuzzing/systemd/*.timer /etc/systemd/system/
+   systemctl daemon-reload
+   systemctl enable --now keyorix-fuzz.service
+   systemctl enable --now keyorix-fuzz-heartbeat.timer
+   ```
+
+8. **Verify:**
+   ```
+   systemctl status keyorix-fuzz.service
+   journalctl -u keyorix-fuzz.service -f
+   ```
+   You should see a target start fuzzing within a few seconds. The daily
+   heartbeat can be triggered on demand to test notifications end-to-end
+   without waiting for 09:00: `systemctl start keyorix-fuzz-heartbeat.service`.
+
+## Day-to-day
+
+- **Crash notification arrives** → SSH in, `cat
+  /opt/keyorix-fuzz/state/last-<FuzzName>.log` for the full failure, or check
+  the `fuzz-corpus` branch for the exact new failing-input file (it's a small
+  Go-syntax file under `testdata/fuzz/<FuzzName>/`). Reproduce locally with
+  `go test -run=<FuzzName>/<hash> ./<package>` once you've pulled that branch.
+- **No heartbeat today** → the service or the box is down; check
+  `systemctl status keyorix-fuzz.service` / whether the LXC itself is up.
+- **Widening coverage** → add a line to `targets.conf`; no script changes
+  needed. The service picks it up on its next full rotation cycle restart
+  (`systemctl restart keyorix-fuzz.service` to pick it up immediately).
+
+## Design notes
+
+- The main clone (`KEYORIX_REPO`) is treated as disposable and dedicated
+  solely to fuzzing — `run-rotation.sh` runs `git reset --hard origin/main`
+  against it once per cycle. Don't use this clone for anything else.
+- Corpus commits land on `fuzz-corpus`, never `main` — nothing here touches
+  CI or requires a PR to keep running; you decide when (and whether) to open
+  a PR merging an interesting find into `main`.
+- Targets run one at a time, not concurrently, to keep resource usage
+  predictable on modest home-lab hardware. If you want parallelism, run
+  multiple instances of this whole setup (separate `KEYORIX_REPO`/
+  `NOTIFIED_STATE_DIR`/systemd unit names) rather than modifying
+  `run-rotation.sh` to fan out.

--- a/scripts/fuzzing/config.env.example
+++ b/scripts/fuzzing/config.env.example
@@ -1,0 +1,22 @@
+# Copy to /etc/keyorix-fuzz/config.env (chmod 600, owned by the `fuzzer`
+# user) and fill in real values. NEVER commit the filled-in version.
+
+# Path to the main keyorix clone this box fuzzes against. Treat this clone as
+# disposable/dedicated to fuzzing only: run-rotation.sh runs `git reset --hard
+# origin/main` against it once per rotation cycle.
+KEYORIX_REPO=/opt/keyorix-fuzz/keyorix
+
+# Path to a SEPARATE git worktree of the same repo, checked out on the
+# fuzz-corpus branch (see README.md's setup steps). Corpus files land here,
+# never in $KEYORIX_REPO.
+FUZZ_CORPUS_WORKTREE=/opt/keyorix-fuzz/keyorix-fuzz-corpus
+FUZZ_CORPUS_BRANCH=fuzz-corpus
+
+# Where per-target logs and crash-notification dedup markers are kept.
+NOTIFIED_STATE_DIR=/opt/keyorix-fuzz/state
+
+# Your ntfy.sh topic URL. Topics are unauthenticated by default — anyone who
+# guesses the name can read or publish to it — so pick something long and
+# random, not "keyorix-fuzz". Generate one with e.g.:
+#   openssl rand -hex 16
+NTFY_TOPIC=https://ntfy.sh/CHANGE-ME-to-a-long-random-topic-name

--- a/scripts/fuzzing/heartbeat.sh
+++ b/scripts/fuzzing/heartbeat.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Sends one daily ntfy.sh ping so the box's silence itself is informative: if
+# the heartbeat stops arriving, keyorix-fuzz.service died (or the box did)
+# without you having to check in manually. Run via keyorix-fuzz-heartbeat.timer.
+set -euo pipefail
+
+: "${NTFY_TOPIC:?}"
+
+if systemctl is-active --quiet keyorix-fuzz.service; then
+  status="running"
+  tags="heartbeat"
+else
+  status="NOT RUNNING"
+  tags="warning,heartbeat"
+fi
+
+curl -fsS \
+  -H "Title: keyorix fuzz heartbeat: $status" \
+  -H "Tags: $tags" \
+  -d "keyorix-fuzz.service: $status
+$(date -u +%FT%TZ)" \
+  "$NTFY_TOPIC" >/dev/null

--- a/scripts/fuzzing/notify-on-crash.sh
+++ b/scripts/fuzzing/notify-on-crash.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Sends one ntfy.sh push notification for a fuzz target's failure, deduped so
+# a target that keeps re-failing against an already-saved crasher on every
+# subsequent rotation cycle (expected Go fuzz behaviour — the failing input is
+# replayed as part of the seed corpus on every future run until it's fixed)
+# does not re-alert every cycle.
+set -euo pipefail
+
+FUNC="${1:?fuzz func name}"
+PKG="${2:?package path}"
+LOGFILE="${3:?path to the log file for this run}"
+
+: "${NTFY_TOPIC:?set NTFY_TOPIC to your ntfy.sh topic URL, e.g. https://ntfy.sh/some-long-random-topic-name}"
+: "${NOTIFIED_STATE_DIR:?}"
+
+fail_line="$(grep -m1 -E 'FAIL|panic:' "$LOGFILE" || true)"
+fail_hash="$(printf '%s' "${fail_line:-unknown}" | sha256sum | cut -c1-16)"
+marker="$NOTIFIED_STATE_DIR/notified-$FUNC-$fail_hash"
+
+if [ -f "$marker" ]; then
+  exit 0 # already alerted for this exact failure
+fi
+
+summary="$(grep -m8 -E 'FAIL|panic:|--- FAIL|Fatalf|\.go:[0-9]+' "$LOGFILE" | head -c 1500 || true)"
+
+curl -fsS \
+  -H "Title: keyorix fuzz: $FUNC crashed" \
+  -H "Priority: high" \
+  -H "Tags: rotating_light" \
+  -d "$PKG :: $FUNC
+
+${summary:-see log on the fuzz box}
+
+Failing input pushed to the fuzz-corpus branch." \
+  "$NTFY_TOPIC" >/dev/null
+
+touch "$marker"

--- a/scripts/fuzzing/run-rotation.sh
+++ b/scripts/fuzzing/run-rotation.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Continuous fuzz-rotation runner. Intended to run as a long-lived systemd
+# service (see systemd/keyorix-fuzz.service) on a dedicated box (e.g. a
+# Proxmox LXC) separate from CI, since deep fuzzing wants hours of continuous
+# runtime that a CI job's budget can't afford.
+#
+# Cycles through every target in targets.conf, each for its configured
+# `go test -fuzz -fuzztime`, forever. Before each full cycle, pulls the repo's
+# main branch so fuzzing tracks the current codebase (including any fix a
+# prior crash here already prompted). After each target run, pushes any new
+# corpus files (crashers or coverage-expanding "interesting" inputs) to the
+# fuzz-corpus branch via sync-corpus.sh, and — on a crash — sends exactly one
+# notification per unique failure via notify-on-crash.sh (a target that keeps
+# re-failing against an already-saved crasher on every subsequent cycle does
+# not re-alert).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+: "${KEYORIX_REPO:?set KEYORIX_REPO to the path of the main keyorix git clone}"
+: "${NOTIFIED_STATE_DIR:=$SCRIPT_DIR/.state}"
+mkdir -p "$NOTIFIED_STATE_DIR"
+
+cd "$KEYORIX_REPO"
+
+while true; do
+  echo "=== $(date -u +%FT%TZ) pulling latest main ==="
+  git fetch origin main --quiet
+  git checkout main --quiet
+  git reset --hard origin/main --quiet
+
+  while IFS='|' read -r pkg func duration; do
+    [ -z "$pkg" ] && continue
+    case "$pkg" in \#*) continue ;; esac
+
+    echo "=== $(date -u +%FT%TZ) fuzzing $func in ./$pkg for $duration ==="
+    logfile="$NOTIFIED_STATE_DIR/last-$func.log"
+
+    set +e
+    go test "./$pkg" -run="^${func}\$" -fuzz="^${func}\$" -fuzztime="$duration" \
+      >"$logfile" 2>&1
+    status=$?
+    set -e
+
+    "$SCRIPT_DIR/sync-corpus.sh" "$func" "$status"
+
+    if [ "$status" -ne 0 ]; then
+      echo "=== $(date -u +%FT%TZ) $func FAILED (exit $status) ==="
+      "$SCRIPT_DIR/notify-on-crash.sh" "$func" "$pkg" "$logfile"
+    fi
+  done <"$SCRIPT_DIR/targets.conf"
+
+  echo "=== $(date -u +%FT%TZ) rotation cycle complete, looping ==="
+done

--- a/scripts/fuzzing/sync-corpus.sh
+++ b/scripts/fuzzing/sync-corpus.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copies any new/changed files under testdata/fuzz/ from the main fuzzing
+# clone into a SEPARATE git worktree checked out on the fuzz-corpus branch,
+# then commits + pushes from there.
+#
+# Deliberately does not touch git branches in $KEYORIX_REPO itself — that
+# clone stays on main throughout a run (run-rotation.sh resets it to
+# origin/main once per cycle), so results land on a distinct branch without
+# ever disturbing the checkout the fuzzer is actively running against.
+#
+# Safe to call after every rotation cycle regardless of outcome: it's a no-op
+# when there's nothing new under testdata/fuzz/.
+set -euo pipefail
+
+FUNC="${1:?fuzz func name}"
+STATUS="${2:-0}"
+
+: "${KEYORIX_REPO:?}"
+: "${FUZZ_CORPUS_WORKTREE:?set FUZZ_CORPUS_WORKTREE to a git worktree checked out on the fuzz-corpus branch}"
+: "${FUZZ_CORPUS_BRANCH:=fuzz-corpus}"
+
+mkdir -p "$FUZZ_CORPUS_WORKTREE/testdata/fuzz"
+rsync -a --update "$KEYORIX_REPO/testdata/fuzz/" "$FUZZ_CORPUS_WORKTREE/testdata/fuzz/"
+
+cd "$FUZZ_CORPUS_WORKTREE"
+git add testdata/fuzz/
+
+if git diff --cached --quiet; then
+  exit 0
+fi
+
+label="new corpus"
+[ "$STATUS" -ne 0 ] && label="CRASH found"
+
+git commit -m "fuzz($FUNC): $label $(date -u +%FT%TZ)" --quiet
+git push origin "$FUZZ_CORPUS_BRANCH" --quiet

--- a/scripts/fuzzing/systemd/keyorix-fuzz-heartbeat.service
+++ b/scripts/fuzzing/systemd/keyorix-fuzz-heartbeat.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Keyorix fuzz daily heartbeat
+
+[Service]
+Type=oneshot
+User=fuzzer
+Group=fuzzer
+EnvironmentFile=/etc/keyorix-fuzz/config.env
+ExecStart=/opt/keyorix-fuzz/keyorix/scripts/fuzzing/heartbeat.sh

--- a/scripts/fuzzing/systemd/keyorix-fuzz-heartbeat.timer
+++ b/scripts/fuzzing/systemd/keyorix-fuzz-heartbeat.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Daily keyorix fuzz heartbeat
+
+[Timer]
+OnCalendar=*-*-* 09:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/fuzzing/systemd/keyorix-fuzz.service
+++ b/scripts/fuzzing/systemd/keyorix-fuzz.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Keyorix continuous fuzz rotation
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=fuzzer
+Group=fuzzer
+EnvironmentFile=/etc/keyorix-fuzz/config.env
+ExecStart=/opt/keyorix-fuzz/keyorix/scripts/fuzzing/run-rotation.sh
+Restart=always
+RestartSec=30
+# Fuzzing is CPU/memory-hungry by design but must never take the box down or
+# starve anything else running on it.
+Nice=10
+MemoryMax=2G
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/fuzzing/targets.conf
+++ b/scripts/fuzzing/targets.conf
@@ -1,0 +1,12 @@
+# Fuzz targets for the continuous-rotation runner (run-rotation.sh).
+# Format: <go-package-path>|<FuzzFuncName>|<go-test-fuzztime>
+# One rotation cycle runs every line in order, each for its configured
+# duration, then loops back to the top (after a `git pull` — see
+# run-rotation.sh). Add a new target by adding a line here; no script changes
+# needed.
+#
+# Lines starting with # or blank lines are ignored.
+
+internal/crypto|FuzzCombineKEK|3h
+internal/core|FuzzOIDCVerifierVerify|3h
+internal/rotation|FuzzAzureGenerateUpstreamRef|3h


### PR DESCRIPTION
## Summary
- Adds `scripts/fuzzing/`: a systemd service + rotation script that cycles through the repo's `func Fuzz*` targets for hours at a time on dedicated infra (e.g. a home-lab LXC/VM), separate from CI's short regression-only pass.
- Corpus results (crash reproductions + coverage-expanding "interesting" inputs) get committed and pushed to a dedicated `fuzz-corpus` branch automatically, via a second git worktree — never touches `main` or the fuzzing clone's own branch.
- Crash notifications via ntfy.sh (deduped, so a target re-failing against an already-known crasher doesn't re-alert every cycle), plus a daily heartbeat so silence itself signals something died.
- Full one-time setup steps in `scripts/fuzzing/README.md` (dedicated user, SSH deploy key scoped to this repo only, git worktree setup, ntfy topic, systemd unit installation).

Not wired into CI — this is meant to run continuously on separate long-lived infrastructure, not as a CI job.

## Test plan
- [x] `bash -n` on all 4 scripts
- [x] `shellcheck` clean on all 4 scripts
- [x] Manually verified the `targets.conf` parsing loop (comment/blank-line skipping) in isolation
- [ ] End-to-end verification happens on actual deployment (out of scope for this PR — this is tooling to be deployed, not application code exercised by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)