### PR TITLE
fix(ci): dco.yml used an arithmetic expression GitHub Actions doesn't support

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -15,12 +15,17 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Fetch exactly enough history to see every commit in this PR (plus
-          # one, for the merge-base) — NOT fetch-depth: 0. A full-history fetch
-          # pulls every OTHER branch in the repo too (actions/checkout's own
-          # documented behavior), which is unrelated noise for a check that
-          # only needs this PR's own commit range.
-          fetch-depth: ${{ github.event.pull_request.commits + 1 }}
+          # A generous fixed depth — NOT fetch-depth: 0 (fetches every OTHER
+          # branch in the repo too, per actions/checkout's own docs) and NOT
+          # `github.event.pull_request.commits + 1` (this workflow originally
+          # shipped with that expression; GitHub Actions' ${{ }} expressions
+          # don't support arithmetic operators at all, so GitHub silently
+          # rejected the whole file as unparseable — zero jobs ran, and it
+          # surfaced as a generic push-event failure rather than a visible
+          # check failure on any PR, since a workflow that fails to parse
+          # can't post a check run for the PR that would have triggered it).
+          # 100 comfortably covers this repo's real PR sizes.
+          fetch-depth: 100
 
       # Self-contained check (no third-party Action/GitHub App) — mirrors this
       # repo's existing preference for pinned binaries/inline scripts over


### PR DESCRIPTION
## Summary
`dco.yml` (merged in #813) has been silently non-functional since it merged: `github.event.pull_request.commits + 1` in the checkout `fetch-depth` value uses `+`, and GitHub Actions' `${{ }}` expression language has **no arithmetic operators at all**. GitHub rejected the entire workflow file as unparseable — zero jobs ever ran (confirmed via `gh run list --workflow dco.yml`: two `push`-event runs, both `conclusion: failure`, both with `jobs: []`), and it never surfaced as a visible check failure on any PR, since a workflow that fails to parse can't post a check run for the PR that would have triggered it.

Found by running `actionlint` against the file post-merge — it pinpoints the exact syntax error precisely. My own pre-merge validation only checked generic YAML syntax (`ruby -ryaml`), not GitHub Actions' own expression grammar, which is why this got through.

## Fix
`fetch-depth: 100` (a generous fixed value) instead of a computed expression — still avoids `fetch-depth: 0`'s all-branches problem (the reason this workflow doesn't use it in the first place, see #806).

## Verification
- `actionlint` now reports clean on `dco.yml`
- Ran `actionlint` across every other workflow file in `.github/workflows/` to check for the same class of bug elsewhere — none found; only pre-existing, low-severity shellcheck style warnings in `ci.yml` (word-splitting/globbing quoting suggestions), out of scope here

🤖 Generated with [Claude Code](https://claude.com/claude-code)