### PR TITLE
Fuzz secrettemplate's placeholder parser; widen GCP rotation-ref metachar check

### DIFF
--- a/internal/rotation/gcpsa.go
+++ b/internal/rotation/gcpsa.go
@@ -68,14 +68,15 @@ func (e *GCPServiceAccountKeyExecutor) GenerateUpstream(ctx context.Context, ref
 	if ref == "" {
 		return "", fmt.Errorf("gcp-service-account: service-account email (ref) is required")
 	}
-	// ref is concatenated into the SA resource name; an email never contains '/', so
-	// reject one defensively (it cannot then introduce extra path segments). This is
-	// layer TWO of defense in depth: layer ONE is core.validateRotationRef
-	// (internal/core/rotation_executor.go), which already rejects '/' (plus other path/
-	// query/SQL metacharacters and control characters) at configuration time, before the
+	// ref is concatenated into the SA resource name; a service-account email never
+	// contains any of "/?#%", so reject them defensively (they cannot then introduce
+	// extra path segments or otherwise reshape the resource name). This is layer TWO of
+	// defense in depth: layer ONE is core.validateRotationRef
+	// (internal/core/rotation_executor.go), which already rejects this same "/?#%" class
+	// (plus SQL metacharacters and control characters) at configuration time, before the
 	// ref is ever persisted. Keep both — this check must not be removed just because the
 	// earlier layer also covers it.
-	if strings.ContainsRune(ref, '/') {
+	if strings.ContainsAny(ref, "/?#%") {
 		return "", fmt.Errorf("gcp-service-account: ref %q must be a service-account email, not a resource path", ref)
 	}
 	if len(e.allowedRefs) == 0 {

--- a/internal/rotation/gcpsa_test.go
+++ b/internal/rotation/gcpsa_test.go
@@ -84,12 +84,19 @@ func TestGCPSA_GenerateUpstream_Errors(t *testing.T) {
 		_, err := gcpWith(&fakeGCP{}, "svc-").GenerateUpstream(context.Background(), "")
 		require.Error(t, err)
 	})
-	t.Run("ref with slash rejected", func(t *testing.T) {
-		fake := &fakeGCP{newJSON: "{}"}
-		_, err := gcpWith(fake, "svc-").GenerateUpstream(context.Background(), "svc-app@p.iam/keys/x")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "resource path")
-		assert.Empty(t, fake.createdAt, "a path-shaped ref never reaches GCP")
+	t.Run("ref with path metacharacters rejected", func(t *testing.T) {
+		for _, ref := range []string{
+			"svc-app@p.iam/keys/x",     // path segment
+			"svc-app@p.iam?query=x",    // query
+			"svc-app@p.iam#fragment",   // fragment
+			"svc-app@p.iam%2Fkeys%2Fx", // percent-encoded path
+		} {
+			fake := &fakeGCP{newJSON: "{}"}
+			_, err := gcpWith(fake, "svc-").GenerateUpstream(context.Background(), ref)
+			require.Error(t, err, "ref %q must be rejected", ref)
+			assert.Contains(t, err.Error(), "resource path")
+			assert.Empty(t, fake.createdAt, "a path-shaped ref %q never reaches GCP", ref)
+		}
 	})
 	t.Run("fail-closed without allowed_refs", func(t *testing.T) {
 		_, err := gcpWith(&fakeGCP{}).GenerateUpstream(context.Background(), "svc-app@p.iam")

--- a/internal/secrettemplate/render_fuzz_test.go
+++ b/internal/secrettemplate/render_fuzz_test.go
@@ -1,0 +1,121 @@
+package secrettemplate
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// FuzzParse fuzzes parse (render.go), the hand-rolled byte-index parser for
+// "${secret:<ref>}" placeholder syntax in user-authored template text. Unlike
+// this package's other logic, parse is genuine custom parsing over arbitrary
+// input — not a stdlib wrapper — so it is worth pressure-testing directly for
+// panics and non-termination, and for the invariants its own doc comment
+// promises: every reference in the returned distinct/segment list must have
+// actually come from a well-formed "${secret:...}" placeholder in the input,
+// and the MaxDistinctReferences cap is never bypassed.
+func FuzzParse(f *testing.F) {
+	// Seed corpus: empty input, a lone "$", the "$$" literal-collapse rule, a
+	// well-formed single and multiple placeholders, back-to-back placeholders
+	// with no literal between them, an empty ref (error), an unterminated
+	// placeholder (error), a nested-looking placeholder, more than
+	// MaxDistinctReferences distinct refs (to hit the cap), a very long
+	// literal run, a very long run of placeholders, and control
+	// characters/NUL mixed with placeholder syntax.
+	f.Add("")
+	f.Add("$")
+	f.Add("$$")
+	f.Add("${secret:x}")
+	f.Add("${secret:a}-${secret:b}")
+	f.Add("${secret:a}${secret:b}")
+	f.Add("${secret:}")
+	f.Add("${secret:x")
+	f.Add("${secret:${secret:x}}")
+	f.Add("$${secret:x}")
+	f.Add("prefix ${secret: ref-with-space } suffix")
+	f.Add(strings.Repeat("${secret:x}", 5))
+
+	var manyRefs strings.Builder
+	for i := 0; i < MaxDistinctReferences+10; i++ {
+		manyRefs.WriteString("${secret:ref")
+		manyRefs.WriteString(strconv.Itoa(i))
+		manyRefs.WriteString("}")
+	}
+	f.Add(manyRefs.String())
+
+	f.Add(strings.Repeat("x", 20000))
+	f.Add(strings.Repeat("${secret:x}", 5000))
+	f.Add("\x00${secret:\x00}\x00")
+	f.Add("${secret:x}\n\r${secret:y}")
+
+	f.Fuzz(func(t *testing.T, tmpl string) {
+		// Must never panic and must never loop forever; go test's fuzz engine
+		// enforces a per-input execution budget, so an infinite loop here
+		// surfaces as a fuzz timeout/hang rather than a clean failure — this
+		// still catches it (see task instructions to prove empirically with a
+		// real -fuzztime burst rather than by code inspection alone).
+		segments, distinct, err := parse(tmpl)
+
+		if err != nil {
+			return
+		}
+
+		// Invariant 1: the MaxDistinctReferences cap is never bypassed on any
+		// codepath that returns success.
+		if len(distinct) > MaxDistinctReferences {
+			t.Fatalf("parse(%q) returned %d distinct refs, exceeding MaxDistinctReferences=%d", tmpl, len(distinct), MaxDistinctReferences)
+		}
+
+		// Invariant 2: "empty ref is an error" is never silently violated —
+		// no entry in distinct (or in any ref-bearing segment) is empty on a
+		// success path.
+		for _, ref := range distinct {
+			if ref == "" {
+				t.Fatalf("parse(%q) returned an empty entry in distinct", tmpl)
+			}
+		}
+
+		distinctSet := make(map[string]bool, len(distinct))
+		for _, ref := range distinct {
+			distinctSet[ref] = true
+		}
+
+		seenSegRefs := make(map[string]bool)
+		var rebuilt strings.Builder
+		for _, seg := range segments {
+			if seg.ref == "" {
+				rebuilt.WriteString(seg.literal)
+				continue
+			}
+			// Invariant 3: no ref-bearing segment has an empty ref.
+			if seg.ref == "" {
+				t.Fatalf("parse(%q) produced a segment with an empty ref", tmpl)
+			}
+			// Invariant 4: every ref-bearing segment's ref must actually have
+			// appeared inside a "${secret:...}" placeholder in the original
+			// input — i.e. it must be a substring of tmpl (parse trims
+			// surrounding whitespace from the raw ref text, so compare
+			// against a whitespace-trimmed substring rather than requiring an
+			// exact placeholder match) and must also be one of the refs
+			// recorded in distinct (no ref fabricated out of thin air,
+			// distinct from what's actually walked).
+			if !distinctSet[seg.ref] {
+				t.Fatalf("parse(%q) produced segment ref %q that isn't in distinct %v", tmpl, seg.ref, distinct)
+			}
+			if !strings.Contains(tmpl, seg.ref) {
+				t.Fatalf("parse(%q) fabricated ref %q that never appears in the input", tmpl, seg.ref)
+			}
+			seenSegRefs[seg.ref] = true
+			rebuilt.WriteString("${secret:" + seg.ref + "}")
+		}
+
+		// Invariant 5: every distinct ref was actually used by at least one
+		// segment (distinct is derived strictly from the segments walk, so it
+		// can never name a reference the segment list doesn't reference).
+		for _, ref := range distinct {
+			if !seenSegRefs[ref] {
+				t.Fatalf("parse(%q) recorded distinct ref %q that no segment references", tmpl, ref)
+			}
+		}
+	})
+}

--- a/scripts/fuzzing/targets.conf
+++ b/scripts/fuzzing/targets.conf
@@ -19,3 +19,7 @@ internal/rotation|FuzzAzureGenerateUpstreamRef|3h
 # logic is much smaller/simpler than a full HTTP-ref-interpolation path.
 internal/rotation|FuzzPostgresQuoting|2h
 internal/rotation|FuzzMySQLQuoteString|2h
+# Hand-rolled byte-index parser for "${secret:<ref>}" placeholder syntax
+# (internal/secrettemplate/render.go's parse) — much smaller/simpler than the
+# targets above, so 1h is plenty.
+internal/secrettemplate|FuzzParse|1h


### PR DESCRIPTION
## Summary
- Adds `FuzzParse` for `internal/secrettemplate/render.go`'s hand-rolled `${secret:<ref>}` placeholder parser, asserting no panic/hang and two success-path invariants: the `MaxDistinctReferences` cap is never exceeded, and no ref-bearing segment/`distinct` entry is ever empty or fabricated (every ref traces back to a `${secret:...}` occurrence in the input). Declared in `scripts/fuzzing/targets.conf` (1h) so the `fuzz-targets` CI job stays green.
- Widens `internal/rotation/gcpsa.go`'s `GenerateUpstream` ref check from rejecting only `/` to the same `strings.ContainsAny(ref, "/?#%")` class Azure already rejects, matching the layer-TWO defense-in-depth pattern documented in `azure.go`/`postgres.go`/`mysql.go` (layer ONE is `core.validateRotationRef`, added recently). Extends the existing `gcpsa_test.go` regression test to cover `?`, `#`, `%` alongside the existing `/` case.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `go test -fuzz='^FuzzParse$' -fuzztime=30s ./internal/secrettemplate` — ~2.75M execs, no crashes
- [x] `go test -list '^Fuzz' ./...` confirms `FuzzParse` is discoverable and matches the new `scripts/fuzzing/targets.conf` line exactly (simulated the `fuzz-targets` CI diff logic locally)
- [x] `internal/rotation` tests pass, including the widened `TestGCPSA_GenerateUpstream_Errors/ref_with_path_metacharacters_rejected` subtest covering `/`, `?`, `#`, `%`

🤖 Generated with Claude Code