### PR TITLE
fix(compliance): narrow dormant-role-grant masking to plain read/write-tier grants (#487)

### DIFF
--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -716,42 +716,70 @@ func (c *KeyorixCore) accessGovernancePostureFromSnapshot(ctx context.Context, p
 // is now assessed independently, so the unused admin-tier grant is correctly
 // flagged even though the same user is actively reading secrets elsewhere.
 //
-// The activity signal used per grant depends on the role's tier (roleIsAdminTier):
-//   - A plain read/write-tier role is "used" by ANY entry in LastUserSecretActivity —
-//     a read OR a create/update/rotate (#424), since a write-tier grant (e.g. a
-//     CI/CD pipeline operator or secret-provisioning admin) may legitimately never
-//     read a secret's value back at all.
+// The activity signal used per grant is matched against the SPECIFIC permission(s)
+// that grant's own bundle confers, at two tiers (roleIsAdminTier):
+//   - A plain read/write-tier role is credited "used" via LastUserSecretReadActivity
+//     when its bundle includes secrets.read, and/or via LastUserSecretWriteActivity
+//     (create/update/rotate — all three are gated by the single secrets.write
+//     permission, #424) when its bundle includes secrets.write (#487 round 112) —
+//     not, as before, by ANY combined read-or-write activity regardless of which of
+//     the two the grant actually confers. A write-tier grant (e.g. a CI/CD pipeline
+//     operator or secret-provisioning admin) may legitimately never read a secret's
+//     value back at all, so it must not need a read to count as used; symmetrically,
+//     a read-only grant must not be masked non-dormant purely because the SAME user
+//     also holds a separate write-only grant they actually exercise.
 //   - An admin-tier role (secrets.delete/admin, or a role-management permission
-//     like roles.assign) additionally requires an entry in
-//     LastUserRoleManagementActivity / LastUserSecretDeletionActivity — an
-//     actually-observed elevated action MATCHING the specific capability this
-//     grant's own permission bundle confers (#487) — since ordinary secret
-//     reads/writes don't attest to any ADMIN capability being used at all, and an
-//     elevated action of a DIFFERENT kind doesn't attest to THIS grant's specific
-//     admin capability being used either.
+//     like roles.assign) is credited via LastUserRoleManagementActivity /
+//     LastUserSecretDeletionActivity — an actually-observed elevated action MATCHING
+//     the specific capability this grant's own permission bundle confers (#487) —
+//     since ordinary secret reads/writes don't attest to any ADMIN capability being
+//     used at all, and an elevated action of a DIFFERENT kind doesn't attest to THIS
+//     grant's specific admin capability being used either.
 //
 // This is an approximation, not a perfect per-grant attribution: the audit trail
 // doesn't record which specific grant authorized a given action, only that SOME
-// action satisfying a given permission occurred. Two admin-tier grants in the same
-// project are distinguished when they confer DIFFERENT specific admin capabilities
-// (#487) — e.g. one bundles only roles.assign, the other only secrets.delete: only
-// the grant whose OWN permission bundle covers the observed action's capability is
-// credited, so exercising one no longer masks the other. Two grants that bundle the
-// SAME specific capability (e.g. two roles that both carry secrets.delete) remain
-// genuinely indistinguishable — either would have authorized the observed action,
-// so there is no principled way to credit one over the other; both are credited
-// (neither shown falsely dormant), which is the same "no worse than before"
-// behaviour as pre-#487 for that narrower, harder case. See roleIsAdminTier's doc
-// for the exact tier boundary.
+// action satisfying a given permission occurred. Two grants in the same project
+// (at either tier) are distinguished whenever they confer DIFFERENT specific
+// capabilities (#487, extended to the plain tier in round 112) — e.g. one role
+// bundles only secrets.read, the other only secrets.write, or one bundles only
+// roles.assign, the other only secrets.delete: only the grant whose OWN permission
+// bundle covers the observed action's capability is credited, so exercising one no
+// longer masks the other.
+//
+// Two grants that bundle the SAME specific capability (e.g. two roles that both
+// carry secrets.delete, or both carry secrets.read) remain genuinely
+// indistinguishable, and — after actually investigating the fix this round (#487,
+// round 112) — this is now a CONFIRMED structural limitation of the authorization
+// model itself, not a gap left by insufficient audit-trail plumbing: Authorize/
+// RoleSetHasPermission resolve permission as a boolean OR across the union of a
+// principal's applicable role IDs (internal/core/authz.go, RoleSetHasPermission's
+// SQL is a plain COUNT(*) over the role-permission join, with no notion of "the one
+// role that matched"). When two grants each individually and equally satisfy the
+// same permission check, there is no principled way to attribute a resulting action
+// to one over the other — recording "which role(s) covered this permission" at the
+// moment of the action would recompute the exact same STATIC role-definition
+// membership test already available at read time (a role's permission bundle
+// doesn't vary per request), so it adds no information the read-time
+// hasPermission check above doesn't already have. Manufacturing a tie-break (e.g.
+// "credit the first matching role ID") would be an arbitrary, unjustified
+// attribution — worse than the current, honestly-ambiguous approximation. Both
+// grants are credited (neither shown falsely dormant) — the same "no worse than
+// before" behaviour as pre-#487 for this narrower, structurally irreducible case.
+// See roleIsAdminTier's doc for the exact tier boundary.
 func (c *KeyorixCore) countDormantRoleGrants(ctx context.Context, projectID uint, cp *CompliancePosture) int {
 	assignments, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
 	if err != nil {
 		cp.degrade(fmt.Sprintf("dormant_role_grants:assignments:project=%d", projectID), err)
 		return 0
 	}
-	activity, err := c.storage.LastUserSecretActivity(ctx, projectID)
+	readActivity, err := c.storage.LastUserSecretReadActivity(ctx, projectID)
 	if err != nil {
-		cp.degrade(fmt.Sprintf("dormant_role_grants:activity:project=%d", projectID), err)
+		cp.degrade(fmt.Sprintf("dormant_role_grants:read_activity:project=%d", projectID), err)
+		return 0
+	}
+	writeActivity, err := c.storage.LastUserSecretWriteActivity(ctx, projectID)
+	if err != nil {
+		cp.degrade(fmt.Sprintf("dormant_role_grants:write_activity:project=%d", projectID), err)
 		return 0
 	}
 	roleMgmtActivity, err := c.storage.LastUserRoleManagementActivity(ctx, projectID)
@@ -810,8 +838,23 @@ func (c *KeyorixCore) countDormantRoleGrants(ctx context.Context, projectID uint
 
 		perms := rolePerms(a.RoleID)
 		if !roleIsAdminTier(perms) {
-			last, ok := activity[a.PrincipalID]
-			if !ok || last.Before(cutoff) {
+			// Plain tier: credit only the activity bucket(s) this SPECIFIC grant's own
+			// permission bundle actually confers (#487 round 112) — a read-tier-only
+			// grant and a separate write-tier-only grant no longer mask each other. A
+			// role bundling neither secrets.read nor secrets.write confers no secret
+			// access to begin with, so it is correctly never credited as "used" here.
+			used := false
+			if hasPermission(perms, "secrets.read") {
+				if last, ok := readActivity[a.PrincipalID]; ok && !last.Before(cutoff) {
+					used = true
+				}
+			}
+			if !used && hasPermission(perms, "secrets.write") {
+				if last, ok := writeActivity[a.PrincipalID]; ok && !last.Before(cutoff) {
+					used = true
+				}
+			}
+			if !used {
 				dormant++
 			}
 			continue

--- a/internal/core/compliance_posture_external_test.go
+++ b/internal/core/compliance_posture_external_test.go
@@ -311,3 +311,83 @@ func TestCompliancePosture_DormantRoleGrants_DistinctAdminTierGrantsNotMaskedByE
 	assert.Equal(t, 1, p.AccessGovernance.DormantRoleGrants,
 		"exercising secrets_admin must not mask the separate, unused role_manager grant")
 }
+
+// #487 round 112: the SAME per-grant, per-specific-permission narrowing #801
+// applied to admin-tier grants now also applies one tier down, to plain
+// read/write-tier grants. Two DIFFERENT plain-tier grants held by the same user in
+// the same project — one conferring only secrets.read, the other only
+// secrets.write — must be assessed independently: exercising the write-only grant
+// must not mask the separate, genuinely-unused read-only grant as non-dormant.
+func TestCompliancePosture_DormantRoleGrants_DistinctPlainTierGrantsNotMaskedByEachOther(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.AuditEvent{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.RotationPolicy{},
+	))
+
+	// Two custom plain-tier roles conferring DIFFERENT specific secret capabilities:
+	// "secrets_reader" (secrets.read only) and "secrets_writer" (secrets.write only).
+	h.CreateTestRole(t, "secrets_reader", "read-only role", 30)
+	h.ExecuteRawSQL(t, `INSERT INTO role_permissions (role_id, permission_id)
+		SELECT 30, p.id FROM permissions p WHERE p.name = 'secrets.read'`)
+	h.CreateTestRole(t, "secrets_writer", "write-only role", 31)
+	h.ExecuteRawSQL(t, `INSERT INTO role_permissions (role_id, permission_id)
+		SELECT 31, p.id FROM permissions p WHERE p.name = 'secrets.write'`)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 30, uptr(proj)) // secrets_reader — never exercised
+	h.AssignUserRole(t, 10, 31, uptr(proj)) // secrets_writer — she exercises this one
+
+	aid := uint(10)
+	pid := proj
+	// Alice creates a secret (exercising secrets_writer) but never reads one back
+	// (secrets_reader stays genuinely unused).
+	require.NoError(t, h.DB.Create(&models.AuditEvent{
+		EventType: "secret.created", UserID: &aid, ProjectID: &pid, EventTime: time.Now().Add(-time.Hour),
+	}).Error)
+
+	p, err := h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, p.AccessGovernance.DormantRoleGrants,
+		"exercising secrets_writer must not mask the separate, unused secrets_reader grant")
+}
+
+// The companion case: once the read-only grant is actually exercised too, BOTH
+// grants are correctly non-dormant — demonstrating the split credits each grant
+// independently rather than only ever flagging the read-tier one dormant.
+func TestCompliancePosture_DormantRoleGrants_DistinctPlainTierGrantsBothCreditedWhenBothExercised(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.AuditEvent{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.RotationPolicy{},
+	))
+
+	h.CreateTestRole(t, "secrets_reader", "read-only role", 30)
+	h.ExecuteRawSQL(t, `INSERT INTO role_permissions (role_id, permission_id)
+		SELECT 30, p.id FROM permissions p WHERE p.name = 'secrets.read'`)
+	h.CreateTestRole(t, "secrets_writer", "write-only role", 31)
+	h.ExecuteRawSQL(t, `INSERT INTO role_permissions (role_id, permission_id)
+		SELECT 31, p.id FROM permissions p WHERE p.name = 'secrets.write'`)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 30, uptr(proj))
+	h.AssignUserRole(t, 10, 31, uptr(proj))
+
+	aid := uint(10)
+	pid := proj
+	require.NoError(t, h.DB.Create(&models.AuditEvent{
+		EventType: "secret.read", UserID: &aid, ProjectID: &pid, EventTime: time.Now().Add(-time.Hour),
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.AuditEvent{
+		EventType: "secret.created", UserID: &aid, ProjectID: &pid, EventTime: time.Now().Add(-time.Hour),
+	}).Error)
+
+	p, err := h.CoreService.GetCompliancePosture(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, p.AccessGovernance.DormantRoleGrants,
+		"both the read-only and write-only grants were actually exercised — neither should be dormant")
+}

--- a/internal/core/compliance_posture_test.go
+++ b/internal/core/compliance_posture_test.go
@@ -268,15 +268,44 @@ func TestGetCompliancePosture_DegradedOnDormantRoleGrantsAssignmentsQueryError(t
 func TestGetCompliancePosture_DegradedOnDormantRoleGrantsActivityQueryError(t *testing.T) {
 	c, db := compliancePostureCoreWithProject(t)
 	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}))
