### PR TITLE
fix(rbac): proxy permission catalog under storage.type: remote

### DIFF
--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -4,6 +4,7 @@
 //
 //	AssignRole, RemoveRole, GetUserRoles, GetUserPermissions,
 //	CreatePermission, AssignPermissionToRole,
+//	ListPermissions, GetPermission, GetRolePermissions (#526),
 //	Project/Environment stubs.
 //
 // For the local (GORM) equivalent see local_rbac.go.
@@ -273,19 +274,97 @@ func (rs *RemoteStorage) AssignPermissionToRole(_ context.Context, _, _ uint) er
 	return fmt.Errorf("not supported in remote storage")
 }
 
-// ListPermissions is not implemented in remote storage.
-func (rs *RemoteStorage) ListPermissions(_ context.Context) ([]*models.Permission, error) {
-	return nil, remoteUnsupported("ListPermissions")
+// ListPermissions lists the full permission catalog via remote API. #526: the
+// permission catalog is a near-static, seeded-not-created-dynamically read —
+// RemoteStorage has no local database to fall back on, so a spoke server's
+// catalog view (and everything that depends on it) was 100% broken. Reuses
+// the EXISTING human-facing GET /api/v1/permissions route
+// (server/http/router.go, roles.read-gated), same as the interactive UI —
+// no new route needed. The handler wraps the list in {"permissions":...,
+// "total":...} (server/http/handlers/rbac.go's ListPermissions), so this
+// unmarshals into that shape rather than a bare array.
+func (rs *RemoteStorage) ListPermissions(ctx context.Context) ([]*models.Permission, error) {
+	resp, err := rs.client.Get(ctx, "/api/v1/permissions")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list permissions: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list permissions failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Permissions []*models.Permission `json:"permissions"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Permissions, nil
 }
 
-// GetPermission is not implemented in remote storage.
-func (rs *RemoteStorage) GetPermission(_ context.Context, _ uint) (*models.Permission, error) {
-	return nil, remoteUnsupported("GetPermission")
+// GetPermission retrieves a single permission by ID via remote API. #526:
+// AssignPermissionToRole (internal/core/rbac_management.go) calls this first
+// to resolve permissionID -> name for the #169 self-permission-check before
+// assigning — with no local DB, this was an unconditional stub, so assigning
+// a permission to a role hard-failed under storage.type: remote. Unlike
+// ListPermissions/GetRolePermissions, no existing route covered a per-ID
+// permission lookup, so this adds GET /api/v1/permissions/{id}
+// (server/http/router.go, server/http/handlers/rbac.go's new GetPermission
+// handler) as a sibling of the existing GET /api/v1/permissions collection,
+// gated by the SAME roles.read — a caller who can already enumerate every
+// permission via ListPermissions gains no new capability by looking one up
+// individually. Mirrors GetRoleByName's bare-object response shape (not
+// wrapped), since the new handler was written to return the permission
+// directly.
+func (rs *RemoteStorage) GetPermission(ctx context.Context, id uint) (*models.Permission, error) {
+	path := fmt.Sprintf("/api/v1/permissions/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get permission: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get permission failed: %s", resp.Error.Error())
+	}
+	var result models.Permission
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &result, nil
 }
 
-// GetRolePermissions is not implemented in remote storage.
-func (rs *RemoteStorage) GetRolePermissions(_ context.Context, _ uint) ([]*models.Permission, error) {
-	return nil, remoteUnsupported("GetRolePermissions")
+// GetRolePermissions retrieves a role's assigned permissions via remote API.
+// #526: real callers span the role-permission view (GetRoleWithPermissions),
+// requireGranterHoldsRolePermissions's grant-time admin-rank-ceiling check
+// (authz.go), and several read-only RBAC-dependent reports — access reviews
+// (access_review.go), compliance posture's dormant-admin-tier-grant scan
+// (compliance_posture.go), and SoD conflict detection (sod.go) — all broken
+// with no local DB fallback. Reuses the EXISTING human-facing
+// GET /api/v1/roles/{id}/permissions route (server/http/router.go,
+// roles.read-gated), same as the interactive UI. Confirmed read-only: every
+// caller either renders a view or feeds a report; the one authorization use
+// (requireGranterHoldsRolePermissions) reads the role's CURRENT permission
+// bundle to check the actor's own standing authority, not as one half of a
+// check-then-act mutation on the bundle itself — the same sequential-read
+// exposure already exists for LocalStorage's two plain (non-transactional)
+// DB calls, so proxying over HTTP (RemoteStorage.WithTransaction is a no-op
+// passthrough) introduces no NEW atomicity gap. The handler wraps the list in
+// {"role_id":...,"role_name":...,"permissions":...} (server/http/handlers/
+// rbac.go's GetRolePermissions), so this unmarshals into that shape rather
+// than a bare array.
+func (rs *RemoteStorage) GetRolePermissions(ctx context.Context, roleID uint) ([]*models.Permission, error) {
+	path := fmt.Sprintf("/api/v1/roles/%d/permissions", roleID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get role permissions: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get role permissions failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Permissions []*models.Permission `json:"permissions"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Permissions, nil
 }
 
 // RemovePermissionFromRole revokes a permission from a role via the REST API.

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -75,10 +75,11 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"ConsumeMFARecoveryCode": {statusIntentional,
 		"round 119 audit: sole caller is VerifyMFACredentials, same bypassed-branch reasoning as MarkTOTPStepUsed — recovery codes are only ever consumed at login, never during enrollment/management"},
 
-	// --- Confirmed genuine gaps, tracked for future fix rounds (47; UpdateLoginLockoutState
+	// --- Confirmed genuine gaps, tracked for future fix rounds (44; UpdateLoginLockoutState
 	// closed by #529, SSO login state closed by #521, GetActiveMFAChallenge/
 	// ConsumeMFAChallenge (WebAuthn-as-second-factor login) closed by #522, Connect
-	// ref-grant CRUD closed by #527) ---
+	// ref-grant CRUD closed by #527, RBAC permission catalog (ListPermissions/
+	// GetPermission/GetRolePermissions) closed by #526) ---
 	// See docs/security/HARDENING-BACKLOG.md's round 119 entry for full detail,
 	// severity, and grouping. Each entry below cites the real caller/route a
 	// round-119 audit traced (not assumed).
@@ -133,12 +134,6 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 		"round 119: multiple last-global-admin guards, access reviews, RestoreProject's admin-ceiling check, compliance posture, SCIM"},
 	"ListProjectMachineRoleAssignments": {statusKnownGap,
 		"round 119: machine-identity access-review coverage (#91), GET /projects/{id}/access-review"},
