### PR TITLE
fix(remote-storage): implement retention-purge storage primitives (#520)

### DIFF
--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -163,9 +163,33 @@ func (rs *RemoteStorage) AssignRoleToGroupWithExpiry(_ context.Context, _, _ uin
 	return remoteUnsupported("AssignRoleToGroupWithExpiry")
 }
 
-// DeleteExpiredRoleGrants is server-side only (run by the expiry scheduler).
-func (rs *RemoteStorage) DeleteExpiredRoleGrants(_ context.Context, _ time.Time) ([]storage.RoleAssignment, error) {
-	return nil, remoteUnsupported("DeleteExpiredRoleGrants")
+// DeleteExpiredRoleGrants proxies onto POST
+// /api/v1/system/retention/role-grants/purge-expired
+// (server/http/handlers/retention_proxy.go, finding #520) — the SAME
+// "RemoteStorage stub -> thin proxy route" pattern established for login-attempts
+// (#452). Returns the full removed storage.RoleAssignment rows, not just a
+// count: the calling server's own internal/core.RemoveExpiredRoleGrants writes
+// one role.expired audit event per grant using exactly this data, which a bare
+// count could not reconstruct. storage.RoleAssignment already carries full
+// snake_case json tags, so no separate wire DTO is needed on either side.
+func (rs *RemoteStorage) DeleteExpiredRoleGrants(ctx context.Context, before time.Time) ([]storage.RoleAssignment, error) {
+	body := struct {
+		Before time.Time `json:"before"`
+	}{Before: before}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/retention/role-grants/purge-expired", body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to purge expired role grants: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("purge expired role grants failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Removed []storage.RoleAssignment `json:"removed"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Removed, nil
 }
 
 // RemoveRole removes a role from a user at scope via remote API.

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -245,26 +245,127 @@ func (rs *RemoteStorage) RestoreSecret(ctx context.Context, id uint) error {
 	return nil
 }
 
-// Retention purge runs server-side (ADR-032/033); not available in remote mode.
-func (rs *RemoteStorage) PurgeDeletedSecretsBefore(_ context.Context, _ time.Time) (int64, error) {
-	return 0, remoteUnsupported("PurgeDeletedSecretsBefore")
+// --- Retention/purge-sweep proxies (finding #520) ---
+//
+// These proxy onto NEW server-side routes under /api/v1/system/retention
+// (server/http/handlers/retention_proxy.go), the SAME "RemoteStorage stub -> thin
+// proxy route" pattern established for login-attempts (#452), project
+// invitations (#507), and dynamic secrets (round 116): a raw passthrough onto
+// storage.Storage's own retention primitives — no purge/retention POLICY decision
+// (which window applies, the legal-hold guard, which rows are "in flight" and
+// therefore excluded) is made server-side; that stays entirely in the CALLING
+// server's own internal/core.KeyorixCore, exactly as it does against a local
+// backend. Gated on the SAME system.read/system.write tier every other
+// RemoteStorage call already needs — no new privilege class. See
+// retention_proxy.go's package doc for the full atomicity and timezone analysis
+// (short version: each of these already resolves in ONE storage.Storage call
+// server-side, so one HTTP round trip preserves whatever transactional guarantee
+// the local implementation has; RemoteStorage.WithTransaction's no-op status is
+// irrelevant here since none of these needed to span multiple calls).
+func (rs *RemoteStorage) PurgeDeletedSecretsBefore(ctx context.Context, before time.Time) (int64, error) {
+	return postRetentionBeforeCountResp(ctx, rs, "/api/v1/system/retention/secrets/purge", before, "purge deleted secrets")
 }
 
-// Data-retention purges run server-side (the scheduler); not available remotely.
-func (rs *RemoteStorage) DeleteAnomalyAlertsBefore(_ context.Context, _, _ time.Time) (int64, error) {
-	return 0, remoteUnsupported("DeleteAnomalyAlertsBefore")
+// DeleteAnomalyAlertsBefore proxies onto POST
+// /api/v1/system/retention/anomaly-alerts/purge. ackBefore/unackCeiling are sent
+// as-is (including when zero) — DeleteAnomalyAlertsBefore's own contract treats a
+// zero time.Time as "this clause is disabled", not "purge everything before year
+// 1" (see local_purge.go), and the proxy handler preserves that by decoding both
+// fields unconditionally rather than rejecting a zero value as invalid.
+func (rs *RemoteStorage) DeleteAnomalyAlertsBefore(ctx context.Context, ackBefore, unackCeiling time.Time) (int64, error) {
+	body := struct {
+		AckBefore    time.Time `json:"ack_before"`
+		UnackCeiling time.Time `json:"unack_ceiling"`
+	}{AckBefore: ackBefore, UnackCeiling: unackCeiling}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/retention/anomaly-alerts/purge", body)
+	if err != nil {
+		return 0, fmt.Errorf("failed to purge anomaly alerts: %w", err)
+	}
+	if !resp.Success {
+		return 0, fmt.Errorf("purge anomaly alerts failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Purged int64 `json:"purged"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Purged, nil
 }
 
-func (rs *RemoteStorage) DeleteClosedAccessReviewsBefore(_ context.Context, _ time.Time) (int64, int64, error) {
-	return 0, 0, remoteUnsupported("DeleteClosedAccessReviewsBefore")
+// DeleteClosedAccessReviewsBefore proxies onto POST
+// /api/v1/system/retention/access-reviews/purge-closed.
+func (rs *RemoteStorage) DeleteClosedAccessReviewsBefore(ctx context.Context, before time.Time) (int64, int64, error) {
+	body := struct {
+		Before time.Time `json:"before"`
+	}{Before: before}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/retention/access-reviews/purge-closed", body)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to purge closed access reviews: %w", err)
+	}
+	if !resp.Success {
+		return 0, 0, fmt.Errorf("purge closed access reviews failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		CampaignsPurged int64 `json:"campaigns_purged"`
+		ItemsPurged     int64 `json:"items_purged"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return 0, 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.CampaignsPurged, result.ItemsPurged, nil
 }
 
-func (rs *RemoteStorage) DeleteExpiredBreakGlassBefore(_ context.Context, _ time.Time) (int64, error) {
-	return 0, remoteUnsupported("DeleteExpiredBreakGlassBefore")
+// DeleteExpiredBreakGlassBefore proxies onto POST
+// /api/v1/system/retention/break-glass/purge-expired.
+func (rs *RemoteStorage) DeleteExpiredBreakGlassBefore(ctx context.Context, before time.Time) (int64, error) {
+	return postRetentionBeforeCountResp(ctx, rs, "/api/v1/system/retention/break-glass/purge-expired", before, "purge expired break-glass activations")
 }
 
-func (rs *RemoteStorage) DeleteResolvedAccessRequestsBefore(_ context.Context, _ time.Time) (int64, int64, error) {
-	return 0, 0, remoteUnsupported("DeleteResolvedAccessRequestsBefore")
+// DeleteResolvedAccessRequestsBefore proxies onto POST
+// /api/v1/system/retention/access-requests/purge-resolved.
+func (rs *RemoteStorage) DeleteResolvedAccessRequestsBefore(ctx context.Context, before time.Time) (int64, int64, error) {
+	body := struct {
+		Before time.Time `json:"before"`
+	}{Before: before}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/retention/access-requests/purge-resolved", body)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to purge resolved access requests: %w", err)
+	}
+	if !resp.Success {
+		return 0, 0, fmt.Errorf("purge resolved access requests failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		RequestsPurged  int64 `json:"requests_purged"`
+		ApprovalsPurged int64 `json:"approvals_purged"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return 0, 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.RequestsPurged, result.ApprovalsPurged, nil
+}
+
+// postRetentionBeforeCountResp is the shared shape for every retention-purge
+// route whose body is a single {"before": ...} timestamp and whose response is a
+// single {"purged": <count>} integer.
+func postRetentionBeforeCountResp(ctx context.Context, rs *RemoteStorage, path string, before time.Time, verb string) (int64, error) {
+	body := struct {
+		Before time.Time `json:"before"`
+	}{Before: before}
+	resp, err := rs.client.Post(ctx, path, body)
+	if err != nil {
+		return 0, fmt.Errorf("failed to %s: %w", verb, err)
+	}
+	if !resp.Success {
+		return 0, fmt.Errorf("%s failed: %s", verb, resp.Error.Error())
+	}
+	var result struct {
+		Purged int64 `json:"purged"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Purged, nil
 }
 
 // ListSecrets lists secrets with optional filtering via remote API.

--- a/internal/storage/store/remote_sharing.go
+++ b/internal/storage/store/remote_sharing.go
@@ -198,7 +198,32 @@ func (rs *RemoteStorage) CheckSharePermission(ctx context.Context, secretID, use
 	return result.Permission, nil
 }
 
-// DeleteExpiredShareRecords is server-side only (run by the JIT expiry scheduler).
-func (rs *RemoteStorage) DeleteExpiredShareRecords(_ context.Context, _ time.Time) ([]*models.ShareRecord, error) {
-	return nil, remoteUnsupported("DeleteExpiredShareRecords")
+// DeleteExpiredShareRecords proxies onto POST
+// /api/v1/system/retention/share-records/purge-expired
+// (server/http/handlers/retention_proxy.go, finding #520) — the SAME
+// "RemoteStorage stub -> thin proxy route" pattern established for login-attempts
+// (#452). Returns the full removed *models.ShareRecord rows, not just a count:
+// the calling server's own internal/core.RemoveExpiredShares writes one
+// share.expired audit event per share using exactly this data, which a bare
+// count could not reconstruct. models.ShareRecord carries no json tags of its
+// own, so this marshals/unmarshals the model directly — matching every other
+// ShareRecord round trip in this file (CreateShareRecord, GetShareRecord, ...).
+func (rs *RemoteStorage) DeleteExpiredShareRecords(ctx context.Context, before time.Time) ([]*models.ShareRecord, error) {
+	body := struct {
+		Before time.Time `json:"before"`
+	}{Before: before}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/retention/share-records/purge-expired", body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to purge expired share records: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("purge expired share records failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Removed []*models.ShareRecord `json:"removed"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Removed, nil
 }

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -414,17 +414,27 @@ func (rs *RemoteStorage) RestoreUser(ctx context.Context, id uint) error {
 	return nil
 }
 
-// Retention purge runs server-side (ADR-032); not available in remote mode.
-func (rs *RemoteStorage) PurgeDeletedUsersBefore(_ context.Context, _ time.Time) (int64, error) {
-	return 0, remoteUnsupported("PurgeDeletedUsersBefore")
+// PurgeDeletedUsersBefore, PurgeDeletedProjectsBefore, PurgeDeletedEnvironmentsBefore
+// (finding #520) proxy onto NEW server-side routes under
+// /api/v1/system/retention (server/http/handlers/retention_proxy.go) — the SAME
+// "RemoteStorage stub -> thin proxy route" pattern established for login-attempts
+// (#452). See remote_secrets.go's package-level retention-proxy doc comment (next
+// to PurgeDeletedSecretsBefore) for the shared atomicity/timezone analysis; each
+// of these three cascades (users -> role grants/memberships/received
+// shares/PATs/sessions; projects -> role grants; environments, no cascade) runs
+// entirely inside the upstream server's own single storage.Storage call, so one
+// HTTP round trip preserves the LOCAL implementation's own transactional
+// guarantee unchanged.
+func (rs *RemoteStorage) PurgeDeletedUsersBefore(ctx context.Context, before time.Time) (int64, error) {
+	return postRetentionBeforeCountResp(ctx, rs, "/api/v1/system/retention/users/purge", before, "purge deleted users")
 }
 
-func (rs *RemoteStorage) PurgeDeletedProjectsBefore(_ context.Context, _ time.Time) (int64, error) {
-	return 0, remoteUnsupported("PurgeDeletedProjectsBefore")
+func (rs *RemoteStorage) PurgeDeletedProjectsBefore(ctx context.Context, before time.Time) (int64, error) {
+	return postRetentionBeforeCountResp(ctx, rs, "/api/v1/system/retention/projects/purge", before, "purge deleted projects")
 }
 
-func (rs *RemoteStorage) PurgeDeletedEnvironmentsBefore(_ context.Context, _ time.Time) (int64, error) {
-	return 0, remoteUnsupported("PurgeDeletedEnvironmentsBefore")
+func (rs *RemoteStorage) PurgeDeletedEnvironmentsBefore(ctx context.Context, before time.Time) (int64, error) {
+	return postRetentionBeforeCountResp(ctx, rs, "/api/v1/system/retention/environments/purge", before, "purge deleted environments")
 }
 
 // ListUsers lists users with optional filtering via remote API.
@@ -451,8 +461,39 @@ func (rs *RemoteStorage) ListUsers(ctx context.Context, filter *storage.UserFilt
 	return users, result.Total, nil
 }
 
-func (rs *RemoteStorage) ListUsersInStateBefore(_ context.Context, _ string, _ time.Time) ([]*models.User, error) {
-	return nil, remoteUnsupported("ListUsersInStateBefore")
+// ListUsersInStateBefore proxies onto GET
+// /api/v1/system/retention/users/stale?state=&before=<RFC3339Nano> (finding
+// #520) — backing the calling server's OWN stale-account warning sweep
+// (internal/core.StaleAccounts, ADR-025) against this server's real storage
+// backend, the SAME "RemoteStorage stub -> thin proxy route" pattern established
+// for login-attempts (#452). A READ, not a delete, so the server-side route is
+// gated system.read rather than system.write (see router.go). Decodes into the
+// SAME userWireResponse type ListUsers already uses, since the server's wire
+// shape (userRetentionProxyWire, server/http/handlers/retention_proxy.go) is a
+// deliberate field-for-field mirror.
+func (rs *RemoteStorage) ListUsersInStateBefore(ctx context.Context, state string, before time.Time) ([]*models.User, error) {
+	q := url.Values{}
+	q.Set("state", state)
+	q.Set("before", before.UTC().Format(time.RFC3339Nano))
+	path := "/api/v1/system/retention/users/stale?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list stale users: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list stale users failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Users []userWireResponse `json:"users"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	users := make([]*models.User, 0, len(result.Users))
+	for _, w := range result.Users {
+		users = append(users, w.toModel())
+	}
+	return users, nil
 }
 
 func (rs *RemoteStorage) CreateUserWithRoleGrants(_ context.Context, _ *models.User, _ []storage.RoleGrant) (*models.User, error) {

--- a/server/http/handlers/retention_proxy.go
+++ b/server/http/handlers/retention_proxy.go
@@ -1,0 +1,410 @@
+// retention_proxy.go — server-side endpoints backing RemoteStorage's
+// data-retention/purge-sweep storage primitives (finding #520):
+// PurgeDeletedSecretsBefore, DeleteAnomalyAlertsBefore,
+// DeleteClosedAccessReviewsBefore, DeleteExpiredBreakGlassBefore,
+// DeleteResolvedAccessRequestsBefore (remote_secrets.go); DeleteExpiredRoleGrants
+// (remote_rbac.go); DeleteExpiredShareRecords (remote_sharing.go);
+// PurgeDeletedUsersBefore/PurgeDeletedProjectsBefore/
+// PurgeDeletedEnvironmentsBefore/ListUsersInStateBefore (remote_users.go).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// its scheduled retention/purge/lifecycle-sweep storage calls to whichever
+// upstream server it's configured against, through these routes (registered in
+// server/http/router.go under /api/v1/system/retention, gated on the existing
+// system.read/system.write RBAC permissions — the SAME credential a RemoteStorage
+// client already needs for every other proxied call, so this introduces no new
+// privilege class). Mirrors dynamic_secrets_proxy.go/login_attempts_proxy.go
+// exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives the
+// ADR-032/ADR-033/A.5.18/A.5.34 schedulers (internal/core/purge.go,
+// data_retention.go, jit_access.go, account_state.go) already use against a local
+// backend — NO retention POLICY decision (which window applies, whether a legal
+// hold blocks the sweep, which rows are "in flight" and therefore excluded) is
+// made here; all of that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore, exactly as it does against a local backend. There is
+// no competing human-facing HTTP surface for any of these eleven methods to avoid
+// (unlike groups/machine-identities, these are purely internal scheduler-driven
+// primitives), so — unlike several proxies before this one — there is no
+// "don't reuse the human-facing route" caveat to document.
+//
+// Atomicity note: every one of these eleven local (GORM) implementations already
+// resolves its "gather eligible rows, then delete/return them" work in ONE
+// storage.Storage method call, either as a single SQL statement (e.g.
+// PurgeDeletedEnvironmentsBefore, DeleteAnomalyAlertsBefore, ListUsersInStateBefore)
+// or as several statements wrapped in the LOCAL backend's own db.Transaction
+// (e.g. PurgeDeletedSecretsBefore's node+version+edge cascade,
+// DeleteExpiredRoleGrants' gather-then-delete-then-report). Proxying each as a
+// single HTTP round trip preserves that guarantee exactly: the transaction (where
+// one exists) runs entirely inside the upstream server's own process, on its own
+// database, in response to this ONE request — RemoteStorage.WithTransaction being
+// a no-op passthrough (internal/storage/store/remote_transaction.go) is irrelevant
+// here, because none of these eleven methods ever needed to SPAN multiple
+// RemoteStorage calls inside one client-side transaction in the first place (unlike
+// WebAuthn's counter race, Machine Identities' state-transition invariant, or
+// Secret Dependencies' cycle check, which each combined several separate storage
+// calls under one lock). No new atomic primitive was needed for any of the eleven.
+//
+// Two methods return the deleted rows themselves, not just a count, because their
+// CALLING core function writes one audit-log entry per removed row —
+// DeleteExpiredRoleGrantsProxy (internal/core.RemoveExpiredRoleGrants writes
+// role.expired per grant) and DeleteExpiredShareRecordsProxy
+// (internal/core.RemoveExpiredShares writes share.expired per share). Both proxy
+// handlers below return the full row set on the wire so that audit trail survives
+// the storage.type: remote hop unchanged, rather than degrading to a bare count a
+// caller could not use to log anything.
+//
+// Timezone note: every method here compares a caller-supplied `before`/`ack_before`/
+// `unack_ceiling` timestamp against a time.Time column with a plain SQL `<`/`<=`
+// operator (deleted_at, detected_at, closed_at, created_at, resolved_at,
+// expires_at, account_state's created_at). GORM's SQLite driver formats a bound
+// time.Time parameter's TEXT representation using THAT VALUE's OWN Location, not a
+// canonical one — see dynamic_secrets_proxy.go's ListExpiredActiveLeasesProxy for
+// the full empirical writeup of the resulting bug (a genuinely-expired row silently
+// excluded because two different UTC-offset TEXT representations sort
+// lexicographically out of instant order). Every decoded timestamp below is
+// therefore converted with .Local() before being handed to storage.Storage, so its
+// TEXT representation is formatted in the SAME Location this server's own rows were
+// written in — matching the one convention every other time.Time comparison in this
+// codebase already relies on (time.Now(), never time.Now().UTC()).
+//
+// Response envelope: like the other proxies, these do NOT use the package's
+// generic sendSuccess/sendError helpers — they construct the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// --- Shared single-`before` request body ---
+
+// retentionBeforeBody is the wire body for every purge/sweep route below that
+// takes a single cutoff timestamp.
+type retentionBeforeBody struct {
+	Before time.Time `json:"before"`
+}
+
+func decodeRetentionBeforeBody(w http.ResponseWriter, r *http.Request) (time.Time, bool) {
+	var body retentionBeforeBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return time.Time{}, false
+	}
+	if body.Before.IsZero() {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "before is required")
+		return time.Time{}, false
+	}
+	// See the package doc's timezone note: re-express in this server's own process
+	// Location before any storage-layer comparison.
+	return body.Before.Local(), true
+}
+
+// --- SecretHandler: PurgeDeletedSecretsBefore (ADR-032) ---
+
+// PurgeDeletedSecretsBeforeProxy handles POST /api/v1/system/retention/secrets/purge.
+func (h *SecretHandler) PurgeDeletedSecretsBeforeProxy(w http.ResponseWriter, r *http.Request) {
+	before, ok := decodeRetentionBeforeBody(w, r)
+	if !ok {
+		return
+	}
+	n, err := h.coreService.Storage().PurgeDeletedSecretsBefore(r.Context(), before)
+	if err != nil {
+		log.Printf("retention proxy: purge deleted secrets failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int64{"purged": n})
+}
+
+// --- AuditHandler: DeleteAnomalyAlertsBefore (#489, ISO A.5.33) ---
+
+// anomalyAlertsPurgeBody is the wire body for
+// POST /api/v1/system/retention/anomaly-alerts/purge. Either field may be the
+// zero time.Time — matching DeleteAnomalyAlertsBefore's own contract, a zero
+// value disables that clause entirely rather than being misread as "purge
+// everything before year 1" (see local_purge.go's DeleteAnomalyAlertsBefore doc).
+type anomalyAlertsPurgeBody struct {
+	AckBefore    time.Time `json:"ack_before"`
+	UnackCeiling time.Time `json:"unack_ceiling"`
+}
+
+// DeleteAnomalyAlertsBeforeProxy handles POST
+// /api/v1/system/retention/anomaly-alerts/purge.
+func (h *AuditHandler) DeleteAnomalyAlertsBeforeProxy(w http.ResponseWriter, r *http.Request) {
+	var body anomalyAlertsPurgeBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	// See the package doc's timezone note. .Local() on an already-zero time.Time
+	// leaves it zero (IsZero() depends only on the represented instant, not the
+	// Location), so DeleteAnomalyAlertsBefore's own "zero disables this clause"
+	// contract is preserved for whichever field the caller left unset.
+	n, err := h.coreService.Storage().DeleteAnomalyAlertsBefore(r.Context(), body.AckBefore.Local(), body.UnackCeiling.Local())
+	if err != nil {
+		log.Printf("retention proxy: purge anomaly alerts failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int64{"purged": n})
+}
+
+// --- CatalogHandler: access-reviews / break-glass / access-requests / projects /
+// environments purges. CatalogHandler already owns the human-facing CRUD (and,
+// for access-reviews/break-glass, the sibling CRUD proxy) for every one of these
+// subsystems (catalog.go's Project/Environment CRUD, invitations.go's
+// AccessRequest CRUD, access_review_campaigns_proxy.go, break_glass_proxy.go), so
+// it is the natural owner of each subsystem's own retention sweep too. ---
+
+// DeleteClosedAccessReviewsBeforeProxy handles POST
+// /api/v1/system/retention/access-reviews/purge-closed.
+func (h *CatalogHandler) DeleteClosedAccessReviewsBeforeProxy(w http.ResponseWriter, r *http.Request) {
+	before, ok := decodeRetentionBeforeBody(w, r)
+	if !ok {
+		return
+	}
+	campaigns, items, err := h.coreService.Storage().DeleteClosedAccessReviewsBefore(r.Context(), before)
+	if err != nil {
+		log.Printf("retention proxy: purge closed access reviews failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int64{"campaigns_purged": campaigns, "items_purged": items})
+}
+
+// DeleteExpiredBreakGlassBeforeProxy handles POST
+// /api/v1/system/retention/break-glass/purge-expired.
+func (h *CatalogHandler) DeleteExpiredBreakGlassBeforeProxy(w http.ResponseWriter, r *http.Request) {
+	before, ok := decodeRetentionBeforeBody(w, r)
+	if !ok {
+		return
+	}
+	n, err := h.coreService.Storage().DeleteExpiredBreakGlassBefore(r.Context(), before)
+	if err != nil {
+		log.Printf("retention proxy: purge expired break-glass failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int64{"purged": n})
+}
+
+// DeleteResolvedAccessRequestsBeforeProxy handles POST
+// /api/v1/system/retention/access-requests/purge-resolved.
+func (h *CatalogHandler) DeleteResolvedAccessRequestsBeforeProxy(w http.ResponseWriter, r *http.Request) {
+	before, ok := decodeRetentionBeforeBody(w, r)
+	if !ok {
+		return
+	}
+	requests, approvals, err := h.coreService.Storage().DeleteResolvedAccessRequestsBefore(r.Context(), before)
+	if err != nil {
+		log.Printf("retention proxy: purge resolved access requests failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int64{"requests_purged": requests, "approvals_purged": approvals})
+}
+
+// PurgeDeletedProjectsBeforeProxy handles POST
+// /api/v1/system/retention/projects/purge.
+func (h *CatalogHandler) PurgeDeletedProjectsBeforeProxy(w http.ResponseWriter, r *http.Request) {
+	before, ok := decodeRetentionBeforeBody(w, r)
+	if !ok {
+		return
+	}
+	n, err := h.coreService.Storage().PurgeDeletedProjectsBefore(r.Context(), before)
+	if err != nil {
+		log.Printf("retention proxy: purge deleted projects failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int64{"purged": n})
+}
+
+// PurgeDeletedEnvironmentsBeforeProxy handles POST
+// /api/v1/system/retention/environments/purge.
+func (h *CatalogHandler) PurgeDeletedEnvironmentsBeforeProxy(w http.ResponseWriter, r *http.Request) {
+	before, ok := decodeRetentionBeforeBody(w, r)
+	if !ok {
+		return
+	}
+	n, err := h.coreService.Storage().PurgeDeletedEnvironmentsBefore(r.Context(), before)
+	if err != nil {
+		log.Printf("retention proxy: purge deleted environments failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int64{"purged": n})
+}
+
+// --- RBACHandler: DeleteExpiredRoleGrants (JIT access expiry) ---
+
+// DeleteExpiredRoleGrantsProxy handles POST
+// /api/v1/system/retention/role-grants/purge-expired. Returns the full removed
+// storage.RoleAssignment rows — not just a count — because the calling server's
+// own internal/core.RemoveExpiredRoleGrants writes one role.expired audit event
+// per grant (principal type/ID, role, scope) using exactly this data; degrading
+// to a bare count here would silently drop that audit trail under
+// storage.type: remote. storage.RoleAssignment already carries full snake_case
+// json tags (internal/core/storage/interface.go) — no separate wire DTO struct is
+// needed, unlike models.DynamicSecretConfig's precedent.
+func (h *RBACHandler) DeleteExpiredRoleGrantsProxy(w http.ResponseWriter, r *http.Request) {
+	before, ok := decodeRetentionBeforeBody(w, r)
+	if !ok {
+		return
+	}
+	removed, err := h.coreService.Storage().DeleteExpiredRoleGrants(r.Context(), before)
+	if err != nil {
+		log.Printf("retention proxy: purge expired role grants failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	if removed == nil {
+		removed = []coreStorage.RoleAssignment{}
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"removed": removed})
+}
+
+// --- ShareHandler: DeleteExpiredShareRecords (JIT access expiry) ---
+
+// DeleteExpiredShareRecordsProxy handles POST
+// /api/v1/system/retention/share-records/purge-expired. Returns the full removed
+// models.ShareRecord rows — not just a count — because the calling server's own
+// internal/core.RemoveExpiredShares writes one share.expired audit event per
+// share (secret ID, recipient kind/ID) using exactly this data; degrading to a
+// bare count here would silently drop that audit trail under storage.type:
+// remote. models.ShareRecord carries no json tags of its own, so this marshals
+// the model directly — matching remote_sharing.go's existing
+// CreateShareRecord/GetShareRecord/UpdateShareRecord precedent (which already
+// round-trips *models.ShareRecord the same way), rather than introducing a new
+// wire DTO struct for the one field this subsystem's other proxied calls didn't
+// need one for.
+func (h *ShareHandler) DeleteExpiredShareRecordsProxy(w http.ResponseWriter, r *http.Request) {
+	before, ok := decodeRetentionBeforeBody(w, r)
+	if !ok {
+		return
+	}
+	removed, err := h.coreService.Storage().DeleteExpiredShareRecords(r.Context(), before)
+	if err != nil {
+		log.Printf("retention proxy: purge expired share records failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	if removed == nil {
+		removed = []*models.ShareRecord{}
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"removed": removed})
+}
+
+// --- UserHandler: PurgeDeletedUsersBefore (ADR-032) / ListUsersInStateBefore
+// (ADR-025 stale-account warnings) ---
+
+// userRetentionProxyWire mirrors models.User's fields the stale-account report
+// (internal/core.StaleAccounts, surfaced by GET /users/stale) actually reads —
+// models.User carries no json tags of its own (PasswordHash's `json:"-"`
+// excepted, and never populated here), so marshaling it directly would send Go
+// field names verbatim and silently drop every underscore-separated field on
+// decode, exactly the #496-class bug documented at length in remote_users.go.
+// Deliberately the SAME field set/tags as remote_users.go's userWireResponse (the
+// client-side decode counterpart) so ListUsersInStateBeforeProxy's response
+// round-trips through the exact same decoder every other User-returning
+// RemoteStorage call already uses.
+type userRetentionProxyWire struct {
+	ID                  uint       `json:"id"`
+	Username            string     `json:"username"`
+	Email               string     `json:"email"`
+	DisplayName         string     `json:"display_name"`
+	Active              bool       `json:"active"`
+	AccountState        string     `json:"account_state"`
+	ExternalID          string     `json:"external_id"`
+	CreatedAt           time.Time  `json:"created_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
+	LastLoginAt         *time.Time `json:"last_login_at"`
+	DeletedAt           *time.Time `json:"deleted_at"`
+	LoginLockedUntil    *time.Time `json:"login_locked_until,omitempty"`
+	FailedLoginAttempts int        `json:"failed_login_attempts"`
+	LoginLockoutCount   int        `json:"login_lockout_count"`
+	LastFailedLoginAt   *time.Time `json:"last_failed_login_at"`
+}
+
+func newUserRetentionProxyWire(u *models.User) userRetentionProxyWire {
+	w := userRetentionProxyWire{
+		ID:                  u.ID,
+		Username:            u.Username,
+		Email:               u.Email,
+		DisplayName:         u.DisplayName,
+		Active:              u.IsActive,
+		AccountState:        u.AccountState,
+		ExternalID:          u.ExternalID,
+		CreatedAt:           u.CreatedAt,
+		UpdatedAt:           u.UpdatedAt,
+		LastLoginAt:         u.LastLoginAt,
+		LoginLockedUntil:    u.LoginLockedUntil,
+		FailedLoginAttempts: u.FailedLoginAttempts,
+		LoginLockoutCount:   u.LoginLockoutCount,
+		LastFailedLoginAt:   u.LastFailedLoginAt,
+	}
+	if u.DeletedAt.Valid {
+		t := u.DeletedAt.Time
+		w.DeletedAt = &t
+	}
+	return w
+}
+
+// PurgeDeletedUsersBeforeProxy handles POST /api/v1/system/retention/users/purge.
+func (h *UserHandler) PurgeDeletedUsersBeforeProxy(w http.ResponseWriter, r *http.Request) {
+	before, ok := decodeRetentionBeforeBody(w, r)
+	if !ok {
+		return
+	}
+	n, err := h.coreService.Storage().PurgeDeletedUsersBefore(r.Context(), before)
+	if err != nil {
+		log.Printf("retention proxy: purge deleted users failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int64{"purged": n})
+}
+
+// ListUsersInStateBeforeProxy handles GET
+// /api/v1/system/retention/users/stale?state=<state>&before=<RFC3339Nano>. Backs
+// the calling server's OWN stale-account warning sweep
+// (internal/core.StaleAccounts) against this server's real storage backend — a
+// READ, not a delete, so it is gated system.read (see router.go) unlike every
+// other route in this file.
+func (h *UserHandler) ListUsersInStateBeforeProxy(w http.ResponseWriter, r *http.Request) {
+	state := r.URL.Query().Get("state")
+	if state == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "state query parameter is required")
+		return
+	}
+	beforeStr := r.URL.Query().Get("before")
+	if beforeStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "before query parameter is required")
+		return
+	}
+	before, err := time.Parse(time.RFC3339Nano, beforeStr)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "before must be an RFC3339 timestamp")
+		return
+	}
+	// See the package doc's timezone note.
+	rows, err := h.coreService.Storage().ListUsersInStateBefore(r.Context(), state, before.Local())
+	if err != nil {
+		log.Printf("retention proxy: list stale users failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]userRetentionProxyWire, 0, len(rows))
+	for _, u := range rows {
+		wire = append(wire, newUserRetentionProxyWire(u))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"users": wire})
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -980,12 +980,18 @@ func TestEveryMutatingRouteDeniesReadOnly(t *testing.T) {
 	// but it is gated on audit.read which system_viewer lacks, so it is correctly DENIED
 	// and not exempted here.) /sw.js is the SPA service-worker static asset, served by the
 	// web handler for any method; serving the file for DELETE/PUT/etc. changes no state,
-	// so it's not an API mutation. These are the only exemptions; any other mutating route
-	// MUST be denied.
+	// so it's not an API mutation. POST .../access-requests and .../access-requests/
+	// {requestId}/withdraw are deliberately self-service (router.go: CreateAccessRequest/
+	// WithdrawAccessRequest carry no permission gate by design — any authenticated project
+	// member may request access to a role, or withdraw their own pending request; only the
+	// approve/reject step, ResolveAccessRequest, is gated on roles.assign). These are the
+	// only exemptions; any other mutating route MUST be denied.
 	allowExact := map[string]bool{
 		"/system/init": true, "/health": true, "/metrics": true,
-		"/api/v1/projects/{id}/secrets/render": true,
-		"/sw.js":                               true, // static service-worker asset, not an API route
+		"/api/v1/projects/{id}/secrets/render":  true,
+		"/sw.js":                                true, // static service-worker asset, not an API route
+		"/api/v1/projects/{id}/access-requests": true, // self-service create
+		"/api/v1/projects/{id}/access-requests/{requestId}/withdraw": true, // self-service withdraw
 	}
 	allowPrefix := []string{"/auth/", "/api/v1/auth/", "/notifications", "/api/v1/notifications"}
 	allowed := func(route string) bool {

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -126,6 +126,13 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		// finding #519: the SoD-policy-proxy end-to-end tests exercise SoDPolicy
 		// CRUD through the real router.
 		&models.SoDPolicy{},
+		// finding #520: the retention-proxy end-to-end tests exercise
+		// DeleteAnomalyAlertsBefore/DeleteResolvedAccessRequestsBefore through the
+		// real router. AccessReviewCampaign/AccessReviewItem/BreakGlassActivation
+		// are already migrated above (#519).
+		&models.AnomalyAlert{},
+		&models.AccessRequest{},
+		&models.AccessRequestApproval{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the

--- a/server/http/remote_storage_retention_test.go
+++ b/server/http/remote_storage_retention_test.go
@@ -1,0 +1,440 @@
+// remote_storage_retention_test.go — end-to-end proxy tests for finding #520's
+// eleven data-retention/purge-sweep RemoteStorage methods
+// (server/http/handlers/retention_proxy.go): each test seeds a mix of
+// eligible/ineligible rows directly against the upstream's real storage, drives
+// the sweep through a REAL downstream RemoteStorage client over a real HTTP
+// server (not a protocol mock), and confirms exactly the eligible rows were
+// purged/returned while every ineligible row survives untouched.
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForRetention builds the standard #507/#511/#519-style
+// two-server harness: an "upstream" exercised through the REAL production
+// NewRouter/handlers (including the new /api/v1/system/retention routes,
+// server/http/handlers/retention_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed at
+// "upstream" over real HTTP via store.RemoteStorage.
+func newUpstreamDownstreamForRetention(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	return upstream, downstream
+}
+
+// TestRemoteStoragePurgeDeletedSecretsBefore_RealServer proves
+// PurgeDeletedSecretsBeforeProxy: a soft-deleted secret past the cutoff is
+// purged; a live secret is left alone.
+func TestRemoteStoragePurgeDeletedSecretsBefore_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRetention(t)
+	ctx := context.Background()
+
+	project, err := upstream.CreateProject(ctx, "Retention Test Project", "")
+	require.NoError(t, err)
+	envs, err := upstream.Storage().ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+	envID := envs[0].ID
+
+	deleted, err := upstream.Storage().CreateSecret(ctx, &models.SecretNode{
+		Name: "old-deleted", ProjectID: project.ID, EnvironmentID: envID, Type: "generic",
+	})
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().DeleteSecret(ctx, deleted.ID))
+
+	live, err := upstream.Storage().CreateSecret(ctx, &models.SecretNode{
+		Name: "still-live", ProjectID: project.ID, EnvironmentID: envID, Type: "generic",
+	})
+	require.NoError(t, err)
+
+	n, err := downstream.Storage().PurgeDeletedSecretsBefore(ctx, time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n, "only the soft-deleted secret is purged")
+
+	_, err = upstream.Storage().GetSecretIncludingDeleted(ctx, deleted.ID)
+	require.Error(t, err, "the purged secret must be gone, even Unscoped")
+
+	stillThere, err := upstream.Storage().GetSecret(ctx, live.ID)
+	require.NoError(t, err, "the live secret must survive the purge")
+	assert.Equal(t, "still-live", stillThere.Name)
+}
+
+// TestRemoteStorageDeleteAnomalyAlertsBefore_RealServer proves
+// DeleteAnomalyAlertsBeforeProxy: an old, acknowledged alert is purged; a
+// never-acknowledged old alert survives (#415's "still a live signal" guarantee).
+func TestRemoteStorageDeleteAnomalyAlertsBefore_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRetention(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	require.NoError(t, upstream.Storage().CreateAnomalyAlert(ctx, &models.AnomalyAlert{
+		SecretNodeID: 1, AlertType: "off_hours", AccessedBy: "alice", IPAddress: "10.0.0.1",
+		DetectedAt: now.AddDate(0, 0, -40), Acknowledged: true,
+	}))
+	require.NoError(t, upstream.Storage().CreateAnomalyAlert(ctx, &models.AnomalyAlert{
+		SecretNodeID: 2, AlertType: "new_ip", AccessedBy: "bob", IPAddress: "10.0.0.2",
+		DetectedAt: now.AddDate(0, 0, -40), Acknowledged: false,
+	}))
+
+	n, err := downstream.Storage().DeleteAnomalyAlertsBefore(ctx, now.AddDate(0, 0, -30), time.Time{})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n, "only the acknowledged, old alert is purged")
+
+	alerts, err := upstream.Storage().ListAnomalyAlerts(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, alerts, 1)
+	assert.False(t, alerts[0].Acknowledged, "the never-acknowledged alert survives")
+}
+
+// TestRemoteStorageDeleteClosedAccessReviewsBefore_RealServer proves
+// DeleteClosedAccessReviewsBeforeProxy: an old closed campaign (and its items) is
+// purged; an open campaign, however old, survives.
+func TestRemoteStorageDeleteClosedAccessReviewsBefore_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRetention(t)
+	ctx := context.Background()
+	now := time.Now()
+	oldClosed := now.AddDate(0, 0, -400)
+
+	closedCampaign, err := upstream.Storage().CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: 1, Name: "old closed", State: "closed", ClosedAt: &oldClosed,
+	})
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().CreateAccessReviewItems(ctx, []*models.AccessReviewItem{
+		{CampaignID: closedCampaign.ID, PrincipalType: "user", PrincipalID: 1, Source: "role", Decision: "attested"},
+		{CampaignID: closedCampaign.ID, PrincipalType: "user", PrincipalID: 2, Source: "role", Decision: "attested"},
+	}))
+
+	openCampaign, err := upstream.Storage().CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: 1, Name: "still open", State: "open", CreatedAt: oldClosed,
+	})
+	require.NoError(t, err)
+
+	camps, items, err := downstream.Storage().DeleteClosedAccessReviewsBefore(ctx, now.AddDate(0, 0, -365))
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, camps, "only the old closed campaign is purged")
+	assert.EqualValues(t, 2, items, "its two snapshot items cascade")
+
+	_, err = upstream.Storage().GetAccessReviewCampaign(ctx, closedCampaign.ID)
+	require.Error(t, err, "the closed campaign must be gone")
+
+	stillOpen, err := upstream.Storage().GetAccessReviewCampaign(ctx, openCampaign.ID)
+	require.NoError(t, err, "the open campaign must survive regardless of age")
+	assert.Equal(t, "open", stillOpen.State)
+}
+
+// TestRemoteStorageDeleteExpiredBreakGlassBefore_RealServer proves
+// DeleteExpiredBreakGlassBeforeProxy: an old, non-active activation is purged; an
+// active one, however old, is never touched.
+func TestRemoteStorageDeleteExpiredBreakGlassBefore_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRetention(t)
+	ctx := context.Background()
+	old := time.Now().AddDate(0, 0, -120)
+
+	expired, err := upstream.Storage().CreateBreakGlassActivation(ctx, &models.BreakGlassActivation{
+		ProjectID: 1, UserID: 1, RoleID: 1, RoleName: "editor", State: "expired", CreatedAt: old,
+	})
+	require.NoError(t, err)
+
+	active, err := upstream.Storage().CreateBreakGlassActivation(ctx, &models.BreakGlassActivation{
+		ProjectID: 1, UserID: 2, RoleID: 1, RoleName: "editor", State: "active", CreatedAt: old,
+	})
+	require.NoError(t, err)
+
+	n, err := downstream.Storage().DeleteExpiredBreakGlassBefore(ctx, time.Now().AddDate(0, 0, -90))
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n)
+
+	_, err = upstream.Storage().GetBreakGlassActivation(ctx, expired.ID)
+	require.Error(t, err, "the expired activation must be gone")
+
+	stillActive, err := upstream.Storage().GetBreakGlassActivation(ctx, active.ID)
+	require.NoError(t, err, "the active activation must survive regardless of age")
+	assert.Equal(t, "active", stillActive.State)
+}
+
+// TestRemoteStorageDeleteResolvedAccessRequestsBefore_RealServer proves
+// DeleteResolvedAccessRequestsBeforeProxy: an old resolved request (and its
+// approvals) is purged; a pending request, however old, survives.
+func TestRemoteStorageDeleteResolvedAccessRequestsBefore_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRetention(t)
+	ctx := context.Background()
+	now := time.Now()
+	oldResolved := now.AddDate(0, 0, -200)
+
+	resolved, err := upstream.Storage().CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: 1, UserID: 1, State: "approved", ResolvedAt: &oldResolved,
+	})
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{
+		RequestID: resolved.ID, ApproverID: 11,
+	}))
+	require.NoError(t, upstream.Storage().CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{
+		RequestID: resolved.ID, ApproverID: 12,
+	}))
+
+	pending, err := upstream.Storage().CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: 1, UserID: 2, State: "pending", CreatedAt: oldResolved,
+	})
+	require.NoError(t, err)
+
+	reqs, appr, err := downstream.Storage().DeleteResolvedAccessRequestsBefore(ctx, now.AddDate(0, 0, -180))
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, reqs)
+	assert.EqualValues(t, 2, appr)
+
+	_, err = upstream.Storage().GetAccessRequest(ctx, resolved.ID)
+	require.Error(t, err, "the resolved request must be gone")
+
+	stillPending, err := upstream.Storage().GetAccessRequest(ctx, pending.ID)
+	require.NoError(t, err, "the pending request must survive regardless of age")
+	assert.Equal(t, "pending", stillPending.State)
+}
+
+// TestRemoteStorageDeleteExpiredRoleGrants_RealServer proves
+// DeleteExpiredRoleGrantsProxy round-trips the FULL removed
+// storage.RoleAssignment rows (not just a count) — internal/core.
+// RemoveExpiredRoleGrants needs the actual principal/role/scope data to write one
+// role.expired audit event per grant. A still-live (unexpired) grant is never
+// touched.
+func TestRemoteStorageDeleteExpiredRoleGrants_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRetention(t)
+	ctx := context.Background()
+	scope := coreStorage.Scope{ProjectID: 7, EnvironmentID: 3}
+
+	require.NoError(t, upstream.Storage().AssignRoleWithExpiry(ctx, 101, 5, scope, time.Now().Add(-time.Hour)))
+	require.NoError(t, upstream.Storage().AssignRoleToGroupWithExpiry(ctx, 202, 6, scope, time.Now().Add(-time.Hour)))
+	// A still-live, non-expiring grant at a DIFFERENT scope — must survive.
+	liveScope := coreStorage.Scope{ProjectID: 8, EnvironmentID: 0}
+	require.NoError(t, upstream.Storage().AssignRole(ctx, 303, 9, liveScope))
+
+	removed, err := downstream.Storage().DeleteExpiredRoleGrants(ctx, time.Now())
+	require.NoError(t, err)
+	require.Len(t, removed, 2, "exactly the two expired grants are removed")
+
+	byType := map[string]coreStorage.RoleAssignment{}
+	for _, r := range removed {
+		byType[r.PrincipalType] = r
+	}
+	require.Contains(t, byType, "user")
+	require.Contains(t, byType, "group")
+	assert.EqualValues(t, 101, byType["user"].PrincipalID, "the full row data (not just a count) round-trips")
+	assert.EqualValues(t, 5, byType["user"].RoleID)
+	assert.EqualValues(t, 7, byType["user"].ProjectID)
+	assert.EqualValues(t, 3, byType["user"].EnvironmentID)
+	assert.EqualValues(t, 202, byType["group"].PrincipalID)
+	assert.EqualValues(t, 6, byType["group"].RoleID)
+
+	liveRoleIDs, err := upstream.Storage().GetUserRoleIDsAt(ctx, 303, liveScope)
+	require.NoError(t, err)
+	assert.Contains(t, liveRoleIDs, uint(9), "the still-live grant at a different scope must survive")
+}
+
+// TestRemoteStorageDeleteExpiredShareRecords_RealServer proves
+// DeleteExpiredShareRecordsProxy round-trips the FULL removed
+// *models.ShareRecord rows (not just a count) — internal/core.RemoveExpiredShares
+// needs the actual secret/recipient data to write one share.expired audit event
+// per share. A permanent (nil ExpiresAt) share is never touched.
+func TestRemoteStorageDeleteExpiredShareRecords_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRetention(t)
+	ctx := context.Background()
+
+	owner, err := upstream.Storage().CreateUser(ctx, &models.User{Username: "owner1", Email: "owner1@example.com", IsActive: true})
+	require.NoError(t, err)
+	recipient, err := upstream.Storage().CreateUser(ctx, &models.User{Username: "recipient1", Email: "recipient1@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	project, err := upstream.CreateProject(ctx, "Share Retention Project", "")
+	require.NoError(t, err)
+	envs, err := upstream.Storage().ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+
+	secret, err := upstream.Storage().CreateSecret(ctx, &models.SecretNode{
+		Name: "shared-secret", ProjectID: project.ID, EnvironmentID: envs[0].ID, Type: "generic", OwnerID: owner.ID,
+	})
+	require.NoError(t, err)
+
+	expiredAt := time.Now().Add(-time.Hour)
+	expiredShare, err := upstream.Storage().CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secret.ID, OwnerID: owner.ID, RecipientID: recipient.ID, Permission: "read", ExpiresAt: &expiredAt,
+	})
+	require.NoError(t, err)
+
+	// A second, permanent share to a different recipient — must survive.
+	recipient2, err := upstream.Storage().CreateUser(ctx, &models.User{Username: "recipient2", Email: "recipient2@example.com", IsActive: true})
+	require.NoError(t, err)
+	_, err = upstream.Storage().CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secret.ID, OwnerID: owner.ID, RecipientID: recipient2.ID, Permission: "write",
+	})
+	require.NoError(t, err)
+
+	removed, err := downstream.Storage().DeleteExpiredShareRecords(ctx, time.Now())
+	require.NoError(t, err)
+	require.Len(t, removed, 1, "only the expired share is removed")
+	assert.Equal(t, secret.ID, removed[0].SecretID, "the full row data (not just a count) round-trips")
+	assert.Equal(t, recipient.ID, removed[0].RecipientID)
+	assert.False(t, removed[0].IsGroup)
+	assert.Equal(t, "read", removed[0].Permission)
+
+	_, err = upstream.Storage().GetShareRecord(ctx, expiredShare.ID)
+	require.Error(t, err, "the expired share must be gone")
+
+	survivors, err := upstream.Storage().ListSharesByUser(ctx, recipient2.ID)
+	require.NoError(t, err)
+	assert.Len(t, survivors, 1, "the permanent share must survive")
+}
+
+// TestRemoteStoragePurgeDeletedUsersBefore_RealServer proves
+// PurgeDeletedUsersBeforeProxy: a soft-deleted user is purged; a live user is
+// left alone.
+func TestRemoteStoragePurgeDeletedUsersBefore_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRetention(t)
+	ctx := context.Background()
+
+	deletedUser, err := upstream.Storage().CreateUser(ctx, &models.User{Username: "todelete", Email: "todelete@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().DeleteUser(ctx, deletedUser.ID))
+
+	liveUser, err := upstream.Storage().CreateUser(ctx, &models.User{Username: "stillhere", Email: "stillhere@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	n, err := downstream.Storage().PurgeDeletedUsersBefore(ctx, time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n)
+
+	_, err = upstream.Storage().GetUser(ctx, deletedUser.ID)
+	require.Error(t, err, "the purged user must be gone")
+
+	stillThere, err := upstream.Storage().GetUser(ctx, liveUser.ID)
+	require.NoError(t, err, "the live user must survive the purge")
+	assert.Equal(t, "stillhere", stillThere.Username)
+}
+
+// TestRemoteStoragePurgeDeletedProjectsBefore_RealServer proves
+// PurgeDeletedProjectsBeforeProxy: a soft-deleted project is purged; a live
+// project is left alone.
+func TestRemoteStoragePurgeDeletedProjectsBefore_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRetention(t)
+	ctx := context.Background()
+
+	deletedProject, err := upstream.Storage().CreateProject(ctx, &models.Project{Name: "to-delete-project"})
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().DeleteProject(ctx, deletedProject.ID))
+
+	liveProject, err := upstream.CreateProject(ctx, "still-here-project", "")
+	require.NoError(t, err)
+
+	n, err := downstream.Storage().PurgeDeletedProjectsBefore(ctx, time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n)
+
+	_, err = upstream.Storage().GetProject(ctx, deletedProject.ID)
+	require.Error(t, err, "the purged project must be gone")
+
+	stillThere, err := upstream.Storage().GetProject(ctx, liveProject.ID)
+	require.NoError(t, err, "the live project must survive the purge")
+	assert.Equal(t, "still-here-project", stillThere.Name)
+}
+
+// TestRemoteStoragePurgeDeletedEnvironmentsBefore_RealServer proves
+// PurgeDeletedEnvironmentsBeforeProxy: a soft-deleted environment is purged; a
+// live environment is left alone.
+func TestRemoteStoragePurgeDeletedEnvironmentsBefore_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRetention(t)
+	ctx := context.Background()
+
+	project, err := upstream.CreateProject(ctx, "Env Retention Project", "")
+	require.NoError(t, err)
+
+	deletedEnv, err := upstream.Storage().CreateEnvironment(ctx, &models.Environment{Name: "to-delete-env", ProjectID: project.ID})
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().DeleteEnvironment(ctx, deletedEnv.ID))
+
+	envs, err := upstream.Storage().ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs, "the project's default environment(s) survive as controls")
+	liveEnvID := envs[0].ID
+
+	n, err := downstream.Storage().PurgeDeletedEnvironmentsBefore(ctx, time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n)
+
+	var remaining []*models.Environment
+	remaining, err = upstream.Storage().ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	found := false
+	for _, e := range remaining {
+		assert.NotEqual(t, deletedEnv.ID, e.ID, "the purged environment must be gone")
+		if e.ID == liveEnvID {
+			found = true
+		}
+	}
+	assert.True(t, found, "the live environment must survive the purge")
+}
+
+// TestRemoteStorageListUsersInStateBefore_RealServer proves
+// ListUsersInStateBeforeProxy: only a user in the requested account_state,
+// created before the cutoff, is returned — backing internal/core.StaleAccounts
+// (ADR-025 stale-account warnings).
+func TestRemoteStorageListUsersInStateBefore_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRetention(t)
+	ctx := context.Background()
+
+	stale, err := upstream.Storage().CreateUser(ctx, &models.User{
+		Username: "stale-invite", Email: "stale-invite@example.com", IsActive: true,
+		AccountState: core.AccountPendingFirstLogin,
+	})
+	require.NoError(t, err)
+
+	// A different account state — must not match the "pending_first_login" query.
+	_, err = upstream.Storage().CreateUser(ctx, &models.User{
+		Username: "active-user", Email: "active-user@example.com", IsActive: true,
+		AccountState: core.AccountActive,
+	})
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListUsersInStateBefore(ctx, core.AccountPendingFirstLogin, time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, stale.ID, rows[0].ID)
+	assert.Equal(t, "stale-invite", rows[0].Username)
+	assert.Equal(t, core.AccountPendingFirstLogin, rows[0].AccountState)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -72,7 +72,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	}))
 
 	// Initialize handlers
-	_, groupHandler, err := handlers.InitCoreHandlers(coreService)
+	userHandler, groupHandler, err := handlers.InitCoreHandlers(coreService)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init core HTTP handlers: %w", err)
 	}
@@ -1243,6 +1243,45 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/sod-policies", catalogHandler.ListSoDPoliciesProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/sod-policies", catalogHandler.CreateSoDPolicyProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Delete("/sod-policies/{id}", catalogHandler.DeleteSoDPolicyProxy)
+
+			// Data-retention/purge-sweep storage-primitive proxy (finding #520). Lets a
+			// downstream Keyorix server booted with storage.type: remote (ADR-049) proxy
+			// PurgeDeletedSecretsBefore/DeleteAnomalyAlertsBefore/
+			// DeleteClosedAccessReviewsBefore/DeleteExpiredBreakGlassBefore/
+			// DeleteResolvedAccessRequestsBefore/DeleteExpiredRoleGrants/
+			// DeleteExpiredShareRecords/PurgeDeletedUsersBefore/
+			// PurgeDeletedProjectsBefore/PurgeDeletedEnvironmentsBefore/
+			// ListUsersInStateBefore to THIS server's real storage backend, instead of
+			// RemoteStorage's eleven data-retention/purge-sweep methods being
+			// unconditional stubs (every scheduled retention/purge/lifecycle sweep —
+			// ADR-032 soft-delete purge, ADR-033/A.5.33 compliance-record retention, the
+			// JIT access-expiry sweep, ADR-025 stale-account warnings — was completely
+			// non-functional under storage.type: remote). Exactly the same pattern as
+			// the SoD-policies/risk-exceptions proxies above: a thin passthrough onto
+			// storage.Storage (no retention POLICY decision — which window applies, the
+			// legal-hold guard, which rows are "in flight" and excluded — is made here;
+			// that stays entirely in the CALLING server's own internal/core.KeyorixCore,
+			// exactly as it does against a local backend), reusing the SAME
+			// system.read/system.write tier — no new privilege class. See
+			// retention_proxy.go's package doc for the atomicity analysis (every method
+			// already resolves in one storage.Storage call server-side, so proxying it
+			// as one HTTP round trip preserves whatever transactional guarantee the local
+			// implementation has) and for why DeleteExpiredRoleGrants/
+			// DeleteExpiredShareRecords return the removed rows rather than a bare count
+			// (their callers write one audit-log entry per removed row). Every route here
+			// is destructive except the one List, gated system.read; every mutating
+			// route requires system.write.
+			r.Get("/retention/users/stale", userHandler.ListUsersInStateBeforeProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/secrets/purge", secretHandler.PurgeDeletedSecretsBeforeProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/anomaly-alerts/purge", auditHandler.DeleteAnomalyAlertsBeforeProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/access-reviews/purge-closed", catalogHandler.DeleteClosedAccessReviewsBeforeProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/break-glass/purge-expired", catalogHandler.DeleteExpiredBreakGlassBeforeProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/access-requests/purge-resolved", catalogHandler.DeleteResolvedAccessRequestsBeforeProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/role-grants/purge-expired", rbacHandler.DeleteExpiredRoleGrantsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/share-records/purge-expired", shareHandler.DeleteExpiredShareRecordsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/users/purge", userHandler.PurgeDeletedUsersBeforeProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/projects/purge", catalogHandler.PurgeDeletedProjectsBeforeProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/environments/purge", catalogHandler.PurgeDeletedEnvironmentsBeforeProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary
- Implements `RemoteStorage` support for the full data-retention/purge sweep method family (#520) — 11 methods across 4 files, wider than originally scoped (2 methods spotted in round 117; a full audit found 9 more): `PurgeDeletedSecretsBefore`, `DeleteAnomalyAlertsBefore`, `DeleteClosedAccessReviewsBefore`, `DeleteExpiredBreakGlassBefore`, `DeleteResolvedAccessRequestsBefore` (`remote_secrets.go`); `DeleteExpiredRoleGrants` (`remote_rbac.go`); `DeleteExpiredShareRecords` (`remote_sharing.go`); `PurgeDeletedUsersBefore`, `PurgeDeletedProjectsBefore`, `PurgeDeletedEnvironmentsBefore`, `ListUsersInStateBefore` (`remote_users.go`).
- New thin passthrough routes under `/api/v1/system/retention/*` (gated `system.write` for all delete/purge methods, `system.read` for the one list method), no new privilege class.
- `DeleteExpiredRoleGrants`/`DeleteExpiredShareRecords` return the full removed rows (not just a count), preserving the semantics their `internal/core` callers need for per-row audit logging.
- Atomicity: none of the 11 local implementations needed a new atomic primitive — each resolves entirely within one `storage.Storage` call server-side (a single SQL statement, or several wrapped in the local backend's own transaction), so one proxied round trip preserves the guarantee unchanged.
- Applied the same UTC/local timezone re-expression fix documented in `dynamic_secrets_proxy.go`'s `ListExpiredActiveLeasesProxy` (SQLite TEXT-comparison hazard) to every decoded timestamp.
- Also fixed a test gap this PR's own `AutoMigrate` addition unmasked: `TestEveryMutatingRouteDeniesReadOnly` had never actually exercised `POST .../access-requests`/`.../withdraw` (the table didn't exist in the test schema before, so both calls errored out before reaching the authorization check). Verified these routes are deliberately self-service by design (`router.go`: no permission gate on `Create`/`WithdrawAccessRequest`, only on `List`/`Resolve`) — not a security gap, just a missing test-exemption entry, now added with an explanatory comment.

## Test plan
- [x] `go build ./...` / `go vet ./...` / `golangci-lint` / `gofmt` clean
- [x] `go test ./internal/storage/store/... ./internal/core/... ./server/http/...` pass (one unrelated, confirmed-flaky-in-isolation test, `TestRemoteStorageMachineIdentities_TransitionState_ConcurrentRaceIsSerialized_RealServer`, occasionally flakes under full-suite load; passes consistently in isolation)
- [x] New `server/http/remote_storage_retention_test.go`: 11 end-to-end tests, including full-row round-trip verification for the two methods that return removed rows rather than a count
- [x] `gosec -severity medium -exclude-generated` — 0 issues (598 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)