### PR TITLE
feat(classification): gate restricted-secret reads behind an opt-in access request (#128)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,7 @@ The config file is located via, in order: an explicit path argument, then
 - [secrets](#secrets) · [security + require_mfa](#security) (ADR-034)
 - [webauthn](#webauthn) (ADR-036) · [dynamic_secrets](#dynamic_secrets) (ADR-035)
 - [oidc](#oidc) (ADR-031) · [session](#session) · [password_policy](#password_policy) (ADR-025)
-- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [data_retention](#data_retention) (A.5.33) · [recertification](#recertification) (A.5.18) · [notifications](#notifications) · [compliance_digest](#compliance_digest) · [evidence_delivery](#evidence_delivery) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [audit.siem](#auditsiem)
+- [soft_delete + purge](#soft_delete--purge) (ADR-032) · [data_retention](#data_retention) (A.5.33) · [recertification](#recertification) (A.5.18) · [notifications](#notifications) · [compliance_digest](#compliance_digest) · [evidence_delivery](#evidence_delivery) · [rotation_reminders](#rotation_reminders) · [audit_checkpoints](#audit_checkpoints) (ADR-029) · [jit_access_expiry](#jit_access_expiry) · [break_glass](#break_glass) · [dual_control](#dual_control) (A.5.3) · [classification](#classification) (A.5.12/A.5.13) · [audit.siem](#auditsiem)
 - [scim](#scim) (RFC 7644) · [sso](#sso) (OIDC) · [membership](#membership) (ADR-022) · [credential_delivery](#credential_delivery) (ADR-028)
 
 ---
@@ -778,6 +778,34 @@ value of `1` (the default) keeps the single-approval behaviour.
 ```yaml
 dual_control:
   required_approvals: 2   # distinct approvers needed per access request (default 1)
+```
+
+## classification
+
+Whether the **"restricted" data-classification label** (the highest tier;
+`public`/`internal`/`confidential`/`restricted`, see `internal/core/classification.go`)
+changes read-time behaviour. **Disabled by default** — today, "restricted" is
+purely informational metadata; setting `restricted_requires_approval: true` for
+the first time is a **breaking behaviour change** for any deployment that already
+has "restricted" secrets, since they were previously readable like any other with
+sufficient RBAC. Opt in deliberately, only once you also have a plan for
+approving requests (below) — otherwise every "restricted" secret's value becomes
+permanently unreadable the moment you enable this.
+
+When enabled, reading a "restricted" secret's **value** (not its metadata —
+`GetSecret`/listing are unaffected) requires an approved, **secret-scoped**
+access request: `keyorix request secret-access --secret-id <id> --user
+<email>` to request it, `keyorix request review --id <id> --action approve
+--by <admin-email>` to approve it (an administrator at the secret's project).
+This reuses the same `AccessRequest` model/flow as `dual_control` above
+(ADR-024), narrowed with a `SecretID` rather than granting a role. A read whose
+acting principal cannot be identified as a specific user — a machine/service
+identity, for instance — is **always denied** when this is on: there is no
+"wait for approval" for automation, and no bypass for it either.
+
+```yaml
+classification:
+  restricted_requires_approval: false   # opt-in; see above before enabling
 ```
 
 ## anomaly_alerts

--- a/internal/cli/request/list.go
+++ b/internal/cli/request/list.go
@@ -46,11 +46,15 @@ func runList(cmd *cobra.Command, args []string) error {
 		fmt.Println("No access requests found.")
 		return nil
 	}
-	fmt.Printf("%-6s %-24s %-14s %-14s %-11s %s\n", "ID", "USER", "SUGGESTED", "GRANTED", "STATE", "REASON")
+	fmt.Printf("%-6s %-24s %-14s %-14s %-11s %-10s %s\n", "ID", "USER", "SUGGESTED", "GRANTED", "STATE", "SECRET", "REASON")
 	for _, req := range requests {
-		fmt.Printf("%-6d %-24s %-14s %-14s %-11s %s\n",
+		secretCol := "-"
+		if req.SecretID != nil {
+			secretCol = fmt.Sprintf("#%d", *req.SecretID)
+		}
+		fmt.Printf("%-6d %-24s %-14s %-14s %-11s %-10s %s\n",
 			req.ID, userLabel(ctx, service, req.UserID), dashIfEmpty(req.SuggestedRole),
-			dashIfEmpty(req.GrantedRole), req.State, dashIfEmpty(req.Reason))
+			dashIfEmpty(req.GrantedRole), req.State, secretCol, dashIfEmpty(req.Reason))
 	}
 	return nil
 }

--- a/internal/cli/request/request.go
+++ b/internal/cli/request/request.go
@@ -2,6 +2,13 @@
 // access requests (ADR-024): access (create), list, withdraw, and review
 // (approve/reject). Requesting and withdrawing are self-service; review is
 // admin-driven. These mirror the HTTP surface under /projects/{id}/access-requests.
+//
+// secret-access is the narrower sibling: a request for approval to read one
+// specific secret's value (the classification gate — see
+// internal/core/classification_gate.go), rather than a role at a project.
+// list/withdraw/review all work on it unchanged (it's the same AccessRequest
+// row, just with SecretID set); review's approve path detects that and routes
+// to ApproveSecretAccessRequest instead of granting a role.
 package request
 
 import (
@@ -21,6 +28,7 @@ var RequestCmd = &cobra.Command{
 
 func init() {
 	RequestCmd.AddCommand(accessCmd)
+	RequestCmd.AddCommand(secretAccessCmd)
 	RequestCmd.AddCommand(listCmd)
 	RequestCmd.AddCommand(withdrawCmd)
 	RequestCmd.AddCommand(reviewCmd)

--- a/internal/cli/request/request_test.go
+++ b/internal/cli/request/request_test.go
@@ -16,9 +16,16 @@ func TestRequestCommandStructure(t *testing.T) {
 	for _, c := range RequestCmd.Commands() {
 		names = append(names, c.Use)
 	}
-	for _, expected := range []string{"access", "list", "withdraw", "review"} {
+	for _, expected := range []string{"access", "secret-access", "list", "withdraw", "review"} {
 		assert.Contains(t, names, expected, "expected subcommand %q", expected)
 	}
+}
+
+func TestRequestSecretAccessFlags(t *testing.T) {
+	for _, name := range []string{"secret-id", "ref", "user", "reason"} {
+		assert.NotNil(t, secretAccessCmd.Flags().Lookup(name), "secret-access should have --%s", name)
+	}
+	assert.NotEmpty(t, secretAccessCmd.Flags().Lookup("user").Annotations[cobraRequired], "--user should be required")
 }
 
 func TestRequestAccessFlags(t *testing.T) {

--- a/internal/cli/request/review.go
+++ b/internal/cli/request/review.go
@@ -72,6 +72,22 @@ func runReview(cmd *cobra.Command, args []string) error {
 
 	switch reviewAction {
 	case "approve":
+		// A secret-scoped request (SecretID set) grants no role at all — it can't go
+		// through ApproveAccessRequestWithExpiry, whose entire body is about granting
+		// one (see classification_gate.go's doc comment for why that function isn't
+		// reused here). Route it to the narrower approval instead.
+		if existing.SecretID != nil {
+			if reviewRole != "" || reviewTTL != "" {
+				return fmt.Errorf("--role and --ttl do not apply to a secret-scoped request (id %d) — it grants no role", reviewID)
+			}
+			req, err := service.ApproveSecretAccessRequest(ctx, reviewID, approverID)
+			if err != nil {
+				return fmt.Errorf("failed to approve secret access request: %w", err)
+			}
+			fmt.Printf("Secret access request %d approved for %s to read secret %d.\n",
+				req.ID, userLabel(ctx, service, req.UserID), *req.SecretID)
+			return nil
+		}
 		var ttl time.Duration
 		if reviewTTL != "" {
 			ttl, err = time.ParseDuration(reviewTTL)

--- a/internal/cli/request/secret_access.go
+++ b/internal/cli/request/secret_access.go
@@ -1,0 +1,69 @@
+package request
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	secretAccessSecretID uint
+	secretAccessRef      string
+	secretAccessUser     string
+	secretAccessReason   string
+)
+
+var secretAccessCmd = &cobra.Command{
+	Use:   "secret-access",
+	Short: "Request approval to read one restricted secret's value",
+	Long: "Create a pending, secret-scoped access request: approval to read ONE specific\n" +
+		"secret's value, distinct from `request access`'s broader project/role request.\n" +
+		"Only relevant when classification.restricted_requires_approval is enabled and\n" +
+		"the target secret's classification is \"restricted\" — the gate this satisfies.",
+	RunE: runSecretAccess,
+}
+
+func init() {
+	secretAccessCmd.Flags().UintVar(&secretAccessSecretID, "secret-id", 0, "Secret ID (or use --ref)")
+	secretAccessCmd.Flags().StringVar(&secretAccessRef, "ref", "", "Secret reference \"project/environment/name\" (or use --secret-id)")
+	secretAccessCmd.Flags().StringVar(&secretAccessUser, "user", "", "Requester email address (required)")
+	secretAccessCmd.Flags().StringVar(&secretAccessReason, "reason", "", "Reason for the request (optional)")
+	_ = secretAccessCmd.MarkFlagRequired("user")
+}
+
+func runSecretAccess(cmd *cobra.Command, args []string) error {
+	if secretAccessUser == "" {
+		return fmt.Errorf("--user is required")
+	}
+	if secretAccessSecretID == 0 && secretAccessRef == "" {
+		return fmt.Errorf("--secret-id or --ref is required")
+	}
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	ctx := context.Background()
+
+	secretID := secretAccessSecretID
+	if secretID == 0 {
+		secret, err := service.ResolveSecretRef(ctx, secretAccessRef)
+		if err != nil {
+			return fmt.Errorf("resolve ref %q: %w", secretAccessRef, err)
+		}
+		secretID = secret.ID
+	}
+
+	userID, err := resolveUserID(ctx, service, secretAccessUser)
+	if err != nil {
+		return err
+	}
+
+	req, err := service.RequestSecretAccess(ctx, secretID, userID, secretAccessReason)
+	if err != nil {
+		return fmt.Errorf("failed to request secret access: %w", err)
+	}
+	fmt.Printf("Secret access requested: id=%d secret=%d state=%s\n", req.ID, secretID, req.State)
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,13 @@ type Config struct {
 	BreakGlass BreakGlassConfig `yaml:"break_glass"`
 	// DualControl configures N-of-M approval for access-request grants (A.5.3).
 	DualControl DualControlConfig `yaml:"dual_control"`
+	// Classification configures whether the "restricted" data-classification label
+	// (the highest tier, see internal/core/classification.go) changes read-time
+	// behaviour. Disabled (zero value) = the label stays purely informational,
+	// exactly like every deployment today — required so enabling this feature is
+	// never a surprise breaking change for an install that already uses
+	// "restricted" as a label with no enforcement behind it.
+	Classification ClassificationConfig `yaml:"classification"`
 	// AnomalyAlerts configures proactive alerting for detected access anomalies.
 	AnomalyAlerts AnomalyAlertsConfig `yaml:"anomaly_alerts"`
 	// DataRetention configures the opt-in scheduler that hard-deletes compliance
@@ -1449,6 +1456,31 @@ func (c DualControlConfig) GetRequiredApprovals() int {
 		return c.RequiredApprovals
 	}
 	return 1
+}
+
+// ClassificationConfig configures label-driven read-time enforcement for the
+// highest data-classification tier ("restricted", ISO 27001 A.5.12/A.5.13).
+//
+// RestrictedRequiresApproval defaults to false — off. Today, "restricted" is
+// purely informational metadata (internal/core/classification.go's package doc
+// documents this as a deliberate scope decision): setting it changes nothing at
+// read time. Turning this on for the first time is a BREAKING BEHAVIOUR CHANGE
+// for any deployment that already has "restricted" secrets, since those secrets
+// were previously readable like any other with sufficient RBAC — an operator
+// must opt in explicitly, which is why the default stays false rather than
+// enforcing the label the moment it exists.
+//
+// When true, a direct read of a "restricted" secret's VALUE (not its metadata —
+// GetSecret/ListSecrets are unaffected) requires an approved, secret-scoped
+// access request (RequestSecretAccess / ApproveSecretAccessRequest, reusing the
+// AccessRequest model/flow ADR-024 introduced for project/role requests) or is
+// denied. A read whose acting principal cannot be identified as a specific user
+// — a machine/service-account credential, or any other caller with no user ID to
+// check an approval against — is ALWAYS denied when this is on: there is no
+// "wait for approval" for automation, and no silent bypass either (fail-closed,
+// matching this codebase's established posture for ambiguous authorization).
+type ClassificationConfig struct {
+	RestrictedRequiresApproval bool `yaml:"restricted_requires_approval"`
 }
 
 // WebAuthnConfig configures the WebAuthn relying party (ADR-036). RPID is the

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -33,7 +33,7 @@ func newBootstrappedCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 		&models.PersonalAccessToken{}, &models.Session{}, &models.ShareRecord{},
 		&models.AuditEvent{},
 		&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.ProjectMembership{},
-		&models.SecretNode{}, &models.DynamicSecretConfig{}, &models.SoDPolicy{},
+		&models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.SoDPolicy{},
 	))
 
 	st := store.NewLocalStorage(db)

--- a/internal/core/classification.go
+++ b/internal/core/classification.go
@@ -3,17 +3,17 @@
 // label; the label drives the classification posture and lets a reviewer find the
 // high-sensitivity secrets. "" means unclassified.
 //
-// KNOWN LIMITATION — classification is a label, not a control: setting a secret (or
-// dynamic-secret config, or machine identity)'s Classification to "restricted" does
-// NOT currently change how it is treated at read time, in RBAC, in rate limiting, or
-// anywhere else in the request path — it is purely informational metadata surfaced in
-// the compliance posture / audit views. Do not assume a "restricted" secret gets any
-// additional gating a "public" one doesn't; if that's the requirement, it must be
-// implemented as an explicit policy check at the relevant enforcement point (there is
-// none today). This is a deliberate scope decision, not an oversight — enforcement is
-// a materially larger feature (would need a policy engine deciding what "restricted"
-// actually restricts: extra approval? MFA step-up? narrower RBAC? all of the above are
-// plausible and none is implemented).
+// UPDATE (#128's residual, resolved by product decision): classification was
+// historically a label with zero enforcement anywhere. It now gates ONE thing, and
+// only when explicitly opted into: config classification.restricted_requires_approval
+// (default false — every deployment's behaviour is unchanged unless an operator turns
+// this on) requires an approved, secret-scoped access request before a direct read of
+// a "restricted"-classified secret's VALUE succeeds (see classification_gate.go). A
+// secret's metadata (this classification label included), RBAC, rate limiting, and
+// every other classification tier remain exactly as informational as before — this is
+// a narrow, additive control on the single highest tier's value-read path, not the
+// general "policy engine" this comment used to describe as unbuilt. MFA step-up and
+// narrower RBAC for "restricted" remain undecided/unimplemented, same as before.
 package core
 
 import (

--- a/internal/core/classification_gate.go
+++ b/internal/core/classification_gate.go
@@ -1,0 +1,246 @@
+// classification_gate.go — read-time enforcement for the highest data-
+// classification tier ("restricted", see classification.go's package doc).
+//
+// Off by default (config classification.restricted_requires_approval, mirrored
+// in-process as KeyorixCore.classificationRestrictedRequiresApproval): with the
+// setting off, this file changes nothing — every existing deployment, and every
+// pre-existing test, is completely unaffected. See classification.go for why
+// this had to stay opt-in rather than becoming an automatic control the moment a
+// secret is labelled "restricted".
+//
+// When the setting is on, a direct read of a "restricted" secret's VALUE (not
+// its metadata — GetSecret/ListSecrets never consult this gate, only the
+// GetSecretValue*/GetSecretValueByVersion* family does, via
+// checkRestrictedSecretReadApproval) requires an approved, secret-scoped access
+// request. This reuses the AccessRequest model/table and its whole state
+// machine, storage, audit, and notification conventions from invitations.go
+// (ADR-024) — the smallest safe extension found: a nullable AccessRequest.
+// SecretID narrows a request from "role at a project" to "read this one secret".
+//
+// It deliberately does NOT reuse ApproveAccessRequestWithExpiry to resolve a
+// secret-scoped request: that function's entire body is about granting an RBAC
+// role (dual-control math keyed to a role name, the escalation-ceiling check
+// scoped to roles, "a role to grant is required" as a hard precondition) and a
+// secret-scoped approval grants no role at all — bending it to accept an empty
+// role would be forcing a project/role-shaped function into a shape it wasn't
+// designed for. RequestSecretAccess/ApproveSecretAccessRequest are new, narrow
+// functions built for exactly this; RejectAccessRequest and
+// WithdrawAccessRequest, which do nothing role-specific, are reused unchanged —
+// they already work for a SecretID-scoped row exactly as they do for a
+// project/role one.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// SetClassificationRestrictedRequiresApproval mirrors config classification.
+// restricted_requires_approval. false (the default, and the zero value) leaves
+// "restricted" purely informational — identical to today's behaviour. See
+// KeyorixCore.classificationRestrictedRequiresApproval.
+func (c *KeyorixCore) SetClassificationRestrictedRequiresApproval(enabled bool) {
+	c.classificationRestrictedRequiresApproval = enabled
+}
+
+// checkRestrictedSecretReadApproval is the fail-closed gate every secret VALUE
+// read path routes through (see versions.go/secret_render.go). It is a no-op
+// (nil, nil) unless BOTH the setting is on AND the secret's own classification is
+// exactly ClassificationRestricted — a lower tier is never gated, regardless of
+// the setting (#128's product decision only concerns the highest tier).
+//
+// userID identifies the acting human principal, if any. 0 means the read has no
+// identifiable user behind it — a machine/service-account credential (the HTTP
+// handlers' isMachine branch calls the base GetSecretValue with no userID at
+// all), the embedded-mode CLI (which has no user/session concept either), or any
+// other caller that cannot present one. Such a read is ALWAYS denied when the
+// gate is active: there is no "wait for approval" for automation, and — just as
+// importantly — no quiet exemption for it either. A machine identity that
+// legitimately needs a restricted secret goes through the exact same
+// RequestSecretAccess/ApproveSecretAccessRequest flow as a human would, on
+// behalf of a user who then reads it, rather than being carved out as a bypass.
+//
+// Any failure to positively confirm approval — including a storage error while
+// checking — denies the read; this never fails open.
+func (c *KeyorixCore) checkRestrictedSecretReadApproval(ctx context.Context, secret *models.SecretNode, userID uint) error {
+	if !c.classificationRestrictedRequiresApproval {
+		return nil
+	}
+	if secret == nil || secret.Classification != ClassificationRestricted {
+		return nil
+	}
+	if userID == 0 {
+		return fmt.Errorf("secret %q is restricted: reading its value requires an approved access request, and this read has no identifiable user to check one against", secret.Name)
+	}
+	ok, err := c.hasApprovedSecretAccessRequest(ctx, secret.ProjectID, secret.ID, userID)
+	if err != nil {
+		return fmt.Errorf("secret %q is restricted: could not verify an approved access request: %w", secret.Name, err)
+	}
+	if !ok {
+		return fmt.Errorf("secret %q is restricted: an approved access request for this specific secret is required before its value can be read", secret.Name)
+	}
+	return nil
+}
+
+// hasApprovedSecretAccessRequest reports whether userID holds a still-approved
+// (not later withdrawn/rejected — those are terminal states a request can't
+// leave) secret-scoped AccessRequest for secretID. Approval is permanent once
+// granted (no separate re-expiry), the same default as a project/role request
+// approved with no grant TTL — mirrored here for consistency rather than
+// inventing a second expiry model.
+//
+// Listing by project and filtering in memory reuses the existing
+// ListAccessRequests storage method as-is (no storage interface change): access
+// requests per project are not high-cardinality, and this mirrors the same
+// list-then-filter pattern ApproveAccessRequestWithExpiry itself uses for
+// ListAccessRequestApprovals.
+func (c *KeyorixCore) hasApprovedSecretAccessRequest(ctx context.Context, projectID, secretID, userID uint) (bool, error) {
+	rows, err := c.storage.ListAccessRequests(ctx, projectID)
+	if err != nil {
+		return false, err
+	}
+	for _, req := range rows {
+		if req.SecretID != nil && *req.SecretID == secretID && req.UserID == userID && req.State == AccessRequestApproved {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// RequestSecretAccess creates a pending, secret-scoped access request: approval
+// to read ONE specific secret's value, distinct from RequestProjectAccess's
+// broader project/role grant. Reuses the AccessRequest model/table and the
+// standard accessRequestTTL (ADR-024); the project is inferred from the secret.
+func (c *KeyorixCore) RequestSecretAccess(ctx context.Context, secretID, userID uint, reason string) (*models.AccessRequest, error) {
+	if secretID == 0 || userID == 0 {
+		return nil, fmt.Errorf("secret ID and user ID are required")
+	}
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("secret %d not found: %w", secretID, err)
+	}
+	now := c.now()
+	expires := now.Add(accessRequestTTL)
+	sid := secretID
+	req := &models.AccessRequest{
+		ProjectID: secret.ProjectID,
+		UserID:    userID,
+		SecretID:  &sid,
+		State:     AccessRequestPending,
+		Reason:    reason,
+		ExpiresAt: &expires,
+		CreatedAt: now,
+	}
+	created, err := c.storage.CreateAccessRequest(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create secret access request: %w", err)
+	}
+	c.auditProjectScoped(ctx, "access_request.secret_created", userID, secret.ProjectID,
+		fmt.Sprintf("user %d requested access to read secret %d (%s)", userID, secretID, secret.Name))
+	c.notifySecretAccessRequested(ctx, created, secret)
+	return created, nil
+}
+
+// ApproveSecretAccessRequest approves a pending secret-scoped access request,
+// letting the classification gate above find it on the requester's next read.
+// Unlike ApproveAccessRequestWithExpiry, no role is granted — approval only
+// flips State to approved. Refuses (does not silently no-op) a request whose
+// SecretID is nil: that is a project/role request and belongs to
+// ApproveAccessRequestWithExpiry instead.
+func (c *KeyorixCore) ApproveSecretAccessRequest(ctx context.Context, requestID, approverID uint) (*models.AccessRequest, error) {
+	req, err := c.storage.GetAccessRequest(ctx, requestID)
+	if err != nil {
+		return nil, fmt.Errorf("access request not found")
+	}
+	if req.SecretID == nil {
+		return nil, fmt.Errorf("access request %d is a project/role request, not a secret-scoped one — use ApproveAccessRequestWithExpiry", requestID)
+	}
+	if req.State != AccessRequestPending {
+		return nil, fmt.Errorf("only a pending request can be approved (state is %s)", req.State)
+	}
+	secret, err := c.storage.GetSecret(ctx, *req.SecretID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot approve: secret %d no longer exists", *req.SecretID)
+	}
+	// Mirrors ApproveAccessRequestWithExpiry's own lazy-expire-and-refuse (#277):
+	// GetAccessRequest returns the row verbatim, so a request whose TTL already
+	// lapsed is still State==pending until something reconciles it.
+	if req.ExpiresAt != nil && c.now().After(*req.ExpiresAt) {
+		req.State = AccessRequestExpired
+		_, _ = c.storage.UpdateAccessRequest(ctx, req)
+		return nil, fmt.Errorf("access request has expired")
+	}
+	// Maker ≠ checker, same as the project/role flow.
+	if approverID == req.UserID {
+		return nil, fmt.Errorf("a requester cannot approve their own access request")
+	}
+	// Approving read access to a "restricted" secret is at least as sensitive as
+	// granting a non-admin project role, so it carries the same admin-authority
+	// ceiling requireAuthorityForRole applies to an admin-role grant — there is no
+	// weaker "roles.assign"-shaped permission that fits (this grants no role at
+	// all), so the bar is set at the ceiling rather than invented lower.
+	if err := c.requireAdminAuthorityAt(ctx, approverID, req.ProjectID); err != nil {
+		return nil, fmt.Errorf("only an administrator can approve access to a restricted secret: %w", err)
+	}
+	now := c.now()
+	req.State = AccessRequestApproved
+	req.ResolvedBy = approverID
+	req.ResolvedAt = &now
+	ok, err := c.storage.UpdateAccessRequest(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update access request: %w", err)
+	}
+	if !ok {
+		// The request stopped being pending between the read above and this write —
+		// e.g. a concurrent withdraw won the race. Nothing was granted on this path
+		// (no role, no side effect besides the row itself), so unlike the project/
+		// role flow there is nothing to revert — just refuse (#277's pattern, the
+		// no-grant-to-unwind case).
+		return nil, fmt.Errorf("access request is no longer pending (it was concurrently withdrawn or resolved)")
+	}
+	c.auditProjectScoped(ctx, "access_request.secret_approved", approverID, req.ProjectID,
+		fmt.Sprintf("approved access request %d for user %d to read secret %d (%s)", req.ID, req.UserID, *req.SecretID, secret.Name))
+	c.notifySecretAccessResolved(ctx, req, secret, true)
+	return req, nil
+}
+
+// notifySecretAccessRequested alerts the project's approvers of a new
+// secret-scoped access request, mirroring notifyAccessRequested but naming the
+// secret rather than a suggested role (there isn't one on this path).
+func (c *KeyorixCore) notifySecretAccessRequested(ctx context.Context, req *models.AccessRequest, secret *models.SecretNode) {
+	members, err := c.storage.ListProjectMembers(ctx, req.ProjectID)
+	if err != nil {
+		return
+	}
+	pid := req.ProjectID
+	link := fmt.Sprintf("/projects/%d", req.ProjectID)
+	for _, mbr := range members {
+		if mbr.UserID == req.UserID || !isApproverRole(mbr.RoleName) {
+			continue
+		}
+		c.notify(ctx, mbr.UserID, NotificationAccessRequested,
+			"New secret access request",
+			fmt.Sprintf("User %d requested access to read secret %q.", req.UserID, secret.Name),
+			&pid, link)
+	}
+}
+
+// notifySecretAccessResolved tells the requester their secret-scoped request was
+// approved/rejected, mirroring notifyAccessResolved.
+func (c *KeyorixCore) notifySecretAccessResolved(ctx context.Context, req *models.AccessRequest, secret *models.SecretNode, approved bool) {
+	pid := req.ProjectID
+	link := fmt.Sprintf("/projects/%d", req.ProjectID)
+	if approved {
+		c.notify(ctx, req.UserID, NotificationAccessApproved,
+			"Secret access request approved",
+			fmt.Sprintf("Your request to read secret %q was approved.", secret.Name),
+			&pid, link)
+		return
+	}
+	c.notify(ctx, req.UserID, NotificationAccessRejected,
+		"Secret access request rejected",
+		fmt.Sprintf("Your request to read secret %q was rejected.", secret.Name),
+		&pid, link)
+}

--- a/internal/core/classification_gate_test.go
+++ b/internal/core/classification_gate_test.go
@@ -1,0 +1,186 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedClassificationGateFixture creates a project, a requester (owner of the
+// secret, so ValidateSecretAccess passes without needing a separate RBAC role),
+// an admin approver, and a secret at the given classification with one version.
+func seedClassificationGateFixture(t *testing.T, st *store.LocalStorage, classification string) (secretID, requesterID, approverID, projectID uint) {
+	t.Helper()
+	ctx := context.Background()
+
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "classification-gate-" + classification + "-test"})
+	require.NoError(t, err)
+
+	requester, err := st.CreateUser(ctx, &models.User{Username: "requester-" + classification, Email: "requester-" + classification + "@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	approver, err := st.CreateUser(ctx, &models.User{Username: "approver-" + classification, Email: "approver-" + classification + "@example.com", IsActive: true})
+	require.NoError(t, err)
+	adminRole, err := st.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, approver.ID, adminRole.ID, storage.Scope{}))
+
+	secret, err := st.CreateSecret(ctx, &models.SecretNode{
+		Name: "db-password", ProjectID: proj.ID, EnvironmentID: 1, Type: "password",
+		IsSecret: true, OwnerID: requester.ID, Status: "active", Classification: classification,
+	})
+	require.NoError(t, err)
+	_, err = st.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: secret.ID, VersionNumber: 1, EncryptedValue: []byte("s3cr3t-value"),
+	})
+	require.NoError(t, err)
+
+	return secret.ID, requester.ID, approver.ID, proj.ID
+}
+
+// Requirement (1): the setting defaults to false, so a "restricted" secret reads
+// exactly like any other, for both a permission-checked user read and a direct
+// (machine-shaped) read with no user ID at all.
+func TestClassificationGate_OffByDefault_RestrictedSecretUnaffected(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, requesterID, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+
+	// c.classificationRestrictedRequiresApproval is the zero value (false) —
+	// never touched in this test, pinning the true out-of-the-box default.
+	val, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, requesterID)
+	require.NoError(t, err, "restricted must read like any other secret while the gate is off")
+	assert.Equal(t, "s3cr3t-value", string(val))
+
+	// Machine-shaped direct read (no user ID) is likewise unaffected.
+	val, err = c.GetSecretValue(ctx, secretID)
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3t-value", string(val))
+
+	// Metadata reads were never gated and stay that way.
+	secret, err := c.GetSecret(ctx, secretID)
+	require.NoError(t, err)
+	assert.Equal(t, ClassificationRestricted, secret.Classification)
+}
+
+// Requirement (2): with the setting on, an unapproved read of a restricted
+// secret is denied — even for a user who otherwise has full (owner) read rights.
+func TestClassificationGate_OnAndUnapproved_Denied(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, requesterID, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresApproval(true)
+
+	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, requesterID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restricted")
+	assert.Contains(t, err.Error(), "approved access request")
+}
+
+// Requirement (2)/machine consideration: a read with no identifiable user (the
+// same shape server/http uses for a machine-principal read, or the embedded
+// CLI) must be denied too — fail-closed, no silent bypass for automation.
+func TestClassificationGate_OnAndNoUser_Denied(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, _, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresApproval(true)
+
+	_, err := c.GetSecretValue(ctx, secretID)
+	require.Error(t, err, "a read with no identifiable user must be denied, not silently allowed")
+	assert.Contains(t, err.Error(), "restricted")
+}
+
+// Requirement (3): with an approved, valid AccessRequest scoped to that secret,
+// the read succeeds.
+func TestClassificationGate_OnAndApproved_Succeeds(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, requesterID, approverID, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresApproval(true)
+
+	// Sanity: unapproved is still denied at this point.
+	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, requesterID)
+	require.Error(t, err)
+
+	req, err := c.RequestSecretAccess(ctx, secretID, requesterID, "need it for an incident")
+	require.NoError(t, err)
+	assert.Equal(t, AccessRequestPending, req.State)
+	require.NotNil(t, req.SecretID)
+	assert.Equal(t, secretID, *req.SecretID)
+
+	approved, err := c.ApproveSecretAccessRequest(ctx, req.ID, approverID)
+	require.NoError(t, err)
+	assert.Equal(t, AccessRequestApproved, approved.State)
+	// No role is granted for a secret-scoped request.
+	assert.Empty(t, approved.GrantedRole)
+
+	val, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, requesterID)
+	require.NoError(t, err, "an approved, secret-scoped access request must let the read through")
+	assert.Equal(t, "s3cr3t-value", string(val))
+
+	// By-version read is gated (and unblocked) the same way.
+	val, err = c.GetSecretValueByVersionWithPermissionCheck(ctx, secretID, requesterID, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3t-value", string(val))
+}
+
+// Requirement (4): a lower-tier classified secret is never gated, regardless of
+// the setting.
+func TestClassificationGate_LowerTierNeverGated(t *testing.T) {
+	for _, level := range []string{ClassificationPublic, ClassificationInternal, ClassificationConfidential, ""} {
+		level := level
+		t.Run("classification="+level, func(t *testing.T) {
+			c, st := newBootstrappedCore(t)
+			secretID, requesterID, _, _ := seedClassificationGateFixture(t, st, level)
+			ctx := context.Background()
+			c.SetClassificationRestrictedRequiresApproval(true)
+
+			val, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, requesterID)
+			require.NoError(t, err, "only the highest tier is gated")
+			assert.Equal(t, "s3cr3t-value", string(val))
+		})
+	}
+}
+
+// ApproveSecretAccessRequest's own guards: maker != checker, admin-authority
+// ceiling, pending-only, and refusing a project/role (SecretID nil) request.
+func TestApproveSecretAccessRequest_Guards(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, requesterID, approverID, projectID := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+
+	req, err := c.RequestSecretAccess(ctx, secretID, requesterID, "")
+	require.NoError(t, err)
+
+	// Maker != checker.
+	_, err = c.ApproveSecretAccessRequest(ctx, req.ID, requesterID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot approve their own")
+
+	// A non-admin approver is refused.
+	nonAdmin, err := st.CreateUser(ctx, &models.User{Username: "nonadmin", Email: "nonadmin@example.com", IsActive: true})
+	require.NoError(t, err)
+	_, err = c.ApproveSecretAccessRequest(ctx, req.ID, nonAdmin.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "administrator")
+
+	// A project/role (SecretID nil) request is refused by this function.
+	roleReq, err := c.RequestProjectAccess(ctx, projectID, requesterID, "viewer", "")
+	require.NoError(t, err)
+	_, err = c.ApproveSecretAccessRequest(ctx, roleReq.ID, approverID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a secret-scoped")
+
+	// The real approval succeeds and is idempotent-refusing on a second attempt.
+	_, err = c.ApproveSecretAccessRequest(ctx, req.ID, approverID)
+	require.NoError(t, err)
+	_, err = c.ApproveSecretAccessRequest(ctx, req.ID, approverID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only a pending")
+}

--- a/internal/core/secret_render.go
+++ b/internal/core/secret_render.go
@@ -64,7 +64,7 @@ func (c *KeyorixCore) RenderSecretTemplate(ctx context.Context, template string,
 		if _, err := c.ValidateSecretAccess(ctx, secret.ID, userID); err != nil {
 			return "", ErrSecretRefNotFound
 		}
-		val, err := c.GetSecretValue(ctx, secret.ID)
+		val, err := c.getSecretValueForUser(ctx, secret.ID, userID)
 		if err != nil {
 			return "", err
 		}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -186,6 +186,13 @@ type KeyorixCore struct {
 	// dualControlRequiredApprovals is the N-of-M approval threshold for access
 	// requests (A.5.3); 0/1 = single approval (disabled). Set via SetDualControlPolicy.
 	dualControlRequiredApprovals int
+	// classificationRestrictedRequiresApproval mirrors config classification.
+	// restricted_requires_approval; false (the default) = "restricted" stays purely
+	// informational metadata, matching every deployment's behaviour today. When
+	// true, a direct value read of a "restricted"-classified secret requires an
+	// approved, secret-scoped access request (see classification_gate.go). Set from
+	// config at startup via SetClassificationRestrictedRequiresApproval.
+	classificationRestrictedRequiresApproval bool
 	// retentionPolicy holds the configured per-record-type data-retention windows
 	// (ISO A.5.33) so the compliance posture can report them; zero value = no
 	// retention configured. Set from config at startup via SetRetentionPolicy.

--- a/internal/core/versions.go
+++ b/internal/core/versions.go
@@ -94,7 +94,22 @@ func (c *KeyorixCore) GetLatestSecretVersionWithPermissionCheck(ctx context.Cont
 }
 
 // GetSecretValue retrieves the decrypted value of the latest version of a secret.
+// It has no user principal of its own — used both directly by machine/embedded
+// callers (server/http's isMachine branch, the embedded CLI) and, via
+// getSecretValueForUser, as the shared tail of the *WithPermissionCheck variants.
+// A direct call here is always treated as userID 0 for the classification gate
+// (see checkRestrictedSecretReadApproval) — there is no user to check an approval
+// against, matching the machine-read design decision.
 func (c *KeyorixCore) GetSecretValue(ctx context.Context, secretID uint) ([]byte, error) {
+	return c.getSecretValueForUser(ctx, secretID, 0)
+}
+
+// getSecretValueForUser is GetSecretValue's real body, plus the classification
+// gate keyed on userID (0 = no identifiable user). Kept unexported and separate
+// from GetSecretValue's public, userID-less signature so *WithPermissionCheck
+// callers — which already resolved a real userID via ValidateSecretAccess — can
+// thread it through instead of losing it at the handoff.
+func (c *KeyorixCore) getSecretValueForUser(ctx context.Context, secretID, userID uint) ([]byte, error) {
 	if secretID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret ID is required")
 	}
@@ -107,6 +122,9 @@ func (c *KeyorixCore) GetSecretValue(ctx context.Context, secretID uint) ([]byte
 	}
 	if secret.Status == SecretStatusSuspended {
 		return nil, fmt.Errorf("secret is suspended")
+	}
+	if err := c.checkRestrictedSecretReadApproval(ctx, secret, userID); err != nil {
+		return nil, err
 	}
 	version, err := c.storage.GetLatestSecretVersion(ctx, secretID)
 	if err != nil {
@@ -123,12 +141,22 @@ func (c *KeyorixCore) GetSecretValueWithPermissionCheck(ctx context.Context, sec
 	if _, err := c.ValidateSecretAccess(ctx, secretID, userID); err != nil {
 		return nil, err
 	}
-	// Delegate to base method — avoids duplicating max-reads logic.
-	return c.GetSecretValue(ctx, secretID)
+	// Delegate to the shared body with the real userID — avoids duplicating
+	// max-reads logic while still giving the classification gate a user to check
+	// an approved secret-scoped access request against.
+	return c.getSecretValueForUser(ctx, secretID, userID)
 }
 
 // GetSecretValueByVersion retrieves the decrypted value of a specific version of a secret.
+// Like GetSecretValue, a direct call has no user principal — see
+// getSecretValueByVersionForUser.
 func (c *KeyorixCore) GetSecretValueByVersion(ctx context.Context, secretID uint, versionNumber int) ([]byte, error) {
+	return c.getSecretValueByVersionForUser(ctx, secretID, versionNumber, 0)
+}
+
+// getSecretValueByVersionForUser is GetSecretValueByVersion's real body, plus the
+// classification gate keyed on userID (0 = no identifiable user).
+func (c *KeyorixCore) getSecretValueByVersionForUser(ctx context.Context, secretID uint, versionNumber int, userID uint) ([]byte, error) {
 	if secretID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret ID is required")
 	}
@@ -144,6 +172,9 @@ func (c *KeyorixCore) GetSecretValueByVersion(ctx context.Context, secretID uint
 	}
 	if secret.Status == SecretStatusSuspended {
 		return nil, fmt.Errorf("secret is suspended")
+	}
+	if err := c.checkRestrictedSecretReadApproval(ctx, secret, userID); err != nil {
+		return nil, err
 	}
 	version, err := c.GetSecretVersion(ctx, secretID, versionNumber)
 	if err != nil {
@@ -200,7 +231,7 @@ func (c *KeyorixCore) GetSecretValueByVersionWithPermissionCheck(ctx context.Con
 	if _, err := c.ValidateSecretAccess(ctx, secretID, userID); err != nil {
 		return nil, err
 	}
-	return c.GetSecretValueByVersion(ctx, secretID, versionNumber)
+	return c.getSecretValueByVersionForUser(ctx, secretID, versionNumber, userID)
 }
 
 // readVersionValue applies max-reads enforcement and decryption for a secret version.

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -753,6 +753,17 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 		if err := db.AutoMigrate(&models.AccessRequest{}); err != nil {
 			return fmt.Errorf("failed to migrate access_requests table: %w", err)
 		}
+	} else {
+		// SecretID was added after this table could already exist in the field (same
+		// pgx hazard as project_invitations above — never full-AutoMigrate an existing
+		// table here); add it via the Migrator so an upgraded install still gets the
+		// column the secret-scoped access-request flow needs (classification gate).
+		m := db.Migrator()
+		if !m.HasColumn(&models.AccessRequest{}, "SecretID") {
+			if err := m.AddColumn(&models.AccessRequest{}, "SecretID"); err != nil {
+				return fmt.Errorf("failed to add access_requests.secret_id column: %w", err)
+			}
+		}
 	}
 
 	// Create the access-request approvals table if missing (N-of-M dual control).

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -59,16 +59,26 @@ type ProjectInvitation struct {
 	RevokedAt       *time.Time
 }
 
-// AccessRequest is a user's request for a role in a project (ADR-024). State
-// machine: pending → approved / rejected / withdrawn / expired. On approval the
-// granted role (which may differ from the suggested one) is assigned at the
-// project scope. No auto-approval.
+// AccessRequest is a user's request for a role in a project (ADR-024), OR — when
+// SecretID is set — a request for approval to read one specific secret's value
+// (classification-gated reads, see internal/core/classification_gate.go). State
+// machine: pending → approved / rejected / withdrawn / expired in both cases. For
+// a project/role request, approval assigns the granted role (which may differ
+// from the suggested one) at the project scope. For a secret-scoped request,
+// approval grants no role at all — it only flips State to approved, which the
+// classification gate looks for; GrantedRole/SuggestedRole are unused (left
+// empty) on that path. No auto-approval either way.
 type AccessRequest struct {
 	ID            uint   `gorm:"primaryKey"`
 	ProjectID     uint   `gorm:"index"`
 	UserID        uint   `gorm:"index"`
-	SuggestedRole string // role the requester asks for
-	GrantedRole   string // role actually granted on approval
+	SuggestedRole string // role the requester asks for (empty for a secret-scoped request)
+	GrantedRole   string // role actually granted on approval (empty for a secret-scoped request)
+	// SecretID, when non-nil, narrows this request to "approval to read this one
+	// secret" rather than a project/role grant (see RequestSecretAccess /
+	// ApproveSecretAccessRequest). nil = the original project/role request this
+	// model was designed for (ADR-024).
+	SecretID      *uint `gorm:"index"`
 	State         string // pending | approved | rejected | withdrawn | expired
 	Reason        string // requester's note, or the rejecter's reason
 	ResolvedBy    uint

--- a/server/main.go
+++ b/server/main.go
@@ -692,6 +692,14 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		log.Printf("Dual-control approval enabled: %d approvals required per access request", n)
 	}
 
+	// Wire the "restricted" classification read-time gate (#128's product
+	// decision); false (the default) leaves the label purely informational,
+	// identical to every deployment's behaviour today.
+	coreService.SetClassificationRestrictedRequiresApproval(cfg.Classification.RestrictedRequiresApproval)
+	if cfg.Classification.RestrictedRequiresApproval {
+		log.Printf("Classification enforcement enabled: reading a \"restricted\" secret's value now requires an approved, secret-scoped access request")
+	}
+
 	// Wire the configured data-retention windows (A.5.33) so the compliance posture
 	// reports them; the scheduler below drives the actual purge. Audited (#160) so a
 	// shortened window is on the record, not just its eventual purge counts.


### PR DESCRIPTION
## Summary

Product decision on backlog finding **#128**'s residual ("classification is a
label, not a control" — documented as a deliberate, deferred scope decision in
`internal/core/classification.go`'s package doc): the highest classification
tier, `restricted`, can now gate a direct secret-VALUE read behind an approved,
secret-scoped access request — but **only when an operator explicitly opts in**.

## Design decisions

- **Off by default, opt-in config** — `classification.restricted_requires_approval`
  (`bool`, default `false`), wired the same way every other system-wide toggle in
  this codebase is (`internal/config/config.go` → `coreService.SetXxx(...)` in
  `server/main.go`, mirroring `dual_control`/`break_glass`/etc.). This had to be
  opt-in: every deployment today has used `restricted` purely as a label, with
  zero enforcement behind it (that's exactly what #128 found) — turning
  enforcement on unconditionally the moment this shipped would silently lock
  existing operators out of secrets they could read yesterday. With the setting
  off (the default), behaviour is byte-for-byte unchanged — verified by both the
  full existing `internal/core` suite (still green) and a new explicit test.

- **Reused the existing `AccessRequest` flow (ADR-024), narrowed with a
  `SecretID`** — investigated extending it in place, per the assignment.
  `AccessRequest` itself is a clean, additive extension: added a nullable
  `SecretID *uint` (migrated via the same "AddColumn on an existing table, never
  full-AutoMigrate" pattern this table's neighbors already use). The state
  machine (pending → approved/rejected/withdrawn/expired), storage CRUD,
  `ListAccessRequests`, audit conventions, and — critically — `RejectAccessRequest`
  and `WithdrawAccessRequest` (neither of which does anything role-specific) are
  reused **unchanged** for a secret-scoped row.

  `ApproveAccessRequestWithExpiry`, however, could **not** be safely reused: its
  entire body is about granting an RBAC role (dual-control math keyed to a role
  name, an escalation ceiling scoped to roles, and a hard `"a role to grant is
  required"` precondition) — a secret-scoped approval grants no role at all.
  Bending that function to accept an empty role would have been forcing a
  project/role-shaped function into a shape it wasn't built for. Instead, two new,
  narrow functions were added: `RequestSecretAccess` / `ApproveSecretAccessRequest`
  (`internal/core/classification_gate.go`), which only flip `State` — no grant, no
  dual-control math.

- **Gated only the value-read paths, not metadata.** `GetSecretValue` /
  `GetSecretValueByVersion` (and their `*WithPermissionCheck` variants) route
  through a shared, userID-aware helper that checks the gate; `RenderSecretTemplate`
  (template-embedded secret refs) was updated the same way. `GetSecret`,
  `ListSecrets`, and every other read of the `Classification` field itself are
  completely untouched.

- **Fail-closed for unidentifiable principals — no automation bypass.** Both the
  HTTP machine-principal read path and the embedded-mode CLI call the base
  `GetSecretValue` with no user ID at all. Rather than silently exempting them (or
  building a "wait for approval" for something that can't wait), a read with no
  identifiable user is **always denied** once the gate is on: a machine identity
  that needs a restricted secret goes through the same
  `RequestSecretAccess`/`ApproveSecretAccessRequest` flow a human would, on behalf
  of a user who then reads it — there is no quiet carve-out.

- **Approval authority**: approving a secret-scoped request requires the approver
  to hold admin authority at the secret's project (`requireAdminAuthorityAt`,
  the same ceiling `requireAuthorityForRole` uses elsewhere) plus the standard
  maker ≠ checker check. There's no weaker "roles.assign"-shaped permission that
  fits a request that grants no role, so the bar was set at the existing ceiling
  rather than inventing a new, narrower one.

- **Admin-facing CLI**: `keyorix request secret-access --secret-id/--ref --user
  --reason` to file a request; `keyorix request review --id --action approve
  --by` detects a secret-scoped request (vs. a project/role one) and routes to
  `ApproveSecretAccessRequest` instead of granting a role. `list`/`withdraw`
  work on both kinds of request unchanged.

## What's gated / what isn't

- Gated: `GetSecretValue*`, `GetSecretValueByVersion*`, `RenderSecretTemplate`'s
  per-reference reads — **only** when (a) the setting is on **and** (b) the
  secret's `Classification == "restricted"` (the highest tier).
- Never gated, regardless of the setting: `public`/`internal`/`confidential`/
  unclassified secrets, and any metadata read (`GetSecret`, listing, filtering).

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/core/... -count=1` — passing (plus `./internal/cli/request/...`, `./internal/config/...`, `./internal/storage/...`)
- `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues
- New tests cover all four required scenarios: default-off unaffected (incl. a
  direct machine-shaped read), on+unapproved denied, on+approved succeeds
  (including by-version), and lower-tier secrets never gated — plus
  `ApproveSecretAccessRequest`'s own guards (maker≠checker, non-admin approver,
  wrong request type, non-pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)