### PR TITLE
fix(remote-storage): implement SoD policy storage primitives (#519)

### DIFF
--- a/internal/storage/store/remote_sod.go
+++ b/internal/storage/store/remote_sod.go
@@ -1,25 +1,118 @@
-// remote_sod.go — separation-of-duties policies for RemoteStorage. Processed
-// server-side; stubs here. See local_sod.go.
+// remote_sod.go — separation-of-duties (SoD) policies for RemoteStorage
+// (finding #519).
+//
+// CreateSoDPolicy/GetSoDPolicy/ListSoDPolicies/DeleteSoDPolicy are thin
+// passthroughs onto four new server-side routes under
+// /api/v1/system/sod-policies (server/http/handlers/sod_proxy.go), following
+// the SAME pattern #507/#510/#511 established (remote_invitations.go,
+// remote_auth.go, remote_memberships.go): gated on the same broad
+// system.read/system.write RBAC permissions a RemoteStorage credential already
+// needs for every other proxied call, so this introduces no new privilege
+// class. No SoD-policy POLICY decision (name/permission-pair validation, the
+// audit-log event, the violation-detection scan itself) is made in these
+// routes — that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore (sod.go), exactly as it does against a local
+// backend.
+//
+// Before this fix, every one of these methods returned ErrRemoteUnsupported,
+// so a downstream server booted with storage.type: remote could neither manage
+// SoD policies (internal/core/sod.go's CreateSoDPolicy/ListSoDPolicies/
+// DeleteSoDPolicy) nor evaluate its own preventive grant-time gates
+// (requireNoSoDViolation and its group/machine/grant-set siblings, #419 —
+// every direct role-grant choke point calls ListSoDPolicies first) against a
+// remote storage backend at all.
+//
+// Atomicity note: the storage.Storage interface exposes no Update method for
+// SoDPolicy at all (a policy is immutable once created — retire it via
+// DeleteSoDPolicy and create a replacement instead), and none of the four
+// methods here rely on a LockXForUpdate + conditional-update pattern locally
+// (local_sod.go's Create/Get/List are plain GORM Create/First/Find, and Delete
+// is a plain GORM Delete keyed by primary key, whose RowsAffected == 0 check
+// only ever races against another delete of the SAME row — both outcomes are
+// "the row is gone," not a lost update). So a single passthrough per call,
+// exactly mirroring local_sod.go's own semantics, introduces no NEW race and
+// needs no additional atomic storage-interface primitive.
+//
+// models.SoDPolicy already carries full explicit json tags (unlike
+// models.DynamicSecretConfig/models.ProjectMembership before their own proxy
+// fixes), so no separate wire-DTO struct is needed here — the model is
+// marshaled/unmarshaled directly, same as remote_rotation_policies.go's
+// pre-existing (non-system-proxy) precedent.
+//
+// For the local (GORM) equivalent of everything here see local_sod.go.
 package store
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-func (rs *RemoteStorage) CreateSoDPolicy(_ context.Context, _ *models.SoDPolicy) (*models.SoDPolicy, error) {
-	return nil, remoteUnsupported("CreateSoDPolicy")
+// CreateSoDPolicy persists an already-validated policy row (name/permission-pair
+// validation is done by the CALLING core.KeyorixCore before this is invoked,
+// exactly as core.CreateSoDPolicy builds one for LocalStorage) via POST
+// /api/v1/system/sod-policies.
+func (rs *RemoteStorage) CreateSoDPolicy(ctx context.Context, p *models.SoDPolicy) (*models.SoDPolicy, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/sod-policies", p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SoD policy: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create SoD policy failed: %s", resp.Error.Error())
+	}
+	var result models.SoDPolicy
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &result, nil
 }
 
-func (rs *RemoteStorage) GetSoDPolicy(_ context.Context, _ uint) (*models.SoDPolicy, error) {
-	return nil, remoteUnsupported("GetSoDPolicy")
+// GetSoDPolicy retrieves a policy by ID via GET /api/v1/system/sod-policies/{id}.
+func (rs *RemoteStorage) GetSoDPolicy(ctx context.Context, id uint) (*models.SoDPolicy, error) {
+	path := fmt.Sprintf("/api/v1/system/sod-policies/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get SoD policy: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get SoD policy failed: %s", resp.Error.Error())
+	}
+	var result models.SoDPolicy
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &result, nil
 }
 
