### PR TITLE
fix(remote-storage): implement ProjectMembership CRUD passthrough (#511)

### DIFF
--- a/internal/core/invitation_accept_remote_membership_test.go
+++ b/internal/core/invitation_accept_remote_membership_test.go
@@ -1,0 +1,270 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// This file proves the #511 fix for the ACTUAL real-world caller it unblocks:
+// applyInvitationGrants (invitations.go) — not the CreateProjectMembership/
+// GetActiveProjectMembership storage primitives in isolation (already covered,
+// against the real production router/handlers, by
+// server/http/remote_storage_project_memberships_test.go).
+//
+// applyInvitationGrants is unexported, and its only exported entry point
+// (setup_consume.go's CompleteSetup → completeInvitationAccept) additionally
+// requires SetupToken CRUD to resolve the raw token — RemoteStorage's SetupToken
+// methods are ENTIRELY stubbed (#510, a separate, already-filed finding, not
+// #511's to fix). Reaching applyInvitationGrants from outside package core
+// therefore isn't possible today without also closing #510. Matching this
+// package's own established test convention for exercising this exact method
+// (TestApplyInvitationGrants_GlobalInvite, invitation_global_test.go) — a
+// same-package test calling c.applyInvitationGrants directly — this test does
+// the same, but backs ONLY the two storage.Storage methods #511 actually
+// implements (CreateProjectMembership, GetActiveProjectMembership) with a REAL
+// store.RemoteStorage client making REAL HTTP calls against a REAL server, while
+// every other storage.Storage method the call path touches
+// (GetRoleByName, GetProject, LogAuditEvent) stays mocked exactly as
+// TestApplyInvitationGrants_GlobalInvite already does — those are unrelated,
+// separately-filed gaps (#512's missing GetRoleByName route,
+// RemoteStorage.GetProject's blanket "remoteUnsupported" stub), not #511's to
+// fix, and mocking them keeps this test isolated to what #511 actually changed.
+
+// membershipTestWire mirrors internal/storage/store's (unexported) membershipWire
+// and server/http/handlers' (unexported) membershipProxyWire field-for-field —
+// this package can reach neither directly (store's types are unexported; handlers
+// can't be imported here at all without an import cycle, since handlers already
+// imports core) — so the server side of this test's httptest handler is written
+// against an independent copy of the exact same wire contract.
+type membershipTestWire struct {
+	ID          uint       `json:"id"`
+	ProjectID   uint       `json:"project_id"`
+	UserID      uint       `json:"user_id"`
+	Role        string     `json:"role"`
+	State       string     `json:"state"`
+	InvitedBy   uint       `json:"invited_by"`
+	InvitedAt   time.Time  `json:"invited_at"`
+	ActivatedAt *time.Time `json:"activated_at"`
+	RevokedAt   *time.Time `json:"revoked_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+}
+
+func newMembershipTestWire(m *models.ProjectMembership) membershipTestWire {
+	return membershipTestWire{
+		ID: m.ID, ProjectID: m.ProjectID, UserID: m.UserID, Role: m.Role, State: m.State,
+		InvitedBy: m.InvitedBy, InvitedAt: m.InvitedAt, ActivatedAt: m.ActivatedAt,
+		RevokedAt: m.RevokedAt, UpdatedAt: m.UpdatedAt,
+	}
+}
+
+func (w membershipTestWire) toModel() *models.ProjectMembership {
+	return &models.ProjectMembership{
+		ID: w.ID, ProjectID: w.ProjectID, UserID: w.UserID, Role: w.Role, State: w.State,
+		InvitedBy: w.InvitedBy, InvitedAt: w.InvitedAt, ActivatedAt: w.ActivatedAt,
+		RevokedAt: w.RevokedAt, UpdatedAt: w.UpdatedAt,
+	}
+}
+
+type testRemoteAPIResponse struct {
+	Success bool        `json:"success"`
+	Data    interface{} `json:"data,omitempty"`
+	Error   *struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+func writeTestRemoteSuccess(w http.ResponseWriter, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(testRemoteAPIResponse{Success: true, Data: data})
+}
+
+func writeTestRemoteError(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(testRemoteAPIResponse{Success: false, Error: &struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}{Code: code, Message: msg}})
+}
+
+// remoteMembershipStorage wraps MockStorage, delegating ONLY
+// CreateProjectMembership/GetActiveProjectMembership — the two primitives
+// applyInvitationGrants' project-scoped path (inviteMemberWithMode) actually
+// calls — to a real store.RemoteStorage client. Every other storage.Storage
+// method stays on the embedded MockStorage, stubbed per-test exactly as
+// TestApplyInvitationGrants_GlobalInvite already does.
+type remoteMembershipStorage struct {
+	*MockStorage
+	rs *store.RemoteStorage
+}
+
+func (s *remoteMembershipStorage) CreateProjectMembership(ctx context.Context, m *models.ProjectMembership) (*models.ProjectMembership, error) {
+	return s.rs.CreateProjectMembership(ctx, m)
+}
+
+func (s *remoteMembershipStorage) GetActiveProjectMembership(ctx context.Context, projectID, userID uint) (*models.ProjectMembership, error) {
+	return s.rs.GetActiveProjectMembership(ctx, projectID, userID)
+}
+
+// newRemoteMembershipStorage builds a remoteMembershipStorage: a real upstream
+// store.LocalStorage (real SQLite, real DB-level uniq_project_memberships_active
+// partial unique index, #309) served over a real httptest.Server whose handler
+// reproduces server/http/handlers/project_memberships_proxy.go's exact wire
+// contract for POST /api/v1/system/project-memberships and
+// GET /api/v1/system/project-memberships/active — fronted by a real
+// store.RemoteStorage client, so CreateProjectMembership/GetActiveProjectMembership
+// genuinely round-trip over HTTP, not an in-process shortcut.
+func newRemoteMembershipStorage(t *testing.T, mockBase *MockStorage) *remoteMembershipStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.ProjectMembership{}))
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_project_memberships_active "+
+		"ON project_memberships (project_id, user_id) WHERE state <> 'revoked'").Error)
+	upstream := store.NewLocalStorage(db)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/system/project-memberships", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeTestRemoteError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "unsupported method")
+			return
+		}
+		var body membershipTestWire
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeTestRemoteError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+			return
+		}
+		created, err := upstream.CreateProjectMembership(r.Context(), body.toModel())
+		if err != nil {
+			if errors.Is(err, coreStorage.ErrDuplicateActiveMembership) {
+				writeTestRemoteError(w, http.StatusConflict, "DUPLICATE_ACTIVE_MEMBERSHIP", coreStorage.ErrDuplicateActiveMembership.Error())
+				return
+			}
+			writeTestRemoteError(w, http.StatusInternalServerError, "STORAGE_ERROR", err.Error())
+			return
+		}
+		writeTestRemoteSuccess(w, newMembershipTestWire(created))
+	})
+	mux.HandleFunc("/api/v1/system/project-memberships/active", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		var projectID, userID uint
+		_, _ = fmt.Sscanf(q.Get("project_id"), "%d", &projectID)
+		_, _ = fmt.Sscanf(q.Get("user_id"), "%d", &userID)
+		m, err := upstream.GetActiveProjectMembership(r.Context(), projectID, userID)
+		if err != nil {
+			writeTestRemoteError(w, http.StatusNotFound, "NOT_FOUND", "no active membership")
+			return
+		}
+		writeTestRemoteSuccess(w, newMembershipTestWire(m))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: srv.URL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: false,
+	})
+	require.NoError(t, err)
+
+	return &remoteMembershipStorage{MockStorage: mockBase, rs: rs}
+}
+
+// TestApplyInvitationGrants_ProjectScopedInvite_RemoteMembershipStorage is the
+// critical #511 proof: applyInvitationGrants — the REAL, unmodified core method
+// completeInvitationAccept calls on every invitation accept — successfully
+// materializes a project membership when its storage backend's
+// CreateProjectMembership/GetActiveProjectMembership are the real
+// storage.type: remote implementation this PR adds, not
+// ErrRemoteUnsupported. Before this fix, this exact call always failed with
+// "operation not supported in remote (client) mode".
+func TestApplyInvitationGrants_ProjectScopedInvite_RemoteMembershipStorage(t *testing.T) {
+	ms := new(MockStorage)
+	rms := newRemoteMembershipStorage(t, ms)
+
+	ctx := context.Background()
+	const projectID, userID, invitedBy = uint(1), uint(20), uint(9)
+
+	ms.On("GetRoleByName", ctx, "viewer").Return(&models.Role{ID: 6, Name: "viewer"}, nil)
+	ms.On("GetProject", ctx, projectID).Return(&models.Project{ID: projectID, Name: "proj"}, nil)
+	anyAudit(ms)
+
+	fixed := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: rms, now: func() time.Time { return fixed }}
+
+	// Allowlist mode: the membership starts "invited", not "active" — so this
+	// exercises applyInvitationGrants without also needing AddProjectMember's
+	// role-grant side effect (an unrelated, already-working code path).
+	inv := &models.ProjectInvitation{
+		ID: 1, ProjectID: projectID, Email: "invitee@example.com", Role: "viewer",
+		InvitedBy: invitedBy, ValidationModeAtInvite: ValidationModeAllowlist,
+	}
+
+	err := c.applyInvitationGrants(ctx, inv, userID)
+	require.NoError(t, err, "applyInvitationGrants must materialize the membership via storage.type: remote")
+
+	// Confirm the membership genuinely landed on the upstream (over the real
+	// RemoteStorage client, hitting the real HTTP server), not merely that the
+	// call didn't error.
+	m, err := rms.GetActiveProjectMembership(ctx, projectID, userID)
+	require.NoError(t, err)
+	assert.Equal(t, userID, m.UserID)
+	assert.Equal(t, "viewer", m.Role)
+	assert.Equal(t, MembershipInvited, m.State)
+
+	ms.AssertExpectations(t)
+}
+
+// TestApplyInvitationGrants_ProjectScopedInvite_DuplicateMembership proves that
+// a second invitation accept for a user who already has a non-revoked membership
+// in the target project surfaces the SAME clean "already has a membership" error
+// applyInvitationGrants produces against LocalStorage — i.e. the #309
+// duplicate-active-membership guarantee (DB-level unique index +
+// storage.ErrDuplicateActiveMembership sentinel translation, #511) survives the
+// HTTP hop end to end through the real caller, not just the storage primitive.
+func TestApplyInvitationGrants_ProjectScopedInvite_DuplicateMembership(t *testing.T) {
+	ms := new(MockStorage)
+	rms := newRemoteMembershipStorage(t, ms)
+
+	ctx := context.Background()
+	const projectID, userID, invitedBy = uint(1), uint(20), uint(9)
+
+	ms.On("GetRoleByName", ctx, "viewer").Return(&models.Role{ID: 6, Name: "viewer"}, nil)
+	ms.On("GetProject", ctx, projectID).Return(&models.Project{ID: projectID, Name: "proj"}, nil)
+	anyAudit(ms)
+
+	fixed := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: rms, now: func() time.Time { return fixed }}
+
+	inv := &models.ProjectInvitation{
+		ID: 1, ProjectID: projectID, Email: "invitee@example.com", Role: "viewer",
+		InvitedBy: invitedBy, ValidationModeAtInvite: ValidationModeAllowlist,
+	}
+	require.NoError(t, c.applyInvitationGrants(ctx, inv, userID))
+
+	// A second accept for the SAME user/project (e.g. a resent, later-accepted
+	// invitation) must be refused cleanly, not silently produce a second row or
+	// an opaque storage error.
+	inv2 := &models.ProjectInvitation{
+		ID: 2, ProjectID: projectID, Email: "invitee@example.com", Role: "viewer",
+		InvitedBy: invitedBy, ValidationModeAtInvite: ValidationModeAllowlist,
+	}
+	err := c.applyInvitationGrants(ctx, inv2, userID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already has a")
+	assert.Contains(t, err.Error(), "membership in this project")
+}

--- a/internal/storage/store/remote_memberships.go
+++ b/internal/storage/store/remote_memberships.go
@@ -1,45 +1,302 @@
-// remote_memberships.go — project membership lifecycle for RemoteStorage.
+// remote_memberships.go — project membership lifecycle for RemoteStorage (ADR-022).
 //
-// Membership lifecycle is processed server-side in remote mode; these are stubs.
-// For the local (GORM) equivalent see local_memberships.go.
+// #511: CreateProjectMembership/GetProjectMembership/UpdateProjectMembership/
+// ListProjectMemberships/GetActiveProjectMembership/ListStaleInvitedMemberships/
+// ListUserProjectMemberships/CountProjectMembershipsByUsers are thin passthroughs
+// onto eight new server-side routes under /api/v1/system/project-memberships
+// (server/http/handlers/project_memberships_proxy.go), following the SAME pattern
+// #507/#510 established (remote_invitations.go, remote_auth.go): gated on the same
+// broad system.read/system.write RBAC permissions a RemoteStorage credential
+// already needs for every other proxied call, so this introduces no new privilege
+// class. No membership-lifecycle POLICY decision (which state a new invite starts
+// in, which transitions are legal, when a role grant is applied/reverted) is made
+// in these routes — that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore (membership_lifecycle.go), exactly as it does against a
+// local backend.
+//
+// Before this fix, every one of these methods returned ErrRemoteUnsupported, so
+// applyInvitationGrants' membership-materialization step (inviteMemberWithMode →
+// storage.CreateProjectMembership) hard-failed under storage.type: remote even
+// after a successful invitation accept (#507) — the invitation itself would flip to
+// "accepted", but the membership/role grant it's supposed to produce could never be
+// persisted.
+//
+// Atomicity note (mirrors #507's UpdateProjectInvitation reasoning, but the
+// conclusion differs): local_memberships.go's CreateProjectMembership relies on a
+// REAL DB-level partial unique index (uniq_project_memberships_active, #309) to
+// reject a second concurrent active membership for the same (project, user) — that
+// guarantee is a property of the upstream's own database and survives this HTTP hop
+// unchanged, since CreateMembershipProxy calls the identical storage.Storage
+// primitive against the same table. UpdateProjectMembership, by contrast, has NO
+// such conditional-write guarantee even locally — local_memberships.go's
+// implementation is a plain GORM Save, and the state-machine legality check
+// (canTransition) is enforced by the CALLING core.KeyorixCore before it ever calls
+// storage.UpdateProjectMembership (membership_lifecycle.go's TransitionMembership),
+// not by the storage layer itself. So, unlike UpdateProjectInvitation, there is no
+// existing atomic "WHERE state = ?" write to preserve here — a single passthrough
+// PUT that maps directly onto the same plain Save is exact behavioral parity with
+// LocalStorage, not a new race introduced by this file. (A client-side
+// "GET, check state, then PUT" sequence would still be strictly worse than what
+// LocalStorage does today, so this deliberately issues one round trip per call,
+// same as every other method here.)
+//
+// For the local (GORM) equivalent of everything here see local_memberships.go.
 package store
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
 )
 
-func (rs *RemoteStorage) CreateProjectMembership(_ context.Context, _ *models.ProjectMembership) (*models.ProjectMembership, error) {
-	return nil, remoteUnsupported("CreateProjectMembership")
+// membershipWire mirrors models.ProjectMembership's fields exactly (snake_case),
+// used for both the create-request body and every response — there is no
+// models.ProjectMembership json tag to fall back on (a GORM model, like
+// models.User before #496 and models.ProjectInvitation before #507), so a direct
+// marshal/unmarshal would silently drop every field whose wire name isn't
+// case-insensitively identical to its Go name. See remote_users.go's
+// userWireResponse comment for the full explanation.
+type membershipWire struct {
+	ID          uint       `json:"id"`
+	ProjectID   uint       `json:"project_id"`
+	UserID      uint       `json:"user_id"`
+	Role        string     `json:"role"`
+	State       string     `json:"state"`
+	InvitedBy   uint       `json:"invited_by"`
+	InvitedAt   time.Time  `json:"invited_at"`
+	ActivatedAt *time.Time `json:"activated_at"`
+	RevokedAt   *time.Time `json:"revoked_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
-func (rs *RemoteStorage) GetProjectMembership(_ context.Context, _ uint) (*models.ProjectMembership, error) {
-	return nil, remoteUnsupported("GetProjectMembership")
+func newMembershipWire(m *models.ProjectMembership) membershipWire {
+	return membershipWire{
+		ID:          m.ID,
+		ProjectID:   m.ProjectID,
+		UserID:      m.UserID,
+		Role:        m.Role,
+		State:       m.State,
+		InvitedBy:   m.InvitedBy,
+		InvitedAt:   m.InvitedAt,
+		ActivatedAt: m.ActivatedAt,
+		RevokedAt:   m.RevokedAt,
+		UpdatedAt:   m.UpdatedAt,
+	}
 }
 
-func (rs *RemoteStorage) UpdateProjectMembership(_ context.Context, _ *models.ProjectMembership) error {
-	return remoteUnsupported("UpdateProjectMembership")
+func (w membershipWire) toModel() *models.ProjectMembership {
+	return &models.ProjectMembership{
+		ID:          w.ID,
+		ProjectID:   w.ProjectID,
+		UserID:      w.UserID,
+		Role:        w.Role,
+		State:       w.State,
+		InvitedBy:   w.InvitedBy,
+		InvitedAt:   w.InvitedAt,
+		ActivatedAt: w.ActivatedAt,
+		RevokedAt:   w.RevokedAt,
+		UpdatedAt:   w.UpdatedAt,
+	}
 }
 
-func (rs *RemoteStorage) ListProjectMemberships(_ context.Context, _ uint) ([]*models.ProjectMembership, error) {
-	return nil, remoteUnsupported("ListProjectMemberships")
+func decodeMembershipResponse(data []byte) (*models.ProjectMembership, error) {
+	var wire membershipWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }
 
-func (rs *RemoteStorage) GetActiveProjectMembership(_ context.Context, _, _ uint) (*models.ProjectMembership, error) {
-	return nil, remoteUnsupported("GetActiveProjectMembership")
+// duplicateActiveMembershipCode is the machine-readable error code
+// CreateMembershipProxy returns when the upstream's own DB-level unique-index
+// rejection (isUniqueViolation, local_memberships.go) fires — the wire-level
+// signal RemoteStorage.CreateProjectMembership uses to reconstruct the same
+// storage.ErrDuplicateActiveMembership sentinel inviteMemberWithMode's
+// errors.Is check (#309) depends on, so that check-and-translate behavior is
+// preserved across this HTTP hop and not silently downgraded to an opaque
+// "failed to create membership" error.
+const duplicateActiveMembershipCode = "DUPLICATE_ACTIVE_MEMBERSHIP"
+
+// CreateProjectMembership persists an already-built membership row (every field —
+// initial state, InvitedBy/InvitedAt, ...) is computed by the CALLING
+// core.KeyorixCore before this is invoked, exactly as inviteMemberWithMode builds
+// one for LocalStorage) via POST /api/v1/system/project-memberships.
+func (rs *RemoteStorage) CreateProjectMembership(ctx context.Context, m *models.ProjectMembership) (*models.ProjectMembership, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/project-memberships", newMembershipWire(m))
+	if err != nil {
+		// #501: makeRequest turns EVERY 4xx/5xx response (including
+		// CreateMembershipProxy's 409 Conflict) into a non-nil error before
+		// resp is ever populated, so the duplicate-membership signal must be
+		// recovered from the *remote.HTTPError itself (its ErrorType, parsed
+		// from the same {"error":{"code",...}} envelope this package's other
+		// methods check via resp.Error.Code), not from resp.Error — reconstructing
+		// the SAME storage.ErrDuplicateActiveMembership sentinel
+		// inviteMemberWithMode's errors.Is check (#309) depends on, so that
+		// check-and-translate behavior survives this HTTP hop rather than
+		// silently downgrading to an opaque "failed to create membership" error.
+		var httpErr *remote.HTTPError
+		if errors.As(err, &httpErr) && httpErr.ErrorType == duplicateActiveMembershipCode {
+			return nil, fmt.Errorf("%w: %s", storage.ErrDuplicateActiveMembership, httpErr.Message)
+		}
+		return nil, fmt.Errorf("failed to create membership: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create membership failed: %s", resp.Error.Error())
+	}
+	return decodeMembershipResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) ListStaleInvitedMemberships(_ context.Context, _ time.Time) ([]*models.ProjectMembership, error) {
-	return nil, remoteUnsupported("ListStaleInvitedMemberships")
+// GetProjectMembership retrieves a membership by ID via GET
+// /api/v1/system/project-memberships/{id}.
+func (rs *RemoteStorage) GetProjectMembership(ctx context.Context, id uint) (*models.ProjectMembership, error) {
+	path := fmt.Sprintf("/api/v1/system/project-memberships/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get membership: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get membership failed: %s", resp.Error.Error())
+	}
+	return decodeMembershipResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) ListUserProjectMemberships(_ context.Context, _ uint) ([]*models.ProjectMembership, error) {
-	return nil, remoteUnsupported("ListUserProjectMemberships")
+// UpdateProjectMembership persists a membership's current state via PUT
+// /api/v1/system/project-memberships/{id} — a single round trip mapping directly
+// onto local_memberships.go's plain Save (see the package doc: there is no
+// conditional-write guarantee to preserve here, unlike UpdateProjectInvitation).
+func (rs *RemoteStorage) UpdateProjectMembership(ctx context.Context, m *models.ProjectMembership) error {
+	path := fmt.Sprintf("/api/v1/system/project-memberships/%d", m.ID)
+	resp, err := rs.client.Put(ctx, path, newMembershipWire(m))
+	if err != nil {
+		return fmt.Errorf("failed to update membership: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("update membership failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) CountProjectMembershipsByUsers(_ context.Context, _ []uint) (map[uint]storage.MembershipCounts, error) {
-	return nil, remoteUnsupported("CountProjectMembershipsByUsers")
+// ListProjectMemberships lists a project's memberships via GET
+// /api/v1/system/project-memberships?project_id=X.
+func (rs *RemoteStorage) ListProjectMemberships(ctx context.Context, projectID uint) ([]*models.ProjectMembership, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	path := "/api/v1/system/project-memberships?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list memberships: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list memberships failed: %s", resp.Error.Error())
+	}
+	return decodeMembershipList(resp.Data)
+}
+
+// GetActiveProjectMembership retrieves the (at most one) non-revoked membership
+// for a (project, user) pair via GET
+// /api/v1/system/project-memberships/active?project_id=X&user_id=Y — the read
+// inviteMemberWithMode uses to reject a duplicate onboarding (#309).
+func (rs *RemoteStorage) GetActiveProjectMembership(ctx context.Context, projectID, userID uint) (*models.ProjectMembership, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	q.Set("user_id", strconv.FormatUint(uint64(userID), 10))
+	path := "/api/v1/system/project-memberships/active?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active membership: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get active membership failed: %s", resp.Error.Error())
+	}
+	return decodeMembershipResponse(resp.Data)
+}
+
+// ListStaleInvitedMemberships lists still-invited memberships older than before
+// via GET /api/v1/system/project-memberships/stale?before=<RFC3339Nano> (ADR-022
+// stale-invite warnings).
+func (rs *RemoteStorage) ListStaleInvitedMemberships(ctx context.Context, before time.Time) ([]*models.ProjectMembership, error) {
+	q := url.Values{}
+	q.Set("before", before.UTC().Format(time.RFC3339Nano))
+	path := "/api/v1/system/project-memberships/stale?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list stale invited memberships: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list stale invited memberships failed: %s", resp.Error.Error())
+	}
+	return decodeMembershipList(resp.Data)
+}
+
+// ListUserProjectMemberships lists all membership rows for a single user via GET
+// /api/v1/system/project-memberships/by-user/{userID} (ADR-025 per-user
+// assignments view).
+func (rs *RemoteStorage) ListUserProjectMemberships(ctx context.Context, userID uint) ([]*models.ProjectMembership, error) {
+	path := fmt.Sprintf("/api/v1/system/project-memberships/by-user/%d", userID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list user memberships: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list user memberships failed: %s", resp.Error.Error())
+	}
+	return decodeMembershipList(resp.Data)
+}
+
+// CountProjectMembershipsByUsers returns per-user membership tallies (active and
+// non-revoked total) for the given user IDs in one call via GET
+// /api/v1/system/project-memberships/counts?user_ids=1,2,3 (ADR-025 user list).
+func (rs *RemoteStorage) CountProjectMembershipsByUsers(ctx context.Context, userIDs []uint) (map[uint]storage.MembershipCounts, error) {
+	if len(userIDs) == 0 {
+		return map[uint]storage.MembershipCounts{}, nil
+	}
+	ids := make([]string, len(userIDs))
+	for i, id := range userIDs {
+		ids[i] = strconv.FormatUint(uint64(id), 10)
+	}
+	q := url.Values{}
+	q.Set("user_ids", strings.Join(ids, ","))
+	path := "/api/v1/system/project-memberships/counts?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count memberships by users: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("count memberships by users failed: %s", resp.Error.Error())
+	}
+	// encoding/json supports unsigned-integer map keys directly (decoded from
+	// their base-10 JSON string form), so this unmarshals straight into the
+	// interface's own map[uint]storage.MembershipCounts shape — no intermediate
+	// string-keyed map or manual strconv needed.
+	var result map[uint]storage.MembershipCounts
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	if result == nil {
+		result = map[uint]storage.MembershipCounts{}
+	}
+	return result, nil
+}
+
+func decodeMembershipList(data []byte) ([]*models.ProjectMembership, error) {
+	var result struct {
+		Memberships []membershipWire `json:"memberships"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.ProjectMembership, 0, len(result.Memberships))
+	for _, w := range result.Memberships {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
 }

--- a/internal/storage/store/remote_unsupported_test.go
+++ b/internal/storage/store/remote_unsupported_test.go
@@ -23,10 +23,11 @@ func TestRemoteStorage_UnsupportedSentinel(t *testing.T) {
 	ctx := context.Background()
 
 	calls := map[string]func() error{
-		"CreateGroup":             func() error { _, e := rs.CreateGroup(ctx, &models.Group{}); return e },
-		"CreateProjectMembership": func() error { _, e := rs.CreateProjectMembership(ctx, &models.ProjectMembership{}); return e },
-		// ListProjectInvitations (#507) now makes a real HTTP call rather than
-		// stubbing out — see server/http/remote_storage_invitations_test.go for its
+		"CreateGroup": func() error { _, e := rs.CreateGroup(ctx, &models.Group{}); return e },
+		// ListProjectInvitations (#507) and CreateProjectMembership (#511) now make
+		// a real HTTP call rather than stubbing out — see
+		// server/http/remote_storage_invitations_test.go and
+		// server/http/remote_storage_project_memberships_test.go for their
 		// end-to-end coverage against a real router.
 		"CreateAccessRequest":   func() error { _, e := rs.CreateAccessRequest(ctx, &models.AccessRequest{}); return e },
 		"CreateNotification":    func() error { _, e := rs.CreateNotification(ctx, &models.Notification{}); return e },

--- a/server/http/handlers/project_memberships_proxy.go
+++ b/server/http/handlers/project_memberships_proxy.go
@@ -1,0 +1,315 @@
+// project_memberships_proxy.go — server-side endpoints backing RemoteStorage's
+// CreateProjectMembership/GetProjectMembership/UpdateProjectMembership/
+// ListProjectMemberships/GetActiveProjectMembership/ListStaleInvitedMemberships/
+// ListUserProjectMemberships/CountProjectMembershipsByUsers (#511).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// its project-membership storage calls to whichever upstream server it's
+// configured against, through these eight routes (registered in
+// server/http/router.go under /api/v1/system/project-memberships, gated on the
+// existing system.read/system.write RBAC permissions — the SAME credential a
+// RemoteStorage client already needs for every other proxied call, e.g. full user
+// CRUD, project-invitation CRUD (#507), so this introduces no new privilege
+// class). This mirrors invitations_proxy.go (#507) and login_attempts_proxy.go
+// exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/membership_lifecycle.go already uses against a local backend — no
+// membership-lifecycle POLICY decision (which state a new invite starts in, which
+// transitions are legal, when the backing role grant is applied/reverted) is made
+// here; that stays entirely in the CALLING server's own internal/core.KeyorixCore.
+//
+// Response envelope: like invitations_proxy.go/login_attempts_proxy.go, these do
+// NOT use the package's generic sendSuccess/sendError helpers — they construct the
+// exact {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// membershipProxyWire mirrors models.ProjectMembership's fields exactly
+// (snake_case) — the wire shape internal/storage/store/remote_memberships.go's
+// membershipWire sends/expects. See invitationProxyWire's comment for why every
+// field is named explicitly rather than relying on encoding/json's
+// case-insensitive fallback.
+type membershipProxyWire struct {
+	ID          uint       `json:"id"`
+	ProjectID   uint       `json:"project_id"`
+	UserID      uint       `json:"user_id"`
+	Role        string     `json:"role"`
+	State       string     `json:"state"`
+	InvitedBy   uint       `json:"invited_by"`
+	InvitedAt   time.Time  `json:"invited_at"`
+	ActivatedAt *time.Time `json:"activated_at"`
+	RevokedAt   *time.Time `json:"revoked_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+}
+
+func newMembershipProxyWire(m *models.ProjectMembership) membershipProxyWire {
+	return membershipProxyWire{
+		ID:          m.ID,
+		ProjectID:   m.ProjectID,
+		UserID:      m.UserID,
+		Role:        m.Role,
+		State:       m.State,
+		InvitedBy:   m.InvitedBy,
+		InvitedAt:   m.InvitedAt,
+		ActivatedAt: m.ActivatedAt,
+		RevokedAt:   m.RevokedAt,
+		UpdatedAt:   m.UpdatedAt,
+	}
+}
+
+func (w membershipProxyWire) toModel() *models.ProjectMembership {
+	return &models.ProjectMembership{
+		ID:          w.ID,
+		ProjectID:   w.ProjectID,
+		UserID:      w.UserID,
+		Role:        w.Role,
+		State:       w.State,
+		InvitedBy:   w.InvitedBy,
+		InvitedAt:   w.InvitedAt,
+		ActivatedAt: w.ActivatedAt,
+		RevokedAt:   w.RevokedAt,
+		UpdatedAt:   w.UpdatedAt,
+	}
+}
+
+// duplicateActiveMembershipCode is the machine-readable error code returned when
+// storage.CreateProjectMembership fails with storage.ErrDuplicateActiveMembership
+// (the upstream's own DB-level partial-unique-index rejection, #309,
+// local_memberships.go) — matches remote_memberships.go's
+// duplicateActiveMembershipCode constant, the wire contract the RemoteStorage
+// client checks for to reconstruct the sentinel client-side.
+const duplicateActiveMembershipCode = "DUPLICATE_ACTIVE_MEMBERSHIP"
+
+// CreateMembershipProxy handles POST /api/v1/system/project-memberships. See the
+// package doc for why this persists the caller's already-fully-built membership
+// row as-is (a raw storage-layer create), not a re-run of
+// InviteMember/inviteMemberWithMode's business logic.
+func (h *CatalogHandler) CreateMembershipProxy(w http.ResponseWriter, r *http.Request) {
+	var body membershipProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.ProjectID == 0 || body.UserID == 0 || body.Role == "" || body.State == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id, user_id, role, and state are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateProjectMembership(r.Context(), body.toModel())
+	if err != nil {
+		if errors.Is(err, coreStorage.ErrDuplicateActiveMembership) {
+			writeRemoteAPIError(w, http.StatusConflict, duplicateActiveMembershipCode, coreStorage.ErrDuplicateActiveMembership.Error())
+			return
+		}
+		log.Printf("project-memberships proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMembershipProxyWire(created))
+}
+
+// GetMembershipProxy handles GET /api/v1/system/project-memberships/{id}.
+func (h *CatalogHandler) GetMembershipProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid membership ID")
+		return
+	}
+	m, err := h.coreService.Storage().GetProjectMembership(r.Context(), uint(id))
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "membership not found")
+			return
+		}
+		log.Printf("project-memberships proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMembershipProxyWire(m))
+}
+
+// UpdateMembershipProxy handles PUT /api/v1/system/project-memberships/{id}. This
+// is a raw passthrough onto storage.UpdateProjectMembership (local_memberships.go's
+// plain Save) — see remote_memberships.go's package doc for why, unlike
+// UpdateInvitationProxy, there is no conditional `WHERE state = ?` write to
+// preserve here: the state-machine legality check (canTransition) already runs in
+// the CALLING core.KeyorixCore before this is ever invoked.
+func (h *CatalogHandler) UpdateMembershipProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid membership ID")
+		return
+	}
+	var body membershipProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	if err := h.coreService.Storage().UpdateProjectMembership(r.Context(), body.toModel()); err != nil {
+		log.Printf("project-memberships proxy: update failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}
+
+// ListMembershipsProxy handles GET /api/v1/system/project-memberships?project_id=X.
+func (h *CatalogHandler) ListMembershipsProxy(w http.ResponseWriter, r *http.Request) {
+	projectIDStr := r.URL.Query().Get("project_id")
+	if projectIDStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id query parameter is required")
+		return
+	}
+	projectID, err := strconv.ParseUint(projectIDStr, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id must be a valid integer")
+		return
+	}
+	rows, err := h.coreService.Storage().ListProjectMemberships(r.Context(), uint(projectID))
+	if err != nil {
+		log.Printf("project-memberships proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, membershipListWire(rows))
+}
+
+// GetActiveMembershipProxy handles GET
+// /api/v1/system/project-memberships/active?project_id=X&user_id=Y — the read
+// inviteMemberWithMode uses to reject a duplicate onboarding (#309). Registered
+// BEFORE the general /project-memberships/{id} pattern would ever shadow it: chi's
+// router matches this literal "active" segment in preference to the {id} wildcard
+// regardless of registration order (static routes always win), the same way
+// /project-memberships/stale, /project-memberships/counts, and
+// /project-memberships/by-user/{userID} below coexist with /project-memberships/{id}.
+func (h *CatalogHandler) GetActiveMembershipProxy(w http.ResponseWriter, r *http.Request) {
+	projectIDStr := r.URL.Query().Get("project_id")
+	userIDStr := r.URL.Query().Get("user_id")
+	if projectIDStr == "" || userIDStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id and user_id query parameters are required")
+		return
+	}
+	projectID, err := strconv.ParseUint(projectIDStr, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id must be a valid integer")
+		return
+	}
+	userID, err := strconv.ParseUint(userIDStr, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "user_id must be a valid integer")
+		return
+	}
+	m, err := h.coreService.Storage().GetActiveProjectMembership(r.Context(), uint(projectID), uint(userID))
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "no active membership for this project and user")
+			return
+		}
+		log.Printf("project-memberships proxy: get active failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMembershipProxyWire(m))
+}
+
+// ListStaleInvitedMembershipsProxy handles GET
+// /api/v1/system/project-memberships/stale?before=<RFC3339Nano> (ADR-022
+// stale-invite warnings).
+func (h *CatalogHandler) ListStaleInvitedMembershipsProxy(w http.ResponseWriter, r *http.Request) {
+	beforeStr := r.URL.Query().Get("before")
+	if beforeStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "before query parameter is required")
+		return
+	}
+	before, err := time.Parse(time.RFC3339Nano, beforeStr)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "before must be an RFC3339 timestamp")
+		return
+	}
+	rows, err := h.coreService.Storage().ListStaleInvitedMemberships(r.Context(), before)
+	if err != nil {
+		log.Printf("project-memberships proxy: list stale failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, membershipListWire(rows))
+}
+
+// ListUserMembershipsProxy handles GET
+// /api/v1/system/project-memberships/by-user/{userID} (ADR-025 per-user
+// assignments view).
+func (h *CatalogHandler) ListUserMembershipsProxy(w http.ResponseWriter, r *http.Request) {
+	userID, err := strconv.ParseUint(chi.URLParam(r, "userID"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid user ID")
+		return
+	}
+	rows, err := h.coreService.Storage().ListUserProjectMemberships(r.Context(), uint(userID))
+	if err != nil {
+		log.Printf("project-memberships proxy: list by user failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, membershipListWire(rows))
+}
+
+// CountMembershipsByUsersProxy handles GET
+// /api/v1/system/project-memberships/counts?user_ids=1,2,3 (ADR-025 user list).
+func (h *CatalogHandler) CountMembershipsByUsersProxy(w http.ResponseWriter, r *http.Request) {
+	raw := r.URL.Query().Get("user_ids")
+	if raw == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "user_ids query parameter is required")
+		return
+	}
+	parts := strings.Split(raw, ",")
+	userIDs := make([]uint, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		id, err := strconv.ParseUint(p, 10, 32)
+		if err != nil {
+			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "user_ids must be a comma-separated list of integers")
+			return
+		}
+		userIDs = append(userIDs, uint(id))
+	}
+	counts, err := h.coreService.Storage().CountProjectMembershipsByUsers(r.Context(), userIDs)
+	if err != nil {
+		log.Printf("project-memberships proxy: count by users failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	// encoding/json supports unsigned-integer map keys directly (encoded as their
+	// base-10 string form), matching what remote_memberships.go's
+	// CountProjectMembershipsByUsers unmarshals into — no wire-shape translation
+	// needed here.
+	writeRemoteAPISuccess(w, counts)
+}
+
+// membershipListWire converts a slice of models.ProjectMembership into the
+// {"memberships": [...]} envelope remote_memberships.go's decodeMembershipList
+// expects.
+func membershipListWire(rows []*models.ProjectMembership) map[string]interface{} {
+	wire := make([]membershipProxyWire, 0, len(rows))
+	for _, m := range rows {
+		wire = append(wire, newMembershipProxyWire(m))
+	}
+	return map[string]interface{}{"memberships": wire}
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -75,8 +75,20 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		// #507: the invitation-proxy end-to-end tests exercise ProjectInvitation
 		// CRUD through the real router.
 		&models.ProjectInvitation{},
+		// #511: the project-membership-proxy end-to-end tests exercise
+		// ProjectMembership CRUD through the real router.
+		&models.ProjectMembership{},
 	)
 	require.NoError(t, err)
+	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the
+	// same production migration path #309's TestConcurrency_InviteMember_
+	// NoDuplicateActiveMembership relies on, internal/core/concurrency_invite_member_test.go):
+	// AutoMigrate alone does not create this partial unique index, so without it, the
+	// #511 project-membership-proxy tests exercising the "duplicate active membership"
+	// path would silently miss the real DB-level guard CreateProjectMembership's
+	// isUniqueViolation branch depends on.
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_project_memberships_active "+
+		"ON project_memberships (project_id, user_id) WHERE state <> 'revoked'").Error)
 	return core.NewKeyorixCore(store.NewLocalStorage(db))
 }
 

