### PR TITLE
fix(remote-storage): proxy misc RemoteStorage gaps under storage.type: remote

### DIFF
--- a/internal/storage/store/remote_access_activity.go
+++ b/internal/storage/store/remote_access_activity.go
@@ -1,28 +1,105 @@
-// remote_access_activity.go — dormant-access activity lookup for RemoteStorage.
-// Computed server-side; stub here. See local_access_activity.go.
+// remote_access_activity.go — dormant-access activity lookup for RemoteStorage
+// (finding #531). Proxies LastUserSecretActivity/LastUserRoleManagementActivity/
+// LastUserSecretDeletionActivity/LastUserSecretReadActivity/
+// LastUserSecretWriteActivity onto NEW server-side routes under
+// /api/v1/system/access-activity (server/http/handlers/access_activity_proxy.go),
+// gated on the SAME system.read RBAC permission every other RemoteStorage read
+// already needs (no new privilege class).
+//
+// Before this fix, every one of these five methods was an unconditional stub:
+// GenerateProjectAccessReview (ISO 27001/SOC2 recertification) and
+// compliance_posture.go's countDormantRoleGrants both degrade gracefully on
+// error (a dormant-access grant is simply never flagged, not a hard failure),
+// so the practical effect was a silently missing detective control rather than
+// an outage — but the dormant-access/dormant-role-grant compliance signal was
+// never available at all under storage.type: remote. Each is a thin passthrough
+// onto storage.Storage's own audit_events query (no POLICY decision — which
+// event types count as "activity" for which bucket, internal/storage/store/
+// local_access_activity.go's accessActivityEventTypes and friends — is made
+// here; that lives entirely server-side in LocalStorage, exactly as it does for
+// a local backend).
+//
+// For the local (GORM) equivalent see local_access_activity.go.
 package store
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
 	"time"
 )
 
