### PR TITLE
fix(remote-storage): implement machine identity storage primitives (#518)

### DIFF
--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -137,10 +137,21 @@ func (c *KeyorixCore) ListStaleMachineIdentities(ctx context.Context, projectID 
 // LockMachineIdentityForUpdate, not a plain GetMachineIdentity — without a DB-level
 // guard, two concurrent transitions racing off the same pre-transition state (e.g.
 // one to revoked, one racing back to active from suspended) can each independently
-// pass canTransitionMachine, and whichever plain Save landed last would silently win
+// pass canTransitionMachine, and whichever write landed last would silently win
 // outright, un-revoking a just-revoked machine identity. The row lock (Postgres:
 // SELECT ... FOR UPDATE) serializes this across replicas; the transaction alone
 // serializes it on SQLite (always single-process).
+//
+// Finding #518: the actual write goes through TransitionMachineIdentityState, a
+// conditional "WHERE id = ? AND state = ?" persist, rather than a plain
+// UpdateMachineIdentity — because storage.type: remote's RemoteStorage.WithTransaction
+// is a no-op passthrough over HTTP (no real transaction/row-lock spans the Lock
+// call and the write), a plain Lock-then-Update proxy pair would silently lose the
+// #388 guarantee entirely under remote mode. Gating the write itself on the state
+// this call observed under the lock restores the guarantee across that HTTP hop:
+// a lost race reports matched=false, treated identically to an illegal transition.
+// This makes no behavioral difference against LocalStorage (the lock already
+// guarantees the state can't have moved by the time the conditional write runs).
 func (c *KeyorixCore) TransitionMachineIdentity(ctx context.Context, projectID, id uint, to string, actorID uint) (*models.MachineIdentity, error) {
 	now := c.now()
 	var result *models.MachineIdentity
@@ -154,16 +165,24 @@ func (c *KeyorixCore) TransitionMachineIdentity(ctx context.Context, projectID, 
 			// avoid confirming the machine's existence to a caller scoped elsewhere.
 			return fmt.Errorf("machine identity not found")
 		}
-		if !canTransitionMachine(m.State, to) {
-			return fmt.Errorf("cannot transition machine identity from %s to %s", m.State, to)
+		fromState := m.State
+		if !canTransitionMachine(fromState, to) {
+			return fmt.Errorf("cannot transition machine identity from %s to %s", fromState, to)
 		}
 		m.State = to
 		m.UpdatedAt = now
 		if to == MachineRevoked {
 			m.RevokedAt = &now
 		}
-		if err := tx.UpdateMachineIdentity(ctx, m); err != nil {
+		matched, err := tx.TransitionMachineIdentityState(ctx, m, fromState)
+		if err != nil {
 			return fmt.Errorf("failed to update machine identity: %w", err)
+		}
+		if !matched {
+			// Lost the race: the row's persisted state moved away from fromState
+			// between the lock read and this write (#388) — treat exactly like an
+			// illegal transition rather than silently overwriting the winner.
+			return fmt.Errorf("cannot transition machine identity from %s to %s", fromState, to)
 		}
 		result = m
 		return nil

--- a/internal/core/machine_identities_test.go
+++ b/internal/core/machine_identities_test.go
@@ -85,9 +85,9 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		c := newMachineCore(store)
 		ctx := context.Background()
 		store.On("LockMachineIdentityForUpdate", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineActive}, nil)
-		store.On("UpdateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+		store.On("TransitionMachineIdentityState", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
 			return m.State == MachineSuspended
-		})).Return(nil)
+		}), MachineActive).Return(true, nil)
 		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
 
 		m, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineSuspended, 9)
@@ -100,9 +100,9 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		c := newMachineCore(store)
 		ctx := context.Background()
 		store.On("LockMachineIdentityForUpdate", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineActive}, nil)
-		store.On("UpdateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+		store.On("TransitionMachineIdentityState", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
 			return m.State == MachineRevoked && m.RevokedAt != nil
-		})).Return(nil)
+		}), MachineActive).Return(true, nil)
 		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
 
 		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineRevoked, 9)
@@ -118,7 +118,7 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineActive, 9)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot transition")
-		store.AssertNotCalled(t, "UpdateMachineIdentity", mock.Anything, mock.Anything)
+		store.AssertNotCalled(t, "TransitionMachineIdentityState", mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	// Cross-project guard: a machine in project 2 must not be reachable when the
@@ -132,7 +132,7 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineSuspended, 9)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
-		store.AssertNotCalled(t, "UpdateMachineIdentity", mock.Anything, mock.Anything)
+		store.AssertNotCalled(t, "TransitionMachineIdentityState", mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	// #388: a concurrent revoke and reactivate racing off the same pre-transition
@@ -152,6 +152,27 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineActive, 9)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot transition")
-		store.AssertNotCalled(t, "UpdateMachineIdentity", mock.Anything, mock.Anything)
+		store.AssertNotCalled(t, "TransitionMachineIdentityState", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	// #518: even after the row-lock read reports a legal from-state, a
+	// concurrent writer (only possible under storage.type: remote, where
+	// WithTransaction is a no-op and the "lock" is a plain read — see
+	// TransitionMachineIdentityState's interface doc) can still win the actual
+	// write race. TransitionMachineIdentityState reporting matched=false must be
+	// treated exactly like an illegal transition, not silently accepted.
+	t.Run("lost race on the conditional write is reported like an illegal transition", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+		store.On("LockMachineIdentityForUpdate", ctx, uint(10)).Return(&models.MachineIdentity{ID: 10, ProjectID: 1, State: MachineActive}, nil)
+		store.On("TransitionMachineIdentityState", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.State == MachineSuspended
+		}), MachineActive).Return(false, nil)
+
+		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineSuspended, 9)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot transition")
+		store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 	})
 }

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1674,6 +1674,11 @@ func (m *MockStorage) UpdateMachineIdentity(ctx context.Context, mi *models.Mach
 	return args.Error(0)
 }
 
