### PR TITLE
fix(remote-storage): expose login-lockout accounting on the wire; bypass cache for LockUserForUpdate (#500)

### DIFF
--- a/internal/core/login_lockout_remote_test.go
+++ b/internal/core/login_lockout_remote_test.go
@@ -22,25 +22,36 @@ import (
 // this shape (#496); a raw-model mock would silently paper over the same
 // request/response field-name mismatch #496 fixed, since both sides would share the
 // identical (wrong) assumption.
+//
+// #500: failed_login_attempts/login_lockout_count/last_failed_login_at are now also
+// part of that real shape (alongside the pre-existing login_locked_until), so this
+// mock includes them unconditionally too — omitting them here would silently
+// reintroduce the exact stale-mock blind spot #496's own fix was written to avoid.
 func apiOKUser(t *testing.T, w http.ResponseWriter, user *models.User) {
 	t.Helper()
 	data := map[string]interface{}{
-		"id":            user.ID,
-		"username":      user.Username,
-		"email":         user.Email,
-		"display_name":  user.DisplayName,
-		"active":        user.IsActive,
-		"account_state": user.AccountState,
-		"created_at":    user.CreatedAt.UTC().Format(time.RFC3339),
-		"updated_at":    user.UpdatedAt.UTC().Format(time.RFC3339),
-		"last_login_at": nil,
-		"deleted_at":    nil,
+		"id":                    user.ID,
+		"username":              user.Username,
+		"email":                 user.Email,
+		"display_name":          user.DisplayName,
+		"active":                user.IsActive,
+		"account_state":         user.AccountState,
+		"created_at":            user.CreatedAt.UTC().Format(time.RFC3339),
+		"updated_at":            user.UpdatedAt.UTC().Format(time.RFC3339),
+		"last_login_at":         nil,
+		"deleted_at":            nil,
+		"failed_login_attempts": user.FailedLoginAttempts,
+		"login_lockout_count":   user.LoginLockoutCount,
+		"last_failed_login_at":  nil,
 	}
 	if user.LastLoginAt != nil {
 		data["last_login_at"] = user.LastLoginAt.UTC().Format(time.RFC3339)
 	}
 	if user.LoginLockedUntil != nil {
 		data["login_locked_until"] = user.LoginLockedUntil.UTC().Format(time.RFC3339)
+	}
+	if user.LastFailedLoginAt != nil {
+		data["last_failed_login_at"] = user.LastFailedLoginAt.UTC().Format(time.RFC3339)
 	}
 	type resp struct {
 		Success bool        `json:"success"`
@@ -109,25 +120,30 @@ func TestLockout_RemoteStorageFailsOpenLoudlyOnce(t *testing.T) {
 	// being permanently unable to clear the counters is not the same as a transient
 	// storage error, and lockout is a backstop, not the primary auth boundary.
 	//
-	// NOTE (discovered fixing #496, filed separately — a different root cause, not a
-	// field-name mismatch): unlike recordFailedLogin above, this path does NOT log the
-	// INERT warning against a REAL remote server. checkLockAndClearLoginFailures
-	// (login_lockout.go) has a "nothing to clear" fast path keyed on the freshly-fetched
-	// u.FailedLoginAttempts/LoginLockedUntil/LoginLockoutCount — fields userToAPIResponse
-	// (server/http/handlers/users_handler.go) never puts on the wire at all (deliberately:
-	// they are internal security-accounting state, not public API surface). Under
-	// storage.type: remote that fast path always observes zero/nil, so it always takes
-	// the early return: UpdateLoginLockoutState is never even attempted and the warning
-	// never fires, silently leaving any real stale accounting uncleared. This is a
-	// pre-existing, independent gap — not introduced by #496 — that #496's response-shape
-	// fix (decodeUserResponse in remote_users.go) simply stopped masking: this test's own
-	// former apiOKUser mock round-tripped FailedLoginAttempts as a raw model field, which
-	// no real server response ever does, exactly the hand-rolled-mock blind spot #496's
-	// own fix was written to avoid repeating.
+	// #500 (this used to be a separately-filed gap, discovered fixing #496): before
+	// this fix, this path did NOT log the INERT warning against a real remote server.
+	// checkLockAndClearLoginFailures's (login_lockout.go) "nothing to clear" fast path
+	// is keyed on the freshly-fetched u.FailedLoginAttempts/LoginLockedUntil/
+	// LoginLockoutCount; when userToAPIResponse (server/http/handlers/users_handler.go)
+	// never put failed_login_attempts/login_lockout_count on the wire at all, that fast
+	// path always observed a false all-zero snapshot under storage.type: remote, so it
+	// always took the early return — UpdateLoginLockoutState was never even attempted
+	// and the warning never fired, silently leaving any real stale accounting
+	// unreported (though, since #454, still safely unpersisted either way — this was an
+	// observability gap in the "loudly" half of "fail open loudly", not a security one).
+	// Now that those fields are on the wire, a user with genuine unreset accounting
+	// (FailedLoginAttempts: 2 below) is no longer mistaken for "nothing to clear": the
+	// fast path is skipped, UpdateLoginLockoutState is attempted, fails unsupported, and
+	// the operator warning correctly fires from this call path too.
 	lockedUser := &models.User{ID: 43, Username: "carol", AccountState: AccountActive, IsActive: true, FailedLoginAttempts: 2}
 	c2 := newRemoteLockoutCore(t, lockedUser, policy)
-	err := c2.checkLockAndClearLoginFailures(ctx, lockedUser)
-	assert.NoError(t, err, "must not block login just because lockout accounting can't be persisted")
+	out3 := captureLog(t, func() {
+		err := c2.checkLockAndClearLoginFailures(ctx, lockedUser)
+		assert.NoError(t, err, "must not block login just because lockout accounting can't be persisted")
+	})
+	assert.Contains(t, out3, "login lockout accounting is INERT",
+		"#500: real unreset accounting (FailedLoginAttempts>0) must no longer be mistaken "+
+			"for 'nothing to clear' now that these fields are on the wire")
 }
 
 // TestUnlockUser_RemoteStorageFailsOpenLoudly is the (#484) regression for the admin

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -93,32 +94,46 @@ func newUserUpdateWireRequest(user *models.User) userUpdateWireRequest {
 // "active", "account_state", "created_at", "updated_at", "last_login_at" all fail
 // the case-insensitive fallback against models.User's untagged field names, so
 // every field but ID/Username/Email came back silently zeroed.
+//
+// FailedLoginAttempts/LoginLockoutCount/LastFailedLoginAt (#500) round out the
+// lockout-accounting fields alongside LoginLockedUntil: LockUserForUpdate is just
+// GetUser (see below) over HTTP, and checkLockAndClearLoginFailures
+// (internal/core/login_lockout.go) reads all four of these off that same response
+// to decide both "is this account currently locked" and its "nothing to clear"
+// fast path — without them on the wire, the fast path always saw a false all-zero
+// snapshot under storage.type: remote.
 type userWireResponse struct {
-	ID               uint       `json:"id"`
-	Username         string     `json:"username"`
-	Email            string     `json:"email"`
-	DisplayName      string     `json:"display_name"`
-	Active           bool       `json:"active"`
-	AccountState     string     `json:"account_state"`
-	CreatedAt        time.Time  `json:"created_at"`
-	UpdatedAt        time.Time  `json:"updated_at"`
-	LastLoginAt      *time.Time `json:"last_login_at"`
-	DeletedAt        *time.Time `json:"deleted_at"`
-	LoginLockedUntil *time.Time `json:"login_locked_until,omitempty"`
+	ID                  uint       `json:"id"`
+	Username            string     `json:"username"`
+	Email               string     `json:"email"`
+	DisplayName         string     `json:"display_name"`
+	Active              bool       `json:"active"`
+	AccountState        string     `json:"account_state"`
+	CreatedAt           time.Time  `json:"created_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
+	LastLoginAt         *time.Time `json:"last_login_at"`
+	DeletedAt           *time.Time `json:"deleted_at"`
+	LoginLockedUntil    *time.Time `json:"login_locked_until,omitempty"`
+	FailedLoginAttempts int        `json:"failed_login_attempts"`
+	LoginLockoutCount   int        `json:"login_lockout_count"`
+	LastFailedLoginAt   *time.Time `json:"last_failed_login_at"`
 }
 
 func (w userWireResponse) toModel() *models.User {
 	u := &models.User{
-		ID:               w.ID,
-		Username:         w.Username,
-		Email:            w.Email,
-		DisplayName:      w.DisplayName,
-		IsActive:         w.Active,
-		AccountState:     w.AccountState,
-		CreatedAt:        w.CreatedAt,
-		UpdatedAt:        w.UpdatedAt,
-		LastLoginAt:      w.LastLoginAt,
-		LoginLockedUntil: w.LoginLockedUntil,
+		ID:                  w.ID,
+		Username:            w.Username,
+		Email:               w.Email,
+		DisplayName:         w.DisplayName,
+		IsActive:            w.Active,
+		AccountState:        w.AccountState,
+		CreatedAt:           w.CreatedAt,
+		UpdatedAt:           w.UpdatedAt,
+		LastLoginAt:         w.LastLoginAt,
+		LoginLockedUntil:    w.LoginLockedUntil,
+		FailedLoginAttempts: w.FailedLoginAttempts,
+		LoginLockoutCount:   w.LoginLockoutCount,
+		LastFailedLoginAt:   w.LastFailedLoginAt,
 	}
 	if w.DeletedAt != nil {
 		u.DeletedAt = gorm.DeletedAt{Time: *w.DeletedAt, Valid: true}
@@ -163,9 +178,34 @@ func (rs *RemoteStorage) GetUser(ctx context.Context, id uint) (*models.User, er
 
 // LockUserForUpdate has no row lock to take over HTTP — each remote API call is already
 // atomic server-side, and the server's own LocalStorage takes the real FOR UPDATE lock
-// when it runs the lockout accounting. So this is a plain read.
+// when it runs the lockout accounting. So this is a plain read — but, unlike GetUser, it
+// deliberately does NOT go through rs.client.Get's 5-minute response cache
+// (internal/storage/remote/client.go).
+//
+// #500: this exact call is internal/core/login_lockout.go's anti-TOCTOU recheck
+// (checkLockAndClearLoginFailures) run immediately before minting a session, and
+// recordFailedLogin's own read-increment-write needs the row's genuinely-current
+// state, not whatever GetUser's blanket path-keyed cache last saw for up to 5
+// minutes. Before this fix, LockUserForUpdate simply called GetUser and so shared
+// its cache: a lock tripped by ANY caller (including this same client's own earlier
+// LockUserForUpdate call for a prior failed attempt in the same burst, or an
+// unrelated admin "view user" GetUser call) since the cache entry was populated
+// would go completely unobserved for up to 5 minutes — silently defeating the
+// recheck exactly as the finding describes, but via response-cache staleness
+// rather than a missing wire field. Cache invalidation on write (client.go's
+// Request) does not help here either: RemoteStorage's own write path for these
+// columns (UpdateLoginLockoutState) is a hard, permanent stub (#454) that never
+// makes an HTTP call at all, so it can never trigger that invalidation.
 func (rs *RemoteStorage) LockUserForUpdate(ctx context.Context, id uint) (*models.User, error) {
-	return rs.GetUser(ctx, id)
+	path := fmt.Sprintf("/api/v1/users/%d", id)
+	resp, err := rs.client.Request(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get user failed: %s", resp.Error.Error())
+	}
+	return decodeUserResponse(resp.Data)
 }
 
 // GetUserByEmail retrieves a user by email via remote API.

--- a/server/http/handlers/users_handler.go
+++ b/server/http/handlers/users_handler.go
@@ -91,6 +91,28 @@ func userToAPIResponse(u *models.User) map[string]interface{} {
 	if u.LoginLockedUntil != nil && time.Now().Before(*u.LoginLockedUntil) {
 		out["login_locked_until"] = u.LoginLockedUntil.UTC().Format(time.RFC3339)
 	}
+	// #500: also surface the raw lockout-accounting counters, not just the derived
+	// "is currently locked" fact above. This endpoint is only reachable with the
+	// users.read/users.write permission (server/http/router.go) — the same
+	// admin-level trust boundary that already sees account_state, active, and (just
+	// above) an active login_locked_until, and that already has UnlockUser authority
+	// over this exact state; the self-service /auth/profile endpoint is a completely
+	// separate handler (auth.go's userProfileMap) that never reaches this function, so
+	// no lower-trust caller gains visibility here. Exposing these matters beyond mere
+	// admin-UI completeness: under storage.type: remote, checkLockAndClearLoginFailures
+	// (internal/core/login_lockout.go) reads this exact response (via LockUserForUpdate,
+	// which is just GetUser over HTTP) to decide its "nothing to clear" fast path;
+	// without these fields on the wire that path always read a false all-zero snapshot
+	// and silently skipped even the operator-visible "lockout accounting is INERT"
+	// warning whenever an account had accumulated (but not yet tripped) failures — the
+	// "fail open" half of that design worked, but the "loudly" half silently didn't,
+	// from this call path.
+	out["failed_login_attempts"] = u.FailedLoginAttempts
+	out["login_lockout_count"] = u.LoginLockoutCount
+	out["last_failed_login_at"] = nil
+	if u.LastFailedLoginAt != nil {
+		out["last_failed_login_at"] = u.LastFailedLoginAt.UTC().Format(time.RFC3339)
+	}
 	return out
 }
 

--- a/server/http/remote_storage_login_lockout_wire_test.go
+++ b/server/http/remote_storage_login_lockout_wire_test.go
@@ -1,0 +1,173 @@
+// remote_storage_login_lockout_wire_test.go — end-to-end regression coverage for
+// #500: RemoteStorage.LockUserForUpdate (internal/storage/store/remote_users.go)
+// is the exact call internal/core/login_lockout.go's checkLockAndClearLoginFailures
+// makes to re-verify an account's lock state immediately before minting a session
+// (its anti-TOCTOU recheck) under storage.type: remote. Two independent gaps used
+// to defeat that recheck:
+//
+//  1. userToAPIResponse (server/http/handlers/users_handler.go) never put
+//     failed_login_attempts/login_lockout_count/last_failed_login_at on the wire at
+//     all — login_locked_until itself was already fixed separately (#496/#803), but
+//     the other three lockout-accounting columns were not, so the recheck's own
+//     "nothing to clear" fast path always saw a false all-zero snapshot.
+//  2. LockUserForUpdate used to simply call GetUser, sharing its 5-minute response
+//     cache (internal/storage/remote/client.go). A lock tripped by ANY caller since
+//     that cache entry was populated — including this same client's own earlier
+//     LockUserForUpdate call, or an unrelated admin "view user" GetUser call — went
+//     completely unobserved for up to 5 minutes, silently defeating the recheck via
+//     stale cache data rather than a missing wire field.
+//
+// Driven against a REAL server (NewRouter), not a hand-rolled mock — a mock that
+// manually sets fields "correctly" can never catch a real field-name/shape
+// mismatch (the same lesson #452/#496/#794's own e2e tests were built around).
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newLockoutWireTestUpstream builds a real upstream server (NewRouter over an
+// in-memory SQLite-backed core) plus an admin token, and seeds one real user.
+func newLockoutWireTestUpstream(t *testing.T) (upstreamCore *core.KeyorixCore, srv *httptest.Server, token string, userID uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstreamCore = newTestCore(t)
+	token = createTestToken(t, upstreamCore)
+
+	cfg := &config.Config{Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"}}}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	srv = httptest.NewServer(upstreamRouter)
+	t.Cleanup(srv.Close)
+
+	seeded, err := upstreamCore.CreateUser(context.Background(), &core.CreateUserRequest{
+		Username: "e2e-lockout-wire", Email: "e2e-lockout-wire@example.com",
+		Password: "Qr7#Kp2$Lm5@Vn9!", DisplayName: "Lockout Wire Test User",
+	})
+	require.NoError(t, err)
+	return upstreamCore, srv, token, seeded.ID
+}
+
+// TestRemoteStorage_LoginLockoutWireFix_RealServerRoundTrip proves the wire-field
+// half of the #500 fix end-to-end: a real server's response must carry the full
+// login-lockout accounting state, and RemoteStorage.LockUserForUpdate — the exact
+// call checkLockAndClearLoginFailures makes — must decode all of it, not just
+// login_locked_until. Uses LockUserForUpdate throughout (never GetUser) since it is
+// deliberately cache-bypassing (see the second test below); GetUser's own 5-minute
+// cache is orthogonal to what this test asserts.
+func TestRemoteStorage_LoginLockoutWireFix_RealServerRoundTrip(t *testing.T) {
+	upstreamCore, srv, token, userID := newLockoutWireTestUpstream(t)
+	ctx := context.Background()
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: srv.URL, APIKey: token, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	// --- baseline: a freshly created user has no lockout state at all ---
+	fresh, err := rs.LockUserForUpdate(ctx, userID)
+	require.NoError(t, err)
+	assert.Zero(t, fresh.FailedLoginAttempts)
+	assert.Zero(t, fresh.LoginLockoutCount)
+	assert.Nil(t, fresh.LastFailedLoginAt)
+	assert.Nil(t, fresh.LoginLockedUntil)
+
+	// --- simulate a concurrent burst of failed logins tripping the lock directly
+	// against the upstream's own storage (exactly what recordFailedLogin does
+	// server-side; this bypasses the wire entirely so the assertions below are only
+	// about the read path this fix touches) ---
+	lastFailed := time.Now().Add(-time.Second).UTC().Truncate(time.Second)
+	lockedUntil := time.Now().Add(30 * time.Minute).UTC().Truncate(time.Second)
+	require.NoError(t, upstreamCore.Storage().UpdateLoginLockoutState(ctx, userID, 3, &lastFailed, &lockedUntil, 2))
+
+	// --- the fix under test: LockUserForUpdate must decode the FULL
+	// lockout-accounting state from the real response, not just login_locked_until ---
+	locked, err := rs.LockUserForUpdate(ctx, userID)
+	require.NoError(t, err, "LockUserForUpdate must not be misreported as a failure for a genuinely successful upstream response")
+
+	require.NotNil(t, locked.LoginLockedUntil, "#500: login_locked_until must decode (this half was already fixed by #803)")
+	assert.WithinDuration(t, lockedUntil, *locked.LoginLockedUntil, time.Second)
+	assert.Equal(t, 3, locked.FailedLoginAttempts,
+		"#500: failed_login_attempts must decode from the response, not silently zero")
+	assert.Equal(t, 2, locked.LoginLockoutCount,
+		"#500: login_lockout_count must decode from the response, not silently zero")
+	require.NotNil(t, locked.LastFailedLoginAt,
+		"#500: last_failed_login_at must decode from the response, not silently nil")
+	assert.WithinDuration(t, lastFailed, *locked.LastFailedLoginAt, time.Second)
+
+	// --- once the lock has genuinely expired (in the past), the server treats the
+	// account as unlocked again and omits login_locked_until — the accounting
+	// counters, however, are unconditional and must still round-trip ---
+	pastLock := time.Now().Add(-time.Minute).UTC().Truncate(time.Second)
+	require.NoError(t, upstreamCore.Storage().UpdateLoginLockoutState(ctx, userID, 1, &lastFailed, &pastLock, 2))
+	expired, err := rs.LockUserForUpdate(ctx, userID)
+	require.NoError(t, err)
+	assert.Nil(t, expired.LoginLockedUntil, "an expired lock must read as unlocked, matching userToAPIResponse's own behaviour")
+	assert.Equal(t, 1, expired.FailedLoginAttempts, "#500: the accounting counters round-trip independently of the derived lock flag")
+	assert.Equal(t, 2, expired.LoginLockoutCount)
+}
+
+// TestRemoteStorage_LockUserForUpdate_BypassesGetUserCache proves the second half
+// of the #500 fix: LockUserForUpdate must always see the row's current state, even
+// when an ordinary GetUser call for the SAME user was recently cached. Before this
+// fix, LockUserForUpdate delegated straight to GetUser and so shared its 5-minute
+// response cache (internal/storage/remote/client.go) — a lock tripped after that
+// cache entry was populated would be invisible to the anti-TOCTOU recheck for up to
+// 5 minutes, exactly the class of bug #500 describes (just rooted in cache
+// staleness rather than a missing wire field).
+func TestRemoteStorage_LockUserForUpdate_BypassesGetUserCache(t *testing.T) {
+	upstreamCore, srv, token, userID := newLockoutWireTestUpstream(t)
+	ctx := context.Background()
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: srv.URL, APIKey: token, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	// Populate GetUser's cache with the account's UNLOCKED state — this is the same
+	// client instance and the same cache key (GET:/api/v1/users/{id}) that
+	// LockUserForUpdate used to share before this fix.
+	unlocked, err := rs.GetUser(ctx, userID)
+	require.NoError(t, err)
+	require.Nil(t, unlocked.LoginLockedUntil)
+
+	// Trip the lock directly against the upstream's own storage — simulating a
+	// concurrent burst of failed logins committing via a path that does not go
+	// through THIS client (e.g. another instance, or the upstream server's own
+	// direct login processing).
+	lockedUntil := time.Now().Add(30 * time.Minute).UTC().Truncate(time.Second)
+	require.NoError(t, upstreamCore.Storage().UpdateLoginLockoutState(ctx, userID, 1, nil, &lockedUntil, 1))
+
+	// The fix under test: LockUserForUpdate must see the fresh, locked state —
+	// never the stale cache entry GetUser just populated above.
+	relocked, err := rs.LockUserForUpdate(ctx, userID)
+	require.NoError(t, err)
+	require.NotNil(t, relocked.LoginLockedUntil,
+		"#500: LockUserForUpdate must bypass GetUser's response cache — the anti-TOCTOU "+
+			"recheck must never observe a lock that was tripped since the last cached GetUser read")
+	assert.WithinDuration(t, lockedUntil, *relocked.LoginLockedUntil, time.Second)
+
+	// Documents the (unchanged, deliberate) other half of this behaviour: an
+	// ordinary GetUser call for the same path is still served from its own
+	// 5-minute cache and so still reports the stale unlocked snapshot — this is
+	// GetUser's existing, intentional performance trade-off, not a regression,
+	// and is exactly why the security-sensitive recheck must use LockUserForUpdate
+	// and not GetUser directly.
+	stillCached, err := rs.GetUser(ctx, userID)
+	require.NoError(t, err)
+	assert.Nil(t, stillCached.LoginLockedUntil,
+		"GetUser's cache is unchanged by this fix; only LockUserForUpdate bypasses it")
+}


### PR DESCRIPTION
## Summary

Closes the anti-TOCTOU login-lockout recheck's gap under `storage.type: remote`
(backlog finding #500), rooted in two independent causes rather than one:

1. **Missing wire fields.** `userToAPIResponse` never put
   `failed_login_attempts`/`login_lockout_count`/`last_failed_login_at` on the
   wire (`login_locked_until` itself was already fixed separately by #803).
   `checkLockAndClearLoginFailures`'s "nothing to clear" fast path read these
   off `LockUserForUpdate`'s response, so under `storage.type: remote` it
   always saw a false all-zero snapshot and silently skipped the
   operator-visible "lockout accounting is INERT" warning (#454) whenever an
   account had accumulated — but not yet tripped — failures.
2. **Stale cache.** `RemoteStorage.LockUserForUpdate` simply delegated to
   `GetUser`, sharing its 5-minute response cache
   (`internal/storage/remote/client.go`). A lock tripped by any caller since
   that cache entry was populated — including this same client's own earlier
   `LockUserForUpdate` call, or an unrelated admin "view user" `GetUser` call
   — went unobserved for up to 5 minutes. This is the more literal, more
   severe match for the finding's headline claim ("the recheck can never
   observe a genuinely locked account"), and was the harder one to find:
   `LockUserForUpdate`'s own doc comment calls it "a plain read" without
   anticipating that the plain read could be years^H^H^H^Hminutes stale.

### Trust-boundary check (per the task's ask)

Before adding these fields I checked who else reaches `userToAPIResponse`:
every call site is gated by the `users.read`/`users.write` RBAC permission
(`server/http/router.go`) — the same admin-level trust boundary that already
sees `account_state`/`active`/an active `login_locked_until`, and that already
has `UnlockUser` authority over this exact state. The self-service
`/auth/profile` endpoint uses a completely separate response builder
(`auth.go`'s `userProfileMap`) that never reaches this function. So exposing
the raw counters adds no new disclosure to a lower-trust caller.

## Root cause

- `server/http/handlers/users_handler.go`'s `userToAPIResponse` omitted three
  of the four lockout-accounting columns from the response DTO.
- `internal/storage/store/remote_users.go`'s `userWireResponse` decoder
  therefore never had those fields to decode either.
- `LockUserForUpdate` reused `GetUser`'s cached HTTP `Get`, so even after
  fixing the wire shape, a stale cache entry could still mask a freshly
  tripped lock for up to 5 minutes.

## Fix

- Added `failed_login_attempts`, `login_lockout_count`, `last_failed_login_at`
  to `userToAPIResponse` and to the client-side `userWireResponse` decoder.
- Changed `RemoteStorage.LockUserForUpdate` to call the HTTP client's
  cache-bypassing `Request` method directly instead of `GetUser`, so the
  anti-TOCTOU recheck (and `recordFailedLogin`'s read-increment-write) always
  see the row's current state.
- Updated `internal/core/login_lockout_remote_test.go`'s wire mock
  (`apiOKUser`) to mirror the real, now-fuller response shape, and
  strengthened its assertions to require the operator warning to fire once
  these fields are genuinely non-zero.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/... ./internal/storage/... ./server/http/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] New end-to-end tests against a real server (`NewRouter`) and a real
      `RemoteStorage` client (not a hand-rolled mock):
      - `TestRemoteStorage_LoginLockoutWireFix_RealServerRoundTrip` — all four
        lockout fields round-trip correctly through `LockUserForUpdate`.
      - `TestRemoteStorage_LockUserForUpdate_BypassesGetUserCache` —
        `LockUserForUpdate` sees a lock tripped after a same-path `GetUser`
        call had already cached the unlocked state; `GetUser` itself is
        confirmed to still (deliberately) serve the stale cache entry.
- [x] Reverted each half of the fix independently and confirmed the
      corresponding test/assertion fails as predicted, then restored and
      confirmed it passes again (rigor pattern established by this campaign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)