### PR TITLE
fix(docker-compose): require KEYORIX_BOOTSTRAP_TOKEN for auto-bootstrap

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,10 +36,14 @@ services:
       # first boot makes all stored secrets undecryptable.
       KEYORIX_MASTER_PASSWORD: ${KEYORIX_MASTER_PASSWORD:?KEYORIX_MASTER_PASSWORD is required}
       # Optional first-boot admin bootstrap (idempotent). Omit to initialise
-      # manually with `keyorix system init`.
+      # manually with `keyorix system init`. KEYORIX_BOOTSTRAP_TOKEN must be set
+      # alongside KEYORIX_ADMIN_PASSWORD — /system/init always requires a matching
+      # bootstrap token, and the entrypoint has no way to read back the random one
+      # the server would otherwise generate for itself.
       KEYORIX_ADMIN_USERNAME: ${KEYORIX_ADMIN_USERNAME:-admin}
       KEYORIX_ADMIN_EMAIL: ${KEYORIX_ADMIN_EMAIL:-admin@keyorix.local}
       KEYORIX_ADMIN_PASSWORD: ${KEYORIX_ADMIN_PASSWORD:-}
+      KEYORIX_BOOTSTRAP_TOKEN: ${KEYORIX_BOOTSTRAP_TOKEN:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -23,33 +23,43 @@ done
 # First-boot admin bootstrap (optional, idempotent). Only runs when an admin
 # password is supplied via the environment — there are NO hardcoded credentials.
 # POST /system/init is safe to call repeatedly: it reports already_initialized
-# and changes nothing once an admin exists.
+# and changes nothing once an admin exists. /system/init always requires a
+# matching bootstrap token (operator-set via KEYORIX_BOOTSTRAP_TOKEN, or else a
+# random one the server generates and only logs) — without KEYORIX_BOOTSTRAP_TOKEN
+# set here, this call has no token to send and is rejected.
 if [ -n "$KEYORIX_ADMIN_PASSWORD" ]; then
     ADMIN_USER="${KEYORIX_ADMIN_USERNAME:-admin}"
     ADMIN_EMAIL="${KEYORIX_ADMIN_EMAIL:-admin@keyorix.local}"
-    echo "Bootstrapping admin user '$ADMIN_USER' (idempotent)..."
-    # Write the POST body (which embeds the admin password) to a private temp
-    # file and hand it to wget via --post-file instead of --post-data: argv is
-    # visible to any process sharing this container's PID namespace via
-    # `ps`/`/proc/<pid>/cmdline`, so passing the password inline as a wget flag
-    # would leak it on every first boot. `mktemp -d` creates the directory with
-    # 0700 permissions (only this UID can traverse it), and the payload file
-    # inside it is additionally chmod'd 0600 as defense in depth. The whole
-    # directory is removed as soon as the request completes (or the shell exits).
-    BOOTSTRAP_TMPDIR=$(mktemp -d)
-    trap 'rm -rf "$BOOTSTRAP_TMPDIR"' EXIT
-    BOOTSTRAP_PAYLOAD_FILE="$BOOTSTRAP_TMPDIR/bootstrap.json"
-    : > "$BOOTSTRAP_PAYLOAD_FILE"
-    chmod 600 "$BOOTSTRAP_PAYLOAD_FILE"
-    printf '{"username":"%s","email":"%s","password":"%s","display_name":"Administrator"}' \
-        "$ADMIN_USER" "$ADMIN_EMAIL" "$KEYORIX_ADMIN_PASSWORD" > "$BOOTSTRAP_PAYLOAD_FILE"
-    wget --quiet -O- \
-        --header='Content-Type: application/json' \
-        --post-file="$BOOTSTRAP_PAYLOAD_FILE" \
-        http://localhost:8080/system/init 2>/dev/null || \
-        echo "Bootstrap call failed (server may already be initialised) — continuing."
-    rm -rf "$BOOTSTRAP_TMPDIR"
-    trap - EXIT
+    if [ -z "$KEYORIX_BOOTSTRAP_TOKEN" ]; then
+        echo "KEYORIX_ADMIN_PASSWORD is set but KEYORIX_BOOTSTRAP_TOKEN is not — skipping"
+        echo "auto-bootstrap (the server-generated random token can't be read back here)."
+        echo "Set KEYORIX_BOOTSTRAP_TOKEN, or initialise manually: keyorix system init --server http://<host>:8080"
+    else
+        echo "Bootstrapping admin user '$ADMIN_USER' (idempotent)..."
+        # Write the POST body (which embeds the admin password) to a private temp
+        # file and hand it to wget via --post-file instead of --post-data: argv is
+        # visible to any process sharing this container's PID namespace via
+        # `ps`/`/proc/<pid>/cmdline`, so passing the password inline as a wget flag
+        # would leak it on every first boot. `mktemp -d` creates the directory with
+        # 0700 permissions (only this UID can traverse it), and the payload file
+        # inside it is additionally chmod'd 0600 as defense in depth. The whole
+        # directory is removed as soon as the request completes (or the shell exits).
+        BOOTSTRAP_TMPDIR=$(mktemp -d)
+        trap 'rm -rf "$BOOTSTRAP_TMPDIR"' EXIT
+        BOOTSTRAP_PAYLOAD_FILE="$BOOTSTRAP_TMPDIR/bootstrap.json"
+        : > "$BOOTSTRAP_PAYLOAD_FILE"
+        chmod 600 "$BOOTSTRAP_PAYLOAD_FILE"
+        printf '{"username":"%s","email":"%s","password":"%s","display_name":"Administrator"}' \
+            "$ADMIN_USER" "$ADMIN_EMAIL" "$KEYORIX_ADMIN_PASSWORD" > "$BOOTSTRAP_PAYLOAD_FILE"
+        wget --quiet -O- \
+            --header='Content-Type: application/json' \
+            --header="X-Keyorix-Bootstrap-Token: $KEYORIX_BOOTSTRAP_TOKEN" \
+            --post-file="$BOOTSTRAP_PAYLOAD_FILE" \
+            http://localhost:8080/system/init 2>/dev/null || \
+            echo "Bootstrap call failed (server may already be initialised) — continuing."
+        rm -rf "$BOOTSTRAP_TMPDIR"
+        trap - EXIT
+    fi
 else
     echo "KEYORIX_ADMIN_PASSWORD not set — skipping auto-bootstrap."
     echo "Initialise manually: keyorix system init --server http://<host>:8080"


### PR DESCRIPTION
## Summary
- `/system/init` always requires a matching bootstrap token now (operator-set via `KEYORIX_BOOTSTRAP_TOKEN`, or else a random one the server generates and only logs). The compose file and entrypoint script never learned to send one, so the auto-bootstrap call was silently rejected on every first boot.
- Send the token as an `X-Keyorix-Bootstrap-Token` header alongside the existing argv-safe `--post-file` payload (from #720), and skip the call with a clear message when the token isn't set instead of failing opaquely.

## Test plan
- [x] `sh -n server/entrypoint.sh` passes
- [ ] Manual: `docker compose up` with `KEYORIX_ADMIN_PASSWORD` + `KEYORIX_BOOTSTRAP_TOKEN` set bootstraps the admin successfully