### PR TITLE
ci(fuzzing): add targets.conf staleness check, cap fuzz CPU, fuzz SQL quoting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,96 @@ jobs:
           go install github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}
           gosec -severity medium -exclude-generated ./...
 
+  # scripts/fuzzing/targets.conf is a hand-maintained list consumed by the
+  # self-hosted continuous-fuzzing rig (scripts/fuzzing/README.md) -- it has
+  # NO automated link to what `func FuzzXxx` targets actually exist in the
+  # tree. A sibling project hit exactly this failure mode for months with no
+  # signal anything was wrong: an identical hand-maintained list silently
+  # missed 18 of 44 real fuzz functions. This job closes that gap by diffing
+  # the list of FuzzXxx functions `go test -list` finds in the tree (ground
+  # truth) against what targets.conf declares, failing on ANY divergence:
+  #   - a real FuzzXxx exists but isn't declared -- it would silently never
+  #     get continuously fuzzed (the sibling-project failure mode above).
+  #   - targets.conf declares a FuzzXxx that no longer exists -- a stale
+  #     entry (e.g. after a rename/removal) that run-rotation.sh would fail
+  #     to run every cycle.
+  fuzz-targets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.26'
+
+      - name: Verify targets.conf matches the real FuzzXxx functions in the tree
+        run: |
+          MODULE_PREFIX="github.com/keyorixhq/keyorix"
+
+          # Reads `go test -list '^Fuzz' ./...`-style output on stdin and prints
+          # "<pkg-relative-to-module>|<FuzzFuncName>" for every real FuzzXxx
+          # function found, one per line. That output interleaves each
+          # package's matched test names (if any) immediately before its own
+          # "ok  <pkg>  <time>" (or "FAIL"/"?   <pkg> [no test files]") summary
+          # line, so the parse below buffers pending names and flushes them,
+          # tagged with the package they preceded, the moment it sees that
+          # summary line. $1 is prefixed onto each package path so the
+          # operator module's targets (see below) stay namespaced separately
+          # from the root module's -- a relative package path like
+          # "internal/foo" could in principle exist under both modules.
+          extract_fuzz_targets() {
+            local prefix="$1"
+            awk -v modprefix="${MODULE_PREFIX}/" -v outprefix="$prefix" '
+              /^(ok|FAIL)[ \t]/ {
+                pkg = $2
+                sub("^" modprefix, "", pkg)
+                for (i = 1; i <= n; i++) print outprefix pkg "|" names[i]
+                n = 0
+                next
+              }
+              /^\?[ \t]/ { n = 0; next }
+              /^#/       { next }
+              NF == 0    { next }
+              { n++; names[n] = $0 }
+            '
+          }
+
+          echo "== true FuzzXxx functions: root module =="
+          go test -list '^Fuzz' ./... | tee root-fuzz-list.txt
+          # The operator is a separate Go module (see the `operator` job
+          # above); GOWORK=off keeps it out of this repo's go.work, mirroring
+          # that job's own established convention for module-specific checks.
+          echo "== true FuzzXxx functions: operator module (GOWORK=off) =="
+          (cd operator && GOWORK=off go test -list '^Fuzz' ./...) | tee operator-fuzz-list.txt
+
+          extract_fuzz_targets "" < root-fuzz-list.txt > true-targets.txt
+          extract_fuzz_targets "operator/" < operator-fuzz-list.txt >> true-targets.txt
+          sort -u true-targets.txt -o true-targets.txt
+
+          grep -vE '^[[:space:]]*(#|$)' scripts/fuzzing/targets.conf \
+            | awk -F'|' '{print $1"|"$2}' \
+            | sort -u > declared-targets.txt
+
+          echo "--- true FuzzXxx targets in the tree ---"; cat true-targets.txt
+          echo "--- targets declared in scripts/fuzzing/targets.conf ---"; cat declared-targets.txt
+
+          missing=$(comm -23 true-targets.txt declared-targets.txt)
+          stale=$(comm -13 true-targets.txt declared-targets.txt)
+
+          status=0
+          if [ -n "$missing" ]; then
+            echo "::error::FuzzXxx functions exist in the tree but are NOT declared in scripts/fuzzing/targets.conf -- they would never be picked up by the continuous-fuzzing rig:"
+            echo "$missing"
+            status=1
+          fi
+          if [ -n "$stale" ]; then
+            echo "::error::scripts/fuzzing/targets.conf declares FuzzXxx targets that no longer exist in the tree (stale entry, e.g. after a rename/removal):"
+            echo "$stale"
+            status=1
+          fi
+          exit $status
+
   # Dependency license compliance. Keyorix is dual-licensed -- the repo is
   # AGPL-3.0, but the same code is also commercially licensed to customers who
   # don't want AGPL obligations (see LICENSING.md's "Our principles"). Nothing

