### PR TITLE
fix(remote-storage): implement Group CRUD/membership for RemoteStorage (#514)

### DIFF
--- a/internal/storage/store/remote_unsupported.go
+++ b/internal/storage/store/remote_unsupported.go
@@ -9,10 +9,14 @@ import (
 // ErrRemoteUnsupported is returned by RemoteStorage methods whose operation has
 // no server REST endpoint to proxy to. These fall into two groups: server-internal
 // primitives that a remote (client-mode) caller never invokes directly — project
-// membership lifecycle, invitation/access-request primitives, notification
-// creation, group CRUD, low-level permission lookups — and a handful not yet
-// exposed for client mode. Callers can errors.Is against it to distinguish
-// "not supported in remote mode" from a genuine transport/API failure.
+// membership lifecycle, access-request primitives, notification creation,
+// low-level permission lookups — and a handful not yet exposed for client mode.
+// (Group CRUD/membership and project-invitation primitives used to fall in this
+// first category too, until each got its own thin /api/v1/system/* proxy route
+// — see internal/storage/store/remote_users.go's Group section and
+// remote_invitations.go's #507 doc comment.) Callers can errors.Is against it to
+// distinguish "not supported in remote mode" from a genuine transport/API
+// failure.
 //
 // The live data path for these features runs on the server (LocalStorage); the
 // remote client reaches them through higher-level REST endpoints, not raw storage

--- a/internal/storage/store/remote_unsupported_test.go
+++ b/internal/storage/store/remote_unsupported_test.go
@@ -23,11 +23,12 @@ func TestRemoteStorage_UnsupportedSentinel(t *testing.T) {
 	ctx := context.Background()
 
 	calls := map[string]func() error{
-		"CreateGroup":             func() error { _, e := rs.CreateGroup(ctx, &models.Group{}); return e },
 		"CreateProjectMembership": func() error { _, e := rs.CreateProjectMembership(ctx, &models.ProjectMembership{}); return e },
-		// ListProjectInvitations (#507) now makes a real HTTP call rather than
-		// stubbing out — see server/http/remote_storage_invitations_test.go for its
-		// end-to-end coverage against a real router.
+		// ListProjectInvitations (#507) and CreateGroup (this finding) now make a
+		// real HTTP call rather than stubbing out — see
+		// server/http/remote_storage_invitations_test.go and
+		// server/http/remote_storage_groups_test.go for their end-to-end coverage
+		// against a real router.
 		"CreateAccessRequest":   func() error { _, e := rs.CreateAccessRequest(ctx, &models.AccessRequest{}); return e },
 		"CreateNotification":    func() error { _, e := rs.CreateNotification(ctx, &models.Notification{}); return e },
 		"ListPermissions":       func() error { _, e := rs.ListPermissions(ctx); return e },

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -4,11 +4,35 @@
 // GetUserByExternalID, UpdateUser,
 //
 //	DeleteUser, RestoreUser, ListUsers, GetUserGroups,
-//	CreateGroup, GetGroup, UpdateGroup, DeleteGroup, ListGroups,
-//	AddUserToGroup, RemoveUserFromGroup, ListGroupMembers.
+//	CreateGroup, GetGroup, UpdateGroup, DeleteGroup, RestoreGroup, ListGroups,
+//	ListGroupsPage, AddUserToGroup, RemoveUserFromGroup, ListGroupMembers,
+//	ListGroupMembersByGroupIDs.
 //
-// Group methods (CreateGroup … ListGroupMembers) are stubs — not yet implemented
-// on the remote API. For the local (GORM) equivalent see local_users.go.
+// Group methods proxy onto NEW server-side routes under /api/v1/system/groups
+// and /api/v1/system/users/{id}/groups (server/http/handlers/groups_proxy.go),
+// mirroring the #452/#507 "RemoteStorage stub -> thin proxy route" pattern
+// established for login-attempts and project invitations: gated on the SAME
+// system.read/system.write RBAC tier every other RemoteStorage call already
+// needs (no new privilege class).
+//
+// These deliberately do NOT reuse the existing human-facing /api/v1/groups
+// routes (server/http/handlers/groups_handler.go, groups_members.go): those run
+// through the CALLING server's own core.KeyorixCore (validation, audit-log
+// events, and escalation-by-proxy ceilings — guardLastGlobalAdminGroupDelete,
+// guardLastGlobalAdminMembership, requireGlobalAdminToReinstateAdminRoles,
+// requireAuthorityForRole; internal/core/groups.go). A RemoteStorage-backed
+// core.KeyorixCore already evaluates all of that itself, client-side, before
+// ever calling down into this storage layer (exactly as it does against
+// LocalStorage) — proxying onto the business-logic routes would run that SAME
+// policy a second time on the upstream server, double-logging every mutation
+// and, worse, re-evaluating the admin-ceiling checks against the UPSTREAM
+// caller's own actor context (the RemoteStorage credential), not the original
+// actor who is already fully vetted by the client's own core layer. The new
+// routes below are raw passthroughs onto storage.Storage's own Group
+// primitives instead — the same semantics local_users.go's LocalStorage
+// implements — so this client's own core.KeyorixCore validation/audit/
+// escalation logic remains the ONLY policy evaluation, identical to a local
+// backend. For the local (GORM) equivalent see local_users.go.
 package store
 
 import (
@@ -17,6 +41,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -448,62 +474,301 @@ func buildUserFilterPath(filter *storage.UserFilter) string {
 	return "/api/v1/users" + params.String()
 }
 
-// GetUserGroups returns all groups a user belongs to.
-// Returns an empty slice — group membership resolution is not yet implemented remotely.
-func (rs *RemoteStorage) GetUserGroups(_ context.Context, _ uint) ([]*models.Group, error) {
-	return []*models.Group{}, nil
+// --- Group wire DTOs ---
+//
+// models.Group carries no json tags of its own (the same #496 class of gap as
+// models.User/models.ProjectInvitation), so a direct marshal would send Go
+// field names verbatim ("Name" and "Description" happen to survive the
+// case-insensitive decode fallback since they are single words, but
+// CreatedAt/UpdatedAt/DeletedAt would collide with server/http/handlers'
+// snake_case wire shape). Named explicitly instead, matching every other
+// RemoteStorage wire DTO in this codebase.
+type groupWire struct {
+	ID          uint       `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
 }
 
-// --- Groups (stubs — not yet implemented on remote API) ---
-
-func (rs *RemoteStorage) CreateGroup(_ context.Context, _ *models.Group) (*models.Group, error) {
-	return nil, remoteUnsupported("CreateGroup")
+func newGroupWire(g *models.Group) groupWire {
+	w := groupWire{
+		ID:          g.ID,
+		Name:        g.Name,
+		Description: g.Description,
+		CreatedAt:   g.CreatedAt,
+		UpdatedAt:   g.UpdatedAt,
+	}
+	if g.DeletedAt.Valid {
+		t := g.DeletedAt.Time
+		w.DeletedAt = &t
+	}
+	return w
 }
 
-func (rs *RemoteStorage) GetGroup(_ context.Context, _ uint) (*models.Group, error) {
-	return nil, remoteUnsupported("GetGroup")
+func (w groupWire) toModel() *models.Group {
+	g := &models.Group{
+		ID:          w.ID,
+		Name:        w.Name,
+		Description: w.Description,
+		CreatedAt:   w.CreatedAt,
+		UpdatedAt:   w.UpdatedAt,
+	}
+	if w.DeletedAt != nil {
+		g.DeletedAt = gorm.DeletedAt{Time: *w.DeletedAt, Valid: true}
+	}
+	return g
 }
 
-func (rs *RemoteStorage) UpdateGroup(_ context.Context, _ *models.Group) (*models.Group, error) {
-	return nil, remoteUnsupported("UpdateGroup")
+func decodeGroupResponse(data []byte) (*models.Group, error) {
+	var wire groupWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }
 
-func (rs *RemoteStorage) DeleteGroup(_ context.Context, _ uint) error {
-	return remoteUnsupported("DeleteGroup")
+// GetUserGroups returns all groups a user belongs to via GET
+// /api/v1/system/users/{id}/groups.
+//
+// Before this fix this unconditionally returned an empty slice instead of an
+// error — a "silent data loss" shape of bug, not a loud failure: every caller
+// (internal/core/permissions.go's effective-permission resolution,
+// internal/core/sso.go's group-membership sync, internal/core/
+// access_review_campaign.go) silently saw "this user belongs to zero groups"
+// under storage.type: remote, regardless of the upstream's real membership
+// data — under-granting every group-inherited role/permission with no error
+// surfaced anywhere, rather than the server genuinely having no groups
+// subsystem at all.
+func (rs *RemoteStorage) GetUserGroups(ctx context.Context, userID uint) ([]*models.Group, error) {
+	path := fmt.Sprintf("/api/v1/system/users/%d/groups", userID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user groups: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get user groups failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Groups []groupWire `json:"groups"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	groups := make([]*models.Group, 0, len(result.Groups))
+	for _, w := range result.Groups {
+		groups = append(groups, w.toModel())
+	}
+	return groups, nil
 }
 
-func (rs *RemoteStorage) RestoreGroup(_ context.Context, _ uint) error {
-	return remoteUnsupported("RestoreGroup")
+// --- Groups ---
+
+// CreateGroup creates a new group via POST /api/v1/system/groups — a raw
+// persist onto storage.Storage.CreateGroup, not the human-facing POST
+// /api/v1/groups (see the package doc for why).
+func (rs *RemoteStorage) CreateGroup(ctx context.Context, group *models.Group) (*models.Group, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/groups", newGroupWire(group))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create group: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create group failed: %s", resp.Error.Error())
+	}
+	return decodeGroupResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) ListGroups(_ context.Context) ([]*models.Group, error) {
-	return nil, remoteUnsupported("ListGroups")
+// GetGroup retrieves a group by ID via GET /api/v1/system/groups/{id}.
+func (rs *RemoteStorage) GetGroup(ctx context.Context, id uint) (*models.Group, error) {
+	path := fmt.Sprintf("/api/v1/system/groups/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get group: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get group failed: %s", resp.Error.Error())
+	}
+	return decodeGroupResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) ListGroupsPage(_ context.Context, _, _ int) ([]*models.Group, int64, error) {
-	return nil, 0, remoteUnsupported("ListGroupsPage")
+// UpdateGroup updates an existing group via PUT /api/v1/system/groups/{id}.
+func (rs *RemoteStorage) UpdateGroup(ctx context.Context, group *models.Group) (*models.Group, error) {
+	path := fmt.Sprintf("/api/v1/system/groups/%d", group.ID)
+	resp, err := rs.client.Put(ctx, path, newGroupWire(group))
+	if err != nil {
+		return nil, fmt.Errorf("failed to update group: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("update group failed: %s", resp.Error.Error())
+	}
+	return decodeGroupResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) AddUserToGroup(_ context.Context, _, _ uint) error {
-	return remoteUnsupported("AddUserToGroup")
+// DeleteGroup soft-deletes a group via DELETE /api/v1/system/groups/{id}.
+func (rs *RemoteStorage) DeleteGroup(ctx context.Context, id uint) error {
+	path := fmt.Sprintf("/api/v1/system/groups/%d", id)
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete group: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete group failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) RemoveUserFromGroup(_ context.Context, _, _ uint) error {
-	return remoteUnsupported("RemoveUserFromGroup")
+// RestoreGroup reverses a soft-delete via POST /api/v1/system/groups/{id}/restore.
+func (rs *RemoteStorage) RestoreGroup(ctx context.Context, id uint) error {
+	path := fmt.Sprintf("/api/v1/system/groups/%d/restore", id)
+	resp, err := rs.client.Post(ctx, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to restore group: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("restore group failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) ListGroupMembers(_ context.Context, _ uint) ([]*models.User, error) {
-	return nil, remoteUnsupported("ListGroupMembers")
+// ListGroups lists every group via GET /api/v1/system/groups.
+func (rs *RemoteStorage) ListGroups(ctx context.Context) ([]*models.Group, error) {
+	resp, err := rs.client.Get(ctx, "/api/v1/system/groups")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list groups: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list groups failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Groups []groupWire `json:"groups"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	groups := make([]*models.Group, 0, len(result.Groups))
+	for _, w := range result.Groups {
+		groups = append(groups, w.toModel())
+	}
+	return groups, nil
 }
 
-// ListGroupMembersByGroupIDs is the batch form of ListGroupMembers, which is itself
-// unsupported in remote mode — so is this, for the same reason (group membership is
-// server-side only). Matches ListGroupMembers' existing per-group unsupported error:
-// a caller (the rotation planner's risk-scoring batch, #409) already degrades a
-// secret's exposure factor to the worst case on this error, exactly as it already
-// does today when a group share's ListGroupMembers call fails in remote mode.
-func (rs *RemoteStorage) ListGroupMembersByGroupIDs(_ context.Context, _ []uint) (map[uint][]*models.User, error) {
-	return nil, remoteUnsupported("ListGroupMembersByGroupIDs")
+// ListGroupsPage returns one name-ordered page of groups and the total count
+// via GET /api/v1/system/groups/page?offset=&limit=.
+func (rs *RemoteStorage) ListGroupsPage(ctx context.Context, offset, pageSize int) ([]*models.Group, int64, error) {
+	path := fmt.Sprintf("/api/v1/system/groups/page?offset=%d&limit=%d", offset, pageSize)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list groups page: %w", err)
+	}
+	if !resp.Success {
+		return nil, 0, fmt.Errorf("list groups page failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Groups []groupWire `json:"groups"`
+		Total  int64       `json:"total"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	groups := make([]*models.Group, 0, len(result.Groups))
+	for _, w := range result.Groups {
+		groups = append(groups, w.toModel())
+	}
+	return groups, result.Total, nil
+}
+
+// AddUserToGroup adds userID to groupID via POST /api/v1/system/groups/{id}/members.
+func (rs *RemoteStorage) AddUserToGroup(ctx context.Context, userID, groupID uint) error {
+	path := fmt.Sprintf("/api/v1/system/groups/%d/members", groupID)
+	body := struct {
+		UserID uint `json:"user_id"`
+	}{UserID: userID}
+	resp, err := rs.client.Post(ctx, path, body)
+	if err != nil {
+		return fmt.Errorf("failed to add user to group: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("add user to group failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// RemoveUserFromGroup removes userID from groupID via DELETE
+// /api/v1/system/groups/{id}/members/{userId}.
+func (rs *RemoteStorage) RemoveUserFromGroup(ctx context.Context, userID, groupID uint) error {
+	path := fmt.Sprintf("/api/v1/system/groups/%d/members/%d", groupID, userID)
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to remove user from group: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("remove user from group failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// ListGroupMembers lists a group's members via GET
+// /api/v1/system/groups/{id}/members.
+func (rs *RemoteStorage) ListGroupMembers(ctx context.Context, groupID uint) ([]*models.User, error) {
+	path := fmt.Sprintf("/api/v1/system/groups/%d/members", groupID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list group members: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list group members failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Members []userWireResponse `json:"members"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	users := make([]*models.User, 0, len(result.Members))
+	for _, w := range result.Members {
+		users = append(users, w.toModel())
+	}
+	return users, nil
+}
+
+// ListGroupMembersByGroupIDs is the batch form of ListGroupMembers via GET
+// /api/v1/system/groups/members-by-ids?ids=1,2,3 — one HTTP round trip for
+// every group ID, matching LocalStorage's single-query batch behavior (used by
+// the rotation planner's risk-scoring batch, #409).
+func (rs *RemoteStorage) ListGroupMembersByGroupIDs(ctx context.Context, groupIDs []uint) (map[uint][]*models.User, error) {
+	out := make(map[uint][]*models.User, len(groupIDs))
+	if len(groupIDs) == 0 {
+		return out, nil
+	}
+	ids := make([]string, 0, len(groupIDs))
+	for _, id := range groupIDs {
+		ids = append(ids, strconv.FormatUint(uint64(id), 10))
+	}
+	path := "/api/v1/system/groups/members-by-ids?ids=" + url.QueryEscape(strings.Join(ids, ","))
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list group members by IDs: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list group members by IDs failed: %s", resp.Error.Error())
+	}
+	var result map[string][]userWireResponse
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	for key, members := range result {
+		groupID, err := strconv.ParseUint(key, 10, 32)
+		if err != nil {
+			continue
+		}
+		users := make([]*models.User, 0, len(members))
+		for _, w := range members {
+			users = append(users, w.toModel())
+		}
+		out[uint(groupID)] = users
+	}
+	return out, nil
 }
 
 // --- Password history (ADR-025) ---

--- a/server/http/handlers/groups_proxy.go
+++ b/server/http/handlers/groups_proxy.go
@@ -1,0 +1,381 @@
+// groups_proxy.go — server-side endpoints backing RemoteStorage's Group CRUD
+// and membership methods (CreateGroup/GetGroup/UpdateGroup/DeleteGroup/
+// RestoreGroup/ListGroups/ListGroupsPage/AddUserToGroup/RemoveUserFromGroup/
+// ListGroupMembers/ListGroupMembersByGroupIDs/GetUserGroups).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049)
+// proxies its Group storage calls to whichever upstream server it's
+// configured against, through these routes (registered in
+// server/http/router.go under /api/v1/system/groups and
+// /api/v1/system/users/{id}/groups, gated on the existing system.read/
+// system.write RBAC permissions — the SAME credential a RemoteStorage client
+// already needs for every other proxied call, e.g. full user CRUD, so this
+// introduces no new privilege class). This mirrors the #452-follow-up
+// login-attempts proxy (login_attempts_proxy.go) and the #507
+// project-invitations proxy (invitations_proxy.go) exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage Group primitives
+// (internal/storage/store/local_users.go's LocalStorage.CreateGroup et al.)
+// internal/core/groups.go already uses against a local backend — NO group
+// policy decision (name/description validation, audit-log events, the
+// escalation-by-proxy ceilings guardLastGlobalAdminGroupDelete/
+// guardLastGlobalAdminMembership/requireGlobalAdminToReinstateAdminRoles/
+// requireAuthorityForRole apply) is made here; that stays entirely in the
+// CALLING server's own internal/core.KeyorixCore, exactly as it does against a
+// local backend. The existing human-facing /api/v1/groups routes
+// (groups_handler.go, groups_members.go) are deliberately NOT reused as the
+// proxy target — see internal/storage/store/remote_users.go's package doc for
+// why (they run through core.KeyorixCore, so proxying onto them would apply
+// that same business logic a second time, upstream, against the wrong actor
+// context).
+//
+// Response envelope: like login_attempts_proxy.go and invitations_proxy.go,
+// these do NOT use the package's generic sendSuccess/sendError helpers — they
+// construct the exact {"success":bool,"data":...,"error":{"code","message"}}
+// shape internal/storage/remote.HTTPClient parses (its APIResponse/APIError
+// types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// groupProxyWire mirrors models.Group's fields exactly (snake_case) — the wire
+// shape internal/storage/store/remote_users.go's groupWire sends/expects. See
+// that type's comment for why every field is named explicitly rather than
+// relying on encoding/json's case-insensitive fallback (the same #496 class of
+// gap: models.Group carries no json tags of its own).
+type groupProxyWire struct {
+	ID          uint       `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
+}
+
+func newGroupProxyWire(g *models.Group) groupProxyWire {
+	w := groupProxyWire{
+		ID:          g.ID,
+		Name:        g.Name,
+		Description: g.Description,
+		CreatedAt:   g.CreatedAt,
+		UpdatedAt:   g.UpdatedAt,
+	}
+	if g.DeletedAt.Valid {
+		t := g.DeletedAt.Time
+		w.DeletedAt = &t
+	}
+	return w
+}
+
+func (w groupProxyWire) toModel() *models.Group {
+	return &models.Group{
+		ID:          w.ID,
+		Name:        w.Name,
+		Description: w.Description,
+	}
+}
+
+// isGroupNotFound reports whether err is LocalStorage's "group not found"
+// error (local_users.go wraps i18n.T("ErrorGroupNotFound", ...), which does
+// not necessarily contain the literal substring "not found" in every locale —
+// but LocalStorage always runs with the server's configured locale, and
+// RestoreGroup's own plain "group not found or not deleted" always does).
+func isGroupNotFound(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") || strings.Contains(msg, "notfound")
+}
+
+// CreateGroupProxy handles POST /api/v1/system/groups.
+func (h *GroupHandler) CreateGroupProxy(w http.ResponseWriter, r *http.Request) {
+	var body groupProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Name == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "name is required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateGroup(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("groups proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newGroupProxyWire(created))
+}
+
+// GetGroupProxy handles GET /api/v1/system/groups/{id}.
+func (h *GroupHandler) GetGroupProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid group ID")
+		return
+	}
+	g, err := h.coreService.Storage().GetGroup(r.Context(), uint(id))
+	if err != nil {
+		if isGroupNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "group not found")
+			return
+		}
+		log.Printf("groups proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newGroupProxyWire(g))
+}
+
+// UpdateGroupProxy handles PUT /api/v1/system/groups/{id}. Like the invitation
+// proxy's raw persist, this trusts the caller's already-fully-resolved final
+// desired state (the calling core.KeyorixCore.UpdateGroup already merged the
+// existing row with the requested changes before invoking storage.UpdateGroup)
+// rather than re-deriving a partial update here.
+func (h *GroupHandler) UpdateGroupProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid group ID")
+		return
+	}
+	var body groupProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	updated, err := h.coreService.Storage().UpdateGroup(r.Context(), body.toModel())
+	if err != nil {
+		if isGroupNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "group not found")
+			return
+		}
+		log.Printf("groups proxy: update failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newGroupProxyWire(updated))
+}
+
+// DeleteGroupProxy handles DELETE /api/v1/system/groups/{id}. Soft-deletes the
+// group (LocalStorage.DeleteGroup), preserving its role grants and
+// memberships for a later RestoreGroupProxy call — identical to a local
+// backend.
+func (h *GroupHandler) DeleteGroupProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid group ID")
+		return
+	}
+	if err := h.coreService.Storage().DeleteGroup(r.Context(), uint(id)); err != nil {
+		if isGroupNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "group not found")
+			return
+		}
+		log.Printf("groups proxy: delete failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}
+
+// RestoreGroupProxy handles POST /api/v1/system/groups/{id}/restore.
+func (h *GroupHandler) RestoreGroupProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid group ID")
+		return
+	}
+	if err := h.coreService.Storage().RestoreGroup(r.Context(), uint(id)); err != nil {
+		if isGroupNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "group not found or not deleted")
+			return
+		}
+		log.Printf("groups proxy: restore failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"restored": true})
+}
+
+// ListGroupsProxy handles GET /api/v1/system/groups.
+func (h *GroupHandler) ListGroupsProxy(w http.ResponseWriter, r *http.Request) {
+	groups, err := h.coreService.Storage().ListGroups(r.Context())
+	if err != nil {
+		log.Printf("groups proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]groupProxyWire, 0, len(groups))
+	for _, g := range groups {
+		wire = append(wire, newGroupProxyWire(g))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"groups": wire})
+}
+
+// ListGroupsPageProxy handles GET /api/v1/system/groups/page?offset=&limit=.
+func (h *GroupHandler) ListGroupsPageProxy(w http.ResponseWriter, r *http.Request) {
+	offset, err := strconv.Atoi(r.URL.Query().Get("offset"))
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "offset must be a valid integer")
+		return
+	}
+	limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "limit must be a valid integer")
+		return
+	}
+	groups, total, err := h.coreService.Storage().ListGroupsPage(r.Context(), offset, limit)
+	if err != nil {
+		log.Printf("groups proxy: list page failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]groupProxyWire, 0, len(groups))
+	for _, g := range groups {
+		wire = append(wire, newGroupProxyWire(g))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"groups": wire, "total": total})
+}
+
+// groupMemberBody is the wire body for POST /api/v1/system/groups/{id}/members.
+type groupMemberBody struct {
+	UserID uint `json:"user_id"`
+}
+
+// AddGroupMemberProxy handles POST /api/v1/system/groups/{id}/members.
+func (h *GroupHandler) AddGroupMemberProxy(w http.ResponseWriter, r *http.Request) {
+	groupID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid group ID")
+		return
+	}
+	var body groupMemberBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.UserID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id is required")
+		return
+	}
+	if err := h.coreService.Storage().AddUserToGroup(r.Context(), body.UserID, uint(groupID)); err != nil {
+		if isGroupNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "user or group not found")
+			return
+		}
+		log.Printf("groups proxy: add member failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"added": true})
+}
+
+// RemoveGroupMemberProxy handles DELETE /api/v1/system/groups/{id}/members/{userId}.
+func (h *GroupHandler) RemoveGroupMemberProxy(w http.ResponseWriter, r *http.Request) {
+	groupID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid group ID")
+		return
+	}
+	userID, err := strconv.ParseUint(chi.URLParam(r, "userId"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid user ID")
+		return
+	}
+	if err := h.coreService.Storage().RemoveUserFromGroup(r.Context(), uint(userID), uint(groupID)); err != nil {
+		log.Printf("groups proxy: remove member failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"removed": true})
+}
+
+// ListGroupMembersProxy handles GET /api/v1/system/groups/{id}/members.
+func (h *GroupHandler) ListGroupMembersProxy(w http.ResponseWriter, r *http.Request) {
+	groupID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid group ID")
+		return
+	}
+	members, err := h.coreService.Storage().ListGroupMembers(r.Context(), uint(groupID))
+	if err != nil {
+		if isGroupNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "group not found")
+			return
+		}
+		log.Printf("groups proxy: list members failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	out := make([]map[string]interface{}, 0, len(members))
+	for _, u := range members {
+		out = append(out, userToAPIResponse(u))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"members": out})
+}
+
+// ListGroupMembersByIDsProxy handles GET
+// /api/v1/system/groups/members-by-ids?ids=1,2,3 — the batch form of
+// ListGroupMembersProxy (used by the rotation planner's risk-scoring batch,
+// #409).
+func (h *GroupHandler) ListGroupMembersByIDsProxy(w http.ResponseWriter, r *http.Request) {
+	idsParam := r.URL.Query().Get("ids")
+	if idsParam == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "ids query parameter is required")
+		return
+	}
+	parts := strings.Split(idsParam, ",")
+	groupIDs := make([]uint, 0, len(parts))
+	for _, p := range parts {
+		id, err := strconv.ParseUint(strings.TrimSpace(p), 10, 32)
+		if err != nil {
+			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "ids must be a comma-separated list of integers")
+			return
+		}
+		groupIDs = append(groupIDs, uint(id))
+	}
+	byGroup, err := h.coreService.Storage().ListGroupMembersByGroupIDs(r.Context(), groupIDs)
+	if err != nil {
+		log.Printf("groups proxy: list members by IDs failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	out := make(map[string]interface{}, len(byGroup))
+	for groupID, members := range byGroup {
+		wire := make([]map[string]interface{}, 0, len(members))
+		for _, u := range members {
+			wire = append(wire, userToAPIResponse(u))
+		}
+		out[strconv.FormatUint(uint64(groupID), 10)] = wire
+	}
+	writeRemoteAPISuccess(w, out)
+}
+
+// GetUserGroupsProxy handles GET /api/v1/system/users/{id}/groups.
+func (h *GroupHandler) GetUserGroupsProxy(w http.ResponseWriter, r *http.Request) {
+	userID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid user ID")
+		return
+	}
+	groups, err := h.coreService.Storage().GetUserGroups(r.Context(), uint(userID))
+	if err != nil {
+		log.Printf("groups proxy: get user groups failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]groupProxyWire, 0, len(groups))
+	for _, g := range groups {
+		wire = append(wire, newGroupProxyWire(g))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"groups": wire})
+}

--- a/server/http/remote_storage_groups_test.go
+++ b/server/http/remote_storage_groups_test.go
@@ -1,0 +1,199 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForGroups builds the standard #452/#507 two-server
+// harness (see remote_storage_invitations_test.go's identical helper): an
+// "upstream" exercised through the REAL production NewRouter/handlers
+// (including the new /api/v1/system/groups and /api/v1/system/users/{id}/groups
+// routes, server/http/handlers/groups_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed at
+// "upstream" over real HTTP via store.RemoteStorage.
+func newUpstreamDownstreamForGroups(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	return upstream, downstream
+}
+
+// TestRemoteStorageGroup_CreateGetUpdateDeleteRestore_RealServer proves the
+// group CRUD fix: a group is genuinely persisted on the upstream server via
+// the DOWNSTREAM's RemoteStorage, fetchable by ID, updatable, soft-deletable,
+// and restorable — all via storage.type: remote against a real router, not a
+// protocol mock.
+func TestRemoteStorageGroup_CreateGetUpdateDeleteRestore_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForGroups(t)
+	ctx := context.Background()
+
+	created, err := downstream.Storage().CreateGroup(ctx, &models.Group{Name: "engineering", Description: "Eng team"})
+	require.NoError(t, err, "creating a group must succeed via storage.type: remote")
+	require.NotZero(t, created.ID, "the upstream must assign a real ID")
+	assert.Equal(t, "engineering", created.Name)
+	assert.Equal(t, "Eng team", created.Description)
+
+	// Confirm it is a REAL row in the upstream's own storage (not just "the
+	// call didn't error"), by reading it back directly against upstream.
+	direct, err := upstream.Storage().GetGroup(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "engineering", direct.Name)
+
+	// GetGroup via the downstream (RemoteStorage) round-trips correctly.
+	fetched, err := downstream.Storage().GetGroup(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, fetched.ID)
+	assert.Equal(t, "engineering", fetched.Name)
+	assert.Equal(t, "Eng team", fetched.Description)
+
+	// UpdateGroup via the downstream persists on the upstream.
+	fetched.Name = "platform-engineering"
+	fetched.Description = "Platform team"
+	updated, err := downstream.Storage().UpdateGroup(ctx, fetched)
+	require.NoError(t, err)
+	assert.Equal(t, "platform-engineering", updated.Name)
+	direct, err = upstream.Storage().GetGroup(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "platform-engineering", direct.Name, "the update must be a REAL upstream write")
+
+	// DeleteGroup via the downstream soft-deletes on the upstream.
+	require.NoError(t, downstream.Storage().DeleteGroup(ctx, created.ID))
+	_, err = upstream.Storage().GetGroup(ctx, created.ID)
+	require.Error(t, err, "a soft-deleted group must no longer be readable as active")
+
+	// RestoreGroup via the downstream brings it back.
+	require.NoError(t, downstream.Storage().RestoreGroup(ctx, created.ID))
+	restored, err := upstream.Storage().GetGroup(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "platform-engineering", restored.Name, "restore must bring back the SAME row, not a blank one")
+}
+
+// TestRemoteStorageGroup_GetNotFound_RealServer proves a clean not-found error
+// (not a panic, not a garbage 500) for a nonexistent group ID.
+func TestRemoteStorageGroup_GetNotFound_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForGroups(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetGroup(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageGroup_ListAndListPage_RealServer proves ListGroups and
+// ListGroupsPage both work via storage.type: remote against a real server.
+func TestRemoteStorageGroup_ListAndListPage_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForGroups(t)
+	ctx := context.Background()
+
+	names := []string{"alpha-team", "beta-team", "gamma-team"}
+	for _, n := range names {
+		_, err := downstream.Storage().CreateGroup(ctx, &models.Group{Name: n})
+		require.NoError(t, err)
+	}
+
+	all, err := downstream.Storage().ListGroups(ctx)
+	require.NoError(t, err)
+	seen := map[string]bool{}
+	for _, g := range all {
+		seen[g.Name] = true
+	}
+	for _, n := range names {
+		assert.True(t, seen[n], "ListGroups must include %q", n)
+	}
+
+	page, total, err := downstream.Storage().ListGroupsPage(ctx, 0, 2)
+	require.NoError(t, err)
+	assert.Len(t, page, 2, "ListGroupsPage must respect the page size limit")
+	assert.GreaterOrEqual(t, total, int64(len(names)), "ListGroupsPage must report the true total, not just this page's length")
+}
+
+// TestRemoteStorageGroup_Membership_RealServer proves the user-membership fix:
+// AddUserToGroup, ListGroupMembers, GetUserGroups, and RemoveUserFromGroup all
+// work correctly via storage.type: remote against a real server.
+func TestRemoteStorageGroup_Membership_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForGroups(t)
+	ctx := context.Background()
+
+	group, err := downstream.Storage().CreateGroup(ctx, &models.Group{Name: "on-call"})
+	require.NoError(t, err)
+
+	user, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "member1",
+		Email:    "member1@example.com",
+		Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, downstream.Storage().AddUserToGroup(ctx, user.ID, group.ID))
+
+	// The membership is a REAL row on the upstream, visible via upstream's own
+	// direct storage call.
+	directMembers, err := upstream.Storage().ListGroupMembers(ctx, group.ID)
+	require.NoError(t, err)
+	require.Len(t, directMembers, 1)
+	assert.Equal(t, user.ID, directMembers[0].ID)
+
+	// ListGroupMembers via the downstream round-trips correctly.
+	members, err := downstream.Storage().ListGroupMembers(ctx, group.ID)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, user.ID, members[0].ID)
+	assert.Equal(t, "member1", members[0].Username)
+
+	// GetUserGroups via the downstream sees the group — this is the #GetUserGroups
+	// silent-empty-slice fix: before it, this always returned zero groups
+	// regardless of real membership.
+	userGroups, err := downstream.Storage().GetUserGroups(ctx, user.ID)
+	require.NoError(t, err)
+	require.Len(t, userGroups, 1, "GetUserGroups must reflect the real membership, not silently report zero")
+	assert.Equal(t, group.ID, userGroups[0].ID)
+
+	// ListGroupMembersByGroupIDs (the batch form) via the downstream.
+	byGroup, err := downstream.Storage().ListGroupMembersByGroupIDs(ctx, []uint{group.ID})
+	require.NoError(t, err)
+	require.Len(t, byGroup[group.ID], 1)
+	assert.Equal(t, user.ID, byGroup[group.ID][0].ID)
+
+	// RemoveUserFromGroup via the downstream removes the REAL upstream row.
+	require.NoError(t, downstream.Storage().RemoveUserFromGroup(ctx, user.ID, group.ID))
+	directMembers, err = upstream.Storage().ListGroupMembers(ctx, group.ID)
+	require.NoError(t, err)
+	assert.Empty(t, directMembers, "the membership removal must be a REAL upstream write")
+
+	userGroups, err = downstream.Storage().GetUserGroups(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Empty(t, userGroups)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -798,6 +798,44 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/invitations", catalogHandler.ListInvitationsProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/invitations", catalogHandler.CreateInvitationProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Put("/invitations/{id}", catalogHandler.UpdateInvitationProxy)
+
+			// Group CRUD/membership storage-primitive proxy (finding filed round 116).
+			// Lets a downstream Keyorix server booted with storage.type: remote
+			// (ADR-049) proxy CreateGroup/GetGroup/UpdateGroup/DeleteGroup/
+			// RestoreGroup/ListGroups/ListGroupsPage/AddUserToGroup/
+			// RemoveUserFromGroup/ListGroupMembers/ListGroupMembersByGroupIDs/
+			// GetUserGroups to THIS server's real storage backend, instead of
+			// RemoteStorage's Group methods having no server endpoint to call at all
+			// (every group-management CLI/API flow, and every group-inherited
+			// permission/role check, was completely non-functional — or, for
+			// GetUserGroups, silently returning "zero groups" rather than erroring —
+			// under storage.type: remote). Exactly the same pattern as the
+			// login-attempts and invitations proxies above: a thin passthrough onto
+			// storage.Storage (no group POLICY decision — name/description
+			// validation, audit-log events, the escalation-by-proxy admin ceilings —
+			// is made here; that stays entirely in the CALLING server's own
+			// internal/core.KeyorixCore, exactly as it does against a local backend),
+			// reusing the SAME system.read/system.write tier rather than the
+			// users.write/roles.assign the human-facing /groups routes use, since a
+			// RemoteStorage credential already needs system.write for the two proxies
+			// above — no new privilege class. Read is baseline system.read;
+			// create/update/delete/restore/membership-mutation require system.write,
+			// matching every other admin-level mutation in this group. The static
+			// "/page" and "/members-by-ids" routes are registered ahead of "/{id}" so
+			// chi's router (which prefers a static path segment over a wildcard at the
+			// same position) never mistakes either literal segment for a group ID.
+			r.Get("/groups/page", groupHandler.ListGroupsPageProxy)
+			r.Get("/groups/members-by-ids", groupHandler.ListGroupMembersByIDsProxy)
+			r.Get("/groups", groupHandler.ListGroupsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/groups", groupHandler.CreateGroupProxy)
+			r.Get("/groups/{id}", groupHandler.GetGroupProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/groups/{id}", groupHandler.UpdateGroupProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Delete("/groups/{id}", groupHandler.DeleteGroupProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/groups/{id}/restore", groupHandler.RestoreGroupProxy)
+			r.Get("/groups/{id}/members", groupHandler.ListGroupMembersProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/groups/{id}/members", groupHandler.AddGroupMemberProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Delete("/groups/{id}/members/{userId}", groupHandler.RemoveGroupMemberProxy)
+			r.Get("/users/{id}/groups", groupHandler.GetUserGroupsProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary

Fixes a newly-discovered gap (filed as #514, part of the comprehensive #513 RemoteStorage audit): `RemoteStorage`'s Group CRUD/membership (`internal/storage/store/remote_users.go` — `CreateGroup`/`GetGroup`/`UpdateGroup`/`DeleteGroup`/`RestoreGroup`/`ListGroups`/`ListGroupsPage`/`AddUserToGroup`/`RemoveUserFromGroup`/`ListGroupMembers`) were all unconditional stubs, while real server-side `/api/v1/groups` routes exist.

## Additional bugs found and fixed along the way

- `GetUserGroups` silently returned an empty slice (not an error) — a silent-data-loss bug, since `internal/core/permissions.go`, `sso.go`, and `access_review_campaign.go` all use it for permission resolution, meaning group-inherited roles/permissions were silently unenforced under `storage.type: remote`.
- `ListGroupMembersByGroupIDs` was also stubbed (used by the rotation risk-scoring batch, #409).

Both share the same wire DTO and root cause as the main Group CRUD gap, so fixed together.

## Design decision

The existing `/api/v1/groups` HTTP routes are NOT a raw storage passthrough — they run through `core.KeyorixCore.CreateGroup`/etc., which bakes in validation, audit-log events, and several escalation-by-proxy admin ceilings (`guardLastGlobalAdminGroupDelete`, `guardLastGlobalAdminMembership`, `requireGlobalAdminToReinstateAdminRoles`, `requireAuthorityForRole`). Since a `RemoteStorage`-backed `core.KeyorixCore` already evaluates all of that client-side before calling into the storage layer, proxying onto those business-logic routes would double-apply that policy against the wrong actor context on the upstream server. Followed the established #452/#507 pattern instead: new thin passthrough routes under `/api/v1/system/groups` and `/api/v1/system/users/{id}/groups`, gated on the same `system.read`/`system.write` tier every other RemoteStorage call already needs (no new privilege class), calling `storage.Storage`'s raw Group primitives directly. Added a `groupWire` DTO since `models.Group` carries no `json` tags (the same #496 class of gap).

## Testing

`server/http/remote_storage_groups_test.go`: real `NewRouter` + real `RemoteStorage` end-to-end tests covering create/get/update/delete/restore/list/list-page and add/remove/list-member/GetUserGroups/batch-members flows.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` — clean
- `go test ./internal/storage/... ./server/http/... ./internal/core/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./...` — 0 issues
- `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)