### PR TITLE
ci(helm): add checkov IaC security-policy scan for the 3 Helm charts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ env:
   GITLEAKS_LINUX_X64_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
   KUBECONFORM_VERSION: 0.8.0
   KUBECONFORM_LINUX_AMD64_SHA256: 9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883
+  # Pinned pyinstaller binary release (not `pip install`, so the scanner brings no
+  # Python/pip dependency-resolution surface of its own). checkov publishes no
+  # official checksums file, so this hash was computed locally from the release
+  # asset and pinned here, matching the gitleaks/kubeconform convention above.
+  CHECKOV_VERSION: 3.3.6
+  CHECKOV_LINUX_X64_SHA256: 0b4f043603225acc55812d896233c98fdfe13e8de31dbbcb18edc669812fb667
 
 jobs:
   build-and-test:
@@ -280,3 +286,73 @@ jobs:
           if ! grep -q -- '-watch-namespaces=team-a,team-b' scoped-render.yaml; then
             echo "expected the -watch-namespaces flag on the manager Deployment"; exit 1
           fi
+
+  # helm-chart (above) validates chart/schema *shape* (helm lint + kubeconform
+  # against the Kubernetes API schema) but asserts nothing about security
+  # *policy* -- it would not catch e.g. a future PR accidentally dropping
+  # `readOnlyRootFilesystem: true` or `allowPrivilegeEscalation: false` from a
+  # pod security context, or a chart that starts granting wildcard/escalate RBAC.
+  # This job closes that gap by running checkov's Kubernetes policy checks
+  # against the same rendered chart output.
+  helm-chart-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: Install checkov
+        run: |
+          # Pinned version + checksum-verified before extraction (#115) -- see the
+          # CHECKOV_VERSION/CHECKOV_LINUX_X64_SHA256 comment in the env block above.
+          curl -fsSLO "https://github.com/bridgecrewio/checkov/releases/download/${CHECKOV_VERSION}/checkov_linux_X86_64.zip"
+          echo "${CHECKOV_LINUX_X64_SHA256}  checkov_linux_X86_64.zip" | sha256sum -c -
+          unzip -q checkov_linux_X86_64.zip -d checkov_dist
+          echo "$PWD/checkov_dist/dist" >> "$GITHUB_PATH"
+
+      - name: Render all 3 charts
+        run: |
+          # Reuses the same --set values as the helm-chart job's renders, so this
+          # job scans exactly what that job already proved schema-valid.
+          helm template kx deploy/helm/keyorix \
+            --set auth.masterPassword=ci --set postgresql.auth.password=ci \
+            --set auth.adminPassword=ci --set ingress.enabled=true > keyorix-render.yaml
+          helm template kx deploy/helm/keyorix-k8s-sync \
+            --set keyorix.url=https://k --set keyorix.tokenSecret.name=tok \
+            --set mappings[0].ref=e/n --set mappings[0].namespace=app \
+            --set mappings[0].name=s --set mappings[0].key=K \
+            --set targetNamespaces='{app,web}' > k8s-sync-render.yaml
+          helm template kx deploy/helm/keyorix-operator > operator-render.yaml
+
+      - name: checkov (pod security + RBAC-escalation policy scan)
+        run: |
+          # Scoped to the hardening properties this repo has already committed to
+          # (non-root, dropped capabilities, read-only rootfs, no privilege
+          # escalation, seccomp, no privileged/hostPID/hostIPC/hostNetwork
+          # containers) plus the RBAC-escalation family named in the background
+          # for this job (wildcard rules, escalate/bind, CSR-approval, webhook
+          # control, default-SA binding) -- NOT checkov's full default Kubernetes
+          # ruleset, which also flags missing resource limits/probes/image pull
+          # policy/etc. Those aren't regressions in anything hardened today and
+          # would just be alert-fatigue noise (a scanner nobody trusts because
+          # it's noisy is worse than no scanner).
+          #
+          # Deliberately excluded after reading their check source, not blind
+          # suppression:
+          #   CKV_K8S_35 ("prefer secret-as-file over secretKeyRef env vars")
+          #     directly contradicts this repo's own #137 fix, which *moved to*
+          #     secretKeyRef env vars as the hardening step -- enabling it would
+          #     permanently flag an intentional, already-reviewed decision.
+          #   CKV_K8S_40 ("runAsUser >= 10000") conflicts with the fixed,
+          #     image-matched UIDs already documented in the deployment templates
+          #     (1001 server, 101 nginx, 999 postgres, 65532 distroless).
+          #
+          # --framework kubernetes: restricts the scan to K8s policy checks only,
+          # skipping checkov's separate secrets-framework (gitleaks above already
+          # covers secret scanning across full git history; these rendered files
+          # are CI-only artifacts, not committed content, and contain only the
+          # placeholder `ci` password values passed via --set above).
+          CHECKS="CKV_K8S_16,CKV_K8S_17,CKV_K8S_18,CKV_K8S_19,CKV_K8S_20,CKV_K8S_22,CKV_K8S_23,CKV_K8S_28,CKV_K8S_31,CKV_K8S_37,CKV_K8S_42,CKV_K8S_49,CKV_K8S_155,CKV_K8S_156,CKV_K8S_157,CKV_K8S_158"
+          checkov --framework kubernetes --compact --check "$CHECKS" \
+            -f keyorix-render.yaml -f k8s-sync-render.yaml -f operator-render.yaml

