### PR TITLE
fix(remote-storage): implement CreateProjectInvitation/GetProjectInvitation/UpdateProjectInvitation/ListProjectInvitations (#507)

### DIFF
--- a/internal/storage/store/remote_invitations.go
+++ b/internal/storage/store/remote_invitations.go
@@ -1,30 +1,217 @@
 // remote_invitations.go — invitations + access requests for RemoteStorage (ADR-024).
 //
-// Processed server-side in remote mode; stubs. For the local (GORM) equivalent
-// see local_invitations.go.
+// Project-invitation methods (#507) are thin passthroughs onto four new
+// server-side routes under /api/v1/system/invitations
+// (server/http/handlers/invitations_proxy.go), mirroring the #452-follow-up
+// login-attempts proxy pattern (internal/storage/store/remote_login_attempts.go,
+// docs/adr-040-distributed-rate-limiting.md's addendum): gated on the SAME broad
+// system.read/system.write RBAC permissions a RemoteStorage credential already
+// needs for every other proxied call (full user CRUD, secret CRUD, ...), so this
+// introduces no new privilege class. No invitation POLICY decision (escalation
+// checks, TTLs, single-use-accept enforcement) is made in these routes — that
+// stays entirely in the CALLING server's own internal/core.KeyorixCore, exactly as
+// it does against a local backend. The routes are raw passthroughs onto
+// storage.Storage's own CreateProjectInvitation/GetProjectInvitation/
+// UpdateProjectInvitation/ListProjectInvitations, including
+// UpdateProjectInvitation's conditional `WHERE id=? AND state='pending'` atomic
+// write (local_invitations.go) — critical, since this is the SAME operation
+// setup_consume.go's completeInvitationAccept relies on for single-use-accept: two
+// concurrent accept requests racing to flip the same invitation must result in
+// exactly one success, both locally and now across this HTTP hop.
+//
+// Two gaps discovered while wiring this up are NOT fixed here (documented, not
+// silently worked around):
+//   - internal/storage/store/remote_auth.go's SetupToken CRUD
+//     (CreateSetupToken/GetSetupTokenByHash/MarkSetupTokenConsumed/...) is entirely
+//     stubbed, so CompleteSetup's very first step (inspectActiveSetupToken) still
+//     hard-fails under storage.type: remote for EVERY setup-token purpose
+//     (account_setup, password_reset_link, invitation_accept), not just invitations.
+//   - remote_memberships.go's CreateProjectMembership/GetActiveProjectMembership are
+//     also entirely stubbed, so applyInvitationGrants' membership-materialization
+//     step (inviteMemberWithMode) still hard-fails after a successful accept.
+//
+// Both are themselves whole missing subsystems (their own atomic-concurrency and
+// authorization design), well beyond this finding's named scope
+// (CreateProjectInvitation/GetProjectInvitation/UpdateProjectInvitation/
+// ListProjectInvitations) — flagged as follow-up findings rather than folded in.
+//
+// Access-request methods (CreateAccessRequest.../CreateAccessRequestApproval...)
+// are unrelated to this finding and remain stubs. For the local (GORM) equivalent
+// of everything here see local_invitations.go.
 package store
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-func (rs *RemoteStorage) CreateProjectInvitation(_ context.Context, _ *models.ProjectInvitation) (*models.ProjectInvitation, error) {
-	return nil, remoteUnsupported("CreateProjectInvitation")
+// invitationWire mirrors models.ProjectInvitation's fields exactly (snake_case),
+// used for both the create-request body and every response (create/get/list) —
+// there is no models.ProjectInvitation json tag to fall back on (a GORM model,
+// like models.User before #496), so a direct marshal/unmarshal would silently
+// drop every field whose wire name isn't case-insensitively identical to its Go
+// name (ValidationModeAtInvite, AssignmentsJSON, ExpiresAt, ...). See
+// remote_users.go's userWireResponse comment for the full explanation of why this
+// codebase names every field explicitly instead of relying on that fallback.
+type invitationWire struct {
+	ID                     uint       `json:"id"`
+	ProjectID              uint       `json:"project_id"`
+	Email                  string     `json:"email"`
+	Role                   string     `json:"role"`
+	State                  string     `json:"state"`
+	InvitedBy              uint       `json:"invited_by"`
+	ValidationModeAtInvite string     `json:"validation_mode_at_invite"`
+	SystemRole             string     `json:"system_role"`
+	AssignmentsJSON        string     `json:"assignments_json"`
+	ExpiresAt              *time.Time `json:"expires_at"`
+	CreatedAt              time.Time  `json:"created_at"`
+	AcceptedAt             *time.Time `json:"accepted_at"`
+	RevokedAt              *time.Time `json:"revoked_at"`
 }
 
-func (rs *RemoteStorage) GetProjectInvitation(_ context.Context, _ uint) (*models.ProjectInvitation, error) {
-	return nil, remoteUnsupported("GetProjectInvitation")
+func newInvitationWire(inv *models.ProjectInvitation) invitationWire {
+	return invitationWire{
+		ID:                     inv.ID,
+		ProjectID:              inv.ProjectID,
+		Email:                  inv.Email,
+		Role:                   inv.Role,
+		State:                  inv.State,
+		InvitedBy:              inv.InvitedBy,
+		ValidationModeAtInvite: inv.ValidationModeAtInvite,
+		SystemRole:             inv.SystemRole,
+		AssignmentsJSON:        inv.AssignmentsJSON,
+		ExpiresAt:              inv.ExpiresAt,
+		CreatedAt:              inv.CreatedAt,
+		AcceptedAt:             inv.AcceptedAt,
+		RevokedAt:              inv.RevokedAt,
+	}
 }
 
-func (rs *RemoteStorage) UpdateProjectInvitation(_ context.Context, _ *models.ProjectInvitation) (bool, error) {
-	return false, remoteUnsupported("UpdateProjectInvitation")
+func (w invitationWire) toModel() *models.ProjectInvitation {
+	return &models.ProjectInvitation{
+		ID:                     w.ID,
+		ProjectID:              w.ProjectID,
+		Email:                  w.Email,
+		Role:                   w.Role,
+		State:                  w.State,
+		InvitedBy:              w.InvitedBy,
+		ValidationModeAtInvite: w.ValidationModeAtInvite,
+		SystemRole:             w.SystemRole,
+		AssignmentsJSON:        w.AssignmentsJSON,
+		ExpiresAt:              w.ExpiresAt,
+		CreatedAt:              w.CreatedAt,
+		AcceptedAt:             w.AcceptedAt,
+		RevokedAt:              w.RevokedAt,
+	}
 }
 
-func (rs *RemoteStorage) ListProjectInvitations(_ context.Context, _ uint) ([]*models.ProjectInvitation, error) {
-	return nil, remoteUnsupported("ListProjectInvitations")
+func decodeInvitationResponse(data []byte) (*models.ProjectInvitation, error) {
+	var wire invitationWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }
+
+// CreateProjectInvitation persists an already-built invitation (every field —
+// state, TTL, validation-mode snapshot, invited_by, ... — is computed by the
+// CALLING core.KeyorixCore before this is invoked, exactly as InviteToProject
+// builds one for LocalStorage) via POST /api/v1/system/invitations. This is a raw
+// persist, NOT the human-facing POST /api/v1/projects/{id}/invitations (which
+// wraps InviteToProjectWithLink and also provisions + delivers a setup-link
+// email): mapping onto that route would re-run full invite business logic AND
+// send a second, real invitation email server-side for every CLI/chained-server
+// invite, since the calling core's own InviteToProjectWithLink already tries its
+// own provisionSetupLinkThrottled step immediately afterward. This route does
+// none of that — it only stores the row — so the caller's own subsequent
+// setup-link provisioning attempt (today, always failing while SetupToken
+// remains stubbed — see the package doc) reports honestly rather than masking a
+// duplicate send.
+func (rs *RemoteStorage) CreateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (*models.ProjectInvitation, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/invitations", newInvitationWire(inv))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create invitation: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create invitation failed: %s", resp.Error.Error())
+	}
+	return decodeInvitationResponse(resp.Data)
+}
+
+// GetProjectInvitation retrieves an invitation by ID via GET
+// /api/v1/system/invitations/{id} — a raw fetch, gated by system.read.
+func (rs *RemoteStorage) GetProjectInvitation(ctx context.Context, id uint) (*models.ProjectInvitation, error) {
+	path := fmt.Sprintf("/api/v1/system/invitations/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get invitation: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get invitation failed: %s", resp.Error.Error())
+	}
+	return decodeInvitationResponse(resp.Data)
+}
+
+// UpdateProjectInvitation persists an invitation state transition via PUT
+// /api/v1/system/invitations/{id}, preserving LocalStorage's exact single-use
+// semantics (#412) end-to-end: the server performs the SAME conditional
+// `WHERE id = ? AND state = 'pending'` write local_invitations.go's
+// UpdateProjectInvitation does, and reports whether it actually matched a row —
+// NOT a client-side "GET then check state then PUT" sequence, which would
+// reintroduce the exact TOCTOU double-accept race this method exists to close
+// (two concurrent accept requests both observing "pending" before either writes).
+// One HTTP round trip maps to one atomic server-side conditional UPDATE.
+func (rs *RemoteStorage) UpdateProjectInvitation(ctx context.Context, inv *models.ProjectInvitation) (bool, error) {
+	path := fmt.Sprintf("/api/v1/system/invitations/%d", inv.ID)
+	resp, err := rs.client.Put(ctx, path, newInvitationWire(inv))
+	if err != nil {
+		return false, fmt.Errorf("failed to update invitation: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("update invitation failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Updated bool `json:"updated"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Updated, nil
+}
+
+// ListProjectInvitations lists a project's invitations via GET
+// /api/v1/system/invitations?project_id=X.
+func (rs *RemoteStorage) ListProjectInvitations(ctx context.Context, projectID uint) ([]*models.ProjectInvitation, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	path := "/api/v1/system/invitations?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list invitations: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list invitations failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Invitations []invitationWire `json:"invitations"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.ProjectInvitation, 0, len(result.Invitations))
+	for _, w := range result.Invitations {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
+}
+
+// --- Access requests (unrelated to #507; still stubs) ---
 
 func (rs *RemoteStorage) CreateAccessRequest(_ context.Context, _ *models.AccessRequest) (*models.AccessRequest, error) {
 	return nil, remoteUnsupported("CreateAccessRequest")

--- a/internal/storage/store/remote_unsupported_test.go
+++ b/internal/storage/store/remote_unsupported_test.go
@@ -25,10 +25,13 @@ func TestRemoteStorage_UnsupportedSentinel(t *testing.T) {
 	calls := map[string]func() error{
 		"CreateGroup":             func() error { _, e := rs.CreateGroup(ctx, &models.Group{}); return e },
 		"CreateProjectMembership": func() error { _, e := rs.CreateProjectMembership(ctx, &models.ProjectMembership{}); return e },
-		"ListProjectInvitations":  func() error { _, e := rs.ListProjectInvitations(ctx, 1); return e },
-		"CreateNotification":      func() error { _, e := rs.CreateNotification(ctx, &models.Notification{}); return e },
-		"ListPermissions":         func() error { _, e := rs.ListPermissions(ctx); return e },
-		"CreateMachineIdentity":   func() error { _, e := rs.CreateMachineIdentity(ctx, &models.MachineIdentity{}); return e },
+		// ListProjectInvitations (#507) now makes a real HTTP call rather than
+		// stubbing out — see server/http/remote_storage_invitations_test.go for its
+		// end-to-end coverage against a real router.
+		"CreateAccessRequest":   func() error { _, e := rs.CreateAccessRequest(ctx, &models.AccessRequest{}); return e },
+		"CreateNotification":    func() error { _, e := rs.CreateNotification(ctx, &models.Notification{}); return e },
+		"ListPermissions":       func() error { _, e := rs.ListPermissions(ctx); return e },
+		"CreateMachineIdentity": func() error { _, e := rs.CreateMachineIdentity(ctx, &models.MachineIdentity{}); return e },
 	}
 	for name, call := range calls {
 		err := call()

--- a/server/http/handlers/invitations_proxy.go
+++ b/server/http/handlers/invitations_proxy.go
@@ -1,0 +1,220 @@
+// invitations_proxy.go — server-side endpoints backing RemoteStorage's
+// CreateProjectInvitation/GetProjectInvitation/UpdateProjectInvitation/
+// ListProjectInvitations (#507).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// its project-invitation storage calls to whichever upstream server it's
+// configured against, through these four routes (registered in
+// server/http/router.go under /api/v1/system/invitations, gated on the existing
+// system.read/system.write RBAC permissions — the SAME credential a RemoteStorage
+// client already needs for every other proxied call, e.g. full user CRUD, so this
+// introduces no new privilege class). This mirrors the #452-follow-up
+// login-attempts proxy (login_attempts_proxy.go) exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// (CreateProjectInvitation/GetProjectInvitation/UpdateProjectInvitation/
+// ListProjectInvitations) internal/core/invitations.go and setup_consume.go
+// already use against a local backend — no invitation POLICY decision
+// (escalation-by-proxy checks, TTLs, which transitions are legal) is made here;
+// that stays entirely in the CALLING server's own internal/core.KeyorixCore.
+// Crucially, UpdateProjectInvitationProxy calls storage.UpdateProjectInvitation
+// directly, so it inherits local_invitations.go's conditional
+// `WHERE id = ? AND state = 'pending'` write verbatim — the single-use-accept
+// race guarantee setup_consume.go's completeInvitationAccept depends on survives
+// this HTTP hop unchanged; there is no separate "check pending, then write"
+// sequence here to reintroduce that TOCTOU.
+//
+// Response envelope: like login_attempts_proxy.go, these do NOT use the package's
+// generic sendSuccess/sendError helpers — they construct the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// invitationProxyWire mirrors models.ProjectInvitation's fields exactly
+// (snake_case) — the wire shape internal/storage/store/remote_invitations.go's
+// invitationWire sends/expects. See that type's comment for why every field is
+// named explicitly rather than relying on encoding/json's case-insensitive
+// fallback (the same #496 class of gap: models.ProjectInvitation carries no json
+// tags of its own).
+type invitationProxyWire struct {
+	ID                     uint       `json:"id"`
+	ProjectID              uint       `json:"project_id"`
+	Email                  string     `json:"email"`
+	Role                   string     `json:"role"`
+	State                  string     `json:"state"`
+	InvitedBy              uint       `json:"invited_by"`
+	ValidationModeAtInvite string     `json:"validation_mode_at_invite"`
+	SystemRole             string     `json:"system_role"`
+	AssignmentsJSON        string     `json:"assignments_json"`
+	ExpiresAt              *time.Time `json:"expires_at"`
+	CreatedAt              time.Time  `json:"created_at"`
+	AcceptedAt             *time.Time `json:"accepted_at"`
+	RevokedAt              *time.Time `json:"revoked_at"`
+}
+
+func newInvitationProxyWire(inv *models.ProjectInvitation) invitationProxyWire {
+	return invitationProxyWire{
+		ID:                     inv.ID,
+		ProjectID:              inv.ProjectID,
+		Email:                  inv.Email,
+		Role:                   inv.Role,
+		State:                  inv.State,
+		InvitedBy:              inv.InvitedBy,
+		ValidationModeAtInvite: inv.ValidationModeAtInvite,
+		SystemRole:             inv.SystemRole,
+		AssignmentsJSON:        inv.AssignmentsJSON,
+		ExpiresAt:              inv.ExpiresAt,
+		CreatedAt:              inv.CreatedAt,
+		AcceptedAt:             inv.AcceptedAt,
+		RevokedAt:              inv.RevokedAt,
+	}
+}
+
+func (w invitationProxyWire) toModel() *models.ProjectInvitation {
+	return &models.ProjectInvitation{
+		ID:                     w.ID,
+		ProjectID:              w.ProjectID,
+		Email:                  w.Email,
+		Role:                   w.Role,
+		State:                  w.State,
+		InvitedBy:              w.InvitedBy,
+		ValidationModeAtInvite: w.ValidationModeAtInvite,
+		SystemRole:             w.SystemRole,
+		AssignmentsJSON:        w.AssignmentsJSON,
+		ExpiresAt:              w.ExpiresAt,
+		CreatedAt:              w.CreatedAt,
+		AcceptedAt:             w.AcceptedAt,
+		RevokedAt:              w.RevokedAt,
+	}
+}
+
+// validInvitationTargetState reports whether s is a state this proxy may WRITE.
+// "pending" is deliberately excluded — it is only ever the initial state a
+// CreateProjectInvitation persists, never a target of an UPDATE (every real
+// transition in internal/core/invitations.go and setup_consume.go moves AWAY
+// from pending), so accepting it here would let a caller resurrect an already
+// resolved invitation back to pending instead of merely transitioning it forward.
+func validInvitationTargetState(s string) bool {
+	switch s {
+	case "accepted", "revoked", "expired":
+		return true
+	default:
+		return false
+	}
+}
+
+// CreateInvitationProxy handles POST /api/v1/system/invitations. See the package
+// doc for why this persists the caller's already-fully-built invitation as-is
+// (a raw storage-layer create) rather than routing through
+// InviteToProject/InviteToProjectWithLink's business logic + email delivery a
+// second time.
+func (h *CatalogHandler) CreateInvitationProxy(w http.ResponseWriter, r *http.Request) {
+	var body invitationProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.ProjectID == 0 && body.SystemRole == "" && body.AssignmentsJSON == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id is required for a project-scoped invitation")
+		return
+	}
+	if body.Email == "" || body.State == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "email and state are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateProjectInvitation(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("invitations proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newInvitationProxyWire(created))
+}
+
+// GetInvitationProxy handles GET /api/v1/system/invitations/{id}.
+func (h *CatalogHandler) GetInvitationProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid invitation ID")
+		return
+	}
+	inv, err := h.coreService.Storage().GetProjectInvitation(r.Context(), uint(id))
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "invitation not found")
+			return
+		}
+		log.Printf("invitations proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newInvitationProxyWire(inv))
+}
+
+// UpdateInvitationProxy handles PUT /api/v1/system/invitations/{id}. It performs
+// the SAME conditional `WHERE id = ? AND state = 'pending'` write LocalStorage's
+// own UpdateProjectInvitation does (h.coreService.Storage() reaches the identical
+// storage.Storage primitive this server's local /auth/setup/consume and
+// /projects/{id}/invitations paths use), returning whether it actually matched a
+// still-pending row — the single round trip a concurrent-accept race resolves in.
+func (h *CatalogHandler) UpdateInvitationProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid invitation ID")
+		return
+	}
+	var body invitationProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if !validInvitationTargetState(body.State) {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "state must be one of accepted, revoked, expired")
+		return
+	}
+	body.ID = uint(id)
+	updated, err := h.coreService.Storage().UpdateProjectInvitation(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("invitations proxy: update failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": updated})
+}
+
+// ListInvitationsProxy handles GET /api/v1/system/invitations?project_id=X.
+func (h *CatalogHandler) ListInvitationsProxy(w http.ResponseWriter, r *http.Request) {
+	projectIDStr := r.URL.Query().Get("project_id")
+	if projectIDStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id query parameter is required")
+		return
+	}
+	projectID, err := strconv.ParseUint(projectIDStr, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id must be a valid integer")
+		return
+	}
+	rows, err := h.coreService.Storage().ListProjectInvitations(r.Context(), uint(projectID))
+	if err != nil {
+		log.Printf("invitations proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]invitationProxyWire, 0, len(rows))
+	for _, inv := range rows {
+		wire = append(wire, newInvitationProxyWire(inv))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"invitations": wire})
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -72,6 +72,9 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		// needs both the global Tag table and the per-secret SecretTag join table.
 		&models.Tag{},
 		&models.SecretTag{},
+		// #507: the invitation-proxy end-to-end tests exercise ProjectInvitation
+		// CRUD through the real router.
+		&models.ProjectInvitation{},
 	)
 	require.NoError(t, err)
 	return core.NewKeyorixCore(store.NewLocalStorage(db))

