### PR TITLE
fix(scheduler): proxy scheduler lock under storage.type: remote

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -19,6 +19,15 @@ func (m *MockStorage) WithSchedulerLock(_ context.Context, _ int64, fn func() er
 	return true, fn()
 }
 
+// TryAcquireSchedulerLock/ReleaseSchedulerLock are no-ops in tests (single
+// instance, nothing to contend with) — mirrors WithSchedulerLock above.
+func (m *MockStorage) TryAcquireSchedulerLock(_ context.Context, _ int64, _ string, _ time.Duration) (bool, error) {
+	return true, nil
+}
+func (m *MockStorage) ReleaseSchedulerLock(_ context.Context, _ int64, _ string) error {
+	return nil
+}
+
 // WithAuditCheckpointLock runs fn directly in tests (single instance, no DB lock).
 func (m *MockStorage) WithAuditCheckpointLock(_ context.Context, fn func() error) error {
 	return fn()

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -33,6 +33,35 @@ type Storage interface {
 	// when another replica holds the lock — the caller should simply skip this tick.
 	WithSchedulerLock(ctx context.Context, key int64, fn func() error) (ran bool, err error)
 
+	// TryAcquireSchedulerLock and ReleaseSchedulerLock (#530) are the two
+	// building blocks WithSchedulerLock is composed from. They exist as their
+	// own Storage methods (rather than being private to one implementation) so
+	// that RemoteStorage's WithSchedulerLock can acquire, run fn locally against
+	// itself (which may in turn make its own further proxied calls), and release
+	// as two separate HTTP round trips — a real cross-process transaction cannot
+	// span the acquire and release the way LocalStorage's single in-process call
+	// does, so each half must be independently atomic and safely idempotent.
+	//
+	// TryAcquireSchedulerLock atomically attempts to take (or renew, if holder
+	// already owns it) the named lock for ttl, in ONE round trip: acquired=true
+	// only when this holder now owns it (a fresh acquire, a reclaim of an
+	// expired lease, or a renewal of its own still-held lease); acquired=false
+	// when a DIFFERENT holder's lease has not yet expired. Calling it again with
+	// the SAME holder before ExpiresAt is therefore a safe heartbeat/renewal,
+	// not a new acquisition attempt.
+	TryAcquireSchedulerLock(ctx context.Context, key int64, holder string, ttl time.Duration) (acquired bool, err error)
+
+	// ReleaseSchedulerLock releases the named lock IFF it is still held by
+	// holder — a conditional delete, never a bare unconditional one, so a
+	// holder whose lease already expired (and was possibly reclaimed by a
+	// different holder in the meantime) can never clobber that newer holder's
+	// lease. A release for a lock this holder does not (or no longer) own is a
+	// silent no-op, not an error — mirroring ConsumeSSOLoginState's
+	// already-consumed-is-not-an-error stance for the same reason: the caller's
+	// own crashed-holder safety net is ExpiresAt, not a hard release
+	// requirement.
+	ReleaseSchedulerLock(ctx context.Context, key int64, holder string) error
+
 	// WithAuditCheckpointLock serializes the audit-checkpoint chain-walk + decide +
 	// create-checkpoint sequence (ADR-029) across every trigger — the scheduler tick,
 	// the HTTP POST /api/v1/audit/checkpoint endpoint, and the gRPC

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -572,6 +572,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	legalHoldExists := tableExists(db, "legal_holds")
 	riskExceptionExists := tableExists(db, "risk_exceptions")
 	ssoLoginStateExists := tableExists(db, "sso_login_states")
+	schedulerLockLeaseExists := tableExists(db, "scheduler_lock_leases")
 	sodExists := tableExists(db, "sod_policies")
 	secretDepExists := tableExists(db, "secret_dependencies")
 	pwHistExists := tableExists(db, "password_histories")
@@ -837,6 +838,17 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error {
 	if !ssoLoginStateExists {
 		if err := db.AutoMigrate(&models.SSOLoginState{}); err != nil {
 			return fmt.Errorf("failed to migrate sso_login_states table: %w", err)
+		}
+	}
+
+	// Create the scheduler-lock-lease table if missing (#530, additive). Backs
+	// TryAcquireSchedulerLock/ReleaseSchedulerLock — the TTL-bounded distributed
+	// mutex a storage.type: remote spoke's WithSchedulerLock now proxies through,
+	// independent of (and never migrated onto) the pre-existing Postgres advisory
+	// lock local WithSchedulerLock still uses for a server's OWN scheduler ticks.
+	if !schedulerLockLeaseExists {
+		if err := db.AutoMigrate(&models.SchedulerLockLease{}); err != nil {
+			return fmt.Errorf("failed to migrate scheduler_lock_leases table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -154,6 +154,27 @@ type SSOLoginState struct {
 	CreatedAt time.Time
 }
 
+// SchedulerLockLease is a TTL-bounded distributed-mutex row backing
+// TryAcquireSchedulerLock/ReleaseSchedulerLock (#530). Unlike LocalStorage's
+// own WithSchedulerLock (a Postgres session advisory lock held for the exact
+// duration of one in-process call), this primitive exists so a
+// storage.type: remote (ADR-049) spoke can acquire the SAME single-replica
+// guarantee over two separate HTTP round trips (acquire, then release once its
+// locally-run scheduler job finishes) without ever pinning a live DB
+// connection across requests: Holder proves ownership so a stale/expired
+// holder can never release (or be mistaken for holding) a lease a newer
+// holder has since won, and ExpiresAt bounds how long a crashed or
+// network-partitioned holder can wedge the key — a fresh acquire attempt past
+// ExpiresAt reclaims the row unconditionally. One row per lock Key — Key is
+// the primary key, so the DB itself rejects a second concurrent row for the
+// same lock (the belt-and-suspenders case TryAcquireSchedulerLock's own
+// isUniqueViolation check handles).
+type SchedulerLockLease struct {
+	Key       int64     `gorm:"primaryKey;autoIncrement:false"`
+	Holder    string    `gorm:"not null"` // opaque per-acquisition token, not a stable identity
+	ExpiresAt time.Time `gorm:"index"`
+}
+
 // RiskException records a governed acceptance of a known control gap or policy
 // exception (ISO 27001 A.5.8 risk treatment / A.5.36 compliance-with-policies): a
 // named risk, accepted by an owner with a written justification, for a bounded time.

--- a/internal/storage/store/local_scheduler_lock_lease.go
+++ b/internal/storage/store/local_scheduler_lock_lease.go
@@ -1,0 +1,98 @@
+// local_scheduler_lock_lease.go — the TTL-bounded distributed-mutex primitive
+// backing RemoteStorage's WithSchedulerLock (#530): TryAcquireSchedulerLock and
+// ReleaseSchedulerLock, both single-round-trip-atomic so they stay safe when
+// called over HTTP by a storage.type: remote spoke (remote_scheduler_lock.go),
+// where no transaction can span two separate requests.
+//
+// Deliberately independent of WithSchedulerLock/local_scheduler_lock.go's
+// Postgres session advisory lock: that mechanism ties the lock's lifetime to a
+// single pinned DB connection held for the exact duration of one in-process
+// call, which cannot survive being split across an acquire request and a LATER
+// release request (the connection would have to stay pinned, out of the pool,
+// for however long the caller's fn takes — unbounded, and it would not
+// auto-release on a crashed HTTP caller the way a dropped DB session does
+// locally). A row-based lease with an explicit TTL sidesteps both problems: it
+// needs no pinned connection between requests, it works identically on
+// Postgres and SQLite (advisory locks are Postgres-only), and a crashed or
+// network-partitioned holder self-heals once ExpiresAt passes rather than
+// wedging the key forever — the same "never permanently blocks a legitimate
+// re-acquire" safety property the local advisory lock gets for free from
+// Postgres closing the session.
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// TryAcquireSchedulerLock attempts, in one transaction (so the read-then-
+// decide-then-write below is atomic against a concurrent attempt on the same
+// key — including on Postgres, where the SELECT is taken under a row lock),
+// to take or renew the named lock for holder.
+//
+//   - No row exists yet: insert one. A concurrent racer's insert can still slip
+//     in between this transaction's own SELECT and INSERT; the primary key
+//     (Key) turns that into a unique-constraint violation, caught below and
+//     treated as "lost the race" rather than a hard error.
+//   - A row exists, held by holder itself (not yet expired, or expired — either
+//     way it's this holder's own lease): update ExpiresAt. This is the renewal/
+//     heartbeat path RemoteStorage.WithSchedulerLock uses to extend the lease
+//     while fn is still running, without needing a distinct "renew" method.
+//   - A row exists, held by a DIFFERENT holder and not yet expired: acquired
+//     stays false — the lock is genuinely contended.
+//   - A row exists, held by a different holder but already expired: reclaim it
+//     for the new holder (crash/partition self-heal).
+func (ls *LocalStorage) TryAcquireSchedulerLock(ctx context.Context, key int64, holder string, ttl time.Duration) (bool, error) {
+	now := time.Now()
+	expiresAt := now.Add(ttl)
+	acquired := false
+	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		q := tx
+		if tx.Dialector.Name() == "postgres" {
+			q = q.Clauses(clause.Locking{Strength: "UPDATE"})
+		}
+		var existing models.SchedulerLockLease
+		err := q.Where("key = ?", key).Take(&existing).Error
+		switch {
+		case errors.Is(err, gorm.ErrRecordNotFound):
+			if createErr := tx.Create(&models.SchedulerLockLease{Key: key, Holder: holder, ExpiresAt: expiresAt}).Error; createErr != nil {
+				if isUniqueViolation(createErr) {
+					return nil // lost the race to a concurrent first-time acquire; acquired stays false
+				}
+				return createErr
+			}
+			acquired = true
+			return nil
+		case err != nil:
+			return err
+		default:
+			if existing.Holder != holder && existing.ExpiresAt.After(now) {
+				return nil // held by someone else and not yet expired — genuinely contended
+			}
+			if updErr := tx.Model(&models.SchedulerLockLease{}).Where("key = ?", key).
+				Updates(map[string]any{"holder": holder, "expires_at": expiresAt}).Error; updErr != nil {
+				return updErr
+			}
+			acquired = true
+			return nil
+		}
+	})
+	if err != nil {
+		return false, err
+	}
+	return acquired, nil
+}
+
+// ReleaseSchedulerLock deletes the lease row IFF it is still held by holder —
+// see the Storage interface doc for why an ownership mismatch is a silent
+// no-op rather than an error.
+func (ls *LocalStorage) ReleaseSchedulerLock(ctx context.Context, key int64, holder string) error {
+	return ls.db.WithContext(ctx).
+		Where("key = ? AND holder = ?", key, holder).
+		Delete(&models.SchedulerLockLease{}).Error
+}

--- a/internal/storage/store/local_scheduler_lock_lease_test.go
+++ b/internal/storage/store/local_scheduler_lock_lease_test.go
@@ -1,0 +1,155 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newSchedLockLeaseStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SchedulerLockLease{}))
+	return NewLocalStorage(db)
+}
+
+// A fresh key is acquired on the very first attempt.
+func TestTryAcquireSchedulerLock_FirstAcquireSucceeds(t *testing.T) {
+	ls := newSchedLockLeaseStore(t)
+	ctx := context.Background()
+
+	acquired, err := ls.TryAcquireSchedulerLock(ctx, 42, "holder-a", time.Minute)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+}
+
+// A second, different holder cannot acquire a lock that's still within its TTL.
+func TestTryAcquireSchedulerLock_ContendedLockRejectsOtherHolder(t *testing.T) {
+	ls := newSchedLockLeaseStore(t)
+	ctx := context.Background()
+
+	acquired, err := ls.TryAcquireSchedulerLock(ctx, 42, "holder-a", time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	acquired, err = ls.TryAcquireSchedulerLock(ctx, 42, "holder-b", time.Minute)
+	require.NoError(t, err)
+	assert.False(t, acquired, "a live, differently-held lease must reject a competing holder")
+}
+
+// Calling TryAcquireSchedulerLock again with the SAME holder renews the lease
+// (the heartbeat path) rather than being rejected as contended.
+func TestTryAcquireSchedulerLock_SameHolderRenews(t *testing.T) {
+	ls := newSchedLockLeaseStore(t)
+	ctx := context.Background()
+
+	acquired, err := ls.TryAcquireSchedulerLock(ctx, 42, "holder-a", time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	acquired, err = ls.TryAcquireSchedulerLock(ctx, 42, "holder-a", time.Minute)
+	require.NoError(t, err)
+	assert.True(t, acquired, "the same holder renewing its own still-live lease must succeed")
+}
+
+// An expired lease is reclaimable by a different holder — the crash/partition
+// self-heal property.
+func TestTryAcquireSchedulerLock_ExpiredLeaseIsReclaimable(t *testing.T) {
+	ls := newSchedLockLeaseStore(t)
+	ctx := context.Background()
+
+	acquired, err := ls.TryAcquireSchedulerLock(ctx, 42, "holder-a", -time.Second) // already expired
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	acquired, err = ls.TryAcquireSchedulerLock(ctx, 42, "holder-b", time.Minute)
+	require.NoError(t, err)
+	assert.True(t, acquired, "an expired lease must be reclaimable by a different holder")
+}
+
+// ReleaseSchedulerLock is a conditional delete: it only removes the row when
+// holder still matches, and is a silent no-op otherwise (never an error).
+func TestReleaseSchedulerLock_OwnershipMismatchIsNoop(t *testing.T) {
+	ls := newSchedLockLeaseStore(t)
+	ctx := context.Background()
+
+	acquired, err := ls.TryAcquireSchedulerLock(ctx, 42, "holder-a", time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	// A DIFFERENT holder attempting to release must be a silent no-op, not an error.
+	require.NoError(t, ls.ReleaseSchedulerLock(ctx, 42, "holder-b"))
+
+	// holder-a's lease must still be intact — a second holder can't acquire it.
+	acquired, err = ls.TryAcquireSchedulerLock(ctx, 42, "holder-b", time.Minute)
+	require.NoError(t, err)
+	assert.False(t, acquired, "release by the wrong holder must not have cleared the lease")
+
+	// The real owner CAN release it, and the key becomes immediately acquirable.
+	require.NoError(t, ls.ReleaseSchedulerLock(ctx, 42, "holder-a"))
+	acquired, err = ls.TryAcquireSchedulerLock(ctx, 42, "holder-c", time.Minute)
+	require.NoError(t, err)
+	assert.True(t, acquired, "a genuine release must free the key for the next acquirer")
+}
+
+// Releasing a lock that was never acquired is a no-op, not an error.
+func TestReleaseSchedulerLock_NeverAcquiredIsNoop(t *testing.T) {
+	ls := newSchedLockLeaseStore(t)
+	require.NoError(t, ls.ReleaseSchedulerLock(context.Background(), 999, "nobody"))
+}
+
+// Concurrent first-time acquire attempts on the SAME key must serialize to
+// exactly one winner — the core exclusivity guarantee this whole primitive
+// exists for. Uses a real file-backed SQLite DB with WAL + a busy timeout
+// (concurrentDB, same helper local_break_glass_test.go's equivalent race test
+// uses) so connections genuinely contend; a single shared in-memory connection
+// would serialize every statement and mask the race this test exists to
+// catch. The real-HTTP version of this race (proving it survives a
+// storage.type: remote HTTP hop, not just an in-process DB transaction) lives
+// in server/http/remote_storage_scheduler_lock_test.go.
+func TestTryAcquireSchedulerLock_ConcurrentFirstAcquireHasExactlyOneWinner(t *testing.T) {
+	db := concurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.SchedulerLockLease{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	const racers = 16
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	winners := 0
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			// Each racer uses its OWN distinct holder token, exactly as the real
+			// RemoteStorage.WithSchedulerLock caller does (newSchedulerLockHolderToken
+			// mints a fresh one per attempt) — using the same token for every
+			// racer would make every attempt after the first look like that
+			// SAME holder legitimately renewing its own lease, masking the
+			// exclusivity race this test exists to catch.
+			holder := fmt.Sprintf("holder-%d", i)
+			acquired, err := ls.TryAcquireSchedulerLock(ctx, 7, holder, time.Minute)
+			assert.NoError(t, err)
+			if acquired {
+				mu.Lock()
+				winners++
+				mu.Unlock()
+			}
+		}(i)
+	}
+	close(start) // release all racers at once
+	wg.Wait()
+
+	assert.Equal(t, 1, winners, "exactly one concurrent first-time acquire attempt may win")
+}

--- a/internal/storage/store/remote_scheduler_lock.go
+++ b/internal/storage/store/remote_scheduler_lock.go
@@ -1,15 +1,176 @@
 package store
 
-import "context"
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+)
 
-// WithSchedulerLock is a confirmed genuine gap (round 119 completeness audit),
-// not the "never reached remotely" claim this comment previously made —
-// server/main.go starts every background scheduler unconditionally regardless
-// of storage.type, so this fails (returning false, not-acquired) on every tick
-// of a storage.type: remote deployment too. It is now the sole blocker keeping
-// several already-remote-proxied maintenance operations (e.g. #520's
-// retention-purge fix) from ever actually running on a schedule there. Tracked
-// in docs/security/HARDENING-BACKLOG.md; see remote_unsupported_completeness_test.go.
-func (rs *RemoteStorage) WithSchedulerLock(_ context.Context, _ int64, _ func() error) (bool, error) {
-	return false, remoteUnsupported("WithSchedulerLock")
+// WithSchedulerLock is reached on EVERY scheduler tick regardless of
+// storage.type — server/main.go starts every background scheduler
+// unconditionally — so a stub here (as this method used to be) is not the
+// "never reached remotely" case some of this package's other stubs are: it was
+// the sole blocker preventing several already-remote-proxied maintenance
+// operations (notably #520's retention-purge fix) from ever actually running
+// on a schedule under storage.type: remote, because the lock wrapping them
+// failed first, before their own proxy logic ever got a chance to run (#530).
+//
+// fn cannot travel over the wire (it's an arbitrary closure that itself makes
+// further RemoteStorage calls back through rs), so this cannot be a single
+// atomic HTTP round trip the way, say, TransitionMachineIdentityState is.
+// Instead it's TWO atomic round trips around fn running locally:
+//
+//  1. TryAcquireSchedulerLock — one atomic conditional write on the upstream,
+//     exactly like LocalStorage's own advisory-lock acquire, just expressed as
+//     a TTL lease row instead of a Postgres session lock (see
+//     local_scheduler_lock_lease.go's package doc for why: a lease survives
+//     being split across requests, an advisory lock does not).
+//  2. fn runs locally, exactly as LocalStorage's WithSchedulerLock runs it
+//     in-process, under panic recovery (runProtected).
+//  3. ReleaseSchedulerLock — one atomic conditional delete, best-effort (its
+//     failure is logged, not returned — see below for why).
+//
+// Between (1) and (3), a background heartbeat renews the lease (calling
+// TryAcquireSchedulerLock again with the SAME holder token, which — per that
+// method's own contract — is a safe renewal, not a new acquisition attempt) so
+// a long-running fn is never preempted by its own lease expiring mid-job. If
+// this process crashes or loses network connectivity to the upstream while fn
+// is running, the heartbeats simply stop and the lease self-heals via
+// ExpiresAt — replicating the exact safety property LocalStorage gets for free
+// from Postgres tearing down the advisory lock's session on a dead connection
+// (see the interface doc's ReleaseSchedulerLock comment).
+//
+// A best-effort release (rather than surfacing its error to the caller)
+// mirrors that the lock has ALREADY served its purpose by the time release
+// runs — fn already committed or failed — and ExpiresAt is the actual
+// correctness backstop either way; failing the whole scheduler tick over a
+// release that didn't make it to the upstream would incorrectly treat this
+// tick's real outcome (whatever fn returned) as a failure.
+func (rs *RemoteStorage) WithSchedulerLock(ctx context.Context, key int64, fn func() error) (bool, error) {
+	holder, err := newSchedulerLockHolderToken()
+	if err != nil {
+		return false, fmt.Errorf("failed to generate scheduler lock holder token: %w", err)
+	}
+
+	acquired, err := rs.TryAcquireSchedulerLock(ctx, key, holder, schedulerLockTTL)
+	if err != nil {
+		return false, err
+	}
+	if !acquired {
+		return false, nil
+	}
+
+	heartbeatCtx, stopHeartbeat := context.WithCancel(context.Background())
+	heartbeatDone := make(chan struct{})
+	go func() {
+		defer close(heartbeatDone)
+		ticker := time.NewTicker(schedulerLockHeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case <-ticker.C:
+				if _, err := rs.TryAcquireSchedulerLock(heartbeatCtx, key, holder, schedulerLockTTL); err != nil {
+					log.Printf("scheduler lock %d: heartbeat renewal failed (holder %s): %v", key, holder, err)
+				}
+			}
+		}
+	}()
+	defer func() {
+		stopHeartbeat()
+		<-heartbeatDone
+		// Best-effort: see the doc comment above for why this must not fail the tick.
+		if err := rs.ReleaseSchedulerLock(context.Background(), key, holder); err != nil {
+			log.Printf("scheduler lock %d: release failed (holder %s), relying on TTL expiry: %v", key, holder, err)
+		}
+	}()
+
+	return true, runProtected(fn)
+}
+
+// schedulerLockTTL is how long an acquired (or renewed) scheduler-lock lease
+// stays valid without a heartbeat. Large relative to
+// schedulerLockHeartbeatInterval so a couple of missed heartbeats (a transient
+// network blip to the upstream) don't cost the lock, while still bounding how
+// long a genuinely crashed/partitioned holder can wedge the key.
+const schedulerLockTTL = 45 * time.Second
+
+// schedulerLockHeartbeatInterval is how often WithSchedulerLock renews its
+// lease while fn is still running. A third of schedulerLockTTL, so a single
+// missed heartbeat is never enough to lose the lock.
+const schedulerLockHeartbeatInterval = 15 * time.Second
+
+// newSchedulerLockHolderToken returns a fresh random per-acquisition-attempt
+// token (mirrors internal/core/sso.go's randToken) — not a stable per-process
+// identity, since a single process can hold multiple different scheduler locks
+// (different keys) concurrently, each needing to prove ownership of only its
+// own lease independently.
+func newSchedulerLockHolderToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// schedulerLockAcquireRequest/schedulerLockAcquireResponse are the wire shapes
+// for POST /api/v1/system/scheduler-lock/acquire.
+type schedulerLockAcquireRequest struct {
+	Key       int64  `json:"key"`
+	Holder    string `json:"holder"`
+	TTLMillis int64  `json:"ttl_millis"`
+}
+
+type schedulerLockAcquireResponse struct {
+	Acquired bool `json:"acquired"`
+}
+
+// TryAcquireSchedulerLock proxies to POST /api/v1/system/scheduler-lock/acquire,
+// which performs the SAME atomic conditional write LocalStorage's
+// TryAcquireSchedulerLock does, server-side, in this ONE request — see that
+// method's doc comment for the full acquire/renew/reclaim decision table this
+// single round trip implements.
+func (rs *RemoteStorage) TryAcquireSchedulerLock(ctx context.Context, key int64, holder string, ttl time.Duration) (bool, error) {
+	body := schedulerLockAcquireRequest{Key: key, Holder: holder, TTLMillis: ttl.Milliseconds()}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/scheduler-lock/acquire", body)
+	if err != nil {
+		return false, fmt.Errorf("failed to acquire scheduler lock: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("acquire scheduler lock failed: %s", resp.Error.Error())
+	}
+	var result schedulerLockAcquireResponse
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Acquired, nil
+}
+
+// schedulerLockReleaseRequest is the wire shape for POST
+// /api/v1/system/scheduler-lock/release.
+type schedulerLockReleaseRequest struct {
+	Key    int64  `json:"key"`
+	Holder string `json:"holder"`
+}
+
+// ReleaseSchedulerLock proxies to POST /api/v1/system/scheduler-lock/release,
+// which performs the SAME atomic conditional delete LocalStorage's
+// ReleaseSchedulerLock does — a release for a lock this holder doesn't (or no
+// longer) own is a silent no-op on the upstream too, matching the interface
+// doc's contract exactly across this HTTP hop.
+func (rs *RemoteStorage) ReleaseSchedulerLock(ctx context.Context, key int64, holder string) error {
+	body := schedulerLockReleaseRequest{Key: key, Holder: holder}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/scheduler-lock/release", body)
+	if err != nil {
+		return fmt.Errorf("failed to release scheduler lock: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("release scheduler lock failed: %s", resp.Error.Error())
+	}
+	return nil
 }

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -75,10 +75,10 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"ConsumeMFARecoveryCode": {statusIntentional,
 		"round 119 audit: sole caller is VerifyMFACredentials, same bypassed-branch reasoning as MarkTOTPStepUsed — recovery codes are only ever consumed at login, never during enrollment/management"},
 
-	// --- Confirmed genuine gaps, tracked for future fix rounds (47; UpdateLoginLockoutState
+	// --- Confirmed genuine gaps, tracked for future fix rounds (46; UpdateLoginLockoutState
 	// closed by #529, SSO login state closed by #521, GetActiveMFAChallenge/
 	// ConsumeMFAChallenge (WebAuthn-as-second-factor login) closed by #522, Connect
-	// ref-grant CRUD closed by #527) ---
+	// ref-grant CRUD closed by #527, WithSchedulerLock closed by #530) ---
 	// See docs/security/HARDENING-BACKLOG.md's round 119 entry for full detail,
 	// severity, and grouping. Each entry below cites the real caller/route a
 	// round-119 audit traced (not assumed).
@@ -160,13 +160,6 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 		"round 119: secret copy (same-project and cross-environment), dynamic-secrets issue/renew-lease. NOTE: CreateSecret's own call site already has a deliberate errors.Is(ErrUnsupportedByBackend) carve-out (#499) and is NOT part of this gap — only every OTHER caller is broken"},
 	"DeleteEnvironment":  {statusKnownGap, "round 119: DELETE /environments/{id}"},
 	"RestoreEnvironment": {statusKnownGap, "round 119: POST /projects/{projectId}/environments/{id}/restore"},
-
-	// Scheduler locking — reached on EVERY tick regardless of storage.type
-	// (server/main.go starts all schedulers unconditionally), and is now the
-	// sole blocker preventing already-remote-proxied maintenance (e.g. #520's
-	// retention-purge fix) from ever running via its scheduler on a spoke server.
-	"WithSchedulerLock": {statusKnownGap,
-		"round 119: server/scheduler_run.go's lockedRun wraps every background scheduler (retention purge, auto-rotation, recertification, dynamic-secret sweep, JIT-access expiry, login-attempt prune, anomaly detection, reminders, compliance digest, evidence delivery) — its own doc comment claiming this, is never reached remotely is disproven by server/main.go starting every scheduler unconditionally"},
 
 	// Misc.
 	"LastUserSecretActivity": {statusKnownGap,

--- a/server/http/handlers/scheduler_lock_proxy.go
+++ b/server/http/handlers/scheduler_lock_proxy.go
@@ -1,0 +1,109 @@
+// scheduler_lock_proxy.go — server-side endpoints backing RemoteStorage's
+// TryAcquireSchedulerLock/ReleaseSchedulerLock (#530).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) runs
+// EVERY background scheduler unconditionally (server/main.go), each wrapped in
+// storage.Storage's single-replica-gating WithSchedulerLock (ADR-039) — but
+// RemoteStorage had no server endpoint to call at all for it, so every one of
+// those schedulers (retention purge, auto-rotation, recertification, dynamic-
+// secret sweep, JIT-access expiry, login-attempt prune, anomaly detection,
+// reminders, compliance digest, evidence delivery) failed to even ACQUIRE the
+// lock on every tick, never mind run — including already-remote-proxied work
+// like #520's retention purge, whose own (correct) proxy logic never got a
+// chance to run. These two routes (registered in server/http/router.go under
+// /api/v1/system/scheduler-lock, gated on the existing system.read/
+// system.write RBAC permissions — the SAME credential a RemoteStorage client
+// already needs for every other proxied call, so this introduces no new
+// privilege class) close that gap.
+//
+// Atomicity: unlike a plain CRUD proxy, a distributed lock's acquire step
+// cannot be "check, then write" over two separate remote calls — that would
+// trivially reopen the exact race the lock exists to prevent (two callers,
+// or a spoke and the hub, both believing they won). Each handler below calls
+// exactly ONE storage.Storage method that performs its ENTIRE conditional
+// decision (acquire vs. reject vs. reclaim-expired, or release-iff-still-owned)
+// server-side inside a single transaction/statement — see
+// internal/storage/store/local_scheduler_lock_lease.go's package doc and
+// method comments for the full atomicity analysis. No lock POLICY (which key,
+// how long to hold it, when to renew) is made here; that stays entirely in the
+// CALLING server's own RemoteStorage.WithSchedulerLock, exactly as
+// LocalStorage.WithSchedulerLock decides it against a local backend.
+//
+// Response envelope: like the other proxies (see login_attempts_proxy.go),
+// these do NOT use the package's generic sendSuccess/sendError helpers — they
+// use writeRemoteAPISuccess/writeRemoteAPIError, the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses.
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+)
+
+// schedulerLockAcquireBody is the wire body for POST
+// /api/v1/system/scheduler-lock/acquire.
+type schedulerLockAcquireBody struct {
+	Key       int64  `json:"key"`
+	Holder    string `json:"holder"`
+	TTLMillis int64  `json:"ttl_millis"`
+}
+
+// AcquireSchedulerLockProxy handles POST /api/v1/system/scheduler-lock/acquire.
+// It calls storage.TryAcquireSchedulerLock directly, so it performs the SAME
+// atomic acquire-or-renew-or-reclaim decision local_scheduler_lock_lease.go's
+// own TryAcquireSchedulerLock does — the exclusivity guarantee
+// RemoteStorage.WithSchedulerLock depends on survives this HTTP hop unchanged.
+func (h *AuthHandler) AcquireSchedulerLockProxy(w http.ResponseWriter, r *http.Request) {
+	var body schedulerLockAcquireBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Holder == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "holder is required")
+		return
+	}
+	if body.TTLMillis <= 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "ttl_millis must be positive")
+		return
+	}
+	acquired, err := h.coreService.Storage().TryAcquireSchedulerLock(r.Context(), body.Key, body.Holder, time.Duration(body.TTLMillis)*time.Millisecond)
+	if err != nil {
+		log.Printf("scheduler-lock proxy: acquire failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"acquired": acquired})
+}
+
+// schedulerLockReleaseBody is the wire body for POST
+// /api/v1/system/scheduler-lock/release.
+type schedulerLockReleaseBody struct {
+	Key    int64  `json:"key"`
+	Holder string `json:"holder"`
+}
+
+// ReleaseSchedulerLockProxy handles POST /api/v1/system/scheduler-lock/release.
+// It calls storage.ReleaseSchedulerLock directly, so a release for a lock this
+// holder does not (or no longer) own is a silent no-op here too, exactly as
+// local_scheduler_lock_lease.go's own ReleaseSchedulerLock behaves.
+func (h *AuthHandler) ReleaseSchedulerLockProxy(w http.ResponseWriter, r *http.Request) {
+	var body schedulerLockReleaseBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Holder == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "holder is required")
+		return
+	}
+	if err := h.coreService.Storage().ReleaseSchedulerLock(r.Context(), body.Key, body.Holder); err != nil {
+		log.Printf("scheduler-lock proxy: release failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"released": true})
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -139,6 +139,9 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		// #521: the SSO-login-state-proxy end-to-end tests exercise
 		// SSOLoginState create/consume through the real router.
 		&models.SSOLoginState{},
+		// #530: the scheduler-lock-proxy end-to-end tests exercise
+		// TryAcquireSchedulerLock/ReleaseSchedulerLock through the real router.
+		&models.SchedulerLockLease{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the

--- a/server/http/remote_storage_scheduler_lock_test.go
+++ b/server/http/remote_storage_scheduler_lock_test.go
@@ -1,0 +1,174 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForSchedulerLock builds the standard #452/#507-style
+// two-server harness (see remote_storage_machine_identities_test.go's
+// newUpstreamDownstreamForMachineIdentities for the full pattern doc): an
+// "upstream" exercised through the REAL production NewRouter/handlers
+// (including the new /api/v1/system/scheduler-lock routes,
+// server/http/handlers/scheduler_lock_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed at
+// "upstream" over real HTTP via store.RemoteStorage.
+func newUpstreamDownstreamForSchedulerLock(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	return upstream, downstream
+}
+
+// TestRemoteStorageSchedulerLock_AcquireRunRelease_RealServer proves the basic
+// fix end to end: a downstream (storage.type: remote) WithSchedulerLock call
+// genuinely acquires a lease row on the upstream, runs fn, and releases it —
+// so a SECOND, sequential call for the same key succeeds again immediately
+// (proving release actually happened, not just that the TTL hadn't expired
+// yet).
+func TestRemoteStorageSchedulerLock_AcquireRunRelease_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForSchedulerLock(t)
+	ctx := context.Background()
+
+	var ran1 bool
+	ok, err := downstream.Storage().WithSchedulerLock(ctx, 4242, func() error {
+		ran1 = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, ok, "an uncontended lock must be acquired via storage.type: remote")
+	assert.True(t, ran1, "fn must run when the lock is acquired")
+
+	var ran2 bool
+	ok, err = downstream.Storage().WithSchedulerLock(ctx, 4242, func() error {
+		ran2 = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, ok, "a second sequential call must re-acquire the SAME key — proving the first call actually released it")
+	assert.True(t, ran2)
+}
+
+// TestRemoteStorageSchedulerLock_ContendedLockIsSkipped_RealServer proves a
+// lock genuinely held by one holder (via the low-level
+// TryAcquireSchedulerLock primitive, simulating a second live scheduler
+// replica) blocks a second WithSchedulerLock caller for the SAME key: it
+// returns (false, nil) — "skip this tick" — rather than running fn.
+func TestRemoteStorageSchedulerLock_ContendedLockIsSkipped_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForSchedulerLock(t)
+	ctx := context.Background()
+
+	acquired, err := downstream.Storage().TryAcquireSchedulerLock(ctx, 777, "other-replica", time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	ran := false
+	ok, err := downstream.Storage().WithSchedulerLock(ctx, 777, func() error {
+		ran = true
+		return nil
+	})
+	require.NoError(t, err, "a skipped tick is not an error")
+	assert.False(t, ok, "a lock already held by a different holder must not be acquired")
+	assert.False(t, ran, "fn must not run when the lock could not be acquired")
+}
+
+// TestRemoteStorageSchedulerLock_ConcurrentRaceIsSerialized_RealServer is the
+// concurrency test for the #530 atomicity fix, mirroring
+// TestRemoteStorageMachineIdentities_TransitionState_ConcurrentRaceIsSerialized_RealServer's
+// style: N goroutines on the SAME downstream (storage.type: remote)
+// core.KeyorixCore race to WithSchedulerLock the SAME key concurrently against
+// a REAL upstream server (not a mock). Without TryAcquireSchedulerLock's
+// single-round-trip atomic conditional write, a naive "check if locked, then
+// acquire" pair of separate remote calls would let two racers both observe
+// "unlocked" and both proceed to "acquire" — reopening the exact
+// double-execution race the lock exists to prevent. This proves fn is never
+// observed running on two racers at once, no matter how many concurrently
+// attempt to acquire the same key.
+func TestRemoteStorageSchedulerLock_ConcurrentRaceIsSerialized_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForSchedulerLock(t)
+	ctx := context.Background()
+
+	const key = 9090
+	const racers = 12
+
+	var mu sync.Mutex
+	inFlight := false
+	var concurrentOverlapDetected atomic.Bool
+	var timesRan atomic.Int64
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			ok, err := downstream.Storage().WithSchedulerLock(ctx, key, func() error {
+				mu.Lock()
+				if inFlight {
+					concurrentOverlapDetected.Store(true)
+				}
+				inFlight = true
+				mu.Unlock()
+
+				// Hold the "lock" for long enough that a broken (non-atomic)
+				// implementation racing another goroutine's acquire attempt
+				// during this window would very likely both observe
+				// "unlocked" and both proceed — giving the race a real chance
+				// to manifest rather than being masked by sheer speed.
+				time.Sleep(30 * time.Millisecond)
+
+				mu.Lock()
+				inFlight = false
+				mu.Unlock()
+				return nil
+			})
+			assert.NoError(t, err)
+			if ok {
+				timesRan.Add(1)
+			}
+		}()
+	}
+	close(start) // release all racers at once
+	wg.Wait()
+
+	assert.False(t, concurrentOverlapDetected.Load(),
+		"fn must never be observed running on two racing WithSchedulerLock callers at the same time")
+	assert.GreaterOrEqual(t, timesRan.Load(), int64(1),
+		"at least one racer must have won the lock and actually run fn")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1356,6 +1356,31 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/users/purge", userHandler.PurgeDeletedUsersBeforeProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/projects/purge", catalogHandler.PurgeDeletedProjectsBeforeProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/environments/purge", catalogHandler.PurgeDeletedEnvironmentsBeforeProxy)
+
+			// Scheduler-lock storage-primitive proxy (#530). Lets a downstream
+			// Keyorix server booted with storage.type: remote (ADR-049) proxy
+			// TryAcquireSchedulerLock/ReleaseSchedulerLock to THIS server's real
+			// storage backend, instead of RemoteStorage.WithSchedulerLock having no
+			// server endpoint to call at all (every background scheduler runs
+			// unconditionally regardless of storage.type, so this was the sole
+			// blocker preventing already-remote-proxied maintenance — e.g. the
+			// retention proxy immediately above, #520 — from ever actually running
+			// on a schedule under storage.type: remote). Exactly the same pattern
+			// as the retention proxy above: a thin passthrough onto storage.Storage
+			// (no lock POLICY — which key, how long to hold it, when to renew — is
+			// made here; that stays entirely in the CALLING server's own
+			// RemoteStorage.WithSchedulerLock, exactly as LocalStorage.
+			// WithSchedulerLock decides it against a local backend), reusing the
+			// SAME system.read/system.write tier — no new privilege class. BOTH
+			// routes are mutations (acquiring or releasing a lock changes state)
+			// and require system.write; there is no read-only variant. See
+			// scheduler_lock_proxy.go's package doc for the atomicity analysis:
+			// each route performs its ENTIRE conditional decision inside ONE
+			// storage.Storage call, so no naive "check, then write" pair is ever
+			// exposed over this HTTP hop to reopen the exclusivity race the lock
+			// exists to prevent.
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/scheduler-lock/acquire", authHandler.AcquireSchedulerLockProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/scheduler-lock/release", authHandler.ReleaseSchedulerLockProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary

`WithSchedulerLock` is reached on **every** scheduler tick regardless of `storage.type` — `server/main.go` starts every background scheduler unconditionally. `RemoteStorage.WithSchedulerLock` was an unconditional `remoteUnsupported(...)` stub (its own doc comment's "never reached remotely" claim was already disproven by round-119's audit), so every scheduler tick on a `storage.type: remote` (ADR-049) spoke failed to even *acquire* the lock — never mind run. This was the sole blocker keeping several already-remote-proxied maintenance operations, notably #520's retention-purge fix, from ever actually running on a schedule there: the lock wrapping them failed first, before their own (already-working) proxy logic ever got a chance to run. Closes #530.

## Atomicity design

`fn` (the scheduler job) can't travel over the wire — it's an arbitrary closure that itself makes further `RemoteStorage` calls back through the client — so this can't be a single atomic HTTP round trip the way, say, `TransitionMachineIdentityState` is. A naive "check if locked, then acquire" pair of separate remote calls would trivially reopen the exact race the lock exists to prevent (two callers, or a spoke and the hub, both believing they won).

Instead:

1. **`TryAcquireSchedulerLock(key, holder, ttl)`** — one atomic conditional write in a single DB transaction, backing a new `scheduler_lock_leases` table (`key` PK, `holder`, `expires_at`). One round trip decides: fresh acquire (no row), renewal (row already held by the same holder — this doubles as the heartbeat path), reject (a different holder's lease hasn't expired), or reclaim (a different holder's lease has expired). Implemented once on `LocalStorage` and called both by the HTTP handler on the hub and, over HTTP, by `RemoteStorage`.
2. `fn` runs **locally** on the spoke (under the existing `runProtected` panic guard), exactly as `LocalStorage.WithSchedulerLock` runs it in-process.
3. A background **heartbeat** renews the lease (same `TryAcquireSchedulerLock` call, same holder token) every 15s against a 45s TTL, so a long-running job is never preempted by its own lease expiring mid-run.
4. **`ReleaseSchedulerLock(key, holder)`** — a conditional delete (`WHERE key = ? AND holder = ?`), best-effort on release: a release for a lock this holder doesn't (or no longer) own is a silent no-op, never an error, so a lease reclaimed by a newer holder can never be clobbered.

This is deliberately a **separate primitive** from `LocalStorage.WithSchedulerLock`'s own Postgres session advisory lock (`pg_try_advisory_lock`/`pg_advisory_unlock`), which stays untouched: an advisory lock is tied to a single pinned DB connection held for the exact duration of one in-process call, and cannot survive being split across an acquire request and a *later* release request without pinning that connection indefinitely between HTTP round trips. A TTL-bounded lease row sidesteps that: no connection needs to stay pinned between requests, it works identically on Postgres and SQLite, and — critically — a crashed or network-partitioned holder self-heals once `ExpiresAt` passes, rather than wedging the key forever. That replicates the same "never permanently blocks a legitimate re-acquire" safety property Postgres gives the local advisory lock for free by tearing down the lock's session when a connection dies.

New routes, gated on the existing `system.write` permission (no new privilege class, same tier every other proxy in this campaign reuses):

- `POST /api/v1/system/scheduler-lock/acquire`
- `POST /api/v1/system/scheduler-lock/release`

## Testing

- `internal/storage/store/local_scheduler_lock_lease_test.go`: unit tests for acquire/renew/reject/reclaim/release semantics, plus an in-process concurrent-race test (`concurrentDB`, real file-backed SQLite with WAL) proving exactly one of 16 concurrent first-time acquire attempts on the same key wins.
- `server/http/remote_storage_scheduler_lock_test.go`: real-HTTP two-server harness (upstream via the real router, downstream via `RemoteStorage`), mirroring `TestRemoteStorageMachineIdentities_TransitionState_ConcurrentRaceIsSerialized_RealServer`'s style:
  - acquire → run → release → re-acquire succeeds (proves release actually happened, not just TTL luck)
  - a lock held by a different holder is skipped (`ran=false`, no error)
  - **the concurrency proof**: 12 goroutines race `WithSchedulerLock` for the same key against a real upstream server; `fn` sleeps 30ms while holding the lock, and the test asserts `fn` is never observed running on two racers simultaneously.
- `remote_unsupported_completeness_test.go`'s `remoteUnsupportedAllowlist`: removed the `WithSchedulerLock` entry, decremented the tracked-gap count, noted "closed by #530".
- `go build ./...` and `go test ./internal/storage/store/... ./server/http/... ./server/...` all pass (1061 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)