### PR TITLE
fix(remote-storage): surface the server's structured error on 4xx/5xx instead of a generic HTTP status string (#501)

### DIFF
--- a/internal/storage/remote/client.go
+++ b/internal/storage/remote/client.go
@@ -258,6 +258,29 @@ func (c *HTTPClient) makeRequest(ctx context.Context, method, path string, body 
 		return &APIResponse{Success: true}, nil
 	}
 
+	// Any 4xx/5xx status is unconditionally a failure (#501): parse the body
+	// for the server's actual structured error detail and return it as an
+	// error, rather than sometimes returning a "successful round trip with
+	// Success:false" *APIResponse (the old behavior when the body didn't
+	// unmarshal into APIResponse — which is the common case for THIS server,
+	// since sendError's "error" field is a bare type string, not the nested
+	// object APIResponse.Error expects, so json.Unmarshal always failed and
+	// the real code/message were discarded into an opaque "HTTP 404: 404 Not
+	// Found" string). Every remote_*.go call site checks `err != nil` before
+	// ever touching the response (verified across all ~60 call sites), so
+	// collapsing onto the error return is safe and gives every caller ONE
+	// consistent failure signal for what is really the same class of failure.
+	//
+	// This also fixes a latent circuit-breaker bug: previously, a real 4xx/5xx
+	// response (which never unmarshaled into APIResponse) came back as
+	// (resp, nil) from makeRequest, and Request() treated a nil error as a
+	// SUCCESSFUL round trip — calling c.resetFailureCount() instead of
+	// c.recordFailure(). The circuit breaker could never open against a real
+	// server returning persistent 5xx errors.
+	if resp.StatusCode >= 400 {
+		return nil, newHTTPError(resp.StatusCode, resp.Status, respBody)
+	}
+
 	var apiResp APIResponse
 	if err := json.Unmarshal(respBody, &apiResp); err != nil {
 		// If we can't parse as API response, create a generic error
@@ -269,20 +292,6 @@ func (c *HTTPClient) makeRequest(ctx context.Context, method, path string, body 
 				Details: string(respBody),
 			},
 		}, nil
-	}
-
-	// Check for HTTP errors
-	if resp.StatusCode >= 400 {
-		if apiResp.Error == nil {
-			apiResp.Error = &APIError{
-				Code:    fmt.Sprintf("HTTP_%d", resp.StatusCode),
-				Message: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, resp.Status),
-			}
-		}
-		// Return a typed status error so isRetryableError can distinguish a
-		// transient server-side failure (worth retrying) from a client error like
-		// 401/403/404 (retrying can never succeed — the request itself is wrong).
-		return nil, &httpStatusError{StatusCode: resp.StatusCode, Status: resp.Status}
 	}
 
 	// #314: a 2xx/3xx upstream response can still carry Success:false with no
@@ -301,15 +310,111 @@ func (c *HTTPClient) makeRequest(ctx context.Context, method, path string, body 
 	return &apiResp, nil
 }
 
