### PR TITLE
fix(remote-storage): implement legal hold storage primitives (#519)

### DIFF
--- a/internal/storage/store/remote_legal_hold.go
+++ b/internal/storage/store/remote_legal_hold.go
@@ -1,21 +1,140 @@
-// remote_legal_hold.go — legal hold for RemoteStorage. Processed server-side;
-// stubs here. See local_legal_hold.go.
+// remote_legal_hold.go — deployment-wide legal hold (ISO 27001 A.5.34 /
+// eDiscovery) for RemoteStorage (finding #519).
+//
+// CreateLegalHold/GetActiveLegalHold/UpdateLegalHold are thin passthroughs onto
+// three new server-side routes under /api/v1/system/legal-hold
+// (server/http/handlers/legal_hold_proxy.go), following the SAME pattern
+// #507/#510/#511 established: gated on the same broad system.read/system.write
+// RBAC permissions a RemoteStorage credential already needs for every other
+// proxied call, so this introduces no new privilege class. No legal-hold POLICY
+// decision (the admin-tier placement gate, the placer-or-admin-tier lift gate,
+// the required-reason validation, the audit events) is made in these routes —
+// that stays entirely in the CALLING server's own internal/core.KeyorixCore
+// (legal_hold.go), exactly as it does against a local backend.
+//
+// Before this fix, every one of these three methods returned
+// ErrRemoteUnsupported, so core.PlaceLegalHold/core.LiftLegalHold/
+// core.IsLegalHoldActive — and therefore every purge/prune scheduler's
+// legalHoldGuard check — hard-failed under storage.type: remote: the purge jobs
+// fail SAFE on that error (they skip the purge rather than risk deleting
+// held data), so the practical effect was "purges never run at all" rather than
+// silent data loss, but the legal-hold control itself was completely
+// non-functional for a remote-storage deployment.
+//
+// Atomicity note (mirrors #511's ProjectMembership precedent):
+// local_legal_hold.go's CreateLegalHold relies on a REAL DB-level partial unique
+// index (uniq_legal_holds_active, `released` WHERE released = false) to reject a
+// second concurrent placement — that guarantee is a property of the upstream's
+// own database and survives this HTTP hop unchanged, since CreateLegalHoldProxy
+// calls the identical storage.Storage primitive against the same table. The
+// resulting storage.ErrLegalHoldAlreadyActive sentinel is translated into a
+// LEGAL_HOLD_ALREADY_ACTIVE wire code (see legalHoldAlreadyActiveCode below) so
+// core.PlaceLegalHold's own errors.Is check is preserved across this HTTP hop.
+// UpdateLegalHold, by contrast, has no conditional-write guarantee even locally
+// (local_legal_hold.go's implementation is a plain GORM Save; the
+// actor/placer-eligibility check is enforced by the CALLING core.KeyorixCore
+// before it ever calls storage.UpdateLegalHold), so a single passthrough PUT is
+// exact behavioral parity with LocalStorage, not a new race introduced here.
+//
+// models.LegalHold already carries full, correct json tags for every field
+// (unlike models.User/ProjectMembership/DynamicSecretConfig, which needed an
+// explicit wire-DTO to avoid GORM-only fields silently dropping out of a direct
+// marshal), so this marshals/unmarshals the model directly — the same
+// direct-marshal precedent remote_rotation_policies.go already uses.
+//
+// For the local (GORM) equivalent of everything here see local_legal_hold.go.
 package store
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
 )
 
