### PR TITLE
fix(remote-storage): implement SetupToken CRUD (#510)

### DIFF
--- a/internal/storage/store/remote_auth.go
+++ b/internal/storage/store/remote_auth.go
@@ -159,29 +159,221 @@ func (rs *RemoteStorage) TouchPersonalAccessToken(_ context.Context, _ uint, _ t
 	return nil // best-effort; no-op on remote storage
 }
 
-// Setup Token Management (ADR-028) — credential delivery is a server-side concern;
-// a remote CLI client does not mint or consume setup tokens.
-
-func (rs *RemoteStorage) CreateSetupToken(_ context.Context, _ *models.SetupToken) (*models.SetupToken, error) {
-	return nil, errUnsupportedRemote
+// Setup Token Management (ADR-028, #510).
+//
+// A remote CLI client does not mint or consume setup tokens — but a DOWNSTREAM
+// Keyorix SERVER booted with storage.type: remote (ADR-049) does: its own
+// core.KeyorixCore issues and consumes setup tokens against ITS storage backend,
+// which happens to be this RemoteStorage. Before #510 every method here was a hard
+// stub, so CompleteSetup's very first step (inspectActiveSetupToken →
+// GetSetupTokenByHash) failed unconditionally under storage.type: remote for EVERY
+// setup-token purpose (account_setup, password_reset_link, invitation_accept), not
+// just invitations.
+//
+// These are thin passthroughs onto six new routes under
+// /api/v1/system/setup-tokens (server/http/handlers/setup_tokens_proxy.go),
+// following the EXACT #507 pattern (remote_invitations.go): gated on the same
+// broad system.read/system.write RBAC tier a RemoteStorage credential already
+// needs for every other proxied call — no new privilege class — and making NO
+// setup-token POLICY decision server-side (purpose validation, TTL, which
+// transitions are legal). That all stays in the CALLING server's own
+// internal/core.KeyorixCore (setup_token.go/setup_consume.go), exactly as it does
+// against a local backend.
+//
+// Critically, MarkSetupTokenConsumed proxies onto local_auth.go's OWN
+// `WHERE id = ? AND state = 'active'` conditional UPDATE — the single-use-consume
+// guarantee consumeInspectedToken (setup_token.go) depends on to reject a
+// concurrent replay. One HTTP round trip maps to one atomic server-side
+// conditional UPDATE, not a client-side "GET, check state, then mark" sequence,
+// which would reopen exactly that TOCTOU race.
+func (rs *RemoteStorage) CreateSetupToken(ctx context.Context, t *models.SetupToken) (*models.SetupToken, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/setup-tokens", newSetupTokenWire(t))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create setup token: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create setup token failed: %s", resp.Error.Error())
+	}
+	return decodeSetupTokenResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) GetSetupTokenByHash(_ context.Context, _ string) (*models.SetupToken, error) {
-	return nil, errUnsupportedRemote
+// GetSetupTokenByHash is the consumption lookup (indexed equality on token_hash) via
+// GET /api/v1/system/setup-tokens/by-hash/{hash}. The hash is a SHA-256 hex digest,
+// never the raw plaintext token, and is path-escaped defensively like GetSession's
+// bearer token above.
+func (rs *RemoteStorage) GetSetupTokenByHash(ctx context.Context, hash string) (*models.SetupToken, error) {
+	path := fmt.Sprintf("/api/v1/system/setup-tokens/by-hash/%s", url.PathEscape(hash))
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get setup token: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get setup token failed: %s", resp.Error.Error())
+	}
+	return decodeSetupTokenResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) SupersedeActiveSetupTokens(_ context.Context, _, _ string) error {
-	return errUnsupportedRemote
+// SupersedeActiveSetupTokens flips every active token for (purpose, email) to
+// superseded via POST /api/v1/system/setup-tokens/supersede, preserving
+// local_auth.go's exact semantics: a reissue kills the prior link atomically.
+func (rs *RemoteStorage) SupersedeActiveSetupTokens(ctx context.Context, purpose, email string) error {
+	body := struct {
+		Purpose      string `json:"purpose"`
+		SubjectEmail string `json:"subject_email"`
+	}{Purpose: purpose, SubjectEmail: email}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/setup-tokens/supersede", body)
+	if err != nil {
+		return fmt.Errorf("failed to supersede setup tokens: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("supersede setup tokens failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) MarkSetupTokenConsumed(_ context.Context, _ uint, _ time.Time) (bool, error) {
-	return false, errUnsupportedRemote
+// MarkSetupTokenConsumed transitions active → consumed only if still active, via
+// POST /api/v1/system/setup-tokens/{id}/consume. See the package doc above: the
+// server performs the SAME conditional `WHERE id = ? AND state = 'active'` write
+// local_auth.go's MarkSetupTokenConsumed does and reports whether it actually
+// matched a row — the single round trip a concurrent-consume race resolves in.
+func (rs *RemoteStorage) MarkSetupTokenConsumed(ctx context.Context, id uint, consumedAt time.Time) (bool, error) {
+	path := fmt.Sprintf("/api/v1/system/setup-tokens/%d/consume", id)
+	// UTC-normalized for the same reason newSetupTokenWire below normalizes
+	// CreatedAt/ExpiresAt: CountSetupTokensSince's own `since` parameter is
+	// always sent UTC-converted, and SQLite (LocalStorage's backend) compares
+	// these TIMESTAMP columns as plain TEXT, not real chronological values — a
+	// timestamp stored with the calling server's local offset (whatever
+	// core.KeyorixCore.now() happens to return there) would sort incorrectly
+	// against a UTC-formatted comparison threshold. Consistently normalizing
+	// every setup-token timestamp that crosses this wire to UTC keeps every
+	// column's stored representation directly comparable.
+	body := struct {
+		ConsumedAt time.Time `json:"consumed_at"`
+	}{ConsumedAt: consumedAt.UTC()}
+	resp, err := rs.client.Post(ctx, path, body)
+	if err != nil {
+		return false, fmt.Errorf("failed to consume setup token: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("consume setup token failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Consumed bool `json:"consumed"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Consumed, nil
 }
 
-func (rs *RemoteStorage) MarkSetupTokenExpired(_ context.Context, _ uint) error {
-	return errUnsupportedRemote
+// MarkSetupTokenExpired transitions active → expired (lazy expiry on read) via
+// POST /api/v1/system/setup-tokens/{id}/expire.
+func (rs *RemoteStorage) MarkSetupTokenExpired(ctx context.Context, id uint) error {
+	path := fmt.Sprintf("/api/v1/system/setup-tokens/%d/expire", id)
+	resp, err := rs.client.Post(ctx, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to expire setup token: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("expire setup token failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) CountSetupTokensSince(_ context.Context, _, _ string, _ time.Time) (int64, error) {
-	return 0, errUnsupportedRemote
+// CountSetupTokensSince counts tokens minted for (purpose, email) since a cutoff via
+// GET /api/v1/system/setup-tokens/count, backing resend throttling and the daily cap.
+func (rs *RemoteStorage) CountSetupTokensSince(ctx context.Context, purpose, email string, since time.Time) (int64, error) {
+	q := url.Values{}
+	q.Set("purpose", purpose)
+	q.Set("subject_email", email)
+	q.Set("since", since.UTC().Format(time.RFC3339Nano))
+	path := "/api/v1/system/setup-tokens/count?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count setup tokens: %w", err)
+	}
+	if !resp.Success {
+		return 0, fmt.Errorf("count setup tokens failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Count int64 `json:"count"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Count, nil
+}
+
+// setupTokenWire mirrors models.SetupToken's fields exactly (snake_case), used for
+// both the create-request body and every response (create/get), for the same
+// reason invitationWire (remote_invitations.go) does: models.SetupToken is a GORM
+// model with no json tags of its own (besides TokenHash's `json:"-"`, which exists
+// to keep the hash out of any USER-facing response — irrelevant here, since this is
+// an internal system-to-system wire format gated on system.read/system.write, the
+// same tier that already round-trips full user/secret/invitation records).
+type setupTokenWire struct {
+	ID            uint       `json:"id"`
+	TokenHash     string     `json:"token_hash"`
+	Purpose       string     `json:"purpose"`
+	SubjectUserID *uint      `json:"subject_user_id"`
+	SubjectEmail  string     `json:"subject_email"`
+	InvitationID  *uint      `json:"invitation_id"`
+	State         string     `json:"state"`
+	ExpiresAt     time.Time  `json:"expires_at"`
+	CreatedBy     uint       `json:"created_by"`
+	CreatedAt     time.Time  `json:"created_at"`
+	ConsumedAt    *time.Time `json:"consumed_at"`
+}
+
+// newSetupTokenWire builds the CreateSetupToken request body. Every timestamp is
+// UTC-normalized: CountSetupTokensSince's `since` query parameter is always sent
+// UTC-converted (see that method below), and the upstream's LocalStorage backend
+// (SQLite) compares these columns as plain TEXT, not real chronological values —
+// a CreatedAt/ExpiresAt persisted with the calling server's local offset (whatever
+// core.KeyorixCore.now() returns there) would sort incorrectly against a
+// UTC-formatted comparison threshold. Normalizing here keeps every setup-token
+// timestamp that crosses this wire directly, lexicographically comparable.
+func newSetupTokenWire(t *models.SetupToken) setupTokenWire {
+	var consumedAt *time.Time
+	if t.ConsumedAt != nil {
+		utc := t.ConsumedAt.UTC()
+		consumedAt = &utc
+	}
+	return setupTokenWire{
+		ID:            t.ID,
+		TokenHash:     t.TokenHash,
+		Purpose:       t.Purpose,
+		SubjectUserID: t.SubjectUserID,
+		SubjectEmail:  t.SubjectEmail,
+		InvitationID:  t.InvitationID,
+		State:         t.State,
+		ExpiresAt:     t.ExpiresAt.UTC(),
+		CreatedBy:     t.CreatedBy,
+		CreatedAt:     t.CreatedAt.UTC(),
+		ConsumedAt:    consumedAt,
+	}
+}
+
+func (w setupTokenWire) toModel() *models.SetupToken {
+	return &models.SetupToken{
+		ID:            w.ID,
+		TokenHash:     w.TokenHash,
+		Purpose:       w.Purpose,
+		SubjectUserID: w.SubjectUserID,
+		SubjectEmail:  w.SubjectEmail,
+		InvitationID:  w.InvitationID,
+		State:         w.State,
+		ExpiresAt:     w.ExpiresAt,
+		CreatedBy:     w.CreatedBy,
+		CreatedAt:     w.CreatedAt,
+		ConsumedAt:    w.ConsumedAt,
+	}
+}
+
+func decodeSetupTokenResponse(data []byte) (*models.SetupToken, error) {
+	var wire setupTokenWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }

--- a/server/http/handlers/setup_tokens_proxy.go
+++ b/server/http/handlers/setup_tokens_proxy.go
@@ -1,0 +1,246 @@
+// setup_tokens_proxy.go — server-side endpoints backing RemoteStorage's
+// CreateSetupToken/GetSetupTokenByHash/SupersedeActiveSetupTokens/
+// MarkSetupTokenConsumed/MarkSetupTokenExpired/CountSetupTokensSince (#510).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// its setup-token storage calls to whichever upstream server it's configured
+// against, through these six routes (registered in server/http/router.go under
+// /api/v1/system/setup-tokens, gated on the existing system.read/system.write RBAC
+// permissions — the SAME credential a RemoteStorage client already needs for every
+// other proxied call, e.g. full user CRUD and the #507 invitations proxy, so this
+// introduces no new privilege class). This mirrors invitations_proxy.go exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/setup_token.go and setup_consume.go already use against a local
+// backend — no setup-token POLICY decision (purpose validation, TTL computation,
+// which transitions are legal) is made here; that stays entirely in the CALLING
+// server's own internal/core.KeyorixCore. Crucially, ConsumeSetupTokenProxy calls
+// storage.MarkSetupTokenConsumed directly, so it inherits local_auth.go's
+// conditional `WHERE id = ? AND state = 'active'` write verbatim — the
+// single-use-consume race guarantee consumeInspectedToken (setup_token.go) depends
+// on survives this HTTP hop unchanged; there is no separate "check active, then
+// write" sequence here to reintroduce that TOCTOU.
+//
+// Response envelope: like invitations_proxy.go/login_attempts_proxy.go, these do
+// NOT use the package's generic sendSuccess/sendError helpers — they construct the
+// exact {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// setupTokenProxyWire mirrors models.SetupToken's fields exactly (snake_case) — the
+// wire shape internal/storage/store/remote_auth.go's setupTokenWire sends/expects.
+// See that type's comment for why every field is named explicitly rather than
+// relying on encoding/json's case-insensitive fallback (models.SetupToken carries
+// no json tags of its own besides TokenHash's `json:"-"`, which exists to keep the
+// hash out of USER-facing responses — irrelevant here, since this is an internal
+// system-to-system wire format gated on system.read/system.write).
+type setupTokenProxyWire struct {
+	ID            uint       `json:"id"`
+	TokenHash     string     `json:"token_hash"`
+	Purpose       string     `json:"purpose"`
+	SubjectUserID *uint      `json:"subject_user_id"`
+	SubjectEmail  string     `json:"subject_email"`
+	InvitationID  *uint      `json:"invitation_id"`
+	State         string     `json:"state"`
+	ExpiresAt     time.Time  `json:"expires_at"`
+	CreatedBy     uint       `json:"created_by"`
+	CreatedAt     time.Time  `json:"created_at"`
+	ConsumedAt    *time.Time `json:"consumed_at"`
+}
+
+func newSetupTokenProxyWire(t *models.SetupToken) setupTokenProxyWire {
+	return setupTokenProxyWire{
+		ID:            t.ID,
+		TokenHash:     t.TokenHash,
+		Purpose:       t.Purpose,
+		SubjectUserID: t.SubjectUserID,
+		SubjectEmail:  t.SubjectEmail,
+		InvitationID:  t.InvitationID,
+		State:         t.State,
+		ExpiresAt:     t.ExpiresAt,
+		CreatedBy:     t.CreatedBy,
+		CreatedAt:     t.CreatedAt,
+		ConsumedAt:    t.ConsumedAt,
+	}
+}
+
+func (w setupTokenProxyWire) toModel() *models.SetupToken {
+	return &models.SetupToken{
+		ID:            w.ID,
+		TokenHash:     w.TokenHash,
+		Purpose:       w.Purpose,
+		SubjectUserID: w.SubjectUserID,
+		SubjectEmail:  w.SubjectEmail,
+		InvitationID:  w.InvitationID,
+		State:         w.State,
+		ExpiresAt:     w.ExpiresAt,
+		CreatedBy:     w.CreatedBy,
+		CreatedAt:     w.CreatedAt,
+		ConsumedAt:    w.ConsumedAt,
+	}
+}
+
+// CreateSetupTokenProxy handles POST /api/v1/system/setup-tokens. The caller (the
+// downstream server's own core.KeyorixCore.IssueSetupToken) has already computed
+// every field — the hash, purpose, TTL, subject — exactly as it would for
+// LocalStorage; this is a raw persist, no policy decision.
+func (h *AuthHandler) CreateSetupTokenProxy(w http.ResponseWriter, r *http.Request) {
+	var body setupTokenProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.TokenHash == "" || body.Purpose == "" || body.SubjectEmail == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "token_hash, purpose, and subject_email are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateSetupToken(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("setup-tokens proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newSetupTokenProxyWire(created))
+}
+
+// GetSetupTokenByHashProxy handles GET /api/v1/system/setup-tokens/by-hash/{hash} —
+// the consumption lookup, keyed on the SHA-256 hex digest, never the raw plaintext
+// token.
+func (h *AuthHandler) GetSetupTokenByHashProxy(w http.ResponseWriter, r *http.Request) {
+	hash := chi.URLParam(r, "hash")
+	if hash == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "hash is required")
+		return
+	}
+	tok, err := h.coreService.Storage().GetSetupTokenByHash(r.Context(), hash)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "setup token not found")
+			return
+		}
+		log.Printf("setup-tokens proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newSetupTokenProxyWire(tok))
+}
+
+// setupTokenSupersedeBody is the wire body for POST
+// /api/v1/system/setup-tokens/supersede.
+type setupTokenSupersedeBody struct {
+	Purpose      string `json:"purpose"`
+	SubjectEmail string `json:"subject_email"`
+}
+
+// SupersedeSetupTokensProxy handles POST /api/v1/system/setup-tokens/supersede. It
+// performs the SAME `WHERE purpose = ? AND subject_email = ? AND state = 'active'`
+// bulk UPDATE local_auth.go's own SupersedeActiveSetupTokens does — a reissue kills
+// every prior active link for the same (purpose, email) atomically.
+func (h *AuthHandler) SupersedeSetupTokensProxy(w http.ResponseWriter, r *http.Request) {
+	var body setupTokenSupersedeBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Purpose == "" || body.SubjectEmail == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "purpose and subject_email are required")
+		return
+	}
+	if err := h.coreService.Storage().SupersedeActiveSetupTokens(r.Context(), body.Purpose, body.SubjectEmail); err != nil {
+		log.Printf("setup-tokens proxy: supersede failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"superseded": true})
+}
+
+// setupTokenConsumeBody is the wire body for POST
+// /api/v1/system/setup-tokens/{id}/consume.
+type setupTokenConsumeBody struct {
+	ConsumedAt time.Time `json:"consumed_at"`
+}
+
+// ConsumeSetupTokenProxy handles POST /api/v1/system/setup-tokens/{id}/consume. It
+// performs the SAME conditional `WHERE id = ? AND state = 'active'` write
+// LocalStorage's own MarkSetupTokenConsumed does (h.coreService.Storage() reaches
+// the identical storage.Storage primitive this server's local /auth/setup/consume
+// path uses), returning whether it actually matched a still-active row — the single
+// round trip a concurrent-consume race resolves in. This is the single-use-consume
+// guarantee: two concurrent consume requests racing on the same token must result
+// in exactly one success, both locally and now across this HTTP hop.
+func (h *AuthHandler) ConsumeSetupTokenProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid setup token ID")
+		return
+	}
+	var body setupTokenConsumeBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.ConsumedAt.IsZero() {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "consumed_at is required")
+		return
+	}
+	consumed, err := h.coreService.Storage().MarkSetupTokenConsumed(r.Context(), uint(id), body.ConsumedAt)
+	if err != nil {
+		log.Printf("setup-tokens proxy: consume failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"consumed": consumed})
+}
+
+// ExpireSetupTokenProxy handles POST /api/v1/system/setup-tokens/{id}/expire (lazy
+// expiry on read, mirroring local_auth.go's MarkSetupTokenExpired).
+func (h *AuthHandler) ExpireSetupTokenProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid setup token ID")
+		return
+	}
+	if err := h.coreService.Storage().MarkSetupTokenExpired(r.Context(), uint(id)); err != nil {
+		log.Printf("setup-tokens proxy: expire failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"expired": true})
+}
+
+// CountSetupTokensSinceProxy handles GET
+// /api/v1/system/setup-tokens/count?purpose=X&subject_email=Y&since=RFC3339,
+// backing resend throttling and the daily cap.
+func (h *AuthHandler) CountSetupTokensSinceProxy(w http.ResponseWriter, r *http.Request) {
+	purpose := r.URL.Query().Get("purpose")
+	email := r.URL.Query().Get("subject_email")
+	sinceStr := r.URL.Query().Get("since")
+	if purpose == "" || email == "" || sinceStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "purpose, subject_email, and since query parameters are required")
+		return
+	}
+	since, err := time.Parse(time.RFC3339Nano, sinceStr)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "since must be an RFC3339 timestamp")
+		return
+	}
+	n, err := h.coreService.Storage().CountSetupTokensSince(r.Context(), purpose, email, since)
+	if err != nil {
+		log.Printf("setup-tokens proxy: count failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int64{"count": n})
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -75,6 +75,9 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		// #507: the invitation-proxy end-to-end tests exercise ProjectInvitation
 		// CRUD through the real router.
 		&models.ProjectInvitation{},
+		// #510: the setup-token-proxy end-to-end tests exercise SetupToken CRUD
+		// through the real router.
+		&models.SetupToken{},
 	)
 	require.NoError(t, err)
 	return core.NewKeyorixCore(store.NewLocalStorage(db))

--- a/server/http/remote_storage_setup_tokens_test.go
+++ b/server/http/remote_storage_setup_tokens_test.go
@@ -1,0 +1,346 @@
+// remote_storage_setup_tokens_test.go — end-to-end coverage for #510: RemoteStorage's
+// SetupToken CRUD (CreateSetupToken/GetSetupTokenByHash/SupersedeActiveSetupTokens/
+// MarkSetupTokenConsumed/MarkSetupTokenExpired/CountSetupTokensSince) was entirely
+// stubbed, so CompleteSetup's very first step (inspectActiveSetupToken) hard-failed
+// under storage.type: remote for EVERY setup-token purpose (account_setup,
+// password_reset_link, invitation_accept) — not just invitations. Mirrors
+// remote_storage_invitations_test.go's #507 harness exactly: a real "upstream"
+// exercised through the production NewRouter/handlers (including the new
+// /api/v1/system/setup-tokens routes, server/http/handlers/setup_tokens_proxy.go),
+// and a "downstream" *core.KeyorixCore configured with storage.type: remote pointed
+// at "upstream" over real HTTP via store.RemoteStorage.
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForSetupTokens builds the standard #452/#507/#510
+// two-server harness: an "upstream" exercised through the REAL production
+// NewRouter/handlers, and a "downstream" *core.KeyorixCore configured with
+// storage.type: remote (ADR-049), pointed at "upstream" over real HTTP via
+// store.RemoteStorage.
+func newUpstreamDownstreamForSetupTokens(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	return upstream, downstream
+}
+
+// buildActiveSetupToken mirrors what internal/core/setup_token.go's IssueSetupToken
+// computes before calling storage.CreateSetupToken — a fully-built, active token
+// with a 24h TTL — WITHOUT going through IssueSetupToken itself, so the
+// storage-primitive tests below can exercise CreateSetupToken/GetSetupTokenByHash/
+// MarkSetupTokenConsumed directly, independent of the higher-level core API.
+func buildActiveSetupToken(now time.Time, tokenHash, purpose, email string) *models.SetupToken {
+	return &models.SetupToken{
+		TokenHash:    tokenHash,
+		Purpose:      purpose,
+		SubjectEmail: email,
+		State:        core.SetupTokenActive,
+		ExpiresAt:    now.Add(24 * time.Hour),
+		CreatedAt:    now,
+	}
+}
+
+// TestRemoteStorageSetupToken_CreateGetConsume_RealServer proves the #510 fix for
+// CreateSetupToken/GetSetupTokenByHash/MarkSetupTokenConsumed: a setup token is
+// genuinely persisted on the upstream server via the DOWNSTREAM's RemoteStorage,
+// fetchable by hash, single-use-consumable, and a replay cleanly loses — all via
+// storage.type: remote against a real router, not a protocol mock.
+func TestRemoteStorageSetupToken_CreateGetConsume_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForSetupTokens(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	tok, err := downstream.Storage().CreateSetupToken(ctx,
+		buildActiveSetupToken(now, "hash-create-get-consume", core.SetupPurposeAccountSetup, "newuser@example.com"))
+	require.NoError(t, err, "creating a setup token must succeed via storage.type: remote")
+	require.NotZero(t, tok.ID, "the upstream must assign a real ID")
+	assert.Equal(t, core.SetupPurposeAccountSetup, tok.Purpose)
+	assert.Equal(t, "newuser@example.com", tok.SubjectEmail)
+	assert.Equal(t, core.SetupTokenActive, tok.State)
+	assert.WithinDuration(t, now.Add(24*time.Hour), tok.ExpiresAt, time.Second)
+
+	// Confirm it is a REAL row in the upstream's own storage (not just "the call
+	// didn't error"), by reading it back directly against upstream.
+	direct, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-create-get-consume")
+	require.NoError(t, err)
+	assert.Equal(t, tok.ID, direct.ID)
+
+	// GetSetupTokenByHash via the downstream (RemoteStorage) round-trips every field.
+	fetched, err := downstream.Storage().GetSetupTokenByHash(ctx, "hash-create-get-consume")
+	require.NoError(t, err)
+	assert.Equal(t, tok.ID, fetched.ID)
+	assert.Equal(t, tok.Purpose, fetched.Purpose)
+	assert.Equal(t, tok.SubjectEmail, fetched.SubjectEmail)
+	assert.Equal(t, core.SetupTokenActive, fetched.State)
+
+	// Consuming an active token via the downstream must succeed exactly once.
+	consumedAt := time.Now()
+	ok, err := downstream.Storage().MarkSetupTokenConsumed(ctx, tok.ID, consumedAt)
+	require.NoError(t, err)
+	assert.True(t, ok, "consuming an active token must succeed")
+
+	// The upstream's own storage must show the real state transition.
+	final, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-create-get-consume")
+	require.NoError(t, err)
+	assert.Equal(t, core.SetupTokenConsumed, final.State)
+	require.NotNil(t, final.ConsumedAt)
+
+	// A second consume attempt against the now-consumed token must cleanly report
+	// false (not an error, not a silent double success) — the single-use guarantee.
+	ok, err = downstream.Storage().MarkSetupTokenConsumed(ctx, tok.ID, time.Now())
+	require.NoError(t, err)
+	assert.False(t, ok, "consuming an already-consumed token must not report success")
+}
+
+// TestRemoteStorageSetupToken_GetByHashNotFound_RealServer proves a clean not-found
+// error (not a panic, not a garbage 500) for an unknown hash.
+func TestRemoteStorageSetupToken_GetByHashNotFound_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForSetupTokens(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetSetupTokenByHash(ctx, "nonexistent-hash-does-not-exist")
+	require.Error(t, err)
+}
+
+// TestRemoteStorageSetupToken_Supersede_RealServer proves SupersedeActiveSetupTokens
+// flips every active token for (purpose, email) to superseded — the atomic
+// "resend kills the old link" guarantee IssueSetupToken relies on.
+func TestRemoteStorageSetupToken_Supersede_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForSetupTokens(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	_, err := downstream.Storage().CreateSetupToken(ctx,
+		buildActiveSetupToken(now, "hash-supersede-1", core.SetupPurposePasswordResetLink, "reset@example.com"))
+	require.NoError(t, err)
+	_, err = downstream.Storage().CreateSetupToken(ctx,
+		buildActiveSetupToken(now, "hash-supersede-2", core.SetupPurposePasswordResetLink, "reset@example.com"))
+	require.NoError(t, err)
+	// A different email must NOT be affected.
+	_, err = downstream.Storage().CreateSetupToken(ctx,
+		buildActiveSetupToken(now, "hash-supersede-other", core.SetupPurposePasswordResetLink, "other@example.com"))
+	require.NoError(t, err)
+
+	require.NoError(t, downstream.Storage().SupersedeActiveSetupTokens(ctx, core.SetupPurposePasswordResetLink, "reset@example.com"))
+
+	s1, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-supersede-1")
+	require.NoError(t, err)
+	assert.Equal(t, core.SetupTokenSuperseded, s1.State)
+
+	s2, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-supersede-2")
+	require.NoError(t, err)
+	assert.Equal(t, core.SetupTokenSuperseded, s2.State)
+
+	other, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-supersede-other")
+	require.NoError(t, err)
+	assert.Equal(t, core.SetupTokenActive, other.State, "a different subject's active token must be untouched")
+}
+
+// TestRemoteStorageSetupToken_Expire_RealServer proves MarkSetupTokenExpired's
+// lazy-expiry transition round-trips over storage.type: remote.
+func TestRemoteStorageSetupToken_Expire_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForSetupTokens(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	tok, err := downstream.Storage().CreateSetupToken(ctx,
+		buildActiveSetupToken(now, "hash-expire", core.SetupPurposeAccountSetup, "expire@example.com"))
+	require.NoError(t, err)
+
+	require.NoError(t, downstream.Storage().MarkSetupTokenExpired(ctx, tok.ID))
+
+	final, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-expire")
+	require.NoError(t, err)
+	assert.Equal(t, core.SetupTokenExpired, final.State)
+}
+
+// TestRemoteStorageSetupToken_CountSince_RealServer proves CountSetupTokensSince
+// backs resend throttling/the daily cap correctly over storage.type: remote.
+func TestRemoteStorageSetupToken_CountSince_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForSetupTokens(t)
+	ctx := context.Background()
+	now := time.Now()
+	since := now.Add(-time.Hour)
+
+	_, err := downstream.Storage().CreateSetupToken(ctx,
+		buildActiveSetupToken(now, "hash-count-1", core.SetupPurposeAccountSetup, "count@example.com"))
+	require.NoError(t, err)
+	_, err = downstream.Storage().CreateSetupToken(ctx,
+		buildActiveSetupToken(now, "hash-count-2", core.SetupPurposeAccountSetup, "count@example.com"))
+	require.NoError(t, err)
+	// A different purpose must not be counted.
+	_, err = downstream.Storage().CreateSetupToken(ctx,
+		buildActiveSetupToken(now, "hash-count-other-purpose", core.SetupPurposePasswordResetLink, "count@example.com"))
+	require.NoError(t, err)
+
+	n, err := downstream.Storage().CountSetupTokensSince(ctx, core.SetupPurposeAccountSetup, "count@example.com", since)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+
+	// Before any token existed, the count from a future cutoff must be zero.
+	n, err = downstream.Storage().CountSetupTokensSince(ctx, core.SetupPurposeAccountSetup, "count@example.com", now.Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}
+
+// TestRemoteStorageSetupToken_ConcurrentConsumeRace_RealServer is the critical #510
+// test: it fires N concurrent "consume" requests at the SAME active setup token
+// over real HTTP against the real upstream router, and asserts EXACTLY ONE
+// succeeds — proving ConsumeSetupTokenProxy's conditional
+// `WHERE id = ? AND state = 'active'` write (local_auth.go, proxied unchanged by
+// server/http/handlers/setup_tokens_proxy.go) still closes the double-consume
+// TOCTOU race consumeInspectedToken (setup_token.go) depends on, even across a
+// network hop — not a client-side "GET, check state, then mark" sequence, which
+// would reopen exactly this race. Mirrors #507's
+// TestRemoteStorageInvitation_ConcurrentAcceptRace_RealServer exactly.
+func TestRemoteStorageSetupToken_ConcurrentConsumeRace_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForSetupTokens(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	tok, err := downstream.Storage().CreateSetupToken(ctx,
+		buildActiveSetupToken(now, "hash-race", core.SetupPurposeAccountSetup, "race@example.com"))
+	require.NoError(t, err)
+
+	const n = 20
+	var successCount atomic.Int64
+	var errCount atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			ok, err := downstream.Storage().MarkSetupTokenConsumed(ctx, tok.ID, time.Now())
+			if err != nil {
+				errCount.Add(1)
+				return
+			}
+			if ok {
+				successCount.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(0), errCount.Load(), "every concurrent consume attempt must get a clean result, not a transport/server error")
+	assert.Equal(t, int64(1), successCount.Load(), "exactly one concurrent consume must win the race — the rest must cleanly lose, never a double consume")
+
+	final, err := downstream.Storage().GetSetupTokenByHash(ctx, "hash-race")
+	require.NoError(t, err)
+	assert.Equal(t, core.SetupTokenConsumed, final.State)
+}
+
+// TestRemoteStorageSetupToken_CompleteSetupEndToEnd_RealServer is the actual
+// user-facing flow #510 fixed: core.KeyorixCore.CompleteSetup, called against a
+// DOWNSTREAM core backed entirely by storage.type: remote. Before this fix,
+// CompleteSetup's very first step (inspectActiveSetupToken → GetSetupTokenByHash)
+// hard-failed with "invalid setup token" for EVERY purpose, unconditionally.
+//
+// This proves inspectActiveSetupToken (GetSetupTokenByHash) and
+// consumeInspectedToken (MarkSetupTokenConsumed) — the two #510 storage
+// primitives on this call path — both now genuinely work end-to-end: CompleteSetup
+// proceeds past both and only then fails at applyNewPassword's SetPasswordHash — a
+// SEPARATE, pre-existing, deliberately-hard-failing gap (#484, documented in
+// remote_users.go: password_hash is tagged json:"-" on models.User and can never
+// cross RemoteStorage's wire format at all, so it fails loud rather than silently
+// no-op). That gap is out of #510's scope, exactly as #507's test file left
+// GetRoleByName's separate gap (#512) undisturbed. If #510 were still broken, this
+// call would fail immediately at the setup-token lookup instead.
+func TestRemoteStorageSetupToken_CompleteSetupEndToEnd_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForSetupTokens(t)
+	ctx := context.Background()
+
+	// A password_reset_link token acts on an EXISTING account (unlike account_setup,
+	// which is more naturally paired with the admin-facing deliver_setup_link/
+	// generate_one_time_password CreateUser flags — flags that RemoteStorage's own
+	// CreateUser wire (remote_users.go's userCreateWireRequest) does not carry at
+	// all, an orthogonal gap out of #510's scope), so the subject is created with an
+	// ordinary initial password here, exactly as a real admin-created account would
+	// have one before a self-service reset.
+	user, err := downstream.Storage().CreateUser(ctx, &models.User{
+		Username:    "newhire",
+		Email:       "newhire@example.com",
+		DisplayName: "New Hire",
+		IsActive:    true,
+	}, "Initial#Passw0rd!")
+	require.NoError(t, err, "creating the subject account must succeed via storage.type: remote")
+
+	issued, err := downstream.IssueSetupToken(ctx, core.IssueSetupTokenRequest{
+		Purpose:       core.SetupPurposePasswordResetLink,
+		SubjectEmail:  user.Email,
+		SubjectUserID: &user.ID,
+	})
+	require.NoError(t, err, "issuing a setup token must succeed via storage.type: remote (#510: SupersedeActiveSetupTokens + CreateSetupToken)")
+	require.NotEmpty(t, issued.PlainToken)
+
+	_, err = downstream.CompleteSetup(ctx, issued.PlainToken, "Str0ngP@ssw0rd123!", "test-agent", "127.0.0.1")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "invalid setup token",
+		"must NOT fail at the #510 setup-token lookup step — that is the bug this fix closes")
+	assert.ErrorIs(t, err, corestorage.ErrUnsupportedByBackend,
+		"must fail at the SEPARATE, already-documented #484 gap (SetPasswordHash), proving inspectActiveSetupToken + consumeInspectedToken both succeeded first")
+
+	// Fail-closed design (setup_token.go's consumeInspectedToken comment): the token
+	// is consumed BEFORE applyNewPassword runs, so even on this later failure it must
+	// already show as genuinely, atomically consumed on the upstream — proving
+	// MarkSetupTokenConsumed's write landed for real, not just "the call didn't error".
+	final, err := upstream.Storage().GetSetupTokenByHash(ctx, issued.Token.TokenHash)
+	require.NoError(t, err)
+	assert.Equal(t, core.SetupTokenConsumed, final.State, "the token must be spent even though the password step failed afterward (fail-closed)")
+}
+
+// TestRemoteStorageSetupToken_CompleteSetupInvalidToken_RealServer proves that an
+// unknown token cleanly fails CompleteSetup via storage.type: remote (the ordinary
+// "bad link" case, not a transport error).
+func TestRemoteStorageSetupToken_CompleteSetupInvalidToken_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForSetupTokens(t)
+	ctx := context.Background()
+
+	_, err := downstream.CompleteSetup(ctx, "kx_setup_totally-bogus-token", "Str0ngP@ssw0rd123!", "test-agent", "127.0.0.1")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, corestorage.ErrUnsupportedByBackend),
+		"an unknown token must fail as 'not found', not be misreported as the unrelated #484 backend gap")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -798,6 +798,29 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/invitations", catalogHandler.ListInvitationsProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/invitations", catalogHandler.CreateInvitationProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Put("/invitations/{id}", catalogHandler.UpdateInvitationProxy)
+
+			// Setup-token storage-primitive proxy (#510). Lets a downstream Keyorix
+			// server booted with storage.type: remote (ADR-049) proxy
+			// CreateSetupToken/GetSetupTokenByHash/SupersedeActiveSetupTokens/
+			// MarkSetupTokenConsumed/MarkSetupTokenExpired/CountSetupTokensSince to
+			// THIS server's real storage backend, instead of RemoteStorage's six
+			// SetupToken methods having no server endpoint to call at all
+			// (setup_consume.go's CompleteSetup — every setup-token purpose:
+			// account_setup, password_reset_link, invitation_accept — was completely
+			// non-functional under storage.type: remote). Exactly the same pattern as
+			// the invitations proxy above: a thin passthrough onto storage.Storage (no
+			// setup-token POLICY decision made here — the calling server's own
+			// core.KeyorixCore still decides that), reusing the SAME
+			// system.read/system.write tier — no new privilege class. Read is baseline
+			// system.read; every mutating operation (including the single-use
+			// consume) requires system.write, matching every other admin-level
+			// mutation in this group.
+			r.Get("/setup-tokens/by-hash/{hash}", authHandler.GetSetupTokenByHashProxy)
+			r.Get("/setup-tokens/count", authHandler.CountSetupTokensSinceProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/setup-tokens", authHandler.CreateSetupTokenProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/setup-tokens/supersede", authHandler.SupersedeSetupTokensProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/setup-tokens/{id}/consume", authHandler.ConsumeSetupTokenProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/setup-tokens/{id}/expire", authHandler.ExpireSetupTokenProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary

Fixes backlog finding #510 (MEDIUM): `RemoteStorage`'s `SetupToken` CRUD (`internal/storage/store/remote_auth.go`) was entirely stubbed, so `CompleteSetup`'s very first step (`inspectActiveSetupToken → GetSetupTokenByHash`) hard-failed under `storage.type: remote` for every setup-token purpose — `account_setup`, `password_reset_link`, and `invitation_accept`, not just invitations.

## Design decisions (atomicity)

Follows #507's exact pattern: six thin passthrough routes under `/api/v1/system/setup-tokens`, gated on the same broad `system.read`/`system.write` tier a RemoteStorage credential already needs elsewhere — no new privilege class, no setup-token policy decision made server-side. Critically, `ConsumeSetupTokenProxy` calls `storage.MarkSetupTokenConsumed` directly, inheriting `local_auth.go`'s `WHERE id = ? AND state = 'active'` conditional UPDATE verbatim — one HTTP round trip maps to one atomic conditional write, not a client-side "GET, check, then mark" sequence that would reopen the double-consume race.

## Bug found and fixed along the way

`CountSetupTokensSince`'s `since` parameter was already UTC-normalized on the wire, but `CreatedAt`/`ExpiresAt`/`ConsumedAt` weren't — SQLite compares these `TEXT` columns lexicographically, so a token created with a non-UTC local offset could sort incorrectly against a UTC-formatted threshold. Fixed by UTC-normalizing every setup-token timestamp sent over the wire.

## Testing

Real end-to-end tests (`server/http/remote_storage_setup_tokens_test.go`, real `NewRouter` + real `RemoteStorage`):
- create/get-by-hash/consume/not-found/supersede/expire/count-since round-trip correctly
- 20 concurrent consume requests against the same token — exactly one succeeds
- the actual user-facing flow through `core.CompleteSetup` itself now works end-to-end for `inspectActiveSetupToken`/`consumeInspectedToken`, failing only afterward at `applyNewPassword`'s `SetPasswordHash` — a separate, pre-existing, already-documented gap (#484), left undisturbed exactly as #507 left `GetRoleByName` (#512) undisturbed.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/storage/... ./internal/core/... ./server/http/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)