### PR TITLE
fix(webauthn): proxy MFA login challenge under storage.type: remote

### DIFF
--- a/internal/storage/store/remote_mfa.go
+++ b/internal/storage/store/remote_mfa.go
@@ -1,19 +1,29 @@
 // remote_mfa.go — MFA persistence is server-side only; the remote client never
 // manages MFA state directly (enrolment/verify go through the server's REST API).
 //
-// The two exceptions are IssueMFAChallenge and VerifyMFALoginCredentials below,
-// which implement core.RemoteMFAVerifier (#509): the upstream half of the
-// storage.type: remote second-factor login proxy, mirroring
-// remote_login_verify.go's password proxy (#506) exactly. The raw TOTP secret
-// is stored reversibly encrypted specifically so it must never leave the
-// server that can decrypt it — GetMFASecret below stays an unconditional stub
-// for that reason — so the ENTIRE TOTP/recovery-code check, not just a wire-DTO
-// passthrough of the storage primitives above, has to run upstream.
+// IssueMFAChallenge and VerifyMFALoginCredentials below implement
+// core.RemoteMFAVerifier (#509): the upstream half of the storage.type: remote
+// TOTP second-factor login proxy, mirroring remote_login_verify.go's password
+// proxy (#506) exactly. The raw TOTP secret is stored reversibly encrypted
+// specifically so it must never leave the server that can decrypt it —
+// GetMFASecret below stays an unconditional stub for that reason — so the
+// ENTIRE TOTP/recovery-code check, not just a wire-DTO passthrough of the
+// storage primitives above, has to run upstream.
 //
