### PR TITLE
fix(auth): detect user-not-found via a backend-agnostic helper (#504)

### DIFF
--- a/internal/core/saml_flow_test.go
+++ b/internal/core/saml_flow_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	samlpkg "github.com/keyorixhq/keyorix/internal/saml"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -17,9 +18,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// userNotFound mirrors the storage "not found" error that resolveSSOUser treats as
-// "no matching account" (rather than a hard error), so the mock matches the real path.
-func userNotFound() error { return fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil)) }
+// userNotFound mirrors the real storage "not found" error (wrapping the typed
+// storage.ErrUserNotFound sentinel, #504) that resolveSSOUser treats as "no matching
+// account" (rather than a hard error), so the mock matches the real path.
+func userNotFound() error {
+	return fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
+}
 
 // stubSAML is a SAMLAuthn whose ParseResponse returns a canned assertion — so the SAML
 // login flow is tested without a live IdP or a signed response.

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -78,7 +78,6 @@ func (c *KeyorixCore) deriveSCIMUsername(ctx context.Context, userName string) (
 	if len(base) > 40 {
 		base = base[:40]
 	}
-	notFound := i18n.T("ErrorUserNotFound", nil)
 	for i := 0; i < 1000; i++ {
 		candidate := base
 		if i > 0 {
@@ -88,7 +87,7 @@ func (c *KeyorixCore) deriveSCIMUsername(ctx context.Context, userName string) (
 		if err == nil {
 			continue // taken — try the next suffix
 		}
-		if strings.Contains(err.Error(), notFound) {
+		if storage.IsUserNotFound(err) {
 			return candidate, nil // available
 		}
 		return "", err // a real lookup error
@@ -114,18 +113,17 @@ func randomPasswordHash() (string, error) {
 // (SCIM userName). Returns (nil, nil) when neither matches — used by the handler to
 // implement userName-filter reconciliation.
 func (c *KeyorixCore) FindSCIMUser(ctx context.Context, externalID, email string) (*models.User, error) {
-	notFound := i18n.T("ErrorUserNotFound", nil)
 	if externalID != "" {
 		if u, err := c.storage.GetUserByExternalID(ctx, externalID); err == nil {
 			return u, nil
-		} else if !strings.Contains(err.Error(), notFound) {
+		} else if !storage.IsUserNotFound(err) {
 			return nil, err
 		}
 	}
 	if email != "" {
 		if u, err := c.storage.GetUserByEmail(ctx, email); err == nil {
 			return u, nil
-		} else if !strings.Contains(err.Error(), notFound) {
+		} else if !storage.IsUserNotFound(err) {
 			return nil, err
 		}
 	}
@@ -251,7 +249,7 @@ func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, disp
 			if existing != nil && existing.ID != id {
 				return nil, fmt.Errorf("%s: email already in use by another user", i18n.T("ErrorValidation", nil))
 			}
-		case strings.Contains(eerr.Error(), i18n.T("ErrorUserNotFound", nil)):
+		case storage.IsUserNotFound(eerr):
 			// Genuinely unused — proceed.
 		default:
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), eerr)

--- a/internal/core/secret_ownership.go
+++ b/internal/core/secret_ownership.go
@@ -8,7 +8,6 @@ package core
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -87,12 +86,17 @@ func (c *KeyorixCore) transferOwnership(ctx context.Context, secretID, newOwnerI
 // currentOwnerGone reports whether a secret's owner is positively absent: ownerless
 // (0) or an account confirmed not to exist. It FAILS CLOSED — a transient GetUser
 // error returns false (owner assumed present), so a non-owner cannot ride a momentary
-// lookup failure into seizing an actively-owned secret. Only the typed not-found
-// sentinel counts as "gone".
+// lookup failure into seizing an actively-owned secret. Only a confirmed "not found"
+// counts as "gone" — checked under BOTH storage backends (#504 sibling): LocalStorage
+// wraps the typed ErrUserNotFound sentinel, while RemoteStorage instead returns a
+// remote.HTTPError; matching the sentinel alone (via errors.Is) silently never
+// recognized a gone owner under storage.type: remote, which — since this still fails
+// closed — only meant a legitimately recoverable secret couldn't be recovered, not a
+// security regression, but was worth closing alongside the rest of #504.
 func (c *KeyorixCore) currentOwnerGone(ctx context.Context, ownerID uint) bool {
 	if ownerID == 0 {
 		return true
 	}
 	_, err := c.storage.GetUser(ctx, ownerID)
-	return errors.Is(err, storage.ErrUserNotFound)
+	return storage.IsUserNotFound(err)
 }

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -320,8 +321,13 @@ func displayNameFromEmail(email string) string {
 }
 
 // isUserNotFound reports whether err is the storage layer's "user not found"
-// sentinel (mirrors the check in CreateUser). Used to fail closed on a real lookup
-// error while treating a clean miss as "no existing account".
+// signal under EITHER active storage backend (#504) — LocalStorage's wrapped
+// ErrUserNotFound sentinel, or RemoteStorage's HTTPError.IsNotFound(). Used to
+// fail closed on a real lookup error while treating a clean miss as "no
+// existing account". Previously matched LocalStorage's i18n error text only,
+// which never matched a RemoteStorage error (before or after round 112's #501
+// fix gave RemoteStorage a structured error type) — every call site below was
+// silently broken under storage.type: remote. See storage.IsUserNotFound.
 func isUserNotFound(err error) bool {
-	return err != nil && strings.Contains(err.Error(), i18n.T("ErrorUserNotFound", nil))
+	return storage.IsUserNotFound(err)
 }

--- a/internal/core/setup_delivery_test.go
+++ b/internal/core/setup_delivery_test.go
@@ -2,10 +2,12 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -304,12 +306,10 @@ func TestGenerateOneTimePassword(t *testing.T) {
 
 // helpers ---------------------------------------------------------------------
 
-// assertNotFoundErr returns an error whose message contains the not-found marker
-// CreateUser checks for, so the "does this user already exist?" probes read as absent.
+// assertNotFoundErr mirrors the real storage "not found" error (wrapping the typed
+// storage.ErrUserNotFound sentinel, same as LocalStorage's GetUser/GetUserByEmail/
+// GetUserByUsername/etc., #504) so the mock is detected the same way CreateUser's
+// "does this user already exist?" probes detect the real thing.
 func assertNotFoundErr() error {
-	return &notFoundError{msg: i18n.T("ErrorUserNotFound", nil)}
+	return fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
 }
-
-type notFoundError struct{ msg string }
-
-func (e *notFoundError) Error() string { return e.msg }

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -391,11 +391,10 @@ func ssoBoundToOtherProvider(externalID, provider string) bool {
 // provider+subject on first link, so a later provider can't re-link it by asserting the
 // same address.
 func (c *KeyorixCore) resolveSSOUser(ctx context.Context, provider, sub, email string, emailVerified bool) (*models.User, error) {
-	notFound := i18n.T("ErrorUserNotFound", nil)
 	if sub != "" {
 		if u, err := c.storage.GetUserByExternalID(ctx, ssoExternalID(provider, sub)); err == nil {
 			return u, nil
-		} else if !strings.Contains(err.Error(), notFound) {
+		} else if !storage.IsUserNotFound(err) {
 			return nil, err
 		}
 	}
@@ -404,7 +403,7 @@ func (c *KeyorixCore) resolveSSOUser(ctx context.Context, provider, sub, email s
 	}
 	u, err := c.storage.GetUserByEmail(ctx, email)
 	if err != nil {
-		if strings.Contains(err.Error(), notFound) {
+		if storage.IsUserNotFound(err) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/oauth2"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -134,7 +135,11 @@ func TestVerifyIDToken_EmailVerified(t *testing.T) {
 }
 
 func TestResolveSSOUser(t *testing.T) {
-	notFound := func() error { return fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil)) }
+	// Mirrors the real storage "not found" error (wrapping the typed
+	// storage.ErrUserNotFound sentinel, #504), so the mock matches the real path.
+	notFound := func() error {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
+	}
 
 	t.Run("externalId match wins", func(t *testing.T) {
 		c, store, _, _ := ssoTestCore(t)
@@ -206,7 +211,9 @@ func TestResolveSSOUser(t *testing.T) {
 }
 
 func TestProvisionSSOUser(t *testing.T) {
-	notFound := func() error { return fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil)) }
+	notFound := func() error {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
+	}
 
 	t.Run("JIT-creates an active passwordless user with the default role", func(t *testing.T) {
 		c, store, _, p := ssoTestCore(t)

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -1,6 +1,10 @@
 package storage
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+)
 
 // ErrUserNotFound is returned (wrapped) by GetUser when the user positively does not
 // exist, as distinct from a transient retrieval failure. Callers that must fail
@@ -114,3 +118,31 @@ var ErrDuplicateDynamicSecretConfig = errors.New("a dynamic-secret config with t
 // loser's insert fail here instead of silently duplicating; callers treat this as a
 // benign no-op skip, not a failure.
 var ErrDuplicateReminderNotification = errors.New("an unread reminder notification already exists for this user, type, and project")
+
+// IsUserNotFound reports whether err represents "this user positively does not
+// exist" under EITHER active storage backend (#504). LocalStorage wraps the
+// ErrUserNotFound sentinel above (errors.Is); RemoteStorage instead returns a
+// remote.HTTPError for every 4xx/5xx response, with its own IsNotFound()
+// helper keyed on the actual HTTP status (errors.As). Neither of those is
+// reliably detectable by matching an error's rendered text — the i18n string
+// LocalStorage happens to embed in ErrUserNotFound's wrapping message is an
+// implementation detail, not a contract, and a RemoteStorage error never
+// contained it in the first place (round 112's #501 fix gave RemoteStorage a
+// structured error but multiple internal/core call sites still matched the
+// old i18n text and so never worked against storage.type: remote, before or
+// after that fix). Callers that must distinguish "genuinely absent" from a
+// transient retrieval failure across both backends should use this instead of
+// either check alone.
+func IsUserNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrUserNotFound) {
+		return true
+	}
+	var httpErr *remote.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.IsNotFound()
+	}
+	return false
+}

--- a/internal/core/user_notfound_backend_test.go
+++ b/internal/core/user_notfound_backend_test.go
@@ -1,0 +1,143 @@
+// user_notfound_backend_test.go — regression coverage for #504: sso.go, scim.go,
+// users.go, and setup_consume.go used to detect "user not found" by string-matching
+// LocalStorage's i18n error text, which never matched a RemoteStorage error (before or
+// after round 112's #501 fix gave RemoteStorage a structured remote.HTTPError type).
+// This file proves the shared storage.IsUserNotFound primitive those call sites now
+// use is correct under BOTH backends, using real errors — a genuine sqlite miss for
+// LocalStorage, and a genuine 404 response (the real sendError JSON shape
+// server/http/handlers actually emits — see helpers.go's sendError) round-tripped
+// through the real remote.HTTPClient/store.RemoteStorage for RemoteStorage. Mirrors
+// #484/#454's own established "real SQLite + real httptest RemoteStorage" test style
+// in this package (see password_remote_test.go, login_lockout_remote_test.go).
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestIsUserNotFound_RealLocalStorage proves storage.IsUserNotFound recognizes a
+// genuine LocalStorage miss for every one of the lookup methods #504's call sites use
+// (GetUser, GetUserByEmail, GetUserByUsername, GetUserByExternalID, RestoreUser) — all
+// against a real sqlite DB, not a hand-rolled mock error.
+func TestIsUserNotFound_RealLocalStorage(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+	local := store.NewLocalStorage(db)
+	ctx := context.Background()
+
+	_, err = local.GetUser(ctx, 999999)
+	require.Error(t, err)
+	assert.True(t, corestorage.IsUserNotFound(err), "GetUser miss must be detected; got: %v", err)
+
+	_, err = local.GetUserByEmail(ctx, "ghost@nowhere.test")
+	require.Error(t, err)
+	assert.True(t, corestorage.IsUserNotFound(err), "GetUserByEmail miss must be detected; got: %v", err)
+
+	_, err = local.GetUserByUsername(ctx, "ghost")
+	require.Error(t, err)
+	assert.True(t, corestorage.IsUserNotFound(err), "GetUserByUsername miss must be detected; got: %v", err)
+
+	_, err = local.GetUserByExternalID(ctx, "sso:none:none")
+	require.Error(t, err)
+	assert.True(t, corestorage.IsUserNotFound(err), "GetUserByExternalID miss must be detected; got: %v", err)
+
+	err = local.RestoreUser(ctx, 999999)
+	require.Error(t, err)
+	assert.True(t, corestorage.IsUserNotFound(err), "RestoreUser miss must be detected; got: %v", err)
+
+	// Negative: an existing user is not "not found".
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "carol", Email: "carol@example.com"}).Error)
+	u, err := local.GetUser(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), u.ID)
+}
+
+// sendErrorJSON writes the exact flat envelope server/http/handlers/helpers.go's
+// sendError emits, so the RemoteStorage side of this test pins the genuine wire shape
+// (see internal/storage/remote/client.go's serverErrorBody), not a stand-in.
+func sendErrorJSON(w http.ResponseWriter, errorType, message string, statusCode int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"success": false,
+		"error":   errorType,
+		"message": message,
+		"code":    statusCode,
+	})
+}
+
+// TestIsUserNotFound_RealRemoteStorage404 proves storage.IsUserNotFound recognizes a
+// genuine RemoteStorage 404 — round-tripped through the real remote.HTTPClient
+// (internal/storage/remote/client.go's newHTTPError/HTTPError.IsNotFound), against a
+// server emitting the exact JSON shape sendError produces — as "not found", and that a
+// real non-404 failure (500) is NOT misclassified as "not found" (fail-closed).
+func TestIsUserNotFound_RealRemoteStorage404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sendErrorJSON(w, "NotFound", "User not found", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: srv.URL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: false,
+	})
+	require.NoError(t, err)
+
+	_, err = rs.GetUser(context.Background(), 999999)
+	require.Error(t, err)
+	assert.True(t, corestorage.IsUserNotFound(err), "a genuine RemoteStorage 404 must be detected; got: %v", err)
+
+	// 403, not 500: a 5xx is retryable (isRetryableError), which would burn real
+	// wall-clock time on the client's exponential backoff for no benefit to this
+	// assertion — 403 exercises the same "not a 404" fail-closed path instantly.
+	srv403 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sendErrorJSON(w, "PermissionDenied", "forbidden", http.StatusForbidden)
+	}))
+	t.Cleanup(srv403.Close)
+	rs403, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: srv403.URL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: false,
+	})
+	require.NoError(t, err)
+	_, err = rs403.GetUser(context.Background(), 1)
+	require.Error(t, err)
+	assert.False(t, corestorage.IsUserNotFound(err), "a real 403 must not be misdetected as not-found; got: %v", err)
+}
+
+// TestResolveSSOUser_EmailFallback_RealRemoteStorage404 is the #504 regression for
+// sso.go's resolveSSOUser email fallback under storage.type: remote. sub is left empty
+// so only the email-fallback branch (c.storage.GetUserByEmail) runs — resolveSSOUser's
+// externalId branch (c.storage.GetUserByExternalID) hard-fails unconditionally under
+// storage.type: remote regardless of #504 (RemoteStorage.GetUserByExternalID is an
+// unconditional storage.ErrUnsupportedByBackend stub, a separate, pre-existing
+// architectural gap — not part of this fix). Before #504's fix, resolveSSOUser's
+// `strings.Contains(err.Error(), notFound)` never matched a real RemoteStorage error,
+// so a genuinely-absent account's email lookup surfaced as a hard login error instead
+// of the documented (nil, nil) "no match" outcome.
+func TestResolveSSOUser_EmailFallback_RealRemoteStorage404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sendErrorJSON(w, "NotFound", "User not found", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: srv.URL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: false,
+	})
+	require.NoError(t, err)
+	c := &KeyorixCore{storage: rs, now: func() time.Time { return time.Now() }, passwordPolicy: DefaultPasswordPolicy()}
+
+	u, err := c.resolveSSOUser(context.Background(), "okta", "", "ghost@example.com", true)
+	require.NoError(t, err, "resolveSSOUser must treat the real 404 as 'no match', not a hard error")
+	assert.Nil(t, u)
+}

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -52,7 +51,7 @@ func (c *KeyorixCore) buildUserForCreate(ctx context.Context, req *CreateUserReq
 
 	if _, err := c.storage.GetUserByUsername(ctx, req.Username); err == nil {
 		return nil, "", fmt.Errorf("%s: username already exists", i18n.T("ErrorValidation", nil))
-	} else if !errors.Is(err, storage.ErrUnsupportedByBackend) && !strings.Contains(err.Error(), i18n.T("ErrorUserNotFound", nil)) {
+	} else if !errors.Is(err, storage.ErrUnsupportedByBackend) && !storage.IsUserNotFound(err) {
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	// RemoteStorage.GetUserByUsername is unimplemented (ErrUnsupportedByBackend, #499):
@@ -67,7 +66,7 @@ func (c *KeyorixCore) buildUserForCreate(ctx context.Context, req *CreateUserReq
 	if err == nil && existing != nil {
 		return nil, "", fmt.Errorf("%s: user with email already exists", i18n.T("ErrorValidation", nil))
 	}
-	if err != nil && !strings.Contains(err.Error(), i18n.T("ErrorUserNotFound", nil)) {
+	if err != nil && !storage.IsUserNotFound(err) {
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 
@@ -260,7 +259,7 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 	if req.Username != "" && req.Username != user.Username {
 		if _, err := c.storage.GetUserByUsername(ctx, req.Username); err == nil {
 			return nil, fmt.Errorf("%s: username already exists", i18n.T("ErrorValidation", nil))
-		} else if err != nil && !strings.Contains(err.Error(), i18n.T("ErrorUserNotFound", nil)) {
+		} else if err != nil && !storage.IsUserNotFound(err) {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 		}
 		user.Username = req.Username
@@ -270,7 +269,7 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 		if err == nil && existing != nil && existing.ID != user.ID {
 			return nil, fmt.Errorf("%s: user with email already exists", i18n.T("ErrorValidation", nil))
 		}
-		if err != nil && !strings.Contains(err.Error(), i18n.T("ErrorUserNotFound", nil)) {
+		if err != nil && !storage.IsUserNotFound(err) {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 		}
 		user.Email = req.Email
@@ -359,7 +358,7 @@ func (c *KeyorixCore) RestoreUser(ctx context.Context, actorID, id uint) error {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "user ID is required")
 	}
 	if err := c.storage.RestoreUser(ctx, id); err != nil {
-		if strings.Contains(err.Error(), i18n.T("ErrorUserNotFound", nil)) {
+		if storage.IsUserNotFound(err) {
 			return fmt.Errorf("%s: user not found or not deleted", i18n.T("ErrorUserNotFound", nil))
 		}
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -144,7 +144,11 @@ func (ls *LocalStorage) GetUserByEmail(ctx context.Context, email string) (*mode
 	// sides matches regardless of stored casing (covers legacy mixed-case rows).
 	if err := ls.db.WithContext(ctx).Where("LOWER(email) = LOWER(?)", email).First(&user).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil))
+			// Wrap the typed sentinel (matching GetUser/LockUserForUpdate, #504) so
+			// callers can detect "genuinely absent" via
+			// errors.Is/storage.IsUserNotFound instead of matching this i18n text,
+			// which is a rendering detail, not a contract.
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
@@ -155,7 +159,7 @@ func (ls *LocalStorage) GetUserByUsername(ctx context.Context, username string) 
 	var user models.User
 	if err := ls.db.WithContext(ctx).Where("username = ?", username).First(&user).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil))
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
@@ -166,7 +170,7 @@ func (ls *LocalStorage) GetUserByExternalID(ctx context.Context, externalID stri
 	var user models.User
 	if err := ls.db.WithContext(ctx).Where("external_id = ?", externalID).First(&user).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil))
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
@@ -287,7 +291,9 @@ func (ls *LocalStorage) RestoreUser(ctx context.Context, id uint) error {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
 	}
 	if result.RowsAffected == 0 {
-		return fmt.Errorf("%s", i18n.T("ErrorUserNotFound", nil))
+		// Wrap the typed sentinel (#504) so RestoreUser's "not found" is detectable
+		// the same way as the other user lookups, instead of only via i18n text.
+		return fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
 	}
 	return nil
 }

--- a/server/http/user_notfound_backend_parity_test.go
+++ b/server/http/user_notfound_backend_parity_test.go
@@ -1,0 +1,179 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newRemoteBackedCore spins up a REAL upstream *core.KeyorixCore (LocalStorage) behind
+// a REAL production NewRouter/httptest server — the same pattern
+// TestRemoteStorage_404_SurfacesStructuredError (#501, PR #812) and
+// TestRemoteStorage_SuccessFieldFix_RealServerRoundTrip (#498, PR #794) use — and
+// returns a SECOND *core.KeyorixCore whose storage is a REAL RemoteStorage client
+// pointed at that server. Calling any exported KeyorixCore method on the returned
+// "downstream" core drives the exact internal/core call sites this file exercises
+// (#504) through a genuine HTTP round trip against a real handler, not a hand-rolled
+// mock standing in for the wire shape.
+func newRemoteBackedCore(t *testing.T) (downstream, upstream *core.KeyorixCore, upstreamSrv *httptest.Server) {
+	t.Helper()
+	upstream = newTestCore(t)
+	token := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	router, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv = httptest.NewServer(router)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         token,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	return downstream, upstream, upstreamSrv
+}
+
+// TestIsUserNotFound_RealBothBackends proves the shared #504 detection primitive,
+// storage.IsUserNotFound, correctly recognizes "this user does not exist" under BOTH
+// active storage backends using REAL errors — not constructed stand-ins:
+//   - LocalStorage: a genuine gorm.ErrRecordNotFound from a real sqlite DB, wrapped by
+//     LocalStorage.GetUserByEmail (internal/storage/store/local_users.go).
+//   - RemoteStorage: a genuine 404 from a REAL NewRouter-backed server
+//     (handlers.GetUser -> sendError), round-tripped through the real
+//     remote.HTTPClient/store.RemoteStorage.
+//
+// It also proves the negative: a real, non-"not found" failure (a 403 from a
+// caller with no permission) is NOT misclassified as "not found" — the fail-closed
+// half of the contract every #504 call site relies on.
+func TestIsUserNotFound_RealBothBackends(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	t.Run("LocalStorage: real gorm.ErrRecordNotFound", func(t *testing.T) {
+		db, err := gorm.Open(sqlite.Open(uniqueMemDSN("&_timeout=30000&_journal_mode=WAL")), &gorm.Config{})
+		require.NoError(t, err)
+		require.NoError(t, db.AutoMigrate(&models.User{}))
+		local := store.NewLocalStorage(db)
+		_, err = local.GetUserByEmail(context.Background(), "ghost-does-not-exist@example.com")
+		require.Error(t, err)
+		assert.True(t, storage.IsUserNotFound(err), "a genuine LocalStorage miss must be detected; got: %v", err)
+	})
+
+	t.Run("RemoteStorage: real 404 from a real NewRouter server", func(t *testing.T) {
+		downstream, _, _ := newRemoteBackedCore(t)
+		const nonExistentUserID = 999999
+		_, err := downstream.GetUser(context.Background(), nonExistentUserID)
+		require.Error(t, err)
+		assert.True(t, storage.IsUserNotFound(err), "a genuine RemoteStorage 404 must be detected; got: %v", err)
+	})
+
+	t.Run("RemoteStorage: a real non-404 failure is NOT misclassified as not-found", func(t *testing.T) {
+		_, upstream, srv := newRemoteBackedCore(t)
+		// A limited (non-admin) token hitting an admin-only route gets a real 403 from
+		// the real permission middleware — a genuine failure that must NOT be
+		// misdetected as "not found" (fail-closed).
+		limitedToken := createLimitedToken(t, upstream)
+		rs, err := store.NewRemoteStorage(&remote.Config{
+			BaseURL: srv.URL, APIKey: limitedToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+		})
+		require.NoError(t, err)
+		limitedCore := core.NewKeyorixCore(rs)
+		_, err = limitedCore.GetUser(context.Background(), 1)
+		require.Error(t, err)
+		var httpErr *remote.HTTPError
+		require.True(t, errors.As(err, &httpErr), "expected a *remote.HTTPError; got: %v", err)
+		require.Equal(t, 403, httpErr.StatusCode, "sanity: this must actually be the 403 case, not a 404")
+		assert.False(t, storage.IsUserNotFound(err), "a permission-denied failure must not be misdetected as not-found; got: %v", err)
+	})
+}
+
+// TestFindSCIMUser_RemoteStorage_NotFoundNoLongerHardFails is the #504 regression for
+// scim.go's FindSCIMUser: GetUserByEmail's route (GET /api/v1/users/by-email/{email})
+// is not yet registered on the server at all (#503, a separate, deliberately
+// out-of-scope gap), so under storage.type: remote it 404s UNCONDITIONALLY — even for
+// an email that genuinely exists. Before #504's fix, that 404 never matched the
+// LocalStorage-only i18n "ErrorUserNotFound" text FindSCIMUser string-matched against,
+// so FindSCIMUser returned a hard error for EVERY SCIM email lookup under
+// storage.type: remote, 100% of the time. After the fix, storage.IsUserNotFound
+// correctly recognizes the real 404 (regardless of its cause) and FindSCIMUser
+// returns its documented (nil, nil) "no match" outcome instead of erroring.
+func TestFindSCIMUser_RemoteStorage_NotFoundNoLongerHardFails(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	downstream, _, _ := newRemoteBackedCore(t)
+	u, err := downstream.FindSCIMUser(context.Background(), "", "nobody@example.com")
+	require.NoError(t, err, "FindSCIMUser must treat the real 404 as 'no match', not a hard error")
+	assert.Nil(t, u)
+}
+
+// TestCreateUser_RemoteStorage_SucceedsForFreshUser is the #504 regression for
+// users.go's buildUserForCreate: its email pre-existence check
+// (c.storage.GetUserByEmail) hits the same always-404 route as the test above.
+// Before #504's fix, buildUserForCreate's `!strings.Contains(err.Error(),
+// i18n.T("ErrorUserNotFound"))` guard was ALWAYS true against a RemoteStorage error
+// (the i18n text never appears in a *remote.HTTPError's message), so it treated every
+// such 404 as a hard retrieval failure — meaning CreateUser was completely broken
+// (100% failure rate) under storage.type: remote for every brand-new signup, not just
+// a corner case. After the fix, a fresh (never-seen) username/email is correctly
+// recognized as "available" and CreateUser succeeds end-to-end through the real
+// handler (which hashes the password server-side, #499).
+func TestCreateUser_RemoteStorage_SucceedsForFreshUser(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	downstream, _, _ := newRemoteBackedCore(t)
+	created, err := downstream.CreateUser(context.Background(), &core.CreateUserRequest{
+		Username:    "freshuser1",
+		Email:       "freshuser1@example.com",
+		DisplayName: "Fresh User",
+		Password:    "Zqx9!TrustNoOne42",
+	})
+	require.NoError(t, err, "CreateUser over storage.type: remote must succeed for a brand-new user")
+	require.NotNil(t, created)
+	assert.Equal(t, "freshuser1", created.Username)
+	assert.Equal(t, "freshuser1@example.com", created.Email)
+}
+
+// TestRestoreUser_RemoteStorage_FriendlyNotFoundError is the #504 regression for
+// users.go's RestoreUser: it exercises BOTH sides of the fix in one real round trip —
+// the upstream handler's own core.RestoreUser (LocalStorage.RestoreUser, whose
+// RowsAffected==0 branch is now wrapped in the typed storage.ErrUserNotFound sentinel)
+// and the downstream (RemoteStorage-backed) core.RestoreUser that receives the
+// resulting real *remote.HTTPError. Before #504's fix, the downstream side's
+// string-match never matched that HTTPError, so RestoreUser over storage.type: remote
+// always surfaced a generic "storage failed" error instead of the friendly, specific
+// "user not found or not deleted" message.
+func TestRestoreUser_RemoteStorage_FriendlyNotFoundError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	downstream, _, _ := newRemoteBackedCore(t)
+	const nonExistentOrNotDeletedID = 999999
+	err := downstream.RestoreUser(context.Background(), 1, nonExistentOrNotDeletedID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user not found or not deleted",
+		"must surface the specific friendly message, not a generic storage-failed wrapper; got: %v", err)
+}


### PR DESCRIPTION
## Summary

Fixes backlog finding #504 (MEDIUM): `internal/core/sso.go`, `scim.go`, `users.go`, and `setup_consume.go` detected "user not found" via `strings.Contains(err.Error(), i18n.T("ErrorUserNotFound", nil))` — this only ever matched LocalStorage's own i18n-text error, and never matched RemoteStorage's errors (a generic `httpStatusError` before round 112's #501/PR #812, a structured `remote.HTTPError` after). Every one of these call sites was broken under `storage.type: remote`, both before and after that fix.

## Fix

- Added `storage.IsUserNotFound(err) bool` (`internal/core/storage/errors.go`) — the single backend-agnostic primitive: `errors.Is(err, storage.ErrUserNotFound)` for LocalStorage, `errors.As(err, &remote.HTTPError{})` + `.IsNotFound()` for RemoteStorage. No prior general-purpose helper existed.
- Made `LocalStorage.GetUserByEmail`/`GetUserByUsername`/`GetUserByExternalID`/`RestoreUser` wrap `storage.ErrUserNotFound`, matching `GetUser`/`LockUserForUpdate` which already did — previously inconsistent and unusable for a real `errors.Is` check.
- Replaced every i18n string-matching site in `sso.go` (`resolveSSOUser`), `scim.go` (`deriveSCIMUsername`, `FindSCIMUser`, `UpdateSCIMUser`), `users.go` (`buildUserForCreate`, `UpdateUser`, `RestoreUser`), and `setup_consume.go` (`isUserNotFound`) with the new helper.
- Fixed the identical, structurally related bug in `secret_ownership.go`'s `currentOwnerGone` (Local-correct, silently wrong for Remote), found via a sibling-call-site check.
- Updated 3 test-mock helpers that previously returned bare i18n-text errors to wrap `storage.ErrUserNotFound`, matching the real (now-fixed) storage contract.

## Testing

- `internal/core/user_notfound_backend_test.go`: `storage.IsUserNotFound` proven against a real sqlite `LocalStorage` miss (all 5 methods) and a real `RemoteStorage` 404/403 round trip; plus a `resolveSSOUser` regression over a real RemoteStorage 404.
- `server/http/user_notfound_backend_parity_test.go`: real `NewRouter` + real `RemoteStorage` client proving `FindSCIMUser`, `CreateUser` (previously 100% broken under `storage.type: remote` — every fresh signup's email pre-check hard-failed), and `RestoreUser` now work correctly, plus a 403 fail-closed check.
- Rigor: neutered `storage.IsUserNotFound` and confirmed all new tests fail as predicted, then restored and re-verified green.

## Known, deliberately out-of-scope adjacent gaps (documented in test comments, not fixed here)

`RemoteStorage.GetUserByEmail`'s route is unregistered server-side (fixed separately in #503/PR #818); `RemoteStorage.GetUserByExternalID`/`GetUserByUsername` remain unconditional stubs — pre-existing architecture gaps blocking a full remote round-trip for SSO's externalId path and invitation-accept (RemoteStorage has zero invitation support).

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/core/... ./internal/storage/... ./server/http/... -count=1` — all pass (one pre-existing unrelated flake, `TestConcurrency_RequestPasswordReset_BurstIsThrottled`, confirmed to fail at the same rate on unmodified HEAD)
- `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)