-	// models.AuditEvent deliberately NOT migrated → LastUserSecretActivity's raw
-	// "audit_events" table query fails.
+	// models.AuditEvent deliberately NOT migrated → LastUserSecretReadActivity's raw
+	// "audit_events" table query fails (the first of the two plain-tier per-
+	// permission activity queries countDormantRoleGrants runs, #487 round 112).
 
 	p, err := c.GetCompliancePosture(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, p.AccessGovernance.DormantRoleGrants)
 	assert.True(t, p.Degraded)
-	assert.True(t, containsSubstring(p.DegradedReasons, "dormant_role_grants:activity:project=1"), "got %v", p.DegradedReasons)
+	assert.True(t, containsSubstring(p.DegradedReasons, "dormant_role_grants:read_activity:project=1"), "got %v", p.DegradedReasons)
+}
+
+// failingSecretWriteActivityStore wraps LocalStorage and fails
+// LastUserSecretWriteActivity, simulating a DB error on the write half of the
+// plain-tier per-permission activity split (#487 round 112) while
+// LastUserSecretReadActivity itself still succeeds.
+type failingSecretWriteActivityStore struct {
+	*store.LocalStorage
+}
+
+func (s *failingSecretWriteActivityStore) LastUserSecretWriteActivity(_ context.Context, _ uint) (map[uint]time.Time, error) {
+	return nil, errors.New("simulated db failure")
+}
+
+// #487 round 112: countDormantRoleGrants's plain-tier write-activity query must
+// independently degrade rather than silently return 0 (undercounting stale
+// standing access) on a storage error.
+func TestGetCompliancePosture_DegradedOnDormantRoleGrantsWriteActivityQueryError(t *testing.T) {
+	c, db := compliancePostureCoreWithProject(t)
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}))
+	c.storage = &failingSecretWriteActivityStore{LocalStorage: c.storage.(*store.LocalStorage)}
+
+	p, err := c.GetCompliancePosture(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, p.AccessGovernance.DormantRoleGrants)
+	assert.True(t, p.Degraded)
+	assert.True(t, containsSubstring(p.DegradedReasons, "dormant_role_grants:write_activity:project=1"), "got %v", p.DegradedReasons)
 }
 
 // failingRoleManagementActivityStore wraps LocalStorage and fails

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -322,6 +322,22 @@ func (m *MockStorage) LastUserSecretDeletionActivity(ctx context.Context, projec
 	return args.Get(0).(map[uint]time.Time), args.Error(1)
 }
 
