### PR TITLE
fix(ci): pin cosign sign-blob to legacy bundle format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,15 @@ jobs:
       # SHA-256 of every release binary, so one signature transitively covers all
       # of them — verify checksums.txt's signature, then verify each downloaded
       # binary against its listed checksum.
+      # --new-bundle-format=false: cosign now defaults to writing a single
+      # `.bundle` file and silently ignores --output-signature/--output-certificate
+      # otherwise (it did so here, producing an empty output path and a hard
+      # failure). SECURITY.md documents verification via the separate
+      # checksums.txt.sig/.pem files, so pin the legacy split-file behavior.
       - name: Sign checksums.txt (keyless)
         run: |
           cosign sign-blob --yes \
+            --new-bundle-format=false \
             --output-signature dist/checksums.txt.sig \
             --output-certificate dist/checksums.txt.pem \
             dist/checksums.txt


### PR DESCRIPTION
## Summary
- The v0.87.2 tag's `release` workflow failed at "Sign checksums.txt (keyless)" — cosign now defaults to `--new-bundle-format=true` and silently drops `--output-signature`/`--output-certificate`, so the GitHub Release was never created for that tag (Docker images and the Helm chart still published fine).
- `SECURITY.md` documents verification via the separate `checksums.txt.sig`/`.pem` files, so pin `--new-bundle-format=false` to keep that flow working rather than reworking the docs.

## Test plan
- [x] Confirmed the failure mode by inspecting the v0.87.2 release run logs.
- [ ] After merge, cut v0.87.3 and confirm `release.yml`'s build-and-release job completes and the GitHub Release gets binaries + `.sig`/`.pem`.