-
-	// RBAC permission catalog — no local fallback exists (RemoteStorage has no DB).
-	"ListPermissions": {statusKnownGap, "round 119: GET /permissions"},
-	"GetPermission":   {statusKnownGap, "round 119: AssignPermissionToRole, POST /roles/{id}/permissions"},
-	"GetRolePermissions": {statusKnownGap,
-		"round 119: role-permission view, access reviews, compliance posture, SoD conflict detection — GET /roles/{id}/permissions and multiple internal core callers"},
 
 	// Project / environment catalog CRUD.
 	"ListProjects": {statusKnownGap,

--- a/internal/storage/store/remote_unsupported_test.go
+++ b/internal/storage/store/remote_unsupported_test.go
@@ -24,16 +24,17 @@ func TestRemoteStorage_UnsupportedSentinel(t *testing.T) {
 
 	calls := map[string]func() error{
 		// ListProjectInvitations (#507), CreateProjectMembership (#511),
-		// CreateGroup (#514), and CreateMachineIdentity (#518) now make a real HTTP
-		// call rather than stubbing out — see
+		// CreateGroup (#514), CreateMachineIdentity (#518), and
+		// ListPermissions/GetPermission/GetRolePermissions (#526) now make a
+		// real HTTP call rather than stubbing out — see
 		// server/http/remote_storage_invitations_test.go,
 		// server/http/remote_storage_project_memberships_test.go,
-		// server/http/remote_storage_groups_test.go, and
-		// server/http/remote_storage_machine_identities_test.go for their
+		// server/http/remote_storage_groups_test.go,
+		// server/http/remote_storage_machine_identities_test.go, and
+		// server/http/remote_storage_rbac_permission_catalog_test.go for their
 		// end-to-end coverage against a real router.
 		"CreateAccessRequest": func() error { _, e := rs.CreateAccessRequest(ctx, &models.AccessRequest{}); return e },
 		"CreateNotification":  func() error { _, e := rs.CreateNotification(ctx, &models.Notification{}); return e },
-		"ListPermissions":     func() error { _, e := rs.ListPermissions(ctx); return e },
 		// CountStaleMachineIdentitiesByProject (#393) legitimately stays a stub —
 		// the grouped hygiene-rollup query runs server-side, out of #518's scope
 		// (see remote_machine_identities.go's own doc comment).

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -2426,6 +2426,20 @@ paths:
           description: "Envelope `data` has `permissions[]` (id, name, resource, ...) and `total`."
         '401': {$ref: '#/components/responses/Error'}
 
+  /api/v1/permissions/{id}:
+    parameters:
+      - {name: id, in: path, required: true, schema: {type: integer}}
+    get:
+      tags: [Permissions]
+      summary: Get a single permission by ID
+      operationId: getPermission
+      security: [{bearerAuth: []}]
+      responses:
+        '200':
+          description: "Envelope `data` is the permission (id, name, description, resource, action)."
+        '401': {$ref: '#/components/responses/Error'}
+        '404': {$ref: '#/components/responses/Error'}
+
   /api/v1/user-roles:
     post:
       tags: [UserRoles]

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -559,6 +559,42 @@ func (h *RBACHandler) ListPermissions(w http.ResponseWriter, r *http.Request) {
 	sendSuccess(w, map[string]interface{}{"permissions": perms, "total": len(perms)}, "")
 }
 
+// GetPermission handles GET /api/v1/permissions/{id} — added for #526 as the
+// sibling lookup RemoteStorage.GetPermission proxies onto (server/http/router.go,
+// internal/storage/store/remote_rbac.go): ListPermissions and
+// GetRolePermissions already had human-facing routes to reuse, but no route
+// previously covered a per-ID permission lookup, which AssignPermissionToRole
+// needs to resolve permissionID -> name. Gated by the SAME roles.read as the
+// rest of the /permissions group — a caller who can already enumerate every
+// permission (including this one) via GET /permissions gains no new
+// capability from looking one up individually. Returns the bare permission
+// object (not wrapped), matching GetRoleByName's response shape.
+func (h *RBACHandler) GetPermission(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	id, ok := parseUintParam(w, r, "id")
+	if !ok {
+		return
+	}
+
+	perm, err := h.coreService.Storage().GetPermission(r.Context(), id)
+	if err != nil {
+		log.Printf("Error getting permission: %v", err)
+		if strings.Contains(err.Error(), "not found") {
+			sendError(w, "NotFound", "Permission not found", http.StatusNotFound, nil)
+		} else {
+			sendError(w, "InternalError", "Failed to get permission", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+
+	sendSuccess(w, perm, "")
+}
+
 // GetRolePermissions handles GET /api/v1/roles/{id}/permissions
 func (h *RBACHandler) GetRolePermissions(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/remote_storage_rbac_permission_catalog_test.go
+++ b/server/http/remote_storage_rbac_permission_catalog_test.go
@@ -1,0 +1,183 @@
+// remote_storage_rbac_permission_catalog_test.go — end-to-end coverage for
+// #526: RemoteStorage's ListPermissions/GetPermission/GetRolePermissions were
+// unconditional stubs, and RemoteStorage has no local database to fall back
+// on (confirmed — it's a pure HTTP client), so the RBAC permission catalog
+// was 100% unreachable under storage.type: remote — breaking the permission
+// catalog view, assigning a permission to a role, and every RBAC-dependent
+// report that resolves a role's permission bundle (access reviews,
+// compliance posture, SoD conflict detection). Mirrors
+// remote_storage_sso_state_test.go's #521 harness exactly: a real "upstream"
+// exercised through the production NewRouter/handlers, and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote pointed at
+// "upstream" over real HTTP via store.RemoteStorage.
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForRBACPermissionCatalog builds the standard
+// #452/#507/#510/#521 two-server harness: an "upstream" exercised through the
+// REAL production NewRouter/handlers, and a "downstream" *core.KeyorixCore
+// configured with storage.type: remote (ADR-049), pointed at "upstream" over
+// real HTTP via store.RemoteStorage.
+func newUpstreamDownstreamForRBACPermissionCatalog(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	return upstream, downstream
+}
+
+// TestRemoteStorageRBACPermissionCatalog_ListPermissions_RealServer proves the
+// #526 fix: the seeded permission catalog is visible via the downstream's
+// RemoteStorage, over a real HTTP round trip against the real router — not a
+// protocol mock.
+func TestRemoteStorageRBACPermissionCatalog_ListPermissions_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRBACPermissionCatalog(t)
+	ctx := context.Background()
+
+	want, err := upstream.Storage().ListPermissions(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, want, "bootstrap must have seeded the permission catalog")
+
+	got, err := downstream.Storage().ListPermissions(ctx)
+	require.NoError(t, err, "listing permissions must succeed via storage.type: remote")
+	assert.Len(t, got, len(want))
+
+	gotNames := make(map[string]bool, len(got))
+	for _, p := range got {
+		gotNames[p.Name] = true
+	}
+	for _, p := range want {
+		assert.True(t, gotNames[p.Name], "seeded permission %q missing from the remote-proxied list", p.Name)
+	}
+}
+
+// TestRemoteStorageRBACPermissionCatalog_GetPermission_RealServer proves a
+// single seeded permission round-trips every field (name/description/
+// resource/action) via the downstream's RemoteStorage.
+func TestRemoteStorageRBACPermissionCatalog_GetPermission_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRBACPermissionCatalog(t)
+	ctx := context.Background()
+
+	perms, err := upstream.Storage().ListPermissions(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, perms)
+
+	var want *struct {
+		ID          uint
+		Name        string
+		Description string
+		Resource    string
+		Action      string
+	}
+	for _, p := range perms {
+		if p.Name == "roles.read" {
+			want = &struct {
+				ID          uint
+				Name        string
+				Description string
+				Resource    string
+				Action      string
+			}{p.ID, p.Name, p.Description, p.Resource, p.Action}
+			break
+		}
+	}
+	require.NotNil(t, want, "bootstrap must seed a roles.read permission")
+
+	got, err := downstream.Storage().GetPermission(ctx, want.ID)
+	require.NoError(t, err, "getting a permission by ID must succeed via storage.type: remote")
+	assert.Equal(t, want.ID, got.ID)
+	assert.Equal(t, want.Name, got.Name)
+	assert.Equal(t, want.Description, got.Description)
+	assert.Equal(t, want.Resource, got.Resource)
+	assert.Equal(t, want.Action, got.Action)
+}
+
+// TestRemoteStorageRBACPermissionCatalog_GetPermission_UnknownID_RealServer
+// proves a clean not-found error (not a panic, not a garbage 500) for a
+// permission ID that was never seeded.
+func TestRemoteStorageRBACPermissionCatalog_GetPermission_UnknownID_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForRBACPermissionCatalog(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetPermission(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageRBACPermissionCatalog_GetRolePermissions_RealServer proves
+// the #526 fix for the real callers this finding named: the role-permission
+// view (GetRoleWithPermissions), the grant-time admin-rank-ceiling check
+// (requireGranterHoldsRolePermissions in authz.go), and RBAC-dependent
+// reports (access reviews, compliance posture, SoD conflict detection) all
+// resolve a role's CURRENT bundled permissions via this method — verified
+// here against the seeded "viewer" role's known, small permission set
+// (secrets.read, users.read, audit.read).
+func TestRemoteStorageRBACPermissionCatalog_GetRolePermissions_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRBACPermissionCatalog(t)
+	ctx := context.Background()
+
+	viewerRole, err := upstream.Storage().GetRoleByName(ctx, "viewer")
+	require.NoError(t, err)
+	require.NotZero(t, viewerRole.ID)
+
+	want, err := upstream.Storage().GetRolePermissions(ctx, viewerRole.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, want)
+
+	got, err := downstream.Storage().GetRolePermissions(ctx, viewerRole.ID)
+	require.NoError(t, err, "getting a role's permissions must succeed via storage.type: remote")
+	assert.Len(t, got, len(want))
+
+	gotNames := make(map[string]bool, len(got))
+	for _, p := range got {
+		gotNames[p.Name] = true
+	}
+	for _, want := range []string{"secrets.read", "users.read", "audit.read"} {
+		assert.True(t, gotNames[want], "viewer role's bundled permission %q missing from the remote-proxied list", want)
+	}
+}
+
+// TestRemoteStorageRBACPermissionCatalog_GetRolePermissions_UnknownRole_RealServer
+// proves a clean not-found error (not a panic, not a silent empty list) for a
+// role ID that was never seeded.
+func TestRemoteStorageRBACPermissionCatalog_GetRolePermissions_UnknownRole_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForRBACPermissionCatalog(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetRolePermissions(ctx, 999999)
+	require.Error(t, err)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -750,6 +750,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Route("/permissions", func(r chi.Router) {
 			r.Use(customMiddleware.RequirePermission("roles.read"))
 			r.Get("/", rbacHandler.ListPermissions)
+			// #526: RemoteStorage's storage.type: remote proxy for
+			// AssignPermissionToRole's permissionID -> name lookup had no route
+			// to call (ListPermissions and GetRolePermissions already had
+			// routes to reuse; this was the one gap). Same roles.read gate as
+			// the collection route above — no new capability, a caller who can
+			// already list every permission can already see this one.
+			r.Get("/{id}", rbacHandler.GetPermission)
 		})
 
 		// NOTE: the legacy admin-managed "service accounts" (APIClient/APIToken)


### PR DESCRIPTION
## Summary
- Round-119 finding #526 (MEDIUM): `ListPermissions`/`GetPermission`/`GetRolePermissions` were unconditional stubs under `storage.type: remote`, and `RemoteStorage` has no local DB fallback — breaking the permission catalog view, role-permission assignment, and several RBAC-dependent compliance reports (access review, compliance posture, SoD conflict detection).
- No atomicity concern: all 3 methods are pure reads. The one authorization-adjacent caller (`requireGranterHoldsRolePermissions`) reads a role's current permission bundle to check the actor's own standing authority at grant time, not one half of a check-then-act mutation — the same sequential-read exposure already exists against `LocalStorage`'s own two plain calls, so proxying over HTTP adds no new gap.
- Reused the existing human-facing routes where they already existed (`GET /api/v1/permissions`, `GET /api/v1/roles/{id}/permissions`, both `roles.read`-gated) rather than adding a new `/api/v1/system/...` namespace — these are plain catalog reads with no actor-context business logic to worry about double-applying. Added the one missing per-ID route, `GET /api/v1/permissions/{id}`, as a sibling under the existing `/permissions` route group with the same gate.
- Removed the 3 allowlist entries from the `RemoteStorage` completeness guard.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/storage/store/... ./server/http/... ./internal/core/...` — 2300 tests pass
- [x] New end-to-end proxy tests in `server/http/remote_storage_rbac_permission_catalog_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)