### PR TITLE
docs: add CONTRIBUTING.md and enforce DCO sign-off on PRs

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,65 @@
+name: DCO
+
+on:
+  pull_request:
+    branches: [main]
+
+# Read-only: this job only inspects commit metadata already in the PR, it
+# never needs to write anything.
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Fetch exactly enough history to see every commit in this PR (plus
+          # one, for the merge-base) — NOT fetch-depth: 0. A full-history fetch
+          # pulls every OTHER branch in the repo too (actions/checkout's own
+          # documented behavior), which is unrelated noise for a check that
+          # only needs this PR's own commit range.
+          fetch-depth: ${{ github.event.pull_request.commits + 1 }}
+
+      # Self-contained check (no third-party Action/GitHub App) — mirrors this
+      # repo's existing preference for pinned binaries/inline scripts over
+      # marketplace dependencies (see gitleaks/gosec in ci.yml). Verifies every
+      # non-merge commit in the PR carries a `Signed-off-by:` trailer whose
+      # email matches that commit's own author email (the standard DCO 1.1
+      # check, https://developercertificate.org/) — i.e. `git commit -s`.
+      - name: Check DCO sign-off
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          fail=0
+          for sha in $(git rev-list --no-merges "$base..$head"); do
+            author_email="$(git log -1 --format=%ae "$sha")"
+            msg="$(git log -1 --format=%B "$sha")"
+            found=0
+            while IFS= read -r line; do
+              case "$line" in
+                "Signed-off-by:"*)
+                  email="$(printf '%s' "$line" | sed -n 's/.*<\(.*\)>.*/\1/p')"
+                  email_lc="$(printf '%s' "$email" | tr '[:upper:]' '[:lower:]')"
+                  author_lc="$(printf '%s' "$author_email" | tr '[:upper:]' '[:lower:]')"
+                  if [ "$email_lc" = "$author_lc" ]; then
+                    found=1
+                  fi
+                  ;;
+              esac
+            done <<EOF
+          $msg
+          EOF
+            if [ "$found" -eq 0 ]; then
+              echo "::error::Commit $sha ($author_email) has no matching Signed-off-by trailer."
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "Every commit needs a Signed-off-by trailer matching its author email (DCO, https://developercertificate.org/) — see CONTRIBUTING.md."
+            echo "Fix a single commit:   git commit --amend -s --no-edit"
+            echo "Fix multiple commits:  git rebase --exec 'git commit --amend --no-edit -s' <base-branch>"
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to Keyorix
+
+Thanks for considering a contribution.
+
+## Before you start
+
+- **Security issues**: do not open a public issue or PR. See
+  [SECURITY.md](SECURITY.md) for the private disclosure process.
+- **Bigger changes**: open an issue first to discuss the approach, especially
+  for anything touching encryption/key management (see
+  [SECURITY.md](SECURITY.md) — those changes need a written ADR before
+  implementation) or authentication/authorization.
+- **License**: everything in this repository is AGPL-3.0 (see
+  [LICENSE](LICENSE) / [LICENSING.md](LICENSING.md)). Your contribution will
+  be under the same license.
+
+## Developer Certificate of Origin (DCO)
+
+Every commit must be signed off, certifying you wrote it (or otherwise have
+the right to submit it) under the
+[Developer Certificate of Origin](https://developercertificate.org/):
+
+```
+git commit -s -m "your commit message"
+```
+
+This adds a `Signed-off-by: Your Name <you@example.com>` trailer to the
+commit, matching your git author identity — nothing more. A CI check
+(`.github/workflows/dco.yml`) verifies every commit in a PR has one; PRs
+without it won't pass CI. If you forgot:
+
+```
+git commit --amend -s --no-edit                              # last commit only
+git rebase --exec 'git commit --amend --no-edit -s' <base>    # every commit since <base>
+```
+
+## Making a change
+
+1. Fork (or branch, if you have write access) and make your change.
+2. Run the checks locally before opening a PR — CI enforces all of these:
+   ```
+   make ci          # go vet + go test -race + gosec + govulncheck + build
+   golangci-lint run ./...
+   ```
+   For a change touching `operator/` (its own Go module):
+   ```
+   cd operator && GOWORK=off go vet ./... && GOWORK=off go test ./...
+   ```
+3. Add a test that fails without your change and passes with it — this is a
+   hard requirement for anything security-relevant (see
+   [docs/compliance/SECURITY-VERIFICATION.md](docs/compliance/SECURITY-VERIFICATION.md)
+   for what that verification standard looks like in practice).
+4. Open a PR against `main`. CI must pass in full before it can merge
+   (branch protection enforces this — there's no bypass, including for
+   maintainers).
+
+## What CI checks
+
+- `go vet`, `go build`, `go test -race` (full suite)
+- `gosec` (medium+ severity) and `golangci-lint`
+- `govulncheck` against known vulnerabilities in dependencies
+- `gitleaks` (full history of the PR's own commits)
+- `CodeQL` (dataflow/taint analysis, both Go modules)
+- Helm chart lint + schema validation (`kubeconform`) for all three charts
+- DCO sign-off on every commit
+
+## Code style
+
+`gofmt` and `golangci-lint` are the source of truth — there's no separate
+style guide to read. If the linter's happy, the style's right.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,10 +71,15 @@ when they ship. Until then, download releases only from
 - Pre-commit gates: `gofmt`, `go vet`, `go build`, `gosec` (MEDIUM+ severity)
 - CI gates on every push and pull request: `go vet`, race-enabled tests,
   `govulncheck`, `gosec` (pinned version), `golangci-lint` (errcheck, staticcheck,
-  unused, and more), `gitleaks` full-history secret scan
+  unused, and more), `gitleaks` secret scan (scoped to the PR's own commit
+  history), `CodeQL` (dataflow/taint analysis, both Go modules), Helm chart
+  schema validation
 - Any change to the encryption layer requires a written Architecture Decision
   Record before implementation
-- External contributions require a signed CLA and maintainer review
+- External contributions require DCO sign-off (`git commit -s` — see
+  [CONTRIBUTING.md](CONTRIBUTING.md)) and maintainer review. Branch protection
+  on `main` requires every CI check to pass (enforced for maintainers too,
+  no bypass) before a PR can merge.
 
 ## Security-Relevant Configuration
 


### PR DESCRIPTION
## Summary
- `SECURITY.md` said external contributions need "a signed CLA" but nothing existed to define or enforce one.
- Given Keyorix's dual-license model (AGPL + commercial, see `LICENSING.md`), a bare DCO doesn't grant the additional relicensing right a full CLA would — **accepted deliberately**: external contributions stay AGPL-only; any future commercial relicensing of a specific contribution gets negotiated with that contributor separately, rather than requiring every contributor to sign a legal document up front just to open a PR.
- Adds `CONTRIBUTING.md` (PR process, local-check commands, DCO explanation).
- Adds `.github/workflows/dco.yml` — a self-contained check (no third-party Action/App) verifying every non-merge commit in a PR carries a `Signed-off-by` trailer matching its author email. Fetches only the PR's own commit range (`github.event.pull_request.commits + 1`), not `fetch-depth: 0` — avoiding the same all-branches-scan issue #806 fixed for gitleaks.
- Updates `SECURITY.md`'s CLA mention to DCO, and notes branch protection now enforces all CI checks with no maintainer bypass.
- This commit itself is DCO-signed, as the first example.

## Test plan
- [x] Verified the DCO-check bash logic locally against a scratch repo: correctly rejects an unsigned commit, correctly rejects a commit signed by someone other than its author, correctly accepts a properly-signed commit
- [x] YAML syntax validated
- [ ] Confirm the new `DCO` check itself runs and passes on this PR (its own commits are all signed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)