### PR TITLE
fix(mfa): proxy MFA enrollment/management under storage.type: remote

### DIFF
--- a/internal/storage/store/remote_mfa.go
+++ b/internal/storage/store/remote_mfa.go
@@ -1,26 +1,77 @@
-// remote_mfa.go — MFA persistence is server-side only; the remote client never
-// manages MFA state directly (enrolment/verify go through the server's REST API).
+// remote_mfa.go — MFA persistence for RemoteStorage: the login-verification
+// half (IssueMFAChallenge/VerifyMFALoginCredentials, below) and the
+// enrolment/management half (UpsertMFASecret..DeleteMFARecoveryCodes, also
+// below, finding #524) are two DIFFERENT proxy shapes for two different
+// problems — see each section's doc for why.
 //
 // IssueMFAChallenge and VerifyMFALoginCredentials below implement
 // core.RemoteMFAVerifier (#509): the upstream half of the storage.type: remote
-// TOTP second-factor login proxy, mirroring remote_login_verify.go's password
-// proxy (#506) exactly. The raw TOTP secret is stored reversibly encrypted
-// specifically so it must never leave the server that can decrypt it —
-// GetMFASecret below stays an unconditional stub for that reason — so the
-// ENTIRE TOTP/recovery-code check, not just a wire-DTO passthrough of the
-// storage primitives above, has to run upstream.
+// TOTP second-factor LOGIN proxy, mirroring remote_login_verify.go's password
+// proxy (#506) exactly. Login verification must run entirely upstream because
+// VerifyMFACredentials (internal/core/mfa.go) needs to compare a caller-supplied
+// code against the DECRYPTED secret, and account lockout accounting has to be
+// serialized with the password-step lockout check — a wire-DTO passthrough of
+// the storage primitives alone would still leave that whole check unreachable
+// on a spoke node.
 //
-// GetActiveMFAChallenge and ConsumeMFAChallenge below are DIFFERENT from that
-// pair: they are ordinary storage.Storage passthroughs (#522), not part of the
+// UpsertMFASecret/GetMFASecret/ActivateMFASecret/DeleteMFAForUser/
+// SetUserMFAEnabled/CreateMFARecoveryCodes/CountUnusedMFARecoveryCodes/
+// DeleteMFARecoveryCodes below are a DIFFERENT, CRUD-shaped problem
+// (finding #524): enrolment (BeginMFAEnrollment/ActivateMFA) and management
+// (DisableMFA/RegenerateMFARecoveryCodes/MFARecoveryCodesRemaining,
+// internal/core/mfa.go) ALWAYS run on whichever server terminates the
+// end-user's /auth/mfa/* request — never delegated to a RemoteMFAVerifier —
+// so before this fix these eight methods being unconditional stubs made MFA
+// enrolment and management 100% broken under storage.type: remote (login
+// itself, once already-active, was unaffected: it goes through the
+// RemotMFAVerifier proxy above). These are thin passthroughs onto new routes
+// under /api/v1/system/mfa (server/http/handlers/mfa_management_proxy.go),
+// gated on the SAME system.read/system.write RBAC tier every other
+// RemoteStorage proxy call already uses — no new privilege class. No MFA
+// POLICY decision (re-auth gate, single-active-method enforcement, recovery
+// code generation/hashing, session invalidation on activation) is made in
+// these routes; that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore, exactly as it does against a local backend.
+//
+// Sensitive-data boundary (investigated, not assumed — mirrors
+// remote_dynamic.go's identical AdminDSN/Credential boundary exactly):
+// MFASecret.SecretEnc/SecretMeta is encrypted by internal/core
+// (KeyorixCore.encryptAuthSecret/decryptAuthSecret) using the CALLING
+// server's own encryption key BEFORE the row is ever handed to
+// UpsertMFASecret, and decrypted only after GetMFASecret returns it — never in
+// plaintext, and never by the upstream server these routes live on. The wire
+// type below carries SecretEnc/SecretMeta as opaque ciphertext bytes; the
+// upstream's proxy handlers never decrypt it. (BeginMFAEnrollment also
+// refuses outright when at-rest encryption is disabled — see
+// models.MFASecret's own doc — so this ciphertext is never actually plaintext
+// even in that degraded case.)
+//
+// Atomicity (checked against local_mfa.go, not assumed): every one of these
+// eight methods is ALREADY a single storage.Storage call in
+// internal/core/mfa.go — none of ActivateMFA/DisableMFA/
+// RegenerateMFARecoveryCodes wraps its several storage calls in
+// core.storage.WithTransaction (RemoteStorage.WithTransaction is a no-op
+// passthrough anyway, remote_transaction.go), and DeleteMFAForUser's OWN
+// internal secret+recovery-codes delete already happens inside ONE local GORM
+// transaction wholly inside local_mfa.go, not split across two core-level
+// calls. So proxying each of these eight as ONE HTTP round trip to the
+// upstream (which still executes local_mfa.go's own UPDATE/transaction
+// server-side) preserves whatever atomicity the local backend already had —
+// unlike AdvanceWebAuthnCredentialCounter (#517) or
+// CreateSecretDependencyExclusive (#519), no NEW combined atomic primitive is
+// needed here, because no caller here composes a Lock-then-Update (or
+// check-then-act) pair across two SEPARATE storage calls that this HTTP hop
+// could reopen a race in.
+//
+// GetActiveMFAChallenge and ConsumeMFAChallenge below are DIFFERENT again:
+// they are ordinary storage.Storage passthroughs (#522), not part of the
 // RemoteMFAVerifier proxy. models.MFAChallenge is a SHARED pre-auth token: the
 // SAME row backs both the TOTP path (proxied wholesale above, since it also
 // needs the encrypted secret) and WebAuthn-as-second-factor login
 // (internal/core/webauthn.go's BeginWebAuthnLogin/FinishWebAuthnLogin), which has
 // no secret of its own to protect — a spoke server that resolves the
 // challenge's user_id can run the entire passkey assertion ceremony locally
-// against its own (already-proxied, #517) WebAuthn credential rows. Before this
-// fix, BOTH were unconditional stubs, so WebAuthn login was 100% broken under
-// storage.type: remote even though the TOTP path already worked.
+// against its own (already-proxied, #517) WebAuthn credential rows.
 //
 // WebAuthn's OWN storage.Storage primitives (registered credentials, ceremony
 // sessions) are handled separately: see remote_webauthn.go / #517.
