### PR TITLE
fix(remote-storage): proxy password login credential checks to the upstream server (#506)

### DIFF
--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -43,14 +43,66 @@ type LoginRequest struct {
 // used as a username-existence oracle. Computed once at package load.
 var dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), bcrypt.DefaultCost)
 
-// Login validates credentials, creates a session, and returns (session, user, error).
-func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Session, *models.User, error) {
-	user, err := c.storage.GetUserByUsername(ctx, req.Username)
+// RemoteLoginVerifier is implemented by storage backends that cannot themselves
+// supply a real password hash for VerifyPasswordCredentials to compare against
+// (#506): models.User.PasswordHash is deliberately `json:"-"` and NEVER crosses
+// the wire, so RemoteStorage's GetUserByUsername always comes back with an
+// empty hash, and a bcrypt compare against it would fail unconditionally — every
+// password login was permanently broken under storage.type: remote before this.
+//
+// The fix is a proxy-login channel: the upstream server (the one actually
+// backed by LocalStorage, which HAS the real hash) performs the credential
+// check itself and returns only a verdict, never the hash. RemoteStorage
+// implements this interface by forwarding to a new POST
+// /api/v1/users/verify-credentials endpoint, whose handler calls the
+// UPSTREAM's own VerifyPasswordCredentials — the SAME function the direct
+// LocalStorage path uses, not a parallel reimplementation of the bcrypt
+// compare. Critically, this means the ENTIRE check is delegated — password
+// compare AND the per-account lockout gate/accounting AND the account-active/
+// account-state checks — not just a bare boolean. Splitting the lockout
+// accounting out and leaving it client-side would be a silent regression:
+// login_lockout.go's UpdateLoginLockoutState is a permanent, unconditional
+// stub under RemoteStorage (#454 — the wire format has no columns for it), so
+// a client-side-only lockout gate can never actually persist a trip and would
+// leave storage.type: remote with NO per-account brute-force backstop at all
+// (only the separate, coarser per-IP rate limiter, #452). Proxying the whole
+// check to the upstream's real, LocalStorage-persisted accounting is the only
+// way this deployment shape can enforce it.
+//
+// core.VerifyPasswordCredentials type-asserts c.storage against this interface
+// and, when present, delegates entirely to it instead of running its own
+// bcrypt.CompareHashAndPassword (which would always fail: it would be
+// comparing against an intentionally-absent hash).
+type RemoteLoginVerifier interface {
+	VerifyLoginCredentials(ctx context.Context, username, password string) (*models.User, error)
+}
+
+// VerifyPasswordCredentials resolves "is this username/password combination
+// valid", enforcing the per-account lockout gate and the account-active/
+// account-state checks Login has always required — extracted out of Login
+// (#506) as the single source of truth so it can ALSO be called directly by
+// the server-side handler for POST /api/v1/users/verify-credentials, the
+// upstream half of the RemoteLoginVerifier proxy-login mechanism (see its doc
+// above). This keeps both the direct LocalStorage login path and the proxied
+// storage.type: remote path running through IDENTICAL bcrypt/lockout/account-
+// state logic — never two, potentially-diverging implementations of the same
+// security check.
+//
+// On success the returned user's MFAEnabled/WebAuthnEnabled/ID/Username/Email/
+// DisplayName fields are populated (Login uses them to decide the MFA-required
+// gate and to mint/describe the session); other fields may be zero-valued when
+// this ran via the remote proxy (see verifyCredentialsWireResponse in
+// internal/storage/store), since nothing past this point needs them.
+func (c *KeyorixCore) VerifyPasswordCredentials(ctx context.Context, username, password string) (*models.User, error) {
+	if verifier, ok := c.storage.(RemoteLoginVerifier); ok {
+		return verifier.VerifyLoginCredentials(ctx, username, password)
+	}
+	user, err := c.storage.GetUserByUsername(ctx, username)
 	if err != nil {
 		// Spend an equivalent bcrypt comparison so a missing username doesn't return
 		// faster than a wrong password (account-enumeration timing side-channel).
-		_ = bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(req.Password))
-		return nil, nil, fmt.Errorf("invalid credentials")
+		_ = bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
+		return nil, fmt.Errorf("invalid credentials")
 	}
 	// Per-account lockout gate: while locked, refuse regardless of the password, so
 	// repeated guessing can't progress. Spend an equivalent bcrypt comparison first so the
@@ -58,12 +110,12 @@ func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Ses
 	// fast (no-bcrypt) response on a locked account is a username-existence oracle (the
 	// attacker first forces the lockout, then probes by timing).
 	if c.loginLocked(user) {
-		_ = bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(req.Password))
-		return nil, nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+		_ = bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
+		return nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
 	}
