### PR TITLE
docs(storage): clarify MFASecret's plaintext-passthrough branch is unreachable in practice (#128)

### DIFF
--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -316,9 +316,21 @@ type User struct {
 // user (UserID unique). Activated flips true on the first valid code at
 // enrolment; a row with Activated=false is a pending enrolment not yet confirmed.
 type MFASecret struct {
-	ID         uint   `gorm:"primaryKey"`
-	UserID     uint   `gorm:"uniqueIndex"`
-	SecretEnc  []byte `json:"-"` // encrypted TOTP secret (passthrough plaintext when encryption is disabled)
+	ID     uint `gorm:"primaryKey"`
+	UserID uint `gorm:"uniqueIndex"`
+	// SecretEnc is the encrypted TOTP secret. Unlike a general secret VALUE (whose
+	// at-rest encryption is an explicit, informed operator trade-off when disabled —
+	// see encryption.SecretEncryption.StoreSecret) or a dynamic-secret admin DSN
+	// (same plaintext-passthrough via core.encryptAuthSecret), MFA does NOT fall
+	// back to plaintext when encryption is off: the sole write path,
+	// core.BeginMFAEnrollment, refuses outright ("... requires at-rest encryption
+	// to be enabled") rather than ever calling encryptAuthSecret with a
+	// disabled/nil encryptor for this row. So although encryptAuthSecret's
+	// plaintext-passthrough branch exists in the shared helper (and is genuinely
+	// used by its other two callers), it is unreachable for MFASecret in
+	// practice — a row here is either genuinely encrypted or, for a pre-#94
+	// legacy row, holds an already-encrypted-under-the-old-scheme value.
+	SecretEnc  []byte `json:"-"`
 	SecretMeta []byte `json:"-"` // encryption metadata (key version etc.)
 	Activated  bool   `gorm:"default:false"`
 	// LastUsedStep is the TOTP time-step (unix/period) of the most recently accepted


### PR DESCRIPTION
## Summary

Strengthens backlog finding #128's MFA-plaintext residual with a round-113 investigation's finding: MFA is not a worse-off outlier among Keyorix's reversibly-encrypted auth secrets — it's actually stricter than its siblings.

## Investigation

Traced the shared helper `core.encryptAuthSecret`/`decryptAuthSecret`, used by MFA TOTP secrets, `DynamicSecretConfig.AdminDSNEnc`, and dynamic-secret lease credentials — all three pass through plaintext when the encryptor is nil/disabled, same as the main secret VALUE path. So at the helper level, MFA is consistent with its siblings, not worse off.

One level up, MFA is actually better protected: `BeginMFAEnrollment` — the sole call site that ever creates an `MFASecret` row — explicitly refuses to enrol when encryption is disabled ("MFA enrolment requires at-rest encryption to be enabled..."), already tested by `TestBeginMFAEnrollment_RefusesWhenNoEncryptor`/`RefusesWhenEncryptorDisabled`. This makes the plaintext-passthrough branch unreachable for MFA in practice, unlike `DynamicSecretConfig.AdminDSNEnc`, which has no such guard.

The only real issue: the field-level comment described only the shared helper's abstract behavior, without noting the enrollment-time fail-closed guard — potentially misleading in isolation.

## Change

Doc-only, no functional/test change: updated `MFASecret.SecretEnc`'s comment (`internal/storage/models/models.go`) to explain the branch is unreachable for MFA specifically, cross-referencing `BeginMFAEnrollment`.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/storage/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)