--- a/server/http/remote_storage_project_memberships_test.go
+++ b/server/http/remote_storage_project_memberships_test.go
@@ -1,0 +1,311 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForMemberships builds the standard #452/#507/#511
+// two-server harness: an "upstream" exercised through the REAL production
+// NewRouter/handlers (including the new /api/v1/system/project-memberships
+// routes, server/http/handlers/project_memberships_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed at
+// "upstream" over real HTTP via store.RemoteStorage. Mirrors
+// newUpstreamDownstreamForInvitations exactly.
+func newUpstreamDownstreamForMemberships(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore, projectID uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+
+	ctx := context.Background()
+	project, err := upstream.CreateProject(ctx, "Memberships Test Project", "")
+	require.NoError(t, err)
+	return upstream, downstream, project.ID
+}
+
+// buildInvitedMembership mirrors what internal/core/membership_lifecycle.go's
+// inviteMemberWithMode computes before calling storage.CreateProjectMembership —
+// a freshly invited (allowlist-mode) membership row — WITHOUT going through
+// InviteMember/inviteMemberWithMode itself (that path also needs
+// storage.GetRoleByName, whose RemoteStorage implementation targets an
+// unregistered route — #512, a separate, pre-existing "implemented client
+// method, missing server route" bug independent of #511, exactly the same class
+// remote_storage_invitations_test.go's buildPendingInvitation already documents
+// working around for InviteToProject).
+func buildInvitedMembership(now time.Time, projectID, userID uint, role string, invitedBy uint) *models.ProjectMembership {
+	return &models.ProjectMembership{
+		ProjectID: projectID,
+		UserID:    userID,
+		Role:      role,
+		State:     core.MembershipInvited,
+		InvitedBy: invitedBy,
+		InvitedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func mustCreateUser(t *testing.T, c *core.KeyorixCore, username, email string) uint {
+	t.Helper()
+	u, err := c.CreateUser(context.Background(), &core.CreateUserRequest{
+		Username: username, Email: email, Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	return u.ID
+}
+
+// TestRemoteStorageMembership_CreateGetList_RealServer proves the #511 fix for
+// CreateProjectMembership/GetProjectMembership/ListProjectMemberships: a
+// membership is genuinely persisted on the upstream server via the DOWNSTREAM's
+// RemoteStorage, fetchable by ID, and listed — all via storage.type: remote
+// against a real router, not a protocol mock.
+func TestRemoteStorageMembership_CreateGetList_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMemberships(t)
+	ctx := context.Background()
+	now := time.Now()
+	userID := mustCreateUser(t, upstream, "invitee1", "invitee1@example.com")
+
+	m, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, "viewer", 1))
+	require.NoError(t, err, "creating a membership must succeed via storage.type: remote")
+	require.NotZero(t, m.ID, "the upstream must assign a real ID")
+	assert.Equal(t, projectID, m.ProjectID)
+	assert.Equal(t, userID, m.UserID)
+	assert.Equal(t, "viewer", m.Role)
+	assert.Equal(t, core.MembershipInvited, m.State)
+
+	// Confirm it is a REAL row in the upstream's own storage (not just "the call
+	// didn't error"), by reading it back directly against upstream.
+	direct, err := upstream.Storage().GetProjectMembership(ctx, m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, userID, direct.UserID)
+
+	// GetProjectMembership via the downstream (RemoteStorage) round-trips every
+	// field correctly.
+	fetched, err := downstream.Storage().GetProjectMembership(ctx, m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, m.ID, fetched.ID)
+	assert.Equal(t, m.ProjectID, fetched.ProjectID)
+	assert.Equal(t, m.UserID, fetched.UserID)
+	assert.Equal(t, m.Role, fetched.Role)
+	assert.Equal(t, m.State, fetched.State)
+	assert.WithinDuration(t, m.InvitedAt, fetched.InvitedAt, time.Second)
+
+	// A second membership for a different user, then list both back via the
+	// downstream's ListProjectMemberships.
+	userID2 := mustCreateUser(t, upstream, "invitee2", "invitee2@example.com")
+	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID2, "viewer", 1))
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListProjectMemberships(ctx, projectID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	users := map[uint]bool{}
+	for _, r := range rows {
+		users[r.UserID] = true
+	}
+	assert.True(t, users[userID])
+	assert.True(t, users[userID2])
+}
+
+// TestRemoteStorageMembership_GetNotFound_RealServer proves a clean not-found
+// error (not a panic, not a garbage 500) for a nonexistent membership ID.
+func TestRemoteStorageMembership_GetNotFound_RealServer(t *testing.T) {
+	_, downstream, _ := newUpstreamDownstreamForMemberships(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetProjectMembership(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageMembership_Update_RealServer proves UpdateProjectMembership
+// round-trips a state transition over the real HTTP hop — a single passthrough
+// PUT onto local_memberships.go's plain Save (see remote_memberships.go's package
+// doc for why no conditional-write guarantee is needed here, unlike
+// UpdateProjectInvitation).
+func TestRemoteStorageMembership_Update_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMemberships(t)
+	ctx := context.Background()
+	now := time.Now()
+	userID := mustCreateUser(t, upstream, "activatee", "activatee@example.com")
+
+	m, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, "viewer", 1))
+	require.NoError(t, err)
+
+	activatedAt := time.Now()
+	m.State = core.MembershipActive
+	m.ActivatedAt = &activatedAt
+	err = downstream.Storage().UpdateProjectMembership(ctx, m)
+	require.NoError(t, err)
+
+	fetched, err := downstream.Storage().GetProjectMembership(ctx, m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.MembershipActive, fetched.State)
+	require.NotNil(t, fetched.ActivatedAt)
+	assert.WithinDuration(t, activatedAt, *fetched.ActivatedAt, time.Second)
+
+	// Directly against the upstream's own storage too, proving this isn't an
+	// artifact of RemoteStorage's response cache.
+	direct, err := upstream.Storage().GetProjectMembership(ctx, m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.MembershipActive, direct.State)
+}
+
+// TestRemoteStorageMembership_GetActive_RealServer proves GetActiveProjectMembership
+// — the read inviteMemberWithMode uses to reject a duplicate onboarding (#309) —
+// finds a non-revoked row and stops finding it once revoked.
+func TestRemoteStorageMembership_GetActive_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMemberships(t)
+	ctx := context.Background()
+	now := time.Now()
+	userID := mustCreateUser(t, upstream, "activeuser", "activeuser@example.com")
+
+	m, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, "viewer", 1))
+	require.NoError(t, err)
+
+	active, err := downstream.Storage().GetActiveProjectMembership(ctx, projectID, userID)
+	require.NoError(t, err)
+	assert.Equal(t, m.ID, active.ID)
+
+	// Revoke it through the SAME downstream RemoteStorage client (not directly
+	// against upstream): RemoteStorage's GET response cache is keyed by path with
+	// a 5-minute TTL and is only invalidated by a write THROUGH THIS SAME client
+	// instance (internal/storage/remote/client.go's Request) — an out-of-band
+	// write via a different client/instance wouldn't invalidate it, which is a
+	// pre-existing, documented characteristic of the cache (see remote_users.go's
+	// LockUserForUpdate comment), not something this test is trying to exercise.
+	revokedAt := time.Now()
+	m.State = core.MembershipRevoked
+	m.RevokedAt = &revokedAt
+	require.NoError(t, downstream.Storage().UpdateProjectMembership(ctx, m))
+
+	_, err = downstream.Storage().GetActiveProjectMembership(ctx, projectID, userID)
+	assert.Error(t, err, "a revoked membership must not be reported as active")
+}
+
+// TestRemoteStorageMembership_DuplicateActiveMembership_RealServer proves the
+// #309 DB-level partial unique index (uniq_project_memberships_active) is still
+// enforced across the HTTP hop, AND that CreateMembershipProxy translates the
+// resulting unique-constraint violation into the SAME storage.ErrDuplicateActiveMembership
+// sentinel inviteMemberWithMode's errors.Is check depends on — not an opaque,
+// unclassifiable storage error.
+func TestRemoteStorageMembership_DuplicateActiveMembership_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMemberships(t)
+	ctx := context.Background()
+	now := time.Now()
+	userID := mustCreateUser(t, upstream, "dupuser", "dupuser@example.com")
+
+	_, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, "viewer", 1))
+	require.NoError(t, err)
+
+	// A second, concurrent-in-spirit invite for the SAME (project, user) pair must
+	// be rejected by the upstream's real DB-level unique index, and the rejection
+	// must reconstruct as storage.ErrDuplicateActiveMembership on this side of the
+	// HTTP hop.
+	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, "editor", 1))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, coreStorage.ErrDuplicateActiveMembership),
+		"a duplicate active membership must surface as storage.ErrDuplicateActiveMembership, not an opaque error: %v", err)
+}
+
+// TestRemoteStorageMembership_ListStaleInvited_RealServer proves
+// ListStaleInvitedMemberships (ADR-022 stale-invite warnings) round-trips over
+// storage.type: remote.
+func TestRemoteStorageMembership_ListStaleInvited_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMemberships(t)
+	ctx := context.Background()
+	old := time.Now().Add(-10 * 24 * time.Hour)
+	fresh := time.Now()
+	staleUserID := mustCreateUser(t, upstream, "staleuser", "staleuser@example.com")
+	freshUserID := mustCreateUser(t, upstream, "freshuser", "freshuser@example.com")
+
+	_, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(old, projectID, staleUserID, "viewer", 1))
+	require.NoError(t, err)
+	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(fresh, projectID, freshUserID, "viewer", 1))
+	require.NoError(t, err)
+
+	cutoff := time.Now().Add(-7 * 24 * time.Hour)
+	stale, err := downstream.Storage().ListStaleInvitedMemberships(ctx, cutoff)
+	require.NoError(t, err)
+	found := false
+	for _, m := range stale {
+		if m.UserID == staleUserID {
+			found = true
+		}
+		assert.NotEqual(t, freshUserID, m.UserID, "a fresh invite must not be reported as stale")
+	}
+	assert.True(t, found, "the old invite must be reported as stale")
+}
+
+// TestRemoteStorageMembership_ListByUserAndCounts_RealServer proves
+// ListUserProjectMemberships and CountProjectMembershipsByUsers (ADR-025 per-user
+// assignments/user-list views) round-trip over storage.type: remote.
+func TestRemoteStorageMembership_ListByUserAndCounts_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMemberships(t)
+	ctx := context.Background()
+	now := time.Now()
+	userID := mustCreateUser(t, upstream, "multiuser", "multiuser@example.com")
+	otherUserID := mustCreateUser(t, upstream, "otheruser", "otheruser@example.com")
+
+	project2, err := upstream.CreateProject(ctx, "Second Project", "")
+	require.NoError(t, err)
+
+	m1, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, "viewer", 1))
+	require.NoError(t, err)
+	activatedAt := time.Now()
+	m1.State = core.MembershipActive
+	m1.ActivatedAt = &activatedAt
+	require.NoError(t, downstream.Storage().UpdateProjectMembership(ctx, m1))
+
+	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, project2.ID, userID, "viewer", 1))
+	require.NoError(t, err)
+	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, otherUserID, "viewer", 1))
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListUserProjectMemberships(ctx, userID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2, "userID has memberships in both projects")
+
+	counts, err := downstream.Storage().CountProjectMembershipsByUsers(ctx, []uint{userID, otherUserID})
+	require.NoError(t, err)
+	require.Contains(t, counts, userID)
+	assert.Equal(t, 1, counts[userID].Active, "one of userID's two memberships is active")
+	assert.Equal(t, 2, counts[userID].Total)
+	require.Contains(t, counts, otherUserID)
+	assert.Equal(t, 0, counts[otherUserID].Active)
+	assert.Equal(t, 1, counts[otherUserID].Total)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -798,6 +798,36 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/invitations", catalogHandler.ListInvitationsProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/invitations", catalogHandler.CreateInvitationProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Put("/invitations/{id}", catalogHandler.UpdateInvitationProxy)
+
+			// Project-membership storage-primitive proxy (#511). Lets a downstream
+			// Keyorix server booted with storage.type: remote (ADR-049) proxy
+			// CreateProjectMembership/GetProjectMembership/UpdateProjectMembership/
+			// ListProjectMemberships/GetActiveProjectMembership/
+			// ListStaleInvitedMemberships/ListUserProjectMemberships/
+			// CountProjectMembershipsByUsers to THIS server's real storage backend,
+			// instead of RemoteStorage's eight ProjectMembership methods having no
+			// server endpoint to call at all (applyInvitationGrants' own
+			// membership-materialization step — the last stage of accepting a project
+			// invitation — was completely non-functional under storage.type: remote,
+			// even after #507 made the invitation-accept step itself work). Same
+			// pattern as the invitations proxy above: a thin passthrough onto
+			// storage.Storage (no membership-lifecycle POLICY decision made here — the
+			// calling server's own core.KeyorixCore still decides which state a new
+			// invite starts in, which transitions are legal, and when the backing role
+			// grant is applied/reverted, exactly as it does against a local backend),
+			// reusing the SAME system.read/system.write tier — no new privilege class.
+			// Static literal segments ("active", "stale", "counts", "by-user/{userID}")
+			// take priority over the "{id}" wildcard at the same route depth (chi's
+			// router always matches a static child before a param child), so they
+			// coexist safely regardless of registration order.
+			r.Get("/project-memberships/active", catalogHandler.GetActiveMembershipProxy)
+			r.Get("/project-memberships/stale", catalogHandler.ListStaleInvitedMembershipsProxy)
+			r.Get("/project-memberships/counts", catalogHandler.CountMembershipsByUsersProxy)
+			r.Get("/project-memberships/by-user/{userID}", catalogHandler.ListUserMembershipsProxy)
+			r.Get("/project-memberships/{id}", catalogHandler.GetMembershipProxy)
+			r.Get("/project-memberships", catalogHandler.ListMembershipsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/project-memberships", catalogHandler.CreateMembershipProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/project-memberships/{id}", catalogHandler.UpdateMembershipProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary

Fixes backlog finding #511 (MEDIUM): `RemoteStorage`'s `ProjectMembership` CRUD (`internal/storage/store/remote_memberships.go`) was entirely stubbed, so `applyInvitationGrants`'s membership-materialization step hard-failed under `storage.type: remote` even after a successful invitation accept (#507).

## Fix

Implemented all 8 methods as thin HTTP passthroughs under `/api/v1/system/project-memberships`, gated on the existing `system.read`/`system.write` tier (no new privilege class), following the #507/#510 pattern exactly.

## Atomicity analysis

`CreateProjectMembership` relies on a real DB-level partial unique index (`uniq_project_memberships_active`, #309) — preserved automatically since the proxy hits the same real storage primitive. Added translation of that unique-violation into a `DUPLICATE_ACTIVE_MEMBERSHIP` wire code so the client reconstructs `storage.ErrDuplicateActiveMembership`, preserving the sentinel `inviteMemberWithMode`'s `errors.Is` check depends on. `UpdateProjectMembership` needed no new conditional-write logic — unlike `UpdateProjectInvitation`, the local implementation is a plain `Save` with the state-machine guard enforced entirely in `core` before the call, so a single passthrough PUT is exact parity.

## Testing

- `server/http/remote_storage_project_memberships_test.go`: real `NewRouter` + real `RemoteStorage` client, proving create/get/list/update/active/stale/by-user/counts all work, plus the duplicate-active-membership sentinel translation, against genuine HTTP.
- `internal/core/invitation_accept_remote_membership_test.go`: proves the actual real-world caller, `applyInvitationGrants`, now materializes a membership via a real `RemoteStorage` client over real HTTP. Unrelated, separately-filed gaps in the same call path (#510 SetupToken, #512 GetRoleByName, `RemoteStorage.GetProject`'s blanket unsupported) were deliberately left mocked/out of scope, exactly as #507's own test file documents doing for its own blockers.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/storage/... ./internal/core/... ./server/http/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)