### PR TITLE
fix(remote-storage): implement secret dependency storage primitives (#519)

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -413,6 +413,14 @@ func (m *MockStorage) DeleteSecretDependency(ctx context.Context, id uint) error
 	return args.Error(0)
 }
 
+func (m *MockStorage) CreateSecretDependencyExclusive(ctx context.Context, d *models.SecretDependency) (*models.SecretDependency, error) {
+	args := m.Called(ctx, d)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.SecretDependency), args.Error(1)
+}
+
 func (m *MockStorage) CreateLegalHold(ctx context.Context, h *models.LegalHold) (*models.LegalHold, error) {
 	args := m.Called(ctx, h)
 	if args.Get(0) == nil {

--- a/internal/core/secret_dependencies.go
+++ b/internal/core/secret_dependencies.go
@@ -11,6 +11,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -73,16 +74,18 @@ type RotationOrder struct {
 // real secrets in the same project; self-edges, duplicates, and edges that would
 // introduce a cycle are rejected. actorID is the acting principal.
 //
-// The cycle-check read and the edge write run inside a single storage transaction,
-// held under secretDependencyMu for its whole duration (#260): without this, two
-// concurrent calls adding A→B and B→A in the same project could each observe "no
-// cycle" from the pre-write graph before either write commits, both succeed, and
-// persist a 2-node cycle that GetProjectRotationOrder then hard-errors on forever
-// (nothing else detects or heals a stuck edge). The transaction's
-// ListSecretDependenciesForProjectForUpdate read takes a row-level lock on every
-// existing edge in the project on backends that support one (Postgres), serializing
-// HA replicas; secretDependencyMu serializes same-process callers — the same
-// two-layer pattern login_lockout.go's recordFailedLogin and RemoveUserRole's
+// The duplicate/cycle check and the edge write are performed by ONE atomic storage call
+// (CreateSecretDependencyExclusive, #260) rather than this method orchestrating a
+// ListSecretDependenciesForProjectForUpdate read and a separate CreateSecretDependency
+// write itself inside a WithTransaction: RemoteStorage.WithTransaction is a no-op
+// passthrough (no real transaction spans the wire), so that older two-call sequence
+// silently lost its whole atomicity guarantee under storage.type: remote — see the
+// storage.Storage interface doc (internal/core/storage/interface.go) for the full
+// reasoning. secretDependencyMu is still held for the call's duration, still serializing
+// same-process callers (SQLite, single instance) exactly as before; the storage layer's
+// own lock (Postgres FOR UPDATE on LocalStorage; whichever server ultimately owns the
+// row, on RemoteStorage) is what now also serializes across replicas/processes — the
+// same two-layer pattern login_lockout.go's recordFailedLogin and RemoveUserRole's
 // guardLastGlobalAdmin use.
 func (c *KeyorixCore) AddSecretDependency(ctx context.Context, actorID, dependentID, dependsOnID uint, note string) (*models.SecretDependency, error) {
 	if dependentID == dependsOnID {
@@ -107,39 +110,23 @@ func (c *KeyorixCore) AddSecretDependency(ctx context.Context, actorID, dependen
 	c.secretDependencyMu.Lock()
 	defer c.secretDependencyMu.Unlock()
 
-	var created *models.SecretDependency
-	err = c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
-		edges, lerr := tx.ListSecretDependenciesForProjectForUpdate(ctx, dependent.ProjectID)
-		if lerr != nil {
-			return lerr
-		}
-		for _, e := range edges {
-			if e.DependentSecretID == dependentID && e.DependsOnSecretID == dependsOnID {
-				return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this dependency already exists")
-			}
-		}
-		// A cycle would form iff dependsOnID can already reach dependentID over existing
-		// edges (then dependent → dependsOn → … → dependent closes the loop).
-		if dependencyReachable(edges, dependsOnID, dependentID) {
-			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this dependency would create a cycle")
-		}
-
-		c1, cerr := tx.CreateSecretDependency(ctx, &models.SecretDependency{
-			ProjectID:         dependent.ProjectID,
-			DependentSecretID: dependentID,
-			DependsOnSecretID: dependsOnID,
-			Note:              note,
-			CreatedBy:         actorID,
-			CreatedAt:         c.now(),
-		})
-		if cerr != nil {
-			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), cerr)
-		}
-		created = c1
-		return nil
+	created, err := c.storage.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID:         dependent.ProjectID,
+		DependentSecretID: dependentID,
+		DependsOnSecretID: dependsOnID,
+		Note:              note,
+		CreatedBy:         actorID,
+		CreatedAt:         c.now(),
 	})
 	if err != nil {
-		return nil, err
+		switch {
+		case errors.Is(err, storage.ErrDuplicateSecretDependency):
+			return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this dependency already exists")
+		case errors.Is(err, storage.ErrSecretDependencyCycle):
+			return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this dependency would create a cycle")
+		default:
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
 	}
 	c.writeAuditEvent(ctx, EventSecretDependencyAdded, actorPtr(actorID), &dependentID,
 		fmt.Sprintf("declared secret %q depends on %q", dependent.Name, dependsOn.Name))

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -119,6 +119,28 @@ var ErrDuplicateDynamicSecretConfig = errors.New("a dynamic-secret config with t
 // benign no-op skip, not a failure.
 var ErrDuplicateReminderNotification = errors.New("an unread reminder notification already exists for this user, type, and project")
 
+// ErrDuplicateSecretDependency is returned (wrapped) by CreateSecretDependencyExclusive
+// when the CURRENT edge set (read under this call's own lock — see that method's doc)
+// already contains the same (dependent, depends_on) pair. Backed by the real unique
+// index on secret_dependencies (idx_secret_dep_edge), so a plain CreateSecretDependency
+// insert would also fail with a unique-constraint violation for the exact same case;
+// CreateSecretDependencyExclusive additionally checks it up front (alongside the cycle
+// check, which the index cannot express) so both rejections share one code path and one
+// sentinel. Callers translate this into a clean "already exists" validation error.
+var ErrDuplicateSecretDependency = errors.New("this secret dependency already exists")
+
+// ErrSecretDependencyCycle is returned (wrapped) by CreateSecretDependencyExclusive when
+// adding the edge would make the depends_on secret transitively depend on the dependent
+// secret, closing a cycle in the project's dependency graph (ADR-052). Unlike
+// ErrDuplicateSecretDependency, no DB constraint can express "acyclic" directly, so this
+// is evaluated in application code against the lock-consistent edge read
+// CreateSecretDependencyExclusive takes — see its doc for why that check must run in the
+// SAME storage-layer call as the write (#260), not as a separate caller-orchestrated
+// read-then-write, once a real cross-call transaction can no longer be assumed
+// (RemoteStorage.WithTransaction is a no-op passthrough). Callers translate this into a
+// clean "would create a cycle" validation error.
+var ErrSecretDependencyCycle = errors.New("this secret dependency would create a cycle")
+
 // IsUserNotFound reports whether err represents "this user positively does not
 // exist" under EITHER active storage backend (#504). LocalStorage wraps the
 // ErrUserNotFound sentinel above (errors.Is); RemoteStorage instead returns a

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -222,11 +222,42 @@ type Storage interface {
 	// ListSecretDependenciesForProjectForUpdate is ListSecretDependenciesForProject,
 	// taking a row-level write lock on every returned edge on backends that support
 	// one (Postgres FOR UPDATE), mirroring LockUserForUpdate/
-	// ListGlobalAdminAssignmentsForUpdate (#260). Used inside a WithTransaction so
-	// AddSecretDependency's cycle-check read and the edge it writes serialize
-	// against a concurrent racing edge addition for the same project on Postgres/HA;
-	// secretDependencyMu covers same-process callers (SQLite, single instance).
+	// ListGlobalAdminAssignmentsForUpdate (#260). Retained as a raw storage
+	// primitive (parity with LocalStorage/RemoteStorage's other List*ForUpdate
+	// methods) but no longer used by AddSecretDependency
+	// (internal/core/secret_dependencies.go) — see CreateSecretDependencyExclusive
+	// below for why the cycle-check read and the edge write had to be collapsed
+	// into ONE storage-layer call rather than orchestrated by the caller across
+	// this method and CreateSecretDependency.
 	ListSecretDependenciesForProjectForUpdate(ctx context.Context, projectID uint) ([]*models.SecretDependency, error)
+	// CreateSecretDependencyExclusive atomically validates and persists one secret
+	// dependency edge under a project-scoped exclusive lock (Postgres FOR UPDATE on
+	// LocalStorage; a single request handled by the upstream's own LocalStorage, on
+	// RemoteStorage), rejecting it with storage.ErrDuplicateSecretDependency or
+	// storage.ErrSecretDependencyCycle if the CURRENT edge set (read under that
+	// same lock) already contains the pair, or adding it would close a cycle.
+	//
+	// This is what AddSecretDependency now calls instead of orchestrating
+	// ListSecretDependenciesForProjectForUpdate + CreateSecretDependency itself
+	// inside a WithTransaction (#260's original design): RemoteStorage.
+	// WithTransaction is a no-op passthrough — no real transaction spans the wire
+	// — so a caller-driven "list under lock, decide, then create" sequence against
+	// a RemoteStorage backend is really two independent HTTP round trips with no
+	// lock held between them, silently losing #260's whole guarantee for any
+	// downstream server booted with storage.type: remote (ADR-049) — including
+	// the exact case that guarantee exists for: multiple such downstream replicas
+	// racing to add a reciprocal edge pair against the SAME upstream project
+	// concurrently. Collapsing the check-and-write into one storage-interface call
+	// fixes that: LocalStorage's implementation runs the identical duplicate/cycle
+	// logic AddSecretDependency used to run itself, just moved down a layer and
+	// wrapped in one real DB transaction; RemoteStorage's implementation is a
+	// single POST to a dedicated upstream route whose handler runs that SAME
+	// LocalStorage method, so the atomicity guarantee is enforced by whichever
+	// server ultimately owns the row — the same wire-code-translation technique
+	// that preserves CreateProjectMembership's DB-level unique-index atomicity
+	// across this boundary (#511), just for an invariant (acyclicity) no unique
+	// index can express.
+	CreateSecretDependencyExclusive(ctx context.Context, d *models.SecretDependency) (*models.SecretDependency, error)
 
 	// Legal hold (ISO 27001 A.5.34 / eDiscovery) — a deployment-wide hold that
 	// blocks the purge jobs from hard-deleting records while active.

--- a/internal/storage/store/local_secret_dependencies.go
+++ b/internal/storage/store/local_secret_dependencies.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
@@ -63,4 +65,80 @@ func (ls *LocalStorage) DeleteSecretDependency(ctx context.Context, id uint) err
 		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
 	}
 	return nil
+}
+
+// CreateSecretDependencyExclusive is the storage-layer half of #260's fix (see the
+// interface doc, internal/core/storage/interface.go): it runs the SAME duplicate/cycle
+// validation AddSecretDependency (internal/core/secret_dependencies.go) used to
+// orchestrate itself across ListSecretDependenciesForProjectForUpdate +
+// CreateSecretDependency, but now as ONE call wrapped in a single real DB transaction —
+// so the guarantee survives being called over HTTP by RemoteStorage's implementation
+// (remote_secret_dependencies.go), where no transaction can span two separate round
+// trips.
+func (ls *LocalStorage) CreateSecretDependencyExclusive(ctx context.Context, d *models.SecretDependency) (*models.SecretDependency, error) {
+	var created *models.SecretDependency
+	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		q := tx
+		if tx.Dialector.Name() == "postgres" {
+			q = q.Clauses(clause.Locking{Strength: "UPDATE"})
+		}
+		var edges []*models.SecretDependency
+		if err := q.Where("project_id = ?", d.ProjectID).Order("id ASC").Find(&edges).Error; err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		for _, e := range edges {
+			if e.DependentSecretID == d.DependentSecretID && e.DependsOnSecretID == d.DependsOnSecretID {
+				return storage.ErrDuplicateSecretDependency
+			}
+		}
+		if secretDependencyReachable(edges, d.DependsOnSecretID, d.DependentSecretID) {
+			return storage.ErrSecretDependencyCycle
+		}
+		if err := tx.Create(d).Error; err != nil {
+			if isUniqueViolation(err) {
+				// Belt-and-suspenders: idx_secret_dep_edge caught a concurrent insert of
+				// the exact same pair that committed between this transaction's own read
+				// above and its write (possible on Postgres if the project had ZERO
+				// existing edges to lock — see the interface doc's parity note).
+				return storage.ErrDuplicateSecretDependency
+			}
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		created = d
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+// secretDependencyReachable reports whether `to` is reachable from `from` following
+// depends-on edges (from depends on … depends on to). Mirrors
+// internal/core/secret_dependencies.go's dependencyReachable exactly (that package
+// cannot be imported here — internal/core depends on this package, not the reverse —
+// so this is intentionally duplicated rather than shared; keep both in sync, and see
+// TestDependencyReachable/TestSecretDependencyReachable for the shared truth table both
+// must satisfy).
+func secretDependencyReachable(edges []*models.SecretDependency, from, to uint) bool {
+	adj := make(map[uint][]uint)
+	for _, e := range edges {
+		adj[e.DependentSecretID] = append(adj[e.DependentSecretID], e.DependsOnSecretID)
+	}
+	seen := map[uint]bool{from: true}
+	stack := []uint{from}
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, next := range adj[n] {
+			if next == to {
+				return true
+			}
+			if !seen[next] {
+				seen[next] = true
+				stack = append(stack, next)
+			}
+		}
+	}
+	return false
 }

--- a/internal/storage/store/local_secret_dependencies_test.go
+++ b/internal/storage/store/local_secret_dependencies_test.go
@@ -1,0 +1,162 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSecretDependencyReachable is the same truth table
+// internal/core/secret_dependencies_test.go's TestDependencyReachable exercises against
+// core's own dependencyReachable — this package cannot import core (core imports this
+// package), so secretDependencyReachable is a deliberate duplicate that must produce
+// identical answers; this test is what keeps the two in sync.
+func TestSecretDependencyReachable(t *testing.T) {
+	edge := func(dependent, dependsOn uint) *models.SecretDependency {
+		return &models.SecretDependency{DependentSecretID: dependent, DependsOnSecretID: dependsOn}
+	}
+	// 1→2→3 (1 depends on 2 depends on 3), plus 4→2.
+	edges := []*models.SecretDependency{edge(1, 2), edge(2, 3), edge(4, 2)}
+	assert.True(t, secretDependencyReachable(edges, 1, 3), "1 transitively depends on 3")
+	assert.True(t, secretDependencyReachable(edges, 1, 2))
+	assert.False(t, secretDependencyReachable(edges, 3, 1), "3 does not depend on 1")
+	assert.True(t, secretDependencyReachable(edges, 4, 3), "4→2→3 reachable")
+	assert.False(t, secretDependencyReachable(edges, 2, 4), "2 does not reach 4")
+}
+
+func newSecretDependencyTestStorage(t *testing.T) *LocalStorage {
+	t.Helper()
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.SecretDependency{}))
+	return NewLocalStorage(db)
+}
+
+// TestCreateSecretDependencyExclusive_HappyPath proves the ordinary case: a fresh edge
+// with no existing rows in the project is created and returned with a real ID.
+func TestCreateSecretDependencyExclusive_HappyPath(t *testing.T) {
+	ls := newSecretDependencyTestStorage(t)
+	ctx := context.Background()
+
+	created, err := ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 10, DependsOnSecretID: 20, Note: "app depends on db",
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, created.ID)
+	assert.Equal(t, uint(10), created.DependentSecretID)
+	assert.Equal(t, uint(20), created.DependsOnSecretID)
+
+	fetched, err := ls.GetSecretDependency(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "app depends on db", fetched.Note)
+}
+
+// TestCreateSecretDependencyExclusive_DuplicateRejected proves the exact
+// (dependent, depends_on) pair is rejected with the ErrDuplicateSecretDependency
+// sentinel, not a raw constraint-violation error.
+func TestCreateSecretDependencyExclusive_DuplicateRejected(t *testing.T) {
+	ls := newSecretDependencyTestStorage(t)
+	ctx := context.Background()
+
+	_, err := ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 10, DependsOnSecretID: 20,
+	})
+	require.NoError(t, err)
+
+	_, err = ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 10, DependsOnSecretID: 20,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, storage.ErrDuplicateSecretDependency))
+}
+
+// TestCreateSecretDependencyExclusive_CycleRejected proves adding the reverse edge of an
+// existing dependency (which would close a 2-node cycle) is rejected with the
+// ErrSecretDependencyCycle sentinel.
+func TestCreateSecretDependencyExclusive_CycleRejected(t *testing.T) {
+	ls := newSecretDependencyTestStorage(t)
+	ctx := context.Background()
+
+	// 10 depends on 20.
+	_, err := ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 10, DependsOnSecretID: 20,
+	})
+	require.NoError(t, err)
+
+	// 20 depends on 10 would close the loop.
+	_, err = ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 20, DependsOnSecretID: 10,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, storage.ErrSecretDependencyCycle))
+
+	// A longer cycle (30 depends on 10, which would close 10→20(nonexistent)... use a
+	// 3-node chain instead: 20 depends on 30, then 30 depends on 10 would close
+	// 10→20→30→10).
+	_, err = ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 20, DependsOnSecretID: 30,
+	})
+	require.NoError(t, err)
+	_, err = ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 30, DependsOnSecretID: 10,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, storage.ErrSecretDependencyCycle), "a longer cycle (10→20→30→10) must also be rejected")
+}
+
+// TestConcurrency_CreateSecretDependencyExclusive_NoCycleUnderRealContention is the
+// storage-layer analogue of internal/core's
+// TestAddSecretDependency_ConcurrentRaceCannotPersistACycle (#260), but exercised
+// directly against CreateSecretDependencyExclusive over a REAL multi-connection SQLite
+// database (concurrentDB, BEGIN IMMEDIATE) with NO process-level mutex held around the
+// call — proving the atomicity guarantee now lives in the storage primitive itself,
+// not only in the caller's secretDependencyMu. This is exactly the property
+// RemoteStorage's implementation depends on: a downstream server's mutex only
+// serializes its OWN goroutines, so multiple downstream replicas (or, here, multiple
+// bare goroutines with no shared mutex at all) must still be unable to both persist
+// reciprocal edges for the same pair.
+func TestConcurrency_CreateSecretDependencyExclusive_NoCycleUnderRealContention(t *testing.T) {
+	ls := newSecretDependencyTestStorage(t)
+	ctx := context.Background()
+
+	const iterations = 20
+	for i := 0; i < iterations; i++ {
+		a := uint(1000 + i*2)
+		b := uint(1000 + i*2 + 1)
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		results := make([]error, 2)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, results[0] = ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+				ProjectID: 1, DependentSecretID: a, DependsOnSecretID: b,
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, results[1] = ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+				ProjectID: 1, DependentSecretID: b, DependsOnSecretID: a,
+			})
+		}()
+		close(start)
+		wg.Wait()
+
+		successes := 0
+		for _, e := range results {
+			if e == nil {
+				successes++
+			}
+		}
+		require.Equal(t, 1, successes,
+			"iteration %d: exactly one of A→B / B→A must win the race under real multi-connection contention", i)
+	}
+}

