### PR TITLE
fix(encryption): derive AuditCheckpointKey from the KEK, not the DEK (#502)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -17,6 +17,8 @@ description = "Demo / docs / scripts / test fixtures — non-real sample credent
 # the `…KeyInfo = "…"` shape.
 regexes = [
   '''keyorix-audit-checkpoint-v1''',
+  '''keyorix-audit-checkpoint-kek-v2''',
+  '''keyorix-audit-checkpoint-kek-id-v2''',
   '''keyorix-evidence-signature-v1''',
   '''keyorix-evidence-signature-kek-v2''',
   '''keyorix-evidence-signature-kek-id-v2''',

--- a/docs/adr-029-audit-log-tamper-evidence.md
+++ b/docs/adr-029-audit-log-tamper-evidence.md
@@ -106,21 +106,30 @@ double-migration hazard).
     too — **delivered.** An opt-in scheduler (`audit_checkpoints.enabled`, HA-gated)
     periodically writes an `audit_checkpoints` row recording the verified
     `(chained_events, head_id, head_hash)` plus an **HMAC-SHA256 signature** keyed
-    by a key the running server holds in memory but the database/DBA does not — it
-    is HKDF-derived from the DEK (`encryption.Service.AuditCheckpointKey`, info
-    `keyorix-audit-checkpoint-v1`), so signed checkpoints require encryption
-    enabled. `VerifyAuditChain` then verifies the live chain against the latest
-    checkpoint. The checkpoint is **authenticated first** (the HMAC covers every
-    field, so nothing it claims — including `key_version` — is trusted until the
-    signature verifies under the current key); then a chain shorter than the
-    certified length, or a rewritten certified head, flips `valid` to false with a
-    `checkpoint_reason` — catching the tail-truncation / genesis re-seed the bare
-    re-walk cannot. A checkpoint row altered in **any** field without the key fails
-    the signature check and is reported as a tamper signal — there is deliberately
-    no unauthenticated field (e.g. `key_version`) a DB-level actor can edit to skip
-    enforcement. A new checkpoint is refused over a chain shorter than an
-    authenticated prior checkpoint, so a truncation is never silently re-baselined
-    away. Surfaced as `checkpointed`/`checkpoint_reason` on `/audit/verify` and in
+    by a key the running server holds in memory but the database/DBA does not —
+    it is HKDF-derived from the **KEK** (`encryption.Service.AuditCheckpointKey`,
+    info `keyorix-audit-checkpoint-kek-v2`; **#502, corrected 2026-07-05** — it was
+    originally HKDF-derived from the DEK, info `keyorix-audit-checkpoint-v1`, which
+    meant every routine `RotateDEKWithSweep` followed by a server restart caused
+    every existing checkpoint to fail its signature check, so `VerifyAuditChain`
+    reported the whole trail invalid until the next checkpoint write re-baselined
+    it — a real, if self-healing, false-tamper-alarm on every DEK rotation. Mirrors
+    the identical #268 fix for the evidence-signing key: the KEK is untouched by a
+    routine DEK rotation and only changes on a rare, deliberate KEK-provider
+    migration, so a checkpoint signed before a DEK rotation now stays verifiable
+    after one, with no window where `keyorix audit verify` falsely reports
+    tampering), so signed checkpoints require encryption enabled. `VerifyAuditChain`
+    then verifies the live chain against the latest checkpoint. The checkpoint is
+    **authenticated first** (the HMAC covers every field, so nothing it claims —
+    including `key_version` — is trusted until the signature verifies under the
+    current key); then a chain shorter than the certified length, or a rewritten
+    certified head, flips `valid` to false with a `checkpoint_reason` — catching
+    the tail-truncation / genesis re-seed the bare re-walk cannot. A checkpoint row
+    altered in **any** field without the key fails the signature check and is
+    reported as a tamper signal — there is deliberately no unauthenticated field
+    (e.g. `key_version`) a DB-level actor can edit to skip enforcement. A new
+    checkpoint is refused over a chain shorter than an authenticated prior
+    checkpoint, so a truncation is never silently re-baselined away. Surfaced as `checkpointed`/`checkpoint_reason` on `/audit/verify` and in
     `keyorix audit verify`.
   - **Checkpoint-write serialization (#300):** `WriteAuditCheckpoint` is reachable
     from three unsynchronized triggers — the scheduler tick, the HTTP
@@ -139,7 +148,7 @@ double-migration hazard).
     per-append lock key). Unlike the scheduler's own `WithSchedulerLock` (a "try"
     lock that skips a tick on contention), this blocks until free, so an
     operator-triggered write racing the scheduler is serialized, not dropped.