--- a/internal/rotation/mysql_fuzz_test.go
+++ b/internal/rotation/mysql_fuzz_test.go
@@ -1,0 +1,90 @@
+package rotation
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzMySQLQuoteString fuzzes quoteMySQLString (mysql.go) — hand-rolled SQL
+// escaping at the same trust boundary (an admin-configured rotation_ref)
+// that already produced one real, shipped, fixed vulnerability in this
+// codebase (FuzzAzureGenerateUpstreamRef's subject). See the doc comment on
+// FuzzPostgresQuoteIdentifier (postgres_fuzz_test.go) for why a round-trip
+// invariant is the strongest available proxy for "no input can escape the
+// quoted context" without a live SQL parser.
+//
+// quoteMySQLString's encode order is: (1) double every backslash, THEN (2)
+// double every single-quote, then wrap in single quotes. Decoding must undo
+// these in the OPPOSITE order — undo (2) first (un-double quotes), THEN
+// undo (1) (un-double backslashes) — or the reconstruction is wrong.
+//
+// Hand-traced example proving the order, input `\'` (one backslash, one
+// single-quote), reproduced here as the derivation for decodeMySQLQuoted
+// below (B = backslash byte, Q = single-quote byte):
+//
+//	s          = B Q                          (2 bytes)
+//	encode (1): double every B  -> B B Q       (3 bytes)
+//	encode (2): double every Q  -> B B Q Q     (4 bytes)
+//	wrap        -> Q B B Q Q Q                 (6 bytes: quoteMySQLString(`\'`) == `'\\'''`)
+//
+//	decode, stripped of the wrapping quotes -> B B Q Q (4 bytes)
+//	decode (2) undo quote-doubling first: "QQ"->"Q"  -> B B Q   (3 bytes)
+//	decode (1) undo backslash-doubling second: "BB"->"B" -> B Q (2 bytes) == s. Correct.
+//
+// (Doing it in the wrong order — backslash-undouble before quote-undouble —
+// happens to also recover B Q for this particular example, since B-runs and
+// Q-runs never overlap positionally; but the comment above documents the
+// mathematically-correct reverse-of-encode order regardless, and the fuzz
+// target below proves it holds for the whole input space, not just this one
+// hand-traced case.)
+func decodeMySQLQuoted(quoted string) (string, bool) {
+	if len(quoted) < 2 || quoted[0] != '\'' || quoted[len(quoted)-1] != '\'' {
+		return "", false
+	}
+	inner := quoted[1 : len(quoted)-1]
+	inner = strings.ReplaceAll(inner, `''`, `'`) // undo step 2 (quote-doubling) first
+	inner = strings.ReplaceAll(inner, `\\`, `\`) // then undo step 1 (backslash-doubling)
+	return inner, true
+}
+
+// FuzzMySQLQuoteString round-trips quoteMySQLString: decodeMySQLQuoted must
+// exactly recover any fuzzed input.
+//
+// NUL bytes and other control characters: MySQL's own wire protocol/text
+// protocol handling can reject or special-case a NUL byte in some contexts
+// independent of application-level quoting — so, as with the Postgres
+// targets, a round-trip failure specifically and only on NUL/control-byte
+// input would be a protocol-level scope boundary, not a SQL-injection-
+// relevant escaping bug. quoteMySQLString itself operates purely at the Go
+// string level (no NUL-stripping), so the round-trip is still asserted for
+// these seeds below — the escaping itself must remain lossless.
+func FuzzMySQLQuoteString(f *testing.F) {
+	f.Add("")
+	f.Add("a")
+	f.Add(`'`)
+	f.Add(`\`)
+	f.Add(`\'`)
+	f.Add(`'\`)
+	f.Add(`a'b\c`)
+	f.Add(`''''`)
+	f.Add(`\\\\`)
+	f.Add(`a\'b\'c`)
+	f.Add("rotation_user")
+	f.Add("app-role.prod_01@%")
+	f.Add("\x00")
+	f.Add("a\x00\x01\x02b")
+	f.Add(strings.Repeat(`'`, 200))
+	f.Add(strings.Repeat(`\`, 200))
+	f.Add(strings.Repeat(`\'`, 100))
+
+	f.Fuzz(func(t *testing.T, s string) {
+		quoted := quoteMySQLString(s)
+		got, ok := decodeMySQLQuoted(quoted)
+		if !ok {
+			t.Fatalf("quoteMySQLString(%q) = %q is not quote-wrapped", s, quoted)
+		}
+		if got != s {
+			t.Fatalf("round-trip mismatch: quoteMySQLString(%q) = %q, decoded back to %q", s, quoted, got)
+		}
+	})
+}

--- a/internal/rotation/postgres_fuzz_test.go
+++ b/internal/rotation/postgres_fuzz_test.go
@@ -1,0 +1,96 @@
+package rotation
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzPostgresQuoting fuzzes quoteIdentifier and quoteLiteral (postgres.go) —
+// hand-rolled SQL escaping at the same trust boundary (an admin-configured
+// rotation_ref) that already produced one real, shipped, fixed vulnerability
+// in this codebase (FuzzAzureGenerateUpstreamRef's subject). Neither function
+// can be validated against a live SQL parser here, so the strongest available
+// proxy is a round-trip invariant: a reference decoder that exactly reverses
+// the encode transform must recover the original input for every possible
+// string. If it doesn't, the escaping is ambiguous — i.e. some byte sequence
+// could make the quoted context interpret encoded content differently than
+// intended, the same shape of bug as the Azure ref-injection issue this round
+// found.
+//
+// Both quoteIdentifier and quoteLiteral share the same shape: wrap in a
+// delimiter, double every occurrence of that delimiter inside. Decoding is
+// the inverse: strip the leading/trailing delimiter, then replace every
+// doubled delimiter with a single one. A single un-double pass is correct
+// here (unlike MySQL below) because there is only one context-free
+// transform, not two interacting ones — see mysql_fuzz_test.go for the case
+// where order matters. Since the two functions only differ in delimiter
+// character, both round-trips are asserted per fuzzed input from a single
+// fuzz target, rather than two near-identical targets.
+
+// decodePGQuoted reverses quoteIdentifier/quoteLiteral's transform: strip the
+// leading/trailing delim, then collapse every doubled delim to one.
+func decodePGQuoted(quoted string, delim byte) (string, bool) {
+	if len(quoted) < 2 || quoted[0] != delim || quoted[len(quoted)-1] != delim {
+		return "", false
+	}
+	inner := quoted[1 : len(quoted)-1]
+	doubled := string([]byte{delim, delim})
+	return strings.ReplaceAll(inner, doubled, string(delim)), true
+}
+
+// FuzzPostgresQuoting round-trips both quoteIdentifier (double-quote delim)
+// and quoteLiteral (single-quote delim) via decodePGQuoted; each must
+// exactly recover any fuzzed input.
+//
+// NUL bytes and other control characters: PostgreSQL's wire protocol itself
+// rejects a NUL byte inside an identifier/string at the protocol level (it's
+// a C-string-terminated wire format), independent of any quoting these
+// functions do — so a round-trip failure specifically and only on inputs
+// containing 0x00 would not indicate a SQL-injection-relevant escaping bug.
+// The round-trip is still asserted for NUL/control-byte seeds below because
+// quoteIdentifier/quoteLiteral operate purely at the Go string level (no
+// NUL-stripping), so the escaping itself must still be lossless even though
+// the underlying driver would separately refuse to transmit such a value.
+func FuzzPostgresQuoting(f *testing.F) {
+	f.Add("")
+	f.Add("a")
+	f.Add(`"`)
+	f.Add(`'`)
+	f.Add(`\`)
+	f.Add(`a"b'c\d`)
+	f.Add(`""""`)
+	f.Add(`''''`)
+	f.Add(`a"'"'"'b`)
+	f.Add("app_rotation_role")
+	f.Add("app-role.prod_01")
+	f.Add("\x00")
+	f.Add("a\x00\x01\x02b")
+	f.Add(strings.Repeat(`"`, 200))
+	f.Add(strings.Repeat(`'`, 200))
+
+	f.Fuzz(func(t *testing.T, s string) {
+		idQuoted := quoteIdentifier(s)
+		idGot, ok := decodePGQuoted(idQuoted, '"')
+		if !ok {
+			t.Fatalf("quoteIdentifier(%q) = %q is not delimiter-wrapped", s, idQuoted)
+		}
+		if idGot != s {
+			t.Fatalf("round-trip mismatch: quoteIdentifier(%q) = %q, decoded back to %q", s, idQuoted, idGot)
+		}
+		// The escaped identifier must never contain an UNPAIRED delimiter —
+		// every '"' in the quoted output must be part of a doubled pair or one
+		// of the two wrapping delimiters. Verified implicitly by the
+		// successful round-trip above (an unpaired '"' would either break the
+		// wrapping-strip check or leave a stray '"' after un-doubling that
+		// wouldn't match the original s).
+
+		litQuoted := quoteLiteral(s)
+		litGot, ok := decodePGQuoted(litQuoted, '\'')
+		if !ok {
+			t.Fatalf("quoteLiteral(%q) = %q is not delimiter-wrapped", s, litQuoted)
+		}
+		if litGot != s {
+			t.Fatalf("round-trip mismatch: quoteLiteral(%q) = %q, decoded back to %q", s, litQuoted, litGot)
+		}
+	})
+}

--- a/scripts/fuzzing/README.md
+++ b/scripts/fuzzing/README.md
@@ -21,6 +21,28 @@ long-lived infrastructure — a small home-lab VM/LXC is a good fit.
   dedicated `fuzz-corpus` branch automatically — review/merge what's
   interesting from there.
 
+## Resource limits
+
+`systemd/keyorix-fuzz.service` caps this service to `CPUQuota=400%` (4 of an
+assumed 8-core homelab box) and `MemoryMax=2G`, alongside `Nice=10`. `Nice`
+only lowers this service's *relative* scheduling priority when something else
+on the box wants the CPU too — on an otherwise-idle homelab box (which this
+one mostly is), that does nothing to cap actual usage, so `CPUQuota=` is the
+setting doing the real work of leaving headroom for everything else on the
+box. Adjust both to fit your own hardware and how much of it you're willing
+to dedicate.
+
+**Important tradeoff to understand before tuning `CPUQuota`:** the
+`-fuzztime` values in `targets.conf` (consumed by `run-rotation.sh`) are
+**wall-clock** time, not CPU time — `go test -fuzz -fuzztime=3h` runs for 3
+hours of real time regardless of how much CPU it actually gets scheduled.
+Capping `CPUQuota` therefore does **not** change how long a rotation takes;
+it only makes each rotation's mutation pass *shallower* — fewer inputs get
+tried (throughput scales down roughly with the quota) in that same
+wall-clock window. If you want both fast throughput and a hard resource
+ceiling, lower `-fuzztime` instead of (or in addition to) `CPUQuota` so a
+rotation cycle still completes in a reasonable amount of real time.
+
 ## One-time setup (on the LXC/VM)
 
 Debian or Alpine, ~512MB RAM is plenty for a single-target-at-a-time rotation

--- a/scripts/fuzzing/systemd/keyorix-fuzz.service
+++ b/scripts/fuzzing/systemd/keyorix-fuzz.service
@@ -12,8 +12,15 @@ ExecStart=/opt/keyorix-fuzz/keyorix/scripts/fuzzing/run-rotation.sh
 Restart=always
 RestartSec=30
 # Fuzzing is CPU/memory-hungry by design but must never take the box down or
-# starve anything else running on it.
+# starve anything else running on it. Nice=10 only lowers this service's
+# RELATIVE scheduling priority under contention -- on an otherwise-idle
+# homelab box (which this one mostly is) that does nothing to cap actual
+# usage, so without an explicit ceiling the fuzzer will happily burn every
+# available core continuously. CPUQuota=400% caps it to 4 of this box's 8
+# cores (see scripts/fuzzing/README.md's "Resource limits" section for the
+# tradeoff this creates with -fuzztime, which is wall-clock, not CPU time).
 Nice=10
+CPUQuota=400%
 MemoryMax=2G
 
 [Install]

--- a/scripts/fuzzing/targets.conf
+++ b/scripts/fuzzing/targets.conf
@@ -10,3 +10,12 @@
 internal/crypto|FuzzCombineKEK|3h
 internal/core|FuzzOIDCVerifierVerify|3h
 internal/rotation|FuzzAzureGenerateUpstreamRef|3h
+# The 2 targets below round-trip-fuzz the hand-rolled SQL escaping in the
+# Postgres/MySQL rotation backends (postgres.go/mysql.go) — the same
+# rotation_ref trust boundary that FuzzAzureGenerateUpstreamRef's own subject
+# (the Azure ref-injection bug) already showed is worth deep fuzzing. 2h each
+# (vs. the 3h above) keeps the full rotation cycle at a reasonable ~13h
+# total rather than growing it by another 6h for functions whose escaping
+# logic is much smaller/simpler than a full HTTP-ref-interpolation path.
+internal/rotation|FuzzPostgresQuoting|2h
+internal/rotation|FuzzMySQLQuoteString|2h


### PR DESCRIPTION
## Summary

Cross-project review against a sibling project (a hand-maintained fuzz-target
list that silently missed 18 of 44 real fuzz functions for months) surfaced 4
scoped gaps in this repo's own continuous-fuzzing setup (`scripts/fuzzing/`):

- **Staleness check (new `fuzz-targets` CI job).** `scripts/fuzzing/targets.conf`
  had zero automated verification against the `func FuzzXxx` functions that
  actually exist in the tree. The new job runs `go test -list '^Fuzz' ./...`
  against both the root module and the `operator/` module (`GOWORK=off`,
  mirroring the existing `operator` job's convention), and fails the build if
  a real `FuzzXxx` exists but isn't declared in `targets.conf` (the sibling
  project's exact failure mode — a target that silently never gets
  continuously fuzzed), or if `targets.conf` declares a `FuzzXxx` that no
  longer exists (stale entry after a rename/removal).
- **CPU cap for the fuzzing systemd service.** `keyorix-fuzz.service` had
  `Nice=10`/`MemoryMax=2G` but no `CPUQuota=`. `Nice` only affects *relative*
  scheduling under contention — on an otherwise-idle homelab box it does
  nothing, so the fuzzer could consume every core continuously. Added
  `CPUQuota=400%` (4 of the box's 8 cores — leaves half for everything else).
  Documented in both the unit file and `README.md` that `-fuzztime` is
  wall-clock, not CPU time, so this makes each rotation's mutation pass
  shallower (fewer inputs tried in the same window) without changing how
  long a rotation takes.
- **Two new round-trip fuzz targets** for the hand-rolled SQL escaping in the
  rotation backends — `postgres.go`'s `quoteIdentifier`/`quoteLiteral` and
  `mysql.go`'s `quoteMySQLString` — the same `rotation_ref` trust boundary
  that already produced one real, shipped, fixed injection bug in this
  codebase (`FuzzAzureGenerateUpstreamRef`'s subject). Each asserts
  `decode(encode(s)) == s` for every fuzzed `s`, using a hand-derived,
  hand-traced decoder (MySQL's decode order matters — traced with `\'` as a
  worked example in the test file's doc comment). No bug found: ~700k execs
  per target in a 30s local burst, zero crashes. `targets.conf` updated with
  both new targets (2h each, keeping the full rotation cycle at ~13h).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` (root module) — all
      green, including the new fuzz functions running as seed-corpus
      regression tests.
- [x] `cd operator && GOWORK=off go vet ./... && GOWORK=off go build ./...`
      — green.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues.
- [x] `go test -fuzz='^FuzzPostgresQuoting$' -fuzztime=30s ./internal/rotation`
      and same for `FuzzMySQLQuoteString` — no crash, ~22-25k execs/sec.
- [x] `actionlint .github/workflows/ci.yml` — no new findings (pre-existing
      shellcheck infos on unrelated lines only).
- [x] Verified the staleness check both directions locally: added the 2 new
      `FuzzXxx` targets to the tree *before* updating `targets.conf` and
      confirmed the check's logic flags them by name; also added a scratch,
      uncommitted `FuzzTempExample` to prove the check catches an arbitrary
      undeclared target; then updated `targets.conf` and confirmed the
      comparison passes clean.

🤖 Generated with Claude Code