### PR TITLE
fix(remote-storage): implement break-glass storage primitives (#519)

### DIFF
--- a/internal/storage/store/remote_break_glass.go
+++ b/internal/storage/store/remote_break_glass.go
@@ -1,30 +1,248 @@
-// remote_break_glass.go — break-glass activations for RemoteStorage. Processed
-// server-side; stubs here. See local_break_glass.go.
+// remote_break_glass.go — break-glass activations for RemoteStorage (#519).
+//
+// CreateBreakGlassActivation/GetBreakGlassActivation/ListBreakGlassActivations/
+// UpdateBreakGlassActivation/RevokeBreakGlassActivation are thin passthroughs onto
+// five new server-side routes under /api/v1/system/break-glass
+// (server/http/handlers/break_glass_proxy.go), following the SAME pattern #507/
+// #510/#511 established (remote_invitations.go, remote_memberships.go): gated on
+// the same broad system.read/system.write RBAC permissions a RemoteStorage
+// credential already needs for every other proxied call, so this introduces no
+// new privilege class. No break-glass POLICY decision (enablement,
+// project-affiliation, emergency-role containment, TTL clamping, the actual JIT
+// role grant) is made in these routes — that stays entirely in the CALLING
+// server's own internal/core.KeyorixCore (break_glass.go), exactly as it does
+// against a local backend.
+//
+// Before this fix, every one of these methods returned ErrRemoteUnsupported, so
+// ActivateBreakGlass/ListBreakGlassActivations/RevokeBreakGlass were completely
+// non-functional under storage.type: remote.
+//
+// Atomicity note (mirrors #511's CreateProjectMembership/#507's
+// UpdateProjectInvitation reasoning): local_break_glass.go's
+// CreateBreakGlassActivation relies on a REAL DB-level partial unique index
+// (uniq_break_glass_active_project_user, ensureBreakGlassActiveIndex, docs/
+// security/BUGS.md #104 / PR #670) to reject a second concurrent active
+// activation for the same (project_id, user_id) — that guarantee is a property of
+// the upstream's own database and survives this HTTP hop unchanged, since
+// CreateBreakGlassActivationProxy calls the identical storage.Storage primitive
+// against the same table (not a client-side "GET then POST" sequence, which would
+// reopen the exact race #104 closed). Likewise, RevokeBreakGlassActivation is a
+// single conditional `UPDATE ... WHERE id = ? AND state = 'active'` (not a
+// read-then-write) — RevokeBreakGlassActivationProxy calls that same primitive
+// directly, so this file's RevokeBreakGlassActivation issues exactly one HTTP
+// round trip per call, never a "GET, check state, then PUT" sequence that would
+// reintroduce a double-revoke TOCTOU race. UpdateBreakGlassActivation, by
+// contrast, has no such conditional-write guarantee even locally (a plain GORM
+// Save), so a single passthrough PUT is exact behavioral parity with LocalStorage,
+// not a new race introduced by this file.
+//
+// For the local (GORM) equivalent of everything here see local_break_glass.go.
 package store
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
 )
 
