### PR TITLE
fix(remote-storage): implement access review campaign storage primitives (#519)

### DIFF
--- a/internal/storage/store/remote_access_review_campaigns.go
+++ b/internal/storage/store/remote_access_review_campaigns.go
@@ -1,54 +1,408 @@
-// remote_access_review_campaigns.go — access-review campaigns for RemoteStorage
-// (ISO 27001 A.5.18). Processed server-side; stubs here. For the local (GORM)
-// equivalent see local_access_review_campaigns.go.
+// remote_access_review_campaigns.go — access-review campaign storage primitives
+// for RemoteStorage (ISO 27001 A.5.18, finding #519): thin passthroughs onto
+// eleven new server-side routes under /api/v1/system/access-review-campaigns
+// (server/http/handlers/access_review_campaigns_proxy.go), mirroring the
+// project-memberships proxy (#511) and dynamic-secrets proxy patterns exactly:
+// gated on the SAME broad system.read/system.write RBAC permissions a
+// RemoteStorage credential already needs for every other proxied call, so this
+// introduces no new privilege class.
+//
+// No campaign-lifecycle POLICY decision (snapshotting the project's live
+// access-review report into items, the reviewer-independence check, the
+// pending-vs-force-close gate, revoking the underlying grant on a "revoke"
+// decision) is made in these routes — that stays entirely in the CALLING
+// server's own internal/core.KeyorixCore (internal/core/access_review_campaign.go),
+// exactly as it does against a local backend.
+//
+// UpdateAccessReviewCampaign/UpdateAccessReviewItem atomicity (investigated,
+// not assumed): both are already a single, self-contained conditional UPDATE on
+// the LocalStorage side (local_access_review_campaigns.go) — not a
+// LockXForUpdate-then-write pair — and the storage.Storage interface already
+// threads the result back as a bool (RowsAffected==1). A single proxied HTTP
+// round trip (the upstream server runs that same one conditional UPDATE and
+// reports the bool back on the wire) therefore preserves the guarantee exactly:
+// no new atomic storage-interface primitive and no cross-call transaction
+// spanning the wire is needed. See access_review_campaigns_proxy.go's package
+// doc for the full reasoning.
+//
+// For the local (GORM) equivalent of every primitive here see
+// local_access_review_campaigns.go.
 package store
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-func (rs *RemoteStorage) CreateAccessReviewCampaign(_ context.Context, _ *models.AccessReviewCampaign) (*models.AccessReviewCampaign, error) {
-	return nil, remoteUnsupported("CreateAccessReviewCampaign")
+// accessReviewCampaignWire mirrors accessReviewCampaignProxyWire in
+// server/http/handlers/access_review_campaigns_proxy.go exactly.
+type accessReviewCampaignWire struct {
+	ID               uint       `json:"id"`
+	ProjectID        uint       `json:"project_id"`
+	Name             string     `json:"name"`
+	State            string     `json:"state"`
+	CreatedBy        uint       `json:"created_by"`
+	CreatedAt        time.Time  `json:"created_at"`
+	ClosedBy         uint       `json:"closed_by,omitempty"`
+	ClosedAt         *time.Time `json:"closed_at,omitempty"`
+	Degraded         bool       `json:"degraded"`
+	DegradedReasons  []string   `json:"degraded_reasons,omitempty"`
+	ForcedIncomplete bool       `json:"forced_incomplete"`
 }
 
-func (rs *RemoteStorage) GetAccessReviewCampaign(_ context.Context, _ uint) (*models.AccessReviewCampaign, error) {
-	return nil, remoteUnsupported("GetAccessReviewCampaign")
+func newAccessReviewCampaignWire(c *models.AccessReviewCampaign) accessReviewCampaignWire {
+	return accessReviewCampaignWire{
+		ID:               c.ID,
+		ProjectID:        c.ProjectID,
+		Name:             c.Name,
+		State:            c.State,
+		CreatedBy:        c.CreatedBy,
+		CreatedAt:        c.CreatedAt,
+		ClosedBy:         c.ClosedBy,
+		ClosedAt:         c.ClosedAt,
+		Degraded:         c.Degraded,
+		DegradedReasons:  c.DegradedReasons,
+		ForcedIncomplete: c.ForcedIncomplete,
+	}
 }
 
-func (rs *RemoteStorage) ListAccessReviewCampaigns(_ context.Context, _ uint) ([]*models.AccessReviewCampaign, error) {
-	return nil, remoteUnsupported("ListAccessReviewCampaigns")
+func (w accessReviewCampaignWire) toModel() *models.AccessReviewCampaign {
+	return &models.AccessReviewCampaign{
+		ID:               w.ID,
+		ProjectID:        w.ProjectID,
+		Name:             w.Name,
+		State:            w.State,
+		CreatedBy:        w.CreatedBy,
+		CreatedAt:        w.CreatedAt,
+		ClosedBy:         w.ClosedBy,
+		ClosedAt:         w.ClosedAt,
+		Degraded:         w.Degraded,
+		DegradedReasons:  w.DegradedReasons,
+		ForcedIncomplete: w.ForcedIncomplete,
+	}
 }
 
-func (rs *RemoteStorage) GetOpenAccessReviewCampaign(_ context.Context, _ uint) (*models.AccessReviewCampaign, error) {
-	return nil, remoteUnsupported("GetOpenAccessReviewCampaign")
+func decodeAccessReviewCampaignResponse(data []byte) (*models.AccessReviewCampaign, error) {
+	var wire accessReviewCampaignWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }
 
-func (rs *RemoteStorage) GetLatestClosedAccessReviewCampaign(_ context.Context, _ uint) (*models.AccessReviewCampaign, error) {
-	return nil, remoteUnsupported("GetLatestClosedAccessReviewCampaign")
+// accessReviewItemWire mirrors accessReviewItemProxyWire exactly.
+type accessReviewItemWire struct {
+	ID            uint       `json:"id"`
+	CampaignID    uint       `json:"campaign_id"`
+	PrincipalType string     `json:"principal_type"`
+	PrincipalID   uint       `json:"principal_id"`
+	PrincipalName string     `json:"principal_name"`
+	Email         string     `json:"email,omitempty"`
+	Source        string     `json:"source"`
+	RoleID        uint       `json:"role_id,omitempty"`
+	RoleName      string     `json:"role_name,omitempty"`
+	AccessLevel   string     `json:"access_level"`
+	EnvironmentID uint       `json:"environment_id"`
+	SecretID      uint       `json:"secret_id,omitempty"`
+	SecretName    string     `json:"secret_name,omitempty"`
+	LastUsedAt    *time.Time `json:"last_used_at,omitempty"`
+	Decision      string     `json:"decision"`
+	Reason        string     `json:"reason,omitempty"`
+	DecidedBy     uint       `json:"decided_by,omitempty"`
+	DecidedAt     *time.Time `json:"decided_at,omitempty"`
 }
 
-func (rs *RemoteStorage) UpdateAccessReviewCampaign(_ context.Context, _ *models.AccessReviewCampaign) (bool, error) {
-	return false, remoteUnsupported("UpdateAccessReviewCampaign")
+func newAccessReviewItemWire(it *models.AccessReviewItem) accessReviewItemWire {
+	return accessReviewItemWire{
+		ID:            it.ID,
+		CampaignID:    it.CampaignID,
+		PrincipalType: it.PrincipalType,
+		PrincipalID:   it.PrincipalID,
+		PrincipalName: it.PrincipalName,
+		Email:         it.Email,
+		Source:        it.Source,
+		RoleID:        it.RoleID,
+		RoleName:      it.RoleName,
+		AccessLevel:   it.AccessLevel,
+		EnvironmentID: it.EnvironmentID,
+		SecretID:      it.SecretID,
+		SecretName:    it.SecretName,
+		LastUsedAt:    it.LastUsedAt,
+		Decision:      it.Decision,
+		Reason:        it.Reason,
+		DecidedBy:     it.DecidedBy,
+		DecidedAt:     it.DecidedAt,
+	}
 }
 
-func (rs *RemoteStorage) CreateAccessReviewItems(_ context.Context, _ []*models.AccessReviewItem) error {
-	return remoteUnsupported("CreateAccessReviewItems")
+func (w accessReviewItemWire) toModel() *models.AccessReviewItem {
+	return &models.AccessReviewItem{
+		ID:            w.ID,
+		CampaignID:    w.CampaignID,
+		PrincipalType: w.PrincipalType,
+		PrincipalID:   w.PrincipalID,
+		PrincipalName: w.PrincipalName,
+		Email:         w.Email,
+		Source:        w.Source,
+		RoleID:        w.RoleID,
+		RoleName:      w.RoleName,
+		AccessLevel:   w.AccessLevel,
+		EnvironmentID: w.EnvironmentID,
+		SecretID:      w.SecretID,
+		SecretName:    w.SecretName,
+		LastUsedAt:    w.LastUsedAt,
+		Decision:      w.Decision,
+		Reason:        w.Reason,
+		DecidedBy:     w.DecidedBy,
+		DecidedAt:     w.DecidedAt,
+	}
 }
 
-func (rs *RemoteStorage) ListAccessReviewItems(_ context.Context, _ uint) ([]*models.AccessReviewItem, error) {
-	return nil, remoteUnsupported("ListAccessReviewItems")
+func decodeAccessReviewItemResponse(data []byte) (*models.AccessReviewItem, error) {
+	var wire accessReviewItemWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }
 
-func (rs *RemoteStorage) CountPendingAccessReviewItems(_ context.Context, _ uint) (int, error) {
-	return 0, remoteUnsupported("CountPendingAccessReviewItems")
+// CreateAccessReviewCampaign persists an already-built campaign (the caller's
+// own core.OpenAccessReviewCampaign already snapshotted the project's live
+// access-review report before this call) via POST
+// /api/v1/system/access-review-campaigns.
+func (rs *RemoteStorage) CreateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (*models.AccessReviewCampaign, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/access-review-campaigns", newAccessReviewCampaignWire(c))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create access-review campaign: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create access-review campaign failed: %s", resp.Error.Error())
+	}
+	return decodeAccessReviewCampaignResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) GetAccessReviewItem(_ context.Context, _ uint) (*models.AccessReviewItem, error) {
-	return nil, remoteUnsupported("GetAccessReviewItem")
+// GetAccessReviewCampaign retrieves a campaign by ID via GET
+// /api/v1/system/access-review-campaigns/{id}.
+func (rs *RemoteStorage) GetAccessReviewCampaign(ctx context.Context, id uint) (*models.AccessReviewCampaign, error) {
+	path := fmt.Sprintf("/api/v1/system/access-review-campaigns/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get access-review campaign: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get access-review campaign failed: %s", resp.Error.Error())
+	}
+	return decodeAccessReviewCampaignResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) UpdateAccessReviewItem(_ context.Context, _ *models.AccessReviewItem) (bool, error) {
-	return false, remoteUnsupported("UpdateAccessReviewItem")
+// ListAccessReviewCampaigns lists a project's campaigns via GET
+// /api/v1/system/access-review-campaigns?project_id=X.
+func (rs *RemoteStorage) ListAccessReviewCampaigns(ctx context.Context, projectID uint) ([]*models.AccessReviewCampaign, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	path := "/api/v1/system/access-review-campaigns?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list access-review campaigns: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list access-review campaigns failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Campaigns []accessReviewCampaignWire `json:"campaigns"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.AccessReviewCampaign, 0, len(result.Campaigns))
+	for _, w := range result.Campaigns {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
+}
+
+// GetOpenAccessReviewCampaign returns the project's open campaign (nil, nil if
+// none is open — matching LocalStorage's own contract) via GET
+// /api/v1/system/access-review-campaigns/open?project_id=X.
+func (rs *RemoteStorage) GetOpenAccessReviewCampaign(ctx context.Context, projectID uint) (*models.AccessReviewCampaign, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	path := "/api/v1/system/access-review-campaigns/open?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get open access-review campaign: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get open access-review campaign failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Campaign *accessReviewCampaignWire `json:"campaign"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	if result.Campaign == nil {
+		return nil, nil
+	}
+	return result.Campaign.toModel(), nil
+}
+
+// GetLatestClosedAccessReviewCampaign returns the project's most recently
+// closed campaign (nil, nil if it has never had one) via GET
+// /api/v1/system/access-review-campaigns/latest-closed?project_id=X.
+func (rs *RemoteStorage) GetLatestClosedAccessReviewCampaign(ctx context.Context, projectID uint) (*models.AccessReviewCampaign, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	path := "/api/v1/system/access-review-campaigns/latest-closed?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest-closed access-review campaign: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get latest-closed access-review campaign failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Campaign *accessReviewCampaignWire `json:"campaign"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	if result.Campaign == nil {
+		return nil, nil
+	}
+	return result.Campaign.toModel(), nil
+}
+
+// UpdateAccessReviewCampaign persists a campaign state transition via PUT
+// /api/v1/system/access-review-campaigns/{id}. See the package doc for why the
+// bool this returns IS the single conditional `WHERE state = 'open'` UPDATE's
+// own RowsAffected==1 result, relayed faithfully across the wire — not
+// synthesized by this method.
+func (rs *RemoteStorage) UpdateAccessReviewCampaign(ctx context.Context, c *models.AccessReviewCampaign) (bool, error) {
+	path := fmt.Sprintf("/api/v1/system/access-review-campaigns/%d", c.ID)
+	resp, err := rs.client.Put(ctx, path, newAccessReviewCampaignWire(c))
+	if err != nil {
+		return false, fmt.Errorf("failed to update access-review campaign: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("update access-review campaign failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Updated bool `json:"updated"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Updated, nil
+}
+
+// CreateAccessReviewItems bulk-persists a campaign's freshly-opened (all
+// "pending") item snapshot via POST
+// /api/v1/system/access-review-campaigns/{id}/items.
+func (rs *RemoteStorage) CreateAccessReviewItems(ctx context.Context, items []*models.AccessReviewItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+	campaignID := items[0].CampaignID
+	wire := make([]accessReviewItemWire, 0, len(items))
+	for _, it := range items {
+		wire = append(wire, newAccessReviewItemWire(it))
+	}
+	path := fmt.Sprintf("/api/v1/system/access-review-campaigns/%d/items", campaignID)
+	resp, err := rs.client.Post(ctx, path, map[string]interface{}{"items": wire})
+	if err != nil {
+		return fmt.Errorf("failed to create access-review items: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("create access-review items failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// ListAccessReviewItems lists a campaign's items via GET
+// /api/v1/system/access-review-campaigns/{id}/items.
+func (rs *RemoteStorage) ListAccessReviewItems(ctx context.Context, campaignID uint) ([]*models.AccessReviewItem, error) {
+	path := fmt.Sprintf("/api/v1/system/access-review-campaigns/%d/items", campaignID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list access-review items: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list access-review items failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Items []accessReviewItemWire `json:"items"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.AccessReviewItem, 0, len(result.Items))
+	for _, w := range result.Items {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
+}
+
+// CountPendingAccessReviewItems returns how many of a campaign's items still
+// await a decision via GET
+// /api/v1/system/access-review-campaigns/{id}/items/pending-count.
+func (rs *RemoteStorage) CountPendingAccessReviewItems(ctx context.Context, campaignID uint) (int, error) {
+	path := fmt.Sprintf("/api/v1/system/access-review-campaigns/%d/items/pending-count", campaignID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count pending access-review items: %w", err)
+	}
+	if !resp.Success {
+		return 0, fmt.Errorf("count pending access-review items failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Count int `json:"count"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Count, nil
+}
+
+// GetAccessReviewItem retrieves a single item by its own ID via GET
+// /api/v1/system/access-review-campaigns/items/{itemID}.
+func (rs *RemoteStorage) GetAccessReviewItem(ctx context.Context, id uint) (*models.AccessReviewItem, error) {
+	path := fmt.Sprintf("/api/v1/system/access-review-campaigns/items/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get access-review item: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get access-review item failed: %s", resp.Error.Error())
+	}
+	return decodeAccessReviewItemResponse(resp.Data)
+}
+
+// UpdateAccessReviewItem persists a recertification decision via PUT
+// /api/v1/system/access-review-campaigns/items/{itemID}. See the package doc
+// for why the bool this returns IS the single conditional `WHERE decision =
+// 'pending' AND campaign state = 'open'` UPDATE's own RowsAffected==1 result,
+// relayed faithfully across the wire — not synthesized by this method.
+func (rs *RemoteStorage) UpdateAccessReviewItem(ctx context.Context, item *models.AccessReviewItem) (bool, error) {
+	path := fmt.Sprintf("/api/v1/system/access-review-campaigns/items/%d", item.ID)
+	resp, err := rs.client.Put(ctx, path, newAccessReviewItemWire(item))
+	if err != nil {
+		return false, fmt.Errorf("failed to update access-review item: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("update access-review item failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Updated bool `json:"updated"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Updated, nil
 }

--- a/server/http/handlers/access_review_campaigns_proxy.go
+++ b/server/http/handlers/access_review_campaigns_proxy.go
@@ -1,0 +1,474 @@
+// access_review_campaigns_proxy.go — server-side endpoints backing
+// RemoteStorage's access-review campaign storage primitives (ISO 27001 A.5.18,
+// finding #519): CreateAccessReviewCampaign/GetAccessReviewCampaign/
+// ListAccessReviewCampaigns/GetOpenAccessReviewCampaign/
+// GetLatestClosedAccessReviewCampaign/UpdateAccessReviewCampaign/
+// CreateAccessReviewItems/ListAccessReviewItems/CountPendingAccessReviewItems/
+// GetAccessReviewItem/UpdateAccessReviewItem.
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// its access-review-campaign storage calls to whichever upstream server it's
+// configured against, through these routes (registered in
+// server/http/router.go under /api/v1/system/access-review-campaigns, gated on
+// the existing system.read/system.write RBAC permissions — the SAME credential
+// a RemoteStorage client already needs for every other proxied call, e.g. full
+// user CRUD, project-membership CRUD (#511), so this introduces no new
+// privilege class). Mirrors project_memberships_proxy.go and
+// dynamic_secrets_proxy.go exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/access_review_campaign.go already uses against a local
+// backend — NO campaign-lifecycle POLICY decision (opening a campaign from a
+// live access-review snapshot, the independence/self-review check, the
+// pending-vs-force-close gate, revoking the underlying grant on a "revoke"
+// decision) is made here; all of that stays entirely in the CALLING server's
+// own internal/core.KeyorixCore, exactly as it does against a local backend.
+// The existing human-facing /api/v1/projects/{id}/access-review/campaigns
+// routes (access_review_campaigns.go's CatalogHandler methods) are
+// deliberately NOT reused as the proxy target — like the human-facing
+// /groups routes were the wrong target for #514 (see groups_proxy.go's
+// package doc), those run the full campaign open/decide/close business logic
+// against the HTTP caller's own identity, the wrong semantics for a raw
+// storage-primitive passthrough whose caller already ran all of that on the
+// downstream side.
+//
+// Atomicity (investigated, not assumed): UpdateAccessReviewCampaign and
+// UpdateAccessReviewItem are each ALREADY a single, self-contained atomic
+// operation — a single conditional `UPDATE ... WHERE <precondition>` statement
+// (local_access_review_campaigns.go), not a separate LockXForUpdate-then-write
+// pair — and the storage.Storage interface already threads the result back as
+// a bool (RowsAffected==1), not a plain error. That means the ENTIRE
+// atomicity guarantee lives inside one storage call, so a single proxied HTTP
+// round trip (this server runs that same one conditional UPDATE, then reports
+// the bool back on the wire) preserves it exactly: no new atomic
+// storage-interface primitive, and no cross-call transaction spanning the
+// wire, is needed here (unlike, say, #511's unique-index-violation
+// translation, which needed the DUPLICATE_ACTIVE_MEMBERSHIP wire code because
+// CreateProjectMembership's atomicity depended on a DB-level constraint
+// surfacing through an untyped error). UpdateAccessReviewCampaignProxy/
+// UpdateAccessReviewItemProxy below MUST relay that bool faithfully — never
+// synthesize "updated: true" independent of the storage call's own result.
+//
+// Response envelope: like project_memberships_proxy.go/dynamic_secrets_proxy.go,
+// these do NOT use the package's generic sendSuccess/sendError helpers — they
+// construct the exact {"success":bool,"data":...,"error":{"code","message"}}
+// shape internal/storage/remote.HTTPClient parses (its APIResponse/APIError
+// types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// accessReviewCampaignProxyWire mirrors models.AccessReviewCampaign's fields
+// exactly (snake_case). Unlike dynamicSecretConfigProxyWire/groupProxyWire,
+// models.AccessReviewCampaign already carries a complete, correct set of json
+// tags (no `json:"-"` fields to route around) — but a named wire type is kept
+// anyway, matching every other proxy in this package, so the wire contract
+// stays stable and explicit even if the model's tags ever change independently.
+type accessReviewCampaignProxyWire struct {
+	ID               uint       `json:"id"`
+	ProjectID        uint       `json:"project_id"`
+	Name             string     `json:"name"`
+	State            string     `json:"state"`
+	CreatedBy        uint       `json:"created_by"`
+	CreatedAt        time.Time  `json:"created_at"`
+	ClosedBy         uint       `json:"closed_by,omitempty"`
+	ClosedAt         *time.Time `json:"closed_at,omitempty"`
+	Degraded         bool       `json:"degraded"`
+	DegradedReasons  []string   `json:"degraded_reasons,omitempty"`
+	ForcedIncomplete bool       `json:"forced_incomplete"`
+}
+
+func newAccessReviewCampaignProxyWire(c *models.AccessReviewCampaign) accessReviewCampaignProxyWire {
+	return accessReviewCampaignProxyWire{
+		ID:               c.ID,
+		ProjectID:        c.ProjectID,
+		Name:             c.Name,
+		State:            c.State,
+		CreatedBy:        c.CreatedBy,
+		CreatedAt:        c.CreatedAt,
+		ClosedBy:         c.ClosedBy,
+		ClosedAt:         c.ClosedAt,
+		Degraded:         c.Degraded,
+		DegradedReasons:  c.DegradedReasons,
+		ForcedIncomplete: c.ForcedIncomplete,
+	}
+}
+
+func (w accessReviewCampaignProxyWire) toModel() *models.AccessReviewCampaign {
+	return &models.AccessReviewCampaign{
+		ID:               w.ID,
+		ProjectID:        w.ProjectID,
+		Name:             w.Name,
+		State:            w.State,
+		CreatedBy:        w.CreatedBy,
+		CreatedAt:        w.CreatedAt,
+		ClosedBy:         w.ClosedBy,
+		ClosedAt:         w.ClosedAt,
+		Degraded:         w.Degraded,
+		DegradedReasons:  w.DegradedReasons,
+		ForcedIncomplete: w.ForcedIncomplete,
+	}
+}
+
+// accessReviewItemProxyWire mirrors models.AccessReviewItem's fields exactly.
+type accessReviewItemProxyWire struct {
+	ID            uint       `json:"id"`
+	CampaignID    uint       `json:"campaign_id"`
+	PrincipalType string     `json:"principal_type"`
+	PrincipalID   uint       `json:"principal_id"`
+	PrincipalName string     `json:"principal_name"`
+	Email         string     `json:"email,omitempty"`
+	Source        string     `json:"source"`
+	RoleID        uint       `json:"role_id,omitempty"`
+	RoleName      string     `json:"role_name,omitempty"`
+	AccessLevel   string     `json:"access_level"`
+	EnvironmentID uint       `json:"environment_id"`
+	SecretID      uint       `json:"secret_id,omitempty"`
+	SecretName    string     `json:"secret_name,omitempty"`
+	LastUsedAt    *time.Time `json:"last_used_at,omitempty"`
+	Decision      string     `json:"decision"`
+	Reason        string     `json:"reason,omitempty"`
+	DecidedBy     uint       `json:"decided_by,omitempty"`
+	DecidedAt     *time.Time `json:"decided_at,omitempty"`
+}
+
+func newAccessReviewItemProxyWire(it *models.AccessReviewItem) accessReviewItemProxyWire {
+	return accessReviewItemProxyWire{
+		ID:            it.ID,
+		CampaignID:    it.CampaignID,
+		PrincipalType: it.PrincipalType,
+		PrincipalID:   it.PrincipalID,
+		PrincipalName: it.PrincipalName,
+		Email:         it.Email,
+		Source:        it.Source,
+		RoleID:        it.RoleID,
+		RoleName:      it.RoleName,
+		AccessLevel:   it.AccessLevel,
+		EnvironmentID: it.EnvironmentID,
+		SecretID:      it.SecretID,
+		SecretName:    it.SecretName,
+		LastUsedAt:    it.LastUsedAt,
+		Decision:      it.Decision,
+		Reason:        it.Reason,
+		DecidedBy:     it.DecidedBy,
+		DecidedAt:     it.DecidedAt,
+	}
+}
+
+func (w accessReviewItemProxyWire) toModel() *models.AccessReviewItem {
+	return &models.AccessReviewItem{
+		ID:            w.ID,
+		CampaignID:    w.CampaignID,
+		PrincipalType: w.PrincipalType,
+		PrincipalID:   w.PrincipalID,
+		PrincipalName: w.PrincipalName,
+		Email:         w.Email,
+		Source:        w.Source,
+		RoleID:        w.RoleID,
+		RoleName:      w.RoleName,
+		AccessLevel:   w.AccessLevel,
+		EnvironmentID: w.EnvironmentID,
+		SecretID:      w.SecretID,
+		SecretName:    w.SecretName,
+		LastUsedAt:    w.LastUsedAt,
+		Decision:      w.Decision,
+		Reason:        w.Reason,
+		DecidedBy:     w.DecidedBy,
+		DecidedAt:     w.DecidedAt,
+	}
+}
+
+// parseRequiredProjectIDQuery parses the required project_id query parameter shared by
+// ListAccessReviewCampaignsProxy/GetOpenAccessReviewCampaignProxy/
+// GetLatestClosedAccessReviewCampaignProxy.
+func parseRequiredProjectIDQuery(w http.ResponseWriter, r *http.Request) (projectID uint, ok bool) {
+	v := r.URL.Query().Get("project_id")
+	if v == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id query parameter is required")
+		return 0, false
+	}
+	id, err := strconv.ParseUint(v, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id must be a valid integer")
+		return 0, false
+	}
+	return uint(id), true
+}
+
+// CreateAccessReviewCampaignProxy handles POST /api/v1/system/access-review-campaigns.
+// Persists the caller's already-fully-built campaign row as-is (a raw
+// storage-layer create) — matching CreateMembershipProxy's precedent, this is
+// NOT the human-facing POST .../access-review/campaigns
+// (CatalogHandler.OpenAccessReviewCampaign), which additionally snapshots the
+// project's live access-review report and generates the campaign's items; the
+// calling server's own core.OpenAccessReviewCampaign already did that and
+// calls CreateAccessReviewItemsProxy separately to persist them.
+func (h *CatalogHandler) CreateAccessReviewCampaignProxy(w http.ResponseWriter, r *http.Request) {
+	var body accessReviewCampaignProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.ProjectID == 0 || body.Name == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id and name are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateAccessReviewCampaign(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("access-review-campaigns proxy: create campaign failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newAccessReviewCampaignProxyWire(created))
+}
+
+// GetAccessReviewCampaignProxy handles GET /api/v1/system/access-review-campaigns/{id}.
+func (h *CatalogHandler) GetAccessReviewCampaignProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid campaign id")
+		return
+	}
+	c, err := h.coreService.Storage().GetAccessReviewCampaign(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "access-review campaign not found")
+			return
+		}
+		log.Printf("access-review-campaigns proxy: get campaign failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newAccessReviewCampaignProxyWire(c))
+}
+
+// ListAccessReviewCampaignsProxy handles GET
+// /api/v1/system/access-review-campaigns?project_id=X.
+func (h *CatalogHandler) ListAccessReviewCampaignsProxy(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := parseRequiredProjectIDQuery(w, r)
+	if !ok {
+		return
+	}
+	rows, err := h.coreService.Storage().ListAccessReviewCampaigns(r.Context(), projectID)
+	if err != nil {
+		log.Printf("access-review-campaigns proxy: list campaigns failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]accessReviewCampaignProxyWire, 0, len(rows))
+	for _, c := range rows {
+		wire = append(wire, newAccessReviewCampaignProxyWire(c))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"campaigns": wire})
+}
+
+// GetOpenAccessReviewCampaignProxy handles GET
+// /api/v1/system/access-review-campaigns/open?project_id=X (a static path,
+// registered before /access-review-campaigns/{id} in router.go). Returns
+// {"campaign": null} (success, no error) when the project has no open
+// campaign — mirroring LocalStorage.GetOpenAccessReviewCampaign's own
+// (nil, nil) "none open" contract, not a 404.
+func (h *CatalogHandler) GetOpenAccessReviewCampaignProxy(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := parseRequiredProjectIDQuery(w, r)
+	if !ok {
+		return
+	}
+	c, err := h.coreService.Storage().GetOpenAccessReviewCampaign(r.Context(), projectID)
+	if err != nil {
+		log.Printf("access-review-campaigns proxy: get open campaign failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	if c == nil {
+		writeRemoteAPISuccess(w, map[string]interface{}{"campaign": nil})
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"campaign": newAccessReviewCampaignProxyWire(c)})
+}
+
+// GetLatestClosedAccessReviewCampaignProxy handles GET
+// /api/v1/system/access-review-campaigns/latest-closed?project_id=X (a static
+// path, registered before /access-review-campaigns/{id} in router.go). Same
+// nil-is-success contract as GetOpenAccessReviewCampaignProxy above.
+func (h *CatalogHandler) GetLatestClosedAccessReviewCampaignProxy(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := parseRequiredProjectIDQuery(w, r)
+	if !ok {
+		return
+	}
+	c, err := h.coreService.Storage().GetLatestClosedAccessReviewCampaign(r.Context(), projectID)
+	if err != nil {
+		log.Printf("access-review-campaigns proxy: get latest-closed campaign failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	if c == nil {
+		writeRemoteAPISuccess(w, map[string]interface{}{"campaign": nil})
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"campaign": newAccessReviewCampaignProxyWire(c)})
+}
+
+// UpdateAccessReviewCampaignProxy handles PUT
+// /api/v1/system/access-review-campaigns/{id}. Runs the SAME single
+// conditional UPDATE (`WHERE id = ? AND state = 'open'`) LocalStorage's own
+// UpdateAccessReviewCampaign does — see the package doc for why relaying that
+// call's bool result (not synthesizing one) is the entire atomicity
+// contract here.
+func (h *CatalogHandler) UpdateAccessReviewCampaignProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid campaign id")
+		return
+	}
+	var body accessReviewCampaignProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	updated, err := h.coreService.Storage().UpdateAccessReviewCampaign(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("access-review-campaigns proxy: update campaign failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": updated})
+}
+
+// CreateAccessReviewItemsProxy handles POST
+// /api/v1/system/access-review-campaigns/{id}/items. Bulk-persists the
+// caller's already-built item snapshot (each "pending") — the calling
+// server's own core.OpenAccessReviewCampaign already generated these from its
+// own live GenerateProjectAccessReview report.
+func (h *CatalogHandler) CreateAccessReviewItemsProxy(w http.ResponseWriter, r *http.Request) {
+	campaignID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid campaign id")
+		return
+	}
+	var body struct {
+		Items []accessReviewItemProxyWire `json:"items"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	items := make([]*models.AccessReviewItem, 0, len(body.Items))
+	for _, w := range body.Items {
+		w.CampaignID = uint(campaignID)
+		items = append(items, w.toModel())
+	}
+	if err := h.coreService.Storage().CreateAccessReviewItems(r.Context(), items); err != nil {
+		log.Printf("access-review-campaigns proxy: create items failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"created": true})
+}
+
+// ListAccessReviewItemsProxy handles GET
+// /api/v1/system/access-review-campaigns/{id}/items.
+func (h *CatalogHandler) ListAccessReviewItemsProxy(w http.ResponseWriter, r *http.Request) {
+	campaignID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid campaign id")
+		return
+	}
+	rows, err := h.coreService.Storage().ListAccessReviewItems(r.Context(), uint(campaignID))
+	if err != nil {
+		log.Printf("access-review-campaigns proxy: list items failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]accessReviewItemProxyWire, 0, len(rows))
+	for _, it := range rows {
+		wire = append(wire, newAccessReviewItemProxyWire(it))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"items": wire})
+}
+
+// CountPendingAccessReviewItemsProxy handles GET
+// /api/v1/system/access-review-campaigns/{id}/items/pending-count (a static
+// path — chi always matches the literal "pending-count" segment over any
+// wildcard sibling at the same depth, so it coexists safely with the item
+// routes below regardless of registration order).
+func (h *CatalogHandler) CountPendingAccessReviewItemsProxy(w http.ResponseWriter, r *http.Request) {
+	campaignID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid campaign id")
+		return
+	}
+	n, err := h.coreService.Storage().CountPendingAccessReviewItems(r.Context(), uint(campaignID))
+	if err != nil {
+		log.Printf("access-review-campaigns proxy: count pending items failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int{"count": n})
+}
+
+// GetAccessReviewItemProxy handles GET
+// /api/v1/system/access-review-campaigns/items/{itemID} — a top-level item
+// lookup by its own ID (not nested under a campaign), matching the storage
+// interface's own GetAccessReviewItem(ctx, id) signature. The literal "items"
+// path segment here takes priority over the /access-review-campaigns/{id}
+// wildcard at the same depth — the same static-vs-wildcard precedence
+// project_memberships_proxy.go's "active"/"stale"/"counts"/"by-user" already
+// rely on.
+func (h *CatalogHandler) GetAccessReviewItemProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "itemID"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid item id")
+		return
+	}
+	it, err := h.coreService.Storage().GetAccessReviewItem(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "access-review item not found")
+			return
+		}
+		log.Printf("access-review-campaigns proxy: get item failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newAccessReviewItemProxyWire(it))
+}
+
+// UpdateAccessReviewItemProxy handles PUT
+// /api/v1/system/access-review-campaigns/items/{itemID}. Runs the SAME single
+// conditional UPDATE (`WHERE id = ? AND decision = 'pending' AND campaign_id
+// IN (SELECT ... WHERE state = 'open')`) LocalStorage's own
+// UpdateAccessReviewItem does — see the package doc for why relaying that
+// call's bool result (not synthesizing one) is the entire atomicity contract
+// here; this single round trip verifies both the item-pending and
+// campaign-open preconditions atomically, exactly as it does against a local
+// backend.
+func (h *CatalogHandler) UpdateAccessReviewItemProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "itemID"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid item id")
+		return
+	}
+	var body accessReviewItemProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	updated, err := h.coreService.Storage().UpdateAccessReviewItem(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("access-review-campaigns proxy: update item failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": updated})
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -94,6 +94,10 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		&models.MFASecret{},
 		&models.MFARecoveryCode{},
 		&models.MFAChallenge{},
+		// #519: the access-review-campaign-proxy end-to-end tests exercise
+		// AccessReviewCampaign/AccessReviewItem CRUD through the real router.
+		&models.AccessReviewCampaign{},
+		&models.AccessReviewItem{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the

--- a/server/http/remote_storage_access_review_campaigns_test.go
+++ b/server/http/remote_storage_access_review_campaigns_test.go
@@ -1,0 +1,358 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForAccessReviewCampaigns builds the standard
+// #452/#507/#511/#519-style two-server harness: an "upstream" exercised
+// through the REAL production NewRouter/handlers (including the new
+// /api/v1/system/access-review-campaigns routes,
+// access_review_campaigns_proxy.go), and a "downstream" *core.KeyorixCore
+// configured with storage.type: remote (ADR-049), pointed at "upstream" over
+// real HTTP via store.RemoteStorage. Mirrors
+// newUpstreamDownstreamForMemberships exactly.
+func newUpstreamDownstreamForAccessReviewCampaigns(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore, projectID uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+
+	ctx := context.Background()
+	project, err := upstream.CreateProject(ctx, "Access Review Campaign Test Project", "")
+	require.NoError(t, err)
+	return upstream, downstream, project.ID
+}
+
+// TestRemoteStorageAccessReviewCampaign_CreateGetList_RealServer proves the
+// #519 fix for CreateAccessReviewCampaign/GetAccessReviewCampaign/
+// ListAccessReviewCampaigns: a campaign is genuinely persisted on the
+// upstream server via the DOWNSTREAM's RemoteStorage, fetchable by ID, and
+// listed — all via storage.type: remote against a real router, not a
+// protocol mock.
+func TestRemoteStorageAccessReviewCampaign_CreateGetList_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForAccessReviewCampaigns(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	c, err := downstream.Storage().CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: projectID,
+		Name:      "Q1 access review",
+		State:     core.CampaignStateOpen,
+		CreatedBy: 1,
+		CreatedAt: now,
+	})
+	require.NoError(t, err, "creating a campaign must succeed via storage.type: remote")
+	require.NotZero(t, c.ID, "the upstream must assign a real ID")
+	assert.Equal(t, projectID, c.ProjectID)
+	assert.Equal(t, "Q1 access review", c.Name)
+	assert.Equal(t, core.CampaignStateOpen, c.State)
+
+	// Confirm it is a REAL row in the upstream's own storage (not just "the call
+	// didn't error"), by reading it back directly against upstream.
+	direct, err := upstream.Storage().GetAccessReviewCampaign(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Q1 access review", direct.Name)
+
+	// GetAccessReviewCampaign via the downstream (RemoteStorage) round-trips
+	// every field correctly.
+	fetched, err := downstream.Storage().GetAccessReviewCampaign(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, c.ID, fetched.ID)
+	assert.Equal(t, c.ProjectID, fetched.ProjectID)
+	assert.Equal(t, c.Name, fetched.Name)
+	assert.Equal(t, c.State, fetched.State)
+	assert.WithinDuration(t, c.CreatedAt, fetched.CreatedAt, time.Second)
+
+	// A second campaign for the same project, then list both back via the
+	// downstream's ListAccessReviewCampaigns.
+	_, err = downstream.Storage().CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: projectID, Name: "Q2 access review", State: core.CampaignStateOpen, CreatedBy: 1, CreatedAt: now,
+	})
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListAccessReviewCampaigns(ctx, projectID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	names := map[string]bool{}
+	for _, r := range rows {
+		names[r.Name] = true
+	}
+	assert.True(t, names["Q1 access review"])
+	assert.True(t, names["Q2 access review"])
+}
+
+// TestRemoteStorageAccessReviewCampaign_GetNotFound_RealServer proves a clean
+// not-found error (not a panic, not a garbage 500) for a nonexistent
+// campaign ID.
+func TestRemoteStorageAccessReviewCampaign_GetNotFound_RealServer(t *testing.T) {
+	_, downstream, _ := newUpstreamDownstreamForAccessReviewCampaigns(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetAccessReviewCampaign(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageAccessReviewCampaign_OpenAndLatestClosed_RealServer proves
+// GetOpenAccessReviewCampaign/GetLatestClosedAccessReviewCampaign round-trip
+// their nil-is-success ("no such campaign") contract, and correctly identify
+// the open vs. most-recently-closed campaign after an UpdateAccessReviewCampaign
+// state transition.
+func TestRemoteStorageAccessReviewCampaign_OpenAndLatestClosed_RealServer(t *testing.T) {
+	_, downstream, projectID := newUpstreamDownstreamForAccessReviewCampaigns(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// No campaign yet: both queries report a clean nil, not an error.
+	open, err := downstream.Storage().GetOpenAccessReviewCampaign(ctx, projectID)
+	require.NoError(t, err)
+	assert.Nil(t, open)
+	closedCampaign, err := downstream.Storage().GetLatestClosedAccessReviewCampaign(ctx, projectID)
+	require.NoError(t, err)
+	assert.Nil(t, closedCampaign)
+
+	c, err := downstream.Storage().CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: projectID, Name: "open campaign", State: core.CampaignStateOpen, CreatedBy: 1, CreatedAt: now,
+	})
+	require.NoError(t, err)
+
+	open, err = downstream.Storage().GetOpenAccessReviewCampaign(ctx, projectID)
+	require.NoError(t, err)
+	require.NotNil(t, open)
+	assert.Equal(t, c.ID, open.ID)
+
+	// Close it via UpdateAccessReviewCampaign's conditional UPDATE.
+	closedAt := time.Now()
+	c.State = core.CampaignStateClosed
+	c.ClosedBy = 1
+	c.ClosedAt = &closedAt
+	updated, err := downstream.Storage().UpdateAccessReviewCampaign(ctx, c)
+	require.NoError(t, err)
+	assert.True(t, updated, "closing a still-open campaign must succeed")
+
+	open, err = downstream.Storage().GetOpenAccessReviewCampaign(ctx, projectID)
+	require.NoError(t, err)
+	assert.Nil(t, open, "no campaign is open once the only one is closed")
+
+	closedCampaign, err = downstream.Storage().GetLatestClosedAccessReviewCampaign(ctx, projectID)
+	require.NoError(t, err)
+	require.NotNil(t, closedCampaign)
+	assert.Equal(t, c.ID, closedCampaign.ID)
+}
+
+// TestRemoteStorageAccessReviewCampaign_UpdateRejectsWhenAlreadyClosed_RealServer
+// proves UpdateAccessReviewCampaign's conditional `WHERE state = 'open'` UPDATE
+// survives the HTTP hop faithfully: a second close attempt against an
+// already-closed campaign must report updated=false (a lost race), not
+// silently re-apply.
+func TestRemoteStorageAccessReviewCampaign_UpdateRejectsWhenAlreadyClosed_RealServer(t *testing.T) {
+	_, downstream, projectID := newUpstreamDownstreamForAccessReviewCampaigns(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	c, err := downstream.Storage().CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: projectID, Name: "double-close", State: core.CampaignStateOpen, CreatedBy: 1, CreatedAt: now,
+	})
+	require.NoError(t, err)
+
+	closedAt := time.Now()
+	firstClose := &models.AccessReviewCampaign{ID: c.ID, ProjectID: projectID, Name: c.Name, State: core.CampaignStateClosed, ClosedBy: 1, ClosedAt: &closedAt}
+	updated, err := downstream.Storage().UpdateAccessReviewCampaign(ctx, firstClose)
+	require.NoError(t, err)
+	assert.True(t, updated, "the first close must win")
+
+	secondClose := &models.AccessReviewCampaign{ID: c.ID, ProjectID: projectID, Name: c.Name, State: core.CampaignStateClosed, ClosedBy: 2, ClosedAt: &closedAt}
+	updated, err = downstream.Storage().UpdateAccessReviewCampaign(ctx, secondClose)
+	require.NoError(t, err, "a lost race is reported via the bool, not an error")
+	assert.False(t, updated, "a second close against an already-closed campaign must be rejected")
+
+	fetched, err := downstream.Storage().GetAccessReviewCampaign(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), fetched.ClosedBy, "the winning close's ClosedBy must not be clobbered by the loser")
+}
+
+// TestRemoteStorageAccessReviewCampaign_ItemsRoundTrip_RealServer proves
+// CreateAccessReviewItems/ListAccessReviewItems/CountPendingAccessReviewItems/
+// GetAccessReviewItem/UpdateAccessReviewItem round-trip over storage.type:
+// remote.
+func TestRemoteStorageAccessReviewCampaign_ItemsRoundTrip_RealServer(t *testing.T) {
+	_, downstream, projectID := newUpstreamDownstreamForAccessReviewCampaigns(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	c, err := downstream.Storage().CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: projectID, Name: "items campaign", State: core.CampaignStateOpen, CreatedBy: 1, CreatedAt: now,
+	})
+	require.NoError(t, err)
+
+	items := []*models.AccessReviewItem{
+		{CampaignID: c.ID, PrincipalType: "user", PrincipalID: 42, PrincipalName: "alice", Source: "direct_share", AccessLevel: "read", EnvironmentID: 1, Decision: core.ReviewItemPending},
+		{CampaignID: c.ID, PrincipalType: "user", PrincipalID: 43, PrincipalName: "bob", Source: "role", AccessLevel: "write", EnvironmentID: 1, Decision: core.ReviewItemPending},
+	}
+	require.NoError(t, downstream.Storage().CreateAccessReviewItems(ctx, items))
+
+	rows, err := downstream.Storage().ListAccessReviewItems(ctx, c.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	for _, r := range rows {
+		require.NotZero(t, r.ID, "the upstream must assign a real item ID")
+		assert.Equal(t, c.ID, r.CampaignID)
+	}
+
+	pending, err := downstream.Storage().CountPendingAccessReviewItems(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, pending)
+
+	target := rows[0]
+	fetched, err := downstream.Storage().GetAccessReviewItem(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, target.PrincipalName, fetched.PrincipalName)
+
+	// Decide it (attest) via UpdateAccessReviewItem's conditional UPDATE.
+	decidedAt := time.Now()
+	fetched.Decision = core.ReviewItemAttested
+	fetched.DecidedBy = 7
+	fetched.DecidedAt = &decidedAt
+	updated, err := downstream.Storage().UpdateAccessReviewItem(ctx, fetched)
+	require.NoError(t, err)
+	assert.True(t, updated, "deciding a still-pending item in an open campaign must succeed")
+
+	pending, err = downstream.Storage().CountPendingAccessReviewItems(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, pending, "the decided item no longer counts as pending")
+
+	refetched, err := downstream.Storage().GetAccessReviewItem(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.ReviewItemAttested, refetched.Decision)
+}
+
+// TestRemoteStorageAccessReviewCampaign_UpdateItemRejectsWhenAlreadyDecided_RealServer
+// proves UpdateAccessReviewItem's conditional `WHERE decision = 'pending' AND
+// campaign_id IN (... WHERE state = 'open')` UPDATE survives the HTTP hop
+// faithfully: a second decision on an already-decided item must report
+// updated=false, not silently flip the recorded decision (#319).
+func TestRemoteStorageAccessReviewCampaign_UpdateItemRejectsWhenAlreadyDecided_RealServer(t *testing.T) {
+	_, downstream, projectID := newUpstreamDownstreamForAccessReviewCampaigns(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	c, err := downstream.Storage().CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: projectID, Name: "redecide", State: core.CampaignStateOpen, CreatedBy: 1, CreatedAt: now,
+	})
+	require.NoError(t, err)
+	items := []*models.AccessReviewItem{
+		{CampaignID: c.ID, PrincipalType: "user", PrincipalID: 1, Source: "role", AccessLevel: "read", EnvironmentID: 1, Decision: core.ReviewItemPending},
+	}
+	require.NoError(t, downstream.Storage().CreateAccessReviewItems(ctx, items))
+	rows, err := downstream.Storage().ListAccessReviewItems(ctx, c.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	item := rows[0]
+
+	decidedAt := time.Now()
+	first := &models.AccessReviewItem{ID: item.ID, CampaignID: c.ID, PrincipalType: "user", PrincipalID: 1, Source: "role", AccessLevel: "read", EnvironmentID: 1, Decision: core.ReviewItemAttested, DecidedBy: 5, DecidedAt: &decidedAt}
+	updated, err := downstream.Storage().UpdateAccessReviewItem(ctx, first)
+	require.NoError(t, err)
+	assert.True(t, updated, "the first decision must win")
+
+	second := &models.AccessReviewItem{ID: item.ID, CampaignID: c.ID, PrincipalType: "user", PrincipalID: 1, Source: "role", AccessLevel: "read", EnvironmentID: 1, Decision: core.ReviewItemRevoked, DecidedBy: 6, DecidedAt: &decidedAt}
+	updated, err = downstream.Storage().UpdateAccessReviewItem(ctx, second)
+	require.NoError(t, err, "a lost race is reported via the bool, not an error")
+	assert.False(t, updated, "a second decision on an already-decided item must be rejected")
+
+	fetched, err := downstream.Storage().GetAccessReviewItem(ctx, item.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.ReviewItemAttested, fetched.Decision, "the winning decision must not be clobbered by the loser")
+}
+
+// TestRemoteStorageAccessReviewCampaign_ConcurrentClose_OnlyOneWins_RealServer
+// drives real concurrent close attempts, through the REAL HTTP proxy hop (not
+// direct LocalStorage calls, unlike
+// store.TestConcurrency_UpdateAccessReviewCampaign_OnlyOneCloseWins), against
+// the SAME open campaign and asserts the conditional UPDATE — running
+// server-side inside a single proxied round trip — still lets exactly one
+// win. This is the end-to-end proof that access_review_campaigns_proxy.go's
+// atomicity analysis holds: no separate lock+update pair was introduced (and
+// none was needed) to preserve the guarantee across the wire.
+func TestRemoteStorageAccessReviewCampaign_ConcurrentClose_OnlyOneWins_RealServer(t *testing.T) {
+	_, downstream, projectID := newUpstreamDownstreamForAccessReviewCampaigns(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	c, err := downstream.Storage().CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: projectID, Name: "concurrent-close", State: core.CampaignStateOpen, CreatedBy: 1, CreatedAt: now,
+	})
+	require.NoError(t, err)
+
+	const racers = 16
+	var succeeded atomic.Int64
+	errs := make(chan error, racers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		closerID := uint(300 + i)
+		go func(closerID uint) {
+			defer wg.Done()
+			<-start
+			closedAt := time.Now()
+			candidate := &models.AccessReviewCampaign{ID: c.ID, ProjectID: projectID, Name: c.Name, State: core.CampaignStateClosed, ClosedBy: closerID, ClosedAt: &closedAt}
+			ok, err := downstream.Storage().UpdateAccessReviewCampaign(context.Background(), candidate)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if ok {
+				succeeded.Add(1)
+			}
+		}(closerID)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(1), succeeded.Load(), "exactly one concurrent close may win over the proxy — never zero, never more than one")
+
+	fetched, err := downstream.Storage().GetAccessReviewCampaign(ctx, c.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.CampaignStateClosed, fetched.State, "the winning close must have been persisted")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -961,6 +961,51 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/project-memberships", catalogHandler.ListMembershipsProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/project-memberships", catalogHandler.CreateMembershipProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Put("/project-memberships/{id}", catalogHandler.UpdateMembershipProxy)
+
+			// Access-review-campaign storage-primitive proxy (ISO 27001 A.5.18,
+			// finding #519). Lets a downstream Keyorix server booted with
+			// storage.type: remote (ADR-049) proxy CreateAccessReviewCampaign/
+			// GetAccessReviewCampaign/ListAccessReviewCampaigns/
+			// GetOpenAccessReviewCampaign/GetLatestClosedAccessReviewCampaign/
+			// UpdateAccessReviewCampaign/CreateAccessReviewItems/
+			// ListAccessReviewItems/CountPendingAccessReviewItems/
+			// GetAccessReviewItem/UpdateAccessReviewItem to THIS server's real
+			// storage backend, instead of RemoteStorage's eleven access-review
+			// -campaign methods having no server endpoint to call at all (every
+			// ISO 27001 A.5.18 periodic-recertification flow was completely
+			// non-functional under storage.type: remote). Exactly the same
+			// pattern as the project-memberships proxy above: a thin passthrough
+			// onto storage.Storage (no campaign-lifecycle POLICY decision —
+			// snapshotting the live access-review report into items, the
+			// reviewer-independence check, the pending-vs-force-close gate,
+			// revoking the underlying grant on a "revoke" decision — is made
+			// here; that stays entirely in the CALLING server's own
+			// internal/core.KeyorixCore, exactly as it does against a local
+			// backend), reusing the SAME system.read/system.write tier rather
+			// than the project-scoped roles.read/roles.assign the human-facing
+			// /projects/{id}/access-review/campaigns routes use — no new
+			// privilege class. Read is baseline system.read; create/update
+			// require system.write, matching every other admin-level mutation
+			// in this group. Static sub-paths ("open", "latest-closed",
+			// "items/{itemID}", "items/pending-count") are registered ahead of
+			// the "/{id}" wildcard, the same static-vs-wildcard precedence
+			// project-memberships' "active"/"stale"/"counts"/"by-user" above
+			// already rely on — see access_review_campaigns_proxy.go's package
+			// doc for the UpdateAccessReviewCampaign/UpdateAccessReviewItem
+			// atomicity analysis (both are already a single conditional UPDATE
+			// on the LocalStorage side, so one proxied round trip preserves the
+			// guarantee exactly; no new atomic primitive was needed).
+			r.Get("/access-review-campaigns/open", catalogHandler.GetOpenAccessReviewCampaignProxy)
+			r.Get("/access-review-campaigns/latest-closed", catalogHandler.GetLatestClosedAccessReviewCampaignProxy)
+			r.Get("/access-review-campaigns/items/{itemID}", catalogHandler.GetAccessReviewItemProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/access-review-campaigns/items/{itemID}", catalogHandler.UpdateAccessReviewItemProxy)
+			r.Get("/access-review-campaigns", catalogHandler.ListAccessReviewCampaignsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/access-review-campaigns", catalogHandler.CreateAccessReviewCampaignProxy)
+			r.Get("/access-review-campaigns/{id}", catalogHandler.GetAccessReviewCampaignProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/access-review-campaigns/{id}", catalogHandler.UpdateAccessReviewCampaignProxy)
+			r.Get("/access-review-campaigns/{id}/items/pending-count", catalogHandler.CountPendingAccessReviewItemsProxy)
+			r.Get("/access-review-campaigns/{id}/items", catalogHandler.ListAccessReviewItemsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/access-review-campaigns/{id}/items", catalogHandler.CreateAccessReviewItemsProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary
- Implements `RemoteStorage` support for Access Review Campaigns (ISO 27001 A.5.18, part of #519): new thin passthrough routes under `/api/v1/system/access-review-campaigns` (gated `system.read`/`system.write`, no new privilege class), replacing the 11 `remoteUnsupported` stubs in `internal/storage/store/remote_access_review_campaigns.go`.
- The existing human-facing `CatalogHandler` routes bake in real business logic (snapshotting the live access review into items, reviewer-independence checks, revoke-on-decision) — confirmed the wrong proxy target (#514-class check) and built new thin routes instead.
- Atomicity: `UpdateAccessReviewCampaign`/`UpdateAccessReviewItem` are each already a single conditional `UPDATE ... WHERE <precondition>` on the local side, with the result threaded back as a bool — the guarantee lives inside one storage call, so a single proxied round trip preserves it exactly. No new atomic primitive needed. Proven via a real 16-way concurrent-close test through the router (exactly one winner).

## Residual (out of scope)
- `DeleteClosedAccessReviewsBefore` (retention-purge sweep) is stubbed separately in `remote_secrets.go` alongside other `Purge*`/`Delete*Before` methods — a distinct, uniformly-stubbed retention subsystem, left out of scope here.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./internal/storage/store/... ./server/http/...` pass; `./internal/core/...` passes except the known pre-existing `TestConcurrency_RequestPasswordReset_BurstIsThrottled` flake (unrelated, reproduced independent of this change)
- [x] New `server/http/remote_storage_access_review_campaigns_test.go`: 7 tests incl. items round-trip, reject-when-already-closed/decided, and a 16-way concurrent-close race
- [x] `gosec -severity medium -exclude-generated` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)