### PR TITLE
fix(remote-storage): implement risk exception storage primitives (#519)

### DIFF
--- a/internal/storage/store/remote_risk_exceptions.go
+++ b/internal/storage/store/remote_risk_exceptions.go
@@ -1,25 +1,187 @@
-// remote_risk_exceptions.go — risk exceptions for RemoteStorage. Processed
-// server-side; stubs here. See local_risk_exceptions.go.
+// remote_risk_exceptions.go — risk-exception storage primitives for
+// RemoteStorage (finding #519): thin passthroughs onto four new server-side
+// routes under /api/v1/system/risk-exceptions
+// (server/http/handlers/risk_exceptions_proxy.go), mirroring the dynamic-secrets
+// (round-116) and project-membership (#511) proxy patterns exactly: gated on the
+// SAME broad system.read/system.write RBAC permissions a RemoteStorage
+// credential already needs for every other proxied call, so this introduces no
+// new privilege class.
+//
+// No risk-exception POLICY decision (title/category/justification validation,
+// the expiry-in-the-future and max-365-day-sunset bounds, dual-control approval,
+// or the effective-status computation from the revoked flag + expiry) is made in
+// these routes — that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore (internal/core/risk_exceptions.go), exactly as it
+// does against a local backend.
+//
+// Atomicity (investigated, not assumed): local_risk_exceptions.go's
+// UpdateRiskException is an unconditional full-row `Save`, not a
+// conditional/optimistic-concurrency write — there is no
+// LockXForUpdate/SELECT ... FOR UPDATE anywhere in this subsystem, unlike, say,
+// UpdateProjectInvitation's `WHERE id = ? AND state = 'pending'` or #511's
+// duplicate-active-membership unique-index translation. internal/core's
+// RevokeRiskException/ApproveRiskException already re-fetch the exception and
+// check its revoked/approved/expiry state before mutating it — a check-then-act
+// sequence with exactly the same (small, pre-existing, accepted) race window
+// against a local backend as against this proxy. This fix preserves that
+// behavior exactly rather than introducing a stricter guarantee the local
+// backend itself doesn't have — no new atomic storage-interface primitive is
+// needed here.
+//
+// For the local (GORM) equivalent of every primitive here see
+// local_risk_exceptions.go.
 package store
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-func (rs *RemoteStorage) CreateRiskException(_ context.Context, _ *models.RiskException) (*models.RiskException, error) {
-	return nil, remoteUnsupported("CreateRiskException")
+// riskExceptionWire mirrors riskExceptionProxyWire in
+// server/http/handlers/risk_exceptions_proxy.go exactly.
+type riskExceptionWire struct {
+	ID            uint       `json:"id"`
+	Title         string     `json:"title"`
+	Category      string     `json:"category"`
+	Reference     string     `json:"reference,omitempty"`
+	Justification string     `json:"justification"`
+	CreatedBy     uint       `json:"created_by"`
+	CreatedAt     time.Time  `json:"created_at"`
+	ExpiresAt     time.Time  `json:"expires_at"`
+	Revoked       bool       `json:"revoked"`
+	RevokedBy     uint       `json:"revoked_by,omitempty"`
+	RevokedAt     *time.Time `json:"revoked_at,omitempty"`
+	Approved      bool       `json:"approved"`
+	ApprovedBy    uint       `json:"approved_by,omitempty"`
+	ApprovedAt    *time.Time `json:"approved_at,omitempty"`
 }
 
-func (rs *RemoteStorage) ListRiskExceptions(_ context.Context, _ bool) ([]*models.RiskException, error) {
-	return nil, remoteUnsupported("ListRiskExceptions")
+func newRiskExceptionWire(e *models.RiskException) riskExceptionWire {
+	return riskExceptionWire{
+		ID:            e.ID,
+		Title:         e.Title,
+		Category:      e.Category,
+		Reference:     e.Reference,
+		Justification: e.Justification,
+		CreatedBy:     e.CreatedBy,
+		CreatedAt:     e.CreatedAt,
+		ExpiresAt:     e.ExpiresAt,
+		Revoked:       e.Revoked,
+		RevokedBy:     e.RevokedBy,
+		RevokedAt:     e.RevokedAt,
+		Approved:      e.Approved,
+		ApprovedBy:    e.ApprovedBy,
+		ApprovedAt:    e.ApprovedAt,
+	}
 }
 
-func (rs *RemoteStorage) GetRiskException(_ context.Context, _ uint) (*models.RiskException, error) {
-	return nil, remoteUnsupported("GetRiskException")
+func (w riskExceptionWire) toModel() *models.RiskException {
+	return &models.RiskException{
+		ID:            w.ID,
+		Title:         w.Title,
+		Category:      w.Category,
+		Reference:     w.Reference,
+		Justification: w.Justification,
+		CreatedBy:     w.CreatedBy,
+		CreatedAt:     w.CreatedAt,
+		ExpiresAt:     w.ExpiresAt,
+		Revoked:       w.Revoked,
+		RevokedBy:     w.RevokedBy,
+		RevokedAt:     w.RevokedAt,
+		Approved:      w.Approved,
+		ApprovedBy:    w.ApprovedBy,
+		ApprovedAt:    w.ApprovedAt,
+	}
 }
 
-func (rs *RemoteStorage) UpdateRiskException(_ context.Context, _ *models.RiskException) error {
-	return remoteUnsupported("UpdateRiskException")
+func decodeRiskExceptionResponse(data []byte) (*models.RiskException, error) {
+	var wire riskExceptionWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
+}
+
+// CreateRiskException persists an already-validated exception row (the
+// title/category/justification/expiry checks already ran in the CALLING
+// server's own core.CreateRiskException) via POST
+// /api/v1/system/risk-exceptions.
+func (rs *RemoteStorage) CreateRiskException(ctx context.Context, e *models.RiskException) (*models.RiskException, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/risk-exceptions", newRiskExceptionWire(e))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create risk exception: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create risk exception failed: %s", resp.Error.Error())
+	}
+	return decodeRiskExceptionResponse(resp.Data)
+}
+
+// ListRiskExceptions lists risk exceptions (newest-first) via GET
+// /api/v1/system/risk-exceptions?active_only=true|false. When activeOnly is set,
+// revoked rows are excluded (expiry is computed in the calling server's own
+// core, not at the storage layer) — matching local_risk_exceptions.go's contract
+// exactly.
+func (rs *RemoteStorage) ListRiskExceptions(ctx context.Context, activeOnly bool) ([]*models.RiskException, error) {
+	q := url.Values{}
+	if activeOnly {
+		q.Set("active_only", "true")
+	}
+	path := "/api/v1/system/risk-exceptions"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list risk exceptions: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list risk exceptions failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Exceptions []riskExceptionWire `json:"exceptions"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.RiskException, 0, len(result.Exceptions))
+	for _, w := range result.Exceptions {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
+}
+
+// GetRiskException retrieves an exception by ID via GET
+// /api/v1/system/risk-exceptions/{id}.
+func (rs *RemoteStorage) GetRiskException(ctx context.Context, id uint) (*models.RiskException, error) {
+	path := fmt.Sprintf("/api/v1/system/risk-exceptions/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get risk exception: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get risk exception failed: %s", resp.Error.Error())
+	}
+	return decodeRiskExceptionResponse(resp.Data)
+}
+
+// UpdateRiskException persists the full exception row (revoke/approve
+// bookkeeping) via PUT /api/v1/system/risk-exceptions/{id}. Matches
+// LocalStorage's own unconditional full-row Save semantics exactly — see the
+// package doc for why no conditional write is needed here.
+func (rs *RemoteStorage) UpdateRiskException(ctx context.Context, e *models.RiskException) error {
+	path := fmt.Sprintf("/api/v1/system/risk-exceptions/%d", e.ID)
+	resp, err := rs.client.Put(ctx, path, newRiskExceptionWire(e))
+	if err != nil {
+		return fmt.Errorf("failed to update risk exception: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("update risk exception failed: %s", resp.Error.Error())
+	}
+	return nil
 }

--- a/server/http/handlers/risk_exceptions_proxy.go
+++ b/server/http/handlers/risk_exceptions_proxy.go
@@ -1,0 +1,208 @@
+// risk_exceptions_proxy.go — server-side endpoints backing RemoteStorage's
+// CreateRiskException/GetRiskException/ListRiskExceptions/UpdateRiskException
+// (finding #519).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// its risk-exception (ISO 27001 A.5.8 risk-register) storage calls to whichever
+// upstream server it's configured against, through these routes (registered in
+// server/http/router.go under /api/v1/system/risk-exceptions, gated on the
+// existing system.read/system.write RBAC permissions — the SAME credential a
+// RemoteStorage client already needs for every other proxied call, e.g. full user
+// CRUD, dynamic-secrets CRUD (round-116 finding), so this introduces no new
+// privilege class). Mirrors dynamic_secrets_proxy.go/project_memberships_proxy.go
+// exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/risk_exceptions.go already uses against a local backend — NO
+// risk-exception POLICY decision (title/category/justification validation, the
+// expiry-in-the-future and max-365-day-sunset bounds, dual-control approval —
+// the creator can never approve their own exception — or the effective-status
+// computation from the revoked flag + expiry) is made here; all of that stays
+// entirely in the CALLING server's own internal/core.KeyorixCore, exactly as it
+// does against a local backend.
+//
+// This also means the human-facing /api/v1/risk-exceptions routes
+// (server/http/handlers/risk_exceptions.go, DashboardHandler.ListRiskExceptions/
+// CreateRiskException/ApproveRiskException/RevokeRiskException) are NOT reused
+// for this proxy: those bake in exactly the policy decisions above (dual-control
+// approval, expiry/duration validation, actor-identity extraction from the HTTP
+// caller's own session) against THIS server's own core — the wrong semantics for
+// a raw storage-primitive passthrough whose caller already ran all of that
+// decision-making on the downstream side and only needs this server to
+// persist/return the resulting row. Exactly the same class of mistake the
+// human-facing /groups routes were for #514's Group-CRUD proxy fix.
+//
+// Atomicity: storage.Storage.UpdateRiskException (local_risk_exceptions.go) is an
+// unconditional full-row `Save`, not a conditional/optimistic-concurrency write —
+// there is no LockXForUpdate/SELECT ... FOR UPDATE anywhere in this subsystem to
+// preserve across the wire. internal/core.RevokeRiskException/ApproveRiskException
+// already re-fetch the exception and check its revoked/approved/expiry state
+// before mutating it — a check-then-act sequence with exactly the same (small,
+// pre-existing, accepted) race window against a local backend as against this
+// proxy. This fix preserves that behavior exactly rather than introducing a
+// stricter guarantee the local backend itself doesn't have (mirrors
+// dynamic_secrets_proxy.go's UpdateDynamicSecretConfigProxy/
+// UpdateDynamicSecretLeaseProxy reasoning).
+//
+// Response envelope: like dynamic_secrets_proxy.go/project_memberships_proxy.go,
+// these do NOT use the package's generic sendSuccess/sendError helpers — they
+// construct the exact {"success":bool,"data":...,"error":{"code","message"}}
+// shape internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// riskExceptionProxyWire mirrors models.RiskException's fields exactly
+// (snake_case) — the wire shape internal/storage/store/remote_risk_exceptions.go
+// sends/expects. Named explicitly (rather than relying on a direct model
+// marshal) to match every other proxy handler's convention in this package.
+type riskExceptionProxyWire struct {
+	ID            uint       `json:"id"`
+	Title         string     `json:"title"`
+	Category      string     `json:"category"`
+	Reference     string     `json:"reference,omitempty"`
+	Justification string     `json:"justification"`
+	CreatedBy     uint       `json:"created_by"`
+	CreatedAt     time.Time  `json:"created_at"`
+	ExpiresAt     time.Time  `json:"expires_at"`
+	Revoked       bool       `json:"revoked"`
+	RevokedBy     uint       `json:"revoked_by,omitempty"`
+	RevokedAt     *time.Time `json:"revoked_at,omitempty"`
+	Approved      bool       `json:"approved"`
+	ApprovedBy    uint       `json:"approved_by,omitempty"`
+	ApprovedAt    *time.Time `json:"approved_at,omitempty"`
+}
+
+func newRiskExceptionProxyWire(e *models.RiskException) riskExceptionProxyWire {
+	return riskExceptionProxyWire{
+		ID:            e.ID,
+		Title:         e.Title,
+		Category:      e.Category,
+		Reference:     e.Reference,
+		Justification: e.Justification,
+		CreatedBy:     e.CreatedBy,
+		CreatedAt:     e.CreatedAt,
+		ExpiresAt:     e.ExpiresAt,
+		Revoked:       e.Revoked,
+		RevokedBy:     e.RevokedBy,
+		RevokedAt:     e.RevokedAt,
+		Approved:      e.Approved,
+		ApprovedBy:    e.ApprovedBy,
+		ApprovedAt:    e.ApprovedAt,
+	}
+}
+
+func (w riskExceptionProxyWire) toModel() *models.RiskException {
+	return &models.RiskException{
+		ID:            w.ID,
+		Title:         w.Title,
+		Category:      w.Category,
+		Reference:     w.Reference,
+		Justification: w.Justification,
+		CreatedBy:     w.CreatedBy,
+		CreatedAt:     w.CreatedAt,
+		ExpiresAt:     w.ExpiresAt,
+		Revoked:       w.Revoked,
+		RevokedBy:     w.RevokedBy,
+		RevokedAt:     w.RevokedAt,
+		Approved:      w.Approved,
+		ApprovedBy:    w.ApprovedBy,
+		ApprovedAt:    w.ApprovedAt,
+	}
+}
+
+// CreateRiskExceptionProxy handles POST /api/v1/system/risk-exceptions. Persists
+// the caller's already-fully-built (and already-validated) exception row as-is —
+// see the package doc for why this is NOT a re-run of
+// core.CreateRiskException's validation.
+func (h *DashboardHandler) CreateRiskExceptionProxy(w http.ResponseWriter, r *http.Request) {
+	var body riskExceptionProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Title == "" || body.Justification == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "title and justification are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateRiskException(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("risk-exceptions proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newRiskExceptionProxyWire(created))
+}
+
+// GetRiskExceptionProxy handles GET /api/v1/system/risk-exceptions/{id}.
+func (h *DashboardHandler) GetRiskExceptionProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid exception id")
+		return
+	}
+	e, err := h.coreService.Storage().GetRiskException(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "risk exception not found")
+			return
+		}
+		log.Printf("risk-exceptions proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newRiskExceptionProxyWire(e))
+}
+
+// ListRiskExceptionsProxy handles GET
+// /api/v1/system/risk-exceptions?active_only=true|false.
+func (h *DashboardHandler) ListRiskExceptionsProxy(w http.ResponseWriter, r *http.Request) {
+	// activeOnly defaults to false (return every non-revoked row, matching
+	// storage.ListRiskExceptions' own contract) unless the caller explicitly asks
+	// to exclude revoked rows.
+	activeOnly := r.URL.Query().Get("active_only") == "true"
+	rows, err := h.coreService.Storage().ListRiskExceptions(r.Context(), activeOnly)
+	if err != nil {
+		log.Printf("risk-exceptions proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]riskExceptionProxyWire, 0, len(rows))
+	for _, e := range rows {
+		wire = append(wire, newRiskExceptionProxyWire(e))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"exceptions": wire})
+}
+
+// UpdateRiskExceptionProxy handles PUT /api/v1/system/risk-exceptions/{id}. A raw
+// persist (storage.Storage.UpdateRiskException is an unconditional full-row Save,
+// matching LocalStorage's own semantics exactly) — see the package doc for why no
+// conditional write is needed here.
+func (h *DashboardHandler) UpdateRiskExceptionProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid exception id")
+		return
+	}
+	var body riskExceptionProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	if err := h.coreService.Storage().UpdateRiskException(r.Context(), body.toModel()); err != nil {
+		log.Printf("risk-exceptions proxy: update failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -94,6 +94,9 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		&models.MFASecret{},
 		&models.MFARecoveryCode{},
 		&models.MFAChallenge{},
+		// #519: the risk-exception-proxy end-to-end tests exercise RiskException
+		// CRUD through the real router.
+		&models.RiskException{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the

--- a/server/http/remote_storage_risk_exceptions_test.go
+++ b/server/http/remote_storage_risk_exceptions_test.go
@@ -1,0 +1,188 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForRiskExceptions builds the standard #452/#507/#511-style
+// two-server harness: an "upstream" exercised through the REAL production
+// NewRouter/handlers (including the new /api/v1/system/risk-exceptions routes,
+// server/http/handlers/risk_exceptions_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed at
+// "upstream" over real HTTP via store.RemoteStorage. Mirrors
+// newUpstreamDownstreamForMemberships exactly.
+func newUpstreamDownstreamForRiskExceptions(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+
+	return upstream, downstream
+}
+
+// buildRiskException mirrors what internal/core.CreateRiskException computes
+// (after its own title/category/justification/expiry validation) before calling
+// storage.CreateRiskException — a fully-built, already-validated exception row —
+// WITHOUT going through CreateRiskException itself (whose validation is
+// out-of-scope core POLICY, not a storage primitive, exactly the same class of
+// out-of-scope prerequisite buildDynamicSecretConfig/buildInvitedMembership
+// document in the sibling proxy test files).
+func buildRiskException(now time.Time, createdBy uint, title, category string, expiresAt time.Time) *models.RiskException {
+	return &models.RiskException{
+		Title:         title,
+		Category:      category,
+		Reference:     "secret:db-password",
+		Justification: "vendor migration in progress; MFA rollout blocked until Q3",
+		CreatedBy:     createdBy,
+		CreatedAt:     now,
+		ExpiresAt:     expiresAt,
+	}
+}
+
+// TestRemoteStorageRiskExceptions_CreateGetListUpdate_RealServer proves the #519
+// fix for CreateRiskException/GetRiskException/ListRiskExceptions/
+// UpdateRiskException: an exception is genuinely persisted on the upstream
+// server via the DOWNSTREAM's RemoteStorage, fetchable by ID, listed, and
+// updatable (revoke/approve bookkeeping) — all via storage.type: remote against
+// a real router, not a protocol mock.
+func TestRemoteStorageRiskExceptions_CreateGetListUpdate_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRiskExceptions(t)
+	ctx := context.Background()
+	now := time.Now()
+	expiresAt := now.Add(30 * 24 * time.Hour)
+
+	exc, err := downstream.Storage().CreateRiskException(ctx, buildRiskException(now, 1, "MFA rollout delay", "mfa", expiresAt))
+	require.NoError(t, err, "creating a risk exception must succeed via storage.type: remote")
+	require.NotZero(t, exc.ID, "the upstream must assign a real ID")
+	assert.Equal(t, "MFA rollout delay", exc.Title)
+	assert.Equal(t, "mfa", exc.Category)
+	assert.False(t, exc.Revoked)
+	assert.False(t, exc.Approved)
+
+	// Confirm it is a REAL row in the upstream's own storage (not just "the call
+	// didn't error"), by reading it back directly against upstream.
+	direct, err := upstream.Storage().GetRiskException(ctx, exc.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "MFA rollout delay", direct.Title)
+
+	// GetRiskException via the downstream (RemoteStorage) round-trips every field
+	// correctly.
+	fetched, err := downstream.Storage().GetRiskException(ctx, exc.ID)
+	require.NoError(t, err)
+	assert.Equal(t, exc.ID, fetched.ID)
+	assert.Equal(t, exc.Title, fetched.Title)
+	assert.Equal(t, exc.Category, fetched.Category)
+	assert.Equal(t, exc.Reference, fetched.Reference)
+	assert.Equal(t, exc.Justification, fetched.Justification)
+	assert.WithinDuration(t, exc.ExpiresAt, fetched.ExpiresAt, time.Second)
+
+	// A second exception, then list both back via the downstream's
+	// ListRiskExceptions(activeOnly=false).
+	_, err = downstream.Storage().CreateRiskException(ctx, buildRiskException(now, 1, "Dormant service account", "dormant_access", expiresAt))
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListRiskExceptions(ctx, false)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	titles := map[string]bool{}
+	for _, r := range rows {
+		titles[r.Title] = true
+	}
+	assert.True(t, titles["MFA rollout delay"])
+	assert.True(t, titles["Dormant service account"])
+
+	// UpdateRiskException: approve the first exception (dual control — a
+	// DIFFERENT actor than the creator) via the downstream, confirm the
+	// transition is visible directly on the upstream.
+	approvedAt := time.Now()
+	fetched.Approved = true
+	fetched.ApprovedBy = 2
+	fetched.ApprovedAt = &approvedAt
+	require.NoError(t, downstream.Storage().UpdateRiskException(ctx, fetched))
+
+	reFetched, err := upstream.Storage().GetRiskException(ctx, exc.ID)
+	require.NoError(t, err)
+	assert.True(t, reFetched.Approved, "the approval must be visible directly on the upstream's own storage")
+	assert.Equal(t, uint(2), reFetched.ApprovedBy)
+	require.NotNil(t, reFetched.ApprovedAt)
+}
+
+// TestRemoteStorageRiskExceptions_GetNotFound_RealServer proves a clean
+// not-found error (not a panic, not a garbage 500) for a nonexistent exception ID.
+func TestRemoteStorageRiskExceptions_GetNotFound_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForRiskExceptions(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetRiskException(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageRiskExceptions_ActiveOnlyExcludesRevoked_RealServer proves
+// ListRiskExceptions(activeOnly=true) excludes revoked rows at the storage
+// layer, matching local_risk_exceptions.go's contract exactly (expiry itself is
+// computed by the calling server's own core, not at the storage layer, so an
+// expired-but-not-revoked row is still returned here — core is what drops it
+// from an "active" view).
+func TestRemoteStorageRiskExceptions_ActiveOnlyExcludesRevoked_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRiskExceptions(t)
+	ctx := context.Background()
+	now := time.Now()
+	expiresAt := now.Add(30 * 24 * time.Hour)
+
+	kept, err := downstream.Storage().CreateRiskException(ctx, buildRiskException(now, 1, "Kept exception", "other", expiresAt))
+	require.NoError(t, err)
+	revoked, err := downstream.Storage().CreateRiskException(ctx, buildRiskException(now, 1, "Revoked exception", "other", expiresAt))
+	require.NoError(t, err)
+
+	revokedAt := time.Now()
+	revoked.Revoked = true
+	revoked.RevokedBy = 1
+	revoked.RevokedAt = &revokedAt
+	require.NoError(t, downstream.Storage().UpdateRiskException(ctx, revoked))
+
+	rows, err := downstream.Storage().ListRiskExceptions(ctx, true)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "active_only=true must exclude the revoked row")
+	assert.Equal(t, kept.ID, rows[0].ID)
+
+	// Directly against the upstream's own storage too, proving this isn't an
+	// artifact of RemoteStorage's response cache.
+	directRows, err := upstream.Storage().ListRiskExceptions(ctx, true)
+	require.NoError(t, err)
+	require.Len(t, directRows, 1)
+	assert.Equal(t, kept.ID, directRows[0].ID)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -961,6 +961,29 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/project-memberships", catalogHandler.ListMembershipsProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/project-memberships", catalogHandler.CreateMembershipProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Put("/project-memberships/{id}", catalogHandler.UpdateMembershipProxy)
+
+			// Risk-exception storage-primitive proxy (#519). Lets a downstream
+			// Keyorix server booted with storage.type: remote (ADR-049) proxy
+			// CreateRiskException/GetRiskException/ListRiskExceptions/
+			// UpdateRiskException to THIS server's real storage backend, instead of
+			// RemoteStorage's four RiskException methods being unconditional stubs
+			// (the risk register — ISO 27001 A.5.8 — was completely non-functional
+			// under storage.type: remote). Exactly the same pattern as the
+			// project-memberships proxy above: a thin passthrough onto
+			// storage.Storage (no risk-exception POLICY decision —
+			// title/category/justification validation, the expiry-in-the-future and
+			// max-365-day-sunset bounds, dual-control approval, or the
+			// effective-status computation from the revoked flag + expiry — is made
+			// here; that stays entirely in the CALLING server's own
+			// internal/core.KeyorixCore, exactly as it does against a local
+			// backend), reusing the SAME system.read/system.write tier rather than
+			// the audit.read the human-facing /risk-exceptions routes use, since a
+			// RemoteStorage credential already needs system.write for the
+			// project-memberships proxy above — no new privilege class.
+			r.Get("/risk-exceptions/{id}", dashboardHandler.GetRiskExceptionProxy)
+			r.Get("/risk-exceptions", dashboardHandler.ListRiskExceptionsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/risk-exceptions", dashboardHandler.CreateRiskExceptionProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/risk-exceptions/{id}", dashboardHandler.UpdateRiskExceptionProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary
- Implements `RemoteStorage` support for Risk Exceptions (part of #519): new thin passthrough routes under `/api/v1/system/risk-exceptions` (gated on the existing `system.read`/`system.write` tier, no new privilege class), replacing the unconditional `remoteUnsupported` stubs in `internal/storage/store/remote_risk_exceptions.go`.
- The existing human-facing routes bake in dual-control approval, expiry/365-day-sunset validation, and actor-identity extraction from the HTTP session — confirmed the wrong proxy target (same #514-class mistake avoided) and built new thin routes instead.
- Atomicity: `UpdateRiskException` is an unconditional full-row `Save` with no `LockXForUpdate`/conditional predicate anywhere in this subsystem locally either — the proxy preserves the exact (pre-existing, accepted) check-then-act race window rather than introducing a stricter guarantee. No new atomic storage-interface primitive needed.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./internal/storage/store/... ./internal/core/... ./server/http/...` pass
- [x] New `server/http/remote_storage_risk_exceptions_test.go`: create/get/list/update round-trip (incl. dual-control-approval fields), `active_only` filtering, not-found handling — against a real router/HTTP hop
- [x] `gosec -severity medium -exclude-generated` — 0 issues (589 files, 109527 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)