--- a/internal/storage/store/remote_secret_dependencies.go
+++ b/internal/storage/store/remote_secret_dependencies.go
@@ -1,29 +1,227 @@
-// remote_secret_dependencies.go — secret dependency edges for RemoteStorage.
-// Processed server-side; stubs here. See local_secret_dependencies.go.
+// remote_secret_dependencies.go — secret dependency edges for RemoteStorage (ADR-052).
+//
+// CreateSecretDependency/GetSecretDependency/ListSecretDependenciesForProject/
+// ListSecretDependenciesForProjectForUpdate/DeleteSecretDependency/
+// CreateSecretDependencyExclusive are thin passthroughs onto new server-side routes
+// under /api/v1/system/secret-dependencies (server/http/handlers/
+// secret_dependencies_proxy.go), following the SAME #452/#507/#510/#511-class pattern
+// established for login-attempts, invitations, setup tokens, and project memberships:
+// gated on the SAME broad system.read/system.write RBAC tier a RemoteStorage credential
+// already needs for every other proxied call, so this introduces no new privilege
+// class. No dependency-graph POLICY decision (which secrets may be linked, cycle
+// rejection, impact analysis, rotation ordering) is made in these routes — that stays
+// entirely in the CALLING server's own internal/core.KeyorixCore
+// (secret_dependencies.go), exactly as it does against a local backend, with ONE
+// deliberate exception: CreateSecretDependencyExclusive's duplicate/cycle check. See
+// its doc on the storage.Storage interface (internal/core/storage/interface.go) for why
+// that one invariant — unlike every other check in this subsystem — has to be
+// evaluated by whichever server ultimately owns the row, not by the caller.
+//
+// Before this fix, every one of these methods returned ErrRemoteUnsupported, so
+// AddSecretDependency/RemoveSecretDependency/ListSecretDependencies/GetSecretImpact/
+// GetProjectRotationOrder (ADR-052, used per ADR-053 for rotation-wave ordering and
+// cascading soft-delete/restore/purge through the dependency graph) were completely
+// non-functional under storage.type: remote.
+//
+// For the local (GORM) equivalent of everything here see local_secret_dependencies.go.
 package store
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
 )
 
