### PR TITLE
fix(audit): persist the high-water mark without embedded NUL bytes

### DIFF
--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -409,17 +409,36 @@ func (c *KeyorixCore) watermark() int64 {
 	return c.auditMaxCertified
 }
 
-// auditHighWaterValue serializes a high-water mark: the checkpoint canonical bytes
-// (chained_events, head_id, head_hash, key_version) plus the HMAC signature, all
-// null-separated so the fields cannot be ambiguously re-split.
+// auditHighWaterSep separates fields in the persisted high-water value. It must not be
+// "\x00": this value is stored as a plain string via SetSystemMetadata, and PostgreSQL's
+// text/varchar columns reject any embedded NUL byte outright ("invalid byte sequence for
+// encoding UTF8: 0x00") — a NUL-separated encoding can never actually persist there, so
+// every write silently failed and the anti-rollback mark was never saved. \x1f (ASCII
+// unit separator) is a single valid UTF-8 byte and never appears in the fields being
+// joined (decimal integers, a hex hash, a key-version string, a hex HMAC signature).
+const auditHighWaterSep = "\x1f"
+
+// auditHighWaterValue serializes a high-water mark: the checkpoint's chained_events,
+// head_id, head_hash, and key_version, plus the HMAC signature, joined with
+// auditHighWaterSep so the fields cannot be ambiguously re-split. This intentionally
+// does not reuse checkpointCanonical's own (NUL-separated) byte layout — that layout is
+// only ever hashed as HMAC input, never persisted as a standalone string, so it doesn't
+// need to dodge the Postgres NUL restriction.
 func auditHighWaterValue(cp *models.AuditCheckpoint, sig string) string {
-	return checkpointCanonical(cp) + "\x00" + sig
+	return strings.Join([]string{
+		"v1",
+		strconv.FormatInt(cp.ChainedEvents, 10),
+		strconv.FormatUint(uint64(cp.HeadID), 10),
+		cp.HeadHash,
+		cp.KeyVersion,
+		sig,
+	}, auditHighWaterSep)
 }
 
 // parseAuditHighWater parses a stored high-water value back into a checkpoint snapshot
 // and its signature. ok is false on any malformed value (treated as "no mark").
 func parseAuditHighWater(val string) (cp *models.AuditCheckpoint, sig string, ok bool) {
-	parts := strings.Split(val, "\x00")
+	parts := strings.Split(val, auditHighWaterSep)
 	if len(parts) != 6 || parts[0] != "v1" {
 		return nil, "", false
 	}

--- a/internal/core/audit_checkpoint_test.go
+++ b/internal/core/audit_checkpoint_test.go
@@ -495,7 +495,7 @@ func TestAuditCheckpoint_TamperedHighWaterDetected(t *testing.T) {
 	// Lower the high-water's claimed length to mask a planned truncation; the signature
 	// no longer matches. Use a fresh core so only the persistent mark is consulted.
 	require.NoError(t, db.Exec("UPDATE system_metadata SET value = ? WHERE key = ?",
-		"v1\x002\x002\x00deadbeef\x00v1\x00bogussig", auditHighWaterKey).Error)
+		"v1\x1f2\x1f2\x1fdeadbeef\x1fv1\x1fbogussig", auditHighWaterKey).Error)
 
 	fresh := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	fresh.SetAuditCheckpointKey(bytes.Repeat([]byte{0x7}, 32), "v1")
@@ -533,7 +533,7 @@ func TestAuditCheckpoint_ForgedKeyVersionHighWaterDetected(t *testing.T) {
 	// real current "v1", and not a genuinely-ever-used version either) and a
 	// garbage signature — this is the exact shape that was previously excused.
 	require.NoError(t, db.Exec("UPDATE system_metadata SET value = ? WHERE key = ?",
-		"v1\x001\x001\x00deadbeef\x00fabricated-v99\x00bogussig", auditHighWaterKey).Error)
+		"v1\x1f1\x1f1\x1fdeadbeef\x1ffabricated-v99\x1fbogussig", auditHighWaterKey).Error)
 	// Attacker: delete the newer checkpoint, keeping the older authentic one.
 	require.NoError(t, db.Exec("DELETE FROM audit_checkpoints WHERE chained_events = 10").Error)
 	// Attacker: truncate events below what the deleted checkpoint certified, but


### PR DESCRIPTION
## Summary
- `auditHighWaterValue` joined its fields with `\x00`, then persisted the result via `SetSystemMetadata` — but PostgreSQL's `text` columns reject any embedded NUL byte outright (`invalid byte sequence for encoding "UTF8": 0x00`). Every write of the audit-checkpoint anti-rollback high-water mark silently failed on Postgres, so the mark was never actually saved in production, undermining the ADR-029 anti-rollback protection.
- Found incidentally while manually verifying #844/#845 against a real Postgres instance: `audit high-water: failed to persist mark at 2 events: ERROR: invalid byte sequence for encoding "UTF8": 0x00 (SQLSTATE 22021)` on every checkpoint write.
- Switch the field separator to `\x1f` (ASCII unit separator) — a valid single UTF-8 byte Postgres accepts. `checkpointCanonical`'s own NUL-separated HMAC input bytes are untouched (never persisted as a standalone string), so existing checkpoint row signatures are unaffected.

## Test plan
- [x] `go test ./internal/core/...` passes (updated the two tests that hand-construct a raw high-water value to use the new separator)
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues
- [x] Manual: built the server against a fresh, disposable Postgres container — pre-fix reproduced the exact `invalid byte sequence` error on every checkpoint write; post-fix, checkpoints write cleanly and `SELECT value FROM system_metadata WHERE key = 'audit_checkpoint_highwater'` shows the persisted mark with the `\x1f`-separated fields intact