-func (rs *RemoteStorage) CreateLegalHold(_ context.Context, _ *models.LegalHold) (*models.LegalHold, error) {
-	return nil, remoteUnsupported("CreateLegalHold")
+// legalHoldAlreadyActiveCode is the machine-readable error code
+// CreateLegalHoldProxy returns when the upstream's own DB-level unique-index
+// rejection (isUniqueConstraintErr, local_legal_hold.go) fires — the wire-level
+// signal RemoteStorage.CreateLegalHold uses to reconstruct the same
+// storage.ErrLegalHoldAlreadyActive sentinel core.PlaceLegalHold's errors.Is
+// check depends on, so that check-and-translate behavior is preserved across
+// this HTTP hop and not silently downgraded to an opaque error.
+const legalHoldAlreadyActiveCode = "LEGAL_HOLD_ALREADY_ACTIVE"
+
+// CreateLegalHold persists an already-built hold row (Reason/PlacedBy/PlacedAt/
+// Released are all computed by the CALLING core.KeyorixCore before this is
+// invoked, exactly as it builds one for LocalStorage) via POST
+// /api/v1/system/legal-hold.
+func (rs *RemoteStorage) CreateLegalHold(ctx context.Context, h *models.LegalHold) (*models.LegalHold, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/legal-hold", h)
+	if err != nil {
+		// #501: makeRequest turns EVERY 4xx/5xx response (including
+		// CreateLegalHoldProxy's 409 Conflict) into a non-nil error before resp
+		// is ever populated, so the already-active signal must be recovered
+		// from the *remote.HTTPError itself (its ErrorType), not from
+		// resp.Error — reconstructing the SAME storage.ErrLegalHoldAlreadyActive
+		// sentinel core.PlaceLegalHold's errors.Is check depends on.
+		var httpErr *remote.HTTPError
+		if errors.As(err, &httpErr) && httpErr.ErrorType == legalHoldAlreadyActiveCode {
+			return nil, fmt.Errorf("%w: %s", storage.ErrLegalHoldAlreadyActive, httpErr.Message)
+		}
+		return nil, fmt.Errorf("failed to create legal hold: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create legal hold failed: %s", resp.Error.Error())
+	}
+	var result models.LegalHold
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &result, nil
 }
 
-func (rs *RemoteStorage) GetActiveLegalHold(_ context.Context) (*models.LegalHold, error) {
-	return nil, remoteUnsupported("GetActiveLegalHold")
+// legalHoldActiveResponse mirrors GetActiveLegalHoldProxy's wire shape
+// ({"active":bool,"hold":...}) — see that handler's doc comment for why a nil
+// (no active hold) result is signalled explicitly rather than as JSON null.
+type legalHoldActiveResponse struct {
+	Active bool              `json:"active"`
+	Hold   *models.LegalHold `json:"hold,omitempty"`
 }
 
-func (rs *RemoteStorage) UpdateLegalHold(_ context.Context, _ *models.LegalHold) error {
-	return remoteUnsupported("UpdateLegalHold")
+// GetActiveLegalHold returns the current un-released hold, or (nil, nil) when
+// none is active, via GET /api/v1/system/legal-hold/active.
+func (rs *RemoteStorage) GetActiveLegalHold(ctx context.Context) (*models.LegalHold, error) {
+	resp, err := rs.client.Get(ctx, "/api/v1/system/legal-hold/active")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active legal hold: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get active legal hold failed: %s", resp.Error.Error())
+	}
+	var result legalHoldActiveResponse
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	if !result.Active {
+		return nil, nil
+	}
+	return result.Hold, nil
+}
+
+// UpdateLegalHold persists a hold's current state (e.g. LiftLegalHold's
+// Released/ReleasedBy/ReleasedAt/ReleaseReason) via PUT
+// /api/v1/system/legal-hold/{id} — a single round trip mapping directly onto
+// local_legal_hold.go's plain Save (see the package doc: there is no
+// conditional-write guarantee to preserve here).
+func (rs *RemoteStorage) UpdateLegalHold(ctx context.Context, h *models.LegalHold) error {
+	path := fmt.Sprintf("/api/v1/system/legal-hold/%d", h.ID)
+	resp, err := rs.client.Put(ctx, path, h)
+	if err != nil {
+		return fmt.Errorf("failed to update legal hold: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("update legal hold failed: %s", resp.Error.Error())
+	}
+	return nil
 }

--- a/server/http/handlers/legal_hold_proxy.go
+++ b/server/http/handlers/legal_hold_proxy.go
@@ -1,0 +1,154 @@
+// legal_hold_proxy.go — server-side endpoints backing RemoteStorage's
+// CreateLegalHold/GetActiveLegalHold/UpdateLegalHold (finding #519).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// its deployment-wide legal-hold storage calls to whichever upstream server it's
+// configured against, through these three routes (registered in
+// server/http/router.go under /api/v1/system/legal-hold, gated on the existing
+// system.read/system.write RBAC permissions — the SAME credential a RemoteStorage
+// client already needs for every other proxied call, e.g. full user CRUD, so this
+// introduces no new privilege class). Mirrors dynamic_secrets_proxy.go and
+// project_memberships_proxy.go exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/legal_hold.go already uses against a local backend — NO
+// legal-hold POLICY decision (the admin-tier placement gate, the
+// placer-or-admin-tier lift gate, the required-reason validation, the audit
+// events) is made here; that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore, exactly as it does against a local backend. This
+// file only persists/returns the raw legal_holds row.
+//
+// This also means the DashboardHandler's existing human-facing
+// /api/v1/legal-hold routes (server/http/handlers/legal_hold.go: GetLegalHold/
+// PlaceLegalHold/LiftLegalHold) are NOT reused for this proxy: PlaceLegalHold
+// there enforces the admin-tier-actor check and required-reason validation, and
+// LiftLegalHold enforces the placer-or-admin-tier check, against THIS server's
+// own HTTP caller identity — the wrong semantics for a raw storage-primitive
+// passthrough, whose caller (the downstream server's own core.KeyorixCore) has
+// already run all of that against ITS OWN caller and only needs this server to
+// persist/return the resulting row (exactly the same class of mistake the
+// human-facing /groups routes were for #514).
+//
+// models.LegalHold already carries full, correct json tags for every field
+// (unlike models.User/ProjectMembership/DynamicSecretConfig, which needed an
+// explicit wire-DTO to avoid GORM-only fields silently dropping out of a direct
+// marshal) — see internal/storage/store/remote_rotation_policies.go for the same
+// direct-marshal precedent used here.
+//
+// Atomicity note: CreateLegalHold relies on a REAL DB-level partial unique index
+// (uniq_legal_holds_active, `released` WHERE released = false — see
+// factory.go's ensureLegalHoldActiveIndex and local_legal_hold.go) to reject a
+// second concurrent placement — that guarantee is a property of the upstream's
+// own database and survives this HTTP hop unchanged, since
+// CreateLegalHoldProxy calls the identical storage.Storage primitive against the
+// same table. Mirroring #511's ProjectMembership precedent, the unique-index
+// rejection (surfaced locally as storage.ErrLegalHoldAlreadyActive) is translated
+// into a LEGAL_HOLD_ALREADY_ACTIVE wire code so the client reconstructs the same
+// sentinel core.PlaceLegalHold's errors.Is check depends on, rather than
+// downgrading it to an opaque error. UpdateLegalHold, by contrast, is a plain
+// unconditional Save (local_legal_hold.go) with no conditional-write guarantee to
+// preserve — core.LiftLegalHold already re-fetches the hold and checks
+// actor/placer eligibility before mutating it, exactly as it does against a
+// local backend.
+//
+// Response envelope: like dynamic_secrets_proxy.go/project_memberships_proxy.go,
+// these do NOT use the package's generic sendSuccess/sendError helpers — they
+// construct the exact {"success":bool,"data":...,"error":{"code","message"}}
+// shape internal/storage/remote.HTTPClient parses (its APIResponse/APIError
+// types).
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// legalHoldAlreadyActiveCode is the machine-readable error code returned when
+// storage.CreateLegalHold fails with storage.ErrLegalHoldAlreadyActive (the
+// upstream's own DB-level partial-unique-index rejection, local_legal_hold.go) —
+// matches internal/storage/store/remote_legal_hold.go's
+// legalHoldAlreadyActiveCode constant, the wire contract the RemoteStorage
+// client checks for to reconstruct the sentinel client-side.
+const legalHoldAlreadyActiveCode = "LEGAL_HOLD_ALREADY_ACTIVE"
+
+// CreateLegalHoldProxy handles POST /api/v1/system/legal-hold. Persists the
+// caller's already-fully-built hold row as-is (a raw storage-layer create) — the
+// admin-tier placement gate and required-reason validation already ran in the
+// CALLING server's own core.PlaceLegalHold before this is ever invoked.
+func (h *DashboardHandler) CreateLegalHoldProxy(w http.ResponseWriter, r *http.Request) {
+	var body models.LegalHold
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Reason == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "reason is required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateLegalHold(r.Context(), &body)
+	if err != nil {
+		if errors.Is(err, storage.ErrLegalHoldAlreadyActive) {
+			writeRemoteAPIError(w, http.StatusConflict, legalHoldAlreadyActiveCode, storage.ErrLegalHoldAlreadyActive.Error())
+			return
+		}
+		log.Printf("legal-hold proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, created)
+}
+
+// legalHoldActiveResponse mirrors GetLegalHold's own human-facing response shape
+// ({"active":bool,"hold":...}) so a nil (no active hold) result is distinguished
+// from an empty/zero-value row, rather than encoding a nil *models.LegalHold as
+// JSON null and forcing the client to special-case that.
+type legalHoldActiveResponse struct {
+	Active bool              `json:"active"`
+	Hold   *models.LegalHold `json:"hold,omitempty"`
+}
+
+// GetActiveLegalHoldProxy handles GET /api/v1/system/legal-hold/active.
+func (h *DashboardHandler) GetActiveLegalHoldProxy(w http.ResponseWriter, r *http.Request) {
+	hold, err := h.coreService.Storage().GetActiveLegalHold(r.Context())
+	if err != nil {
+		log.Printf("legal-hold proxy: get active failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	if hold == nil {
+		writeRemoteAPISuccess(w, legalHoldActiveResponse{Active: false})
+		return
+	}
+	writeRemoteAPISuccess(w, legalHoldActiveResponse{Active: true, Hold: hold})
+}
+
+// UpdateLegalHoldProxy handles PUT /api/v1/system/legal-hold/{id}. A raw persist
+// (storage.Storage.UpdateLegalHold is an unconditional full-row Save, matching
+// LocalStorage's own semantics exactly — see the package doc for why there is no
+// conditional-write guarantee to preserve here).
+func (h *DashboardHandler) UpdateLegalHoldProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid legal hold id")
+		return
+	}
+	var body models.LegalHold
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	if err := h.coreService.Storage().UpdateLegalHold(r.Context(), &body); err != nil {
+		log.Printf("legal-hold proxy: update failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -94,6 +94,9 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		&models.MFASecret{},
 		&models.MFARecoveryCode{},
 		&models.MFAChallenge{},
+		// finding #519: the legal-hold-proxy end-to-end tests exercise LegalHold
+		// CRUD through the real router.
+		&models.LegalHold{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the
@@ -105,6 +108,12 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 	// isUniqueViolation branch depends on.
 	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_project_memberships_active "+
 		"ON project_memberships (project_id, user_id) WHERE state <> 'revoked'").Error)
+	// Mirror internal/storage/factory.go's ensureLegalHoldActiveIndex exactly: without
+	// this partial unique index, the legal-hold-proxy test exercising the
+	// "already active" rejection path would silently miss the real DB-level guard
+	// CreateLegalHold's isUniqueConstraintErr branch depends on.
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_legal_holds_active "+
+		"ON legal_holds (released) WHERE released = false").Error)
 	return core.NewKeyorixCore(store.NewLocalStorage(db))
 }
 

--- a/server/http/remote_storage_legal_hold_test.go
+++ b/server/http/remote_storage_legal_hold_test.go
@@ -1,0 +1,202 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForLegalHold builds the standard #452/#507/#510/#511
+// two-server harness: an "upstream" exercised through the REAL production
+// NewRouter/handlers (including the new /api/v1/system/legal-hold routes,
+// server/http/handlers/legal_hold_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed at
+// "upstream" over real HTTP via store.RemoteStorage. Mirrors
+// newUpstreamDownstreamForMemberships exactly.
+func newUpstreamDownstreamForLegalHold(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	return upstream, downstream
+}
+
+// TestRemoteStorageLegalHold_CreateGetUpdate_RealServer proves finding #519's
+// fix: a legal hold is genuinely persisted on the upstream server via the
+// DOWNSTREAM's RemoteStorage, fetchable as the active hold, and its lift
+// (release) round-trips too — all via storage.type: remote against a real
+// router, not a protocol mock.
+func TestRemoteStorageLegalHold_CreateGetUpdate_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForLegalHold(t)
+	ctx := context.Background()
+
+	// No hold active yet.
+	active, err := downstream.Storage().GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, active, "no hold should be active initially")
+
+	placedAt := time.Now()
+	hold, err := downstream.Storage().CreateLegalHold(ctx, &models.LegalHold{
+		Reason: "litigation hold: Doe v. Acme", PlacedBy: 1, PlacedAt: placedAt, Released: false,
+	})
+	require.NoError(t, err, "creating a legal hold must succeed via storage.type: remote")
+	require.NotZero(t, hold.ID, "the upstream must assign a real ID")
+	assert.Equal(t, "litigation hold: Doe v. Acme", hold.Reason)
+	assert.Equal(t, uint(1), hold.PlacedBy)
+	assert.False(t, hold.Released)
+
+	// Confirm it is a REAL row in the upstream's own storage (not just "the call
+	// didn't error"), by reading it back directly against upstream.
+	direct, err := upstream.Storage().GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, direct)
+	assert.Equal(t, hold.ID, direct.ID)
+
+	// GetActiveLegalHold via the downstream (RemoteStorage) round-trips every
+	// field correctly.
+	fetched, err := downstream.Storage().GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, fetched)
+	assert.Equal(t, hold.ID, fetched.ID)
+	assert.Equal(t, hold.Reason, fetched.Reason)
+	assert.Equal(t, hold.PlacedBy, fetched.PlacedBy)
+	assert.WithinDuration(t, placedAt, fetched.PlacedAt, time.Second)
+	assert.False(t, fetched.Released)
+
+	// Lift it: UpdateLegalHold is a plain full-row Save (see the package doc),
+	// so this round-trips Released/ReleasedBy/ReleasedAt/ReleaseReason.
+	releasedAt := time.Now()
+	fetched.Released = true
+	fetched.ReleasedBy = 2
+	fetched.ReleasedAt = &releasedAt
+	fetched.ReleaseReason = "case settled"
+	require.NoError(t, downstream.Storage().UpdateLegalHold(ctx, fetched))
+
+	// No hold should be reported as active anymore.
+	afterLift, err := downstream.Storage().GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, afterLift, "a released hold must not be reported as active")
+
+	// Directly against the upstream's own storage too, proving this isn't an
+	// artifact of RemoteStorage's response cache.
+	directAfterLift, err := upstream.Storage().GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, directAfterLift)
+}
+
+// TestRemoteStorageLegalHold_AlreadyActive_RealServer proves the real DB-level
+// partial unique index (uniq_legal_holds_active, `released` WHERE
+// released = false) is still enforced across the HTTP hop, AND that
+// CreateLegalHoldProxy translates the resulting unique-constraint violation
+// into the SAME storage.ErrLegalHoldAlreadyActive sentinel core.PlaceLegalHold's
+// errors.Is check depends on — not an opaque, unclassifiable storage error.
+func TestRemoteStorageLegalHold_AlreadyActive_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForLegalHold(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().CreateLegalHold(ctx, &models.LegalHold{
+		Reason: "first hold", PlacedBy: 1, PlacedAt: time.Now(), Released: false,
+	})
+	require.NoError(t, err)
+
+	// A second, concurrent-in-spirit placement attempt must be rejected by the
+	// upstream's real DB-level unique index, and the rejection must reconstruct
+	// as storage.ErrLegalHoldAlreadyActive on this side of the HTTP hop.
+	_, err = downstream.Storage().CreateLegalHold(ctx, &models.LegalHold{
+		Reason: "second hold", PlacedBy: 2, PlacedAt: time.Now(), Released: false,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, coreStorage.ErrLegalHoldAlreadyActive),
+		"a duplicate active legal hold must surface as storage.ErrLegalHoldAlreadyActive, not an opaque error: %v", err)
+}
+
+// TestRemoteStorageLegalHold_ConcurrentCreate_OnlyOneWins_RealServer is the
+// concurrency proof for the TOCTOU race core.PlaceLegalHold's own doc comment
+// describes (#305): many concurrent CreateLegalHold calls through the SAME
+// downstream RemoteStorage client race to place a hold; the real upstream
+// database's partial unique index must let exactly one commit, with every
+// other caller observing storage.ErrLegalHoldAlreadyActive — never two active
+// holds, and never a caller silently swallowing an error and believing its own
+// placement won when it didn't.
+func TestRemoteStorageLegalHold_ConcurrentCreate_OnlyOneWins_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForLegalHold(t)
+	ctx := context.Background()
+
+	const n = 10
+	var wg sync.WaitGroup
+	successes := make([]bool, n)
+	alreadyActive := make([]bool, n)
+	otherErrs := make([]error, n)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := downstream.Storage().CreateLegalHold(ctx, &models.LegalHold{
+				Reason: "race", PlacedBy: uint(i + 1), PlacedAt: time.Now(), Released: false,
+			})
+			switch {
+			case err == nil:
+				successes[i] = true
+			case errors.Is(err, coreStorage.ErrLegalHoldAlreadyActive):
+				alreadyActive[i] = true
+			default:
+				otherErrs[i] = err
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	successCount := 0
+	for i := 0; i < n; i++ {
+		require.NoError(t, otherErrs[i], "every non-winning call must fail specifically with ErrLegalHoldAlreadyActive, not an opaque error")
+		if successes[i] {
+			successCount++
+		}
+	}
+	assert.Equal(t, 1, successCount, "exactly one concurrent placement must win")
+	for i := 0; i < n; i++ {
+		assert.True(t, successes[i] || alreadyActive[i], "every call must either win or observe ErrLegalHoldAlreadyActive")
+	}
+
+	// The upstream's own storage must show exactly one active hold, not zero
+	// (silently lost) and not more than one (the race actually won).
+	active, err := upstream.Storage().GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, active)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -961,6 +961,30 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/project-memberships", catalogHandler.ListMembershipsProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/project-memberships", catalogHandler.CreateMembershipProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Put("/project-memberships/{id}", catalogHandler.UpdateMembershipProxy)
+
+			// Legal-hold storage-primitive proxy (finding #519). Lets a downstream
+			// Keyorix server booted with storage.type: remote (ADR-049) proxy
+			// CreateLegalHold/GetActiveLegalHold/UpdateLegalHold to THIS server's real
+			// storage backend, instead of RemoteStorage's three legal-hold methods
+			// having no server endpoint to call at all (core.PlaceLegalHold/
+			// LiftLegalHold/IsLegalHoldActive — and therefore every purge/prune
+			// scheduler's legalHoldGuard check — were completely non-functional under
+			// storage.type: remote; the schedulers fail SAFE on that error, so the
+			// practical effect was "purges never run" rather than silent data loss,
+			// but the legal-hold control itself did not work). Exactly the same
+			// pattern as the project-membership proxy above: a thin passthrough onto
+			// storage.Storage (no legal-hold POLICY decision — the admin-tier
+			// placement gate, the placer-or-admin-tier lift gate, the required-reason
+			// validation, the audit events — is made here; that stays entirely in the
+			// CALLING server's own internal/core.KeyorixCore, exactly as it does
+			// against a local backend), reusing the SAME system.read/system.write
+			// tier — no new privilege class. There is no competing GET "{id}" route
+			// at this depth (unlike groups/project-memberships, this subsystem has
+			// only ever one active row, looked up by "active" rather than by ID), so
+			// route registration order here is purely cosmetic.
+			r.Get("/legal-hold/active", dashboardHandler.GetActiveLegalHoldProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/legal-hold", dashboardHandler.CreateLegalHoldProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/legal-hold/{id}", dashboardHandler.UpdateLegalHoldProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary
- Implements `RemoteStorage` support for Legal Hold (part of #519): new thin passthrough routes under `/api/v1/system/legal-hold` (gated `system.read`/`system.write`, no new privilege class), replacing the 3 `remoteUnsupported` stubs in `internal/storage/store/remote_legal_hold.go`.
- The existing human-facing routes bake in real policy (admin-tier placement/lift gates, required-reason validation, audit events) — confirmed the wrong proxy target (#514-class check) and built new thin routes instead.
- Atomicity: `CreateLegalHold` relies on a real DB-level partial unique index (`uniq_legal_holds_active`) to reject concurrent placement (#305's documented TOCTOU) — that guarantee is a property of the upstream's own table and survives the HTTP hop unchanged. The resulting `ErrLegalHoldAlreadyActive` sentinel is translated across the wire via a `LEGAL_HOLD_ALREADY_ACTIVE` 409 code and reconstructed client-side, mirroring #511's pattern. Proven via a 10-way concurrent-create test (exactly one winner, everyone else gets the sentinel, never an opaque error).

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./internal/storage/store/... ./internal/core/... ./server/http/...` pass
- [x] New `server/http/remote_storage_legal_hold_test.go`: create/get/update round-trip, already-active rejection, 10-way concurrent-create race
- [x] `gosec -severity medium -exclude-generated` — 0 issues (589 files, 109431 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)