### PR TITLE
ci(dco): exempt dependabot[bot] from the DCO sign-off check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -34,7 +34,25 @@ jobs:
       # email matches that commit's own author email (the standard DCO 1.1
       # check, https://developercertificate.org/) — i.e. `git commit -s`.
       - name: Check DCO sign-off
+        env:
+          # Dependabot has no mechanism to add a Signed-off-by trailer to its
+          # own commits, and its diffs are machine-generated version bumps
+          # with no attributable human author to certify authorship of in the
+          # DCO sense — exempt it rather than block every automated
+          # dependency-update PR forever. `check` is a REQUIRED status check
+          # (branch protection), so this exemption must still let the JOB
+          # complete with a real success exit code, not skip the step
+          # entirely — a skipped/never-run required check blocks merge
+          # exactly as much as a failed one ("Expected — waiting for status").
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
+          case "$PR_AUTHOR" in
+            'dependabot[bot]'|'app/dependabot')
+              echo "Skipping DCO check for automated dependency-update PR from $PR_AUTHOR."
+              exit 0
+              ;;
+          esac
+
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
           fail=0


### PR DESCRIPTION
## Summary
PR #816 (Dependabot's automated `go-chi/chi/v5` 5.2.2 → 5.2.4 security bump, fixing CVE-2025-69725) fails the required `check` (DCO) job — Dependabot has no mechanism to add a `Signed-off-by` trailer to its own commits, and its diffs are machine-generated version bumps with no attributable human author to certify authorship of in the DCO sense.

## Fix
Exempts `dependabot[bot]` (both the classic REST-API bot-suffixed login and the newer GraphQL `app/dependabot` actor format) by short-circuiting to a clean `exit 0` before the real check runs — **not** by skipping the step/job entirely, since `check` is a REQUIRED status check and a never-run required check blocks merge exactly the same way a failure does ("Expected — waiting for status to be reported").

## Verification
- `actionlint` clean
- Verified the case-statement logic locally against both Dependabot login formats and two ordinary human/agent author logins — only the two Dependabot formats skip, everything else still gets checked

## Context
Also confirmed while investigating: the vulnerable `RedirectSlashes` middleware isn't used anywhere in this codebase, so practical exposure to CVE-2025-69725 was already zero — but the bump is trivial and safe to take regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)