-// httpStatusError carries the upstream HTTP status so isRetryableError can
-// distinguish a transient server failure from a client error (#317).
-type httpStatusError struct {
-	StatusCode int
-	Status     string
+// serverErrorBody mirrors the JSON shape sendError actually writes
+// (server/http/handlers/helpers.go): a flat object with a short
+// machine-readable "error" type string (e.g. "NotFound", "ValidationError",
+// "ConflictError"), not the nested {"error": {"code":...,"message":...}}
+// shape APIResponse.Error/APIError models. That mismatch is why
+// json.Unmarshal(respBody, &APIResponse{}) always failed with a type error
+// for a real 4xx/5xx response from this server, discarding the server's
+// actual code/message/details (#501).
+type serverErrorBody struct {
+	Success bool            `json:"success"`
+	Error   string          `json:"error"`
+	Message string          `json:"message"`
+	Code    int             `json:"code"`
+	Details json.RawMessage `json:"details,omitempty"`
 }
 
-func (e *httpStatusError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Status)
+// HTTPError is returned by makeRequest for every 4xx/5xx HTTP response. It
+// carries the server's actual structured error type/message when the body
+// parses — as either the flat shape sendError emits (the common case against
+// this codebase's own server) or, defensively, the nested
+// {"error":{"code","message","details"}} shape in case some other upstream
+// emits that instead — rather than collapsing every distinct failure mode
+// (not found vs. validation vs. permission denied vs. rate limited) into an
+// identical generic "HTTP 404: 404 Not Found" string.
+//
+// Callers that need to distinguish specific outcomes should use
+// errors.As(err, &httpErr) and branch on StatusCode/ErrorType (or the
+// IsNotFound helper) instead of string-matching Error().
+type HTTPError struct {
+	StatusCode int
+	Status     string
+	ErrorType  string // e.g. "NotFound", "ValidationError", "ConflictError"; empty if unavailable
+	Message    string
+	Details    string
+}
+
+// newHTTPError builds an HTTPError for a 4xx/5xx response, extracting
+// whatever structured detail the body actually contains. It never panics and
+// always returns a non-nil, usable error, even for an empty or non-JSON body
+// (e.g. a proxy/WAF interstitial or a plain-text upstream error page) — the
+// raw body is preserved in Details rather than silently dropped.
+func newHTTPError(statusCode int, status string, body []byte) *HTTPError {
+	e := &HTTPError{StatusCode: statusCode, Status: status}
+
+	var flat serverErrorBody
+	if err := json.Unmarshal(body, &flat); err == nil && (flat.Error != "" || flat.Message != "") {
+		e.ErrorType = flat.Error
+		e.Message = flat.Message
+		e.Details = rawJSONToString(flat.Details)
+		return e
+	}
+
+	// Defensive fallback: some upstream might emit the nested APIResponse.Error
+	// shape instead of the flat sendError shape.
+	var nested APIResponse
+	if err := json.Unmarshal(body, &nested); err == nil && nested.Error != nil {
+		e.ErrorType = nested.Error.Code
+		e.Message = nested.Error.Message
+		e.Details = nested.Error.Details
+		return e
+	}
+
+	// Body didn't parse as either known shape (empty, non-JSON, or an
+	// unrelated JSON document) — preserve the raw text as Details rather than
+	// pretending it's a structured error.
+	e.Details = string(body)
+	return e
+}
+
+// rawJSONToString renders a json.RawMessage as plain text: unwraps a JSON
+// string to its literal value, otherwise falls back to the raw JSON text
+// (e.g. an object/array details payload).
+func rawJSONToString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return string(raw)
+}
+
+func (e *HTTPError) Error() string {
+	switch {
+	case e.ErrorType != "" && e.Message != "":
+		if e.Details != "" {
+			return fmt.Sprintf("%s: %s (%s)", e.ErrorType, e.Message, e.Details)
+		}
+		return fmt.Sprintf("%s: %s", e.ErrorType, e.Message)
+	case e.Message != "":
+		return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Message)
+	case e.Details != "":
+		return fmt.Sprintf("HTTP %d: %s: %s", e.StatusCode, e.Status, e.Details)
+	default:
+		return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Status)
+	}
+}
+
+// IsNotFound reports whether the server identified this failure as a
+// not-found condition. Checked against the actual HTTP status rather than
+// ErrorType text, since handler-chosen ErrorType strings aren't a guaranteed-
+// stable API contract — callers should prefer this over matching Error() text.
+func (e *HTTPError) IsNotFound() bool {
+	return e.StatusCode == http.StatusNotFound
 }
 
 // isRetryableError determines whether a failed request is worth retrying