-  - **DEK rotation:** a checkpoint signed under a superseded DEK cannot be
+  - **Key rotation:** a checkpoint signed under a superseded signing key cannot be
     re-verified on-box, so after a rotation `verify` fails closed (reports invalid)
     until the next checkpoint write re-baselines under the new key — the scheduler
     does this on its next tick / at startup, and an operator can force it
@@ -147,7 +156,10 @@ double-migration hazard).
     system.write). `WriteAuditCheckpoint` re-baselines over an *unverifiable* prior
     checkpoint but still refuses over an *authenticated* truncation. Trusting the
     unauthenticated `key_version` to suppress that alarm was rejected — it would let
-    an attacker forge the rotation case to mask a truncation.
+    an attacker forge the rotation case to mask a truncation. **Since #502** the
+    signing key is KEK-derived, not DEK-derived (see above), so a routine
+    `RotateDEKWithSweep` no longer triggers this at all — only a genuine
+    KEK-provider migration (ADR-041, a far rarer, deliberate operator action) does.
   - **Residual (honest scope):** enforcement consults the latest checkpoint row.
     A DB-level actor who can write `audit_checkpoints` can therefore *neutralise*
     on-box enforcement — delete every row, or overwrite the latest slot with an

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -4,12 +4,13 @@
 // row detectable, but an unanchored on-box re-walk cannot catch tail-truncation
 // or a genesis re-seed: a shorter, self-consistent chain still verifies. A
 // checkpoint closes that gap on-box. It records (chained_events, head_id,
-// head_hash) and signs them with an HMAC keyed by a DEK-derived key the running
+// head_hash) and signs them with an HMAC keyed by a KEK-derived key the running
 // server holds in memory but the database/DBA does not (see
