### PR TITLE
fix(catalog): proxy project/environment catalog CRUD under storage.type: remote

### DIFF
--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -137,30 +137,29 @@ func (c *KeyorixCore) ProjectRequiresMFA(ctx context.Context, projectID uint) (b
 // itself (the lease stays revoke_failed/retryable, same as any other RevokeLeasesForConfig
 // use, and is reachable again via the sweep or a manual retry once the target recovers).
 func (c *KeyorixCore) DeleteProject(ctx context.Context, id uint, force bool) error {
-	// #313: the guard count and the cascade delete used to be two separate top-level
-	// storage calls, with core-layer control flow in between — a secret created in that
-	// window silently got swept into the cascade despite the caller expecting the delete
-	// to be rejected. Run the guard and the delete inside one transaction (a nested
-	// savepoint over LocalStorage.DeleteProject's own transaction) so the count that
-	// gates the reject is the same one the cascade acts on, not a stale read.
-	if err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
-		if !force {
-			projectID := id
-			_, total, err := tx.ListSecrets(ctx, &storage.SecretFilter{
-				ProjectID: &projectID,
-				Page:      1,
-				PageSize:  1,
-			})
-			if err != nil {
-				return fmt.Errorf("failed to check project secrets: %w", err)
-			}
-			if total > 0 {
-				return fmt.Errorf("project has %d secret(s) — delete them first or use --force to cascade", total)
-			}
+	// #313 / #528: the guard count and the cascade delete must not run as two separate
+	// top-level storage calls with core-layer control flow in between — a secret created
+	// in that window would silently get swept into the cascade despite the caller
+	// expecting the delete to be rejected. #313 originally closed this by running both
+	// inside one storage.WithTransaction call; #528 replaced that with
+	// DeleteProjectIfEmpty, a single atomic storage primitive doing the same guard+
+	// cascade in ONE call — WithTransaction is a real transaction only for LocalStorage
+	// (RemoteStorage.WithTransaction is a no-op passthrough over HTTP, so the original
+	// two-call pair reopened this exact TOCTOU window across a full network round trip
+	// under storage.type: remote). force=true intentionally skips the guard entirely and
+	// keeps calling the plain unconditional cascade.
+	if force {
+		if err := c.storage.DeleteProject(ctx, id); err != nil {
+			return err
 		}
-		return tx.DeleteProject(ctx, id)
-	}); err != nil {
-		return err
+	} else {
+		blocking, err := c.storage.DeleteProjectIfEmpty(ctx, id)
+		if err != nil {
+			return err
+		}
+		if blocking > 0 {
+			return fmt.Errorf("project has %d secret(s) — delete them first or use --force to cascade", blocking)
+		}
 	}
 	c.revokeProjectDynamicSecretLeases(ctx, id)
 	return nil

--- a/internal/core/catalog_delete_project_test.go
+++ b/internal/core/catalog_delete_project_test.go
@@ -18,60 +18,44 @@ import (
 	"gorm.io/gorm"
 )
 
-// --- #313 structural regression -------------------------------------------------
+// --- #313 / #528 structural regression --------------------------------------------
 //
-// DeleteProject's non-force guard (count-then-reject) used to run as a separate
-// top-level storage call, entirely before — not inside — the cascade delete's own
-// transaction. A secret created in that window silently got swept into the cascade
-// despite the caller expecting the delete to be rejected. The fix runs the guard and
-// the cascade inside one storage.WithTransaction call, so the count the guard acts on
-// is read from, and committed alongside, the exact same transaction as the delete.
+// DeleteProject's non-force guard (count-then-reject) must never run as two separate
+// top-level storage calls with core-layer control flow in between — a secret created
+// in that window would silently get swept into the cascade despite the caller
+// expecting the delete to be rejected. #313 originally closed this by running the
+// guard and the cascade inside one storage.WithTransaction call. #528 replaced that
+// with DeleteProjectIfEmpty, a single atomic storage.Storage primitive doing the same
+// guard+cascade in ONE call — necessary because WithTransaction is a real transaction
+// only for LocalStorage; RemoteStorage.WithTransaction is a no-op passthrough over
+// HTTP, so the original two-call pair reopened this exact TOCTOU window across a full
+// network round trip under storage.type: remote. See the storage.Storage interface's
+// DeleteProjectIfEmpty doc comment for the full rationale.
 //
-// deleteProjectOuterSpy/deleteProjectTxSpy assert that structurally: the outer spy
-// implements only WithTransaction (every other storage.Storage method is left on a
-// nil-embedded interface, so calling one panics on a nil pointer dereference) — so if
-// DeleteProject ever again calls ListSecrets or DeleteProject directly on the
-// non-transactional outer storage instead of the tx-scoped one WithTransaction hands
-// it, this test fails loudly instead of silently passing.
+// deleteProjectSpy asserts that structurally: it implements ONLY DeleteProject and
+// DeleteProjectIfEmpty (every other storage.Storage method is left on a nil-embedded
+// interface, so calling one panics on a nil pointer dereference) — so if DeleteProject
+// ever again decomposes the guard+cascade into separate ListSecrets/DeleteProject
+// calls (reopening the #313/#528 TOCTOU under storage.type: remote), this test fails
+// loudly instead of silently passing.
 
-type deleteProjectOuterSpy struct {
-	storage.Storage // left nil: any method besides WithTransaction panics if reached
-	txCalled        bool
-	tx              *deleteProjectTxSpy
+type deleteProjectSpy struct {
+	storage.Storage     // left nil: any method besides the ones below panics if reached
+	blockingSecretCount int
+	deleteIfEmptyErr    error
+	deleteErr           error
+	callOrder           []string
 }
 
-func (s *deleteProjectOuterSpy) WithTransaction(ctx context.Context, fn func(storage.Storage) error) error {
-	s.txCalled = true
-	return fn(s.tx)
-}
-
-// ListDynamicSecretConfigs is called on the OUTER (non-transactional) storage by
-// DeleteProject's #369 post-commit dynamic-secrets cascade, deliberately after
-// WithTransaction returns (see revokeProjectDynamicSecretLeases's doc comment) — so,
-// unlike ListSecrets/DeleteProject above, it must be implemented here, not on the tx
-// spy. Returns none: these tests aren't exercising the dynamic-secrets cascade itself
-// (see TestDeleteProject_RealStorage_DisablesDynamicSecretConfigsAndRevokesLeases).
-func (s *deleteProjectOuterSpy) ListDynamicSecretConfigs(_ context.Context, _, _ uint) ([]*models.DynamicSecretConfig, error) {
-	return nil, nil
-}
-
-type deleteProjectTxSpy struct {
-	storage.Storage // left nil: any method besides the two below panics if reached
-	listSecretsTotal int64
-	listSecretsErr   error
-	deleteErr        error
-	callOrder        []string
-}
-
-func (s *deleteProjectTxSpy) ListSecrets(_ context.Context, filter *storage.SecretFilter) ([]*models.SecretNode, int64, error) {
-	s.callOrder = append(s.callOrder, "ListSecrets")
-	if filter.ProjectID == nil || *filter.ProjectID != 7 {
-		return nil, 0, fmt.Errorf("unexpected filter: %+v", filter)
+func (s *deleteProjectSpy) DeleteProjectIfEmpty(_ context.Context, id uint) (int, error) {
+	s.callOrder = append(s.callOrder, "DeleteProjectIfEmpty")
+	if id != 7 {
+		return 0, fmt.Errorf("unexpected project id %d", id)
 	}
-	return nil, s.listSecretsTotal, s.listSecretsErr
+	return s.blockingSecretCount, s.deleteIfEmptyErr
 }
 
-func (s *deleteProjectTxSpy) DeleteProject(_ context.Context, id uint) error {
+func (s *deleteProjectSpy) DeleteProject(_ context.Context, id uint) error {
 	s.callOrder = append(s.callOrder, "DeleteProject")
 	if id != 7 {
 		return fmt.Errorf("unexpected project id %d", id)
@@ -79,38 +63,42 @@ func (s *deleteProjectTxSpy) DeleteProject(_ context.Context, id uint) error {
 	return s.deleteErr
 }
 
-func TestDeleteProject_GuardAndCascadeRunInSameTransaction(t *testing.T) {
-	tx := &deleteProjectTxSpy{listSecretsTotal: 0}
-	outer := &deleteProjectOuterSpy{tx: tx}
-	c := core.NewKeyorixCore(outer)
-
-	require.NoError(t, c.DeleteProject(context.Background(), 7, false))
-	assert.True(t, outer.txCalled, "DeleteProject must run inside storage.WithTransaction")
-	assert.Equal(t, []string{"ListSecrets", "DeleteProject"}, tx.callOrder,
-		"the guard read must happen before the cascade delete, both on the tx-scoped storage")
+// ListDynamicSecretConfigs backs DeleteProject's #369 post-commit dynamic-secrets
+// cascade (see revokeProjectDynamicSecretLeases's doc comment), deliberately after the
+// delete itself. Returns none: these tests aren't exercising the dynamic-secrets
+// cascade itself (see TestDeleteProject_RealStorage_DisablesDynamicSecretConfigsAndRevokesLeases).
+func (s *deleteProjectSpy) ListDynamicSecretConfigs(_ context.Context, _, _ uint) ([]*models.DynamicSecretConfig, error) {
+	return nil, nil
 }
 
-func TestDeleteProject_RejectsWithinTransactionWhenSecretsExist(t *testing.T) {
-	tx := &deleteProjectTxSpy{listSecretsTotal: 3}
-	outer := &deleteProjectOuterSpy{tx: tx}
-	c := core.NewKeyorixCore(outer)
+func TestDeleteProject_EmptyProjectDeletesAtomically(t *testing.T) {
+	spy := &deleteProjectSpy{blockingSecretCount: 0}
+	c := core.NewKeyorixCore(spy)
+
+	require.NoError(t, c.DeleteProject(context.Background(), 7, false))
+	assert.Equal(t, []string{"DeleteProjectIfEmpty"}, spy.callOrder,
+		"force=false must call the atomic guard+cascade primitive, not a separate ListSecrets+DeleteProject pair")
+}
+
+func TestDeleteProject_RejectsWhenSecretsExist(t *testing.T) {
+	spy := &deleteProjectSpy{blockingSecretCount: 3}
+	c := core.NewKeyorixCore(spy)
 
 	err := c.DeleteProject(context.Background(), 7, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "3 secret(s)")
-	assert.True(t, outer.txCalled, "the guard itself must still run inside the transaction")
-	assert.Equal(t, []string{"ListSecrets"}, tx.callOrder,
-		"a rejected guard must short-circuit before reaching the cascade delete")
+	assert.Equal(t, []string{"DeleteProjectIfEmpty"}, spy.callOrder,
+		"a rejected guard must not additionally call the unconditional cascade")
 }
 
-func TestDeleteProject_ForceSkipsGuardButStaysTransactional(t *testing.T) {
-	tx := &deleteProjectTxSpy{listSecretsTotal: 99} // would reject if the guard ran
-	outer := &deleteProjectOuterSpy{tx: tx}
-	c := core.NewKeyorixCore(outer)
+func TestDeleteProject_ForceSkipsGuardEntirely(t *testing.T) {
+	// blockingSecretCount would reject if the guard ran; deleteIfEmptyErr would fail
+	// the test if DeleteProjectIfEmpty were reached at all.
+	spy := &deleteProjectSpy{blockingSecretCount: 99, deleteIfEmptyErr: fmt.Errorf("must not be called")}
+	c := core.NewKeyorixCore(spy)
 
 	require.NoError(t, c.DeleteProject(context.Background(), 7, true))
-	assert.True(t, outer.txCalled)
-	assert.Equal(t, []string{"DeleteProject"}, tx.callOrder, "force=true must skip the guard entirely")
+	assert.Equal(t, []string{"DeleteProject"}, spy.callOrder, "force=true must skip the guard entirely")
 }
 
 // --- #313 real-storage integration (sequential, deterministic) -------------------

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -87,6 +87,13 @@ func (m *MockStorage) DeleteProject(_ context.Context, _ uint) error {
 	return nil
 }
 
+// DeleteProjectIfEmpty defaults to "empty, delete succeeded" (0 blocking secrets) —
+// the same trivial-success default DeleteProject above uses. Tests exercising the
+// #528 guard behavior use catalog_delete_project_test.go's dedicated spies instead.
+func (m *MockStorage) DeleteProjectIfEmpty(_ context.Context, _ uint) (int, error) {
+	return 0, nil
+}
+
 func (m *MockStorage) RestoreProject(_ context.Context, _ uint) (int, int, error) {
 	return 0, 0, nil
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -58,6 +58,25 @@ type Storage interface {
 	GetProject(ctx context.Context, id uint) (*models.Project, error)
 	UpdateProject(ctx context.Context, project *models.Project) (*models.Project, error)
 	DeleteProject(ctx context.Context, id uint) error
+	// DeleteProjectIfEmpty atomically enforces DeleteProject(force=false)'s guard —
+	// reject the delete if the project still has any live secret — and, only when the
+	// project IS empty, performs the SAME cascade soft-delete DeleteProject does, all as
+	// ONE storage operation (#528). It replaces core.DeleteProject's prior
+	// WithTransaction-wrapped ListSecrets+DeleteProject pair (#313): that pair depended
+	// on WithTransaction opening a REAL transaction to keep the guard's read and the
+	// cascade's write atomic, which holds for LocalStorage but NOT for RemoteStorage —
+	// WithTransaction there is a no-op passthrough over HTTP (see its doc comment above),
+	// so a naive two-call proxy of that same pair would reopen a TOCTOU window across a
+	// full network round trip: a secret created between the count and the cascade would
+	// silently let a force=false delete cascade over it anyway, the same check-then-act-
+	// split-by-a-non-transactional-WithTransaction bug class this campaign has already
+	// hit repeatedly. Folding the guard and the cascade into one call closes that gap for
+	// both backends alike — under LocalStorage it is (and always was) one DB transaction;
+	// under RemoteStorage it is now one HTTP round trip executing the whole guard+cascade
+	// server-side. Returns the count of live secrets blocking the delete (0 means the
+	// delete happened) so the caller can format the same "project has N secret(s)..."
+	// error DeleteProject(force=false) has always returned.
+	DeleteProjectIfEmpty(ctx context.Context, id uint) (blockingSecretCount int, err error)
 	// RestoreProject reverses a project soft-delete and cascades to the environments/
 	// secrets that were removed WITH it (matched by deletion timestamp — independently
 	// retired children stay deleted, see LocalStorage.RestoreProject). It returns the

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -154,7 +154,14 @@ func (ls *LocalStorage) UpdateProject(ctx context.Context, project *models.Proje
 	return project, nil
 }
 
-func (ls *LocalStorage) DeleteProject(ctx context.Context, id uint) error {
+// deleteProjectCascade performs DeleteProject's soft-delete cascade (secrets, their
+// shares, environments, dynamic-secret configs, then the project itself) against tx —
+// the transaction-scoped *gorm.DB the caller (DeleteProject or DeleteProjectIfEmpty,
+// #528) is already running inside. Factored out of DeleteProject so
+// DeleteProjectIfEmpty can run the exact SAME cascade, inside its own transaction,
+// immediately after its own empty-project check, without duplicating this logic or
+// splitting the check and the cascade across two top-level storage calls.
+func deleteProjectCascade(tx *gorm.DB, id uint) error {
 	// Stamp the project and the rows the cascade soft-deletes with ONE uniform
 	// deleted_at, so RestoreProject can bring back exactly this cascade's rows and not
 	// resurrect secrets/environments that were retired independently earlier (which
@@ -162,71 +169,102 @@ func (ls *LocalStorage) DeleteProject(ctx context.Context, id uint) error {
 	// model to deleted_at IS NULL, so already-deleted children are left untouched and
 	// keep their original timestamp.
 	deletedAt := time.Now()
+	// Soft-delete all currently-live secrets in the project.
+	if err := tx.Model(&models.SecretNode{}).
+		Where("project_id = ?", id).Update("deleted_at", deletedAt).Error; err != nil {
+		return fmt.Errorf("failed to soft-delete project secrets: %w", err)
+	}
+	// Revoke every still-active share for every secret in this project (#119
+	// residual): the bulk update above is a raw UPDATE on secret_nodes, unlike
+	// DeleteSecret's per-secret path, which also revokes that secret's ShareRecord
+	// rows (#370) — so a project-cascade delete used to skip that step entirely,
+	// leaving shares for the project's secrets live. Left alone, a share would
+	// silently reactivate (via CheckSharePermission) the instant the project (and
+	// its secrets) is later restored, with zero re-authorization — exactly the
+	// hazard #370 closed for a single secret delete. The subquery is raw SQL,
+	// deliberately bypassing GORM's default deleted_at IS NULL scope on
+	// SecretNode, so it also reaches the secrets just soft-deleted above. Mirrors
+	// #370: like RestoreSecret, RestoreProject does NOT bring these shares back —
+	// "delete means gone" for sharing, whether the secret was deleted directly or
+	// via a project cascade.
+	if err := tx.Where("secret_id IN (SELECT id FROM secret_nodes WHERE project_id = ?) AND deleted_at IS NULL", id).
+		Delete(&models.ShareRecord{}).Error; err != nil {
+		return fmt.Errorf("failed to revoke project secret shares: %w", err)
+	}
+	// UserRole/GroupRole grants scoped to this project are deliberately left
+	// untouched here, unlike ShareRecord above. Both are plain composite-primary-key
+	// join rows (UserID/GroupID, RoleID, ProjectID, EnvironmentID) with no DeletedAt
+	// column of their own — soft-deleting them isn't possible without a schema
+	// migration that also reworks their primary key (a soft-deleted grant would
+	// collide with a later re-grant of the identical scope under today's PK), and
+	// RestoreProject's design (see requireAuthorityToReinstateProjectRoles / #161)
+	// depends on these rows surviving the soft-delete window unchanged so a restore
+	// fully reinstates the project's prior grants, gated by the actor's own
+	// authority. PurgeDeletedProjectsBefore already hard-deletes them once the
+	// project passes its retention window and can no longer be restored — the same
+	// cascade, just necessarily deferred until undo is off the table.
+	//
+	// Soft-delete all currently-live environments in the project.
+	if err := tx.Model(&models.Environment{}).
+		Where("project_id = ?", id).Update("deleted_at", deletedAt).Error; err != nil {
+		return fmt.Errorf("failed to soft-delete project environments: %w", err)
+	}
+	// Disable every dynamic-secret config scoped to the project (#369): a
+	// disabled project must not go on minting live database credentials.
+	// IssueLease/RenewLease refuse against a Disabled config; the caller
+	// (core.DeleteProject) revokes the configs' outstanding active leases
+	// against their real targets AFTER this transaction commits — that's
+	// network I/O to arbitrary external systems and must not hold this DB
+	// transaction open. Unlike secrets/environments, Disabled is a plain
+	// boolean with no cascade timestamp: RestoreProject deliberately does
+	// NOT clear it (see the Disabled field doc on DynamicSecretConfig).
+	if err := tx.Model(&models.DynamicSecretConfig{}).
+		Where("project_id = ? AND disabled = ?", id, false).Update("disabled", true).Error; err != nil {
+		return fmt.Errorf("failed to disable project dynamic-secret configs: %w", err)
+	}
+	// Soft-delete the project itself with the same timestamp.
+	result := tx.Model(&models.Project{}).
+		Where("id = ?", id).Update("deleted_at", deletedAt)
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete project: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("project not found")
+	}
+	return nil
+}
+
+func (ls *LocalStorage) DeleteProject(ctx context.Context, id uint) error {
 	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// Soft-delete all currently-live secrets in the project.
-		if err := tx.Model(&models.SecretNode{}).
-			Where("project_id = ?", id).Update("deleted_at", deletedAt).Error; err != nil {
-			return fmt.Errorf("failed to soft-delete project secrets: %w", err)
-		}
-		// Revoke every still-active share for every secret in this project (#119
-		// residual): the bulk update above is a raw UPDATE on secret_nodes, unlike
-		// DeleteSecret's per-secret path, which also revokes that secret's ShareRecord
-		// rows (#370) — so a project-cascade delete used to skip that step entirely,
-		// leaving shares for the project's secrets live. Left alone, a share would
-		// silently reactivate (via CheckSharePermission) the instant the project (and
-		// its secrets) is later restored, with zero re-authorization — exactly the
-		// hazard #370 closed for a single secret delete. The subquery is raw SQL,
-		// deliberately bypassing GORM's default deleted_at IS NULL scope on
-		// SecretNode, so it also reaches the secrets just soft-deleted above. Mirrors
-		// #370: like RestoreSecret, RestoreProject does NOT bring these shares back —
-		// "delete means gone" for sharing, whether the secret was deleted directly or
-		// via a project cascade.
-		if err := tx.Where("secret_id IN (SELECT id FROM secret_nodes WHERE project_id = ?) AND deleted_at IS NULL", id).
-			Delete(&models.ShareRecord{}).Error; err != nil {
-			return fmt.Errorf("failed to revoke project secret shares: %w", err)
-		}
-		// UserRole/GroupRole grants scoped to this project are deliberately left
-		// untouched here, unlike ShareRecord above. Both are plain composite-primary-key
-		// join rows (UserID/GroupID, RoleID, ProjectID, EnvironmentID) with no DeletedAt
-		// column of their own — soft-deleting them isn't possible without a schema
-		// migration that also reworks their primary key (a soft-deleted grant would
-		// collide with a later re-grant of the identical scope under today's PK), and
-		// RestoreProject's design (see requireAuthorityToReinstateProjectRoles / #161)
-		// depends on these rows surviving the soft-delete window unchanged so a restore
-		// fully reinstates the project's prior grants, gated by the actor's own
-		// authority. PurgeDeletedProjectsBefore already hard-deletes them once the
-		// project passes its retention window and can no longer be restored — the same
-		// cascade, just necessarily deferred until undo is off the table.
-		//
-		// Soft-delete all currently-live environments in the project.
-		if err := tx.Model(&models.Environment{}).
-			Where("project_id = ?", id).Update("deleted_at", deletedAt).Error; err != nil {
-			return fmt.Errorf("failed to soft-delete project environments: %w", err)
-		}
-		// Disable every dynamic-secret config scoped to the project (#369): a
-		// disabled project must not go on minting live database credentials.
-		// IssueLease/RenewLease refuse against a Disabled config; the caller
-		// (core.DeleteProject) revokes the configs' outstanding active leases
-		// against their real targets AFTER this transaction commits — that's
-		// network I/O to arbitrary external systems and must not hold this DB
-		// transaction open. Unlike secrets/environments, Disabled is a plain
-		// boolean with no cascade timestamp: RestoreProject deliberately does
-		// NOT clear it (see the Disabled field doc on DynamicSecretConfig).
-		if err := tx.Model(&models.DynamicSecretConfig{}).
-			Where("project_id = ? AND disabled = ?", id, false).Update("disabled", true).Error; err != nil {
-			return fmt.Errorf("failed to disable project dynamic-secret configs: %w", err)
-		}
-		// Soft-delete the project itself with the same timestamp.
-		result := tx.Model(&models.Project{}).
-			Where("id = ?", id).Update("deleted_at", deletedAt)
-		if result.Error != nil {
-			return fmt.Errorf("failed to delete project: %w", result.Error)
-		}
-		if result.RowsAffected == 0 {
-			return fmt.Errorf("project not found")
-		}
-		return nil
+		return deleteProjectCascade(tx, id)
 	})
+}
+
+// DeleteProjectIfEmpty is the atomic form of DeleteProject(force=false)'s guard+cascade
+// pair (#528 — see the storage.Storage interface doc comment on this method for why).
+// Counts the project's live secrets and, only if zero, runs the exact same cascade
+// DeleteProject does — all inside ONE transaction, so the count the guard rejects on
+// is read from, and committed alongside, the same transaction as the delete (mirrors
+// #313's original guarantee, just via a single storage-layer call instead of a
+// core-layer WithTransaction wrapper).
+func (ls *LocalStorage) DeleteProjectIfEmpty(ctx context.Context, id uint) (int, error) {
+	var blockingSecretCount int
+	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var secretCount int64
+		if err := tx.Model(&models.SecretNode{}).
+			Where("project_id = ?", id).Count(&secretCount).Error; err != nil {
+			return fmt.Errorf("failed to count project secrets: %w", err)
+		}
+		if secretCount > 0 {
+			blockingSecretCount = int(secretCount)
+			return nil
+		}
+		return deleteProjectCascade(tx, id)
+	})
+	if err != nil {
+		return 0, err
+	}
+	return blockingSecretCount, nil
 }
 
 // RestoreProject reverses a project soft-delete: it clears deleted_at on the project

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -4,7 +4,8 @@
 //
 //	AssignRole, RemoveRole, GetUserRoles, GetUserPermissions,
 //	CreatePermission, AssignPermissionToRole,
-//	Project/Environment stubs.
+//	Project/Environment catalog CRUD (proxied over HTTP, #528 — see
+//	server/http/handlers/project_catalog_proxy.go and environment_catalog_proxy.go).
 //
 // For the local (GORM) equivalent see local_rbac.go.
 package store
@@ -511,7 +512,16 @@ func (rs *RemoteStorage) RoleSetHasPermission(_ context.Context, _ []uint, _ str
 	return false, fmt.Errorf("not supported in remote storage")
 }
 
-// --- Project / Environment (not supported in remote mode) ---
+// --- Project / Environment ---
+//
+// CreateProject/CreateEnvironment remain deliberately unsupported (below); every
+// OTHER project/environment catalog method is proxied over HTTP (#528) to
+// server/http/handlers/project_catalog_proxy.go and environment_catalog_proxy.go's
+// /api/v1/system/projects* and /api/v1/system/environments* routes — thin
+// passthroughs onto the SAME storage.Storage primitives internal/core/catalog.go
+// already uses against a local backend. See those handler files' package docs for
+// the reuse-vs-new-route rationale (why the human-facing /api/v1/projects routes are
+// NOT reused as the proxy target).
 
 func (rs *RemoteStorage) CreateProject(_ context.Context, _ *models.Project) (*models.Project, error) {
 	return nil, fmt.Errorf("not supported in remote storage")
@@ -521,44 +531,341 @@ func (rs *RemoteStorage) CreateEnvironment(_ context.Context, _ *models.Environm
 	return nil, fmt.Errorf("not supported in remote storage")
 }
 
-func (rs *RemoteStorage) ListProjects(_ context.Context) ([]*models.Project, error) {
-	return nil, remoteUnsupported("ListProjects")
+// projectWire mirrors models.Project's fields exactly (snake_case) — the wire shape
+// project_catalog_proxy.go's projectProxyWire sends/expects.
+type projectWire struct {
+	ID          uint       `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	RequireMFA  bool       `json:"require_mfa"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
 }
 
-func (rs *RemoteStorage) ListProjectsWithCounts(_ context.Context, _ bool) ([]storage.ProjectWithCounts, error) {
-	return nil, remoteUnsupported("ListProjectsWithCounts")
+func (w projectWire) toModel() *models.Project {
+	p := &models.Project{
+		ID:          w.ID,
+		Name:        w.Name,
+		Description: w.Description,
+		RequireMFA:  w.RequireMFA,
+		CreatedAt:   w.CreatedAt,
+		UpdatedAt:   w.UpdatedAt,
+	}
+	if w.DeletedAt != nil {
+		p.DeletedAt.Time = *w.DeletedAt
+		p.DeletedAt.Valid = true
+	}
+	return p
 }
 
-func (rs *RemoteStorage) GetProject(_ context.Context, _ uint) (*models.Project, error) {
-	return nil, remoteUnsupported("GetProject")
+func newProjectWire(p *models.Project) projectWire {
+	w := projectWire{
+		ID:          p.ID,
+		Name:        p.Name,
+		Description: p.Description,
+		RequireMFA:  p.RequireMFA,
+		CreatedAt:   p.CreatedAt,
+		UpdatedAt:   p.UpdatedAt,
+	}
+	if p.DeletedAt.Valid {
+		t := p.DeletedAt.Time
+		w.DeletedAt = &t
+	}
+	return w
 }
 
-func (rs *RemoteStorage) UpdateProject(_ context.Context, _ *models.Project) (*models.Project, error) {
-	return nil, remoteUnsupported("UpdateProject")
+func decodeProjectResponse(data json.RawMessage) (*models.Project, error) {
+	var w projectWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return w.toModel(), nil
 }
 
-func (rs *RemoteStorage) DeleteProject(_ context.Context, _ uint) error {
-	return remoteUnsupported("DeleteProject")
+// ListProjects lists every project via GET /api/v1/system/projects.
+func (rs *RemoteStorage) ListProjects(ctx context.Context) ([]*models.Project, error) {
+	resp, err := rs.client.Get(ctx, "/api/v1/system/projects")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list projects: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list projects failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Projects []projectWire `json:"projects"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	projects := make([]*models.Project, 0, len(result.Projects))
+	for _, w := range result.Projects {
+		projects = append(projects, w.toModel())
+	}
+	return projects, nil
 }
 
-func (rs *RemoteStorage) RestoreProject(_ context.Context, _ uint) (int, int, error) {
-	return 0, 0, remoteUnsupported("RestoreProject")
+// ListProjectsWithCounts lists every project with secret/environment counts via GET
+// /api/v1/system/projects/with-counts?include_deleted=.
+func (rs *RemoteStorage) ListProjectsWithCounts(ctx context.Context, includeDeleted bool) ([]storage.ProjectWithCounts, error) {
+	path := fmt.Sprintf("/api/v1/system/projects/with-counts?include_deleted=%t", includeDeleted)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list projects with counts: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list projects with counts failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Projects []storage.ProjectWithCounts `json:"projects"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Projects, nil
 }
 
-func (rs *RemoteStorage) ListEnvironments(_ context.Context) ([]*models.Environment, error) {
-	return nil, remoteUnsupported("ListEnvironments")
+// GetProject retrieves a project by ID via GET /api/v1/system/projects/{id}.
+func (rs *RemoteStorage) GetProject(ctx context.Context, id uint) (*models.Project, error) {
+	path := fmt.Sprintf("/api/v1/system/projects/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get project: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get project failed: %s", resp.Error.Error())
+	}
+	return decodeProjectResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) ListEnvironmentsByProject(_ context.Context, _ uint) ([]*models.Environment, error) {
-	return nil, remoteUnsupported("ListEnvironmentsByProject")
+// UpdateProject updates an existing project via PUT /api/v1/system/projects/{id}.
+func (rs *RemoteStorage) UpdateProject(ctx context.Context, project *models.Project) (*models.Project, error) {
+	path := fmt.Sprintf("/api/v1/system/projects/%d", project.ID)
+	resp, err := rs.client.Put(ctx, path, newProjectWire(project))
+	if err != nil {
+		return nil, fmt.Errorf("failed to update project: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("update project failed: %s", resp.Error.Error())
+	}
+	return decodeProjectResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) ListEnvironmentsByProjectIncludingDeleted(_ context.Context, _ uint) ([]*models.Environment, error) {
-	return nil, remoteUnsupported("ListEnvironmentsByProjectIncludingDeleted")
+// DeleteProject cascade-deletes a project (unconditionally — no empty-project guard)
+// via DELETE /api/v1/system/projects/{id}. This backs the force=true path; the
+// force=false guard+cascade is DeleteProjectIfEmpty below.
+func (rs *RemoteStorage) DeleteProject(ctx context.Context, id uint) error {
+	path := fmt.Sprintf("/api/v1/system/projects/%d", id)
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete project: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete project failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) ListProjectMembers(_ context.Context, _ uint) ([]storage.ProjectMember, error) {
-	return nil, remoteUnsupported("ListProjectMembers")
+// DeleteProjectIfEmpty is the atomic guard+cascade form of DeleteProject(force=false)
+// (#528), proxied as ONE HTTP call to POST
+// /api/v1/system/projects/{id}/delete-if-empty — see the storage.Storage interface
+// doc comment on this method for the full TOCTOU rationale this closes relative to a
+// naive two-call (count, then delete) proxy.
+func (rs *RemoteStorage) DeleteProjectIfEmpty(ctx context.Context, id uint) (int, error) {
+	path := fmt.Sprintf("/api/v1/system/projects/%d/delete-if-empty", id)
+	resp, err := rs.client.Post(ctx, path, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete project if empty: %w", err)
+	}
+	if !resp.Success {
+		return 0, fmt.Errorf("delete project if empty failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		BlockingSecretCount int `json:"blocking_secret_count"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.BlockingSecretCount, nil
+}
+
+// RestoreProject reverses a project soft-delete (and its cascade) via POST
+// /api/v1/system/projects/{id}/restore.
+func (rs *RemoteStorage) RestoreProject(ctx context.Context, id uint) (int, int, error) {
+	path := fmt.Sprintf("/api/v1/system/projects/%d/restore", id)
+	resp, err := rs.client.Post(ctx, path, nil)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to restore project: %w", err)
+	}
+	if !resp.Success {
+		return 0, 0, fmt.Errorf("restore project failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		RestoredEnvironments int `json:"restored_environments"`
+		RestoredSecrets      int `json:"restored_secrets"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return 0, 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.RestoredEnvironments, result.RestoredSecrets, nil
+}
+
+// environmentWire mirrors models.Environment's fields exactly (snake_case) — the
+// wire shape environment_catalog_proxy.go's environmentProxyWire sends/expects.
+type environmentWire struct {
+	ID        uint       `json:"id"`
+	ProjectID uint       `json:"project_id"`
+	Name      string     `json:"name"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
+}
+
+func (w environmentWire) toModel() *models.Environment {
+	e := &models.Environment{
+		ID:        w.ID,
+		ProjectID: w.ProjectID,
+		Name:      w.Name,
+		CreatedAt: w.CreatedAt,
+		UpdatedAt: w.UpdatedAt,
+	}
+	if w.DeletedAt != nil {
+		e.DeletedAt.Time = *w.DeletedAt
+		e.DeletedAt.Valid = true
+	}
+	return e
+}
+
+func decodeEnvironmentResponse(data json.RawMessage) (*models.Environment, error) {
+	var w environmentWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return w.toModel(), nil
+}
+
+// ListEnvironments lists every environment via GET /api/v1/system/environments.
+func (rs *RemoteStorage) ListEnvironments(ctx context.Context) ([]*models.Environment, error) {
+	resp, err := rs.client.Get(ctx, "/api/v1/system/environments")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list environments: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list environments failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Environments []environmentWire `json:"environments"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	environments := make([]*models.Environment, 0, len(result.Environments))
+	for _, w := range result.Environments {
+		environments = append(environments, w.toModel())
+	}
+	return environments, nil
+}
+
+// listEnvironmentsByProject is the shared implementation behind
+// ListEnvironmentsByProject/ListEnvironmentsByProjectIncludingDeleted via GET
+// /api/v1/system/projects/{id}/environments?include_deleted=.
+func (rs *RemoteStorage) listEnvironmentsByProject(ctx context.Context, projectID uint, includeDeleted bool) ([]*models.Environment, error) {
+	path := fmt.Sprintf("/api/v1/system/projects/%d/environments?include_deleted=%t", projectID, includeDeleted)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list environments by project: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list environments by project failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Environments []environmentWire `json:"environments"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	environments := make([]*models.Environment, 0, len(result.Environments))
+	for _, w := range result.Environments {
+		environments = append(environments, w.toModel())
+	}
+	return environments, nil
+}
+
+func (rs *RemoteStorage) ListEnvironmentsByProject(ctx context.Context, projectID uint) ([]*models.Environment, error) {
+	return rs.listEnvironmentsByProject(ctx, projectID, false)
+}
+
+// ListEnvironmentsByProjectIncludingDeleted is like ListEnvironmentsByProject but
+// also returns soft-deleted environments, for the restore UI.
+func (rs *RemoteStorage) ListEnvironmentsByProjectIncludingDeleted(ctx context.Context, projectID uint) ([]*models.Environment, error) {
+	return rs.listEnvironmentsByProject(ctx, projectID, true)
+}
+
+// GetEnvironment retrieves an environment by ID via GET
+// /api/v1/system/environments/{id}.
+//
+// #499 carve-out (untouched by #528): CreateSecret's own call site
+// (internal/core/secrets.go) special-cases errors.Is(ErrUnsupportedByBackend) to skip
+// its ownership pre-check when this was unsupported. Now that it's proxied for real,
+// that pre-check simply starts running for real too — no change was needed there.
+func (rs *RemoteStorage) GetEnvironment(ctx context.Context, id uint) (*models.Environment, error) {
+	path := fmt.Sprintf("/api/v1/system/environments/%d", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get environment: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get environment failed: %s", resp.Error.Error())
+	}
+	return decodeEnvironmentResponse(resp.Data)
+}
+
+// DeleteEnvironment deletes an environment (refusing if it still has active secrets)
+// via DELETE /api/v1/system/environments/{id}.
+func (rs *RemoteStorage) DeleteEnvironment(ctx context.Context, id uint) error {
+	path := fmt.Sprintf("/api/v1/system/environments/%d", id)
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete environment: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete environment failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// RestoreEnvironment reverses a soft-delete, scoped to projectID, via POST
+// /api/v1/system/projects/{projectId}/environments/{id}/restore.
+func (rs *RemoteStorage) RestoreEnvironment(ctx context.Context, projectID, id uint) error {
+	path := fmt.Sprintf("/api/v1/system/projects/%d/environments/%d/restore", projectID, id)
+	resp, err := rs.client.Post(ctx, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to restore environment: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("restore environment failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// ListProjectMembers lists a project's user members via GET
+// /api/v1/system/projects/{id}/members.
+func (rs *RemoteStorage) ListProjectMembers(ctx context.Context, projectID uint) ([]storage.ProjectMember, error) {
+	path := fmt.Sprintf("/api/v1/system/projects/%d/members", projectID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list project members: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list project members failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Members []storage.ProjectMember `json:"members"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Members, nil
 }
 
 func (rs *RemoteStorage) ListProjectRoleAssignments(_ context.Context, _ uint) ([]storage.RoleAssignment, error) {
@@ -575,16 +882,4 @@ func (rs *RemoteStorage) ListProjectMachineRoleAssignments(_ context.Context, _ 
 // LocalStorage server-side, so this is unsupported here.
 func (rs *RemoteStorage) ListGlobalAdminAssignmentsForUpdate(_ context.Context, _ []uint) ([]storage.RoleAssignment, error) {
 	return nil, remoteUnsupported("ListGlobalAdminAssignmentsForUpdate")
-}
-
-func (rs *RemoteStorage) GetEnvironment(_ context.Context, _ uint) (*models.Environment, error) {
-	return nil, remoteUnsupported("GetEnvironment")
-}
-
-func (rs *RemoteStorage) DeleteEnvironment(_ context.Context, _ uint) error {
-	return remoteUnsupported("DeleteEnvironment")
-}
-
-func (rs *RemoteStorage) RestoreEnvironment(_ context.Context, _, _ uint) error {
-	return remoteUnsupported("RestoreEnvironment")
 }

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -75,10 +75,10 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"ConsumeMFARecoveryCode": {statusIntentional,
 		"round 119 audit: sole caller is VerifyMFACredentials, same bypassed-branch reasoning as MarkTOTPStepUsed — recovery codes are only ever consumed at login, never during enrollment/management"},
 
-	// --- Confirmed genuine gaps, tracked for future fix rounds (47; UpdateLoginLockoutState
+	// --- Confirmed genuine gaps, tracked for future fix rounds (34; UpdateLoginLockoutState
 	// closed by #529, SSO login state closed by #521, GetActiveMFAChallenge/
 	// ConsumeMFAChallenge (WebAuthn-as-second-factor login) closed by #522, Connect
-	// ref-grant CRUD closed by #527) ---
+	// ref-grant CRUD closed by #527, project/environment catalog CRUD closed by #528) ---
 	// See docs/security/HARDENING-BACKLOG.md's round 119 entry for full detail,
 	// severity, and grouping. Each entry below cites the real caller/route a
 	// round-119 audit traced (not assumed).
@@ -140,26 +140,21 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"GetRolePermissions": {statusKnownGap,
 		"round 119: role-permission view, access reviews, compliance posture, SoD conflict detection — GET /roles/{id}/permissions and multiple internal core callers"},
 
-	// Project / environment catalog CRUD.
-	"ListProjects": {statusKnownGap,
-		"round 119: hygiene report, compliance posture, rotation planner, secret_ref/secret_render, deployment hygiene, name-conformance report, auth bootstrap"},
-	"ListProjectsWithCounts": {statusKnownGap, "round 119: GET /projects"},
-	"GetProject": {statusKnownGap,
-		"round 119: GET /projects/{id}; also invitations, membership lifecycle, notifications, users, dynamic-secrets' requireLiveProjectAndEnvironment"},
-	"UpdateProject":    {statusKnownGap, "round 119: PUT /projects/{id}"},
-	"DeleteProject":    {statusKnownGap, "round 119: DELETE /projects/{id}"},
-	"RestoreProject":   {statusKnownGap, "round 119: POST /projects/{id}/restore"},
-	"ListEnvironments": {statusKnownGap, "round 119: GET /environments; also dashboard, auth bootstrap"},
-	"ListEnvironmentsByProject": {statusKnownGap,
-		"round 119: GET /projects/{id}/environments; also drift, secret_ref, secret_render, secret_inventory"},
-	"ListEnvironmentsByProjectIncludingDeleted": {statusKnownGap,
-		"round 119: the environments-listing restore-UI branch (?include_deleted=true)"},
-	"ListProjectMembers": {statusKnownGap,
-		"round 119: GET /projects/{id}/members; also a wide swath of scheduled reminder/notification jobs (anomaly, break-glass, cert expiry, classification gate, expiry/rotation reminders, invitations, recertification)"},
-	"GetEnvironment": {statusKnownGap,
-		"round 119: secret copy (same-project and cross-environment), dynamic-secrets issue/renew-lease. NOTE: CreateSecret's own call site already has a deliberate errors.Is(ErrUnsupportedByBackend) carve-out (#499) and is NOT part of this gap — only every OTHER caller is broken"},
-	"DeleteEnvironment":  {statusKnownGap, "round 119: DELETE /environments/{id}"},
-	"RestoreEnvironment": {statusKnownGap, "round 119: POST /projects/{projectId}/environments/{id}/restore"},
+	// Project / environment catalog CRUD was fixed in #528: ListProjects/
+	// ListProjectsWithCounts/GetProject/UpdateProject/DeleteProject/RestoreProject/
+	// ListEnvironments/ListEnvironmentsByProject/
+	// ListEnvironmentsByProjectIncludingDeleted/ListProjectMembers/GetEnvironment/
+	// DeleteEnvironment/RestoreEnvironment are now proxied via
+	// /api/v1/system/projects* and /api/v1/system/environments*
+	// (server/http/handlers/project_catalog_proxy.go,
+	// environment_catalog_proxy.go), no longer unconditional stubs — see
+	// internal/storage/store/remote_rbac.go's Project/Environment section. The
+	// force=false delete guard now runs as ONE atomic storage.Storage call
+	// (DeleteProjectIfEmpty) instead of a WithTransaction-wrapped
+	// ListSecrets+DeleteProject pair, closing a TOCTOU window that pair would have
+	// reopened across the HTTP hop (see that method's interface doc comment).
+	// GetEnvironment's #499 carve-out inside core.CreateSecret is unaffected —
+	// see internal/core/secrets.go.
 
 	// Scheduler locking — reached on EVERY tick regardless of storage.type
 	// (server/main.go starts all schedulers unconditionally), and is now the

--- a/server/http/handlers/environment_catalog_proxy.go
+++ b/server/http/handlers/environment_catalog_proxy.go
@@ -1,0 +1,187 @@
+// environment_catalog_proxy.go — server-side endpoints backing RemoteStorage's
+// Environment catalog methods (ListEnvironments/ListEnvironmentsByProject/
+// ListEnvironmentsByProjectIncludingDeleted/GetEnvironment/DeleteEnvironment/
+// RestoreEnvironment).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies its
+// environment-catalog storage calls to whichever upstream server it's configured
+// against, through these routes (registered in server/http/router.go under
+// /api/v1/system/environments* and /api/v1/system/projects/{id}/environments*, gated
+// on the existing system.read/system.write RBAC permissions — no new privilege
+// class). Exactly the same pattern as project_catalog_proxy.go: thin passthroughs
+// onto the SAME storage.Storage primitives
+// (internal/storage/store/local_secrets.go's LocalStorage.ListEnvironments et al.)
+// internal/core/catalog.go already uses against a local backend — no environment
+// POLICY decision (parent-project liveness, the requireAuthorityToReinstateProjectRoles
+// admin-ceiling check on restore, audit-log events) is made here; that stays entirely
+// in the CALLING server's own internal/core.KeyorixCore, exactly as it does against a
+// local backend.
+//
+// NOTE (#499 carve-out, untouched by #528): CreateSecret's own GetEnvironment call
+// site (internal/core/secrets.go) already special-cases errors.Is(ErrUnsupportedByBackend)
+// to skip its ownership pre-check when GetEnvironment is unsupported. Now that
+// GetEnvironmentProxy makes GetEnvironment actually succeed under storage.type: remote,
+// that call site's pre-check simply starts running for real (the upstream server's own
+// CreateSecret handler already re-verifies the same invariant authoritatively either
+// way) — no code change was needed or made there.
+//
+// Response envelope: like project_catalog_proxy.go, these do NOT use the package's
+// generic sendSuccess/sendError helpers — they construct the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// environmentProxyWire mirrors models.Environment's fields exactly (snake_case) —
+// the wire shape RemoteStorage's environment methods
+// (internal/storage/store/remote_rbac.go) expect. See projectProxyWire's comment for
+// why every field is named explicitly (models.Environment carries no json tags).
+type environmentProxyWire struct {
+	ID        uint       `json:"id"`
+	ProjectID uint       `json:"project_id"`
+	Name      string     `json:"name"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
+}
+
+func newEnvironmentProxyWire(e *models.Environment) environmentProxyWire {
+	w := environmentProxyWire{
+		ID:        e.ID,
+		ProjectID: e.ProjectID,
+		Name:      e.Name,
+		CreatedAt: e.CreatedAt,
+		UpdatedAt: e.UpdatedAt,
+	}
+	if e.DeletedAt.Valid {
+		t := e.DeletedAt.Time
+		w.DeletedAt = &t
+	}
+	return w
+}
+
+// isEnvironmentNotFound reports whether err is an "environment not found" error from
+// LocalStorage (local_secrets.go's GetEnvironment/DeleteEnvironment/RestoreEnvironment
+// all use this literal substring).
+func isEnvironmentNotFound(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
+}
+
+// ListEnvironmentsProxy handles GET /api/v1/system/environments (global list).
+func (h *CatalogHandler) ListEnvironmentsProxy(w http.ResponseWriter, r *http.Request) {
+	environments, err := h.coreService.Storage().ListEnvironments(r.Context())
+	if err != nil {
+		log.Printf("environment catalog proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]environmentProxyWire, 0, len(environments))
+	for _, e := range environments {
+		wire = append(wire, newEnvironmentProxyWire(e))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"environments": wire})
+}
+
+// ListEnvironmentsByProjectProxy handles GET
+// /api/v1/system/projects/{id}/environments?include_deleted=true.
+func (h *CatalogHandler) ListEnvironmentsByProjectProxy(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid project ID")
+		return
+	}
+	var environments []*models.Environment
+	if r.URL.Query().Get("include_deleted") == "true" {
+		environments, err = h.coreService.Storage().ListEnvironmentsByProjectIncludingDeleted(r.Context(), uint(projectID))
+	} else {
+		environments, err = h.coreService.Storage().ListEnvironmentsByProject(r.Context(), uint(projectID))
+	}
+	if err != nil {
+		log.Printf("environment catalog proxy: list by project failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]environmentProxyWire, 0, len(environments))
+	for _, e := range environments {
+		wire = append(wire, newEnvironmentProxyWire(e))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"environments": wire})
+}
+
+// GetEnvironmentProxy handles GET /api/v1/system/environments/{id}.
+func (h *CatalogHandler) GetEnvironmentProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid environment ID")
+		return
+	}
+	env, err := h.coreService.Storage().GetEnvironment(r.Context(), uint(id))
+	if err != nil {
+		if isEnvironmentNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "environment not found")
+			return
+		}
+		log.Printf("environment catalog proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newEnvironmentProxyWire(env))
+}
+
+// DeleteEnvironmentProxy handles DELETE /api/v1/system/environments/{id}.
+func (h *CatalogHandler) DeleteEnvironmentProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid environment ID")
+		return
+	}
+	if err := h.coreService.Storage().DeleteEnvironment(r.Context(), uint(id)); err != nil {
+		if isEnvironmentNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "environment not found")
+			return
+		}
+		if strings.Contains(err.Error(), "active secret") {
+			writeRemoteAPIError(w, http.StatusConflict, "CONFLICT", err.Error())
+			return
+		}
+		log.Printf("environment catalog proxy: delete failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}
+
+// RestoreEnvironmentProxy handles POST
+// /api/v1/system/projects/{projectId}/environments/{id}/restore.
+func (h *CatalogHandler) RestoreEnvironmentProxy(w http.ResponseWriter, r *http.Request) {
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "projectId"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid project ID")
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid environment ID")
+		return
+	}
+	if err := h.coreService.Storage().RestoreEnvironment(r.Context(), uint(projectID), uint(id)); err != nil {
+		if isEnvironmentNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "environment not found or not deleted")
+			return
+		}
+		log.Printf("environment catalog proxy: restore failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"restored": true})
+}

--- a/server/http/handlers/project_catalog_proxy.go
+++ b/server/http/handlers/project_catalog_proxy.go
@@ -1,0 +1,261 @@
+// project_catalog_proxy.go — server-side endpoints backing RemoteStorage's Project
+// catalog methods (ListProjects/ListProjectsWithCounts/GetProject/UpdateProject/
+// DeleteProject/DeleteProjectIfEmpty/RestoreProject/ListProjectMembers).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies its
+// project-catalog storage calls to whichever upstream server it's configured against,
+// through these routes (registered in server/http/router.go under
+// /api/v1/system/projects*, gated on the existing system.read/system.write RBAC
+// permissions — the SAME credential a RemoteStorage client already needs for every
+// other proxied call, so this introduces no new privilege class). Exactly the same
+// pattern as groups_proxy.go/login_attempts_proxy.go/invitations_proxy.go: thin
+// passthroughs onto the SAME storage.Storage primitives
+// (internal/storage/store/local_secrets.go's LocalStorage.ListProjects et al.)
+// internal/core/catalog.go already uses against a local backend — NO project POLICY
+// decision (name/description validation, MFA-requirement authorization, invitation/
+// membership side effects, dynamic-secret-lease revocation, audit-log events, the
+// requireAuthorityToReinstateProjectRoles admin-ceiling check) is made here; that
+// stays entirely in the CALLING server's own internal/core.KeyorixCore, exactly as it
+// does against a local backend. The existing human-facing /api/v1/projects routes
+// (catalog.go) are deliberately NOT reused as the proxy target for the same reason
+// groups_proxy.go's doc comment gives: they run through core.KeyorixCore, so proxying
+// onto them would apply that business logic a second time, upstream, against the
+// wrong actor context.
+//
+// DeleteProjectIfEmptyProxy is the one exception to "thin passthrough onto an
+// existing local primitive": it backs storage.Storage.DeleteProjectIfEmpty, a NEW
+// atomic primitive added by #528 specifically so a force=false project delete stays
+// atomic (guard-count + cascade in ONE call) across the HTTP hop — see that method's
+// doc comment on the storage.Storage interface for the full TOCTOU rationale. It is
+// still a thin passthrough: the guard threshold (zero secrets) and the cascade itself
+// are unchanged storage-layer behavior, just invoked as one call instead of two.
+//
+// Response envelope: like the proxies above, these do NOT use the package's generic
+// sendSuccess/sendError helpers — they construct the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// projectProxyWire mirrors models.Project's fields exactly (snake_case) — the wire
+// shape RemoteStorage's project methods (internal/storage/store/remote_rbac.go)
+// send/expect. See groupProxyWire's comment for why every field is named explicitly
+// rather than relying on encoding/json's case-insensitive fallback (models.Project
+// carries no json tags of its own).
+type projectProxyWire struct {
+	ID          uint       `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	RequireMFA  bool       `json:"require_mfa"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
+}
+
+func newProjectProxyWire(p *models.Project) projectProxyWire {
+	w := projectProxyWire{
+		ID:          p.ID,
+		Name:        p.Name,
+		Description: p.Description,
+		RequireMFA:  p.RequireMFA,
+		CreatedAt:   p.CreatedAt,
+		UpdatedAt:   p.UpdatedAt,
+	}
+	if p.DeletedAt.Valid {
+		t := p.DeletedAt.Time
+		w.DeletedAt = &t
+	}
+	return w
+}
+
+func (w projectProxyWire) toModel() *models.Project {
+	return &models.Project{
+		ID:          w.ID,
+		Name:        w.Name,
+		Description: w.Description,
+		RequireMFA:  w.RequireMFA,
+	}
+}
+
+// isProjectNotFound reports whether err is a "project not found" error from
+// LocalStorage (local_secrets.go's GetProject/DeleteProject/DeleteProjectIfEmpty
+// cascade/RestoreProject all use this literal substring).
+func isProjectNotFound(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
+}
+
+// ListProjectsProxy handles GET /api/v1/system/projects.
+func (h *CatalogHandler) ListProjectsProxy(w http.ResponseWriter, r *http.Request) {
+	projects, err := h.coreService.Storage().ListProjects(r.Context())
+	if err != nil {
+		log.Printf("project catalog proxy: list failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make([]projectProxyWire, 0, len(projects))
+	for _, p := range projects {
+		wire = append(wire, newProjectProxyWire(p))
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"projects": wire})
+}
+
+// ListProjectsWithCountsProxy handles GET
+// /api/v1/system/projects/with-counts?include_deleted=true.
+func (h *CatalogHandler) ListProjectsWithCountsProxy(w http.ResponseWriter, r *http.Request) {
+	includeDeleted := r.URL.Query().Get("include_deleted") == "true"
+	projects, err := h.coreService.Storage().ListProjectsWithCounts(r.Context(), includeDeleted)
+	if err != nil {
+		log.Printf("project catalog proxy: list with counts failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"projects": projects})
+}
+
+// GetProjectProxy handles GET /api/v1/system/projects/{id}.
+func (h *CatalogHandler) GetProjectProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid project ID")
+		return
+	}
+	p, err := h.coreService.Storage().GetProject(r.Context(), uint(id))
+	if err != nil {
+		if isProjectNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "project not found")
+			return
+		}
+		log.Printf("project catalog proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newProjectProxyWire(p))
+}
+
+// UpdateProjectProxy handles PUT /api/v1/system/projects/{id}. Like the group/
+// invitation proxies' raw persist, this trusts the caller's already-fully-resolved
+// final desired state (the calling core.KeyorixCore.UpdateProject already merged the
+// existing row with the requested changes before invoking storage.UpdateProject)
+// rather than re-deriving a partial update here.
+func (h *CatalogHandler) UpdateProjectProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid project ID")
+		return
+	}
+	var body projectProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	updated, err := h.coreService.Storage().UpdateProject(r.Context(), body.toModel())
+	if err != nil {
+		if isProjectNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "project not found")
+			return
+		}
+		log.Printf("project catalog proxy: update failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newProjectProxyWire(updated))
+}
+
+// DeleteProjectProxy handles DELETE /api/v1/system/projects/{id} — the plain,
+// unconditional cascade (storage.Storage.DeleteProject), backing the CALLING
+// server's force=true path. The force=false guard+cascade is DeleteProjectIfEmptyProxy
+// below, not this endpoint.
+func (h *CatalogHandler) DeleteProjectProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid project ID")
+		return
+	}
+	if err := h.coreService.Storage().DeleteProject(r.Context(), uint(id)); err != nil {
+		if isProjectNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "project not found")
+			return
+		}
+		log.Printf("project catalog proxy: delete failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}
+
+// DeleteProjectIfEmptyProxy handles POST /api/v1/system/projects/{id}/delete-if-empty
+// — the atomic guard+cascade backing storage.Storage.DeleteProjectIfEmpty (#528; see
+// that method's interface doc comment). Runs the whole guard-count-then-cascade
+// sequence in ONE call against THIS server's real storage, so the count the guard
+// rejects on is read from, and committed alongside, the same transaction as the
+// cascade — closing the TOCTOU window a naive two-call (count, then delete) proxy
+// would reopen across the network hop.
+func (h *CatalogHandler) DeleteProjectIfEmptyProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid project ID")
+		return
+	}
+	blocking, err := h.coreService.Storage().DeleteProjectIfEmpty(r.Context(), uint(id))
+	if err != nil {
+		if isProjectNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "project not found")
+			return
+		}
+		log.Printf("project catalog proxy: delete-if-empty failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"blocking_secret_count": blocking})
+}
+
+// RestoreProjectProxy handles POST /api/v1/system/projects/{id}/restore.
+func (h *CatalogHandler) RestoreProjectProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid project ID")
+		return
+	}
+	restoredEnvironments, restoredSecrets, err := h.coreService.Storage().RestoreProject(r.Context(), uint(id))
+	if err != nil {
+		if isProjectNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "project not found or not deleted")
+			return
+		}
+		log.Printf("project catalog proxy: restore failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{
+		"restored_environments": restoredEnvironments,
+		"restored_secrets":      restoredSecrets,
+	})
+}
+
+// ListProjectMembersProxy handles GET /api/v1/system/projects/{id}/members.
+func (h *CatalogHandler) ListProjectMembersProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid project ID")
+		return
+	}
+	members, err := h.coreService.Storage().ListProjectMembers(r.Context(), uint(id))
+	if err != nil {
+		log.Printf("project catalog proxy: list members failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"members": members})
+}

--- a/server/http/remote_storage_environment_catalog_test.go
+++ b/server/http/remote_storage_environment_catalog_test.go
@@ -1,0 +1,138 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteStorageEnvironment_ListGet_RealServer proves the read fix: environments
+// seeded by CreateProject on the upstream are listed (globally and per-project) and
+// fetched correctly via the DOWNSTREAM's RemoteStorage, against a real router.
+func TestRemoteStorageEnvironment_ListGet_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForProjectCatalog(t)
+	ctx := context.Background()
+
+	project, err := upstream.CreateProject(ctx, "env-catalog-project", "")
+	require.NoError(t, err)
+	seeded, err := upstream.Storage().ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, seeded, "CreateProject must seed default environments")
+	envID := seeded[0].ID
+
+	// ListEnvironments via the downstream (global list) sees the real upstream rows.
+	all, err := downstream.Storage().ListEnvironments(ctx)
+	require.NoError(t, err)
+	found := false
+	for _, e := range all {
+		if e.ID == envID {
+			found = true
+		}
+	}
+	assert.True(t, found, "ListEnvironments must include the real upstream environment")
+
+	// ListEnvironmentsByProject via the downstream.
+	byProject, err := downstream.Storage().ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	assert.Len(t, byProject, len(seeded))
+
+	// GetEnvironment via the downstream round-trips correctly.
+	fetched, err := downstream.Storage().GetEnvironment(ctx, envID)
+	require.NoError(t, err)
+	assert.Equal(t, envID, fetched.ID)
+	assert.Equal(t, project.ID, fetched.ProjectID)
+	assert.Equal(t, seeded[0].Name, fetched.Name)
+}
+
+// TestRemoteStorageEnvironment_GetNotFound_RealServer proves a clean not-found error
+// for a nonexistent environment ID.
+func TestRemoteStorageEnvironment_GetNotFound_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForProjectCatalog(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetEnvironment(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageEnvironment_DeleteRestore_RealServer proves the DeleteEnvironment/
+// RestoreEnvironment/ListEnvironmentsByProjectIncludingDeleted fix: an environment
+// with no active secrets is soft-deletable and restorable via the downstream's
+// RemoteStorage, and the soft-deleted row is only visible via the
+// include-deleted listing.
+func TestRemoteStorageEnvironment_DeleteRestore_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForProjectCatalog(t)
+	ctx := context.Background()
+
+	project, err := upstream.CreateProject(ctx, "env-delete-project", "")
+	require.NoError(t, err)
+	seeded, err := upstream.Storage().ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, seeded)
+	envID := seeded[0].ID
+
+	// DeleteEnvironment via the downstream soft-deletes the real upstream row.
+	require.NoError(t, downstream.Storage().DeleteEnvironment(ctx, envID))
+	_, err = upstream.Storage().GetEnvironment(ctx, envID)
+	require.Error(t, err, "a soft-deleted environment must no longer be readable as active")
+
+	live, err := downstream.Storage().ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	for _, e := range live {
+		assert.NotEqual(t, envID, e.ID, "the live listing must exclude the soft-deleted environment")
+	}
+
+	includingDeleted, err := downstream.Storage().ListEnvironmentsByProjectIncludingDeleted(ctx, project.ID)
+	require.NoError(t, err)
+	foundDeleted := false
+	for _, e := range includingDeleted {
+		if e.ID == envID {
+			foundDeleted = true
+		}
+	}
+	assert.True(t, foundDeleted, "the include-deleted listing must still show the soft-deleted environment")
+
+	// RestoreEnvironment via the downstream brings it back.
+	require.NoError(t, downstream.Storage().RestoreEnvironment(ctx, project.ID, envID))
+	restored, err := upstream.Storage().GetEnvironment(ctx, envID)
+	require.NoError(t, err)
+	assert.Equal(t, envID, restored.ID)
+	assert.Equal(t, seeded[0].Name, restored.Name, "restore must bring back the SAME row")
+}
+
+// TestRemoteStorageEnvironment_DeleteBlockedByActiveSecret_RealServer proves
+// DeleteEnvironment's active-secret guard survives the HTTP hop unchanged: it is a
+// single storage.Storage call (no core-layer decomposition), so one proxied round
+// trip preserves LocalStorage's own count-then-reject semantics exactly — unlike
+// DeleteProject(force=false), no new atomic primitive was needed here (see
+// project_catalog_proxy.go's package doc for the contrast).
+func TestRemoteStorageEnvironment_DeleteBlockedByActiveSecret_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForProjectCatalog(t)
+	ctx := context.Background()
+
+	project, err := upstream.CreateProject(ctx, "env-guard-project", "")
+	require.NoError(t, err)
+	seeded, err := upstream.Storage().ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, seeded)
+	envID := seeded[0].ID
+
+	_, err = upstream.Storage().CreateSecret(ctx, &models.SecretNode{
+		Name:          "guard-secret",
+		ProjectID:     project.ID,
+		EnvironmentID: envID,
+		IsSecret:      true,
+		Status:        "active",
+	})
+	require.NoError(t, err)
+
+	err = downstream.Storage().DeleteEnvironment(ctx, envID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "active secret")
+
+	direct, err := upstream.Storage().GetEnvironment(ctx, envID)
+	require.NoError(t, err)
+	assert.Equal(t, envID, direct.ID, "a rejected delete must leave the environment live")
+}

--- a/server/http/remote_storage_project_catalog_test.go
+++ b/server/http/remote_storage_project_catalog_test.go
@@ -1,0 +1,243 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForProjectCatalog builds the standard #452/#507-style
+// two-server harness (see remote_storage_groups_test.go's identical helper): an
+// "upstream" exercised through the REAL production NewRouter/handlers (including the
+// new /api/v1/system/projects* routes, server/http/handlers/project_catalog_proxy.go),
+// and a "downstream" *core.KeyorixCore configured with storage.type: remote
+// (ADR-049), pointed at "upstream" over real HTTP via store.RemoteStorage.
+func newUpstreamDownstreamForProjectCatalog(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	return upstream, downstream
+}
+
+// TestRemoteStorageProject_ListGetUpdate_RealServer proves the read/update fix: a
+// project created directly on the upstream (RemoteStorage has no CreateProject —
+// that stays an intentional stub, see remote_rbac.go) is listed, fetched, and
+// updated correctly via the DOWNSTREAM's RemoteStorage, all against a real router,
+// not a protocol mock.
+func TestRemoteStorageProject_ListGetUpdate_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForProjectCatalog(t)
+	ctx := context.Background()
+
+	created, err := upstream.CreateProject(ctx, "catalog-project", "initial description")
+	require.NoError(t, err)
+
+	// ListProjects via the downstream sees the real upstream row.
+	all, err := downstream.Storage().ListProjects(ctx)
+	require.NoError(t, err)
+	found := false
+	for _, p := range all {
+		if p.ID == created.ID {
+			found = true
+			assert.Equal(t, "catalog-project", p.Name)
+		}
+	}
+	assert.True(t, found, "ListProjects must include the real upstream project")
+
+	// ListProjectsWithCounts via the downstream.
+	withCounts, err := downstream.Storage().ListProjectsWithCounts(ctx, false)
+	require.NoError(t, err)
+	foundCounts := false
+	for _, p := range withCounts {
+		if p.ID == created.ID {
+			foundCounts = true
+			// CreateProject seeds default environments, so this must be > 0.
+			assert.Greater(t, p.EnvironmentCount, int64(0))
+		}
+	}
+	assert.True(t, foundCounts, "ListProjectsWithCounts must include the real upstream project")
+
+	// GetProject via the downstream round-trips correctly.
+	fetched, err := downstream.Storage().GetProject(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, fetched.ID)
+	assert.Equal(t, "catalog-project", fetched.Name)
+	assert.Equal(t, "initial description", fetched.Description)
+
+	// UpdateProject via the downstream persists on the upstream.
+	fetched.Name = "renamed-project"
+	fetched.Description = "updated description"
+	fetched.RequireMFA = true
+	updated, err := downstream.Storage().UpdateProject(ctx, fetched)
+	require.NoError(t, err)
+	assert.Equal(t, "renamed-project", updated.Name)
+	assert.True(t, updated.RequireMFA)
+
+	direct, err := upstream.Storage().GetProject(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "renamed-project", direct.Name, "the update must be a REAL upstream write")
+	assert.Equal(t, "updated description", direct.Description)
+	assert.True(t, direct.RequireMFA)
+}
+
+// TestRemoteStorageProject_GetNotFound_RealServer proves a clean not-found error for
+// a nonexistent project ID.
+func TestRemoteStorageProject_GetNotFound_RealServer(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForProjectCatalog(t)
+	ctx := context.Background()
+
+	_, err := downstream.Storage().GetProject(ctx, 999999)
+	require.Error(t, err)
+}
+
+// TestRemoteStorageProject_DeleteIfEmpty_And_Force_RealServer proves the #528
+// DeleteProjectIfEmpty fix end to end: a project with a live secret blocks a
+// force=false delete (reporting the real blocking count), while force=true
+// (plain DeleteProject) cascades over it regardless — both via the downstream's
+// RemoteStorage against a real upstream server.
+func TestRemoteStorageProject_DeleteIfEmpty_And_Force_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForProjectCatalog(t)
+	ctx := context.Background()
+
+	project, err := upstream.CreateProject(ctx, "delete-guard-project", "")
+	require.NoError(t, err)
+	envs, err := upstream.Storage().ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs, "CreateProject must have seeded default environments")
+	envID := envs[0].ID
+
+	_, err = upstream.Storage().CreateSecret(ctx, &models.SecretNode{
+		Name:          "guard-secret",
+		ProjectID:     project.ID,
+		EnvironmentID: envID,
+		IsSecret:      true,
+	})
+	require.NoError(t, err)
+
+	// DeleteProjectIfEmpty via the downstream must reject: the project has a live
+	// secret, reporting the real blocking count (not silently cascading over it).
+	blocking, err := downstream.Storage().DeleteProjectIfEmpty(ctx, project.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, blocking, "DeleteProjectIfEmpty must report the real blocking secret count")
+
+	direct, err := upstream.Storage().GetProject(ctx, project.ID)
+	require.NoError(t, err)
+	assert.Equal(t, project.ID, direct.ID, "a rejected guard must leave the project live")
+
+	// DeleteProject (the plain, unconditional cascade — the force=true path) via the
+	// downstream cascades over the secret regardless.
+	require.NoError(t, downstream.Storage().DeleteProject(ctx, project.ID))
+	_, err = upstream.Storage().GetProject(ctx, project.ID)
+	require.Error(t, err, "a soft-deleted project must no longer be readable as active")
+
+	// RestoreProject via the downstream brings back the project AND the cascaded
+	// secret/environment.
+	restoredEnvs, restoredSecrets, err := downstream.Storage().RestoreProject(ctx, project.ID)
+	require.NoError(t, err)
+	assert.Positive(t, restoredEnvs)
+	assert.Equal(t, 1, restoredSecrets)
+	restored, err := upstream.Storage().GetProject(ctx, project.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "delete-guard-project", restored.Name, "restore must bring back the SAME row")
+}
+
+// TestRemoteStorageProject_DeleteIfEmpty_EmptyProjectSucceeds_RealServer proves the
+// success path: an empty project's force=false delete actually deletes (reports
+// blockingSecretCount 0), matching DeleteProject(force=false)'s LocalStorage
+// behavior exactly.
+func TestRemoteStorageProject_DeleteIfEmpty_EmptyProjectSucceeds_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForProjectCatalog(t)
+	ctx := context.Background()
+
+	project, err := upstream.CreateProject(ctx, "empty-delete-project", "")
+	require.NoError(t, err)
+
+	blocking, err := downstream.Storage().DeleteProjectIfEmpty(ctx, project.ID)
+	require.NoError(t, err)
+	assert.Zero(t, blocking)
+
+	_, err = upstream.Storage().GetProject(ctx, project.ID)
+	require.Error(t, err, "an empty project's force=false delete must actually delete it")
+}
+
+// TestRemoteStorageProject_DeleteIfEmpty_ConcurrentRaceIsSerialized_RealServer is the
+// concurrency test for the #528 atomicity fix: N goroutines on the SAME downstream
+// (storage.type: remote) core.KeyorixCore race to DeleteProjectIfEmpty the SAME empty
+// project concurrently. Before this fix, core.DeleteProject's force=false guard ran
+// as a WithTransaction-wrapped ListSecrets-then-DeleteProject pair — safe under
+// LocalStorage's real transaction, but WithTransaction is a no-op passthrough over
+// HTTP for RemoteStorage, so under storage.type: remote a naive proxy of that same
+// pair could let TWO racers both observe "empty" and both attempt the cascade,
+// double-processing the delete (e.g. double-counting the #369 dynamic-secret-lease
+// revocation, or racing the #311 restored-count audit math). DeleteProjectIfEmpty
+// folds the guard and the cascade into ONE atomic call, so exactly one racer's
+// cascade must ever actually commit — proven here against a REAL upstream server,
+// not a mock.
+func TestRemoteStorageProject_DeleteIfEmpty_ConcurrentRaceIsSerialized_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForProjectCatalog(t)
+	ctx := context.Background()
+
+	project, err := upstream.CreateProject(ctx, "race-delete-project", "")
+	require.NoError(t, err)
+
+	const n = 8
+	var wg sync.WaitGroup
+	blockingCounts := make([]int, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			blockingCounts[i], errs[i] = downstream.Storage().DeleteProjectIfEmpty(ctx, project.ID)
+		}(i)
+	}
+	wg.Wait()
+
+	successes := 0
+	for i := 0; i < n; i++ {
+		if errs[i] == nil {
+			successes++
+			assert.Zero(t, blockingCounts[i], "a successful racer must report zero blocking secrets")
+		} else {
+			assert.Contains(t, errs[i].Error(), "not found",
+				"a losing racer must see a clean 'not found' (the row the winner already soft-deleted), not a corrupted partial state")
+		}
+	}
+	assert.Equal(t, 1, successes, "exactly one racer's cascade must actually commit — no double-delete, no double-processing")
+
+	direct, err := upstream.Storage().GetProject(ctx, project.ID)
+	require.Error(t, err, "the project must end up soft-deleted exactly once")
+	_ = direct
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1356,6 +1356,69 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/users/purge", userHandler.PurgeDeletedUsersBeforeProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/projects/purge", catalogHandler.PurgeDeletedProjectsBeforeProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/environments/purge", catalogHandler.PurgeDeletedEnvironmentsBeforeProxy)
+
+			// Project/environment catalog CRUD storage-primitive proxy (finding #528).
+			// Lets a downstream Keyorix server booted with storage.type: remote
+			// (ADR-049) proxy ListProjects/ListProjectsWithCounts/GetProject/
+			// UpdateProject/DeleteProject/RestoreProject/ListEnvironments/
+			// ListEnvironmentsByProject/ListEnvironmentsByProjectIncludingDeleted/
+			// ListProjectMembers/GetEnvironment/DeleteEnvironment/RestoreEnvironment to
+			// THIS server's real storage backend, instead of RemoteStorage's thirteen
+			// project/environment catalog methods being unconditional stubs (project and
+			// environment catalog CRUD was broadly broken under storage.type: remote —
+			// reachable via invitations, membership lifecycle, notifications, users,
+			// secret_ref/render, drift, the rotation planner, compliance posture,
+			// recertification, deployment hygiene, and a wide swath of scheduled
+			// reminder/notification jobs). Exactly the same pattern as the proxies
+			// above: a thin passthrough onto storage.Storage (no project/environment
+			// POLICY decision — name/description validation, the per-project MFA
+			// roles.assign gate, invitation/membership side effects, dynamic-secret
+			// lease revocation, audit-log events, the requireAuthorityToReinstateProjectRoles
+			// admin-ceiling check on restore — is made here; that stays entirely in the
+			// CALLING server's own internal/core.KeyorixCore, exactly as it does against
+			// a local backend), reusing the SAME system.read/system.write tier rather
+			// than the project-scoped secrets.read/write/roles.assign the human-facing
+			// /projects and /environments routes use — no new privilege class. Read is
+			// baseline system.read; every mutating operation requires system.write.
+			//
+			// CreateProject/CreateEnvironment remain deliberately unsupported here (no
+			// route registered) — see internal/storage/store/remote_rbac.go's Project/
+			// Environment section doc for why. #499's GetEnvironment carve-out inside
+			// core.CreateSecret (internal/core/secrets.go) is explicitly untouched by
+			// this finding — see environment_catalog_proxy.go's package doc.
+			//
+			// DeleteProjectIfEmptyProxy is the one atomicity exception here (see
+			// project_catalog_proxy.go's package doc and the storage.Storage
+			// interface's DeleteProjectIfEmpty doc comment): core.DeleteProject's
+			// force=false guard used to run as a WithTransaction-wrapped
+			// ListSecrets-then-DeleteProject pair — safe under LocalStorage (a real DB
+			// transaction) but WithTransaction is a no-op passthrough over HTTP for
+			// RemoteStorage, so a naive two-call proxy of that pair would reopen a
+			// TOCTOU window across a full network round trip (a secret created between
+			// the count and the cascade would let a force=false delete silently cascade
+			// over it anyway). DeleteProjectIfEmpty folds the guard and the cascade into
+			// ONE atomic call/route instead, closing that gap for both backends. Static
+			// sub-paths ("with-counts", "{id}/delete-if-empty", "{id}/restore",
+			// "{id}/members", "{id}/environments") are registered ahead of/alongside the
+			// "{id}" wildcard, matching the static-vs-wildcard precedence the proxies
+			// above already rely on; "/projects/{projectId}/environments/{id}/restore"
+			// reuses a DIFFERENT param name ("projectId") than "/projects/{id}" at the
+			// same path depth, exactly like the existing human-facing
+			// "/projects/{id}/environments/{envId}/copy-secrets" vs
+			// "/projects/{projectId}/environments/{id}/restore" routes already do.
+			r.Get("/projects/with-counts", catalogHandler.ListProjectsWithCountsProxy)
+			r.Get("/projects", catalogHandler.ListProjectsProxy)
+			r.Get("/projects/{id}", catalogHandler.GetProjectProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/projects/{id}", catalogHandler.UpdateProjectProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Delete("/projects/{id}", catalogHandler.DeleteProjectProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/projects/{id}/delete-if-empty", catalogHandler.DeleteProjectIfEmptyProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/projects/{id}/restore", catalogHandler.RestoreProjectProxy)
+			r.Get("/projects/{id}/members", catalogHandler.ListProjectMembersProxy)
+			r.Get("/projects/{id}/environments", catalogHandler.ListEnvironmentsByProjectProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/projects/{projectId}/environments/{id}/restore", catalogHandler.RestoreEnvironmentProxy)
+			r.Get("/environments", catalogHandler.ListEnvironmentsProxy)
+			r.Get("/environments/{id}", catalogHandler.GetEnvironmentProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Delete("/environments/{id}", catalogHandler.DeleteEnvironmentProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary

Closes #528 (MEDIUM). Project and environment catalog CRUD was broadly broken under `storage.type: remote` (ADR-049): `ListProjects`, `ListProjectsWithCounts`, `GetProject`, `UpdateProject`, `DeleteProject`, `RestoreProject`, `ListEnvironments`, `ListEnvironmentsByProject`, `ListEnvironmentsByProjectIncludingDeleted`, `ListProjectMembers`, `GetEnvironment`, `DeleteEnvironment`, `RestoreEnvironment` (13 `internal/storage/store/remote_rbac.go` methods) were all unconditional `remoteUnsupported(...)` stubs. These are reachable via `server/http/handlers/catalog.go`'s routes and used pervasively across core: invitations, membership lifecycle, notifications, users, secret_ref/render, drift, the rotation planner, compliance posture, recertification, deployment hygiene, and a wide swath of scheduled reminder/notification jobs.

- Adds two new thin proxy handler files, `server/http/handlers/project_catalog_proxy.go` and `environment_catalog_proxy.go`, registered under new `/api/v1/system/projects*` and `/api/v1/system/environments*` routes in `server/http/router.go`, gated on the existing `system.read`/`system.write` tier — no new privilege class. These are thin passthroughs onto `storage.Storage`, matching the established pattern (login-attempts/invitations/groups/machine-identities/etc. proxies) — no project/environment POLICY decision (validation, MFA-requirement authorization, invitation/membership side effects, dynamic-secret lease revocation, audit-log events, the admin-ceiling restore check) is made here; that stays entirely in the calling server's own `internal/core.KeyorixCore`. The human-facing `/api/v1/projects` routes are deliberately NOT reused as the proxy target for the same reason other proxies give: they run through `core.KeyorixCore`, so proxying onto them would apply that business logic a second time, upstream, against the wrong actor context.
- `#499`'s `GetEnvironment`/`CreateSecret` carve-out (`internal/core/secrets.go`, `errors.Is(ErrUnsupportedByBackend)`) is untouched — it simply starts exercising the ownership pre-check for real now that `GetEnvironment` is proxied.
- Updates `internal/storage/store/remote_unsupported_completeness_test.go`'s allowlist, removing all 13 closed entries.

## Atomicity analysis

Traced every real caller (catalog.go route handlers, invitations, membership, secrets, drift, rotation, compliance, recertification, deployment hygiene, scheduled jobs) to check whether any delete/restore pair relies on a local-DB transaction, row lock, or check-then-act sequence that a naive two-call HTTP proxy would break (this campaign has hit that bug class 3 times already: WebAuthn credential counter, Machine Identity state transitions, Secret Dependency cycle-check).

- `DeleteProject`/`RestoreProject`/`DeleteEnvironment`/`RestoreEnvironment` themselves are each a SINGLE `storage.Storage` call, so proxying each as ONE HTTP round trip to a hub-side handler that calls the hub's own storage method preserves whatever transactional guarantee the local implementation already has (each of these already resolves in one call server-side — no decomposition, no new race).
- **Found a real gap**: `core.DeleteProject`'s `force=false` guard (`internal/core/catalog.go`) ran as `c.storage.WithTransaction(...)` wrapping a separate `ListSecrets` count call and a `DeleteProject` cascade call — two top-level `storage.Storage` calls. `RemoteStorage.WithTransaction` is a documented no-op passthrough over HTTP (`return fn(rs)`), so once `DeleteProject` stopped being an unconditional stub, this pair would have reopened a TOCTOU window across a full network round trip: a secret created between the count and the cascade would silently let a `force=false` delete cascade over it anyway, bypassing the guard's "reject if secrets exist" promise (ADR-019). Before this PR the guard was moot (`DeleteProject` always errored); this PR is what makes the race live, so it had to be fixed in the same change.
- **Fix**: added `DeleteProjectIfEmpty`, a new `storage.Storage` primitive that does the guard-count and the cascade as ONE atomic call — a real DB transaction for `LocalStorage` (refactored `DeleteProject`'s cascade into a shared `deleteProjectCascade` helper reused by both), and ONE HTTP round trip for `RemoteStorage` (`POST /api/v1/system/projects/{id}/delete-if-empty`), executed entirely server-side against the hub's own storage. `core.DeleteProject` now calls this instead of the `WithTransaction`-wrapped pair. Updated `internal/core/catalog_delete_project_test.go`'s #313 structural regression tests to match (spy asserts `DeleteProjectIfEmpty` is called as one atomic op, not a `ListSecrets`+`DeleteProject` pair) — all existing behavior/error messages preserved. Added `TestRemoteStorageProject_DeleteIfEmpty_ConcurrentRaceIsSerialized_RealServer`, mirroring the Machine Identity race test: 8 goroutines race `DeleteProjectIfEmpty` on the same empty project against a real upstream server — exactly one commits, the rest cleanly see "not found" (no double-delete, no double-processing of the #369 dynamic-secret-lease revocation or #311 restored-count audit math).
- `RestoreProject`/`RestoreEnvironment`'s core-layer `requireAuthorityToReinstateProjectRoles` admin-ceiling check depends on `ListProjectRoleAssignments`, a separately-tracked, deliberately-unsupported RBAC primitive (out of scope for #528, per its own doc comment: "RBAC admin-removal guarding runs entirely against LocalStorage server-side"). The human-facing restore endpoints on a spoke server therefore still hit that wall — a known, pre-existing, separately-tracked gap, unaffected by this PR either way.

## Route decision rationale

New system routes are thin `storage.Storage` passthroughs (not reusing the human-facing `/api/v1/projects`/`/api/v1/environments` routes), matching every other proxy in this campaign — those routes run through `core.KeyorixCore` and would re-apply policy/audit/RBAC logic a second time, upstream, against the wrong actor context. Static sub-paths (`with-counts`, `{id}/delete-if-empty`, `{id}/restore`, `{id}/members`, `{id}/environments`) are registered ahead of/alongside the `{id}` wildcard, matching the precedence other proxies in this file already rely on. `/projects/{projectId}/environments/{id}/restore` reuses a different param name than `/projects/{id}` at the same depth, mirroring the existing human-facing routes' identical pattern.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/storage/store/... ./server/http/... ./internal/core/...` — 2304 tests pass
- [x] New e2e tests: `server/http/remote_storage_project_catalog_test.go`, `server/http/remote_storage_environment_catalog_test.go` (CRUD round-trips, not-found handling, the `DeleteProjectIfEmpty` guard/force/restore flow, and the concurrent-race regression), all against a real upstream server (not a protocol mock)