--- a/deploy/helm/keyorix/templates/postgresql.yaml
+++ b/deploy/helm/keyorix/templates/postgresql.yaml
@@ -41,6 +41,14 @@ metadata:
   labels:
     {{- include "keyorix.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgresql
+  annotations:
+    # checkov (helm-chart-security CI job): postgres needs a writable root
+    # filesystem for its unix socket (/var/run/postgresql) and temp files outside
+    # the PVC-backed data directory -- the container is otherwise fully hardened
+    # (allowPrivilegeEscalation: false, capabilities dropped, non-root uid 999,
+    # seccomp RuntimeDefault at the pod level), so only this one property is
+    # suppressed, not the whole check family.
+    checkov.io/skip1: CKV_K8S_22=postgres requires a writable root filesystem for its socket/temp files
 spec:
   replicas: 1
   strategy:

--- a/deploy/helm/keyorix/templates/server-deployment.yaml
+++ b/deploy/helm/keyorix/templates/server-deployment.yaml
@@ -40,7 +40,6 @@ spec:
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           ports:

--- a/deploy/helm/keyorix/templates/server-deployment.yaml
+++ b/deploy/helm/keyorix/templates/server-deployment.yaml
@@ -40,6 +40,7 @@ spec:
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           ports:

--- a/deploy/helm/keyorix/templates/tests/test-connection.yaml
+++ b/deploy/helm/keyorix/templates/tests/test-connection.yaml
@@ -9,6 +9,13 @@ metadata:
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 spec:
   restartPolicy: Never
+  securityContext:
+    # A plain `wget --spider` needs no elevated privileges at all -- matches the
+    # same hardening baseline as the application's own containers (#helm-chart-security).
+    runAsNonRoot: true
+    runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: health
       image: busybox:1.36
@@ -17,3 +24,8 @@ spec:
         - "--spider"
         - "-S"
         - "http://{{ include "keyorix.server.fullname" . }}:{{ .Values.server.service.port }}/health"
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]

--- a/deploy/helm/keyorix/templates/web-deployment.yaml
+++ b/deploy/helm/keyorix/templates/web-deployment.yaml
@@ -6,6 +6,13 @@ metadata:
   labels:
     {{- include "keyorix.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
+  annotations:
+    # checkov (helm-chart-security CI job): nginx needs a writable root filesystem
+    # for /var/cache/nginx, /var/run/nginx.pid and client-body temp files -- the
+    # container is otherwise fully hardened (allowPrivilegeEscalation: false,
+    # capabilities dropped, non-root uid 101, seccomp RuntimeDefault at the pod
+    # level), so only this one property is suppressed, not the whole check family.
+    checkov.io/skip1: CKV_K8S_22=nginx requires a writable root filesystem for its cache/pid/temp files
 spec:
   replicas: {{ .Values.web.replicas }}
   selector:


### PR DESCRIPTION
## Summary

- `helm-chart` already validates chart **schema** shape (`helm lint` + `kubeconform` against the Kubernetes API schema), but asserts nothing about security **policy** — it would not catch a future regression like dropping `readOnlyRootFilesystem: true` / `allowPrivilegeEscalation: false` from a pod security context, or a chart that starts granting wildcard/escalate RBAC.
- Adds a new `helm-chart-security` job that renders all 3 charts (`keyorix`, `keyorix-k8s-sync`, `keyorix-operator`) with the same `--set` values already exercised by `helm-chart`, then runs a pinned, checksum-verified [checkov](https://github.com/bridgecrewio/checkov) binary against the rendered output.
- Tool choice: **checkov** over kubesec — kubesec's CLI historically posts manifests to a hosted `kubesec.io` API by default (a real concern for a security scanner's own CI sending manifests to a third party), and checkov ships a pinned, self-contained pyinstaller binary (Apache-2.0) with zero network calls needed for a plain Kubernetes-framework scan, checked directly against its `3.3.6` release source before pinning.
- Scoped to `--check` with the 16 specific `CKV_K8S_*` IDs matching the properties this repo already hardens (non-root, dropped capabilities, read-only rootfs, no privilege escalation, seccomp, no privileged/host-namespace containers) plus the RBAC-escalation family (wildcard rules, escalate/bind, CSR-approval, webhook control, default-SA binding) — not checkov's full default ruleset, to avoid alert fatigue from unrelated checks (resource limits, probes, image pull policy, etc.).
- Two checks were read and deliberately excluded, not blindly suppressed: `CKV_K8S_35` ("prefer secret-as-file over secretKeyRef env vars") directly contradicts this repo's own #137 fix, and `CKV_K8S_40` ("runAsUser >= 10000") conflicts with the fixed, image-matched UIDs already documented in the templates.
- nginx and the bundled postgres container legitimately need a writable root filesystem (cache/pid/socket/temp files); rather than weakening the check everywhere, `CKV_K8S_22` is suppressed only for those two resources via an inline `checkov.io/skip1` annotation with a documented reason. Every other container (server, web's sidecar-free case doesn't apply here, k8s-sync, operator) keeps the check fully enforced.

## How this was verified

- `helm template`/`helm lint` for all 3 charts run locally against the edited templates — same commands the new job uses.
- The exact checkov check IDs (`CKV_K8S_16/17/18/19/20/22/23/28/31/37/42/49/155/156/157/158`) and their pass/fail semantics were confirmed by reading the actual check source at the pinned `3.3.6` tag (not from memory/docs), including verifying `CKV_K8S_37`/`CKV_K8S_28` pass with `capabilities.drop: ["ALL"]` even when `web`'s container also *adds* `NET_BIND_SERVICE`, and that the `keyorix-operator`/`keyorix-k8s-sync` RBAC rules contain no wildcards/escalate/bind verbs today.
- checkov's checksum was computed locally against the pinned `3.3.6` GitHub release asset (checkov publishes no official checksums file) and hardcoded into `ci.yml`, matching the existing gitleaks/kubeconform convention.

## Test plan

- [x] `helm lint`/`helm template` for all 3 charts run locally with the new templates
- [x] Workflow YAML validated (`ruby -ryaml`)
- [ ] CI green on this PR (`build-and-test`, `lint`, `gitleaks`, `helm-chart`, `operator`, CodeQL — none of which this change should affect — plus the new `helm-chart-security` job)
- [ ] A temporary follow-up commit on this branch removes `readOnlyRootFilesystem: true` from an enforced container to prove `helm-chart-security` actually fails on the regression, then reverts it to confirm green again

🤖 Generated with [Claude Code](https://claude.com/claude-code)