### PR TITLE
fix(fuzzing): pull main before every target, not once per rotation cycle

### DIFF
--- a/scripts/fuzzing/README.md
+++ b/scripts/fuzzing/README.md
@@ -183,7 +183,10 @@ one at a time, not concurrently).
 
 - The main clone (`KEYORIX_REPO`) is treated as disposable and dedicated
   solely to fuzzing — `run-rotation.sh` runs `git reset --hard origin/main`
-  against it once per cycle. Don't use this clone for anything else.
+  against it before every target (not just once per cycle — this repo merges
+  dozens of commits a day, so a once-per-cycle pull could leave a target
+  fuzzing code that was already stale for most of a ~14h rotation by the time
+  it ran). Don't use this clone for anything else.
 - Corpus commits land on `fuzz-corpus`, never `main` — nothing here touches
   CI or requires a PR to keep running; you decide when (and whether) to open
   a PR merging an interesting find into `main`.

--- a/scripts/fuzzing/run-rotation.sh
+++ b/scripts/fuzzing/run-rotation.sh
@@ -5,10 +5,15 @@
 # runtime that a CI job's budget can't afford.
 #
 # Cycles through every target in targets.conf, each for its configured
-# `go test -fuzz -fuzztime`, forever. Before each full cycle, pulls the repo's
-# main branch so fuzzing tracks the current codebase (including any fix a
-# prior crash here already prompted). After each target run, pushes any new
-# corpus files (crashers or coverage-expanding "interesting" inputs) to the
+# `go test -fuzz -fuzztime`, forever. Pulls the repo's main branch before EACH
+# target (not just once per full cycle) so fuzzing stays close to the current
+# codebase — this repo merges dozens of commits a day, so a once-per-cycle
+# pull (the original design) could leave a target fuzzing code that was
+# already half a rotation cycle stale by the time it ran. Per-target pulls
+# cost a few seconds of git overhead against hours of fuzzing time, in
+# exchange for freshness bounded by the PRECEDING target's own duration
+# instead of the whole cycle's. After each target run, pushes any new corpus
+# files (crashers or coverage-expanding "interesting" inputs) to the
 # fuzz-corpus branch via sync-corpus.sh, and — on a crash — sends exactly one
 # notification per unique failure via notify-on-crash.sh (a target that keeps
 # re-failing against an already-saved crasher on every subsequent cycle does
@@ -24,14 +29,14 @@ mkdir -p "$NOTIFIED_STATE_DIR"
 cd "$KEYORIX_REPO"
 
 while true; do
-  echo "=== $(date -u +%FT%TZ) pulling latest main ==="
-  git fetch origin main --quiet
-  git checkout main --quiet
-  git reset --hard origin/main --quiet
-
   while IFS='|' read -r pkg func duration; do
     [ -z "$pkg" ] && continue
     case "$pkg" in \#*) continue ;; esac
+
+    echo "=== $(date -u +%FT%TZ) pulling latest main ==="
+    git fetch origin main --quiet
+    git checkout main --quiet
+    git reset --hard origin/main --quiet
 
     echo "=== $(date -u +%FT%TZ) fuzzing $func in ./$pkg for $duration ==="
     logfile="$NOTIFIED_STATE_DIR/last-$func.log"


### PR DESCRIPTION
## Summary
Measured actual commit velocity on this repo: **276 commits in the last 7 days** (~39/day average), **57 in the last 24h**. At that pace, the original once-per-cycle pull design (a ~14h full rotation) could leave a target fuzzing code that was already stale for most of a day by the time it ran — undercutting the whole point of continuous fuzzing, which is testing what was just changed, not what shipped half a day ago.

## Fix
Moves `git fetch`/`checkout`/`reset --hard origin/main` from the outer loop (once per full cycle) into the inner loop (once before each target). Freshness is now bounded by the *preceding* target's own duration (currently at most 3h) instead of the whole ~14h cycle. Cost is a few seconds of git overhead per target against hours of fuzzing time — negligible.

## Verification
Built a scratch bare git repo + a mocked `go` binary standing in for `go test` (so the loop iterates many times quickly in a few seconds) and confirmed empirically: `"pulling latest main"` now logs exactly once per target (twice per 2-target test cycle), not once per cycle, across dozens of observed iterations.

## Deployment
Will deploy this to the live `keyorix-fuzz` rig directly after merge (it can't self-heal on its own mid-cycle — same reasoning as the earlier `sync-corpus.sh` fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)