-func (rs *RemoteStorage) LastUserSecretActivity(_ context.Context, _ uint) (map[uint]time.Time, error) {
-	return nil, remoteUnsupported("LastUserSecretActivity")
+// accessActivityWireResponse wraps the per-user last-activity map. JSON object
+// keys must be strings, so the uint user IDs are carried as decimal strings on
+// the wire and parsed back into a map[uint]time.Time on decode.
+type accessActivityWireResponse struct {
+	Activity map[string]time.Time `json:"activity"`
 }
 
-func (rs *RemoteStorage) LastUserRoleManagementActivity(_ context.Context, _ uint) (map[uint]time.Time, error) {
-	return nil, remoteUnsupported("LastUserRoleManagementActivity")
+func decodeAccessActivityResponse(data []byte) (map[uint]time.Time, error) {
+	var wire accessActivityWireResponse
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	out := make(map[uint]time.Time, len(wire.Activity))
+	for k, v := range wire.Activity {
+		id, err := strconv.ParseUint(k, 10, 32)
+		if err != nil {
+			continue
+		}
+		out[uint(id)] = v
+	}
+	return out, nil
 }
 
-func (rs *RemoteStorage) LastUserSecretDeletionActivity(_ context.Context, _ uint) (map[uint]time.Time, error) {
-	return nil, remoteUnsupported("LastUserSecretDeletionActivity")
+// getAccessActivity is the shared GET behind all five methods below — they
+// differ only in which server-side route (and therefore which event-type
+// bucket) they hit.
+func (rs *RemoteStorage) getAccessActivity(ctx context.Context, route string, projectID uint) (map[uint]time.Time, error) {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
+	path := "/api/v1/system/access-activity/" + route + "?" + q.Encode()
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s activity: %w", route, err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get %s activity failed: %s", route, resp.Error.Error())
+	}
+	return decodeAccessActivityResponse(resp.Data)
 }
 
-func (rs *RemoteStorage) LastUserSecretReadActivity(_ context.Context, _ uint) (map[uint]time.Time, error) {
-	return nil, remoteUnsupported("LastUserSecretReadActivity")
+// LastUserSecretActivity returns the most recent secret-access time per user in
+// the project via GET /api/v1/system/access-activity/secret.
+func (rs *RemoteStorage) LastUserSecretActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {
+	return rs.getAccessActivity(ctx, "secret", projectID)
 }
 
-func (rs *RemoteStorage) LastUserSecretWriteActivity(_ context.Context, _ uint) (map[uint]time.Time, error) {
-	return nil, remoteUnsupported("LastUserSecretWriteActivity")
+// LastUserRoleManagementActivity returns the most recent role-management
+// activity time per user in the project via GET
+// /api/v1/system/access-activity/role-management.
+func (rs *RemoteStorage) LastUserRoleManagementActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {
+	return rs.getAccessActivity(ctx, "role-management", projectID)
+}
+
+// LastUserSecretDeletionActivity returns the most recent secret-deletion time
+// per user in the project via GET
+// /api/v1/system/access-activity/secret-deletion.
+func (rs *RemoteStorage) LastUserSecretDeletionActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {
+	return rs.getAccessActivity(ctx, "secret-deletion", projectID)
+}
+
+// LastUserSecretReadActivity returns the most recent secret.read time per user
+// in the project via GET /api/v1/system/access-activity/secret-read.
+func (rs *RemoteStorage) LastUserSecretReadActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {
+	return rs.getAccessActivity(ctx, "secret-read", projectID)
+}
+
+// LastUserSecretWriteActivity returns the most recent
+// secret.created/updated/rotated time per user in the project via GET
+// /api/v1/system/access-activity/secret-write.
+func (rs *RemoteStorage) LastUserSecretWriteActivity(ctx context.Context, projectID uint) (map[uint]time.Time, error) {
+	return rs.getAccessActivity(ctx, "secret-write", projectID)
 }

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -228,9 +228,34 @@ func (rs *RemoteStorage) DeleteSecret(ctx context.Context, id uint) error {
 	return nil
 }
 
-// GetSecretIncludingDeleted is not available in remote mode; restore resolves server-side.
-func (rs *RemoteStorage) GetSecretIncludingDeleted(_ context.Context, _ uint) (*models.SecretNode, error) {
-	return nil, remoteUnsupported("GetSecretIncludingDeleted")
+// GetSecretIncludingDeleted loads a secret even when soft-deleted, via GET
+// /api/v1/system/secrets/{id}/including-deleted (finding #531). Before this fix,
+// the unconditional stub broke ScopeFromDeletedSecretParam — the scope resolver
+// ahead of POST /secrets/{id}/restore (server/middleware/auth.go) — so every
+// restore request 404'd before ever reaching the already-correctly-proxied
+// RestoreSecret. A thin passthrough onto storage.Storage's own Unscoped lookup
+// (no policy decision made here); gated on the SAME system.read tier every
+// other RemoteStorage read already needs. The response marshals models.SecretNode
+// directly (it carries no json tags of its own beyond ValueStored's `json:"-"`,
+// so a Go-to-Go round trip between this client and the handler's identical type
+// preserves every field exactly, mirroring DeleteExpiredShareRecords' identical
+// choice for models.ShareRecord), wrapped in a small envelope.
+func (rs *RemoteStorage) GetSecretIncludingDeleted(ctx context.Context, id uint) (*models.SecretNode, error) {
+	path := fmt.Sprintf("/api/v1/system/secrets/%d/including-deleted", id)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret including deleted: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get secret including deleted failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Secret *models.SecretNode `json:"secret"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Secret, nil
 }
 
 func (rs *RemoteStorage) RestoreSecret(ctx context.Context, id uint) error {

--- a/internal/storage/store/remote_sharing.go
+++ b/internal/storage/store/remote_sharing.go
@@ -135,14 +135,31 @@ func (rs *RemoteStorage) ListSharesByUser(ctx context.Context, userID uint) ([]*
 	return result, nil
 }
 
-// ListSharesByOwner is not implemented for remote storage: there is no server REST
-// endpoint to proxy this to. Returning an empty slice here would make a caller (and
-// any authz/audit logic downstream) see "user has zero shares" when the truth is
-// "we don't know" — potentially masking access it should have surfaced (#455).
-// Surface the unsupported-operation error instead, matching every sibling stub in
-// this file.
-func (rs *RemoteStorage) ListSharesByOwner(_ context.Context, _ uint) ([]*models.ShareRecord, error) {
-	return nil, remoteUnsupported("ListSharesByOwner")
+// ListSharesByOwner lists currently-active share records created by ownerID, via
+// GET /api/v1/system/shares/by-owner/{ownerID} (finding #531). Before this fix,
+// the unconditional stub made core.ListSharesByUser hard-fail (no fallback —
+// unlike the graceful-degrade access-activity gaps above, this one returns an
+// ERROR to its own caller), breaking the gRPC "list my shares" call (and the
+// owned-share half of ListSharesByUser generally) end to end under
+// storage.type: remote. A thin passthrough onto storage.Storage's own
+// active-share query (no policy decision made here); gated on the SAME
+// system.read tier every other RemoteStorage read already needs.
+func (rs *RemoteStorage) ListSharesByOwner(ctx context.Context, ownerID uint) ([]*models.ShareRecord, error) {
+	path := fmt.Sprintf("/api/v1/system/shares/by-owner/%d", ownerID)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list shares by owner: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("list shares by owner failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Shares []*models.ShareRecord `json:"shares"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Shares, nil
 }
 
 // ListSharesByGroup lists all share records where groupID is the recipient via remote API.

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -22,7 +22,12 @@ const (
 	// statusKnownGap means the stub is a confirmed, currently-reachable bug —
 	// something breaks under storage.type: remote today. Tracked in
 	// docs/security/HARDENING-BACKLOG.md; see Reason for the finding reference.
-	statusKnownGap
+	//
+	// Round 119's entire genuine-gap list is closed as of #531, so no allowlist
+	// entry currently uses this value — kept (not deleted) since the NEXT stub a
+	// future round finds needs it immediately; deleting and re-adding it every
+	// time the count round-trips through zero would just be churn.
+	statusKnownGap //nolint:unused
 )
 
 type remoteUnsupportedEntry struct {

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -75,10 +75,12 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"ConsumeMFARecoveryCode": {statusIntentional,
 		"round 119 audit: sole caller is VerifyMFACredentials, same bypassed-branch reasoning as MarkTOTPStepUsed — recovery codes are only ever consumed at login, never during enrollment/management"},
 
-	// --- Confirmed genuine gaps, tracked for future fix rounds (47; UpdateLoginLockoutState
+	// --- Confirmed genuine gaps, tracked for future fix rounds (39; UpdateLoginLockoutState
 	// closed by #529, SSO login state closed by #521, GetActiveMFAChallenge/
 	// ConsumeMFAChallenge (WebAuthn-as-second-factor login) closed by #522, Connect
-	// ref-grant CRUD closed by #527) ---
+	// ref-grant CRUD closed by #527, the five LastUser*Activity methods/
+	// GetSecretIncludingDeleted/ListSharesByOwner/CreateUserWithRoleGrants (misc
+	// gaps closed by #531)) ---
 	// See docs/security/HARDENING-BACKLOG.md's round 119 entry for full detail,
 	// severity, and grouping. Each entry below cites the real caller/route a
 	// round-119 audit traced (not assumed).
@@ -167,21 +169,6 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	// retention-purge fix) from ever running via its scheduler on a spoke server.
 	"WithSchedulerLock": {statusKnownGap,
 		"round 119: server/scheduler_run.go's lockedRun wraps every background scheduler (retention purge, auto-rotation, recertification, dynamic-secret sweep, JIT-access expiry, login-attempt prune, anomaly detection, reminders, compliance digest, evidence delivery) — its own doc comment claiming this, is never reached remotely is disproven by server/main.go starting every scheduler unconditionally"},
-
-	// Misc.
-	"LastUserSecretActivity": {statusKnownGap,
-		"round 119: GenerateProjectAccessReview (ISO 27001/SOC2 recertification) — degrades gracefully but the dormant-access signal is never available"},
-	"LastUserRoleManagementActivity": {statusKnownGap,
-		"round 119: compliance_posture.go's countDormantRoleGrants — degrades gracefully, same missing-signal issue"},
-	"LastUserSecretDeletionActivity": {statusKnownGap, "round 119: same flow as LastUserRoleManagementActivity"},
-	"LastUserSecretReadActivity":     {statusKnownGap, "round 119: same flow as LastUserRoleManagementActivity"},
-	"LastUserSecretWriteActivity":    {statusKnownGap, "round 119: same flow as LastUserRoleManagementActivity"},
-	"GetSecretIncludingDeleted": {statusKnownGap,
-		"round 119: ScopeFromDeletedSecretParam's scope check ahead of POST /secrets/{id}/restore — every restore request 404s before ever reaching the (already-proxied) RestoreSecret"},
-	"ListSharesByOwner": {statusKnownGap,
-		"round 119: core.ListSharesByUser hard-fails (no fallback), backing the gRPC ListShares \"my shares\" call"},
-	"CreateUserWithRoleGrants": {statusKnownGap,
-		"round 119: CreateUserWithAssignments (atomic create-user+role-grants), POST /api/v1/users and gRPC CreateUser"},
 }
 
 // remoteUnsupportedCallRe matches the exact, 100%-consistent call pattern every

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -38,6 +38,7 @@ package store
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -47,6 +48,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
 	"gorm.io/gorm"
 )
 
@@ -539,8 +541,110 @@ func (rs *RemoteStorage) ListUsersInStateBefore(ctx context.Context, state strin
 	return users, nil
 }
 
-func (rs *RemoteStorage) CreateUserWithRoleGrants(_ context.Context, _ *models.User, _ []storage.RoleGrant) (*models.User, error) {
-	return nil, remoteUnsupported("CreateUserWithRoleGrants")
+// roleGrantWire mirrors storage.RoleGrant's fields exactly.
+type roleGrantWire struct {
+	RoleID        uint `json:"role_id"`
+	ProjectID     uint `json:"project_id"`
+	EnvironmentID uint `json:"environment_id"`
+}
+
+func newRoleGrantWire(g storage.RoleGrant) roleGrantWire {
+	return roleGrantWire{RoleID: g.RoleID, ProjectID: g.Scope.ProjectID, EnvironmentID: g.Scope.EnvironmentID}
+}
+
+// duplicateEmailProxyCode is the machine-readable error code
+// CreateUserWithRoleGrantsProxy returns when the upstream's own partial
+// unique-index rejection (uniq_users_email_active, #117) fires — the wire-level
+// signal used below to reconstruct the same storage.ErrDuplicateEmail sentinel
+// core.CreateUserWithAssignments' own errors.Is check depends on, mirroring
+// legalHoldAlreadyActiveCode's identical two-package-duplicated-constant
+// pattern (server/http/handlers/legal_hold_proxy.go / remote_legal_hold.go).
+const duplicateEmailProxyCode = "DUPLICATE_EMAIL"
+
+// createUserWithRoleGrantsWireRequest is the wire body for CreateUserWithRoleGrants
+// (finding #531). Unlike CreateUser's userCreateWireRequest — which sends the
+// PLAINTEXT password and lets the upstream handler compute its own bcrypt hash,
+// because that route runs through the calling server's core.CreateUser business
+// logic a second time server-side — this is a raw storage-primitive passthrough,
+// exactly like AdvanceWebAuthnCredentialCounter/TransitionMachineIdentityState:
+// the CALLING server's own core.CreateUserWithAssignments (internal/core/users.go)
+// already ran buildUserForCreate (validation, password-policy check, bcrypt hash)
+// BEFORE ever reaching storage.Storage, so PasswordHash here carries that
+// already-computed hash directly — the upstream handler must persist it
+// unconditionally, not re-derive it from a plaintext it was never given.
+type createUserWithRoleGrantsWireRequest struct {
+	Username          string          `json:"username"`
+	Email             string          `json:"email"`
+	DisplayName       string          `json:"display_name"`
+	PasswordHash      string          `json:"password_hash"`
+	IsActive          bool            `json:"is_active"`
+	AccountState      string          `json:"account_state"`
+	PasswordChangedAt *time.Time      `json:"password_changed_at,omitempty"`
+	Grants            []roleGrantWire `json:"grants"`
+}
+
+func newCreateUserWithRoleGrantsWireRequest(user *models.User, grants []storage.RoleGrant) createUserWithRoleGrantsWireRequest {
+	wireGrants := make([]roleGrantWire, 0, len(grants))
+	for _, g := range grants {
+		wireGrants = append(wireGrants, newRoleGrantWire(g))
+	}
+	return createUserWithRoleGrantsWireRequest{
+		Username:          user.Username,
+		Email:             user.Email,
+		DisplayName:       user.DisplayName,
+		PasswordHash:      user.PasswordHash,
+		IsActive:          user.IsActive,
+		AccountState:      user.AccountState,
+		PasswordChangedAt: user.PasswordChangedAt,
+		Grants:            wireGrants,
+	}
+}
+
+// CreateUserWithRoleGrants creates a user and every role grant in ONE atomic
+// request via POST /api/v1/system/users/with-role-grants (finding #531).
+//
+// Atomicity note (investigated, not assumed safe): LocalStorage.CreateUserWithRoleGrants
+// wraps the user INSERT and every role-grant INSERT in a single real DB
+// transaction (ADR-028) — if any grant insert fails, the user insert is rolled
+// back too, so a create never leaves a half-provisioned account (a user with
+// SOME but not all intended grants, or a user with grants pointing at nothing).
+// RemoteStorage.WithTransaction is a no-op passthrough (remote_transaction.go —
+// each remote call is independent), so naively proxying this as "POST the user,
+// then POST each grant" as separate HTTP calls would silently drop that
+// guarantee: a failure partway through (a bad role ID, a SoD-policy violation
+// surfacing only at insert time, a network blip) would leave a user record
+// committed upstream with only the grants that happened to land before the
+// failure — exactly the partial-provisioning bug ADR-028's transaction exists to
+// prevent, reopened by composing two independent round trips. Instead, this is
+// ONE PATCH-equivalent POST whose server-side handler
+// (CreateUserWithRoleGrantsProxy, server/http/handlers/misc_remote_proxy.go)
+// calls storage.Storage.CreateUserWithRoleGrants DIRECTLY against THIS server's
+// own storage inside that single request — the real atomicity is achieved
+// server-side in one round trip, not orchestrated client-side across several,
+// mirroring AdvanceWebAuthnCredentialCounter's (#517) and
+// TransitionMachineIdentityState's (#518) identical "new atomic primitive,
+// not a naive multi-call proxy" precedent.
+//
+// A duplicate-email race (uniq_users_email_active, #117) is translated back
+// into storage.ErrDuplicateEmail from the wire-level duplicateEmailProxyCode
+// (see #501's note on makeRequest collapsing every 4xx/5xx into a non-nil
+// error before resp is ever populated — the same recovery-from-*remote.HTTPError
+// pattern remote_legal_hold.go's CreateLegalHold already uses), so
+// core.CreateUserWithAssignments' own errors.Is(err, storage.ErrDuplicateEmail)
+// check is preserved across this HTTP hop exactly as it is for a local backend.
+func (rs *RemoteStorage) CreateUserWithRoleGrants(ctx context.Context, user *models.User, grants []storage.RoleGrant) (*models.User, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/users/with-role-grants", newCreateUserWithRoleGrantsWireRequest(user, grants))
+	if err != nil {
+		var httpErr *remote.HTTPError
+		if errors.As(err, &httpErr) && httpErr.ErrorType == duplicateEmailProxyCode {
+			return nil, fmt.Errorf("%w: %s", storage.ErrDuplicateEmail, httpErr.Message)
+		}
+		return nil, fmt.Errorf("failed to create user with role grants: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create user with role grants failed: %s", resp.Error.Error())
+	}
+	return decodeUserResponse(resp.Data)
 }
 
 // buildUserFilterPath constructs the /api/v1/users query string.

--- a/server/http/handlers/misc_remote_proxy.go
+++ b/server/http/handlers/misc_remote_proxy.go
@@ -1,0 +1,288 @@
+// misc_remote_proxy.go — server-side endpoints backing four unrelated
+// RemoteStorage storage-primitive gaps grouped under finding #531 (a grab-bag of
+// small, low-to-moderate-severity fixes filed together for convenience — each
+// sub-fix below is independent):
+//
+//  1. Dormant-access activity lookup (LastUserSecretActivity/
+//     LastUserRoleManagementActivity/LastUserSecretDeletionActivity/
+//     LastUserSecretReadActivity/LastUserSecretWriteActivity,
+//     internal/storage/store/remote_access_activity.go): registered under
+//     /api/v1/system/access-activity, gated system.read.
+//  2. GetSecretIncludingDeleted (internal/storage/store/remote_secrets.go):
+//     registered under /api/v1/system/secrets/{id}/including-deleted, gated
+//     system.read — unblocks ScopeFromDeletedSecretParam ahead of POST
+//     /secrets/{id}/restore, which 404'd on every request under
+//     storage.type: remote.
+//  3. ListSharesByOwner (internal/storage/store/remote_sharing.go): registered
+//     under /api/v1/system/shares/by-owner/{ownerID}, gated system.read —
+//     unblocks core.ListSharesByUser (the gRPC "list my shares" call), which
+//     hard-failed with no fallback.
+//  4. CreateUserWithRoleGrants (internal/storage/store/remote_users.go):
+//     registered under /api/v1/system/users/with-role-grants, gated
+//     system.write — the ONE atomic primitive in this file (see its own doc
+//     below): preserves ADR-028's all-or-nothing create-user+role-grants
+//     transaction across the storage.type: remote HTTP hop, the same
+//     "new atomic primitive, not a naive multi-call proxy" pattern established
+//     by AdvanceWebAuthnCredentialCounter (#517) and
+//     TransitionMachineIdentityState (#518).
+//
+// Every handler here is a thin passthrough onto the identical storage.Storage
+// primitive the local (LocalStorage-backed) path already uses — no POLICY
+// decision (which activity counts as "dormant", the restore scope check, the
+// role-grant validation/escalation ceiling) is made here; that stays entirely
+// in the CALLING server's own internal/core.KeyorixCore, exactly as it does
+// against a local backend. All four reuse the SAME system.read/system.write
+// RBAC tier every other RemoteStorage proxy already needs — no new privilege
+// class.
+//
+// Response envelope: like every other proxy in this package, these do NOT use
+// the package's generic sendSuccess/sendError helpers — they construct the
+// exact {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// --- 1. Access-activity proxy (UserHandler) ---
+
+// accessActivityKindToMethod maps the route's static "kind" segment to the
+// storage.Storage method it backs. A single handler function serves all five
+// GET routes (they differ only in which underlying event-type bucket the
+// LocalStorage-backed upstream queries), keeping this file from repeating the
+// same query-param parsing/response-encoding boilerplate five times.
+type accessActivityLookup func(h *UserHandler, r *http.Request, projectID uint) (map[uint]time.Time, error)
+
+var accessActivityLookups = map[string]accessActivityLookup{
+	"secret": func(h *UserHandler, r *http.Request, projectID uint) (map[uint]time.Time, error) {
+		return h.coreService.Storage().LastUserSecretActivity(r.Context(), projectID)
+	},
+	"role-management": func(h *UserHandler, r *http.Request, projectID uint) (map[uint]time.Time, error) {
+		return h.coreService.Storage().LastUserRoleManagementActivity(r.Context(), projectID)
+	},
+	"secret-deletion": func(h *UserHandler, r *http.Request, projectID uint) (map[uint]time.Time, error) {
+		return h.coreService.Storage().LastUserSecretDeletionActivity(r.Context(), projectID)
+	},
+	"secret-read": func(h *UserHandler, r *http.Request, projectID uint) (map[uint]time.Time, error) {
+		return h.coreService.Storage().LastUserSecretReadActivity(r.Context(), projectID)
+	},
+	"secret-write": func(h *UserHandler, r *http.Request, projectID uint) (map[uint]time.Time, error) {
+		return h.coreService.Storage().LastUserSecretWriteActivity(r.Context(), projectID)
+	},
+}
+
+// accessActivityProxy handles GET /api/v1/system/access-activity/{kind}, where
+// kind is one of secret/role-management/secret-deletion/secret-read/secret-write
+// (registered as five separate static routes in router.go — chi has no
+// wildcard-segment dispatch here, so the kind is baked into which route matched,
+// not parsed from the path; this shared function is called once per route with
+// its own kind literal).
+func (h *UserHandler) accessActivityProxy(w http.ResponseWriter, r *http.Request, kind string) {
+	projectIDStr := r.URL.Query().Get("project_id")
+	if projectIDStr == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id query parameter is required")
+		return
+	}
+	projectID, err := strconv.ParseUint(projectIDStr, 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "project_id must be a valid integer")
+		return
+	}
+	lookup := accessActivityLookups[kind]
+	activity, err := lookup(h, r, uint(projectID))
+	if err != nil {
+		log.Printf("access-activity proxy: %s lookup failed: %v", kind, err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	wire := make(map[string]time.Time, len(activity))
+	for userID, t := range activity {
+		wire[strconv.FormatUint(uint64(userID), 10)] = t
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"activity": wire})
+}
+
+// LastUserSecretActivityProxy handles GET /api/v1/system/access-activity/secret.
+func (h *UserHandler) LastUserSecretActivityProxy(w http.ResponseWriter, r *http.Request) {
+	h.accessActivityProxy(w, r, "secret")
+}
+
+// LastUserRoleManagementActivityProxy handles GET
+// /api/v1/system/access-activity/role-management.
+func (h *UserHandler) LastUserRoleManagementActivityProxy(w http.ResponseWriter, r *http.Request) {
+	h.accessActivityProxy(w, r, "role-management")
+}
+
+// LastUserSecretDeletionActivityProxy handles GET
+// /api/v1/system/access-activity/secret-deletion.
+func (h *UserHandler) LastUserSecretDeletionActivityProxy(w http.ResponseWriter, r *http.Request) {
+	h.accessActivityProxy(w, r, "secret-deletion")
+}
+
+// LastUserSecretReadActivityProxy handles GET
+// /api/v1/system/access-activity/secret-read.
+func (h *UserHandler) LastUserSecretReadActivityProxy(w http.ResponseWriter, r *http.Request) {
+	h.accessActivityProxy(w, r, "secret-read")
+}
+
+// LastUserSecretWriteActivityProxy handles GET
+// /api/v1/system/access-activity/secret-write.
+func (h *UserHandler) LastUserSecretWriteActivityProxy(w http.ResponseWriter, r *http.Request) {
+	h.accessActivityProxy(w, r, "secret-write")
+}
+
+// --- 2. GetSecretIncludingDeleted proxy (SecretHandler) ---
+
+// GetSecretIncludingDeletedProxy handles GET
+// /api/v1/system/secrets/{id}/including-deleted. Calls
+// storage.Storage.GetSecretIncludingDeleted directly (an Unscoped lookup that
+// reaches a soft-deleted row) rather than the human-facing GetSecret handler,
+// which scopes out soft-deleted rows by design. The response marshals
+// models.SecretNode directly (see remote_secrets.go's doc for why that's safe
+// for this Go-to-Go internal wire), wrapped in a small envelope.
+func (h *SecretHandler) GetSecretIncludingDeletedProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid secret id")
+		return
+	}
+	secret, err := h.coreService.Storage().GetSecretIncludingDeleted(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "secret not found")
+			return
+		}
+		log.Printf("secrets proxy: get secret including deleted failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"secret": secret})
+}
+
+// --- 3. ListSharesByOwner proxy (ShareHandler) ---
+
+// ListSharesByOwnerProxy handles GET /api/v1/system/shares/by-owner/{ownerID}.
+// The response marshals []*models.ShareRecord directly (no json tags of its
+// own beyond the embedded gorm.DeletedAt — the same Go-to-Go round-trip choice
+// already used by DeleteExpiredShareRecordsProxy for the identical type),
+// wrapped in a small envelope.
+func (h *ShareHandler) ListSharesByOwnerProxy(w http.ResponseWriter, r *http.Request) {
+	ownerID, err := strconv.ParseUint(chi.URLParam(r, "ownerID"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid owner id")
+		return
+	}
+	shares, err := h.coreService.Storage().ListSharesByOwner(r.Context(), uint(ownerID))
+	if err != nil {
+		log.Printf("shares proxy: list shares by owner failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"shares": shares})
+}
+
+// --- 4. CreateUserWithRoleGrants proxy (UserHandler) — the atomic primitive ---
+
+// createUserWithRoleGrantsProxyBody mirrors remote_users.go's
+// createUserWithRoleGrantsWireRequest exactly.
+type createUserWithRoleGrantsProxyBody struct {
+	Username          string          `json:"username"`
+	Email             string          `json:"email"`
+	DisplayName       string          `json:"display_name"`
+	PasswordHash      string          `json:"password_hash"`
+	IsActive          bool            `json:"is_active"`
+	AccountState      string          `json:"account_state"`
+	PasswordChangedAt *time.Time      `json:"password_changed_at,omitempty"`
+	Grants            []roleGrantBody `json:"grants"`
+}
+
+// roleGrantBody mirrors storage.RoleGrant's fields exactly.
+type roleGrantBody struct {
+	RoleID        uint `json:"role_id"`
+	ProjectID     uint `json:"project_id"`
+	EnvironmentID uint `json:"environment_id"`
+}
+
+// duplicateEmailProxyCode is the machine-readable error code
+// CreateUserWithRoleGrantsProxy returns when the upstream's own partial
+// unique-index rejection (uniq_users_email_active, #117) fires — the wire-level
+// signal RemoteStorage.CreateUserWithRoleGrants uses to reconstruct the same
+// storage.ErrDuplicateEmail sentinel core.CreateUserWithAssignments' own
+// errors.Is check depends on, mirroring legalHoldAlreadyActiveCode's identical
+// two-package-duplicated-constant pattern (server/http/handlers/legal_hold_proxy.go
+// / internal/storage/store/remote_legal_hold.go).
+const duplicateEmailProxyCode = "DUPLICATE_EMAIL"
+
+// CreateUserWithRoleGrantsProxy handles POST /api/v1/system/users/with-role-grants
+// — the ONE handler in this file that is not a plain CRUD passthrough.
+//
+// It calls storage.Storage.CreateUserWithRoleGrants directly
+// (h.coreService.Storage() reaches the identical primitive this server's own
+// local admin "create user with project assignments" path uses via
+// core.CreateUserWithAssignments), which performs the user INSERT and every
+// role-grant INSERT inside ONE real DB transaction (ADR-028) — server-side,
+// inside this single request, against THIS server's own storage. That is the
+// critical property a downstream (spoke) server depends on for correctness
+// under storage.type: remote: a failure partway through (bad role ID, a
+// SoD-policy violation, a duplicate email) must roll back the ENTIRE create,
+// never leaving a user committed with only some of its intended grants — see
+// remote_users.go's CreateUserWithRoleGrants doc for the full "why a naive
+// two-call proxy would reopen this" reasoning.
+//
+// The caller (internal/core.CreateUserWithAssignments on the downstream server)
+// has already run every validation/escalation-ceiling/SoD check BEFORE ever
+// reaching storage.Storage, so this handler makes NO policy decision of its
+// own — it persists exactly what it's given, mirroring LocalStorage's own raw
+// tx.Create semantics.
+func (h *UserHandler) CreateUserWithRoleGrantsProxy(w http.ResponseWriter, r *http.Request) {
+	var body createUserWithRoleGrantsProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Username == "" || body.Email == "" || body.PasswordHash == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "username, email, and password_hash are required")
+		return
+	}
+	user := &models.User{
+		Username:          body.Username,
+		Email:             body.Email,
+		DisplayName:       body.DisplayName,
+		PasswordHash:      body.PasswordHash,
+		IsActive:          body.IsActive,
+		AccountState:      body.AccountState,
+		PasswordChangedAt: body.PasswordChangedAt,
+	}
+	grants := make([]storage.RoleGrant, 0, len(body.Grants))
+	for _, g := range body.Grants {
+		grants = append(grants, storage.RoleGrant{
+			RoleID: g.RoleID,
+			Scope:  storage.Scope{ProjectID: g.ProjectID, EnvironmentID: g.EnvironmentID},
+		})
+	}
+	created, err := h.coreService.Storage().CreateUserWithRoleGrants(r.Context(), user, grants)
+	if err != nil {
+		// #858/#859: a duplicate-email race (uniq_users_email_active, #117) is a
+		// validation-shaped outcome, not a server-side failure — classify it 409,
+		// matching the same duplicate-email handling core.CreateUserWithAssignments
+		// applies against a local backend.
+		if errors.Is(err, storage.ErrDuplicateEmail) {
+			writeRemoteAPIError(w, http.StatusConflict, duplicateEmailProxyCode, storage.ErrDuplicateEmail.Error())
+			return
+		}
+		log.Printf("users proxy: create user with role grants failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newUserRetentionProxyWire(created))
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -165,6 +165,8 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 	// CreateBreakGlassActivation's OnConflict DoNothing branch depends on.
 	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_break_glass_active_project_user "+
 		"ON break_glass_activations (project_id, user_id) WHERE state = 'active'").Error)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active "+
+		"ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error)
 	return core.NewKeyorixCore(store.NewLocalStorage(db))
 }
 

--- a/server/http/remote_storage_misc_proxy_atomic_test.go
+++ b/server/http/remote_storage_misc_proxy_atomic_test.go
@@ -1,0 +1,100 @@
+// remote_storage_misc_proxy_atomic_test.go — the concurrency/atomicity
+// regression test for #531's CreateUserWithRoleGrants fix, the one sub-item of
+// the four that needed a genuinely NEW atomic storage primitive (not a naive
+// multi-call proxy) — see remote_users.go's CreateUserWithRoleGrants doc and
+// server/http/handlers/misc_remote_proxy.go's CreateUserWithRoleGrantsProxy doc
+// for the full atomicity analysis. Mirrors
+// TestRemoteStorageMachineIdentities_TransitionState_ConcurrentRaceIsSerialized_RealServer's
+// structure: N goroutines on the SAME downstream (storage.type: remote)
+// core.KeyorixCore race a create that can only ever have ONE winner (here: N
+// creates racing the identical email), proving the atomic guarantee holds
+// under real concurrent load against a REAL upstream server, not a mock.
+package http
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteStorageCreateUserWithRoleGrants_ConcurrentDuplicateEmailRace_RealServer
+// fires N concurrent CreateUserWithRoleGrants calls at the SAME email (each
+// with a distinct username, each requesting TWO role grants) over real HTTP
+// against the real upstream router, and asserts:
+//
+//  1. Exactly ONE create wins (the real uniq_users_email_active partial unique
+//     index — the same DB-level guarantee CreateUser's #117 race fix relies
+//     on — still serializes concurrent creates correctly via
+//     storage.type: remote, not just sequentially).
+//  2. The winner's user row carries BOTH of its role grants — the atomic
+//     primitive's core guarantee.
+//  3. Every LOSING attempt leaves NO trace at all: no user row under its own
+//     (unique) username, proving the transaction genuinely rolled back rather
+//     than leaving a half-provisioned account behind. A naive "create user,
+//     then POST each grant separately" proxy would not exhibit this failure
+//     mode under a duplicate-email race specifically (the loser's user INSERT
+//     itself would still fail atomically even naively) — the real risk a
+//     naive proxy reopens is a grant-insert failure LATER in the sequence
+//     leaving an already-committed user with partial grants, which is why
+//     TestRemoteStorageCreateUserWithRoleGrants_RealServer above additionally
+//     proves both grants land together on an uncontested create.
+func TestRemoteStorageCreateUserWithRoleGrants_ConcurrentDuplicateEmailRace_RealServer(t *testing.T) {
+	upstream, downstream, _, _ := newUpstreamDownstreamForMiscProxy(t)
+	ctx := context.Background()
+
+	viewerRole, err := upstream.Storage().GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err)
+	adminRole, err := upstream.Storage().GetRoleByName(ctx, "system_admin")
+	require.NoError(t, err)
+
+	const n = 8
+	const raceEmail = "atomic-race@example.com"
+	var successCount atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			user := &models.User{
+				Username:     fmt.Sprintf("atomic-race-user-%d", i),
+				Email:        raceEmail,
+				DisplayName:  "Atomic Race",
+				PasswordHash: "$2a$10$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01",
+				IsActive:     true,
+				AccountState: "active",
+			}
+			grants := []corestorage.RoleGrant{{RoleID: viewerRole.ID}, {RoleID: adminRole.ID}}
+			if _, err := downstream.Storage().CreateUserWithRoleGrants(ctx, user, grants); err == nil {
+				successCount.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(1), successCount.Load(),
+		"exactly one concurrent create must win the duplicate-email race — the rest must cleanly lose, never a double create")
+
+	// Exactly one of the N candidate usernames exists on the upstream, and it
+	// carries BOTH role grants.
+	var winners int
+	for i := 0; i < n; i++ {
+		username := fmt.Sprintf("atomic-race-user-%d", i)
+		u, err := upstream.Storage().GetUserByUsername(ctx, username)
+		if err != nil {
+			continue // this racer lost — must have left no trace, checked below
+		}
+		winners++
+		roleIDs, err := upstream.Storage().GetUserRoleIDsAt(ctx, u.ID, corestorage.Scope{})
+		require.NoError(t, err)
+		assert.Contains(t, roleIDs, viewerRole.ID, "the winner must carry BOTH of its intended role grants, not a partial subset")
+		assert.Contains(t, roleIDs, adminRole.ID, "the winner must carry BOTH of its intended role grants, not a partial subset")
+	}
+	assert.Equal(t, 1, winners, "exactly one of the N candidate usernames must have been persisted")
+}

--- a/server/http/remote_storage_misc_proxy_test.go
+++ b/server/http/remote_storage_misc_proxy_test.go
@@ -1,0 +1,340 @@
+// remote_storage_misc_proxy_test.go — end-to-end coverage for #531's four
+// independent sub-fixes. Mirrors remote_storage_sso_state_test.go's harness
+// exactly: a real "upstream" exercised through the production NewRouter/
+// handlers (including the new /api/v1/system/access-activity,
+// /api/v1/system/secrets/{id}/including-deleted,
+// /api/v1/system/shares/by-owner/{ownerID}, and
+// /api/v1/system/users/with-role-grants routes,
+// server/http/handlers/misc_remote_proxy.go), and a "downstream"
+// *core.KeyorixCore configured with storage.type: remote pointed at "upstream"
+// over real HTTP via store.RemoteStorage.
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUpstreamDownstreamForMiscProxy builds the standard two-server harness for
+// #531's four sub-fixes, plus a live project and the bootstrap admin's own user
+// ID (needed as an already-vetted actorID for CreateUserWithAssignments' own
+// escalation-ceiling check).
+func newUpstreamDownstreamForMiscProxy(t *testing.T) (upstream, downstream *core.KeyorixCore, projectID, adminID uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	upstreamToken := createTestToken(t, upstream)
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        upstreamSrv.URL,
+		APIKey:         upstreamToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	downstream = core.NewKeyorixCore(rs)
+
+	ctx := context.Background()
+	project, err := upstream.CreateProject(ctx, "Misc Proxy Test Project", "")
+	require.NoError(t, err)
+
+	admin, err := upstream.GetUserByUsername(ctx, "testadmin")
+	require.NoError(t, err)
+
+	return upstream, downstream, project.ID, admin.ID
+}
+
+// --- 1. Access-activity ---
+
+// TestRemoteStorageAccessActivity_RealServer proves the fix for all five
+// LastUser*Activity methods: an activity event logged directly against the
+// upstream's own storage is genuinely visible via the DOWNSTREAM's
+// RemoteStorage, keyed by the right user, all via storage.type: remote against
+// a real router, not a protocol mock.
+func TestRemoteStorageAccessActivity_RealServer(t *testing.T) {
+	upstream, downstream, projectID, adminID := newUpstreamDownstreamForMiscProxy(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	require.NoError(t, upstream.Storage().LogAuditEvent(ctx, &models.AuditEvent{
+		EventType: "secret.read",
+		UserID:    &adminID,
+		ProjectID: &projectID,
+		EventTime: now,
+	}))
+	require.NoError(t, upstream.Storage().LogAuditEvent(ctx, &models.AuditEvent{
+		EventType: "secret.created",
+		UserID:    &adminID,
+		ProjectID: &projectID,
+		EventTime: now.Add(time.Second),
+	}))
+	require.NoError(t, upstream.Storage().LogAuditEvent(ctx, &models.AuditEvent{
+		EventType: "secret.deleted",
+		UserID:    &adminID,
+		ProjectID: &projectID,
+		EventTime: now.Add(2 * time.Second),
+	}))
+	require.NoError(t, upstream.Storage().LogAuditEvent(ctx, &models.AuditEvent{
+		EventType: "role.assigned",
+		UserID:    &adminID,
+		ProjectID: &projectID,
+		EventTime: now.Add(3 * time.Second),
+	}))
+
+	readActivity, err := downstream.Storage().LastUserSecretReadActivity(ctx, projectID)
+	require.NoError(t, err, "secret-read activity lookup must succeed via storage.type: remote")
+	require.Contains(t, readActivity, adminID)
+	assert.WithinDuration(t, now, readActivity[adminID], time.Second)
+
+	writeActivity, err := downstream.Storage().LastUserSecretWriteActivity(ctx, projectID)
+	require.NoError(t, err)
+	require.Contains(t, writeActivity, adminID)
+	assert.WithinDuration(t, now.Add(time.Second), writeActivity[adminID], time.Second)
+
+	deletionActivity, err := downstream.Storage().LastUserSecretDeletionActivity(ctx, projectID)
+	require.NoError(t, err)
+	require.Contains(t, deletionActivity, adminID)
+	assert.WithinDuration(t, now.Add(2*time.Second), deletionActivity[adminID], time.Second)
+
+	roleMgmtActivity, err := downstream.Storage().LastUserRoleManagementActivity(ctx, projectID)
+	require.NoError(t, err)
+	require.Contains(t, roleMgmtActivity, adminID)
+	assert.WithinDuration(t, now.Add(3*time.Second), roleMgmtActivity[adminID], time.Second)
+
+	// The broader "any secret activity" bucket (read+create+update+rotate)
+	// picks up both the read and the create event, keeping the latest.
+	broadActivity, err := downstream.Storage().LastUserSecretActivity(ctx, projectID)
+	require.NoError(t, err)
+	require.Contains(t, broadActivity, adminID)
+	assert.WithinDuration(t, now.Add(time.Second), broadActivity[adminID], time.Second)
+
+	// A project with no activity at all cleanly returns an empty map, not an
+	// error.
+	otherProject, err := upstream.CreateProject(ctx, "Empty Activity Project", "")
+	require.NoError(t, err)
+	empty, err := downstream.Storage().LastUserSecretActivity(ctx, otherProject.ID)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}
+
+// --- 2. GetSecretIncludingDeleted ---
+
+// TestRemoteStorageGetSecretIncludingDeleted_RealServer proves the #531 fix:
+// ScopeFromDeletedSecretParam's scope check ahead of POST /secrets/{id}/restore
+// now resolves a soft-deleted secret's scope via storage.type: remote instead
+// of 404ing before ever reaching the already-proxied RestoreSecret.
+func TestRemoteStorageGetSecretIncludingDeleted_RealServer(t *testing.T) {
+	upstream, downstream, projectID, adminID := newUpstreamDownstreamForMiscProxy(t)
+	ctx := context.Background()
+
+	env, err := upstream.CreateEnvironment(ctx, projectID, "misc-proxy-env-2")
+	require.NoError(t, err)
+
+	secret, err := upstream.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name:          "misc-proxy-secret",
+		Value:         []byte("s3cr3t"),
+		ProjectID:     projectID,
+		EnvironmentID: env.ID,
+		Type:          "generic",
+		CreatedBy:     "testadmin",
+		OwnerID:       adminID,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, upstream.DeleteSecret(ctx, secret.ID))
+
+	// A live (non-deleted) lookup would 404; GetSecretIncludingDeleted must
+	// still resolve it via storage.type: remote.
+	fetched, err := downstream.Storage().GetSecretIncludingDeleted(ctx, secret.ID)
+	require.NoError(t, err, "fetching a soft-deleted secret must succeed via storage.type: remote")
+	require.NotNil(t, fetched)
+	assert.Equal(t, secret.ID, fetched.ID)
+	assert.Equal(t, projectID, fetched.ProjectID)
+	assert.Equal(t, env.ID, fetched.EnvironmentID)
+	assert.True(t, fetched.DeletedAt.Valid, "the soft-delete marker must round-trip")
+
+	// A nonexistent ID cleanly not-founds rather than panicking.
+	_, err = downstream.Storage().GetSecretIncludingDeleted(ctx, 999999)
+	require.Error(t, err)
+}
+
+// --- 3. ListSharesByOwner ---
+
+// TestRemoteStorageListSharesByOwner_RealServer proves the #531 fix:
+// core.ListSharesByUser's owned-share half no longer hard-fails under
+// storage.type: remote.
+func TestRemoteStorageListSharesByOwner_RealServer(t *testing.T) {
+	upstream, downstream, projectID, adminID := newUpstreamDownstreamForMiscProxy(t)
+	ctx := context.Background()
+
+	env, err := upstream.CreateEnvironment(ctx, projectID, "misc-proxy-env-3")
+	require.NoError(t, err)
+
+	secret, err := upstream.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name:          "misc-proxy-shared-secret",
+		Value:         []byte("s3cr3t"),
+		ProjectID:     projectID,
+		EnvironmentID: env.ID,
+		Type:          "generic",
+		CreatedBy:     "testadmin",
+		OwnerID:       adminID,
+	})
+	require.NoError(t, err)
+
+	recipient, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
+		Username:    "shareowner-recipient",
+		Email:       "shareowner-recipient@example.com",
+		DisplayName: "Recipient",
+		Password:    "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+
+	created, err := upstream.Storage().CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID:    secret.ID,
+		OwnerID:     adminID,
+		RecipientID: recipient.ID,
+		Permission:  "read",
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+
+	shares, err := downstream.Storage().ListSharesByOwner(ctx, adminID)
+	require.NoError(t, err, "listing shares by owner must succeed via storage.type: remote")
+	require.Len(t, shares, 1)
+	assert.Equal(t, secret.ID, shares[0].SecretID)
+	assert.Equal(t, recipient.ID, shares[0].RecipientID)
+
+	// An owner with no shares cleanly returns an empty slice.
+	empty, err := downstream.Storage().ListSharesByOwner(ctx, recipient.ID)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+
+	// NOTE: core.ListSharesByUser (the gRPC "list my shares" call) combines
+	// storage.ListSharesByUser (the recipient half) with storage.ListSharesByOwner
+	// (the owner half, fixed here). Only the latter is in scope for #531 —
+	// storage.ListSharesByUser itself is a SEPARATE, pre-existing gap (its
+	// client-side call targets GET /api/v1/users/{id}/shares, a route
+	// server/http/router.go never registers, so it 404s independently of this
+	// fix) discovered incidentally while testing this fix; core.ListSharesByUser
+	// is therefore not yet fully functional end to end and is intentionally not
+	// exercised here.
+}
+
+// --- 4. CreateUserWithRoleGrants (basic success + duplicate-email) ---
+// See remote_storage_misc_proxy_atomic_test.go for the concurrent-race
+// regression test proving the atomic primitive itself.
+
+// TestRemoteStorageCreateUserWithRoleGrants_RealServer proves the basic
+// success path: a user plus every role grant lands atomically on the upstream
+// via the DOWNSTREAM's RemoteStorage. Calls storage.Storage.CreateUserWithRoleGrants
+// directly (the raw storage primitive), not core.CreateUserWithAssignments —
+// the latter's project-assignment loop needs storage.GetProject, a SEPARATE,
+// still-open round-119 gap (unrelated to #531) that would make this test
+// depend on a fix outside this PR's scope.
+func TestRemoteStorageCreateUserWithRoleGrants_RealServer(t *testing.T) {
+	upstream, downstream, _, _ := newUpstreamDownstreamForMiscProxy(t)
+	ctx := context.Background()
+
+	viewerRole, err := upstream.Storage().GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err)
+	adminRole, err := upstream.Storage().GetRoleByName(ctx, "system_admin")
+	require.NoError(t, err)
+
+	user := &models.User{
+		Username:     "atomic-create-user",
+		Email:        "atomic-create-user@example.com",
+		DisplayName:  "Atomic Create",
+		PasswordHash: "$2a$10$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01",
+		IsActive:     true,
+		AccountState: "active",
+	}
+	grants := []corestorage.RoleGrant{
+		{RoleID: viewerRole.ID},
+		{RoleID: adminRole.ID},
+	}
+	created, err := downstream.Storage().CreateUserWithRoleGrants(ctx, user, grants)
+	require.NoError(t, err, "creating a user with role grants must succeed via storage.type: remote")
+	require.NotZero(t, created.ID)
+
+	// The user is a REAL row on the upstream, with the already-computed hash
+	// persisted verbatim (not re-derived from a plaintext it was never given).
+	direct, err := upstream.Storage().GetUser(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "atomic-create-user", direct.Username)
+
+	// BOTH grants landed alongside the user — the whole point of the atomic
+	// primitive.
+	roleIDs, err := upstream.Storage().GetUserRoleIDsAt(ctx, created.ID, corestorage.Scope{})
+	require.NoError(t, err)
+	assert.Contains(t, roleIDs, viewerRole.ID)
+	assert.Contains(t, roleIDs, adminRole.ID)
+}
+
+// TestRemoteStorageCreateUserWithRoleGrants_DuplicateEmail_RealServer proves
+// the storage.ErrDuplicateEmail sentinel survives the storage.type: remote HTTP
+// hop (#117-class race, translated via the duplicateEmailProxyCode wire
+// signal), matching #858/#859's "classify validation-shaped errors, don't
+// collapse to 500" convention. Calls the storage primitive directly (bypassing
+// core.CreateUserWithAssignments' own check-then-act GetUserByEmail pre-check,
+// which would otherwise short-circuit before ever reaching
+// storage.CreateUserWithRoleGrants) so this genuinely exercises the DB-level
+// race guard, not just the ordinary pre-check.
+func TestRemoteStorageCreateUserWithRoleGrants_DuplicateEmail_RealServer(t *testing.T) {
+	upstream, downstream, _, _ := newUpstreamDownstreamForMiscProxy(t)
+	ctx := context.Background()
+
+	_, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
+		Username:    "dup-email-owner",
+		Email:       "dup-email@example.com",
+		DisplayName: "Dup Owner",
+		Password:    "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+
+	viewerRole, err := upstream.Storage().GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err)
+
+	_, err = downstream.Storage().CreateUserWithRoleGrants(ctx, &models.User{
+		Username:     "dup-email-newcomer",
+		Email:        "dup-email@example.com",
+		DisplayName:  "Dup Newcomer",
+		PasswordHash: "$2a$10$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01",
+		IsActive:     true,
+		AccountState: "active",
+	}, []corestorage.RoleGrant{{RoleID: viewerRole.ID}})
+	require.Error(t, err, "creating a user with an already-used email must fail, not silently succeed")
+	assert.True(t, errors.Is(err, corestorage.ErrDuplicateEmail),
+		"the storage.ErrDuplicateEmail sentinel must survive the storage.type: remote HTTP hop")
+
+	// The rejected create must not have persisted a half-formed user (the
+	// atomic transaction must have rolled back entirely).
+	_, lookupErr := upstream.Storage().GetUserByUsername(ctx, "dup-email-newcomer")
+	require.Error(t, lookupErr, "a rejected duplicate-email create must not leave a stray user row behind")
+	assert.True(t, errors.Is(lookupErr, corestorage.ErrUserNotFound) || corestorage.IsUserNotFound(lookupErr))
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1356,6 +1356,56 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/users/purge", userHandler.PurgeDeletedUsersBeforeProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/projects/purge", catalogHandler.PurgeDeletedProjectsBeforeProxy)
 			r.With(customMiddleware.RequirePermission("system.write")).Post("/retention/environments/purge", catalogHandler.PurgeDeletedEnvironmentsBeforeProxy)