@@ -326,9 +431,9 @@ func isRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
-	var statusErr *httpStatusError
-	if errors.As(err, &statusErr) {
-		return statusErr.StatusCode >= 500 || statusErr.StatusCode == http.StatusTooManyRequests
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode >= 500 || httpErr.StatusCode == http.StatusTooManyRequests
 	}
 	msg := err.Error()
 	if strings.Contains(msg, "failed to marshal request body") || strings.Contains(msg, "failed to create request") {

--- a/internal/storage/remote/client_test.go
+++ b/internal/storage/remote/client_test.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -235,8 +236,15 @@ func TestHTTPClient_RetryLogic(t *testing.T) {
 	assert.Equal(t, 3, attemptCount) // Should have retried 3 times
 }
 
+// TestHTTPClient_CircuitBreaker was previously skipped as flaky/"needs
+// debugging". Root cause (#501): a real 5xx from an httptest server with an
+// empty body never unmarshaled into APIResponse, so makeRequest returned
+// (resp, nil) — a nil error — and Request() treated that as a SUCCESSFUL
+// round trip, calling c.resetFailureCount() instead of c.recordFailure(). The
+// circuit breaker's failureCount could never accumulate against a real
+// server, so it never opened. Fixed by unconditionally treating every 4xx/5xx
+// status as an error (see makeRequest), which is now enabled.
 func TestHTTPClient_CircuitBreaker(t *testing.T) {
-	t.Skip("Circuit breaker test needs debugging - skipping for now")
 	// Create a test server that always fails
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -399,6 +407,202 @@ func TestAPIError_ErrorMethod_NilSafe(t *testing.T) {
 	})
 }
 