+func (m *MockStorage) LastUserSecretReadActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[uint]time.Time), args.Error(1)
+}
+
+func (m *MockStorage) LastUserSecretWriteActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[uint]time.Time), args.Error(1)
+}
+
 func (m *MockStorage) CreateSoDPolicy(ctx context.Context, p *models.SoDPolicy) (*models.SoDPolicy, error) {
 	args := m.Called(ctx, p)
 	if args.Get(0) == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -124,6 +124,25 @@ type Storage interface {
 	// activity" signal. Users with no recorded deletion activity are absent from
 	// the map.
 	LastUserSecretDeletionActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error)
+	// LastUserSecretReadActivity returns, per user, the most recent secret.read
+	// time attributable to this project — the secrets.read half of plain-tier
+	// dormant-role-grant detection (#487 round 112). Mirrors
+	// LastUserRoleManagementActivity/LastUserSecretDeletionActivity's per-
+	// permission split, one level down from admin-tier: before this, a plain-tier
+	// grant was credited "used" by ANY secret activity (read OR write) in
+	// LastUserSecretActivity regardless of which specific permission (secrets.read
+	// vs secrets.write) the grant's OWN bundle actually confers, so a user holding
+	// a read-only grant AND a separate write-only grant in the same project had
+	// BOTH masked non-dormant by either one's activity. Users with no recorded
+	// read activity are absent from the map.
+	LastUserSecretReadActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error)
+	// LastUserSecretWriteActivity returns, per user, the most recent
+	// secret.created/updated/rotated time attributable to this project — the
+	// secrets.write half of plain-tier dormant-role-grant detection (#487 round
+	// 112). See LastUserSecretReadActivity's doc for why this is kept separate
+	// rather than folded into one combined signal. Users with no recorded write
+	// activity are absent from the map.
+	LastUserSecretWriteActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error)
 
 	// Project invitations (ADR-024).
 	CreateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (*models.ProjectInvitation, error)

