### PR TITLE
harden(rotation): reject dangerous rotation_ref metacharacters at config time

### DIFF
--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -504,6 +504,39 @@ func (c *KeyorixCore) RotateSecretOnDemand(ctx context.Context, id uint, newValu
 	}
 }
 
+// rotationRefDisallowedChars are the URL/path and SQL metacharacters rejected in a
+// rotation_ref (validateRotationRef also separately rejects control characters). This
+// is a DENYLIST, not a strict allowlist: a strict allowlist would break real, already-
+// exercised ref shapes — GCP service-account refs are emails ('@', '.'), AWS IAM
+// usernames can legitimately contain '+', '=', ',' per AWS's own naming rules — so we
+// only reject characters that have no legitimate role in a service-account email, IAM
+// username, or DB role/user name.
+const rotationRefDisallowedChars = "/?#%'\"\\;"
+
+// validateRotationRef rejects a rotation_ref containing a URL/path metacharacter, a SQL
+// metacharacter, or a control character, BEFORE it is ever persisted to
+// secret.RotationRef in SetSecretAutoRotate. This is the single choke point every
+// transport (HTTP/gRPC/CLI) goes through to set a rotation ref, so this is the earliest
+// and only fully-shared layer of defense against a malicious ref (e.g. SQL injection via
+// a crafted role name, or path traversal via "<allowed-prefix>/../<victim>").
+//
+// This is layer ONE of defense-in-depth, not a replacement for the backend-specific
+// checks in internal/rotation/{azure,gcpsa}.go (layer TWO, at ROTATION time) or the
+// SQL-quoting functions in internal/rotation/{postgres,mysql}.go (also layer TWO) — keep
+// all of them; each guards a slightly different trust boundary and this function must
+// never narrow to only what one particular backend needs.
+func validateRotationRef(ref string) error {
+	for i := 0; i < len(ref); i++ {
+		if b := ref[i]; b <= 0x1F || b == 0x7F {
+			return fmt.Errorf("rotation_ref %q contains a disallowed control character %#02x — refs must not contain quotes, backslashes, semicolons, path/query metacharacters, or control characters", ref, b)
+		}
+	}
+	if i := strings.IndexAny(ref, rotationRefDisallowedChars); i >= 0 {
+		return fmt.Errorf("rotation_ref %q contains a disallowed character %q — refs must not contain quotes, backslashes, semicolons, path/query metacharacters, or control characters", ref, ref[i])
+	}
+	return nil
+}
+
 // knownRotationCharset reports whether name is a recognized charset (or "" = default).
 func knownRotationCharset(name string) bool {
 	switch name {
@@ -542,6 +575,14 @@ func (c *KeyorixCore) SetSecretAutoRotate(ctx context.Context, id uint, spec Aut
 	// ref with no backend is meaningless.
 	if (spec.Backend == "") != (spec.Ref == "") {
 		return fmt.Errorf("rotation_backend and rotation_ref must be set together (or both empty)")
+	}
+	// Reject dangerous ref metacharacters here, at CONFIGURATION time — the single
+	// shared choke point every transport goes through — rather than relying solely on
+	// the per-backend defenses discovered/added after the fact (see validateRotationRef).
+	if spec.Ref != "" {
+		if err := validateRotationRef(spec.Ref); err != nil {
+			return err
+		}
 	}
 	// Reject an unknown backend at configuration time (the backend's own allowed_refs
 	// then bounds, at rotation time, which refs it will actually rotate).

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -353,6 +353,85 @@ func TestSetSecretAutoRotate_InKeyorixRotationNoAdminRequired(t *testing.T) {
 		"enabling in-Keyorix rotation (no backend) needs no elevated authority")
 }
 
+// TestSetSecretAutoRotate_RejectsDangerousRefChars pins the earliest, shared layer of
+// defense against a malicious rotation_ref: SetSecretAutoRotate is the single
+// core-layer choke point every transport (HTTP/gRPC/CLI) goes through to set a
+// rotation ref, so rejecting dangerous metacharacters here — BEFORE the ref is ever
+// persisted to secret.RotationRef — covers every backend without relying solely on
+// each backend's own (partial, discovered-after-the-fact) defenses.
+func TestSetSecretAutoRotate_RejectsDangerousRefChars(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  string
+	}{
+		{"slash", "svc/app"},
+		{"question-mark", "svc?app"},
+		{"hash", "svc#app"},
+		{"percent", "svc%app"},
+		{"single-quote", "svc'app"},
+		{"double-quote", `svc"app`},
+		{"backslash", `svc\app`},
+		{"semicolon", "svc;app"},
+		{"sql-injection-attempt", "app_svc'; DROP TABLE users; --"},
+		{"path-traversal-attempt", "allowed-prefix/../victim"},
+		{"control-null", "svc\x00app"},
+		{"control-newline", "svc\napp"},
+		{"control-tab", "svc\tapp"},
+		{"control-del", "svc\x7fapp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, db, fixed := rotationExecCore(t)
+			seedRotatableSecret(t, db, 1, "key", false, fixed.Add(-24*time.Hour))
+			c.SetRotationManager(rotation.NewManager([]rotation.Executor{&fakeExecutor{name: "pg"}}))
+			require.NoError(t, db.Create(&models.Role{ID: 1, Name: "project_admin"}).Error)
+			require.NoError(t, db.Create(&models.UserRole{UserID: 9, RoleID: 1, ProjectID: 1}).Error)
+
+			err := c.SetSecretAutoRotate(context.Background(), 1,
+				AutoRotateSpec{Enabled: true, Backend: "pg", Ref: tc.ref}, 9)
+			require.Error(t, err, "ref %q must be rejected", tc.ref)
+			assert.Contains(t, err.Error(), "disallowed")
+
+			var s models.SecretNode
+			require.NoError(t, db.First(&s, 1).Error)
+			assert.Empty(t, s.RotationRef, "the dangerous ref must never be persisted")
+		})
+	}
+}
+
+// TestSetSecretAutoRotate_AllowsRealisticLegitimateRefs pins that the new denylist does
+// NOT break real ref shapes already exercised by the per-backend tests (awsiam_test.go,
+// gcpsa_test.go, postgres_test.go, mysql_test.go): a strict allowlist would have broken
+// these, which is why validateRotationRef is a denylist instead.
+func TestSetSecretAutoRotate_AllowsRealisticLegitimateRefs(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  string
+	}{
+		{"gcp-service-account-email", "svc-app@my-project.iam.gserviceaccount.com"},
+		{"aws-iam-username-with-allowed-punctuation", "svc-app+ci=prod,tier1"},
+		{"plain-postgres-mysql-role-name", "app_svc"},
+		{"azure-app-object-id-guid", "3fa85f64-5717-4562-b3fc-2c963f66afa6"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, db, fixed := rotationExecCore(t)
+			seedRotatableSecret(t, db, 1, "key", false, fixed.Add(-24*time.Hour))
+			c.SetRotationManager(rotation.NewManager([]rotation.Executor{&fakeExecutor{name: "pg"}}))
+			require.NoError(t, db.Create(&models.Role{ID: 1, Name: "project_admin"}).Error)
+			require.NoError(t, db.Create(&models.UserRole{UserID: 9, RoleID: 1, ProjectID: 1}).Error)
+
+			err := c.SetSecretAutoRotate(context.Background(), 1,
+				AutoRotateSpec{Enabled: true, Backend: "pg", Ref: tc.ref}, 9)
+			require.NoError(t, err, "legitimate ref %q must be accepted", tc.ref)
+
+			var s models.SecretNode
+			require.NoError(t, db.First(&s, 1).Error)
+			assert.Equal(t, tc.ref, s.RotationRef)
+		})
+	}
+}
+
 // fakeGenExecutor is a generate-upstream backend: GenerateUpstream mints the value.
 type fakeGenExecutor struct {
 	name   string

--- a/internal/rotation/azure.go
+++ b/internal/rotation/azure.go
@@ -80,7 +80,11 @@ func (e *AzureAppSecretExecutor) GenerateUpstream(ctx context.Context, ref strin
 	// ref is interpolated into the Graph URL path; an app object id is a GUID, so reject
 	// any path/query metacharacter. Without this, a crafted ref that begins with an
 	// allowed prefix (e.g. "<allowed-guid>/../<victim-guid>") could path-traverse to a
-	// different application and defeat allowed_refs.
+	// different application and defeat allowed_refs. This is layer TWO of defense in
+	// depth: layer ONE is core.validateRotationRef (internal/core/rotation_executor.go),
+	// which already rejects this same "/?#%" class (plus SQL metacharacters and control
+	// characters) at configuration time, before the ref is ever persisted. Keep both —
+	// this check must not be removed just because the earlier layer also covers it.
 	if strings.ContainsAny(ref, "/?#%") {
 		return "", fmt.Errorf("azure-app: invalid application object id %q (must be a bare GUID)", ref)
 	}

--- a/internal/rotation/gcpsa.go
+++ b/internal/rotation/gcpsa.go
@@ -69,7 +69,12 @@ func (e *GCPServiceAccountKeyExecutor) GenerateUpstream(ctx context.Context, ref
 		return "", fmt.Errorf("gcp-service-account: service-account email (ref) is required")
 	}
 	// ref is concatenated into the SA resource name; an email never contains '/', so
-	// reject one defensively (it cannot then introduce extra path segments).
+	// reject one defensively (it cannot then introduce extra path segments). This is
+	// layer TWO of defense in depth: layer ONE is core.validateRotationRef
+	// (internal/core/rotation_executor.go), which already rejects '/' (plus other path/
+	// query/SQL metacharacters and control characters) at configuration time, before the
+	// ref is ever persisted. Keep both — this check must not be removed just because the
+	// earlier layer also covers it.
 	if strings.ContainsRune(ref, '/') {
 		return "", fmt.Errorf("gcp-service-account: ref %q must be a service-account email, not a resource path", ref)
 	}

--- a/internal/rotation/mysql.go
+++ b/internal/rotation/mysql.go
@@ -98,7 +98,13 @@ func (e *MySQLExecutor) Rotate(ctx context.Context, ref, newValue string) error 
 
 // quoteMySQLString renders s as a single-quoted MySQL string literal with internal
 // backslashes and single-quotes doubled — injection-safe under both the default and
-// NO_BACKSLASH_ESCAPES sql_modes.
+// NO_BACKSLASH_ESCAPES sql_modes. This is layer TWO of defense in depth: layer ONE is
+// core.validateRotationRef (internal/core/rotation_executor.go), which already rejects
+// quotes/backslashes/semicolons (plus path/query metacharacters and control characters)
+// in the ref at configuration time, before it is ever persisted. Keep both — this
+// quoting must not be removed just because the earlier layer also covers it; this
+// function is the only defense against a ref/host reaching this backend through any
+// future write path.
 func quoteMySQLString(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `'`, `''`)

--- a/internal/rotation/postgres.go
+++ b/internal/rotation/postgres.go
@@ -89,14 +89,21 @@ func (e *PostgresExecutor) Rotate(ctx context.Context, ref, newValue string) err
 }
 
 // quoteIdentifier renders s as a double-quoted PostgreSQL identifier (internal quotes
-// doubled), so a crafted role name cannot break out into SQL.
+// doubled), so a crafted role name cannot break out into SQL. This is layer TWO of
+// defense in depth: layer ONE is core.validateRotationRef
+// (internal/core/rotation_executor.go), which already rejects quotes/backslashes/
+// semicolons (plus path/query metacharacters and control characters) in the ref at
+// configuration time, before it is ever persisted. Keep both — this quoting must not be
+// removed just because the earlier layer also covers it; this function is the only
+// defense against a role name reaching this backend through any future write path.
 func quoteIdentifier(s string) string {
 	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
 }
 
 // quoteLiteral renders s as a single-quoted PostgreSQL string literal (internal quotes
 // doubled). Relies on standard_conforming_strings (the default), so backslashes are
-// literal.
+// literal. See quoteIdentifier's comment above: this is layer TWO of defense in depth
+// alongside core.validateRotationRef.
 func quoteLiteral(s string) string {
 	return `'` + strings.ReplaceAll(s, `'`, `''`) + `'`
 }


### PR DESCRIPTION
## Summary

- `SetSecretAutoRotate` (internal/core/rotation_executor.go) is the single core-layer choke point every transport (HTTP/gRPC/CLI) goes through to set a secret's `RotationRef`, but the ref itself had NO character-class validation before being persisted - the only defense lived deep in each of the 7 backend-specific rotation executors (Postgres/MySQL SQL-quoting, Azure's `/?#%` check, GCP's bare `/` check), discovered and added one at a time, after the fact.
- Adds `validateRotationRef`, a **denylist** (not a strict allowlist) rejecting:
  - URL/path metacharacters: `/ ? # %` (matches Azure's existing precedent - the one real, shipped ref-injection bug)
  - SQL metacharacters: `' " \ ;`
  - Any control character (0x00-0x1F, 0x7F)
- Called from `SetSecretAutoRotate` before `secret.RotationRef = spec.Ref` is ever persisted. Verified this is the *only* non-test write path to `RotationRef` in the codebase (`grep -rn "RotationRef ="` finds nothing else outside this function).
- A denylist was chosen deliberately over a strict allowlist, since real refs already in use would break under one: GCP service-account refs are emails (`@`, `.`), AWS IAM usernames legitimately allow `+`, `=`, `,` per AWS's own naming rules.
- Kept all existing backend-specific checks (Azure's `/?#%`, GCP's `/`, Postgres/MySQL quoting) unchanged - added cross-reference comments at each site (and at the new function) so a future reader understands both layers are deliberate, not redundant.

## Test plan

- [x] New table-driven tests in `internal/core/rotation_executor_test.go`: `TestSetSecretAutoRotate_RejectsDangerousRefChars` (one case per dangerous character class, plus a SQL-injection-shaped and path-traversal-shaped ref) and `TestSetSecretAutoRotate_AllowsRealisticLegitimateRefs` (GCP-email-shaped, AWS-IAM-shaped with `+=,`, plain Postgres/MySQL role name, Azure-GUID-shaped) - all pass.
- [x] Full suite: `go test ./... -race` - all packages pass, confirming no existing test fixture's ref shape was broken by the new denylist.
- [x] `gosec -severity medium -exclude-generated ./...` - 0 issues.
- [x] `golangci-lint run` on touched packages - 0 issues.

🤖 Generated with Claude Code
