### PR TITLE
fix(remote-storage): thread plaintext password/value through to RemoteStorage's CreateUser/CreateSecret (#496, #499)

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -508,7 +508,10 @@ func (m *MockStorage) RestoreEnvironment(_ context.Context, _, _ uint) error {
 
 // Secret Management
 
-func (m *MockStorage) CreateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error) {
+// CreateSecret ignores the optional plaintextValue variadic (#499) — it is not
+// forwarded to m.Called, so existing `.On("CreateSecret", ctx, secret)`
+// expectations (2 args) keep matching regardless of what core passes.
+func (m *MockStorage) CreateSecret(ctx context.Context, secret *models.SecretNode, _ ...string) (*models.SecretNode, error) {
 	args := m.Called(ctx, secret)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -789,7 +792,10 @@ func (m *MockStorage) DeleteExpiredShareRecords(ctx context.Context, before time
 
 // User Management
 
-func (m *MockStorage) CreateUser(ctx context.Context, user *models.User) (*models.User, error) {
+// CreateUser ignores the optional plaintextPassword variadic (#499) — it is not
+// forwarded to m.Called, so existing `.On("CreateUser", ctx, user)`
+// expectations (2 args) keep matching regardless of what core passes.
+func (m *MockStorage) CreateUser(ctx context.Context, user *models.User, _ ...string) (*models.User, error) {
 	args := m.Called(ctx, user)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -69,12 +70,20 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 		return nil, fmt.Errorf("%s: description exceeds %d characters", i18n.T("ErrorValidation", nil), maxSecretDescriptionLen)
 	}
 
-	// Verify the environment belongs to the stated project.
+	// Verify the environment belongs to the stated project. RemoteStorage.GetEnvironment
+	// is unimplemented (ErrUnsupportedByBackend, #499): it has no by-ID lookup route to
+	// call without also knowing the project (which this pre-check exists to establish).
+	// Rather than hard-failing every remote CreateSecret on a pre-check the backend can't
+	// perform, skip it when unsupported — the upstream server's own CreateSecret handler
+	// runs this identical ownership check against its own LocalStorage when it receives
+	// the forwarded request, so the invariant is still enforced authoritatively, just on
+	// the other side of the wire instead of redundantly on both.
 	env, err := c.storage.GetEnvironment(ctx, req.EnvironmentID)
 	if err != nil {
-		return nil, fmt.Errorf("environment %d not found", req.EnvironmentID)
-	}
-	if env.ProjectID != req.ProjectID {
+		if !errors.Is(err, storage.ErrUnsupportedByBackend) {
+			return nil, fmt.Errorf("environment %d not found", req.EnvironmentID)
+		}
+	} else if env.ProjectID != req.ProjectID {
 		return nil, fmt.Errorf("environment %d does not belong to project %d", req.EnvironmentID, req.ProjectID)
 	}
 
@@ -116,16 +125,28 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 		UpdatedAt:      time.Now(),
 	}
 
-	createdSecret, err := c.storage.CreateSecret(ctx, secret)
+	// req.Value is forwarded as the optional plaintext argument (#499): LocalStorage
+	// ignores it (a no-op — the value still flows through the storeSecretVersion call
+	// below, unchanged), while RemoteStorage forwards it over the wire so the real
+	// upstream handler's required "value" field is satisfied and version 1 is created
+	// atomically server-side. Never logged.
+	createdSecret, err := c.storage.CreateSecret(ctx, secret, string(req.Value))
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 
-	if err := c.storeSecretVersion(ctx, createdSecret, req.Value, 1); err != nil {
-		if delErr := c.storage.DeleteSecret(ctx, createdSecret.ID); delErr != nil {
-			log.Printf("warning: failed to cleanup orphaned secret %d after failed version creation: %v", createdSecret.ID, delErr)
+	// Skip the separate version-creation call when the backend already stored the value
+	// atomically as part of CreateSecret itself (RemoteStorage, #499): calling
+	// storeSecretVersion again here would try to mint a conflicting duplicate version 1
+	// against a secret that already has one. LocalStorage never sets ValueStored, so this
+	// call remains exactly as before for it.
+	if !createdSecret.ValueStored {
+		if err := c.storeSecretVersion(ctx, createdSecret, req.Value, 1); err != nil {
+			if delErr := c.storage.DeleteSecret(ctx, createdSecret.ID); delErr != nil {
+				log.Printf("warning: failed to cleanup orphaned secret %d after failed version creation: %v", createdSecret.ID, delErr)
+			}
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 		}
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 
 	// Apply the create-time tags (#390) now that the secret and its first version both

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -344,7 +344,27 @@ type Storage interface {
 	CountProjectMembershipsByUsers(ctx context.Context, userIDs []uint) (map[uint]MembershipCounts, error)
 
 	// Secret Management
-	CreateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error)
+	//
+	// CreateSecret persists secret's metadata; secret itself carries no value
+	// field at all (models.SecretNode has none — the plaintext normally lives
+	// only in core.CreateSecretRequest.Value and is routed to a separate
+	// CreateSecretVersion call core.CreateSecret makes right after this one).
+	// The optional plaintextValue variadic (#499) exists ONLY for RemoteStorage:
+	// the real upstream HTTP handler (server/http/handlers/secrets_crud.go)
+	// requires "value" in the SAME POST /api/v1/secrets body and creates version
+	// 1 atomically as part of handling it — there is no separate
+	// "create metadata now, add the value later" route to call instead. At most
+	// one value is meaningful; callers pass zero or one. LocalStorage's
+	// implementation MUST ignore this parameter (its CreateSecret has never
+	// touched the value and must keep not doing so — the value continues to
+	// flow through the existing, unchanged CreateSecretVersion path). When
+	// RemoteStorage successfully forwards a plaintextValue, the *models.SecretNode
+	// it returns has ValueStored set (a transient, never-persisted field — see
+	// models.SecretNode) so core.CreateSecret knows version 1 already exists
+	// upstream and must NOT also call CreateSecretVersion itself, which would
+	// otherwise mint a conflicting duplicate version 1 (or, until that route
+	// exists server-side, simply fail).
+	CreateSecret(ctx context.Context, secret *models.SecretNode, plaintextValue ...string) (*models.SecretNode, error)
 	GetSecret(ctx context.Context, id uint) (*models.SecretNode, error)
 	// GetSecretsByIDs is the batch form of GetSecret: every secret in ids, in one
 	// query, instead of one GetSecret call per ID. IDs with no matching row are
@@ -442,7 +462,26 @@ type Storage interface {
 	DeleteExpiredShareRecords(ctx context.Context, before time.Time) ([]*models.ShareRecord, error)
 
 	// User Management
-	CreateUser(ctx context.Context, user *models.User) (*models.User, error)
+	//
+	// CreateUser persists user, which by this point already carries its final
+	// bcrypt PasswordHash (`json:"-"` — core.buildUserForCreate hashes and
+	// discards the caller-supplied plaintext before ever reaching here). The
+	// optional plaintextPassword variadic (#499) exists ONLY for RemoteStorage:
+	// the real upstream HTTP handler (server/http/handlers/users_crud.go)
+	// re-hashes its own bcrypt copy server-side and therefore requires the
+	// PLAINTEXT password in its request body, not a hash it cannot verify was
+	// produced honestly. Passing it through here — rather than adding it to
+	// models.User itself — keeps the plaintext out of the persisted/logged user
+	// record entirely; it exists only as a function-call argument for the single
+	// call that needs it. At most one value is meaningful; callers pass zero or
+	// one. LocalStorage's implementation MUST ignore this parameter (it already
+	// has the hash and must never additionally receive, log, or persist the
+	// plaintext) — a no-op, not a new capability. Callers with no real plaintext
+	// to offer (SSO/SCIM auto-provisioning, which mints an unusable random
+	// password precisely because the account is never meant to authenticate
+	// with one) must not pass anything here; RemoteStorage.CreateUser then omits
+	// the wire field entirely, exactly as it did before #499 for those flows.
+	CreateUser(ctx context.Context, user *models.User, plaintextPassword ...string) (*models.User, error)
 	// CreateUserWithRoleGrants creates the user and applies all role grants in a
 	// single transaction (ADR-028 atomic provisioning); on any failure nothing is
 	// persisted.

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -52,9 +52,16 @@ func (c *KeyorixCore) buildUserForCreate(ctx context.Context, req *CreateUserReq
 
 	if _, err := c.storage.GetUserByUsername(ctx, req.Username); err == nil {
 		return nil, "", fmt.Errorf("%s: username already exists", i18n.T("ErrorValidation", nil))
-	} else if err != nil && !strings.Contains(err.Error(), i18n.T("ErrorUserNotFound", nil)) {
+	} else if !errors.Is(err, storage.ErrUnsupportedByBackend) && !strings.Contains(err.Error(), i18n.T("ErrorUserNotFound", nil)) {
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
+	// RemoteStorage.GetUserByUsername is unimplemented (ErrUnsupportedByBackend, #499):
+	// it has no by-username lookup route to call. Rather than hard-failing every
+	// remote CreateUser on a pre-check the backend can't perform, skip it here — the
+	// upstream server's own CreateUser handler runs this exact same buildUserForCreate
+	// check against its own LocalStorage when it receives the forwarded request, so the
+	// duplicate-username invariant is still enforced authoritatively, just on the other
+	// side of the wire instead of redundantly on both.
 
 	existing, err := c.storage.GetUserByEmail(ctx, req.Email)
 	if err == nil && existing != nil {
@@ -92,7 +99,14 @@ func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*
 		return nil, err
 	}
 
-	createdUser, err := c.storage.CreateUser(ctx, user)
+	// req.Password is forwarded as the optional plaintext argument (#499): LocalStorage
+	// ignores it (a no-op — it already has the hash above), while RemoteStorage forwards
+	// it over the wire so the real upstream handler can hash its own copy. This covers
+	// every core.CreateUser caller uniformly (the admin classic path, CreateUserWithSetupLink,
+	// and CreateUserWithOneTimePassword all populate req.Password with a real, hashable
+	// string before reaching here — see buildUserForCreate above and setup_delivery.go),
+	// and it is never logged.
+	createdUser, err := c.storage.CreateUser(ctx, user, req.Password)
 	if err != nil {
 		// #117: the pre-check above (GetUserByEmail) is a check-then-act read that races
 		// with a concurrent create for the identical email — both can pass it before

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -567,6 +567,16 @@ type SecretNode struct {
 	// auto-scopes `deleted_at IS NULL` on model-based queries — raw/Table/Joins
 	// queries on secret_nodes must filter it explicitly.
 	DeletedAt gorm.DeletedAt `gorm:"index"`
+	// ValueStored is a transient, in-process-only signal (#499): never persisted
+	// (`gorm:"-"`) and never serialized (`json:"-"`). storage.Storage.CreateSecret
+	// sets it true on the node it returns ONLY when the backend already durably
+	// stored the secret's initial value as part of that same call (RemoteStorage,
+	// when core forwarded a plaintextValue and the upstream server created
+	// version 1 atomically). core.CreateSecret checks this to decide whether its
+	// own follow-up CreateSecretVersion call is still needed (LocalStorage,
+	// where it always is) or would create a conflicting duplicate (RemoteStorage,
+	// where the value is already stored). Never carries the value itself.
+	ValueStored bool `gorm:"-" json:"-"`
 }
 
 // SecretDependency is a directed edge in a project's secret dependency graph:

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -354,7 +354,12 @@ func (ls *LocalStorage) RestoreEnvironment(ctx context.Context, projectID, id ui
 // --- Secrets ---
 
 // CreateSecret creates a new secret in the database.
-func (ls *LocalStorage) CreateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error) {
+// CreateSecret ignores the optional plaintextValue variadic (#499): the value
+// continues to flow through the existing, unchanged CreateSecretVersion path —
+// this is a no-op parameter here, never read, never persisted. secret.ValueStored
+// is deliberately left false (the zero value): the caller (core.CreateSecret)
+// must still make its own CreateSecretVersion call for LocalStorage.
+func (ls *LocalStorage) CreateSecret(ctx context.Context, secret *models.SecretNode, _ ...string) (*models.SecretNode, error) {
 	if err := ls.db.WithContext(ctx).Create(secret).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -54,7 +54,11 @@ func isDuplicateEmailViolation(err error) bool {
 
 // --- Users ---
 
-func (ls *LocalStorage) CreateUser(ctx context.Context, user *models.User) (*models.User, error) {
+// CreateUser ignores the optional plaintextPassword variadic (#499): user
+// already carries its final PasswordHash by the time core calls this, and
+// LocalStorage has no wire format to leak the plaintext into — it is simply
+// never read here, matching the interface doc's no-op requirement.
+func (ls *LocalStorage) CreateUser(ctx context.Context, user *models.User, _ ...string) (*models.User, error) {
 	if err := ls.db.WithContext(ctx).Create(user).Error; err != nil {
 		if isDuplicateEmailViolation(err) {
 			// The partial unique index uniq_users_email_active (#117) caught a concurrent

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -36,28 +36,27 @@ import (
 // in server/http, which already had to work around the MaxReads/max_reads gap by
 // asserting on UpdatedAt instead of the field it actually changed).
 //
-// Note what is deliberately NOT sent, in both directions, because there is no
-// channel in the storage.Storage interface to carry it:
-//   - CreateSecret: "value" (required by the handler). models.SecretNode has no
-//     value field at all — the plaintext lives only in
-//     core.CreateSecretRequest.Value (internal/core/secrets.go), which
-//     core.CreateSecret hands to storeSecretVersion/CreateSecretVersion
-//     separately, never to CreateSecret's own SecretNode argument. So this call
-//     will still fail the handler's "value" required validation today — a
-//     separate, deeper gap (the interface itself never receives the value) than
-//     this fix's field-name-mismatch scope. This fix only ensures the OTHER
-//     fields are no longer ALSO silently wrong, so the resulting error
-//     accurately blames the missing value, not a coincidentally-also-broken
-//     project_id/environment_id/max_reads.
+// Note what is deliberately NOT sent, in both directions:
+//   - CreateSecret: "value" (required by the handler) IS now sent (#499, closing
+//     the residual gap #496 left open) via the optional plaintextValue variadic
+//     on storage.Storage.CreateSecret — see the interface doc
+//     (internal/core/storage/interface.go) for why it is a call argument rather
+//     than a models.SecretNode field. Sent unconditionally required (no
+//     omitempty): the handler always requires it, and core.CreateSecret always
+//     has a value to offer (CreateSecretRequest.Value itself is
+//     validate:"required").
 //   - CreateSecret: "tags". core.CreateSecret applies create-time tags via a
 //     separate SetSecretTags storage call (already documented as
 //     remote-unsupported below), never through the SecretNode passed to
 //     CreateSecret, so there is nothing to forward here either.
-//   - UpdateSecret: "value" (optional). Same reasoning as CreateSecret — value
-//     changes go through storeNextSecretVersion/CreateSecretVersion, not
-//     UpdateSecret's own SecretNode argument.
+//   - UpdateSecret: "value" (optional). UpdateSecret has no equivalent
+//     plaintextValue channel — value changes still go through
+//     storeNextSecretVersion/CreateSecretVersion, not UpdateSecret's own
+//     SecretNode argument. Left as a documented residual gap; UpdateSecret was
+//     out of #499's scope (CreateUser/CreateSecret only).
 type secretCreateWireRequest struct {
 	Name           string      `json:"name"`
+	Value          string      `json:"value"`
 	ProjectID      uint        `json:"project_id"`
 	EnvironmentID  uint        `json:"environment_id"`
 	Type           string      `json:"type"`
@@ -66,9 +65,10 @@ type secretCreateWireRequest struct {
 	Classification string      `json:"classification,omitempty"`
 }
 
-func newSecretCreateWireRequest(secret *models.SecretNode) secretCreateWireRequest {
+func newSecretCreateWireRequest(secret *models.SecretNode, plaintextValue string) secretCreateWireRequest {
 	return secretCreateWireRequest{
 		Name:           secret.Name,
+		Value:          plaintextValue,
 		ProjectID:      secret.ProjectID,
 		EnvironmentID:  secret.EnvironmentID,
 		Type:           secret.Type,
@@ -103,9 +103,23 @@ func newSecretUpdateWireRequest(secret *models.SecretNode) secretUpdateWireReque
 	return req
 }
 
-// CreateSecret creates a new secret via remote API.
-func (rs *RemoteStorage) CreateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error) {
-	resp, err := rs.client.Post(ctx, "/api/v1/secrets", newSecretCreateWireRequest(secret))
+// CreateSecret creates a new secret via remote API. plaintextValue is optional
+// (#499) — see the interface doc and secretCreateWireRequest's comment above
+// for why it is a call argument rather than a models.SecretNode field. At most
+// the first value is used; the rest is accepted only to satisfy the variadic
+// interface signature (callers pass zero or one).
+//
+// When plaintextValue is supplied, the upstream server's CreateSecret handler
+// creates version 1 atomically as part of this same request — so the returned
+// node has ValueStored set, telling core.CreateSecret its own separate
+// CreateSecretVersion call is unnecessary (and would otherwise try to mint a
+// conflicting duplicate version 1).
+func (rs *RemoteStorage) CreateSecret(ctx context.Context, secret *models.SecretNode, plaintextValue ...string) (*models.SecretNode, error) {
+	var value string
+	if len(plaintextValue) > 0 {
+		value = plaintextValue[0]
+	}
+	resp, err := rs.client.Post(ctx, "/api/v1/secrets", newSecretCreateWireRequest(secret, value))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create secret: %w", err)
 	}
@@ -115,6 +129,9 @@ func (rs *RemoteStorage) CreateSecret(ctx context.Context, secret *models.Secret
 	var result models.SecretNode
 	if err := json.Unmarshal(resp.Data, &result); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	if value != "" {
+		result.ValueStored = true
 	}
 	return &result, nil
 }

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -38,23 +38,24 @@ import (
 // value server-side. The wire types below name every field explicitly so nothing
 // depends on that fallback (or the handler's specific field-naming choices) again.
 //
-// Password is deliberately never sent by userCreateWireRequest: models.User only
+// Password (#499, closing the residual gap #496 left open): models.User only
 // ever carries a bcrypt PasswordHash (`json:"-"`, intentionally excluded from the
-// wire) by the time CreateUser is invoked — buildUserForCreate
-// (internal/core/users.go) discards the plaintext once it computes the hash, and
-// storage.Storage.CreateUser(ctx, *models.User) has no other channel to carry a
-// plaintext password. That means the server's own "password is required unless
-// deliver_setup_link/generate_one_time_password is set" check will still reject
-// this call — a separate, deeper gap (the Storage interface itself never receives
-// the one field the server needs) than this fix's field-name-mismatch scope. This
-// fix at least ensures the OTHER fields are no longer ALSO silently wrong, so the
-// error the caller now sees accurately blames the missing password, not a
-// coincidentally-also-broken display_name/is_active.
+// wire — it must never be sent) by the time CreateUser is invoked;
+// buildUserForCreate (internal/core/users.go) discards the plaintext once it
+// computes the hash. The server's own "password is required unless
+// deliver_setup_link/generate_one_time_password is set" check needs the
+// PLAINTEXT (it hashes its own copy), which storage.Storage.CreateUser's new
+// optional plaintextPassword variadic now carries specifically for this call —
+// see the interface doc (internal/core/storage/interface.go) for why it is a
+// call argument and not a models.User field. Omitted (empty string) whenever the
+// caller has no real plaintext to offer (SSO/SCIM auto-provisioning), in which
+// case this field is simply left out of the JSON body, exactly as before.
 type userCreateWireRequest struct {
 	Username    string `json:"username"`
 	Email       string `json:"email"`
 	DisplayName string `json:"display_name"`
 	IsActive    *bool  `json:"is_active,omitempty"`
+	Password    string `json:"password,omitempty"`
 }
 
 // userUpdateWireRequest mirrors UpdateUser's handler DTO exactly (all optional,
@@ -66,13 +67,14 @@ type userUpdateWireRequest struct {
 	Active      *bool   `json:"active,omitempty"`
 }
 
-func newUserCreateWireRequest(user *models.User) userCreateWireRequest {
+func newUserCreateWireRequest(user *models.User, plaintextPassword string) userCreateWireRequest {
 	active := user.IsActive
 	return userCreateWireRequest{
 		Username:    user.Username,
 		Email:       user.Email,
 		DisplayName: user.DisplayName,
 		IsActive:    &active,
+		Password:    plaintextPassword,
 	}
 }
 
@@ -136,9 +138,17 @@ func decodeUserResponse(data []byte) (*models.User, error) {
 
 // --- Users ---
 
-// CreateUser creates a new user via remote API.
-func (rs *RemoteStorage) CreateUser(ctx context.Context, user *models.User) (*models.User, error) {
-	resp, err := rs.client.Post(ctx, "/api/v1/users", newUserCreateWireRequest(user))
+// CreateUser creates a new user via remote API. plaintextPassword is optional
+// (#499) — see the interface doc and userCreateWireRequest's comment above for
+// why it is a call argument rather than a models.User field. At most the first
+// value is used; the rest is accepted only to satisfy the variadic interface
+// signature (callers pass zero or one).
+func (rs *RemoteStorage) CreateUser(ctx context.Context, user *models.User, plaintextPassword ...string) (*models.User, error) {
+	var password string
+	if len(plaintextPassword) > 0 {
+		password = plaintextPassword[0]
+	}
+	resp, err := rs.client.Post(ctx, "/api/v1/users", newUserCreateWireRequest(user, password))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user: %w", err)
 	}

--- a/server/http/remote_storage_field_mismatch_test.go
+++ b/server/http/remote_storage_field_mismatch_test.go
@@ -72,19 +72,23 @@ func rawPost(t *testing.T, baseURL, path, token string, body []byte) (status int
 // #496 fix for RemoteStorage.CreateUser's request wire shape against the REAL
 // CreateUser handler (server/http/handlers/users_crud.go).
 //
-// Before the fix, models.User (no json tags of its own besides PasswordHash's
-// json:"-") was marshaled directly: "DisplayName" and "IsActive" do not
-// case-insensitively match the handler's "display_name"/"active"... sorry,
-// "is_active" tags (only single-word fields like "Username"/"Email" happened to
-// still match). DisplayName landed as "" server-side, which fails the handler's
-// OWN "required,min=1" structural validation — producing a generic "Invalid
-// request data" error that (wrongly) implicated display_name, masking the
-// separate, genuine, and NOT-fixable-here gap: models.User only ever carries a
-// bcrypt PasswordHash (json:"-"), never a plaintext password, so CreateUser via
-// remote storage can never satisfy the handler's password requirement regardless
-// of the other fields. After the fix, username/email/display_name/is_active all
-// reach the handler correctly, so the ONLY remaining failure is the accurate one:
-// the explicit "password is required" business-logic check, not a structural
+// Before the #496 fix, models.User (no json tags of its own besides
+// PasswordHash's json:"-") was marshaled directly: "DisplayName" and "IsActive"
+// do not case-insensitively match the handler's "display_name"/"active"...
+// sorry, "is_active" tags (only single-word fields like "Username"/"Email"
+// happened to still match). DisplayName landed as "" server-side, which fails
+// the handler's OWN "required,min=1" structural validation — producing a
+// generic "Invalid request data" error that (wrongly) implicated display_name,
+// masking the separate, genuine gap #496 deliberately left open and #499 later
+// closed: CreateUser's optional plaintextPassword variadic can now convey the
+// password (see TestRemoteStorage_PlaintextChannel_CreateUser_RealServerRoundTrip
+// for the genuine end-to-end success proof). THIS test calls rs.CreateUser with
+// NO plaintextPassword argument — exactly what SSO/SCIM auto-provisioning (which
+// has no real plaintext to offer) sends — so "password" is correctly absent from
+// the wire and the handler's business-logic check still (correctly) rejects it.
+// After the #496 fix, username/email/display_name/is_active all reach the
+// handler correctly, so the ONLY remaining failure is the accurate one: the
+// explicit "password is required" business-logic check, not a structural
 // validation error blaming the wrong field.
 func TestRemoteStorage_FieldMismatchFix_CreateUser_WireShapeAndValidation(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
@@ -108,15 +112,14 @@ func TestRemoteStorage_FieldMismatchFix_CreateUser_WireShapeAndValidation(t *tes
 	require.NoError(t, err)
 
 	active := true
+	// No plaintextPassword argument passed (#499): this call has nothing real to
+	// offer, so it must still fail — matching an SSO/SCIM-style auto-provisioned
+	// caller that genuinely has no plaintext credential to send.
 	_, createErr := rs.CreateUser(ctx, &models.User{
 		Username: "e2e-mismatch-newuser", Email: "e2e-mismatch-newuser@example.com",
 		DisplayName: "E2E New User", IsActive: active,
 		PasswordHash: "irrelevant-bcrypt-hash-never-sent", // json:"-": must never reach the wire
 	})
-	// This call can never succeed end-to-end: models.User has no plaintext password
-	// channel at all, so the server's password-required check always rejects it
-	// (a separate, deeper gap than #496's field-name-mismatch scope, tracked
-	// separately). What matters here is WHY it fails.
 	require.Error(t, createErr)
 
 	// --- prove the exact bytes sent match the real handler's expected DTO shape ---
@@ -148,18 +151,21 @@ func TestRemoteStorage_FieldMismatchFix_CreateUser_WireShapeAndValidation(t *tes
 // the CreateUser test above for RemoteStorage.CreateSecret against the real
 // CreateSecret handler (server/http/handlers/secrets_crud.go).
 //
-// Before the fix, models.SecretNode (no json tags at all) was marshaled
+// Before the #496 fix, models.SecretNode (no json tags at all) was marshaled
 // directly: "ProjectID"/"EnvironmentID"/"MaxReads" do not case-insensitively
 // match "project_id"/"environment_id"/"max_reads", so environment_id (required)
 // landed as 0 server-side, producing a generic "Invalid request data" error
-// blaming environment_id/project_id — masking the separate, genuine, and
-// NOT-fixable-here gap: models.SecretNode carries no value field at all (the
-// plaintext lives only in core.CreateSecretRequest.Value, handed to a wholly
-// separate CreateSecretVersion call), so CreateSecret via remote storage can
-// never satisfy the handler's "value" requirement regardless of the other
-// fields. After the fix, name/project_id/environment_id/type/max_reads/
-// classification all reach the handler correctly, so the ONLY remaining
-// validation failure is the accurate one: "value" missing.
+// blaming environment_id/project_id — masking the separate, genuine gap #496
+// deliberately left open and #499 later closed: CreateSecret's optional
+// plaintextValue variadic can now convey the value (see
+// TestRemoteStorage_PlaintextChannel_CreateSecret_RealServerRoundTrip for the
+// genuine end-to-end success proof). THIS test calls rs.CreateSecret with NO
+// plaintextValue argument — exactly what a caller with nothing to offer sends —
+// so "value" is present on the wire but empty, and the handler's structural
+// "required" check still (correctly) rejects it. After the #496 fix,
+// name/project_id/environment_id/type/max_reads/classification all reach the
+// handler correctly, so the ONLY remaining validation failure is the accurate
+// one: "value" missing.
 func TestRemoteStorage_FieldMismatchFix_CreateSecret_WireShapeAndValidation(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 	defer i18n.ResetForTesting()
@@ -190,14 +196,13 @@ func TestRemoteStorage_FieldMismatchFix_CreateSecret_WireShapeAndValidation(t *t
 	require.NoError(t, err)
 
 	maxReads := 5
+	// No plaintextValue argument passed (#499): this call has nothing real to offer,
+	// so it must still fail — the server's "value" required check correctly rejects
+	// an empty value exactly as it would reject an absent one.
 	_, createErr := rs.CreateSecret(ctx, &models.SecretNode{
 		Name: "e2e-mismatch-secret", ProjectID: project.ID, EnvironmentID: envID,
 		Type: "generic", MaxReads: &maxReads, Classification: "internal",
 	})
-	// This call can never succeed end-to-end: models.SecretNode carries no value
-	// field at all, so the server's "value" required check always rejects it (a
-	// separate, deeper gap than #496's field-name-mismatch scope, tracked
-	// separately). What matters here is WHY it fails.
 	require.Error(t, createErr)
 
 	// --- prove the exact bytes sent match the real handler's expected DTO shape ---
@@ -209,8 +214,10 @@ func TestRemoteStorage_FieldMismatchFix_CreateSecret_WireShapeAndValidation(t *t
 	assert.Equal(t, "generic", sentBody["type"])
 	assert.Equal(t, float64(5), sentBody["max_reads"], "#496: max_reads must be sent, not silently dropped as MaxReads")
 	assert.Equal(t, "internal", sentBody["classification"])
-	_, hasValue := sentBody["value"]
-	assert.False(t, hasValue, "models.SecretNode has no value field to send at all")
+	value, hasValue := sentBody["value"]
+	assert.True(t, hasValue, "#499: the wire request always includes a value key now that "+
+		"CreateSecret can convey one via its optional plaintextValue argument")
+	assert.Equal(t, "", value, "no plaintextValue was passed to this call, so it must be empty, not a real secret value")
 	for _, badKey := range []string{"ProjectID", "EnvironmentID", "MaxReads", "Name", "Type"} {
 		_, present := sentBody[badKey]
 		assert.False(t, present, "must not send the old PascalCase Go field name %q", badKey)

--- a/server/http/remote_storage_plaintext_channel_test.go
+++ b/server/http/remote_storage_plaintext_channel_test.go
@@ -1,0 +1,209 @@
+// remote_storage_plaintext_channel_test.go — end-to-end regression coverage for
+// #499: storage.Storage.CreateUser/CreateSecret had no field or argument at all
+// to carry the plaintext password/secret value, so — even after #496's wire-DTO
+// field-name fix — RemoteStorage.CreateUser/CreateSecret could never fully
+// succeed against a real upstream server; they'd always fail the handler's
+// "password"/"value is required" check. #496's own test file
+// (remote_storage_field_mismatch_test.go) proves exactly that residual failure
+// mode. This file proves the fix: with the plaintext threaded through
+// storage.Storage.CreateUser/CreateSecret's new optional variadic argument, both
+// calls now genuinely succeed end-to-end — not just "the wire shape is
+// correct", but the account is created with a real, usable password and the
+// secret is created with its real value, both durably landing in the
+// upstream's own storage — driven through the full core.CreateUser/
+// core.CreateSecret business logic (core.NewKeyorixCore(rs) as the downstream,
+// exactly as a real storage.type: remote deployment would run it), against a
+// REAL upstream server (NewRouter), not a hand-rolled mock.
+package http
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// captureLog redirects the standard library "log" package's global output to a
+// buffer for the duration of fn, then restores it — used to prove a plaintext
+// credential/value never reaches any log line anywhere along the call path
+// (client, HTTP transport, real handler, real core), not just that it isn't
+// deliberately logged in the one function we happen to be reading.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOutput := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetOutput(prevOutput)
+		log.SetFlags(prevFlags)
+	}()
+	fn()
+	return buf.String()
+}
+
+// TestRemoteStorage_PlaintextChannel_CreateUser_RealServerRoundTrip proves the
+// #499 fix at the storage.Storage.CreateUser layer: RemoteStorage.CreateUser,
+// given the new optional plaintextPassword argument, genuinely creates a
+// user — with a real, working password — against a real upstream server.
+// Before the fix this call always failed the upstream's "password is required"
+// check (see TestRemoteStorage_FieldMismatchFix_CreateUser_WireShapeAndValidation);
+// this proves it now succeeds, and that the password supplied is the ACTUAL
+// password the account uses (verified by a real login against the upstream —
+// not just that the client call didn't error).
+//
+// This drives RemoteStorage.CreateUser directly (mirroring the #496
+// field-mismatch test's own scoping), not the full core.CreateUser business
+// flow: core.CreateUser's shared buildUserForCreate helper ALSO pre-checks
+// storage.GetUserByEmail before ever reaching CreateUser, and — independent of
+// #499 and unlike GetUserByUsername (cleanly stubbed with ErrUnsupportedByBackend,
+// see the buildUserForCreate skip-and-defer-to-upstream comment in
+// internal/core/users.go) — RemoteStorage.GetUserByEmail targets
+// "/api/v1/users/by-email/{email}", a route this server never registers at all,
+// so every call to it 404s unconditionally against a real server. That is a
+// separate, pre-existing, and notably WIDER bug (GetUserByEmail also backs
+// several RBAC/SSO/SCIM lookups elsewhere in internal/core, not just this one
+// pre-check) that needs its own dedicated fix — adding a new authenticated
+// by-email HTTP surface deserves its own security review (permission gating,
+// email-enumeration risk) rather than being folded into this round. Filed as a
+// new finding rather than forced here; see the PR description.
+func TestRemoteStorage_PlaintextChannel_CreateUser_RealServerRoundTrip(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+
+	cfg := &config.Config{Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"}}}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: upstreamSrv.URL, APIKey: upstreamToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	const plaintextPassword = "Tr8#Qm2$Zx9!Fv6@"
+	active := true
+
+	var created *models.User
+	logOutput := captureLog(t, func() {
+		created, err = rs.CreateUser(ctx, &models.User{
+			Username: "e2e-plaintext-newuser", Email: "e2e-plaintext-newuser@example.com",
+			DisplayName: "E2E Plaintext User", IsActive: active,
+		}, plaintextPassword)
+	})
+	require.NoError(t, err, "#499: RemoteStorage.CreateUser must genuinely succeed against a real server when given a plaintextPassword")
+	require.NotNil(t, created)
+	assert.NotZero(t, created.ID)
+
+	// The plaintext password must never appear in any log line produced anywhere
+	// along the call path (client, transport, real handler, real core).
+	assert.NotContains(t, logOutput, plaintextPassword,
+		"the plaintext password must never be logged anywhere along the CreateUser call path")
+
+	// --- confirm it genuinely landed server-side with a REAL, usable password —
+	// not just that the client call didn't error ---
+	direct, err := upstreamCore.Storage().GetUser(ctx, created.ID)
+	require.NoError(t, err, "the user must be a real row in the upstream's own users table")
+	assert.Equal(t, "e2e-plaintext-newuser", direct.Username)
+	assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(direct.PasswordHash), []byte(plaintextPassword)),
+		"#499: the upstream must have hashed the SAME plaintext password supplied, not an empty/garbage value")
+
+	// The strongest possible proof: log in against the upstream with exactly the
+	// password we supplied through RemoteStorage.CreateUser.
+	session, loggedInUser, err := upstreamCore.Login(ctx, &core.LoginRequest{
+		Username: "e2e-plaintext-newuser", Password: plaintextPassword,
+	})
+	require.NoError(t, err, "#499: the password conveyed through RemoteStorage.CreateUser must be genuinely usable to log in")
+	assert.NotNil(t, session)
+	assert.Equal(t, created.ID, loggedInUser.ID)
+}
+
+// TestRemoteStorage_PlaintextChannel_CreateSecret_RealServerRoundTrip proves the
+// #499 fix for RemoteStorage.CreateSecret: a downstream core.KeyorixCore backed
+// by RemoteStorage can genuinely create a secret — with its real value — against
+// a real upstream server. Before the fix this call always failed the upstream's
+// "value is required" check (see TestRemoteStorage_FieldMismatchFix_
+// CreateSecret_WireShapeAndValidation); this proves it now succeeds and that the
+// value read back from the upstream's own storage is the exact plaintext that
+// was supplied — not just that the client call didn't error.
+func TestRemoteStorage_PlaintextChannel_CreateSecret_RealServerRoundTrip(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+
+	cfg := &config.Config{Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"}}}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	ctx := context.Background()
+
+	// Seed a real project/environment directly against the upstream's own core
+	// (bypassing the wire for setup, mirroring the #496/#794 e2e tests' own
+	// pattern) — CreateSecret needs a real environment to validate against.
+	project, err := upstreamCore.CreateProject(ctx, "e2e-plaintext-project", "seeded for #499's e2e test")
+	require.NoError(t, err)
+	envs, err := upstreamCore.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+	envID := envs[0].ID
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: upstreamSrv.URL, APIKey: upstreamToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+	downstream := core.NewKeyorixCore(rs)
+
+	const plaintextValue = "s3cr3t-plaintext-payload-#499"
+
+	var createdSecret *models.SecretNode
+	logOutput := captureLog(t, func() {
+		createdSecret, err = downstream.CreateSecret(ctx, &core.CreateSecretRequest{
+			Name: "e2e-plaintext-secret", Value: []byte(plaintextValue),
+			ProjectID: project.ID, EnvironmentID: envID, Type: "generic", CreatedBy: "e2e-tester",
+		})
+	})
+	require.NoError(t, err, "#499: CreateSecret via storage.type: remote must genuinely succeed against a real server")
+	require.NotNil(t, createdSecret)
+	assert.NotZero(t, createdSecret.ID)
+
+	// The plaintext value must never appear in any log line produced anywhere
+	// along the call path (client, transport, real handler, real core).
+	assert.NotContains(t, logOutput, plaintextValue,
+		"the plaintext secret value must never be logged anywhere along the CreateSecret call path")
+	// Belt-and-braces: nothing resembling the value's distinguishing substring
+	// should leak into logs either.
+	assert.False(t, strings.Contains(logOutput, "s3cr3t-plaintext-payload"),
+		"the plaintext secret value must never be logged, even partially")
+
+	// --- confirm it genuinely landed server-side with the REAL value — not just
+	// that the client call didn't error ---
+	direct, err := upstreamCore.Storage().GetSecret(ctx, createdSecret.ID)
+	require.NoError(t, err, "the secret must be a real row in the upstream's own secret_nodes table")
+	assert.Equal(t, "e2e-plaintext-secret", direct.Name)
+
+	value, err := upstreamCore.GetSecretValue(ctx, createdSecret.ID)
+	require.NoError(t, err, "#499: version 1 must have been created atomically upstream — no separate CreateSecretVersion call should have been needed (or attempted)")
+	assert.Equal(t, plaintextValue, string(value),
+		"#499: the value read back from the upstream's own storage must be the exact plaintext supplied through RemoteStorage.CreateSecret")
+}


### PR DESCRIPTION
## Summary

- `storage.Storage.CreateUser`/`CreateSecret` had no field or argument to carry the plaintext password/secret value at all: `models.User` only ever holds a bcrypt `PasswordHash` (`json:"-"`) by the time `CreateUser` is invoked, and `models.SecretNode` has no value field. The real upstream HTTP handlers need the plaintext (they hash/store it themselves), so even after #496's wire-DTO field-name fix, `RemoteStorage.CreateUser`/`CreateSecret` could never fully succeed against a real server — both always failed the handler's "password"/"value is required" check.
- Fix: add an optional `plaintextPassword`/`plaintextValue` variadic argument to `CreateUser`/`CreateSecret`'s interface signatures. `LocalStorage` ignores it (a no-op — it already has the hash, and the value continues to flow through the existing `CreateSecretVersion` path unchanged); `RemoteStorage` forwards it over the wire (same trusted TLS connection an existing bearer-credential `RemoteStorage` client already uses). A new transient `models.SecretNode.ValueStored` field (`gorm:"-"`, `json:"-"`) signals when `RemoteStorage.CreateSecret` already stored version 1 atomically server-side, so `core.CreateSecret`'s own follow-up `CreateSecretVersion` call is skipped instead of minting a conflicting duplicate version 1.
- Along the way, two more narrow pre-existing gaps were found blocking genuine end-to-end success and fixed the same way (skip a client-side pre-check the remote backend can't perform when it returns `ErrUnsupportedByBackend`, since the upstream's own handler performs the identical check authoritatively): `GetUserByUsername` and `GetEnvironment` are both unimplemented stubs on `RemoteStorage`.
- A separate, WIDER gap was found but deliberately NOT fixed here: `RemoteStorage.GetUserByEmail` targets a route the server never registers at all (`/api/v1/users/by-email/{email}`), so it 404s unconditionally against any real server — used not just by `CreateUser`'s duplicate-email pre-check but by several RBAC/SSO/SCIM lookups elsewhere in `internal/core` (auth.go, rbac.go, scim.go, sso.go, setup_consume.go). Adding a real by-email HTTP endpoint needs its own security review (permission gating, email-enumeration risk, rate limiting) and is left as a new, separate finding rather than folded into this PR.

## Root cause

`core.CreateUser`/`core.CreateSecret` compute/consume the plaintext locally (hash it, or hand it to a separate `CreateSecretVersion` call) before ever calling `storage.Storage.CreateUser`/`CreateSecret` — so the interface methods those calls actually invoke never had a channel to carry the plaintext through to a remote upstream server, which needs it to do its own hashing/storage.

## Fix

- `internal/core/storage/interface.go`: `CreateUser`/`CreateSecret` gain an optional variadic plaintext argument (backward compatible — every existing call site, including ~40 direct test calls, is unaffected).
- `internal/storage/store/local_users.go` / `local_secrets.go`: ignore the new argument (no-op, matches existing behavior exactly).
- `internal/storage/store/remote_users.go` / `remote_secrets.go`: forward the plaintext in the wire request; `CreateSecret` marks the returned node `ValueStored` when a value was actually sent.
- `internal/storage/models/models.go`: new transient `SecretNode.ValueStored` field.
- `internal/core/users.go` / `secrets.go`: pass `req.Password`/`req.Value` through; skip the redundant `CreateSecretVersion` call when `ValueStored`; skip the `GetUserByUsername`/`GetEnvironment` pre-checks when the backend reports `ErrUnsupportedByBackend`, deferring to the upstream's own authoritative check.
- `internal/core/mock_storage_test.go`: signatures updated to match; existing `.On(...)` expectations (2 args) are untouched since the mock doesn't forward the new argument to `m.Called`.

## Verification

- `go build ./...`, `go vet ./...` — clean.
- `go test ./internal/storage/... ./internal/core/... ./server/http/... -count=1` — all pass; also ran the full repo test suite (`go test ./...`) — all pass.
- `gosec -severity medium -exclude-generated ./...` — 0 issues.
- `golangci-lint run` on the touched packages — 0 issues.
- New end-to-end tests in `server/http/remote_storage_plaintext_channel_test.go`, following the #803/#794 pattern (a real `NewRouter` upstream, a real `RemoteStorage` client):
  - `TestRemoteStorage_PlaintextChannel_CreateSecret_RealServerRoundTrip`: drives the FULL `core.CreateSecret` business path over `storage.type: remote` end-to-end — genuinely succeeds, and the plaintext value read back from the upstream's own storage matches exactly what was sent (proving version 1 was created atomically upstream, with no redundant/conflicting client-side `CreateSecretVersion` call).
  - `TestRemoteStorage_PlaintextChannel_CreateUser_RealServerRoundTrip`: proves the fix at the `RemoteStorage.CreateUser` layer directly (the full `core.CreateUser` flow is separately blocked by the `GetUserByEmail` gap described above) — creates a real user with a genuinely usable password, verified via `bcrypt.CompareHashAndPassword` against the upstream's own stored hash AND a real login.
  - Both tests capture and assert against global `log` output to prove the plaintext password/value never appears in any log line anywhere along the call path.
  - Updated the pre-existing `#496` field-mismatch tests (`remote_storage_field_mismatch_test.go`) to reflect the new (correct) wire shape when no plaintext is supplied.

This closes #496's residual annotation and #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)