--- a/internal/storage/store/local_access_activity.go
+++ b/internal/storage/store/local_access_activity.go
@@ -40,6 +40,22 @@ var accessActivityEventTypes = []string{
 	"secret.read", "secret.created", "secret.updated", "secret.rotated",
 }
 
+// secretReadActivityEventTypes / secretWriteActivityEventTypes split
+// accessActivityEventTypes along the two permissions that actually gate these
+// actions (secrets.read vs secrets.write — create/update/rotate are ALL gated by
+// the single secrets.write permission, see auth_bootstrap.go's permission
+// catalog), so a plain-tier grant's dormancy can be credited against the
+// SPECIFIC permission its own bundle confers (#487 round 112), the same
+// per-permission narrowing roleManagementActivityEventTypes/
+// secretsDeletionActivityEventTypes already apply one tier up. Before this
+// split, a read-only grant and a separate write-only grant held by the same
+// user in the same project masked each other via the single combined
+// accessActivityEventTypes/LastUserSecretActivity bucket: exercising either
+// permission satisfied BOTH grants' dormancy check, identical in shape to the
+// admin-tier masking #487/#801 already closed.
+var secretReadActivityEventTypes = []string{"secret.read"}
+var secretWriteActivityEventTypes = []string{"secret.created", "secret.updated", "secret.rotated"}
+
 // roleManagementActivityEventTypes are the audit event types that count as
 // exercising a role-management (roles.assign) capability, one of the two
 // admin-tier activity buckets behind dormant-role-grant detection (#258, narrowed
