### PR TITLE
fix(rbac): proxy role-grant primitives under storage.type: remote

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -143,6 +143,19 @@ func (m *MockStorage) ListGlobalAdminAssignmentsForUpdate(_ context.Context, _ [
 	return nil, nil
 }
 
+// RemoveGlobalAdminRoleGuarded (#525) is likewise unused by MockStorage-driven
+// tests — every one of them mocks the three install-admin role names
+// (super_admin/admin/system_admin) as absent via GetRoleByName, so
+// RemoveUserRole's installAdminRoleIDSet is always empty and this is never
+// reached (real-storage RemoveUserRole/last-admin coverage lives in
+// last_admin_guard_external_test.go and concurrency_last_admin_removal_test.go,
+// both against a real store.LocalStorage). If a future test DOES reach this
+// unmocked, m.Called panics loudly rather than silently allowing the removal.
+func (m *MockStorage) RemoveGlobalAdminRoleGuarded(ctx context.Context, userID, roleID uint, adminRoleIDs []uint) error {
+	args := m.Called(ctx, userID, roleID, adminRoleIDs)
+	return args.Error(0)
+}
+
 func (m *MockStorage) ListGroupRoleAssignments(ctx context.Context, groupID uint) ([]storage.RoleAssignment, error) {
 	args := m.Called(ctx, groupID)
 	if args.Get(0) == nil {

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -337,32 +337,47 @@ func (c *KeyorixCore) assignUserRoleSystemGrant(ctx context.Context, actorID, us
 
 // RemoveUserRole removes a role from a user at the given scope and records an
 // RBAC audit event. See AssignUserRole for actorID semantics. It refuses to remove
-// the last install administrator (see guardLastGlobalAdmin). This is the choke point
-// SetUserRoles and the HTTP/gRPC role-removal handlers funnel through.
+// the last install administrator (see RemoveGlobalAdminRoleGuarded). This is the
+// choke point SetUserRoles and the HTTP/gRPC role-removal handlers funnel through.
 //
-// The last-admin check and the removal itself run inside a single storage
-// transaction, held under globalAdminGuardMu for its whole duration (#340):
-// without this, two concurrent removals of two different admins' role
-// assignments could each observe "another admin still exists" before either
-// write commits, stranding the install with zero admins. The transaction's
-// ListGlobalAdminAssignmentsForUpdate read takes a row-level lock on every
-// candidate admin-conferring assignment on backends that support one (Postgres),
-// serializing HA replicas; globalAdminGuardMu serializes same-process callers —
-// the same two-layer pattern login_lockout.go's recordFailedLogin uses.
+// #340/#525: for a global-scope (project 0, environment 0) admin-conferring role,
+// the last-admin check and the removal itself must be ATOMIC — otherwise two
+// concurrent removals of two different admins' role assignments could each
+// observe "another admin still exists" before either write commits, stranding
+// the install with zero admins. Prior to #525 this ran as
+// ListGlobalAdminAssignmentsForUpdate + RemoveRole inside a single
+// storage.WithTransaction closure: correct against LocalStorage (a real DB
+// transaction + Postgres row lock spans both calls), but
+// RemoteStorage.WithTransaction is a no-op passthrough — under storage.type:
+// remote those were two independent HTTP round trips with nothing serializing
+// them beyond globalAdminGuardMu, which only covers same-process callers (not a
+// second spoke, or the hub's own direct callers, racing the same admin set).
+// RemoveGlobalAdminRoleGuarded folds the check and the write into ONE storage
+// call, so whichever server actually owns the row — the hub, for a remote spoke —
+// is the only one that ever needs to enforce it atomically; globalAdminGuardMu is
+// kept as a cheap same-process fast-path serializer (mirroring
+// login_lockout.go's recordFailedLogin two-layer pattern), not as the sole
+// correctness mechanism.
 func (c *KeyorixCore) RemoveUserRole(ctx context.Context, actorID, userID, roleID uint, scope Scope) error {
 	c.globalAdminGuardMu.Lock()
 	defer c.globalAdminGuardMu.Unlock()
-	err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
-		if err := c.guardLastGlobalAdmin(ctx, tx, userID, roleID, scope); err != nil {
-			return err
+
+	if scope.ProjectID == 0 && scope.EnvironmentID == 0 {
+		adminIDs := c.installAdminRoleIDSet(ctx)
+		if adminIDs[roleID] {
+			ids := make([]uint, 0, len(adminIDs))
+			for id := range adminIDs {
+				ids = append(ids, id)
+			}
+			if err := c.storage.RemoveGlobalAdminRoleGuarded(ctx, userID, roleID, ids); err != nil {
+				return err
+			}
+			c.LogRoleRemoved(ctx, actorID, userID, roleID, scope)
+			return nil
 		}
-		if err := tx.RemoveRole(ctx, userID, roleID, scope); err != nil {
-			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-		}
-		return nil
-	})
-	if err != nil {
-		return err
+	}
+	if err := c.storage.RemoveRole(ctx, userID, roleID, scope); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	c.LogRoleRemoved(ctx, actorID, userID, roleID, scope)
 	return nil
@@ -374,61 +389,15 @@ func (c *KeyorixCore) RemoveUserRole(ctx context.Context, actorID, userID, roleI
 var installAdminRoleNames = []string{"super_admin", "admin", "system_admin"}
 
 // installAdminRoleIDSet resolves installAdminRoleNames to their role IDs (skipping
-// any that a given install did not seed).
+// any that a given install did not seed). Used by RemoveUserRole's global-admin
+// guard (RemoveGlobalAdminRoleGuarded, #340/#525) and by the group-level admin
+// guards in authz.go (guardLastGlobalAdminGroupRole/GroupDelete/Membership).
 func (c *KeyorixCore) installAdminRoleIDSet(ctx context.Context) map[uint]bool {
-	return c.installAdminRoleIDSetFrom(ctx, c.storage)
-}
-
-// installAdminRoleIDSetFrom is installAdminRoleIDSet against an explicit Storage
-// handle. Callers running inside a WithTransaction callback (guardLastGlobalAdmin,
-// #340) MUST pass the transaction-scoped Storage they were handed, not c.storage:
-// on the local (DB) backend, a read issued through c.storage while a transaction
-// is still open checks out a SEPARATE pooled connection — for SQLite ":memory:"
-// specifically, a distinct, empty database — silently missing the very rows the
-// transaction just wrote or is checking.
-func (c *KeyorixCore) installAdminRoleIDSetFrom(ctx context.Context, s storage.Storage) map[uint]bool {
 	set := make(map[uint]bool, len(installAdminRoleNames))
 	for _, name := range installAdminRoleNames {
-		if role, err := s.GetRoleByName(ctx, name); err == nil && role != nil {
+		if role, err := c.storage.GetRoleByName(ctx, name); err == nil && role != nil {
 			set[role.ID] = true
 		}
 	}
 	return set
-}
-
-// guardLastGlobalAdmin refuses to remove a user's global (install-wide) admin role
-// when no other global admin-role assignment would remain — preventing a
-// self-inflicted or malicious-insider lockout that strands the install with no
-// administrator (and no recovery short of DB surgery). Only the global scope is
-// guarded: a project-scoped admin can always be restored by a global admin.
-//
-// tx is the transaction-scoped Storage the caller (RemoveUserRole) is running
-// inside (#340): the read MUST go through it, not c.storage, so the row lock
-// ListGlobalAdminAssignmentsForUpdate takes is actually held for the lifetime of
-// this decision rather than released before the caller's own write runs.
-func (c *KeyorixCore) guardLastGlobalAdmin(ctx context.Context, tx storage.Storage, userID, roleID uint, scope Scope) error {
-	if scope.ProjectID != 0 || scope.EnvironmentID != 0 {
-		return nil // not the global scope — project admins are recoverable
-	}
-	adminIDs := c.installAdminRoleIDSetFrom(ctx, tx)
-	if !adminIDs[roleID] {
-		return nil // not removing an install-admin role
-	}
-	ids := make([]uint, 0, len(adminIDs))
-	for id := range adminIDs {
-		ids = append(ids, id)
-	}
-	assignments, err := tx.ListGlobalAdminAssignmentsForUpdate(ctx, ids)
-	if err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
-	}
-	for _, a := range assignments {
-		// Ignore the exact assignment being removed; any OTHER global admin grant
-		// (held by another user, or by a group) means governance survives.
-		if a.PrincipalType == "user" && a.PrincipalID == userID && a.RoleID == roleID {
-			continue
-		}
-		return nil
-	}
-	return fmt.Errorf("refusing to remove the last install administrator: the install would be left with no super_admin/admin/system_admin at the global scope and no one able to manage users, roles, or settings")
 }

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -19,6 +19,13 @@ var ErrUserNotFound = errors.New("user not found")
 // errors.Is rather than swallowing every error identically.
 var ErrRoleNotAssigned = errors.New("role not assigned")
 
+// ErrWouldStrandLastAdmin is returned (wrapped) by RemoveGlobalAdminRoleGuarded when
+// removing the (user, role) grant at the global scope would leave the install with
+// zero super_admin/admin/system_admin holders (#340, #525) — the storage-layer
+// sentinel for guardLastGlobalAdmin's refusal, preserved across the RemoteStorage HTTP
+// hop the same way ErrDuplicateSecretDependency/ErrSecretDependencyCycle are.
+var ErrWouldStrandLastAdmin = errors.New("refusing to remove the last install administrator")
+
 // ErrBreakGlassNotActive is returned (wrapped) when a conditional break-glass state
 // transition (e.g. revoke) finds the activation is no longer in the expected prior
 // state — most often because a concurrent revoke already won the race. Distinct

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -98,6 +98,30 @@ type Storage interface {
 	// the caller's own process-level mutex serializes same-process callers,
 	// mirroring LockUserForUpdate/LockWebAuthnCredentialForUpdate.
 	ListGlobalAdminAssignmentsForUpdate(ctx context.Context, adminRoleIDs []uint) ([]RoleAssignment, error)
+	// RemoveGlobalAdminRoleGuarded atomically checks-then-removes a user's
+	// global-scope (project 0, environment 0) role grant, refusing (without
+	// removing anything) if doing so would leave the install with zero
+	// admin-tier holders among adminRoleIDs — the exact guardLastGlobalAdmin
+	// (#340) check and its RemoveRole write, folded into ONE storage call.
+	//
+	// Added for #525: RemoveUserRole previously ran this check (via
+	// ListGlobalAdminAssignmentsForUpdate) and the removal (via RemoveRole) as TWO
+	// separate calls inside a WithTransaction closure. That is correct against
+	// LocalStorage (a real DB transaction + Postgres row lock spans both), but
+	// RemoteStorage.WithTransaction is a no-op passthrough — two separate HTTP
+	// round trips give a concurrent racing removal (from another spoke, or the
+	// hub's own direct callers) a window to observe "another admin still exists"
+	// before either write lands, reopening the exact cross-process last-admin
+	// lockout race #340 closed for HA Postgres replicas. Folding the check and the
+	// write into one call means whichever server actually owns the row — the hub,
+	// for a remote spoke — is the only one that ever needs to enforce it
+	// atomically, exactly like CreateSecretDependencyExclusive (#260) and
+	// TransitionMachineIdentityState (#388/#518) did for their own TOCTOU classes.
+	//
+	// Returns ErrWouldStrandLastAdmin if the removal is refused, or
+	// ErrRoleNotAssigned (wrapped) if the (userID, roleID) grant does not exist at
+	// the global scope.
+	RemoveGlobalAdminRoleGuarded(ctx context.Context, userID, roleID uint, adminRoleIDs []uint) error
 	// LastUserSecretActivity returns, per user, the most recent secret-access time
 	// in the project (from the audit trail). Backs dormant-access detection in the
 	// access review — a grant whose principal has no recent activity is stale

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -374,6 +374,39 @@ func (ls *LocalStorage) ListGlobalAdminAssignmentsForUpdate(ctx context.Context,
 	return out, nil
 }
 
+// RemoveGlobalAdminRoleGuarded is the atomic, single-storage-call form of
+// guardLastGlobalAdmin (#340) + RemoveRole — added for #525 so RemoteStorage can
+// proxy it as ONE HTTP round trip instead of the two separate calls
+// (ListGlobalAdminAssignmentsForUpdate then RemoveRole) RemoveUserRole previously
+// made inside a WithTransaction closure. See the Storage interface doc for the full
+// atomicity reasoning. Runs in its own transaction (mirroring WithTransaction's own
+// db.Transaction wrapping) so the row lock ListGlobalAdminAssignmentsForUpdate takes
+// on Postgres is actually held for the whole check-then-delete, exactly as it was
+// when the caller drove both calls under its own WithTransaction.
+func (ls *LocalStorage) RemoveGlobalAdminRoleGuarded(ctx context.Context, userID, roleID uint, adminRoleIDs []uint) error {
+	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		txStorage := &LocalStorage{db: tx, auditChainMu: ls.auditChainMu, auditCheckpointMu: ls.auditCheckpointMu}
+		assignments, err := txStorage.ListGlobalAdminAssignmentsForUpdate(ctx, adminRoleIDs)
+		if err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		survives := false
+		for _, a := range assignments {
+			// Ignore the exact assignment being removed; any OTHER global admin
+			// grant (held by another user, or by a group) means governance survives.
+			if a.PrincipalType == "user" && a.PrincipalID == userID && a.RoleID == roleID {
+				continue
+			}
+			survives = true
+			break
+		}
+		if !survives {
+			return fmt.Errorf("%w: the install would be left with no super_admin/admin/system_admin at the global scope and no one able to manage users, roles, or settings", storage.ErrWouldStrandLastAdmin)
+		}
+		return txStorage.RemoveRole(ctx, userID, roleID, storage.Scope{})
+	})
+}
+
 // GetUserRoleIDsExact returns the IDs of roles directly assigned to userID at
 // exactly the given scope (no global/inherited matching). Used for full
 // replacement of a user's roles at one scope.

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -12,12 +12,16 @@ package store
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
 )
 
 // --- Roles ---
@@ -146,24 +150,85 @@ func (rs *RemoteStorage) AssignRole(ctx context.Context, userID, roleID uint, sc
 	return nil
 }
 
-// GetGroupRoleGrants is a confirmed genuine gap (round 119 completeness
-// audit), not the "HTTP handler reads it from local storage instead" claim
-// this comment previously made — GetGroupRoles (server/http/handlers/rbac.go)
-// calls THIS method, not a different one. Tracked in
-// docs/security/HARDENING-BACKLOG.md; see remote_unsupported_completeness_test.go.
-func (rs *RemoteStorage) GetGroupRoleGrants(_ context.Context, _ uint) ([]*storage.GroupRoleGrant, error) {
-	return nil, remoteUnsupported("GetGroupRoleGrants")
+// GetGroupRoleGrants is a thin passthrough onto GET
+// /api/v1/system/rbac/groups/{groupID}/role-grants (finding #525) —
+// GetGroupRoles (server/http/handlers/rbac.go) calls THIS method, not a
+// different one, so RemoveUserFromGroup/AddUserToGroup and the human-facing
+// "group roles" tab were completely non-functional under storage.type: remote
+// before this fix. A previous version of this doc comment claimed the HTTP
+// handler read this from local storage instead — independently confirmed
+// FALSE during the audit that found this gap (round 119 completeness sweep).
+func (rs *RemoteStorage) GetGroupRoleGrants(ctx context.Context, groupID uint) ([]*storage.GroupRoleGrant, error) {
+	path := fmt.Sprintf("/api/v1/system/rbac/groups/%d/role-grants", groupID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get group role grants: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get group role grants failed: %s", resp.Error.Error())
+	}
+	var result []*storage.GroupRoleGrant
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result, nil
 }
 
-// AssignRoleWithExpiry is server-side only (the JIT grant happens during access-
-// request approval on the server); not driven over the remote client.
-func (rs *RemoteStorage) AssignRoleWithExpiry(_ context.Context, _, _ uint, _ storage.Scope, _ time.Time) error {
-	return remoteUnsupported("AssignRoleWithExpiry")
+// AssignRoleWithExpiry proxies onto POST /api/v1/system/rbac/assign-role-with-expiry
+// (finding #525) — the JIT time-bound grant path (invitations.go's access-request
+// TTL approval, jit_access.go's direct grant, break_glass.go's emergency
+// activation) was completely non-functional under storage.type: remote before this
+// fix. This is a single storage-layer call on either backend (LocalStorage's
+// assignUserRole does its own existing-row read/expired-row-replace/create dance
+// entirely within ONE Go function, not across a WithTransaction boundary), so one
+// HTTP round trip preserves the same atomicity guarantee LocalStorage already has —
+// no NEW race is introduced by proxying it, unlike RemoveGlobalAdminRoleGuarded
+// below.
+func (rs *RemoteStorage) AssignRoleWithExpiry(ctx context.Context, userID, roleID uint, scope storage.Scope, expiresAt time.Time) error {
+	payload := roleWithExpiryWire{
+		UserID: userID, RoleID: roleID,
+		ProjectID: scope.ProjectID, EnvironmentID: scope.EnvironmentID,
+		ExpiresAt: expiresAt,
+	}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/rbac/assign-role-with-expiry", payload)
+	if err != nil {
+		return fmt.Errorf("failed to assign role with expiry: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("assign role with expiry failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
-// AssignRoleToGroupWithExpiry is server-side only; see AssignRoleWithExpiry.
-func (rs *RemoteStorage) AssignRoleToGroupWithExpiry(_ context.Context, _, _ uint, _ storage.Scope, _ time.Time) error {
-	return remoteUnsupported("AssignRoleToGroupWithExpiry")
+// AssignRoleToGroupWithExpiry proxies onto POST
+// /api/v1/system/rbac/assign-role-to-group-with-expiry (finding #525); see
+// AssignRoleWithExpiry for the atomicity reasoning (identical single-call shape).
+func (rs *RemoteStorage) AssignRoleToGroupWithExpiry(ctx context.Context, groupID, roleID uint, scope storage.Scope, expiresAt time.Time) error {
+	payload := roleWithExpiryWire{
+		GroupID: groupID, RoleID: roleID,
+		ProjectID: scope.ProjectID, EnvironmentID: scope.EnvironmentID,
+		ExpiresAt: expiresAt,
+	}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/rbac/assign-role-to-group-with-expiry", payload)
+	if err != nil {
+		return fmt.Errorf("failed to assign role to group with expiry: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("assign role to group with expiry failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// roleWithExpiryWire is the shared wire body for AssignRoleWithExpiry (UserID set,
+// GroupID zero) and AssignRoleToGroupWithExpiry (GroupID set, UserID zero) —
+// mirrored exactly in server/http/handlers/rbac_role_grants_proxy.go.
+type roleWithExpiryWire struct {
+	UserID        uint      `json:"user_id,omitempty"`
+	GroupID       uint      `json:"group_id,omitempty"`
+	RoleID        uint      `json:"role_id"`
+	ProjectID     uint      `json:"project_id"`
+	EnvironmentID uint      `json:"environment_id"`
+	ExpiresAt     time.Time `json:"expires_at"`
 }
 
 // DeleteExpiredRoleGrants proxies onto POST
@@ -213,10 +278,22 @@ func (rs *RemoteStorage) RemoveRole(ctx context.Context, userID, roleID uint, sc
 	return nil
 }
 
-// RemoveAllProjectRoleGrants is a server-internal RBAC primitive (project
-// membership management runs entirely against LocalStorage); unsupported here.
-func (rs *RemoteStorage) RemoveAllProjectRoleGrants(_ context.Context, _, _ uint) error {
-	return remoteUnsupported("RemoveAllProjectRoleGrants")
+// RemoveAllProjectRoleGrants proxies onto POST
+// /api/v1/system/rbac/remove-all-project-role-grants (finding #525) —
+// RemoveProjectMember's bulk-delete step (DELETE /projects/{id}/members/{userId})
+// was completely non-functional under storage.type: remote before this fix. A
+// single bulk DELETE (no read-check-write sequence), so one HTTP round trip is
+// exactly as atomic as the local call.
+func (rs *RemoteStorage) RemoveAllProjectRoleGrants(ctx context.Context, userID, projectID uint) error {
+	payload := map[string]uint{"user_id": userID, "project_id": projectID}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/rbac/remove-all-project-role-grants", payload)
+	if err != nil {
+		return fmt.Errorf("failed to remove all project role grants: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("remove all project role grants failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
 // GetUserRoles retrieves all roles for a user via remote API.
@@ -443,11 +520,28 @@ func (rs *RemoteStorage) GetGroupRoles(ctx context.Context, groupID uint) ([]*mo
 	return result, nil
 }
 
-// ListGroupRoleAssignments is not supported in remote storage — the client reaches
-// group role state through GetGroupRoles/GetGroupRoleGrants (per-group, scope-less)
-// via their REST endpoints; there is no all-scope listing endpoint to proxy to.
-func (rs *RemoteStorage) ListGroupRoleAssignments(_ context.Context, _ uint) ([]storage.RoleAssignment, error) {
-	return nil, remoteUnsupported("ListGroupRoleAssignments")
+// ListGroupRoleAssignments proxies onto GET
+// /api/v1/system/rbac/groups/{groupID}/role-assignments (finding #525) —
+// AddUserToGroup's escalation-by-proxy ceiling check (requireAuthorityForRole,
+// looped over every role the target group holds) was completely non-functional
+// under storage.type: remote before this fix, so POST /groups/{id}/members either
+// failed closed (blocking every legitimate group join) or, worse, could not enforce
+// the ceiling at all depending on call order — this closes that gap with a genuine
+// read.
+func (rs *RemoteStorage) ListGroupRoleAssignments(ctx context.Context, groupID uint) ([]storage.RoleAssignment, error) {
+	path := fmt.Sprintf("/api/v1/system/rbac/groups/%d/role-assignments", groupID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list group role assignments: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list group role assignments failed: %s", resp.Error.Error())
+	}
+	var result []storage.RoleAssignment
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result, nil
 }
 
 // AssignRoleToGroup assigns a role to a group at scope via remote API.
@@ -561,20 +655,136 @@ func (rs *RemoteStorage) ListProjectMembers(_ context.Context, _ uint) ([]storag
 	return nil, remoteUnsupported("ListProjectMembers")
 }
 
-func (rs *RemoteStorage) ListProjectRoleAssignments(_ context.Context, _ uint) ([]storage.RoleAssignment, error) {
-	return nil, remoteUnsupported("ListProjectRoleAssignments")
+// ListProjectRoleAssignments proxies onto GET
+// /api/v1/system/rbac/project-role-assignments?project_id=X (finding #525) —
+// RemoveProjectMember's audit-trail capture, guardLastProjectAdmin, the access
+// review (access_review.go/access_review_revoke.go), catalog.go, compliance
+// posture, scim.go, and the global-admin group guards (authz.go, project_id=0)
+// all call this; every one of them was completely non-functional under
+// storage.type: remote before this fix. A plain read — no read-check-write
+// sequence of its own, so a single HTTP round trip introduces no new race.
+func (rs *RemoteStorage) ListProjectRoleAssignments(ctx context.Context, projectID uint) ([]storage.RoleAssignment, error) {
+	path := fmt.Sprintf("/api/v1/system/rbac/project-role-assignments?project_id=%d", projectID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list project role assignments: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list project role assignments failed: %s", resp.Error.Error())
+	}
+	var result []storage.RoleAssignment
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result, nil
 }
 
-func (rs *RemoteStorage) ListProjectMachineRoleAssignments(_ context.Context, _ uint) ([]storage.RoleAssignment, error) {
-	return nil, remoteUnsupported("ListProjectMachineRoleAssignments")
+// ListProjectMachineRoleAssignments proxies onto GET
+// /api/v1/system/rbac/project-machine-role-assignments?project_id=X (finding
+// #525) — the access review's machine-identity role enumeration
+// (access_review.go) was completely non-functional under storage.type: remote
+// before this fix.
+func (rs *RemoteStorage) ListProjectMachineRoleAssignments(ctx context.Context, projectID uint) ([]storage.RoleAssignment, error) {
+	path := fmt.Sprintf("/api/v1/system/rbac/project-machine-role-assignments?project_id=%d", projectID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list project machine role assignments: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list project machine role assignments failed: %s", resp.Error.Error())
+	}
+	var result []storage.RoleAssignment
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result, nil
 }
 
-// ListGlobalAdminAssignmentsForUpdate is a server-internal RBAC primitive backing
-// the last-admin-removal guard's atomicity fix (#340); like
-// ListProjectRoleAssignments, RBAC admin-removal guarding runs entirely against
-// LocalStorage server-side, so this is unsupported here.
-func (rs *RemoteStorage) ListGlobalAdminAssignmentsForUpdate(_ context.Context, _ []uint) ([]storage.RoleAssignment, error) {
-	return nil, remoteUnsupported("ListGlobalAdminAssignmentsForUpdate")
+// ListGlobalAdminAssignmentsForUpdate proxies onto GET
+// /api/v1/system/rbac/global-admin-assignments (finding #525) as a PLAIN read —
+// like LockMachineIdentityForUpdate/ListSecretDependenciesForProjectForUpdate
+// before it, there is no row lock to take over HTTP, so the "ForUpdate" naming is
+// aspirational here; safety comes entirely from RemoveGlobalAdminRoleGuarded's
+// atomic conditional write below, not from this read. Direct callers of this
+// method alone (outside RemoveUserRole's guarded removal path) get the same
+// read-only visibility LocalStorage's real row lock would give them anyway on
+// SQLite (a plain read); only Postgres HA replication needed the lock, and that's
+// entirely a hub-side concern once this method's own caller no longer spans an
+// HTTP hop with a subsequent write (see RemoveGlobalAdminRoleGuarded).
+func (rs *RemoteStorage) ListGlobalAdminAssignmentsForUpdate(ctx context.Context, adminRoleIDs []uint) ([]storage.RoleAssignment, error) {
+	path := "/api/v1/system/rbac/global-admin-assignments?role_ids=" + joinUintsCSV(adminRoleIDs)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list global admin assignments: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list global admin assignments failed: %s", resp.Error.Error())
+	}
+	var result []storage.RoleAssignment
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result, nil
+}
+
+// removeGlobalAdminRoleGuardedRefusedCode is the machine-readable error code
+// RemoveGlobalAdminRoleGuardedProxy returns when the upstream refuses the removal
+// (storage.ErrWouldStrandLastAdmin) — mirrored exactly in
+// server/http/handlers/rbac_role_grants_proxy.go, the wire-level contract this
+// method's error-recovery switch depends on to reconstruct that sentinel on the
+// calling side, the same #511-style translation
+// CreateSecretDependencyExclusive's duplicate/cycle codes use.
+const removeGlobalAdminRoleGuardedRefusedCode = "WOULD_STRAND_LAST_ADMIN"
+
+// RemoveGlobalAdminRoleGuarded proxies onto POST
+// /api/v1/system/rbac/global-admin-role/remove-guarded (finding #525) — see the
+// Storage interface doc for why this is ONE atomic call rather than a
+// ListGlobalAdminAssignmentsForUpdate-then-RemoveRole pair: RemoteStorage.
+// WithTransaction is a no-op passthrough, so nothing would otherwise span the
+// guard read and the delete across this HTTP hop, reopening the exact
+// cross-process last-admin-lockout race #340 closed for HA Postgres replicas —
+// this time between concurrent spokes (or a spoke and the hub itself).
+func (rs *RemoteStorage) RemoveGlobalAdminRoleGuarded(ctx context.Context, userID, roleID uint, adminRoleIDs []uint) error {
+	payload := struct {
+		UserID       uint   `json:"user_id"`
+		RoleID       uint   `json:"role_id"`
+		AdminRoleIDs []uint `json:"admin_role_ids"`
+	}{UserID: userID, RoleID: roleID, AdminRoleIDs: adminRoleIDs}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/rbac/global-admin-role/remove-guarded", payload)
+	if err != nil {
+		var httpErr *remote.HTTPError
+		if errors.As(err, &httpErr) {
+			switch httpErr.ErrorType {
+			case removeGlobalAdminRoleGuardedRefusedCode:
+				return fmt.Errorf("%w: %s", storage.ErrWouldStrandLastAdmin, httpErr.Message)
+			case notAssignedCode:
+				return fmt.Errorf("%w: %s", storage.ErrRoleNotAssigned, httpErr.Message)
+			}
+		}
+		return fmt.Errorf("failed to remove global admin role: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("remove global admin role failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
+// notAssignedCode is the machine-readable error code
+// RemoveGlobalAdminRoleGuardedProxy returns when the (userID, roleID) grant does
+// not exist (storage.ErrRoleNotAssigned) — mirrored exactly in
+// server/http/handlers/rbac_role_grants_proxy.go.
+const notAssignedCode = "ROLE_NOT_ASSIGNED"
+
+// joinUintsCSV renders ids as a comma-separated query value (empty string for an
+// empty slice), the wire shape RemoveGlobalAdminRoleGuardedProxy's sibling GET
+// /api/v1/system/rbac/global-admin-assignments handler parses back with
+// strconv.ParseUint per component.
+func joinUintsCSV(ids []uint) string {
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, strconv.FormatUint(uint64(id), 10))
+	}
+	return strings.Join(parts, ",")
 }
 
 func (rs *RemoteStorage) GetEnvironment(_ context.Context, _ uint) (*models.Environment, error) {

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -75,10 +75,10 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"ConsumeMFARecoveryCode": {statusIntentional,
 		"round 119 audit: sole caller is VerifyMFACredentials, same bypassed-branch reasoning as MarkTOTPStepUsed — recovery codes are only ever consumed at login, never during enrollment/management"},
 
-	// --- Confirmed genuine gaps, tracked for future fix rounds (47; UpdateLoginLockoutState
+	// --- Confirmed genuine gaps, tracked for future fix rounds (39; UpdateLoginLockoutState
 	// closed by #529, SSO login state closed by #521, GetActiveMFAChallenge/
 	// ConsumeMFAChallenge (WebAuthn-as-second-factor login) closed by #522, Connect
-	// ref-grant CRUD closed by #527) ---
+	// ref-grant CRUD closed by #527, RBAC role-grant primitives closed by #525) ---
 	// See docs/security/HARDENING-BACKLOG.md's round 119 entry for full detail,
 	// severity, and grouping. Each entry below cites the real caller/route a
 	// round-119 audit traced (not assumed).
@@ -116,23 +116,18 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"DeleteMFARecoveryCodes": {statusKnownGap,
 		"round 119: RegenerateMFARecoveryCodes, POST /auth/mfa/recovery-codes/regenerate"},
 
-	// RBAC role-grant primitives + last-admin/escalation guards.
-	"GetGroupRoleGrants": {statusKnownGap,
-		"round 119: GetGroupRoles handler (GET /groups/{id}/roles) — the method's own doc comment claiming the HTTP handler reads local storage instead is stale/wrong"},
-	"AssignRoleWithExpiry": {statusKnownGap,
-		"round 119: JIT-assign-with-expiry (POST /user-roles with expires_at) and the access-request TTL-grant approval path"},
-	"AssignRoleToGroupWithExpiry": {statusKnownGap,
-		"round 119: JIT group role grants, POST /groups/{id}/roles with expires_at"},
-	"RemoveAllProjectRoleGrants": {statusKnownGap,
-		"round 119: RemoveProjectMember, DELETE /projects/{id}/members/{userId} — a routine member-offboarding action"},
-	"ListGroupRoleAssignments": {statusKnownGap,
-		"round 119: AddUserToGroup's escalation-by-proxy ceiling check, POST /groups/{id}/members — breaks adding a user to a group for every authenticated caller"},
-	"ListGlobalAdminAssignmentsForUpdate": {statusKnownGap,
-		"round 119: guardLastGlobalAdmin (last-install-admin lockout guard), reached via DELETE /user-roles"},
-	"ListProjectRoleAssignments": {statusKnownGap,
-		"round 119: multiple last-global-admin guards, access reviews, RestoreProject's admin-ceiling check, compliance posture, SCIM"},
-	"ListProjectMachineRoleAssignments": {statusKnownGap,
-		"round 119: machine-identity access-review coverage (#91), GET /projects/{id}/access-review"},
+	// RBAC role-grant primitives + last-admin/escalation guards were closed by
+	// #525: GetGroupRoleGrants/AssignRoleWithExpiry/AssignRoleToGroupWithExpiry/
+	// RemoveAllProjectRoleGrants/ListGroupRoleAssignments/
+	// ListGlobalAdminAssignmentsForUpdate/ListProjectRoleAssignments/
+	// ListProjectMachineRoleAssignments are now proxied via
+	// /api/v1/system/rbac/... (server/http/handlers/rbac_role_grants_proxy.go) —
+	// see internal/storage/store/remote_rbac.go. RemoveUserRole's last-global-admin
+	// guard additionally gained a new atomic primitive,
+	// RemoveGlobalAdminRoleGuarded, folding the check and the removal into ONE
+	// storage call (a naive two-call proxy would have reopened #340's
+	// cross-process TOCTOU race across an HTTP hop — RemoteStorage.WithTransaction
+	// is a no-op passthrough).
 
 	// RBAC permission catalog — no local fallback exists (RemoteStorage has no DB).
 	"ListPermissions": {statusKnownGap, "round 119: GET /permissions"},

--- a/server/http/handlers/rbac_role_grants_proxy.go
+++ b/server/http/handlers/rbac_role_grants_proxy.go
@@ -1,0 +1,320 @@
+// rbac_role_grants_proxy.go — server-side endpoints backing RemoteStorage's
+// RBAC role-grant primitives (finding #525): GetGroupRoleGrants/
+// AssignRoleWithExpiry/AssignRoleToGroupWithExpiry/RemoveAllProjectRoleGrants/
+// ListGroupRoleAssignments/ListGlobalAdminAssignmentsForUpdate/
+// ListProjectRoleAssignments/ListProjectMachineRoleAssignments/
+// RemoveGlobalAdminRoleGuarded.
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
+// these RBAC role-grant storage calls to whichever upstream server it's configured
+// against, through these routes (registered in server/http/router.go under
+// /api/v1/system/rbac, gated on the existing system.read/system.write RBAC
+// permissions — the SAME credential a RemoteStorage client already needs for every
+// other proxied call, so this introduces no new privilege class). Mirrors
+// secret_dependencies_proxy.go/retention_proxy.go exactly.
+//
+// These are thin passthroughs onto the SAME storage.Storage primitives
+// internal/core/jit_access.go, project_members.go, groups.go, and
+// rbac_management.go already use against a local backend — no RBAC POLICY
+// decision (escalation-by-proxy ceiling checks, separation-of-duties, audit-log
+// writes) is made here; that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore, exactly as it does against a local backend.
+//
+// This is deliberately NOT a reuse of RBACHandler/GroupHandler's existing
+// human-facing routes (POST /groups/{id}/members, DELETE
+// /projects/{id}/members/{userId}, etc.): those require an authenticated actor
+// from the HTTP request context and run THIS server's own core methods
+// (validation, audit-log writes, last-admin/last-project-admin ceiling checks)
+// against THIS server's identity — the wrong semantics for a raw storage-primitive
+// passthrough, whose caller already ran all of that on the downstream side and
+// only needs this server to persist/return the already-decided row. Exactly the
+// same reasoning the #519/#520/#527 proxies in this package already established.
+//
+// One deliberate exception: RemoveGlobalAdminRoleGuardedProxy calls
+// storage.RemoveGlobalAdminRoleGuarded, which DOES evaluate the last-global-admin
+// invariant server-side — not because that's this server's OWN policy decision,
+// but because no real transaction can span the HTTP hop back to the calling
+// server (RemoteStorage.WithTransaction is a no-op passthrough), so whichever
+// server ultimately owns the row is the only one that CAN enforce it atomically.
+// See the storage.Storage interface doc (internal/core/storage/interface.go) and
+// internal/core/rbac_management.go's RemoveUserRole doc for the full reasoning —
+// the same pattern CreateSecretDependencyExclusiveProxy (#260) and
+// AdvanceWebAuthnCredentialCounterProxy (#306/#517) already established for their
+// own TOCTOU classes.
+//
+// Response envelope: like the other proxies, these do NOT use the package's
+// generic sendSuccess/sendError helpers — they construct the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// roleWithExpiryProxyWire mirrors internal/storage/store/remote_rbac.go's
+// roleWithExpiryWire exactly — the shared wire body for
+// AssignRoleWithExpiryProxy (UserID set, GroupID zero) and
+// AssignRoleToGroupWithExpiryProxy (GroupID set, UserID zero).
+type roleWithExpiryProxyWire struct {
+	UserID        uint      `json:"user_id,omitempty"`
+	GroupID       uint      `json:"group_id,omitempty"`
+	RoleID        uint      `json:"role_id"`
+	ProjectID     uint      `json:"project_id"`
+	EnvironmentID uint      `json:"environment_id"`
+	ExpiresAt     time.Time `json:"expires_at"`
+}
+
+// GetGroupRoleGrantsProxy handles GET
+// /api/v1/system/rbac/groups/{groupID}/role-grants.
+func (h *RBACHandler) GetGroupRoleGrantsProxy(w http.ResponseWriter, r *http.Request) {
+	groupID, err := strconv.ParseUint(chi.URLParam(r, "groupID"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid group id")
+		return
+	}
+	grants, err := h.coreService.Storage().GetGroupRoleGrants(r.Context(), uint(groupID))
+	if err != nil {
+		log.Printf("rbac role-grants proxy: get group role grants failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, grants)
+}
+
+// AssignRoleWithExpiryProxy handles POST
+// /api/v1/system/rbac/assign-role-with-expiry.
+func (h *RBACHandler) AssignRoleWithExpiryProxy(w http.ResponseWriter, r *http.Request) {
+	var body roleWithExpiryProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.UserID == 0 || body.RoleID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id and role_id are required")
+		return
+	}
+	scope := coreStorage.Scope{ProjectID: body.ProjectID, EnvironmentID: body.EnvironmentID}
+	if err := h.coreService.Storage().AssignRoleWithExpiry(r.Context(), body.UserID, body.RoleID, scope, body.ExpiresAt); err != nil {
+		log.Printf("rbac role-grants proxy: assign role with expiry failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"assigned": true})
+}
+
+// AssignRoleToGroupWithExpiryProxy handles POST
+// /api/v1/system/rbac/assign-role-to-group-with-expiry.
+func (h *RBACHandler) AssignRoleToGroupWithExpiryProxy(w http.ResponseWriter, r *http.Request) {
+	var body roleWithExpiryProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.GroupID == 0 || body.RoleID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "group_id and role_id are required")
+		return
+	}
+	scope := coreStorage.Scope{ProjectID: body.ProjectID, EnvironmentID: body.EnvironmentID}
+	if err := h.coreService.Storage().AssignRoleToGroupWithExpiry(r.Context(), body.GroupID, body.RoleID, scope, body.ExpiresAt); err != nil {
+		log.Printf("rbac role-grants proxy: assign role to group with expiry failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"assigned": true})
+}
+
+// removeAllProjectRoleGrantsProxyWire is the request body for
+// RemoveAllProjectRoleGrantsProxy.
+type removeAllProjectRoleGrantsProxyWire struct {
+	UserID    uint `json:"user_id"`
+	ProjectID uint `json:"project_id"`
+}
+
+// RemoveAllProjectRoleGrantsProxy handles POST
+// /api/v1/system/rbac/remove-all-project-role-grants.
+func (h *RBACHandler) RemoveAllProjectRoleGrantsProxy(w http.ResponseWriter, r *http.Request) {
+	var body removeAllProjectRoleGrantsProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.UserID == 0 || body.ProjectID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id and project_id are required")
+		return
+	}
+	if err := h.coreService.Storage().RemoveAllProjectRoleGrants(r.Context(), body.UserID, body.ProjectID); err != nil {
+		log.Printf("rbac role-grants proxy: remove all project role grants failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"removed": true})
+}
+
+// ListGroupRoleAssignmentsProxy handles GET
+// /api/v1/system/rbac/groups/{groupID}/role-assignments.
+func (h *RBACHandler) ListGroupRoleAssignmentsProxy(w http.ResponseWriter, r *http.Request) {
+	groupID, err := strconv.ParseUint(chi.URLParam(r, "groupID"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid group id")
+		return
+	}
+	assignments, err := h.coreService.Storage().ListGroupRoleAssignments(r.Context(), uint(groupID))
+	if err != nil {
+		log.Printf("rbac role-grants proxy: list group role assignments failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, assignments)
+}
+
+// ListProjectRoleAssignmentsProxy handles GET
+// /api/v1/system/rbac/project-role-assignments?project_id=X.
+func (h *RBACHandler) ListProjectRoleAssignmentsProxy(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := parseRBACProxyProjectIDQuery(w, r)
+	if !ok {
+		return
+	}
+	assignments, err := h.coreService.Storage().ListProjectRoleAssignments(r.Context(), projectID)
+	if err != nil {
+		log.Printf("rbac role-grants proxy: list project role assignments failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, assignments)
+}
+
+// ListProjectMachineRoleAssignmentsProxy handles GET
+// /api/v1/system/rbac/project-machine-role-assignments?project_id=X.
+func (h *RBACHandler) ListProjectMachineRoleAssignmentsProxy(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := parseRBACProxyProjectIDQuery(w, r)
+	if !ok {
+		return
+	}
+	assignments, err := h.coreService.Storage().ListProjectMachineRoleAssignments(r.Context(), projectID)
+	if err != nil {
+		log.Printf("rbac role-grants proxy: list project machine role assignments failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, assignments)
+}
+
+// ListGlobalAdminAssignmentsForUpdateProxy handles GET
+// /api/v1/system/rbac/global-admin-assignments?role_ids=1,2,3. A PLAIN read — see
+// RemoteStorage.ListGlobalAdminAssignmentsForUpdate's doc (remote_rbac.go) for why
+// no lock is taken over this hop; safety comes entirely from
+// RemoveGlobalAdminRoleGuardedProxy's atomic conditional write below.
+func (h *RBACHandler) ListGlobalAdminAssignmentsForUpdateProxy(w http.ResponseWriter, r *http.Request) {
+	roleIDs, ok := parseRBACProxyRoleIDsQuery(w, r)
+	if !ok {
+		return
+	}
+	assignments, err := h.coreService.Storage().ListGlobalAdminAssignmentsForUpdate(r.Context(), roleIDs)
+	if err != nil {
+		log.Printf("rbac role-grants proxy: list global admin assignments failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, assignments)
+}
+
+// removeGlobalAdminRoleGuardedProxyWire is the request body for
+// RemoveGlobalAdminRoleGuardedProxy.
+type removeGlobalAdminRoleGuardedProxyWire struct {
+	UserID       uint   `json:"user_id"`
+	RoleID       uint   `json:"role_id"`
+	AdminRoleIDs []uint `json:"admin_role_ids"`
+}
+
+// removeGlobalAdminRoleGuardedRefusedCode/notAssignedCode are the machine-readable
+// error codes this proxy returns when RemoveGlobalAdminRoleGuarded rejects the
+// removal — mirrored EXACTLY (same string values) in
+// internal/storage/store/remote_rbac.go, the wire-level contract
+// RemoteStorage.RemoveGlobalAdminRoleGuarded's error-recovery switch depends on to
+// reconstruct storage.ErrWouldStrandLastAdmin/storage.ErrRoleNotAssigned on the
+// calling side (#511-style wire-code translation, the same one
+// CreateSecretDependencyExclusiveProxy's duplicate/cycle codes use).
+const (
+	removeGlobalAdminRoleGuardedRefusedCode = "WOULD_STRAND_LAST_ADMIN"
+	roleNotAssignedCode                     = "ROLE_NOT_ASSIGNED"
+)
+
+// RemoveGlobalAdminRoleGuardedProxy handles POST
+// /api/v1/system/rbac/global-admin-role/remove-guarded. See the package doc and
+// the storage.Storage interface doc for why this atomically validates the
+// last-global-admin invariant rather than being a raw passthrough like every
+// other method here.
+func (h *RBACHandler) RemoveGlobalAdminRoleGuardedProxy(w http.ResponseWriter, r *http.Request) {
+	var body removeGlobalAdminRoleGuardedProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.UserID == 0 || body.RoleID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id and role_id are required")
+		return
+	}
+	err := h.coreService.Storage().RemoveGlobalAdminRoleGuarded(r.Context(), body.UserID, body.RoleID, body.AdminRoleIDs)
+	if err != nil {
+		switch {
+		case errors.Is(err, coreStorage.ErrWouldStrandLastAdmin):
+			writeRemoteAPIError(w, http.StatusConflict, removeGlobalAdminRoleGuardedRefusedCode, coreStorage.ErrWouldStrandLastAdmin.Error())
+		case errors.Is(err, coreStorage.ErrRoleNotAssigned):
+			writeRemoteAPIError(w, http.StatusNotFound, roleNotAssignedCode, coreStorage.ErrRoleNotAssigned.Error())
+		default:
+			log.Printf("rbac role-grants proxy: remove global admin role guarded failed: %v", err)
+			writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		}
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"removed": true})
+}
+
+// parseRBACProxyProjectIDQuery parses the required project_id query parameter
+// shared by ListProjectRoleAssignmentsProxy/ListProjectMachineRoleAssignmentsProxy.
+func parseRBACProxyProjectIDQuery(w http.ResponseWriter, r *http.Request) (projectID uint, ok bool) {
+	v := r.URL.Query().Get("project_id")
+	if v == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id query parameter is required")
+		return 0, false
+	}
+	id, err := strconv.ParseUint(v, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id must be a valid integer")
+		return 0, false
+	}
+	return uint(id), true
+}
+
+// parseRBACProxyRoleIDsQuery parses the optional, comma-separated role_ids query
+// parameter ListGlobalAdminAssignmentsForUpdateProxy takes — an empty/absent value
+// is valid (no install-admin role seeded yet) and yields an empty slice, mirroring
+// LocalStorage.ListGlobalAdminAssignmentsForUpdate's own "len(adminRoleIDs) == 0 →
+// nil, nil" short-circuit.
+func parseRBACProxyRoleIDsQuery(w http.ResponseWriter, r *http.Request) (roleIDs []uint, ok bool) {
+	v := r.URL.Query().Get("role_ids")
+	if v == "" {
+		return nil, true
+	}
+	parts := strings.Split(v, ",")
+	ids := make([]uint, 0, len(parts))
+	for _, p := range parts {
+		id, err := strconv.ParseUint(strings.TrimSpace(p), 10, 32)
+		if err != nil {
+			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "role_ids must be a comma-separated list of integers")
+			return nil, false
+		}
+		ids = append(ids, uint(id))
+	}
+	return ids, true
+}

--- a/server/http/remote_storage_rbac_role_grants_test.go
+++ b/server/http/remote_storage_rbac_role_grants_test.go
@@ -1,0 +1,322 @@
+// remote_storage_rbac_role_grants_test.go — end-to-end coverage for finding #525:
+// RemoteStorage's RBAC role-grant primitives (GetGroupRoleGrants/
+// AssignRoleWithExpiry/AssignRoleToGroupWithExpiry/RemoveAllProjectRoleGrants/
+// ListGroupRoleAssignments/ListGlobalAdminAssignmentsForUpdate/
+// ListProjectRoleAssignments/ListProjectMachineRoleAssignments/
+// RemoveGlobalAdminRoleGuarded) were unconditional stubs, breaking adding a user
+// to a group, removing a project member, JIT time-bound role grants, and every
+// last-global-admin lockout guard under storage.type: remote.
+//
+// Follows this package's established real-server harness (see
+// remote_storage_secret_dependencies_test.go): a REAL upstream exercised through
+// the production NewRouter/handlers (including the new
+// /api/v1/system/rbac/... routes, server/http/handlers/
+// rbac_role_grants_proxy.go), and a downstream *core.KeyorixCore backed by a real
+// store.RemoteStorage client over real HTTP.
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createRBACDriverToken creates a fresh admin identity (held via the
+// system_admin role, deliberately DISTINCT from the "admin" role the
+// last-global-admin tests below juggle) and returns a session token for it —
+// used to drive the downstream RemoteStorage client in tests that remove the
+// bootstrap admin's OWN "admin"-role grant. Reusing the bootstrap admin's own
+// token for those calls would be self-defeating: the moment that removal
+// succeeds, the bootstrap admin's session immediately loses system.write
+// (permissions are evaluated per-request against CURRENT role assignments, not
+// cached at login), so every SUBSEQUENT call over that same token would 403
+// regardless of whether the RBAC logic under test is correct.
+func createRBACDriverToken(t *testing.T, c *core.KeyorixCore) string {
+	t.Helper()
+	ctx := context.Background()
+	systemAdminRole, err := c.Storage().GetRoleByName(ctx, "system_admin")
+	require.NoError(t, err)
+	driver, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "rbacguardtestdriver", Email: "rbac-guard-test-driver@example.com",
+		DisplayName: "RBAC Guard Driver", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.Storage().AssignRole(ctx, driver.ID, systemAdminRole.ID, coreStorage.Scope{}))
+	session, _, err := c.Login(ctx, &core.LoginRequest{Username: "rbacguardtestdriver", Password: "Qr7#Kp2$Lm5@Vn9!"})
+	require.NoError(t, err)
+	return session.SessionToken
+}
+
+// TestRemoteStorageRBACRoleGrants_ReadsAndWrites_RealServer proves the fix for
+// GetGroupRoleGrants/AssignRoleWithExpiry/AssignRoleToGroupWithExpiry/
+// ListGroupRoleAssignments/ListProjectRoleAssignments/
+// ListProjectMachineRoleAssignments/RemoveAllProjectRoleGrants/
+// ListGlobalAdminAssignmentsForUpdate: every one of these round-trips through the
+// downstream's RemoteStorage against real rows on the upstream's own storage, not
+// just "the call didn't error".
+func TestRemoteStorageRBACRoleGrants_ReadsAndWrites_RealServer(t *testing.T) {
+	upstream, srv, token := newUpstreamForSecretDependencies(t) // shared harness helper
+	downstream := newDownstreamRemoteStorage(t, srv, token)
+	ctx := context.Background()
+
+	// Fixtures, created directly against the upstream's own storage (exactly what
+	// a real admin action would have produced).
+	role, err := upstream.Storage().CreateRole(ctx, &models.Role{Name: "rbac-grants-test-role", Description: "test role"})
+	require.NoError(t, err)
+
+	group, err := upstream.Storage().CreateGroup(ctx, &models.Group{Name: "rbac-grants-test-group"})
+	require.NoError(t, err)
+
+	user, err := upstream.Storage().CreateUser(ctx, &models.User{
+		Username: "rbac-grants-test-user", Email: "rbac-grants-test-user@example.com",
+	}, "TestPassword123!")
+	require.NoError(t, err)
+
+	const projectID = uint(777)
+	expiresAt := time.Now().Add(2 * time.Hour).UTC().Truncate(time.Second)
+
+	// --- AssignRoleWithExpiry: a JIT time-bound grant to the user, via the downstream ---
+	require.NoError(t, downstream.Storage().AssignRoleWithExpiry(ctx, user.ID, role.ID, coreStorage.Scope{ProjectID: projectID}, expiresAt),
+		"AssignRoleWithExpiry must reach the real /api/v1/system/rbac/assign-role-with-expiry route")
+
+	// A REAL row on the upstream's own storage, not just "the call didn't error".
+	directAssignments, err := upstream.Storage().ListProjectRoleAssignments(ctx, projectID)
+	require.NoError(t, err)
+	require.Len(t, directAssignments, 1)
+	assert.Equal(t, "user", directAssignments[0].PrincipalType)
+	assert.Equal(t, user.ID, directAssignments[0].PrincipalID)
+	assert.Equal(t, role.ID, directAssignments[0].RoleID)
+
+	// --- ListProjectRoleAssignments via the downstream ---
+	remoteAssignments, err := downstream.Storage().ListProjectRoleAssignments(ctx, projectID)
+	require.NoError(t, err, "ListProjectRoleAssignments must reach the real proxy route")
+	require.Len(t, remoteAssignments, 1)
+	assert.Equal(t, user.ID, remoteAssignments[0].PrincipalID)
+
+	// --- AssignRoleToGroupWithExpiry: a JIT time-bound grant to the group ---
+	require.NoError(t, downstream.Storage().AssignRoleToGroupWithExpiry(ctx, group.ID, role.ID, coreStorage.Scope{ProjectID: projectID}, expiresAt),
+		"AssignRoleToGroupWithExpiry must reach the real proxy route")
+
+	// --- GetGroupRoleGrants via the downstream ---
+	grants, err := downstream.Storage().GetGroupRoleGrants(ctx, group.ID)
+	require.NoError(t, err, "GetGroupRoleGrants must reach the real proxy route")
+	require.Len(t, grants, 1)
+	assert.Equal(t, role.ID, grants[0].ID)
+	assert.Equal(t, role.Name, grants[0].Name)
+	require.NotNil(t, grants[0].ExpiresAt)
+	assert.WithinDuration(t, expiresAt, *grants[0].ExpiresAt, time.Second)
+
+	// --- ListGroupRoleAssignments via the downstream ---
+	groupAssignments, err := downstream.Storage().ListGroupRoleAssignments(ctx, group.ID)
+	require.NoError(t, err, "ListGroupRoleAssignments must reach the real proxy route")
+	require.Len(t, groupAssignments, 1)
+	assert.Equal(t, "group", groupAssignments[0].PrincipalType)
+	assert.Equal(t, group.ID, groupAssignments[0].PrincipalID)
+	assert.Equal(t, projectID, groupAssignments[0].ProjectID)
+
+	// --- ListProjectMachineRoleAssignments: a machine-identity grant ---
+	machine, err := upstream.Storage().CreateMachineIdentity(ctx, &models.MachineIdentity{
+		ProjectID: projectID, Name: "rbac-grants-test-machine", IdentityType: "service", State: "active",
+	})
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().AssignMachineRole(ctx, machine.ID, role.ID, coreStorage.Scope{ProjectID: projectID}))
+
+	machineAssignments, err := downstream.Storage().ListProjectMachineRoleAssignments(ctx, projectID)
+	require.NoError(t, err, "ListProjectMachineRoleAssignments must reach the real proxy route")
+	require.Len(t, machineAssignments, 1)
+	assert.Equal(t, "machine", machineAssignments[0].PrincipalType)
+	assert.Equal(t, machine.ID, machineAssignments[0].PrincipalID)
+
+	// --- ListGlobalAdminAssignmentsForUpdate: a plain read over the seeded admin ---
+	adminRole, err := upstream.Storage().GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	globalAdmins, err := downstream.Storage().ListGlobalAdminAssignmentsForUpdate(ctx, []uint{adminRole.ID})
+	require.NoError(t, err, "ListGlobalAdminAssignmentsForUpdate must reach the real proxy route")
+	require.Len(t, globalAdmins, 1, "the bootstrap admin holds the seeded global admin role")
+	assert.Equal(t, adminRole.ID, globalAdmins[0].RoleID)
+
+	// --- RemoveAllProjectRoleGrants: bulk-removes the user's project-scoped grant ---
+	require.NoError(t, downstream.Storage().RemoveAllProjectRoleGrants(ctx, user.ID, projectID),
+		"RemoveAllProjectRoleGrants must reach the real proxy route")
+
+	after, err := upstream.Storage().ListProjectRoleAssignments(ctx, projectID)
+	require.NoError(t, err)
+	for _, a := range after {
+		assert.False(t, a.PrincipalType == "user" && a.PrincipalID == user.ID,
+			"the user's project-scoped grant must actually be gone from the upstream's own storage")
+	}
+}
+
+// TestRemoteStorageRBACRoleGrants_RemoveGlobalAdminRoleGuarded_RealServer proves
+// RemoveGlobalAdminRoleGuarded's atomic check-then-remove: refuses when the
+// target is the last global admin, succeeds and actually removes the row when
+// another survives, and reports ErrRoleNotAssigned (not a generic error) when the
+// grant doesn't exist — the exact sentinels internal/core/rbac_management.go's
+// RemoveUserRole depends on surviving the HTTP hop.
+func TestRemoteStorageRBACRoleGrants_RemoveGlobalAdminRoleGuarded_RealServer(t *testing.T) {
+	upstream, srv, _ := newUpstreamForSecretDependencies(t)
+	driverToken := createRBACDriverToken(t, upstream)
+	downstream := newDownstreamRemoteStorage(t, srv, driverToken)
+	ctx := context.Background()
+
+	adminRole, err := upstream.Storage().GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	adminIDs := []uint{adminRole.ID}
+
+	bootstrapAdmin, err := upstream.Storage().GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+
+	// --- refused: the bootstrap admin is currently the ONLY global admin ---
+	err = downstream.Storage().RemoveGlobalAdminRoleGuarded(ctx, bootstrapAdmin.ID, adminRole.ID, adminIDs)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, coreStorage.ErrWouldStrandLastAdmin),
+		"the refusal must survive the HTTP hop as the exact sentinel, not an opaque error: %v", err)
+
+	// A second global admin — now the removal above would no longer strand the install.
+	secondAdmin, err := upstream.Storage().CreateUser(ctx, &models.User{
+		Username: "rbac-guarded-second-admin", Email: "rbac-guarded-second-admin@example.com",
+	}, "TestPassword123!")
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().AssignRole(ctx, secondAdmin.ID, adminRole.ID, coreStorage.Scope{}))
+
+	// --- succeeds: another admin survives ---
+	require.NoError(t, downstream.Storage().RemoveGlobalAdminRoleGuarded(ctx, bootstrapAdmin.ID, adminRole.ID, adminIDs))
+
+	// A REAL removal on the upstream's own storage.
+	remaining, err := upstream.Storage().ListGlobalAdminAssignmentsForUpdate(ctx, adminIDs)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1, "exactly the second admin's grant must remain")
+	assert.Equal(t, secondAdmin.ID, remaining[0].PrincipalID)
+
+	// --- refused again: the second admin is now the last one ---
+	err = downstream.Storage().RemoveGlobalAdminRoleGuarded(ctx, secondAdmin.ID, adminRole.ID, adminIDs)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, coreStorage.ErrWouldStrandLastAdmin))
+
+	// --- not assigned: the bootstrap admin's grant was already removed above ---
+	err = downstream.Storage().RemoveGlobalAdminRoleGuarded(ctx, bootstrapAdmin.ID, adminRole.ID, adminIDs)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, coreStorage.ErrRoleNotAssigned),
+		"a nonexistent grant must surface ErrRoleNotAssigned, not ErrWouldStrandLastAdmin: %v", err)
+}
+
+// TestRemoteStorageRBACRoleGrants_ConcurrentRace_LastAdminNeverStranded_RealServer
+// is the cross-process analogue of internal/core's
+// TestConcurrency_RemoveUserRole_CannotStrandLastTwoAdmins (#340): TWO INDEPENDENT
+// *store.RemoteStorage clients (standing in for two downstream spoke servers, each
+// with its OWN process-local globalAdminGuardMu that cannot serialize across them)
+// race to remove each OTHER's global admin grant against the SAME upstream, via
+// RemoveGlobalAdminRoleGuarded directly.
+//
+// Before this fix (a caller-orchestrated ListGlobalAdminAssignmentsForUpdate +
+// RemoveRole sequence inside a WithTransaction closure, with
+// RemoteStorage.WithTransaction a no-op passthrough), nothing would have prevented
+// both requests from observing "another admin still exists" and both succeeding,
+// stranding the install with zero admins. With RemoveGlobalAdminRoleGuarded, the
+// upstream's own LocalStorage transaction serializes the two concurrent HTTP
+// requests, so exactly one must win.
+func TestRemoteStorageRBACRoleGrants_ConcurrentRace_LastAdminNeverStranded_RealServer(t *testing.T) {
+	upstream, srv, _ := newUpstreamForSecretDependencies(t)
+	driverToken := createRBACDriverToken(t, upstream)
+	ctx := context.Background()
+
+	adminRole, err := upstream.Storage().GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	adminIDs := []uint{adminRole.ID}
+
+	// The bootstrap admin ALSO holds the "admin" role at the global scope
+	// (createTestToken's bootstrap flow) — left in place, it would permanently
+	// satisfy "another admin survives" for every userA/userB pair below,
+	// letting BOTH concurrent removals succeed regardless of the race this test
+	// exists to prove. Strip it up front via a raw storage call (no HTTP hop, no
+	// guard needed — this is fixture setup, not the flow under test) so the
+	// admin-role holder set for the rest of this test is EXACTLY {userA, userB}
+	// each iteration.
+	bootstrapAdmin, err := upstream.Storage().GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().RemoveRole(ctx, bootstrapAdmin.ID, adminRole.ID, coreStorage.Scope{}))
+
+	const iterations = 6
+	for i := 0; i < iterations; i++ {
+		// Exactly two global admins per iteration: userA and userB, freshly
+		// created. The previous iteration's WINNER (if any) is stripped of its
+		// admin-role grant at the end of the loop body below, so the admin-role
+		// holder set going into THIS iteration's race is exactly {userA, userB} —
+		// otherwise every prior iteration's survivor would silently accumulate as
+		// a permanent extra admin, letting BOTH of the current iteration's
+		// concurrent removals succeed regardless of whether the fix under test
+		// actually serializes them.
+		userA, err := upstream.Storage().CreateUser(ctx, &models.User{
+			Username: fmt.Sprintf("rbac-race-admin-a-%d", i), Email: fmt.Sprintf("rbac-race-admin-a-%d@example.com", i),
+		}, "TestPassword123!")
+		require.NoError(t, err)
+		userB, err := upstream.Storage().CreateUser(ctx, &models.User{
+			Username: fmt.Sprintf("rbac-race-admin-b-%d", i), Email: fmt.Sprintf("rbac-race-admin-b-%d@example.com", i),
+		}, "TestPassword123!")
+		require.NoError(t, err)
+		require.NoError(t, upstream.Storage().AssignRole(ctx, userA.ID, adminRole.ID, coreStorage.Scope{}))
+		require.NoError(t, upstream.Storage().AssignRole(ctx, userB.ID, adminRole.ID, coreStorage.Scope{}))
+
+		downstreamA := newDownstreamRemoteStorage(t, srv, driverToken)
+		downstreamB := newDownstreamRemoteStorage(t, srv, driverToken)
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		results := make([]error, 2)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			results[0] = downstreamA.Storage().RemoveGlobalAdminRoleGuarded(ctx, userA.ID, adminRole.ID, adminIDs)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			results[1] = downstreamB.Storage().RemoveGlobalAdminRoleGuarded(ctx, userB.ID, adminRole.ID, adminIDs)
+		}()
+		close(start)
+		wg.Wait()
+
+		succeeded, refused := 0, 0
+		for _, e := range results {
+			if e == nil {
+				succeeded++
+			} else {
+				assert.True(t, errors.Is(e, coreStorage.ErrWouldStrandLastAdmin),
+					"iteration %d: the loser must fail with the exact sentinel, not an opaque error: %v", i, e)
+				refused++
+			}
+		}
+		assert.Equal(t, 1, succeeded, "iteration %d: exactly one of the two concurrent removals must succeed", i)
+		assert.Equal(t, 1, refused, "iteration %d: exactly one of the two concurrent removals must be refused", i)
+
+		stillHeld, err := upstream.Storage().ListGlobalAdminAssignmentsForUpdate(ctx, adminIDs)
+		require.NoError(t, err)
+		heldByUserAOrB := 0
+		var survivorID uint
+		for _, a := range stillHeld {
+			if a.PrincipalType == "user" && (a.PrincipalID == userA.ID || a.PrincipalID == userB.ID) {
+				heldByUserAOrB++
+				survivorID = a.PrincipalID
+			}
+		}
+		assert.Equal(t, 1, heldByUserAOrB,
+			"iteration %d: exactly one of userA/userB must still hold the admin grant — never both removed, never both surviving unresolved", i)
+
+		// Strip the survivor's grant (raw storage call, outside the flow under
+		// test) so it doesn't silently become a permanent extra admin the NEXT
+		// iteration's pair could lean on instead of actually racing each other.
+		if survivorID != 0 {
+			require.NoError(t, upstream.Storage().RemoveRole(ctx, survivorID, adminRole.ID, coreStorage.Scope{}))
+		}
+	}
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1356,6 +1356,51 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/users/purge", userHandler.PurgeDeletedUsersBeforeProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/projects/purge", catalogHandler.PurgeDeletedProjectsBeforeProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/environments/purge", catalogHandler.PurgeDeletedEnvironmentsBeforeProxy)
+
+			// RBAC role-grant primitive proxy (finding #525). Lets a downstream
+			// Keyorix server booted with storage.type: remote (ADR-049) proxy
+			// GetGroupRoleGrants/AssignRoleWithExpiry/AssignRoleToGroupWithExpiry/
+			// RemoveAllProjectRoleGrants/ListGroupRoleAssignments/
+			// ListGlobalAdminAssignmentsForUpdate/ListProjectRoleAssignments/
+			// ListProjectMachineRoleAssignments to THIS server's real storage
+			// backend, instead of RemoteStorage's eight RBAC role-grant methods
+			// being unconditional stubs (adding a user to a group, removing a
+			// project member, JIT time-bound role grants, and several
+			// last-global-admin lockout guards were completely non-functional
+			// under storage.type: remote — the guards specifically failed CLOSED,
+			// blocking the underlying legitimate action too, not just leaving a
+			// gap). Exactly the same pattern as the secret-dependencies/retention
+			// proxies above: a thin passthrough onto storage.Storage (no RBAC
+			// POLICY decision — the escalation-by-proxy ceiling checks,
+			// separation-of-duties, audit-log writes — is made here; that stays
+			// entirely in the CALLING server's own internal/core.KeyorixCore,
+			// exactly as it does against a local backend), reusing the SAME
+			// system.read/system.write tier — no new privilege class.
+			//
+			// RemoveGlobalAdminRoleGuardedProxy is the ONE exception: it DOES
+			// evaluate the last-global-admin invariant server-side, because no
+			// real transaction can span this HTTP hop (RemoteStorage.
+			// WithTransaction is a no-op passthrough) — see
+			// rbac_role_grants_proxy.go's package doc and
+			// internal/core/rbac_management.go's RemoveUserRole doc for why
+			// RemoveUserRole now calls this instead of a
+			// ListGlobalAdminAssignmentsForUpdate-then-RemoveRole sequence for a
+			// global-scope admin-conferring role: two separate HTTP round trips
+			// would reopen the exact cross-process last-admin-lockout race #340
+			// closed for HA Postgres replicas, this time between concurrent
+			// spokes (or a spoke and the hub itself). Static sub-paths
+			// ("role-grants", "role-assignments" under "/groups/{groupID}",
+			// "global-admin-assignments", "global-admin-role/remove-guarded") are
+			// registered ahead of nothing that would collide at this depth.
+			r.Get("/rbac/groups/{groupID}/role-grants", rbacHandler.GetGroupRoleGrantsProxy)
+			r.Get("/rbac/groups/{groupID}/role-assignments", rbacHandler.ListGroupRoleAssignmentsProxy)
+			r.Get("/rbac/project-role-assignments", rbacHandler.ListProjectRoleAssignmentsProxy)
+			r.Get("/rbac/project-machine-role-assignments", rbacHandler.ListProjectMachineRoleAssignmentsProxy)
+			r.Get("/rbac/global-admin-assignments", rbacHandler.ListGlobalAdminAssignmentsForUpdateProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/rbac/assign-role-with-expiry", rbacHandler.AssignRoleWithExpiryProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/rbac/assign-role-to-group-with-expiry", rbacHandler.AssignRoleToGroupWithExpiryProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/rbac/remove-all-project-role-grants", rbacHandler.RemoveAllProjectRoleGrantsProxy)
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/rbac/global-admin-role/remove-guarded", rbacHandler.RemoveGlobalAdminRoleGuardedProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary

RemoteStorage's 8 RBAC role-grant primitives were unconditional stubs, breaking core admin flows under `storage.type: remote` (ADR-049 spoke):

- `GetGroupRoleGrants`, `ListGroupRoleAssignments` — POST `/groups/{id}/members` (escalation ceiling check) and the group-roles tab
- `AssignRoleWithExpiry`, `AssignRoleToGroupWithExpiry` — JIT time-bound role grants (access-request TTL approval, break-glass)
- `RemoveAllProjectRoleGrants`, `ListProjectRoleAssignments` — DELETE `/projects/{id}/members/{userId}` (routine member offboarding)
- `ListProjectMachineRoleAssignments` — machine-identity access-review coverage (#91)
- `ListGlobalAdminAssignmentsForUpdate` — the last-global-admin lockout guard, which failed *closed*, blocking the underlying legitimate role removal too, not just leaving a silent gap

Note: `GetGroupRoleGrants`'s prior doc comment claiming the HTTP handler reads local storage instead was independently confirmed **false** — `GetGroupRoles` (`server/http/handlers/rbac.go`) calls this method directly.

## Fix

- All 8 methods are now thin passthroughs onto new routes under `/api/v1/system/rbac/...` (`server/http/handlers/rbac_role_grants_proxy.go`), gated by the same `system.read`/`system.write` tier every other proxy uses — no new privilege class. The existing human-facing routes (`/groups/{id}/members`, `/projects/{id}/members/{userId}`) are deliberately **not** reused: they bake in this server's own validation/audit-log writes/last-admin-ceiling checks against this server's actor context, which would double-apply or apply against the wrong identity if re-invoked on the upstream hub.

- **Atomicity fix:** `RemoveUserRole`'s last-global-admin guard previously ran `ListGlobalAdminAssignmentsForUpdate` (the check) and `RemoveRole` (the write) as two calls inside a `storage.WithTransaction` closure — correct against `LocalStorage` (a real DB transaction + Postgres row lock spans both), but `RemoteStorage.WithTransaction` is a no-op passthrough. Two separate HTTP round trips would have reopened the exact cross-process last-admin-lockout race #340 closed for HA Postgres replicas — this time between concurrent spokes, or a spoke racing the hub's own direct callers. Added a new atomic primitive, `RemoveGlobalAdminRoleGuarded`, folding the check and the removal into **one** storage call (one hub-side transaction for the remote case), mirroring the same pattern this campaign already used for `TransitionMachineIdentityState` (#388/#518) and `CreateSecretDependencyExclusive` (#260). `RemoveUserRole` now calls it directly for global-scope admin-conferring role removals instead of the old two-call transaction dance.

- Updated `remote_unsupported_completeness_test.go`'s allowlist: removed the 8 closed entries, decremented the genuine-gap counter.

- Added `server/http/remote_storage_rbac_role_grants_test.go`: real-server round-trip coverage for all 8 methods plus `RemoveGlobalAdminRoleGuarded`'s refuse/succeed/not-assigned paths, and a concurrent-race regression test (two independent `RemoteStorage` clients racing to remove each other's admin grant against the same upstream) proving the install is never stranded with zero admins.

Refs #525.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/storage/store/... ./server/http/... ./internal/core/...` (2298 tests pass)
- [x] `go vet ./...`, `gofmt -l` on all changed files
- [x] New concurrent-race test passes under `-race -count=2`