### PR TITLE
fix(remote-storage): wire ListNotifications/CountUnreadNotifications to the real self-scoped route (#516)

### DIFF
--- a/internal/storage/store/remote_notifications.go
+++ b/internal/storage/store/remote_notifications.go
@@ -1,12 +1,31 @@
-// remote_notifications.go — in-app notifications for RemoteStorage.
+// remote_notifications.go — in-app notifications for RemoteStorage (ADR-024).
 //
-// Notifications are processed server-side in remote mode; these are stubs. For
-// the local (GORM) equivalent see local_notifications.go.
+// The self-scoped user-facing surface (GET /notifications, POST /notifications/
+// {id}/read, POST /notifications/read-all — see server/http/router.go and
+// notifications_handler.go) is real and proxied below for ListNotifications/
+// CountUnreadNotifications/MarkNotificationRead/MarkAllNotificationsRead.
+//
+// CreateNotification/HasUnreadNotification/GetUnreadNotification/
+// UpdateNotification stay unconditional stubs: these are the reminder/dedup
+// write path (internal/core/notifications.go's notify(), and the escalation
+// dedup in rotation_reminders.go et al.), invoked only from server-internal
+// background jobs and the system.write-gated POST /admin/jobs/* on-demand
+// triggers — both of which always run against the server's own LocalStorage,
+// never against a remote client's storage.Storage. There is no self-scoped route
+// that lets an authenticated end user create/escalate an arbitrary notification
+// for themselves (rightly so: that would let a self-scoped-only credential forge
+// notifications, e.g. impersonate a "your access was approved" system message),
+// so there is nothing for these four to proxy to.
+//
+// For the local (GORM) equivalent see local_notifications.go.
 package store
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -15,12 +34,111 @@ func (rs *RemoteStorage) CreateNotification(_ context.Context, _ *models.Notific
 	return nil, remoteUnsupported("CreateNotification")
 }
 
-func (rs *RemoteStorage) ListNotifications(_ context.Context, _ uint, _ bool, _ int) ([]*models.Notification, error) {
-	return nil, remoteUnsupported("ListNotifications")
+// notificationWireResponse mirrors notificationToAPI's response shape
+// (server/http/handlers/notifications_handler.go) — the actual wire shape GET
+// /notifications returns. models.Notification carries no json tags of its own,
+// so decoding straight into it would suffer the identical field-name mismatch
+// class as #496: encoding/json's case-insensitive fallback saves single-word
+// fields ("id"/"type"/"title"/"message"/"link" happen to still match "ID"/
+// "Type"/"Title"/"Message"/"Link"), but "is_read"/"created_at"/"project_id" do
+// NOT case-insensitively equal "IsRead"/"CreatedAt"/"ProjectID" — those three
+// would silently come back zeroed (a read notification would misreport as
+// unread, and every list/scoping decision keyed on CreatedAt ordering or
+// ProjectID would be wrong) without this explicit tagging.
+type notificationWireResponse struct {
+	ID        uint      `json:"id"`
+	Type      string    `json:"type"`
+	Title     string    `json:"title"`
+	Message   string    `json:"message"`
+	Link      string    `json:"link"`
+	IsRead    bool      `json:"is_read"`
+	CreatedAt time.Time `json:"created_at"`
+	ProjectID *uint     `json:"project_id,omitempty"`
 }
 
-func (rs *RemoteStorage) CountUnreadNotifications(_ context.Context, _ uint) (int64, error) {
-	return 0, remoteUnsupported("CountUnreadNotifications")
+func (w notificationWireResponse) toModel() *models.Notification {
+	return &models.Notification{
+		ID:        w.ID,
+		ProjectID: w.ProjectID,
+		Type:      w.Type,
+		Title:     w.Title,
+		Message:   w.Message,
+		Link:      w.Link,
+		IsRead:    w.IsRead,
+		CreatedAt: w.CreatedAt,
+	}
+}
+
+// notificationListResponse is the full GET /notifications envelope: the page of
+// notifications plus the bell-badge unread count, computed server-side
+// independently of the list's own unread/limit filters.
+type notificationListResponse struct {
+	Notifications []notificationWireResponse `json:"notifications"`
+	UnreadCount   int64                      `json:"unread_count"`
+}
+
+// fetchNotifications calls the self-scoped GET /notifications route. userID is
+// deliberately not sent: like MarkNotificationRead/MarkAllNotificationsRead
+// below, the server derives the caller from the authenticated session/token
+// (ADR-024, "self-scoped, no permission gate") — there is no user_id query
+// parameter honored server-side, so a caller can never widen this beyond its own
+// identity by passing a different userID here.
+func (rs *RemoteStorage) fetchNotifications(ctx context.Context, unreadOnly bool, limit int) (*notificationListResponse, error) {
+	path := "/api/v1/notifications"
+	q := ""
+	if unreadOnly {
+		q += "unread=true"
+	}
+	if limit > 0 {
+		if q != "" {
+			q += "&"
+		}
+		q += "limit=" + strconv.Itoa(limit)
+	}
+	if q != "" {
+		path += "?" + q
+	}
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list notifications: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list notifications failed: %s", resp.Error.Error())
+	}
+	var result notificationListResponse
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &result, nil
+}
+
+// ListNotifications returns the caller's notifications, newest first, via the
+// self-scoped GET /notifications route. See fetchNotifications for the
+// userID-is-implicit scoping note.
+func (rs *RemoteStorage) ListNotifications(ctx context.Context, _ uint, unreadOnly bool, limit int) ([]*models.Notification, error) {
+	result, err := rs.fetchNotifications(ctx, unreadOnly, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*models.Notification, 0, len(result.Notifications))
+	for _, w := range result.Notifications {
+		out = append(out, w.toModel())
+	}
+	return out, nil
+}
+
+// CountUnreadNotifications reads the unread count off the same GET
+// /notifications response used by ListNotifications — there is no separate
+// count-only endpoint. limit=1 keeps the accompanying (here-discarded)
+// notification page minimal; the server computes unread_count independently of
+// the list's own unread/limit filters, so a small limit does not affect the
+// count itself.
+func (rs *RemoteStorage) CountUnreadNotifications(ctx context.Context, _ uint) (int64, error) {
+	result, err := rs.fetchNotifications(ctx, false, 1)
+	if err != nil {
+		return 0, err
+	}
+	return result.UnreadCount, nil
 }
 
 func (rs *RemoteStorage) HasUnreadNotification(_ context.Context, _ uint, _ string, _ uint) (bool, error) {

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -75,6 +75,9 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		// #507: the invitation-proxy end-to-end tests exercise ProjectInvitation
 		// CRUD through the real router.
 		&models.ProjectInvitation{},
+		// In-app notifications (ADR-024) — exercised end-to-end through the real
+		// router by the RemoteStorage notification proxy tests.
+		&models.Notification{},
 	)
 	require.NoError(t, err)
 	return core.NewKeyorixCore(store.NewLocalStorage(db))

--- a/server/http/remote_storage_notifications_test.go
+++ b/server/http/remote_storage_notifications_test.go
@@ -1,0 +1,255 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteStorage_Notifications_RealServerRoundTrip proves the fix for the
+// RemoteStorage stub-coverage audit (round 116): ListNotifications and
+// CountUnreadNotifications were unconditional storage.ErrUnsupportedByBackend
+// stubs even though a real, self-scoped GET /notifications route exists
+// (ADR-024). MarkNotificationRead/MarkAllNotificationsRead were already wired
+// and are re-verified here alongside the two fixes for good measure.
+//
+// Drives every method through a REAL running server (NewRouter) via a REAL
+// RemoteStorage client over real HTTP, per this package's established pattern
+// (see TestRemoteStorage_GetUserByEmail_RealServerRoundTrip).
+func TestRemoteStorage_Notifications_RealServerRoundTrip(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	ctx := context.Background()
+
+	admin, err := upstreamCore.Storage().GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+
+	// Seed three notifications directly against the upstream's own storage —
+	// exactly what internal/core/notifications.go's notify() does server-side —
+	// two unread, one already read, so List/Count have real, distinct data to
+	// prove against rather than an empty inbox.
+	var seeded []*models.Notification
+	for _, n := range []*models.Notification{
+		{UserID: admin.ID, Type: "secret.shared", Title: "Shared", Message: "m1"},
+		{UserID: admin.ID, Type: "access_request.approved", Title: "Approved", Message: "m2"},
+		{UserID: admin.ID, Type: "membership.activated", Title: "Activated", Message: "m3", IsRead: true},
+	} {
+		created, err := upstreamCore.Storage().CreateNotification(ctx, n)
+		require.NoError(t, err)
+		seeded = append(seeded, created)
+	}
+
+	newClient := func(token string) *store.RemoteStorage {
+		rs, err := store.NewRemoteStorage(&remote.Config{
+			BaseURL:        upstreamSrv.URL,
+			APIKey:         token,
+			TimeoutSeconds: 5,
+			RetryAttempts:  0,
+			TLSVerify:      true,
+		})
+		require.NoError(t, err)
+		return rs
+	}
+
+	rs := newClient(upstreamToken)
+
+	// --- ListNotifications: must reach the real route and decode every field
+	// correctly, not just the case-insensitively-lucky ones (#496-class bug) ---
+	all, err := rs.ListNotifications(ctx, admin.ID, false, 0)
+	require.NoError(t, err, "ListNotifications must reach the real GET /notifications route (round-116 fix)")
+	require.Len(t, all, 3, "all three seeded notifications")
+
+	// Newest-first ordering, and the already-read one's IsRead must round-trip
+	// as true — this is exactly the field encoding/json's case-insensitive
+	// fallback would silently zero without the wire DTO (is_read != IsRead).
+	var readCount, unreadCount int
+	var sawReadTitle string
+	for _, n := range all {
+		if n.IsRead {
+			readCount++
+			sawReadTitle = n.Title
+		} else {
+			unreadCount++
+		}
+		assert.NotZero(t, n.ID, "id must round-trip")
+		assert.NotEmpty(t, n.Type, "type must round-trip")
+		assert.NotEmpty(t, n.Title, "title must round-trip")
+		assert.NotEmpty(t, n.Message, "message must round-trip")
+		assert.False(t, n.CreatedAt.IsZero(), "created_at must round-trip, not silently zero")
+	}
+	assert.Equal(t, 1, readCount)
+	assert.Equal(t, 2, unreadCount)
+	assert.Equal(t, "Activated", sawReadTitle)
+
+	// unread=true must filter server-side.
+	unreadOnly, err := rs.ListNotifications(ctx, admin.ID, true, 0)
+	require.NoError(t, err)
+	assert.Len(t, unreadOnly, 2)
+
+	// limit must be honored.
+	limited, err := rs.ListNotifications(ctx, admin.ID, false, 1)
+	require.NoError(t, err)
+	assert.Len(t, limited, 1)
+
+	// --- CountUnreadNotifications: must reach the real route (round-116 fix) ---
+	count, err := rs.CountUnreadNotifications(ctx, admin.ID)
+	require.NoError(t, err, "CountUnreadNotifications must reach the real GET /notifications route (round-116 fix)")
+	assert.Equal(t, int64(2), count)
+
+	// --- MarkNotificationRead: mark one of the two unread ones ---
+	var unreadID uint
+	for _, n := range seeded {
+		if !n.IsRead {
+			unreadID = n.ID
+			break
+		}
+	}
+	require.NotZero(t, unreadID)
+	require.NoError(t, rs.MarkNotificationRead(ctx, unreadID, admin.ID))
+
+	count, err = rs.CountUnreadNotifications(ctx, admin.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "marking one read must drop the unread count by one")
+
+	// --- MarkAllNotificationsRead: zero unread afterward ---
+	require.NoError(t, rs.MarkAllNotificationsRead(ctx, admin.ID))
+	count, err = rs.CountUnreadNotifications(ctx, admin.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+// TestRemoteStorage_Notifications_ScopingPreserved proves the passthrough
+// preserves ADR-024's self-scoping: a RemoteStorage client only ever sees/
+// mutates the notifications belonging to whichever identity its own token
+// authenticates as. The storage.Storage interface's userID parameter is
+// deliberately NOT sent on the wire (see fetchNotifications/
+// MarkNotificationRead's doc comments) — the server derives the caller from the
+// authenticated session, so passing a different user's ID can never widen
+// access. This is enforced entirely at the handler layer (middleware.
+// GetUserFromContext + LocalStorage's `WHERE user_id = ?` scoping), not by any
+// check inside RemoteStorage itself — this test proves that server-side
+// enforcement holds end-to-end through the real remote client, not that
+// RemoteStorage adds its own redundant check.
+func TestRemoteStorage_Notifications_ScopingPreserved(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	upstreamCore := newTestCore(t)
+	adminToken := createTestToken(t, upstreamCore)
+	limitedToken := createLimitedToken(t, upstreamCore)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	ctx := context.Background()
+
+	admin, err := upstreamCore.Storage().GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+	limited, err := upstreamCore.Storage().GetUserByEmail(ctx, "limited@example.com")
+	require.NoError(t, err)
+
+	adminNote, err := upstreamCore.Storage().CreateNotification(ctx, &models.Notification{
+		UserID: admin.ID, Type: "secret.shared", Title: "Admin's", Message: "admin-only",
+	})
+	require.NoError(t, err)
+	limitedNote, err := upstreamCore.Storage().CreateNotification(ctx, &models.Notification{
+		UserID: limited.ID, Type: "secret.shared", Title: "Limited's", Message: "limited-only",
+	})
+	require.NoError(t, err)
+
+	newClient := func(token string) *store.RemoteStorage {
+		rs, err := store.NewRemoteStorage(&remote.Config{
+			BaseURL:        upstreamSrv.URL,
+			APIKey:         token,
+			TimeoutSeconds: 5,
+			RetryAttempts:  0,
+			TLSVerify:      true,
+		})
+		require.NoError(t, err)
+		return rs
+	}
+
+	adminRS := newClient(adminToken)
+	limitedRS := newClient(limitedToken)
+
+	// --- List: each client only ever sees its own identity's notification,
+	// even when the (unused-on-the-wire) userID argument names the OTHER user ---
+	adminList, err := adminRS.ListNotifications(ctx, limited.ID, false, 0)
+	require.NoError(t, err)
+	require.Len(t, adminList, 1)
+	assert.Equal(t, "Admin's", adminList[0].Title,
+		"admin's token must return only admin's own notification, regardless of the userID argument passed")
+
+	limitedList, err := limitedRS.ListNotifications(ctx, admin.ID, false, 0)
+	require.NoError(t, err)
+	require.Len(t, limitedList, 1)
+	assert.Equal(t, "Limited's", limitedList[0].Title,
+		"limited's token must return only limited's own notification, regardless of the userID argument passed")
+
+	// --- Count: same identity-scoping, same argument-is-ignored property ---
+	adminCount, err := adminRS.CountUnreadNotifications(ctx, limited.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), adminCount)
+
+	limitedCount, err := limitedRS.CountUnreadNotifications(ctx, admin.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), limitedCount)
+
+	// --- MarkNotificationRead: the limited user CANNOT mark the admin's
+	// notification read by ID, even though it authenticates fine and the ID is
+	// a real, existing row — it is simply not scoped to this caller ---
+	err = limitedRS.MarkNotificationRead(ctx, adminNote.ID, admin.ID)
+	require.Error(t, err, "a caller must not be able to mark another user's notification read by ID")
+
+	// The admin's notification must still be unread — the cross-user attempt
+	// above must not have mutated it.
+	stillThere, err := upstreamCore.Storage().ListNotifications(ctx, admin.ID, true, 0)
+	require.NoError(t, err)
+	require.Len(t, stillThere, 1)
+	assert.Equal(t, adminNote.ID, stillThere[0].ID)
+
+	// Conversely, the admin cannot mark the limited user's notification read.
+	err = adminRS.MarkNotificationRead(ctx, limitedNote.ID, limited.ID)
+	require.Error(t, err, "a caller must not be able to mark another user's notification read by ID")
+
+	stillThereLimited, err := upstreamCore.Storage().ListNotifications(ctx, limited.ID, true, 0)
+	require.NoError(t, err)
+	require.Len(t, stillThereLimited, 1)
+	assert.Equal(t, limitedNote.ID, stillThereLimited[0].ID)
+
+	// --- MarkAllNotificationsRead: scoped the same way — marking "all read"
+	// as the limited user must not touch the admin's notification ---
+	require.NoError(t, limitedRS.MarkAllNotificationsRead(ctx, admin.ID))
+	adminStillUnread, err := upstreamCore.Storage().ListNotifications(ctx, admin.ID, true, 0)
+	require.NoError(t, err)
+	assert.Len(t, adminStillUnread, 1, "limited user's mark-all-read must not affect admin's notifications")
+}


### PR DESCRIPTION
## Summary

Fixes a newly-discovered gap (filed as #516, part of the comprehensive #513 RemoteStorage audit): `RemoteStorage.ListNotifications`/`CountUnreadNotifications` were unconditional stubs despite a real, self-scoped `GET /api/v1/notifications` route existing (ADR-024) that returns exactly the data both need.

## What's intentionally still a stub

`CreateNotification`/`HasUnreadNotification`/`GetUnreadNotification`/`UpdateNotification` remain stubs by design — they're the reminder/dedup write path (`internal/core/notifications.go`'s `notify()`, `rotation_reminders.go`), invoked only by server-internal background jobs and `system.write`-gated admin triggers, both of which always run against the server's own `LocalStorage`. There's no self-scoped route an end-user credential could hit to create/escalate an arbitrary notification (rightly so — that would let a self-scoped token forge system notifications), so nothing exists to proxy these four to.

## Fix

Wired `ListNotifications`/`CountUnreadNotifications` to `GET /api/v1/notifications`, adding a `notificationWireResponse` client-side DTO — `models.Notification` carries no json tags, and the real handler's response is a hand-built snake_case map, so a direct unmarshal would silently zero `is_read`/`created_at`/`project_id` (identical bug class to #496's wire-DTO fix). `userID` is deliberately not sent on the wire, matching the already-shipped `MarkNotificationRead`/`MarkAllNotificationsRead` convention: the server derives the caller from the session/token, so a RemoteStorage caller can never widen access by passing a different `userID` — the real scoping is the handler + `LocalStorage`'s `WHERE user_id = ?`, unchanged by this fix.

## Testing

`server/http/remote_storage_notifications_test.go`: real `NewRouter` + real `RemoteStorage` client — proves List/Count/MarkRead/MarkAllRead all reach the real routes and every field round-trips correctly, plus a two-identity cross-access test proving one user's notifications never leak or become mutable via another user's request.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/storage/... ./server/http/... -count=1` — all pass
- `gosec -severity medium -exclude-generated ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)