@@ -121,4 +137,19 @@ func (ls *LocalStorage) LastUserRoleManagementActivity(ctx context.Context, proj
 // exactly which events count.
 func (ls *LocalStorage) LastUserSecretDeletionActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {
 	return ls.lastUserActivityByEventTypes(ctx, projectID, secretsDeletionActivityEventTypes)
+}
+
+// LastUserSecretReadActivity returns the most recent secret.read time per user in
+// the project — the secrets.read half of plain-tier dormant-role-grant detection
+// (#487 round 112). See secretReadActivityEventTypes.
+func (ls *LocalStorage) LastUserSecretReadActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {
+	return ls.lastUserActivityByEventTypes(ctx, projectID, secretReadActivityEventTypes)
+}
+
+// LastUserSecretWriteActivity returns the most recent
+// secret.created/updated/rotated time per user in the project — the
+// secrets.write half of plain-tier dormant-role-grant detection (#487 round
+// 112). See secretWriteActivityEventTypes.
+func (ls *LocalStorage) LastUserSecretWriteActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {
+	return ls.lastUserActivityByEventTypes(ctx, projectID, secretWriteActivityEventTypes)
 }

--- a/internal/storage/store/remote_access_activity.go
+++ b/internal/storage/store/remote_access_activity.go
@@ -18,3 +18,11 @@ func (rs *RemoteStorage) LastUserRoleManagementActivity(_ context.Context, _ uin
 func (rs *RemoteStorage) LastUserSecretDeletionActivity(_ context.Context, _ uint) (map[uint]time.Time, error) {
 	return nil, remoteUnsupported("LastUserSecretDeletionActivity")
 }
+
+func (rs *RemoteStorage) LastUserSecretReadActivity(_ context.Context, _ uint) (map[uint]time.Time, error) {
+	return nil, remoteUnsupported("LastUserSecretReadActivity")
+}
+
+func (rs *RemoteStorage) LastUserSecretWriteActivity(_ context.Context, _ uint) (map[uint]time.Time, error) {
+	return nil, remoteUnsupported("LastUserSecretWriteActivity")
+}


### PR DESCRIPTION
## Summary

Round 112 of the security-hardening backlog: closes as much of #487 as is
structurally tractable, and definitively establishes what remains isn't a
deferred design gap but a mathematical property of the current RBAC model.

**Root cause.** `countDormantRoleGrants` (round 111 / PR #801) already
narrows admin-tier dormancy per grant, per specific capability
(`roles.assign` vs `secrets.delete/admin`), so two admin-tier grants
conferring *different* capabilities no longer mask each other. The same
masking bug still existed one tier down: a **plain** read/write-tier grant
was credited "used" from *any* combined `secret.read/created/updated/rotated`
activity by the user in the project, with no check against which specific
permission (`secrets.read` vs `secrets.write`) that grant's own bundle
confers. A user holding a read-only grant and a separate write-only grant in
the same project had both masked non-dormant by exercising either one.

**Fix.** Split `LastUserSecretActivity` into
`LastUserSecretReadActivity`/`LastUserSecretWriteActivity` and credit a
plain-tier grant as used only when its own permission bundle covers the
specific activity observed — the identical per-grant, per-permission
technique #801 already validated as safe: no authorization-hot-path change
(`authz.go` untouched), no schema/migration, purely a read-side refinement of
the existing on-demand compliance-posture query.

**Investigated and confirmed structural, not deferred a third time.** Two
grants that bundle the *identical* specific permission (e.g. two roles that
both carry `secrets.read`, or both carry `secrets.delete`) remain genuinely
indistinguishable. Traced through `Authorize`/`RoleSetHasPermission`
(`internal/core/authz.go`, `internal/storage/store/local_rbac.go`):
permission resolution is a boolean OR across the union of a principal's
applicable role IDs (`RoleSetHasPermission`'s SQL is a plain `COUNT(*)` over
the role-permission join with no per-grant selection). When two grants each
individually and equally satisfy a permission check, there is no
authorization-time signal that distinguishes them — recording "which
role(s) covered this permission" at write time would only recompute the same
static role-definition membership test already available at read time, since
a role's permission bundle never varies per request. Manufacturing a
tie-break would be an arbitrary, unjustified attribution, worse than the
current honestly-ambiguous approximation. Both grants remain credited
(never falsely dormant) for this narrower, irreducible case.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./internal/core/... -count=1` (full suite green; one unrelated
  pre-existing flake, `TestConcurrency_RequestPasswordReset_BurstIsThrottled`,
  reproduced and confirmed to pass reliably in isolation across 3 repeated
  runs — not touched by this change)
- `go test ./internal/storage/... ./server/... -count=1` — all green
- `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues
- New tests proving disambiguation: a read-only grant and a write-only grant
  held by the same user in the same project are now tracked independently —
  exercising one no longer masks the other as non-dormant, and both are
  correctly non-dormant once both are actually exercised.