### PR TITLE
docs: refresh SECURITY.md/CONTRIBUTING.md/SECURITY-VERIFICATION.md for the SSDLC hardening pass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,13 +56,22 @@ git rebase --exec 'git commit --amend --no-edit -s' <base>    # every commit sin
 
 ## What CI checks
 
+11 required checks gate every merge to `main` (branch protection, no bypass):
+
 - `go vet`, `go build`, `go test -race` (full suite)
 - `gosec` (medium+ severity) and `golangci-lint`
 - `govulncheck` against known vulnerabilities in dependencies
-- `gitleaks` (full history of the PR's own commits)
+- `gitleaks` (the PR's own commit history, not the whole repo's other branches)
 - `CodeQL` (dataflow/taint analysis, both Go modules)
 - Helm chart lint + schema validation (`kubeconform`) for all three charts
-- DCO sign-off on every commit
+- `checkov` — Helm chart security-policy scanning (pod security context,
+  RBAC-escalation checks), distinct from `kubeconform`'s schema-only validation
+- Go dependency license compliance (`go-licenses`) — rejects any dependency
+  outside an explicit permissive-license allowlist, both Go modules
+- Fuzz-target staleness — `scripts/fuzzing/targets.conf` (the self-hosted
+  continuous-fuzzing rig's config) must exactly match every real `func FuzzXxx`
+  in the tree; adding a fuzz target without declaring it here fails CI
+- DCO sign-off (`git commit -s` on every commit — see above)
 
 ## Code style
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,25 +61,55 @@ sha256sum --check --ignore-missing checksums.txt
 ```
 
 Release binaries are built with `-trimpath` and `CGO_ENABLED=0` from the tagged
-commit. Cryptographic release signing (Sigstore/cosign) and SLSA build provenance
-are being rolled out — this section will be updated with verification commands
-when they ship. Until then, download releases only from
-`github.com/keyorixhq/keyorix/releases` over HTTPS and verify checksums.
+commit. `checksums.txt` and every container image are keylessly signed with
+[Sigstore/cosign](https://www.sigstore.dev/) via GitHub's OIDC token — no
+long-lived signing key exists to leak. Verify with `cosign` installed:
+
+```bash
+# checksums.txt (release binaries)
+cosign verify-blob \
+  --certificate checksums.txt.pem --signature checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/keyorixhq/keyorix/\.github/workflows/release\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
+
+# container images (also carries an SBOM + SLSA build provenance attestation)
+cosign verify \
+  --certificate-identity-regexp 'https://github.com/keyorixhq/keyorix/\.github/workflows/docker-publish\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/keyorixhq/keyorix-server:<tag>
+```
+
+Download releases only from `github.com/keyorixhq/keyorix/releases` over HTTPS.
 
 ## Secure Development
 
 - Pre-commit gates: `gofmt`, `go vet`, `go build`, `gosec` (MEDIUM+ severity)
-- CI gates on every push and pull request: `go vet`, race-enabled tests,
-  `govulncheck`, `gosec` (pinned version), `golangci-lint` (errcheck, staticcheck,
-  unused, and more), `gitleaks` secret scan (scoped to the PR's own commit
-  history), `CodeQL` (dataflow/taint analysis, both Go modules), Helm chart
-  schema validation
+- CI gates on every push and pull request (11+ required checks, see
+  [CONTRIBUTING.md](CONTRIBUTING.md) for the full list): `go vet`, race-enabled
+  tests, `govulncheck`, `gosec` (pinned version), `golangci-lint`, `gitleaks`
+  secret scan (scoped to the PR's own commit history), `CodeQL` (dataflow/taint
+  analysis, both Go modules), Helm chart schema validation (`kubeconform`) and
+  security-policy scanning (`checkov` — pod security context, RBAC-escalation
+  checks), Go dependency license compliance (rejects any dependency outside an
+  explicit permissive-license allowlist), and DCO sign-off verification
+- Continuous fuzzing: native Go fuzz targets (`go test -fuzz`) at the
+  codebase's highest-risk parsing/escaping boundaries (Shamir secret-share
+  reconstruction, JWT/OIDC verification, rotation-credential SQL escaping and
+  ref interpolation, secret-template parsing) run for hours at a time on
+  dedicated infrastructure, well beyond what a CI job's budget allows — see
+  [`scripts/fuzzing/README.md`](scripts/fuzzing/README.md)
+- [CODEOWNERS](.github/CODEOWNERS) requires review on cryptography, auth/RBAC,
+  middleware, database migrations, the CI/CD pipeline itself, and this policy
+- GitHub-native repository security: secret scanning, push protection (blocks
+  a commit containing a detected secret before it lands), Dependabot security
+  updates, and private vulnerability reporting are all enabled
 - Any change to the encryption layer requires a written Architecture Decision
   Record before implementation
 - External contributions require DCO sign-off (`git commit -s` — see
   [CONTRIBUTING.md](CONTRIBUTING.md)) and maintainer review. Branch protection
-  on `main` requires every CI check to pass (enforced for maintainers too,
-  no bypass) before a PR can merge.
+  on `main` requires every required CI check to pass (enforced for maintainers
+  too, no bypass) before a PR can merge.
 
 ## Security-Relevant Configuration
 

--- a/docs/compliance/SECURITY-VERIFICATION.md
+++ b/docs/compliance/SECURITY-VERIFICATION.md
@@ -116,15 +116,100 @@ each strengthens:
 
 ## Standing CI security gates
 
-Every pull request and merge to `main` runs:
+11 required status checks gate every pull request and merge to `main` — branch
+protection enforces this with no bypass, including for maintainers:
 
 - **`govulncheck`** — fails the build on a known vulnerability in any dependency
   reachable from the code.
-- **`gosec`** (medium+) — static analysis for insecure patterns (weak crypto,
-  hardcoded credentials, unsafe SQL, etc.).
+- **`gosec`** (medium+) and **`golangci-lint`** — static analysis for insecure
+  patterns (weak crypto, hardcoded credentials, unsafe SQL, etc.).
 - **`go test -race`** — the full test suite under the race detector, including the
   security regression tests above.
 - **`go vet`**.
+- **`gitleaks`** — full commit-history secret scan, scoped to the PR's own
+  history (not the whole repository's other branches — an earlier version of
+  this gate scanned every branch present in the CI runner's git clone, so an
+  unrelated secret-shaped string on a completely different in-flight branch
+  could fail an unconnected PR; fixed).
+- **`CodeQL`** — dataflow/taint-tracking analysis across both Go modules
+  (root + the Kubernetes operator), catching cross-function-boundary taint
+  flows that pattern-based linters don't model.
+- **`checkov`** — Helm chart *security-policy* scanning (non-root, dropped
+  capabilities, no privilege escalation, seccomp, RBAC-escalation patterns),
+  distinct from the existing `kubeconform` gate, which only validates chart
+  *schema* correctness against the Kubernetes API and would not catch a future
+  regression like accidentally removing `readOnlyRootFilesystem: true`.
+- **`go-licenses`** — Go dependency license compliance for both modules.
+  Keyorix is dual-licensed (AGPL-3.0 + commercial); a dependency under an
+  actual copyleft or source-available-but-restrictive license (GPL/AGPL/LGPL,
+  SSPL, BSL, Commons Clause, Elastic License) could complicate the ability to
+  relicense the resulting binary commercially. The allowlist (MIT, Apache-2.0,
+  BSD-2/3-Clause, ISC, MPL-2.0) was derived from the actual dependency tree,
+  not assumed, and the gate was verified to genuinely fail on an injected
+  AGPL-licensed test dependency before shipping.
+- **Fuzz-target staleness** — `scripts/fuzzing/targets.conf` (the config for
+  the continuous-fuzzing rig, below) must exactly match every real
+  `func FuzzXxx` that exists in the tree, in both directions: a target that
+  exists but isn't declared would otherwise silently never get fuzzed with no
+  signal anything was wrong (an identical hand-maintained list on a sibling
+  project missed 18 of 44 real fuzz functions for months before this pattern
+  was recognized and guarded against here).
+- **DCO sign-off** — every commit needs a `Signed-off-by` trailer matching its
+  author (`git commit -s`), certifying the contributor has the right to submit
+  the change under the project's license (Developer Certificate of Origin;
+  Keyorix uses DCO rather than a full CLA — a deliberate tradeoff given the
+  dual-license model, documented in [CONTRIBUTING.md](../../CONTRIBUTING.md)).
+
+## Continuous fuzzing
+
+Native Go fuzzing (`go test -fuzz`, coverage-guided, mutation-based) targets
+the codebase's highest-risk parsing/escaping boundaries — chosen by evidence,
+not blanket coverage:
+
+- **`FuzzCombineKEK`** (`internal/crypto`) — the Shamir secret-share
+  reconstruction path, the exact subsystem behind a genuine cryptographic
+  forgery finding (an attacker holding threshold-1 genuine shares could
+  previously forge one additional share reconstructing to an attacker-chosen
+  KEK; fixed with an HMAC commitment verified outside the interpolated
+  payload).
+- **`FuzzOIDCVerifierVerify`** (`internal/core`) — JWT parsing for machine-
+  identity OIDC federation, the most attacker-exposed token-parsing boundary
+  (validated by decoding, not just a DB lookup like session/PAT/machine
+  tokens).
+- **`FuzzAzureGenerateUpstreamRef`**, **`FuzzPostgresQuoting`**,
+  **`FuzzMySQLQuoteString`** (`internal/rotation`) — the rotation-credential
+  trust boundary (an admin-configured `rotation_ref` interpolated into a URL
+  or hand-rolled SQL escaping), the exact class of bug that already produced
+  one real, shipped, fixed path-traversal vulnerability here. `rotation_ref`
+  additionally now gets denylist-validated at configuration time (rejecting
+  URL/path/SQL metacharacters and control characters) as an earlier, shared
+  layer of defense-in-depth ahead of the per-backend checks these fuzz targets
+  exercise.
+- **`FuzzParse`** (`internal/secrettemplate`) — the hand-rolled byte-index
+  parser for `${secret:<ref>}` template placeholder syntax.
+
+Runs continuously (not a scheduled job) on dedicated home-lab infrastructure
+separate from CI, rotating through all 6 targets roughly every 14 hours,
+re-pulling `main` before each target (this repo's commit velocity — dozens of
+merges a day at points — made a once-per-cycle pull leave a target testing
+code that was already stale for most of a rotation). A genuine crash
+auto-commits its reproducer to a dedicated `fuzz-corpus` branch and triggers
+an immediate alert; a daily heartbeat confirms the rig itself is still
+running. As of this writing, no crash has been found across any target —
+recorded here as a real, verified-clean result, not silence. See
+[`scripts/fuzzing/README.md`](../../scripts/fuzzing/README.md) for the full
+design and setup.
+
+## Process controls
+
+- **[CODEOWNERS](../../.github/CODEOWNERS)** requires review on
+  cryptography/encryption, auth/authz/RBAC core, HTTP/gRPC middleware,
+  database migrations, the CI/CD pipeline itself, and this policy.
+- **GitHub-native repository security**: secret scanning, push protection
+  (blocks a `git push` containing a detected secret before it lands, not just
+  scanning after the fact), Dependabot security updates (auto-PRs a
+  dependency the moment a CVE is published against the current version), and
+  private vulnerability reporting are all enabled.
 
 ## Known, accepted residual risks
 
@@ -143,4 +228,12 @@ Documented tradeoffs, not open defects:
 
 All five security-critical surfaces — authentication/cryptography/RBAC, the HTTP
 API, token/credential/OIDC, and storage/remote-client — have now been audited and
-hardened. This document is updated as further reviews complete.
+hardened.
+
+A subsequent SSDLC hardening pass added the process/pipeline controls
+documented above: CodeQL, Helm chart security-policy scanning (`checkov`), Go
+dependency license compliance, DCO enforcement, CODEOWNERS, branch protection
+with no maintainer bypass, GitHub-native secret scanning/push protection/
+Dependabot security updates/private vulnerability reporting, and the
+continuous-fuzzing rig (6 targets, clean so far). This document is updated as
+further reviews or pipeline changes complete.


### PR DESCRIPTION
## Summary
Brings three docs current with everything actually implemented in this session's SSDLC hardening thread, none of which was previously documented anywhere:

- **`SECURITY.md`** — "Verifying a Release" claimed cosign/SLSA signing was "being rolled out"; it's actually already fully shipped (verified directly against `docker-publish.yml`/`release.yml`), just never written up. Replaced with real, working `cosign verify-blob`/`verify` commands. Also expanded the CI-gates summary (checkov, go-licenses, fuzz-targets staleness, DCO) and added the continuous-fuzzing rig, CODEOWNERS, and GitHub-native secret scanning/push protection/Dependabot security updates/private vulnerability reporting.
- **`CONTRIBUTING.md`** — "What CI checks" only listed 6 of the 11 required status checks.
- **`docs/compliance/SECURITY-VERIFICATION.md`** — "Standing CI security gates" only listed 4 gates; expanded to all 11 with rationale for each, added a new "Continuous fuzzing" section (all 6 targets, why each was chosen — evidenced by a real prior vulnerability in each trust-boundary class), and a new "Process controls" section.

## Scope note
Deliberately did **not** touch `docs/security/BUGS.md` or `HARDENING-BACKLOG.md` (on the `security/hardening-backlog` branch) — those track numbered vulnerability findings from a separate, parallel adversarial-audit campaign with its own numbering scheme. This SSDLC infrastructure work was never filed there and doesn't fit that format.

## Test plan
- N/A (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)