-// WebAuthn's storage.Storage primitives are DIFFERENT from MFA's: see
-// remote_webauthn.go — a passkey's public key and ceremony session state are not
-// secret the way a TOTP shared secret is, so WebAuthn is an ordinary CRUD/wire-DTO
-// passthrough, not a verification proxy (#517).
+// GetActiveMFAChallenge and ConsumeMFAChallenge below are DIFFERENT from that
+// pair: they are ordinary storage.Storage passthroughs (#522), not part of the
+// RemoteMFAVerifier proxy. models.MFAChallenge is a SHARED pre-auth token: the
+// SAME row backs both the TOTP path (proxied wholesale above, since it also
+// needs the encrypted secret) and WebAuthn-as-second-factor login
+// (internal/core/webauthn.go's BeginWebAuthnLogin/FinishWebAuthnLogin), which has
+// no secret of its own to protect — a spoke server that resolves the
+// challenge's user_id can run the entire passkey assertion ceremony locally
+// against its own (already-proxied, #517) WebAuthn credential rows. Before this
+// fix, BOTH were unconditional stubs, so WebAuthn login was 100% broken under
+// storage.type: remote even though the TOTP path already worked.
+//
+// WebAuthn's OWN storage.Storage primitives (registered credentials, ceremony
+// sessions) are handled separately: see remote_webauthn.go / #517.
 package store
 
 import (
@@ -69,12 +79,96 @@ func (rs *RemoteStorage) CreateMFAChallenge(_ context.Context, _ *models.MFAChal
 	return remoteUnsupported("CreateMFAChallenge")
 }
 
-func (rs *RemoteStorage) ConsumeMFAChallenge(_ context.Context, _ string, _ time.Time) (*models.MFAChallenge, error) {
-	return nil, remoteUnsupported("ConsumeMFAChallenge")
+// mfaChallengeWire mirrors models.MFAChallenge's fields exactly (snake_case).
+// models.MFAChallenge tags TokenHash json:"-" to keep it out of USER-facing
+// responses — irrelevant here, since this is an internal system-to-system wire
+// format gated on users.write, matching webAuthnSessionWire's identical
+// TokenHash precedent (remote_webauthn.go).
+type mfaChallengeWire struct {
+	ID        uint       `json:"id"`
+	UserID    uint       `json:"user_id"`
+	TokenHash string     `json:"token_hash"`
+	ExpiresAt time.Time  `json:"expires_at"`
+	UsedAt    *time.Time `json:"used_at"`
+	CreatedAt time.Time  `json:"created_at"`
 }
 
-func (rs *RemoteStorage) GetActiveMFAChallenge(_ context.Context, _ string, _ time.Time) (*models.MFAChallenge, error) {
-	return nil, remoteUnsupported("GetActiveMFAChallenge")
+func (w mfaChallengeWire) toModel() *models.MFAChallenge {
+	return &models.MFAChallenge{
+		ID:        w.ID,
+		UserID:    w.UserID,
+		TokenHash: w.TokenHash,
+		ExpiresAt: w.ExpiresAt,
+		UsedAt:    w.UsedAt,
+		CreatedAt: w.CreatedAt,
+	}
+}
+
+func decodeMFAChallengeResponse(data []byte) (*models.MFAChallenge, error) {
+	var wire mfaChallengeWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
+}
+
+// mfaChallengeLookupWire is the wire body shared by GetActiveMFAChallenge and
+// ConsumeMFAChallenge below — both take the identical (tokenHash, now) pair
+// internal/core/webauthn.go already passes to storage.Storage's local
+// implementation (local_mfa.go).
+type mfaChallengeLookupWire struct {
+	TokenHash string    `json:"token_hash"`
+	Now       time.Time `json:"now"`
+}
+
+// ConsumeMFAChallenge atomically marks a valid (unused, unexpired) challenge used
+// and returns it, via POST /api/v1/users/mfa-challenge/consume (#522) — the
+// single-use gate FinishWebAuthnLogin spends before verifying the assertion. The
+// atomicity guarantee is unchanged from LocalStorage's own implementation (an
+// UPDATE ... WHERE used_at IS NULL AND expires_at > ? inside one DB transaction,
+// local_mfa.go): the proxy handler calls storage.Storage.ConsumeMFAChallenge
+// directly against the upstream's real storage in this single request, so the
+// single-use invariant holds across this HTTP hop too — mirroring
+// ConsumeWebAuthnSession's (#517) and MarkSetupTokenConsumed's (#510) identical
+// one-round-trip-atomic-consume precedent, not a separate GET-then-mark-used
+// pair that would reopen the exact concurrent-consume race those were built to
+// close. This is an ordinary storage passthrough, NOT part of the
+// RemoteMFAVerifier proxy above — see the package doc for why that split is
+// correct here (the challenge row carries no secret of its own).
+func (rs *RemoteStorage) ConsumeMFAChallenge(ctx context.Context, tokenHash string, now time.Time) (*models.MFAChallenge, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/users/mfa-challenge/consume", mfaChallengeLookupWire{
+		TokenHash: tokenHash,
+		Now:       now,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("invalid or expired challenge")
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("invalid or expired challenge")
+	}
+	return decodeMFAChallengeResponse(resp.Data)
+}
+
+// GetActiveMFAChallenge resolves the (still-unconsumed) challenge
+// BeginWebAuthnLogin needs to identify which user's passkeys to begin the
+// assertion ceremony against, via POST /api/v1/users/mfa-challenge/active
+// (#522). A read, not a consume: WebAuthn's two-step login (Begin then Finish)
+// must look up the user WITHOUT spending the challenge's single use yet —
+// ConsumeMFAChallenge above (called from FinishWebAuthnLogin) is what actually
+// spends it, matching local_mfa.go's own GetActiveMFAChallenge/
+// ConsumeMFAChallenge split exactly.
+func (rs *RemoteStorage) GetActiveMFAChallenge(ctx context.Context, tokenHash string, now time.Time) (*models.MFAChallenge, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/users/mfa-challenge/active", mfaChallengeLookupWire{
+		TokenHash: tokenHash,
+		Now:       now,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("invalid or expired challenge")
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("invalid or expired challenge")
+	}
+	return decodeMFAChallengeResponse(resp.Data)
 }
 
 // issueMFAChallengeWireResponse carries only the opaque challenge token: the

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -75,7 +75,9 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"ConsumeMFARecoveryCode": {statusIntentional,
 		"round 119 audit: sole caller is VerifyMFACredentials, same bypassed-branch reasoning as MarkTOTPStepUsed — recovery codes are only ever consumed at login, never during enrollment/management"},
 
-	// --- Confirmed genuine gaps, tracked for future fix rounds (55) ---
+	// --- Confirmed genuine gaps, tracked for future fix rounds (53; #522 fixed
+	// GetActiveMFAChallenge/ConsumeMFAChallenge, the WebAuthn-as-second-factor
+	// login gap, from the original 55) ---
 	// See docs/security/HARDENING-BACKLOG.md's round 119 entry for full detail,
 	// severity, and grouping. Each entry below cites the real caller/route a
 	// round-119 audit traced (not assumed).
@@ -99,13 +101,6 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 		"round 119: dual-control (N-of-M) approval recording inside ApproveAccessRequestWithExpiry"},
 	"ListAccessRequestApprovals": {statusKnownGap,
 		"round 119: progress annotation + duplicate-approver check during approve"},
