### PR TITLE
fix(remote-storage): register the missing GET /roles/by-name route (#512)

### DIFF
--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -56,8 +56,16 @@ func (rs *RemoteStorage) GetRole(ctx context.Context, id uint) (*models.Role, er
 }
 
 // GetRoleByName retrieves a role by name via remote API.
+//
+// The server registers this lookup as GET /api/v1/roles/by-name with the name as
+// a query parameter (mirroring GetSecretByName's #497 / GetUserByEmail's #503
+// query-scoped convention), not as a path segment (#512: an earlier version of
+// this method requested /api/v1/roles/by-name/{name}, a route
+// server/http/router.go never registered, so every call 404'd against a real
+// server regardless of whether the role existed — blocking InviteToProject for
+// EVERY role, not just admin roles, under storage.type: remote).
 func (rs *RemoteStorage) GetRoleByName(ctx context.Context, name string) (*models.Role, error) {
-	path := fmt.Sprintf("/api/v1/roles/by-name/%s", url.PathEscape(name))
+	path := fmt.Sprintf("/api/v1/roles/by-name?name=%s", url.QueryEscape(name))
 	resp, err := rs.client.Get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get role by name: %w", err)

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -239,6 +239,49 @@ func (h *RBACHandler) GetRole(w http.ResponseWriter, r *http.Request) {
 	sendSuccess(w, map[string]interface{}{"role": role, "permissions": perms}, "")
 }
 
+// GetRoleByName handles GET /api/v1/roles/by-name?name=X — looks up a role by
+// name for callers (e.g. RemoteStorage, #512) that only have the role's name
+// rather than its numeric ID (InviteToProject resolves every invited role —
+// system and project roles alike — by name this way). The route's permission
+// gate (roles.read, inherited from the /roles group — the same gate GetRole-
+// by-id uses) is the sole authz check, matching GetRole's model exactly; there
+// is no additional per-record check to bypass. Deliberately mirrors GetRole's
+// generic NotFound response (same status code, same static message) rather
+// than a distinct shape, so a caller cannot use response differences to probe
+// for valid role names — a caller without roles.read never reaches this
+// handler at all (401/403 from the route middleware, identical for every
+// name), and a caller WITH roles.read can already enumerate every role
+// (including name) via GET /roles, so this route grants no new capability at
+// that permission level. Unlike GetRole, this returns the bare role (no
+// permissions payload), matching what RemoteStorage.GetRoleByName's remote-API
+// contract expects (models.Role).
+func (h *RBACHandler) GetRoleByName(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	name := strings.TrimSpace(r.URL.Query().Get("name"))
+	if name == "" {
+		sendError(w, "InvalidParameter", "name is required", http.StatusBadRequest, nil)
+		return
+	}
+
+	role, err := h.coreService.Storage().GetRoleByName(r.Context(), name)
+	if err != nil {
+		log.Printf("Error getting role by name: %v", err)
+		if strings.Contains(err.Error(), "not found") {
+			sendError(w, "NotFound", "Role not found", http.StatusNotFound, nil)
+		} else {
+			sendError(w, "InternalError", "Failed to get role", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+
+	sendSuccess(w, role, "")
+}
+
 // UpdateRole handles PUT /api/v1/roles/{id}
 func (h *RBACHandler) UpdateRole(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/remote_storage_get_role_by_name_test.go
+++ b/server/http/remote_storage_get_role_by_name_test.go
@@ -1,0 +1,132 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteStorage_GetRoleByName_RealServerRoundTrip proves the fix for #512:
+// RemoteStorage.GetRoleByName targeted /api/v1/roles/by-name/{name}, a route
+// server/http/router.go never registered, so every call 404'd against a real
+// production server regardless of whether the role actually existed — blocking
+// InviteToProject for EVERY role (not just admin roles), the same "implemented
+// client method, missing server route" class #503 fixed for users.
+//
+// The fix adds GET /api/v1/roles/by-name (query-parameter scoped, mirroring
+// GetUserByEmail's #503 / GetSecretByName's #497 convention rather than a path
+// segment), gated by the SAME roles.read permission GetRole-by-id already
+// requires (the group-wide r.Use(RequirePermission("roles.read")) on /roles),
+// and returns the same generic NotFound shape GetRole-by-id uses on a miss —
+// deliberately NOT a distinct shape, so the route introduces no new
+// role-name-enumeration surface: a caller without roles.read never reaches the
+// handler (401/403, identical for every name), and a caller WITH roles.read
+// can already enumerate every role's name via GET /roles, so this route
+// grants no new capability at that permission level.
+//
+// Like TestRemoteStorage_GetUserByEmail_RealServerRoundTrip and
+// TestRemoteStorage_GetSecretByName_RealServerRoundTrip, this drives the
+// method through a REAL running server (NewRouter) via a REAL RemoteStorage
+// client over real HTTP — not a hand-rolled mock — so the test would have
+// failed against the pre-fix code with a 404, not just against a synthetic
+// stand-in of the route.
+func TestRemoteStorage_GetRoleByName_RealServerRoundTrip(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	// --- upstream: a real Keyorix server ---
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+	// A non-admin user with only the system_viewer baseline (system.read) — NOT
+	// roles.read — the under-permissioned caller for the gating assertions below.
+	limitedToken := createLimitedToken(t, upstreamCore)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	ctx := context.Background()
+
+	newClient := func(token string) *store.RemoteStorage {
+		rs, err := store.NewRemoteStorage(&remote.Config{
+			BaseURL:        upstreamSrv.URL,
+			APIKey:         token,
+			TimeoutSeconds: 5,
+			RetryAttempts:  0,
+			TLSVerify:      true,
+		})
+		require.NoError(t, err)
+		return rs
+	}
+
+	// --- downstream: storage.type: remote, pointed at the upstream, as an
+	// admin caller (holds roles.read) ---
+	rs := newClient(upstreamToken)
+
+	// --- the role genuinely exists (seeded by BootstrapSystem): must be found,
+	// not 404 ---
+	got, err := rs.GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err, "GetRoleByName must reach the real /api/v1/roles/by-name route and succeed for a role that genuinely exists (#512)")
+	require.NotNil(t, got)
+	assert.Equal(t, "system_viewer", got.Name)
+
+	// --- the role genuinely does NOT exist: must be a real not-found, not a
+	// routing 404 confused with "found nothing" ---
+	_, err = rs.GetRoleByName(ctx, "does_not_exist_role")
+	require.Error(t, err, "a role name that genuinely doesn't exist must still return an error")
+	var notFoundErr *remote.HTTPError
+	require.True(t, errors.As(err, &notFoundErr), "expected a structured remote.HTTPError")
+	assert.Equal(t, http.StatusNotFound, notFoundErr.StatusCode)
+
+	// --- gating: an authenticated caller who lacks roles.read must be denied
+	// identically whether the target role exists or not — proving the route
+	// cannot be used to enumerate role names by an under-permissioned caller ---
+	limitedRS := newClient(limitedToken)
+
+	_, existsErr := limitedRS.GetRoleByName(ctx, "system_viewer")
+	require.Error(t, existsErr, "an under-permissioned caller must be denied even for a role name that exists")
+	var existsHTTPErr *remote.HTTPError
+	require.True(t, errors.As(existsErr, &existsHTTPErr))
+
+	_, notExistsErr := limitedRS.GetRoleByName(ctx, "does_not_exist_role")
+	require.Error(t, notExistsErr, "an under-permissioned caller must be denied even for a role name that does not exist")
+	var notExistsHTTPErr *remote.HTTPError
+	require.True(t, errors.As(notExistsErr, &notExistsHTTPErr))
+
+	// The denial must carry the SAME status for both cases (403 Forbidden, the
+	// route's permission gate) — not a 404 for one and a 403 for the other,
+	// which would itself leak existence to an under-permissioned caller.
+	assert.Equal(t, http.StatusForbidden, existsHTTPErr.StatusCode)
+	assert.Equal(t, existsHTTPErr.StatusCode, notExistsHTTPErr.StatusCode,
+		"gating must not leak existence via a different status for an existing vs a non-existing role name")
+
+	// --- a fully unauthenticated caller must also be denied, identically
+	// regardless of whether the role exists (401, before the handler even
+	// parses the query) ---
+	unauthResp1, err := http.Get(upstreamSrv.URL + "/api/v1/roles/by-name?name=system_viewer")
+	require.NoError(t, err)
+	defer func() { _ = unauthResp1.Body.Close() }()
+	assert.Equal(t, http.StatusUnauthorized, unauthResp1.StatusCode)
+
+	unauthResp2, err := http.Get(upstreamSrv.URL + "/api/v1/roles/by-name?name=does_not_exist_role")
+	require.NoError(t, err)
+	defer func() { _ = unauthResp2.Body.Close() }()
+	assert.Equal(t, http.StatusUnauthorized, unauthResp2.StatusCode)
+	assert.Equal(t, unauthResp1.StatusCode, unauthResp2.StatusCode,
+		"an unauthenticated caller must not be able to distinguish an existing from a non-existing role name")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -689,6 +689,16 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Use(customMiddleware.RequirePermission("roles.read"))
 			r.Get("/", rbacHandler.ListRoles)
 			r.With(customMiddleware.RequirePermission("roles.write")).Post("/", rbacHandler.CreateRole)
+			// By-name lookup, scoped by the group-wide roles.read gate above — the
+			// server-side counterpart RemoteStorage.GetRoleByName (#512) needs, for a
+			// caller (e.g. InviteToProject resolving an invited role by name) with
+			// only a role's name, not its numeric ID. Deliberately the SAME gate as
+			// GetRole-by-id (not a stricter one): roles.read already lets a caller
+			// enumerate every role (including name) via GET /roles with no filter,
+			// so this route grants no new capability at that permission level.
+			// Static path, before /{id} — mirrors GetUserByEmail (#503) /
+			// GetSecretByName (#497)'s query-param "by-X" convention.
+			r.Get("/by-name", rbacHandler.GetRoleByName)
 			r.Get("/{id}", rbacHandler.GetRole)
 			r.With(customMiddleware.RequirePermission("roles.write")).Put("/{id}", rbacHandler.UpdateRole)
 			r.With(customMiddleware.RequirePermission("roles.write")).Delete("/{id}", rbacHandler.DeleteRole)


### PR DESCRIPTION
## Summary

Fixes backlog finding #512 (MEDIUM): `RemoteStorage.GetRoleByName` targeted `GET /api/v1/roles/by-name/{name}`, a route `server/http/router.go` never registered. Every call therefore 404'd against a real server regardless of whether the role existed, silently breaking `InviteToProject` for every invited role (not just admin roles) under `storage.type: remote` — the same "implemented client method, missing server route" class #503 fixed for `GetUserByEmail` and #497 fixed for `GetSecretByName`.

## Fix

- Added `GET /api/v1/roles/by-name` (query-param route, `?name=X`) inside the existing `/roles` group, gated by the same group-wide `roles.read` permission `GetRole`-by-id already uses.
- Added `RBACHandler.GetRoleByName`, returning the bare `models.Role` with the same generic `NotFound` shape `GetRole` uses, so the route adds no name-enumeration surface.
- Fixed `RemoteStorage.GetRoleByName` to build the query-param URL (`url.QueryEscape`) instead of a path segment, mirroring `GetUserByEmail`/`GetSecretByName`'s established convention.

## Testing

`server/http/remote_storage_get_role_by_name_test.go`: real `NewRouter` + real `RemoteStorage` client proving an existing role is found by name, a non-existent name returns a clean 404, and the route is gated identically to `GetRole`-by-id (403/401 with no existence leak either way).

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/storage/... ./server/http/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./...` — 0 issues
- `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)