### PR TITLE
fix(remote-storage): proxy TOTP/MFA credential checks to the upstream server (#509)

### DIFF
--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -197,9 +197,53 @@ func (c *KeyorixCore) MFARecoveryCodesRemaining(ctx context.Context, userID uint
 	return remaining, mfaRecoveryCodeCount, nil
 }
 
+// RemoteMFAVerifier is implemented by storage backends that cannot themselves
+// hold the raw TOTP secret (#509), for the identical reason RemoteLoginVerifier
+// (auth.go) exists for passwords: the shared secret is stored reversibly
+// ENCRYPTED specifically so it must never leave the server that can decrypt it,
+// so RemoteStorage's GetMFASecret is an unconditional stub — loadTOTPSecret/
+// validateTOTPStep can never run locally against a "spoke" server backed by
+// RemoteStorage.
+//
+// Mirrors #506's proxy-login pattern exactly, extended to the second factor:
+// the upstream server (the one actually backed by LocalStorage, which HAS the
+// encrypted secret and the key to decrypt it) performs BOTH steps —
+//
+//  1. IssueMFAChallenge mints the short-lived, single-use challenge (the same
+//     shape CreateMFAChallenge always minted, just persisted upstream instead
+//     of locally) via POST /api/v1/users/{id}/mfa-challenge.
+//  2. VerifyMFALoginCredentials consumes that challenge and performs the ENTIRE
+//     TOTP/recovery-code check — validateTOTPStep, MarkTOTPStepUsed (anti-
+//     replay), ConsumeMFARecoveryCode, AND the per-account lockout gate/
+//     accounting and account-active/account-state checks (the exact set
+//     VerifyPasswordCredentials's proxy already delegates for the first
+//     factor) — via POST /api/v1/users/verify-mfa, calling the upstream's own
+//     core.VerifyMFACredentials, the SAME function the upstream's own direct
+//     second-factor login uses, not a parallel reimplementation.
+//
+// Both endpoints are gated by the SAME users.write permission CreateUser/
+// UnlockUser/verify-credentials already require of the RemoteStorage service
+// credential — not a new, weaker trust boundary. Minting a challenge here is
+// specifically NOT the privilege-escalation oracle #508 identified for a
+// generic "create a session for this user_id" primitive (deliberately NOT
+// implemented for that reason): a challenge alone grants nothing by itself —
+// the caller must still supply the correct plaintext TOTP code or recovery
+// code, throttled by the identical per-account lockout #506 already proxies —
+// so at most it lets this already-highly-trusted credential skip re-proving a
+// password it (or rather, the legitimate #506 proxy call preceding this one)
+// already proved once, exactly as CreateUser/UnlockUser already let it act on
+// an arbitrary account without a fresh password check.
+type RemoteMFAVerifier interface {
+	IssueMFAChallenge(ctx context.Context, userID uint) (string, error)
+	VerifyMFALoginCredentials(ctx context.Context, challenge, code string) (*models.User, bool, error)
+}
+
 // CreateMFAChallenge issues a short-lived single-use challenge for an MFA-enabled
 // user that has passed the password step. Only the token hash is stored.
 func (c *KeyorixCore) CreateMFAChallenge(ctx context.Context, userID uint) (string, error) {
+	if verifier, ok := c.storage.(RemoteMFAVerifier); ok {
+		return verifier.IssueMFAChallenge(ctx, userID)
+	}
 	token, err := generateSecureToken()
 	if err != nil {
 		return "", err
@@ -212,16 +256,29 @@ func (c *KeyorixCore) CreateMFAChallenge(ctx context.Context, userID uint) (stri
 	return token, nil
 }
 
-// VerifyMFALogin consumes a challenge, verifies a TOTP code or a recovery code,
-// and on success mints and returns the session (the second login step).
-func (c *KeyorixCore) VerifyMFALogin(ctx context.Context, challenge, code, userAgent, ip string) (*models.Session, *models.User, error) {
+// VerifyMFACredentials consumes a challenge and verifies a TOTP code or a
+// recovery code against LocalStorage — everything VerifyMFALogin does EXCEPT
+// minting the session and the two post-mint audit writes, extracted (#509) so
+// it can ALSO be called directly by the server-side handler for POST
+// /api/v1/users/verify-mfa, the upstream half of the RemoteMFAVerifier proxy
+// (see its doc above) — the identical split #506 already established between
+// VerifyPasswordCredentials (the shared check) and Login (which additionally
+// mints the session). This keeps the direct LocalStorage second-factor login
+// and the proxied storage.type: remote path running through IDENTICAL TOTP/
+// recovery-code/lockout/account-state logic — never two, potentially-
+// diverging implementations of the same security check. Returns the verified
+// user (ID and Username only are guaranteed populated — see
+// verifyMFAWireResponse in internal/storage/store for why nothing else is
+// needed past this point) and whether a recovery code (rather than a TOTP
+// code) was used.
+func (c *KeyorixCore) VerifyMFACredentials(ctx context.Context, challenge, code string) (*models.User, bool, error) {
 	ch, err := c.storage.ConsumeMFAChallenge(ctx, sha256Hex(challenge), c.now())
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid or expired challenge")
+		return nil, false, fmt.Errorf("invalid or expired challenge")
 	}
 	user, err := c.storage.GetUser(ctx, ch.UserID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("user not found")
+		return nil, false, fmt.Errorf("user not found")
 	}
 	// Completing a second factor still mints a login session, so a suspended or
 	// deactivated account must be refused here too — the challenge may have been
@@ -229,7 +286,7 @@ func (c *KeyorixCore) VerifyMFALogin(ctx context.Context, challenge, code, userA
 	// nothing rechecks the state between the two steps. Mirrors the password,
 	// session, PAT, and passwordless-WebAuthn gates.
 	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
-		return nil, nil, fmt.Errorf("account is not active")
+		return nil, false, fmt.Errorf("account is not active")
 	}
 	// Per-account lockout also gates the second factor. The per-IP rate limiter is
 	// spoofable behind a misconfigured proxy, and it is otherwise the ONLY online
@@ -237,7 +294,7 @@ func (c *KeyorixCore) VerifyMFALogin(ctx context.Context, challenge, code, userA
 	// by ch.UserID, which the attacker does not control) makes second-factor brute force
 	// cost the same lockout as password brute force.
 	if c.loginLocked(user) {
-		return nil, nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+		return nil, false, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
 	}
 	verified, usedRecovery := false, false
 	if secret, err := c.loadTOTPSecret(ctx, ch.UserID); err == nil {
@@ -259,20 +316,37 @@ func (c *KeyorixCore) VerifyMFALogin(ctx context.Context, challenge, code, userA
 	if !verified {
 		c.auditMFAFailed(ctx, ch.UserID, "login")
 		c.recordFailedLogin(ctx, user) // count the failed second factor toward the lockout
-		return nil, nil, fmt.Errorf("invalid code")
+		return nil, false, fmt.Errorf("invalid code")
 	}
 	// Cleared the second factor — but a concurrent burst of failed second-factor
 	// attempts against this account may have tripped the lock since the
 	// pre-verification snapshot check above (TOCTOU). Re-check under the same
 	// serialization recordFailedLogin uses before minting a session.
 	if err := c.checkLockAndClearLoginFailures(ctx, user); err != nil {
-		return nil, nil, err
+		return nil, false, err
 	}
-	session, err := c.mintSession(ctx, ch.UserID, userAgent, ip)
+	return user, usedRecovery, nil
+}
+
+// VerifyMFALogin consumes a challenge, verifies a TOTP code or a recovery code,
+// and on success mints and returns the session (the second login step).
+func (c *KeyorixCore) VerifyMFALogin(ctx context.Context, challenge, code, userAgent, ip string) (*models.Session, *models.User, error) {
+	var user *models.User
+	var usedRecovery bool
+	var err error
+	if verifier, ok := c.storage.(RemoteMFAVerifier); ok {
+		user, usedRecovery, err = verifier.VerifyMFALoginCredentials(ctx, challenge, code)
+	} else {
+		user, usedRecovery, err = c.VerifyMFACredentials(ctx, challenge, code)
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	uid := ch.UserID
+	session, err := c.mintSession(ctx, user.ID, userAgent, ip)
+	if err != nil {
+		return nil, nil, err
+	}
+	uid := user.ID
 	if usedRecovery {
 		c.writeAuditEventFull(ctx, "mfa.recovery_used", &uid, nil, nil, ip, fmt.Sprintf("user %s used a recovery code", user.Username))
 	}

--- a/internal/storage/store/remote_mfa.go
+++ b/internal/storage/store/remote_mfa.go
@@ -1,9 +1,20 @@
 // remote_mfa.go — MFA persistence is server-side only; the remote client never
 // manages MFA state directly (enrolment/verify go through the server's REST API).
+//
+// The two exceptions are IssueMFAChallenge and VerifyMFALoginCredentials below,
+// which implement core.RemoteMFAVerifier (#509): the upstream half of the
+// storage.type: remote second-factor login proxy, mirroring
+// remote_login_verify.go's password proxy (#506) exactly. The raw TOTP secret
+// is stored reversibly encrypted specifically so it must never leave the
+// server that can decrypt it — GetMFASecret below stays an unconditional stub
+// for that reason — so the ENTIRE TOTP/recovery-code check, not just a wire-DTO
+// passthrough of the storage primitives above, has to run upstream.
 package store
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -92,4 +103,94 @@ func (rs *RemoteStorage) CreateWebAuthnSession(_ context.Context, _ *models.WebA
 }
 func (rs *RemoteStorage) ConsumeWebAuthnSession(_ context.Context, _ string, _ time.Time) (*models.WebAuthnSession, error) {
 	return nil, remoteUnsupported("ConsumeWebAuthnSession")
+}
+
+// issueMFAChallengeWireResponse carries only the opaque challenge token: the
+// upstream server minted and persisted the actual MFAChallenge row itself (it
+// never crosses the wire), matching the "the caller never sees storage
+// internals" boundary the rest of this proxy mechanism follows.
+type issueMFAChallengeWireResponse struct {
+	Challenge string `json:"challenge"`
+}
+
+// IssueMFAChallenge implements core.RemoteMFAVerifier: it asks the upstream
+// server to mint the short-lived, single-use MFA challenge for userID (the SAME
+// shape core.CreateMFAChallenge always minted, just persisted upstream via POST
+// /api/v1/users/{id}/mfa-challenge instead of locally), gated by the same
+// users.write permission CreateUser/UnlockUser/verify-credentials already
+// require of the RemoteStorage service credential (#506/#509) — see the
+// RemoteMFAVerifier doc in internal/core/mfa.go for why this is not a new,
+// weaker trust boundary: the challenge alone grants nothing without the
+// correct TOTP/recovery code that follows.
+func (rs *RemoteStorage) IssueMFAChallenge(ctx context.Context, userID uint) (string, error) {
+	resp, err := rs.client.Post(ctx, fmt.Sprintf("/api/v1/users/%d/mfa-challenge", userID), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to start MFA challenge")
+	}
+	if !resp.Success {
+		return "", fmt.Errorf("failed to start MFA challenge")
+	}
+	var wire issueMFAChallengeWireResponse
+	if err := json.Unmarshal(resp.Data, &wire); err != nil {
+		return "", fmt.Errorf("failed to start MFA challenge")
+	}
+	return wire.Challenge, nil
+}
+
+// verifyMFAWireRequest carries the plaintext TOTP/recovery code deliberately
+// (see the package doc above and #506's precedent) — the upstream server needs
+// it to run its own TOTP validation / recovery-code compare against the real,
+// decrypted secret; there is no other way this check could ever work under
+// storage.type: remote.
+type verifyMFAWireRequest struct {
+	Challenge string `json:"challenge"`
+	Code      string `json:"code"`
+}
+
+// verifyMFAWireResponse is deliberately narrow — it carries exactly what
+// core.VerifyMFALogin needs after a successful verdict (enough identity to
+// mint/describe the session, plus whether a recovery code was used for the
+// matching audit event) and nothing else: no TOTP secret, no recovery-code
+// hashes, no lockout-accounting counters (meaningless here — the upstream
+// already applied/cleared them before ever returning success).
+type verifyMFAWireResponse struct {
+	ID           uint   `json:"id"`
+	Username     string `json:"username"`
+	UsedRecovery bool   `json:"used_recovery"`
+}
+
+func (w verifyMFAWireResponse) toModel() *models.User {
+	return &models.User{ID: w.ID, Username: w.Username}
+}
+
+// VerifyMFALoginCredentials implements core.RemoteMFAVerifier: it proxies the
+// ENTIRE second-factor check — challenge consumption, TOTP/recovery-code
+// verification, anti-replay (MarkTOTPStepUsed), and the per-account lockout/
+// account-state gates — to the upstream server via POST
+// /api/v1/users/verify-mfa, gated by the same users.write permission
+// verify-credentials already requires (#506/#509).
+//
+// Every failure — an expired/consumed challenge, a wrong code, a tripped
+// lockout, or a network/parse error — collapses to the SAME generic "invalid
+// code" error here, mirroring VerifyLoginCredentials (remote_login_verify.go):
+// the actual end-user-facing /auth/mfa/verify handler already collapses every
+// failure reason to one generic 401 regardless of cause (server/http/handlers/
+// mfa.go), so no caller-visible behavior is lost; this just keeps the internal
+// proxy call from becoming a richer oracle than the direct path ever was.
+func (rs *RemoteStorage) VerifyMFALoginCredentials(ctx context.Context, challenge, code string) (*models.User, bool, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/users/verify-mfa", verifyMFAWireRequest{
+		Challenge: challenge,
+		Code:      code,
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid code")
+	}
+	if !resp.Success {
+		return nil, false, fmt.Errorf("invalid code")
+	}
+	var wire verifyMFAWireResponse
+	if err := json.Unmarshal(resp.Data, &wire); err != nil {
+		return nil, false, fmt.Errorf("invalid code")
+	}
+	return wire.toModel(), wire.UsedRecovery, nil
 }

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -383,6 +383,94 @@ func (h *UserHandler) VerifyCredentials(w http.ResponseWriter, r *http.Request) 
 	}, "")
 }
 
+// IssueMFAChallenge handles POST /api/v1/users/{id}/mfa-challenge (#509) — the
+// upstream half of the core.RemoteMFAVerifier proxy-login mechanism
+// (internal/core/mfa.go), mirroring VerifyCredentials above: it exists SOLELY
+// so a storage.type: remote deployment's own core.CreateMFAChallenge (called
+// right after VerifyCredentials/VerifyPasswordCredentials reports MFA is
+// required) can mint a challenge at all — RemoteStorage has nowhere of its own
+// to persist one. It mints and persists the SAME MFAChallenge row
+// core.CreateMFAChallenge always has, just on this (the hub's) LocalStorage,
+// and returns only the opaque token, never any storage internals.
+//
+// Gated by users.write, the SAME permission verify-credentials already
+// requires — see its doc above and the RemoteMFAVerifier doc for why a
+// challenge alone (with no valid TOTP/recovery code to redeem it) grants
+// nothing and so is not a new, weaker trust boundary.
+func (h *UserHandler) IssueMFAChallenge(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		sendError(w, "InvalidParameter", "Invalid user ID", http.StatusBadRequest, nil)
+		return
+	}
+	challenge, err := h.coreService.CreateMFAChallenge(r.Context(), uint(id))
+	if err != nil {
+		sendError(w, "Internal", "failed to start MFA challenge", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"challenge": challenge}, "")
+}
+
+// VerifyMFACredentials handles POST /api/v1/users/verify-mfa (#509) — the
+// upstream half of the core.RemoteMFAVerifier proxy-login mechanism
+// (internal/core/mfa.go): checks a plaintext TOTP or recovery code against the
+// real, decrypted TOTP secret this server holds and returns only a verdict,
+// never the secret, so a RemoteStorage-backed "spoke" deployment (which never
+// receives the secret at all) can complete a second-factor login by proxying
+// the ENTIRE check here rather than reimplementing it. Calls
+// core.VerifyMFACredentials directly — the SAME function the hub's own direct
+// second-factor login uses — so the per-account lockout gate/accounting,
+// anti-replay (MarkTOTPStepUsed), and account-active/account-state checks
+// apply identically regardless of which path reached them.
+//
+// Gated by users.write, the SAME permission verify-credentials already
+// requires. Like VerifyCredentials, the response never distinguishes WHY a
+// check failed — an expired challenge, a wrong code, a tripped lockout, or a
+// suspended/inactive account all produce the SAME generic 401 here, mirroring
+// how /auth/mfa/verify itself already collapses every failure reason to one
+// generic message for the actual end user (server/http/handlers/mfa.go). A
+// compromised RemoteStorage credential must not be able to use this endpoint
+// to enumerate accounts or lockout state beyond "that attempt failed" — nor is
+// any of this logged with per-reason detail, for the same reason.
+func (h *UserHandler) VerifyMFACredentials(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Challenge string `json:"challenge"`
+		Code      string `json:"code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
+		return
+	}
+	if body.Challenge == "" || body.Code == "" {
+		sendError(w, "ValidationError", "challenge and code are required", http.StatusBadRequest, nil)
+		return
+	}
+	u, usedRecovery, err := h.coreService.VerifyMFACredentials(r.Context(), body.Challenge, body.Code)
+	if err != nil {
+		// Deliberately no log.Printf here (see VerifyCredentials above): logging
+		// the real error would re-open exactly the oracle the generic response
+		// below exists to close.
+		sendError(w, "Unauthorized", "Invalid code", http.StatusUnauthorized, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"id":            u.ID,
+		"username":      u.Username,
+		"used_recovery": usedRecovery,
+	}, "")
+}
+
 // UpdateUser handles PUT /api/v1/users/{id}
 func (h *UserHandler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/handlers/users_handler.go
+++ b/server/http/handlers/users_handler.go
@@ -321,6 +321,24 @@ func VerifyCredentials(w http.ResponseWriter, r *http.Request) {
 	defaultUserHandler.VerifyCredentials(w, r)
 }
 
+// VerifyMFACredentials handles POST /api/v1/users/verify-mfa (#509).
+func VerifyMFACredentials(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.VerifyMFACredentials(w, r)
+}
+
+// IssueMFAChallenge handles POST /api/v1/users/{id}/mfa-challenge (#509).
+func IssueMFAChallenge(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.IssueMFAChallenge(w, r)
+}
+
 // UpdateUser handles PUT /api/v1/users/{id}
 func UpdateUser(w http.ResponseWriter, r *http.Request) {
 	if defaultUserHandler == nil {

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -75,6 +75,12 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		// #507: the invitation-proxy end-to-end tests exercise ProjectInvitation
 		// CRUD through the real router.
 		&models.ProjectInvitation{},
+		// #509: the MFA-login-proxy end-to-end tests exercise TOTP enrolment,
+		// challenge issuance, and second-factor verification through the real
+		// router.
+		&models.MFASecret{},
+		&models.MFARecoveryCode{},
+		&models.MFAChallenge{},
 	)
 	require.NoError(t, err)
 	return core.NewKeyorixCore(store.NewLocalStorage(db))

--- a/server/http/remote_storage_mfa_login_test.go
+++ b/server/http/remote_storage_mfa_login_test.go
@@ -1,0 +1,170 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogin_RemoteStorage_ProxiesMFACredentialCheck proves the #509 fix for the
+// second-factor half of storage.type: remote login: a "spoke" server backed by
+// RemoteStorage, pointed at a real "hub" server backed by LocalStorage, can now
+// complete a TOTP-protected login end-to-end (up to the SAME pre-existing
+// session-persistence gap #506's own test documents, #508 — see below), proxied
+// via core.RemoteMFAVerifier (internal/core/mfa.go) and POST
+// /api/v1/users/{id}/mfa-challenge + POST /api/v1/users/verify-mfa
+// (server/http/handlers/users_crud.go).
+//
+// Before this fix, EVERY storage method mfa.go relies on (GetMFASecret,
+// CreateMFAChallenge, ConsumeMFAChallenge, MarkTOTPStepUsed, ...) was an
+// unconditional stub on RemoteStorage, so a "spoke" deployment could not even
+// ISSUE a challenge, let alone verify one — an MFA-enabled account could not
+// complete login at all under storage.type: remote. This test proves that is no
+// longer true: a challenge can be issued, a wrong code is rejected, a correct
+// code's CHECK now genuinely succeeds (proceeding past that gate into
+// mintSession — blocked only by the separate, pre-existing #508 gap, exactly
+// like #506's own password-only test), and repeated wrong codes trip the SAME
+// per-account lockout the direct LocalStorage path enforces.
+func TestLogin_RemoteStorage_ProxiesMFACredentialCheck(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	// --- upstream ("hub"): the real holder of the user record + TOTP secret ---
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+
+	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
+	require.NoError(t, enc.Initialize("test-passphrase"))
+	upstreamCore.SetAuthEncryptor(enc)
+
+	ctx := context.Background()
+
+	// A dedicated MFA-enabled user, distinct from the admin service-credential
+	// identity (upstreamToken/"testadmin") — enrolling MFA purges every existing
+	// session for the enrolled user (mfa.go's ActivateMFA), so reusing the same
+	// account here would invalidate the very token this test authenticates the
+	// RemoteStorage client with.
+	const mfaPassword = "Zq8#Trn4$Vhx2@Wp!"
+	mfaUser, err := upstreamCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "mfauser", Email: "mfauser@example.com", DisplayName: "MFA User", Password: mfaPassword,
+	})
+	require.NoError(t, err)
+
+	_, totpSecret, err := upstreamCore.BeginMFAEnrollment(ctx, mfaUser.ID)
+	require.NoError(t, err)
+	actCode, err := totp.GenerateCode(totpSecret, time.Now())
+	require.NoError(t, err)
+	_, err = upstreamCore.ActivateMFA(ctx, mfaUser.ID, actCode, mfaPassword)
+	require.NoError(t, err)
+
+	// A tight lockout policy (2 attempts) so this test can trip it in a handful
+	// of calls below, proving the SAME per-account lockout gating the direct
+	// LocalStorage path enforces also applies via this proxied path (#509's
+	// primary security concern) — not a parallel, unprotected check.
+	upstreamCore.SetLoginLockoutPolicy(core.LoginLockoutPolicy{
+		Enabled: true, MaxAttempts: 2, Window: 15 * time.Minute,
+		BaseCooldown: time.Hour, MaxCooldown: time.Hour,
+	})
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"}},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	// --- downstream ("spoke"): storage.type: remote, pointed at the upstream ---
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstreamCore := core.NewKeyorixCore(rs)
+
+	// Password step: the account requires MFA, so Login must report
+	// ErrMFARequired (proxied via the #506 fix) rather than returning a session
+	// or a bare error — proving the password-verification proxy correctly
+	// surfaces MFAEnabled even under storage.type: remote.
+	_, loginUser, err := downstreamCore.Login(ctx, &core.LoginRequest{Username: "mfauser", Password: mfaPassword})
+	require.ErrorIs(t, err, core.ErrMFARequired)
+	require.NotNil(t, loginUser)
+	assert.True(t, loginUser.MFAEnabled)
+
+	// Second-factor step: issue a challenge via the (#509) proxy.
+	challenge, err := downstreamCore.CreateMFAChallenge(ctx, loginUser.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, challenge)
+
+	// A wrong code must fail through the proxied path exactly like it always
+	// has — the credential check itself rejects it before ever reaching session
+	// minting.
+	_, _, err = downstreamCore.VerifyMFALogin(ctx, challenge, "000000", "test-agent", "203.0.113.1")
+	require.Error(t, err)
+	assert.Equal(t, "invalid code", err.Error())
+
+	// The CORRECT code now gets PAST the credential check (the #509 fix) —
+	// proceeding to mintSession, which fails on a DIFFERENT, session-specific
+	// error (the same pre-existing session-persistence gap #506's own test
+	// documents, #508), not the generic "invalid code" every failure reason
+	// collapsed to before this fix. A fresh challenge is required: the previous
+	// one was consumed above.
+	challenge2, err := downstreamCore.CreateMFAChallenge(ctx, loginUser.ID)
+	require.NoError(t, err)
+	correctCode, err := totp.GenerateCode(totpSecret, time.Now())
+	require.NoError(t, err)
+	_, _, err = downstreamCore.VerifyMFALogin(ctx, challenge2, correctCode, "test-agent", "203.0.113.1")
+	require.Error(t, err, "session persistence is a separate, unimplemented gap (#508) — "+
+		"but the error must no longer be the generic credential-check failure")
+	assert.NotEqual(t, "invalid code", err.Error(),
+		"a CORRECT TOTP code must be distinguishable from a wrong one: it should fail at session "+
+			"minting, not at the credential check the #509 fix targets")
+	assert.Contains(t, err.Error(), "session", "expected a session-persistence failure, not a credential-check failure")
+
+	// --- lockout: repeated wrong codes via THIS proxied path must trip the SAME
+	// per-account lockout the direct path enforces (MaxAttempts=2 above),
+	// proving it is not a parallel, unprotected credential check — #509's
+	// primary security concern. Verified directly against the upstream's own
+	// (LocalStorage-backed) user record, since VerifyMFALogin's return error
+	// alone can't distinguish "wrong code" from "locked" through this proxy
+	// (deliberate, mirroring #506's collapse).
+	ch1, err := downstreamCore.CreateMFAChallenge(ctx, loginUser.ID)
+	require.NoError(t, err)
+	_, _, err = downstreamCore.VerifyMFALogin(ctx, ch1, "111111", "test-agent", "203.0.113.1")
+	require.Error(t, err)
+
+	ch2, err := downstreamCore.CreateMFAChallenge(ctx, loginUser.ID)
+	require.NoError(t, err)
+	_, _, err = downstreamCore.VerifyMFALogin(ctx, ch2, "222222", "test-agent", "203.0.113.1")
+	require.Error(t, err)
+
+	locked, err := upstreamCore.GetUser(ctx, mfaUser.ID)
+	require.NoError(t, err)
+	require.NotNil(t, locked.LoginLockedUntil, "the account must be locked upstream after "+
+		"MaxAttempts failed second-factor attempts reached via the proxied path, exactly like "+
+		"the direct LocalStorage path")
+	assert.True(t, locked.LoginLockedUntil.After(time.Now()))
+
+	// While locked, even a fresh challenge + the CORRECT code must be refused —
+	// proxied through the identical path.
+	ch3, err := downstreamCore.CreateMFAChallenge(ctx, loginUser.ID)
+	require.NoError(t, err)
+	lockedCode, lerr := totp.GenerateCode(totpSecret, time.Now())
+	require.NoError(t, lerr)
+	_, _, err = downstreamCore.VerifyMFALogin(ctx, ch3, lockedCode, "test-agent", "203.0.113.1")
+	require.Error(t, err)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -606,6 +606,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// deliberately not a new, separately-provisioned permission. Static path,
 			// before /{id}.
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/verify-credentials", handlers.VerifyCredentials)
+			// VerifyMFACredentials (#509) — the upstream half of the storage.type:
+			// remote second-factor login proxy (internal/core/mfa.go's
+			// RemoteMFAVerifier): checks a plaintext TOTP/recovery code against the
+			// real, decrypted TOTP secret this server holds and returns only a
+			// verdict, never the secret. Same gate and reasoning as
+			// verify-credentials above. Static path, before /{id}.
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/verify-mfa", handlers.VerifyMFACredentials)
 			r.Get("/{id}", handlers.GetUser)
 			// Mutations need users.write, not the group-wide users.read (which the
 			// read-only system_auditor persona holds) — these were the missed
@@ -617,6 +624,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("users.delete")).Delete("/{id}", handlers.DeleteUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/restore", handlers.RestoreUser)
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/unlock", handlers.UnlockUser)
+			// IssueMFAChallenge (#509) — the upstream half of the storage.type: remote
+			// second-factor login proxy (internal/core/mfa.go's RemoteMFAVerifier):
+			// mints and persists the short-lived, single-use MFA challenge on this
+			// (the hub's) LocalStorage on behalf of a RemoteStorage-backed "spoke"
+			// deployment, which has nowhere of its own to persist one. Same gate and
+			// reasoning as verify-credentials/verify-mfa above.
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/mfa-challenge", handlers.IssueMFAChallenge)
 			// Admin force-logout: revoke all of a user's sessions (no state change).
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/revoke-sessions", handlers.RevokeSessions)
 			// Account state transitions (ADR-025).


### PR DESCRIPTION
## Summary

Fixes backlog finding #509 (MEDIUM) for the TOTP/MFA half: MFA/WebAuthn login was completely unsupported under `storage.type: remote`. A password-only account could authenticate through round 115's #506 proxy, but any MFA-enabled account couldn't complete login at all.

## Design

Mirrors #506's established proxy-verification pattern exactly:
- `internal/core/mfa.go`: added `RemoteMFAVerifier` interface (`IssueMFAChallenge`, `VerifyMFALoginCredentials`); extracted `VerifyMFACredentials` (challenge consume + TOTP/recovery-code check + lockout/account-state, no session mint) out of `VerifyMFALogin`, mirroring the `VerifyPasswordCredentials`/`Login` split #506 established. Both `CreateMFAChallenge` and `VerifyMFALogin` delegate entirely to `RemoteStorage` when present.
- `internal/storage/store/remote_mfa.go`: `RemoteStorage` now implements `IssueMFAChallenge` (proxies to `POST /api/v1/users/{id}/mfa-challenge`) and `VerifyMFALoginCredentials` (proxies to `POST /api/v1/users/verify-mfa`), sending the plaintext TOTP/recovery code — never the secret — and collapsing every failure to a generic "invalid code", matching #506's oracle-avoidance pattern.
- New upstream handlers/routes gated by the same `users.write` permission `verify-credentials`/`CreateUser`/`UnlockUser` already require — not a new trust boundary (a challenge alone grants nothing without the correct code).

## What remains out of scope: WebAuthn

Investigated honestly rather than assuming symmetry with TOTP. WebAuthn's assertion ceremony binds to the RP's own `RPID`/`RPOrigins` (per-server config, independent of storage backend). Since the credential's public key and ceremony session state are not secret (unlike a TOTP seed or password hash), verification can actually run locally on the spoke — making WebAuthn a CRUD/wire-DTO problem (proxying `WebAuthnCredential`/`WebAuthnSession` CRUD, plus safe concurrent signature-counter update semantics currently done via `LockWebAuthnCredentialForUpdate` + `WithTransaction`, nontrivial over stateless HTTP) rather than a verification-proxy problem like TOTP — a distinct, larger design effort left for a follow-up finding.

## Testing

`server/http/remote_storage_mfa_login_test.go`: real upstream `NewRouter` + downstream `KeyorixCore` backed by `RemoteStorage`, proving password step correctly surfaces `ErrMFARequired`, wrong TOTP code fails with a generic message, correct TOTP code passes verification (failing only at the pre-existing, unrelated #508 session-persistence gap — same as #506's own test before that was fixed separately), and repeated failures trip the same per-account lockout.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/core/... ./server/http/... ./internal/storage/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./...` — 0 issues
- `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)