@@ -30,49 +81,220 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-func (rs *RemoteStorage) UpsertMFASecret(_ context.Context, _ *models.MFASecret) error {
-	return remoteUnsupported("UpsertMFASecret")
+// mfaSecretWire mirrors models.MFASecret's fields exactly (snake_case).
+// SecretEnc/SecretMeta/LastUsedStep are tagged json:"-" on the model (to keep
+// them out of USER-facing responses) — irrelevant here, since this is an
+// internal system-to-system wire format gated on system.read/system.write,
+// matching webAuthnSessionWire's identical json:"-"-field precedent. SecretEnc/
+// SecretMeta carry the CALLING server's own ciphertext verbatim — see this
+// file's package doc for why that is safe to transmit as opaque bytes.
+type mfaSecretWire struct {
+	ID           uint      `json:"id"`
+	UserID       uint      `json:"user_id"`
+	SecretEnc    []byte    `json:"secret_enc"`
+	SecretMeta   []byte    `json:"secret_meta"`
+	Activated    bool      `json:"activated"`
+	LastUsedStep *int64    `json:"last_used_step"`
+	CreatedAt    time.Time `json:"created_at"`
 }
 
-func (rs *RemoteStorage) GetMFASecret(_ context.Context, _ uint) (*models.MFASecret, error) {
-	return nil, remoteUnsupported("GetMFASecret")
+func newMFASecretWire(s *models.MFASecret) mfaSecretWire {
+	return mfaSecretWire{
+		ID:           s.ID,
+		UserID:       s.UserID,
+		SecretEnc:    s.SecretEnc,
+		SecretMeta:   s.SecretMeta,
+		Activated:    s.Activated,
+		LastUsedStep: s.LastUsedStep,
+		CreatedAt:    s.CreatedAt,
+	}
 }
 
-func (rs *RemoteStorage) ActivateMFASecret(_ context.Context, _ uint) error {
-	return remoteUnsupported("ActivateMFASecret")
+func (w mfaSecretWire) toModel() *models.MFASecret {
+	return &models.MFASecret{
+		ID:           w.ID,
+		UserID:       w.UserID,
+		SecretEnc:    w.SecretEnc,
+		SecretMeta:   w.SecretMeta,
+		Activated:    w.Activated,
+		LastUsedStep: w.LastUsedStep,
+		CreatedAt:    w.CreatedAt,
+	}
+}
+
+func decodeMFASecretResponse(data []byte) (*models.MFASecret, error) {
+	var wire mfaSecretWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
+}
+
+// UpsertMFASecret persists the user's TOTP secret row via POST
+// /api/v1/system/mfa/secrets, then copies the upstream-assigned fields (ID,
+// CreatedAt) back into s — mirroring CreateWebAuthnCredential's identical
+// in-place-mutate contract, and LocalStorage's own GORM Create-with-OnConflict,
+// which does the same.
+func (rs *RemoteStorage) UpsertMFASecret(ctx context.Context, s *models.MFASecret) error {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/mfa/secrets", newMFASecretWire(s))
+	if err != nil {
+		return fmt.Errorf("failed to store MFA secret: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("store MFA secret failed: %s", resp.Error.Error())
+	}
+	saved, err := decodeMFASecretResponse(resp.Data)
+	if err != nil {
+		return err
+	}
+	*s = *saved
+	return nil
+}
+
+// GetMFASecret fetches a user's TOTP secret row via GET
+// /api/v1/system/mfa/secrets?user_id=X — the CALLING server then decrypts
+// SecretEnc/SecretMeta with its own key (loadTOTPSecret,
+// internal/core/mfa.go), exactly as it would against a local backend.
+func (rs *RemoteStorage) GetMFASecret(ctx context.Context, userID uint) (*models.MFASecret, error) {
+	q := url.Values{}
+	q.Set("user_id", strconv.FormatUint(uint64(userID), 10))
+	path := "/api/v1/system/mfa/secrets?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get MFA secret: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get MFA secret failed: %s", resp.Error.Error())
+	}
+	return decodeMFASecretResponse(resp.Data)
+}
+
+// ActivateMFASecret marks the user's pending TOTP secret activated via POST
+// /api/v1/system/mfa/secrets/{userId}/activate — an unconditional single-column
+// UPDATE, matching LocalStorage's own semantics exactly (no WHERE-activated
+// guard locally either; ActivateMFA's password/TOTP re-auth is the only gate).
+func (rs *RemoteStorage) ActivateMFASecret(ctx context.Context, userID uint) error {
+	path := fmt.Sprintf("/api/v1/system/mfa/secrets/%d/activate", userID)
+	resp, err := rs.client.Post(ctx, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to activate MFA secret: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("activate MFA secret failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
 func (rs *RemoteStorage) MarkTOTPStepUsed(_ context.Context, _ uint, _ int64) (bool, error) {
 	return false, remoteUnsupported("MarkTOTPStepUsed")
 }
 
-func (rs *RemoteStorage) DeleteMFAForUser(_ context.Context, _ uint) error {
-	return remoteUnsupported("DeleteMFAForUser")
+// DeleteMFAForUser clears a user's secret and all recovery codes via DELETE
+// /api/v1/system/mfa/users/{userId} — ONE HTTP round trip onto the upstream's
+// own DeleteMFAForUser, so this inherits local_mfa.go's internal
+// secret-then-codes GORM transaction unchanged; there is no separate
+// "delete secret, then delete codes" sequence here to reopen a partial-delete
+// gap across the HTTP hop.
+func (rs *RemoteStorage) DeleteMFAForUser(ctx context.Context, userID uint) error {
+	path := fmt.Sprintf("/api/v1/system/mfa/users/%d", userID)
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete MFA for user: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete MFA for user failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-func (rs *RemoteStorage) SetUserMFAEnabled(_ context.Context, _ uint, _ bool) error {
-	return remoteUnsupported("SetUserMFAEnabled")
+// setUserMFAEnabledWire is the wire body for SetUserMFAEnabledProxy, mirroring
+// setUserWebAuthnEnabledWire exactly.
+type setUserMFAEnabledWire struct {
+	Enabled bool `json:"enabled"`
 }
 
-func (rs *RemoteStorage) CreateMFARecoveryCodes(_ context.Context, _ uint, _ []string) error {
-	return remoteUnsupported("CreateMFARecoveryCodes")
+// SetUserMFAEnabled flips the user's MFAEnabled flag via PUT
+// /api/v1/system/mfa/users/{userId}/mfa-enabled.
+func (rs *RemoteStorage) SetUserMFAEnabled(ctx context.Context, userID uint, enabled bool) error {
+	path := fmt.Sprintf("/api/v1/system/mfa/users/%d/mfa-enabled", userID)
+	resp, err := rs.client.Put(ctx, path, setUserMFAEnabledWire{Enabled: enabled})
+	if err != nil {
+		return fmt.Errorf("failed to set MFA enabled: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("set MFA enabled failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// createMFARecoveryCodesWire is the wire body for CreateMFARecoveryCodesProxy.
+type createMFARecoveryCodesWire struct {
+	CodeHashes []string `json:"code_hashes"`
+}
+
+// CreateMFARecoveryCodes bulk-inserts the user's hashed recovery codes via
+// POST /api/v1/system/mfa/recovery-codes. The plaintext codes themselves never
+// cross the wire — ActivateMFA/RegenerateMFARecoveryCodes
+// (internal/core/mfa.go) hash them locally first, exactly as they do against a
+// local backend.
+func (rs *RemoteStorage) CreateMFARecoveryCodes(ctx context.Context, userID uint, codeHashes []string) error {
+	path := fmt.Sprintf("/api/v1/system/mfa/recovery-codes?user_id=%d", userID)
+	resp, err := rs.client.Post(ctx, path, createMFARecoveryCodesWire{CodeHashes: codeHashes})
+	if err != nil {
+		return fmt.Errorf("failed to store MFA recovery codes: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("store MFA recovery codes failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
 func (rs *RemoteStorage) ConsumeMFARecoveryCode(_ context.Context, _ uint, _ string, _ time.Time) (bool, error) {
 	return false, remoteUnsupported("ConsumeMFARecoveryCode")
 }
 
-func (rs *RemoteStorage) CountUnusedMFARecoveryCodes(_ context.Context, _ uint) (int, error) {
-	return 0, remoteUnsupported("CountUnusedMFARecoveryCodes")
+// CountUnusedMFARecoveryCodes reports how many of a user's recovery codes
+// remain unused via GET /api/v1/system/mfa/recovery-codes/count?user_id=X.
+func (rs *RemoteStorage) CountUnusedMFARecoveryCodes(ctx context.Context, userID uint) (int, error) {
+	q := url.Values{}
+	q.Set("user_id", strconv.FormatUint(uint64(userID), 10))
+	path := "/api/v1/system/mfa/recovery-codes/count?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count MFA recovery codes: %w", err)
+	}
+	if !resp.Success {
+		return 0, fmt.Errorf("count MFA recovery codes failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Count int `json:"count"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Count, nil
 }
 
-func (rs *RemoteStorage) DeleteMFARecoveryCodes(_ context.Context, _ uint) error {
-	return remoteUnsupported("DeleteMFARecoveryCodes")
+// DeleteMFARecoveryCodes removes ALL of a user's recovery codes via DELETE
+// /api/v1/system/mfa/recovery-codes/{userId} — the regenerate flow's "clear old
+// codes" half.
+func (rs *RemoteStorage) DeleteMFARecoveryCodes(ctx context.Context, userID uint) error {
+	path := fmt.Sprintf("/api/v1/system/mfa/recovery-codes/%d", userID)
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete MFA recovery codes: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete MFA recovery codes failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
 func (rs *RemoteStorage) CreateMFAChallenge(_ context.Context, _ *models.MFAChallenge) error {

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -75,10 +75,11 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"ConsumeMFARecoveryCode": {statusIntentional,
 		"round 119 audit: sole caller is VerifyMFACredentials, same bypassed-branch reasoning as MarkTOTPStepUsed — recovery codes are only ever consumed at login, never during enrollment/management"},
 
-	// --- Confirmed genuine gaps, tracked for future fix rounds (47; UpdateLoginLockoutState
+	// --- Confirmed genuine gaps, tracked for future fix rounds (39; UpdateLoginLockoutState
 	// closed by #529, SSO login state closed by #521, GetActiveMFAChallenge/
 	// ConsumeMFAChallenge (WebAuthn-as-second-factor login) closed by #522, Connect
-	// ref-grant CRUD closed by #527) ---
+	// ref-grant CRUD closed by #527, MFA enrolment/management (the 8 entries below)
+	// closed by #524) ---
 	// See docs/security/HARDENING-BACKLOG.md's round 119 entry for full detail,
 	// severity, and grouping. Each entry below cites the real caller/route a
 	// round-119 audit traced (not assumed).
@@ -102,19 +103,9 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"ListAccessRequestApprovals": {statusKnownGap,
 		"round 119: progress annotation + duplicate-approver check during approve"},
 
-	// MFA enrollment/management (not just login) — 100% broken.
-	"UpsertMFASecret": {statusKnownGap, "round 119: BeginMFAEnrollment, POST /auth/mfa/enroll"},
-	"GetMFASecret": {statusKnownGap,
-		"round 119: ActivateMFA (POST /auth/mfa/activate) and requireReauth (gates disable/regenerate-codes/WebAuthn register-delete)"},
-	"ActivateMFASecret": {statusKnownGap, "round 119: ActivateMFA, POST /auth/mfa/activate"},
-	"DeleteMFAForUser":  {statusKnownGap, "round 119: DisableMFA, POST /auth/mfa/disable"},
-	"SetUserMFAEnabled": {statusKnownGap, "round 119: ActivateMFA and DisableMFA"},
-	"CreateMFARecoveryCodes": {statusKnownGap,
-		"round 119: ActivateMFA and RegenerateMFARecoveryCodes (POST /auth/mfa/recovery-codes/regenerate)"},
-	"CountUnusedMFARecoveryCodes": {statusKnownGap,
-		"round 119: MFARecoveryCodesRemaining, GET /auth/mfa/recovery-codes"},
-	"DeleteMFARecoveryCodes": {statusKnownGap,
-		"round 119: RegenerateMFARecoveryCodes, POST /auth/mfa/recovery-codes/regenerate"},
+	// MFA enrollment/management (not just login) — closed by #524: now proxied via
+	// /api/v1/system/mfa (server/http/handlers/mfa_management_proxy.go), see
+	// internal/storage/store/remote_mfa.go.
 
 	// RBAC role-grant primitives + last-admin/escalation guards.
 	"GetGroupRoleGrants": {statusKnownGap,

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -141,6 +141,22 @@ func newUserUpdateWireRequest(user *models.User) userUpdateWireRequest {
 // never-federated account, regardless of what the upstream's own row actually
 // stored. This affected the already-shipped #504 email-fallback path, not just the
 // new by-external-id lookup this change adds.
+// MFAEnabled (#524) rounds out the wire response with the two-factor-enrolment
+// flag. The server side (users_crud.go) always sent "mfa_enabled" in its
+// response, but this wire type never had a field to decode it into, so every
+// decoded user's MFAEnabled read back as the Go zero value (false) under
+// storage.type: remote — regardless of what the upstream's own row actually
+// stored. This silently broke every internal/core/mfa.go caller that branches
+// on user.MFAEnabled once #524's storage-primitive proxies made the rest of
+// the enrolment/management flow reachable: MFARecoveryCodesRemaining always
+// reported 0/0, DisableMFA/RegenerateMFARecoveryCodes always refused with "MFA
+// is not enabled", and requireReauth's TOTP-code re-auth branch (the ONLY
+// re-auth path that works under storage.type: remote — its password fallback
+// needs PasswordHash, which is deliberately never sent, see above) was
+// unreachable dead code. A pre-existing gap in remote_users.go, not one of
+// #524's eight remote_mfa.go storage methods, but load-bearing for the SAME
+// described bug ("disabling [MFA], or viewing/regenerating recovery codes
+// cannot work at all in this mode") and fixed in the same PR for that reason.
 type userWireResponse struct {
 	ID                  uint       `json:"id"`
 	Username            string     `json:"username"`
@@ -149,6 +165,7 @@ type userWireResponse struct {
 	Active              bool       `json:"active"`
 	AccountState        string     `json:"account_state"`
 	ExternalID          string     `json:"external_id"`
+	MFAEnabled          bool       `json:"mfa_enabled"`
 	CreatedAt           time.Time  `json:"created_at"`
 	UpdatedAt           time.Time  `json:"updated_at"`
 	LastLoginAt         *time.Time `json:"last_login_at"`
@@ -168,6 +185,7 @@ func (w userWireResponse) toModel() *models.User {
 		IsActive:            w.Active,
 		AccountState:        w.AccountState,
 		ExternalID:          w.ExternalID,
+		MFAEnabled:          w.MFAEnabled,
 		CreatedAt:           w.CreatedAt,
 		UpdatedAt:           w.UpdatedAt,
 		LastLoginAt:         w.LastLoginAt,

--- a/server/http/handlers/mfa_management_proxy.go
+++ b/server/http/handlers/mfa_management_proxy.go
@@ -1,0 +1,278 @@
+// mfa_management_proxy.go — server-side endpoints backing RemoteStorage's MFA
+// enrolment/management storage primitives (finding #524):
+// UpsertMFASecret/GetMFASecret/ActivateMFASecret/DeleteMFAForUser/
+// SetUserMFAEnabled/CreateMFARecoveryCodes/CountUnusedMFARecoveryCodes/
+// DeleteMFARecoveryCodes.
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049)
+// terminates every /auth/mfa/* request itself — BeginMFAEnrollment/ActivateMFA/
+// DisableMFA/RegenerateMFARecoveryCodes/MFARecoveryCodesRemaining
+// (internal/core/mfa.go) — it just needs somewhere to persist the TOTP secret
+// and recovery-code rows. Before this fix none of these eight storage methods
+// had a server route to call at all, so MFA enrolment and management (though
+// NOT already-active MFA login, which is proxied separately via
+// RemoteMFAVerifier — see remote_mfa.go's package doc) were 100% broken under
+// storage.type: remote. These routes (registered in server/http/router.go
+// under /api/v1/system/mfa, gated on the existing system.read/system.write
+// RBAC permissions — the SAME tier a RemoteStorage credential already needs
+// for every other proxied call) mirror webauthn_proxy.go/sso_state_proxy.go
+// exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/mfa.go already uses against a local backend — NO MFA POLICY
+// decision (the re-auth gate before activate/disable/regenerate, the
+// single-active-method enforcement, recovery-code generation/hashing, or the
+// post-activation session invalidation) is made here; that stays entirely in
+// the CALLING server's own internal/core.KeyorixCore, exactly as it does
+// against a local backend.
+//
+// Sensitive-data boundary: SecretEnc/SecretMeta arrive and leave as opaque
+// ciphertext, encrypted/decrypted only by the CALLING server's own
+// internal/core.KeyorixCore.encryptAuthSecret/decryptAuthSecret — this file
+// never touches plaintext. See remote_mfa.go's package doc for the full
+// investigated reasoning (mirrors remote_dynamic.go's AdminDSN/Credential
+// boundary exactly).
+//
+// Atomicity: every handler below calls exactly ONE storage.Storage method, so
+// each preserves whatever transactional guarantee local_mfa.go's own
+// implementation already has (DeleteMFAForUserProxy's DELETE inherits
+// local_mfa.go's internal secret+recovery-codes GORM transaction unchanged;
+// every other handler is a single unconditional UPDATE/INSERT/DELETE/SELECT,
+// matching the local backend's own semantics exactly) — see remote_mfa.go's
+// package doc for the full analysis of why no NEW combined atomic primitive
+// (unlike AdvanceWebAuthnCredentialCounterProxy/
+// CreateSecretDependencyExclusiveProxy) is needed here.
+//
+// Response envelope: like every other proxy in this package, these do NOT use
+// the package's generic sendSuccess/sendError helpers — they construct the
+// exact {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// mfaSecretProxyWire mirrors models.MFASecret's fields exactly (snake_case)
+// and mfaSecretWire in internal/storage/store/remote_mfa.go. SecretEnc/
+// SecretMeta/LastUsedStep are tagged json:"-" on the model (to keep them out
+// of USER-facing responses) — irrelevant here, since this is an internal
+// system-to-system wire format gated on system.read/system.write, matching
+// webAuthnSessionProxyWire's identical json:"-"-field precedent.
+type mfaSecretProxyWire struct {
+	ID           uint      `json:"id"`
+	UserID       uint      `json:"user_id"`
+	SecretEnc    []byte    `json:"secret_enc"`
+	SecretMeta   []byte    `json:"secret_meta"`
+	Activated    bool      `json:"activated"`
+	LastUsedStep *int64    `json:"last_used_step"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+func newMFASecretProxyWire(s *models.MFASecret) mfaSecretProxyWire {
+	return mfaSecretProxyWire{
+		ID:           s.ID,
+		UserID:       s.UserID,
+		SecretEnc:    s.SecretEnc,
+		SecretMeta:   s.SecretMeta,
+		Activated:    s.Activated,
+		LastUsedStep: s.LastUsedStep,
+		CreatedAt:    s.CreatedAt,
+	}
+}
+
+func parseMFAUserIDQuery(w http.ResponseWriter, r *http.Request) (userID uint, ok bool) {
+	v := r.URL.Query().Get("user_id")
+	if v == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "user_id query parameter is required")
+		return 0, false
+	}
+	id, err := strconv.ParseUint(v, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "user_id must be a valid integer")
+		return 0, false
+	}
+	return uint(id), true
+}
+
+func parseMFAUserIDParam(w http.ResponseWriter, r *http.Request, name string) (userID uint, ok bool) {
+	id, err := strconv.ParseUint(chi.URLParam(r, name), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid user id")
+		return 0, false
+	}
+	return uint(id), true
+}
+
+// UpsertMFASecretProxy handles POST /api/v1/system/mfa/secrets. A raw persist
+// of the caller's already-encrypted secret row (core.BeginMFAEnrollment has
+// already encrypted it and refuses outright when encryption is unavailable —
+// see models.MFASecret's doc) — matching LocalStorage's own GORM
+// Create-with-OnConflict, this is an upsert keyed on user_id.
+func (h *AuthHandler) UpsertMFASecretProxy(w http.ResponseWriter, r *http.Request) {
+	var body mfaSecretProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.UserID == 0 || len(body.SecretEnc) == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id and secret_enc are required")
+		return
+	}
+	row := &models.MFASecret{
+		UserID:       body.UserID,
+		SecretEnc:    body.SecretEnc,
+		SecretMeta:   body.SecretMeta,
+		Activated:    body.Activated,
+		LastUsedStep: body.LastUsedStep,
+		CreatedAt:    body.CreatedAt,
+	}
+	if err := h.coreService.Storage().UpsertMFASecret(r.Context(), row); err != nil {
+		log.Printf("mfa proxy: upsert secret failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMFASecretProxyWire(row))
+}
+
+// GetMFASecretProxy handles GET /api/v1/system/mfa/secrets?user_id=X.
+func (h *AuthHandler) GetMFASecretProxy(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseMFAUserIDQuery(w, r)
+	if !ok {
+		return
+	}
+	s, err := h.coreService.Storage().GetMFASecret(r.Context(), userID)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "MFA secret not found")
+			return
+		}
+		log.Printf("mfa proxy: get secret failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newMFASecretProxyWire(s))
+}
+
+// ActivateMFASecretProxy handles POST
+// /api/v1/system/mfa/secrets/{userId}/activate.
+func (h *AuthHandler) ActivateMFASecretProxy(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseMFAUserIDParam(w, r, "userId")
+	if !ok {
+		return
+	}
+	if err := h.coreService.Storage().ActivateMFASecret(r.Context(), userID); err != nil {
+		log.Printf("mfa proxy: activate secret failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"activated": true})
+}
+
+// DeleteMFAForUserProxy handles DELETE /api/v1/system/mfa/users/{userId}. Calls
+// storage.Storage.DeleteMFAForUser directly, so this inherits local_mfa.go's
+// own secret+recovery-codes GORM transaction unchanged.
+func (h *AuthHandler) DeleteMFAForUserProxy(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseMFAUserIDParam(w, r, "userId")
+	if !ok {
+		return
+	}
+	if err := h.coreService.Storage().DeleteMFAForUser(r.Context(), userID); err != nil {
+		log.Printf("mfa proxy: delete for user failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}
+
+// setUserMFAEnabledProxyBody is the wire body for SetUserMFAEnabledProxy.
+type setUserMFAEnabledProxyBody struct {
+	Enabled bool `json:"enabled"`
+}
+
+// SetUserMFAEnabledProxy handles PUT
+// /api/v1/system/mfa/users/{userId}/mfa-enabled.
+func (h *AuthHandler) SetUserMFAEnabledProxy(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseMFAUserIDParam(w, r, "userId")
+	if !ok {
+		return
+	}
+	var body setUserMFAEnabledProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if err := h.coreService.Storage().SetUserMFAEnabled(r.Context(), userID, body.Enabled); err != nil {
+		log.Printf("mfa proxy: set mfa enabled failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}
+
+// createMFARecoveryCodesProxyBody is the wire body for
+// CreateMFARecoveryCodesProxy.
+type createMFARecoveryCodesProxyBody struct {
+	CodeHashes []string `json:"code_hashes"`
+}
+
+// CreateMFARecoveryCodesProxy handles POST
+// /api/v1/system/mfa/recovery-codes?user_id=X. Only the SHA-256 hashes ever
+// cross the wire — the caller (ActivateMFA/RegenerateMFARecoveryCodes,
+// internal/core/mfa.go) generates and hashes the plaintext codes itself,
+// exactly as it does against a local backend.
+func (h *AuthHandler) CreateMFARecoveryCodesProxy(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseMFAUserIDQuery(w, r)
+	if !ok {
+		return
+	}
+	var body createMFARecoveryCodesProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if err := h.coreService.Storage().CreateMFARecoveryCodes(r.Context(), userID, body.CodeHashes); err != nil {
+		log.Printf("mfa proxy: create recovery codes failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"created": true})
+}
+
+// CountUnusedMFARecoveryCodesProxy handles GET
+// /api/v1/system/mfa/recovery-codes/count?user_id=X.
+func (h *AuthHandler) CountUnusedMFARecoveryCodesProxy(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseMFAUserIDQuery(w, r)
+	if !ok {
+		return
+	}
+	n, err := h.coreService.Storage().CountUnusedMFARecoveryCodes(r.Context(), userID)
+	if err != nil {
+		log.Printf("mfa proxy: count recovery codes failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int{"count": n})
+}
+
+// DeleteMFARecoveryCodesProxy handles DELETE
+// /api/v1/system/mfa/recovery-codes/{userId}.
+func (h *AuthHandler) DeleteMFARecoveryCodesProxy(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseMFAUserIDParam(w, r, "userId")
+	if !ok {
+		return
+	}
+	if err := h.coreService.Storage().DeleteMFARecoveryCodes(r.Context(), userID); err != nil {
+		log.Printf("mfa proxy: delete recovery codes failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}

--- a/server/http/handlers/users_handler.go
+++ b/server/http/handlers/users_handler.go
@@ -121,6 +121,23 @@ func userToAPIResponse(u *models.User) map[string]interface{} {
 	if u.LastFailedLoginAt != nil {
 		out["last_failed_login_at"] = u.LastFailedLoginAt.UTC().Format(time.RFC3339)
 	}
+	// mfa_enabled (#524): this endpoint already surfaces the identical
+	// admin-level lockout-accounting fields just above (users.read/users.write
+	// trust boundary — not a lower-trust caller, and MFAEnabled is not
+	// sensitive the way PasswordHash is; VerifyCredentials's proxy response
+	// already sends it at the SAME trust tier, see auth #506/#509). Without it
+	// here, RemoteStorage's GetUser (internal/storage/store/remote_users.go)
+	// decoded every user's MFAEnabled as the Go zero value (false) regardless
+	// of the upstream's real state under storage.type: remote — silently
+	// breaking every internal/core/mfa.go caller that branches on
+	// user.MFAEnabled once #524's storage-primitive proxies made the rest of
+	// the enrolment/management flow reachable (MFARecoveryCodesRemaining
+	// always reported 0/0, DisableMFA/RegenerateMFARecoveryCodes always
+	// refused with "MFA is not enabled", and requireReauth's TOTP-code re-auth
+	// branch — the only re-auth path that can work under storage.type: remote,
+	// since PasswordHash is deliberately never sent — was unreachable dead
+	// code).
+	out["mfa_enabled"] = u.MFAEnabled
 	return out
 }
 

--- a/server/http/remote_storage_mfa_management_test.go
+++ b/server/http/remote_storage_mfa_management_test.go
@@ -1,0 +1,277 @@
+// remote_storage_mfa_management_test.go — end-to-end coverage for #524:
+// RemoteStorage's UpsertMFASecret/GetMFASecret/ActivateMFASecret/
+// DeleteMFAForUser/SetUserMFAEnabled/CreateMFARecoveryCodes/
+// CountUnusedMFARecoveryCodes/DeleteMFARecoveryCodes were all unconditional
+// stubs, so MFA enrolment and management (internal/core/mfa.go's
+// BeginMFAEnrollment/ActivateMFA/DisableMFA/RegenerateMFARecoveryCodes/
+// MFARecoveryCodesRemaining — every /auth/mfa/* route except already-active
+// MFA LOGIN, separately proxied by #509/remote_storage_mfa_login_test.go) was
+// 100% broken under storage.type: remote. Mirrors
+// remote_storage_sso_state_test.go's (#521) and
+// remote_storage_login_lockout_write_test.go's (#529) harness exactly: a real
+// "upstream" exercised through the production NewRouter/handlers (including
+// the new /api/v1/system/mfa routes, server/http/handlers/mfa_management_proxy.go),
+// and a "downstream" *core.KeyorixCore configured with storage.type: remote
+// pointed at "upstream" over real HTTP via store.RemoteStorage.
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForMFAManagement builds the standard two-server harness
+// used across this campaign, PLUS a real encryption.Service wired into BOTH
+// cores — needed because BeginMFAEnrollment refuses outright when at-rest
+// encryption is unavailable, and because the downstream core must be able to
+// decrypt what it itself just encrypted (see remote_mfa.go's package doc for
+// why that "same calling server does both halves" property is what makes
+// proxying SecretEnc/SecretMeta as opaque ciphertext safe here).
+func newUpstreamDownstreamForMFAManagement(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
+	require.NoError(t, enc.Initialize("test-passphrase"))
+	upstream.SetAuthEncryptor(enc)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+	// The downstream is the server that actually terminates /auth/mfa/*
+	// requests under storage.type: remote, so it needs its OWN encryption
+	// service wired up too — exactly like a real spoke deployment configured
+	// with its own at-rest encryption.
+	downstream.SetAuthEncryptor(enc)
+	return upstream, downstream
+}
+
+// TestRemoteStorageMFAManagement_StoragePrimitives_RealServer proves each of
+// the eight #524 storage primitives genuinely round-trips through a real
+// upstream server, exercised directly (not via internal/core), mirroring
+// TestRemoteStorageSSOState_CreateConsume_RealServer's storage-primitive-level
+// coverage.
+func TestRemoteStorageMFAManagement_StoragePrimitives_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForMFAManagement(t)
+	ctx := context.Background()
+
+	seeded, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "mfa-mgmt-primitives", Email: "mfa-mgmt-primitives@example.com",
+		Password: "Qr7#Kp2$Lm5@Vn9!", DisplayName: "MFA Management Primitives Test User",
+	})
+	require.NoError(t, err)
+
+	// --- UpsertMFASecret / GetMFASecret ---
+	secret := &models.MFASecret{
+		UserID:     seeded.ID,
+		SecretEnc:  []byte("ciphertext-bytes-not-a-real-secret"),
+		SecretMeta: []byte("meta-v1"),
+		Activated:  false,
+		CreatedAt:  time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, downstream.Storage().UpsertMFASecret(ctx, secret),
+		"UpsertMFASecret must succeed via storage.type: remote")
+	require.NotZero(t, secret.ID, "the upstream must assign a real ID")
+
+	fetched, err := downstream.Storage().GetMFASecret(ctx, seeded.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("ciphertext-bytes-not-a-real-secret"), fetched.SecretEnc)
+	assert.Equal(t, []byte("meta-v1"), fetched.SecretMeta)
+	assert.False(t, fetched.Activated)
+
+	// Confirm it is a REAL row in the upstream's own storage.
+	directFetch, err := upstream.Storage().GetMFASecret(ctx, seeded.ID)
+	require.NoError(t, err)
+	assert.Equal(t, secret.ID, directFetch.ID)
+
+	// --- ActivateMFASecret ---
+	require.NoError(t, downstream.Storage().ActivateMFASecret(ctx, seeded.ID))
+	activated, err := upstream.Storage().GetMFASecret(ctx, seeded.ID)
+	require.NoError(t, err)
+	assert.True(t, activated.Activated, "activation must genuinely persist upstream")
+
+	// --- SetUserMFAEnabled ---
+	require.NoError(t, downstream.Storage().SetUserMFAEnabled(ctx, seeded.ID, true))
+	enabledUser, err := upstream.Storage().GetUser(ctx, seeded.ID)
+	require.NoError(t, err)
+	assert.True(t, enabledUser.MFAEnabled, "MFAEnabled must genuinely persist upstream")
+
+	// --- CreateMFARecoveryCodes / CountUnusedMFARecoveryCodes ---
+	hashes := []string{"hash1", "hash2", "hash3"}
+	require.NoError(t, downstream.Storage().CreateMFARecoveryCodes(ctx, seeded.ID, hashes))
+	count, err := downstream.Storage().CountUnusedMFARecoveryCodes(ctx, seeded.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+
+	upstreamCount, err := upstream.Storage().CountUnusedMFARecoveryCodes(ctx, seeded.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, upstreamCount, "the recovery codes must be REAL rows in the upstream's own storage")
+
+	// --- DeleteMFARecoveryCodes ---
+	require.NoError(t, downstream.Storage().DeleteMFARecoveryCodes(ctx, seeded.ID))
+	countAfterDelete, err := upstream.Storage().CountUnusedMFARecoveryCodes(ctx, seeded.ID)
+	require.NoError(t, err)
+	assert.Zero(t, countAfterDelete, "recovery codes must genuinely be gone upstream")
+
+	// --- DeleteMFAForUser: clears the secret AND leaves no dangling recovery codes ---
+	require.NoError(t, downstream.Storage().CreateMFARecoveryCodes(ctx, seeded.ID, []string{"hash-again"}))
+	require.NoError(t, downstream.Storage().DeleteMFAForUser(ctx, seeded.ID))
+
+	_, err = upstream.Storage().GetMFASecret(ctx, seeded.ID)
+	assert.Error(t, err, "the secret row must genuinely be gone upstream")
+	afterDeleteForUser, err := upstream.Storage().CountUnusedMFARecoveryCodes(ctx, seeded.ID)
+	require.NoError(t, err)
+	assert.Zero(t, afterDeleteForUser, "DeleteMFAForUser must also clear recovery codes upstream (local_mfa.go's own transaction)")
+}
+
+// TestRemoteStorageMFAManagement_FullLifecycle_RealServer is the critical #524
+// test: it drives the ACTUAL end-user-facing entry points
+// (BeginMFAEnrollment/ActivateMFA/MFARecoveryCodesRemaining/
+// RegenerateMFARecoveryCodes/DisableMFA, internal/core/mfa.go) entirely
+// through the DOWNSTREAM core — exactly what a Keyorix server booted with
+// storage.type: remote does when it terminates a real user's /auth/mfa/*
+// requests — proving the whole enrolment/management lifecycle that was 100%
+// broken before this fix now works end-to-end against a real upstream server,
+// not a protocol mock.
+func TestRemoteStorageMFAManagement_FullLifecycle_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForMFAManagement(t)
+	ctx := context.Background()
+
+	const password = "Zq8#Trn4$Vhx2@Wp!"
+	user, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "mfa-mgmt-lifecycle", Email: "mfa-mgmt-lifecycle@example.com",
+		Password: password, DisplayName: "MFA Management Lifecycle Test User",
+	})
+	require.NoError(t, err)
+
+	// BeginMFAEnrollment: generates + encrypts a fresh TOTP secret and persists
+	// it via the new UpsertMFASecret proxy.
+	_, totpSecret, err := downstream.BeginMFAEnrollment(ctx, user.ID)
+	require.NoError(t, err, "BeginMFAEnrollment must succeed against a real remote-storage upstream")
+	require.NotEmpty(t, totpSecret)
+
+	// The pending secret must be a REAL row upstream, not activated yet.
+	pending, err := upstream.Storage().GetMFASecret(ctx, user.ID)
+	require.NoError(t, err)
+	assert.False(t, pending.Activated)
+
+	// NOTE — a genuine, PRE-EXISTING, OUT-OF-SCOPE gap discovered while building
+	// this test, distinct from #524's eight storage primitives: ActivateMFA's
+	// own requireReauth call ALWAYS falls back to bcrypt-comparing the caller's
+	// password against user.PasswordHash (it cannot use a TOTP code here — see
+	// ActivateMFA's doc for why), but RemoteStorage.GetUser deliberately never
+	// returns PasswordHash (`json:"-"` on models.User, mirroring the #506
+	// password-proxy security boundary — the hash must never leave the server
+	// that owns it). So core.ActivateMFA's password-reauth branch can never
+	// succeed under storage.type: remote today; the same requireReauth helper
+	// gates WebAuthn's register/delete (internal/core/webauthn.go) with the
+	// identical gap, already merged under #517 without addressing it — this is
+	// a systemic, cross-feature limitation, not something #524's eight
+	// enrolment/management storage primitives were ever meant to fix (closing
+	// it would need a NEW RemoteReauthVerifier-shaped proxy, mirroring
+	// RemoteLoginVerifier/RemoteMFAVerifier, as a SEPARATE finding). What #524
+	// DOES fix and this test proves below: once a secret is activated (done
+	// here via the SAME storage-primitive calls ActivateMFA itself would make,
+	// bypassing only its currently-broken password-reauth gate),
+	// DisableMFA/RegenerateMFARecoveryCodes re-authenticate with a CURRENT TOTP
+	// code instead — requireReauth's TOTP branch never touches PasswordHash, so
+	// it genuinely works end-to-end via the #524 proxies below.
+	require.NoError(t, downstream.Storage().ActivateMFASecret(ctx, user.ID))
+	require.NoError(t, downstream.Storage().SetUserMFAEnabled(ctx, user.ID, true))
+	hashes := make([]string, 10)
+	for i := range hashes {
+		hashes[i] = fmt.Sprintf("recovery-code-hash-%d", i)
+	}
+	require.NoError(t, downstream.Storage().CreateMFARecoveryCodes(ctx, user.ID, hashes))
+
+	enabledUser, err := upstream.Storage().GetUser(ctx, user.ID)
+	require.NoError(t, err)
+	assert.True(t, enabledUser.MFAEnabled, "MFAEnabled must genuinely persist upstream after activation")
+
+	// Confirm MFAEnabled genuinely round-trips through the DOWNSTREAM's own
+	// RemoteStorage.GetUser too (the users_handler.go/remote_users.go wire fix
+	// this PR also needed — see the NOTE above and each file's doc comment):
+	// requireReauth's TOTP branch (exercised by RegenerateMFARecoveryCodes/
+	// DisableMFA below) depends on THIS read reporting the real value, not the
+	// Go zero value.
+	viaDownstream, err := downstream.Storage().GetUser(ctx, user.ID)
+	require.NoError(t, err)
+	assert.True(t, viaDownstream.MFAEnabled,
+		"MFAEnabled must round-trip through RemoteStorage.GetUser's wire response, not silently read back false")
+
+	// MFARecoveryCodesRemaining: reads the freshly-issued codes back via the
+	// downstream — an ordinary, unauthenticated-by-password read, so it is
+	// unaffected by the requireReauth gap above.
+	remaining, total, err := downstream.MFARecoveryCodesRemaining(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 10, remaining)
+	assert.Equal(t, 10, total)
+
+	// RegenerateMFARecoveryCodes: re-authenticates with a CURRENT TOTP code
+	// (MFA is now active, so requireReauth's TOTP branch runs and succeeds,
+	// never reaching the broken password fallback), replaces the old code set
+	// wholesale — genuinely end-to-end via the #524 proxies.
+	regenCode, err := totp.GenerateCode(totpSecret, time.Now())
+	require.NoError(t, err)
+	newCodes, err := downstream.RegenerateMFARecoveryCodes(ctx, user.ID, regenCode)
+	require.NoError(t, err, "RegenerateMFARecoveryCodes must succeed against a real remote-storage upstream, "+
+		"authenticated via a CURRENT TOTP code (not password — see the NOTE above)")
+	require.Len(t, newCodes, 10)
+
+	remainingAfterRegen, _, err := downstream.MFARecoveryCodesRemaining(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 10, remainingAfterRegen)
+
+	// DisableMFA: re-authenticates with a CURRENT TOTP code (same TOTP-branch
+	// reasoning as above), then clears the secret, recovery codes, and the
+	// MFAEnabled flag — all via the #524 proxies.
+	disableCode, err := totp.GenerateCode(totpSecret, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, downstream.DisableMFA(ctx, user.ID, disableCode),
+		"DisableMFA must succeed against a real remote-storage upstream, authenticated via a CURRENT TOTP code")
+
+	disabledUser, err := upstream.Storage().GetUser(ctx, user.ID)
+	require.NoError(t, err)
+	assert.False(t, disabledUser.MFAEnabled, "MFAEnabled must genuinely be cleared upstream")
+
+	_, err = upstream.Storage().GetMFASecret(ctx, user.ID)
+	assert.Error(t, err, "the TOTP secret must genuinely be gone upstream after disable")
+
+	afterDisableRemaining, err := upstream.Storage().CountUnusedMFARecoveryCodes(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Zero(t, afterDisableRemaining, "recovery codes must genuinely be gone upstream after disable")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1356,6 +1356,40 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/users/purge", userHandler.PurgeDeletedUsersBeforeProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/projects/purge", catalogHandler.PurgeDeletedProjectsBeforeProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/environments/purge", catalogHandler.PurgeDeletedEnvironmentsBeforeProxy)
+
+			// MFA enrolment/management storage-primitive proxy (finding #524). Lets a
+			// downstream Keyorix server booted with storage.type: remote (ADR-049) proxy
+			// UpsertMFASecret/GetMFASecret/ActivateMFASecret/DeleteMFAForUser/
+			// SetUserMFAEnabled/CreateMFARecoveryCodes/CountUnusedMFARecoveryCodes/
+			// DeleteMFARecoveryCodes to THIS server's real storage backend, instead of
+			// RemoteStorage's eight MFA storage methods having no server endpoint to call
+			// at all (BeginMFAEnrollment/ActivateMFA/DisableMFA/
+			// RegenerateMFARecoveryCodes/MFARecoveryCodesRemaining — every /auth/mfa/*
+			// route in internal/core/mfa.go except already-active MFA LOGIN, which #509
+			// already proxies separately via RemoteMFAVerifier — was completely
+			// non-functional under storage.type: remote). Exactly the same pattern as the
+			// webauthn/setup-tokens proxies above: a thin passthrough onto
+			// storage.Storage (no MFA POLICY decision — the re-auth gate, recovery-code
+			// generation/hashing, post-activation session invalidation — is made here;
+			// that stays entirely in the CALLING server's own internal/core.KeyorixCore,
+			// exactly as it does against a local backend), reusing the SAME
+			// system.read/system.write tier — no new privilege class. See
+			// mfa_management_proxy.go's package doc for the atomicity analysis: every
+			// route here resolves in ONE storage.Storage call server-side (including
+			// DeleteMFAForUserProxy, which inherits local_mfa.go's own internal
+			// secret+recovery-codes transaction unchanged), so proxying each as one HTTP
+			// round trip preserves whatever guarantee the local backend already had — no
+			// new atomic primitive needed, unlike AdvanceWebAuthnCredentialCounterProxy
+			// above. Static sub-paths ("secrets", "recovery-codes/count") are registered
+			// before their sibling {userId} routes.
+			r.Get("/mfa/secrets", authHandler.GetMFASecretProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/mfa/secrets", authHandler.UpsertMFASecretProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/mfa/secrets/{userId}/activate", authHandler.ActivateMFASecretProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Delete("/mfa/users/{userId}", authHandler.DeleteMFAForUserProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Put("/mfa/users/{userId}/mfa-enabled", authHandler.SetUserMFAEnabledProxy)
+			r.Get("/mfa/recovery-codes/count", authHandler.CountUnusedMFARecoveryCodesProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/mfa/recovery-codes", authHandler.CreateMFARecoveryCodesProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Delete("/mfa/recovery-codes/{userId}", authHandler.DeleteMFARecoveryCodesProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary
- Round-119 finding #524 (MEDIUM): `UpsertMFASecret`/`GetMFASecret`/`ActivateMFASecret`/`DeleteMFAForUser`/`SetUserMFAEnabled`/`CreateMFARecoveryCodes`/`CountUnusedMFARecoveryCodes`/`DeleteMFARecoveryCodes` were unconditional stubs under `storage.type: remote` — a broader gap than #509's earlier fix, which covered only login verification, not enrollment/management. Enrolling in MFA, disabling it, or viewing/regenerating recovery codes couldn't work at all in this mode.
- Added 8 new thin passthrough routes under `/api/v1/system/mfa/*`, gated on the existing `system.read`/`system.write` tier (no new privilege class). This follows the CRUD-passthrough pattern from #521/#527, not the `RemoteMFAVerifier` login-proxy pattern from #509/#522 — enrollment/management always runs on whichever server terminates the `/auth/mfa/*` request, never delegated.
- No new atomic primitive needed: every one of the 8 methods already resolves within a single `storage.Storage` call in every caller (confirmed by tracing `internal/core/mfa.go` and `local_mfa.go`), so a 1:1 HTTP proxy preserves the same guarantees.
- **Found and fixed a real latent bug along the way**: `RemoteStorage.GetUser`'s wire response never carried `MFAEnabled` (missing from both the server-side `userToAPIResponse` and the client wire struct), so every caller branching on `user.MFAEnabled` under `storage.type: remote` silently read `false` regardless of upstream reality — breaking `MFARecoveryCodesRemaining`, `DisableMFA`, and `RegenerateMFARecoveryCodes` even with the 8 proxy methods in place. Fixed by adding the field to both sides of the wire contract.
- **Documented, not fixed (out of scope for #524)**: `requireReauth`'s password-fallback branch can never succeed under `storage.type: remote`, since `RemoteStorage.GetUser` deliberately never returns `PasswordHash` (a real security boundary, mirroring #506). This affects `ActivateMFA` (password-only reauth) and, systemically, WebAuthn register/delete (already shipped under #517 without addressing it). Needs its own `RemoteReauthVerifier`-shaped fix as a separate finding — flagging here rather than scope-creeping this PR.
- Removed the 8 allowlist entries from the completeness guard.

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt -l` all clean
- [x] `go test ./internal/storage/store/... ./internal/core/... ./server/http/...` — all pass
- [x] `gosec -severity medium -exclude-generated` on changed packages — 0 issues
- [x] New tests in `server/http/remote_storage_mfa_management_test.go` (storage round-trip + full-lifecycle proxy test against a real upstream server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)