-func (rs *RemoteStorage) ListSoDPolicies(_ context.Context) ([]*models.SoDPolicy, error) {
-	return nil, remoteUnsupported("ListSoDPolicies")
+// ListSoDPolicies lists every policy via GET /api/v1/system/sod-policies.
+func (rs *RemoteStorage) ListSoDPolicies(ctx context.Context) ([]*models.SoDPolicy, error) {
+	resp, err := rs.client.Get(ctx, "/api/v1/system/sod-policies")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list SoD policies: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list SoD policies failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Policies []*models.SoDPolicy `json:"policies"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Policies, nil
 }
 
-func (rs *RemoteStorage) DeleteSoDPolicy(_ context.Context, _ uint) error {
-	return remoteUnsupported("DeleteSoDPolicy")
+// DeleteSoDPolicy retires a policy via DELETE /api/v1/system/sod-policies/{id}.
+func (rs *RemoteStorage) DeleteSoDPolicy(ctx context.Context, id uint) error {
+	path := fmt.Sprintf("/api/v1/system/sod-policies/%d", id)
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete SoD policy: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete SoD policy failed: %s", resp.Error.Error())
+	}
+	return nil
 }

--- a/server/http/handlers/sod_proxy.go
+++ b/server/http/handlers/sod_proxy.go
@@ -1,0 +1,126 @@
+// sod_proxy.go — server-side endpoints backing RemoteStorage's
+// separation-of-duties (SoD) policy storage primitives (finding #519):
+// CreateSoDPolicy/GetSoDPolicy/ListSoDPolicies/DeleteSoDPolicy.
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// its SoD-policy storage calls to whichever upstream server it's configured
+// against, through these routes (registered in server/http/router.go under
+// /api/v1/system/sod-policies, gated on the existing system.read/system.write
+// RBAC permissions — the SAME credential a RemoteStorage client already needs for
+// every other proxied call, e.g. full user CRUD, project-membership CRUD (#511),
+// so this introduces no new privilege class). Mirrors project_memberships_proxy.go
+// (#511) and dynamic_secrets_proxy.go exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/sod.go already uses against a local backend — NO SoD-policy
+// POLICY decision (name/permission-pair validation — required, distinct — the
+// audit-log event, or the violation-detection scan itself, DetectSoDViolations)
+// is made here; all of that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore, exactly as it does against a local backend.
+//
+// This is deliberately NOT a reuse of CatalogHandler's existing human-facing
+// /api/v1/sod/policies routes (server/http/handlers/sod.go), exactly like the
+// human-facing /groups routes were the wrong proxy target for the group-CRUD
+// proxy (round-116 finding, groups_proxy.go): CreateSoDPolicy/DeleteSoDPolicy
+// there require an authenticated actor from the HTTP request context and run
+// THIS server's own core.CreateSoDPolicy/DeleteSoDPolicy (validation +
+// audit-event write) — the wrong semantics for a raw storage-primitive
+// passthrough, whose caller already ran all of that on the downstream side and
+// only needs this server to persist/return the already-validated row.
+//
+// models.SoDPolicy already carries full explicit json tags (unlike
+// models.DynamicSecretConfig/models.ProjectMembership before their own proxy
+// fixes), so no separate wire-DTO struct is needed here — the model is
+// marshaled/unmarshaled directly, same as remote_rotation_policies.go's
+// pre-existing (non-system-proxy) precedent.
+//
+// Response envelope: like the other proxies in this package, these do NOT use
+// the package's generic sendSuccess/sendError helpers — they construct the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// CreateSoDPolicyProxy handles POST /api/v1/system/sod-policies. Persists the
+// caller's already-fully-validated policy row as-is (a raw storage-layer
+// create) — matching CreateMembershipProxy's precedent, this is NOT the
+// human-facing POST /api/v1/sod/policies (CatalogHandler.CreateSoDPolicy),
+// which additionally requires an authenticated actor and runs this server's own
+// name/permission-pair validation and audit-event write.
+func (h *CatalogHandler) CreateSoDPolicyProxy(w http.ResponseWriter, r *http.Request) {
+	var body models.SoDPolicy
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Name == "" || body.PermissionA == "" || body.PermissionB == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "name, permission_a, and permission_b are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateSoDPolicy(r.Context(), &body)
+	if err != nil {
+		log.Printf("sod-policies proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, created)
+}
+
+// GetSoDPolicyProxy handles GET /api/v1/system/sod-policies/{id}.
+func (h *CatalogHandler) GetSoDPolicyProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid policy id")
+		return
+	}
+	policy, err := h.coreService.Storage().GetSoDPolicy(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "SoD policy not found")
+			return
+		}
+		log.Printf("sod-policies proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, policy)
+}
+
+// ListSoDPoliciesProxy handles GET /api/v1/system/sod-policies.
+func (h *CatalogHandler) ListSoDPoliciesProxy(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.coreService.Storage().ListSoDPolicies(r.Context())
+	if err != nil {
+		log.Printf("sod-policies proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"policies": rows})
+}
+
+// DeleteSoDPolicyProxy handles DELETE /api/v1/system/sod-policies/{id}.
+func (h *CatalogHandler) DeleteSoDPolicyProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid policy id")
+		return
+	}
+	if err := h.coreService.Storage().DeleteSoDPolicy(r.Context(), uint(id)); err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "SoD policy not found")
+			return
+		}
+		log.Printf("sod-policies proxy: delete failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -94,6 +94,9 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		&models.MFASecret{},
 		&models.MFARecoveryCode{},
 		&models.MFAChallenge{},
+		// finding #519: the SoD-policy-proxy end-to-end tests exercise SoDPolicy
+		// CRUD through the real router.
+		&models.SoDPolicy{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the

--- a/server/http/remote_storage_sod_test.go
+++ b/server/http/remote_storage_sod_test.go
@@ -1,0 +1,167 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForSoD builds the standard #452/#507/#511/#519
+// two-server harness: an "upstream" exercised through the REAL production
+// NewRouter/handlers (including the new /api/v1/system/sod-policies routes,
+// server/http/handlers/sod_proxy.go), and a "downstream" *core.KeyorixCore
+// configured with storage.type: remote (ADR-049), pointed at "upstream" over
+// real HTTP via store.RemoteStorage. Mirrors
+// newUpstreamDownstreamForMemberships exactly.
+func newUpstreamDownstreamForSoD(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	return upstream, downstream
+}
+
+// TestRemoteStorageSoDPolicy_CreateGetList_RealServer proves the #519 fix for
+// CreateSoDPolicy/GetSoDPolicy/ListSoDPolicies: a policy is genuinely persisted
+// on the upstream server via the DOWNSTREAM's RemoteStorage, fetchable by ID,
+// and listed — all via storage.type: remote against a real router, not a
+// protocol mock.
+func TestRemoteStorageSoDPolicy_CreateGetList_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForSoD(t)
+	ctx := context.Background()
+
+	p, err := downstream.Storage().CreateSoDPolicy(ctx, &models.SoDPolicy{
+		Name:        "no-approve-and-administer",
+		Description: "one principal must not both approve access requests and administer secrets",
+		PermissionA: "access_requests.approve",
+		PermissionB: "secrets.admin",
+		CreatedBy:   1,
+	})
+	require.NoError(t, err, "creating a SoD policy must succeed via storage.type: remote")
+	require.NotZero(t, p.ID, "the upstream must assign a real ID")
+	assert.Equal(t, "no-approve-and-administer", p.Name)
+	assert.Equal(t, "access_requests.approve", p.PermissionA)
+	assert.Equal(t, "secrets.admin", p.PermissionB)
+
+	// Confirm it is a REAL row in the upstream's own storage (not just "the call
+	// didn't error"), by reading it back directly against upstream.
+	direct, err := upstream.Storage().GetSoDPolicy(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "no-approve-and-administer", direct.Name)
+
+	// GetSoDPolicy via the downstream (RemoteStorage) round-trips every field
+	// correctly.
+	fetched, err := downstream.Storage().GetSoDPolicy(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Equal(t, p.ID, fetched.ID)
+	assert.Equal(t, p.Name, fetched.Name)
+	assert.Equal(t, p.Description, fetched.Description)
+	assert.Equal(t, p.PermissionA, fetched.PermissionA)
+	assert.Equal(t, p.PermissionB, fetched.PermissionB)
+
+	// A second policy, then list both back via the downstream's
+	// ListSoDPolicies.
+	p2, err := downstream.Storage().CreateSoDPolicy(ctx, &models.SoDPolicy{
+		Name:        "no-create-and-delete-users",
+		PermissionA: "users.create",
+		PermissionB: "users.delete",
+	})
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListSoDPolicies(ctx)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	names := map[string]bool{}
+	for _, r := range rows {
+		names[r.Name] = true
+	}
+	assert.True(t, names[p.Name])
+	assert.True(t, names[p2.Name])
+}
+
+// TestRemoteStorageSoDPolicy_GetNotFound_RealServer proves a clean not-found
+// error (not a panic, not a garbage 500) for a nonexistent policy ID.
+func TestRemoteStorageSoDPolicy_GetNotFound_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForSoD(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetSoDPolicy(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageSoDPolicy_Delete_RealServer proves DeleteSoDPolicy removes
+// the row on the upstream (a policy existing = active; deleting it retires the
+// rule, per local_sod.go's own doc), and that a second delete of the same ID
+// (or a delete of a nonexistent ID) surfaces a clean not-found error rather
+// than silently "succeeding" — mirroring local_sod.go's own
+// RowsAffected == 0 check.
+func TestRemoteStorageSoDPolicy_Delete_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForSoD(t)
+	ctx := context.Background()
+
+	p, err := downstream.Storage().CreateSoDPolicy(ctx, &models.SoDPolicy{
+		Name:        "to-be-deleted",
+		PermissionA: "roles.assign",
+		PermissionB: "secrets.delete",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, downstream.Storage().DeleteSoDPolicy(ctx, p.ID))
+
+	// Confirm it's gone on the upstream directly.
+	_, err = upstream.Storage().GetSoDPolicy(ctx, p.ID)
+	require.Error(t, err, "the policy must be gone from the upstream's real storage")
+
+	// A second delete of the same (now-gone) ID must fail cleanly, not silently
+	// report success.
+	err = downstream.Storage().DeleteSoDPolicy(ctx, p.ID)
+	require.Error(t, err, "deleting an already-deleted policy must surface a clean not-found error")
+}
+
+// TestRemoteStorageSoDPolicy_CreateValidation_RealServer proves
+// CreateSoDPolicyProxy rejects an incomplete policy body (matching
+// local_sod.go's own contract — CreateSoDPolicy has no NOT NULL enforcement of
+// its own, but the storage-primitive proxy still refuses an obviously-broken
+// payload rather than persisting a useless half-empty row).
+func TestRemoteStorageSoDPolicy_CreateValidation_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForSoD(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().CreateSoDPolicy(ctx, &models.SoDPolicy{
+		Name:        "incomplete",
+		PermissionA: "",
+		PermissionB: "secrets.delete",
+	})
+	require.Error(t, err, "a policy missing permission_a must be rejected")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -961,6 +961,30 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/project-memberships", catalogHandler.ListMembershipsProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/project-memberships", catalogHandler.CreateMembershipProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Put("/project-memberships/{id}", catalogHandler.UpdateMembershipProxy)
+
+			// Separation-of-duties (SoD) policy storage-primitive proxy (finding
+			// #519). Lets a downstream Keyorix server booted with storage.type:
+			// remote (ADR-049) proxy CreateSoDPolicy/GetSoDPolicy/ListSoDPolicies/
+			// DeleteSoDPolicy to THIS server's real storage backend, instead of
+			// RemoteStorage's four SoD-policy methods having no server endpoint to
+			// call at all (internal/core/sod.go's policy CRUD, plus every preventive
+			// grant-time gate that lists policies — requireNoSoDViolation and
+			// friends, #419 — was completely non-functional under storage.type:
+			// remote). Exactly the same pattern as the project-memberships proxy
+			// above: a thin passthrough onto storage.Storage (no SoD-policy POLICY
+			// decision — name/permission-pair validation, the audit-log event, the
+			// violation-detection scan itself — is made here; that stays entirely in
+			// the CALLING server's own internal/core.KeyorixCore, exactly as it does
+			// against a local backend), reusing the SAME system.read/system.write
+			// tier rather than the human-facing /sod/policies routes' calibration,
+			// since a RemoteStorage credential already needs system.write for the
+			// proxies above — no new privilege class. Read is baseline system.read;
+			// create/delete require system.write, matching every other admin-level
+			// mutation in this group.
+			r.Get("/sod-policies/{id}", catalogHandler.GetSoDPolicyProxy)
+			r.Get("/sod-policies", catalogHandler.ListSoDPoliciesProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/sod-policies", catalogHandler.CreateSoDPolicyProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Delete("/sod-policies/{id}", catalogHandler.DeleteSoDPolicyProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary
- Implements `RemoteStorage` support for Separation-of-Duties (SoD) policies (part of #519): new thin passthrough routes under `/api/v1/system/sod-policies` (gated on the existing `system.read`/`system.write` tier, no new privilege class), replacing the unconditional `remoteUnsupported` stubs in `internal/storage/store/remote_sod.go`.
- The existing human-facing `/api/v1/sod/policies` routes bake in real business logic (actor-context requirement, validation, audit-event writes) and were correctly NOT reused as the proxy target, per the #514-class precedent.
- No atomicity concern: `SoDPolicy` has no `Update` method (policies are immutable, retired via delete+recreate); `Create`/`Get`/`List`/`Delete` are all plain single-row GORM operations with no `LockXForUpdate`+conditional-update pattern to preserve.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./internal/storage/store/... ./internal/core/... ./server/http/...` pass
- [x] New `server/http/remote_storage_sod_test.go`: create/get/list round-trip, not-found, delete + double-delete rejection, create-validation rejection — all against a real router/HTTP hop
- [x] `gosec -severity medium -exclude-generated` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)