+
+			// Misc storage-primitive proxies (finding #531 — four independent,
+			// unrelated small gaps grouped by similar low-to-moderate severity;
+			// see server/http/handlers/misc_remote_proxy.go's package doc for the
+			// full per-item detail). Every route here reuses the SAME
+			// system.read/system.write tier every other proxy above already
+			// needs — no new privilege class.
+			//
+			// Dormant-access activity lookup: lets a downstream Keyorix server
+			// booted with storage.type: remote (ADR-049) proxy
+			// LastUserSecretActivity/LastUserRoleManagementActivity/
+			// LastUserSecretDeletionActivity/LastUserSecretReadActivity/
+			// LastUserSecretWriteActivity to THIS server's real storage backend.
+			// GenerateProjectAccessReview (ISO 27001/SOC2 recertification) and
+			// compliance_posture.go's countDormantRoleGrants both degrade
+			// gracefully on a lookup failure, so this was a missing detective
+			// signal rather than an outage — but the dormant-access/dormant-
+			// role-grant signal was never available at all under storage.type:
+			// remote before this fix. Reads only, gated system.read.
+			r.Get("/access-activity/secret", userHandler.LastUserSecretActivityProxy)
+			r.Get("/access-activity/role-management", userHandler.LastUserRoleManagementActivityProxy)
+			r.Get("/access-activity/secret-deletion", userHandler.LastUserSecretDeletionActivityProxy)
+			r.Get("/access-activity/secret-read", userHandler.LastUserSecretReadActivityProxy)
+			r.Get("/access-activity/secret-write", userHandler.LastUserSecretWriteActivityProxy)
+
+			// GetSecretIncludingDeleted: lets a downstream server proxy an
+			// Unscoped (soft-delete-aware) secret lookup to THIS server's real
+			// storage backend. Before this fix, ScopeFromDeletedSecretParam (the
+			// scope resolver ahead of POST /secrets/{id}/restore,
+			// server/middleware/auth.go) hard-failed on this stub, so every
+			// restore request 404'd before ever reaching the
+			// already-correctly-proxied RestoreSecret. A read, gated
+			// system.read.
+			r.Get("/secrets/{id}/including-deleted", secretHandler.GetSecretIncludingDeletedProxy)
+
+			// ListSharesByOwner: lets a downstream server proxy the "shares I
+			// created" query to THIS server's real storage backend. Before this
+			// fix, core.ListSharesByUser (backing the gRPC "list my shares"
+			// call) hard-failed with no fallback, unlike the graceful-degrade
+			// access-activity gaps above. A read, gated system.read.
+			r.Get("/shares/by-owner/{ownerID}", shareHandler.ListSharesByOwnerProxy)
+
+			// CreateUserWithRoleGrants: the ONE atomic primitive in this group —
+			// see misc_remote_proxy.go's CreateUserWithRoleGrantsProxy doc and
+			// remote_users.go's CreateUserWithRoleGrants doc for the full
+			// atomicity analysis. Before this fix, core.CreateUserWithAssignments
+			// (atomic create-user+role-grants, backing POST /api/v1/users and
+			// gRPC CreateUser whenever role grants are included) hard-failed on
+			// this stub. A mutation, gated system.write.
+			r.With(customMiddleware.RequirePermission("system.write")).Post("/users/with-role-grants", userHandler.CreateUserWithRoleGrantsProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary

Closes #531 — a grab-bag of 4 independent, unrelated small `RemoteStorage` gaps grouped by similar low-to-moderate severity. Each is a separate mini-fix:

- **LastUserSecretActivity / LastUserRoleManagementActivity / LastUserSecretDeletionActivity / LastUserSecretReadActivity / LastUserSecretWriteActivity** (`internal/storage/store/remote_access_activity.go`): proxied under new `GET /api/v1/system/access-activity/{kind}` routes. These degrade gracefully today (access reviews / `countDormantRoleGrants` just see "no signal"), but under `storage.type: remote` the dormant-access/dormant-role-grant compliance signal was never available at all.
- **GetSecretIncludingDeleted** (`internal/storage/store/remote_secrets.go`): proxied under `GET /api/v1/system/secrets/{id}/including-deleted`. Unblocks `ScopeFromDeletedSecretParam`, the scope resolver ahead of `POST /secrets/{id}/restore` — every restore request 404'd before ever reaching the already-correctly-proxied `RestoreSecret`.
- **ListSharesByOwner** (`internal/storage/store/remote_sharing.go`): proxied under `GET /api/v1/system/shares/by-owner/{ownerID}`. Unblocks the owner half of `core.ListSharesByUser`, which hard-fails (no fallback) and backs the gRPC "list my shares" call.
- **CreateUserWithRoleGrants** (`internal/storage/store/remote_users.go`): the one atomic primitive in this PR. `LocalStorage.CreateUserWithRoleGrants` wraps the user INSERT and every role-grant INSERT in one real DB transaction (ADR-028) — a naive two-call proxy (create user, then separately assign each grant) would have silently dropped that all-or-nothing guarantee across the HTTP hop. Instead this adds one new atomic endpoint, `POST /api/v1/system/users/with-role-grants`, whose handler calls the identical storage primitive against the upstream's own storage in a single request — the same "new atomic primitive, not a naive multi-call proxy" pattern already established by `AdvanceWebAuthnCredentialCounter` (#517) and `TransitionMachineIdentityState` (#518). A duplicate-email race (`storage.ErrDuplicateEmail`) is translated back across the HTTP hop via a wire error code, matching #858/#859's "classify validation-shaped errors, don't collapse to 500" convention.

All four routes are registered under the existing `/api/v1/system/...` group and reuse the same `system.read`/`system.write` RBAC tier every other `RemoteStorage` proxy already needs — no new privilege class.

Also removes the 8 corresponding entries from `remoteUnsupportedAllowlist`'s `statusKnownGap` set (the completeness guard, `internal/storage/store/remote_unsupported_completeness_test.go`).

**Note:** while testing the `ListSharesByOwner` fix, discovered that `RemoteStorage.ListSharesByUser` (the *sibling* half of `core.ListSharesByUser`, not itself one of #531's four items) targets `GET /api/v1/users/{id}/shares`, a route that is never registered in `router.go` — so `core.ListSharesByUser` still 404s end-to-end even after this fix, on the *other* half. That's a separate, pre-existing gap outside this PR's scope; flagging for a follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/storage/store/...` (196 passed, includes the completeness-guard test)
- [x] `go test ./server/http/...` (541 passed, includes 6 new end-to-end tests against a real upstream router: activity lookup, `GetSecretIncludingDeleted`, `ListSharesByOwner`, `CreateUserWithRoleGrants` success + duplicate-email, and a concurrent-race regression test proving the atomic primitive)
- [x] `go test ./internal/core/...` (1564 passed; one unrelated pre-existing flake in `TestConcurrency_RequestPasswordReset_BurstIsThrottled` reproduced clean on retry)
- [x] `gosec -severity medium -exclude-generated` on touched packages: 0 issues
- [x] `gitleaks git`: no leaks found