-func (rs *RemoteStorage) CreateSecretDependency(_ context.Context, _ *models.SecretDependency) (*models.SecretDependency, error) {
-	return nil, remoteUnsupported("CreateSecretDependency")
+// secretDependencyWire mirrors models.SecretDependency's fields exactly (snake_case) —
+// a GORM model with no json tags of its own, so a direct marshal would silently drop
+// every field whose wire name isn't case-insensitively identical to its Go name (see
+// remote_users.go's userWireResponse comment for the full explanation).
+type secretDependencyWire struct {
+	ID                uint      `json:"id"`
+	ProjectID         uint      `json:"project_id"`
+	DependentSecretID uint      `json:"dependent_secret_id"`
+	DependsOnSecretID uint      `json:"depends_on_secret_id"`
+	Note              string    `json:"note,omitempty"`
+	CreatedBy         uint      `json:"created_by,omitempty"`
+	CreatedAt         time.Time `json:"created_at"`
 }
 
-func (rs *RemoteStorage) GetSecretDependency(_ context.Context, _ uint) (*models.SecretDependency, error) {
-	return nil, remoteUnsupported("GetSecretDependency")
+func newSecretDependencyWire(d *models.SecretDependency) secretDependencyWire {
+	return secretDependencyWire{
+		ID:                d.ID,
+		ProjectID:         d.ProjectID,
+		DependentSecretID: d.DependentSecretID,
+		DependsOnSecretID: d.DependsOnSecretID,
+		Note:              d.Note,
+		CreatedBy:         d.CreatedBy,
+		CreatedAt:         d.CreatedAt,
+	}
 }
 
-func (rs *RemoteStorage) ListSecretDependenciesForProject(_ context.Context, _ uint) ([]*models.SecretDependency, error) {
-	return nil, remoteUnsupported("ListSecretDependenciesForProject")
+func (w secretDependencyWire) toModel() *models.SecretDependency {
+	return &models.SecretDependency{
+		ID:                w.ID,
+		ProjectID:         w.ProjectID,
+		DependentSecretID: w.DependentSecretID,
+		DependsOnSecretID: w.DependsOnSecretID,
+		Note:              w.Note,
+		CreatedBy:         w.CreatedBy,
+		CreatedAt:         w.CreatedAt,
+	}
 }
 
-func (rs *RemoteStorage) ListSecretDependenciesForProjectForUpdate(_ context.Context, _ uint) ([]*models.SecretDependency, error) {
-	return nil, remoteUnsupported("ListSecretDependenciesForProjectForUpdate")
+func decodeSecretDependencyResponse(data []byte) (*models.SecretDependency, error) {
+	var wire secretDependencyWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }
 
-func (rs *RemoteStorage) DeleteSecretDependency(_ context.Context, _ uint) error {
-	return remoteUnsupported("DeleteSecretDependency")
+func decodeSecretDependencyList(data []byte) ([]*models.SecretDependency, error) {
+	var result struct {
+		Dependencies []secretDependencyWire `json:"dependencies"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.SecretDependency, 0, len(result.Dependencies))
+	for _, w := range result.Dependencies {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
+}
+
+// duplicateSecretDependencyCode/secretDependencyCycleCode are the machine-readable
+// error codes CreateSecretDependencyExclusiveProxy returns when
+// storage.CreateSecretDependencyExclusive rejects the edge server-side — the wire-level
+// signal this file uses to reconstruct the same storage.ErrDuplicateSecretDependency/
+// storage.ErrSecretDependencyCycle sentinels AddSecretDependency's errors.Is checks
+// depend on, so that check-and-translate behavior is preserved across this HTTP hop
+// exactly as duplicateActiveMembershipCode does for CreateProjectMembership (#511).
+const (
+	duplicateSecretDependencyCode = "DUPLICATE_SECRET_DEPENDENCY"
+	secretDependencyCycleCode     = "SECRET_DEPENDENCY_CYCLE"
+)
+
+// CreateSecretDependency persists an already-built edge row as-is (a raw storage-layer
+// create, no duplicate/cycle check) via POST /api/v1/system/secret-dependencies. Kept
+// for parity with LocalStorage's own unconditional CreateSecretDependency — the
+// dependency graph's actual add path (AddSecretDependency) calls
+// CreateSecretDependencyExclusive below instead, exactly as it does against a local
+// backend.
+func (rs *RemoteStorage) CreateSecretDependency(ctx context.Context, d *models.SecretDependency) (*models.SecretDependency, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/secret-dependencies", newSecretDependencyWire(d))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create secret dependency: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create secret dependency failed: %s", resp.Error.Error())
+	}
+	return decodeSecretDependencyResponse(resp.Data)
+}
+
+// GetSecretDependency retrieves one edge by ID via GET /api/v1/system/secret-dependencies/{id}.
+func (rs *RemoteStorage) GetSecretDependency(ctx context.Context, id uint) (*models.SecretDependency, error) {
+	path := fmt.Sprintf("/api/v1/system/secret-dependencies/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret dependency: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get secret dependency failed: %s", resp.Error.Error())
+	}
+	return decodeSecretDependencyResponse(resp.Data)
+}
+
+// ListSecretDependenciesForProject lists a project's edges via GET
+// /api/v1/system/secret-dependencies?project_id=X.
+func (rs *RemoteStorage) ListSecretDependenciesForProject(ctx context.Context, projectID uint) ([]*models.SecretDependency, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	path := "/api/v1/system/secret-dependencies?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secret dependencies: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list secret dependencies failed: %s", resp.Error.Error())
+	}
+	return decodeSecretDependencyList(resp.Data)
+}
+
+// ListSecretDependenciesForProjectForUpdate is ListSecretDependenciesForProject over
+// HTTP via GET /api/v1/system/secret-dependencies/for-update?project_id=X — kept for
+// interface parity, but note there is no lock to take over this hop (each remote API
+// call is already atomic server-side; see AddSecretDependency's use of
+// CreateSecretDependencyExclusive instead, which — unlike this method — genuinely
+// preserves #260's cycle-check-under-lock guarantee across storage.type: remote).
+func (rs *RemoteStorage) ListSecretDependenciesForProjectForUpdate(ctx context.Context, projectID uint) ([]*models.SecretDependency, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	path := "/api/v1/system/secret-dependencies/for-update?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secret dependencies for update: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list secret dependencies for update failed: %s", resp.Error.Error())
+	}
+	return decodeSecretDependencyList(resp.Data)
+}
+
+// DeleteSecretDependency removes one edge via DELETE /api/v1/system/secret-dependencies/{id}.
+func (rs *RemoteStorage) DeleteSecretDependency(ctx context.Context, id uint) error {
+	path := fmt.Sprintf("/api/v1/system/secret-dependencies/%d", id)
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete secret dependency: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete secret dependency failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// CreateSecretDependencyExclusive persists an edge with the SAME duplicate/cycle
+// validation LocalStorage's implementation runs, via POST
+// /api/v1/system/secret-dependencies/exclusive — see the interface doc
+// (internal/core/storage/interface.go) for why this, not a caller-orchestrated
+// ListSecretDependenciesForProjectForUpdate + CreateSecretDependency sequence, is what
+// AddSecretDependency now calls.
+func (rs *RemoteStorage) CreateSecretDependencyExclusive(ctx context.Context, d *models.SecretDependency) (*models.SecretDependency, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/secret-dependencies/exclusive", newSecretDependencyWire(d))
+	if err != nil {
+		// #501-style recovery: makeRequest turns every 4xx/5xx response (including
+		// CreateSecretDependencyExclusiveProxy's 409 Conflict / 400 Bad Request for a
+		// rejected edge) into a non-nil error before resp is ever populated, so the
+		// duplicate/cycle signal must be recovered from the *remote.HTTPError itself
+		// (its ErrorType), not from resp.Error — reconstructing the SAME
+		// storage.ErrDuplicateSecretDependency/storage.ErrSecretDependencyCycle
+		// sentinels AddSecretDependency's errors.Is checks depend on, so that
+		// check-and-translate behavior survives this HTTP hop rather than silently
+		// downgrading to an opaque "failed to create secret dependency" error.
+		var httpErr *remote.HTTPError
+		if errors.As(err, &httpErr) {
+			switch httpErr.ErrorType {
+			case duplicateSecretDependencyCode:
+				return nil, fmt.Errorf("%w: %s", storage.ErrDuplicateSecretDependency, httpErr.Message)
+			case secretDependencyCycleCode:
+				return nil, fmt.Errorf("%w: %s", storage.ErrSecretDependencyCycle, httpErr.Message)
+			}
+		}
+		return nil, fmt.Errorf("failed to create secret dependency: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create secret dependency failed: %s", resp.Error.Error())
+	}
+	return decodeSecretDependencyResponse(resp.Data)
 }

--- a/server/http/handlers/secret_dependencies_proxy.go
+++ b/server/http/handlers/secret_dependencies_proxy.go
@@ -1,0 +1,256 @@
+// secret_dependencies_proxy.go — server-side endpoints backing RemoteStorage's secret
+// dependency-graph storage primitives (ADR-052): CreateSecretDependency/
+// GetSecretDependency/ListSecretDependenciesForProject/
+// ListSecretDependenciesForProjectForUpdate/DeleteSecretDependency/
+// CreateSecretDependencyExclusive.
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies its
+// secret-dependency storage calls to whichever upstream server it's configured
+// against, through these routes (registered in server/http/router.go under
+// /api/v1/system/secret-dependencies, gated on the existing system.read/system.write
+// RBAC permissions — the SAME credential a RemoteStorage client already needs for
+// every other proxied call, so this introduces no new privilege class). Mirrors
+// dynamic_secrets_proxy.go/project_memberships_proxy.go exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/secret_dependencies.go already uses against a local backend — NO
+// dependency-graph POLICY decision (which secrets a caller may link, environment/
+// project scoping, audit logging) is made here; all of that stays entirely in the
+// CALLING server's own internal/core.KeyorixCore, exactly as it does against a local
+// backend.
+//
+// This also means the SecretHandler's existing human-facing
+// /api/v1/secrets/{id}/dependencies routes (secret_dependencies.go) are NOT reused for
+// this proxy: AddSecretDependency there runs THIS server's own core.AddSecretDependency
+// (including its own same-project/same-environment/self-edge/duplicate/cycle checks
+// against the HTTP caller's identity) — the wrong semantics for a raw storage-primitive
+// passthrough, whose caller already ran its OWN core logic and only needs this server
+// to persist/return rows, exactly like the human-facing /groups routes were the wrong
+// proxy target for Group storage (a prior fix in this same campaign).
+//
+// One deliberate exception: CreateSecretDependencyExclusiveProxy calls
+// storage.CreateSecretDependencyExclusive, which DOES evaluate the duplicate/cycle
+// invariant — not because that's this server's OWN policy decision, but because no
+// real transaction can span the HTTP hop back to the calling server (RemoteStorage.
+// WithTransaction is a no-op passthrough), so whichever server ultimately owns the
+// row is the only one that CAN enforce it atomically. See the storage.Storage
+// interface doc (internal/core/storage/interface.go) for the full reasoning.
+//
+// Response envelope: like the other proxies, these do NOT use the package's generic
+// sendSuccess/sendError helpers — they construct the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// secretDependencyProxyWire mirrors models.SecretDependency's fields exactly
+// (snake_case) — see remote_secret_dependencies.go's identically-shaped wire type for
+// why (a GORM model with no json tags of its own).
+type secretDependencyProxyWire struct {
+	ID                uint      `json:"id"`
+	ProjectID         uint      `json:"project_id"`
+	DependentSecretID uint      `json:"dependent_secret_id"`
+	DependsOnSecretID uint      `json:"depends_on_secret_id"`
+	Note              string    `json:"note,omitempty"`
+	CreatedBy         uint      `json:"created_by,omitempty"`
+	CreatedAt         time.Time `json:"created_at"`
+}
+
+func newSecretDependencyProxyWire(d *models.SecretDependency) secretDependencyProxyWire {
+	return secretDependencyProxyWire{
+		ID:                d.ID,
+		ProjectID:         d.ProjectID,
+		DependentSecretID: d.DependentSecretID,
+		DependsOnSecretID: d.DependsOnSecretID,
+		Note:              d.Note,
+		CreatedBy:         d.CreatedBy,
+		CreatedAt:         d.CreatedAt,
+	}
+}
+
+func (w secretDependencyProxyWire) toModel() *models.SecretDependency {
+	return &models.SecretDependency{
+		ID:                w.ID,
+		ProjectID:         w.ProjectID,
+		DependentSecretID: w.DependentSecretID,
+		DependsOnSecretID: w.DependsOnSecretID,
+		Note:              w.Note,
+		CreatedBy:         w.CreatedBy,
+		CreatedAt:         w.CreatedAt,
+	}
+}
+
+// duplicateSecretDependencyCode/secretDependencyCycleCode are the machine-readable
+// error codes this proxy returns when CreateSecretDependencyExclusive rejects an edge —
+// mirrored EXACTLY (same string values) in
+// internal/storage/store/remote_secret_dependencies.go, the wire-level contract
+// RemoteStorage.CreateSecretDependencyExclusive's error-recovery switch depends on to
+// reconstruct storage.ErrDuplicateSecretDependency/storage.ErrSecretDependencyCycle on
+// the calling side (#511-style wire-code translation).
+const (
+	duplicateSecretDependencyCode = "DUPLICATE_SECRET_DEPENDENCY"
+	secretDependencyCycleCode     = "SECRET_DEPENDENCY_CYCLE"
+)
+
+// CreateSecretDependencyProxy handles POST /api/v1/system/secret-dependencies. A raw,
+// unconditional persist (storage.Storage.CreateSecretDependency), kept for interface
+// parity — AddSecretDependency's real add path goes through
+// CreateSecretDependencyExclusiveProxy below instead.
+func (h *SecretHandler) CreateSecretDependencyProxy(w http.ResponseWriter, r *http.Request) {
+	var body secretDependencyProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.ProjectID == 0 || body.DependentSecretID == 0 || body.DependsOnSecretID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id, dependent_secret_id, and depends_on_secret_id are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateSecretDependency(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("secret-dependencies proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newSecretDependencyProxyWire(created))
+}
+
+// CreateSecretDependencyExclusiveProxy handles POST
+// /api/v1/system/secret-dependencies/exclusive. See the package doc and the
+// storage.Storage interface doc for why this atomically validates the edge (duplicate/
+// cycle rejection) rather than being a raw passthrough like every other method here.
+func (h *SecretHandler) CreateSecretDependencyExclusiveProxy(w http.ResponseWriter, r *http.Request) {
+	var body secretDependencyProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.ProjectID == 0 || body.DependentSecretID == 0 || body.DependsOnSecretID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id, dependent_secret_id, and depends_on_secret_id are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateSecretDependencyExclusive(r.Context(), body.toModel())
+	if err != nil {
+		switch {
+		case errors.Is(err, coreStorage.ErrDuplicateSecretDependency):
+			writeRemoteAPIError(w, http.StatusConflict, duplicateSecretDependencyCode, coreStorage.ErrDuplicateSecretDependency.Error())
+		case errors.Is(err, coreStorage.ErrSecretDependencyCycle):
+			writeRemoteAPIError(w, http.StatusBadRequest, secretDependencyCycleCode, coreStorage.ErrSecretDependencyCycle.Error())
+		default:
+			log.Printf("secret-dependencies proxy: exclusive create failed: %v", err)
+			writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		}
+		return
+	}
+	writeRemoteAPISuccess(w, newSecretDependencyProxyWire(created))
+}
+
+// GetSecretDependencyProxy handles GET /api/v1/system/secret-dependencies/{id}.
+func (h *SecretHandler) GetSecretDependencyProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid dependency id")
+		return
+	}
+	d, err := h.coreService.Storage().GetSecretDependency(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "secret dependency not found")
+			return
+		}
+		log.Printf("secret-dependencies proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newSecretDependencyProxyWire(d))
+}
+
+// ListSecretDependenciesForProjectProxy handles GET
+// /api/v1/system/secret-dependencies?project_id=X.
+func (h *SecretHandler) ListSecretDependenciesForProjectProxy(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := parseProxyProjectIDQuery(w, r)
+	if !ok {
+		return
+	}
+	rows, err := h.coreService.Storage().ListSecretDependenciesForProject(r.Context(), projectID)
+	if err != nil {
+		log.Printf("secret-dependencies proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"dependencies": newSecretDependencyProxyWireList(rows)})
+}
+
+// ListSecretDependenciesForProjectForUpdateProxy handles GET
+// /api/v1/system/secret-dependencies/for-update?project_id=X (a static path, registered
+// before /secret-dependencies/{id} in router.go). Kept for interface parity — see this
+// method's doc on RemoteStorage (remote_secret_dependencies.go) for why it takes no
+// lock over this hop.
+func (h *SecretHandler) ListSecretDependenciesForProjectForUpdateProxy(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := parseProxyProjectIDQuery(w, r)
+	if !ok {
+		return
+	}
+	rows, err := h.coreService.Storage().ListSecretDependenciesForProjectForUpdate(r.Context(), projectID)
+	if err != nil {
+		log.Printf("secret-dependencies proxy: list-for-update failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"dependencies": newSecretDependencyProxyWireList(rows)})
+}
+
+// DeleteSecretDependencyProxy handles DELETE /api/v1/system/secret-dependencies/{id}.
+func (h *SecretHandler) DeleteSecretDependencyProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid dependency id")
+		return
+	}
+	if err := h.coreService.Storage().DeleteSecretDependency(r.Context(), uint(id)); err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "secret dependency not found")
+			return
+		}
+		log.Printf("secret-dependencies proxy: delete failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}
+
+func newSecretDependencyProxyWireList(rows []*models.SecretDependency) []secretDependencyProxyWire {
+	wire := make([]secretDependencyProxyWire, 0, len(rows))
+	for _, d := range rows {
+		wire = append(wire, newSecretDependencyProxyWire(d))
+	}
+	return wire
+}
+
+// parseProxyProjectIDQuery parses the required project_id query parameter shared by
+// ListSecretDependenciesForProjectProxy/ListSecretDependenciesForProjectForUpdateProxy.
+func parseProxyProjectIDQuery(w http.ResponseWriter, r *http.Request) (projectID uint, ok bool) {
+	v := r.URL.Query().Get("project_id")
+	if v == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id query parameter is required")
+		return 0, false
+	}
+	id, err := strconv.ParseUint(v, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id must be a valid integer")
+		return 0, false
+	}
+	return uint(id), true
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -94,6 +94,10 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		&models.MFASecret{},
 		&models.MFARecoveryCode{},
 		&models.MFAChallenge{},
+		// #519: the secret-dependency-proxy end-to-end tests exercise
+		// SecretDependency CRUD (and the atomic duplicate/cycle-checked create)
+		// through the real router.
+		&models.SecretDependency{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the

--- a/server/http/remote_storage_secret_dependencies_test.go
+++ b/server/http/remote_storage_secret_dependencies_test.go
@@ -1,0 +1,239 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamForSecretDependencies builds the standard #452/#507-style harness: an
+// "upstream" exercised through the REAL production NewRouter/handlers (including the
+// new /api/v1/system/secret-dependencies routes, server/http/handlers/
+// secret_dependencies_proxy.go) and returns an httptest.Server plus the admin token a
+// downstream RemoteStorage client needs to reach it.
+func newUpstreamForSecretDependencies(t *testing.T) (upstream *core.KeyorixCore, srv *httptest.Server, token string) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	token = createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	router, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	srv = httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	return upstream, srv, token
+}
+
+// newDownstreamRemoteStorage points a fresh *core.KeyorixCore, backed by
+// store.RemoteStorage, at the given upstream test server.
+func newDownstreamRemoteStorage(t *testing.T, srv *httptest.Server, token string) *core.KeyorixCore {
+	t.Helper()
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        srv.URL,
+		APIKey:         token,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	return core.NewKeyorixCore(rs)
+}
+
+// TestRemoteStorageSecretDependencies_CreateGetListDelete_RealServer proves the fix for
+// CreateSecretDependency/GetSecretDependency/ListSecretDependenciesForProject/
+// ListSecretDependenciesForProjectForUpdate/DeleteSecretDependency: an edge is
+// genuinely persisted on the upstream via the downstream's RemoteStorage, fetchable by
+// ID, listed both ways, and removable — all via storage.type: remote against a real
+// router, not a protocol mock.
+func TestRemoteStorageSecretDependencies_CreateGetListDelete_RealServer(t *testing.T) {
+	upstream, srv, token := newUpstreamForSecretDependencies(t)
+	downstream := newDownstreamRemoteStorage(t, srv, token)
+	ctx := context.Background()
+
+	created, err := downstream.Storage().CreateSecretDependency(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 501, DependsOnSecretID: 502, Note: "app token derives from db password", CreatedBy: 10,
+	})
+	require.NoError(t, err, "creating a secret dependency must succeed via storage.type: remote")
+	require.NotZero(t, created.ID, "the upstream must assign a real ID")
+	assert.Equal(t, uint(501), created.DependentSecretID)
+	assert.Equal(t, uint(502), created.DependsOnSecretID)
+
+	// A REAL row on the upstream's own storage, not just "the call didn't error".
+	direct, err := upstream.Storage().GetSecretDependency(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "app token derives from db password", direct.Note)
+	assert.Equal(t, uint(10), direct.CreatedBy)
+
+	// GetSecretDependency via the downstream round-trips every field.
+	fetched, err := downstream.Storage().GetSecretDependency(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, fetched.ID)
+	assert.Equal(t, created.Note, fetched.Note)
+	assert.Equal(t, created.ProjectID, fetched.ProjectID)
+
+	// A second edge, then list both back via the downstream's
+	// ListSecretDependenciesForProject / ListSecretDependenciesForProjectForUpdate.
+	second, err := downstream.Storage().CreateSecretDependency(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 503, DependsOnSecretID: 501,
+	})
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListSecretDependenciesForProject(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	rowsForUpdate, err := downstream.Storage().ListSecretDependenciesForProjectForUpdate(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, rowsForUpdate, 2)
+
+	// DeleteSecretDependency via the downstream removes it from the upstream's own
+	// storage.
+	require.NoError(t, downstream.Storage().DeleteSecretDependency(ctx, second.ID))
+	_, err = upstream.Storage().GetSecretDependency(ctx, second.ID)
+	require.Error(t, err, "the deleted edge must no longer exist directly on the upstream")
+
+	remaining, err := downstream.Storage().ListSecretDependenciesForProject(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, created.ID, remaining[0].ID)
+}
+
+// TestRemoteStorageSecretDependencies_GetNotFound_RealServer proves a clean not-found
+// error (not a panic, not a garbage 500) for a nonexistent edge ID.
+func TestRemoteStorageSecretDependencies_GetNotFound_RealServer(t *testing.T) {
+	_, srv, token := newUpstreamForSecretDependencies(t)
+	downstream := newDownstreamRemoteStorage(t, srv, token)
+
+	_, err := downstream.Storage().GetSecretDependency(context.Background(), 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageSecretDependencies_Exclusive_DuplicateAndCycleRejected proves
+// CreateSecretDependencyExclusive's wire-code translation (#511-style): the upstream's
+// 409/400 rejection round-trips back into the exact
+// storage.ErrDuplicateSecretDependency / storage.ErrSecretDependencyCycle sentinels,
+// not an opaque error, so AddSecretDependency's errors.Is checks
+// (internal/core/secret_dependencies.go) still work against storage.type: remote.
+func TestRemoteStorageSecretDependencies_Exclusive_DuplicateAndCycleRejected(t *testing.T) {
+	_, srv, token := newUpstreamForSecretDependencies(t)
+	downstream := newDownstreamRemoteStorage(t, srv, token)
+	ctx := context.Background()
+
+	created, err := downstream.Storage().CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 601, DependsOnSecretID: 602,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+
+	// Exact duplicate pair.
+	_, err = downstream.Storage().CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 601, DependsOnSecretID: 602,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, coreStorage.ErrDuplicateSecretDependency),
+		"the upstream's duplicate rejection must survive as the exact sentinel, not an opaque error: %v", err)
+
+	// Reverse edge would close a 2-node cycle.
+	_, err = downstream.Storage().CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 602, DependsOnSecretID: 601,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, coreStorage.ErrSecretDependencyCycle),
+		"the upstream's cycle rejection must survive as the exact sentinel, not an opaque error: %v", err)
+}
+
+// TestRemoteStorageSecretDependencies_ConcurrentRace_NoCycleAcrossTwoDownstreams is the
+// cross-process analogue of internal/core's
+// TestAddSecretDependency_ConcurrentRaceCannotPersistACycle (#260): TWO INDEPENDENT
+// *store.RemoteStorage clients (standing in for two downstream server replicas — e.g.
+// two separate *core.KeyorixCore instances, each with its OWN process-local
+// secretDependencyMu that cannot serialize across them) race to persist reciprocal
+// edges A→B / B→A in the same project against the SAME upstream, via
+// CreateSecretDependencyExclusive directly (the raw storage primitive
+// AddSecretDependency calls, exercised here without core's own project/secret
+// authorization plumbing, which is a separate, pre-existing concern — mirroring
+// buildDynamicSecretConfig's documented precedent in
+// remote_storage_dynamic_secrets_test.go for testing the storage-primitive proxy layer
+// directly rather than the full core happy path).
+//
+// Before this fix (a caller-orchestrated ListSecretDependenciesForProjectForUpdate +
+// CreateSecretDependency sequence, with RemoteStorage.WithTransaction a no-op
+// passthrough), nothing would have prevented both requests from observing "no cycle"
+// and both succeeding, persisting a 2-node cycle. With CreateSecretDependencyExclusive,
+// the upstream's own LocalStorage transaction serializes the two concurrent HTTP
+// requests, so exactly one must win — proving the fix closes the gap the interface doc
+// describes, not just the same-process case the mutex already covered.
+func TestRemoteStorageSecretDependencies_ConcurrentRace_NoCycleAcrossTwoDownstreams(t *testing.T) {
+	_, srv, token := newUpstreamForSecretDependencies(t)
+	ctx := context.Background()
+
+	const iterations = 8
+	for i := 0; i < iterations; i++ {
+		a := uint(2000 + i*2)
+		b := uint(2000 + i*2 + 1)
+
+		// Fresh RemoteStorage clients each iteration: every pair has exactly one
+		// "loser" that gets an expected 400/409 rejection, and the client's circuit
+		// breaker (internal/storage/remote/client.go) opens after 5 CONSECUTIVE
+		// failures regardless of whether they were expected application-level
+		// rejections or genuine transport failures (a separate, pre-existing
+		// design point, out of scope here) — reusing one client across many
+		// iterations would eventually trip it on the same side repeatedly,
+		// masking the real property this test checks with an unrelated
+		// "circuit breaker is open" error.
+		downstreamA := newDownstreamRemoteStorage(t, srv, token)
+		downstreamB := newDownstreamRemoteStorage(t, srv, token)
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		results := make([]error, 2)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, results[0] = downstreamA.Storage().CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+				ProjectID: 1, DependentSecretID: a, DependsOnSecretID: b,
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, results[1] = downstreamB.Storage().CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+				ProjectID: 1, DependentSecretID: b, DependsOnSecretID: a,
+			})
+		}()
+		close(start)
+		wg.Wait()
+
+		successes := 0
+		for _, e := range results {
+			if e == nil {
+				successes++
+			} else {
+				assert.True(t, errors.Is(e, coreStorage.ErrDuplicateSecretDependency) || errors.Is(e, coreStorage.ErrSecretDependencyCycle),
+					"iteration %d: the loser must fail with a recognised sentinel, not an opaque error: %v", i, e)
+			}
+		}
+		require.Equal(t, 1, successes,
+			"iteration %d: exactly one of A→B / B→A must win the race across two independent downstream RemoteStorage clients — both winning would persist a cycle on the shared upstream", i)
+	}
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -961,6 +961,38 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/project-memberships", catalogHandler.ListMembershipsProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/project-memberships", catalogHandler.CreateMembershipProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Put("/project-memberships/{id}", catalogHandler.UpdateMembershipProxy)
+
+			// Secret-dependency storage-primitive proxy (finding #519). Lets a
+			// downstream Keyorix server booted with storage.type: remote (ADR-049)
+			// proxy CreateSecretDependency/GetSecretDependency/
+			// ListSecretDependenciesForProject/
+			// ListSecretDependenciesForProjectForUpdate/DeleteSecretDependency/
+			// CreateSecretDependencyExclusive to THIS server's real storage backend,
+			// instead of RemoteStorage's six secret-dependency methods having no
+			// server endpoint to call at all (ADR-052's dependency graph — used per
+			// ADR-053 for rotation-wave ordering and cascading soft-delete/restore/
+			// purge through the graph — was completely non-functional under
+			// storage.type: remote). Same pattern as the invitations/memberships
+			// proxies above: a thin passthrough onto storage.Storage (no
+			// dependency-graph POLICY decision — same-project/same-environment
+			// scoping, audit logging — is made here; that stays entirely in the
+			// CALLING server's own internal/core.KeyorixCore, exactly as it does
+			// against a local backend), reusing the SAME system.read/system.write
+			// tier — no new privilege class. The ONE exception is
+			// CreateSecretDependencyExclusiveProxy: it DOES evaluate the
+			// duplicate/cycle invariant server-side, because no real transaction can
+			// span this HTTP hop (RemoteStorage.WithTransaction is a no-op
+			// passthrough) — see secret_dependencies_proxy.go's package doc and the
+			// storage.Storage interface doc for why AddSecretDependency now calls
+			// this instead of orchestrating a list-under-lock-then-create sequence
+			// itself. Static sub-paths ("for-update", "exclusive") are registered
+			// before the "{id}" wildcard.
+			r.Get("/secret-dependencies/for-update", secretHandler.ListSecretDependenciesForProjectForUpdateProxy)
+			r.Get("/secret-dependencies/{id}", secretHandler.GetSecretDependencyProxy)
+			r.Get("/secret-dependencies", secretHandler.ListSecretDependenciesForProjectProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/secret-dependencies", secretHandler.CreateSecretDependencyProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/secret-dependencies/exclusive", secretHandler.CreateSecretDependencyExclusiveProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Delete("/secret-dependencies/{id}", secretHandler.DeleteSecretDependencyProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary

Implements RemoteStorage support for ADR-052's secret-dependency graph, part of the ongoing security-hardening campaign's finding #519.

- Adds new thin passthrough routes under `/api/v1/system/secret-dependencies/...` (`server/http/handlers/secret_dependencies_proxy.go`), gated on the existing `system.read`/`system.write` RBAC tier — no new privilege class. Confirmed the existing human-facing `/api/v1/secrets/{id}/dependencies` routes bake in real business logic (same-project/environment scoping, cycle detection, audit logging), so — same class of mistake as the prior Groups fix (#514) — they were the wrong proxy target.
- Implements every `RemoteStorage` method in `internal/storage/store/remote_secret_dependencies.go` (previously all unconditional `remoteUnsupported` stubs): `CreateSecretDependency`/`GetSecretDependency`/`ListSecretDependenciesForProject`/`ListSecretDependenciesForProjectForUpdate`/`DeleteSecretDependency`.

**Atomicity finding + fix:** `AddSecretDependency`'s cycle-check read + edge write used to be orchestrated by the *caller* inside a `WithTransaction`, relying on `ListSecretDependenciesForProjectForUpdate`'s Postgres `FOR UPDATE` lock plus an in-process mutex (`secretDependencyMu`, #260). `RemoteStorage.WithTransaction` is a no-op passthrough — no real transaction spans the wire — so under `storage.type: remote` that orchestration silently lost its whole guarantee across multiple downstream replicas racing to add a reciprocal edge pair (A→B / B→A) against the same upstream project.

Fixed by adding one new atomic storage primitive, `CreateSecretDependencyExclusive`, that performs the duplicate/cycle check and the write as ONE call:
- LocalStorage: wraps the check + create in a single real DB transaction (Postgres `FOR UPDATE` on the read).
- RemoteStorage: a single HTTP round trip to a dedicated upstream route, whose handler runs that same LocalStorage method — so whichever server ultimately owns the row enforces the invariant, mirroring the wire-code-translation technique #511 used to preserve `CreateProjectMembership`'s DB-level unique-index atomicity across the same boundary.

`AddSecretDependency` (`internal/core/secret_dependencies.go`) now calls this new primitive instead of orchestrating the old two-call sequence itself; its public error messages/behavior are unchanged (existing tests pass unmodified).

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` — full suite green, including the existing local-only `TestAddSecretDependency_ConcurrentRaceCannotPersistACycle` (#260)
- [x] New storage-layer tests (`internal/storage/store/local_secret_dependencies_test.go`): reachability-helper parity test, duplicate/cycle rejection, and a real multi-connection SQLite (`BEGIN IMMEDIATE`) concurrency test proving `CreateSecretDependencyExclusive` itself — not just the caller's mutex — is atomic
- [x] New `server/http` round-trip tests against a real router (`remote_storage_secret_dependencies_test.go`): create/get/list/list-for-update/delete, plus wire-code duplicate/cycle sentinel translation
- [x] New cross-process concurrency test: two independent `RemoteStorage` clients (standing in for two downstream replicas, each with its own process-local mutex) race reciprocal edges against one shared upstream — exactly one wins every iteration, proving the fix closes the gap the old design left open
- [x] `gosec -severity medium -exclude-generated` on the changed packages: 0 issues (note: this sandboxed environment's Go build cache degraded gosec's SSA-based analysis to AST-only checks — worth relying on CI's gosec gate as the authoritative run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)