--- a/server/http/remote_storage_invitations_test.go
+++ b/server/http/remote_storage_invitations_test.go
@@ -1,0 +1,234 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForInvitations builds the standard #452/#507 two-server
+// harness: an "upstream" exercised through the REAL production NewRouter/handlers
+// (including the new /api/v1/system/invitations routes,
+// server/http/handlers/invitations_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed at
+// "upstream" over real HTTP via store.RemoteStorage. Mirrors
+// remote_storage_login_rate_limit_test.go's harness exactly.
+func newUpstreamDownstreamForInvitations(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore, projectID uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+
+	ctx := context.Background()
+	project, err := upstream.CreateProject(ctx, "Invitations Test Project", "")
+	require.NoError(t, err)
+	return upstream, downstream, project.ID
+}
+
+// buildPendingInvitation mirrors exactly what internal/core/invitations.go's
+// InviteToProject computes before calling storage.CreateProjectInvitation — a
+// fully-built, pending invitation with a 14-day TTL — WITHOUT going through
+// InviteToProject itself. InviteToProject's own escalation-guard path first
+// calls storage.GetRoleByName, whose RemoteStorage implementation requests
+// GET /api/v1/roles/by-name/{name} — a route this codebase never registered
+// (server/http/router.go has no such handler), an entirely separate,
+// pre-existing bug independent of #507 (the same "implemented client method,
+// missing server route" class #503 fixed for GetUserByEmail) that would
+// otherwise block every test in this file. Flagged as a discovered follow-up
+// in the PR, not fixed here — out of this finding's scope.
+func buildPendingInvitation(now time.Time, projectID uint, email, role string, invitedBy uint) *models.ProjectInvitation {
+	expires := now.Add(14 * 24 * time.Hour)
+	return &models.ProjectInvitation{
+		ProjectID:              projectID,
+		Email:                  email,
+		Role:                   role,
+		State:                  core.InvitationPending,
+		InvitedBy:              invitedBy,
+		ValidationModeAtInvite: core.ValidationModeOpen,
+		ExpiresAt:              &expires,
+		CreatedAt:              now,
+	}
+}
+
+// TestRemoteStorageInvitation_CreateGetList_RealServer proves the #507 fix for
+// CreateProjectInvitation/GetProjectInvitation/ListProjectInvitations: an
+// invitation is genuinely persisted on the upstream server via the DOWNSTREAM's
+// RemoteStorage, fetchable by ID, and listed — all via storage.type: remote
+// against a real router, not a protocol mock.
+func TestRemoteStorageInvitation_CreateGetList_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForInvitations(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	inv, err := downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "invitee@example.com", "viewer", 1))
+	require.NoError(t, err, "creating an invitation must succeed via storage.type: remote")
+	require.NotZero(t, inv.ID, "the upstream must assign a real ID")
+	assert.Equal(t, "invitee@example.com", inv.Email)
+	assert.Equal(t, "viewer", inv.Role)
+	assert.Equal(t, core.InvitationPending, inv.State)
+	assert.Equal(t, projectID, inv.ProjectID)
+	assert.NotNil(t, inv.ExpiresAt, "the 14-day TTL must round-trip")
+
+	// Confirm it is a REAL row in the upstream's own storage (not just "the call
+	// didn't error"), by reading it back directly against upstream.
+	direct, err := upstream.Storage().GetProjectInvitation(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "invitee@example.com", direct.Email)
+
+	// GetProjectInvitation via the downstream (RemoteStorage) round-trips every
+	// field correctly.
+	fetched, err := downstream.Storage().GetProjectInvitation(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, inv.ID, fetched.ID)
+	assert.Equal(t, inv.Email, fetched.Email)
+	assert.Equal(t, inv.Role, fetched.Role)
+	assert.Equal(t, inv.State, fetched.State)
+	assert.Equal(t, inv.ProjectID, fetched.ProjectID)
+	assert.WithinDuration(t, *inv.ExpiresAt, *fetched.ExpiresAt, time.Second)
+
+	// A second invitation to a different email, then list both back via the
+	// downstream's ListProjectInvitations.
+	_, err = downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "second@example.com", "viewer", 1))
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListProjectInvitations(ctx, projectID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	emails := map[string]bool{}
+	for _, r := range rows {
+		emails[r.Email] = true
+	}
+	assert.True(t, emails["invitee@example.com"])
+	assert.True(t, emails["second@example.com"])
+}
+
+// TestRemoteStorageInvitation_GetNotFound_RealServer proves a clean not-found
+// error (not a panic, not a garbage 500) for a nonexistent invitation ID.
+func TestRemoteStorageInvitation_GetNotFound_RealServer(t *testing.T) {
+	_, downstream, _ := newUpstreamDownstreamForInvitations(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetProjectInvitation(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageInvitation_UpdateAlreadyResolved_RealServer proves that
+// UpdateProjectInvitation's conditional write correctly reports ok=false (no
+// error) once an invitation is no longer pending — exactly the signal
+// RevokeInvitation/completeInvitationAccept rely on to detect a lost race.
+func TestRemoteStorageInvitation_UpdateAlreadyResolved_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForInvitations(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	inv, err := downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "resolved@example.com", "viewer", 1))
+	require.NoError(t, err)
+
+	// Resolve it once (accept) directly against the upstream's real storage.
+	acceptedAt := time.Now()
+	inv.State = core.InvitationAccepted
+	inv.AcceptedAt = &acceptedAt
+	ok, err := upstream.Storage().UpdateProjectInvitation(ctx, inv)
+	require.NoError(t, err)
+	require.True(t, ok, "the first transition off pending must succeed")
+
+	// A second attempt via the DOWNSTREAM (over real HTTP) to revoke the SAME
+	// already-accepted invitation must cleanly report ok=false, not an error and
+	// not a silent false success.
+	revokedAt := time.Now()
+	attempt := &models.ProjectInvitation{ID: inv.ID, State: core.InvitationRevoked, RevokedAt: &revokedAt}
+	ok, err = downstream.Storage().UpdateProjectInvitation(ctx, attempt)
+	require.NoError(t, err)
+	assert.False(t, ok, "an update against a non-pending invitation must not report success")
+
+	// The invitation must still read as accepted (untouched by the failed revoke).
+	final, err := downstream.Storage().GetProjectInvitation(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.InvitationAccepted, final.State)
+}
+
+// TestRemoteStorageInvitation_ConcurrentAcceptRace_RealServer is the critical
+// #507 test: it fires N concurrent "accept" requests at the SAME pending
+// invitation over real HTTP against the real upstream router, and asserts
+// EXACTLY ONE succeeds — proving UpdateProjectInvitationProxy's conditional
+// `WHERE id = ? AND state = 'pending'` write (local_invitations.go, proxied
+// unchanged by server/http/handlers/invitations_proxy.go) still closes the
+// double-accept TOCTOU race setup_consume.go's completeInvitationAccept depends
+// on, even across a network hop — not a client-side
+// "GET, check state, then PUT" sequence, which would reopen exactly this race.
+func TestRemoteStorageInvitation_ConcurrentAcceptRace_RealServer(t *testing.T) {
+	_, downstream, projectID := newUpstreamDownstreamForInvitations(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	inv, err := downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "race@example.com", "viewer", 1))
+	require.NoError(t, err)
+
+	const n = 20
+	var successCount atomic.Int64
+	var errCount atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			acceptedAt := time.Now()
+			attempt := &models.ProjectInvitation{
+				ID:         inv.ID,
+				State:      core.InvitationAccepted,
+				AcceptedAt: &acceptedAt,
+			}
+			ok, err := downstream.Storage().UpdateProjectInvitation(ctx, attempt)
+			if err != nil {
+				errCount.Add(1)
+				return
+			}
+			if ok {
+				successCount.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(0), errCount.Load(), "every concurrent accept attempt must get a clean result, not a transport/server error")
+	assert.Equal(t, int64(1), successCount.Load(), "exactly one concurrent accept must win the race — the rest must cleanly lose, never a double grant")
+
+	final, err := downstream.Storage().GetProjectInvitation(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.InvitationAccepted, final.State)
+	assert.NotNil(t, final.AcceptedAt)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -764,6 +764,28 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/login-attempts/count", authHandler.CountLoginAttemptsProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/login-attempts", authHandler.RecordLoginAttemptProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/login-attempts/prune", authHandler.PruneLoginAttemptsProxy)
+
+			// Project-invitation storage-primitive proxy (#507). Lets a downstream
+			// Keyorix server booted with storage.type: remote (ADR-049) proxy
+			// CreateProjectInvitation/GetProjectInvitation/UpdateProjectInvitation/
+			// ListProjectInvitations to THIS server's real storage backend, instead of
+			// RemoteStorage's four ProjectInvitation methods having no server endpoint
+			// to call at all (setup_consume.go's completeInvitationAccept — and every
+			// other invitation flow — was completely non-functional under
+			// storage.type: remote). Exactly the same pattern as the login-attempts
+			// proxy above: a thin passthrough onto storage.Storage (no invitation
+			// POLICY decision made here — the calling server's own core.KeyorixCore
+			// still decides that, exactly as it does against a local backend), reusing
+			// the SAME system.read/system.write tier rather than the project-scoped
+			// roles.assign the human-facing /projects/{id}/invitations routes use,
+			// since a RemoteStorage credential already needs system.write for the
+			// login-attempts proxy — no new privilege class. Read is baseline
+			// system.read; create/update require system.write, matching every other
+			// admin-level mutation in this group.
+			r.Get("/invitations/{id}", catalogHandler.GetInvitationProxy)
+			r.Get("/invitations", catalogHandler.ListInvitationsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/invitations", catalogHandler.CreateInvitationProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/invitations/{id}", catalogHandler.UpdateInvitationProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary

Fixes backlog finding #507 (MEDIUM): `RemoteStorage`'s four `ProjectInvitation` methods (`internal/storage/store/remote_invitations.go`) were unconditional stubs. Every invitation flow that touches storage — admin create/list/revoke/resend in `internal/core/invitations.go`, and critically `setup_consume.go`'s `completeInvitationAccept` — hard-failed under `storage.type: remote`.

## Design decisions

**Scope/architecture**: rather than reusing the existing human-facing `/api/v1/projects/{id}/invitations` routes (which wrap `InviteToProjectWithLink`'s full business logic + real email delivery), added four new thin passthrough routes under `/api/v1/system/invitations`, gated on `system.read`/`system.write` — the same broad tier a `RemoteStorage` credential already needs elsewhere, so no new privilege class — with no invitation policy decision made server-side; that stays in the calling server's own `core.KeyorixCore`, exactly as against a local backend. This avoids double-creating invitations/double-sending emails, which reusing the business-logic route would have caused.

**Atomicity (the critical piece)**: `UpdateInvitationProxy` calls `storage.UpdateProjectInvitation` directly, so it inherits `local_invitations.go`'s conditional `WHERE id = ? AND state = 'pending'` write verbatim — one HTTP round trip maps to one atomic server-side conditional UPDATE, not a client-side "GET, check state, then PUT" sequence (which would reopen the exact double-accept TOCTOU race #412 closed). Verified with a 20-way concurrent-accept test against a real router: exactly one wins, the rest cleanly report `ok=false`.

## Fixed

`CreateProjectInvitation`, `GetProjectInvitation`, `UpdateProjectInvitation`, `ListProjectInvitations` all now make real HTTP calls; server-side handlers in `server/http/handlers/invitations_proxy.go`, routes registered in `server/http/router.go`.

## What remains a documented gap (discovered during investigation, out of scope here)

1. `SetupToken` CRUD (`remote_auth.go`) is entirely stubbed, so `CompleteSetup`'s very first step (`inspectActiveSetupToken`) still hard-fails under `storage.type: remote` for every setup-token purpose (account_setup, password_reset_link, invitation_accept) — not just invitations.
2. `ProjectMembership` CRUD (`remote_memberships.go`) is also entirely stubbed, so `applyInvitationGrants`'s membership-materialization step still hard-fails after a successful accept.
3. `RemoteStorage.GetRoleByName` calls `GET /api/v1/roles/by-name/{name}`, a route that was never registered — the same "implemented client method, missing server route" class #503 fixed for users; this blocks `InviteToProject` for every role, not just admin roles.

Each is its own separate, larger subsystem, well beyond this fix's named scope. Given these, `completeInvitationAccept` still cannot run fully end-to-end via real `/auth/setup/consume` HTTP today — this fix proves the storage-primitive layer itself (create/get/list, and critically the atomic accept-race) works correctly end-to-end over real HTTP, which any future SetupToken/ProjectMembership/GetRoleByName fix will build on.

## Testing

4 new tests in `server/http/remote_storage_invitations_test.go`: create+get+list, not-found, already-resolved-update, and the 20-way concurrent-accept race.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/storage/... ./internal/core/... ./server/http/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)