+func (m *MockStorage) TransitionMachineIdentityState(ctx context.Context, mi *models.MachineIdentity, fromState string) (bool, error) {
+	args := m.Called(ctx, mi, fromState)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *MockStorage) ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error) {
 	args := m.Called(ctx, projectID)
 	if args.Get(0) == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -272,6 +272,29 @@ type Storage interface {
 	// #388) that must not lose an update under concurrency.
 	LockMachineIdentityForUpdate(ctx context.Context, id uint) (*models.MachineIdentity, error)
 	UpdateMachineIdentity(ctx context.Context, m *models.MachineIdentity) error
+	// TransitionMachineIdentityState persists m's full row via a single
+	// conditional write — "UPDATE ... WHERE id = ? AND state = ?" — succeeding
+	// only if the row's CURRENT persisted state still equals fromState (the
+	// value TransitionMachineIdentity observed via LockMachineIdentityForUpdate
+	// immediately before mutating m in memory), mirroring
+	// UpdateProjectInvitation's `WHERE id = ? AND state = 'pending'` pattern
+	// (#412). Returns whether the write actually matched a row.
+	//
+	// This exists because RemoteStorage.WithTransaction is a no-op passthrough
+	// (remote_transaction.go: "there is no client-side transaction to open over
+	// HTTP") — so a generic two-call Lock-then-Update sequence run against
+	// RemoteStorage gets NONE of the atomicity LocalStorage provides via a real
+	// DB transaction + row lock (Postgres: SELECT ... FOR UPDATE), silently
+	// reopening the exact #388 race (a concurrent revoke and reactivate racing
+	// off the same pre-transition state could un-revoke a just-revoked machine
+	// identity) across the HTTP hop. Routing the actual write through this one
+	// conditional round trip instead of a separate proxied Update restores the
+	// same guarantee LocalStorage already has, without making any
+	// transition-legality decision here: the caller (core.TransitionMachineIdentity)
+	// still decides fromState/to via canTransitionMachine before calling this;
+	// a false match result must be treated exactly like an illegal transition,
+	// not retried or silently overwritten.
+	TransitionMachineIdentityState(ctx context.Context, m *models.MachineIdentity, fromState string) (bool, error)
 	ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error)
 	// ListAllMachineIdentities returns every machine identity across all projects —
 	// for install-wide sweeps such as SoD conflict detection over non-human principals.

--- a/internal/storage/store/local_machine_identities.go
+++ b/internal/storage/store/local_machine_identities.go
@@ -54,6 +54,24 @@ func (ls *LocalStorage) UpdateMachineIdentity(ctx context.Context, m *models.Mac
 	return nil
 }
 
+// TransitionMachineIdentityState persists m's full row via a conditional UPDATE
+// gated on the row's CURRENT state still being fromState (#388, see the
+// interface doc in internal/core/storage/interface.go for why this exists
+// alongside — not instead of — LockMachineIdentityForUpdate). Mirrors
+// UpdateProjectInvitation's `WHERE id = ? AND state = ?` + `Select("*")` shape
+// exactly, so every field the caller mutated on m (State, UpdatedAt, RevokedAt,
+// ...) is persisted in the same statement, not just a hardcoded column subset.
+func (ls *LocalStorage) TransitionMachineIdentityState(ctx context.Context, m *models.MachineIdentity, fromState string) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.MachineIdentity{}).
+		Where("id = ? AND state = ?", m.ID, fromState).
+		Select("*").
+		Updates(m)
+	if res.Error != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	return res.RowsAffected == 1, nil
+}
+
 func (ls *LocalStorage) ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error) {
 	var rows []*models.MachineIdentity
 	err := ls.db.WithContext(ctx).

--- a/internal/storage/store/remote_machine_identities.go
+++ b/internal/storage/store/remote_machine_identities.go
@@ -1,43 +1,400 @@
-// remote_machine_identities.go — machine identities for RemoteStorage (ADR-023).
+// remote_machine_identities.go — machine identities, machine-token credentials,
+// machine role grants, and OIDC bindings for RemoteStorage (ADR-023/ADR-030/
+// ADR-031, finding #518): thin passthroughs onto new server-side routes under
+// /api/v1/system/machine-identities, /machine-credentials, and
+// /machine-oidc-bindings (server/http/handlers/machine_identities_proxy.go),
+// mirroring the dynamic-secrets/groups proxy pattern exactly: gated on the SAME
+// broad system.read/system.write RBAC permissions a RemoteStorage credential
+// already needs for every other proxied call, so this introduces no new
+// privilege class.
 //
-// Machine identity management is processed server-side in remote mode; stubs.
-// For the local (GORM) equivalent see local_machine_identities.go.
+// No machine-identity POLICY decision (state-machine transition legality,
+// role-grant authorization, token issuance/hashing, OIDC-subject federation
+// policy) is made in these routes — that stays entirely in the CALLING server's
+// own internal/core.KeyorixCore (machine_identities.go, machine_token.go), exactly
+// as it does against a local backend.
+//
+// Before this fix every method here unconditionally returned
+// ErrRemoteUnsupported ("machine identity management is processed server-side in
+// remote mode" — the actual state was: it isn't processed anywhere at all under
+// storage.type: remote), so a downstream server's ENTIRE machine-identity
+// subsystem (CI/service-account provisioning, machine-token issuance/validation,
+// machine role grants, Kubernetes/OIDC workload federation) was completely
+// non-functional.
+//
+// Atomicity note (investigated, not assumed safe — see
+// internal/core/storage/interface.go's TransitionMachineIdentityState doc and
+// internal/core/machine_identities.go's TransitionMachineIdentity doc for the
+// full reasoning): core.TransitionMachineIdentity's #388 fix relies on
+// LockMachineIdentityForUpdate + a DB transaction/row-lock to keep "revoked is
+// terminal" atomic against a concurrent writer of the same row. RemoteStorage.
+// WithTransaction (remote_transaction.go) is a no-op passthrough — there is no
+// client-side transaction to open over HTTP — so a plain two-call
+// LockMachineIdentityForUpdate-then-UpdateMachineIdentity proxy pair would lose
+// that guarantee entirely: two concurrent transitions on the SAME downstream
+// server, both racing against this SAME upstream, could each independently
+// observe the pre-transition state and each "win" a Save, silently un-revoking a
+// just-revoked machine identity. TransitionMachineIdentityState exists
+// specifically to close this: ONE round trip carries the already-mutated target
+// row plus the fromState the caller observed, and the upstream applies the exact
+// same conditional "WHERE id = ? AND state = ?" write its own LocalStorage would
+// (mirroring UpdateProjectInvitation's #412 `WHERE id = ? AND state = 'pending'`
+// pattern) — a lost race reports matched=false rather than silently overwriting
+// the winner. LockMachineIdentityForUpdate itself remains a plain read here (see
+// its doc below), exactly like LockUserForUpdate's remote equivalent
+// (remote_users.go) — the ACTUAL atomicity guarantee now lives in the
+// TransitionMachineIdentityState write, not in the read.
+//
+// Sensitive-data note: MachineIdentityCredential.TokenHash (tagged `json:"-"` on
+// the model) is a SHA-256 hex digest of the one-time-displayed raw token, never
+// the raw secret — see machine_identities_proxy.go's package doc for the full
+// verification (its only reader, core.ValidateMachineToken, looks it up via
+// GetMachineIdentityCredentialByHash(ctx, sha256Hex(raw))). This package's wire
+// type carries it explicitly, like dynamicSecretConfigWire's AdminDSNEnc.
+//
+// CountStaleMachineIdentitiesByProject remains an intentional stub (see its own
+// doc below) — the grouped hygiene-rollup query (#393) runs server-side and is
+// out of this finding's scope.
+//
+// For the local (GORM) equivalent of everything here see
+// local_machine_identities.go / local_machine_credentials.go.
 package store
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-func (rs *RemoteStorage) CreateMachineIdentity(_ context.Context, _ *models.MachineIdentity) (*models.MachineIdentity, error) {
-	return nil, remoteUnsupported("CreateMachineIdentity")
+// --- Wire types (mirror server/http/handlers/machine_identities_proxy.go's
+// proxy-side wire types exactly) ---
+
+type machineIdentityWire struct {
+	ID             uint       `json:"id"`
+	ProjectID      uint       `json:"project_id"`
+	Name           string     `json:"name"`
+	IdentityType   string     `json:"identity_type"`
+	State          string     `json:"state"`
+	Description    string     `json:"description"`
+	CreatedBy      uint       `json:"created_by"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+	LastSeenAt     *time.Time `json:"last_seen_at"`
+	RevokedAt      *time.Time `json:"revoked_at"`
+	Classification string     `json:"classification"`
 }
 
-func (rs *RemoteStorage) GetMachineIdentity(_ context.Context, _ uint) (*models.MachineIdentity, error) {
-	return nil, remoteUnsupported("GetMachineIdentity")
+func newMachineIdentityWire(m *models.MachineIdentity) machineIdentityWire {
+	return machineIdentityWire{
+		ID:             m.ID,
+		ProjectID:      m.ProjectID,
+		Name:           m.Name,
+		IdentityType:   m.IdentityType,
+		State:          m.State,
+		Description:    m.Description,
+		CreatedBy:      m.CreatedBy,
+		CreatedAt:      m.CreatedAt,
+		UpdatedAt:      m.UpdatedAt,
+		LastSeenAt:     m.LastSeenAt,
+		RevokedAt:      m.RevokedAt,
+		Classification: m.Classification,
+	}
 }
 
-func (rs *RemoteStorage) LockMachineIdentityForUpdate(_ context.Context, _ uint) (*models.MachineIdentity, error) {
-	return nil, remoteUnsupported("LockMachineIdentityForUpdate")
+func (w machineIdentityWire) toModel() *models.MachineIdentity {
+	return &models.MachineIdentity{
+		ID:             w.ID,
+		ProjectID:      w.ProjectID,
+		Name:           w.Name,
+		IdentityType:   w.IdentityType,
+		State:          w.State,
+		Description:    w.Description,
+		CreatedBy:      w.CreatedBy,
+		CreatedAt:      w.CreatedAt,
+		UpdatedAt:      w.UpdatedAt,
+		LastSeenAt:     w.LastSeenAt,
+		RevokedAt:      w.RevokedAt,
+		Classification: w.Classification,
+	}
 }
 
-func (rs *RemoteStorage) UpdateMachineIdentity(_ context.Context, _ *models.MachineIdentity) error {
-	return remoteUnsupported("UpdateMachineIdentity")
+func decodeMachineIdentityResponse(data []byte) (*models.MachineIdentity, error) {
+	var wire machineIdentityWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }
 
-func (rs *RemoteStorage) ListMachineIdentities(_ context.Context, _ uint) ([]*models.MachineIdentity, error) {
-	return nil, remoteUnsupported("ListMachineIdentities")
+type machineIdentityCredentialWire struct {
+	ID                uint       `json:"id"`
+	MachineIdentityID uint       `json:"machine_identity_id"`
+	Name              string     `json:"name"`
+	TokenHash         string     `json:"token_hash"`
+	TokenPrefix       string     `json:"token_prefix"`
+	LastUsedAt        *time.Time `json:"last_used_at"`
+	ExpiresAt         *time.Time `json:"expires_at"`
+	Revoked           bool       `json:"revoked"`
+	CreatedAt         time.Time  `json:"created_at"`
+	Classification    string     `json:"classification"`
 }
 
-func (rs *RemoteStorage) ListAllMachineIdentities(_ context.Context) ([]*models.MachineIdentity, error) {
-	return nil, remoteUnsupported("ListAllMachineIdentities")
+func newMachineIdentityCredentialWire(c *models.MachineIdentityCredential) machineIdentityCredentialWire {
+	return machineIdentityCredentialWire{
+		ID:                c.ID,
+		MachineIdentityID: c.MachineIdentityID,
+		Name:              c.Name,
+		TokenHash:         c.TokenHash,
+		TokenPrefix:       c.TokenPrefix,
+		LastUsedAt:        c.LastUsedAt,
+		ExpiresAt:         c.ExpiresAt,
+		Revoked:           c.Revoked,
+		CreatedAt:         c.CreatedAt,
+		Classification:    c.Classification,
+	}
 }
 
-func (rs *RemoteStorage) CountMachineIdentitiesByClassification(_ context.Context) (map[string]int, error) {
-	return nil, remoteUnsupported("CountMachineIdentitiesByClassification")
+func (w machineIdentityCredentialWire) toModel() *models.MachineIdentityCredential {
+	return &models.MachineIdentityCredential{
+		ID:                w.ID,
+		MachineIdentityID: w.MachineIdentityID,
+		Name:              w.Name,
+		TokenHash:         w.TokenHash,
+		TokenPrefix:       w.TokenPrefix,
+		LastUsedAt:        w.LastUsedAt,
+		ExpiresAt:         w.ExpiresAt,
+		Revoked:           w.Revoked,
+		CreatedAt:         w.CreatedAt,
+		Classification:    w.Classification,
+	}
+}
+
+func decodeMachineIdentityCredentialResponse(data []byte) (*models.MachineIdentityCredential, error) {
+	var wire machineIdentityCredentialWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
+}
+
+type machineIdentityOIDCBindingWire struct {
+	ID                uint      `json:"id"`
+	MachineIdentityID uint      `json:"machine_identity_id"`
+	Issuer            string    `json:"issuer"`
+	Subject           string    `json:"subject"`
+	CreatedBy         uint      `json:"created_by"`
+	CreatedAt         time.Time `json:"created_at"`
+}
+
+func newMachineIdentityOIDCBindingWire(b *models.MachineIdentityOIDCBinding) machineIdentityOIDCBindingWire {
+	return machineIdentityOIDCBindingWire{
+		ID:                b.ID,
+		MachineIdentityID: b.MachineIdentityID,
+		Issuer:            b.Issuer,
+		Subject:           b.Subject,
+		CreatedBy:         b.CreatedBy,
+		CreatedAt:         b.CreatedAt,
+	}
+}
+
+func (w machineIdentityOIDCBindingWire) toModel() *models.MachineIdentityOIDCBinding {
+	return &models.MachineIdentityOIDCBinding{
+		ID:                w.ID,
+		MachineIdentityID: w.MachineIdentityID,
+		Issuer:            w.Issuer,
+		Subject:           w.Subject,
+		CreatedBy:         w.CreatedBy,
+		CreatedAt:         w.CreatedAt,
+	}
+}
+
+func decodeMachineIdentityOIDCBindingResponse(data []byte) (*models.MachineIdentityOIDCBinding, error) {
+	var wire machineIdentityOIDCBindingWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
+}
+
+type roleWire struct {
+	ID          uint   `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+func (w roleWire) toModel() *models.Role {
+	return &models.Role{ID: w.ID, Name: w.Name, Description: w.Description}
+}
+
+// --- Machine identities ---
+
+// CreateMachineIdentity persists an already-built machine identity via POST
+// /api/v1/system/machine-identities.
+func (rs *RemoteStorage) CreateMachineIdentity(ctx context.Context, m *models.MachineIdentity) (*models.MachineIdentity, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/machine-identities", newMachineIdentityWire(m))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create machine identity: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create machine identity failed: %s", resp.Error.Error())
+	}
+	return decodeMachineIdentityResponse(resp.Data)
+}
+
+// GetMachineIdentity retrieves a machine identity by ID via GET
+// /api/v1/system/machine-identities/{id}.
+func (rs *RemoteStorage) GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error) {
+	path := fmt.Sprintf("/api/v1/system/machine-identities/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine identity: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get machine identity failed: %s", resp.Error.Error())
+	}
+	return decodeMachineIdentityResponse(resp.Data)
+}
+
+// LockMachineIdentityForUpdate has no row lock to take over HTTP — each remote
+// API call is already atomic server-side, and the ACTUAL atomicity guarantee
+// TransitionMachineIdentity needs (#388) is now provided by
+// TransitionMachineIdentityState's conditional write below, not by this read —
+// mirroring LockUserForUpdate's remote equivalent (remote_users.go). Deliberately
+// NOT routed through the client's 5-minute response cache (rs.client.Request
+// directly, like LockUserForUpdate), so a caller always observes the genuinely
+// current row before deciding fromState/legality.
+func (rs *RemoteStorage) LockMachineIdentityForUpdate(ctx context.Context, id uint) (*models.MachineIdentity, error) {
+	path := fmt.Sprintf("/api/v1/system/machine-identities/%d", id)
+	resp, err := rs.client.Request(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine identity: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get machine identity failed: %s", resp.Error.Error())
+	}
+	return decodeMachineIdentityResponse(resp.Data)
+}
+
+// UpdateMachineIdentity persists the full row via PUT
+// /api/v1/system/machine-identities/{id}. Matches LocalStorage's own
+// unconditional full-row Save semantics exactly — used by
+// core.ClassifyMachineIdentity, which has no state-machine invariant to protect.
+// core.TransitionMachineIdentity does NOT use this method — see
+// TransitionMachineIdentityState below for why.
+func (rs *RemoteStorage) UpdateMachineIdentity(ctx context.Context, m *models.MachineIdentity) error {
+	path := fmt.Sprintf("/api/v1/system/machine-identities/%d", m.ID)
+	resp, err := rs.client.Put(ctx, path, newMachineIdentityWire(m))
+	if err != nil {
+		return fmt.Errorf("failed to update machine identity: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("update machine identity failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// TransitionMachineIdentityState persists m's full row via a single conditional
+// PUT to /api/v1/system/machine-identities/{id}/transition (mirroring
+// UpdateProjectInvitation's #412 `WHERE id = ? AND state = 'pending'` pattern),
+// carrying fromState alongside so the upstream applies the exact SAME
+// conditional "WHERE id = ? AND state = ?" write its own LocalStorage would —
+// see the package doc's atomicity note for why this exists as a single
+// round-trip primitive rather than a generic Lock-then-Update proxy pair.
+func (rs *RemoteStorage) TransitionMachineIdentityState(ctx context.Context, m *models.MachineIdentity, fromState string) (bool, error) {
+	path := fmt.Sprintf("/api/v1/system/machine-identities/%d/transition", m.ID)
+	body := struct {
+		MachineIdentity machineIdentityWire `json:"machine_identity"`
+		FromState       string              `json:"from_state"`
+	}{MachineIdentity: newMachineIdentityWire(m), FromState: fromState}
+	resp, err := rs.client.Put(ctx, path, body)
+	if err != nil {
+		return false, fmt.Errorf("failed to transition machine identity: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("transition machine identity failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Matched bool `json:"matched"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Matched, nil
+}
+
+// ListMachineIdentities lists a project's machine identities via GET
+// /api/v1/system/machine-identities?project_id=X.
+func (rs *RemoteStorage) ListMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	path := "/api/v1/system/machine-identities?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list machine identities: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list machine identities failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		MachineIdentities []machineIdentityWire `json:"machine_identities"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.MachineIdentity, 0, len(result.MachineIdentities))
+	for _, w := range result.MachineIdentities {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
+}
+
+// ListAllMachineIdentities lists every machine identity across all projects via
+// GET /api/v1/system/machine-identities/all.
+func (rs *RemoteStorage) ListAllMachineIdentities(ctx context.Context) ([]*models.MachineIdentity, error) {
+	resp, err := rs.client.Get(ctx, "/api/v1/system/machine-identities/all")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list all machine identities: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list all machine identities failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		MachineIdentities []machineIdentityWire `json:"machine_identities"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.MachineIdentity, 0, len(result.MachineIdentities))
+	for _, w := range result.MachineIdentities {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
+}
+
+// CountMachineIdentitiesByClassification returns install-wide counts keyed by
+// classification label via GET
+// /api/v1/system/machine-identities/classification-counts.
+func (rs *RemoteStorage) CountMachineIdentitiesByClassification(ctx context.Context) (map[string]int, error) {
+	resp, err := rs.client.Get(ctx, "/api/v1/system/machine-identities/classification-counts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to count machine identities by classification: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("count machine identities by classification failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Counts map[string]int `json:"counts"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Counts, nil
 }
 
 // CountStaleMachineIdentitiesByProject is not available in remote mode; the
@@ -46,74 +403,330 @@ func (rs *RemoteStorage) CountStaleMachineIdentitiesByProject(_ context.Context,
 	return nil, remoteUnsupported("CountStaleMachineIdentitiesByProject")
 }
 
-func (rs *RemoteStorage) CreateMachineIdentityCredential(_ context.Context, _ *models.MachineIdentityCredential) (*models.MachineIdentityCredential, error) {
-	return nil, remoteUnsupported("CreateMachineIdentityCredential")
+// --- Machine-token credentials ---
+
+// CreateMachineIdentityCredential persists an already-built (already-hashed)
+// credential via POST /api/v1/system/machine-credentials.
+func (rs *RemoteStorage) CreateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) (*models.MachineIdentityCredential, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/machine-credentials", newMachineIdentityCredentialWire(c))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create machine credential: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create machine credential failed: %s", resp.Error.Error())
+	}
+	return decodeMachineIdentityCredentialResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) GetMachineIdentityCredentialByHash(_ context.Context, _ string) (*models.MachineIdentityCredential, error) {
-	return nil, remoteUnsupported("GetMachineIdentityCredentialByHash")
+// GetMachineIdentityCredentialByHash retrieves a credential by its SHA-256 hash
+// via GET /api/v1/system/machine-credentials/by-hash/{hash} — backs
+// core.ValidateMachineToken's machine-token authentication lookup.
+func (rs *RemoteStorage) GetMachineIdentityCredentialByHash(ctx context.Context, hash string) (*models.MachineIdentityCredential, error) {
+	path := fmt.Sprintf("/api/v1/system/machine-credentials/by-hash/%s", url.PathEscape(hash))
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine credential by hash: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get machine credential by hash failed: %s", resp.Error.Error())
+	}
+	return decodeMachineIdentityCredentialResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) GetMachineIdentityCredentialByID(_ context.Context, _ uint) (*models.MachineIdentityCredential, error) {
-	return nil, remoteUnsupported("GetMachineIdentityCredentialByID")
+// GetMachineIdentityCredentialByID retrieves a credential by ID via GET
+// /api/v1/system/machine-credentials/{id}.
+func (rs *RemoteStorage) GetMachineIdentityCredentialByID(ctx context.Context, id uint) (*models.MachineIdentityCredential, error) {
+	path := fmt.Sprintf("/api/v1/system/machine-credentials/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine credential: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get machine credential failed: %s", resp.Error.Error())
+	}
+	return decodeMachineIdentityCredentialResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) ListMachineIdentityCredentials(_ context.Context, _ uint) ([]*models.MachineIdentityCredential, error) {
-	return nil, remoteUnsupported("ListMachineIdentityCredentials")
+// ListMachineIdentityCredentials lists a machine identity's credentials via GET
+// /api/v1/system/machine-identities/{id}/credentials.
+func (rs *RemoteStorage) ListMachineIdentityCredentials(ctx context.Context, machineID uint) ([]*models.MachineIdentityCredential, error) {
+	path := fmt.Sprintf("/api/v1/system/machine-identities/%d/credentials", machineID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list machine credentials: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list machine credentials failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Credentials []machineIdentityCredentialWire `json:"credentials"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.MachineIdentityCredential, 0, len(result.Credentials))
+	for _, w := range result.Credentials {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
 }
 
-func (rs *RemoteStorage) ListActiveMachineIdentityCredentials(_ context.Context) ([]*models.MachineIdentityCredential, error) {
-	return nil, remoteUnsupported("ListActiveMachineIdentityCredentials")
+// ListActiveMachineIdentityCredentials lists every non-revoked credential
+// install-wide via GET /api/v1/system/machine-credentials/active.
+func (rs *RemoteStorage) ListActiveMachineIdentityCredentials(ctx context.Context) ([]*models.MachineIdentityCredential, error) {
+	resp, err := rs.client.Get(ctx, "/api/v1/system/machine-credentials/active")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list active machine credentials: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list active machine credentials failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Credentials []machineIdentityCredentialWire `json:"credentials"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.MachineIdentityCredential, 0, len(result.Credentials))
+	for _, w := range result.Credentials {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
 }
 
-func (rs *RemoteStorage) UpdateMachineIdentityCredential(_ context.Context, _ *models.MachineIdentityCredential) error {
-	return remoteUnsupported("UpdateMachineIdentityCredential")
+// UpdateMachineIdentityCredential persists the full row via PUT
+// /api/v1/system/machine-credentials/{id}. Matches LocalStorage's own
+// unconditional full-row Save semantics exactly — used by
+// core.ClassifyMachineToken.
+func (rs *RemoteStorage) UpdateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) error {
+	path := fmt.Sprintf("/api/v1/system/machine-credentials/%d", c.ID)
+	resp, err := rs.client.Put(ctx, path, newMachineIdentityCredentialWire(c))
+	if err != nil {
+		return fmt.Errorf("failed to update machine credential: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("update machine credential failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) CountMachineIdentityCredentialsByClassification(_ context.Context) (map[string]int, error) {
-	return nil, remoteUnsupported("CountMachineIdentityCredentialsByClassification")
+// CountMachineIdentityCredentialsByClassification returns install-wide counts
+// keyed by classification label via GET
+// /api/v1/system/machine-credentials/classification-counts.
+func (rs *RemoteStorage) CountMachineIdentityCredentialsByClassification(ctx context.Context) (map[string]int, error) {
+	resp, err := rs.client.Get(ctx, "/api/v1/system/machine-credentials/classification-counts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to count machine credentials by classification: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("count machine credentials by classification failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Counts map[string]int `json:"counts"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Counts, nil
 }
 
-func (rs *RemoteStorage) RevokeMachineIdentityCredential(_ context.Context, _ uint) error {
-	return remoteUnsupported("RevokeMachineIdentityCredential")
+// RevokeMachineIdentityCredential revokes a credential via POST
+// /api/v1/system/machine-credentials/{id}/revoke — the server applies the SAME
+// atomic conditional UPDATE local_machine_credentials.go does.
+func (rs *RemoteStorage) RevokeMachineIdentityCredential(ctx context.Context, id uint) error {
+	path := fmt.Sprintf("/api/v1/system/machine-credentials/%d/revoke", id)
+	resp, err := rs.client.Post(ctx, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to revoke machine credential: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("revoke machine credential failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) TouchMachineIdentityCredential(_ context.Context, _ uint, _ time.Time, _ time.Duration) error {
-	return remoteUnsupported("TouchMachineIdentityCredential")
+// TouchMachineIdentityCredential updates a credential's last-used timestamp via
+// POST /api/v1/system/machine-credentials/{id}/touch — the server applies the
+// SAME throttled conditional UPDATE local_machine_credentials.go does.
+func (rs *RemoteStorage) TouchMachineIdentityCredential(ctx context.Context, id uint, usedAt time.Time, staleness time.Duration) error {
+	path := fmt.Sprintf("/api/v1/system/machine-credentials/%d/touch", id)
+	body := struct {
+		UsedAt           time.Time `json:"used_at"`
+		StalenessSeconds int64     `json:"staleness_seconds"`
+	}{UsedAt: usedAt, StalenessSeconds: int64(staleness / time.Second)}
+	resp, err := rs.client.Post(ctx, path, body)
+	if err != nil {
+		return fmt.Errorf("failed to touch machine credential: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("touch machine credential failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) AssignMachineRole(_ context.Context, _, _ uint, _ storage.Scope) error {
-	return remoteUnsupported("AssignMachineRole")
+// --- Machine role grants ---
+
+func machineRoleScopeQueryParams(scope storage.Scope) url.Values {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(scope.ProjectID), 10))
+	q.Set("environment_id", strconv.FormatUint(uint64(scope.EnvironmentID), 10))
+	return q
 }
 
-func (rs *RemoteStorage) RemoveMachineRole(_ context.Context, _, _ uint, _ storage.Scope) error {
-	return remoteUnsupported("RemoveMachineRole")
+// AssignMachineRole grants roleID to machineID at scope via POST
+// /api/v1/system/machine-identities/{id}/roles/{roleId}?project_id=&environment_id=.
+func (rs *RemoteStorage) AssignMachineRole(ctx context.Context, machineID, roleID uint, scope storage.Scope) error {
+	path := fmt.Sprintf("/api/v1/system/machine-identities/%d/roles/%d?%s", machineID, roleID, machineRoleScopeQueryParams(scope).Encode())
+	resp, err := rs.client.Post(ctx, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to assign machine role: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("assign machine role failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) GetMachineRoleIDsAt(_ context.Context, _ uint, _ storage.Scope) ([]uint, error) {
-	return nil, remoteUnsupported("GetMachineRoleIDsAt")
+// RemoveMachineRole revokes roleID from machineID at scope via DELETE
+// /api/v1/system/machine-identities/{id}/roles/{roleId}?project_id=&environment_id=.
+func (rs *RemoteStorage) RemoveMachineRole(ctx context.Context, machineID, roleID uint, scope storage.Scope) error {
+	path := fmt.Sprintf("/api/v1/system/machine-identities/%d/roles/%d?%s", machineID, roleID, machineRoleScopeQueryParams(scope).Encode())
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to remove machine role: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("remove machine role failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) GetMachineRoles(_ context.Context, _ uint) ([]*models.Role, error) {
-	return nil, remoteUnsupported("GetMachineRoles")
+// GetMachineRoleIDsAt returns the role IDs granted to machineID that apply at
+// scope via GET
+// /api/v1/system/machine-identities/{id}/roles/ids?project_id=&environment_id=.
+func (rs *RemoteStorage) GetMachineRoleIDsAt(ctx context.Context, machineID uint, scope storage.Scope) ([]uint, error) {
+	path := fmt.Sprintf("/api/v1/system/machine-identities/%d/roles/ids?%s", machineID, machineRoleScopeQueryParams(scope).Encode())
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine role ids: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get machine role ids failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		RoleIDs []uint `json:"role_ids"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.RoleIDs, nil
 }
 
-func (rs *RemoteStorage) CreateOIDCBinding(_ context.Context, _ *models.MachineIdentityOIDCBinding) (*models.MachineIdentityOIDCBinding, error) {
-	return nil, remoteUnsupported("CreateOIDCBinding")
+// GetMachineRoles returns every role granted to machineID (any scope) via GET
+// /api/v1/system/machine-identities/{id}/roles.
+func (rs *RemoteStorage) GetMachineRoles(ctx context.Context, machineID uint) ([]*models.Role, error) {
+	path := fmt.Sprintf("/api/v1/system/machine-identities/%d/roles", machineID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine roles: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get machine roles failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Roles []roleWire `json:"roles"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.Role, 0, len(result.Roles))
+	for _, w := range result.Roles {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
 }
 
-func (rs *RemoteStorage) GetMachineByOIDCSubject(_ context.Context, _, _ string) (*models.MachineIdentity, error) {
-	return nil, remoteUnsupported("GetMachineByOIDCSubject")
+// --- OIDC bindings ---
+
+// CreateOIDCBinding persists an already-built binding via POST
+// /api/v1/system/machine-oidc-bindings.
+func (rs *RemoteStorage) CreateOIDCBinding(ctx context.Context, b *models.MachineIdentityOIDCBinding) (*models.MachineIdentityOIDCBinding, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/machine-oidc-bindings", newMachineIdentityOIDCBindingWire(b))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create oidc binding: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create oidc binding failed: %s", resp.Error.Error())
+	}
+	return decodeMachineIdentityOIDCBindingResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) ListOIDCBindings(_ context.Context, _ uint) ([]*models.MachineIdentityOIDCBinding, error) {
-	return nil, remoteUnsupported("ListOIDCBindings")
+// GetMachineByOIDCSubject resolves the machine identity bound to (issuer,
+// subject) via GET
+// /api/v1/system/machine-oidc-bindings/by-subject?issuer=&subject=.
+func (rs *RemoteStorage) GetMachineByOIDCSubject(ctx context.Context, issuer, subject string) (*models.MachineIdentity, error) {
+	q := url.Values{}
+	q.Set("issuer", issuer)
+	q.Set("subject", subject)
+	path := "/api/v1/system/machine-oidc-bindings/by-subject?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine by oidc subject: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get machine by oidc subject failed: %s", resp.Error.Error())
+	}
+	return decodeMachineIdentityResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) GetOIDCBindingByID(_ context.Context, _ uint) (*models.MachineIdentityOIDCBinding, error) {
-	return nil, remoteUnsupported("GetOIDCBindingByID")
+// ListOIDCBindings lists a machine identity's OIDC bindings via GET
+// /api/v1/system/machine-identities/{id}/oidc-bindings.
+func (rs *RemoteStorage) ListOIDCBindings(ctx context.Context, machineID uint) ([]*models.MachineIdentityOIDCBinding, error) {
+	path := fmt.Sprintf("/api/v1/system/machine-identities/%d/oidc-bindings", machineID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list oidc bindings: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list oidc bindings failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Bindings []machineIdentityOIDCBindingWire `json:"bindings"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.MachineIdentityOIDCBinding, 0, len(result.Bindings))
+	for _, w := range result.Bindings {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
 }
 
-func (rs *RemoteStorage) DeleteOIDCBinding(_ context.Context, _ uint) error {
-	return remoteUnsupported("DeleteOIDCBinding")
+// GetOIDCBindingByID retrieves a binding by ID via GET
+// /api/v1/system/machine-oidc-bindings/{id}.
+func (rs *RemoteStorage) GetOIDCBindingByID(ctx context.Context, id uint) (*models.MachineIdentityOIDCBinding, error) {
+	path := fmt.Sprintf("/api/v1/system/machine-oidc-bindings/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get oidc binding: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get oidc binding failed: %s", resp.Error.Error())
+	}
+	return decodeMachineIdentityOIDCBindingResponse(resp.Data)
+}
+
+// DeleteOIDCBinding deletes a binding via DELETE
+// /api/v1/system/machine-oidc-bindings/{id}.
+func (rs *RemoteStorage) DeleteOIDCBinding(ctx context.Context, id uint) error {
+	path := fmt.Sprintf("/api/v1/system/machine-oidc-bindings/%d", id)
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete oidc binding: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete oidc binding failed: %s", resp.Error.Error())
+	}
+	return nil
 }

--- a/internal/storage/store/remote_unsupported_test.go
+++ b/internal/storage/store/remote_unsupported_test.go
@@ -23,16 +23,24 @@ func TestRemoteStorage_UnsupportedSentinel(t *testing.T) {
 	ctx := context.Background()
 
 	calls := map[string]func() error{
-		// ListProjectInvitations (#507), CreateProjectMembership (#511), and
-		// CreateGroup (#514) now make a real HTTP call rather than stubbing out —
-		// see server/http/remote_storage_invitations_test.go,
-		// server/http/remote_storage_project_memberships_test.go, and
-		// server/http/remote_storage_groups_test.go for their end-to-end coverage
-		// against a real router.
-		"CreateAccessRequest":   func() error { _, e := rs.CreateAccessRequest(ctx, &models.AccessRequest{}); return e },
-		"CreateNotification":    func() error { _, e := rs.CreateNotification(ctx, &models.Notification{}); return e },
-		"ListPermissions":       func() error { _, e := rs.ListPermissions(ctx); return e },
-		"CreateMachineIdentity": func() error { _, e := rs.CreateMachineIdentity(ctx, &models.MachineIdentity{}); return e },
+		// ListProjectInvitations (#507), CreateProjectMembership (#511),
+		// CreateGroup (#514), and CreateMachineIdentity (#518) now make a real HTTP
+		// call rather than stubbing out — see
+		// server/http/remote_storage_invitations_test.go,
+		// server/http/remote_storage_project_memberships_test.go,
+		// server/http/remote_storage_groups_test.go, and
+		// server/http/remote_storage_machine_identities_test.go for their
+		// end-to-end coverage against a real router.
+		"CreateAccessRequest": func() error { _, e := rs.CreateAccessRequest(ctx, &models.AccessRequest{}); return e },
+		"CreateNotification":  func() error { _, e := rs.CreateNotification(ctx, &models.Notification{}); return e },
+		"ListPermissions":     func() error { _, e := rs.ListPermissions(ctx); return e },
+		// CountStaleMachineIdentitiesByProject (#393) legitimately stays a stub —
+		// the grouped hygiene-rollup query runs server-side, out of #518's scope
+		// (see remote_machine_identities.go's own doc comment).
+		"CountStaleMachineIdentitiesByProject": func() error {
+			_, e := rs.CountStaleMachineIdentitiesByProject(ctx, []uint{1}, time.Now())
+			return e
+		},
 	}
 	for name, call := range calls {
 		err := call()

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -1,0 +1,868 @@
+// machine_identities_proxy.go — server-side endpoints backing RemoteStorage's
+// machine-identity storage primitives (ADR-023/ADR-030/ADR-031, finding #518):
+// CreateMachineIdentity/GetMachineIdentity/LockMachineIdentityForUpdate/
+// UpdateMachineIdentity/TransitionMachineIdentityState/ListMachineIdentities/
+// ListAllMachineIdentities/CountMachineIdentitiesByClassification/
+// CreateMachineIdentityCredential/GetMachineIdentityCredentialByHash/
+// GetMachineIdentityCredentialByID/ListMachineIdentityCredentials/
+// ListActiveMachineIdentityCredentials/UpdateMachineIdentityCredential/
+// CountMachineIdentityCredentialsByClassification/RevokeMachineIdentityCredential/
+// TouchMachineIdentityCredential/AssignMachineRole/RemoveMachineRole/
+// GetMachineRoleIDsAt/GetMachineRoles/CreateOIDCBinding/GetMachineByOIDCSubject/
+// ListOIDCBindings/GetOIDCBindingByID/DeleteOIDCBinding.
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// its machine-identity storage calls to whichever upstream server it's configured
+// against, through these routes (registered in server/http/router.go under
+// /api/v1/system/machine-identities, /machine-credentials, and
+// /machine-oidc-bindings, gated on the existing system.read/system.write RBAC
+// permissions — the SAME tier every RemoteStorage credential already needs for
+// every other proxied call), mirroring dynamic_secrets_proxy.go/groups_proxy.go
+// exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/machine_identities.go, machine_token.go, and machine_oidc.go
+// already use against a local backend. NO authorization/business-logic decision
+// (state-machine transition legality, role-grant authorization, token
+// issuance/hashing, OIDC-subject federation policy) is made here — that stays
+// entirely in the CALLING server's own internal/core.KeyorixCore, exactly as it
+// does against a local backend.
+//
+// This is why the existing human-facing routes under
+// /api/v1/projects/{id}/machine-identities/... (server/http/handlers/
+// machine_identities.go, CatalogHandler.TransitionMachineIdentity/
+// ClassifyMachineIdentity/IssueMachineToken/GrantMachineRole/CreateOIDCBinding)
+// are NOT reused for this proxy — exactly like the human-facing /groups routes
+// were the wrong target for the Groups fix (#514): those handlers bake in real
+// authorization decisions (project-scoped RBAC via RequireScopedPermission),
+// state-machine legality checks, token minting/hashing, and audit-event
+// construction against the calling HTTP request's OWN identity — the wrong
+// semantics for a raw storage-primitive passthrough, whose caller (the
+// downstream server's own internal/core, already authorized against ITS OWN
+// caller) only needs this server to persist/return rows.
+//
+// Sensitive-data note: MachineIdentityCredential.TokenHash is tagged `json:"-"`
+// on the model (never exposed on the human-facing API — see
+// machine_identities.go's model doc), but it is only ever a SHA-256 hex digest
+// of the one-time-displayed raw token, never the raw secret itself (verified via
+// its only reader, internal/core/machine_token.go's ValidateMachineToken, which
+// looks it up via GetMachineIdentityCredentialByHash(ctx, sha256Hex(raw))) — so,
+// like dynamicSecretConfigProxyWire's AdminDSNEnc/AdminDSNMeta, this proxy's wire
+// type carries it explicitly rather than silently dropping it, which would
+// otherwise make GetMachineIdentityCredentialByHash/CreateMachineIdentityCredential
+// entirely non-functional under storage.type: remote (ValidateMachineToken's
+// lookup has nothing to match against).
+//
+// Atomicity note (investigated, not assumed safe): TransitionMachineIdentityState
+// exists (internal/core/storage/interface.go) precisely because a naive two-call
+// LockMachineIdentityForUpdate-then-UpdateMachineIdentity proxy pair would lose
+// the #388 "revoked is terminal" guarantee entirely under storage.type: remote —
+// RemoteStorage.WithTransaction is a no-op passthrough (remote_transaction.go), so
+// nothing serializes the Lock read against a concurrent writer's commit the way a
+// real DB transaction + row lock does locally. TransitionMachineIdentityStateProxy
+// runs core.KeyorixCore's SAME conditional "WHERE id = ? AND state = ?" write
+// (local_machine_identities.go) in ONE round trip, making no transition-legality
+// decision of its own — core.TransitionMachineIdentity still decides fromState/to
+// via canTransitionMachine before calling this, exactly as it does locally.
+//
+// Response envelope: like dynamic_secrets_proxy.go/groups_proxy.go, these
+// construct the exact {"success":bool,"data":...,"error":{"code","message"}}
+// shape internal/storage/remote.HTTPClient parses.
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// isAlreadyAssignedErr reports whether err is local_machine_credentials.go's
+// AssignMachineRole "already assigned" client error — a conflict, not a storage
+// failure. Classifying it as 409 (rather than a generic 500) matters beyond
+// HTTP semantics purity: internal/storage/remote.HTTPClient's isRetryableError
+// treats ANY 5xx as retryable and re-sends the request with exponential
+// backoff, and 5 CONSECUTIVE recorded failures — which a single retried 500
+// call reaches on its own, one per attempt — trips its circuit breaker,
+// locking out every OTHER call through the same RemoteStorage instance for the
+// next 30s. An expected, deterministic "already assigned" client error must
+// therefore map to a genuinely non-retryable 4xx status.
+func isAlreadyAssignedErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "already assigned")
+}
+
+// isNotAssignedErr reports whether err is RemoveMachineRole's "not assigned"
+// client error (the grant doesn't exist) — see isAlreadyAssignedErr's doc for
+// why this must be a non-retryable 4xx, not a 500.
+func isNotAssignedErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "not assigned")
+}
+
+// isUniqueViolationErr reports whether err looks like a unique-constraint
+// violation from either backing DB driver — mirrors
+// internal/storage/store/local_memberships.go's isUniqueViolation exactly
+// (matching driver-native message text, since this codebase doesn't opt into
+// gorm.Config{TranslateError: true}). Used by CreateOIDCBindingProxy to map
+// CreateOIDCBinding's duplicate (issuer, subject) failure to 409 rather than a
+// retryable 500 — see isAlreadyAssignedErr's doc for why that distinction
+// matters beyond HTTP semantics purity.
+func isUniqueViolationErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed") || // SQLite
+		strings.Contains(msg, "duplicate key value violates unique constraint") // Postgres
+}
+
+// machineIdentityProxyWire mirrors models.MachineIdentity's fields exactly
+// (snake_case) — the model carries no json tags of its own, so a direct
+// marshal/unmarshal would produce Go-cased keys ("ID", "ProjectID", ...) instead
+// of the snake_case wire shape every other proxy in this package uses.
+type machineIdentityProxyWire struct {
+	ID             uint       `json:"id"`
+	ProjectID      uint       `json:"project_id"`
+	Name           string     `json:"name"`
+	IdentityType   string     `json:"identity_type"`
+	State          string     `json:"state"`
+	Description    string     `json:"description"`
+	CreatedBy      uint       `json:"created_by"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+	LastSeenAt     *time.Time `json:"last_seen_at"`
+	RevokedAt      *time.Time `json:"revoked_at"`
+	Classification string     `json:"classification"`
+}
+
+func newMachineIdentityProxyWire(m *models.MachineIdentity) machineIdentityProxyWire {
+	return machineIdentityProxyWire{
+		ID:             m.ID,
+		ProjectID:      m.ProjectID,
+		Name:           m.Name,
+		IdentityType:   m.IdentityType,
+		State:          m.State,
+		Description:    m.Description,
+		CreatedBy:      m.CreatedBy,
+		CreatedAt:      m.CreatedAt,
+		UpdatedAt:      m.UpdatedAt,
+		LastSeenAt:     m.LastSeenAt,
+		RevokedAt:      m.RevokedAt,
+		Classification: m.Classification,
+	}
+}
+
+func (w machineIdentityProxyWire) toModel() *models.MachineIdentity {
+	return &models.MachineIdentity{
+		ID:             w.ID,
+		ProjectID:      w.ProjectID,
+		Name:           w.Name,
+		IdentityType:   w.IdentityType,
+		State:          w.State,
+		Description:    w.Description,
+		CreatedBy:      w.CreatedBy,
+		CreatedAt:      w.CreatedAt,
+		UpdatedAt:      w.UpdatedAt,
+		LastSeenAt:     w.LastSeenAt,
+		RevokedAt:      w.RevokedAt,
+		Classification: w.Classification,
+	}
+}
+
+// machineIdentityCredentialProxyWire mirrors models.MachineIdentityCredential's
+// fields exactly, INCLUDING TokenHash (tagged `json:"-"` on the model, which
+// would otherwise silently drop it from a direct marshal) — see the package doc
+// for why sending this SHA-256 hash (never the raw token) across this internal
+// boundary is safe.
+type machineIdentityCredentialProxyWire struct {
+	ID                uint       `json:"id"`
+	MachineIdentityID uint       `json:"machine_identity_id"`
+	Name              string     `json:"name"`
+	TokenHash         string     `json:"token_hash"`
+	TokenPrefix       string     `json:"token_prefix"`
+	LastUsedAt        *time.Time `json:"last_used_at"`
+	ExpiresAt         *time.Time `json:"expires_at"`
+	Revoked           bool       `json:"revoked"`
+	CreatedAt         time.Time  `json:"created_at"`
+	Classification    string     `json:"classification"`
+}
+
+func newMachineIdentityCredentialProxyWire(c *models.MachineIdentityCredential) machineIdentityCredentialProxyWire {
+	return machineIdentityCredentialProxyWire{
+		ID:                c.ID,
+		MachineIdentityID: c.MachineIdentityID,
+		Name:              c.Name,
+		TokenHash:         c.TokenHash,
+		TokenPrefix:       c.TokenPrefix,
+		LastUsedAt:        c.LastUsedAt,
+		ExpiresAt:         c.ExpiresAt,
+		Revoked:           c.Revoked,
+		CreatedAt:         c.CreatedAt,
+		Classification:    c.Classification,
+	}
+}
+
+func (w machineIdentityCredentialProxyWire) toModel() *models.MachineIdentityCredential {
+	return &models.MachineIdentityCredential{
+		ID:                w.ID,
+		MachineIdentityID: w.MachineIdentityID,
+		Name:              w.Name,
+		TokenHash:         w.TokenHash,
+		TokenPrefix:       w.TokenPrefix,
+		LastUsedAt:        w.LastUsedAt,
+		ExpiresAt:         w.ExpiresAt,
+		Revoked:           w.Revoked,
+		CreatedAt:         w.CreatedAt,
+		Classification:    w.Classification,
+	}
+}
+
+// machineIdentityOIDCBindingProxyWire mirrors models.MachineIdentityOIDCBinding's
+// fields exactly (snake_case).
+type machineIdentityOIDCBindingProxyWire struct {
+	ID                uint      `json:"id"`
+	MachineIdentityID uint      `json:"machine_identity_id"`
+	Issuer            string    `json:"issuer"`
+	Subject           string    `json:"subject"`
+	CreatedBy         uint      `json:"created_by"`
+	CreatedAt         time.Time `json:"created_at"`
+}
+
+func newMachineIdentityOIDCBindingProxyWire(b *models.MachineIdentityOIDCBinding) machineIdentityOIDCBindingProxyWire {
+	return machineIdentityOIDCBindingProxyWire{
+		ID:                b.ID,
+		MachineIdentityID: b.MachineIdentityID,
+		Issuer:            b.Issuer,
+		Subject:           b.Subject,
+		CreatedBy:         b.CreatedBy,
+		CreatedAt:         b.CreatedAt,
+	}
+}
+
+func (w machineIdentityOIDCBindingProxyWire) toModel() *models.MachineIdentityOIDCBinding {
+	return &models.MachineIdentityOIDCBinding{
+		ID:                w.ID,
+		MachineIdentityID: w.MachineIdentityID,
+		Issuer:            w.Issuer,
+		Subject:           w.Subject,
+		CreatedBy:         w.CreatedBy,
+		CreatedAt:         w.CreatedAt,
+	}
+}
+
+// roleProxyWire mirrors models.Role's fields exactly (snake_case) — used only by
+// GetMachineRolesProxy's response.
+type roleProxyWire struct {
+	ID          uint   `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+func newRoleProxyWire(r *models.Role) roleProxyWire {
+	return roleProxyWire{ID: r.ID, Name: r.Name, Description: r.Description}
+}
+
+// --- Machine identities ---
+
+// CreateMachineIdentityProxy handles POST /api/v1/system/machine-identities.
+func (h *CatalogHandler) CreateMachineIdentityProxy(w http.ResponseWriter, r *http.Request) {
+	var body machineIdentityProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Name == "" || body.ProjectID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "name and project_id are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateMachineIdentity(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("machine-identities proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMachineIdentityProxyWire(created))
+}
+
+// GetMachineIdentityProxy handles GET /api/v1/system/machine-identities/{id}.
+// Also backs RemoteStorage.LockMachineIdentityForUpdate: LockMachineIdentityForUpdate
+// has no row lock to take over HTTP (mirroring LockUserForUpdate's remote
+// equivalent, remote_users.go) — it is a plain read, deliberately NOT routed
+// through the client's response cache (see remote_machine_identities.go).
+func (h *CatalogHandler) GetMachineIdentityProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid machine identity id")
+		return
+	}
+	m, err := h.coreService.Storage().GetMachineIdentity(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "machine identity not found")
+			return
+		}
+		log.Printf("machine-identities proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMachineIdentityProxyWire(m))
+}
+
+// UpdateMachineIdentityProxy handles PUT /api/v1/system/machine-identities/{id}.
+// A raw persist (storage.Storage.UpdateMachineIdentity is an unconditional
+// full-row Save, matching LocalStorage's own semantics exactly — used by
+// core.ClassifyMachineIdentity, which has no state-machine invariant to protect).
+// core.TransitionMachineIdentity does NOT use this path — see
+// TransitionMachineIdentityStateProxy below.
+func (h *CatalogHandler) UpdateMachineIdentityProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid machine identity id")
+		return
+	}
+	var body machineIdentityProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	if err := h.coreService.Storage().UpdateMachineIdentity(r.Context(), body.toModel()); err != nil {
+		log.Printf("machine-identities proxy: update failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}
+
+// transitionMachineIdentityStateBody is the request body
+// TransitionMachineIdentityStateProxy expects: the full machine-identity row the
+// caller already mutated in memory (m.State/UpdatedAt/RevokedAt already set to
+// the target values), plus the fromState the caller observed under its own
+// LockMachineIdentityForUpdate read.
+type transitionMachineIdentityStateBody struct {
+	MachineIdentity machineIdentityProxyWire `json:"machine_identity"`
+	FromState       string                   `json:"from_state"`
+}
+
+// TransitionMachineIdentityStateProxy handles PUT
+// /api/v1/system/machine-identities/{id}/transition. Runs the SAME conditional
+// "WHERE id = ? AND state = ?" write core.KeyorixCore.TransitionMachineIdentity
+// already relies on against a local backend (#388) — see the package doc's
+// atomicity note for why this is a dedicated route rather than a generic
+// UpdateMachineIdentityProxy call.
+func (h *CatalogHandler) TransitionMachineIdentityStateProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid machine identity id")
+		return
+	}
+	var body transitionMachineIdentityStateBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.FromState == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "from_state is required")
+		return
+	}
+	body.MachineIdentity.ID = uint(id)
+	m := body.MachineIdentity.toModel()
+	matched, err := h.coreService.Storage().TransitionMachineIdentityState(r.Context(), m, body.FromState)
+	if err != nil {
+		log.Printf("machine-identities proxy: transition failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"matched": matched})
+}
+
+// ListMachineIdentitiesProxy handles GET
+// /api/v1/system/machine-identities?project_id=X.
+func (h *CatalogHandler) ListMachineIdentitiesProxy(w http.ResponseWriter, r *http.Request) {
+	projectIDStr := r.URL.Query().Get("project_id")
+	if projectIDStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id query parameter is required")
+		return
+	}
+	projectID, err := strconv.ParseUint(projectIDStr, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id must be a valid integer")
+		return
+	}
+	rows, err := h.coreService.Storage().ListMachineIdentities(r.Context(), uint(projectID))
+	if err != nil {
+		log.Printf("machine-identities proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]machineIdentityProxyWire, 0, len(rows))
+	for _, m := range rows {
+		wire = append(wire, newMachineIdentityProxyWire(m))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"machine_identities": wire})
+}
+
+// ListAllMachineIdentitiesProxy handles GET
+// /api/v1/system/machine-identities/all (a static path, registered before
+// /machine-identities/{id} in router.go).
+func (h *CatalogHandler) ListAllMachineIdentitiesProxy(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.coreService.Storage().ListAllMachineIdentities(r.Context())
+	if err != nil {
+		log.Printf("machine-identities proxy: list-all failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]machineIdentityProxyWire, 0, len(rows))
+	for _, m := range rows {
+		wire = append(wire, newMachineIdentityProxyWire(m))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"machine_identities": wire})
+}
+
+// CountMachineIdentitiesByClassificationProxy handles GET
+// /api/v1/system/machine-identities/classification-counts (a static path,
+// registered before /machine-identities/{id} in router.go).
+func (h *CatalogHandler) CountMachineIdentitiesByClassificationProxy(w http.ResponseWriter, r *http.Request) {
+	counts, err := h.coreService.Storage().CountMachineIdentitiesByClassification(r.Context())
+	if err != nil {
+		log.Printf("machine-identities proxy: count-by-classification failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"counts": counts})
+}
+
+// --- Machine-token credentials ---
+
+// CreateMachineIdentityCredentialProxy handles POST /api/v1/system/machine-credentials.
+func (h *CatalogHandler) CreateMachineIdentityCredentialProxy(w http.ResponseWriter, r *http.Request) {
+	var body machineIdentityCredentialProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.MachineIdentityID == 0 || body.TokenHash == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "machine_identity_id and token_hash are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateMachineIdentityCredential(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("machine-credentials proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMachineIdentityCredentialProxyWire(created))
+}
+
+// GetMachineIdentityCredentialByHashProxy handles GET
+// /api/v1/system/machine-credentials/by-hash/{hash} (a static prefix, registered
+// before /machine-credentials/{id} in router.go). Backs
+// core.ValidateMachineToken's machine-token authentication lookup — see the
+// package doc for why sending this SHA-256 hash (never the raw token) is safe.
+func (h *CatalogHandler) GetMachineIdentityCredentialByHashProxy(w http.ResponseWriter, r *http.Request) {
+	hash := chi.URLParam(r, "hash")
+	c, err := h.coreService.Storage().GetMachineIdentityCredentialByHash(r.Context(), hash)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "machine credential not found")
+			return
+		}
+		log.Printf("machine-credentials proxy: get-by-hash failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMachineIdentityCredentialProxyWire(c))
+}
+
+// GetMachineIdentityCredentialByIDProxy handles GET
+// /api/v1/system/machine-credentials/{id}.
+func (h *CatalogHandler) GetMachineIdentityCredentialByIDProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid credential id")
+		return
+	}
+	c, err := h.coreService.Storage().GetMachineIdentityCredentialByID(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "machine credential not found")
+			return
+		}
+		log.Printf("machine-credentials proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMachineIdentityCredentialProxyWire(c))
+}
+
+// ListMachineIdentityCredentialsProxy handles GET
+// /api/v1/system/machine-identities/{id}/credentials.
+func (h *CatalogHandler) ListMachineIdentityCredentialsProxy(w http.ResponseWriter, r *http.Request) {
+	machineID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid machine identity id")
+		return
+	}
+	rows, err := h.coreService.Storage().ListMachineIdentityCredentials(r.Context(), uint(machineID))
+	if err != nil {
+		log.Printf("machine-credentials proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]machineIdentityCredentialProxyWire, 0, len(rows))
+	for _, c := range rows {
+		wire = append(wire, newMachineIdentityCredentialProxyWire(c))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"credentials": wire})
+}
+
+// ListActiveMachineIdentityCredentialsProxy handles GET
+// /api/v1/system/machine-credentials/active (a static path, registered before
+// /machine-credentials/{id} in router.go).
+func (h *CatalogHandler) ListActiveMachineIdentityCredentialsProxy(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.coreService.Storage().ListActiveMachineIdentityCredentials(r.Context())
+	if err != nil {
+		log.Printf("machine-credentials proxy: list-active failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]machineIdentityCredentialProxyWire, 0, len(rows))
+	for _, c := range rows {
+		wire = append(wire, newMachineIdentityCredentialProxyWire(c))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"credentials": wire})
+}
+
+// UpdateMachineIdentityCredentialProxy handles PUT
+// /api/v1/system/machine-credentials/{id}. A raw persist (storage.Storage.
+// UpdateMachineIdentityCredential is an unconditional full-row Save, matching
+// LocalStorage's own semantics exactly — used by core.ClassifyMachineToken).
+func (h *CatalogHandler) UpdateMachineIdentityCredentialProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid credential id")
+		return
+	}
+	var body machineIdentityCredentialProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	if err := h.coreService.Storage().UpdateMachineIdentityCredential(r.Context(), body.toModel()); err != nil {
+		log.Printf("machine-credentials proxy: update failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}
+
+// CountMachineIdentityCredentialsByClassificationProxy handles GET
+// /api/v1/system/machine-credentials/classification-counts (a static path,
+// registered before /machine-credentials/{id} in router.go).
+func (h *CatalogHandler) CountMachineIdentityCredentialsByClassificationProxy(w http.ResponseWriter, r *http.Request) {
+	counts, err := h.coreService.Storage().CountMachineIdentityCredentialsByClassification(r.Context())
+	if err != nil {
+		log.Printf("machine-credentials proxy: count-by-classification failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"counts": counts})
+}
+
+// RevokeMachineIdentityCredentialProxy handles POST
+// /api/v1/system/machine-credentials/{id}/revoke. storage.Storage.
+// RevokeMachineIdentityCredential is itself an atomic conditional UPDATE
+// (local_machine_credentials.go: `UpdateColumn("revoked", true)` gated on
+// `id = ?`), so a single passthrough call here preserves that guarantee exactly.
+func (h *CatalogHandler) RevokeMachineIdentityCredentialProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid credential id")
+		return
+	}
+	if err := h.coreService.Storage().RevokeMachineIdentityCredential(r.Context(), uint(id)); err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "machine credential not found")
+			return
+		}
+		log.Printf("machine-credentials proxy: revoke failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"revoked": true})
+}
+
+// touchMachineIdentityCredentialBody is TouchMachineIdentityCredentialProxy's
+// request body. StalenessSeconds is sent as whole seconds rather than a raw
+// time.Duration (nanoseconds) to keep the wire value human-readable/debuggable.
+type touchMachineIdentityCredentialBody struct {
+	UsedAt           time.Time `json:"used_at"`
+	StalenessSeconds int64     `json:"staleness_seconds"`
+}
+
+// TouchMachineIdentityCredentialProxy handles POST
+// /api/v1/system/machine-credentials/{id}/touch. Preserves
+// TouchMachineIdentityCredential's own throttled-write semantics
+// (local_machine_credentials.go's `WHERE id = ? AND (last_used_at IS NULL OR
+// last_used_at < cutoff)`) via a single passthrough call.
+func (h *CatalogHandler) TouchMachineIdentityCredentialProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid credential id")
+		return
+	}
+	var body touchMachineIdentityCredentialBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	staleness := time.Duration(body.StalenessSeconds) * time.Second
+	if err := h.coreService.Storage().TouchMachineIdentityCredential(r.Context(), uint(id), body.UsedAt, staleness); err != nil {
+		log.Printf("machine-credentials proxy: touch failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"touched": true})
+}
+
+// --- Machine role grants ---
+
+// machineRoleScopeQuery parses the required project_id/environment_id query
+// parameters shared by every machine-role route below (0 is a valid "global
+// scope" value for either, so both are required rather than defaulted).
+func machineRoleScopeQuery(w http.ResponseWriter, r *http.Request) (storage.Scope, bool) {
+	projectIDStr := r.URL.Query().Get("project_id")
+	environmentIDStr := r.URL.Query().Get("environment_id")
+	if projectIDStr == "" || environmentIDStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id and environment_id query parameters are required")
+		return storage.Scope{}, false
+	}
+	projectID, err := strconv.ParseUint(projectIDStr, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id must be a valid integer")
+		return storage.Scope{}, false
+	}
+	environmentID, err := strconv.ParseUint(environmentIDStr, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "environment_id must be a valid integer")
+		return storage.Scope{}, false
+	}
+	return storage.Scope{ProjectID: uint(projectID), EnvironmentID: uint(environmentID)}, true
+}
+
+// AssignMachineRoleProxy handles POST
+// /api/v1/system/machine-identities/{id}/roles/{roleId}?project_id=&environment_id=.
+func (h *CatalogHandler) AssignMachineRoleProxy(w http.ResponseWriter, r *http.Request) {
+	machineID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid machine identity id")
+		return
+	}
+	roleID, err := strconv.ParseUint(chi.URLParam(r, "roleId"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid role id")
+		return
+	}
+	scope, ok := machineRoleScopeQuery(w, r)
+	if !ok {
+		return
+	}
+	if err := h.coreService.Storage().AssignMachineRole(r.Context(), uint(machineID), uint(roleID), scope); err != nil {
+		if isAlreadyAssignedErr(err) {
+			writeRemoteAPIError(w, http.StatusConflict, "ALREADY_ASSIGNED", "role already assigned")
+			return
+		}
+		log.Printf("machine-roles proxy: assign failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"assigned": true})
+}
+
+// RemoveMachineRoleProxy handles DELETE
+// /api/v1/system/machine-identities/{id}/roles/{roleId}?project_id=&environment_id=.
+func (h *CatalogHandler) RemoveMachineRoleProxy(w http.ResponseWriter, r *http.Request) {
+	machineID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid machine identity id")
+		return
+	}
+	roleID, err := strconv.ParseUint(chi.URLParam(r, "roleId"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid role id")
+		return
+	}
+	scope, ok := machineRoleScopeQuery(w, r)
+	if !ok {
+		return
+	}
+	if err := h.coreService.Storage().RemoveMachineRole(r.Context(), uint(machineID), uint(roleID), scope); err != nil {
+		if isNotFoundErr(err) || isNotAssignedErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "role grant not found")
+			return
+		}
+		log.Printf("machine-roles proxy: remove failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"removed": true})
+}
+
+// GetMachineRoleIDsAtProxy handles GET
+// /api/v1/system/machine-identities/{id}/roles/ids?project_id=&environment_id=
+// (a static "ids" path, registered before the /roles/{roleId} routes above in
+// router.go).
+func (h *CatalogHandler) GetMachineRoleIDsAtProxy(w http.ResponseWriter, r *http.Request) {
+	machineID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid machine identity id")
+		return
+	}
+	scope, ok := machineRoleScopeQuery(w, r)
+	if !ok {
+		return
+	}
+	ids, err := h.coreService.Storage().GetMachineRoleIDsAt(r.Context(), uint(machineID), scope)
+	if err != nil {
+		log.Printf("machine-roles proxy: get-ids-at failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"role_ids": ids})
+}
+
+// GetMachineRolesProxy handles GET /api/v1/system/machine-identities/{id}/roles.
+func (h *CatalogHandler) GetMachineRolesProxy(w http.ResponseWriter, r *http.Request) {
+	machineID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid machine identity id")
+		return
+	}
+	roles, err := h.coreService.Storage().GetMachineRoles(r.Context(), uint(machineID))
+	if err != nil {
+		log.Printf("machine-roles proxy: get-roles failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]roleProxyWire, 0, len(roles))
+	for _, ro := range roles {
+		wire = append(wire, newRoleProxyWire(ro))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"roles": wire})
+}
+
+// --- OIDC bindings ---
+
+// CreateOIDCBindingProxy handles POST /api/v1/system/machine-oidc-bindings.
+func (h *CatalogHandler) CreateOIDCBindingProxy(w http.ResponseWriter, r *http.Request) {
+	var body machineIdentityOIDCBindingProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.MachineIdentityID == 0 || body.Issuer == "" || body.Subject == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "machine_identity_id, issuer, and subject are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateOIDCBinding(r.Context(), body.toModel())
+	if err != nil {
+		if isUniqueViolationErr(err) {
+			writeRemoteAPIError(w, http.StatusConflict, "DUPLICATE_BINDING", "a binding for this issuer/subject already exists")
+			return
+		}
+		log.Printf("machine-oidc-bindings proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMachineIdentityOIDCBindingProxyWire(created))
+}
+
+// GetMachineByOIDCSubjectProxy handles GET
+// /api/v1/system/machine-oidc-bindings/by-subject?issuer=&subject= (a static
+// path, registered before /machine-oidc-bindings/{id} in router.go).
+func (h *CatalogHandler) GetMachineByOIDCSubjectProxy(w http.ResponseWriter, r *http.Request) {
+	issuer := r.URL.Query().Get("issuer")
+	subject := r.URL.Query().Get("subject")
+	if issuer == "" || subject == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "issuer and subject query parameters are required")
+		return
+	}
+	m, err := h.coreService.Storage().GetMachineByOIDCSubject(r.Context(), issuer, subject)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "no machine identity bound to that issuer/subject")
+			return
+		}
+		log.Printf("machine-oidc-bindings proxy: get-by-subject failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMachineIdentityProxyWire(m))
+}
+
+// ListOIDCBindingsProxy handles GET
+// /api/v1/system/machine-identities/{id}/oidc-bindings.
+func (h *CatalogHandler) ListOIDCBindingsProxy(w http.ResponseWriter, r *http.Request) {
+	machineID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid machine identity id")
+		return
+	}
+	rows, err := h.coreService.Storage().ListOIDCBindings(r.Context(), uint(machineID))
+	if err != nil {
+		log.Printf("machine-oidc-bindings proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]machineIdentityOIDCBindingProxyWire, 0, len(rows))
+	for _, b := range rows {
+		wire = append(wire, newMachineIdentityOIDCBindingProxyWire(b))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"bindings": wire})
+}
+
+// GetOIDCBindingByIDProxy handles GET
+// /api/v1/system/machine-oidc-bindings/{id}.
+func (h *CatalogHandler) GetOIDCBindingByIDProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid binding id")
+		return
+	}
+	b, err := h.coreService.Storage().GetOIDCBindingByID(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "oidc binding not found")
+			return
+		}
+		log.Printf("machine-oidc-bindings proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMachineIdentityOIDCBindingProxyWire(b))
+}
+
+// DeleteOIDCBindingProxy handles DELETE /api/v1/system/machine-oidc-bindings/{id}.
+func (h *CatalogHandler) DeleteOIDCBindingProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid binding id")
+		return
+	}
+	if err := h.coreService.Storage().DeleteOIDCBinding(r.Context(), uint(id)); err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "oidc binding not found")
+			return
+		}
+		log.Printf("machine-oidc-bindings proxy: delete failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -94,6 +94,13 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		&models.MFASecret{},
 		&models.MFARecoveryCode{},
 		&models.MFAChallenge{},
+		// #518: the machine-identity-proxy end-to-end tests exercise
+		// MachineIdentity/MachineIdentityCredential/MachineIdentityRole/
+		// MachineIdentityOIDCBinding CRUD through the real router.
+		&models.MachineIdentity{},
+		&models.MachineIdentityCredential{},
+		&models.MachineIdentityRole{},
+		&models.MachineIdentityOIDCBinding{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the

--- a/server/http/remote_storage_machine_identities_test.go
+++ b/server/http/remote_storage_machine_identities_test.go
@@ -1,0 +1,424 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForMachineIdentities builds the standard #452/#507-style
+// two-server harness: an "upstream" exercised through the REAL production
+// NewRouter/handlers (including the new /api/v1/system/machine-identities,
+// /machine-credentials, and /machine-oidc-bindings routes,
+// server/http/handlers/machine_identities_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed at
+// "upstream" over real HTTP via store.RemoteStorage.
+func newUpstreamDownstreamForMachineIdentities(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore, projectID uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+
+	ctx := context.Background()
+	project, err := upstream.CreateProject(ctx, "Machine Identities Test Project", "")
+	require.NoError(t, err)
+	return upstream, downstream, project.ID
+}
+
+func buildMachineIdentity(now time.Time, projectID uint, name string) *models.MachineIdentity {
+	return &models.MachineIdentity{
+		ProjectID:    projectID,
+		Name:         name,
+		IdentityType: core.MachineTypeCI,
+		State:        core.MachineActive,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+}
+
+// TestRemoteStorageMachineIdentities_CreateGetListUpdate_RealServer proves the
+// fix for CreateMachineIdentity/GetMachineIdentity/ListMachineIdentities/
+// ListAllMachineIdentities/UpdateMachineIdentity/
+// CountMachineIdentitiesByClassification: a machine identity is genuinely
+// persisted on the upstream server via the DOWNSTREAM's RemoteStorage, fetchable
+// by ID, listed, and updatable — all via storage.type: remote against a real
+// router, not a protocol mock.
+func TestRemoteStorageMachineIdentities_CreateGetListUpdate_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMachineIdentities(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	m, err := downstream.Storage().CreateMachineIdentity(ctx, buildMachineIdentity(now, projectID, "ci-runner"))
+	require.NoError(t, err, "creating a machine identity must succeed via storage.type: remote")
+	require.NotZero(t, m.ID, "the upstream must assign a real ID")
+	assert.Equal(t, "ci-runner", m.Name)
+	assert.Equal(t, core.MachineActive, m.State)
+
+	// Confirm it is a REAL row in the upstream's own storage.
+	direct, err := upstream.Storage().GetMachineIdentity(ctx, m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "ci-runner", direct.Name)
+
+	// GetMachineIdentity via the downstream round-trips every field correctly.
+	fetched, err := downstream.Storage().GetMachineIdentity(ctx, m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, m.ID, fetched.ID)
+	assert.Equal(t, m.Name, fetched.Name)
+	assert.Equal(t, m.IdentityType, fetched.IdentityType)
+
+	// A second identity, then list both back via ListMachineIdentities and
+	// ListAllMachineIdentities.
+	_, err = downstream.Storage().CreateMachineIdentity(ctx, buildMachineIdentity(now, projectID, "k8s-workload"))
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListMachineIdentities(ctx, projectID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	all, err := downstream.Storage().ListAllMachineIdentities(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(all), 2)
+
+	// UpdateMachineIdentity persists a classification change via the downstream.
+	fetched.Classification = "confidential"
+	require.NoError(t, downstream.Storage().UpdateMachineIdentity(ctx, fetched))
+	reFetched, err := upstream.Storage().GetMachineIdentity(ctx, m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "confidential", reFetched.Classification, "the update must be visible directly on the upstream's own storage")
+
+	counts, err := downstream.Storage().CountMachineIdentitiesByClassification(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, counts["confidential"])
+}
+
+// TestRemoteStorageMachineIdentities_GetNotFound_RealServer proves a clean
+// not-found error for a nonexistent machine identity ID.
+func TestRemoteStorageMachineIdentities_GetNotFound_RealServer(t *testing.T) {
+	_, downstream, _ := newUpstreamDownstreamForMachineIdentities(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetMachineIdentity(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageMachineIdentities_TransitionState_RealServer proves the fix
+// for TransitionMachineIdentityState end-to-end: core.TransitionMachineIdentity,
+// run against the DOWNSTREAM's RemoteStorage, drives the exact same conditional
+// write against the upstream, and a legal transition is genuinely persisted.
+func TestRemoteStorageMachineIdentities_TransitionState_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMachineIdentities(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	m, err := downstream.Storage().CreateMachineIdentity(ctx, buildMachineIdentity(now, projectID, "transition-test"))
+	require.NoError(t, err)
+
+	transitioned, err := downstream.TransitionMachineIdentity(ctx, projectID, m.ID, core.MachineSuspended, 1)
+	require.NoError(t, err, "a legal transition must succeed via storage.type: remote")
+	assert.Equal(t, core.MachineSuspended, transitioned.State)
+
+	direct, err := upstream.Storage().GetMachineIdentity(ctx, m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.MachineSuspended, direct.State, "the transition must be visible directly on the upstream's own storage")
+
+	// Revoking stamps RevokedAt, and revoked is terminal — a subsequent
+	// transition attempt must fail, exactly as it does against a local backend.
+	revoked, err := downstream.TransitionMachineIdentity(ctx, projectID, m.ID, core.MachineRevoked, 1)
+	require.NoError(t, err)
+	require.NotNil(t, revoked.RevokedAt)
+
+	_, err = downstream.TransitionMachineIdentity(ctx, projectID, m.ID, core.MachineActive, 1)
+	require.Error(t, err, "revoked is terminal — reactivating a revoked machine identity must fail")
+}
+
+// TestRemoteStorageMachineIdentities_TransitionState_ConcurrentRaceIsSerialized_RealServer
+// is the concurrency test for the #518 atomicity fix: N goroutines on the SAME
+// downstream (storage.type: remote) core.KeyorixCore race to transition the SAME
+// machine identity concurrently — one set toward "revoked", the rest toward
+// "suspended" — starting from the identity's initial "active" state. Without
+// TransitionMachineIdentityState's conditional write, a naive Lock-then-Update
+// proxy pair would let a "suspended" writer silently win after a "revoked"
+// writer already committed (#388), un-revoking a just-revoked identity. This
+// proves that, under storage.type: remote against a REAL upstream server (not a
+// mock), at most one revoke ever succeeds and the final persisted state is never
+// un-revoked once a revoke has committed.
+func TestRemoteStorageMachineIdentities_TransitionState_ConcurrentRaceIsSerialized_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMachineIdentities(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	m, err := downstream.Storage().CreateMachineIdentity(ctx, buildMachineIdentity(now, projectID, "race-test"))
+	require.NoError(t, err)
+
+	const n = 8
+	var wg sync.WaitGroup
+	successes := make([]bool, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			to := core.MachineSuspended
+			if i%2 == 0 {
+				to = core.MachineRevoked
+			}
+			_, err := downstream.TransitionMachineIdentity(ctx, projectID, m.ID, to, 1)
+			successes[i] = err == nil
+		}(i)
+	}
+	wg.Wait()
+
+	// Whatever the final state, it must be internally consistent: if ANY revoke
+	// succeeded, the persisted state must be "revoked" (terminal) — never
+	// silently un-revoked by a racing suspend that observed a stale pre-revoke
+	// read. Exactly one racer transitioning FROM "active" can ever win (#388);
+	// every other racer must have observed the loser's error.
+	direct, err := upstream.Storage().GetMachineIdentity(ctx, m.ID)
+	require.NoError(t, err)
+	assert.Contains(t, []string{core.MachineSuspended, core.MachineRevoked}, direct.State)
+
+	winners := 0
+	revokeWon := false
+	for i, ok := range successes {
+		if ok {
+			winners++
+			if i%2 == 0 {
+				revokeWon = true
+			}
+		}
+	}
+	require.Equal(t, 1, winners, "exactly one racing transition from the same pre-transition state must win (#388)")
+	if revokeWon {
+		assert.Equal(t, core.MachineRevoked, direct.State, "once a revoke commits, the persisted state must never be un-revoked")
+	}
+}
+
+// buildMachineIdentityCredential mirrors what internal/core.IssueMachineToken
+// computes before calling storage.CreateMachineIdentityCredential — an
+// already-hashed credential row (the raw token itself is shown once at
+// issuance and never persisted).
+func buildMachineIdentityCredential(now time.Time, machineID uint, tokenHash string) *models.MachineIdentityCredential {
+	return &models.MachineIdentityCredential{
+		MachineIdentityID: machineID,
+		Name:              "ci token",
+		TokenHash:         tokenHash,
+		TokenPrefix:       "kx_machine_ab12cd",
+		CreatedAt:         now,
+	}
+}
+
+// TestRemoteStorageMachineIdentities_CredentialCreateGetHashListRevokeTouch_RealServer
+// proves the fix for CreateMachineIdentityCredential/
+// GetMachineIdentityCredentialByHash/GetMachineIdentityCredentialByID/
+// ListMachineIdentityCredentials/ListActiveMachineIdentityCredentials/
+// UpdateMachineIdentityCredential/CountMachineIdentityCredentialsByClassification/
+// RevokeMachineIdentityCredential/TouchMachineIdentityCredential.
+func TestRemoteStorageMachineIdentities_CredentialCreateGetHashListRevokeTouch_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMachineIdentities(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	m, err := downstream.Storage().CreateMachineIdentity(ctx, buildMachineIdentity(now, projectID, "cred-test"))
+	require.NoError(t, err)
+
+	const hash = "deadbeef00112233445566778899aabbccddeeff0011223344556677889900"
+	cred, err := downstream.Storage().CreateMachineIdentityCredential(ctx, buildMachineIdentityCredential(now, m.ID, hash))
+	require.NoError(t, err, "creating a machine credential must succeed via storage.type: remote")
+	require.NotZero(t, cred.ID)
+
+	// The upstream's own row carries the hash (never the raw token, which the
+	// caller never had a reason to send in the first place).
+	direct, err := upstream.Storage().GetMachineIdentityCredentialByID(ctx, cred.ID)
+	require.NoError(t, err)
+	assert.Equal(t, hash, direct.TokenHash)
+
+	// GetMachineIdentityCredentialByHash via the downstream — the lookup
+	// core.ValidateMachineToken relies on for machine-token authentication.
+	byHash, err := downstream.Storage().GetMachineIdentityCredentialByHash(ctx, hash)
+	require.NoError(t, err)
+	assert.Equal(t, cred.ID, byHash.ID)
+
+	byID, err := downstream.Storage().GetMachineIdentityCredentialByID(ctx, cred.ID)
+	require.NoError(t, err)
+	assert.Equal(t, cred.MachineIdentityID, byID.MachineIdentityID)
+
+	rows, err := downstream.Storage().ListMachineIdentityCredentials(ctx, m.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	active, err := downstream.Storage().ListActiveMachineIdentityCredentials(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(active), 1)
+
+	// UpdateMachineIdentityCredential persists a classification change.
+	byID.Classification = "restricted"
+	require.NoError(t, downstream.Storage().UpdateMachineIdentityCredential(ctx, byID))
+	reFetched, err := upstream.Storage().GetMachineIdentityCredentialByID(ctx, cred.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "restricted", reFetched.Classification)
+
+	counts, err := downstream.Storage().CountMachineIdentityCredentialsByClassification(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, counts["restricted"])
+
+	// TouchMachineIdentityCredential updates LastUsedAt.
+	require.NoError(t, downstream.Storage().TouchMachineIdentityCredential(ctx, cred.ID, now, time.Minute))
+	touched, err := upstream.Storage().GetMachineIdentityCredentialByID(ctx, cred.ID)
+	require.NoError(t, err)
+	require.NotNil(t, touched.LastUsedAt)
+
+	// RevokeMachineIdentityCredential flips Revoked and is visible directly on
+	// the upstream.
+	require.NoError(t, downstream.Storage().RevokeMachineIdentityCredential(ctx, cred.ID))
+	revoked, err := upstream.Storage().GetMachineIdentityCredentialByID(ctx, cred.ID)
+	require.NoError(t, err)
+	assert.True(t, revoked.Revoked)
+
+	// Now excluded from the active list.
+	activeAfter, err := downstream.Storage().ListActiveMachineIdentityCredentials(ctx)
+	require.NoError(t, err)
+	for _, c := range activeAfter {
+		assert.NotEqual(t, cred.ID, c.ID, "a revoked credential must not appear in the active list")
+	}
+}
+
+// TestRemoteStorageMachineIdentities_RoleGrantAssignRemoveListIDs_RealServer
+// proves the fix for AssignMachineRole/RemoveMachineRole/GetMachineRoleIDsAt/
+// GetMachineRoles.
+func TestRemoteStorageMachineIdentities_RoleGrantAssignRemoveListIDs_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMachineIdentities(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	m, err := downstream.Storage().CreateMachineIdentity(ctx, buildMachineIdentity(now, projectID, "role-test"))
+	require.NoError(t, err)
+
+	role, err := upstream.Storage().CreateRole(ctx, &models.Role{Name: "machine-role-test", Description: "test"})
+	require.NoError(t, err)
+
+	scope := corestorage.Scope{ProjectID: projectID, EnvironmentID: 0}
+	require.NoError(t, downstream.Storage().AssignMachineRole(ctx, m.ID, role.ID, scope), "granting a machine role must succeed via storage.type: remote")
+
+	// The grant is a REAL row on the upstream.
+	ids, err := upstream.Storage().GetMachineRoleIDsAt(ctx, m.ID, scope)
+	require.NoError(t, err)
+	assert.Contains(t, ids, role.ID)
+
+	// GetMachineRoleIDsAt/GetMachineRoles via the downstream.
+	idsViaDownstream, err := downstream.Storage().GetMachineRoleIDsAt(ctx, m.ID, scope)
+	require.NoError(t, err)
+	assert.Contains(t, idsViaDownstream, role.ID)
+
+	roles, err := downstream.Storage().GetMachineRoles(ctx, m.ID)
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+	assert.Equal(t, role.Name, roles[0].Name)
+
+	// A second concurrent grant of the same (machine, role, scope) must fail
+	// (mirrors LocalStorage's own AssignMachineRole semantics).
+	err = downstream.Storage().AssignMachineRole(ctx, m.ID, role.ID, scope)
+	require.Error(t, err, "granting the same role twice must fail, exactly as against a local backend")
+
+	// RemoveMachineRole revokes the grant; a second remove of the same grant
+	// must fail (already gone).
+	require.NoError(t, downstream.Storage().RemoveMachineRole(ctx, m.ID, role.ID, scope))
+	idsAfter, err := upstream.Storage().GetMachineRoleIDsAt(ctx, m.ID, scope)
+	require.NoError(t, err)
+	assert.NotContains(t, idsAfter, role.ID)
+
+	err = downstream.Storage().RemoveMachineRole(ctx, m.ID, role.ID, scope)
+	require.Error(t, err, "removing an already-removed grant must fail")
+}
+
+// TestRemoteStorageMachineIdentities_OIDCBindingCreateGetListDelete_RealServer
+// proves the fix for CreateOIDCBinding/GetMachineByOIDCSubject/
+// ListOIDCBindings/GetOIDCBindingByID/DeleteOIDCBinding.
+func TestRemoteStorageMachineIdentities_OIDCBindingCreateGetListDelete_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMachineIdentities(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	m, err := downstream.Storage().CreateMachineIdentity(ctx, buildMachineIdentity(now, projectID, "oidc-test"))
+	require.NoError(t, err)
+
+	binding, err := downstream.Storage().CreateOIDCBinding(ctx, &models.MachineIdentityOIDCBinding{
+		MachineIdentityID: m.ID,
+		Issuer:            "https://issuer.example",
+		Subject:           "system:serviceaccount:default:ci-runner",
+		CreatedAt:         now,
+	})
+	require.NoError(t, err, "creating an oidc binding must succeed via storage.type: remote")
+	require.NotZero(t, binding.ID)
+
+	// A REAL row on the upstream.
+	direct, err := upstream.Storage().GetOIDCBindingByID(ctx, binding.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "https://issuer.example", direct.Issuer)
+
+	// GetMachineByOIDCSubject/ListOIDCBindings/GetOIDCBindingByID via the downstream.
+	resolved, err := downstream.Storage().GetMachineByOIDCSubject(ctx, "https://issuer.example", "system:serviceaccount:default:ci-runner")
+	require.NoError(t, err)
+	assert.Equal(t, m.ID, resolved.ID)
+
+	bindings, err := downstream.Storage().ListOIDCBindings(ctx, m.ID)
+	require.NoError(t, err)
+	require.Len(t, bindings, 1)
+
+	fetched, err := downstream.Storage().GetOIDCBindingByID(ctx, binding.ID)
+	require.NoError(t, err)
+	assert.Equal(t, binding.Subject, fetched.Subject)
+
+	// A second binding with the SAME (issuer, subject) must fail (unique index).
+	_, err = downstream.Storage().CreateOIDCBinding(ctx, &models.MachineIdentityOIDCBinding{
+		MachineIdentityID: m.ID,
+		Issuer:            "https://issuer.example",
+		Subject:           "system:serviceaccount:default:ci-runner",
+		CreatedAt:         now,
+	})
+	require.Error(t, err, "a duplicate (issuer, subject) binding must fail, exactly as against a local backend")
+
+	// DeleteOIDCBinding removes it; a second delete must fail (already gone).
+	require.NoError(t, downstream.Storage().DeleteOIDCBinding(ctx, binding.ID))
+	_, err = upstream.Storage().GetOIDCBindingByID(ctx, binding.ID)
+	require.Error(t, err, "the deletion must be visible directly on the upstream's own storage")
+
+	err = downstream.Storage().DeleteOIDCBinding(ctx, binding.ID)
+	require.Error(t, err, "deleting an already-deleted binding must fail")
+
+	// GetMachineByOIDCSubject for an unbound subject must cleanly not-found.
+	_, err = downstream.Storage().GetMachineByOIDCSubject(ctx, "https://issuer.example", "no-such-subject")
+	require.Error(t, err)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -909,6 +909,76 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("system.write")).Delete("/groups/{id}/members/{userId}", groupHandler.RemoveGroupMemberProxy)
 			r.Get("/users/{id}/groups", groupHandler.GetUserGroupsProxy)
 
+			// Machine-identity storage-primitive proxy (finding #518). Lets a
+			// downstream Keyorix server booted with storage.type: remote (ADR-049)
+			// proxy CreateMachineIdentity/GetMachineIdentity/
+			// LockMachineIdentityForUpdate/UpdateMachineIdentity/ListMachineIdentities/
+			// ListAllMachineIdentities/CountMachineIdentitiesByClassification/
+			// CreateMachineIdentityCredential/GetMachineIdentityCredentialByHash/
+			// GetMachineIdentityCredentialByID/ListMachineIdentityCredentials/
+			// ListActiveMachineIdentityCredentials/UpdateMachineIdentityCredential/
+			// CountMachineIdentityCredentialsByClassification/
+			// RevokeMachineIdentityCredential/TouchMachineIdentityCredential/
+			// AssignMachineRole/RemoveMachineRole/GetMachineRoleIDsAt/GetMachineRoles/
+			// CreateOIDCBinding/GetMachineByOIDCSubject/ListOIDCBindings/
+			// GetOIDCBindingByID/DeleteOIDCBinding to THIS server's real storage
+			// backend, instead of every one of these methods unconditionally
+			// returning ErrRemoteUnsupported (machine-identity provisioning,
+			// machine-token issuance/validation, machine role grants, and
+			// Kubernetes/OIDC workload federation were entirely non-functional under
+			// storage.type: remote). Exactly the same pattern as the groups/
+			// dynamic-secrets proxies above: a thin passthrough onto storage.Storage
+			// (no machine-identity POLICY decision — state-machine transition
+			// legality, role-grant authorization, token issuance/hashing, OIDC
+			// federation policy — is made here; that stays entirely in the CALLING
+			// server's own internal/core.KeyorixCore, exactly as it does against a
+			// local backend), reusing the SAME system.read/system.write tier rather
+			// than the project-scoped roles.assign the human-facing
+			// /projects/{id}/machine-identities routes use — no new privilege class.
+			// Read is baseline system.read; every mutating operation requires
+			// system.write, matching every other admin-level mutation in this group.
+			//
+			// TransitionMachineIdentityState is a dedicated conditional-write route
+			// (NOT a generic Update), preserving #388's "revoked is terminal"
+			// row-lock guarantee across this HTTP hop — see
+			// machine_identities_proxy.go's package doc for the full atomicity
+			// investigation. CountStaleMachineIdentitiesByProject has no route here;
+			// it remains an intentional RemoteStorage stub (the #393 grouped
+			// hygiene-rollup query stays server-side, out of this finding's scope).
+			//
+			// Static sub-paths ("all", "classification-counts", "active", "by-hash/
+			// {hash}", "by-subject", and "roles/ids") are registered ahead of their
+			// sibling {id}/{roleId} routes, matching chi's static-before-dynamic
+			// preference at the same path position (the same ordering the
+			// dynamic-secrets/groups proxies above already rely on).
+			r.Get("/machine-identities/classification-counts", catalogHandler.CountMachineIdentitiesByClassificationProxy)
+			r.Get("/machine-identities/all", catalogHandler.ListAllMachineIdentitiesProxy)
+			r.Get("/machine-identities", catalogHandler.ListMachineIdentitiesProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/machine-identities", catalogHandler.CreateMachineIdentityProxy)
+			r.Get("/machine-identities/{id}", catalogHandler.GetMachineIdentityProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/machine-identities/{id}", catalogHandler.UpdateMachineIdentityProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/machine-identities/{id}/transition", catalogHandler.TransitionMachineIdentityStateProxy)
+			r.Get("/machine-identities/{id}/credentials", catalogHandler.ListMachineIdentityCredentialsProxy)
+			r.Get("/machine-identities/{id}/roles/ids", catalogHandler.GetMachineRoleIDsAtProxy)
+			r.Get("/machine-identities/{id}/roles", catalogHandler.GetMachineRolesProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/machine-identities/{id}/roles/{roleId}", catalogHandler.AssignMachineRoleProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Delete("/machine-identities/{id}/roles/{roleId}", catalogHandler.RemoveMachineRoleProxy)
+			r.Get("/machine-identities/{id}/oidc-bindings", catalogHandler.ListOIDCBindingsProxy)
+
+			r.Get("/machine-credentials/classification-counts", catalogHandler.CountMachineIdentityCredentialsByClassificationProxy)
+			r.Get("/machine-credentials/active", catalogHandler.ListActiveMachineIdentityCredentialsProxy)
+			r.Get("/machine-credentials/by-hash/{hash}", catalogHandler.GetMachineIdentityCredentialByHashProxy)
+			r.Get("/machine-credentials/{id}", catalogHandler.GetMachineIdentityCredentialByIDProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/machine-credentials", catalogHandler.CreateMachineIdentityCredentialProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/machine-credentials/{id}", catalogHandler.UpdateMachineIdentityCredentialProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/machine-credentials/{id}/revoke", catalogHandler.RevokeMachineIdentityCredentialProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/machine-credentials/{id}/touch", catalogHandler.TouchMachineIdentityCredentialProxy)
+
+			r.Get("/machine-oidc-bindings/by-subject", catalogHandler.GetMachineByOIDCSubjectProxy)
+			r.Get("/machine-oidc-bindings/{id}", catalogHandler.GetOIDCBindingByIDProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/machine-oidc-bindings", catalogHandler.CreateOIDCBindingProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Delete("/machine-oidc-bindings/{id}", catalogHandler.DeleteOIDCBindingProxy)
+
 			// Setup-token storage-primitive proxy (#510). Lets a downstream Keyorix
 			// server booted with storage.type: remote (ADR-049) proxy
 			// CreateSetupToken/GetSetupTokenByHash/SupersedeActiveSetupTokens/


### PR DESCRIPTION
## Summary
- Implements `RemoteStorage` support for Machine Identities (#518, the largest remaining gap from #513's audit): new thin passthrough routes under `/api/v1/system/machine-identities`, `/machine-credentials`, `/machine-oidc-bindings` (gated `system.read`/`system.write`, no new privilege class), replacing 24 of the 25 `remoteUnsupported` stubs in `internal/storage/store/remote_machine_identities.go`. `CountStaleMachineIdentitiesByProject` intentionally stays a stub (the #393 hygiene rollup runs server-side, per its existing doc comment).
- The existing human-facing routes bake in business-action logic (Transition/Classify/IssueToken/GrantMachineRole/CreateOIDCBinding) — confirmed the wrong proxy target and built new thin routes instead.
- **Atomicity issue found and fixed**: `core.TransitionMachineIdentity`'s #388 fix relies on a real DB transaction/row lock to keep "revoked is terminal" atomic. Since `RemoteStorage.WithTransaction` is a no-op passthrough, a naive Lock-then-Update proxy pair would reopen that race under `storage.type: remote`. Fixed by adding one new atomic primitive, `TransitionMachineIdentityState(ctx, m, fromState) (bool, error)`, persisting via a single conditional `WHERE id = ? AND state = ?` write in one round trip (mirroring #412's `UpdateProjectInvitation` pattern) — no transition-legality decision made in the primitive itself. Proven via an 8-way concurrent-race test against a real upstream server.
- **Secondary fix**: mapped expected client errors (already-assigned role, duplicate OIDC binding, etc.) to proper 409/404s instead of a generic 500 — the client's circuit breaker treats any 5xx as retryable-then-trippable, so an expected conflict was at risk of stalling every other concurrent call for 30s.

## Test plan
- [x] `go build ./...` / `go vet ./...` / `golangci-lint` / `gofmt` clean, including the separate `operator` module
- [x] `go test ./...` (whole repo) passes
- [x] New `server/http/remote_storage_machine_identities_test.go`: 7 tests incl. identity/credential/role/OIDC-binding CRUD and the 8-way transition-race test
- [x] `gosec -severity medium -exclude-generated` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)