### PR TITLE
fix(auth): proxy login-lockout accounting under storage.type: remote

### DIFF
--- a/internal/core/login_lockout_remote_test.go
+++ b/internal/core/login_lockout_remote_test.go
@@ -1,17 +1,32 @@
+// login_lockout_remote_test.go — regression coverage for backlog #529:
+// RemoteStorage.UpdateLoginLockoutState (internal/storage/store/remote_users.go)
+// used to be a hard, permanent remoteUnsupported(...) stub (#454) — every
+// recordFailedLogin/checkLockAndClearLoginFailures/clearLoginFailures/UnlockUser
+// write in login_lockout.go silently failed OPEN under storage.type: remote,
+// making per-account brute-force lockout accounting completely inert for that
+// deployment mode. It is now a genuine thin passthrough onto a new
+// PUT /api/v1/system/users/{id}/login-lockout route
+// (server/http/handlers/login_lockout_proxy.go), so this file proves the
+// accounting genuinely PERSISTS across the wire — not just that the call no
+// longer errors.
 package core
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,12 +36,13 @@ import (
 // LockUserForUpdate, which is just GetUser — see remote_users.go) decodes exactly
 // this shape (#496); a raw-model mock would silently paper over the same
 // request/response field-name mismatch #496 fixed, since both sides would share the
-// identical (wrong) assumption.
+// identical (wrong) assumption. Shared with password_remote_test.go (#484), which
+// also needs a stand-in GetUser response.
 //
-// #500: failed_login_attempts/login_lockout_count/last_failed_login_at are now also
-// part of that real shape (alongside the pre-existing login_locked_until), so this
-// mock includes them unconditionally too — omitting them here would silently
-// reintroduce the exact stale-mock blind spot #496's own fix was written to avoid.
+// failed_login_attempts/login_lockout_count/last_failed_login_at are part of that
+// real shape (alongside login_locked_until), so this mock includes them
+// unconditionally too — omitting them here would silently reintroduce the exact
+// stale-mock blind spot #496's own fix was written to avoid.
 func apiOKUser(t *testing.T, w http.ResponseWriter, user *models.User) {
 	t.Helper()
 	data := map[string]interface{}{
@@ -60,21 +76,131 @@ func apiOKUser(t *testing.T, w http.ResponseWriter, user *models.User) {
 	require.NoError(t, json.NewEncoder(w).Encode(resp{Success: true, Data: data}))
 }
 
-// newRemoteLockoutCore builds a KeyorixCore backed by RemoteStorage against a real
-// httptest server that only serves GET /api/v1/users/{id} (LockUserForUpdate's
-// underlying call, per remote_users.go) — always returning `user` unchanged, since
-// nothing this test does can ever actually persist anything server-side.
-// UpdateLoginLockoutState never has a wire endpoint to call at all (#454): it always
-// returns storage.ErrUnsupportedByBackend regardless of what the test server does.
-func newRemoteLockoutCore(t *testing.T, user *models.User, policy LoginLockoutPolicy) *KeyorixCore {
-	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		apiOKUser(t, w, user)
-	}))
-	t.Cleanup(srv.Close)
+// fakeUpstreamLoginLockout is a minimal, in-memory stand-in for the real
+// server-side login-lockout proxy (server/http/handlers/login_lockout_proxy.go,
+// registered in server/http/router.go under
+// /api/v1/system/users/{id}/login-lockout) PLUS the ordinary GET /api/v1/users/{id}
+// route LockUserForUpdate uses. internal/core cannot import server/http (server/http
+// imports internal/core — that would be a package cycle), so this hand-rolls the
+// identical wire contract, matching the existing convention rate_limit_test.go's
+// fakeUpstreamLoginAttempts already uses for the sibling #452 fix. The
+// production-router version of the admin-unlock half of this scenario is
+// TestUnlockUser_RemoteStorageGenuinelyPersistsAndAudits in server/http, which
+// exercises the ACTUAL handler code, not this stand-in.
+type fakeUpstreamLoginLockout struct {
+	mu     sync.Mutex
+	user   models.User
+	events []string // audit event types recorded via POST /api/v1/audit/events
+}
 
+func newFakeUpstreamLoginLockout(user models.User) *fakeUpstreamLoginLockout {
+	return &fakeUpstreamLoginLockout{user: user}
+}
+
+func (f *fakeUpstreamLoginLockout) snapshot() models.User {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.user
+}
+
+func (f *fakeUpstreamLoginLockout) auditEventTypes() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.events...)
+}
+
+func (f *fakeUpstreamLoginLockout) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// GET /api/v1/users/{id} — backs LockUserForUpdate/GetUser. Mirrors
+	// userToAPIResponse's real snake_case wire shape (#496/#500) so this stand-in
+	// can't paper over a field-name mismatch the same way the real handler couldn't.
+	mux.HandleFunc("/api/v1/users/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		u := f.snapshot()
+		data := map[string]interface{}{
+			"id":                    u.ID,
+			"username":              u.Username,
+			"email":                 u.Email,
+			"display_name":          u.DisplayName,
+			"active":                u.IsActive,
+			"account_state":         u.AccountState,
+			"created_at":            time.Now().UTC().Format(time.RFC3339),
+			"updated_at":            time.Now().UTC().Format(time.RFC3339),
+			"last_login_at":         nil,
+			"deleted_at":            nil,
+			"failed_login_attempts": u.FailedLoginAttempts,
+			"login_lockout_count":   u.LoginLockoutCount,
+			"last_failed_login_at":  nil,
+			"login_locked_until":    nil,
+		}
+		if u.LastFailedLoginAt != nil {
+			data["last_failed_login_at"] = u.LastFailedLoginAt.UTC().Format(time.RFC3339)
+		}
+		if u.LoginLockedUntil != nil {
+			data["login_locked_until"] = u.LoginLockedUntil.UTC().Format(time.RFC3339)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "data": data})
+	})
+
+	// PUT /api/v1/system/users/{id}/login-lockout — backs UpdateLoginLockoutState.
+	mux.HandleFunc("/api/v1/system/users/1/login-lockout", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			FailedLoginAttempts int        `json:"failed_login_attempts"`
+			LastFailedLoginAt   *time.Time `json:"last_failed_login_at"`
+			LoginLockedUntil    *time.Time `json:"login_locked_until"`
+			LoginLockoutCount   int        `json:"login_lockout_count"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		f.mu.Lock()
+		f.user.FailedLoginAttempts = body.FailedLoginAttempts
+		f.user.LastFailedLoginAt = body.LastFailedLoginAt
+		f.user.LoginLockedUntil = body.LoginLockedUntil
+		f.user.LoginLockoutCount = body.LoginLockoutCount
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"success":true,"data":{"updated":true}}`)
+	})
+
+	// POST /api/v1/audit/events — backs LogAuditEvent, so UnlockUser's audit write
+	// (EventAccountUnlocked) genuinely round-trips too, not just the counter reset.
+	mux.HandleFunc("/api/v1/audit/events", func(w http.ResponseWriter, r *http.Request) {
+		var event models.AuditEvent
+		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		f.mu.Lock()
+		f.events = append(f.events, event.EventType)
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"success":true,"data":{"id":1}}`)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// newRemoteLockoutCoreAgainst builds a KeyorixCore backed by RemoteStorage — the
+// backend a server runs when configured with storage.type: remote — pointed at a
+// real (test) HTTP server, so recordFailedLogin/checkLockAndClearLoginFailures/
+// clearLoginFailures/UnlockUser genuinely round-trip over HTTP rather than being
+// stubbed out.
+func newRemoteLockoutCoreAgainst(t *testing.T, baseURL string, policy LoginLockoutPolicy) *KeyorixCore {
+	t.Helper()
 	rs, err := store.NewRemoteStorage(&remote.Config{
-		BaseURL: srv.URL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: false,
+		BaseURL: baseURL, APIKey: "test-key", TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
 	})
 	require.NoError(t, err)
 	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
@@ -83,93 +209,146 @@ func newRemoteLockoutCore(t *testing.T, user *models.User, policy LoginLockoutPo
 	return c
 }
 
-// TestLockout_RemoteStorageFailsOpenLoudlyOnce is the (#454) regression for the
-// "passive accounting" half of the fix: under storage.type: remote,
-// UpdateLoginLockoutState can never persist anything (the upstream wire format has no
-// field for these columns), so recordFailedLogin/checkLockAndClearLoginFailures must
-// (a) never panic or block a login over it, and (b) log the operator-visible warning
-// exactly ONCE per process — mirroring #452's identical treatment of the per-IP rate
-// limiter's RemoteStorage gap.
-func TestLockout_RemoteStorageFailsOpenLoudlyOnce(t *testing.T) {
-	// MaxAttempts=1 so a single recordFailedLogin call already tries to trip the lock,
-	// forcing an immediate attempt to persist via UpdateLoginLockoutState.
-	policy := LoginLockoutPolicy{Enabled: true, MaxAttempts: 1, Window: 15 * time.Minute, BaseCooldown: time.Minute, MaxCooldown: time.Hour}
-	user := &models.User{ID: 42, Username: "bob", AccountState: AccountActive, IsActive: true}
-	c := newRemoteLockoutCore(t, user, policy)
+// TestLockout_RemoteStorageGenuinelyPersistsAndLocks (#529) proves the fix: under
+// storage.type: remote, recordFailedLogin's writes now genuinely land on the
+// upstream server — the failed-attempt counter increments across calls and the
+// account actually locks at the threshold, exactly matching LocalStorage's own
+// behavior (TestLoginLockout_LocksAfterMaxAttempts) — instead of every write
+// silently no-op'ing for the life of the process.
+func TestLockout_RemoteStorageGenuinelyPersistsAndLocks(t *testing.T) {
+	upstream := newFakeUpstreamLoginLockout(models.User{ID: 1, Username: "bob", AccountState: AccountActive, IsActive: true})
+	srv := upstream.server(t)
+	defer srv.Close()
+
+	policy := LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: 15 * time.Minute, BaseCooldown: time.Minute, MaxCooldown: time.Hour}
+	c := newRemoteLockoutCoreAgainst(t, srv.URL, policy)
 	ctx := context.Background()
+	user := &models.User{ID: 1, Username: "bob", AccountState: AccountActive, IsActive: true}
 
 	out := captureLog(t, func() {
-		assert.NotPanics(t, func() { c.recordFailedLogin(ctx, user) })
+		c.recordFailedLogin(ctx, user)
 	})
-	assert.Contains(t, out, "login lockout accounting is INERT", "first call must log the operator warning")
-	assert.Contains(t, out, "storage.type: remote")
-	// Nothing was actually persisted, so the caller's in-memory struct must not be
-	// mutated to falsely reflect a lock that was never recorded anywhere.
-	assert.Nil(t, user.LoginLockedUntil, "must not claim a lock was applied when persistence failed")
+	assert.Empty(t, out, "the accounting write now genuinely succeeds — no more INERT operator warning")
+	assert.Equal(t, 1, upstream.snapshot().FailedLoginAttempts,
+		"#529: the failed-attempt counter must genuinely persist upstream, not silently no-op")
+	assert.Nil(t, upstream.snapshot().LoginLockedUntil, "below the threshold, not yet locked")
 
-	// The warning fires once per process, not once per call.
-	out2 := captureLog(t, func() {
-		for i := 0; i < 5; i++ {
-			c.recordFailedLogin(ctx, user)
-		}
-	})
-	assert.Empty(t, out2, "the warning must not repeat on subsequent calls")
+	c.recordFailedLogin(ctx, user)
+	assert.Equal(t, 2, upstream.snapshot().FailedLoginAttempts)
 
-	// checkLockAndClearLoginFailures must fail OPEN (allow the login) rather than
-	// return its "unable to verify account lock state" fail-closed error — the backend
-	// being permanently unable to clear the counters is not the same as a transient
-	// storage error, and lockout is a backstop, not the primary auth boundary.
-	//
-	// #500 (this used to be a separately-filed gap, discovered fixing #496): before
-	// this fix, this path did NOT log the INERT warning against a real remote server.
-	// checkLockAndClearLoginFailures's (login_lockout.go) "nothing to clear" fast path
-	// is keyed on the freshly-fetched u.FailedLoginAttempts/LoginLockedUntil/
-	// LoginLockoutCount; when userToAPIResponse (server/http/handlers/users_handler.go)
-	// never put failed_login_attempts/login_lockout_count on the wire at all, that fast
-	// path always observed a false all-zero snapshot under storage.type: remote, so it
-	// always took the early return — UpdateLoginLockoutState was never even attempted
-	// and the warning never fired, silently leaving any real stale accounting
-	// unreported (though, since #454, still safely unpersisted either way — this was an
-	// observability gap in the "loudly" half of "fail open loudly", not a security one).
-	// Now that those fields are on the wire, a user with genuine unreset accounting
-	// (FailedLoginAttempts: 2 below) is no longer mistaken for "nothing to clear": the
-	// fast path is skipped, UpdateLoginLockoutState is attempted, fails unsupported, and
-	// the operator warning correctly fires from this call path too.
-	lockedUser := &models.User{ID: 43, Username: "carol", AccountState: AccountActive, IsActive: true, FailedLoginAttempts: 2}
-	c2 := newRemoteLockoutCore(t, lockedUser, policy)
-	out3 := captureLog(t, func() {
-		err := c2.checkLockAndClearLoginFailures(ctx, lockedUser)
-		assert.NoError(t, err, "must not block login just because lockout accounting can't be persisted")
-	})
-	assert.Contains(t, out3, "login lockout accounting is INERT",
-		"#500: real unreset accounting (FailedLoginAttempts>0) must no longer be mistaken "+
-			"for 'nothing to clear' now that these fields are on the wire")
+	// The 3rd failure trips the lock.
+	c.recordFailedLogin(ctx, user)
+	locked := upstream.snapshot()
+	require.NotNil(t, locked.LoginLockedUntil,
+		"#529: the account must genuinely lock upstream at MaxAttempts, matching LocalStorage's behavior")
+	assert.Equal(t, 1, locked.LoginLockoutCount)
+	assert.Equal(t, 0, locked.FailedLoginAttempts, "the window counter resets once the lock itself takes over")
 }
 
-// TestUnlockUser_RemoteStorageFailsOpenLoudly is the (#484) regression for the admin
-// UnlockUser path: it clears the identical four lockout-accounting columns that
-// recordFailedLogin/checkLockAndClearLoginFailures clear automatically on a successful
-// login, via the SAME UpdateLoginLockoutState primitive #454 already established for
-// them — so it must get the identical fail-OPEN-but-loud treatment under storage.type:
-// remote (log the operator warning once, return no error to the admin), not a hard
-// failure: this is still passive lockout accounting, not an explicit security
-// directive like account_state, and the worst case of the write silently no-op'ing is
-// merely that the lock expires on its own cooldown instead of clearing early.
-func TestUnlockUser_RemoteStorageFailsOpenLoudly(t *testing.T) {
+// TestLockout_RemoteStorageGenuinelyClears (#529) proves
+// checkLockAndClearLoginFailures/clearLoginFailures genuinely reset the upstream
+// accounting after a successful login, instead of the reset silently no-op'ing.
+func TestLockout_RemoteStorageGenuinelyClears(t *testing.T) {
+	past := time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC) // already-expired lock
+	upstream := newFakeUpstreamLoginLockout(models.User{
+		ID: 1, Username: "carol", AccountState: AccountActive, IsActive: true,
+		FailedLoginAttempts: 2, LoginLockoutCount: 1, LoginLockedUntil: &past,
+	})
+	srv := upstream.server(t)
+	defer srv.Close()
+
 	policy := LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: 15 * time.Minute, BaseCooldown: time.Minute, MaxCooldown: time.Hour}
-	user := &models.User{ID: 44, Username: "dave", AccountState: AccountActive, IsActive: true, FailedLoginAttempts: 2, LoginLockoutCount: 1}
-	c := newRemoteLockoutCore(t, user, policy)
+	c := newRemoteLockoutCoreAgainst(t, srv.URL, policy)
+	ctx := context.Background()
+	user := &models.User{ID: 1, Username: "carol", AccountState: AccountActive, IsActive: true, FailedLoginAttempts: 2, LoginLockoutCount: 1}
+
+	out := captureLog(t, func() {
+		err := c.checkLockAndClearLoginFailures(ctx, user)
+		assert.NoError(t, err, "the (already-expired) lock must not block login")
+	})
+	assert.Empty(t, out, "clearing now genuinely succeeds — no more INERT operator warning")
+
+	cleared := upstream.snapshot()
+	assert.Zero(t, cleared.FailedLoginAttempts, "#529: the failure counters must genuinely reset upstream")
+	assert.Zero(t, cleared.LoginLockoutCount)
+	assert.Nil(t, cleared.LoginLockedUntil)
+	assert.Zero(t, user.FailedLoginAttempts, "the caller's in-memory struct reflects the persisted clear")
+}
+
+// TestUnlockUser_RemoteStorageGenuinelyPersistsAndAudits (#529, closing #484's own
+// follow-up gap) proves the admin UnlockUser action genuinely clears the upstream
+// lockout state AND its audit event genuinely lands upstream too — not just that
+// the call returns no error to the admin.
+func TestUnlockUser_RemoteStorageGenuinelyPersistsAndAudits(t *testing.T) {
+	future := time.Date(2026, 6, 12, 11, 0, 0, 0, time.UTC) // still-active lock
+	upstream := newFakeUpstreamLoginLockout(models.User{
+		ID: 1, Username: "dave", AccountState: AccountActive, IsActive: true,
+		FailedLoginAttempts: 2, LoginLockoutCount: 1, LoginLockedUntil: &future,
+	})
+	srv := upstream.server(t)
+	defer srv.Close()
+
+	policy := LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: 15 * time.Minute, BaseCooldown: time.Minute, MaxCooldown: time.Hour}
+	c := newRemoteLockoutCoreAgainst(t, srv.URL, policy)
 	ctx := context.Background()
 
 	out := captureLog(t, func() {
-		err := c.UnlockUser(ctx, 1, 44)
-		assert.NoError(t, err, "an admin unlock must not fail just because lockout accounting can't be persisted")
+		err := c.UnlockUser(ctx, 99, 1)
+		assert.NoError(t, err)
+	})
+	assert.Empty(t, out, "the unlock write now genuinely succeeds — no more INERT operator warning")
+
+	unlocked := upstream.snapshot()
+	assert.Zero(t, unlocked.FailedLoginAttempts, "#529: an admin unlock must genuinely clear the upstream lockout state")
+	assert.Zero(t, unlocked.LoginLockoutCount)
+	assert.Nil(t, unlocked.LoginLockedUntil, "the still-active lock must be genuinely lifted, not merely left to expire")
+
+	assert.Contains(t, upstream.auditEventTypes(), EventAccountUnlocked,
+		"the admin unlock must still be audited even though the write now succeeds")
+}
+
+// TestLockout_UnsupportedBackendStillFailsOpenLoudly is defense in depth (mirroring
+// rate_limit.go's identical #452 precedent): RemoteStorage itself no longer hits
+// this path (see above), but isUnsupportedByBackend/warnLockoutUnsupportedOnce stay
+// in login_lockout.go for any FUTURE storage.Storage implementation that genuinely
+// cannot satisfy UpdateLoginLockoutState. A mock standing in for that hypothetical
+// backend must still fail OPEN with exactly one loud operator warning, never block
+// or repeat-log.
+func TestLockout_UnsupportedBackendStillFailsOpenLoudly(t *testing.T) {
+	m := new(MockStorage)
+	uid := uint(7)
+	user := &models.User{ID: uid, Username: "erin", AccountState: AccountActive, IsActive: true}
+	// freshUnlockedUser returns a brand-new, never-mutated pointer reflecting the
+	// pristine (never-actually-persisted) state — since the write always fails here,
+	// nothing was genuinely written anywhere, so every fresh LockUserForUpdate read
+	// must keep observing the SAME pristine row, never a previous call's in-memory-only
+	// mutation of a shared/reused pointer (which would be a test artifact, not
+	// something a real backend could ever produce).
+	freshUnlockedUser := func() *models.User {
+		return &models.User{ID: uid, Username: "erin", AccountState: AccountActive, IsActive: true}
+	}
+	// LockUserForUpdate (internal/core/mock_storage_test.go) delegates to the GetUser
+	// expectation, not its own.
+	m.On("UpdateLoginLockoutState", mock.Anything, uid, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(fmt.Errorf("wrap: %w", storage.ErrUnsupportedByBackend))
+
+	policy := LoginLockoutPolicy{Enabled: true, MaxAttempts: 1, Window: 15 * time.Minute, BaseCooldown: time.Minute, MaxCooldown: time.Hour}
+	c := &KeyorixCore{storage: m, now: func() time.Time { return time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC) }, passwordPolicy: DefaultPasswordPolicy()}
+	c.SetLoginLockoutPolicy(policy)
+	ctx := context.Background()
+
+	out := captureLog(t, func() {
+		m.On("GetUser", mock.Anything, uid).Return(freshUnlockedUser(), nil).Once()
+		assert.NotPanics(t, func() { c.recordFailedLogin(ctx, user) })
 	})
 	assert.Contains(t, out, "login lockout accounting is INERT")
+	assert.Nil(t, user.LoginLockedUntil, "must not claim a lock was applied when persistence failed")
 
-	// The warning fires once per process; a second unlock attempt logs nothing further.
 	out2 := captureLog(t, func() {
-		assert.NoError(t, c.UnlockUser(ctx, 1, 44))
+		for i := 0; i < 5; i++ {
+			m.On("GetUser", mock.Anything, uid).Return(freshUnlockedUser(), nil).Once()
+			c.recordFailedLogin(ctx, user)
+		}
 	})
 	assert.Empty(t, out2, "the warning must not repeat on subsequent calls")
 }

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -75,7 +75,8 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"ConsumeMFARecoveryCode": {statusIntentional,
 		"round 119 audit: sole caller is VerifyMFACredentials, same bypassed-branch reasoning as MarkTOTPStepUsed — recovery codes are only ever consumed at login, never during enrollment/management"},
 
-	// --- Confirmed genuine gaps, tracked for future fix rounds (55) ---
+	// --- Confirmed genuine gaps, tracked for future fix rounds (54; UpdateLoginLockoutState
+	// closed by #529) ---
 	// See docs/security/HARDENING-BACKLOG.md's round 119 entry for full detail,
 	// severity, and grouping. Each entry below cites the real caller/route a
 	// round-119 audit traced (not assumed).
@@ -174,12 +175,6 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 		"round 119: secret copy (same-project and cross-environment), dynamic-secrets issue/renew-lease. NOTE: CreateSecret's own call site already has a deliberate errors.Is(ErrUnsupportedByBackend) carve-out (#499) and is NOT part of this gap — only every OTHER caller is broken"},
 	"DeleteEnvironment":  {statusKnownGap, "round 119: DELETE /environments/{id}"},
 	"RestoreEnvironment": {statusKnownGap, "round 119: POST /projects/{projectId}/environments/{id}/restore"},
-
-	// Login-lockout accounting — fails OPEN (silently continues) rather than
-	// closed; a real, currently-reachable security gap on every login attempt,
-	// only partly mitigated by the separate per-IP rate limiter (ADR-040/#452).
-	"UpdateLoginLockoutState": {statusKnownGap,
-		"round 119: recordFailedLogin/checkLockAndClearLoginFailures/clearLoginFailures/UnlockUser — per-account brute-force lockout is inert under storage.type: remote (fail-open, not fail-closed)"},
 
 	// Scheduler locking — reached on EVERY tick regardless of storage.type
 	// (server/main.go starts all schedulers unconditionally), and is now the

--- a/internal/storage/store/remote_unsupported_test.go
+++ b/internal/storage/store/remote_unsupported_test.go
@@ -83,22 +83,6 @@ func TestRemoteStorage_SetPasswordHash_HardFails(t *testing.T) {
 	assert.True(t, errors.Is(err, corestorage.ErrUnsupportedByBackend))
 }
 
-// TestRemoteStorage_UpdateLoginLockoutState_ReturnsUnsupportedSentinel proves the
-// #454 fix for the lockout-accounting columns: same wire-format gap as
-// SetAccountState, but this one is a passive backstop counter, not an explicit
-// security directive — the caller (login_lockout.go) distinguishes it from
-// SetAccountState's hard-fail treatment by matching storage.ErrUnsupportedByBackend
-// via isUnsupportedByBackend, so it must errors.Is-wrap that sentinel too.
-func TestRemoteStorage_UpdateLoginLockoutState_ReturnsUnsupportedSentinel(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("https://unused.example"))
-	require.NoError(t, err)
-
-	err = rs.UpdateLoginLockoutState(context.Background(), 1, 3, nil, nil, 1)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported))
-	assert.True(t, errors.Is(err, corestorage.ErrUnsupportedByBackend))
-}
-
 func TestRemoteStorage_MarkAllNotificationsRead(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -241,10 +241,14 @@ func (rs *RemoteStorage) GetUser(ctx context.Context, id uint) (*models.User, er
 // unrelated admin "view user" GetUser call) since the cache entry was populated
 // would go completely unobserved for up to 5 minutes — silently defeating the
 // recheck exactly as the finding describes, but via response-cache staleness
-// rather than a missing wire field. Cache invalidation on write (client.go's
-// Request) does not help here either: RemoteStorage's own write path for these
-// columns (UpdateLoginLockoutState) is a hard, permanent stub (#454) that never
-// makes an HTTP call at all, so it can never trigger that invalidation.
+// rather than a missing wire field. This deliberately bypasses rs.client.Get's
+// cache rather than relying on write-triggered invalidation for correctness: even
+// now that UpdateLoginLockoutState (#529) genuinely proxies its write and so DOES
+// invalidate the cache on success (client.go's Request), a concurrent second
+// LockUserForUpdate call racing that write could still observe a cache entry
+// populated between the write and its invalidation if this method went through
+// the cache at all — the anti-TOCTOU recheck needs an unconditionally fresh read,
+// not "usually fresh because writes happen to invalidate it".
 func (rs *RemoteStorage) LockUserForUpdate(ctx context.Context, id uint) (*models.User, error) {
 	path := fmt.Sprintf("/api/v1/users/%d", id)
 	resp, err := rs.client.Request(ctx, http.MethodGet, path, nil)
@@ -378,14 +382,53 @@ func (rs *RemoteStorage) SetPasswordHash(_ context.Context, _ uint, _ string, _ 
 		"upstream PUT /api/v1/users/{id} endpoint does not accept this field: %w", ErrRemoteUnsupported)
 }
 
-// UpdateLoginLockoutState always returns ErrRemoteUnsupported: none of the four
-// login-lockout columns are expressible in the wire format either (#454), so, unlike
-// SetAccountState above, the caller (login_lockout.go) treats this as the same
-// "permanent architectural gap" #452 already established for the login rate limiter —
-// log a loud one-time operator warning and fail OPEN, rather than blocking every login
-// under storage.type: remote.
-func (rs *RemoteStorage) UpdateLoginLockoutState(_ context.Context, _ uint, _ int, _, _ *time.Time, _ int) error {
-	return remoteUnsupported("UpdateLoginLockoutState")
+// loginLockoutUpdateWireRequest mirrors server/http/handlers/login_lockout_proxy.go's
+// loginLockoutUpdateProxyBody exactly — the four positional parameters
+// UpdateLoginLockoutState takes, named on the wire.
+type loginLockoutUpdateWireRequest struct {
+	FailedLoginAttempts int        `json:"failed_login_attempts"`
+	LastFailedLoginAt   *time.Time `json:"last_failed_login_at"`
+	LoginLockedUntil    *time.Time `json:"login_locked_until"`
+	LoginLockoutCount   int        `json:"login_lockout_count"`
+}
+
+// UpdateLoginLockoutState persists ONLY the four login-lockout accounting columns via
+// a single HTTP round trip to the NEW PUT /api/v1/system/users/{id}/login-lockout
+// route (server/http/handlers/login_lockout_proxy.go), closing backlog #529: this
+// method used to be a hard, permanent remoteUnsupported(...) stub (#454), silently
+// making per-account brute-force lockout inert for every storage.type: remote
+// deployment (recordFailedLogin/checkLockAndClearLoginFailures/clearLoginFailures/
+// UnlockUser in internal/core/login_lockout.go all fail OPEN — log once, continue —
+// whenever this returns storage.ErrUnsupportedByBackend, exactly the "permanent
+// architectural gap" treatment #452 established for the login rate limiter).
+//
+// This is a THIN passthrough, not a new atomic primitive: LocalStorage's own
+// implementation (internal/storage/store/local_users.go) is a single unconditional
+// column UPDATE with no server-side read-modify-write or compare-and-set condition —
+// every caller in login_lockout.go already computes the final values itself (under
+// its own LockUserForUpdate + WithTransaction + per-user loginFailureMu shard
+// serialization) before calling this method, so one HTTP round trip preserves the
+// LOCAL implementation's semantics exactly unchanged. Unlike
+// AdvanceWebAuthnCredentialCounterProxy (a genuine compare-and-swap needing the
+// entire check-then-write to run server-side in one request because
+// RemoteStorage.WithTransaction is a no-op passthrough), there is no analogous race
+// to reopen here.
+func (rs *RemoteStorage) UpdateLoginLockoutState(ctx context.Context, id uint, attempts int, lastFailedAt, lockedUntil *time.Time, lockoutCount int) error {
+	path := fmt.Sprintf("/api/v1/system/users/%d/login-lockout", id)
+	body := loginLockoutUpdateWireRequest{
+		FailedLoginAttempts: attempts,
+		LastFailedLoginAt:   lastFailedAt,
+		LoginLockedUntil:    lockedUntil,
+		LoginLockoutCount:   lockoutCount,
+	}
+	resp, err := rs.client.Put(ctx, path, body)
+	if err != nil {
+		return fmt.Errorf("failed to update login lockout state: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("update login lockout state failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
 // DeleteUser deletes a user via remote API.

--- a/server/http/handlers/login_lockout_proxy.go
+++ b/server/http/handlers/login_lockout_proxy.go
@@ -1,0 +1,87 @@
+// login_lockout_proxy.go — server-side endpoint backing RemoteStorage's
+// UpdateLoginLockoutState (backlog #529, closing the #454 gap that left this one
+// method a hard, permanent stub after login-attempts/setup-tokens/groups/etc. were
+// each proxied in turn).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies its
+// per-account login-lockout accounting write to whichever upstream server it's
+// configured against, through this route (registered in server/http/router.go under
+// /api/v1/system/users/{id}/login-lockout, gated on the existing system.read/
+// system.write RBAC permissions — the SAME credential a RemoteStorage client already
+// needs for every other proxied call, e.g. full user CRUD and the login-attempts
+// proxy, so this introduces no new privilege class).
+//
+// This is a thin passthrough onto the SAME storage.Storage.UpdateLoginLockoutState
+// primitive internal/core/login_lockout.go already calls against a local backend — no
+// lockout POLICY decision (the failure threshold, the exponential cooldown, WHEN to
+// trip or clear the lock) is made here; that stays entirely in the CALLING server's
+// own internal/core.KeyorixCore, exactly as it does against a local backend. This
+// handler only persists the four already-computed columns the caller hands it.
+//
+// Atomicity: LocalStorage.UpdateLoginLockoutState (internal/storage/store/
+// local_users.go) is a single unconditional `UPDATE ... SET` over the four
+// login-lockout columns — no server-side read-modify-write, no compare-and-set
+// condition. Every caller in login_lockout.go already does its own
+// read-increment-compute step under its own locking (LockUserForUpdate inside
+// c.storage.WithTransaction, serialized additionally by the per-user loginFailureMu
+// shard) and only then calls this method with the final values to persist. So a
+// single HTTP round trip here preserves the LOCAL implementation's semantics exactly
+// unchanged — unlike WebAuthn's AdvanceWebAuthnCredentialCounterProxy (a genuine
+// compare-and-swap that needs the entire check-then-write to run in ONE request
+// because RemoteStorage.WithTransaction is a no-op passthrough), there is no
+// analogous race to reopen here: this handler does not need to re-derive or validate
+// anything, it just writes the four values it was given.
+//
+// Response envelope: like every other proxy in this package, this does NOT use the
+// package's generic sendSuccess/sendError helpers — it constructs the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// loginLockoutUpdateProxyBody is the wire body for PUT
+// /api/v1/system/users/{id}/login-lockout, mirroring
+// storage.Storage.UpdateLoginLockoutState's four positional parameters exactly
+// (attempts, lastFailedAt, lockedUntil, lockoutCount).
+type loginLockoutUpdateProxyBody struct {
+	FailedLoginAttempts int        `json:"failed_login_attempts"`
+	LastFailedLoginAt   *time.Time `json:"last_failed_login_at"`
+	LoginLockedUntil    *time.Time `json:"login_locked_until"`
+	LoginLockoutCount   int        `json:"login_lockout_count"`
+}
+
+// UpdateLoginLockoutStateProxy handles PUT
+// /api/v1/system/users/{id}/login-lockout.
+func (h *AuthHandler) UpdateLoginLockoutStateProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid user id")
+		return
+	}
+	var body loginLockoutUpdateProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	err = h.coreService.Storage().UpdateLoginLockoutState(
+		r.Context(), uint(id), body.FailedLoginAttempts, body.LastFailedLoginAt, body.LoginLockedUntil, body.LoginLockoutCount)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "user not found")
+			return
+		}
+		log.Printf("login-lockout proxy: update failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}

--- a/server/http/remote_storage_login_lockout_write_test.go
+++ b/server/http/remote_storage_login_lockout_write_test.go
@@ -1,0 +1,116 @@
+// remote_storage_login_lockout_write_test.go — end-to-end regression coverage for
+// backlog #529: RemoteStorage.UpdateLoginLockoutState (internal/storage/store/
+// remote_users.go) used to be a hard, permanent remoteUnsupported(...) stub
+// (#454) — every login-lockout accounting write in internal/core/login_lockout.go
+// silently failed OPEN under storage.type: remote. It is now a genuine thin
+// passthrough onto a new PUT /api/v1/system/users/{id}/login-lockout route
+// (server/http/handlers/login_lockout_proxy.go).
+//
+// Driven against a REAL server (NewRouter), not a hand-rolled mock of the wire
+// protocol — the internal/core-level coverage
+// (internal/core/login_lockout_remote_test.go) already exercises
+// recordFailedLogin/checkLockAndClearLoginFailures directly (unexported, only
+// reachable from within package core); this file instead proves the ACTUAL
+// production route/handler/permission-gating work, via UnlockUser (core's one
+// EXPORTED entry point onto the same UpdateLoginLockoutState primitive).
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteStorageLoginLockout_UnlockUserGenuinelyPersistsAcrossRealServer proves
+// the #529 fix end-to-end against the REAL, production router and handlers — not a
+// synthetic mock of the wire protocol. It builds two independent
+// *core.KeyorixCore instances, each with its own SQLite-backed storage:
+//
+//   - "upstream": a normal Keyorix server, exercised through the ACTUAL
+//     NewRouter(...)/handlers this package registers, including the new
+//     PUT /api/v1/system/users/{id}/login-lockout route
+//     (server/http/handlers/login_lockout_proxy.go).
+//   - "downstream": a Keyorix server configured with storage.type: remote,
+//     pointed at "upstream" over real HTTP via store.RemoteStorage — exactly the
+//     deployment ADR-049/#454/#529 describe.
+//
+// Driving an admin UnlockUser call through the DOWNSTREAM core's real, exported
+// entry point proves the write genuinely lands in the upstream's own storage —
+// closing the gap where storage.type: remote used to make every login-lockout
+// write a silent, permanent no-op.
+func TestRemoteStorageLoginLockout_UnlockUserGenuinelyPersistsAcrossRealServer(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	// --- upstream: a real Keyorix server ---
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	// Seed a real user, upstream, already in a tripped-lockout state (simulating
+	// prior failed logins) so UnlockUser has genuine state to clear.
+	seeded, err := upstreamCore.CreateUser(context.Background(), &core.CreateUserRequest{
+		Username: "e2e-lockout-write", Email: "e2e-lockout-write@example.com",
+		Password: "Qr7#Kp2$Lm5@Vn9!", DisplayName: "Lockout Write Test User",
+	})
+	require.NoError(t, err)
+	lockedUntil := time.Now().Add(30 * time.Minute).UTC().Truncate(time.Second)
+	lastFailed := time.Now().Add(-time.Minute).UTC().Truncate(time.Second)
+	require.NoError(t, upstreamCore.Storage().UpdateLoginLockoutState(
+		context.Background(), seeded.ID, 3, &lastFailed, &lockedUntil, 1))
+
+	// --- downstream: storage.type: remote, pointed at the upstream ---
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream := core.NewKeyorixCore(rs)
+
+	// The admin action, driven entirely through the downstream client — exactly
+	// what a server booted with storage.type: remote does when an admin unlocks a
+	// user via its own API.
+	require.NoError(t, downstream.UnlockUser(context.Background(), 1, seeded.ID),
+		"UnlockUser must succeed against a real remote-storage upstream, not fail open silently")
+
+	// Confirm the clear genuinely landed in the upstream's OWN storage (not just
+	// "the client call didn't error") by reading directly against it.
+	fresh, err := upstreamCore.Storage().GetUser(context.Background(), seeded.ID)
+	require.NoError(t, err)
+	assert.Zero(t, fresh.FailedLoginAttempts, "#529: the upstream's own row must show the lockout counters genuinely cleared")
+	assert.Zero(t, fresh.LoginLockoutCount)
+	assert.Nil(t, fresh.LoginLockedUntil, "the still-active lock must be genuinely lifted upstream, not merely left to expire")
+
+	// NOTE: this deliberately does NOT also assert the admin-unlock audit event
+	// landed in the UPSTREAM's audit log over this same HTTP hop: there is
+	// currently no server route backing RemoteStorage.LogAuditEvent's
+	// POST /api/v1/audit/events at all (a separate, pre-existing gap discovered
+	// while building this test, out of scope for backlog #529 — the downstream
+	// core's own emitAudit call fails best-effort, exactly as it does for any
+	// other transient storage error, and does not affect UnlockUser's own
+	// success above). The write-and-audit call sequence itself IS covered at the
+	// internal/core level, against a hand-rolled stand-in server that DOES
+	// implement that route (TestUnlockUser_RemoteStorageGenuinelyPersistsAndAudits,
+	// internal/core/login_lockout_remote_test.go).
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1100,6 +1100,30 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/webauthn/sessions", authHandler.CreateWebAuthnSessionProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/webauthn/sessions/consume", authHandler.ConsumeWebAuthnSessionProxy)
 
+			// Login-lockout accounting storage-primitive proxy (backlog #529). Lets a
+			// downstream Keyorix server booted with storage.type: remote (ADR-049) proxy
+			// UpdateLoginLockoutState to THIS server's real storage backend, instead of
+			// RemoteStorage's one remaining login-lockout method having no server endpoint
+			// to call at all (per-account brute-force lockout accounting — every
+			// recordFailedLogin/checkLockAndClearLoginFailures/clearLoginFailures/
+			// UnlockUser call in internal/core/login_lockout.go — silently failed OPEN
+			// under storage.type: remote, the last piece of the #454 gap left after the
+			// login-attempts/setup-tokens/groups/webauthn proxies above each closed their
+			// own slice of it). Exactly the same pattern as the webauthn proxy above: a
+			// thin passthrough onto storage.Storage (no lockout POLICY decision — the
+			// failure threshold, the exponential cooldown, WHEN to trip or clear — is made
+			// here; that stays entirely in the CALLING server's own
+			// internal/core.KeyorixCore, exactly as it does against a local backend),
+			// reusing the SAME system.read/system.write tier — no new privilege class.
+			// This is a single unconditional column UPDATE, not a compare-and-swap (see
+			// login_lockout_proxy.go's package doc for the atomicity analysis): every
+			// caller already computes the final values itself under its own
+			// LockUserForUpdate + WithTransaction + per-user mutex-shard serialization, so
+			// one proxied round trip preserves LocalStorage's own semantics unchanged —
+			// unlike AdvanceWebAuthnCredentialCounterProxy just above, no new atomic
+			// primitive is needed.
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/users/{id}/login-lockout", authHandler.UpdateLoginLockoutStateProxy)
+
 			// Legal-hold storage-primitive proxy (finding #519). Lets a downstream
 			// Keyorix server booted with storage.type: remote (ADR-049) proxy
 			// CreateLegalHold/GetActiveLegalHold/UpdateLegalHold to THIS server's real


### PR DESCRIPTION
## Bug

`internal/storage/store/remote_users.go`'s `UpdateLoginLockoutState` was a hard,
permanent stub (#454): every write from `internal/core/login_lockout.go` -
`recordFailedLogin`, `checkLockAndClearLoginFailures`, `clearLoginFailures`, and
the admin-triggered `UnlockUser` - silently failed OPEN under `storage.type:
remote` (log a one-time warning, continue as if nothing happened). Per-account
brute-force lockout was therefore inert for any deployment in that mode,
closing backlog item #529.

## Atomicity investigation (what I found)

`LocalStorage.UpdateLoginLockoutState` (`internal/storage/store/local_users.go`)
is a single unconditional `UPDATE ... SET` over the four lockout columns -
no server-side read-modify-write, no compare-and-set condition. Every caller in
`login_lockout.go` already computes the final values itself, under its own
`LockUserForUpdate` + `WithTransaction` + per-user `loginFailureMu` shard
serialization, before calling this method. So a **single HTTP round trip**
proxying the already-computed values preserves the local implementation's
semantics exactly - unlike the WebAuthn signature-counter fix (#306/#517),
there is no read-then-write race to reopen here, and no new atomic primitive
was needed.

I also traced which real login paths reach this under `storage.type: remote`:
the plain-password path (`VerifyLoginCredentials`) and TOTP/recovery-code MFA
(`RemoteMFAVerifier`) both delegate the ENTIRE check (including lockout) to the
upstream server's own `core.Login`/`verify-mfa`, so they never call these
methods client-side. WebAuthn login (`FinishWebAuthnLogin` /
`FinishWebAuthnPasswordlessLogin`) and the self-service re-auth gate
(`requireReauth`, used by `DisableMFA`/`RegenerateMFARecoveryCodes`/etc.) have
no such delegation and DO call `recordFailedLogin`/`checkLockAndClearLoginFailures`/
`clearLoginFailures` directly against `c.storage` - these were genuinely,
silently broken before this fix, alongside the admin `UnlockUser` action.

## Fix

- New route `PUT /api/v1/system/users/{id}/login-lockout`
  (`server/http/handlers/login_lockout_proxy.go`), gated on the same
  `system.read`/`system.write` tier every other RemoteStorage primitive proxy
  in this group uses - no narrower tier exists even for adjacent user-security
  proxies (e.g. the groups proxy reuses `system.write` rather than
  `users.write`), so this introduces no new privilege class.
- `RemoteStorage.UpdateLoginLockoutState` now proxies to it in one HTTP call.
- Removed the method from `TestRemoteUnsupportedStubsAreAllowlisted`'s
  allowlist (round-119 completeness guard, PR #856) and the now-stale
  "hard, permanent stub" doc comments.
- Test coverage:
  - `internal/core/login_lockout_remote_test.go` rewritten: proves failed
    logins genuinely increment the counter and trip the lock, clearing
    genuinely resets the counters, and admin `UnlockUser` genuinely persists
    and is audited - all against a hand-rolled stand-in upstream (mirrors the
    existing `rate_limit_test.go` #452 convention, since `internal/core` can't
    import `server/http`). Kept one MockStorage-backed defense-in-depth test
    for a hypothetical future backend that genuinely can't satisfy this call.
  - `server/http/remote_storage_login_lockout_write_test.go` (new): end-to-end
    `UnlockUser` proxy test against the REAL production router/handlers.

## Out of scope (found, not fixed)

While building the end-to-end test I found that `RemoteStorage.LogAuditEvent`
(`POST /api/v1/audit/events`) has no matching server route at all today, so a
downstream node's own audit trail (e.g. this fix's `account.unlocked` event)
currently 404s silently upstream under `storage.type: remote` - a real,
separate gap, unrelated to `UpdateLoginLockoutState`. `emitAudit` already
treats this as best-effort (it doesn't fail the underlying `UnlockUser` call),
so this doesn't block the fix, but it means "is audited" can only be asserted
against the hand-rolled stand-in in `internal/core`, not the real router, until
that's addressed separately.

## Verification

- `go build ./...` passes.
- `go test ./internal/storage/... ./internal/core/... ./server/...` - 2712
  passed, 0 failed (one pre-existing, unrelated flaky concurrency test
  (`TestConcurrency_RequestPasswordReset_BurstIsThrottled`, untouched by this
  diff) was confirmed to fail intermittently on `main` too under load).
- `gosec -severity medium -exclude-generated ./...` (scoped to the touched
  packages) - 0 issues.

Closes backlog item #529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)