### PR TITLE
fix(users): classify user-creation validation errors as 400, not 500

### DIFF
--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -97,6 +97,10 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 				sendError(w, "ConflictError", "User already exists", http.StatusConflict, nil)
 				return
 			}
+			if strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)) {
+				sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
+				return
+			}
 			sendError(w, "InternalError", "Failed to create user", http.StatusInternalServerError, nil)
 			return
 		}
@@ -119,6 +123,10 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 			}
 			if errors.Is(err, core.ErrSetupBaseURLRequired) {
 				sendError(w, "ConfigError", err.Error(), http.StatusBadRequest, nil)
+				return
+			}
+			if strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)) {
+				sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
 				return
 			}
 			sendError(w, "InternalError", "Failed to create user", http.StatusInternalServerError, nil)
@@ -177,7 +185,8 @@ func (h *UserHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		case strings.Contains(err.Error(), "only an administrator can grant"):
 			sendError(w, "Forbidden", err.Error(), http.StatusForbidden, nil)
 		case strings.Contains(err.Error(), "unknown role"), strings.Contains(err.Error(), "unknown project"),
-			strings.Contains(err.Error(), "each project assignment"):
+			strings.Contains(err.Error(), "each project assignment"),
+			strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)):
 			sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
 		default:
 			sendError(w, "InternalError", "Failed to create user", http.StatusInternalServerError, nil)


### PR DESCRIPTION
## Summary
- Found while exploratory-testing the API against a fresh Postgres: `POST /api/v1/users` with a password that fails the configured password policy returns HTTP 500 `{"error":"InternalError","message":"Failed to create user"}` instead of a 400 with the actual reason — the server log shows the real cause (`Error creating user: Validation error: password must be at least 16 characters, ...`), but the client never sees it.
- Root cause: `CreateUser`'s error-handling special-cased only `"already exists"` (plus, on the setup-link path, `ErrSetupBaseURLRequired`) before falling through to a generic 500. Any other validation failure from `buildUserForCreate` — most notably password-policy violations — was misreported as a server crash, on all three creation paths (classic admin-set-password, setup-link, one-time-password), since all three funnel through the same validation.
- Fix: check for the `i18n.T("ErrorValidation")` prefix these errors carry (the same pattern `server/http/handlers/auth.go` already uses for `/system/init`) and map them to 400 `ValidationError` with the real message, on all three paths.

## Test plan
- [x] `go test ./server/http/...` passes
- [x] `gosec -severity medium -exclude-generated ./server/http/handlers/...` — 0 issues
- [x] Manual: built and ran the server against a fresh Postgres — a weak password now returns `400 {"error":"ValidationError","message":"Validation error: password must be at least 16 characters, not contain your username, email, or display name"}`; a valid user still creates (201) and a duplicate username still returns 409 (unaffected)