### PR TITLE
fix(remote-storage): add the missing GetUserByEmail route (#503)

### DIFF
--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -219,8 +219,17 @@ func (rs *RemoteStorage) LockUserForUpdate(ctx context.Context, id uint) (*model
 }
 
 // GetUserByEmail retrieves a user by email via remote API.
+//
+// The server registers this lookup as GET /api/v1/users/by-email with the email as
+// a query parameter (mirroring GetSecretByName's #497 query-scoped convention), not
+// as a path segment (#503: an earlier version of this method requested
+// /api/v1/users/by-email/{email}, a route server/http/router.go never registered,
+// so every call 404'd against a real server regardless of whether the user
+// existed — affecting every internal/core call site that resolves a user by email
+// under storage.type: remote, e.g. RBAC/SSO/SCIM lookups, not just CreateUser's
+// pre-existence check).
 func (rs *RemoteStorage) GetUserByEmail(ctx context.Context, email string) (*models.User, error) {
-	path := fmt.Sprintf("/api/v1/users/by-email/%s", url.PathEscape(email))
+	path := fmt.Sprintf("/api/v1/users/by-email?email=%s", url.QueryEscape(email))
 	resp, err := rs.client.Get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user by email: %w", err)

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -217,6 +217,44 @@ func (h *UserHandler) GetUser(w http.ResponseWriter, r *http.Request) {
 	sendSuccess(w, resp, "")
 }
 
+// GetUserByEmail handles GET /api/v1/users/by-email?email=X — looks up a user by
+// email address for callers (e.g. RemoteStorage, #503) that only have the email
+// rather than the numeric ID. The route's permission gate (users.read, inherited
+// from the /users group — the same gate GetUser-by-id uses) is the sole authz
+// check, matching GetUser's model exactly; there is no additional per-record
+// check to bypass. Deliberately mirrors GetUser's generic NotFound response
+// (same status code, same static message) rather than a distinct shape, so a
+// caller cannot use response differences to enumerate valid email addresses —
+// a caller without users.read never reaches this handler at all (401/403 from
+// the route middleware, identical for every email), and a caller WITH users.read
+// can already enumerate every user (including email) via GET /users, so this
+// route grants no new capability at that permission level.
+func (h *UserHandler) GetUserByEmail(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	email := strings.TrimSpace(r.URL.Query().Get("email"))
+	if email == "" {
+		sendError(w, "InvalidParameter", "email is required", http.StatusBadRequest, nil)
+		return
+	}
+	u, err := h.coreService.GetUserByEmail(r.Context(), email)
+	if err != nil {
+		log.Printf("Error getting user by email: %v", err)
+		if strings.Contains(err.Error(), "not found") {
+			sendError(w, "NotFound", "User not found", http.StatusNotFound, nil)
+			return
+		}
+		sendError(w, "InternalError", "Failed to get user", http.StatusInternalServerError, nil)
+		return
+	}
+	resp := userToAPIResponse(u)
+	h.attachProjectCounts(r.Context(), []map[string]interface{}{resp}, []uint{u.ID})
+	sendSuccess(w, resp, "")
+}
+
 // UpdateUser handles PUT /api/v1/users/{id}
 func (h *UserHandler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/handlers/users_handler.go
+++ b/server/http/handlers/users_handler.go
@@ -277,6 +277,15 @@ func GetUser(w http.ResponseWriter, r *http.Request) {
 	defaultUserHandler.GetUser(w, r)
 }
 
+// GetUserByEmail handles GET /api/v1/users/by-email?email=X (#503).
+func GetUserByEmail(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.GetUserByEmail(w, r)
+}
+
 // UpdateUser handles PUT /api/v1/users/{id}
 func UpdateUser(w http.ResponseWriter, r *http.Request) {
 	if defaultUserHandler == nil {

--- a/server/http/remote_storage_get_user_by_email_test.go
+++ b/server/http/remote_storage_get_user_by_email_test.go
@@ -1,0 +1,132 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteStorage_GetUserByEmail_RealServerRoundTrip proves the fix for #503:
+// RemoteStorage.GetUserByEmail targeted /api/v1/users/by-email/{email}, a route
+// server/http/router.go never registered, so every call 404'd against a real
+// production server regardless of whether the user actually existed. This
+// affected every internal/core call site that resolves a user by email under
+// storage.type: remote (CreateUser's pre-existence check, plus RBAC/SSO/SCIM
+// lookups) — not just CreateUser.
+//
+// The fix adds GET /api/v1/users/by-email (query-parameter scoped, mirroring
+// GetSecretByName's #497 convention rather than a path segment), gated by the
+// SAME users.read permission GetUser-by-id already requires (the group-wide
+// r.Use(RequirePermission("users.read")) on /users), and returns the same
+// generic NotFound shape GetUser-by-id uses on a miss — deliberately NOT a
+// distinct shape, so the route introduces no new email-enumeration surface:
+// a caller without users.read never reaches the handler (401/403, identical
+// for every email), and a caller WITH users.read can already enumerate every
+// user's email via GET /users, so this route grants no new capability at that
+// permission level.
+//
+// Like TestRemoteStorage_GetSecretByName_RealServerRoundTrip, this drives the
+// method through a REAL running server (NewRouter) via a REAL RemoteStorage
+// client over real HTTP — not a hand-rolled mock — so the test would have
+// failed against the pre-fix code with a 404, not just against a synthetic
+// stand-in of the route.
+func TestRemoteStorage_GetUserByEmail_RealServerRoundTrip(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	// --- upstream: a real Keyorix server ---
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+	// A non-admin user with only the system_viewer baseline (system.read) — NOT
+	// users.read — the under-permissioned caller for the gating assertions below.
+	limitedToken := createLimitedToken(t, upstreamCore)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	ctx := context.Background()
+
+	newClient := func(token string) *store.RemoteStorage {
+		rs, err := store.NewRemoteStorage(&remote.Config{
+			BaseURL:        upstreamSrv.URL,
+			APIKey:         token,
+			TimeoutSeconds: 5,
+			RetryAttempts:  0,
+			TLSVerify:      true,
+		})
+		require.NoError(t, err)
+		return rs
+	}
+
+	// --- downstream: storage.type: remote, pointed at the upstream, as an
+	// admin caller (holds users.read) ---
+	rs := newClient(upstreamToken)
+
+	// --- the user genuinely exists: must be found, not 404 ---
+	got, err := rs.GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err, "GetUserByEmail must reach the real /api/v1/users/by-email route and succeed for a user that genuinely exists (#503)")
+	require.NotNil(t, got)
+	assert.Equal(t, "testadmin", got.Username)
+	assert.Equal(t, "testadmin@example.com", got.Email)
+
+	// --- the user genuinely does NOT exist: must be a real not-found, not a
+	// routing 404 confused with "found nothing" ---
+	_, err = rs.GetUserByEmail(ctx, "does-not-exist@example.com")
+	require.Error(t, err, "an email that genuinely doesn't exist must still return an error")
+	var notFoundErr *remote.HTTPError
+	require.True(t, errors.As(err, &notFoundErr), "expected a structured remote.HTTPError")
+	assert.Equal(t, http.StatusNotFound, notFoundErr.StatusCode)
+
+	// --- gating: an authenticated caller who lacks users.read must be denied
+	// identically whether the target email exists or not — proving the route
+	// cannot be used to enumerate emails by an under-permissioned caller ---
+	limitedRS := newClient(limitedToken)
+
+	_, existsErr := limitedRS.GetUserByEmail(ctx, "testadmin@example.com")
+	require.Error(t, existsErr, "an under-permissioned caller must be denied even for an email that exists")
+	var existsHTTPErr *remote.HTTPError
+	require.True(t, errors.As(existsErr, &existsHTTPErr))
+
+	_, notExistsErr := limitedRS.GetUserByEmail(ctx, "does-not-exist@example.com")
+	require.Error(t, notExistsErr, "an under-permissioned caller must be denied even for an email that does not exist")
+	var notExistsHTTPErr *remote.HTTPError
+	require.True(t, errors.As(notExistsErr, &notExistsHTTPErr))
+
+	// The denial must carry the SAME status for both cases (403 Forbidden, the
+	// route's permission gate) — not a 404 for one and a 403 for the other,
+	// which would itself leak existence to an under-permissioned caller.
+	assert.Equal(t, http.StatusForbidden, existsHTTPErr.StatusCode)
+	assert.Equal(t, existsHTTPErr.StatusCode, notExistsHTTPErr.StatusCode,
+		"gating must not leak existence via a different status for an existing vs a non-existing email")
+
+	// --- a fully unauthenticated caller must also be denied, identically
+	// regardless of whether the email exists (401, before the handler even
+	// parses the query) ---
+	unauthResp1, err := http.Get(upstreamSrv.URL + "/api/v1/users/by-email?email=testadmin@example.com")
+	require.NoError(t, err)
+	defer unauthResp1.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, unauthResp1.StatusCode)
+
+	unauthResp2, err := http.Get(upstreamSrv.URL + "/api/v1/users/by-email?email=does-not-exist@example.com")
+	require.NoError(t, err)
+	defer unauthResp2.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, unauthResp2.StatusCode)
+	assert.Equal(t, unauthResp1.StatusCode, unauthResp2.StatusCode,
+		"an unauthenticated caller must not be able to distinguish an existing from a non-existing email")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -578,6 +578,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/search", handlers.SearchUsers)
 			// Stale-account warnings (ADR-025): static path before /{id}.
 			r.Get("/stale", handlers.StaleAccounts)
+			// By-email lookup, scoped by the group-wide users.read gate above — the
+			// server-side counterpart RemoteStorage.GetUserByEmail (#503) needs, for a
+			// caller with only a user's email (not their numeric ID). Deliberately the
+			// SAME gate as GetUser-by-id (not a stricter one): users.read already lets a
+			// caller enumerate every user (including email) via GET /users with no
+			// filter, so this route grants no new capability at that permission level.
+			// Static path, before /{id}.
+			r.Get("/by-email", handlers.GetUserByEmail)
 			r.Get("/{id}", handlers.GetUser)
 			// Mutations need users.write, not the group-wide users.read (which the
 			// read-only system_auditor persona holds) — these were the missed


### PR DESCRIPTION
## Summary

Fixes backlog finding #503 (MEDIUM): `RemoteStorage.GetUserByEmail` (`internal/storage/store/remote_users.go`) targeted `GET /api/v1/users/by-email/{email}`, a route `server/http/router.go` never registered — every call 404'd unconditionally, regardless of whether the user existed. This affected every `internal/core` call site resolving a user by email under `storage.type: remote` (`CreateUser`'s pre-existence check, plus RBAC/SSO/SCIM lookups).

## Investigation (deliberately deferred in round 112 pending this review)

Checked the existing analogous routes before adding a new one:
- `GET /users/{id}` is gated only by the group-wide `users.read` permission, with a generic `NotFound`/404 on a miss — no per-record check.
- `GET /users` (`ListUsers`) already supports `?email=` filtering at the same `users.read` gate and returns a uniform 200 (empty array on no match) — a caller with `users.read` can already enumerate every user's email, so there's no stricter existing model to match.
- `#497`'s `GetSecretByName` fix established the precedent: register a real route using a query parameter, gated by the same permission the closest analogous route uses.

## Fix

- Added `GET /api/v1/users/by-email?email=X` in `server/http/router.go`, gated by the same `users.read` permission `GetUser`-by-id uses.
- Added `UserHandler.GetUserByEmail`, returning the identical generic `NotFound`/404 shape `GetUser` uses on a miss — no enumeration-enabling response-shape difference.
- Repointed `RemoteStorage.GetUserByEmail` at the new query-param route.

## Testing

New end-to-end test (`server/http/remote_storage_get_user_by_email_test.go`, real `NewRouter` + real `RemoteStorage` client) proving: existing user found correctly; non-existent email returns a real 404; an under-permissioned caller is denied identically (403) for both existing/non-existing emails; an unauthenticated caller is denied identically (401) for both.

## Verification

- `go build ./...` — clean
- `go test ./internal/storage/... ./server/http/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)