-func (rs *RemoteStorage) CreateBreakGlassActivation(_ context.Context, _ *models.BreakGlassActivation) (*models.BreakGlassActivation, error) {
-	return nil, remoteUnsupported("CreateBreakGlassActivation")
+// breakGlassActivationWire mirrors models.BreakGlassActivation's fields exactly
+// (snake_case), used for both the create/update request body and every response
+// (create/get/list) — there is no models.BreakGlassActivation json tag to fall
+// back on in a way that survives a direct marshal reliably (a GORM model, like
+// models.ProjectInvitation before #507), so — matching membershipWire's/
+// invitationWire's reasoning — every field is named explicitly here.
+type breakGlassActivationWire struct {
+	ID            uint       `json:"id"`
+	ProjectID     uint       `json:"project_id"`
+	UserID        uint       `json:"user_id"`
+	RoleID        uint       `json:"role_id"`
+	RoleName      string     `json:"role_name"`
+	Justification string     `json:"justification"`
+	State         string     `json:"state"`
+	ExpiresAt     *time.Time `json:"expires_at,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
+	RevokedBy     uint       `json:"revoked_by,omitempty"`
+	RevokedAt     *time.Time `json:"revoked_at,omitempty"`
 }
 
-func (rs *RemoteStorage) GetBreakGlassActivation(_ context.Context, _ uint) (*models.BreakGlassActivation, error) {
-	return nil, remoteUnsupported("GetBreakGlassActivation")
+func newBreakGlassActivationWire(a *models.BreakGlassActivation) breakGlassActivationWire {
+	return breakGlassActivationWire{
+		ID:            a.ID,
+		ProjectID:     a.ProjectID,
+		UserID:        a.UserID,
+		RoleID:        a.RoleID,
+		RoleName:      a.RoleName,
+		Justification: a.Justification,
+		State:         a.State,
+		ExpiresAt:     a.ExpiresAt,
+		CreatedAt:     a.CreatedAt,
+		RevokedBy:     a.RevokedBy,
+		RevokedAt:     a.RevokedAt,
+	}
 }
 
-func (rs *RemoteStorage) ListBreakGlassActivations(_ context.Context, _ uint) ([]*models.BreakGlassActivation, error) {
-	return nil, remoteUnsupported("ListBreakGlassActivations")
+func (w breakGlassActivationWire) toModel() *models.BreakGlassActivation {
+	return &models.BreakGlassActivation{
+		ID:            w.ID,
+		ProjectID:     w.ProjectID,
+		UserID:        w.UserID,
+		RoleID:        w.RoleID,
+		RoleName:      w.RoleName,
+		Justification: w.Justification,
+		State:         w.State,
+		ExpiresAt:     w.ExpiresAt,
+		CreatedAt:     w.CreatedAt,
+		RevokedBy:     w.RevokedBy,
+		RevokedAt:     w.RevokedAt,
+	}
 }
 
-func (rs *RemoteStorage) UpdateBreakGlassActivation(_ context.Context, _ *models.BreakGlassActivation) error {
-	return remoteUnsupported("UpdateBreakGlassActivation")
+func decodeBreakGlassActivationResponse(data []byte) (*models.BreakGlassActivation, error) {
+	var wire breakGlassActivationWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }
 
-func (rs *RemoteStorage) RevokeBreakGlassActivation(_ context.Context, _, _ uint, _ time.Time) error {
-	return remoteUnsupported("RevokeBreakGlassActivation")
+// breakGlassAlreadyActiveCode/breakGlassNotActiveCode must match
+// server/http/handlers/break_glass_proxy.go's constants of the same name exactly
+// — the wire contract this file's error-translation logic depends on.
+const (
+	breakGlassAlreadyActiveCode = "BREAK_GLASS_ALREADY_ACTIVE"
+	breakGlassNotActiveCode     = "BREAK_GLASS_NOT_ACTIVE"
+)
+
+// CreateBreakGlassActivation persists an already-built activation row (every
+// field — state, ExpiresAt, RoleID/RoleName, ...) is computed by the CALLING
+// core.KeyorixCore before this is invoked, exactly as ActivateBreakGlass builds
+// one for LocalStorage) via POST /api/v1/system/break-glass. See the package doc
+// for why the upstream's real DB-level unique-index race gate
+// (CreateBreakGlassActivationProxy → storage.CreateBreakGlassActivation) is what
+// actually enforces "at most one active activation per project+user", not this
+// client.
+func (rs *RemoteStorage) CreateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) (*models.BreakGlassActivation, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/break-glass", newBreakGlassActivationWire(a))
+	if err != nil {
+		// #501: makeRequest turns EVERY 4xx/5xx response (including
+		// CreateBreakGlassActivationProxy's 409 Conflict) into a non-nil error
+		// before resp is ever populated, so the already-active signal must be
+		// recovered from the *remote.HTTPError itself (its ErrorType), not from
+		// resp.Error — reconstructing the SAME storage.ErrBreakGlassAlreadyActive
+		// sentinel core.ActivateBreakGlass's errors.Is check depends on, so that
+		// check-and-translate behavior survives this HTTP hop rather than
+		// silently downgrading to an opaque "failed to create activation" error.
+		var httpErr *remote.HTTPError
+		if errors.As(err, &httpErr) && httpErr.ErrorType == breakGlassAlreadyActiveCode {
+			return nil, fmt.Errorf("%w: %s", storage.ErrBreakGlassAlreadyActive, httpErr.Message)
+		}
+		return nil, fmt.Errorf("failed to create break-glass activation: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create break-glass activation failed: %s", resp.Error.Error())
+	}
+	return decodeBreakGlassActivationResponse(resp.Data)
+}
+
+// GetBreakGlassActivation retrieves an activation by ID via GET
+// /api/v1/system/break-glass/{id}.
+func (rs *RemoteStorage) GetBreakGlassActivation(ctx context.Context, id uint) (*models.BreakGlassActivation, error) {
+	path := fmt.Sprintf("/api/v1/system/break-glass/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get break-glass activation: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get break-glass activation failed: %s", resp.Error.Error())
+	}
+	return decodeBreakGlassActivationResponse(resp.Data)
+}
+
+// ListBreakGlassActivations lists a project's activations via GET
+// /api/v1/system/break-glass?project_id=X.
+func (rs *RemoteStorage) ListBreakGlassActivations(ctx context.Context, projectID uint) ([]*models.BreakGlassActivation, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	path := "/api/v1/system/break-glass?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list break-glass activations: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list break-glass activations failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Activations []breakGlassActivationWire `json:"activations"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.BreakGlassActivation, 0, len(result.Activations))
+	for _, w := range result.Activations {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
+}
+
+// UpdateBreakGlassActivation persists a full-row change via PUT
+// /api/v1/system/break-glass/{id} — a raw passthrough onto
+// storage.UpdateBreakGlassActivation (local_break_glass.go's plain Save); see the
+// package doc for why there is no conditional write to preserve here, unlike
+// Create/Revoke.
+func (rs *RemoteStorage) UpdateBreakGlassActivation(ctx context.Context, a *models.BreakGlassActivation) error {
+	path := fmt.Sprintf("/api/v1/system/break-glass/%d", a.ID)
+	resp, err := rs.client.Put(ctx, path, newBreakGlassActivationWire(a))
+	if err != nil {
+		return fmt.Errorf("failed to update break-glass activation: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("update break-glass activation failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// breakGlassRevokeRequest is RevokeBreakGlassActivation's request body, matching
+// server/http/handlers/break_glass_proxy.go's breakGlassRevokeProxyRequest.
+type breakGlassRevokeRequest struct {
+	RevokedBy uint      `json:"revoked_by"`
+	RevokedAt time.Time `json:"revoked_at"`
+}
+
+// RevokeBreakGlassActivation atomically transitions activation id from active to
+// revoked via POST /api/v1/system/break-glass/{id}/revoke, preserving
+// LocalStorage's exact conditional-update semantics end-to-end: the server
+// performs the SAME conditional `UPDATE ... WHERE id = ? AND state = 'active'`
+// write local_break_glass.go's RevokeBreakGlassActivation does — NOT a
+// client-side "GET then check state then PUT" sequence, which would reintroduce
+// the exact double-revoke TOCTOU race this method exists to close (two
+// concurrent revoke requests both observing "active" before either writes). One
+// HTTP round trip maps to one atomic server-side conditional UPDATE.
+func (rs *RemoteStorage) RevokeBreakGlassActivation(ctx context.Context, id, revokedBy uint, revokedAt time.Time) error {
+	path := fmt.Sprintf("/api/v1/system/break-glass/%d/revoke", id)
+	resp, err := rs.client.Post(ctx, path, breakGlassRevokeRequest{RevokedBy: revokedBy, RevokedAt: revokedAt})
+	if err != nil {
+		// Same reasoning as CreateBreakGlassActivation above: makeRequest turns
+		// RevokeBreakGlassActivationProxy's 409 Conflict into a non-nil error
+		// before resp is populated, so the not-active signal must be recovered
+		// from the *remote.HTTPError itself, reconstructing the SAME
+		// storage.ErrBreakGlassNotActive sentinel a losing racer (or a caller
+		// revoking an already-revoked/expired activation) depends on.
+		var httpErr *remote.HTTPError
+		if errors.As(err, &httpErr) && httpErr.ErrorType == breakGlassNotActiveCode {
+			return fmt.Errorf("%w: %s", storage.ErrBreakGlassNotActive, httpErr.Message)
+		}
+		return fmt.Errorf("failed to revoke break-glass activation: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("revoke break-glass activation failed: %s", resp.Error.Error())
+	}
+	return nil
 }

--- a/server/http/handlers/break_glass_proxy.go
+++ b/server/http/handlers/break_glass_proxy.go
@@ -1,0 +1,274 @@
+// break_glass_proxy.go — server-side endpoints backing RemoteStorage's
+// break-glass storage primitives (finding #519): CreateBreakGlassActivation/
+// GetBreakGlassActivation/ListBreakGlassActivations/UpdateBreakGlassActivation/
+// RevokeBreakGlassActivation.
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// its break-glass storage calls to whichever upstream server it's configured
+// against, through these routes (registered in server/http/router.go under
+// /api/v1/system/break-glass, gated on the existing system.read/system.write RBAC
+// permissions — the SAME credential a RemoteStorage client already needs for every
+// other proxied call, e.g. full user CRUD, project-invitation CRUD (#507),
+// project-membership CRUD (#511), so this introduces no new privilege class).
+// Mirrors project_memberships_proxy.go/invitations_proxy.go exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/break_glass.go already uses against a local backend — NO
+// break-glass POLICY decision (policy-enabled check, project-affiliation check,
+// emergency-role containment checks, TTL clamping, the actual JIT role grant) is
+// made here; all of that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore, exactly as it does against a local backend. The
+// existing human-facing /api/v1/projects/{id}/break-glass routes
+// (server/http/handlers/break_glass.go, CatalogHandler.ActivateBreakGlass/
+// ListBreakGlassActivations/RevokeBreakGlass) are NOT reused for this proxy: they
+// run this server's OWN core.ActivateBreakGlass/RevokeBreakGlass against the HTTP
+// caller's own identity, which is the wrong semantics for a raw storage-primitive
+// passthrough whose caller already ran all of that on the downstream side.
+//
+// Atomicity note — the critical property for this subsystem (docs/security/
+// BUGS.md #104, PR #670): local_break_glass.go's CreateBreakGlassActivation relies
+// on a REAL DB-level partial unique index (uniq_break_glass_active_project_user,
+// ensureBreakGlassActiveIndex) scoped to state='active' to reject a second
+// concurrent active activation for the same (project_id, user_id) — an
+// `INSERT ... ON CONFLICT DO NOTHING` whose RowsAffected==0 is translated to
+// storage.ErrBreakGlassAlreadyActive. CreateBreakGlassActivationProxy calls that
+// SAME storage.Storage primitive directly against this server's own database, so
+// that guarantee is a property of the upstream's own database and survives this
+// HTTP hop unchanged — NOT a client-side "GET then POST" sequence, which would
+// reopen exactly the TOCTOU race #104 closed. Similarly, RevokeBreakGlassActivation
+// is a single conditional `UPDATE ... WHERE id = ? AND state = 'active'` (not a
+// read-then-write) — RevokeBreakGlassActivationProxy calls that same primitive
+// directly, so a losing racer against a concurrent revoke gets
+// storage.ErrBreakGlassNotActive rather than silently double-revoking. Only
+// UpdateBreakGlassActivationProxy is a plain unconditional Save (matching
+// local_break_glass.go's own UpdateBreakGlassActivation semantics exactly — there
+// is no conditional write to preserve there, mirroring
+// UpdateDynamicSecretConfigProxy's precedent).
+//
+// Response envelope: like project_memberships_proxy.go/invitations_proxy.go,
+// these do NOT use the package's generic sendSuccess/sendError helpers — they
+// construct the exact {"success":bool,"data":...,"error":{"code","message"}}
+// shape internal/storage/remote.HTTPClient parses (its APIResponse/APIError
+// types).
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// breakGlassActivationProxyWire mirrors models.BreakGlassActivation's fields
+// exactly (snake_case) — a GORM model with no json tags of its own beyond the
+// struct-literal defaults, so — matching membershipProxyWire's/
+// invitationProxyWire's reasoning — every field is named explicitly here rather
+// than relying on a direct marshal of the model.
+type breakGlassActivationProxyWire struct {
+	ID            uint       `json:"id"`
+	ProjectID     uint       `json:"project_id"`
+	UserID        uint       `json:"user_id"`
+	RoleID        uint       `json:"role_id"`
+	RoleName      string     `json:"role_name"`
+	Justification string     `json:"justification"`
+	State         string     `json:"state"`
+	ExpiresAt     *time.Time `json:"expires_at,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
+	RevokedBy     uint       `json:"revoked_by,omitempty"`
+	RevokedAt     *time.Time `json:"revoked_at,omitempty"`
+}
+
+func newBreakGlassActivationProxyWire(a *models.BreakGlassActivation) breakGlassActivationProxyWire {
+	return breakGlassActivationProxyWire{
+		ID:            a.ID,
+		ProjectID:     a.ProjectID,
+		UserID:        a.UserID,
+		RoleID:        a.RoleID,
+		RoleName:      a.RoleName,
+		Justification: a.Justification,
+		State:         a.State,
+		ExpiresAt:     a.ExpiresAt,
+		CreatedAt:     a.CreatedAt,
+		RevokedBy:     a.RevokedBy,
+		RevokedAt:     a.RevokedAt,
+	}
+}
+
+func (w breakGlassActivationProxyWire) toModel() *models.BreakGlassActivation {
+	return &models.BreakGlassActivation{
+		ID:            w.ID,
+		ProjectID:     w.ProjectID,
+		UserID:        w.UserID,
+		RoleID:        w.RoleID,
+		RoleName:      w.RoleName,
+		Justification: w.Justification,
+		State:         w.State,
+		ExpiresAt:     w.ExpiresAt,
+		CreatedAt:     w.CreatedAt,
+		RevokedBy:     w.RevokedBy,
+		RevokedAt:     w.RevokedAt,
+	}
+}
+
+// breakGlassAlreadyActiveCode is the machine-readable error code
+// CreateBreakGlassActivationProxy returns when the upstream's own DB-level
+// partial-unique-index rejection (storage.ErrBreakGlassAlreadyActive,
+// local_break_glass.go) fires — the wire-level signal
+// RemoteStorage.CreateBreakGlassActivation uses to reconstruct the same sentinel
+// core.ActivateBreakGlass's errors.Is check depends on, so that check-and-translate
+// behavior is preserved across this HTTP hop and not silently downgraded to an
+// opaque "failed to create activation" error.
+const breakGlassAlreadyActiveCode = "BREAK_GLASS_ALREADY_ACTIVE"
+
+// breakGlassNotActiveCode is the machine-readable error code
+// RevokeBreakGlassActivationProxy returns when the conditional
+// `WHERE state = 'active'` update matches no row (storage.ErrBreakGlassNotActive,
+// local_break_glass.go) — the wire-level signal RemoteStorage.
+// RevokeBreakGlassActivation uses to reconstruct that sentinel.
+const breakGlassNotActiveCode = "BREAK_GLASS_NOT_ACTIVE"
+
+// CreateBreakGlassActivationProxy handles POST /api/v1/system/break-glass. See
+// the package doc for why this persists the caller's already-fully-built
+// activation row as-is (a raw storage-layer create backed by a real DB-level
+// unique-index race gate), not a re-run of ActivateBreakGlass's own business
+// logic.
+func (h *CatalogHandler) CreateBreakGlassActivationProxy(w http.ResponseWriter, r *http.Request) {
+	var body breakGlassActivationProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.ProjectID == 0 || body.UserID == 0 || body.State == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id, user_id, and state are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateBreakGlassActivation(r.Context(), body.toModel())
+	if err != nil {
+		if errors.Is(err, coreStorage.ErrBreakGlassAlreadyActive) {
+			writeRemoteAPIError(w, http.StatusConflict, breakGlassAlreadyActiveCode, coreStorage.ErrBreakGlassAlreadyActive.Error())
+			return
+		}
+		log.Printf("break-glass proxy: create activation failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newBreakGlassActivationProxyWire(created))
+}
+
+// GetBreakGlassActivationProxy handles GET /api/v1/system/break-glass/{id}.
+func (h *CatalogHandler) GetBreakGlassActivationProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid activation id")
+		return
+	}
+	a, err := h.coreService.Storage().GetBreakGlassActivation(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "break-glass activation not found")
+			return
+		}
+		log.Printf("break-glass proxy: get activation failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newBreakGlassActivationProxyWire(a))
+}
+
+// ListBreakGlassActivationsProxy handles GET
+// /api/v1/system/break-glass?project_id=X.
+func (h *CatalogHandler) ListBreakGlassActivationsProxy(w http.ResponseWriter, r *http.Request) {
+	projectIDStr := r.URL.Query().Get("project_id")
+	if projectIDStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id query parameter is required")
+		return
+	}
+	projectID, err := strconv.ParseUint(projectIDStr, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id must be a valid integer")
+		return
+	}
+	rows, err := h.coreService.Storage().ListBreakGlassActivations(r.Context(), uint(projectID))
+	if err != nil {
+		log.Printf("break-glass proxy: list activations failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]breakGlassActivationProxyWire, 0, len(rows))
+	for _, a := range rows {
+		wire = append(wire, newBreakGlassActivationProxyWire(a))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"activations": wire})
+}
+
+// UpdateBreakGlassActivationProxy handles PUT /api/v1/system/break-glass/{id}. A
+// raw persist (storage.Storage.UpdateBreakGlassActivation is an unconditional
+// full-row Save, matching LocalStorage's own semantics exactly — the actual
+// atomicity guarantee for this subsystem lives in CreateBreakGlassActivation's
+// unique-index insert and RevokeBreakGlassActivation's conditional update, both
+// proxied separately below).
+func (h *CatalogHandler) UpdateBreakGlassActivationProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid activation id")
+		return
+	}
+	var body breakGlassActivationProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	if err := h.coreService.Storage().UpdateBreakGlassActivation(r.Context(), body.toModel()); err != nil {
+		log.Printf("break-glass proxy: update activation failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}
+
+// breakGlassRevokeProxyRequest is RevokeBreakGlassActivationProxy's request body.
+type breakGlassRevokeProxyRequest struct {
+	RevokedBy uint      `json:"revoked_by"`
+	RevokedAt time.Time `json:"revoked_at"`
+}
+
+// RevokeBreakGlassActivationProxy handles POST
+// /api/v1/system/break-glass/{id}/revoke. Calls storage.RevokeBreakGlassActivation
+// DIRECTLY — the SAME single conditional `UPDATE ... WHERE id = ? AND
+// state = 'active'` local_break_glass.go's RevokeBreakGlassActivation performs —
+// rather than a client-side "GET, check state, then PUT" sequence, which would
+// reopen the exact double-revoke TOCTOU race that conditional write exists to
+// close. One HTTP round trip maps to one atomic server-side conditional UPDATE.
+func (h *CatalogHandler) RevokeBreakGlassActivationProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid activation id")
+		return
+	}
+	var body breakGlassRevokeProxyRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.RevokedBy == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "revoked_by is required")
+		return
+	}
+	if err := h.coreService.Storage().RevokeBreakGlassActivation(r.Context(), uint(id), body.RevokedBy, body.RevokedAt); err != nil {
+		if errors.Is(err, coreStorage.ErrBreakGlassNotActive) {
+			writeRemoteAPIError(w, http.StatusConflict, breakGlassNotActiveCode, coreStorage.ErrBreakGlassNotActive.Error())
+			return
+		}
+		log.Printf("break-glass proxy: revoke activation failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"revoked": true})
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -94,6 +94,9 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		&models.MFASecret{},
 		&models.MFARecoveryCode{},
 		&models.MFAChallenge{},
+		// #519: the break-glass-proxy end-to-end tests exercise BreakGlassActivation
+		// CRUD through the real router.
+		&models.BreakGlassActivation{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the
@@ -105,6 +108,15 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 	// isUniqueViolation branch depends on.
 	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_project_memberships_active "+
 		"ON project_memberships (project_id, user_id) WHERE state <> 'revoked'").Error)
+	// Mirror internal/storage/factory.go's ensureBreakGlassActiveIndex exactly (the
+	// same production migration path TestCreateBreakGlassActivation_
+	// ConcurrentRaceYieldsExactlyOneWinner relies on,
+	// internal/storage/store/local_break_glass_test.go): AutoMigrate alone does not
+	// create this partial unique index, so without it, the #519 break-glass-proxy
+	// concurrent-activation test would silently miss the real DB-level guard
+	// CreateBreakGlassActivation's OnConflict DoNothing branch depends on.
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_break_glass_active_project_user "+
+		"ON break_glass_activations (project_id, user_id) WHERE state = 'active'").Error)
 	return core.NewKeyorixCore(store.NewLocalStorage(db))
 }
 

--- a/server/http/remote_storage_break_glass_test.go
+++ b/server/http/remote_storage_break_glass_test.go
@@ -1,0 +1,332 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForBreakGlass builds the standard #507/#511-style
+// two-server harness: an "upstream" exercised through the REAL production
+// NewRouter/handlers (including the new /api/v1/system/break-glass routes,
+// server/http/handlers/break_glass_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed at
+// "upstream" over real HTTP via store.RemoteStorage. Also returns the upstream's
+// base URL/token so concurrency tests can mint additional, independent
+// RemoteStorage clients against the SAME upstream server (see
+// newBreakGlassRemoteClient).
+func newUpstreamDownstreamForBreakGlass(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore, projectID uint, baseURL, apiKey string) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	downstream = newBreakGlassRemoteClient(t, upstreamSrv.URL, upstreamToken)
+
+	ctx := context.Background()
+	project, err := upstream.CreateProject(ctx, "Break Glass Test Project", "")
+	require.NoError(t, err)
+	return upstream, downstream, project.ID, upstreamSrv.URL, upstreamToken
+}
+
+// newBreakGlassRemoteClient builds a fresh *core.KeyorixCore backed by its OWN
+// store.RemoteStorage/HTTPClient instance pointed at baseURL. Used by the
+// concurrency tests below to give EACH concurrent racer its own client (and
+// thus its own independent circuit breaker / failure counter,
+// internal/storage/remote.HTTPClient): the client's circuit breaker treats
+// every 4xx/5xx response (including a genuine, expected 409 Conflict from a
+// losing racer, #501) as a "failure" and trips after 5 consecutive ones on a
+// SHARED client — a real concern unique to this subsystem, since (unlike
+// #507's UpdateProjectInvitation, which reports a losing racer via a plain
+// `{"updated": false}` 200) CreateBreakGlassActivation/
+// RevokeBreakGlassActivation communicate a losing racer as a genuine error
+// even against LocalStorage (storage.ErrBreakGlassAlreadyActive/
+// ErrBreakGlassNotActive), so a client-side circuit breaker is not something
+// this proxy can or should paper over — it is exactly the same behavior a
+// downstream server's OWN client would exhibit in production if many break-glass
+// activations for the same project+user raced in a short window. Giving each
+// simulated caller its own client isolates that (expected, orthogonal)
+// resilience behavior from the atomicity property this test exists to prove.
+func newBreakGlassRemoteClient(t *testing.T, baseURL, apiKey string) *core.KeyorixCore {
+	t.Helper()
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        baseURL,
+		APIKey:         apiKey,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	return core.NewKeyorixCore(rs)
+}
+
+// buildActiveBreakGlassActivation mirrors what internal/core.ActivateBreakGlass
+// computes before calling storage.CreateBreakGlassActivation — a fully-built
+// active activation row — WITHOUT going through ActivateBreakGlass itself (which
+// additionally requires the calling server's own break-glass policy/RBAC/
+// project-affiliation setup, out of this finding's raw storage-primitive scope,
+// mirroring buildDynamicSecretConfig's/buildPendingInvitation's precedent).
+func buildActiveBreakGlassActivation(now time.Time, projectID, userID uint) *models.BreakGlassActivation {
+	expiresAt := now.Add(4 * time.Hour)
+	return &models.BreakGlassActivation{
+		ProjectID:     projectID,
+		UserID:        userID,
+		RoleID:        3,
+		RoleName:      "editor",
+		Justification: "prod incident #42",
+		State:         core.BreakGlassActive,
+		ExpiresAt:     &expiresAt,
+		CreatedAt:     now,
+	}
+}
+
+// TestRemoteStorageBreakGlass_CreateGetListUpdate_RealServer proves the fix for
+// CreateBreakGlassActivation/GetBreakGlassActivation/ListBreakGlassActivations/
+// UpdateBreakGlassActivation: an activation is genuinely persisted on the
+// upstream server via the DOWNSTREAM's RemoteStorage, fetchable by ID, listed,
+// and updatable — all via storage.type: remote against a real router, not a
+// protocol mock.
+func TestRemoteStorageBreakGlass_CreateGetListUpdate_RealServer(t *testing.T) {
+	upstream, downstream, projectID, _, _ := newUpstreamDownstreamForBreakGlass(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	act, err := downstream.Storage().CreateBreakGlassActivation(ctx, buildActiveBreakGlassActivation(now, projectID, 10))
+	require.NoError(t, err, "creating a break-glass activation must succeed via storage.type: remote")
+	require.NotZero(t, act.ID, "the upstream must assign a real ID")
+	assert.Equal(t, "editor", act.RoleName)
+	assert.Equal(t, core.BreakGlassActive, act.State)
+	assert.Equal(t, projectID, act.ProjectID)
+	assert.EqualValues(t, 10, act.UserID)
+
+	// Confirm it is a REAL row in the upstream's own storage (not just "the call
+	// didn't error"), by reading it back directly against upstream.
+	direct, err := upstream.Storage().GetBreakGlassActivation(ctx, act.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "prod incident #42", direct.Justification)
+
+	// GetBreakGlassActivation via the downstream (RemoteStorage) round-trips
+	// every field correctly.
+	fetched, err := downstream.Storage().GetBreakGlassActivation(ctx, act.ID)
+	require.NoError(t, err)
+	assert.Equal(t, act.ID, fetched.ID)
+	assert.Equal(t, act.Justification, fetched.Justification)
+	require.NotNil(t, fetched.ExpiresAt)
+	assert.WithinDuration(t, *act.ExpiresAt, *fetched.ExpiresAt, time.Second)
+
+	// A second activation for a DIFFERENT user, then list both back via the
+	// downstream's ListBreakGlassActivations.
+	_, err = downstream.Storage().CreateBreakGlassActivation(ctx, buildActiveBreakGlassActivation(now, projectID, 11))
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListBreakGlassActivations(ctx, projectID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	userIDs := map[uint]bool{}
+	for _, r := range rows {
+		userIDs[r.UserID] = true
+	}
+	assert.True(t, userIDs[10])
+	assert.True(t, userIDs[11])
+
+	// UpdateBreakGlassActivation persists a change via the downstream.
+	fetched.Justification = "updated justification text"
+	require.NoError(t, downstream.Storage().UpdateBreakGlassActivation(ctx, fetched))
+	reFetched, err := upstream.Storage().GetBreakGlassActivation(ctx, act.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "updated justification text", reFetched.Justification, "the update must be visible directly on the upstream's own storage")
+}
+
+// TestRemoteStorageBreakGlass_GetNotFound_RealServer proves a clean not-found
+// error (not a panic, not a garbage 500) for a nonexistent activation ID.
+func TestRemoteStorageBreakGlass_GetNotFound_RealServer(t *testing.T) {
+	_, downstream, _, _, _ := newUpstreamDownstreamForBreakGlass(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetBreakGlassActivation(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageBreakGlass_CreateRejectsSecondActiveForSameProjectUser_RealServer
+// proves CreateBreakGlassActivationProxy's 409/BREAK_GLASS_ALREADY_ACTIVE
+// wire-code translation round-trips correctly: a second concurrent-active
+// activation for the SAME (project_id, user_id) is rejected with the same
+// storage.ErrBreakGlassAlreadyActive sentinel core.ActivateBreakGlass's
+// errors.Is check depends on — not an opaque "create failed" error — even though
+// this now went over a real HTTP hop instead of a direct in-process call.
+func TestRemoteStorageBreakGlass_CreateRejectsSecondActiveForSameProjectUser_RealServer(t *testing.T) {
+	_, downstream, projectID, _, _ := newUpstreamDownstreamForBreakGlass(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	first, err := downstream.Storage().CreateBreakGlassActivation(ctx, buildActiveBreakGlassActivation(now, projectID, 42))
+	require.NoError(t, err)
+	assert.NotZero(t, first.ID)
+
+	_, err = downstream.Storage().CreateBreakGlassActivation(ctx, buildActiveBreakGlassActivation(now, projectID, 42))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, coreStorage.ErrBreakGlassAlreadyActive), "got %v", err)
+}
+
+// TestRemoteStorageBreakGlass_RevokeThenRevokeAgainFails_RealServer proves
+// RevokeBreakGlassActivationProxy's conditional `WHERE state = 'active'` update
+// (and its 409/BREAK_GLASS_NOT_ACTIVE wire-code translation) round-trips
+// correctly: revoking an already-revoked activation cleanly fails with
+// storage.ErrBreakGlassNotActive, the sentinel core.RevokeBreakGlass's
+// errors.Is check depends on.
+func TestRemoteStorageBreakGlass_RevokeThenRevokeAgainFails_RealServer(t *testing.T) {
+	_, downstream, projectID, _, _ := newUpstreamDownstreamForBreakGlass(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	act, err := downstream.Storage().CreateBreakGlassActivation(ctx, buildActiveBreakGlassActivation(now, projectID, 7))
+	require.NoError(t, err)
+
+	require.NoError(t, downstream.Storage().RevokeBreakGlassActivation(ctx, act.ID, 1, time.Now()))
+
+	final, err := downstream.Storage().GetBreakGlassActivation(ctx, act.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.BreakGlassRevoked, final.State)
+
+	err = downstream.Storage().RevokeBreakGlassActivation(ctx, act.ID, 1, time.Now())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, coreStorage.ErrBreakGlassNotActive), "got %v", err)
+}
+
+// TestRemoteStorageBreakGlass_ConcurrentActivationRace_RealServer is the critical
+// #519 test (mirroring #507's TestRemoteStorageInvitation_ConcurrentAcceptRace_
+// RealServer and #511's project-membership race test): it fires N concurrent
+// "activate" requests for the SAME (project_id, user_id) over real HTTP against
+// the real upstream router, and asserts EXACTLY ONE succeeds — proving
+// CreateBreakGlassActivationProxy's real DB-level partial-unique-index race gate
+// (local_break_glass.go's `OnConflict{DoNothing: true}` insert, backing
+// uniq_break_glass_active_project_user — docs/security/BUGS.md #104, PR #670)
+// still closes the double-activation race even across a network hop, not a
+// client-side "check-then-create" sequence, which would reopen exactly that race.
+func TestRemoteStorageBreakGlass_ConcurrentActivationRace_RealServer(t *testing.T) {
+	_, downstream, projectID, baseURL, apiKey := newUpstreamDownstreamForBreakGlass(t)
+	now := time.Now()
+
+	const n = 20
+	var successCount atomic.Int64
+	var conflictCount atomic.Int64
+	var otherErrCount atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			// Each racer gets its OWN RemoteStorage client (see
+			// newBreakGlassRemoteClient's doc comment) so the 19 EXPECTED 409
+			// Conflict responses from losing racers can't trip a shared client's
+			// circuit breaker.
+			client := newBreakGlassRemoteClient(t, baseURL, apiKey)
+			_, err := client.Storage().CreateBreakGlassActivation(
+				context.Background(), buildActiveBreakGlassActivation(now, projectID, 99))
+			switch {
+			case err == nil:
+				successCount.Add(1)
+			case errors.Is(err, coreStorage.ErrBreakGlassAlreadyActive):
+				conflictCount.Add(1)
+			default:
+				otherErrCount.Add(1)
+				t.Logf("unexpected error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Zero(t, otherErrCount.Load(), "every losing racer must fail with the sentinel, not some other error")
+	assert.EqualValues(t, 1, successCount.Load(), "exactly one concurrent activation must win, regardless of goroutine scheduling")
+	assert.EqualValues(t, n-1, conflictCount.Load())
+
+	// And the upstream's own storage agrees: exactly one 'active' row exists for
+	// this (project, user).
+	rows, err := downstream.Storage().ListBreakGlassActivations(context.Background(), projectID)
+	require.NoError(t, err)
+	activeCount := 0
+	for _, r := range rows {
+		if r.UserID == 99 && r.State == core.BreakGlassActive {
+			activeCount++
+		}
+	}
+	assert.Equal(t, 1, activeCount)
+}
+
+// TestRemoteStorageBreakGlass_ConcurrentRevokeRace_RealServer proves the OTHER
+// half of #519's atomicity requirement: N concurrent "revoke" requests against
+// the SAME already-active activation must yield exactly one winner, via
+// RevokeBreakGlassActivationProxy's conditional `UPDATE ... WHERE id = ? AND
+// state = 'active'` write (local_break_glass.go's RevokeBreakGlassActivation) —
+// not a client-side "GET, check state, then PUT" sequence, which would reopen a
+// double-revoke TOCTOU race.
+func TestRemoteStorageBreakGlass_ConcurrentRevokeRace_RealServer(t *testing.T) {
+	_, downstream, projectID, baseURL, apiKey := newUpstreamDownstreamForBreakGlass(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	act, err := downstream.Storage().CreateBreakGlassActivation(ctx, buildActiveBreakGlassActivation(now, projectID, 55))
+	require.NoError(t, err)
+
+	const n = 20
+	var successCount atomic.Int64
+	var conflictCount atomic.Int64
+	var otherErrCount atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(revokedBy uint) {
+			defer wg.Done()
+			// Each racer gets its OWN RemoteStorage client (see
+			// newBreakGlassRemoteClient's doc comment) so the 19 EXPECTED 409
+			// Conflict responses from losing racers can't trip a shared client's
+			// circuit breaker.
+			client := newBreakGlassRemoteClient(t, baseURL, apiKey)
+			err := client.Storage().RevokeBreakGlassActivation(context.Background(), act.ID, revokedBy, time.Now())
+			switch {
+			case err == nil:
+				successCount.Add(1)
+			case errors.Is(err, coreStorage.ErrBreakGlassNotActive):
+				conflictCount.Add(1)
+			default:
+				otherErrCount.Add(1)
+				t.Logf("unexpected error: %v", err)
+			}
+		}(uint(i + 1))
+	}
+	wg.Wait()
+
+	assert.Zero(t, otherErrCount.Load(), "every losing racer must fail with the sentinel, not some other error")
+	assert.EqualValues(t, 1, successCount.Load(), "exactly one concurrent revoke must win, regardless of goroutine scheduling")
+	assert.EqualValues(t, n-1, conflictCount.Load())
+
+	final, err := downstream.Storage().GetBreakGlassActivation(ctx, act.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.BreakGlassRevoked, final.State)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -961,6 +961,34 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/project-memberships", catalogHandler.ListMembershipsProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/project-memberships", catalogHandler.CreateMembershipProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Put("/project-memberships/{id}", catalogHandler.UpdateMembershipProxy)
+
+			// Break-glass activation storage-primitive proxy (#519). Lets a
+			// downstream Keyorix server booted with storage.type: remote (ADR-049)
+			// proxy CreateBreakGlassActivation/GetBreakGlassActivation/
+			// ListBreakGlassActivations/UpdateBreakGlassActivation/
+			// RevokeBreakGlassActivation to THIS server's real storage backend,
+			// instead of RemoteStorage's five break-glass methods having no server
+			// endpoint to call at all (emergency-access self-activation —
+			// NIS2/DORA incident response — was completely non-functional under
+			// storage.type: remote). Exactly the same pattern as the
+			// project-memberships/invitations proxies above: a thin passthrough
+			// onto storage.Storage (no break-glass POLICY decision — enablement,
+			// project-affiliation, emergency-role containment, TTL clamping, the
+			// actual JIT role grant — is made here; that stays entirely in the
+			// CALLING server's own internal/core.KeyorixCore, exactly as it does
+			// against a local backend), reusing the SAME system.read/system.write
+			// tier — no new privilege class. Critically, CreateBreakGlassActivationProxy
+			// and RevokeBreakGlassActivationProxy call storage.Storage's own
+			// unique-index-backed create and conditional `WHERE state = 'active'`
+			// update DIRECTLY (see break_glass_proxy.go's package doc), preserving
+			// the #104/PR #670 concurrent-activation race fix across this HTTP hop.
+			// Read is baseline system.read; create/update/revoke require
+			// system.write, matching every other admin-level mutation in this group.
+			r.Get("/break-glass/{id}", catalogHandler.GetBreakGlassActivationProxy)
+			r.Get("/break-glass", catalogHandler.ListBreakGlassActivationsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/break-glass", catalogHandler.CreateBreakGlassActivationProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/break-glass/{id}", catalogHandler.UpdateBreakGlassActivationProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/break-glass/{id}/revoke", catalogHandler.RevokeBreakGlassActivationProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary
- Implements `RemoteStorage` support for Break Glass Activations (part of #519): new thin passthrough routes under `/api/v1/system/break-glass` (gated on `system.read`/`system.write`, no new privilege class), replacing the `remoteUnsupported` stubs in `internal/storage/store/remote_break_glass.go`.
- Preserves the atomic activation/revoke semantics from PR #670 (BUGS.md #104's break-glass race fix): the proxy handlers call `storage.Storage.CreateBreakGlassActivation`/`RevokeBreakGlassActivation` directly server-side (the same partial-unique-index-backed insert / conditional `WHERE state='active'` update) rather than a client-side get-then-write sequence. Sentinel errors (`ErrBreakGlassAlreadyActive`/`ErrBreakGlassNotActive`) are translated across the wire via dedicated 409 codes and reconstructed client-side, mirroring #511's `ErrDuplicateActiveMembership` pattern, so `core.ActivateBreakGlass`/`RevokeBreakGlass`'s existing `errors.Is` checks keep working under `storage.type: remote`.
- Proven with two independent 20-way concurrent-race tests against a real router/HTTP hop (activation race and revoke race) — each shows exactly 1 winner and 19 clean sentinel-error losers, confirmed against DB state.

## Residual (out of scope)
- `DeleteExpiredBreakGlassBefore` (in `remote_secrets.go`, backs the data-retention purge sweep) is a separate, still-stubbed method — distinct from this finding's scope, worth its own follow-up.

## Test plan
- [x] `go build ./...` / `go vet ./...` / `golangci-lint run` clean
- [x] `go test ./internal/storage/store/... ./internal/core/... ./server/http/...` pass
- [x] New `server/http/remote_storage_break_glass_test.go`: 6 tests incl. two 20-way concurrency races proving exactly-one-winner semantics
- [x] `gosec -severity medium -exclude-generated` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)