### PR TITLE
fix(remote-storage): implement DynamicSecretConfig/Lease CRUD (#515)

### DIFF
--- a/internal/storage/store/remote_dynamic.go
+++ b/internal/storage/store/remote_dynamic.go
@@ -1,44 +1,416 @@
-// remote_dynamic.go — dynamic secrets are a server-side capability; the remote
-// client manages them through the REST API, not the storage interface directly.
+// remote_dynamic.go — dynamic-secrets storage primitives for RemoteStorage
+// (ADR-035/ADR-049): thin passthroughs onto ten new server-side routes under
+// /api/v1/system/dynamic-secrets (server/http/handlers/dynamic_secrets_proxy.go),
+// mirroring the #452-follow-up login-attempts proxy and #507's invitations proxy
+// pattern exactly: gated on the SAME broad system.read/system.write RBAC
+// permissions a RemoteStorage credential already needs for every other proxied
+// call, so this introduces no new privilege class.
+//
+// No dynamic-secrets POLICY decision (admin-authority binding check, TTL/max-lease
+// clamping, active-lease ceiling enforcement, disabled/soft-deleted-project
+// refusal, or the encrypt/decrypt of the admin DSN and issued credential) is made
+// in these routes — that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore (internal/core/dynamic_secrets.go), exactly as it does
+// against a local backend.
+//
+// Sensitive-data boundary (investigated, not assumed): the admin DSN
+// (models.DynamicSecretConfig.AdminDSNEnc/AdminDSNMeta) and each issued credential
+// (models.DynamicSecretLease.CredentialEnc/CredentialMeta) are encrypted by
+// internal/core (KeyorixCore.encryptAuthSecret/decryptAuthSecret) using the
+// CALLING server's own encryption key, BEFORE the config/lease is ever handed to
+// this package's methods below — never in plaintext, and never by the upstream
+// server this proxies to. The wire DTOs below carry that ciphertext as opaque
+// bytes; the upstream server's proxy handlers never decrypt it (see
+// dynamic_secrets_proxy.go's package doc for the full reasoning, including why
+// this is a STRONGER boundary than remote_secrets.go's CreateSecret, which does
+// send an ordinary secret's plaintext value across the wire once).
+//
+// A genuine, deliberate scope boundary: CreateDynamicSecretConfig/IssueLease
+// themselves — i.e. actually minting a live credential against a target database
+// or cloud-IAM engine — can only ever run on whichever server calls these methods
+// (this codebase's dynamic.CredentialEngine implementations dial the target
+// directly), which for a storage.type: remote deployment is the DOWNSTREAM
+// ("spoke") server, not the upstream one these routes live on. That is unchanged
+// by this fix: these are storage-persistence primitives only, exactly like every
+// other RemoteStorage method — they do not make a spoke deployment capable of
+// engine.Issue/engine.Revoke against a target it has no network path to; that
+// requirement was already true (and unrelated to storage.type).
+//
+// UpdateDynamicSecretLease/UpdateDynamicSecretConfig atomicity: LocalStorage's own
+// implementations (internal/storage/store/local_dynamic.go) are both an
+// unconditional full-row `Save`, not a conditional/optimistic-concurrency write
+// (unlike, say, UpdateProjectInvitation's `WHERE id = ? AND state = 'pending'`).
+// internal/core.RevokeLease/RenewLease already re-fetch the lease and check its
+// status before mutating it — a check-then-act sequence with exactly the same
+// (small, pre-existing, accepted) race window against a local backend as against
+// this proxy. This fix preserves that behavior exactly rather than introducing a
+// stricter guarantee the local backend itself doesn't have.
+//
+// For the local (GORM) equivalent of every primitive here see local_dynamic.go.
 package store
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-func (rs *RemoteStorage) CreateDynamicSecretConfig(_ context.Context, _ *models.DynamicSecretConfig) (*models.DynamicSecretConfig, error) {
-	return nil, remoteUnsupported("CreateDynamicSecretConfig")
+// dynamicSecretConfigWire mirrors dynamicSecretConfigProxyWire in
+// server/http/handlers/dynamic_secrets_proxy.go exactly — see that type's comment
+// for why every field (including the admin-DSN ciphertext) is named explicitly.
+type dynamicSecretConfigWire struct {
+	ID                uint      `json:"id"`
+	Name              string    `json:"name"`
+	ProjectID         uint      `json:"project_id"`
+	EnvironmentID     uint      `json:"environment_id"`
+	BackendType       string    `json:"backend_type"`
+	AdminDSNEnc       []byte    `json:"admin_dsn_enc,omitempty"`
+	AdminDSNMeta      []byte    `json:"admin_dsn_meta,omitempty"`
+	CreationTemplate  string    `json:"creation_template"`
+	DefaultTTLSeconds int       `json:"default_ttl_seconds"`
+	MaxTTLSeconds     int       `json:"max_ttl_seconds"`
+	MaxActiveLeases   int       `json:"max_active_leases"`
+	Classification    string    `json:"classification"`
+	Disabled          bool      `json:"disabled"`
+	CreatedBy         string    `json:"created_by"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
 }
-func (rs *RemoteStorage) GetDynamicSecretConfig(_ context.Context, _ uint) (*models.DynamicSecretConfig, error) {
-	return nil, remoteUnsupported("GetDynamicSecretConfig")
+
+func newDynamicSecretConfigWire(c *models.DynamicSecretConfig) dynamicSecretConfigWire {
+	return dynamicSecretConfigWire{
+		ID:                c.ID,
+		Name:              c.Name,
+		ProjectID:         c.ProjectID,
+		EnvironmentID:     c.EnvironmentID,
+		BackendType:       c.BackendType,
+		AdminDSNEnc:       c.AdminDSNEnc,
+		AdminDSNMeta:      c.AdminDSNMeta,
+		CreationTemplate:  c.CreationTemplate,
+		DefaultTTLSeconds: c.DefaultTTLSeconds,
+		MaxTTLSeconds:     c.MaxTTLSeconds,
+		MaxActiveLeases:   c.MaxActiveLeases,
+		Classification:    c.Classification,
+		Disabled:          c.Disabled,
+		CreatedBy:         c.CreatedBy,
+		CreatedAt:         c.CreatedAt,
+		UpdatedAt:         c.UpdatedAt,
+	}
 }
-func (rs *RemoteStorage) ListDynamicSecretConfigs(_ context.Context, _, _ uint) ([]*models.DynamicSecretConfig, error) {
-	return nil, remoteUnsupported("ListDynamicSecretConfigs")
+
+func (w dynamicSecretConfigWire) toModel() *models.DynamicSecretConfig {
+	return &models.DynamicSecretConfig{
+		ID:                w.ID,
+		Name:              w.Name,
+		ProjectID:         w.ProjectID,
+		EnvironmentID:     w.EnvironmentID,
+		BackendType:       w.BackendType,
+		AdminDSNEnc:       w.AdminDSNEnc,
+		AdminDSNMeta:      w.AdminDSNMeta,
+		CreationTemplate:  w.CreationTemplate,
+		DefaultTTLSeconds: w.DefaultTTLSeconds,
+		MaxTTLSeconds:     w.MaxTTLSeconds,
+		MaxActiveLeases:   w.MaxActiveLeases,
+		Classification:    w.Classification,
+		Disabled:          w.Disabled,
+		CreatedBy:         w.CreatedBy,
+		CreatedAt:         w.CreatedAt,
+		UpdatedAt:         w.UpdatedAt,
+	}
 }
-func (rs *RemoteStorage) UpdateDynamicSecretConfig(_ context.Context, _ *models.DynamicSecretConfig) error {
-	return remoteUnsupported("UpdateDynamicSecretConfig")
+
+func decodeDynamicSecretConfigResponse(data []byte) (*models.DynamicSecretConfig, error) {
+	var wire dynamicSecretConfigWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }
-func (rs *RemoteStorage) CountDynamicSecretConfigsByClassification(_ context.Context) (map[string]int, error) {
-	return nil, remoteUnsupported("CountDynamicSecretConfigsByClassification")
+
+// dynamicSecretLeaseWire mirrors dynamicSecretLeaseProxyWire exactly.
+type dynamicSecretLeaseWire struct {
+	ID             uint       `json:"id"`
+	ConfigID       uint       `json:"config_id"`
+	LeaseID        string     `json:"lease_id"`
+	ProjectID      uint       `json:"project_id"`
+	EnvironmentID  uint       `json:"environment_id"`
+	RoleName       string     `json:"role_name"`
+	CredentialEnc  []byte     `json:"credential_enc,omitempty"`
+	CredentialMeta []byte     `json:"credential_meta,omitempty"`
+	Status         string     `json:"status"`
+	RevokeReason   string     `json:"revoke_reason"`
+	RevokeError    string     `json:"revoke_error"`
+	IssuedAt       time.Time  `json:"issued_at"`
+	ExpiresAt      time.Time  `json:"expires_at"`
+	RevokedAt      *time.Time `json:"revoked_at"`
 }
-func (rs *RemoteStorage) CreateDynamicSecretLease(_ context.Context, _ *models.DynamicSecretLease) (*models.DynamicSecretLease, error) {
-	return nil, remoteUnsupported("CreateDynamicSecretLease")
+
+func newDynamicSecretLeaseWire(l *models.DynamicSecretLease) dynamicSecretLeaseWire {
+	return dynamicSecretLeaseWire{
+		ID:             l.ID,
+		ConfigID:       l.ConfigID,
+		LeaseID:        l.LeaseID,
+		ProjectID:      l.ProjectID,
+		EnvironmentID:  l.EnvironmentID,
+		RoleName:       l.RoleName,
+		CredentialEnc:  l.CredentialEnc,
+		CredentialMeta: l.CredentialMeta,
+		Status:         l.Status,
+		RevokeReason:   l.RevokeReason,
+		RevokeError:    l.RevokeError,
+		IssuedAt:       l.IssuedAt,
+		ExpiresAt:      l.ExpiresAt,
+		RevokedAt:      l.RevokedAt,
+	}
 }
-func (rs *RemoteStorage) GetDynamicSecretLease(_ context.Context, _ string) (*models.DynamicSecretLease, error) {
-	return nil, remoteUnsupported("GetDynamicSecretLease")
+
+func (w dynamicSecretLeaseWire) toModel() *models.DynamicSecretLease {
+	return &models.DynamicSecretLease{
+		ID:             w.ID,
+		ConfigID:       w.ConfigID,
+		LeaseID:        w.LeaseID,
+		ProjectID:      w.ProjectID,
+		EnvironmentID:  w.EnvironmentID,
+		RoleName:       w.RoleName,
+		CredentialEnc:  w.CredentialEnc,
+		CredentialMeta: w.CredentialMeta,
+		Status:         w.Status,
+		RevokeReason:   w.RevokeReason,
+		RevokeError:    w.RevokeError,
+		IssuedAt:       w.IssuedAt,
+		ExpiresAt:      w.ExpiresAt,
+		RevokedAt:      w.RevokedAt,
+	}
 }
-func (rs *RemoteStorage) ListDynamicSecretLeases(_ context.Context, _ uint) ([]*models.DynamicSecretLease, error) {
-	return nil, remoteUnsupported("ListDynamicSecretLeases")
+
+func decodeDynamicSecretLeaseResponse(data []byte) (*models.DynamicSecretLease, error) {
+	var wire dynamicSecretLeaseWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }
-func (rs *RemoteStorage) CountActiveLeases(_ context.Context, _ uint) (int64, error) {
-	return 0, remoteUnsupported("CountActiveLeases")
+
+// CreateDynamicSecretConfig persists an already-built config (metadata only —
+// AdminDSNEnc/AdminDSNMeta are typically still empty at this point, mirroring
+// internal/core.CreateDynamicSecretConfig's own two-phase create-then-update, #94)
+// via POST /api/v1/system/dynamic-secrets/configs.
+func (rs *RemoteStorage) CreateDynamicSecretConfig(ctx context.Context, c *models.DynamicSecretConfig) (*models.DynamicSecretConfig, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/dynamic-secrets/configs", newDynamicSecretConfigWire(c))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic-secret config: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create dynamic-secret config failed: %s", resp.Error.Error())
+	}
+	return decodeDynamicSecretConfigResponse(resp.Data)
 }
-func (rs *RemoteStorage) UpdateDynamicSecretLease(_ context.Context, _ *models.DynamicSecretLease) error {
-	return remoteUnsupported("UpdateDynamicSecretLease")
+
+// GetDynamicSecretConfig retrieves a config by ID via GET
+// /api/v1/system/dynamic-secrets/configs/{id} — including its admin-DSN
+// ciphertext, which the CALLING server (not this package) decrypts.
+func (rs *RemoteStorage) GetDynamicSecretConfig(ctx context.Context, id uint) (*models.DynamicSecretConfig, error) {
+	path := fmt.Sprintf("/api/v1/system/dynamic-secrets/configs/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dynamic-secret config: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get dynamic-secret config failed: %s", resp.Error.Error())
+	}
+	return decodeDynamicSecretConfigResponse(resp.Data)
 }
-func (rs *RemoteStorage) ListExpiredActiveLeases(_ context.Context, _ time.Time) ([]*models.DynamicSecretLease, error) {
-	return nil, remoteUnsupported("ListExpiredActiveLeases")
+
+// ListDynamicSecretConfigs lists a project's (optionally environment-scoped)
+// configs via GET /api/v1/system/dynamic-secrets/configs?project_id=&environment_id=.
+func (rs *RemoteStorage) ListDynamicSecretConfigs(ctx context.Context, projectID, environmentID uint) ([]*models.DynamicSecretConfig, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	if environmentID != 0 {
+		q.Set("environment_id", strconv.FormatUint(uint64(environmentID), 10))
+	}
+	path := "/api/v1/system/dynamic-secrets/configs?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list dynamic-secret configs: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list dynamic-secret configs failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Configs []dynamicSecretConfigWire `json:"configs"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.DynamicSecretConfig, 0, len(result.Configs))
+	for _, w := range result.Configs {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
+}
+
+// UpdateDynamicSecretConfig persists the full config row (including, on the
+// second phase of a create, the now-encrypted admin-DSN ciphertext) via PUT
+// /api/v1/system/dynamic-secrets/configs/{id}. Matches LocalStorage's own
+// unconditional full-row Save semantics exactly — see the package doc for why no
+// conditional write is needed here.
+func (rs *RemoteStorage) UpdateDynamicSecretConfig(ctx context.Context, c *models.DynamicSecretConfig) error {
+	path := fmt.Sprintf("/api/v1/system/dynamic-secrets/configs/%d", c.ID)
+	resp, err := rs.client.Put(ctx, path, newDynamicSecretConfigWire(c))
+	if err != nil {
+		return fmt.Errorf("failed to update dynamic-secret config: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("update dynamic-secret config failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// CountDynamicSecretConfigsByClassification returns install-wide config counts
+// keyed by classification label via GET
+// /api/v1/system/dynamic-secrets/configs/classification-counts.
+func (rs *RemoteStorage) CountDynamicSecretConfigsByClassification(ctx context.Context) (map[string]int, error) {
+	resp, err := rs.client.Get(ctx, "/api/v1/system/dynamic-secrets/configs/classification-counts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to count dynamic-secret configs by classification: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("count dynamic-secret configs by classification failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Counts map[string]int `json:"counts"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Counts, nil
+}
+
+// CreateDynamicSecretLease persists an already-issued lease (the credential was
+// minted on the target and encrypted by the CALLING server's own
+// internal/core.IssueLease before this call) via POST
+// /api/v1/system/dynamic-secrets/leases.
+func (rs *RemoteStorage) CreateDynamicSecretLease(ctx context.Context, l *models.DynamicSecretLease) (*models.DynamicSecretLease, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/dynamic-secrets/leases", newDynamicSecretLeaseWire(l))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic-secret lease: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create dynamic-secret lease failed: %s", resp.Error.Error())
+	}
+	return decodeDynamicSecretLeaseResponse(resp.Data)
+}
+
+// GetDynamicSecretLease retrieves a lease by its opaque public LeaseID via GET
+// /api/v1/system/dynamic-secrets/leases/{leaseID}.
+func (rs *RemoteStorage) GetDynamicSecretLease(ctx context.Context, leaseID string) (*models.DynamicSecretLease, error) {
+	path := fmt.Sprintf("/api/v1/system/dynamic-secrets/leases/%s", url.PathEscape(leaseID))
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dynamic-secret lease: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get dynamic-secret lease failed: %s", resp.Error.Error())
+	}
+	return decodeDynamicSecretLeaseResponse(resp.Data)
+}
+
+// ListDynamicSecretLeases lists a config's leases via GET
+// /api/v1/system/dynamic-secrets/leases?config_id=X.
+func (rs *RemoteStorage) ListDynamicSecretLeases(ctx context.Context, configID uint) ([]*models.DynamicSecretLease, error) {
+	q := url.Values{}
+	q.Set("config_id", strconv.FormatUint(uint64(configID), 10))
+	path := "/api/v1/system/dynamic-secrets/leases?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list dynamic-secret leases: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list dynamic-secret leases failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Leases []dynamicSecretLeaseWire `json:"leases"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.DynamicSecretLease, 0, len(result.Leases))
+	for _, w := range result.Leases {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
+}
+
+// CountActiveLeases returns how many of a config's leases still hold a live
+// credential upstream via GET
+// /api/v1/system/dynamic-secrets/leases/active-count?config_id=X.
+func (rs *RemoteStorage) CountActiveLeases(ctx context.Context, configID uint) (int64, error) {
+	q := url.Values{}
+	q.Set("config_id", strconv.FormatUint(uint64(configID), 10))
+	path := "/api/v1/system/dynamic-secrets/leases/active-count?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count active dynamic-secret leases: %w", err)
+	}
+	if !resp.Success {
+		return 0, fmt.Errorf("count active dynamic-secret leases failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Count int64 `json:"count"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Count, nil
+}
+
+// UpdateDynamicSecretLease persists the full lease row (status transitions,
+// revoke bookkeeping, renewed expiry) via PUT
+// /api/v1/system/dynamic-secrets/leases/{leaseID}. Matches LocalStorage's own
+// unconditional full-row Save semantics exactly — see the package doc for why no
+// conditional write is needed here.
+func (rs *RemoteStorage) UpdateDynamicSecretLease(ctx context.Context, l *models.DynamicSecretLease) error {
+	path := fmt.Sprintf("/api/v1/system/dynamic-secrets/leases/%s", url.PathEscape(l.LeaseID))
+	resp, err := rs.client.Put(ctx, path, newDynamicSecretLeaseWire(l))
+	if err != nil {
+		return fmt.Errorf("failed to update dynamic-secret lease: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("update dynamic-secret lease failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// ListExpiredActiveLeases lists every lease past `before` that still needs its
+// target credential dropped, via GET
+// /api/v1/system/dynamic-secrets/leases/expired?before=<RFC3339Nano> — backing the
+// CALLING server's own auto-revoke sweep (internal/core.RevokeExpiredLeases).
+func (rs *RemoteStorage) ListExpiredActiveLeases(ctx context.Context, before time.Time) ([]*models.DynamicSecretLease, error) {
+	q := url.Values{}
+	q.Set("before", before.UTC().Format(time.RFC3339Nano))
+	path := "/api/v1/system/dynamic-secrets/leases/expired?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list expired dynamic-secret leases: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list expired dynamic-secret leases failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Leases []dynamicSecretLeaseWire `json:"leases"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.DynamicSecretLease, 0, len(result.Leases))
+	for _, w := range result.Leases {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
 }

--- a/server/http/handlers/dynamic_secrets_proxy.go
+++ b/server/http/handlers/dynamic_secrets_proxy.go
@@ -1,0 +1,492 @@
+// dynamic_secrets_proxy.go — server-side endpoints backing RemoteStorage's
+// dynamic-secrets storage primitives (ADR-035/ADR-049): CreateDynamicSecretConfig/
+// GetDynamicSecretConfig/ListDynamicSecretConfigs/UpdateDynamicSecretConfig/
+// CountDynamicSecretConfigsByClassification/CreateDynamicSecretLease/
+// GetDynamicSecretLease/ListDynamicSecretLeases/CountActiveLeases/
+// UpdateDynamicSecretLease/ListExpiredActiveLeases.
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// its dynamic-secrets storage calls to whichever upstream server it's configured
+// against, through these routes (registered in server/http/router.go under
+// /api/v1/system/dynamic-secrets, gated on the existing system.read/system.write
+// RBAC permissions — the SAME credential a RemoteStorage client already needs for
+// every other proxied call, e.g. full user CRUD, login-attempts, invitations — so
+// this introduces no new privilege class). Mirrors login_attempts_proxy.go and
+// invitations_proxy.go exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/dynamic_secrets.go already uses against a local backend — NO
+// dynamic-secrets POLICY decision (admin-authority binding check, TTL/max-lease
+// clamping, active-lease ceiling enforcement, disabled/soft-deleted-project
+// refusal, the encrypt/decrypt of the admin DSN and issued credential) is made
+// here; all of that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore, exactly as it does against a local backend.
+//
+// Critically, the admin DSN (models.DynamicSecretConfig.AdminDSNEnc/AdminDSNMeta)
+// and the issued credential (models.DynamicSecretLease.CredentialEnc/
+// CredentialMeta) NEVER cross this boundary in plaintext: internal/core encrypts
+// the admin DSN with the CALLING server's own encryption key BEFORE ever handing
+// the config to storage.CreateDynamicSecretConfig/UpdateDynamicSecretConfig, and
+// decrypts it only after storage.GetDynamicSecretConfig returns the ciphertext
+// bytes back to that SAME calling server. These proxy handlers persist/return
+// those bytes as opaque ciphertext — this server (the upstream) never decrypts
+// them, and in a storage.type: remote deployment generally CANNOT: it has no
+// reason to hold the downstream's encryption key at all. This is a stronger
+// boundary than CreateSecret's remote passthrough (internal/storage/store/
+// remote_secrets.go), which does send a secret's plaintext value across the wire
+// once, because for ordinary secrets encryption happens in the STORAGE layer of
+// whichever server ultimately persists the row (this server, for a config/lease
+// round-tripped through here). For dynamic secrets it happens in core, one layer
+// up, so the ciphertext is already opaque by the time it reaches here.
+//
+// This also means the DynamicSecretHandler's existing human-facing
+// /api/v1/dynamic-secrets/* routes (server/http/handlers/dynamic_secrets.go) are
+// NOT reused for this proxy, unlike the login-attempts/invitations precedent might
+// suggest at a glance: CreateConfig there requires a PLAINTEXT admin_dsn field and
+// runs this server's OWN core.CreateDynamicSecretConfig (including this server's
+// own admin-authority/project-scope authorization against the HTTP caller's
+// identity and this server's own encryption key) — the wrong semantics for a raw
+// storage-primitive passthrough, whose caller already ran all of that on the
+// downstream side and only needs this server to persist/return already-encrypted
+// bytes.
+//
+// Response envelope: like login_attempts_proxy.go/invitations_proxy.go, these do
+// NOT use the package's generic sendSuccess/sendError helpers — they construct the
+// exact {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// dynamicSecretConfigProxyWire mirrors models.DynamicSecretConfig's fields
+// exactly (snake_case), INCLUDING the encrypted admin-DSN ciphertext + metadata —
+// see the package doc for why sending that ciphertext (never plaintext) across
+// this boundary is safe. models.DynamicSecretConfig carries no json tags of its
+// own (AdminDSNEnc/AdminDSNMeta are actually tagged `json:"-"`, which would
+// silently drop them from a direct marshal), so — matching invitationProxyWire's
+// (#496-class) reasoning — every field is named explicitly here rather than
+// relying on a direct marshal of the model.
+type dynamicSecretConfigProxyWire struct {
+	ID                uint      `json:"id"`
+	Name              string    `json:"name"`
+	ProjectID         uint      `json:"project_id"`
+	EnvironmentID     uint      `json:"environment_id"`
+	BackendType       string    `json:"backend_type"`
+	AdminDSNEnc       []byte    `json:"admin_dsn_enc,omitempty"`
+	AdminDSNMeta      []byte    `json:"admin_dsn_meta,omitempty"`
+	CreationTemplate  string    `json:"creation_template"`
+	DefaultTTLSeconds int       `json:"default_ttl_seconds"`
+	MaxTTLSeconds     int       `json:"max_ttl_seconds"`
+	MaxActiveLeases   int       `json:"max_active_leases"`
+	Classification    string    `json:"classification"`
+	Disabled          bool      `json:"disabled"`
+	CreatedBy         string    `json:"created_by"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
+}
+
+func newDynamicSecretConfigProxyWire(c *models.DynamicSecretConfig) dynamicSecretConfigProxyWire {
+	return dynamicSecretConfigProxyWire{
+		ID:                c.ID,
+		Name:              c.Name,
+		ProjectID:         c.ProjectID,
+		EnvironmentID:     c.EnvironmentID,
+		BackendType:       c.BackendType,
+		AdminDSNEnc:       c.AdminDSNEnc,
+		AdminDSNMeta:      c.AdminDSNMeta,
+		CreationTemplate:  c.CreationTemplate,
+		DefaultTTLSeconds: c.DefaultTTLSeconds,
+		MaxTTLSeconds:     c.MaxTTLSeconds,
+		MaxActiveLeases:   c.MaxActiveLeases,
+		Classification:    c.Classification,
+		Disabled:          c.Disabled,
+		CreatedBy:         c.CreatedBy,
+		CreatedAt:         c.CreatedAt,
+		UpdatedAt:         c.UpdatedAt,
+	}
+}
+
+func (w dynamicSecretConfigProxyWire) toModel() *models.DynamicSecretConfig {
+	return &models.DynamicSecretConfig{
+		ID:                w.ID,
+		Name:              w.Name,
+		ProjectID:         w.ProjectID,
+		EnvironmentID:     w.EnvironmentID,
+		BackendType:       w.BackendType,
+		AdminDSNEnc:       w.AdminDSNEnc,
+		AdminDSNMeta:      w.AdminDSNMeta,
+		CreationTemplate:  w.CreationTemplate,
+		DefaultTTLSeconds: w.DefaultTTLSeconds,
+		MaxTTLSeconds:     w.MaxTTLSeconds,
+		MaxActiveLeases:   w.MaxActiveLeases,
+		Classification:    w.Classification,
+		Disabled:          w.Disabled,
+		CreatedBy:         w.CreatedBy,
+		CreatedAt:         w.CreatedAt,
+		UpdatedAt:         w.UpdatedAt,
+	}
+}
+
+// dynamicSecretLeaseProxyWire mirrors models.DynamicSecretLease's fields exactly,
+// including the encrypted credential ciphertext + metadata (CredentialEnc/
+// CredentialMeta, tagged `json:"-"` on the model) — same reasoning as
+// dynamicSecretConfigProxyWire above: this ciphertext was produced by the CALLING
+// server's own core using its own encryption key, and is never decrypted here.
+type dynamicSecretLeaseProxyWire struct {
+	ID             uint       `json:"id"`
+	ConfigID       uint       `json:"config_id"`
+	LeaseID        string     `json:"lease_id"`
+	ProjectID      uint       `json:"project_id"`
+	EnvironmentID  uint       `json:"environment_id"`
+	RoleName       string     `json:"role_name"`
+	CredentialEnc  []byte     `json:"credential_enc,omitempty"`
+	CredentialMeta []byte     `json:"credential_meta,omitempty"`
+	Status         string     `json:"status"`
+	RevokeReason   string     `json:"revoke_reason"`
+	RevokeError    string     `json:"revoke_error"`
+	IssuedAt       time.Time  `json:"issued_at"`
+	ExpiresAt      time.Time  `json:"expires_at"`
+	RevokedAt      *time.Time `json:"revoked_at"`
+}
+
+func newDynamicSecretLeaseProxyWire(l *models.DynamicSecretLease) dynamicSecretLeaseProxyWire {
+	return dynamicSecretLeaseProxyWire{
+		ID:             l.ID,
+		ConfigID:       l.ConfigID,
+		LeaseID:        l.LeaseID,
+		ProjectID:      l.ProjectID,
+		EnvironmentID:  l.EnvironmentID,
+		RoleName:       l.RoleName,
+		CredentialEnc:  l.CredentialEnc,
+		CredentialMeta: l.CredentialMeta,
+		Status:         l.Status,
+		RevokeReason:   l.RevokeReason,
+		RevokeError:    l.RevokeError,
+		IssuedAt:       l.IssuedAt,
+		ExpiresAt:      l.ExpiresAt,
+		RevokedAt:      l.RevokedAt,
+	}
+}
+
+func (w dynamicSecretLeaseProxyWire) toModel() *models.DynamicSecretLease {
+	return &models.DynamicSecretLease{
+		ID:             w.ID,
+		ConfigID:       w.ConfigID,
+		LeaseID:        w.LeaseID,
+		ProjectID:      w.ProjectID,
+		EnvironmentID:  w.EnvironmentID,
+		RoleName:       w.RoleName,
+		CredentialEnc:  w.CredentialEnc,
+		CredentialMeta: w.CredentialMeta,
+		Status:         w.Status,
+		RevokeReason:   w.RevokeReason,
+		RevokeError:    w.RevokeError,
+		IssuedAt:       w.IssuedAt,
+		ExpiresAt:      w.ExpiresAt,
+		RevokedAt:      w.RevokedAt,
+	}
+}
+
+func isNotFoundErr(err error) bool {
+	return strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "record not found")
+}
+
+// CreateDynamicSecretConfigProxy handles POST /api/v1/system/dynamic-secrets/configs.
+// Persists the caller's already-fully-built config row as-is (a raw storage-layer
+// create) — matching CreateProjectInvitationProxy's precedent, this is NOT the
+// human-facing POST /api/v1/dynamic-secrets/configs (DynamicSecretHandler.CreateConfig),
+// which additionally requires a plaintext admin_dsn and runs this server's own
+// authorization + encryption. The caller (internal/core.CreateDynamicSecretConfig
+// on the downstream server) itself does the same two-phase create-then-update this
+// server's LocalStorage-backed path does (#94): the DSN ciphertext is usually empty
+// on this initial create and arrives moments later via UpdateDynamicSecretConfigProxy.
+func (h *DynamicSecretHandler) CreateDynamicSecretConfigProxy(w http.ResponseWriter, r *http.Request) {
+	var body dynamicSecretConfigProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Name == "" || body.ProjectID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "name and project_id are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateDynamicSecretConfig(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("dynamic-secrets proxy: create config failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newDynamicSecretConfigProxyWire(created))
+}
+
+// GetDynamicSecretConfigProxy handles GET /api/v1/system/dynamic-secrets/configs/{id}.
+func (h *DynamicSecretHandler) GetDynamicSecretConfigProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid config id")
+		return
+	}
+	cfg, err := h.coreService.Storage().GetDynamicSecretConfig(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "dynamic-secret config not found")
+			return
+		}
+		log.Printf("dynamic-secrets proxy: get config failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newDynamicSecretConfigProxyWire(cfg))
+}
+
+// ListDynamicSecretConfigsProxy handles GET
+// /api/v1/system/dynamic-secrets/configs?project_id=&environment_id=.
+func (h *DynamicSecretHandler) ListDynamicSecretConfigsProxy(w http.ResponseWriter, r *http.Request) {
+	projectID, environmentID, ok := parseProxyScopeQuery(w, r)
+	if !ok {
+		return
+	}
+	rows, err := h.coreService.Storage().ListDynamicSecretConfigs(r.Context(), projectID, environmentID)
+	if err != nil {
+		log.Printf("dynamic-secrets proxy: list configs failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]dynamicSecretConfigProxyWire, 0, len(rows))
+	for _, c := range rows {
+		wire = append(wire, newDynamicSecretConfigProxyWire(c))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"configs": wire})
+}
+
+// UpdateDynamicSecretConfigProxy handles PUT /api/v1/system/dynamic-secrets/configs/{id}.
+// A raw persist (storage.Storage.UpdateDynamicSecretConfig is an unconditional
+// full-row Save, matching LocalStorage's own semantics exactly — there is no
+// conditional/optimistic-concurrency write to preserve here, unlike
+// UpdateProjectInvitation's `WHERE ... AND state = 'pending'`).
+func (h *DynamicSecretHandler) UpdateDynamicSecretConfigProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid config id")
+		return
+	}
+	var body dynamicSecretConfigProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	if err := h.coreService.Storage().UpdateDynamicSecretConfig(r.Context(), body.toModel()); err != nil {
+		log.Printf("dynamic-secrets proxy: update config failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}
+
+// CountDynamicSecretConfigsByClassificationProxy handles GET
+// /api/v1/system/dynamic-secrets/configs/classification-counts (a static path,
+// registered before /configs/{id} in router.go).
+func (h *DynamicSecretHandler) CountDynamicSecretConfigsByClassificationProxy(w http.ResponseWriter, r *http.Request) {
+	counts, err := h.coreService.Storage().CountDynamicSecretConfigsByClassification(r.Context())
+	if err != nil {
+		log.Printf("dynamic-secrets proxy: count-by-classification failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"counts": counts})
+}
+
+// CreateDynamicSecretLeaseProxy handles POST /api/v1/system/dynamic-secrets/leases.
+// The calling server has already minted the credential on the target and
+// encrypted it with its own key (internal/core.IssueLease) before this call — this
+// only persists the resulting lease row (with its opaque ciphertext).
+func (h *DynamicSecretHandler) CreateDynamicSecretLeaseProxy(w http.ResponseWriter, r *http.Request) {
+	var body dynamicSecretLeaseProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.ConfigID == 0 || body.LeaseID == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "config_id and lease_id are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateDynamicSecretLease(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("dynamic-secrets proxy: create lease failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newDynamicSecretLeaseProxyWire(created))
+}
+
+// GetDynamicSecretLeaseProxy handles GET /api/v1/system/dynamic-secrets/leases/{leaseID}.
+func (h *DynamicSecretHandler) GetDynamicSecretLeaseProxy(w http.ResponseWriter, r *http.Request) {
+	leaseID := chi.URLParam(r, "leaseID")
+	lease, err := h.coreService.Storage().GetDynamicSecretLease(r.Context(), leaseID)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "lease not found")
+			return
+		}
+		log.Printf("dynamic-secrets proxy: get lease failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newDynamicSecretLeaseProxyWire(lease))
+}
+
+// ListDynamicSecretLeasesProxy handles GET
+// /api/v1/system/dynamic-secrets/leases?config_id=X.
+func (h *DynamicSecretHandler) ListDynamicSecretLeasesProxy(w http.ResponseWriter, r *http.Request) {
+	configID, ok := parseProxyConfigIDQuery(w, r)
+	if !ok {
+		return
+	}
+	rows, err := h.coreService.Storage().ListDynamicSecretLeases(r.Context(), configID)
+	if err != nil {
+		log.Printf("dynamic-secrets proxy: list leases failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]dynamicSecretLeaseProxyWire, 0, len(rows))
+	for _, l := range rows {
+		wire = append(wire, newDynamicSecretLeaseProxyWire(l))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"leases": wire})
+}
+
+// CountActiveLeasesProxy handles GET
+// /api/v1/system/dynamic-secrets/leases/active-count?config_id=X (a static path,
+// registered before /leases/{leaseID} in router.go).
+func (h *DynamicSecretHandler) CountActiveLeasesProxy(w http.ResponseWriter, r *http.Request) {
+	configID, ok := parseProxyConfigIDQuery(w, r)
+	if !ok {
+		return
+	}
+	n, err := h.coreService.Storage().CountActiveLeases(r.Context(), configID)
+	if err != nil {
+		log.Printf("dynamic-secrets proxy: count active leases failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int64{"count": n})
+}
+
+// UpdateDynamicSecretLeaseProxy handles PUT /api/v1/system/dynamic-secrets/leases/{leaseID}.
+// A raw persist (storage.Storage.UpdateDynamicSecretLease is an unconditional
+// full-row Save, matching LocalStorage's own semantics exactly — the calling
+// server's own core.RevokeLease/RenewLease already re-fetches the lease and checks
+// its status before mutating it, exactly as it does against a local backend; this
+// proxy adds no NEW atomicity guarantee beyond what LocalStorage already provides,
+// and removes none).
+func (h *DynamicSecretHandler) UpdateDynamicSecretLeaseProxy(w http.ResponseWriter, r *http.Request) {
+	leaseID := chi.URLParam(r, "leaseID")
+	var body dynamicSecretLeaseProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.LeaseID = leaseID
+	if err := h.coreService.Storage().UpdateDynamicSecretLease(r.Context(), body.toModel()); err != nil {
+		log.Printf("dynamic-secrets proxy: update lease failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}
+
+// ListExpiredActiveLeasesProxy handles GET
+// /api/v1/system/dynamic-secrets/leases/expired?before=<RFC3339> (a static path,
+// registered before /leases/{leaseID} in router.go). Backs the calling server's
+// OWN auto-revoke sweep (internal/core.RevokeExpiredLeases) against this server's
+// real storage backend.
+func (h *DynamicSecretHandler) ListExpiredActiveLeasesProxy(w http.ResponseWriter, r *http.Request) {
+	beforeStr := r.URL.Query().Get("before")
+	if beforeStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "before query parameter is required")
+		return
+	}
+	before, err := time.Parse(time.RFC3339Nano, beforeStr)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "before must be an RFC3339 timestamp")
+		return
+	}
+	// Reparsing an RFC3339 "Z"-suffixed wire timestamp always yields a UTC
+	// time.Time — but this server's OWN ExpiresAt rows were stored using
+	// whichever timezone its process clock (c.now = time.Now()) runs in, and
+	// GORM's SQLite driver formats a bound time.Time parameter's TEXT
+	// representation using ITS OWN Location, not a canonical one. If this
+	// server's process timezone is not UTC, comparing a UTC-formatted `before`
+	// against locally-formatted stored rows via SQLite's TEXT `<` operator can
+	// silently give the WRONG answer for genuinely-expired rows (verified
+	// empirically: a lease expired exactly 1 hour ago was excluded entirely,
+	// because "07:...+0000" sorts lexicographically before "08:...+0200" even
+	// though the latter is the earlier instant). Convert to Local so this
+	// proxy's comparison matches the SAME convention every other ExpiresAt
+	// comparison in this codebase already uses (time.Now(), never time.Now().UTC()).
+	rows, err := h.coreService.Storage().ListExpiredActiveLeases(r.Context(), before.Local())
+	if err != nil {
+		log.Printf("dynamic-secrets proxy: list expired leases failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]dynamicSecretLeaseProxyWire, 0, len(rows))
+	for _, l := range rows {
+		wire = append(wire, newDynamicSecretLeaseProxyWire(l))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"leases": wire})
+}
+
+// parseProxyScopeQuery parses the optional project_id/environment_id query
+// parameters shared by ListDynamicSecretConfigsProxy. project_id is required (0
+// is not a valid project); environment_id 0 means "all environments" — mirroring
+// core.ListDynamicSecretConfigs' own storage-layer contract.
+func parseProxyScopeQuery(w http.ResponseWriter, r *http.Request) (projectID, environmentID uint, ok bool) {
+	projectIDStr := r.URL.Query().Get("project_id")
+	if projectIDStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id query parameter is required")
+		return 0, 0, false
+	}
+	pid, err := strconv.ParseUint(projectIDStr, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id must be a valid integer")
+		return 0, 0, false
+	}
+	projectID = uint(pid)
+	if v := r.URL.Query().Get("environment_id"); v != "" {
+		eid, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "environment_id must be a valid integer")
+			return 0, 0, false
+		}
+		environmentID = uint(eid)
+	}
+	return projectID, environmentID, true
+}
+
+// parseProxyConfigIDQuery parses the required config_id query parameter shared by
+// ListDynamicSecretLeasesProxy/CountActiveLeasesProxy.
+func parseProxyConfigIDQuery(w http.ResponseWriter, r *http.Request) (configID uint, ok bool) {
+	v := r.URL.Query().Get("config_id")
+	if v == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "config_id query parameter is required")
+		return 0, false
+	}
+	id, err := strconv.ParseUint(v, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "config_id must be a valid integer")
+		return 0, false
+	}
+	return uint(id), true
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -75,6 +75,10 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		// #507: the invitation-proxy end-to-end tests exercise ProjectInvitation
 		// CRUD through the real router.
 		&models.ProjectInvitation{},
+		// round-116 finding: the dynamic-secrets-proxy end-to-end tests exercise
+		// DynamicSecretConfig/DynamicSecretLease CRUD through the real router.
+		&models.DynamicSecretConfig{},
+		&models.DynamicSecretLease{},
 	)
 	require.NoError(t, err)
 	return core.NewKeyorixCore(store.NewLocalStorage(db))

--- a/server/http/remote_storage_dynamic_secrets_test.go
+++ b/server/http/remote_storage_dynamic_secrets_test.go
@@ -1,0 +1,325 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForDynamicSecrets builds the standard #452/#507-style
+// two-server harness: an "upstream" exercised through the REAL production
+// NewRouter/handlers (including the new /api/v1/system/dynamic-secrets routes,
+// server/http/handlers/dynamic_secrets_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed at
+// "upstream" over real HTTP via store.RemoteStorage.
+func newUpstreamDownstreamForDynamicSecrets(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore, projectID, environmentID uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+
+	ctx := context.Background()
+	project, err := upstream.CreateProject(ctx, "Dynamic Secrets Test Project", "")
+	require.NoError(t, err)
+	// CreateProject auto-seeds default environments (e.g. "production"); reuse one
+	// rather than creating a new one, which would collide on the (project_id, name)
+	// unique index.
+	envs, err := upstream.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs, "CreateProject must seed at least one default environment")
+	return upstream, downstream, project.ID, envs[0].ID
+}
+
+// buildDynamicSecretConfig mirrors what internal/core.CreateDynamicSecretConfig
+// computes before calling storage.CreateDynamicSecretConfig — a fully-built config
+// row (metadata only, no admin-DSN ciphertext yet, mirroring the #94 two-phase
+// create-then-update) — WITHOUT going through CreateDynamicSecretConfig itself
+// (which additionally requires an admin-authority RBAC check whose own storage
+// primitives — role resolution — are a separate, pre-existing gap independent of
+// this finding, exactly the same class of out-of-scope prerequisite
+// remote_storage_invitations_test.go's buildPendingInvitation documents for
+// GetRoleByName).
+func buildDynamicSecretConfig(now time.Time, projectID, environmentID uint, name string) *models.DynamicSecretConfig {
+	return &models.DynamicSecretConfig{
+		Name:              name,
+		ProjectID:         projectID,
+		EnvironmentID:     environmentID,
+		BackendType:       "postgres",
+		CreationTemplate:  "GRANT SELECT ON ALL TABLES IN SCHEMA public TO {{name}};",
+		DefaultTTLSeconds: 3600,
+		MaxTTLSeconds:     86400,
+		MaxActiveLeases:   5,
+		CreatedBy:         "alice",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+}
+
+// TestRemoteStorageDynamicSecrets_ConfigCreateGetListUpdate_RealServer proves the
+// fix for CreateDynamicSecretConfig/GetDynamicSecretConfig/ListDynamicSecretConfigs/
+// UpdateDynamicSecretConfig: a config is genuinely persisted on the upstream server
+// via the DOWNSTREAM's RemoteStorage, fetchable by ID, listed, and updatable — all
+// via storage.type: remote against a real router, not a protocol mock.
+func TestRemoteStorageDynamicSecrets_ConfigCreateGetListUpdate_RealServer(t *testing.T) {
+	upstream, downstream, projectID, environmentID := newUpstreamDownstreamForDynamicSecrets(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	cfg, err := downstream.Storage().CreateDynamicSecretConfig(ctx, buildDynamicSecretConfig(now, projectID, environmentID, "app-db"))
+	require.NoError(t, err, "creating a dynamic-secret config must succeed via storage.type: remote")
+	require.NotZero(t, cfg.ID, "the upstream must assign a real ID")
+	assert.Equal(t, "app-db", cfg.Name)
+	assert.Equal(t, "postgres", cfg.BackendType)
+	assert.Equal(t, projectID, cfg.ProjectID)
+	assert.Equal(t, environmentID, cfg.EnvironmentID)
+
+	// Confirm it is a REAL row in the upstream's own storage (not just "the call
+	// didn't error"), by reading it back directly against upstream.
+	direct, err := upstream.Storage().GetDynamicSecretConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "app-db", direct.Name)
+
+	// GetDynamicSecretConfig via the downstream (RemoteStorage) round-trips every
+	// field correctly.
+	fetched, err := downstream.Storage().GetDynamicSecretConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, cfg.ID, fetched.ID)
+	assert.Equal(t, cfg.Name, fetched.Name)
+	assert.Equal(t, cfg.CreationTemplate, fetched.CreationTemplate)
+	assert.Equal(t, cfg.MaxTTLSeconds, fetched.MaxTTLSeconds)
+	assert.Equal(t, cfg.MaxActiveLeases, fetched.MaxActiveLeases)
+
+	// A second config, then list both back via the downstream's ListDynamicSecretConfigs.
+	_, err = downstream.Storage().CreateDynamicSecretConfig(ctx, buildDynamicSecretConfig(now, projectID, environmentID, "cache-db"))
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListDynamicSecretConfigs(ctx, projectID, environmentID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	names := map[string]bool{}
+	for _, r := range rows {
+		names[r.Name] = true
+	}
+	assert.True(t, names["app-db"])
+	assert.True(t, names["cache-db"])
+
+	// UpdateDynamicSecretConfig persists a change (classification) via the downstream.
+	fetched.Classification = "confidential"
+	require.NoError(t, downstream.Storage().UpdateDynamicSecretConfig(ctx, fetched))
+	reFetched, err := upstream.Storage().GetDynamicSecretConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "confidential", reFetched.Classification, "the update must be visible directly on the upstream's own storage")
+
+	// CountDynamicSecretConfigsByClassification via the downstream.
+	counts, err := downstream.Storage().CountDynamicSecretConfigsByClassification(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, counts["confidential"])
+}
+
+// TestRemoteStorageDynamicSecrets_GetConfigNotFound_RealServer proves a clean
+// not-found error (not a panic, not a garbage 500) for a nonexistent config ID.
+func TestRemoteStorageDynamicSecrets_GetConfigNotFound_RealServer(t *testing.T) {
+	_, downstream, _, _ := newUpstreamDownstreamForDynamicSecrets(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetDynamicSecretConfig(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageDynamicSecrets_AdminDSNNeverPlaintextOnUpstream_RealServer is
+// the critical sensitive-data-boundary test for this finding: it encrypts an
+// admin DSN with a LOCAL encryption service (standing in for the downstream
+// server's own encryptAuthSecret, exactly as internal/core.CreateDynamicSecretConfig
+// does before ever calling storage.CreateDynamicSecretConfig/
+// UpdateDynamicSecretConfig), persists ONLY the resulting ciphertext through the
+// downstream's RemoteStorage, and proves:
+//  1. the RAW bytes visible directly in the upstream's own storage are NOT the
+//     plaintext admin DSN (the upstream never sees it — it only ever receives
+//     opaque ciphertext over the wire);
+//  2. fetching the config back via the downstream's RemoteStorage and decrypting
+//     with the SAME encryption service reproduces the exact original plaintext,
+//     proving the ciphertext round-trips through this HTTP hop byte-for-byte
+//     (encoding/json base64 for []byte fields), unmodified.
+func TestRemoteStorageDynamicSecrets_AdminDSNNeverPlaintextOnUpstream_RealServer(t *testing.T) {
+	upstream, downstream, projectID, environmentID := newUpstreamDownstreamForDynamicSecrets(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
+	require.NoError(t, enc.Initialize("test-passphrase"))
+
+	const adminDSNPlain = "postgres://admin:s3cr3t@db.internal:5432/app"
+
+	// Phase 1 (mirrors #94): create the row with no DSN ciphertext yet — cfg.ID
+	// isn't known until the row exists, and the AAD binds to it.
+	cfg, err := downstream.Storage().CreateDynamicSecretConfig(ctx, buildDynamicSecretConfig(now, projectID, environmentID, "sensitive-db"))
+	require.NoError(t, err)
+
+	// Phase 2: encrypt LOCALLY (standing in for the downstream server's own
+	// encryptAuthSecret) and persist only the ciphertext.
+	ct, meta, err := enc.EncryptSecretWithAAD([]byte(adminDSNPlain), encryption.DynamicSecretConfigAAD(cfg.ID, projectID, environmentID))
+	require.NoError(t, err)
+	require.NotEqual(t, adminDSNPlain, string(ct), "the encrypted bytes must not equal the plaintext")
+	cfg.AdminDSNEnc = ct
+	cfg.AdminDSNMeta = meta
+	require.NoError(t, downstream.Storage().UpdateDynamicSecretConfig(ctx, cfg))
+
+	// Property 1: the upstream's OWN storage never holds the plaintext DSN anywhere
+	// in the row — only the ciphertext this test encrypted itself.
+	direct, err := upstream.Storage().GetDynamicSecretConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.NotContains(t, string(direct.AdminDSNEnc), "s3cr3t", "the upstream must never receive/store the plaintext admin DSN")
+	assert.Equal(t, ct, direct.AdminDSNEnc, "the upstream stores the exact ciphertext bytes it was given, unmodified")
+
+	// Property 2: fetching back through the downstream's RemoteStorage and
+	// decrypting with the SAME encryption service reproduces the original
+	// plaintext exactly — the ciphertext round-trips through the HTTP hop intact.
+	fetched, err := downstream.Storage().GetDynamicSecretConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	plain, err := enc.DecryptSecretWithAAD(fetched.AdminDSNEnc, encryption.DynamicSecretConfigAAD(cfg.ID, projectID, environmentID))
+	require.NoError(t, err)
+	assert.Equal(t, adminDSNPlain, string(plain), "decrypting the round-tripped ciphertext must reproduce the original admin DSN")
+}
+
+// buildDynamicSecretLease mirrors what internal/core.IssueLease computes before
+// calling storage.CreateDynamicSecretLease — an already-minted, already-encrypted
+// lease row (the credential ciphertext here is a placeholder standing in for a
+// real engine.Issue result + encryptAuthSecret call, since minting against a real
+// target and the full IssueLease business-logic path are out of this finding's
+// storage-primitive scope, mirroring buildDynamicSecretConfig's docs above).
+func buildDynamicSecretLease(now time.Time, configID, projectID, environmentID uint, leaseID string) *models.DynamicSecretLease {
+	return &models.DynamicSecretLease{
+		ConfigID:      configID,
+		LeaseID:       leaseID,
+		ProjectID:     projectID,
+		EnvironmentID: environmentID,
+		RoleName:      "kx_lease_" + leaseID,
+		Status:        "active",
+		IssuedAt:      now,
+		ExpiresAt:     now.Add(time.Hour),
+	}
+}
+
+// TestRemoteStorageDynamicSecrets_LeaseCreateGetListCountUpdate_RealServer proves
+// the fix for CreateDynamicSecretLease/GetDynamicSecretLease/
+// ListDynamicSecretLeases/CountActiveLeases/UpdateDynamicSecretLease: a lease is
+// genuinely persisted, fetchable by its opaque LeaseID, listed/counted, and its
+// status transition (revoke) is visible directly on the upstream — all via
+// storage.type: remote against a real router.
+func TestRemoteStorageDynamicSecrets_LeaseCreateGetListCountUpdate_RealServer(t *testing.T) {
+	upstream, downstream, projectID, environmentID := newUpstreamDownstreamForDynamicSecrets(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	cfg, err := downstream.Storage().CreateDynamicSecretConfig(ctx, buildDynamicSecretConfig(now, projectID, environmentID, "lease-test-db"))
+	require.NoError(t, err)
+
+	lease, err := downstream.Storage().CreateDynamicSecretLease(ctx, buildDynamicSecretLease(now, cfg.ID, projectID, environmentID, "lease-abc-123"))
+	require.NoError(t, err, "creating a dynamic-secret lease must succeed via storage.type: remote")
+	require.NotZero(t, lease.ID)
+	assert.Equal(t, "lease-abc-123", lease.LeaseID)
+	assert.Equal(t, "active", lease.Status)
+
+	// A REAL row on the upstream's own storage.
+	direct, err := upstream.Storage().GetDynamicSecretLease(ctx, "lease-abc-123")
+	require.NoError(t, err)
+	assert.Equal(t, cfg.ID, direct.ConfigID)
+
+	// GetDynamicSecretLease/ListDynamicSecretLeases/CountActiveLeases via the downstream.
+	fetched, err := downstream.Storage().GetDynamicSecretLease(ctx, "lease-abc-123")
+	require.NoError(t, err)
+	assert.Equal(t, lease.RoleName, fetched.RoleName)
+
+	_, err = downstream.Storage().CreateDynamicSecretLease(ctx, buildDynamicSecretLease(now, cfg.ID, projectID, environmentID, "lease-def-456"))
+	require.NoError(t, err)
+
+	leases, err := downstream.Storage().ListDynamicSecretLeases(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.Len(t, leases, 2)
+
+	active, err := downstream.Storage().CountActiveLeases(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), active)
+
+	// UpdateDynamicSecretLease: revoke one lease via the downstream, confirm the
+	// transition is visible directly on the upstream.
+	fetched.Status = "revoked"
+	revokedAt := time.Now()
+	fetched.RevokedAt = &revokedAt
+	fetched.RevokeReason = "manual"
+	require.NoError(t, downstream.Storage().UpdateDynamicSecretLease(ctx, fetched))
+
+	reFetched, err := upstream.Storage().GetDynamicSecretLease(ctx, "lease-abc-123")
+	require.NoError(t, err)
+	assert.Equal(t, "revoked", reFetched.Status)
+	assert.Equal(t, "manual", reFetched.RevokeReason)
+	require.NotNil(t, reFetched.RevokedAt)
+
+	// The active count now reflects only the still-active second lease.
+	activeAfter, err := downstream.Storage().CountActiveLeases(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), activeAfter)
+}
+
+// TestRemoteStorageDynamicSecrets_ListExpiredActiveLeases_RealServer proves the
+// fix for ListExpiredActiveLeases, which backs the calling server's own
+// auto-revoke sweep (internal/core.RevokeExpiredLeases) against a real upstream.
+func TestRemoteStorageDynamicSecrets_ListExpiredActiveLeases_RealServer(t *testing.T) {
+	upstream, downstream, projectID, environmentID := newUpstreamDownstreamForDynamicSecrets(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	cfg, err := upstream.Storage().CreateDynamicSecretConfig(ctx, buildDynamicSecretConfig(now, projectID, environmentID, "expiry-test-db"))
+	require.NoError(t, err)
+
+	// One lease already expired an hour ago, one still valid for another hour —
+	// created directly against the upstream (any caller, local or remote, would
+	// produce identical rows).
+	expired := buildDynamicSecretLease(now, cfg.ID, projectID, environmentID, "lease-expired")
+	expired.ExpiresAt = now.Add(-time.Hour)
+	_, err = upstream.Storage().CreateDynamicSecretLease(ctx, expired)
+	require.NoError(t, err)
+
+	stillValid := buildDynamicSecretLease(now, cfg.ID, projectID, environmentID, "lease-valid")
+	stillValid.ExpiresAt = now.Add(time.Hour)
+	_, err = upstream.Storage().CreateDynamicSecretLease(ctx, stillValid)
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListExpiredActiveLeases(ctx, now)
+	require.NoError(t, err, "listing expired leases must succeed via storage.type: remote")
+	require.Len(t, rows, 1)
+	assert.Equal(t, "lease-expired", rows[0].LeaseID)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -798,6 +798,41 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/invitations", catalogHandler.ListInvitationsProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/invitations", catalogHandler.CreateInvitationProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Put("/invitations/{id}", catalogHandler.UpdateInvitationProxy)
+
+			// Dynamic-secrets storage-primitive proxy (round-116 finding). Lets a
+			// downstream Keyorix server booted with storage.type: remote (ADR-049)
+			// proxy CreateDynamicSecretConfig/GetDynamicSecretConfig/
+			// ListDynamicSecretConfigs/UpdateDynamicSecretConfig/
+			// CountDynamicSecretConfigsByClassification/CreateDynamicSecretLease/
+			// GetDynamicSecretLease/ListDynamicSecretLeases/CountActiveLeases/
+			// UpdateDynamicSecretLease/ListExpiredActiveLeases to THIS server's real
+			// storage backend, instead of RemoteStorage's eleven dynamic-secrets
+			// methods having no server endpoint to call at all (dynamic secrets —
+			// ADR-035 — were entirely non-functional under storage.type: remote).
+			// Exactly the same pattern as the invitations/login-attempts proxies
+			// above: a thin passthrough onto storage.Storage (no dynamic-secrets
+			// POLICY decision — admin-authority checks, TTL/lease-count clamping, the
+			// admin-DSN/credential encrypt-decrypt — is made here; that stays
+			// entirely in the CALLING server's own core.KeyorixCore, exactly as it
+			// does against a local backend), reusing the SAME system.read/
+			// system.write tier — no new privilege class. See
+			// dynamic_secrets_proxy.go's package doc for why the admin-DSN/
+			// credential ciphertext crossing this boundary is safe (it is already
+			// opaque ciphertext by the time it reaches here, encrypted with the
+			// CALLING server's own key). Static sub-paths
+			// (classification-counts, active-count, expired) are registered before
+			// their sibling {id}/{leaseID} routes.
+			r.Get("/dynamic-secrets/configs/classification-counts", dynamicSecretHandler.CountDynamicSecretConfigsByClassificationProxy)
+			r.Get("/dynamic-secrets/configs/{id}", dynamicSecretHandler.GetDynamicSecretConfigProxy)
+			r.Get("/dynamic-secrets/configs", dynamicSecretHandler.ListDynamicSecretConfigsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/dynamic-secrets/configs", dynamicSecretHandler.CreateDynamicSecretConfigProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/dynamic-secrets/configs/{id}", dynamicSecretHandler.UpdateDynamicSecretConfigProxy)
+			r.Get("/dynamic-secrets/leases/active-count", dynamicSecretHandler.CountActiveLeasesProxy)
+			r.Get("/dynamic-secrets/leases/expired", dynamicSecretHandler.ListExpiredActiveLeasesProxy)
+			r.Get("/dynamic-secrets/leases/{leaseID}", dynamicSecretHandler.GetDynamicSecretLeaseProxy)
+			r.Get("/dynamic-secrets/leases", dynamicSecretHandler.ListDynamicSecretLeasesProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/dynamic-secrets/leases", dynamicSecretHandler.CreateDynamicSecretLeaseProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/dynamic-secrets/leases/{leaseID}", dynamicSecretHandler.UpdateDynamicSecretLeaseProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary

Fixes a newly-discovered gap (filed as #515, part of the comprehensive #513 RemoteStorage audit): `RemoteStorage`'s `DynamicSecretConfig`/`DynamicSecretLease` CRUD (`internal/storage/store/remote_dynamic.go`) had all 11 methods as unconditional stubs, while real server-side routes/handlers already existed.

## Design decision (important nuance)

The existing human-facing `/api/v1/dynamic-secrets/*` routes are the WRONG target to proxy to. They require a plaintext `admin_dsn` and run the receiving server's own `core.CreateDynamicSecretConfig` (its own RBAC/admin-authority check, its own encryption key). But `internal/core/dynamic_secrets.go` encrypts the admin DSN and issued credential via `KeyorixCore.encryptAuthSecret`/`decryptAuthSecret` in `core`, before ever calling storage — so by the time a value reaches any storage primitive it's already opaque ciphertext, encrypted by the CALLING server's own key. That's a stronger boundary than `CreateSecret`'s remote passthrough. The correct fix is a raw storage-primitive proxy (matching the established #452/#507 pattern under `/api/v1/system/*`), not reuse of the business-logic routes.

Checked the atomicity concern for `UpdateDynamicSecretLease`: `LocalStorage`'s own implementation is an unconditional full-row `Save` (no conditional `WHERE`), so there's no existing atomic-concurrency guarantee to preserve — the proxy matches local semantics exactly, introducing no new race.

## Fix

- `internal/storage/store/remote_dynamic.go`: all 11 methods now proxy over HTTP to 10 new upstream routes under `/api/v1/system/dynamic-secrets/...`, gated by `system.read`/`system.write` (same tier every other RemoteStorage proxy already uses).
- `server/http/handlers/dynamic_secrets_proxy.go` (new): thin passthroughs onto `storage.Storage`.

## Bug found and fixed during testing

`ListExpiredActiveLeasesProxy` reparsed the wire `before` timestamp via `time.Parse(RFC3339Nano, ...)`, yielding a UTC `time.Time`. Since this codebase compares timestamps via SQLite's text ordering and every other caller always passes `time.Now()` (process-local timezone), a non-UTC upstream server timezone caused genuinely-expired leases to be silently excluded from the sweep. Fixed by normalizing to `.Local()` before the storage call; verified empirically (reproduced the bug, then confirmed the fix).

## Testing

`server/http/remote_storage_dynamic_secrets_test.go`: 5 real `NewRouter` + real `RemoteStorage` end-to-end tests, including one that specifically proves the admin-DSN ciphertext never appears in plaintext on the upstream and round-trips correctly for decryption.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/storage/... ./internal/core/... ./server/http/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./...` — 0 issues
- `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)