### PR TITLE
harden(rbac): make RequireRole unconditionally reject machine/OIDC principals (#308)

### DIFF
--- a/internal/storage/store/local_machine_credentials.go
+++ b/internal/storage/store/local_machine_credentials.go
@@ -170,10 +170,17 @@ func (ls *LocalStorage) GetMachineRoleIDsAt(ctx context.Context, machineID uint,
 // It is intentionally UNSCOPED — it returns roles across every project/
 // environment flattened into one list, with no deleted_at gate on the scope
 // project/environment (unlike GetMachineRoleIDsAt). Do NOT reuse this result
-// for an authorization decision: pair it with an unscoped role-name check (e.g.
-// RequireRole, see its own warning) on a machine-token-reachable route and a
-// role granted only for a now-soft-deleted or entirely different project would
-// wrongly authorize (#308). Use GetMachineRoleIDsAt for any authorization path.
+// for an authorization decision: a role granted only for a now-soft-deleted or
+// entirely different project would wrongly authorize (#308). Use
+// GetMachineRoleIDsAt for any authorization path instead.
+//
+// (#308) As defense in depth, RequireRole (server/middleware) additionally
+// refuses to gate on a machine principal at all, so even this method's output
+// reaching a machine's userCtx.Roles cannot be paired with an unscoped
+// role-name check to bypass scoping — but that guard lives at the consumer,
+// not here, so any OTHER future unscoped role-name check written against this
+// method's result would reintroduce the same bypass. Do not add one; use
+// GetMachineRoleIDsAt / core.Authorize instead.
 func (ls *LocalStorage) GetMachineRoles(ctx context.Context, machineID uint) ([]*models.Role, error) {
 	var roles []*models.Role
 	err := ls.db.WithContext(ctx).Table("roles").

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -655,14 +655,23 @@ func derefUint(p *uint) uint {
 // honoured on this role-based gate, which does not funnel through core.Authorize
 // (where the restriction is otherwise enforced). Fail-closed.
 //
-// WARNING (#308): this match is UNSCOPED — it checks only the role name against
-// userCtx.Roles, with no project/environment scope check at all. It currently has
-// no production route caller (only exercised by auth_test.go). Do NOT wire this
-// onto a machine-token-reachable route: combined with a machine identity's
-// unscoped role list (e.g. store.GetMachineRoles, itself for-display only, see
-// its own warning), it would bypass project/environment scoping entirely for
-// machine principals. If a role-based gate is ever needed on a scoped route, use
-// a scope-aware check (core.Authorize / the RBAC choke point) instead.
+// This match is UNSCOPED — it checks only the role name against userCtx.Roles,
+// with no project/environment scope check at all. It currently has no
+// production route caller (only exercised by auth_test.go). If a role-based
+// gate is ever needed on a scoped route, use a scope-aware check
+// (core.Authorize / the RBAC choke point) instead.
+//
+// (#308) A machine identity's role list (e.g. store.GetMachineRoles, itself
+// for-display only — see its own warning) is unscoped across every
+// project/environment, so an unscoped name match here would bypass
+// project/environment scoping entirely for machine principals: a role granted
+// only in Project A would incorrectly satisfy this gate on a route in Project
+// B. Rather than rely on every future caller remembering never to wire this
+// onto a machine-token-reachable route, this is enforced here, at the
+// consumer, so it holds regardless of what unscoped data source ever feeds
+// userCtx.Roles: a machine/OIDC principal (ActorType machine_identity)
+// unconditionally cannot satisfy a role gate. Fail-closed, mirroring the PAT
+// restriction check above.
 func RequireRole(role string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -673,6 +682,16 @@ func RequireRole(role string) func(next http.Handler) http.Handler {
 			}
 			if userCtx.PATRestriction != nil {
 				forbiddenResponse(w, "A scoped personal access token cannot satisfy a role requirement")
+				return
+			}
+			// #308: a machine/OIDC-federated principal's role list is resolved
+			// unscoped (across every project/environment) at authentication time,
+			// so it must never be allowed to satisfy this unscoped role-name gate —
+			// doing so would silently bypass project/environment scoping for
+			// machine principals. Machine authorization must go through a
+			// scope-aware check (core.Authorize) instead.
+			if userCtx.MachineIdentityID != nil {
+				forbiddenResponse(w, "A machine identity cannot satisfy an unscoped role requirement")
 				return
 			}
 			for _, userRole := range userCtx.Roles {

--- a/server/middleware/auth_test.go
+++ b/server/middleware/auth_test.go
@@ -330,6 +330,53 @@ func TestRequireRole_DeniesScopedPAT(t *testing.T) {
 	})
 }
 
+// TestRequireRole_DeniesMachinePrincipal reproduces the exact #308 landmine
+// scenario: a machine identity holds "deployer" only via a grant scoped to
+// Project A (10), but store.GetMachineRoles is intentionally unscoped and
+// flattens that grant into a bare role name with no project attached —
+// precisely what ValidateMachineToken/machineUserContext feed into
+// userCtx.Roles for every machine-token-authenticated request. If RequireRole
+// were ever wired onto an authorization-gating route, an unscoped name match
+// against that role list would wrongly authorize the same machine identity on
+// a request for a DIFFERENT project (B, 99) that its grant was never scoped
+// to — silently bypassing project scoping entirely for machine principals.
+//
+// Before the #308 fix, RequireRole only checked the role name against
+// userCtx.Roles and had no machine-principal guard, so this exact request
+// would have incorrectly succeeded (StatusOK). After the fix, RequireRole
+// unconditionally refuses to gate on any machine principal, so it is
+// rejected — regardless of which project the route targets — closing the
+// landmine at the consumer rather than depending on GetMachineRoles (or any
+// other future unscoped data source) never being wired in.
+func TestRequireRole_DeniesMachinePrincipal(t *testing.T) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := RequireRole("deployer")(testHandler)
+
+	// Mirrors machineUserContext(m, roleNames) exactly as validateToken builds
+	// it for a machine-token request: roleNames is store.GetMachineRoles's
+	// unscoped output ("deployer" appears with no indication it was granted
+	// only at project A/10) for a machine whose real grant is scoped to
+	// project A alone.
+	machineID := uint(42)
+	userCtx := machineUserContext(
+		&models.MachineIdentity{ID: machineID, Name: "ci-deployer"},
+		[]string{"deployer"}, // GetMachineRoles' unscoped flattening of a project-A-only grant
+	)
+	require.NotNil(t, userCtx.MachineIdentityID)
+	require.Equal(t, machineID, *userCtx.MachineIdentityID)
+
+	// The request targets project B (99) — a project the machine's grant was
+	// never scoped to.
+	req := httptest.NewRequest(http.MethodGet, "/projects/99/deploy", nil)
+	req = req.WithContext(context.WithValue(req.Context(), userContextKey, userCtx))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "a machine principal must never satisfy RequireRole's unscoped name match (#308)")
+}
+
 func TestGetUserFromContext(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Summary

Fixes backlog finding #308 (LOW): `RequireRole` middleware does an unscoped role-name match against `userCtx.Roles`, with no project/environment scoping.

## Root cause

For machine/OIDC-federated requests, `userCtx.Roles` is populated from `store.GetMachineRoles`, which is intentionally unscoped (for-display only, flattens roles across every project/environment). `RequireRole` has zero production route callers today, so this wasn't live — but `GetMachineRoles`'s unscoped output already reaches every machine-authenticated request's context via `ValidateMachineToken`/`ValidateOIDCToken` → `machineUserContext`. Mounting `RequireRole` on any scoped route in the future would silently bypass project/environment scoping for machine principals — an easy, innocent-looking future change, since the unscoped roles are already sitting in the request context.

## Fix

`RequireRole` now unconditionally refuses to gate on any machine/OIDC principal (`userCtx.MachineIdentityID != nil`), mirroring its existing PAT-restriction guard. This closes the landmine at the consumer, independent of `GetMachineRoles` or any future unscoped data source. `GetMachineRoles` itself is untouched — its legitimate for-display callers (`ListMachineRoles`, `ValidateMachineToken`, `ValidateOIDCToken`) are unaffected. Doc comments on both updated to record the guard and steer future authors toward `GetMachineRoleIDsAt`/`core.Authorize` for any real machine authorization path.

## Testing

New `TestRequireRole_DeniesMachinePrincipal` (`server/middleware/auth_test.go`) builds the exact `machineUserContext` shape `ValidateMachineToken` produces (role granted only in Project A, flattened unscoped by `GetMachineRoles`) and hits a Project-B route — proven to fail (200, incorrectly authorized) with the guard reverted, and pass (403) with it in place.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./server/middleware/... ./internal/storage/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)