### PR TITLE
fix(remote-storage): implement WebAuthn storage primitives (#517)

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -2026,6 +2026,9 @@ func (m *MockStorage) LockWebAuthnCredentialForUpdate(_ context.Context, _ []byt
 func (m *MockStorage) UpdateWebAuthnCredential(_ context.Context, _ *models.WebAuthnCredential) error {
 	return nil
 }
+func (m *MockStorage) AdvanceWebAuthnCredentialCounter(_ context.Context, _ []byte, _ uint, _ []byte, _ uint32, _ time.Time) (bool, error) {
+	return false, nil
+}
 func (m *MockStorage) DeleteWebAuthnCredential(_ context.Context, _, _ uint) error { return nil }
 func (m *MockStorage) CountWebAuthnCredentials(_ context.Context, _ uint) (int64, error) {
 	return 0, nil

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -904,14 +904,52 @@ type Storage interface {
 	// fetch (#307).
 	GetWebAuthnCredentialByCredID(ctx context.Context, credentialID []byte, userID uint) (*models.WebAuthnCredential, error)
 	// LockWebAuthnCredentialForUpdate re-reads a WebAuthn credential by (credential_id,
-	// user_id) inside a WithTransaction, taking a row-level write lock on backends that
-	// support one (Postgres: SELECT … FOR UPDATE), so a read-modify-write of the
-	// advanced signature counter serializes against a concurrent write for the same
-	// credential — closing the cloned-authenticator race where two concurrent
-	// authentications both read the stale counter and the last UPDATE silently wins,
-	// suppressing the clone-detection audit signal (#306).
+	// user_id), taking a row-level write lock on backends that support one
+	// (Postgres: SELECT … FOR UPDATE). This is now an ORDINARY (non-atomic) read
+	// primitive: it and UpdateWebAuthnCredential remain for callers that read/write a
+	// credential outside the signature-counter race (e.g. a plain lookup, or
+	// rejectIfCloned's best-effort "mark disabled" write, whose worst outcome under a
+	// lost race is a harmless redundant write, not a security regression). The
+	// counter-advance path that USED to compose these two into a single
+	// WithTransaction call (closing the cloned-authenticator race, #306) now goes
+	// through AdvanceWebAuthnCredentialCounter below instead, which performs the
+	// lock+compare+write as ONE atomic storage-layer call — required because
+	// RemoteStorage.WithTransaction is a no-op passthrough (see
+	// internal/storage/store/remote_transaction.go): composing
+	// LockWebAuthnCredentialForUpdate + UpdateWebAuthnCredential as two separate
+	// remote calls would reopen the exact TOCTOU race the transaction was built to
+	// prevent.
 	LockWebAuthnCredentialForUpdate(ctx context.Context, credentialID []byte, userID uint) (*models.WebAuthnCredential, error)
 	UpdateWebAuthnCredential(ctx context.Context, c *models.WebAuthnCredential) error
+	// AdvanceWebAuthnCredentialCounter conditionally persists an advanced signature
+	// counter (newBlob/newSignCount) and lastUsedAt for the credential identified by
+	// (credentialID, userID), IFF newSignCount is not stale relative to whatever
+	// counter is CURRENTLY persisted — the single atomic primitive
+	// persistUpdatedCredential (internal/core/webauthn.go) is built on to close the
+	// cloned-authenticator race (#306/#517): two concurrent logins asserting the same
+	// credential must never let the loser's stale, lower counter clobber the
+	// winner's already-persisted higher one. "Not stale" mirrors go-webauthn's own
+	// Authenticator.UpdateCounter gate exactly: a (0, 0) comparison (many platform
+	// authenticators never implement a counter and always report 0) is never
+	// stale — only reject when at least one side is nonzero and newSignCount fails to
+	// strictly exceed the row's current stored count.
+	//
+	// LocalStorage implements this as a single row-locked transaction (the exact
+	// Lock+compare+Update sequence persistUpdatedCredential used to run inline, moved
+	// down into this one storage-layer call so ALL backends — not just
+	// RemoteStorage — get it for free). RemoteStorage implements it as ONE HTTP call
+	// whose SERVER-SIDE handler performs the identical locked compare-and-swap
+	// against its OWN storage in a single request: the real atomicity is achieved
+	// server-side inside that one call, not via any client-side multi-step
+	// transaction (RemoteStorage.WithTransaction cannot provide one — it is a no-op
+	// passthrough).
+	//
+	// Returns advanced=false, err=nil (not an error) when the write was skipped as
+	// stale — a benign, expected outcome of losing a race, not a failure — mirroring
+	// persistUpdatedCredential's pre-existing best-effort semantics (a write failure
+	// here must never fail an otherwise-valid login). err is reserved for a genuine
+	// storage-layer failure (e.g. the credential row doesn't exist).
+	AdvanceWebAuthnCredentialCounter(ctx context.Context, credentialID []byte, userID uint, newBlob []byte, newSignCount uint32, lastUsedAt time.Time) (advanced bool, err error)
 	DeleteWebAuthnCredential(ctx context.Context, userID, id uint) error
 	CountWebAuthnCredentials(ctx context.Context, userID uint) (int64, error)
 	SetUserWebAuthnEnabled(ctx context.Context, userID uint, enabled bool) error

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
-	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -503,13 +502,18 @@ func (c *KeyorixCore) rejectIfCloned(ctx context.Context, userID uint, cred *web
 // predicate, a blind Save would let the loser's stale (lower) counter overwrite the
 // winner's already-persisted higher one — last UPDATE wins — silently regressing the
 // on-disk counter and suppressing the clone-detection audit signal on subsequent
-// logins (#306). webauthnCredentialMu serializes same-process callers (and so the
-// whole single-process SQLite case); combined with the row lock
-// LockWebAuthnCredentialForUpdate takes on Postgres, the read-validate-write stays
-// correct across replicas too. Inside the transaction the counter check is re-done
-// against the row's CURRENT persisted value (re-read under the lock), not the value
-// `cred` was validated against at the top of Finish*Login, so only a genuinely higher
-// counter is ever persisted.
+// logins (#306). The actual read-validate-write now happens in ONE atomic
+// storage-layer call, storage.Storage.AdvanceWebAuthnCredentialCounter (#517) — see
+// its doc (internal/core/storage/interface.go) for why this had to move down a
+// layer: RemoteStorage.WithTransaction is a no-op passthrough (each remote call is
+// independent), so composing LockWebAuthnCredentialForUpdate + UpdateWebAuthnCredential
+// as two separate remote round trips (as this function used to, against
+// LocalStorage only) would reopen the exact TOCTOU race the transaction was built to
+// prevent. webauthnCredentialMu still serializes same-process callers (belt-and-
+// suspenders for the single-process SQLite case, where AdvanceWebAuthnCredentialCounter's
+// own row lock is a no-op); combined with LocalStorage's row lock on Postgres, or the
+// upstream server's own equivalent lock for a storage.type: remote deployment, the
+// counter stays monotonic across replicas too.
 func (c *KeyorixCore) persistUpdatedCredential(ctx context.Context, userID uint, cred *webauthn.Credential) {
 	blob, err := json.Marshal(cred)
 	if err != nil {
@@ -520,32 +524,7 @@ func (c *KeyorixCore) persistUpdatedCredential(ctx context.Context, userID uint,
 	c.webauthnCredentialMu.Lock()
 	defer c.webauthnCredentialMu.Unlock()
 
-	_ = c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
-		row, err := tx.LockWebAuthnCredentialForUpdate(ctx, cred.ID, userID)
-		if err != nil {
-			return err
-		}
-		var stored webauthn.Credential
-		if err := json.Unmarshal(row.CredentialBlob, &stored); err != nil {
-			return err
-		}
-		// Mirrors go-webauthn's own Authenticator.UpdateCounter gate: many platform
-		// authenticators (Touch ID, Windows Hello, and most passkeys) never implement a
-		// counter and always report 0, so a (0, 0) comparison must NOT be treated as
-		// stale — that would silently stop LastUsedAt/blob updates from ever persisting
-		// again for the common case. Only reject when at least one side is nonzero and
-		// the new value fails to advance past the row's CURRENT stored value.
-		newCount, storedCount := cred.Authenticator.SignCount, stored.Authenticator.SignCount
-		if newCount <= storedCount && (newCount != 0 || storedCount != 0) {
-			// A concurrent request already advanced the stored counter past (or to) this
-			// assertion's value: this write is stale, so skip it rather than regress the
-			// persisted counter.
-			return nil
-		}
-		row.CredentialBlob = blob
-		row.LastUsedAt = &now
-		return tx.UpdateWebAuthnCredential(ctx, row)
-	})
+	_, _ = c.storage.AdvanceWebAuthnCredentialCounter(ctx, cred.ID, userID, blob, cred.Authenticator.SignCount, now)
 }
 
 func (c *KeyorixCore) auditWebAuthnFailed(ctx context.Context, userID uint, phase string) {

--- a/internal/storage/store/local_webauthn.go
+++ b/internal/storage/store/local_webauthn.go
@@ -4,9 +4,11 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -37,11 +39,15 @@ func (ls *LocalStorage) GetWebAuthnCredentialByCredID(ctx context.Context, crede
 
 // LockWebAuthnCredentialForUpdate re-reads a credential by (credential_id, user_id),
 // taking a row-level write lock on backends that support one (Postgres: SELECT …
-// FOR UPDATE). Used inside WithTransaction so a read-modify-write of the advanced
-// signature counter serializes against a concurrent write for the same credential
-// (#306). On backends without row locks (SQLite) it is a plain scoped read, and the
-// caller is responsible for its own process-level serialization — mirrors
-// LockUserForUpdate.
+// FOR UPDATE). Historically used inside WithTransaction so a read-modify-write of
+// the advanced signature counter serialized against a concurrent write for the same
+// credential (#306) — that specific path now goes through
+// AdvanceWebAuthnCredentialCounter below instead (a single atomic call, required so
+// RemoteStorage — whose WithTransaction is a no-op passthrough — gets the same
+// guarantee, #517). This method remains for callers that need a locked read outside
+// that race (e.g. rejectIfCloned's best-effort disable). On backends without row
+// locks (SQLite) it is a plain scoped read, and the caller is responsible for its
+// own process-level serialization — mirrors LockUserForUpdate.
 func (ls *LocalStorage) LockWebAuthnCredentialForUpdate(ctx context.Context, credentialID []byte, userID uint) (*models.WebAuthnCredential, error) {
 	q := ls.db.WithContext(ctx)
 	if ls.db.Dialector.Name() == "postgres" {
@@ -56,6 +62,62 @@ func (ls *LocalStorage) LockWebAuthnCredentialForUpdate(ctx context.Context, cre
 
 func (ls *LocalStorage) UpdateWebAuthnCredential(ctx context.Context, c *models.WebAuthnCredential) error {
 	return ls.db.WithContext(ctx).Save(c).Error
+}
+
+// webauthnStoredCounter decodes just the one field this package needs out of a
+// WebAuthnCredential.CredentialBlob (the JSON-serialized go-webauthn Credential) —
+// deliberately NOT the full github.com/go-webauthn/webauthn.Credential type, so this
+// storage-layer package doesn't need to import that library merely to read back a
+// uint32 it never otherwise interprets. The field name mirrors go-webauthn's own
+// Authenticator.SignCount json tag (`json:"signCount,omitempty"`,
+// webauthn/authenticator.go) exactly; encoding/json ignores every other field in the
+// blob it doesn't recognize.
+type webauthnStoredCounter struct {
+	Authenticator struct {
+		SignCount uint32 `json:"signCount"`
+	} `json:"authenticator"`
+}
+
+// AdvanceWebAuthnCredentialCounter is the storage.Storage primitive
+// persistUpdatedCredential (internal/core/webauthn.go) is built on: it conditionally
+// persists newBlob/lastUsedAt for the credential identified by (credentialID,
+// userID) IFF newSignCount is not stale relative to whatever counter is CURRENTLY
+// persisted, all inside ONE row-locked transaction — extracted, unchanged in
+// behavior, from what persistUpdatedCredential used to run inline via
+// WithTransaction(Lock+compare+Update) (#306), just moved down a layer so every
+// backend gets it for free, not only LocalStorage (#517). See the interface doc
+// (internal/core/storage/interface.go) for the full contract, including the (0, 0)
+// "authenticator doesn't implement a counter" carve-out.
+func (ls *LocalStorage) AdvanceWebAuthnCredentialCounter(ctx context.Context, credentialID []byte, userID uint, newBlob []byte, newSignCount uint32, lastUsedAt time.Time) (bool, error) {
+	advanced := false
+	err := ls.WithTransaction(ctx, func(tx storage.Storage) error {
+		row, err := tx.LockWebAuthnCredentialForUpdate(ctx, credentialID, userID)
+		if err != nil {
+			return err
+		}
+		var stored webauthnStoredCounter
+		if err := json.Unmarshal(row.CredentialBlob, &stored); err != nil {
+			return err
+		}
+		storedCount := stored.Authenticator.SignCount
+		if newSignCount <= storedCount && (newSignCount != 0 || storedCount != 0) {
+			// A concurrent writer already advanced the stored counter past (or to)
+			// this candidate: stale, so skip the write rather than regress the
+			// persisted counter.
+			return nil
+		}
+		row.CredentialBlob = newBlob
+		row.LastUsedAt = &lastUsedAt
+		if err := tx.UpdateWebAuthnCredential(ctx, row); err != nil {
+			return err
+		}
+		advanced = true
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return advanced, nil
 }
 
 // DeleteWebAuthnCredential removes one of the user's credentials (scoped by user

--- a/internal/storage/store/remote_mfa.go
+++ b/internal/storage/store/remote_mfa.go
@@ -9,6 +9,11 @@
 // server that can decrypt it — GetMFASecret below stays an unconditional stub
 // for that reason — so the ENTIRE TOTP/recovery-code check, not just a wire-DTO
 // passthrough of the storage primitives above, has to run upstream.
+//
+// WebAuthn's storage.Storage primitives are DIFFERENT from MFA's: see
+// remote_webauthn.go — a passkey's public key and ceremony session state are not
+// secret the way a TOTP shared secret is, so WebAuthn is an ordinary CRUD/wire-DTO
+// passthrough, not a verification proxy (#517).
 package store
 
 import (
@@ -70,39 +75,6 @@ func (rs *RemoteStorage) ConsumeMFAChallenge(_ context.Context, _ string, _ time
 
 func (rs *RemoteStorage) GetActiveMFAChallenge(_ context.Context, _ string, _ time.Time) (*models.MFAChallenge, error) {
 	return nil, remoteUnsupported("GetActiveMFAChallenge")
-}
-
-// WebAuthn persistence is server-side only (ADR-036); the remote client manages
-// passkeys through the server's REST API, not the storage interface directly.
-func (rs *RemoteStorage) CreateWebAuthnCredential(_ context.Context, _ *models.WebAuthnCredential) error {
-	return remoteUnsupported("CreateWebAuthnCredential")
-}
-func (rs *RemoteStorage) ListWebAuthnCredentials(_ context.Context, _ uint) ([]*models.WebAuthnCredential, error) {
-	return nil, remoteUnsupported("ListWebAuthnCredentials")
-}
-func (rs *RemoteStorage) GetWebAuthnCredentialByCredID(_ context.Context, _ []byte, _ uint) (*models.WebAuthnCredential, error) {
-	return nil, remoteUnsupported("GetWebAuthnCredentialByCredID")
-}
-func (rs *RemoteStorage) LockWebAuthnCredentialForUpdate(_ context.Context, _ []byte, _ uint) (*models.WebAuthnCredential, error) {
-	return nil, remoteUnsupported("LockWebAuthnCredentialForUpdate")
-}
-func (rs *RemoteStorage) UpdateWebAuthnCredential(_ context.Context, _ *models.WebAuthnCredential) error {
-	return remoteUnsupported("UpdateWebAuthnCredential")
-}
-func (rs *RemoteStorage) DeleteWebAuthnCredential(_ context.Context, _, _ uint) error {
-	return remoteUnsupported("DeleteWebAuthnCredential")
-}
-func (rs *RemoteStorage) CountWebAuthnCredentials(_ context.Context, _ uint) (int64, error) {
-	return 0, remoteUnsupported("CountWebAuthnCredentials")
-}
-func (rs *RemoteStorage) SetUserWebAuthnEnabled(_ context.Context, _ uint, _ bool) error {
-	return remoteUnsupported("SetUserWebAuthnEnabled")
-}
-func (rs *RemoteStorage) CreateWebAuthnSession(_ context.Context, _ *models.WebAuthnSession) error {
-	return remoteUnsupported("CreateWebAuthnSession")
-}
-func (rs *RemoteStorage) ConsumeWebAuthnSession(_ context.Context, _ string, _ time.Time) (*models.WebAuthnSession, error) {
-	return nil, remoteUnsupported("ConsumeWebAuthnSession")
 }
 
 // issueMFAChallengeWireResponse carries only the opaque challenge token: the

--- a/internal/storage/store/remote_webauthn.go
+++ b/internal/storage/store/remote_webauthn.go
@@ -1,0 +1,413 @@
+// remote_webauthn.go — WebAuthn / passkey storage primitives for RemoteStorage
+// (ADR-036/ADR-049, finding #517): thin CRUD passthroughs onto new server-side
+// routes under /api/v1/system/webauthn (server/http/handlers/webauthn_proxy.go),
+// gated on the SAME broad system.read/system.write RBAC permissions a
+// RemoteStorage credential already needs for every other proxied call (dynamic
+// secrets, groups, project memberships, setup tokens, invitations, login
+// attempts) — so this introduces no new privilege class.
+//
+// Unlike remote_mfa.go's TOTP methods (IssueMFAChallenge/VerifyMFALoginCredentials,
+// a verification PROXY: the raw TOTP secret must never leave the server that can
+// decrypt it, so the entire check runs upstream), WebAuthn's registered-credential
+// public key and its in-flight ceremony session state are not secret — a spoke
+// server that holds a credential row can verify an assertion against it entirely
+// locally, with no need for the upstream server to do any cryptography on its
+// behalf. So every method here is an ordinary storage-primitive passthrough (no
+// WebAuthn ceremony/ownership/reauth POLICY decision is made in these routes —
+// that stays entirely in the CALLING server's own internal/core.KeyorixCore,
+// exactly as it does against a local backend), matching the Groups/Dynamic-Secrets
+// precedent (remote_groups.go/remote_dynamic.go) rather than the MFA one.
+//
+// The signature-counter race (#306/#517): AdvanceWebAuthnCredentialCounter is the
+// ONE method here that is NOT a plain CRUD passthrough. LockWebAuthnCredentialForUpdate
+// + UpdateWebAuthnCredential remain ordinary (independent, non-atomic) proxies —
+// fine for a plain read or rejectIfCloned's best-effort "mark disabled" write, whose
+// worst outcome under a lost race is a harmless redundant write. But
+// persistUpdatedCredential's read-validate-write of the advanced sign counter
+// (internal/core/webauthn.go) MUST be atomic: RemoteStorage.WithTransaction is a
+// no-op passthrough (remote_transaction.go — each remote call is independent), so
+// composing a plain GET (Lock) and a plain PUT (Update) as two separate remote
+// calls would reopen the exact TOCTOU race a local transaction's row lock exists to
+// close — two concurrent logins could both GET the stale counter, both pass their
+// local staleness check, and the loser's PUT could stomp the winner's
+// already-persisted higher counter, silently defeating clone detection. Instead,
+// AdvanceWebAuthnCredentialCounter is ONE PATCH call whose server-side handler runs
+// the identical locked compare-and-swap against its OWN storage inside that single
+// request — the real atomicity is achieved server-side in one round trip, not
+// client-side across several.
+//
+// For the local (GORM) equivalent of every primitive here see local_webauthn.go.
+package store
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// webAuthnCredentialWire mirrors webAuthnCredentialProxyWire in
+// server/http/handlers/webauthn_proxy.go exactly. models.WebAuthnCredential carries
+// no json tags of its own, so every field is named explicitly rather than relying
+// on encoding/json's case-insensitive fallback (matching every other proxy wire
+// type in this package, e.g. dynamicSecretConfigWire).
+type webAuthnCredentialWire struct {
+	ID             uint       `json:"id"`
+	UserID         uint       `json:"user_id"`
+	CredentialID   []byte     `json:"credential_id"`
+	Name           string     `json:"name"`
+	CredentialBlob []byte     `json:"credential_blob"`
+	CreatedAt      time.Time  `json:"created_at"`
+	LastUsedAt     *time.Time `json:"last_used_at"`
+	Disabled       bool       `json:"disabled"`
+}
+
+func newWebAuthnCredentialWire(c *models.WebAuthnCredential) webAuthnCredentialWire {
+	return webAuthnCredentialWire{
+		ID:             c.ID,
+		UserID:         c.UserID,
+		CredentialID:   c.CredentialID,
+		Name:           c.Name,
+		CredentialBlob: c.CredentialBlob,
+		CreatedAt:      c.CreatedAt,
+		LastUsedAt:     c.LastUsedAt,
+		Disabled:       c.Disabled,
+	}
+}
+
+func (w webAuthnCredentialWire) toModel() *models.WebAuthnCredential {
+	return &models.WebAuthnCredential{
+		ID:             w.ID,
+		UserID:         w.UserID,
+		CredentialID:   w.CredentialID,
+		Name:           w.Name,
+		CredentialBlob: w.CredentialBlob,
+		CreatedAt:      w.CreatedAt,
+		LastUsedAt:     w.LastUsedAt,
+		Disabled:       w.Disabled,
+	}
+}
+
+func decodeWebAuthnCredentialResponse(data []byte) (*models.WebAuthnCredential, error) {
+	var wire webAuthnCredentialWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
+}
+
+// webAuthnSessionWire mirrors webAuthnSessionProxyWire exactly. TokenHash is
+// tagged `json:"-"` on models.WebAuthnSession (to keep it out of USER-facing
+// responses) — irrelevant here, since this is an internal system-to-system wire
+// format gated on system.read/system.write, matching setupTokenWire's identical
+// TokenHash precedent (remote_auth.go).
+type webAuthnSessionWire struct {
+	ID        uint       `json:"id"`
+	UserID    uint       `json:"user_id"`
+	TokenHash string     `json:"token_hash"`
+	Purpose   string     `json:"purpose"`
+	Data      []byte     `json:"data"`
+	ExpiresAt time.Time  `json:"expires_at"`
+	UsedAt    *time.Time `json:"used_at"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+func newWebAuthnSessionWire(s *models.WebAuthnSession) webAuthnSessionWire {
+	return webAuthnSessionWire{
+		ID:        s.ID,
+		UserID:    s.UserID,
+		TokenHash: s.TokenHash,
+		Purpose:   s.Purpose,
+		Data:      s.Data,
+		ExpiresAt: s.ExpiresAt,
+		UsedAt:    s.UsedAt,
+		CreatedAt: s.CreatedAt,
+	}
+}
+
+func (w webAuthnSessionWire) toModel() *models.WebAuthnSession {
+	return &models.WebAuthnSession{
+		ID:        w.ID,
+		UserID:    w.UserID,
+		TokenHash: w.TokenHash,
+		Purpose:   w.Purpose,
+		Data:      w.Data,
+		ExpiresAt: w.ExpiresAt,
+		UsedAt:    w.UsedAt,
+		CreatedAt: w.CreatedAt,
+	}
+}
+
+func decodeWebAuthnSessionResponse(data []byte) (*models.WebAuthnSession, error) {
+	var wire webAuthnSessionWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
+}
+
+// webAuthnCredentialIDQuery base64-encodes a raw (binary) credential ID for use as
+// a URL query value — the same encoding encoding/json already uses for a []byte
+// field, so this is the least surprising choice, and net/url's Encode
+// percent-escapes whatever the base64 alphabet produces, so no character is
+// URL-unsafe in the resulting query string.
+func webAuthnCredentialIDQuery(credentialID []byte) string {
+	return base64.StdEncoding.EncodeToString(credentialID)
+}
+
+// CreateWebAuthnCredential persists a newly-registered passkey via POST
+// /api/v1/system/webauthn/credentials, then copies the upstream-assigned fields
+// (ID, CreatedAt) back into c — mirroring LocalStorage's own GORM Create, which
+// mutates its argument in place, so callers that read c.ID/c.CreatedAt immediately
+// after (e.g. FinishWebAuthnRegistration's audit log) see the real values under
+// either backend.
+func (rs *RemoteStorage) CreateWebAuthnCredential(ctx context.Context, c *models.WebAuthnCredential) error {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/webauthn/credentials", newWebAuthnCredentialWire(c))
+	if err != nil {
+		return fmt.Errorf("failed to create webauthn credential: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("create webauthn credential failed: %s", resp.Error.Error())
+	}
+	created, err := decodeWebAuthnCredentialResponse(resp.Data)
+	if err != nil {
+		return err
+	}
+	*c = *created
+	return nil
+}
+
+// ListWebAuthnCredentials lists a user's registered passkeys via GET
+// /api/v1/system/webauthn/credentials?user_id=X.
+func (rs *RemoteStorage) ListWebAuthnCredentials(ctx context.Context, userID uint) ([]*models.WebAuthnCredential, error) {
+	q := url.Values{}
+	q.Set("user_id", strconv.FormatUint(uint64(userID), 10))
+	path := "/api/v1/system/webauthn/credentials?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list webauthn credentials: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list webauthn credentials failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Credentials []webAuthnCredentialWire `json:"credentials"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.WebAuthnCredential, 0, len(result.Credentials))
+	for _, w := range result.Credentials {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
+}
+
+// GetWebAuthnCredentialByCredID looks up a credential by (credential_id, user_id)
+// via GET /api/v1/system/webauthn/credentials/lookup?user_id=&credential_id=
+// (base64). The query itself requires user_id, so this preserves the local
+// implementation's ownership scoping (#307): a caller cannot fetch another user's
+// credential blob by omitting or forgetting the check.
+func (rs *RemoteStorage) GetWebAuthnCredentialByCredID(ctx context.Context, credentialID []byte, userID uint) (*models.WebAuthnCredential, error) {
+	q := url.Values{}
+	q.Set("user_id", strconv.FormatUint(uint64(userID), 10))
+	q.Set("credential_id", webAuthnCredentialIDQuery(credentialID))
+	path := "/api/v1/system/webauthn/credentials/lookup?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get webauthn credential: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get webauthn credential failed: %s", resp.Error.Error())
+	}
+	return decodeWebAuthnCredentialResponse(resp.Data)
+}
+
+// LockWebAuthnCredentialForUpdate is, over the wire, the SAME plain (uncached-by-
+// this-package, but see HTTPClient.Get's own 5-minute GET cache — an existing,
+// pre-#517 tradeoff shared by every other proxied read in this package, e.g.
+// ListDynamicSecretConfigs) read as GetWebAuthnCredentialByCredID: there is no
+// row lock that could usefully persist across a single, standalone HTTP request
+// with no further statement to serialize against. That's fine — the ONE caller
+// that used to need this method's lock for correctness, persistUpdatedCredential's
+// signature-counter advance, now calls AdvanceWebAuthnCredentialCounter below
+// instead, which achieves real atomicity in one call. This method remains for
+// interface conformance and any caller that just wants the current row (a locked
+// read is a strict superset of a plain one).
+func (rs *RemoteStorage) LockWebAuthnCredentialForUpdate(ctx context.Context, credentialID []byte, userID uint) (*models.WebAuthnCredential, error) {
+	return rs.GetWebAuthnCredentialByCredID(ctx, credentialID, userID)
+}
+
+// UpdateWebAuthnCredential persists the full credential row via PUT
+// /api/v1/system/webauthn/credentials/{id} — an unconditional full-row Save,
+// matching LocalStorage's own semantics exactly. Used by rejectIfCloned's
+// best-effort "mark disabled" write (internal/core/webauthn.go); the
+// signature-counter advance path does NOT use this method — see
+// AdvanceWebAuthnCredentialCounter.
+func (rs *RemoteStorage) UpdateWebAuthnCredential(ctx context.Context, c *models.WebAuthnCredential) error {
+	path := fmt.Sprintf("/api/v1/system/webauthn/credentials/%d", c.ID)
+	resp, err := rs.client.Put(ctx, path, newWebAuthnCredentialWire(c))
+	if err != nil {
+		return fmt.Errorf("failed to update webauthn credential: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("update webauthn credential failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// advanceWebAuthnCounterWire is the wire body for
+// AdvanceWebAuthnCredentialCounterProxy — see that method's doc
+// (internal/core/storage/interface.go) for the full contract.
+type advanceWebAuthnCounterWire struct {
+	CredentialID []byte    `json:"credential_id"`
+	UserID       uint      `json:"user_id"`
+	NewBlob      []byte    `json:"new_blob"`
+	NewSignCount uint32    `json:"new_sign_count"`
+	LastUsedAt   time.Time `json:"last_used_at"`
+}
+
+// AdvanceWebAuthnCredentialCounter is the ONE non-plain-CRUD method in this file:
+// see the package doc above and the storage.Storage interface doc for why the
+// signature-counter advance needs a single atomic PATCH
+// (/api/v1/system/webauthn/credentials/advance-counter) rather than a
+// Lock-then-Update pair. Deliberately bypasses rs.client.Get's cache (it is a
+// PATCH, not a GET) — the security-critical compare-and-swap must always hit the
+// upstream server fresh, never a stale cached response.
+func (rs *RemoteStorage) AdvanceWebAuthnCredentialCounter(ctx context.Context, credentialID []byte, userID uint, newBlob []byte, newSignCount uint32, lastUsedAt time.Time) (bool, error) {
+	resp, err := rs.client.Request(ctx, http.MethodPatch, "/api/v1/system/webauthn/credentials/advance-counter", advanceWebAuthnCounterWire{
+		CredentialID: credentialID,
+		UserID:       userID,
+		NewBlob:      newBlob,
+		NewSignCount: newSignCount,
+		LastUsedAt:   lastUsedAt,
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to advance webauthn credential counter: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("advance webauthn credential counter failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Advanced bool `json:"advanced"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Advanced, nil
+}
+
+// DeleteWebAuthnCredential removes one of the user's credentials via DELETE
+// /api/v1/system/webauthn/users/{userID}/credentials/{id} — scoped by user (in
+// the path, not just a query parameter) so a caller can't delete another user's
+// passkey by id, mirroring the local implementation's own ownership check.
+func (rs *RemoteStorage) DeleteWebAuthnCredential(ctx context.Context, userID, id uint) error {
+	path := fmt.Sprintf("/api/v1/system/webauthn/users/%d/credentials/%d", userID, id)
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete webauthn credential: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete webauthn credential failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// CountWebAuthnCredentials returns a user's registered-passkey count via GET
+// /api/v1/system/webauthn/credentials/count?user_id=X.
+func (rs *RemoteStorage) CountWebAuthnCredentials(ctx context.Context, userID uint) (int64, error) {
+	q := url.Values{}
+	q.Set("user_id", strconv.FormatUint(uint64(userID), 10))
+	path := "/api/v1/system/webauthn/credentials/count?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count webauthn credentials: %w", err)
+	}
+	if !resp.Success {
+		return 0, fmt.Errorf("count webauthn credentials failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Count int64 `json:"count"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Count, nil
+}
+
+// setUserWebAuthnEnabledWire is the wire body for SetUserWebAuthnEnabledProxy.
+type setUserWebAuthnEnabledWire struct {
+	Enabled bool `json:"enabled"`
+}
+
+// SetUserWebAuthnEnabled flips the user's WebAuthnEnabled flag via PUT
+// /api/v1/system/webauthn/users/{userID}/webauthn-enabled.
+func (rs *RemoteStorage) SetUserWebAuthnEnabled(ctx context.Context, userID uint, enabled bool) error {
+	path := fmt.Sprintf("/api/v1/system/webauthn/users/%d/webauthn-enabled", userID)
+	resp, err := rs.client.Put(ctx, path, setUserWebAuthnEnabledWire{Enabled: enabled})
+	if err != nil {
+		return fmt.Errorf("failed to set webauthn enabled: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("set webauthn enabled failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// CreateWebAuthnSession persists a new ceremony session via POST
+// /api/v1/system/webauthn/sessions, then copies the upstream-assigned fields (ID,
+// CreatedAt) back into s — mirroring CreateWebAuthnCredential's same in-place-mutate
+// contract.
+func (rs *RemoteStorage) CreateWebAuthnSession(ctx context.Context, s *models.WebAuthnSession) error {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/webauthn/sessions", newWebAuthnSessionWire(s))
+	if err != nil {
+		return fmt.Errorf("failed to create webauthn session: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("create webauthn session failed: %s", resp.Error.Error())
+	}
+	created, err := decodeWebAuthnSessionResponse(resp.Data)
+	if err != nil {
+		return err
+	}
+	*s = *created
+	return nil
+}
+
+// webAuthnSessionConsumeWire is the wire body for ConsumeWebAuthnSessionProxy.
+type webAuthnSessionConsumeWire struct {
+	TokenHash string    `json:"token_hash"`
+	Now       time.Time `json:"now"`
+}
+
+// ConsumeWebAuthnSession atomically marks a valid (unused, unexpired) ceremony
+// session used and returns it, via POST /api/v1/system/webauthn/sessions/consume.
+// The atomicity guarantee is unchanged from LocalStorage's own implementation
+// (an UPDATE ... WHERE used_at IS NULL AND expires_at > ?): the proxy handler calls
+// storage.ConsumeWebAuthnSession directly against the upstream's real storage in
+// this single request, so the single-use invariant holds across this HTTP hop too
+// (mirroring MarkSetupTokenConsumed's #510 precedent exactly). Every failure —
+// missing/already-used/expired token, or a network/parse error — collapses to the
+// same generic error, mirroring VerifyMFALoginCredentials' error-collapsing above:
+// the caller (internal/core.FinishWebAuthnRegistration/FinishWebAuthnLogin) already
+// treats any error here as "invalid or expired registration/login session"
+// regardless of cause.
+func (rs *RemoteStorage) ConsumeWebAuthnSession(ctx context.Context, tokenHash string, now time.Time) (*models.WebAuthnSession, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/webauthn/sessions/consume", webAuthnSessionConsumeWire{
+		TokenHash: tokenHash,
+		Now:       now,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("invalid or expired webauthn session")
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("invalid or expired webauthn session")
+	}
+	return decodeWebAuthnSessionResponse(resp.Data)
+}

--- a/server/http/handlers/webauthn_proxy.go
+++ b/server/http/handlers/webauthn_proxy.go
@@ -1,0 +1,436 @@
+// webauthn_proxy.go — server-side endpoints backing RemoteStorage's WebAuthn
+// storage primitives (ADR-036/ADR-049, finding #517): CreateWebAuthnCredential/
+// ListWebAuthnCredentials/GetWebAuthnCredentialByCredID/
+// LockWebAuthnCredentialForUpdate/UpdateWebAuthnCredential/
+// AdvanceWebAuthnCredentialCounter/DeleteWebAuthnCredential/
+// CountWebAuthnCredentials/SetUserWebAuthnEnabled/CreateWebAuthnSession/
+// ConsumeWebAuthnSession.
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// its WebAuthn storage calls to whichever upstream server it's configured
+// against, through these routes (registered in server/http/router.go under
+// /api/v1/system/webauthn, gated on the existing system.read/system.write RBAC
+// permissions — the SAME tier every RemoteStorage credential already needs for
+// every other proxied call, so this introduces no new privilege class). Mirrors
+// dynamic_secrets_proxy.go/groups_proxy.go exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/webauthn.go already uses against a local backend — NO WebAuthn
+// ceremony/ownership/reauth POLICY decision (attestation/assertion verification,
+// the re-auth-before-register check, first-enrolment session purge, clone-warning
+// handling) is made here; all of that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore, exactly as it does against a local backend.
+//
+// Unlike MFA's TOTP proxy (remote_mfa.go's IssueMFAChallenge/
+// VerifyMFALoginCredentials, a verification proxy — the raw TOTP secret must never
+// leave the server that can decrypt it, so the ENTIRE check runs upstream),
+// WebAuthn's registered-credential public key and ceremony session state are not
+// secret: a spoke server that holds the row can verify an assertion against it
+// entirely on its own. So this file is an ordinary CRUD/wire-DTO passthrough,
+// matching the Groups/Dynamic-Secrets precedent.
+//
+// The signature-counter race (#306/#517): AdvanceWebAuthnCredentialCounterProxy is
+// the ONE handler here that is not a plain CRUD passthrough. See its doc below and
+// storage.Storage's interface doc (internal/core/storage/interface.go) for why the
+// counter-advance path needs a single atomic call rather than a
+// Lock-then-Update pair — RemoteStorage.WithTransaction is a no-op passthrough
+// (internal/storage/store/remote_transaction.go), so this handler performs the
+// entire locked compare-and-swap against THIS server's own storage inside one
+// request; that is where the real atomicity for a storage.type: remote deployment
+// comes from.
+//
+// Response envelope: like every other proxy in this package, these do NOT use the
+// package's generic sendSuccess/sendError helpers — they construct the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// webAuthnCredentialProxyWire mirrors models.WebAuthnCredential's fields exactly
+// (snake_case). models.WebAuthnCredential carries no json tags of its own, so
+// every field is named explicitly here rather than relying on encoding/json's
+// case-insensitive fallback — matching dynamicSecretConfigProxyWire's precedent.
+type webAuthnCredentialProxyWire struct {
+	ID             uint       `json:"id"`
+	UserID         uint       `json:"user_id"`
+	CredentialID   []byte     `json:"credential_id"`
+	Name           string     `json:"name"`
+	CredentialBlob []byte     `json:"credential_blob"`
+	CreatedAt      time.Time  `json:"created_at"`
+	LastUsedAt     *time.Time `json:"last_used_at"`
+	Disabled       bool       `json:"disabled"`
+}
+
+func newWebAuthnCredentialProxyWire(c *models.WebAuthnCredential) webAuthnCredentialProxyWire {
+	return webAuthnCredentialProxyWire{
+		ID:             c.ID,
+		UserID:         c.UserID,
+		CredentialID:   c.CredentialID,
+		Name:           c.Name,
+		CredentialBlob: c.CredentialBlob,
+		CreatedAt:      c.CreatedAt,
+		LastUsedAt:     c.LastUsedAt,
+		Disabled:       c.Disabled,
+	}
+}
+
+func (w webAuthnCredentialProxyWire) toModel() *models.WebAuthnCredential {
+	return &models.WebAuthnCredential{
+		ID:             w.ID,
+		UserID:         w.UserID,
+		CredentialID:   w.CredentialID,
+		Name:           w.Name,
+		CredentialBlob: w.CredentialBlob,
+		CreatedAt:      w.CreatedAt,
+		LastUsedAt:     w.LastUsedAt,
+		Disabled:       w.Disabled,
+	}
+}
+
+// webAuthnSessionProxyWire mirrors models.WebAuthnSession's fields exactly.
+// TokenHash is tagged `json:"-"` on the model (to keep it out of USER-facing
+// responses) — irrelevant here, since this is an internal system-to-system wire
+// format gated on system.read/system.write, matching setupTokenProxyWire's
+// identical TokenHash precedent.
+type webAuthnSessionProxyWire struct {
+	ID        uint       `json:"id"`
+	UserID    uint       `json:"user_id"`
+	TokenHash string     `json:"token_hash"`
+	Purpose   string     `json:"purpose"`
+	Data      []byte     `json:"data"`
+	ExpiresAt time.Time  `json:"expires_at"`
+	UsedAt    *time.Time `json:"used_at"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+func newWebAuthnSessionProxyWire(s *models.WebAuthnSession) webAuthnSessionProxyWire {
+	return webAuthnSessionProxyWire{
+		ID:        s.ID,
+		UserID:    s.UserID,
+		TokenHash: s.TokenHash,
+		Purpose:   s.Purpose,
+		Data:      s.Data,
+		ExpiresAt: s.ExpiresAt,
+		UsedAt:    s.UsedAt,
+		CreatedAt: s.CreatedAt,
+	}
+}
+
+func (w webAuthnSessionProxyWire) toModel() *models.WebAuthnSession {
+	return &models.WebAuthnSession{
+		ID:        w.ID,
+		UserID:    w.UserID,
+		TokenHash: w.TokenHash,
+		Purpose:   w.Purpose,
+		Data:      w.Data,
+		ExpiresAt: w.ExpiresAt,
+		UsedAt:    w.UsedAt,
+		CreatedAt: w.CreatedAt,
+	}
+}
+
+// parseWebAuthnUserIDQuery parses the required user_id query parameter shared by
+// several of this file's GET handlers.
+func parseWebAuthnUserIDQuery(w http.ResponseWriter, r *http.Request) (userID uint, ok bool) {
+	v := r.URL.Query().Get("user_id")
+	if v == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "user_id query parameter is required")
+		return 0, false
+	}
+	id, err := strconv.ParseUint(v, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "user_id must be a valid integer")
+		return 0, false
+	}
+	return uint(id), true
+}
+
+// CreateWebAuthnCredentialProxy handles POST /api/v1/system/webauthn/credentials.
+func (h *AuthHandler) CreateWebAuthnCredentialProxy(w http.ResponseWriter, r *http.Request) {
+	var body webAuthnCredentialProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.UserID == 0 || len(body.CredentialID) == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id and credential_id are required")
+		return
+	}
+	row := body.toModel()
+	if err := h.coreService.Storage().CreateWebAuthnCredential(r.Context(), row); err != nil {
+		log.Printf("webauthn proxy: create credential failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newWebAuthnCredentialProxyWire(row))
+}
+
+// ListWebAuthnCredentialsProxy handles GET
+// /api/v1/system/webauthn/credentials?user_id=X.
+func (h *AuthHandler) ListWebAuthnCredentialsProxy(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseWebAuthnUserIDQuery(w, r)
+	if !ok {
+		return
+	}
+	rows, err := h.coreService.Storage().ListWebAuthnCredentials(r.Context(), userID)
+	if err != nil {
+		log.Printf("webauthn proxy: list credentials failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]webAuthnCredentialProxyWire, 0, len(rows))
+	for _, c := range rows {
+		wire = append(wire, newWebAuthnCredentialProxyWire(c))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"credentials": wire})
+}
+
+// GetWebAuthnCredentialByCredIDProxy handles GET
+// /api/v1/system/webauthn/credentials/lookup?user_id=&credential_id=<base64>.
+// Also backs RemoteStorage.LockWebAuthnCredentialForUpdate (see that method's doc,
+// internal/storage/store/remote_webauthn.go, for why a standalone HTTP request
+// cannot usefully hold a row lock past its own response, and why that is fine: the
+// one caller that used to need the lock for correctness now calls
+// AdvanceWebAuthnCredentialCounterProxy below instead).
+func (h *AuthHandler) GetWebAuthnCredentialByCredIDProxy(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseWebAuthnUserIDQuery(w, r)
+	if !ok {
+		return
+	}
+	credIDStr := r.URL.Query().Get("credential_id")
+	if credIDStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "credential_id query parameter is required")
+		return
+	}
+	credID, err := base64.StdEncoding.DecodeString(credIDStr)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "credential_id must be valid base64")
+		return
+	}
+	cred, err := h.coreService.Storage().GetWebAuthnCredentialByCredID(r.Context(), credID, userID)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "webauthn credential not found")
+			return
+		}
+		log.Printf("webauthn proxy: get credential failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newWebAuthnCredentialProxyWire(cred))
+}
+
+// UpdateWebAuthnCredentialProxy handles PUT /api/v1/system/webauthn/credentials/{id}.
+// A raw persist (storage.Storage.UpdateWebAuthnCredential is an unconditional
+// full-row Save, matching LocalStorage's own semantics exactly) — used by
+// rejectIfCloned's best-effort "mark disabled" write. The signature-counter
+// advance path does NOT go through this route; see
+// AdvanceWebAuthnCredentialCounterProxy below.
+func (h *AuthHandler) UpdateWebAuthnCredentialProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid credential id")
+		return
+	}
+	var body webAuthnCredentialProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	if err := h.coreService.Storage().UpdateWebAuthnCredential(r.Context(), body.toModel()); err != nil {
+		log.Printf("webauthn proxy: update credential failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}
+
+// advanceWebAuthnCounterProxyBody is the wire body for
+// AdvanceWebAuthnCredentialCounterProxy.
+type advanceWebAuthnCounterProxyBody struct {
+	CredentialID []byte    `json:"credential_id"`
+	UserID       uint      `json:"user_id"`
+	NewBlob      []byte    `json:"new_blob"`
+	NewSignCount uint32    `json:"new_sign_count"`
+	LastUsedAt   time.Time `json:"last_used_at"`
+}
+
+// AdvanceWebAuthnCredentialCounterProxy handles PATCH
+// /api/v1/system/webauthn/credentials/advance-counter — the ONE handler in this
+// file that is not a plain CRUD passthrough.
+//
+// It calls storage.Storage.AdvanceWebAuthnCredentialCounter directly
+// (h.coreService.Storage() reaches the identical primitive this server's own
+// local /auth/webauthn login path uses via persistUpdatedCredential), which
+// performs the ENTIRE locked compare-and-swap — re-reading the row's CURRENT
+// persisted counter under a row lock (Postgres: SELECT ... FOR UPDATE) and only
+// conditionally overwriting it — inside this single request, against THIS
+// server's own storage. That is the critical property a downstream (spoke) server
+// depends on for security under storage.type: remote: two concurrent logins racing
+// the same credential (e.g. a cloned authenticator authenticating alongside the
+// legitimate device) must never let the loser's stale, lower counter clobber the
+// winner's already-persisted higher one, even when each login is itself proxied
+// from a DIFFERENT spoke process — closing exactly the race a naive
+// Lock-then-Update pair over two separate HTTP calls would reopen (see this
+// file's package doc, and storage.Storage's interface doc, for the full
+// reasoning).
+func (h *AuthHandler) AdvanceWebAuthnCredentialCounterProxy(w http.ResponseWriter, r *http.Request) {
+	var body advanceWebAuthnCounterProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if len(body.CredentialID) == 0 || body.UserID == 0 || len(body.NewBlob) == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "credential_id, user_id, and new_blob are required")
+		return
+	}
+	advanced, err := h.coreService.Storage().AdvanceWebAuthnCredentialCounter(
+		r.Context(), body.CredentialID, body.UserID, body.NewBlob, body.NewSignCount, body.LastUsedAt)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "webauthn credential not found")
+			return
+		}
+		log.Printf("webauthn proxy: advance counter failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"advanced": advanced})
+}
+
+// DeleteWebAuthnCredentialProxy handles DELETE
+// /api/v1/system/webauthn/users/{userId}/credentials/{id} — scoped by user (in
+// the path, not just a query parameter) so a caller can't delete another user's
+// passkey by id, mirroring the local implementation's own ownership check.
+func (h *AuthHandler) DeleteWebAuthnCredentialProxy(w http.ResponseWriter, r *http.Request) {
+	userID, err := strconv.ParseUint(chi.URLParam(r, "userId"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid user id")
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid credential id")
+		return
+	}
+	if err := h.coreService.Storage().DeleteWebAuthnCredential(r.Context(), uint(userID), uint(id)); err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "webauthn credential not found")
+			return
+		}
+		log.Printf("webauthn proxy: delete credential failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}
+
+// CountWebAuthnCredentialsProxy handles GET
+// /api/v1/system/webauthn/credentials/count?user_id=X.
+func (h *AuthHandler) CountWebAuthnCredentialsProxy(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseWebAuthnUserIDQuery(w, r)
+	if !ok {
+		return
+	}
+	n, err := h.coreService.Storage().CountWebAuthnCredentials(r.Context(), userID)
+	if err != nil {
+		log.Printf("webauthn proxy: count credentials failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int64{"count": n})
+}
+
+// setUserWebAuthnEnabledProxyBody is the wire body for SetUserWebAuthnEnabledProxy.
+type setUserWebAuthnEnabledProxyBody struct {
+	Enabled bool `json:"enabled"`
+}
+
+// SetUserWebAuthnEnabledProxy handles PUT
+// /api/v1/system/webauthn/users/{userId}/webauthn-enabled.
+func (h *AuthHandler) SetUserWebAuthnEnabledProxy(w http.ResponseWriter, r *http.Request) {
+	userID, err := strconv.ParseUint(chi.URLParam(r, "userId"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid user id")
+		return
+	}
+	var body setUserWebAuthnEnabledProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if err := h.coreService.Storage().SetUserWebAuthnEnabled(r.Context(), uint(userID), body.Enabled); err != nil {
+		log.Printf("webauthn proxy: set webauthn enabled failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}
+
+// CreateWebAuthnSessionProxy handles POST /api/v1/system/webauthn/sessions.
+func (h *AuthHandler) CreateWebAuthnSessionProxy(w http.ResponseWriter, r *http.Request) {
+	var body webAuthnSessionProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.UserID == 0 || body.TokenHash == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id and token_hash are required")
+		return
+	}
+	row := body.toModel()
+	if err := h.coreService.Storage().CreateWebAuthnSession(r.Context(), row); err != nil {
+		log.Printf("webauthn proxy: create session failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newWebAuthnSessionProxyWire(row))
+}
+
+// webAuthnSessionConsumeProxyBody is the wire body for
+// ConsumeWebAuthnSessionProxy.
+type webAuthnSessionConsumeProxyBody struct {
+	TokenHash string    `json:"token_hash"`
+	Now       time.Time `json:"now"`
+}
+
+// ConsumeWebAuthnSessionProxy handles POST
+// /api/v1/system/webauthn/sessions/consume. Calls
+// storage.Storage.ConsumeWebAuthnSession directly, so this inherits
+// local_webauthn.go's own atomic "UPDATE ... WHERE used_at IS NULL AND
+// expires_at > ?" single-use guarantee unchanged — the single round trip a
+// concurrent-consume race resolves in, mirroring ConsumeSetupTokenProxy's #510
+// precedent. Every failure (no matching row, already used, expired, or a genuine
+// storage error) collapses to the same 404 — LocalStorage's own
+// ConsumeWebAuthnSession already returns one generic "invalid or expired webauthn
+// session" error for all of those cases, so this loses no information the local
+// path ever exposed.
+func (h *AuthHandler) ConsumeWebAuthnSessionProxy(w http.ResponseWriter, r *http.Request) {
+	var body webAuthnSessionConsumeProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.TokenHash == "" || body.Now.IsZero() {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "token_hash and now are required")
+		return
+	}
+	sess, err := h.coreService.Storage().ConsumeWebAuthnSession(r.Context(), body.TokenHash, body.Now)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "invalid or expired webauthn session")
+		return
+	}
+	writeRemoteAPISuccess(w, newWebAuthnSessionProxyWire(sess))
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -94,6 +94,11 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		&models.MFASecret{},
 		&models.MFARecoveryCode{},
 		&models.MFAChallenge{},
+		// #517: the webauthn-proxy end-to-end tests exercise WebAuthnCredential/
+		// WebAuthnSession CRUD (including the atomic signature-counter advance)
+		// through the real router.
+		&models.WebAuthnCredential{},
+		&models.WebAuthnSession{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the

--- a/server/http/remote_storage_webauthn_test.go
+++ b/server/http/remote_storage_webauthn_test.go
@@ -1,0 +1,359 @@
+// remote_storage_webauthn_test.go — end-to-end coverage for #517: RemoteStorage's
+// WebAuthn storage primitives (CreateWebAuthnCredential/ListWebAuthnCredentials/
+// GetWebAuthnCredentialByCredID/LockWebAuthnCredentialForUpdate/
+// UpdateWebAuthnCredential/AdvanceWebAuthnCredentialCounter/
+// DeleteWebAuthnCredential/CountWebAuthnCredentials/SetUserWebAuthnEnabled/
+// CreateWebAuthnSession/ConsumeWebAuthnSession) were entirely stubbed
+// (remoteUnsupported), so every passkey registration/login flow was completely
+// non-functional under storage.type: remote. Mirrors
+// remote_storage_dynamic_secrets_test.go/remote_storage_setup_tokens_test.go's
+// #452/#507/#510 harness exactly: a real "upstream" exercised through the
+// production NewRouter/handlers (including the new /api/v1/system/webauthn
+// routes, server/http/handlers/webauthn_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed at
+// "upstream" over real HTTP via store.RemoteStorage.
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForWebAuthn builds the standard two-server harness.
+func newUpstreamDownstreamForWebAuthn(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	return upstream, downstream
+}
+
+// webAuthnCredentialBlob builds the same JSON shape internal/core/webauthn.go's
+// persistUpdatedCredential marshals (json.Marshal of a *webauthn.Credential) —
+// AdvanceWebAuthnCredentialCounter/local_webauthn.go's webauthnStoredCounter reads
+// back exactly the "authenticator.signCount" field this produces.
+func webAuthnCredentialBlob(t *testing.T, credID []byte, signCount uint32) []byte {
+	t.Helper()
+	blob, err := json.Marshal(webauthn.Credential{ID: credID, Authenticator: webauthn.Authenticator{SignCount: signCount}})
+	require.NoError(t, err)
+	return blob
+}
+
+// TestRemoteStorageWebAuthn_CredentialCRUD_RealServer proves the fix for
+// CreateWebAuthnCredential/ListWebAuthnCredentials/GetWebAuthnCredentialByCredID/
+// LockWebAuthnCredentialForUpdate/UpdateWebAuthnCredential/
+// CountWebAuthnCredentials/DeleteWebAuthnCredential/SetUserWebAuthnEnabled: a
+// credential is genuinely persisted on the upstream server via the downstream's
+// RemoteStorage, fetchable both by ID (lock) and cred ID, listed, counted,
+// updatable, and deletable — all via storage.type: remote against a real router.
+func TestRemoteStorageWebAuthn_CredentialCRUD_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForWebAuthn(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	user, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "passkeyuser",
+		Email:    "passkeyuser@example.com",
+		Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+
+	credID := []byte("credential-id-1")
+	row := &models.WebAuthnCredential{
+		UserID:         user.ID,
+		CredentialID:   credID,
+		Name:           "YubiKey 5C",
+		CredentialBlob: webAuthnCredentialBlob(t, credID, 0),
+		CreatedAt:      now,
+	}
+	require.NoError(t, downstream.Storage().CreateWebAuthnCredential(ctx, row))
+	require.NotZero(t, row.ID, "the upstream must assign a real ID")
+
+	// A REAL row on the upstream's own storage.
+	direct, err := upstream.Storage().GetWebAuthnCredentialByCredID(ctx, credID, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "YubiKey 5C", direct.Name)
+
+	// GetWebAuthnCredentialByCredID / LockWebAuthnCredentialForUpdate via the
+	// downstream both round-trip correctly.
+	fetched, err := downstream.Storage().GetWebAuthnCredentialByCredID(ctx, credID, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, row.ID, fetched.ID)
+	assert.Equal(t, "YubiKey 5C", fetched.Name)
+
+	locked, err := downstream.Storage().LockWebAuthnCredentialForUpdate(ctx, credID, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, row.ID, locked.ID)
+
+	// A second credential, then list + count both via the downstream.
+	credID2 := []byte("credential-id-2")
+	row2 := &models.WebAuthnCredential{
+		UserID:         user.ID,
+		CredentialID:   credID2,
+		Name:           "Touch ID",
+		CredentialBlob: webAuthnCredentialBlob(t, credID2, 0),
+		CreatedAt:      now,
+	}
+	require.NoError(t, downstream.Storage().CreateWebAuthnCredential(ctx, row2))
+
+	rows, err := downstream.Storage().ListWebAuthnCredentials(ctx, user.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	names := map[string]bool{}
+	for _, r := range rows {
+		names[r.Name] = true
+	}
+	assert.True(t, names["YubiKey 5C"])
+	assert.True(t, names["Touch ID"])
+
+	count, err := downstream.Storage().CountWebAuthnCredentials(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	// UpdateWebAuthnCredential (rejectIfCloned's own write path): mark the first
+	// credential disabled via the downstream, confirm it's visible directly on the
+	// upstream.
+	fetched.Disabled = true
+	require.NoError(t, downstream.Storage().UpdateWebAuthnCredential(ctx, fetched))
+	reFetched, err := upstream.Storage().GetWebAuthnCredentialByCredID(ctx, credID, user.ID)
+	require.NoError(t, err)
+	assert.True(t, reFetched.Disabled, "the disable must be visible directly on the upstream's own storage")
+
+	// SetUserWebAuthnEnabled via the downstream.
+	require.NoError(t, downstream.Storage().SetUserWebAuthnEnabled(ctx, user.ID, true))
+	directUser, err := upstream.Storage().GetUser(ctx, user.ID)
+	require.NoError(t, err)
+	assert.True(t, directUser.WebAuthnEnabled)
+
+	// DeleteWebAuthnCredential via the downstream; count drops to 1.
+	require.NoError(t, downstream.Storage().DeleteWebAuthnCredential(ctx, user.ID, row2.ID))
+	countAfter, err := downstream.Storage().CountWebAuthnCredentials(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), countAfter)
+}
+
+// TestRemoteStorageWebAuthn_GetCredentialNotFound_RealServer proves a clean
+// not-found error (not a panic, not a garbage 500) for a nonexistent credential.
+func TestRemoteStorageWebAuthn_GetCredentialNotFound_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForWebAuthn(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetWebAuthnCredentialByCredID(ctx, []byte("nope"), 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageWebAuthn_SessionCreateConsume_RealServer proves the fix for
+// CreateWebAuthnSession/ConsumeWebAuthnSession: a ceremony session is genuinely
+// persisted, consumable exactly once, and a second consume of the same token
+// cleanly fails — all via storage.type: remote.
+func TestRemoteStorageWebAuthn_SessionCreateConsume_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForWebAuthn(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	user, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "sessionuser",
+		Email:    "sessionuser@example.com",
+		Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+
+	sess := &models.WebAuthnSession{
+		UserID:    user.ID,
+		TokenHash: "session-hash-1",
+		Purpose:   "register",
+		Data:      []byte(`{"challenge":"abc"}`),
+		ExpiresAt: now.Add(5 * time.Minute),
+		CreatedAt: now,
+	}
+	require.NoError(t, downstream.Storage().CreateWebAuthnSession(ctx, sess))
+	require.NotZero(t, sess.ID, "the upstream must assign a real ID")
+
+	// ConsumeWebAuthnSession via the downstream succeeds exactly once.
+	consumed, err := downstream.Storage().ConsumeWebAuthnSession(ctx, "session-hash-1", time.Now())
+	require.NoError(t, err, "consuming a valid session must succeed via storage.type: remote")
+	assert.Equal(t, "register", consumed.Purpose)
+	assert.Equal(t, user.ID, consumed.UserID)
+
+	// A second consume of the same token must cleanly fail (single-use).
+	_, err = downstream.Storage().ConsumeWebAuthnSession(ctx, "session-hash-1", time.Now())
+	require.Error(t, err, "a second consume of the same session token must fail")
+}
+
+// TestRemoteStorageWebAuthn_ConcurrentCounterAdvanceRace_RealServer is the
+// critical #306/#517 test: it fires N concurrent AdvanceWebAuthnCredentialCounter
+// calls at the SAME credential, over real HTTP against the real upstream router,
+// each proposing a different candidate signature counter. It asserts the FINAL
+// persisted counter is exactly the maximum of every candidate — i.e. no
+// concurrent write, regardless of goroutine scheduling or network interleaving,
+// is ever allowed to regress the persisted counter below a value some other
+// concurrent (or already-completed) call already established. This proves
+// AdvanceWebAuthnCredentialCounterProxy's single-request locked compare-and-swap
+// (server/http/handlers/webauthn_proxy.go) closes the exact TOCTOU race a naive
+// client-side Lock-then-Update pair over two separate remote calls would reopen
+// (RemoteStorage.WithTransaction is a no-op passthrough, remote_transaction.go).
+func TestRemoteStorageWebAuthn_ConcurrentCounterAdvanceRace_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForWebAuthn(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	user, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "raceuser",
+		Email:    "raceuser@example.com",
+		Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+
+	credID := []byte("race-credential")
+	row := &models.WebAuthnCredential{
+		UserID:         user.ID,
+		CredentialID:   credID,
+		Name:           "Race Key",
+		CredentialBlob: webAuthnCredentialBlob(t, credID, 0),
+		CreatedAt:      now,
+	}
+	require.NoError(t, upstream.Storage().CreateWebAuthnCredential(ctx, row))
+
+	// A mix of candidate counters, deliberately unordered and including values both
+	// above and below one another, so no goroutine start order could accidentally
+	// produce a monotonic sequence on its own.
+	candidates := []uint32{15, 3, 42, 8, 100, 1, 77, 29, 64, 5, 91, 12, 55, 2, 88, 33, 60, 9, 47, 21}
+	maxCandidate := uint32(0)
+	for _, c := range candidates {
+		if c > maxCandidate {
+			maxCandidate = c
+		}
+	}
+
+	var wg sync.WaitGroup
+	var errCount atomic.Int64
+	wg.Add(len(candidates))
+	start := make(chan struct{})
+	for _, c := range candidates {
+		c := c
+		go func() {
+			defer wg.Done()
+			<-start
+			blob := webAuthnCredentialBlob(t, credID, c)
+			_, err := downstream.Storage().AdvanceWebAuthnCredentialCounter(ctx, credID, user.ID, blob, c, time.Now())
+			if err != nil {
+				errCount.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	require.Equal(t, int64(0), errCount.Load(), "every concurrent advance-counter call must get a clean result, not a transport/server error")
+
+	final, err := upstream.Storage().GetWebAuthnCredentialByCredID(ctx, credID, user.ID)
+	require.NoError(t, err)
+	var stored webauthn.Credential
+	require.NoError(t, json.Unmarshal(final.CredentialBlob, &stored))
+	assert.Equal(t, maxCandidate, stored.Authenticator.SignCount,
+		"the persisted counter must end at the maximum candidate regardless of goroutine scheduling — any lower final value means a stale write clobbered a genuinely higher one")
+}
+
+// TestRemoteStorageWebAuthn_StaleCounterAdvanceRejectedAfterWinner_RealServer pins
+// the exact sequential case the concurrent test above proves statistically: a
+// stale (lower) counter arriving AFTER a higher one has already committed must be
+// rejected (advanced=false), and must never overwrite the already-persisted higher
+// value — all via storage.type: remote.
+func TestRemoteStorageWebAuthn_StaleCounterAdvanceRejectedAfterWinner_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForWebAuthn(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	user, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "staleuser",
+		Email:    "staleuser@example.com",
+		Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+
+	credID := []byte("stale-credential")
+	row := &models.WebAuthnCredential{
+		UserID:         user.ID,
+		CredentialID:   credID,
+		Name:           "Stale Test Key",
+		CredentialBlob: webAuthnCredentialBlob(t, credID, 0),
+		CreatedAt:      now,
+	}
+	require.NoError(t, upstream.Storage().CreateWebAuthnCredential(ctx, row))
+
+	// Winner commits first: counter advances 0 -> 100.
+	advanced, err := downstream.Storage().AdvanceWebAuthnCredentialCounter(ctx, credID, user.ID, webAuthnCredentialBlob(t, credID, 100), 100, time.Now())
+	require.NoError(t, err)
+	assert.True(t, advanced)
+
+	// A stale (lower) counter arrives after: must be rejected, not persisted.
+	advanced, err = downstream.Storage().AdvanceWebAuthnCredentialCounter(ctx, credID, user.ID, webAuthnCredentialBlob(t, credID, 50), 50, time.Now())
+	require.NoError(t, err, "a stale advance-counter call is a benign rejected write, not a storage error")
+	assert.False(t, advanced, "a stale (lower) counter must never be reported as advanced")
+
+	final, err := upstream.Storage().GetWebAuthnCredentialByCredID(ctx, credID, user.ID)
+	require.NoError(t, err)
+	var stored webauthn.Credential
+	require.NoError(t, json.Unmarshal(final.CredentialBlob, &stored))
+	assert.Equal(t, uint32(100), stored.Authenticator.SignCount, "the stale write must not have clobbered the winner's persisted counter")
+
+	// The (0, 0) "authenticator doesn't implement a counter" carve-out: an
+	// authenticator that always reports 0 must still get its blob/LastUsedAt
+	// updated (e.g. for a DIFFERENT credential starting fresh at 0), not be
+	// treated as permanently stale.
+	credID2 := []byte("zero-counter-credential")
+	row2 := &models.WebAuthnCredential{
+		UserID:         user.ID,
+		CredentialID:   credID2,
+		Name:           "Touch ID (no counter)",
+		CredentialBlob: webAuthnCredentialBlob(t, credID2, 0),
+		CreatedAt:      now,
+	}
+	require.NoError(t, upstream.Storage().CreateWebAuthnCredential(ctx, row2))
+
+	lastUsed := time.Now()
+	advanced, err = downstream.Storage().AdvanceWebAuthnCredentialCounter(ctx, credID2, user.ID, webAuthnCredentialBlob(t, credID2, 0), 0, lastUsed)
+	require.NoError(t, err)
+	assert.True(t, advanced, "a (0, 0) counter comparison must not be treated as stale")
+
+	final2, err := upstream.Storage().GetWebAuthnCredentialByCredID(ctx, credID2, user.ID)
+	require.NoError(t, err)
+	require.NotNil(t, final2.LastUsedAt)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -961,6 +961,42 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/project-memberships", catalogHandler.ListMembershipsProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/project-memberships", catalogHandler.CreateMembershipProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Put("/project-memberships/{id}", catalogHandler.UpdateMembershipProxy)
+
+			// WebAuthn / passkey storage-primitive proxy (finding #517). Lets a
+			// downstream Keyorix server booted with storage.type: remote (ADR-049)
+			// proxy CreateWebAuthnCredential/ListWebAuthnCredentials/
+			// GetWebAuthnCredentialByCredID/LockWebAuthnCredentialForUpdate/
+			// UpdateWebAuthnCredential/AdvanceWebAuthnCredentialCounter/
+			// DeleteWebAuthnCredential/CountWebAuthnCredentials/
+			// SetUserWebAuthnEnabled/CreateWebAuthnSession/ConsumeWebAuthnSession to
+			// THIS server's real storage backend, instead of RemoteStorage's ten
+			// WebAuthn methods having no server endpoint to call at all (every
+			// passkey registration/login flow was completely non-functional under
+			// storage.type: remote). Unlike the MFA/TOTP proxy above (a
+			// verification proxy — the raw TOTP secret must never leave the server
+			// that can decrypt it), a passkey's public key and ceremony session
+			// state are not secret, so this is an ordinary CRUD passthrough — no
+			// WebAuthn ceremony/ownership/reauth POLICY decision is made here; that
+			// stays entirely in the CALLING server's own internal/core.KeyorixCore,
+			// exactly as it does against a local backend. Reuses the SAME
+			// system.read/system.write tier — no new privilege class. See
+			// webauthn_proxy.go's package doc for the signature-counter race fix:
+			// AdvanceWebAuthnCredentialCounter is the one route here that performs
+			// a full locked compare-and-swap in a single request rather than a
+			// plain CRUD read/write, closing the cloned-authenticator TOCTOU a
+			// naive Lock-then-Update pair over two separate remote calls would
+			// reopen (#306/#517). Static sub-paths (lookup, count,
+			// advance-counter) are registered before their sibling {id} routes.
+			r.Get("/webauthn/credentials/lookup", authHandler.GetWebAuthnCredentialByCredIDProxy)
+			r.Get("/webauthn/credentials/count", authHandler.CountWebAuthnCredentialsProxy)
+			r.Get("/webauthn/credentials", authHandler.ListWebAuthnCredentialsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/webauthn/credentials", authHandler.CreateWebAuthnCredentialProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/webauthn/credentials/{id}", authHandler.UpdateWebAuthnCredentialProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Patch("/webauthn/credentials/advance-counter", authHandler.AdvanceWebAuthnCredentialCounterProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Delete("/webauthn/users/{userId}/credentials/{id}", authHandler.DeleteWebAuthnCredentialProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/webauthn/users/{userId}/webauthn-enabled", authHandler.SetUserWebAuthnEnabledProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/webauthn/sessions", authHandler.CreateWebAuthnSessionProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/webauthn/sessions/consume", authHandler.ConsumeWebAuthnSessionProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary
- Implements `RemoteStorage` support for WebAuthn (#517, the residual of #509 after TOTP was fixed): new thin passthrough routes under `/api/v1/system/webauthn` (gated `system.read`/`system.write`, no new privilege class), replacing all 10 `remoteUnsupported` stubs.
- Unlike TOTP, WebAuthn's public key and ceremony state aren't secret, so this is a CRUD/wire-DTO problem, not a verification-proxy problem.
- **The hard part**: `RemoteStorage.WithTransaction` is a no-op passthrough — a naive Lock+check+Update proxy for the signature-counter update would reopen the exact clone-detection TOCTOU race `persistUpdatedCredential` prevents locally via a real DB transaction. Fixed by adding a new atomic `storage.Storage.AdvanceWebAuthnCredentialCounter` primitive: extracted from `persistUpdatedCredential`'s existing Lock+compare+Update logic for `LocalStorage` (identical behavior, moved down a layer), and implemented as ONE atomic HTTP `PATCH` for `RemoteStorage` — the real atomicity is achieved server-side in a single request. `persistUpdatedCredential` is now a thin caller of this primitive for all backends.
- Proven via a 20-way concurrent counter-advance race (asserts the final persisted counter is the max of all candidates, with a pinned stale-after-winner case and the `(0,0)` no-counter carve-out preserved), run with `-race`.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] Full `go test ./...` passes, including existing `TestConcurrency_WebAuthnPersistUpdatedCredential_*` (behavior unchanged) and 5 new tests, verified with `-race`
- [x] `gosec -severity medium -exclude-generated` — 0 issues

## Residual (not a regression)
- `RemoteStorage`'s GET responses are cached client-side for 5 minutes (pre-existing, repo-wide tradeoff shared by every proxied list/get) — the security-critical counter-advance path is a `PATCH`, never a cached GET, so this doesn't affect the atomicity fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)