### PR TITLE
fix(fuzzing): sync-corpus.sh crashed on the common no-testdata-yet case

### DIFF
--- a/scripts/fuzzing/sync-corpus.sh
+++ b/scripts/fuzzing/sync-corpus.sh
@@ -20,6 +20,22 @@ STATUS="${2:-0}"
 : "${FUZZ_CORPUS_BRANCH:=fuzz-corpus}"
 
 mkdir -p "$FUZZ_CORPUS_WORKTREE/testdata/fuzz"
+
+# Go's fuzz engine only ever creates testdata/fuzz/<FuncName>/ when a target
+# actually CRASHES — never for ordinary coverage-expanding exploration (that
+# non-crashing "new interesting" corpus stays in the local build cache,
+# $GOCACHE/fuzz, and is never written into the source tree). So on any target
+# that hasn't crashed yet, $KEYORIX_REPO/testdata/fuzz doesn't exist at all —
+# this is the normal, expected common case, not an error. Without this guard,
+# rsync's sender failed with "No such file or directory" (exit 23), and
+# because run-rotation.sh calls this script with `set -e` active, that
+# non-zero exit killed the ENTIRE run-rotation.sh process — which systemd's
+# Restart=always then restarted from the top of targets.conf, re-fuzzing the
+# FIRST target instead of advancing to the next one. Confirmed live: the rig
+# had been stuck re-fuzzing target #1 in a 3-hour crash/restart loop since
+# deployment, having never once reached a second target or a corpus commit.
+[ -d "$KEYORIX_REPO/testdata/fuzz" ] || exit 0
+
 rsync -a --update "$KEYORIX_REPO/testdata/fuzz/" "$FUZZ_CORPUS_WORKTREE/testdata/fuzz/"
 
 cd "$FUZZ_CORPUS_WORKTREE"


### PR DESCRIPTION
## Summary
Confirmed live on the running `keyorix-fuzz` rig, not hypothetical: `sync-corpus.sh` ran `rsync ... "$KEYORIX_REPO/testdata/fuzz/" ...` unconditionally, but Go's fuzz engine only creates `testdata/fuzz/<FuncName>/` when a target actually **crashes** — never for ordinary coverage-expanding exploration. On any target that hasn't crashed yet (every target so far), that directory doesn't exist, rsync fails with "No such file or directory" (exit 23), and `set -e` in `run-rotation.sh` propagated that into killing the entire process. `systemd`'s `Restart=always` then restarted it **from the top of `targets.conf`**, re-fuzzing the first target instead of advancing.

**Confirmed impact** via `journalctl` on the live box: exactly 3h after starting `FuzzCombineKEK` (the first `targets.conf` entry), the process exited with `status=23`, and on restart it began fuzzing `FuzzCombineKEK` again — not the second entry. The `fuzz-corpus` branch has zero commits matching this script's own commit format, ever. The rig has likely never advanced past the first target or synced anything since deployment.

## Fix
Guard the rsync on `testdata/fuzz` actually existing — "nothing to sync yet" is the normal no-op case the script's own header comment already (falsely) claimed it handled.

## Verification
Built a real scratch git repo (bare origin + fuzzing clone + corpus worktree, mirroring the live deployment shape) and confirmed all 4 cases:
1. Unfixed script reproducibly exits 23 with the exact rsync error on the no-testdata-yet scenario
2. Fixed script exits 0 cleanly on the identical scenario
3. A genuine crash (a real `testdata/fuzz/<Func>/<hash>` file) still gets synced, committed with the correct "CRASH found" label, and pushed
4. Re-running with no new content is a clean idempotent no-op, not a duplicate commit

## Next step (not in this PR)
Once merged, I'll deploy this directly to the live box and restart the service — it can't self-heal via its own `git reset --hard origin/main` step, since that only runs after completing a full rotation cycle through every target, which is exactly what this bug has been preventing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)