+// TestHTTPClient_4xx_ParsesFlatSendErrorEnvelope pins #501: a 4xx/5xx response
+// whose body matches the ACTUAL shape server/http/handlers/helpers.go's
+// sendError writes — a flat object with a bare "error" type string, not the
+// nested {"error":{"code":...}} shape APIResponse.Error models — must surface
+// the real ErrorType/Message/Details via *HTTPError, not a generic
+// "HTTP 404: 404 Not Found" string. Before the fix, json.Unmarshal into
+// APIResponse failed on this exact shape (string into a struct field) and the
+// real detail was discarded.
+func TestHTTPClient_4xx_ParsesFlatSendErrorEnvelope(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantType   string
+		wantMsg    string
+	}{
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			body:       `{"success":false,"error":"NotFound","message":"User not found","code":404}`,
+			wantType:   "NotFound",
+			wantMsg:    "User not found",
+		},
+		{
+			name:       "validation failure",
+			statusCode: http.StatusBadRequest,
+			body:       `{"success":false,"error":"ValidationError","message":"Invalid request data","code":400,"details":"name is required"}`,
+			wantType:   "ValidationError",
+			wantMsg:    "Invalid request data",
+		},
+		{
+			name:       "conflict",
+			statusCode: http.StatusConflict,
+			body:       `{"success":false,"error":"ConflictError","message":"Group name already exists","code":409}`,
+			wantType:   "ConflictError",
+			wantMsg:    "Group name already exists",
+		},
+		{
+			name:       "permission denied",
+			statusCode: http.StatusForbidden,
+			body:       `{"success":false,"error":"Forbidden","message":"insufficient permissions","code":403}`,
+			wantType:   "Forbidden",
+			wantMsg:    "insufficient permissions",
+		},
+		{
+			name:       "rate limited",
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"success":false,"error":"RateLimited","message":"too many requests","code":429}`,
+			wantType:   "RateLimited",
+			wantMsg:    "too many requests",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(c.statusCode)
+				_, _ = w.Write([]byte(c.body))
+			}))
+			defer server.Close()
+
+			client, err := NewHTTPClient(&Config{
+				BaseURL: server.URL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 1, TLSVerify: false,
+			})
+			require.NoError(t, err)
+
+			_, err = client.Get(context.Background(), "/test")
+			require.Error(t, err)
+
+			var httpErr *HTTPError
+			require.True(t, errors.As(err, &httpErr), "error must unwrap to *HTTPError")
+			assert.Equal(t, c.statusCode, httpErr.StatusCode)
+			assert.Equal(t, c.wantType, httpErr.ErrorType)
+			assert.Equal(t, c.wantMsg, httpErr.Message)
+			assert.NotEqual(t, fmt.Sprintf("HTTP %d: %d %s", c.statusCode, c.statusCode, http.StatusText(c.statusCode)), err.Error())
+		})
+	}
+}
+
+// TestHTTPClient_4xx_NestedErrorShape_StillParses is the defensive-fallback
+// half of #501: if some OTHER upstream (not this codebase's own sendError)
+// emits the nested {"error":{"code","message","details"}} shape that
+// APIResponse.Error/APIError already models, that structured detail must
+// still be extracted rather than only supporting the flat shape.
+func TestHTTPClient_4xx_NestedErrorShape_StillParses(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "SERVICE_UNAVAILABLE", "message": "unavailable", "details": "db down"},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(&Config{
+		BaseURL: server.URL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 1, TLSVerify: false,
+	})
+	require.NoError(t, err)
+
+	_, err = client.Get(context.Background(), "/test")
+	require.Error(t, err)
+
+	var httpErr *HTTPError
+	require.True(t, errors.As(err, &httpErr))
+	assert.Equal(t, http.StatusServiceUnavailable, httpErr.StatusCode)
+	assert.Equal(t, "SERVICE_UNAVAILABLE", httpErr.ErrorType)
+	assert.Equal(t, "unavailable", httpErr.Message)
+	assert.Equal(t, "db down", httpErr.Details)
+}
+
+// TestHTTPClient_4xx_MalformedNonJSONBody_DegradesGracefully pins requirement
+// (b): a 4xx/5xx response with a body that ISN'T JSON at all (e.g. a
+// proxy/WAF interstitial, an nginx default error page, a plain-text upstream
+// error) must not panic and must still produce a usable, non-empty error —
+// falling back to the raw status/body instead of silently dropping it.
+func TestHTTPClient_4xx_MalformedNonJSONBody_DegradesGracefully(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("<html><body>502 Bad Gateway</body></html>"))
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(&Config{
+		BaseURL: server.URL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 1, TLSVerify: false,
+	})
+	require.NoError(t, err)
+
+	var got error
+	assert.NotPanics(t, func() {
+		_, got = client.Get(context.Background(), "/test")
+	})
+	require.Error(t, got)
+
+	var httpErr *HTTPError
+	require.True(t, errors.As(got, &httpErr))
+	assert.Equal(t, http.StatusBadGateway, httpErr.StatusCode)
+	assert.Empty(t, httpErr.ErrorType, "a non-JSON body has no structured error type to extract")
+	assert.Contains(t, httpErr.Details, "502 Bad Gateway", "the raw body must be preserved, not silently dropped")
+	assert.NotPanics(t, func() { _ = got.Error() })
+}
+
+// TestHTTPClient_4xx_EmptyBody_DegradesGracefully covers a 4xx/5xx status with
+// a genuinely empty body (no JSON, no text at all) — must not panic and must
+// still carry the HTTP status in the resulting error.
+func TestHTTPClient_4xx_EmptyBody_DegradesGracefully(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(&Config{
+		BaseURL: server.URL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 1, TLSVerify: false,
+	})
+	require.NoError(t, err)
+
+	var got error
+	assert.NotPanics(t, func() {
+		_, got = client.Get(context.Background(), "/test")
+	})
+	require.Error(t, got)
+
+	var httpErr *HTTPError
+	require.True(t, errors.As(got, &httpErr))
+	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+	assert.NotPanics(t, func() { _ = got.Error() })
+}
+
+// TestHTTPClient_NetworkUnreachable_DegradesGracefully pins the other half of
+// requirement (b): a genuine network-level failure (the server is
+// unreachable entirely, not merely returning an error status) must not panic
+// and must still surface a sensible, non-empty error.
+func TestHTTPClient_NetworkUnreachable_DegradesGracefully(t *testing.T) {
+	// Bind and immediately close a listener so the port is refusing
+	// connections deterministically (no real service behind it).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	unreachableURL := server.URL
+	server.Close()
+
+	client, err := NewHTTPClient(&Config{
+		BaseURL: unreachableURL, APIKey: "test-key", TimeoutSeconds: 2, RetryAttempts: 1, TLSVerify: false,
+	})
+	require.NoError(t, err)
+
+	var got error
+	assert.NotPanics(t, func() {
+		_, got = client.Get(context.Background(), "/test")
+	})
+	require.Error(t, got)
+	assert.NotPanics(t, func() { _ = got.Error() })
+
+	// A pure network failure is NOT a structured HTTPError (there is no HTTP
+	// response at all to parse a status/body from).
+	var httpErr *HTTPError
+	assert.False(t, errors.As(got, &httpErr), "a connection-refused failure has no HTTP response to build an HTTPError from")
+}
+
 func TestHTTPClient_Timeout(t *testing.T) {
 	// Create a test server that delays response
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -438,11 +642,11 @@ func TestIsRetryableError(t *testing.T) {
 		want bool
 	}{
 		{"nil", nil, false},
-		{"5xx is retryable", &httpStatusError{StatusCode: http.StatusInternalServerError}, true},
-		{"429 is retryable", &httpStatusError{StatusCode: http.StatusTooManyRequests}, true},
-		{"401 is not retryable", &httpStatusError{StatusCode: http.StatusUnauthorized}, false},
-		{"403 is not retryable", &httpStatusError{StatusCode: http.StatusForbidden}, false},
-		{"404 is not retryable", &httpStatusError{StatusCode: http.StatusNotFound}, false},
+		{"5xx is retryable", &HTTPError{StatusCode: http.StatusInternalServerError}, true},
+		{"429 is retryable", &HTTPError{StatusCode: http.StatusTooManyRequests}, true},
+		{"401 is not retryable", &HTTPError{StatusCode: http.StatusUnauthorized}, false},
+		{"403 is not retryable", &HTTPError{StatusCode: http.StatusForbidden}, false},
+		{"404 is not retryable", &HTTPError{StatusCode: http.StatusNotFound}, false},
 		{"marshal error is not retryable", fmt.Errorf("failed to marshal request body: boom"), false},
 		{"request-construction error is not retryable", fmt.Errorf("failed to create request: boom"), false},
 		{"generic network error is retryable", fmt.Errorf("request failed: connection refused"), true},

--- a/server/http/remote_storage_error_envelope_test.go
+++ b/server/http/remote_storage_error_envelope_test.go
@@ -1,0 +1,79 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteStorage_404_SurfacesStructuredError proves the fix for #501: a
+// genuine 404 from a REAL production handler (server/http/handlers.GetUser,
+// via sendError) must surface the server's actual structured error type and
+// message through store.RemoteStorage/internal/storage/remote.HTTPClient,
+// instead of the old generic "HTTP 404: 404 Not Found" string that discarded
+// the parsed JSON error envelope on every 4xx/5xx response.
+//
+// This talks to an ACTUAL httptest-backed NewRouter(...) instance (the same
+// pattern as TestRemoteStorage_SuccessFieldFix_RealServerRoundTrip, #794) —
+// not a hand-rolled mock server standing in for the wire shape — so it also
+// pins the real wire format sendError emits (a flat {"error":"<type
+// string>","message":...} object, not the nested {"error":{"code":...}}
+// shape internal/storage/remote.APIError models).
+func TestRemoteStorage_404_SurfacesStructuredError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+
+	// A user ID that genuinely does not exist on the real upstream — this hits
+	// handlers.GetUser -> sendError(w, "NotFound", "User not found", 404, nil).
+	const nonExistentUserID = 999999
+	_, err = rs.GetUser(context.Background(), nonExistentUserID)
+	require.Error(t, err)
+
+	var httpErr *remote.HTTPError
+	require.True(t, errors.As(err, &httpErr),
+		"GetUser's error must unwrap to *remote.HTTPError so callers can type-assert instead of string-matching; got: %v", err)
+
+	assert.Equal(t, 404, httpErr.StatusCode)
+	assert.True(t, httpErr.IsNotFound())
+	assert.Equal(t, "NotFound", httpErr.ErrorType,
+		"the real handler's structured error type ('NotFound') must survive, not be discarded")
+	assert.Equal(t, "User not found", httpErr.Message,
+		"the real handler's structured error message must survive, not be replaced with a generic HTTP status string")
+
+	// The old, pre-fix failure mode: the ONLY information reaching the caller
+	// was a generic status-line string. Confirm that's no longer all we get —
+	// the real message must appear in Error() text too.
+	assert.Contains(t, err.Error(), "User not found")
+	assert.NotEqual(t, "HTTP 404: 404 Not Found", err.Error(),
+		"the structured server error must not collapse into the old generic HTTP-status-only string")
+}


### PR DESCRIPTION
## Summary

Fixes backlog finding #501 (MEDIUM): the shared remote-storage HTTP client (`internal/storage/remote/client.go`) discarded the server's actual structured error for every 4xx/5xx response.

## Root cause

Worse than the backlog description assumed: the real server-side error envelope (`sendError` in `server/http/handlers/helpers.go`) writes a **flat** JSON body — `{"success":false,"error":"NotFound","message":"User not found","code":404}` — where `"error"` is a bare type string, not the nested `{"error":{"code","message"}}` object the client's `APIResponse`/`APIError` expected. That mismatch made `json.Unmarshal` **always fail** for any real 4xx/5xx response, so the client's "can't parse" fallback silently replaced the real code/message with a generic `"HTTP 404: 404 Not Found"` — and because that fallback returned `(resp, nil)` with no error, `Request()` treated the failed call as a *successful* round trip, calling `resetFailureCount()` instead of `recordFailure()`. This meant the circuit breaker could never open against a real server returning persistent 5xx errors (exactly why `TestHTTPClient_CircuitBreaker` had been `t.Skip`'d as "needs debugging").

## Fix

- Any `resp.StatusCode >= 400` is now unconditionally treated as a Go `error`, never a "successful" `*APIResponse` with `Success:false`.
- Added exported `HTTPError{StatusCode, Status, ErrorType, Message, Details}` and `newHTTPError(...)`, which parses the real flat `sendError` shape first, falls back to the nested shape defensively, and finally falls back to raw body text — never panicking.
- `HTTPError` implements `error` and supports `errors.As`; added `IsNotFound()` so callers can branch on status instead of string-matching.
- Replaced the old unexported `httpStatusError` with `HTTPError` throughout; `isRetryableError` updated accordingly.
- Checked all ~61 `remote_*.go` call sites — every one checks `err != nil` before touching the response, so collapsing onto the error return is safe.

Checked for fragile string-matching against RemoteStorage's error text: the only matches (`internal/core/sso.go`, `scim.go`, `users.go`, `setup_consume.go`) match local-storage's i18n text and were already non-functional for `storage.type: remote` before this change — untouched by this fix, but a separate pre-existing gap worth a future look.

## Testing

- `internal/storage/remote/client_test.go`: table test parsing the real flat `sendError` shape (NotFound/ValidationError/ConflictError/Forbidden/RateLimited), nested-shape fallback, malformed non-JSON body, empty 4xx/5xx body, network-unreachable — all proving no panic and graceful degradation. Un-skipped `TestHTTPClient_CircuitBreaker` (now passes, since the circuit breaker can finally observe real failures).
- `server/http/remote_storage_error_envelope_test.go` (new): end-to-end test against a real `NewRouter`-backed server hitting the real `GetUser` 404 handler, proving `errors.As` recovers `ErrorType:"NotFound"`/`Message:"User not found"` instead of a generic string.

## Verification

- `go build ./...` — clean
- `go test ./internal/storage/... ./server/http/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./internal/storage/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)