### PR TITLE
docs(crypto): document why TPM PCR-policy binding is deferred, not just noted (#104)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -206,7 +206,16 @@ storage:
   verified/measured boot state — no PolicyPCR session is used. Any code capable of
   asking the TPM to unseal the blob succeeds regardless of firmware/bootloader/kernel
   integrity, so this provider does **not** currently protect against a compromised
-  boot chain on an otherwise-genuine, present TPM.
+  boot chain on an otherwise-genuine, present TPM. This is a deliberate deferral, not
+  an oversight: Keyorix ships as a plain binary/container with no owned host OS image
+  or update hook, so it has no way to detect an impending firmware/bootloader/kernel
+  patch and reseal beforehand, and there is no recovery/escrow fallback if a legitimate
+  host update changes the PCR values — `migrate-provider` itself needs to unseal the
+  *current* blob first, so it can't rescue a PCR-mismatched one. Adding PCR binding
+  without also building that update-integration and recovery story would trade a
+  narrow, known limitation for a silent risk of a routine host patch permanently
+  destroying the KEK (and every secret under it); see `internal/crypto/tpm_provider.go`
+  for the full reasoning.
 - **`aws-kms`** / **`gcp-kms`** / **`azure-kms`** (ADR-041): the KEK is a random key
   **wrapped by a cloud KMS/HSM key**; only the wrapped blob is on disk
   (`wrapped_key_path`), unwrapped via the KMS at startup. The wrapping key never

--- a/internal/crypto/tpm_provider.go
+++ b/internal/crypto/tpm_provider.go
@@ -17,6 +17,36 @@
 // there; a compromised-but-still-genuine boot chain unseals the KEK exactly as
 // successfully as a clean one would. Do not describe this provider as boot-attestation
 // or measured-boot binding until PCR policy sealing is implemented.
+//
+// This is a deliberate deferral, not an oversight — investigated for real PCR-policy
+// binding (go-tpm v0.9.8's tpm2.PolicyPCR/PolicySession fully support it; a trial
+// session at seal time plus a real session at unseal time is a well-trodden pattern,
+// verifiable against the go-tpm-tools simulator) and concluded impractical to add
+// *as a standalone change* given how this provider's surrounding machinery works
+// today:
+//   - Keyorix does not own or control the host's boot chain. It ships as a plain Go
+//     binary / container image (see install.sh, deploy/helm/); there is no
+//     Keyorix-authored OS image, systemd/package-manager hook, or any other
+//     mechanism to detect an impending firmware/bootloader/kernel update and reseal
+//     beforehand. Any customer-driven OS patch on the host silently changes PCR 0-7
+//     and would fail closed on next restart with zero warning.
+//   - There is no recovery/escrow fallback (e.g. a PolicyOR combining the PCR
+//     policy with a break-glass password/share) if the PCR values do change. A
+//     sealed blob whose PCR policy no longer matches is unseal-proof by design —
+//     that is the entire point — so without a second authorization path a routine,
+//     uncoordinated host patch converts into unrecoverable loss of the KEK and
+//     therefore the DEK and every encrypted secret behind it.
+//   - `keyorix encryption migrate-provider` cannot serve as that recovery path
+//     either: it re-wraps the DEK by first calling KEK() on the *current* provider,
+//     so once a PCR mismatch makes this provider's blob unsealable there is no way
+//     to migrate off it. There is no in-place "reseal under fresh PCR values"
+//     command today.
+//
+// In short: PCR binding is real and testable, but bolting it on here without also
+// building host-update integration and a recovery/escrow path would trade a known,
+// narrow limitation (host-binding only) for a silent single-outage-away total data
+// loss risk — worse for a secrets manager than the status quo. Revisit only
+// alongside a reseal/recovery design, not as an isolated fix.
 package crypto
 
 import (


### PR DESCRIPTION
## Summary

Strengthens backlog finding #104's residual (TPM PCR-policy binding) with concrete reasoning, per a round-113 investigation that concluded implementing it would be a net-negative tradeoff for Keyorix's current deployment model — not just an unexamined gap.

## Investigation

`go-tpm v0.9.8` (already a dependency) fully supports real PCR-policy binding — the cryptographic mechanism itself is not the blocker. The blocker is operational:

1. Keyorix doesn't own the host's boot chain (ships as a plain binary or container image; no Keyorix-authored OS image or update hook to detect an impending firmware/bootloader/kernel change and reseal beforehand).
2. There's no recovery/escrow fallback — a PCR mismatch is unseal-proof by design, so a routine, uncoordinated host patch would silently convert into permanent loss of the KEK (and everything behind it), with zero warning.
3. `keyorix encryption migrate-provider` can't rescue a PCR-mismatched blob either — it re-wraps the DEK via `KEK()` on the *current* provider, which is exactly what becomes unsealable.

Adding PCR binding without also building host-update integration and a recovery/escrow story would trade a narrow, well-understood limitation for a silent risk of a routine host patch causing an unrecoverable, whole-store outage.

## Change

Doc/comment-only, no functional or test change:
- `internal/crypto/tpm_provider.go`: expanded the `KNOWN LIMITATION` doc comment with this reasoning.
- `docs/CONFIGURATION.md`: added the same reasoning to the `tpm` provider's caveat.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/crypto/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./internal/crypto/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)