### PR TITLE
fix(handlers): classify more validation errors as 400, not 500

### DIFF
--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
 	"github.com/keyorixhq/keyorix/server/validation"
@@ -151,7 +152,14 @@ func (h *CatalogHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		log.Printf("Error creating project: %v", err)
-		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
+		switch {
+		case strings.Contains(err.Error(), "already exists"):
+			sendError(w, "ConflictError", err.Error(), http.StatusConflict, nil)
+		case strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)):
+			sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
+		default:
+			sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
+		}
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -279,6 +287,10 @@ func (h *CatalogHandler) CreateProjectEnvironment(w http.ResponseWriter, r *http
 	env, err := h.coreService.CreateEnvironment(r.Context(), uint(id), body.Name)
 	if err != nil {
 		log.Printf("Error creating environment for project %d: %v", id, err)
+		if strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)) {
+			sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
+			return
+		}
 		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}

--- a/server/http/handlers/groups_handler.go
+++ b/server/http/handlers/groups_handler.go
@@ -95,6 +95,10 @@ func (h *GroupHandler) CreateGroup(w http.ResponseWriter, r *http.Request) {
 			sendError(w, "ConflictError", "Group name already exists", http.StatusConflict, nil)
 			return
 		}
+		if strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)) {
+			sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
+			return
+		}
 		sendError(w, "InternalError", "Failed to create group", http.StatusInternalServerError, nil)
 		return
 	}
@@ -163,6 +167,10 @@ func (h *GroupHandler) UpdateGroup(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Error updating group: %v", err)
 		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), i18n.T("ErrorGroupNotFound", nil)) {
 			sendError(w, "NotFound", "Group not found", http.StatusNotFound, nil)
+			return
+		}
+		if strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)) {
+			sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
 			return
 		}
 		sendError(w, "InternalError", "Failed to update group", http.StatusInternalServerError, nil)

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -86,6 +86,8 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 			h.sendError(w, "ConflictError", "Secret with this name already exists", http.StatusConflict, nil)
 		} else if strings.Contains(err.Error(), "does not belong to project") || strings.Contains(err.Error(), "environment") && strings.Contains(err.Error(), "not found") {
 			h.sendError(w, "ValidationError", err.Error(), http.StatusUnprocessableEntity, nil)
+		} else if strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)) {
+			h.sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
 		} else {
 			h.sendError(w, "InternalError", "Failed to create secret", http.StatusInternalServerError, nil)
 		}
@@ -476,6 +478,8 @@ func (h *SecretHandler) UpdateSecret(w http.ResponseWriter, r *http.Request) {
 			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
 		} else if strings.Contains(err.Error(), "permission denied") {
 			h.sendError(w, "Forbidden", "Access denied", http.StatusForbidden, nil)
+		} else if strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)) {
+			h.sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
 		} else {
 			h.sendError(w, "InternalError", "Failed to update secret", http.StatusInternalServerError, nil)
 		}

--- a/server/http/handlers/secrets_versions.go
+++ b/server/http/handlers/secrets_versions.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
@@ -105,6 +106,8 @@ func (h *SecretHandler) RotateSecret(w http.ResponseWriter, r *http.Request) {
 			// even though a partial attempt may have stored a new value; see the audit
 			// trail (secret.rotate_failed / secret.rotate_incomplete) for the outcome.
 			h.sendError(w, "BackendRotationFailed", err.Error(), http.StatusBadGateway, nil)
+		case strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)):
+			h.sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
 		default:
 			h.sendError(w, "InternalError", "Failed to rotate secret", http.StatusInternalServerError, nil)
 		}


### PR DESCRIPTION
## Summary
Follow-up to #858, which fixed this exact class of bug in `CreateUser`. Prompted a broader static-analysis sweep (Explore agent) over handlers with a generic 500 fallback, followed by manual verification of each candidate against `internal/core` and a live fresh-Postgres repro before touching anything.

Confirmed and fixed:
- **groups_handler.go**: `CreateGroup`/`UpdateGroup` only checked for a duplicate-name/not-found substring before a generic 500. An over-long description (`validateDescription`, >1024 chars) falls through and was misreported as a crash. Verified live: now returns `400 {"error":"ValidationError","message":"Validation error: description exceeds 1024 characters"}`.
- **secrets_crud.go**: `CreateSecret`/`UpdateSecret` only checked "already exists"/"does not belong to project"/"not found"/"permission denied". Invalid classification, secret-name-policy violations, and secret-value-policy violations (when the policy is enabled) fell through to 500. Verified live: an invalid `classification` now returns `400 {"error":"ValidationError","message":"Validation error: invalid classification"}`.
- **secrets_versions.go**: `RotateSecret` had the same secret-value-policy gap as `UpdateSecret` (same underlying `secretValuePolicy.Validate` call).
- **catalog.go**: `CreateProject`/`CreateProjectEnvironment` had **no error branching at all** — every error, including a plain duplicate project name, always returned `500` with a generic `clientSafe()` message ("an internal error occurred..."), giving the caller zero signal to react to. Verified live: a duplicate project name now returns `409 Conflict`, and an over-long name/description/environment name returns `400` with the real reason.

All fixes follow the same pattern already used in `server/http/handlers/auth.go:640` and applied to `CreateUser` in #858: check for the `i18n.T("ErrorValidation")` prefix that `internal/core` wraps client-facing validation failures with, before falling through to the generic 500.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./server/http/...` passes
- [x] `gosec -severity medium -exclude-generated ./server/http/handlers/...` — 0 issues
- [x] Manual, against a fresh Postgres + running server:
  - over-long group description → 400 (was 500)
  - invalid secret classification → 400 (was 500)
  - duplicate project name → 409 (was 500)
  - over-long environment name → 400 (was 500)
  - regression check: valid group/secret/project creation still succeeds; duplicate username still 409; not-found/permission-denied paths unaffected