### PR TITLE
fix(remote-storage): proxy ListSharesByUser under storage.type: remote

### DIFF
--- a/internal/storage/store/remote_sharing.go
+++ b/internal/storage/store/remote_sharing.go
@@ -118,9 +118,20 @@ func (rs *RemoteStorage) ListSharesBySecretIDs(ctx context.Context, secretIDs []
 	return out, nil
 }
 
-// ListSharesByUser lists all share records where userID is the recipient via remote API.
+// ListSharesByUser lists all share records where userID is the recipient, via
+// GET /api/v1/system/shares/by-user/{userID}. This used to target
+// /api/v1/users/{id}/shares — a route that was never registered server-side
+// (there is no, and never was, a human-facing "list shares received by an
+// arbitrary user ID" endpoint; the closest human-facing route, GET
+// /api/v1/shares, resolves the CALLER's own ID from the request's auth
+// context, not a path parameter). That meant core.ListSharesByUser (backing
+// both GET /api/v1/shares and gRPC ShareService.ListShares) 404'd on this half
+// unconditionally under storage.type: remote, even after #531 fixed the
+// ListSharesByOwner half. Same thin-passthrough pattern as ListSharesByOwner
+// immediately below: no policy decision made here, gated on the SAME
+// system.read tier.
 func (rs *RemoteStorage) ListSharesByUser(ctx context.Context, userID uint) ([]*models.ShareRecord, error) {
-	path := fmt.Sprintf("/api/v1/users/%d/shares", userID)
+	path := fmt.Sprintf("/api/v1/system/shares/by-user/%d", userID)
 	resp, err := rs.client.Get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list shares by user: %w", err)
@@ -128,11 +139,13 @@ func (rs *RemoteStorage) ListSharesByUser(ctx context.Context, userID uint) ([]*
 	if !resp.Success {
 		return nil, fmt.Errorf("list shares by user failed: %s", resp.Error.Error())
 	}
-	var result []*models.ShareRecord
+	var result struct {
+		Shares []*models.ShareRecord `json:"shares"`
+	}
 	if err := json.Unmarshal(resp.Data, &result); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
-	return result, nil
+	return result.Shares, nil
 }
 
 // ListSharesByOwner lists currently-active share records created by ownerID, via

--- a/server/http/handlers/misc_remote_proxy.go
+++ b/server/http/handlers/misc_remote_proxy.go
@@ -13,10 +13,14 @@
 //     system.read — unblocks ScopeFromDeletedSecretParam ahead of POST
 //     /secrets/{id}/restore, which 404'd on every request under
 //     storage.type: remote.
-//  3. ListSharesByOwner (internal/storage/store/remote_sharing.go): registered
-//     under /api/v1/system/shares/by-owner/{ownerID}, gated system.read —
-//     unblocks core.ListSharesByUser (the gRPC "list my shares" call), which
-//     hard-failed with no fallback.
+//  3. ListSharesByOwner and ListSharesByUser (internal/storage/store/
+//     remote_sharing.go): registered under /api/v1/system/shares/by-owner/
+//     {ownerID} and /api/v1/system/shares/by-user/{userID}, gated system.read
+//     — both halves core.ListSharesByUser (backing GET /api/v1/shares and
+//     gRPC ShareService.ListShares) needs. ListSharesByOwner hard-failed with
+//     no fallback; ListSharesByUser 404'd against a human-facing route
+//     (/api/v1/users/{id}/shares) that was never registered at all — see
+//     remote_sharing.go's doc for why that route could never have existed.
 //  4. CreateUserWithRoleGrants (internal/storage/store/remote_users.go):
 //     registered under /api/v1/system/users/with-role-grants, gated
 //     system.write — the ONE atomic primitive in this file (see its own doc
@@ -169,7 +173,7 @@ func (h *SecretHandler) GetSecretIncludingDeletedProxy(w http.ResponseWriter, r 
 	writeRemoteAPISuccess(w, map[string]interface{}{"secret": secret})
 }
 
-// --- 3. ListSharesByOwner proxy (ShareHandler) ---
+// --- 3. ListSharesByOwner / ListSharesByUser proxy (ShareHandler) ---
 
 // ListSharesByOwnerProxy handles GET /api/v1/system/shares/by-owner/{ownerID}.
 // The response marshals []*models.ShareRecord directly (no json tags of its
@@ -185,6 +189,25 @@ func (h *ShareHandler) ListSharesByOwnerProxy(w http.ResponseWriter, r *http.Req
 	shares, err := h.coreService.Storage().ListSharesByOwner(r.Context(), uint(ownerID))
 	if err != nil {
 		log.Printf("shares proxy: list shares by owner failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"shares": shares})
+}
+
+// ListSharesByUserProxy handles GET /api/v1/system/shares/by-user/{userID} —
+// the "received as recipient" half of core.ListSharesByUser, mirroring
+// ListSharesByOwnerProxy immediately above exactly (same response envelope,
+// same lack of a POLICY decision).
+func (h *ShareHandler) ListSharesByUserProxy(w http.ResponseWriter, r *http.Request) {
+	userID, err := strconv.ParseUint(chi.URLParam(r, "userID"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid user id")
+		return
+	}
+	shares, err := h.coreService.Storage().ListSharesByUser(r.Context(), uint(userID))
+	if err != nil {
+		log.Printf("shares proxy: list shares by user failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
 	}

--- a/server/http/remote_storage_misc_proxy_test.go
+++ b/server/http/remote_storage_misc_proxy_test.go
@@ -184,7 +184,7 @@ func TestRemoteStorageGetSecretIncludingDeleted_RealServer(t *testing.T) {
 	require.Error(t, err)
 }
 
-// --- 3. ListSharesByOwner ---
+// --- 3. ListSharesByOwner / ListSharesByUser ---
 
 // TestRemoteStorageListSharesByOwner_RealServer proves the #531 fix:
 // core.ListSharesByUser's owned-share half no longer hard-fails under
@@ -235,15 +235,27 @@ func TestRemoteStorageListSharesByOwner_RealServer(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, empty)
 
-	// NOTE: core.ListSharesByUser (the gRPC "list my shares" call) combines
-	// storage.ListSharesByUser (the recipient half) with storage.ListSharesByOwner
-	// (the owner half, fixed here). Only the latter is in scope for #531 —
-	// storage.ListSharesByUser itself is a SEPARATE, pre-existing gap (its
-	// client-side call targets GET /api/v1/users/{id}/shares, a route
-	// server/http/router.go never registers, so it 404s independently of this
-	// fix) discovered incidentally while testing this fix; core.ListSharesByUser
-	// is therefore not yet fully functional end to end and is intentionally not
-	// exercised here.
+	// The recipient half (storage.ListSharesByUser) — previously 404'd against
+	// a human-facing route that was never registered, closed as an incidental
+	// fix alongside this one — proxies correctly too.
+	received, err := downstream.Storage().ListSharesByUser(ctx, recipient.ID)
+	require.NoError(t, err, "listing shares by user must succeed via storage.type: remote")
+	require.Len(t, received, 1)
+	assert.Equal(t, secret.ID, received[0].SecretID)
+	assert.Equal(t, recipient.ID, received[0].RecipientID)
+
+	// A recipient with no shares cleanly returns an empty slice.
+	emptyReceived, err := downstream.Storage().ListSharesByUser(ctx, adminID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyReceived)
+
+	// Now that both halves are fixed, core.ListSharesByUser itself (backing GET
+	// /api/v1/shares and gRPC ShareService.ListShares) works end to end under
+	// storage.type: remote for the first time.
+	combined, err := downstream.ListSharesByUser(ctx, recipient.ID)
+	require.NoError(t, err, "core.ListSharesByUser must succeed via storage.type: remote")
+	require.Len(t, combined, 1)
+	assert.Equal(t, created.ID, combined[0].ID)
 }
 
 // --- 4. CreateUserWithRoleGrants (basic success + duplicate-email) ---

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1445,6 +1445,16 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// access-activity gaps above. A read, gated system.read.
 			r.Get("/shares/by-owner/{ownerID}", shareHandler.ListSharesByOwnerProxy)
 
+			// ListSharesByUser: the "shares I received" half of the same
+			// core.ListSharesByUser call. Its client method used to target a
+			// human-facing /api/v1/users/{id}/shares route that was never
+			// registered — there never was a "list an arbitrary user's
+			// received shares" endpoint (GET /api/v1/shares only resolves the
+			// CALLER's own ID from auth context, not a path parameter) — so
+			// this was a 404, not a stub, and slipped past the completeness
+			// guard for that reason. A read, gated system.read.
+			r.Get("/shares/by-user/{userID}", shareHandler.ListSharesByUserProxy)
+
 			// CreateUserWithRoleGrants: the ONE atomic primitive in this group —
 			// see misc_remote_proxy.go's CreateUserWithRoleGrantsProxy doc and
 			// remote_users.go's CreateUserWithRoleGrants doc for the full


### PR DESCRIPTION
## Summary
- Follow-up to #531's `ListSharesByOwner` fix. That PR fixed one half of `core.ListSharesByUser` (backing `GET /api/v1/shares` and gRPC `ShareService.ListShares`) but discovered, incidentally, that the sibling half — `RemoteStorage.ListSharesByUser` — targets `GET /api/v1/users/{id}/shares`, a route that was never registered server-side (there never was a human-facing "list an arbitrary user's received shares" endpoint; `GET /api/v1/shares` resolves the caller's own ID from auth context, not a path parameter). That meant `core.ListSharesByUser` still 404'd end to end under `storage.type: remote` even after #531.
- Fixed the same way as `ListSharesByOwner`: a new thin passthrough route, `GET /api/v1/system/shares/by-user/{userID}`, gated `system.read` (same tier every other system proxy uses — no new privilege class), with `RemoteStorage.ListSharesByUser` retargeted to call it.
- Extended the existing `TestRemoteStorageListSharesByOwner_RealServer` test to also exercise the newly-fixed `ListSharesByUser` half and, now that both halves work, `core.ListSharesByUser` itself end to end.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/storage/store/... ./server/http/... ./internal/core/...` — 2335 tests pass
- [x] `golangci-lint run` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)