-	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)); err != nil {
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)); err != nil {
 		c.recordFailedLogin(ctx, user) // increment + lock at the threshold
-		return nil, nil, fmt.Errorf("invalid credentials")
+		return nil, fmt.Errorf("invalid credentials")
 	}
 	// Correct password — but a concurrent burst of failed attempts against this
 	// account may have tripped the lock between the snapshot read at the top of
@@ -72,7 +124,7 @@ func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Ses
 	// row lock) before minting a session, and only then clear any accumulated
 	// failure state — never trust the stale pre-bcrypt snapshot alone.
 	if err := c.checkLockAndClearLoginFailures(ctx, user); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	// A deactivated account (IsActive=false — e.g. admin deactivation via UpdateUser,
 	// or a SCIM/IdP deactivation) is refused login regardless of account_state. The
@@ -80,13 +132,22 @@ func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Ses
 	// still knew their password could authenticate; it also lets SCIM deactivation
 	// preserve a restricted account_state (forced reset) while still blocking login.
 	if !user.IsActive {
-		return nil, nil, fmt.Errorf("account is not active")
+		return nil, fmt.Errorf("account is not active")
 	}
 	// A suspended account is refused login outright (ADR-025). Restricted states
 	// (pending_first_login / password_reset_required) still log in, but the auth
 	// middleware confines the session to the password-change allowlist.
 	if AccountLoginBlocked(user.AccountState) {
-		return nil, nil, fmt.Errorf("account suspended")
+		return nil, fmt.Errorf("account suspended")
+	}
+	return user, nil
+}
+
+// Login validates credentials, creates a session, and returns (session, user, error).
+func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Session, *models.User, error) {
+	user, err := c.VerifyPasswordCredentials(ctx, req.Username, req.Password)
+	if err != nil {
+		return nil, nil, err
 	}
 	// Accounts with any second factor (TOTP or a passkey) get no session from the
 	// password step — the caller must complete it (CreateMFAChallenge →

--- a/internal/core/setup_delivery.go
+++ b/internal/core/setup_delivery.go
@@ -28,6 +28,17 @@ import (
 // rather than a generic 500 — letting an admin fix the config.
 var ErrSetupBaseURLRequired = errors.New("credential_delivery.base_url is required to issue a setup link")
 
+// auditCredentialDisplayedOutOfBand records that a human saw a credential
+// out-of-band (ADR-028's one audited "a human saw this" checkpoint). Deliberately
+// takes ONLY the non-sensitive fields the description needs (subject email, actor,
+// artifact type label) — never the credential/password value itself — so the
+// actual secret is never even in scope in the function that builds the audit
+// description, not merely unreferenced by convention.
+func (c *KeyorixCore) auditCredentialDisplayedOutOfBand(ctx context.Context, actor *uint, subjectEmail, artifact string) {
+	c.writeAuditEventFull(ctx, "credential.displayed_out_of_band", actor, nil, nil, "",
+		fmt.Sprintf("credential shown out-of-band to admin (subject=%s, artifact=%s)", subjectEmail, artifact))
+}
+
 // Resend throttling (ADR-028 abuse section): a minimum interval between issues for
 // the same subject, and a daily cap, both per (purpose, email).
 const (
@@ -126,8 +137,7 @@ func (c *KeyorixCore) deliverSetupLink(ctx context.Context, issued *IssueSetupTo
 	// When the link is shown to the admin out of band, record that a human saw a
 	// credential — the one path the ADR singles out for compliance.
 	if result.LinkForAdmin != "" {
-		c.writeAuditEventFull(ctx, "credential.displayed_out_of_band", actor, nil, nil, "",
-			fmt.Sprintf("setup link shown out-of-band to admin (subject=%s, artifact=link)", req.SubjectEmail))
+		c.auditCredentialDisplayedOutOfBand(ctx, actor, req.SubjectEmail, "link")
 	}
 
 	return &ProvisionSetupResult{
@@ -211,10 +221,13 @@ func (c *KeyorixCore) CreateUserWithOneTimePassword(ctx context.Context, req *Cr
 	}
 
 	// Record that a human saw a credential — the one path the ADR singles out for
-	// compliance (artifact=one_time_password, vs the setup-link artifact).
+	// compliance (artifact=one_time_password, vs the setup-link artifact). Uses
+	// req.Email (the original request parameter, never touched by the
+	// otp-carrying reqCopy/CreateUser call above) rather than user.Email, so the
+	// audit description's only input never shares a struct/call with the actual
+	// generated password.
 	actor := actorOrSubject(createdBy, &user.ID)
-	c.writeAuditEventFull(ctx, "credential.displayed_out_of_band", actor, nil, nil, "",
-		fmt.Sprintf("one-time password shown out-of-band to admin (subject=%s, artifact=one_time_password)", user.Email))
+	c.auditCredentialDisplayedOutOfBand(ctx, actor, req.Email, "one_time_password")
 
 	return user, &OneTimePasswordResult{Email: user.Email, OneTimePassword: otp}, nil
 }

--- a/internal/storage/store/remote_login_verify.go
+++ b/internal/storage/store/remote_login_verify.go
@@ -1,0 +1,110 @@
+// remote_login_verify.go — the upstream half of the storage.type: remote
+// proxy-login mechanism (#506).
+//
+// models.User.PasswordHash is deliberately `json:"-"` and never crosses the
+// wire, so RemoteStorage can never itself compare a submitted password against
+// a real hash — GetUserByUsername's decoded user always has an empty hash.
+// VerifyLoginCredentials closes that gap not by relaxing the "never send a
+// hash" rule, but by sending the PLAINTEXT password (the same trust boundary
+// #499/#505 already established for CreateUser's password field: a bearer-
+// authenticated, TLS-protected RemoteStorage↔upstream service call, not a
+// public/unauthenticated route) to a dedicated upstream endpoint that performs
+// the ENTIRE check — password compare, per-account lockout gating and
+// accounting, and account-active/account-state — using the exact same
+// core.VerifyPasswordCredentials function the upstream's own direct login uses,
+// and returns only a pass/fail verdict plus the minimal fields core.Login needs
+// to proceed (never the hash, never a lockout/account-state reason — see
+// verifyCredentialsWireResponse below for why the failure path is a single,
+// generic error regardless of the real reason).
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// verifyCredentialsWireRequest carries the plaintext password deliberately
+// (see the package doc above and #499's precedent) — the upstream server
+// needs it to run its own bcrypt compare; there is no other way this check
+// could ever work under storage.type: remote.
+type verifyCredentialsWireRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// verifyCredentialsWireResponse is deliberately a NARROW, separate DTO from
+// userWireResponse (remote_users.go) — it carries exactly what core.Login
+// needs after a successful verdict (the MFA-required gate: user.MFAEnabled ||
+// user.WebAuthnEnabled — fields userWireResponse does not even carry — plus
+// enough identity to mint/describe the session) and nothing else: no
+// password_hash (obviously), no lockout-accounting counters (meaningless
+// here — the upstream already applied/cleared them before ever returning
+// success), no other account fields core.Login has no use for once the
+// upstream has already run every gate on its own real, authoritative record.
+type verifyCredentialsWireResponse struct {
+	ID              uint   `json:"id"`
+	Username        string `json:"username"`
+	Email           string `json:"email"`
+	DisplayName     string `json:"display_name"`
+	AccountState    string `json:"account_state"`
+	MFAEnabled      bool   `json:"mfa_enabled"`
+	WebAuthnEnabled bool   `json:"webauthn_enabled"`
+}
+
+func (w verifyCredentialsWireResponse) toModel() *models.User {
+	return &models.User{
+		ID:              w.ID,
+		Username:        w.Username,
+		Email:           w.Email,
+		DisplayName:     w.DisplayName,
+		AccountState:    w.AccountState,
+		MFAEnabled:      w.MFAEnabled,
+		WebAuthnEnabled: w.WebAuthnEnabled,
+		// The upstream endpoint already enforced IsActive/AccountLoginBlocked
+		// before ever returning success, and core.Login's remote-proxy branch
+		// does not re-check them (see VerifyPasswordCredentials) — IsActive is
+		// set true here only so nothing downstream that happens to read it
+		// (e.g. an audit-log helper) sees a false "inactive" for an account
+		// the upstream just proved was allowed to log in.
+		IsActive: true,
+	}
+}
+
+// VerifyLoginCredentials implements core.RemoteLoginVerifier: it proxies the
+// ENTIRE password + lockout + account-state check to the upstream server via
+// POST /api/v1/users/verify-credentials, gated by the same users.write
+// permission CreateUser/UnlockUser already require of the RemoteStorage
+// service credential (#506) — this is not a new, weaker trust boundary, it
+// reuses the existing one.
+//
+// Every failure — wrong password, a tripped lockout, a suspended/inactive
+// account, or a network/parse error — collapses to the SAME generic "invalid
+// credentials" error. This is deliberate: the actual end-user-facing
+// /auth/login handler (server/http/handlers/auth.go) already collapses every
+// non-MFA-required Login error to one generic 401 regardless of the real
+// reason, so no caller-visible behavior is lost; but it also means this proxy
+// call cannot become a richer oracle than the direct path ever was — a
+// compromised RemoteStorage credential learns nothing from this endpoint
+// beyond "that attempt failed", not why. Fail-closed applies uniformly too: a
+// transport error or a malformed response is treated exactly like a rejected
+// credential, never as "let the caller in".
+func (rs *RemoteStorage) VerifyLoginCredentials(ctx context.Context, username, password string) (*models.User, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/users/verify-credentials", verifyCredentialsWireRequest{
+		Username: username,
+		Password: password,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("invalid credentials")
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("invalid credentials")
+	}
+	var wire verifyCredentialsWireResponse
+	if err := json.Unmarshal(resp.Data, &wire); err != nil {
+		return nil, fmt.Errorf("invalid credentials")
+	}
+	return wire.toModel(), nil
+}

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -316,6 +316,73 @@ func (h *UserHandler) GetUserByExternalID(w http.ResponseWriter, r *http.Request
 	sendSuccess(w, resp, "")
 }
 
+// VerifyCredentials handles POST /api/v1/users/verify-credentials (#506) — the
+// upstream half of the RemoteLoginVerifier proxy-login mechanism
+// (internal/core/auth.go). It exists SOLELY so a storage.type: remote
+// deployment's own core.Login can authenticate a password at all:
+// models.User.PasswordHash never crosses the wire, so a "spoke" server backed
+// by RemoteStorage has no real hash to bcrypt-compare against locally — this
+// endpoint runs that compare on the "hub" server that actually has it,
+// against the SAME core.VerifyPasswordCredentials the hub's own direct login
+// uses (not a parallel bcrypt reimplementation), so the per-account lockout
+// gate/accounting and account-active/account-state checks apply identically
+// regardless of which path reached them.
+//
+// Gated by users.write — the SAME permission CreateUser/UnlockUser already
+// require of the RemoteStorage service credential (server/http/router.go) —
+// deliberately not a new, separately-provisioned permission: a credential
+// trusted enough to create/unlock/suspend arbitrary accounts is already
+// trusted enough to check whether a password matches one, and requiring a
+// fresh grant here would silently strand every existing storage.type: remote
+// deployment's login until an operator noticed and granted it.
+//
+// The response never distinguishes WHY a check failed — wrong password, an
+// active lockout, or a suspended/inactive account all produce the SAME
+// generic 401 here, mirroring how /auth/login itself already collapses every
+// non-MFA-required Login error to one generic message for the actual end
+// user (server/http/handlers/auth.go). A compromised RemoteStorage credential
+// must not be able to use this endpoint to enumerate accounts or their
+// lockout state beyond "that attempt failed" — nor is any of this logged with
+// per-reason detail, for the same reason.
+func (h *UserHandler) VerifyCredentials(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
+		return
+	}
+	if body.Username == "" || body.Password == "" {
+		sendError(w, "ValidationError", "username and password are required", http.StatusBadRequest, nil)
+		return
+	}
+	u, err := h.coreService.VerifyPasswordCredentials(r.Context(), body.Username, body.Password)
+	if err != nil {
+		// Deliberately no log.Printf here (unlike every other handler in this
+		// file): logging the real error would record which of "no such user" /
+		// "wrong password" / "locked" / "not active" / "suspended" applied,
+		// re-opening exactly the oracle the generic response below exists to
+		// close.
+		sendError(w, "Unauthorized", "Invalid credentials", http.StatusUnauthorized, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"id":               u.ID,
+		"username":         u.Username,
+		"email":            u.Email,
+		"display_name":     u.DisplayName,
+		"account_state":    core.NormalizeAccountState(u.AccountState),
+		"mfa_enabled":      u.MFAEnabled,
+		"webauthn_enabled": u.WebAuthnEnabled,
+	}, "")
+}
+
 // UpdateUser handles PUT /api/v1/users/{id}
 func (h *UserHandler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/handlers/users_handler.go
+++ b/server/http/handlers/users_handler.go
@@ -312,6 +312,15 @@ func GetUserByExternalID(w http.ResponseWriter, r *http.Request) {
 	defaultUserHandler.GetUserByExternalID(w, r)
 }
 
+// VerifyCredentials handles POST /api/v1/users/verify-credentials (#506).
+func VerifyCredentials(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.VerifyCredentials(w, r)
+}
+
 // UpdateUser handles PUT /api/v1/users/{id}
 func UpdateUser(w http.ResponseWriter, r *http.Request) {
 	if defaultUserHandler == nil {

--- a/server/http/remote_storage_get_user_by_username_and_external_id_test.go
+++ b/server/http/remote_storage_get_user_by_username_and_external_id_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
-	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -194,71 +193,4 @@ func TestRemoteStorage_GetUserByExternalID_RealServerRoundTrip(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, existsHTTPErr.StatusCode)
 	assert.Equal(t, existsHTTPErr.StatusCode, notExistsHTTPErr.StatusCode,
 		"gating must not leak existence via a different status for an existing vs a non-existing external_id")
-}
-
-// TestLogin_RemoteStorage_StillFailsClosed_PasswordHashNeverOnWire documents a
-// discovery made while investigating #505, and proves this fix does not
-// accidentally change it: Login (internal/core/auth.go) resolves the submitted
-// username via c.storage.GetUserByUsername, which — before this fix — always
-// errored (storage.ErrUnsupportedByBackend), so Login always failed at the
-// lookup step under storage.type: remote. GetUserByUsername now genuinely
-// succeeds, but Login still cannot succeed: models.User.PasswordHash is tagged
-// `json:"-"` DELIBERATELY (see userCreateWireRequest's doc in remote_users.go —
-// "it must never be sent") and userWireResponse has no password_hash field
-// either, so bcrypt.CompareHashAndPassword always runs against an empty hash
-// and always fails. This is a real, pre-existing, and much larger architectural
-// gap (native password login cannot work through storage.type: remote at all,
-// by a deliberate security boundary — a proxy-login design would be needed to
-// close it) that is NOT part of #505's scope: #505 is about the externalId/
-// username LOOKUP being a stub, not about building a remote credential-
-// verification channel. This test exists so a future change to
-// GetUserByUsername/CreateUser's wire shape cannot silently start leaking
-// password hashes without an explicit, deliberate decision to do so — it must
-// keep failing exactly this way.
-func TestLogin_RemoteStorage_StillFailsClosed_PasswordHashNeverOnWire(t *testing.T) {
-	require.NoError(t, i18n.InitializeForTesting())
-	defer i18n.ResetForTesting()
-
-	// --- upstream: a real Keyorix server, the actual holder of user records ---
-	upstreamCore := newTestCore(t)
-	upstreamToken := createTestToken(t, upstreamCore)
-
-	cfg := &config.Config{
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
-		},
-	}
-	upstreamRouter, err := NewRouter(cfg, upstreamCore)
-	require.NoError(t, err)
-	upstreamSrv := httptest.NewServer(upstreamRouter)
-	defer upstreamSrv.Close()
-
-	// --- downstream: storage.type: remote, pointed at the upstream ---
-	rs, err := store.NewRemoteStorage(&remote.Config{
-		BaseURL:        upstreamSrv.URL,
-		APIKey:         upstreamToken,
-		TimeoutSeconds: 5,
-		RetryAttempts:  0,
-		TLSVerify:      true,
-	})
-	require.NoError(t, err)
-	downstreamCore := core.NewKeyorixCore(rs)
-
-	ctx := context.Background()
-
-	// The lookup itself now genuinely succeeds (the #505 fix) — prove that
-	// directly first, so a failure below is attributable to the password-hash
-	// gap, not a regression of the lookup this PR just fixed.
-	found, err := rs.GetUserByUsername(ctx, "testadmin")
-	require.NoError(t, err, "the underlying username lookup must succeed (#505)")
-	require.Equal(t, "testadmin", found.Username)
-
-	// Even the CORRECT password must still fail closed — not because
-	// GetUserByUsername is broken (it isn't, anymore), but because the wire
-	// never carries a password hash to compare against.
-	_, _, err = downstreamCore.Login(ctx, &core.LoginRequest{
-		Username: "testadmin",
-		Password: "TestPassword123!",
-	})
-	require.Error(t, err, "native password Login cannot succeed through storage.type: remote — password_hash is deliberately never sent over the wire; this is a separate, larger gap, out of #505's scope")
 }

--- a/server/http/remote_storage_login_test.go
+++ b/server/http/remote_storage_login_test.go
@@ -1,0 +1,154 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogin_RemoteStorage_ProxiesPasswordCredentialCheck proves the #506 fix
+// for the credential-verification half of storage.type: remote password
+// login: a "spoke" server backed by RemoteStorage, pointed at a real "hub"
+// server backed by LocalStorage, can now run the ENTIRE password + per-account
+// lockout + account-state check against the hub's real bcrypt hash and real,
+// persisted lockout accounting — proxied via core.RemoteLoginVerifier
+// (internal/core/auth.go) and POST /api/v1/users/verify-credentials
+// (server/http/handlers/users_crud.go).
+//
+// This SUPERSEDES TestLogin_RemoteStorage_StillFailsClosed_PasswordHashNeverOnWire
+// (round 114's #828), which deliberately pinned the PRE-fix fail-ALWAYS
+// behavior: before this fix, EVERY call below — including the CORRECT
+// password — returned "invalid credentials" indistinguishably, because
+// Login's bcrypt compare always ran against an empty hash. This test proves
+// that is no longer true: a wrong password is rejected, a correct password's
+// credential CHECK now genuinely succeeds (proceeding past that gate into
+// mintSession — see below for why it does not go further YET), and repeated
+// wrong passwords trip the SAME per-account lockout the direct LocalStorage
+// path enforces, via the identical core.VerifyPasswordCredentials logic
+// (reverting internal/core/auth.go's RemoteLoginVerifier/
+// VerifyPasswordCredentials changes, or
+// internal/storage/store/remote_login_verify.go, or the
+// POST /api/v1/users/verify-credentials route/handler, makes this test fail
+// exactly as the old #828 pinning test predicted — verified by hand while
+// developing this fix).
+//
+// What this test deliberately does NOT prove — because it is not true yet —
+// is a fully USABLE end-to-end login (a session the caller can actually
+// authenticate subsequent requests with). That is blocked by a separate,
+// pre-existing, larger gap this fix does not attempt to close: RemoteStorage's
+// session persistence (CreateSession/GetSession/DeleteSession, remote_auth.go)
+// has no corresponding server routes at all — POST /api/v1/sessions 404s
+// unconditionally today, entirely independent of the password-hash problem
+// #506 is about. A correct password's Login call below therefore still
+// returns an error, but a DIFFERENT one than an incorrect password: it fails
+// at mintSession (session persistence), not at the credential check — proving
+// the two are now genuinely distinguishable, which they were not before this
+// fix (every failure reason collapsed to the identical "invalid credentials").
+// See the PR description for why closing the session-persistence gap safely
+// (a naive "create a session for this user_id" wire primitive would be a
+// privilege-escalation oracle far worse than today's "login doesn't work")
+// needs its own dedicated design pass, not a rushed addition here.
+func TestLogin_RemoteStorage_ProxiesPasswordCredentialCheck(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	// --- upstream ("hub"): the real holder of the user record + password hash ---
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+	// A tight lockout policy (2 attempts) so this test can trip it in a
+	// handful of calls below, proving the SAME per-account lockout gating the
+	// direct LocalStorage path enforces also applies via this proxied path
+	// (#506's primary security concern) — not a parallel, unprotected check.
+	upstreamCore.SetLoginLockoutPolicy(core.LoginLockoutPolicy{
+		Enabled: true, MaxAttempts: 2, Window: 15 * time.Minute,
+		BaseCooldown: time.Hour, MaxCooldown: time.Hour,
+	})
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"}},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	// --- downstream ("spoke"): storage.type: remote, pointed at the upstream ---
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstreamCore := core.NewKeyorixCore(rs)
+
+	ctx := context.Background()
+
+	// A wrong password must fail through the proxied path exactly like it
+	// always has — the credential check itself rejects it before ever
+	// reaching session minting.
+	_, _, err = downstreamCore.Login(ctx, &core.LoginRequest{
+		Username: "definitely-the-wrong-password-user", Password: "irrelevant",
+	})
+	require.Error(t, err)
+	assert.Equal(t, "invalid credentials", err.Error())
+
+	_, _, err = downstreamCore.Login(ctx, &core.LoginRequest{
+		Username: "testadmin", Password: "definitely-the-wrong-password",
+	})
+	require.Error(t, err)
+	assert.Equal(t, "invalid credentials", err.Error())
+
+	// The CORRECT password now gets PAST the credential check (the #506 fix) —
+	// proceeding to mintSession, which fails on a DIFFERENT, session-specific
+	// error (the separate, pre-existing session-persistence gap documented
+	// above), not the generic "invalid credentials" every failure reason
+	// collapsed to before this fix.
+	_, _, err = downstreamCore.Login(ctx, &core.LoginRequest{
+		Username: "testadmin", Password: "TestPassword123!",
+	})
+	require.Error(t, err, "session persistence is a separate, unimplemented gap (see test doc) — "+
+		"but the error must no longer be the generic credential-check failure")
+	assert.NotEqual(t, "invalid credentials", err.Error(),
+		"a CORRECT password must be distinguishable from a wrong one: it should fail at session "+
+			"minting, not at the credential check the #506 fix targets")
+	assert.Contains(t, err.Error(), "session", "expected a session-persistence failure, not a credential-check failure")
+
+	// --- lockout: repeated wrong passwords via THIS proxied path must trip
+	// the SAME per-account lockout the direct path enforces (MaxAttempts=2
+	// above), proving it is not a parallel, unprotected credential check —
+	// #506's primary security concern. Verified directly against the
+	// upstream's own (LocalStorage-backed) user record, since Login's return
+	// error alone can't distinguish "wrong password" from "locked" through
+	// this proxy (see remote_login_verify.go's doc for why that collapse is
+	// deliberate).
+	_, _, err = downstreamCore.Login(ctx, &core.LoginRequest{Username: "testadmin", Password: "wrong-1"})
+	require.Error(t, err)
+	_, _, err = downstreamCore.Login(ctx, &core.LoginRequest{Username: "testadmin", Password: "wrong-2"})
+	require.Error(t, err)
+
+	locked, err := upstreamCore.GetUserByUsername(ctx, "testadmin")
+	require.NoError(t, err)
+	require.NotNil(t, locked.LoginLockedUntil, "the account must be locked upstream after "+
+		"MaxAttempts failures reached via the proxied path, exactly like the direct LocalStorage path")
+	assert.True(t, locked.LoginLockedUntil.After(time.Now()))
+
+	// While locked, even the CORRECT password must be refused (rejected at the
+	// credential check, before ever reaching session minting) — proxied
+	// through the identical path.
+	_, _, err = downstreamCore.Login(ctx, &core.LoginRequest{Username: "testadmin", Password: "TestPassword123!"})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "locked") || err.Error() == "invalid credentials",
+		"a locked account's correct password must still be refused at the credential check")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -594,6 +594,18 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// new capability at that permission level. Static paths, before /{id}.
 			r.Get("/by-username", handlers.GetUserByUsername)
 			r.Get("/by-external-id", handlers.GetUserByExternalID)
+			// VerifyCredentials (#506) — the upstream half of the storage.type: remote
+			// proxy-login mechanism (internal/core/auth.go's RemoteLoginVerifier):
+			// checks a plaintext username/password against the real bcrypt hash this
+			// server holds and returns only a verdict, never the hash, so a
+			// RemoteStorage-backed "spoke" deployment (which never receives the hash
+			// at all) can authenticate a password login by proxying the ENTIRE check
+			// here rather than reimplementing it. Gated by users.write, the same
+			// permission the RemoteStorage service credential already needs for
+			// CreateUser/UnlockUser — see the handler's doc for why this is
+			// deliberately not a new, separately-provisioned permission. Static path,
+			// before /{id}.
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/verify-credentials", handlers.VerifyCredentials)
 			r.Get("/{id}", handlers.GetUser)
 			// Mutations need users.write, not the group-wide users.read (which the
 			// read-only system_auditor persona holds) — these were the missed


### PR DESCRIPTION
## Summary

Fixes backlog finding #506 (MEDIUM): `storage.type: remote` deployments could not log in via password at all — `models.User.PasswordHash` is intentionally `json:"-"` and never crosses the wire, so `core.Login`'s bcrypt comparison never had a real hash to compare against. Every password-based login attempt failed, regardless of whether the credentials were correct. Pinned with a regression test in round 114's PR #828, deliberately left unfixed pending a proxy-login design.

## Design

- Extracted `Login`'s password/lockout/account-state check into `VerifyPasswordCredentials`, and added `RemoteLoginVerifier`, an interface `core.Login` type-asserts `c.storage` against. When present (RemoteStorage), the **entire** check delegates to the upstream server instead of a bare bcrypt boolean — closing the same gap #454 already documents (RemoteStorage's own lockout accounting is permanently inert otherwise).
- New `RemoteStorage.VerifyLoginCredentials` (`internal/storage/store/remote_login_verify.go`) proxies to a new endpoint, sending the plaintext password over the same trust boundary #499/#505 already established for `CreateUser`. Every failure reason (wrong password, lockout, suspended, transport error) collapses to one generic error — matching how `/auth/login`'s HTTP handler already treats every non-MFA error identically, so the proxy can't become a richer oracle than the existing local path.
- New `POST /api/v1/users/verify-credentials`, gated by `users.write` (the same permission already required for `CreateUser`/`UnlockUser`) — deliberately reusing the existing trust boundary rather than provisioning a new permission.

## Discovered but deliberately NOT fixed here (security-critical scoping decision)

**RemoteStorage session persistence (`CreateSession`/`GetSession`/`DeleteSession`) has no corresponding server routes at all** — `POST /api/v1/sessions` 404s unconditionally. A naive fix (a generic "create a session for this user_id" wire endpoint) would be a privilege-escalation oracle far worse than the current "doesn't work" state, so this was left untouched and documented rather than papered over. Filing as a separate, dedicated finding rather than folding a rushed fix in here.

**MFA/WebAuthn login remains completely unsupported** under `storage.type: remote`, unaffected by this fix — every MFA/WebAuthn storage method is an unconditional stub, since the raw TOTP secret and WebAuthn credential public key never cross the wire either. A password-only account can now authenticate through this proxy; an MFA- or WebAuthn-enabled account still cannot complete login at all. Separate, large subsystem gap, out of scope here.

## Testing

Updated the round-114 pinning test (removed `TestLogin_RemoteStorage_StillFailsClosed_PasswordHashNeverOnWire`, which asserted the broken behavior on purpose): new `server/http/remote_storage_login_test.go`'s `TestLogin_RemoteStorage_ProxiesPasswordCredentialCheck` proves wrong passwords fail, correct passwords now pass the credential check, and repeated failures trip the same lockout as the direct path — verified against the upstream's real user record. Confirmed by reverting the fix that this test fails exactly as predicted.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/core/... ./server/http/... ./internal/storage/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./...` — 0 issues
- `golangci-lint run` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)