### PR TITLE
fix(remote-storage): mint sessions atomically with login verification (#508)

### DIFF
--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -53,11 +53,11 @@ var dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timin
 // The fix is a proxy-login channel: the upstream server (the one actually
 // backed by LocalStorage, which HAS the real hash) performs the credential
 // check itself and returns only a verdict, never the hash. RemoteStorage
-// implements this interface by forwarding to a new POST
+// implements this interface by forwarding to a POST
 // /api/v1/users/verify-credentials endpoint, whose handler calls the
-// UPSTREAM's own VerifyPasswordCredentials — the SAME function the direct
-// LocalStorage path uses, not a parallel reimplementation of the bcrypt
-// compare. Critically, this means the ENTIRE check is delegated — password
+// UPSTREAM's own core.Login — the SAME function the direct LocalStorage path
+// uses, not a parallel reimplementation of the bcrypt compare or of session
+// minting. Critically, this means the ENTIRE check is delegated — password
 // compare AND the per-account lockout gate/accounting AND the account-active/
 // account-state checks — not just a bare boolean. Splitting the lockout
 // accounting out and leaving it client-side would be a silent regression:
@@ -69,34 +69,38 @@ var dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timin
 // check to the upstream's real, LocalStorage-persisted accounting is the only
 // way this deployment shape can enforce it.
 //
-// core.VerifyPasswordCredentials type-asserts c.storage against this interface
-// and, when present, delegates entirely to it instead of running its own
-// bcrypt.CompareHashAndPassword (which would always fail: it would be
-// comparing against an intentionally-absent hash).
+// #508 — session minting is ATOMIC with verification, not a second, separate
+// step: VerifyLoginCredentials returns the upstream-minted *models.Session in
+// the SAME call that proved the password correct, exactly when the account
+// needs no MFA/WebAuthn second factor (mirroring Login's own gate below). A
+// nil session with a nil error means the account requires MFA/WebAuthn — the
+// upstream deliberately withheld a session for that case, just as Login does
+// for the direct LocalStorage path. There is deliberately NO separate,
+// independently-callable "create a session for this user_id" wire primitive:
+// that would let anyone holding the RemoteStorage service credential mint a
+// session for an arbitrary user without ever proving that user's actual
+// credentials (a confused-deputy / privilege-escalation oracle). Tying
+// issuance inseparably to a specific, just-completed verification — the same
+// pattern OAuth/OIDC token-exchange flows use — is what makes this safe.
 type RemoteLoginVerifier interface {
-	VerifyLoginCredentials(ctx context.Context, username, password string) (*models.User, error)
+	VerifyLoginCredentials(ctx context.Context, username, password, userAgent, ipAddress string) (*models.User, *models.Session, error)
 }
 
 // VerifyPasswordCredentials resolves "is this username/password combination
 // valid", enforcing the per-account lockout gate and the account-active/
 // account-state checks Login has always required — extracted out of Login
-// (#506) as the single source of truth so it can ALSO be called directly by
-// the server-side handler for POST /api/v1/users/verify-credentials, the
-// upstream half of the RemoteLoginVerifier proxy-login mechanism (see its doc
-// above). This keeps both the direct LocalStorage login path and the proxied
-// storage.type: remote path running through IDENTICAL bcrypt/lockout/account-
-// state logic — never two, potentially-diverging implementations of the same
-// security check.
+// (#506) as the single source of truth for the LOCAL bcrypt-backed check.
 //
-// On success the returned user's MFAEnabled/WebAuthnEnabled/ID/Username/Email/
-// DisplayName fields are populated (Login uses them to decide the MFA-required
-// gate and to mint/describe the session); other fields may be zero-valued when
-// this ran via the remote proxy (see verifyCredentialsWireResponse in
-// internal/storage/store), since nothing past this point needs them.
+// This never delegates to RemoteLoginVerifier (see Login below for that
+// dispatch): under storage.type: remote, calling this directly always fails
+// closed (RemoteStorage.GetUserByUsername's decoded user always has an empty
+// PasswordHash, so the bcrypt compare below can never succeed) — exactly the
+// same fail-closed behavior storage.type: remote password login had before
+// #506. The only supported entry point for a proxied, storage.type: remote
+// login is Login itself, which mints (or, via the proxy, receives) a session
+// atomically with verification (#508) — a capability this function
+// deliberately does not have, since it returns no session.
 func (c *KeyorixCore) VerifyPasswordCredentials(ctx context.Context, username, password string) (*models.User, error) {
-	if verifier, ok := c.storage.(RemoteLoginVerifier); ok {
-		return verifier.VerifyLoginCredentials(ctx, username, password)
-	}
 	user, err := c.storage.GetUserByUsername(ctx, username)
 	if err != nil {
 		// Spend an equivalent bcrypt comparison so a missing username doesn't return
@@ -144,7 +148,32 @@ func (c *KeyorixCore) VerifyPasswordCredentials(ctx context.Context, username, p
 }
 
 // Login validates credentials, creates a session, and returns (session, user, error).
+//
+// #508: under storage.type: remote (c.storage implements RemoteLoginVerifier),
+// verification and session minting happen as ONE atomic upstream call —
+// VerifyLoginCredentials returns the upstream-minted session directly,
+// mirroring the MFA gate below exactly (a nil session means the upstream
+// itself withheld one because the account needs a second factor). Login never
+// separately asks the upstream to "create a session for this user" after the
+// fact — see RemoteLoginVerifier's doc for why that split would be unsafe.
 func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Session, *models.User, error) {
+	if verifier, ok := c.storage.(RemoteLoginVerifier); ok {
+		user, session, err := verifier.VerifyLoginCredentials(ctx, req.Username, req.Password, req.UserAgent, req.IPAddress)
+		if err != nil {
+			return nil, nil, err
+		}
+		if user.MFAEnabled || user.WebAuthnEnabled {
+			return nil, user, ErrMFARequired
+		}
+		if session == nil {
+			// Defensive, should not happen: the upstream reported no MFA/WebAuthn gate
+			// but withheld a session anyway. Fail closed rather than let the caller
+			// proceed with no usable session.
+			return nil, nil, fmt.Errorf("failed to create session: upstream did not return one")
+		}
+		return session, user, nil
+	}
+
 	user, err := c.VerifyPasswordCredentials(ctx, req.Username, req.Password)
 	if err != nil {
 		return nil, nil, err
@@ -228,6 +257,43 @@ func (c *KeyorixCore) Logout(ctx context.Context, token string) error {
 		return fmt.Errorf("session not found")
 	}
 	return c.storage.DeleteSession(ctx, session.ID)
+}
+
+// GetSessionForRemoteProxy resolves a session by its presented plaintext token.
+// It is the server-side counterpart RemoteStorage.GetSession (#508) needs so a
+// storage.type: remote "spoke" deployment can validate/revoke sessions that
+// were minted upstream — the upstream server remains the sole source of truth
+// for session validity, exactly as it already is for the user record and
+// password hash (#505/#506). Unlike VerifyLoginCredentials, this performs NO
+// credential check of its own: it only ever returns a session for a caller who
+// already presents that session's own opaque token (a lookup, not a mint), so
+// it cannot be used to obtain access to an account without already holding one
+// of its live session tokens.
+func (c *KeyorixCore) GetSessionForRemoteProxy(ctx context.Context, token string) (*models.Session, error) {
+	return c.storage.GetSession(ctx, token)
+}
+
+// DeleteSessionForRemoteProxy deletes a session by its numeric ID — the
+// server-side counterpart RemoteStorage.DeleteSession (#508) needs so Logout
+// (and any other session-invalidation path) works end-to-end under
+// storage.type: remote. Gated the same way VerifyLoginCredentials/CreateUser/
+// UnlockUser already are (users.write on the RemoteStorage service credential,
+// server/http/router.go) — not a new, wider trust boundary: that credential
+// can already force-logout an arbitrary user's every session via
+// RevokeUserSessions (POST /users/{id}/revoke-sessions), so deleting a single
+// session by ID grants no capability beyond what is already accepted there.
+// Evicts the deleted session's token hash from the local auth cache too, so a
+// revoke takes effect immediately rather than lingering for the cache TTL if
+// this same process also happens to be validating that exact token directly.
+func (c *KeyorixCore) DeleteSessionForRemoteProxy(ctx context.Context, id uint) error {
+	session, lookupErr := c.storage.GetSessionByID(ctx, id)
+	if err := c.storage.DeleteSession(ctx, id); err != nil {
+		return err
+	}
+	if lookupErr == nil {
+		c.invalidateTokenCache(session.SessionToken)
+	}
+	return nil
 }
 
 // EventSessionReuseDetected audits a refresh attempt against an already-rotated

--- a/internal/storage/store/remote_auth.go
+++ b/internal/storage/store/remote_auth.go
@@ -19,20 +19,34 @@ import (
 
 // --- Sessions ---
 
-// CreateSession creates a new session via remote API.
-func (rs *RemoteStorage) CreateSession(ctx context.Context, session *models.Session) (*models.Session, error) {
-	resp, err := rs.client.Post(ctx, "/api/v1/sessions", session)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create session: %w", err)
-	}
-	if !resp.Success {
-		return nil, fmt.Errorf("create session failed: %s", resp.Error.Error())
-	}
-	var result models.Session
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return &result, nil
+// CreateSession deliberately has NO working remote implementation, and never
+// will: a generic "persist this session" wire primitive — accepting an
+// arbitrary UserID and minting a session for it — would be a confused-deputy /
+// privilege-escalation oracle. Anyone holding the RemoteStorage service
+// credential could mint a session for ANY user without ever proving that
+// user's actual credentials, which is exactly the risk #508 was filed to
+// avoid introducing. (It would also be silently broken in a different way:
+// models.Session.SessionToken is tagged `json:"-"` specifically so a raw
+// session can never cross the wire generically, so even a naive server route
+// accepting this payload would receive an always-empty token.)
+//
+// Session issuance under storage.type: remote instead happens ATOMICALLY with
+// credential verification, via VerifyLoginCredentials (remote_login_verify.go)
+// — the upstream's own core.Login mints the session as part of the SAME call
+// that proves the password correct, and returns its token directly. core.Login
+// (internal/core/auth.go) uses that pre-minted session and never calls
+// mintSession/CreateSession for a RemoteStorage-backed core.
+//
+// The two other mintSession call sites (MFA/WebAuthn login completion,
+// internal/core/mfa.go; setup-token consume auto-login,
+// internal/core/setup_consume.go) still reach this stub under
+// storage.type: remote — both remain separately, pre-existingly unsupported
+// there regardless of this function (MFA/WebAuthn: #509; setup tokens: #510),
+// so failing loudly here is a strict improvement over a doomed 404 round-trip
+// with no explanation.
+func (rs *RemoteStorage) CreateSession(_ context.Context, _ *models.Session) (*models.Session, error) {
+	return nil, fmt.Errorf("create session is not supported as a standalone remote storage operation " +
+		"(see #508) — sessions are minted atomically as part of login verification instead")
 }
 
 // GetSession retrieves a session by token via remote API.

--- a/internal/storage/store/remote_login_verify.go
+++ b/internal/storage/store/remote_login_verify.go
@@ -1,5 +1,5 @@
 // remote_login_verify.go — the upstream half of the storage.type: remote
-// proxy-login mechanism (#506).
+// proxy-login mechanism (#506/#508).
 //
 // models.User.PasswordHash is deliberately `json:"-"` and never crosses the
 // wire, so RemoteStorage can never itself compare a submitted password against
@@ -11,17 +11,28 @@
 // public/unauthenticated route) to a dedicated upstream endpoint that performs
 // the ENTIRE check — password compare, per-account lockout gating and
 // accounting, and account-active/account-state — using the exact same
-// core.VerifyPasswordCredentials function the upstream's own direct login uses,
-// and returns only a pass/fail verdict plus the minimal fields core.Login needs
-// to proceed (never the hash, never a lockout/account-state reason — see
-// verifyCredentialsWireResponse below for why the failure path is a single,
-// generic error regardless of the real reason).
+// core.Login function the upstream's own direct login uses.
+//
+// #508: that same upstream call ALSO mints the session, atomically, whenever
+// the account needs no MFA/WebAuthn second factor. This is deliberate and
+// load-bearing for security: there is no separate, independently-callable
+// "create a session for this user_id" endpoint anywhere in this mechanism. A
+// generic mint-any-session primitive would let anyone holding the
+// RemoteStorage service credential (which this endpoint is already gated
+// behind) mint a session for an ARBITRARY user without ever proving that
+// user's actual credentials — a confused-deputy / privilege-escalation
+// oracle. Tying issuance inseparably to a specific, just-completed
+// verification (the same call, not a follow-up one) is what makes this safe —
+// mirroring how OAuth/OIDC token-exchange flows avoid the identical class of
+// bug by making verification and issuance one atomic, non-replayable
+// operation.
 package store
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -29,17 +40,24 @@ import (
 // verifyCredentialsWireRequest carries the plaintext password deliberately
 // (see the package doc above and #499's precedent) — the upstream server
 // needs it to run its own bcrypt compare; there is no other way this check
-// could ever work under storage.type: remote.
+// could ever work under storage.type: remote. UserAgent/IPAddress are the
+// REAL end-user's values, forwarded from the spoke's own LoginRequest, so a
+// session minted upstream (#508) carries accurate device metadata for the "My
+// Account active sessions" view, and the upstream's own audit trail
+// (LogAuthLogin/LogAuthFailure) attributes the attempt to the real caller
+// rather than to the spoke server's own service-to-service connection.
 type verifyCredentialsWireRequest struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username  string `json:"username"`
+	Password  string `json:"password"`
+	UserAgent string `json:"user_agent"`
+	IPAddress string `json:"ip_address"`
 }
 
 // verifyCredentialsWireResponse is deliberately a NARROW, separate DTO from
 // userWireResponse (remote_users.go) — it carries exactly what core.Login
 // needs after a successful verdict (the MFA-required gate: user.MFAEnabled ||
 // user.WebAuthnEnabled — fields userWireResponse does not even carry — plus
-// enough identity to mint/describe the session) and nothing else: no
+// enough identity to describe the session) and nothing else: no
 // password_hash (obviously), no lockout-accounting counters (meaningless
 // here — the upstream already applied/cleared them before ever returning
 // success), no other account fields core.Login has no use for once the
@@ -52,6 +70,29 @@ type verifyCredentialsWireResponse struct {
 	AccountState    string `json:"account_state"`
 	MFAEnabled      bool   `json:"mfa_enabled"`
 	WebAuthnEnabled bool   `json:"webauthn_enabled"`
+	// Session is populated (#508) if and only if MFAEnabled and WebAuthnEnabled
+	// are both false — i.e. exactly when the upstream's own core.Login minted
+	// one, atomically, as part of THIS SAME verification call. Never populated
+	// on any failure path, and never obtainable via any other, separately
+	// callable endpoint — see the package doc above for why that atomicity is
+	// the whole point.
+	Session *sessionMintWireDTO `json:"session,omitempty"`
+}
+
+// sessionMintWireDTO carries a freshly minted session's opaque bearer token
+// back across the wire. Deliberately NOT models.Session (whose SessionToken
+// field is tagged `json:"-"` specifically so a session can never be
+// reconstituted or replayed from a generic read of that model, e.g. via
+// RemoteStorage.GetSession's response) — this is a narrow, one-shot delivery
+// of a newly minted secret to the one party that just proved, via THIS SAME
+// call, that it is entitled to receive it.
+type sessionMintWireDTO struct {
+	ID                uint       `json:"id"`
+	Token             string     `json:"token"`
+	FamilyID          string     `json:"family_id"`
+	CreatedAt         time.Time  `json:"created_at"`
+	ExpiresAt         *time.Time `json:"expires_at"`
+	AbsoluteExpiresAt *time.Time `json:"absolute_expires_at"`
 }
 
 func (w verifyCredentialsWireResponse) toModel() *models.User {
@@ -74,11 +115,11 @@ func (w verifyCredentialsWireResponse) toModel() *models.User {
 }
 
 // VerifyLoginCredentials implements core.RemoteLoginVerifier: it proxies the
-// ENTIRE password + lockout + account-state check to the upstream server via
-// POST /api/v1/users/verify-credentials, gated by the same users.write
-// permission CreateUser/UnlockUser already require of the RemoteStorage
-// service credential (#506) — this is not a new, weaker trust boundary, it
-// reuses the existing one.
+// ENTIRE password + lockout + account-state check, AND (#508) atomic session
+// minting, to the upstream server via POST /api/v1/users/verify-credentials,
+// gated by the same users.write permission CreateUser/UnlockUser already
+// require of the RemoteStorage service credential (#506) — this is not a
+// new, weaker trust boundary, it reuses the existing one.
 //
 // Every failure — wrong password, a tripped lockout, a suspended/inactive
 // account, or a network/parse error — collapses to the SAME generic "invalid
@@ -91,20 +132,45 @@ func (w verifyCredentialsWireResponse) toModel() *models.User {
 // beyond "that attempt failed", not why. Fail-closed applies uniformly too: a
 // transport error or a malformed response is treated exactly like a rejected
 // credential, never as "let the caller in".
-func (rs *RemoteStorage) VerifyLoginCredentials(ctx context.Context, username, password string) (*models.User, error) {
+//
+// The returned *models.Session is non-nil exactly when the upstream's
+// response carries one (i.e. no MFA/WebAuthn gate applied) — core.Login uses
+// it directly as the session for this login, rather than trying to persist a
+// session of its own via a second, separately callable call.
+func (rs *RemoteStorage) VerifyLoginCredentials(ctx context.Context, username, password, userAgent, ipAddress string) (*models.User, *models.Session, error) {
 	resp, err := rs.client.Post(ctx, "/api/v1/users/verify-credentials", verifyCredentialsWireRequest{
-		Username: username,
-		Password: password,
+		Username:  username,
+		Password:  password,
+		UserAgent: userAgent,
+		IPAddress: ipAddress,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("invalid credentials")
+		return nil, nil, fmt.Errorf("invalid credentials")
 	}
 	if !resp.Success {
-		return nil, fmt.Errorf("invalid credentials")
+		return nil, nil, fmt.Errorf("invalid credentials")
 	}
 	var wire verifyCredentialsWireResponse
 	if err := json.Unmarshal(resp.Data, &wire); err != nil {
-		return nil, fmt.Errorf("invalid credentials")
+		return nil, nil, fmt.Errorf("invalid credentials")
 	}
-	return wire.toModel(), nil
+	user := wire.toModel()
+	if wire.Session == nil {
+		// MFA/WebAuthn required (or, for a malformed-but-Success response, a
+		// defensive absence) — core.Login's MFA gate decides what happens next;
+		// no session to return either way.
+		return user, nil, nil
+	}
+	session := &models.Session{
+		ID:                wire.Session.ID,
+		UserID:            user.ID,
+		SessionToken:      wire.Session.Token, // plaintext bearer token, handed to the caller
+		FamilyID:          wire.Session.FamilyID,
+		UserAgent:         userAgent,
+		IPAddress:         ipAddress,
+		CreatedAt:         wire.Session.CreatedAt,
+		ExpiresAt:         wire.Session.ExpiresAt,
+		AbsoluteExpiresAt: wire.Session.AbsoluteExpiresAt,
+	}
+	return user, session, nil
 }

--- a/server/http/handlers/sessions_remote.go
+++ b/server/http/handlers/sessions_remote.go
@@ -1,0 +1,93 @@
+// sessions_remote.go — server-side counterparts of RemoteStorage's session
+// lookup/deletion (#508): GET /api/v1/sessions/{token} and
+// DELETE /api/v1/sessions/{id}.
+//
+// Deliberately NOT a POST /api/v1/sessions "create session" route — see
+// internal/storage/store/remote_auth.go's CreateSession doc for why a
+// generic mint-any-session wire primitive is unsafe. Session issuance under
+// storage.type: remote happens atomically with credential verification via
+// POST /api/v1/users/verify-credentials (users_crud.go's VerifyCredentials)
+// instead. These two routes only ever LOOK UP or DELETE a session that
+// already exists — a lookup requires presenting that exact session's own
+// opaque token (proof of possession, not a credential check bypass), and a
+// delete-by-ID grants no capability beyond what RevokeUserSessions
+// (POST /users/{id}/revoke-sessions) already grants the same service
+// credential today.
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// GetSessionByToken handles GET /api/v1/sessions/{token} (#508) — the
+// server-side counterpart RemoteStorage.GetSession needs to validate a
+// session under storage.type: remote (core.ValidateSessionToken, on every
+// authenticated request via a spoke deployment) and to resolve a session's ID
+// before deleting it (core.Logout). Gated by users.write, the same
+// permission VerifyCredentials/CreateUser/UnlockUser already require of the
+// RemoteStorage service credential.
+func (h *UserHandler) GetSessionByToken(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	token := chi.URLParam(r, "token")
+	if token == "" {
+		sendError(w, "InvalidParameter", "session token is required", http.StatusBadRequest, nil)
+		return
+	}
+	session, err := h.coreService.GetSessionForRemoteProxy(r.Context(), token)
+	if err != nil {
+		sendError(w, "NotFound", "Session not found", http.StatusNotFound, nil)
+		return
+	}
+	// session.SessionToken is the at-rest HASH (never the plaintext — see
+	// models.Session's json:"-" tag), so this response never carries a
+	// replayable secret; it's plain lookup metadata (ID, user, expiry).
+	sendSuccess(w, session, "")
+}
+
+// DeleteSessionByID handles DELETE /api/v1/sessions/{id} (#508) — the
+// server-side counterpart RemoteStorage.DeleteSession needs so Logout works
+// end-to-end under storage.type: remote. Gated by users.write, matching
+// GetSessionByToken above.
+func (h *UserHandler) DeleteSessionByID(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid session ID", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.DeleteSessionForRemoteProxy(r.Context(), uint(id)); err != nil {
+		sendError(w, "InternalError", "Failed to delete session", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, nil, "")
+}
+
+// GetSessionByToken handles GET /api/v1/sessions/{token} (#508).
+func GetSessionByToken(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.GetSessionByToken(w, r)
+}
+
+// DeleteSessionByID handles DELETE /api/v1/sessions/{id} (#508).
+func DeleteSessionByID(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.DeleteSessionByID(w, r)
+}

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -316,17 +316,28 @@ func (h *UserHandler) GetUserByExternalID(w http.ResponseWriter, r *http.Request
 	sendSuccess(w, resp, "")
 }
 
-// VerifyCredentials handles POST /api/v1/users/verify-credentials (#506) — the
-// upstream half of the RemoteLoginVerifier proxy-login mechanism
+// VerifyCredentials handles POST /api/v1/users/verify-credentials (#506/#508)
+// — the upstream half of the RemoteLoginVerifier proxy-login mechanism
 // (internal/core/auth.go). It exists SOLELY so a storage.type: remote
 // deployment's own core.Login can authenticate a password at all:
 // models.User.PasswordHash never crosses the wire, so a "spoke" server backed
 // by RemoteStorage has no real hash to bcrypt-compare against locally — this
-// endpoint runs that compare on the "hub" server that actually has it,
-// against the SAME core.VerifyPasswordCredentials the hub's own direct login
-// uses (not a parallel bcrypt reimplementation), so the per-account lockout
-// gate/accounting and account-active/account-state checks apply identically
-// regardless of which path reached them.
+// endpoint runs the ENTIRE login on the "hub" server that actually has it, by
+// calling the hub's own core.Login (not a parallel reimplementation of either
+// the bcrypt compare or of session minting), so the per-account lockout
+// gate/accounting, account-active/account-state checks, and — #508 — session
+// issuance all apply IDENTICALLY regardless of which path reached them.
+//
+// #508: this is the atomic verify-AND-mint step. A successful, non-MFA-gated
+// call mints a REAL session on the hub (via core.Login, the exact same
+// function the hub's own direct /auth/login handler calls) and returns its
+// token in this SAME response — never via a second, separately callable
+// "create a session for this user_id" endpoint. That second-call shape is
+// exactly the confused-deputy risk this design avoids: splitting verification
+// from issuance would let anyone holding the RemoteStorage service credential
+// mint a session for an arbitrary user without ever proving that user's real
+// credentials. See internal/storage/store/remote_login_verify.go's package
+// doc for the full rationale.
 //
 // Gated by users.write — the SAME permission CreateUser/UnlockUser already
 // require of the RemoteStorage service credential (server/http/router.go) —
@@ -343,7 +354,11 @@ func (h *UserHandler) GetUserByExternalID(w http.ResponseWriter, r *http.Request
 // user (server/http/handlers/auth.go). A compromised RemoteStorage credential
 // must not be able to use this endpoint to enumerate accounts or their
 // lockout state beyond "that attempt failed" — nor is any of this logged with
-// per-reason detail, for the same reason.
+// per-reason detail, for the same reason. ErrMFARequired is the one
+// distinguished outcome: it is still a SUCCESSFUL verification (the password
+// was correct), just one core.Login itself declines to mint a session for —
+// the response reports mfa_enabled/webauthn_enabled with no session, so the
+// spoke's own Login can apply the identical MFA gate it always has.
 func (h *UserHandler) VerifyCredentials(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())
 	if userCtx == nil {
@@ -351,8 +366,10 @@ func (h *UserHandler) VerifyCredentials(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	var body struct {
-		Username string `json:"username"`
-		Password string `json:"password"`
+		Username  string `json:"username"`
+		Password  string `json:"password"`
+		UserAgent string `json:"user_agent"`
+		IPAddress string `json:"ip_address"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
@@ -362,17 +379,26 @@ func (h *UserHandler) VerifyCredentials(w http.ResponseWriter, r *http.Request) 
 		sendError(w, "ValidationError", "username and password are required", http.StatusBadRequest, nil)
 		return
 	}
-	u, err := h.coreService.VerifyPasswordCredentials(r.Context(), body.Username, body.Password)
-	if err != nil {
+	session, u, err := h.coreService.Login(r.Context(), &core.LoginRequest{
+		Username:  body.Username,
+		Password:  body.Password,
+		UserAgent: body.UserAgent,
+		IPAddress: body.IPAddress,
+	})
+	if err != nil && !errors.Is(err, core.ErrMFARequired) {
 		// Deliberately no log.Printf here (unlike every other handler in this
 		// file): logging the real error would record which of "no such user" /
 		// "wrong password" / "locked" / "not active" / "suspended" applied,
 		// re-opening exactly the oracle the generic response below exists to
-		// close.
+		// close. The audit event mirrors the real /auth/login handler's
+		// LogAuthFailure exactly — username + IP, no per-reason detail — so the
+		// hub's own audit trail still sees brute-force attempts proxied through
+		// a spoke, without widening the oracle.
+		goSafe(func() { h.coreService.LogAuthFailure(context.Background(), body.Username, body.IPAddress) })
 		sendError(w, "Unauthorized", "Invalid credentials", http.StatusUnauthorized, nil)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{
+	resp := map[string]interface{}{
 		"id":               u.ID,
 		"username":         u.Username,
 		"email":            u.Email,
@@ -380,7 +406,27 @@ func (h *UserHandler) VerifyCredentials(w http.ResponseWriter, r *http.Request) 
 		"account_state":    core.NormalizeAccountState(u.AccountState),
 		"mfa_enabled":      u.MFAEnabled,
 		"webauthn_enabled": u.WebAuthnEnabled,
-	}, "")
+	}
+	// session is nil exactly when err is ErrMFARequired (core.Login's contract) —
+	// no session to report in that case; the spoke applies its own MFA gate from
+	// mfa_enabled/webauthn_enabled above.
+	if session != nil {
+		resp["session"] = map[string]interface{}{
+			"id":                  session.ID,
+			"token":               session.SessionToken,
+			"family_id":           session.FamilyID,
+			"created_at":          session.CreatedAt,
+			"expires_at":          session.ExpiresAt,
+			"absolute_expires_at": session.AbsoluteExpiresAt,
+		}
+		// The hub's own audit trail should reflect this login exactly like a
+		// direct one — best-effort, non-blocking, mirroring the real /auth/login
+		// handler (server/http/handlers/auth.go).
+		goSafe(func() {
+			h.coreService.LogAuthLogin(context.Background(), u.ID, u.Username, body.IPAddress, body.UserAgent)
+		})
+	}
+	sendSuccess(w, resp, "")
 }
 
 // UpdateUser handles PUT /api/v1/users/{id}

--- a/server/http/remote_storage_login_test.go
+++ b/server/http/remote_storage_login_test.go
@@ -1,7 +1,10 @@
 package http
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -25,39 +28,14 @@ import (
 // (internal/core/auth.go) and POST /api/v1/users/verify-credentials
 // (server/http/handlers/users_crud.go).
 //
-// This SUPERSEDES TestLogin_RemoteStorage_StillFailsClosed_PasswordHashNeverOnWire
-// (round 114's #828), which deliberately pinned the PRE-fix fail-ALWAYS
-// behavior: before this fix, EVERY call below — including the CORRECT
-// password — returned "invalid credentials" indistinguishably, because
-// Login's bcrypt compare always ran against an empty hash. This test proves
-// that is no longer true: a wrong password is rejected, a correct password's
-// credential CHECK now genuinely succeeds (proceeding past that gate into
-// mintSession — see below for why it does not go further YET), and repeated
-// wrong passwords trip the SAME per-account lockout the direct LocalStorage
-// path enforces, via the identical core.VerifyPasswordCredentials logic
-// (reverting internal/core/auth.go's RemoteLoginVerifier/
-// VerifyPasswordCredentials changes, or
-// internal/storage/store/remote_login_verify.go, or the
-// POST /api/v1/users/verify-credentials route/handler, makes this test fail
-// exactly as the old #828 pinning test predicted — verified by hand while
-// developing this fix).
-//
-// What this test deliberately does NOT prove — because it is not true yet —
-// is a fully USABLE end-to-end login (a session the caller can actually
-// authenticate subsequent requests with). That is blocked by a separate,
-// pre-existing, larger gap this fix does not attempt to close: RemoteStorage's
-// session persistence (CreateSession/GetSession/DeleteSession, remote_auth.go)
-// has no corresponding server routes at all — POST /api/v1/sessions 404s
-// unconditionally today, entirely independent of the password-hash problem
-// #506 is about. A correct password's Login call below therefore still
-// returns an error, but a DIFFERENT one than an incorrect password: it fails
-// at mintSession (session persistence), not at the credential check — proving
-// the two are now genuinely distinguishable, which they were not before this
-// fix (every failure reason collapsed to the identical "invalid credentials").
-// See the PR description for why closing the session-persistence gap safely
-// (a naive "create a session for this user_id" wire primitive would be a
-// privilege-escalation oracle far worse than today's "login doesn't work")
-// needs its own dedicated design pass, not a rushed addition here.
+// #508 extends this: the correct-password case below now succeeds all the
+// way through to a genuinely usable session (see
+// TestLogin_RemoteStorage_SessionUsableEndToEnd for the full lifecycle:
+// login → validate → logout → validate-fails). Before #508, this same call
+// got PAST the credential check but then failed at session persistence
+// (RemoteStorage's CreateSession had no corresponding server route at all) —
+// this test used to pin that intermediate, still-broken state; it now pins
+// the actual fix.
 func TestLogin_RemoteStorage_ProxiesPasswordCredentialCheck(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 	defer i18n.ResetForTesting()
@@ -110,20 +88,16 @@ func TestLogin_RemoteStorage_ProxiesPasswordCredentialCheck(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, "invalid credentials", err.Error())
 
-	// The CORRECT password now gets PAST the credential check (the #506 fix) —
-	// proceeding to mintSession, which fails on a DIFFERENT, session-specific
-	// error (the separate, pre-existing session-persistence gap documented
-	// above), not the generic "invalid credentials" every failure reason
-	// collapsed to before this fix.
-	_, _, err = downstreamCore.Login(ctx, &core.LoginRequest{
+	// The CORRECT password now succeeds end-to-end (#508): verification AND
+	// session minting happen atomically on the upstream, and the minted
+	// session's token comes back on this same call.
+	session, user, err := downstreamCore.Login(ctx, &core.LoginRequest{
 		Username: "testadmin", Password: "TestPassword123!",
 	})
-	require.Error(t, err, "session persistence is a separate, unimplemented gap (see test doc) — "+
-		"but the error must no longer be the generic credential-check failure")
-	assert.NotEqual(t, "invalid credentials", err.Error(),
-		"a CORRECT password must be distinguishable from a wrong one: it should fail at session "+
-			"minting, not at the credential check the #506 fix targets")
-	assert.Contains(t, err.Error(), "session", "expected a session-persistence failure, not a credential-check failure")
+	require.NoError(t, err, "a correct password must now succeed all the way to a usable session")
+	require.NotNil(t, session)
+	assert.NotEmpty(t, session.SessionToken, "the upstream-minted session's token must be delivered to the caller")
+	assert.Equal(t, "testadmin", user.Username)
 
 	// --- lockout: repeated wrong passwords via THIS proxied path must trip
 	// the SAME per-account lockout the direct path enforces (MaxAttempts=2
@@ -151,4 +125,141 @@ func TestLogin_RemoteStorage_ProxiesPasswordCredentialCheck(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "locked") || err.Error() == "invalid credentials",
 		"a locked account's correct password must still be refused at the credential check")
+}
+
+// TestLogin_RemoteStorage_SessionUsableEndToEnd proves #508's core security
+// requirement (a): a storage.type: remote login produces a REAL, usable
+// session — not just a verified credential with nowhere to go. It exercises
+// the full lifecycle entirely through the downstream ("spoke") core, backed
+// by RemoteStorage, against a real upstream ("hub") server:
+//
+//  1. Login succeeds and returns a session minted BY THE UPSTREAM.
+//  2. That session validates (core.ValidateSessionToken proxies the lookup to
+//     the upstream via the new GET /api/v1/sessions/{token} route, #508) —
+//     proving the upstream remains the sole source of truth for session
+//     validity, not merely for the login step.
+//  3. Logout deletes it (proxied via the new DELETE /api/v1/sessions/{id}
+//     route, #508) — requirement (c).
+//  4. After logout, the same token no longer validates — the deletion
+//     actually took effect upstream, not just locally.
+func TestLogin_RemoteStorage_SessionUsableEndToEnd(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"}},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstreamCore := core.NewKeyorixCore(rs)
+
+	ctx := context.Background()
+
+	session, user, err := downstreamCore.Login(ctx, &core.LoginRequest{
+		Username: "testadmin", Password: "TestPassword123!",
+		UserAgent: "test-agent", IPAddress: "203.0.113.7",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.NotEmpty(t, session.SessionToken)
+
+	// The session validates through the SAME proxy path a real authenticated
+	// request would use (core.ValidateSessionToken -> RemoteStorage.GetSession
+	// -> GET /api/v1/sessions/{token} on the hub).
+	validatedUser, _, err := downstreamCore.ValidateSessionToken(ctx, session.SessionToken)
+	require.NoError(t, err, "a session minted by the atomic verify+mint call must actually validate afterward")
+	assert.Equal(t, user.ID, validatedUser.ID)
+	assert.Equal(t, "testadmin", validatedUser.Username)
+
+	// The session genuinely lives on the upstream, not just in the spoke's
+	// process: fetching it directly via the upstream's own core confirms a
+	// real row was persisted there (not merely echoed back).
+	upstreamSession, err := upstreamCore.GetSessionForRemoteProxy(ctx, session.SessionToken)
+	require.NoError(t, err, "the minted session must be a REAL row on the upstream, not just a wire echo")
+	assert.Equal(t, user.ID, upstreamSession.UserID)
+
+	// Logout must actually revoke it upstream (requirement (c)).
+	require.NoError(t, downstreamCore.Logout(ctx, session.SessionToken))
+
+	_, _, err = downstreamCore.ValidateSessionToken(ctx, session.SessionToken)
+	assert.Error(t, err, "a logged-out session must no longer validate")
+
+	_, err = upstreamCore.GetSessionForRemoteProxy(ctx, session.SessionToken)
+	assert.Error(t, err, "the session row must actually be gone upstream after logout, not just locally forgotten")
+}
+
+// TestVerifyCredentials_WrongPasswordNeverMintsSession proves #508's core
+// security requirement (b): an attacker who does NOT have valid credentials
+// for user X cannot obtain a session for user X — even while holding a fully
+// valid RemoteStorage service credential (the same bearer token a compromised
+// "spoke" deployment's credential would be) — by calling
+// POST /api/v1/users/verify-credentials directly with a wrong password. This
+// is the endpoint that atomically verifies AND mints (#508); it must never
+// mint on a failed verification, and there must be no OTHER, separate
+// endpoint that could mint one instead.
+func TestVerifyCredentials_WrongPasswordNeverMintsSession(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"}},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	// createTestToken already logged testadmin in once (to mint upstreamToken
+	// itself) — capture that baseline so the assertion below proves this call
+	// added NO new session, not merely that zero happen to exist.
+	admin, err := upstreamCore.GetUserByUsername(context.Background(), "testadmin")
+	require.NoError(t, err)
+	before, err := upstreamCore.ListOwnSessions(context.Background(), admin.ID)
+	require.NoError(t, err)
+
+	body, err := json.Marshal(map[string]string{
+		"username": "testadmin",
+		"password": "definitely-not-the-real-password",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, upstreamSrv.URL+"/api/v1/users/verify-credentials", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+upstreamToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"a wrong password must be rejected outright — never a 2xx with a session attached")
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&decoded))
+	assert.Equal(t, false, decoded["success"])
+	_, hasData := decoded["data"]
+	assert.False(t, hasData, "a failed verification must never carry a data payload, let alone a session")
+
+	// Confirm directly against the upstream's own record: this call added NO
+	// new session on top of the pre-existing baseline.
+	after, err := upstreamCore.ListOwnSessions(context.Background(), admin.ID)
+	require.NoError(t, err)
+	assert.Len(t, after, len(before), "a rejected verification attempt must mint NO session at all")
 }

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -649,6 +649,19 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission("users.impersonate")).
 			Post("/admin/impersonate", impersonationHandler.Start)
 
+		// Sessions (#508) — the server-side counterparts RemoteStorage.GetSession/
+		// DeleteSession need so a storage.type: remote deployment can validate and
+		// revoke sessions minted upstream by POST /api/v1/users/verify-credentials
+		// (#506/#508's atomic verify+mint). Deliberately NO POST "/" here — there is
+		// no generic "create a session" route; see remote_auth.go's CreateSession
+		// doc for why that would be a privilege-escalation oracle. Gated by
+		// users.write, the SAME permission verify-credentials/CreateUser/UnlockUser
+		// already require of the RemoteStorage service credential.
+		r.Route("/sessions", func(r chi.Router) {
+			r.With(customMiddleware.RequirePermission("users.write")).Get("/{token}", handlers.GetSessionByToken)
+			r.With(customMiddleware.RequirePermission("users.write")).Delete("/{id}", handlers.DeleteSessionByID)
+		})
+
 		// Groups endpoints
 		r.Route("/groups", func(r chi.Router) {
 			r.Use(customMiddleware.RequirePermission("users.read"))


### PR DESCRIPTION
## Summary

`storage.type: remote` login could verify a password end-to-end (#506) but had nowhere to persist the resulting session: `RemoteStorage.CreateSession`/`GetSession`/`DeleteSession` had no corresponding server routes, so `POST /api/v1/sessions` 404'd unconditionally and login never actually completed.

### Why a naive fix is unsafe

A generic "create a session for this `user_id`" wire endpoint would let anyone holding the `RemoteStorage` service credential mint a session for an **arbitrary** user, without that call ever proving the target user's real credentials — a classic confused-deputy / privilege-escalation oracle. That is explicitly why round 115 (#506) stopped short of closing this gap.

### Design

Verification and session issuance now happen as **one atomic, non-replayable upstream call**, mirroring how OAuth/OIDC token-exchange flows avoid the identical class of bug:

- `POST /api/v1/users/verify-credentials` (`server/http/handlers/users_crud.go`) now calls the upstream's own `core.Login` directly (not `VerifyPasswordCredentials`) — the exact same function the hub's own `/auth/login` handler uses. A successful, non-MFA-gated call mints a real session on the hub and returns its token in the **same** response. There is no second, separately callable "mint a session" step.
- `core.KeyorixCore.Login` (`internal/core/auth.go`) special-cases `RemoteLoginVerifier`-backed storage: `VerifyLoginCredentials` now returns `(*models.User, *models.Session, error)` — the session is non-nil exactly when the upstream verified the password **and** decided no MFA/WebAuthn gate applies (mirroring `Login`'s own gate). `Login` uses that pre-minted session directly; it never separately asks the upstream to persist one after the fact.
- `RemoteStorage.CreateSession` (`internal/storage/store/remote_auth.go`) is hardened to fail loudly with an explanatory error instead of attempting a wire call that would have been unsafe (and was already silently broken — `models.Session.SessionToken` is tagged `json:"-"` so it can never cross the wire generically).
- New `GET /api/v1/sessions/{token}` and `DELETE /api/v1/sessions/{id}` routes (`server/http/handlers/sessions_remote.go`, gated by the same `users.write` permission `verify-credentials`/`CreateUser`/`UnlockUser` already require) let a "spoke" deployment validate and revoke sessions minted upstream — the upstream remains the sole source of truth for session validity on every subsequent request (`ValidateSessionToken`) and on logout, not just at login. Deleting a session by ID grants no capability beyond what `POST /users/{id}/revoke-sessions` already grants the same service credential today.

### Remaining, explicitly out-of-scope gaps

- MFA/WebAuthn login under `storage.type: remote` remains unsupported (tracked separately as #509) — the atomic verify+mint here still withholds a session whenever a second factor is required, exactly like the direct `LocalStorage` path.
- Setup-token consume auto-login (#510) and session refresh (`RefreshSession`/`RotateSession`) remain unimplemented under `storage.type: remote` — a spoke session, once minted, can be validated and revoked (login + logout work end-to-end) but not silently refreshed, forcing re-login once the access TTL lapses. This is a real, separate limitation worth a follow-up finding, not something this PR papers over.

## Test plan

- [x] `TestLogin_RemoteStorage_ProxiesPasswordCredentialCheck` (updated) — correct password now succeeds end-to-end instead of failing at session persistence; wrong password / lockout behavior unchanged.
- [x] `TestLogin_RemoteStorage_SessionUsableEndToEnd` (new) — login → the session validates via the new proxy route → logout deletes it upstream → the same token no longer validates.
- [x] `TestVerifyCredentials_WrongPasswordNeverMintsSession` (new) — calling `POST /api/v1/users/verify-credentials` directly with a wrong password (holding a fully valid service credential) returns 401 with no session and mints no new session row upstream.
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/core/... ./server/http/... ./internal/storage/... -count=1`
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)