### PR TITLE
fix(access-requests): proxy access-request workflow under storage.type: remote

### DIFF
--- a/internal/storage/store/remote_invitations.go
+++ b/internal/storage/store/remote_invitations.go
@@ -35,9 +35,44 @@
 // (CreateProjectInvitation/GetProjectInvitation/UpdateProjectInvitation/
 // ListProjectInvitations) — flagged as follow-up findings rather than folded in.
 //
-// Access-request methods (CreateAccessRequest.../CreateAccessRequestApproval...)
-// are unrelated to this finding and remain stubs. For the local (GORM) equivalent
-// of everything here see local_invitations.go.
+// Access-request methods (#523) — CreateAccessRequest/GetAccessRequest/
+// UpdateAccessRequest/ListAccessRequests/CreateAccessRequestApproval/
+// ListAccessRequestApprovals — are thin passthroughs onto four new server-side
+// routes under /api/v1/system/access-requests(+/{id}/approvals)
+// (server/http/handlers/access_request_proxy.go), gated on the SAME
+// system.read/system.write tier as everything else in this file — no new
+// privilege class. No access-request POLICY decision (dual-control threshold,
+// maker-checker, TTL/expiry, the role grant itself) is made in these routes —
+// that stays entirely in the CALLING server's own internal/core.KeyorixCore
+// (RequestProjectAccess/ApproveAccessRequestWithExpiry/RejectAccessRequest/
+// WithdrawAccessRequest in internal/core/invitations.go), exactly as it does
+// against a local backend.
+//
+// Atomicity analysis: every one of these 6 methods already resolves in exactly
+// ONE storage.Storage call server-side (there is no multi-call sequence inside
+// any single method that needs to become atomic). The state-transition race
+// guard local_invitations.go documents for UpdateProjectInvitation applies
+// identically here — UpdateAccessRequest performs a conditional
+// `WHERE id = ? AND state = 'pending'` write (local_invitations.go) and reports
+// whether it actually matched a row; ApproveAccessRequestWithExpiry/
+// RejectAccessRequest/WithdrawAccessRequest all rely on THIS write's atomicity
+// (not on spanning their own separate Get+Update calls transactionally) to
+// resolve concurrent approve/reject/withdraw races — see #277. Proxying
+// UpdateAccessRequest as one HTTP round trip onto the hub's own conditional
+// UPDATE preserves that guarantee unchanged; there is no client-side
+// "GET then check state then PUT" sequence here that could reopen it.
+// CreateAccessRequestApproval similarly relies on a DB-level UNIQUE index
+// (RequestID, ApproverID) plus ON CONFLICT DO NOTHING (local_invitations.go) to
+// keep one sign-off per distinct approver honest under concurrent approvals;
+// that constraint lives at the hub's own database and is enforced identically
+// whether the INSERT arrives locally or via this proxy. Unlike the WebAuthn
+// credential-counter / Machine-Identity state-transition / Secret-Dependency
+// cycle-check gaps this campaign hit previously, no NEW atomic storage
+// primitive was needed here — the existing conditional-UPDATE/unique-index
+// primitives already do the whole read-check-write (or insert-or-noop) in one
+// server-side operation, so a naive 1:1 proxy per method is correct.
+//
+// For the local (GORM) equivalent of everything here see local_invitations.go.
 package store
 
 import (
@@ -211,28 +246,219 @@ func (rs *RemoteStorage) ListProjectInvitations(ctx context.Context, projectID u
 	return rows, nil
 }
 
-// --- Access requests (unrelated to #507; still stubs) ---
+// --- Access requests (#523) ---
 
-func (rs *RemoteStorage) CreateAccessRequest(_ context.Context, _ *models.AccessRequest) (*models.AccessRequest, error) {
-	return nil, remoteUnsupported("CreateAccessRequest")
+// accessRequestWire mirrors models.AccessRequest's PERSISTED fields exactly
+// (snake_case). ApprovalsReceived/RequiredApprovals are deliberately excluded —
+// models.AccessRequest itself tags them `gorm:"-"` (transient, never
+// persisted); internal/core/invitations.go only ever populates them on a
+// value it's about to return to an HTTP caller, never on one it passes INTO
+// CreateAccessRequest/UpdateAccessRequest, so there is nothing for this wire
+// type to carry. See invitationWire's comment above for why every field is
+// named explicitly rather than relying on encoding/json's case-insensitive
+// fallback onto a GORM model with no json tags of its own.
+type accessRequestWire struct {
+	ID            uint       `json:"id"`
+	ProjectID     uint       `json:"project_id"`
+	UserID        uint       `json:"user_id"`
+	SuggestedRole string     `json:"suggested_role"`
+	GrantedRole   string     `json:"granted_role"`
+	SecretID      *uint      `json:"secret_id"`
+	State         string     `json:"state"`
+	Reason        string     `json:"reason"`
+	ResolvedBy    uint       `json:"resolved_by"`
+	ExpiresAt     *time.Time `json:"expires_at"`
+	CreatedAt     time.Time  `json:"created_at"`
+	ResolvedAt    *time.Time `json:"resolved_at"`
 }
 
-func (rs *RemoteStorage) GetAccessRequest(_ context.Context, _ uint) (*models.AccessRequest, error) {
-	return nil, remoteUnsupported("GetAccessRequest")
+func newAccessRequestWire(req *models.AccessRequest) accessRequestWire {
+	return accessRequestWire{
+		ID:            req.ID,
+		ProjectID:     req.ProjectID,
+		UserID:        req.UserID,
+		SuggestedRole: req.SuggestedRole,
+		GrantedRole:   req.GrantedRole,
+		SecretID:      req.SecretID,
+		State:         req.State,
+		Reason:        req.Reason,
+		ResolvedBy:    req.ResolvedBy,
+		ExpiresAt:     req.ExpiresAt,
+		CreatedAt:     req.CreatedAt,
+		ResolvedAt:    req.ResolvedAt,
+	}
 }
 
-func (rs *RemoteStorage) UpdateAccessRequest(_ context.Context, _ *models.AccessRequest) (bool, error) {
-	return false, remoteUnsupported("UpdateAccessRequest")
+func (w accessRequestWire) toModel() *models.AccessRequest {
+	return &models.AccessRequest{
+		ID:            w.ID,
+		ProjectID:     w.ProjectID,
+		UserID:        w.UserID,
+		SuggestedRole: w.SuggestedRole,
+		GrantedRole:   w.GrantedRole,
+		SecretID:      w.SecretID,
+		State:         w.State,
+		Reason:        w.Reason,
+		ResolvedBy:    w.ResolvedBy,
+		ExpiresAt:     w.ExpiresAt,
+		CreatedAt:     w.CreatedAt,
+		ResolvedAt:    w.ResolvedAt,
+	}
 }
 
-func (rs *RemoteStorage) ListAccessRequests(_ context.Context, _ uint) ([]*models.AccessRequest, error) {
-	return nil, remoteUnsupported("ListAccessRequests")
+func decodeAccessRequestResponse(data []byte) (*models.AccessRequest, error) {
+	var wire accessRequestWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
 }
 
-func (rs *RemoteStorage) CreateAccessRequestApproval(_ context.Context, _ *models.AccessRequestApproval) error {
-	return remoteUnsupported("CreateAccessRequestApproval")
+// accessRequestApprovalWire mirrors models.AccessRequestApproval's fields
+// exactly (snake_case).
+type accessRequestApprovalWire struct {
+	ID         uint      `json:"id"`
+	RequestID  uint      `json:"request_id"`
+	ApproverID uint      `json:"approver_id"`
+	CreatedAt  time.Time `json:"created_at"`
 }
 
-func (rs *RemoteStorage) ListAccessRequestApprovals(_ context.Context, _ uint) ([]*models.AccessRequestApproval, error) {
-	return nil, remoteUnsupported("ListAccessRequestApprovals")
+func newAccessRequestApprovalWire(a *models.AccessRequestApproval) accessRequestApprovalWire {
+	return accessRequestApprovalWire{
+		ID:         a.ID,
+		RequestID:  a.RequestID,
+		ApproverID: a.ApproverID,
+		CreatedAt:  a.CreatedAt,
+	}
+}
+
+// CreateAccessRequest persists an already-built access request (every field —
+// state, TTL, suggested role, ... — is computed by the CALLING core.KeyorixCore
+// before this is invoked, exactly as RequestProjectAccess/RequestSecretAccess
+// build one for LocalStorage) via POST /api/v1/system/access-requests.
+func (rs *RemoteStorage) CreateAccessRequest(ctx context.Context, req *models.AccessRequest) (*models.AccessRequest, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/access-requests", newAccessRequestWire(req))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create access request: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create access request failed: %s", resp.Error.Error())
+	}
+	return decodeAccessRequestResponse(resp.Data)
+}
+
+// GetAccessRequest retrieves an access request by ID via GET
+// /api/v1/system/access-requests/{id} — a raw fetch, gated by system.read.
+func (rs *RemoteStorage) GetAccessRequest(ctx context.Context, id uint) (*models.AccessRequest, error) {
+	path := fmt.Sprintf("/api/v1/system/access-requests/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get access request: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get access request failed: %s", resp.Error.Error())
+	}
+	return decodeAccessRequestResponse(resp.Data)
+}
+
+// UpdateAccessRequest persists an access-request state transition via PUT
+// /api/v1/system/access-requests/{id}, preserving local_invitations.go's exact
+// conditional `WHERE id = ? AND state = 'pending'` semantics end-to-end: the
+// server performs the SAME conditional write, and reports whether it actually
+// matched a row — NOT a client-side "GET then check state then PUT" sequence,
+// which would reintroduce the #277 TOCTOU race ApproveAccessRequestWithExpiry/
+// RejectAccessRequest/WithdrawAccessRequest all depend on this write to close.
+// One HTTP round trip maps to one atomic server-side conditional UPDATE.
+func (rs *RemoteStorage) UpdateAccessRequest(ctx context.Context, req *models.AccessRequest) (bool, error) {
+	path := fmt.Sprintf("/api/v1/system/access-requests/%d", req.ID)
+	resp, err := rs.client.Put(ctx, path, newAccessRequestWire(req))
+	if err != nil {
+		return false, fmt.Errorf("failed to update access request: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("update access request failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Updated bool `json:"updated"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Updated, nil
+}
+
+// ListAccessRequests lists a project's access requests via GET
+// /api/v1/system/access-requests?project_id=X.
+func (rs *RemoteStorage) ListAccessRequests(ctx context.Context, projectID uint) ([]*models.AccessRequest, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	path := "/api/v1/system/access-requests?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list access requests: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list access requests failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		AccessRequests []accessRequestWire `json:"access_requests"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.AccessRequest, 0, len(result.AccessRequests))
+	for _, w := range result.AccessRequests {
+		rows = append(rows, w.toModel())
+	}
+	return rows, nil
+}
+
+// CreateAccessRequestApproval records one approver's sign-off via POST
+// /api/v1/system/access-requests/{id}/approvals. The server performs the SAME
+// INSERT ... ON CONFLICT (request_id, approver_id) DO NOTHING
+// local_invitations.go does, backed by the DB-level unique index — a duplicate
+// sign-off from the same approver (including one racing a concurrent identical
+// call through this proxy) is a benign no-op here exactly as it is locally,
+// keeping the M-of-K dual-control count honest.
+func (rs *RemoteStorage) CreateAccessRequestApproval(ctx context.Context, a *models.AccessRequestApproval) error {
+	path := fmt.Sprintf("/api/v1/system/access-requests/%d/approvals", a.RequestID)
+	resp, err := rs.client.Post(ctx, path, newAccessRequestApprovalWire(a))
+	if err != nil {
+		return fmt.Errorf("failed to create access request approval: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("create access request approval failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// ListAccessRequestApprovals lists every approval recorded for a request via
+// GET /api/v1/system/access-requests/{id}/approvals — used both to annotate
+// dual-control progress (ListAccessRequests) and to enforce one-sign-off-per-
+// approver (ApproveAccessRequestWithExpiry).
+func (rs *RemoteStorage) ListAccessRequestApprovals(ctx context.Context, requestID uint) ([]*models.AccessRequestApproval, error) {
+	path := fmt.Sprintf("/api/v1/system/access-requests/%d/approvals", requestID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list access request approvals: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list access request approvals failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Approvals []accessRequestApprovalWire `json:"approvals"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	rows := make([]*models.AccessRequestApproval, 0, len(result.Approvals))
+	for _, w := range result.Approvals {
+		rows = append(rows, &models.AccessRequestApproval{
+			ID:         w.ID,
+			RequestID:  w.RequestID,
+			ApproverID: w.ApproverID,
+			CreatedAt:  w.CreatedAt,
+		})
+	}
+	return rows, nil
 }

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -75,10 +75,11 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"ConsumeMFARecoveryCode": {statusIntentional,
 		"round 119 audit: sole caller is VerifyMFACredentials, same bypassed-branch reasoning as MarkTOTPStepUsed — recovery codes are only ever consumed at login, never during enrollment/management"},
 
-	// --- Confirmed genuine gaps, tracked for future fix rounds (47; UpdateLoginLockoutState
+	// --- Confirmed genuine gaps, tracked for future fix rounds (41; UpdateLoginLockoutState
 	// closed by #529, SSO login state closed by #521, GetActiveMFAChallenge/
 	// ConsumeMFAChallenge (WebAuthn-as-second-factor login) closed by #522, Connect
-	// ref-grant CRUD closed by #527) ---
+	// ref-grant CRUD closed by #527, self-service access-request workflow closed by
+	// #523) ---
 	// See docs/security/HARDENING-BACKLOG.md's round 119 entry for full detail,
 	// severity, and grouping. Each entry below cites the real caller/route a
 	// round-119 audit traced (not assumed).
@@ -88,19 +89,12 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	// (server/http/handlers/sso_state_proxy.go), no longer unconditional stubs —
 	// see internal/storage/store/remote_sso.go.
 
-	// Self-service access-requests — 100% broken (request/list/approve/reject/withdraw).
-	"CreateAccessRequest": {statusKnownGap,
-		"round 119: RequestProjectAccess, POST /projects/{id}/access-requests (self-service)"},
-	"GetAccessRequest": {statusKnownGap,
-		"round 119: ApproveAccessRequestWithExpiry/RejectAccessRequest, PUT /projects/{id}/access-requests/{requestId}"},
-	"UpdateAccessRequest": {statusKnownGap,
-		"round 119: same approve/reject paths, plus lazy-expiry in ListAccessRequests"},
-	"ListAccessRequests": {statusKnownGap,
-		"round 119: GET /projects/{id}/access-requests"},
-	"CreateAccessRequestApproval": {statusKnownGap,
-		"round 119: dual-control (N-of-M) approval recording inside ApproveAccessRequestWithExpiry"},
-	"ListAccessRequestApprovals": {statusKnownGap,
-		"round 119: progress annotation + duplicate-approver check during approve"},
+	// Self-service access-requests (request/list/approve/reject/withdraw) were
+	// fixed in #523: CreateAccessRequest/GetAccessRequest/UpdateAccessRequest/
+	// ListAccessRequests/CreateAccessRequestApproval/ListAccessRequestApprovals
+	// are now proxied via /api/v1/system/access-requests(+/{id}/approvals)
+	// (server/http/handlers/access_request_proxy.go), no longer unconditional
+	// stubs — see internal/storage/store/remote_invitations.go.
 
 	// MFA enrollment/management (not just login) — 100% broken.
 	"UpsertMFASecret": {statusKnownGap, "round 119: BeginMFAEnrollment, POST /auth/mfa/enroll"},

--- a/internal/storage/store/remote_unsupported_test.go
+++ b/internal/storage/store/remote_unsupported_test.go
@@ -24,15 +24,15 @@ func TestRemoteStorage_UnsupportedSentinel(t *testing.T) {
 
 	calls := map[string]func() error{
 		// ListProjectInvitations (#507), CreateProjectMembership (#511),
-		// CreateGroup (#514), and CreateMachineIdentity (#518) now make a real HTTP
-		// call rather than stubbing out — see
+		// CreateGroup (#514), CreateMachineIdentity (#518), and CreateAccessRequest
+		// (#523) now make a real HTTP call rather than stubbing out — see
 		// server/http/remote_storage_invitations_test.go,
 		// server/http/remote_storage_project_memberships_test.go,
-		// server/http/remote_storage_groups_test.go, and
-		// server/http/remote_storage_machine_identities_test.go for their
-		// end-to-end coverage against a real router.
-		"CreateAccessRequest": func() error { _, e := rs.CreateAccessRequest(ctx, &models.AccessRequest{}); return e },
-		"CreateNotification":  func() error { _, e := rs.CreateNotification(ctx, &models.Notification{}); return e },
+		// server/http/remote_storage_groups_test.go,
+		// server/http/remote_storage_machine_identities_test.go, and
+		// server/http/remote_storage_access_request_test.go for their end-to-end
+		// coverage against a real router.
+		"CreateNotification": func() error { _, e := rs.CreateNotification(ctx, &models.Notification{}); return e },
 		"ListPermissions":     func() error { _, e := rs.ListPermissions(ctx); return e },
 		// CountStaleMachineIdentitiesByProject (#393) legitimately stays a stub —
 		// the grouped hygiene-rollup query runs server-side, out of #518's scope

--- a/server/http/handlers/access_request_proxy.go
+++ b/server/http/handlers/access_request_proxy.go
@@ -1,0 +1,310 @@
+// access_request_proxy.go — server-side endpoints backing RemoteStorage's
+// CreateAccessRequest/GetAccessRequest/UpdateAccessRequest/ListAccessRequests/
+// CreateAccessRequestApproval/ListAccessRequestApprovals (#523).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049)
+// proxies its self-service access-request storage calls to whichever upstream
+// server it's configured against, through these six routes (registered in
+// server/http/router.go under /api/v1/system/access-requests, gated on the
+// existing system.read/system.write RBAC permissions — the SAME credential a
+// RemoteStorage client already needs for every other proxied call, e.g. full
+// user CRUD). This mirrors invitations_proxy.go exactly.
+//
+// Deliberately NOT reused: the existing human-facing
+// /api/v1/projects/{id}/access-requests* routes (ListAccessRequests/
+// CreateAccessRequest/ResolveAccessRequest/WithdrawAccessRequest in
+// invitations.go). Those handlers call straight into
+// core.KeyorixCore.RequestProjectAccess/ApproveAccessRequestWithExpiry/
+// RejectAccessRequest/WithdrawAccessRequest — full business logic that writes
+// its own audit-log events, sends its own notifications, and resolves the
+// acting user from THIS server's own request context
+// (middleware.GetUserFromContext). Routing the proxy through them would (a)
+// double-apply that business logic server-side on top of whatever the
+// DOWNSTREAM server's core.KeyorixCore already did before ever making the
+// HTTP call, and (b) attribute every audit event/notification to the wrong
+// actor — the hub's own service credential, not the real requester/approver
+// the downstream server is acting on behalf of. These six routes below are
+// raw passthroughs onto storage.Storage's own CreateAccessRequest/
+// GetAccessRequest/UpdateAccessRequest/ListAccessRequests/
+// CreateAccessRequestApproval/ListAccessRequestApprovals instead — exactly the
+// primitives internal/core/invitations.go and classification_gate.go already
+// call against a local backend. No access-request POLICY decision (dual-control
+// threshold, maker-checker, TTL/expiry, the role grant itself, audit writes,
+// notifications) is made here; that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore, exactly as it does against a local backend.
+//
+// UpdateAccessRequestProxy calls storage.UpdateAccessRequest directly, so it
+// inherits local_invitations.go's conditional `WHERE id = ? AND state =
+// 'pending'` write verbatim — the #277 approve/reject/withdraw race guarantee
+// survives this HTTP hop unchanged. CreateAccessRequestApprovalProxy similarly
+// inherits the DB-level unique-index-backed ON CONFLICT DO NOTHING insert. See
+// remote_invitations.go's package doc for the full atomicity analysis.
+//
+// Response envelope: like invitations_proxy.go, these do NOT use the package's
+// generic sendSuccess/sendError helpers — they construct the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// accessRequestProxyWire mirrors models.AccessRequest's PERSISTED fields
+// exactly (snake_case) — the wire shape
+// internal/storage/store/remote_invitations.go's accessRequestWire
+// sends/expects. ApprovalsReceived/RequiredApprovals are excluded: they are
+// tagged `gorm:"-"` on the model itself (transient, computed by
+// internal/core/invitations.go only on a value about to be returned to an
+// HTTP caller), so there is nothing here to persist or round-trip.
+type accessRequestProxyWire struct {
+	ID            uint       `json:"id"`
+	ProjectID     uint       `json:"project_id"`
+	UserID        uint       `json:"user_id"`
+	SuggestedRole string     `json:"suggested_role"`
+	GrantedRole   string     `json:"granted_role"`
+	SecretID      *uint      `json:"secret_id"`
+	State         string     `json:"state"`
+	Reason        string     `json:"reason"`
+	ResolvedBy    uint       `json:"resolved_by"`
+	ExpiresAt     *time.Time `json:"expires_at"`
+	CreatedAt     time.Time  `json:"created_at"`
+	ResolvedAt    *time.Time `json:"resolved_at"`
+}
+
+func newAccessRequestProxyWire(req *models.AccessRequest) accessRequestProxyWire {
+	return accessRequestProxyWire{
+		ID:            req.ID,
+		ProjectID:     req.ProjectID,
+		UserID:        req.UserID,
+		SuggestedRole: req.SuggestedRole,
+		GrantedRole:   req.GrantedRole,
+		SecretID:      req.SecretID,
+		State:         req.State,
+		Reason:        req.Reason,
+		ResolvedBy:    req.ResolvedBy,
+		ExpiresAt:     req.ExpiresAt,
+		CreatedAt:     req.CreatedAt,
+		ResolvedAt:    req.ResolvedAt,
+	}
+}
+
+func (w accessRequestProxyWire) toModel() *models.AccessRequest {
+	return &models.AccessRequest{
+		ID:            w.ID,
+		ProjectID:     w.ProjectID,
+		UserID:        w.UserID,
+		SuggestedRole: w.SuggestedRole,
+		GrantedRole:   w.GrantedRole,
+		SecretID:      w.SecretID,
+		State:         w.State,
+		Reason:        w.Reason,
+		ResolvedBy:    w.ResolvedBy,
+		ExpiresAt:     w.ExpiresAt,
+		CreatedAt:     w.CreatedAt,
+		ResolvedAt:    w.ResolvedAt,
+	}
+}
+
+// accessRequestApprovalProxyWire mirrors models.AccessRequestApproval's
+// fields exactly (snake_case).
+type accessRequestApprovalProxyWire struct {
+	ID         uint      `json:"id"`
+	RequestID  uint      `json:"request_id"`
+	ApproverID uint      `json:"approver_id"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+func newAccessRequestApprovalProxyWire(a *models.AccessRequestApproval) accessRequestApprovalProxyWire {
+	return accessRequestApprovalProxyWire{
+		ID:         a.ID,
+		RequestID:  a.RequestID,
+		ApproverID: a.ApproverID,
+		CreatedAt:  a.CreatedAt,
+	}
+}
+
+// validAccessRequestTargetState reports whether s is a state this proxy may
+// WRITE via UpdateAccessRequestProxy. "pending" is deliberately excluded — it
+// is only ever the initial state CreateAccessRequest persists, never a target
+// of an UPDATE (every real transition in internal/core/invitations.go and
+// classification_gate.go moves AWAY from pending), so accepting it here would
+// let a caller resurrect an already-resolved request back to pending instead
+// of merely transitioning it forward.
+func validAccessRequestTargetState(s string) bool {
+	switch s {
+	case "approved", "rejected", "withdrawn", "expired":
+		return true
+	default:
+		return false
+	}
+}
+
+// CreateAccessRequestProxy handles POST /api/v1/system/access-requests. See
+// the package doc for why this persists the caller's already-fully-built
+// access request as-is (a raw storage-layer create) rather than routing
+// through RequestProjectAccess/RequestSecretAccess's business logic (audit
+// writes, notifications) a second time.
+func (h *CatalogHandler) CreateAccessRequestProxy(w http.ResponseWriter, r *http.Request) {
+	var body accessRequestProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.ProjectID == 0 || body.UserID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id and user_id are required")
+		return
+	}
+	if body.State == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "state is required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateAccessRequest(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("access-requests proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newAccessRequestProxyWire(created))
+}
+
+// GetAccessRequestProxy handles GET /api/v1/system/access-requests/{id}.
+func (h *CatalogHandler) GetAccessRequestProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid access request ID")
+		return
+	}
+	req, err := h.coreService.Storage().GetAccessRequest(r.Context(), uint(id))
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "access request not found")
+			return
+		}
+		log.Printf("access-requests proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newAccessRequestProxyWire(req))
+}
+
+// UpdateAccessRequestProxy handles PUT /api/v1/system/access-requests/{id}. It
+// performs the SAME conditional `WHERE id = ? AND state = 'pending'` write
+// LocalStorage's own UpdateAccessRequest does (h.coreService.Storage() reaches
+// the identical storage.Storage primitive this server's local
+// /projects/{id}/access-requests* paths use), returning whether it actually
+// matched a still-pending row — the single round trip a concurrent
+// approve/reject/withdraw race resolves in (#277).
+func (h *CatalogHandler) UpdateAccessRequestProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid access request ID")
+		return
+	}
+	var body accessRequestProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if !validAccessRequestTargetState(body.State) {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "state must be one of approved, rejected, withdrawn, expired")
+		return
+	}
+	body.ID = uint(id)
+	updated, err := h.coreService.Storage().UpdateAccessRequest(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("access-requests proxy: update failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": updated})
+}
+
+// ListAccessRequestsProxy handles GET
+// /api/v1/system/access-requests?project_id=X.
+func (h *CatalogHandler) ListAccessRequestsProxy(w http.ResponseWriter, r *http.Request) {
+	projectIDStr := r.URL.Query().Get("project_id")
+	if projectIDStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id query parameter is required")
+		return
+	}
+	projectID, err := strconv.ParseUint(projectIDStr, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id must be a valid integer")
+		return
+	}
+	rows, err := h.coreService.Storage().ListAccessRequests(r.Context(), uint(projectID))
+	if err != nil {
+		log.Printf("access-requests proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]accessRequestProxyWire, 0, len(rows))
+	for _, req := range rows {
+		wire = append(wire, newAccessRequestProxyWire(req))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"access_requests": wire})
+}
+
+// CreateAccessRequestApprovalProxy handles POST
+// /api/v1/system/access-requests/{id}/approvals. It performs the SAME
+// INSERT ... ON CONFLICT (request_id, approver_id) DO NOTHING
+// local_invitations.go's CreateAccessRequestApproval does, backed by the
+// DB-level unique index — a duplicate sign-off from the same approver is a
+// benign no-op here exactly as it is locally.
+func (h *CatalogHandler) CreateAccessRequestApprovalProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid access request ID")
+		return
+	}
+	var body accessRequestApprovalProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.ApproverID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "approver_id is required")
+		return
+	}
+	approval := &models.AccessRequestApproval{
+		RequestID:  uint(id),
+		ApproverID: body.ApproverID,
+		CreatedAt:  body.CreatedAt,
+	}
+	if err := h.coreService.Storage().CreateAccessRequestApproval(r.Context(), approval); err != nil {
+		log.Printf("access-requests proxy: create approval failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newAccessRequestApprovalProxyWire(approval))
+}
+
+// ListAccessRequestApprovalsProxy handles GET
+// /api/v1/system/access-requests/{id}/approvals.
+func (h *CatalogHandler) ListAccessRequestApprovalsProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid access request ID")
+		return
+	}
+	rows, err := h.coreService.Storage().ListAccessRequestApprovals(r.Context(), uint(id))
+	if err != nil {
+		log.Printf("access-requests proxy: list approvals failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]accessRequestApprovalProxyWire, 0, len(rows))
+	for _, a := range rows {
+		wire = append(wire, newAccessRequestApprovalProxyWire(a))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"approvals": wire})
+}

--- a/server/http/remote_storage_access_request_test.go
+++ b/server/http/remote_storage_access_request_test.go
@@ -1,0 +1,290 @@
+// remote_storage_access_request_test.go — end-to-end coverage for #523:
+// RemoteStorage's CreateAccessRequest/GetAccessRequest/UpdateAccessRequest/
+// ListAccessRequests/CreateAccessRequestApproval/ListAccessRequestApprovals
+// were entirely stubbed, so the ENTIRE self-service access-request workflow
+// (request/list/approve/reject/withdraw, ADR-024) was 100% broken under
+// storage.type: remote. Mirrors remote_storage_sso_state_test.go's #521
+// harness exactly: a real "upstream" exercised through the production
+// NewRouter/handlers (including the new /api/v1/system/access-requests
+// routes, server/http/handlers/access_request_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote pointed at
+// "upstream" over real HTTP via store.RemoteStorage.
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForAccessRequests builds the standard
+// #452/#507/#510/#521/#523 two-server harness: an "upstream" exercised
+// through the REAL production NewRouter/handlers, and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed
+// at "upstream" over real HTTP via store.RemoteStorage. Returns the upstream
+// core and a live project ID (BootstrapSystem seeds one) alongside both
+// cores.
+func newUpstreamDownstreamForAccessRequests(t *testing.T) (upstream, downstream *core.KeyorixCore, projectID uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	projects, err := upstream.ListProjects(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, projects, "BootstrapSystem must seed at least one project")
+	projectID = projects[0].ID
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	return upstream, downstream, projectID
+}
+
+// buildAccessRequest mirrors what internal/core/invitations.go's
+// RequestProjectAccess computes before calling storage.CreateAccessRequest —
+// a fully-built, pending request — WITHOUT going through RequestProjectAccess
+// itself, so the storage-primitive tests below can exercise
+// CreateAccessRequest/GetAccessRequest/UpdateAccessRequest directly.
+func buildAccessRequest(now time.Time, projectID, userID uint, suggestedRole string) *models.AccessRequest {
+	expires := now.Add(72 * time.Hour)
+	return &models.AccessRequest{
+		ProjectID:     projectID,
+		UserID:        userID,
+		SuggestedRole: suggestedRole,
+		State:         "pending",
+		Reason:        "need access for on-call rotation",
+		ExpiresAt:     &expires,
+		CreatedAt:     now,
+	}
+}
+
+// TestRemoteStorageAccessRequest_CreateGetList_RealServer proves the #523 fix:
+// an access request is genuinely persisted on the upstream server via the
+// DOWNSTREAM's RemoteStorage, retrievable by ID, and listed by project — all
+// via storage.type: remote against a real router, not a protocol mock.
+func TestRemoteStorageAccessRequest_CreateGetList_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForAccessRequests(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	req := buildAccessRequest(now, projectID, 42, "developer")
+	created, err := downstream.Storage().CreateAccessRequest(ctx, req)
+	require.NoError(t, err, "creating an access request must succeed via storage.type: remote")
+	require.NotZero(t, created.ID, "the upstream must assign a real ID")
+
+	// Confirm it is a REAL row in the upstream's own storage (not just "the
+	// call didn't error"), by fetching it directly against upstream.
+	direct, err := upstream.Storage().GetAccessRequest(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "developer", direct.SuggestedRole)
+	assert.Equal(t, "pending", direct.State)
+
+	// Fetching via the downstream (RemoteStorage) round-trips every field.
+	fetched, err := downstream.Storage().GetAccessRequest(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, projectID, fetched.ProjectID)
+	assert.Equal(t, uint(42), fetched.UserID)
+	assert.Equal(t, "developer", fetched.SuggestedRole)
+	assert.Equal(t, "need access for on-call rotation", fetched.Reason)
+	assert.Equal(t, "pending", fetched.State)
+	require.NotNil(t, fetched.ExpiresAt)
+	assert.WithinDuration(t, now.Add(72*time.Hour), *fetched.ExpiresAt, time.Second)
+
+	// A second, unrelated request in the same project must both list.
+	req2 := buildAccessRequest(now, projectID, 43, "viewer")
+	_, err = downstream.Storage().CreateAccessRequest(ctx, req2)
+	require.NoError(t, err)
+
+	rows, err := downstream.Storage().ListAccessRequests(ctx, projectID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	userIDs := []uint{rows[0].UserID, rows[1].UserID}
+	assert.ElementsMatch(t, []uint{42, 43}, userIDs)
+}
+
+// TestRemoteStorageAccessRequest_GetUnknown_RealServer proves a clean
+// not-found error (not a panic, not a garbage 500) for a request that was
+// never created.
+func TestRemoteStorageAccessRequest_GetUnknown_RealServer(t *testing.T) {
+	_, downstream, _ := newUpstreamDownstreamForAccessRequests(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetAccessRequest(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageAccessRequest_UpdateConditional_RealServer proves
+// UpdateAccessRequestProxy performs the SAME conditional
+// `WHERE id = ? AND state = 'pending'` write local_invitations.go's
+// UpdateAccessRequest does, end-to-end over HTTP: a first transition off
+// "pending" succeeds and reports updated=true; a second transition attempt
+// against the now-non-pending row reports updated=false rather than silently
+// clobbering it — the #277 race guarantee ApproveAccessRequestWithExpiry/
+// RejectAccessRequest/WithdrawAccessRequest all depend on.
+func TestRemoteStorageAccessRequest_UpdateConditional_RealServer(t *testing.T) {
+	_, downstream, projectID := newUpstreamDownstreamForAccessRequests(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	req := buildAccessRequest(now, projectID, 7, "developer")
+	created, err := downstream.Storage().CreateAccessRequest(ctx, req)
+	require.NoError(t, err)
+
+	// First transition: pending -> approved. Must match the row.
+	created.State = "approved"
+	created.GrantedRole = "developer"
+	resolvedAt := now.Add(time.Minute)
+	created.ResolvedAt = &resolvedAt
+	created.ResolvedBy = 99
+	updated, err := downstream.Storage().UpdateAccessRequest(ctx, created)
+	require.NoError(t, err)
+	assert.True(t, updated, "the first conditional update against a still-pending row must succeed")
+
+	fetched, err := downstream.Storage().GetAccessRequest(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "approved", fetched.State)
+	assert.Equal(t, "developer", fetched.GrantedRole)
+
+	// Second transition attempt (e.g. a concurrent reject/withdraw that lost
+	// the race): the row is no longer "pending", so this must cleanly report
+	// updated=false, NOT silently overwrite the already-approved row.
+	fetched.State = "rejected"
+	updatedAgain, err := downstream.Storage().UpdateAccessRequest(ctx, fetched)
+	require.NoError(t, err)
+	assert.False(t, updatedAgain, "an update against a non-pending row must not match")
+
+	stillApproved, err := downstream.Storage().GetAccessRequest(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "approved", stillApproved.State, "the losing update must not have clobbered the winner")
+}
+
+// TestRemoteStorageAccessRequest_ConcurrentUpdateRace_RealServer is the
+// critical #523 test: it fires N concurrent conditional updates at the SAME
+// pending access request over real HTTP against the real upstream router,
+// and asserts EXACTLY ONE succeeds — proving UpdateAccessRequestProxy's
+// direct passthrough onto local_invitations.go's conditional
+// `WHERE id = ? AND state = 'pending'` UPDATE still closes the
+// double-approve/reject/withdraw TOCTOU race, even across a network hop —
+// not a client-side "GET, then PUT" sequence, which would reopen exactly
+// this race. Mirrors #521's
+// TestRemoteStorageSSOState_ConcurrentConsumeRace_RealServer exactly.
+func TestRemoteStorageAccessRequest_ConcurrentUpdateRace_RealServer(t *testing.T) {
+	_, downstream, projectID := newUpstreamDownstreamForAccessRequests(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	req := buildAccessRequest(now, projectID, 11, "developer")
+	created, err := downstream.Storage().CreateAccessRequest(ctx, req)
+	require.NoError(t, err)
+
+	const n = 20
+	var successCount atomic.Int64
+	var failCount atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			resolvedAt := now.Add(time.Duration(i) * time.Second)
+			candidate := &models.AccessRequest{
+				ID:            created.ID,
+				ProjectID:     created.ProjectID,
+				UserID:        created.UserID,
+				SuggestedRole: created.SuggestedRole,
+				GrantedRole:   "developer",
+				State:         "approved",
+				ExpiresAt:     created.ExpiresAt,
+				CreatedAt:     created.CreatedAt,
+				ResolvedBy:    uint(i + 1),
+				ResolvedAt:    &resolvedAt,
+			}
+			updated, err := downstream.Storage().UpdateAccessRequest(ctx, candidate)
+			if err != nil || !updated {
+				failCount.Add(1)
+				return
+			}
+			successCount.Add(1)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(1), successCount.Load(), "exactly one concurrent conditional update must win the race — the rest must cleanly report updated=false, never a double-resolve")
+	assert.Equal(t, int64(n-1), failCount.Load())
+}
+
+// TestRemoteStorageAccessRequest_Approvals_RealServer proves
+// CreateAccessRequestApproval/ListAccessRequestApprovals round-trip over the
+// proxy, and that the DB-level unique-index-backed
+// ON CONFLICT (request_id, approver_id) DO NOTHING guard survives the HTTP
+// hop: a duplicate sign-off from the same approver is a benign no-op, not a
+// second row (which would defeat the M-of-K dual-control count).
+func TestRemoteStorageAccessRequest_Approvals_RealServer(t *testing.T) {
+	_, downstream, projectID := newUpstreamDownstreamForAccessRequests(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	req := buildAccessRequest(now, projectID, 21, "developer")
+	created, err := downstream.Storage().CreateAccessRequest(ctx, req)
+	require.NoError(t, err)
+
+	approvals, err := downstream.Storage().ListAccessRequestApprovals(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Empty(t, approvals)
+
+	err = downstream.Storage().CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{
+		RequestID: created.ID, ApproverID: 100, CreatedAt: now,
+	})
+	require.NoError(t, err)
+	err = downstream.Storage().CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{
+		RequestID: created.ID, ApproverID: 200, CreatedAt: now,
+	})
+	require.NoError(t, err)
+
+	approvals, err = downstream.Storage().ListAccessRequestApprovals(ctx, created.ID)
+	require.NoError(t, err)
+	require.Len(t, approvals, 2)
+	approverIDs := []uint{approvals[0].ApproverID, approvals[1].ApproverID}
+	assert.ElementsMatch(t, []uint{100, 200}, approverIDs)
+
+	// Duplicate sign-off from approver 100 must be a benign no-op, not a
+	// second row.
+	err = downstream.Storage().CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{
+		RequestID: created.ID, ApproverID: 100, CreatedAt: now.Add(time.Second),
+	})
+	require.NoError(t, err)
+
+	approvals, err = downstream.Storage().ListAccessRequestApprovals(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Len(t, approvals, 2, "a duplicate approver sign-off must not insert a second row")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -848,6 +848,46 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/invitations", catalogHandler.CreateInvitationProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Put("/invitations/{id}", catalogHandler.UpdateInvitationProxy)
 
+			// Self-service access-request storage-primitive proxy (#523). Lets a
+			// downstream Keyorix server booted with storage.type: remote (ADR-049)
+			// proxy CreateAccessRequest/GetAccessRequest/UpdateAccessRequest/
+			// ListAccessRequests/CreateAccessRequestApproval/
+			// ListAccessRequestApprovals to THIS server's real storage backend,
+			// instead of RemoteStorage's six AccessRequest methods having no server
+			// endpoint to call at all (the ENTIRE self-service access-request
+			// workflow — request/list/approve/reject/withdraw, ADR-024 — was
+			// completely non-functional under storage.type: remote). Exactly the
+			// same pattern as the invitations proxy above: a thin passthrough onto
+			// storage.Storage (no access-request POLICY decision — dual-control
+			// threshold, maker-checker, TTL/expiry, the role grant itself, audit
+			// writes, notifications — is made here; that stays entirely in the
+			// CALLING server's own internal/core.KeyorixCore, exactly as it does
+			// against a local backend). Deliberately does NOT reuse the human-facing
+			// /projects/{id}/access-requests* routes as the proxy target — those
+			// call straight into core.KeyorixCore business logic (audit writes,
+			// notifications, actor resolved from THIS server's own request context)
+			// which would double-apply and misattribute to the hub's own service
+			// credential rather than the real requester/approver; see
+			// access_request_proxy.go's package doc. Reuses the SAME
+			// system.read/system.write tier as every other proxy in this group — no
+			// new privilege class. UpdateAccessRequestProxy inherits
+			// local_invitations.go's conditional `WHERE id = ? AND state =
+			// 'pending'` write verbatim, and CreateAccessRequestApprovalProxy
+			// inherits the DB-level unique-index-backed ON CONFLICT DO NOTHING
+			// insert — see remote_invitations.go's package doc for the full
+			// atomicity analysis (every method already resolves in one
+			// storage.Storage call server-side, so proxying it as one HTTP round
+			// trip preserves the #277 approve/reject/withdraw race guarantee
+			// unchanged). Read is baseline system.read; create/update require
+			// system.write, matching every other admin-level mutation in this
+			// group.
+			r.Get("/access-requests/{id}", catalogHandler.GetAccessRequestProxy)
+			r.Get("/access-requests", catalogHandler.ListAccessRequestsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/access-requests", catalogHandler.CreateAccessRequestProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/access-requests/{id}", catalogHandler.UpdateAccessRequestProxy)
+			r.Get("/access-requests/{id}/approvals", catalogHandler.ListAccessRequestApprovalsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/access-requests/{id}/approvals", catalogHandler.CreateAccessRequestApprovalProxy)
+
 			// Dynamic-secrets storage-primitive proxy (round-116 finding). Lets a
 			// downstream Keyorix server booted with storage.type: remote (ADR-049)
 			// proxy CreateDynamicSecretConfig/GetDynamicSecretConfig/


### PR DESCRIPTION
## Summary
- Round-119 finding #523 (MEDIUM): `CreateAccessRequest`/`GetAccessRequest`/`UpdateAccessRequest`/`ListAccessRequests`/`CreateAccessRequestApproval`/`ListAccessRequestApprovals` were unconditional stubs under `storage.type: remote`, breaking the entire self-service access-request workflow (request/list/approve/reject/withdraw) end to end.
- Added 6 new thin passthrough routes under `/api/v1/system/access-requests*`, gated by the same `system.read`/`system.write` tier used by every other system-proxy route (no new privilege class) — the existing human-facing `/projects/{id}/access-requests*` routes bake in audit-log writes and actor-context logic that would be wrong to re-invoke on the upstream hub, so those were deliberately not reused (same class of mistake this campaign has previously caught and avoided).
- No new atomic storage primitive was needed: both `UpdateAccessRequest` and `CreateAccessRequestApproval` already resolve within a single conditional storage call locally (`UPDATE ... WHERE state='pending'` / unique-constrained `INSERT ... ON CONFLICT DO NOTHING`), so a 1:1 HTTP proxy preserves the same atomicity guarantee — verified via a 20-way concurrent-update race test asserting exactly one winner.
- Removed the 6 allowlist entries from the `RemoteStorage` completeness guard (`internal/storage/store/remote_unsupported_completeness_test.go`).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/storage/store/... ./server/http/... ./internal/core/...` — all pass (one pre-existing, unrelated flake: `TestConcurrency_RequestPasswordReset_BurstIsThrottled`)
- [x] New end-to-end proxy test suite in `server/http/remote_storage_access_request_test.go`, including the concurrent-race proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)