-// encryption.Service.AuditCheckpointKey). Verifying the live chain against the
-// latest signed checkpoint then detects a drop below the certified length or a
-// rewrite of the certified head — tampering a DB-level actor cannot hide without
-// the signing key.
+// encryption.Service.AuditCheckpointKey — derived from the KEK rather than the
+// DEK, #502, so a routine DEK rotation does not affect it). Verifying the live
+// chain against the latest signed checkpoint then detects a drop below the
+// certified length or a rewrite of the certified head — tampering a DB-level
+// actor cannot hide without the signing key.
 package core
 
 import (
@@ -38,8 +39,8 @@ import (
 // the in-memory watermark. See ADR-029.
 const auditHighWaterKey = "audit_checkpoint_highwater" // #nosec G101 -- metadata key name, not a credential
 
-// SetAuditCheckpointKey wires the DEK-derived HMAC key (and the DEK key version
-// it was derived from) used to sign and verify audit checkpoints. Called at
+// SetAuditCheckpointKey wires the KEK-derived HMAC key (and its own fingerprint,
+// used as the "key version") used to sign and verify audit checkpoints. Called at
 // startup when encryption is enabled; with no key set, checkpoints are
 // unavailable and VerifyAuditChain runs without on-box checkpoint enforcement.
 func (c *KeyorixCore) SetAuditCheckpointKey(key []byte, keyVersion string) {
@@ -183,9 +184,10 @@ func (c *KeyorixCore) writeAuditCheckpointLocked(ctx context.Context) (*models.A
 	}
 	// Refuse to re-baseline over a truncation that an AUTHENTICATED prior checkpoint
 	// proves — otherwise a scheduled write would silently bless a shortened chain and
-	// erase the evidence. An unverifiable prior checkpoint (a stale one after a DEK
-	// rotation) does not block re-baselining; that is how the system recovers from a
-	// key rotation.
+	// erase the evidence. An unverifiable prior checkpoint (a stale one after a
+	// signing-key change — a KEK-provider migration; a routine DEK rotation no
+	// longer affects this KEK-derived key, #502) does not block re-baselining; that
+	// is how the system recovers from a key rotation.
 	cp, err := c.storage.LatestAuditCheckpoint(ctx)
 	if err != nil {
 		return nil, err
@@ -199,7 +201,7 @@ func (c *KeyorixCore) writeAuditCheckpointLocked(ctx context.Context) (*models.A
 			}
 		} else if cp.KeyVersion == c.auditCkptKeyVersion {
 			// The prior checkpoint claims the CURRENT signing-key version yet fails its
-			// signature. That is tampering, not a DEK rotation (a rotation would carry a
+			// signature. That is tampering, not a key rotation (a rotation would carry a
 			// superseded key_version). Re-baselining here would let a DB-level actor
 			// launder a tail-truncation by flipping one signature byte: the read path
 			// flags this as Valid=false, but a silent re-baseline would write a fresh,
@@ -207,8 +209,10 @@ func (c *KeyorixCore) writeAuditCheckpointLocked(ctx context.Context) (*models.A
 			// closed and leave the tamper signal standing for an operator to investigate.
 			return nil, fmt.Errorf("refusing to checkpoint: latest checkpoint #%d fails its signature under the current key version %q — the checkpoint row was tampered with, not rotated", cp.ID, cp.KeyVersion)
 		}
-		// else: signature fails AND key_version is superseded → consistent with a DEK
-		// rotation; fall through and re-baseline under the new key (recovery path).
+		// else: signature fails AND key_version is superseded → consistent with a
+		// signing-key rotation (a KEK-provider migration, since #502 — a routine DEK
+		// rotation no longer changes this key at all); fall through and re-baseline
+		// under the new key (recovery path).
 	}
 	// Refuse to checkpoint a chain that sits below the certified high-water mark —
 	// otherwise a scheduled write would launder a truncation into a fresh, authentic
@@ -250,11 +254,13 @@ func (c *KeyorixCore) writeAuditCheckpointLocked(ctx context.Context) (*models.A
 // shortfall or head rewrite flips Valid to false.
 //
 // A signature that does not verify is treated as a tamper signal (Valid=false). It
-// also fires for a stale checkpoint signed under a superseded DEK version after a
-// key rotation — by design: we cannot re-verify an old-key signature on-box, and
-// silently trusting the unauthenticated key_version field would reopen the bypass.
-// WriteAuditCheckpoint re-baselines under the new key (it does not block on an
-// unverifiable checkpoint), clearing the state on the next checkpoint write.
+// also fires for a stale checkpoint signed under a superseded key version after a
+// signing-key rotation (a KEK-provider migration — since #502 the signing key is
+// KEK-derived, so a routine DEK rotation no longer triggers this at all) — by
+// design: we cannot re-verify an old-key signature on-box, and silently trusting
+// the unauthenticated key_version field would reopen the bypass. WriteAuditCheckpoint
+// re-baselines under the new key (it does not block on an unverifiable checkpoint),
+// clearing the state on the next checkpoint write.
 func (c *KeyorixCore) enforceAuditCheckpoint(ctx context.Context, v *storage.AuditChainVerification) error {
 	if !c.AuditCheckpointsAvailable() {
 		return nil
@@ -292,7 +298,7 @@ func (c *KeyorixCore) enforceAuditCheckpoint(ctx context.Context, v *storage.Aud
 
 	if !c.checkpointSignatureValid(cp) {
 		c.failCheckpoint(v, nil,
-			fmt.Sprintf("audit checkpoint #%d does not verify under the current signing key — the checkpoint was tampered, or a DEK rotation occurred and no fresh checkpoint has been written yet", cp.ID))
+			fmt.Sprintf("audit checkpoint #%d does not verify under the current signing key — the checkpoint was tampered, or a KEK-provider migration occurred and no fresh checkpoint has been written yet", cp.ID))
 		return nil
 	}
 	reason, tampered, err := c.checkpointTruncation(ctx, v.ChainedEvents, cp)
@@ -449,9 +455,11 @@ func parseAuditHighWater(val string) (cp *models.AuditCheckpoint, sig string, ok
 //     (enforceAuditCheckpoint), which has never had a superseded-key exception.
 //   - strict=false (the WRITE/recovery path, WriteAuditCheckpoint, and the
 //     non-enforcing SeedAuditWatermark/advanceAuditHighWater callers): a sig
-//     failure under a claimed-superseded key_version is treated as a genuine DEK
-//     rotation and ignored, so the system can still self-heal by writing a fresh,
-//     correctly-signed checkpoint under the new key. This does not reopen #110:
+//     failure under a claimed-superseded key_version is treated as a genuine
+//     signing-key rotation (a KEK-provider migration; since #502 a routine DEK
+//     rotation no longer changes this key) and ignored, so the system can still
+//     self-heal by writing a fresh, correctly-signed checkpoint under the new
+//     key. This does not reopen #110:
 //     the very next VerifyAuditChain call uses strict=true and will flag the
 //     stale/unverifiable mark until that fresh write actually happens.
 func (c *KeyorixCore) auditHighWaterFloor(ctx context.Context, strict bool) (floor int64, found, tampered bool, reason string, err error) {
@@ -484,12 +492,13 @@ func (c *KeyorixCore) auditHighWaterFloor(ctx context.Context, strict bool) (flo
 			return 0, false, false, "", cerr
 		} else if exists {
 			return floor, true, true,
-				fmt.Sprintf("audit high-water mark fails its signature (claiming key version %q) while signed checkpoints exist — an unverifiable key_version claim is not trusted as proof of a DEK rotation", cp.KeyVersion), nil
+				fmt.Sprintf("audit high-water mark fails its signature (claiming key version %q) while signed checkpoints exist — an unverifiable key_version claim is not trusted as proof of a key rotation", cp.KeyVersion), nil
 		}
 	}
 	// Lenient path, or no checkpoint exists yet to protect: signature fails and
-	// key_version is (claimed) superseded → consistent with a DEK rotation; ignore
-	// the stale mark (the next checkpoint write re-establishes it under the new key).
+	// key_version is (claimed) superseded → consistent with a signing-key rotation
+	// (a KEK-provider migration); ignore the stale mark (the next checkpoint write
+	// re-establishes it under the new key).
 	return floor, true, false, "", nil
 }
 

--- a/internal/core/audit_checkpoint_test.go
+++ b/internal/core/audit_checkpoint_test.go
@@ -283,9 +283,12 @@ func TestAuditCheckpoint_TamperedKeyVersionDetected(t *testing.T) {
 	assert.Contains(t, v.CheckpointReason, "does not verify under the current signing key")
 }
 
-// After a genuine DEK rotation the prior checkpoint cannot be re-verified, so
-// verify reports invalid until the next checkpoint write re-baselines under the
-// new key — and that write must succeed (no deadlock).
+// After a genuine signing-key rotation (a KEK-provider migration — since #502 the
+// audit-checkpoint key is KEK-derived, so a routine DEK rotation no longer changes
+// it at all; see TestAuditCheckpointKey_StableAcrossDEKRotation in the encryption
+// package) the prior checkpoint cannot be re-verified, so verify reports invalid
+// until the next checkpoint write re-baselines under the new key — and that write
+// must succeed (no deadlock).
 func TestAuditCheckpoint_RotationRebaselines(t *testing.T) {
 	ctx := context.Background()
 	c, _ := newCheckpointCore(t)
@@ -293,7 +296,9 @@ func TestAuditCheckpoint_RotationRebaselines(t *testing.T) {
 	_, _, err := c.WriteAuditCheckpoint(ctx) // signed under "v1"
 	require.NoError(t, err)
 
-	// Rotate the DEK → a new signing key + version.
+	// Simulate a KEK-provider migration → a new signing key + version wired in at
+	// the next server startup (SetAuditCheckpointKey is only called at startup; see
+	// server/main.go).
 	c.SetAuditCheckpointKey(bytes.Repeat([]byte{0x9}, 32), "v2")
 
 	// The stale "v1" checkpoint no longer verifies → flagged (fail closed).

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -219,13 +219,16 @@ type KeyorixCore struct {
 	// setupBaseURL is the absolute base (e.g. https://keyorix.acme.internal) used to
 	// build setup links. Required to mint a link; a relative link is a misconfig.
 	setupBaseURL string
-	// auditCkptKey signs/verifies audit-chain checkpoints (ADR-029): a DEK-derived
-	// HMAC key the database/DBA does not hold. nil = signed checkpoints unavailable
+	// auditCkptKey signs/verifies audit-chain checkpoints (ADR-029): a KEK-derived
+	// HMAC key the database/DBA does not hold (#502 — mirroring #268's fix for the
+	// evidence-signing key: deriving from the KEK rather than the DEK means a
+	// routine DEK rotation does not affect it, so a checkpoint signed before a DEK
+	// rotation stays verifiable after one). nil = signed checkpoints unavailable
 	// (encryption disabled), in which case WriteAuditCheckpoint is a no-op and
 	// VerifyAuditChain runs without on-box checkpoint enforcement. Set at startup
-	// via SetAuditCheckpointKey. auditCkptKeyVersion records which DEK version it
-	// was derived from, so a checkpoint signed under a superseded key is not
-	// enforced after a DEK rotation.
+	// via SetAuditCheckpointKey. auditCkptKeyVersion records the KEK-derived key's
+	// own fingerprint, so a checkpoint signed under a superseded key (a genuine
+	// KEK-provider migration, far rarer than a DEK rotation) is not enforced.
 	auditCkptKey        []byte
 	auditCkptKeyVersion string
 	// tokenCacheInvalidator evicts a bearer token from the HTTP auth cache by its hash.

--- a/internal/encryption/audit_checkpoint_key_test.go
+++ b/internal/encryption/audit_checkpoint_key_test.go
@@ -1,10 +1,19 @@
 package encryption
 
+// audit_checkpoint_key_test.go also carries the #502 regression tests: the
+// audit-checkpoint signing key (used to sign/verify audit-chain checkpoints,
+// ADR-029, see internal/core/audit_checkpoint.go) must be derived from the KEK,
+// not the DEK, so a routine DEK rotation does not affect it — mirroring #268's
+// fix for the evidence-signing key (evidence_sign_key_test.go). It should only
+// change on a genuine KEK change (a KEK-provider migration, ADR-041).
+
 import (
 	"bytes"
+	"path/filepath"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,4 +47,113 @@ func TestAuditCheckpointKey_UnavailableWhenDisabled(t *testing.T) {
 	svc2 := NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
 	_, _, ok2 := svc2.AuditCheckpointKey()
 	assert.False(t, ok2, "an uninitialised service has no DEK yet")
+}
+
+// TestAuditCheckpointKey_StableAcrossDEKRotation is the core regression test for
+// #502: signing key and version must be BYTE-IDENTICAL before and after a full
+// RotateDEKWithSweep, even though the DEK itself (and its own key version)
+// changes. This is what makes a checkpoint signed before a DEK rotation still
+// verifiable after one — closing the false-tamper-alarm window a DEK-derived key
+// used to open on every rotation.
+func TestAuditCheckpointKey_StableAcrossDEKRotation(t *testing.T) {
+	db := newTestDB(t)
+	svc, _ := newTestService(t, "test-passphrase")
+
+	keyBefore, verBefore, ok := svc.AuditCheckpointKey()
+	if !ok {
+		t.Fatal("AuditCheckpointKey unavailable before rotation")
+	}
+	if len(keyBefore) != 32 {
+		t.Fatalf("expected a 32-byte key, got %d bytes", len(keyBefore))
+	}
+
+	dekBefore := captureCurrentDEK(t, svc)
+	dekVerBefore := svc.GetKeyVersion()
+
+	if _, err := svc.RotateDEKWithSweep("test-passphrase", db); err != nil {
+		t.Fatalf("RotateDEKWithSweep failed: %v", err)
+	}
+
+	// Sanity: the DEK and its own version DID change (that's the whole point of
+	// rotation) — otherwise this test would be vacuous.
+	dekAfter := captureCurrentDEK(t, svc)
+	if bytes.Equal(dekBefore, dekAfter) {
+		t.Fatal("DEK did not change after rotation — test setup is broken")
+	}
+	if svc.GetKeyVersion() == dekVerBefore {
+		t.Fatal("DEK key version did not change after rotation — test setup is broken")
+	}
+
+	keyAfter, verAfter, ok := svc.AuditCheckpointKey()
+	if !ok {
+		t.Fatal("AuditCheckpointKey unavailable after rotation")
+	}
+	if !bytes.Equal(keyBefore, keyAfter) {
+		t.Fatalf("audit-checkpoint key changed across a DEK rotation: before=%x after=%x", keyBefore, keyAfter)
+	}
+	if verBefore != verAfter {
+		t.Fatalf("audit-checkpoint key version changed across a DEK rotation: before=%q after=%q", verBefore, verAfter)
+	}
+}
+
+// TestAuditCheckpointKey_ChangesAcrossKEKMigration proves the corresponding
+// negative: a genuine KEK change (KEK-provider migration, ADR-041) DOES change
+// the audit-checkpoint key and its version. This is expected and correctly
+// reported by enforceAuditCheckpoint as a superseded key version needing
+// re-baselining, not silently accepted and not reported as tampering — the same
+// non-regression the #502 fix preserves (mirroring #268's evidence-key test).
+func TestAuditCheckpointKey_ChangesAcrossKEKMigration(t *testing.T) {
+	dir := t.TempDir()
+	oldKEK := filepath.Join(dir, "old.kek")
+	newKEK := filepath.Join(dir, "new.kek")
+	writeHexKEK(t, oldKEK)
+	writeHexKEK(t, newKEK)
+
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	km.SetKeyProvider(crypto.NewFileKeyProvider(oldKEK))
+	if err := km.Initialize(""); err != nil {
+		t.Fatalf("initialize old: %v", err)
+	}
+	keyBefore, verBefore, ok := km.GetAuditCheckpointKey()
+	if !ok {
+		t.Fatal("GetAuditCheckpointKey unavailable after initialize")
+	}
+
+	if err := km.RewrapDEK(crypto.NewFileKeyProvider(newKEK)); err != nil {
+		t.Fatalf("rewrap: %v", err)
+	}
+
+	// A fresh manager loading under the NEW provider (mirroring a server restart
+	// after migrate-provider, since RewrapDEK itself doesn't live-update an
+	// already-running process) must derive a DIFFERENT audit-checkpoint key/version.
+	kmNew := NewKeyManager(dir, "dek.key", "kek.salt")
+	kmNew.SetKeyProvider(crypto.NewFileKeyProvider(newKEK))
+	if err := kmNew.Initialize(""); err != nil {
+		t.Fatalf("initialize new: %v", err)
+	}
+	keyAfter, verAfter, ok := kmNew.GetAuditCheckpointKey()
+	if !ok {
+		t.Fatal("GetAuditCheckpointKey unavailable after re-initialize with new provider")
+	}
+
+	if bytes.Equal(keyBefore, keyAfter) {
+		t.Fatal("audit-checkpoint key did NOT change across a KEK-provider migration — it should have")
+	}
+	if verBefore == verAfter {
+		t.Fatalf("audit-checkpoint key version did NOT change across a KEK-provider migration — it should have (got %q both times)", verBefore)
+	}
+}
+
+// TestAuditCheckpointKey_WipedOnShutdown proves Wipe() zeroes the
+// audit-checkpoint key alongside the DEK, so neither lingers in memory after
+// shutdown.
+func TestAuditCheckpointKey_WipedOnShutdown(t *testing.T) {
+	svc, _ := newTestService(t, "test-passphrase")
+	if _, _, ok := svc.AuditCheckpointKey(); !ok {
+		t.Fatal("AuditCheckpointKey unavailable before shutdown")
+	}
+	svc.keyManager.Wipe()
+	if _, _, ok := svc.keyManager.GetAuditCheckpointKey(); ok {
+		t.Fatal("expected the audit-checkpoint key to be gone after Wipe()")
+	}
 }

--- a/internal/encryption/keymanager_io.go
+++ b/internal/encryption/keymanager_io.go
@@ -41,6 +41,20 @@ func (km *KeyManager) GetEvidenceSignKey() (key []byte, keyID string, ok bool) {
 	return key, km.evidenceSignKeyID, true
 }
 
+// GetAuditCheckpointKey returns a copy of the KEK-derived audit-checkpoint signing
+// key and its fingerprint ("key version"), or ok=false if the manager has not been
+// initialized (no KEK has been derived yet, so no checkpoint-signing key exists).
+func (km *KeyManager) GetAuditCheckpointKey() (key []byte, keyID string, ok bool) {
+	km.mu.RLock()
+	defer km.mu.RUnlock()
+	if len(km.auditCheckpointKey) == 0 {
+		return nil, "", false
+	}
+	key = make([]byte, len(km.auditCheckpointKey))
+	copy(key, km.auditCheckpointKey)
+	return key, km.auditCheckpointKeyID, true
+}
+
 // ValidateKeyFiles checks that key files exist and have correct permissions (0600).
 func (km *KeyManager) ValidateKeyFiles() error {
 	files := []securefiles.FilePermSpec{
@@ -59,7 +73,8 @@ func (km *KeyManager) FixKeyFilePermissions() error {
 	return securefiles.FixFilePerms(files, true)
 }
 
-// Wipe securely removes the DEK and the evidence-signing key from memory.
+// Wipe securely removes the DEK, the evidence-signing key, and the
+// audit-checkpoint signing key from memory.
 func (km *KeyManager) Wipe() {
 	km.mu.Lock()
 	defer km.mu.Unlock()
@@ -71,5 +86,9 @@ func (km *KeyManager) Wipe() {
 	if km.evidenceSignKey != nil {
 		wipeBytes(km.evidenceSignKey)
 		km.evidenceSignKey = nil
+	}
+	if km.auditCheckpointKey != nil {
+		wipeBytes(km.auditCheckpointKey)
+		km.auditCheckpointKey = nil
 	}
 }

--- a/internal/encryption/keymanager_lifecycle.go
+++ b/internal/encryption/keymanager_lifecycle.go
@@ -70,7 +70,28 @@ type KeyManager struct {
 	// before. Never persisted to disk — held only in memory, like currentDEK.
 	evidenceSignKey   []byte
 	evidenceSignKeyID string
-	mu                sync.RWMutex
+	// auditCheckpointKey/auditCheckpointKeyID are a 32-byte HMAC key and its public
+	// fingerprint, derived from the KEK (NOT the DEK) via HKDF-SHA256 at Initialize
+	// time — before the KEK is wiped below. Used to sign/verify audit-chain
+	// checkpoints (ADR-029, internal/core/audit_checkpoint.go). Deriving from the
+	// KEK rather than the DEK is the point (#502, mirroring #268's fix for
+	// evidenceSignKey above): a routine DEK rotation (RotateDEKWithSweep, ADR-010)
+	// re-wraps a brand-new DEK under the SAME KEK, so this key — and its
+	// fingerprint — is completely unaffected by it, and a checkpoint signed before a
+	// DEK rotation stays verifiable after one (previously, deriving from the DEK
+	// meant every DEK rotation followed by a server restart caused every existing
+	// checkpoint to fail its signature check and `audit verify` to report the trail
+	// invalid until the next checkpoint write re-baselined it — a real, if
+	// self-healing, false-tamper-alarm window). Only a genuine KEK change
+	// (KEK-provider migration, RewrapDEK / ADR-041 — a far rarer, deliberate
+	// operator action) changes it; when that happens the existing superseded-key
+	// handling in enforceAuditCheckpoint/writeAuditCheckpointLocked correctly
+	// treats the stale checkpoint as needing re-baselining rather than as tampered,
+	// same as before. Never persisted to disk — held only in memory, like
+	// currentDEK/evidenceSignKey.
+	auditCheckpointKey   []byte
+	auditCheckpointKeyID string
+	mu                   sync.RWMutex
 }
 
 // evidenceSignKeyInfo/evidenceSignKeyIDInfo domain-separate the evidence-signing
@@ -79,6 +100,16 @@ type KeyManager struct {
 const (
 	evidenceSignKeyInfo   = "keyorix-evidence-signature-kek-v2"
 	evidenceSignKeyIDInfo = "keyorix-evidence-signature-kek-id-v2"
+)
+
+// auditCheckpointKeyInfo/auditCheckpointKeyIDInfo domain-separate the
+// audit-checkpoint signing key (and its public fingerprint) from any other use of
+// the KEK (HKDF info parameter). Bump the suffix only if the derivation scheme
+// changes. The "-v1" DEK-derived label this superseded (#502) remains allowlisted
+// in .gitleaks.toml for historical/git-blame reasons but is no longer used.
+const (
+	auditCheckpointKeyInfo   = "keyorix-audit-checkpoint-kek-v2"
+	auditCheckpointKeyIDInfo = "keyorix-audit-checkpoint-kek-id-v2"
 )
 
 // deriveEvidenceSignKey derives the 32-byte evidence-signing HMAC key and its
@@ -100,6 +131,27 @@ func deriveEvidenceSignKey(kek []byte) (key []byte, keyID string, err error) {
 		return nil, "", fmt.Errorf("derive evidence-signing key id: %w", err)
 	}
 	return key, "esk-" + hex.EncodeToString(idBytes), nil
+}
+
+// deriveAuditCheckpointKey derives the 32-byte audit-checkpoint-signing HMAC key
+// and its 16-byte public key-ID fingerprint from kek via HKDF-SHA256, exactly
+// mirroring deriveEvidenceSignKey above (independently domain-separated so
+// neither output reveals anything about the other, or about the KEK itself).
+// Both are pure, deterministic functions of the KEK alone, so they are stable
+// across a DEK rotation (same KEK) and only change when the KEK itself does.
+func deriveAuditCheckpointKey(kek []byte) (key []byte, keyID string, err error) {
+	keyR := hkdf.New(sha256.New, kek, nil, []byte(auditCheckpointKeyInfo))
+	key = make([]byte, 32)
+	if _, err = io.ReadFull(keyR, key); err != nil {
+		return nil, "", fmt.Errorf("derive audit-checkpoint key: %w", err)
+	}
+	idR := hkdf.New(sha256.New, kek, nil, []byte(auditCheckpointKeyIDInfo))
+	idBytes := make([]byte, 16)
+	if _, err = io.ReadFull(idR, idBytes); err != nil {
+		wipeBytes(key)
+		return nil, "", fmt.Errorf("derive audit-checkpoint key id: %w", err)
+	}
+	return key, "ack-" + hex.EncodeToString(idBytes), nil
 }
 
 // SetKeyProvider configures where the KEK comes from. Must be called before
@@ -175,9 +227,19 @@ func (km *KeyManager) Initialize(passphrase string) error {
 		return fmt.Errorf("failed to derive evidence-signing key: %w", err)
 	}
 
+	// Derive the audit-checkpoint signing key from the KEK too (#502), for the same
+	// reason: NOT from dek, so a checkpoint signed before a DEK rotation stays
+	// verifiable after one.
+	ack, ackID, err := deriveAuditCheckpointKey(kek)
+	if err != nil {
+		return fmt.Errorf("failed to derive audit-checkpoint key: %w", err)
+	}
+
 	km.currentDEK = dek
 	km.evidenceSignKey = esk
 	km.evidenceSignKeyID = eskID
+	km.auditCheckpointKey = ack
+	km.auditCheckpointKeyID = ackID
 	return nil
 }
 

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -5,15 +5,11 @@ package encryption
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"sync"
-
-	"golang.org/x/crypto/hkdf"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/crypto"
@@ -155,35 +151,25 @@ func (s *Service) IsInitialized() bool {
 	return s.initialized
 }
 
-// auditCheckpointKeyInfo domain-separates the audit-checkpoint signing key from
-// the DEK's other uses (HKDF info parameter). Bump the suffix only if the
-// derivation scheme changes.
-const auditCheckpointKeyInfo = "keyorix-audit-checkpoint-v1"
-
-// AuditCheckpointKey derives a 32-byte HMAC key for signing audit-chain
-// checkpoints (ADR-029) from the current DEK via HKDF-SHA256, alongside the
-// current key version. The key is bound to the DEK but domain-separated from
-// secret encryption, so it is held only in application memory and never written
-// to the database — a checkpoint therefore cannot be forged from database access
-// alone. Returns ok=false when encryption is disabled or uninitialised (no DEK),
-// in which case signed checkpoints are unavailable.
+// AuditCheckpointKey returns the 32-byte HMAC key used to sign/verify audit-chain
+// checkpoints (ADR-029), alongside its fingerprint ("key version"). Like
+// EvidenceSignKey below, this key is derived from the KEK, not the DEK (see
+// KeyManager.deriveAuditCheckpointKey and #502 — mirroring #268's fix for
+// EvidenceSignKey): a routine DEK rotation (RotateDEKWithSweep, ADR-010) re-wraps a
+// brand-new DEK under the SAME KEK, so this key is completely unaffected by it, and
+// a checkpoint signed before a DEK rotation stays verifiable after one. Domain-
+// separated from secret encryption and from EvidenceSignKey, held only in
+// application memory and never written to the database — a checkpoint therefore
+// cannot be forged from database access alone. Returns ok=false when encryption is
+// disabled or uninitialised (no KEK has been derived), in which case signed
+// checkpoints are unavailable.
 func (s *Service) AuditCheckpointKey() (key []byte, keyVersion string, ok bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if !s.config.Enabled || !s.initialized {
 		return nil, "", false
 	}
-	dek := s.keyManager.GetDEK()
-	defer wipeBytes(dek)
-	if len(dek) == 0 {
-		return nil, "", false
-	}
-	r := hkdf.New(sha256.New, dek, nil, []byte(auditCheckpointKeyInfo))
-	out := make([]byte, 32)
-	if _, err := io.ReadFull(r, out); err != nil {
-		return nil, "", false
-	}
-	return out, s.keyManager.GetKeyVersion(), true
+	return s.keyManager.GetAuditCheckpointKey()
 }
 
 // EvidenceSignKey returns the 32-byte HMAC key used to sign exported compliance-


### PR DESCRIPTION
## Summary

- Round-111's #268 fix found the evidence-signing key (`EvidenceSignKey`) was
  DEK-derived, so a routine `RotateDEKWithSweep` permanently and silently broke
  every previously-exported compliance-evidence pack — fixed by deriving from
  the KEK instead (untouched by routine DEK rotation, only changed by a rare
  deliberate KEK-provider migration). That PR explicitly flagged, but did not
  investigate, whether `AuditCheckpointKey` (ADR-029, tamper-evident audit-log
  checkpointing) shared the same vulnerability — this PR is that investigation
  and, since it turned out to be a real (if less severe) instance, the fix.
- **Root cause:** `AuditCheckpointKey` was HKDF-derived from the live DEK.
  `SetAuditCheckpointKey` is wired once at server startup only, so a DEK
  rotation (via `keyorix encryption rotate`) followed by the next server
  restart re-derives a *different* signing key. Every existing checkpoint then
  fails its signature check, and `keyorix audit verify` /
  `GET /audit/verify` falsely report the whole audit trail as tampered — a
  loud, self-healing (next checkpoint write re-baselines) but still real and
  entirely avoidable false-tamper-alarm on every routine DEK rotation.
- **Fix:** mirror #268 exactly — derive the audit-checkpoint signing key (and
  its own fingerprint, used as `key_version`) from the KEK at
  `KeyManager.Initialize()` time via HKDF-SHA256 with a distinct
  domain-separation label (`keyorix-audit-checkpoint-kek-v2`), held only in
  memory, never persisted. A DEK rotation no longer changes this key at all —
  only a genuine KEK-provider migration (ADR-041) does, which correctly
  triggers the existing re-baseline recovery path (unchanged).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/encryption/... ./internal/core/... -count=1` — all
      pass. New regression tests added:
      `TestAuditCheckpointKey_StableAcrossDEKRotation` (the core proof: key +
      version byte-identical across a real `RotateDEKWithSweep`),
      `TestAuditCheckpointKey_ChangesAcrossKEKMigration` (correctly *does*
      change on a genuine KEK-provider migration), `TestAuditCheckpointKey_
      WipedOnShutdown`. (One unrelated pre-existing failure,
      `TestConcurrency_RequestPasswordReset_BurstIsThrottled`, reproduces
      identically on `main` and is untouched by this change.)
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] Targeted `gitleaks` scan confirming the new HKDF label
      (`keyorix-audit-checkpoint-kek-v2` / `-id-v2`) is allowlisted and does
      not trip the scanner (added to `.gitleaks.toml` alongside the existing
      audit-checkpoint/evidence-signature entries)
- [x] ADR-029 and inline comments updated to describe the key as KEK-derived
      and to correct "DEK rotation" language in the recovery-path comments to
      "KEK-provider migration" where that's now the only trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)