### PR TITLE
fix(connect): proxy ConnectRefGrant CRUD under storage.type: remote

### DIFF
--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -300,28 +300,130 @@ func (rs *RemoteStorage) RemovePermissionFromRole(ctx context.Context, roleID, p
 	return nil
 }
 
-// Keyorix Connect per-reference grants (ADR-045) are a server-side concern: the live
-// federated-read path and grant management both run against LocalStorage, so the
-// remote (client) storage does not proxy these primitives.
-
-// ListConnectRefGrantsByConnector is not supported in remote storage.
-func (rs *RemoteStorage) ListConnectRefGrantsByConnector(_ context.Context, _ string) ([]*models.ConnectRefGrant, error) {
-	return nil, remoteUnsupported("ListConnectRefGrantsByConnector")
+// Keyorix Connect per-reference grants (ADR-045) — backlog #527. This doc comment
+// PREVIOUSLY claimed these four primitives were a server-side-only concern because
+// "the live federated-read path and grant management both run against LocalStorage,
+// so the remote (client) storage does not proxy these primitives." That claim was
+// wrong: a downstream Keyorix server booted with storage.type: remote (ADR-049) runs
+// the SAME core.KeyorixCore as any other node, and ReadFederatedSecret (the HTTP
+// GetSecret handler and gRPC ConnectService.ReadSecret both call it unconditionally)
+// calls connectRefAllowed, which calls ListConnectRefGrantsByConnector on EVERY
+// federated read regardless of whether the connector actually has any ref-grants.
+// Before this fix, that stub's error made connectRefAllowed fail closed, so EVERY
+// Keyorix Connect read failed on EVERY connector on any storage.type: remote node
+// with Connect configured — not a hub-only feature at all. These are now thin
+// passthroughs onto four new routes under /api/v1/system/connect-grants
+// (server/http/handlers/connect_grants_proxy.go), following the EXACT #510
+// setup-token-proxy pattern: gated on the same system.read/system.write tier a
+// RemoteStorage credential already needs for every other proxied call — no new
+// privilege class — and making NO Connect POLICY decision here (role resolution,
+// prefix/glob matching, expiry) — that all stays in the CALLING server's own
+// internal/core/connect.go, exactly as it does against a local backend.
+func (rs *RemoteStorage) ListConnectRefGrantsByConnector(ctx context.Context, connector string) ([]*models.ConnectRefGrant, error) {
+	path := "/api/v1/system/connect-grants/by-connector/" + url.PathEscape(connector)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list connect ref-grants by connector: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list connect ref-grants by connector failed: %s", resp.Error.Error())
+	}
+	var wire []connectRefGrantWire
+	if err := json.Unmarshal(resp.Data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return connectRefGrantsFromWire(wire), nil
 }
 
-// ListConnectRefGrants is not supported in remote storage.
-func (rs *RemoteStorage) ListConnectRefGrants(_ context.Context) ([]*models.ConnectRefGrant, error) {
-	return nil, remoteUnsupported("ListConnectRefGrants")
+// ListConnectRefGrants lists every per-reference grant via remote API — see the
+// package doc above (backlog #527) for why this is genuinely reachable under
+// storage.type: remote.
+func (rs *RemoteStorage) ListConnectRefGrants(ctx context.Context) ([]*models.ConnectRefGrant, error) {
+	resp, err := rs.client.Get(ctx, "/api/v1/system/connect-grants")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list connect ref-grants: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list connect ref-grants failed: %s", resp.Error.Error())
+	}
+	var wire []connectRefGrantWire
+	if err := json.Unmarshal(resp.Data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return connectRefGrantsFromWire(wire), nil
 }
 
-// CreateConnectRefGrant is not supported in remote storage.
-func (rs *RemoteStorage) CreateConnectRefGrant(_ context.Context, _ *models.ConnectRefGrant) (*models.ConnectRefGrant, error) {
-	return nil, remoteUnsupported("CreateConnectRefGrant")
+// CreateConnectRefGrant creates a per-reference grant via remote API — see the
+// package doc above (backlog #527).
+func (rs *RemoteStorage) CreateConnectRefGrant(ctx context.Context, g *models.ConnectRefGrant) (*models.ConnectRefGrant, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/connect-grants", newConnectRefGrantWire(g))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connect ref-grant: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create connect ref-grant failed: %s", resp.Error.Error())
+	}
+	var wire connectRefGrantWire
+	if err := json.Unmarshal(resp.Data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }
 
-// DeleteConnectRefGrant is not supported in remote storage.
-func (rs *RemoteStorage) DeleteConnectRefGrant(_ context.Context, _ uint) error {
-	return remoteUnsupported("DeleteConnectRefGrant")
+// DeleteConnectRefGrant deletes a per-reference grant by id via remote API — see the
+// package doc above (backlog #527).
+func (rs *RemoteStorage) DeleteConnectRefGrant(ctx context.Context, id uint) error {
+	path := fmt.Sprintf("/api/v1/system/connect-grants/%d", id)
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete connect ref-grant: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete connect ref-grant failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// connectRefGrantWire mirrors models.ConnectRefGrant's fields exactly (snake_case) —
+// the wire shape server/http/handlers/connect_grants_proxy.go sends/expects, mirroring
+// remote_auth.go's setupTokenWire pattern (#510).
+type connectRefGrantWire struct {
+	ID        uint       `json:"id"`
+	RoleID    uint       `json:"role_id"`
+	Connector string     `json:"connector"`
+	RefPrefix string     `json:"ref_prefix"`
+	ExpiresAt *time.Time `json:"expires_at"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+func newConnectRefGrantWire(g *models.ConnectRefGrant) connectRefGrantWire {
+	return connectRefGrantWire{
+		ID:        g.ID,
+		RoleID:    g.RoleID,
+		Connector: g.Connector,
+		RefPrefix: g.RefPrefix,
+		ExpiresAt: g.ExpiresAt,
+		CreatedAt: g.CreatedAt,
+	}
+}
+
+func (w connectRefGrantWire) toModel() *models.ConnectRefGrant {
+	return &models.ConnectRefGrant{
+		ID:        w.ID,
+		RoleID:    w.RoleID,
+		Connector: w.Connector,
+		RefPrefix: w.RefPrefix,
+		ExpiresAt: w.ExpiresAt,
+		CreatedAt: w.CreatedAt,
+	}
+}
+
+func connectRefGrantsFromWire(wire []connectRefGrantWire) []*models.ConnectRefGrant {
+	out := make([]*models.ConnectRefGrant, 0, len(wire))
+	for _, w := range wire {
+		out = append(out, w.toModel())
+	}
+	return out
 }
 
 // GetGroupRoles lists the roles assigned to a group via remote API.

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -75,7 +75,7 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"ConsumeMFARecoveryCode": {statusIntentional,
 		"round 119 audit: sole caller is VerifyMFACredentials, same bypassed-branch reasoning as MarkTOTPStepUsed — recovery codes are only ever consumed at login, never during enrollment/management"},
 
-	// --- Confirmed genuine gaps, tracked for future fix rounds (55) ---
+	// --- Confirmed genuine gaps, tracked for future fix rounds (51) ---
 	// See docs/security/HARDENING-BACKLOG.md's round 119 entry for full detail,
 	// severity, and grouping. Each entry below cites the real caller/route a
 	// round-119 audit traced (not assumed).
@@ -144,15 +144,6 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"GetPermission":   {statusKnownGap, "round 119: AssignPermissionToRole, POST /roles/{id}/permissions"},
 	"GetRolePermissions": {statusKnownGap,
 		"round 119: role-permission view, access reviews, compliance posture, SoD conflict detection — GET /roles/{id}/permissions and multiple internal core callers"},
-
-	// Keyorix Connect (ADR-045) federated reads — 100% broken on EVERY
-	// connector, not just ref-scoped ones (connectRefAllowed calls this
-	// unconditionally before any ref-matching logic runs).
-	"ListConnectRefGrantsByConnector": {statusKnownGap,
-		"round 119: connectRefAllowed, called unconditionally by every ReadFederatedSecret — breaks every federated read whenever Connect is enabled"},
-	"ListConnectRefGrants":  {statusKnownGap, "round 119: GET /connect/ref-grants"},
-	"CreateConnectRefGrant": {statusKnownGap, "round 119: POST /connect/ref-grants"},
-	"DeleteConnectRefGrant": {statusKnownGap, "round 119: DELETE /connect/ref-grants/{id}"},
 
 	// Project / environment catalog CRUD.
 	"ListProjects": {statusKnownGap,

--- a/server/http/handlers/connect_grants_proxy.go
+++ b/server/http/handlers/connect_grants_proxy.go
@@ -1,0 +1,153 @@
+// connect_grants_proxy.go — server-side endpoints backing RemoteStorage's
+// ListConnectRefGrantsByConnector/ListConnectRefGrants/CreateConnectRefGrant/
+// DeleteConnectRefGrant (Keyorix Connect per-reference grants, ADR-045; backlog
+// #527).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) runs the
+// SAME core.KeyorixCore as any other node. Its ReadFederatedSecret (the HTTP
+// GetSecret handler and gRPC ConnectService.ReadSecret both call it unconditionally)
+// calls connectRefAllowed (internal/core/connect.go), which calls
+// ListConnectRefGrantsByConnector on EVERY federated read — regardless of whether
+// the connector actually has any ref-grants configured. Before this fix, RemoteStorage
+// hard-stubbed all four of these primitives, so connectRefAllowed failed closed and
+// EVERY Keyorix Connect read failed on EVERY connector on any storage.type: remote
+// node with Connect configured.
+//
+// These four routes (registered in server/http/router.go under
+// /api/v1/system/connect-grants, gated on the existing system.read/system.write RBAC
+// permissions — the SAME credential a RemoteStorage client already needs for every
+// other proxied call, e.g. full user CRUD and the #510 setup-tokens proxy, so this
+// introduces no new privilege class) are thin passthroughs onto the SAME
+// storage.Storage primitives internal/core/connect.go already uses against a local
+// backend — no Connect POLICY decision (role resolution, prefix/glob matching,
+// expiry) is made here; that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore. This mirrors setup_tokens_proxy.go (#510) exactly.
+//
+// Response envelope: like setup_tokens_proxy.go/login_attempts_proxy.go, these do
+// NOT use the package's generic sendSuccess/sendError helpers — they construct the
+// exact {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// connectRefGrantProxyWire mirrors models.ConnectRefGrant's fields exactly
+// (snake_case) — the wire shape internal/storage/store/remote_rbac.go's
+// connectRefGrantWire sends/expects, following setup_tokens_proxy.go's
+// setupTokenProxyWire pattern (#510).
+type connectRefGrantProxyWire struct {
+	ID        uint       `json:"id"`
+	RoleID    uint       `json:"role_id"`
+	Connector string     `json:"connector"`
+	RefPrefix string     `json:"ref_prefix"`
+	ExpiresAt *time.Time `json:"expires_at"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+func newConnectRefGrantProxyWire(g *models.ConnectRefGrant) connectRefGrantProxyWire {
+	return connectRefGrantProxyWire{
+		ID:        g.ID,
+		RoleID:    g.RoleID,
+		Connector: g.Connector,
+		RefPrefix: g.RefPrefix,
+		ExpiresAt: g.ExpiresAt,
+		CreatedAt: g.CreatedAt,
+	}
+}
+
+func connectRefGrantsProxyWireList(grants []*models.ConnectRefGrant) []connectRefGrantProxyWire {
+	out := make([]connectRefGrantProxyWire, 0, len(grants))
+	for _, g := range grants {
+		out = append(out, newConnectRefGrantProxyWire(g))
+	}
+	return out
+}
+
+// ListConnectRefGrantsByConnectorProxy handles GET
+// /api/v1/system/connect-grants/by-connector/{connector} — the exact filtered lookup
+// connectRefAllowed performs on every federated read.
+func (h *AuthHandler) ListConnectRefGrantsByConnectorProxy(w http.ResponseWriter, r *http.Request) {
+	connector := chi.URLParam(r, "connector")
+	if connector == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "connector is required")
+		return
+	}
+	grants, err := h.coreService.Storage().ListConnectRefGrantsByConnector(r.Context(), connector)
+	if err != nil {
+		log.Printf("connect-grants proxy: list by connector failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, connectRefGrantsProxyWireList(grants))
+}
+
+// ListConnectRefGrantsProxy handles GET /api/v1/system/connect-grants.
+func (h *AuthHandler) ListConnectRefGrantsProxy(w http.ResponseWriter, r *http.Request) {
+	grants, err := h.coreService.Storage().ListConnectRefGrants(r.Context())
+	if err != nil {
+		log.Printf("connect-grants proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, connectRefGrantsProxyWireList(grants))
+}
+
+// connectRefGrantCreateBody is the wire body for POST /api/v1/system/connect-grants.
+// The server assigns ID/CreatedAt, so the body carries only the mutable fields.
+type connectRefGrantCreateBody struct {
+	RoleID    uint       `json:"role_id"`
+	Connector string     `json:"connector"`
+	RefPrefix string     `json:"ref_prefix"`
+	ExpiresAt *time.Time `json:"expires_at"`
+}
+
+// CreateConnectRefGrantProxy handles POST /api/v1/system/connect-grants. The caller
+// (the downstream server's own core.KeyorixCore.CreateConnectRefGrant) has already
+// validated the role and connector exist; this is a raw persist, no policy decision.
+func (h *AuthHandler) CreateConnectRefGrantProxy(w http.ResponseWriter, r *http.Request) {
+	var body connectRefGrantCreateBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.RoleID == 0 || body.Connector == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "role_id and connector are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateConnectRefGrant(r.Context(), &models.ConnectRefGrant{
+		RoleID:    body.RoleID,
+		Connector: body.Connector,
+		RefPrefix: body.RefPrefix,
+		ExpiresAt: body.ExpiresAt,
+	})
+	if err != nil {
+		log.Printf("connect-grants proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newConnectRefGrantProxyWire(created))
+}
+
+// DeleteConnectRefGrantProxy handles DELETE /api/v1/system/connect-grants/{id}.
+func (h *AuthHandler) DeleteConnectRefGrantProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid grant id")
+		return
+	}
+	if err := h.coreService.Storage().DeleteConnectRefGrant(r.Context(), uint(id)); err != nil {
+		log.Printf("connect-grants proxy: delete failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -126,6 +126,9 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		// finding #519: the SoD-policy-proxy end-to-end tests exercise SoDPolicy
 		// CRUD through the real router.
 		&models.SoDPolicy{},
+		// backlog #527: the Keyorix Connect ref-grant-proxy end-to-end tests
+		// exercise ConnectRefGrant CRUD through the real router.
+		&models.ConnectRefGrant{},
 		// finding #520: the retention-proxy end-to-end tests exercise
 		// DeleteAnomalyAlertsBefore/DeleteResolvedAccessRequestsBefore through the
 		// real router. AccessReviewCampaign/AccessReviewItem/BreakGlassActivation

--- a/server/http/remote_storage_connect_grants_test.go
+++ b/server/http/remote_storage_connect_grants_test.go
@@ -1,0 +1,220 @@
+// remote_storage_connect_grants_test.go — end-to-end coverage for backlog #527:
+// RemoteStorage's ListConnectRefGrantsByConnector/ListConnectRefGrants/
+// CreateConnectRefGrant/DeleteConnectRefGrant (Keyorix Connect per-reference
+// grants, ADR-045) were entirely stubbed, so connectRefAllowed — called
+// unconditionally by every ReadFederatedSecret — failed closed on EVERY
+// federated read on EVERY connector whenever Connect was configured on a
+// storage.type: remote node. Mirrors remote_storage_setup_tokens_test.go's
+// (#510) and remote_storage_machine_identities_test.go's harness exactly: a
+// real "upstream" exercised through the production NewRouter/handlers
+// (including the new /api/v1/system/connect-grants routes,
+// server/http/handlers/connect_grants_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote pointed at "upstream"
+// over real HTTP via store.RemoteStorage.
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/connect"
+	"github.com/keyorixhq/keyorix/internal/core"
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeConnectGrantsConnector is a minimal connect.Connector for exercising
+// ReadFederatedSecret end-to-end without a real external secret store.
+type fakeConnectGrantsConnector struct {
+	name string
+	val  string
+}
+
+func (f fakeConnectGrantsConnector) Name() string { return f.name }
+func (f fakeConnectGrantsConnector) Type() string { return "fake" }
+func (f fakeConnectGrantsConnector) GetSecret(_ context.Context, _ string) (string, error) {
+	return f.val, nil
+}
+
+// newUpstreamDownstreamForConnectGrants builds the standard #510/#527-style
+// two-server harness: an "upstream" exercised through the REAL production
+// NewRouter/handlers, and a "downstream" *core.KeyorixCore configured with
+// storage.type: remote (ADR-049), pointed at "upstream" over real HTTP via
+// store.RemoteStorage.
+func newUpstreamDownstreamForConnectGrants(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	return upstream, downstream
+}
+
+// TestRemoteStorageConnectGrants_CreateListDeleteByConnector_RealServer proves the
+// #527 fix for ListConnectRefGrantsByConnector/ListConnectRefGrants/
+// CreateConnectRefGrant/DeleteConnectRefGrant: grants are genuinely persisted on
+// the upstream via the DOWNSTREAM's RemoteStorage, filterable by connector, and
+// deletable — all via storage.type: remote against a real router, not a protocol
+// mock.
+func TestRemoteStorageConnectGrants_CreateListDeleteByConnector_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForConnectGrants(t)
+	ctx := context.Background()
+
+	roleAWS, err := upstream.Storage().CreateRole(ctx, &models.Role{Name: "connect-grant-role-aws"})
+	require.NoError(t, err)
+	roleGCP, err := upstream.Storage().CreateRole(ctx, &models.Role{Name: "connect-grant-role-gcp"})
+	require.NoError(t, err)
+
+	g1, err := downstream.Storage().CreateConnectRefGrant(ctx, &models.ConnectRefGrant{
+		RoleID: roleAWS.ID, Connector: "aws", RefPrefix: "prod/",
+	})
+	require.NoError(t, err, "creating a connect ref-grant must succeed via storage.type: remote")
+	require.NotZero(t, g1.ID, "the upstream must assign a real ID")
+
+	g2, err := downstream.Storage().CreateConnectRefGrant(ctx, &models.ConnectRefGrant{
+		RoleID: roleAWS.ID, Connector: "aws", RefPrefix: "staging/",
+	})
+	require.NoError(t, err)
+
+	g3, err := downstream.Storage().CreateConnectRefGrant(ctx, &models.ConnectRefGrant{
+		RoleID: roleGCP.ID, Connector: "gcp", RefPrefix: "",
+	})
+	require.NoError(t, err)
+
+	// Confirm these are REAL rows in the upstream's own storage (not just "the
+	// call didn't error"), by reading back directly against upstream.
+	all, err := upstream.Storage().ListConnectRefGrants(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	// ListConnectRefGrants via the downstream round-trips every grant.
+	allViaDownstream, err := downstream.Storage().ListConnectRefGrants(ctx)
+	require.NoError(t, err)
+	assert.Len(t, allViaDownstream, 3)
+
+	// ListConnectRefGrantsByConnector filters correctly — the exact call
+	// connectRefAllowed makes on every federated read.
+	awsGrants, err := downstream.Storage().ListConnectRefGrantsByConnector(ctx, "aws")
+	require.NoError(t, err)
+	require.Len(t, awsGrants, 2)
+	awsIDs := []uint{awsGrants[0].ID, awsGrants[1].ID}
+	assert.Contains(t, awsIDs, g1.ID)
+	assert.Contains(t, awsIDs, g2.ID)
+
+	gcpGrants, err := downstream.Storage().ListConnectRefGrantsByConnector(ctx, "gcp")
+	require.NoError(t, err)
+	require.Len(t, gcpGrants, 1)
+	assert.Equal(t, g3.ID, gcpGrants[0].ID)
+
+	// A connector with no grants at all returns an empty (not error) result.
+	noneGrants, err := downstream.Storage().ListConnectRefGrantsByConnector(ctx, "azure")
+	require.NoError(t, err)
+	assert.Empty(t, noneGrants)
+
+	// DeleteConnectRefGrant removes exactly the targeted grant.
+	require.NoError(t, downstream.Storage().DeleteConnectRefGrant(ctx, g1.ID))
+	awsGrantsAfter, err := upstream.Storage().ListConnectRefGrantsByConnector(ctx, "aws")
+	require.NoError(t, err)
+	require.Len(t, awsGrantsAfter, 1)
+	assert.Equal(t, g2.ID, awsGrantsAfter[0].ID)
+}
+
+// TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer is the core
+// #527 regression test: before this fix, ReadFederatedSecret failed
+// UNCONDITIONALLY on a storage.type: remote node whenever Connect was
+// configured, even for a connector with NO ref-grants at all, because
+// connectRefAllowed's ListConnectRefGrantsByConnector call hard-errored on
+// RemoteStorage's stub. This proves the read now succeeds end-to-end over a
+// real HTTP hop.
+func TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForConnectGrants(t)
+	downstream.SetConnectManager(connect.NewManager([]connect.Connector{
+		fakeConnectGrantsConnector{name: "aws", val: "v3ry-secret"},
+	}))
+	require.True(t, downstream.ConnectEnabled())
+
+	val, err := downstream.ReadFederatedSecret(context.Background(), core.ActorTypeUser, 1, "aws", "prod/db")
+	require.NoError(t, err, "a federated read on storage.type: remote must not fail closed for a connector with no ref-grants (backlog #527)")
+	assert.Equal(t, "v3ry-secret", val)
+}
+
+// TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer proves the
+// per-reference RBAC policy (ADR-045) itself round-trips correctly over
+// storage.type: remote once a connector has a ref-grant: a machine identity
+// holding the granted role can read a ref under the granted prefix, but is
+// denied a ref outside it — enforced via the real upstream, not a protocol
+// mock. Uses a machine-identity actor (not a user) because actorRoleIDs's
+// underlying GetMachineRoleIDsAt is already proxied for RemoteStorage; the
+// user-role equivalent (GetUserRoleIDsAt/GetUserGroupRoleIDsAt) is a separate,
+// pre-existing, out-of-scope gap this fix does not touch.
+func TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForConnectGrants(t)
+	ctx := context.Background()
+
+	downstream.SetConnectManager(connect.NewManager([]connect.Connector{
+		fakeConnectGrantsConnector{name: "aws", val: "v3ry-secret"},
+	}))
+
+	project, err := upstream.CreateProject(ctx, "Connect Grants Test Project", "")
+	require.NoError(t, err)
+
+	m, err := downstream.Storage().CreateMachineIdentity(ctx, &models.MachineIdentity{
+		ProjectID:    project.ID,
+		Name:         "connect-grant-machine",
+		IdentityType: core.MachineTypeCI,
+		State:        core.MachineActive,
+	})
+	require.NoError(t, err)
+
+	role, err := upstream.Storage().CreateRole(ctx, &models.Role{Name: "connect-grant-enforcement-role"})
+	require.NoError(t, err)
+
+	// Connect ref-grants are resolved at GLOBAL scope (internal/core/connect.go's
+	// actorRoleIDs), mirroring the production grant scope exactly.
+	globalScope := corestorage.Scope{}
+	require.NoError(t, downstream.Storage().AssignMachineRole(ctx, m.ID, role.ID, globalScope))
+
+	_, err = downstream.Storage().CreateConnectRefGrant(ctx, &models.ConnectRefGrant{
+		RoleID: role.ID, Connector: "aws", RefPrefix: "prod/",
+	})
+	require.NoError(t, err)
+
+	// A ref under the granted prefix succeeds.
+	val, err := downstream.ReadFederatedSecret(ctx, core.ActorTypeMachine, m.ID, "aws", "prod/db")
+	require.NoError(t, err)
+	assert.Equal(t, "v3ry-secret", val)
+
+	// A ref outside the granted prefix is denied — deny-by-default once the
+	// connector is scoped.
+	_, err = downstream.ReadFederatedSecret(ctx, core.ActorTypeMachine, m.ID, "aws", "dev/db")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not permitted")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1002,6 +1002,28 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/setup-tokens/{id}/consume", authHandler.ConsumeSetupTokenProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/setup-tokens/{id}/expire", authHandler.ExpireSetupTokenProxy)
 
+			// Keyorix Connect per-reference-grant storage-primitive proxy (ADR-045;
+			// backlog #527). Lets a downstream Keyorix server booted with
+			// storage.type: remote (ADR-049) proxy ListConnectRefGrantsByConnector/
+			// ListConnectRefGrants/CreateConnectRefGrant/DeleteConnectRefGrant to THIS
+			// server's real storage backend, instead of RemoteStorage's four
+			// ConnectRefGrant methods having no server endpoint to call at all
+			// (connectRefAllowed, called unconditionally by every ReadFederatedSecret,
+			// was hard-failing EVERY Keyorix Connect federated read on EVERY connector
+			// whenever Connect was configured on a storage.type: remote node — not a
+			// hub-only feature at all). Exactly the same pattern as the setup-tokens
+			// proxy above: a thin passthrough onto storage.Storage (no Connect POLICY
+			// decision — role resolution, prefix/glob matching, expiry — made here;
+			// that stays entirely in the CALLING server's own core.KeyorixCore, exactly
+			// as it does against a local backend), reusing the SAME
+			// system.read/system.write tier — no new privilege class. Read is baseline
+			// system.read; create/delete require system.write, matching every other
+			// admin-level mutation in this group.
+			r.Get("/connect-grants/by-connector/{connector}", authHandler.ListConnectRefGrantsByConnectorProxy)
+			r.Get("/connect-grants", authHandler.ListConnectRefGrantsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/connect-grants", authHandler.CreateConnectRefGrantProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Delete("/connect-grants/{id}", authHandler.DeleteConnectRefGrantProxy)
+
 			// Project-membership storage-primitive proxy (#511). Lets a downstream
 			// Keyorix server booted with storage.type: remote (ADR-049) proxy
 			// CreateProjectMembership/GetProjectMembership/UpdateProjectMembership/


### PR DESCRIPTION
## Summary
- Backlog #527 claimed Keyorix Connect (ADR-045) federated reads were 100% broken on every connector under `storage.type: remote`. Verified this by tracing real callers: `ReadFederatedSecret` (called unconditionally by both the HTTP `GetSecret` handler and gRPC `ConnectService.ReadSecret`, neither of which is hub-only or gated by storage backend) calls `connectRefAllowed`, which calls `storage.ListConnectRefGrantsByConnector` on **every** federated read regardless of whether the connector has any ref-grants configured. `RemoteStorage` hard-stubbed all four `ConnectRefGrant` primitives, so this failed closed unconditionally — confirming the audit's finding and disproving the existing doc comment's "server-side only concern" claim (the same pattern this campaign has hit twice before with `GetGroupRoleGrants` and `WithSchedulerLock`).
- Add four new `/api/v1/system/connect-grants` routes (`server/http/handlers/connect_grants_proxy.go`), gated on the existing `system.read`/`system.write` tier — no new privilege class — following the established `#510` setup-token-proxy pattern exactly.
- Wire `RemoteStorage.ListConnectRefGrantsByConnector`/`ListConnectRefGrants`/`CreateConnectRefGrant`/`DeleteConnectRefGrant` onto those routes (`internal/storage/store/remote_rbac.go`), and correct the now-disproven doc comment.
- Update the round-119 completeness-guard allowlist (`TestRemoteUnsupportedStubsAreAllowlisted`) to drop these four now-fixed entries.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/storage/... ./internal/core/... ./server/...` — all pass
- [x] New end-to-end tests (`server/http/remote_storage_connect_grants_test.go`) against a real upstream/downstream harness (storage.type: remote):
  - `TestRemoteStorageConnectGrants_CreateListDeleteByConnector_RealServer` — create/list/list-by-connector/delete round-trip
  - `TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer` — the core regression test: a federated read on a connector with no ref-grants no longer fails closed
  - `TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer` — per-reference RBAC enforcement (allow/deny by prefix) round-trips correctly over the real HTTP hop
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues

Addresses backlog item #527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)