-
-	// WebAuthn-as-second-factor login — 100% broken (distinct from #517's
-	// WebAuthn CREDENTIAL CRUD fix, which never touched this).
-	"GetActiveMFAChallenge": {statusKnownGap,
-		"round 119: BeginWebAuthnLogin calls this directly with NO RemoteMFAVerifier gate (unlike VerifyMFALogin's TOTP path) — POST /auth/webauthn/login/begin"},
-	"ConsumeMFAChallenge": {statusKnownGap,
-		"round 119: FinishWebAuthnLogin calls this directly with no gate — POST /auth/webauthn/login/finish"},
 
 	// MFA enrollment/management (not just login) — 100% broken.
 	"UpsertMFASecret": {statusKnownGap, "round 119: BeginMFAEnrollment, POST /auth/mfa/enroll"},

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -524,6 +525,121 @@ func (h *UserHandler) VerifyMFACredentials(w http.ResponseWriter, r *http.Reques
 		"username":      u.Username,
 		"used_recovery": usedRecovery,
 	}, "")
+}
+
+// mfaChallengeProxyWire mirrors models.MFAChallenge's fields exactly (snake_case),
+// matching remote_mfa.go's identical mfaChallengeWire type on the RemoteStorage
+// side of this proxy. models.MFAChallenge tags TokenHash json:"-" (kept out of
+// USER-facing responses) — irrelevant here, an internal system-to-system wire
+// format gated on users.write.
+type mfaChallengeProxyWire struct {
+	ID        uint       `json:"id"`
+	UserID    uint       `json:"user_id"`
+	TokenHash string     `json:"token_hash"`
+	ExpiresAt time.Time  `json:"expires_at"`
+	UsedAt    *time.Time `json:"used_at"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+func newMFAChallengeProxyWire(c *models.MFAChallenge) mfaChallengeProxyWire {
+	return mfaChallengeProxyWire{
+		ID:        c.ID,
+		UserID:    c.UserID,
+		TokenHash: c.TokenHash,
+		ExpiresAt: c.ExpiresAt,
+		UsedAt:    c.UsedAt,
+		CreatedAt: c.CreatedAt,
+	}
+}
+
+// mfaChallengeLookupBody is the wire body shared by GetActiveMFAChallenge and
+// ConsumeMFAChallenge below — both take the identical (token_hash, now) pair
+// storage.Storage's GetActiveMFAChallenge/ConsumeMFAChallenge already take.
+type mfaChallengeLookupBody struct {
+	TokenHash string    `json:"token_hash"`
+	Now       time.Time `json:"now"`
+}
+
+// GetActiveMFAChallenge handles POST /api/v1/users/mfa-challenge/active (#522) —
+// the upstream half of the storage.type: remote WebAuthn-as-second-factor login
+// proxy: BeginWebAuthnLogin (internal/core/webauthn.go) resolves which user's
+// passkeys to begin the assertion ceremony against from the (still-unconsumed)
+// MFAChallenge the password step minted, and a RemoteStorage-backed "spoke"
+// deployment has nowhere of its own to look that up. Calls
+// storage.Storage.GetActiveMFAChallenge directly against THIS server's own
+// storage — a plain read, not a consume (BeginWebAuthnLogin must not spend the
+// challenge's single use; FinishWebAuthnLogin's ConsumeMFAChallenge below does
+// that) — so this is an ordinary CRUD passthrough, unlike verify-mfa/
+// mfa-challenge above: the challenge row carries no secret of its own the way a
+// TOTP shared secret does, so there is no policy check that has to run
+// upstream instead of in the calling (spoke) server's own core.KeyorixCore.
+//
+// Gated by the SAME users.write permission verify-mfa/mfa-challenge above
+// already require of the RemoteStorage service credential — not a new, weaker
+// trust boundary. Every failure (no matching row, already used, expired, or a
+// genuine storage error) collapses to the same generic 404, matching
+// local_mfa.go's own GetActiveMFAChallenge, which already returns one generic
+// error for all of those cases.
+func (h *UserHandler) GetActiveMFAChallenge(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body mfaChallengeLookupBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
+		return
+	}
+	if body.TokenHash == "" || body.Now.IsZero() {
+		sendError(w, "ValidationError", "token_hash and now are required", http.StatusBadRequest, nil)
+		return
+	}
+	ch, err := h.coreService.Storage().GetActiveMFAChallenge(r.Context(), body.TokenHash, body.Now)
+	if err != nil {
+		sendError(w, "NotFound", "invalid or expired challenge", http.StatusNotFound, nil)
+		return
+	}
+	sendSuccess(w, newMFAChallengeProxyWire(ch), "")
+}
+
+// ConsumeMFAChallenge handles POST /api/v1/users/mfa-challenge/consume (#522) —
+// the other half of the storage.type: remote WebAuthn-as-second-factor login
+// proxy: FinishWebAuthnLogin (internal/core/webauthn.go) spends the challenge's
+// single use BEFORE verifying the passkey assertion. Calls
+// storage.Storage.ConsumeMFAChallenge directly against THIS server's own
+// storage, which performs the ENTIRE atomic "UPDATE ... WHERE used_at IS NULL
+// AND expires_at > ?" inside one DB transaction (local_mfa.go) in this single
+// request — the single-use invariant holds across this HTTP hop too, exactly
+// like ConsumeWebAuthnSessionProxy's (#517) and ConsumeSetupTokenProxy's (#510)
+// identical one-round-trip-atomic-consume precedent, not a separate
+// GET-then-mark-used pair that would reopen the exact concurrent-consume race
+// those were built to close.
+//
+// Gated by the SAME users.write permission verify-mfa/mfa-challenge above
+// already require. Every failure collapses to the same generic 404, matching
+// GetActiveMFAChallenge above and local_mfa.go's own ConsumeMFAChallenge.
+func (h *UserHandler) ConsumeMFAChallenge(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	var body mfaChallengeLookupBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
+		return
+	}
+	if body.TokenHash == "" || body.Now.IsZero() {
+		sendError(w, "ValidationError", "token_hash and now are required", http.StatusBadRequest, nil)
+		return
+	}
+	ch, err := h.coreService.Storage().ConsumeMFAChallenge(r.Context(), body.TokenHash, body.Now)
+	if err != nil {
+		sendError(w, "NotFound", "invalid or expired challenge", http.StatusNotFound, nil)
+		return
+	}
+	sendSuccess(w, newMFAChallengeProxyWire(ch), "")
 }
 
 // UpdateUser handles PUT /api/v1/users/{id}

--- a/server/http/handlers/users_handler.go
+++ b/server/http/handlers/users_handler.go
@@ -339,6 +339,24 @@ func IssueMFAChallenge(w http.ResponseWriter, r *http.Request) {
 	defaultUserHandler.IssueMFAChallenge(w, r)
 }
 
+// GetActiveMFAChallenge handles POST /api/v1/users/mfa-challenge/active (#522).
+func GetActiveMFAChallenge(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.GetActiveMFAChallenge(w, r)
+}
+
+// ConsumeMFAChallenge handles POST /api/v1/users/mfa-challenge/consume (#522).
+func ConsumeMFAChallenge(w http.ResponseWriter, r *http.Request) {
+	if defaultUserHandler == nil {
+		sendError(w, "ServiceUnavailable", "User handler not initialised", http.StatusServiceUnavailable, nil)
+		return
+	}
+	defaultUserHandler.ConsumeMFAChallenge(w, r)
+}
+
 // UpdateUser handles PUT /api/v1/users/{id}
 func UpdateUser(w http.ResponseWriter, r *http.Request) {
 	if defaultUserHandler == nil {

--- a/server/http/remote_storage_webauthn_login_test.go
+++ b/server/http/remote_storage_webauthn_login_test.go
@@ -1,0 +1,156 @@
+package http
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mfaChallengeTokenHash mirrors internal/core.sha256Hex (unexported), which is
+// what BeginWebAuthnLogin/FinishWebAuthnLogin actually hash a raw challenge
+// token with before ever calling storage.Storage. Duplicated here (rather than
+// exported) since this test needs to call RemoteStorage's GetActiveMFAChallenge/
+// ConsumeMFAChallenge directly with the SAME hash the core layer would use, to
+// exercise the proxy's single-use guarantee without needing a real, signed
+// WebAuthn assertion (out of scope for this proxy-focused test).
+func mfaChallengeTokenHash(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+// TestWebAuthnLogin_RemoteStorage_ProxiesMFAChallenge proves the #522 fix: a
+// "spoke" server backed by RemoteStorage, pointed at a real "hub" server backed
+// by LocalStorage, can now complete the WebAuthn-as-second-factor login's
+// challenge-resolution step (BeginWebAuthnLogin) end-to-end, and that the
+// challenge's single-use consume (FinishWebAuthnLogin's first step) is atomic
+// across the HTTP hop — proxied via the NEW GetActiveMFAChallenge/
+// ConsumeMFAChallenge routes (server/http/handlers/users_crud.go), distinct
+// from #509's already-working TOTP proxy (verify-mfa/mfa-challenge) and #517's
+// already-working WebAuthn CREDENTIAL CRUD proxy (webauthn_proxy.go) — neither
+// of which this bug touched.
+//
+// Before this fix, GetActiveMFAChallenge/ConsumeMFAChallenge were unconditional
+// stubs on RemoteStorage, so BeginWebAuthnLogin/FinishWebAuthnLogin failed
+// immediately with "operation not supported in remote (client) mode" for EVERY
+// WebAuthn-as-second-factor login attempt under storage.type: remote.
+func TestWebAuthnLogin_RemoteStorage_ProxiesMFAChallenge(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	// --- upstream ("hub"): the real holder of the user record + WebAuthn rows ---
+	upstreamCore := newTestCore(t)
+	upstreamToken := createTestToken(t, upstreamCore)
+
+	rp, err := webauthn.New(&webauthn.Config{
+		RPID: "localhost", RPDisplayName: "Keyorix", RPOrigins: []string{"https://localhost"},
+	})
+	require.NoError(t, err)
+	upstreamCore.SetWebAuthn(rp)
+
+	ctx := context.Background()
+
+	waUser, err := upstreamCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "wauser", Email: "wauser@example.com", DisplayName: "WebAuthn User",
+		Password: "Zq8#Trn4$Vhx2@Wp!",
+	})
+	require.NoError(t, err)
+
+	// Seed a passkey directly (bypassing the real attestation ceremony) so
+	// BeginWebAuthnLogin has a registered credential to build assertion options
+	// from — matching internal/core/webauthn_test.go's seedCredential helper.
+	blob, err := json.Marshal(webauthn.Credential{ID: []byte("cred-1")})
+	require.NoError(t, err)
+	require.NoError(t, upstreamCore.Storage().CreateWebAuthnCredential(ctx, &models.WebAuthnCredential{
+		UserID: waUser.ID, CredentialID: []byte("cred-1"), Name: "test key", CredentialBlob: blob,
+	}))
+	require.NoError(t, upstreamCore.Storage().SetUserWebAuthnEnabled(ctx, waUser.ID, true))
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"}},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstreamCore)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	defer upstreamSrv.Close()
+
+	// --- downstream ("spoke"): storage.type: remote, pointed at the upstream ---
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstreamCore := core.NewKeyorixCore(rs)
+	downstreamCore.SetWebAuthn(rp)
+
+	// Second-factor login issues the SAME shared MFAChallenge every second-factor
+	// path uses (TOTP or WebAuthn), already proxied by #509's IssueMFAChallenge.
+	challenge, err := downstreamCore.CreateMFAChallenge(ctx, waUser.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, challenge)
+
+	// BeginWebAuthnLogin resolves the user from the challenge via
+	// GetActiveMFAChallenge — the #522 fix. Before it, this failed immediately
+	// with "operation not supported in remote (client) mode", making WebAuthn
+	// login 100% broken under storage.type: remote.
+	assertion, token, err := downstreamCore.BeginWebAuthnLogin(ctx, challenge)
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+	require.NotEmpty(t, assertion.Response.Challenge)
+	require.Len(t, assertion.Response.AllowedCredentials, 1, "the user's passkey is in allowCredentials")
+
+	// Begin does NOT consume the challenge — GetActiveMFAChallenge is a peek, not
+	// a consume, matching the local (non-remote) path's exact semantics
+	// (internal/core/webauthn_test.go's TestWebAuthn_BeginLoginResolvesUserFromChallenge).
+	// Calling it again must still succeed.
+	assertion2, _, err := downstreamCore.BeginWebAuthnLogin(ctx, challenge)
+	require.NoError(t, err, "the login challenge must stay valid until finish, matching the local path")
+	require.NotEmpty(t, assertion2.Response.Challenge)
+
+	// A bad/unknown challenge must fail through the proxy exactly like it does
+	// locally.
+	_, _, err = downstreamCore.BeginWebAuthnLogin(ctx, "not-a-real-challenge")
+	require.Error(t, err)
+
+	// ConsumeMFAChallenge (#522's other new route) atomically spends the
+	// challenge in ONE round trip — the primitive FinishWebAuthnLogin calls
+	// before verifying the assertion (a live, signed assertion is beyond this
+	// proxy-focused test's scope; internal/core/webauthn_test.go already covers
+	// the ceremony logic itself against LocalStorage).
+	hash := mfaChallengeTokenHash(challenge)
+	consumed, err := rs.ConsumeMFAChallenge(ctx, hash, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, waUser.ID, consumed.UserID)
+
+	// Single-use: a second consume of the SAME challenge must fail — proving the
+	// atomic "UPDATE ... WHERE used_at IS NULL" guarantee local_mfa.go's
+	// ConsumeMFAChallenge already provides survives this HTTP hop too, not a
+	// naive GET-then-mark-used pair that would reopen a concurrent-consume race.
+	_, err = rs.ConsumeMFAChallenge(ctx, hash, time.Now())
+	require.Error(t, err, "a challenge must be single-use even through the remote proxy")
+
+	// GetActiveMFAChallenge must also now report the challenge as no longer active.
+	_, err = rs.GetActiveMFAChallenge(ctx, hash, time.Now())
+	require.Error(t, err, "a consumed challenge must not still read as active")
+
+	// A challenge that never existed must fail the same way, not silently
+	// succeed against some other row.
+	_, err = rs.GetActiveMFAChallenge(ctx, mfaChallengeTokenHash("never-issued"), time.Now())
+	require.Error(t, err)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -631,6 +631,18 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// deployment, which has nowhere of its own to persist one. Same gate and
 			// reasoning as verify-credentials/verify-mfa above.
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/mfa-challenge", handlers.IssueMFAChallenge)
+			// GetActiveMFAChallenge/ConsumeMFAChallenge (#522) — the upstream half of
+			// the storage.type: remote WebAuthn-as-second-factor login proxy
+			// (internal/core/webauthn.go's BeginWebAuthnLogin/FinishWebAuthnLogin):
+			// unlike the TOTP path above, these are plain storage.Storage passthroughs
+			// on the SAME shared MFAChallenge model, not a verification proxy — a
+			// passkey assertion carries no server-held secret the way a TOTP shared
+			// secret does, so the ceremony itself still runs entirely in the calling
+			// (spoke) server's own core.KeyorixCore, exactly as it does locally. Same
+			// gate and reasoning as verify-mfa/mfa-challenge above. Static paths,
+			// before /{id}.
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/mfa-challenge/active", handlers.GetActiveMFAChallenge)
+			r.With(customMiddleware.RequirePermission("users.write")).Post("/mfa-challenge/consume", handlers.ConsumeMFAChallenge)
 			// Admin force-logout: revoke all of a user's sessions (no state change).
 			r.With(customMiddleware.RequirePermission("users.write")).Post("/{id}/revoke-sessions", handlers.RevokeSessions)
 			// Account state transitions (ADR-025).


### PR DESCRIPTION
## Summary

- WebAuthn-as-second-factor **login** was 100% broken under `storage.type: remote` deployments: `BeginWebAuthnLogin`/`FinishWebAuthnLogin` (`internal/core/webauthn.go`) call `storage.GetActiveMFAChallenge`/`storage.ConsumeMFAChallenge` directly, with no `RemoteMFAVerifier` gate the way the TOTP second-factor path has — both were unconditional stubs on `RemoteStorage`, so every WebAuthn login attempt failed immediately with "operation not supported in remote (client) mode". This is distinct from #517 (WebAuthn *credential* CRUD proxy), which never touched this path.
- Added `GetActiveMFAChallenge`/`ConsumeMFAChallenge` as ordinary `storage.Storage` passthroughs — new routes `POST /api/v1/users/mfa-challenge/active` and `POST /api/v1/users/mfa-challenge/consume`, gated by the same `users.write` permission the neighboring `verify-mfa`/`mfa-challenge` routes already require.
- **Architectural call**: `models.MFAChallenge` is a *shared* pre-auth token used by both the TOTP path (`CreateMFAChallenge`/`VerifyMFACredentials`, already proxied under `/api/v1/users/...` for #509) and the WebAuthn login path. Unlike TOTP's *verification proxy* (the raw shared secret can never leave the server that can decrypt it, so the entire check runs upstream), the challenge row itself carries no secret — a spoke server that resolves the challenge's `user_id` can run the whole passkey assertion ceremony locally against its own (already-proxied, #517) WebAuthn credential rows. So these two routes are plain CRUD passthroughs, and they belong as siblings of the existing `verify-mfa`/`{id}/mfa-challenge` routes under `/api/v1/users/...` (`server/http/handlers/users_crud.go`) — **not** inside `webauthn_proxy.go`'s `/api/v1/system/webauthn/...` group (that group is scoped to a different model, `WebAuthnCredential`/`WebAuthnSession`), and not a new `/api/v1/system/mfa-challenges` group either.
- The consume endpoint preserves `local_mfa.go`'s atomic single-DB-transaction "UPDATE ... WHERE used_at IS NULL AND expires_at > ?" consume in **one HTTP round trip** (not a separate GET+mark-used pair, which would reopen a concurrent-consume race) — mirroring the `ConsumeWebAuthnSession`/`MarkSetupTokenConsumed` precedent this campaign already established.
- Removed `GetActiveMFAChallenge`/`ConsumeMFAChallenge` from `remoteUnsupportedAllowlist` (`TestRemoteUnsupportedStubsAreAllowlisted`, added in round 119/PR #856) since they're no longer stubs.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/storage/... ./internal/core/... ./server/...` — all pass (one unrelated pre-existing flake, `TestConcurrency_RequestPasswordReset_BurstIsThrottled`, confirmed to pass on retry and unrelated to this change)
- [x] `go vet ./internal/storage/store/... ./server/http/...`
- [x] `gosec -severity medium -exclude-generated ./internal/storage/store/... ./server/http/...` — 0 issues
- [x] New end-to-end test `TestWebAuthnLogin_RemoteStorage_ProxiesMFAChallenge` (`server/http/remote_storage_webauthn_login_test.go`): a RemoteStorage-backed "spoke" pointed at a real "hub" server proves `CreateMFAChallenge` → `BeginWebAuthnLogin` (challenge lookup, non-consuming — can be called twice) → `ConsumeMFAChallenge` (atomic single-use consume; a second consume fails; a subsequent `GetActiveMFAChallenge` reports it as no longer active) all work proxied over HTTP

Closes #522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)