### PR TITLE
fix(cli): decode remote list responses correctly (+ project coverage)

### DIFF
--- a/internal/cli/machine/machine.go
+++ b/internal/cli/machine/machine.go
@@ -48,18 +48,17 @@ func resolveProjectContext(flagValue string) (string, uint, error) {
 	}
 	ctx := context.Background()
 	if rc, ok := common.NewRemoteClient(); ok {
+		// rc.Get already strips the {"data":…} envelope — decode the inner payload directly.
 		var resp struct {
-			Data struct {
-				Projects []struct {
-					ID   uint   `json:"id"`
-					Name string `json:"name"`
-				} `json:"projects"`
-			} `json:"data"`
+			Projects []struct {
+				ID   uint   `json:"id"`
+				Name string `json:"name"`
+			} `json:"projects"`
 		}
 		if err := rc.Get(ctx, "/api/v1/projects", &resp); err != nil {
 			return "", 0, fmt.Errorf("failed to list projects: %w", err)
 		}
-		for _, p := range resp.Data.Projects {
+		for _, p := range resp.Projects {
 			if p.Name == name {
 				return name, p.ID, nil
 			}
@@ -85,16 +84,15 @@ func resolveProjectContext(flagValue string) (string, uint, error) {
 // fetchMachineIdentities lists a project's machine identities (remote or local).
 func fetchMachineIdentities(ctx context.Context, projectID uint) ([]*models.MachineIdentity, error) {
 	if rc, ok := common.NewRemoteClient(); ok {
+		// rc.Get already strips the {"data":…} envelope — decode the inner payload directly.
 		var resp struct {
-			Data struct {
-				MachineIdentities []*models.MachineIdentity `json:"machine_identities"`
-			} `json:"data"`
+			MachineIdentities []*models.MachineIdentity `json:"machine_identities"`
 		}
 		path := fmt.Sprintf("/api/v1/projects/%d/machine-identities", projectID)
 		if err := rc.Get(ctx, path, &resp); err != nil {
 			return nil, err
 		}
-		return resp.Data.MachineIdentities, nil
+		return resp.MachineIdentities, nil
 	}
 	svc, err := common.InitializeCoreService()
 	if err != nil {

--- a/internal/cli/machine/project_resolve_remote_test.go
+++ b/internal/cli/machine/project_resolve_remote_test.go
@@ -1,0 +1,56 @@
+package machine
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveProjectContext_Remote is the regression for the double-{"data":…}
+// envelope bug: rc.Get already strips the envelope, so the remote resolver must
+// decode {"projects":[…]} directly. With the old nested Data wrapper the project
+// list decoded empty and every remote machine command failed with "project not
+// found". Uses the real sendSuccess envelope shape.
+func TestResolveProjectContext_Remote(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/projects" {
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":7,"name":"web"}]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	name, id, err := resolveProjectContext("web")
+	require.NoError(t, err)
+	assert.Equal(t, "web", name)
+	assert.Equal(t, uint(7), id)
+}
+
+// TestFetchMachineIdentities_Remote guards the same fix on the machine-identities
+// list endpoint: the identities must decode from the stripped envelope, not an
+// always-empty nested Data wrapper.
+func TestFetchMachineIdentities_Remote(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/projects/7/machine-identities" {
+			_, _ = w.Write([]byte(`{"success":true,"data":{"machine_identities":[{"id":1,"name":"ci-runner"},{"id":2,"name":"deployer"}]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	ids, err := fetchMachineIdentities(context.Background(), 7)
+	require.NoError(t, err)
+	require.Len(t, ids, 2)
+	assert.Equal(t, "ci-runner", ids[0].Name)
+	assert.Equal(t, "deployer", ids[1].Name)
+}

--- a/internal/cli/project/command_test.go
+++ b/internal/cli/project/command_test.go
@@ -1,0 +1,207 @@
+package project
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupEmbedded points the project commands at an isolated temp config in local
+// (embedded SQLite) mode, so common.NewRemoteClient returns false and the commands
+// take their embedded path against a throwaway database. Also resets the package-level
+// command flag vars after the test so cases don't leak into each other.
+func setupEmbedded(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "test.db")}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir) // isolate cli.yaml: embedded, no active project
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_PROJECT", "")
+	require.NoError(t, i18n.InitializeForTesting())
+
+	t.Cleanup(func() {
+		createName, createDescription, createEnvs = "", "", ""
+		envProjectFlag, envCreateName = "", ""
+	})
+}
+
+func embeddedCore(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	return svc
+}
+
+func TestRunCreate_Embedded(t *testing.T) {
+	setupEmbedded(t)
+	createName = "web"
+	createEnvs = "dev,prod"
+
+	out := captureStdout(t, func() { require.NoError(t, runCreate(nil, nil)) })
+	assert.Contains(t, out, "Project created: id=")
+	assert.Contains(t, out, "Environments seeded: dev,prod")
+
+	svc := embeddedCore(t)
+	projects, err := svc.ListProjects(context.Background())
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+	assert.Equal(t, "web", projects[0].Name)
+
+	envs, err := svc.ListEnvironmentsByProject(context.Background(), projects[0].ID)
+	require.NoError(t, err)
+	var names []string
+	for _, e := range envs {
+		names = append(names, e.Name)
+	}
+	assert.ElementsMatch(t, []string{"dev", "prod"}, names)
+}
+
+func TestRunCreate_RequiresName(t *testing.T) {
+	setupEmbedded(t)
+	createName = ""
+	err := runCreate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--name is required")
+}
+
+func TestRunCreate_RejectsEmptyEnvs(t *testing.T) {
+	setupEmbedded(t)
+	createName = "x"
+	createEnvs = " , , "
+	err := runCreate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--envs must not be empty")
+}
+
+func TestRunList_Embedded(t *testing.T) {
+	setupEmbedded(t)
+
+	out := captureStdout(t, func() { require.NoError(t, runList(nil, nil)) })
+	assert.Contains(t, out, "No projects found.")
+
+	_, err := embeddedCore(t).CreateProject(context.Background(), "alpha", "first project")
+	require.NoError(t, err)
+
+	out = captureStdout(t, func() { require.NoError(t, runList(nil, nil)) })
+	assert.Contains(t, out, "alpha")
+	assert.Contains(t, out, "first project")
+}
+
+func TestRunEnvironments_Embedded(t *testing.T) {
+	setupEmbedded(t)
+	p, err := embeddedCore(t).CreateProjectWithEnvs(context.Background(), "web", "", []string{"dev"})
+	require.NoError(t, err)
+
+	out := captureStdout(t, func() {
+		require.NoError(t, runEnvironments(nil, []string{strconv.Itoa(int(p.ID))}))
+	})
+	assert.Contains(t, out, "dev")
+
+	err = runEnvironments(nil, []string{"not-a-number"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid project ID")
+}
+
+func TestRunEnv_CreateListDelete_Embedded(t *testing.T) {
+	setupEmbedded(t)
+	ctx := context.Background()
+	_, err := embeddedCore(t).CreateProject(ctx, "web", "")
+	require.NoError(t, err)
+	envProjectFlag = "web"
+
+	// create
+	envCreateName = "qa"
+	out := captureStdout(t, func() { require.NoError(t, runEnvCreate(nil, nil)) })
+	assert.Contains(t, out, `Environment "qa" created`)
+
+	// list shows it
+	out = captureStdout(t, func() { require.NoError(t, runEnvList(nil, nil)) })
+	assert.Contains(t, out, "qa")
+
+	// delete it (resolve its id first)
+	svc := embeddedCore(t)
+	projects, err := svc.ListProjects(ctx)
+	require.NoError(t, err)
+	envs, err := svc.ListEnvironmentsByProject(ctx, projects[0].ID)
+	require.NoError(t, err)
+	var qaID uint
+	for _, e := range envs {
+		if e.Name == "qa" {
+			qaID = e.ID
+		}
+	}
+	require.NotZero(t, qaID)
+
+	out = captureStdout(t, func() {
+		require.NoError(t, runEnvDelete(nil, []string{strconv.Itoa(int(qaID))}))
+	})
+	assert.Contains(t, out, "deleted")
+
+	err = runEnvDelete(nil, []string{"bad"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid environment ID")
+}
+
+func TestResolveProjectContext_NoProject(t *testing.T) {
+	setupEmbedded(t)
+	// No --project flag, no KEYORIX_PROJECT, no active cli.yaml project.
+	_, _, err := resolveProjectContext("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no project specified")
+}
+
+func TestRunUse_And_Current_Embedded(t *testing.T) {
+	setupEmbedded(t)
+	_, err := embeddedCore(t).CreateProject(context.Background(), "web", "")
+	require.NoError(t, err)
+
+	out := captureStdout(t, func() { require.NoError(t, runCurrent(nil, nil)) })
+	assert.Contains(t, out, "No active project set.")
+
+	out = captureStdout(t, func() { require.NoError(t, runUse(nil, []string{"web"})) })
+	assert.Contains(t, out, `Active project set to "web"`)
+
+	out = captureStdout(t, func() { require.NoError(t, runCurrent(nil, nil)) })
+	assert.Contains(t, out, "web")
+
+	err = runUse(nil, []string{"ghost"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRunCurrent_FromEnvVar(t *testing.T) {
+	setupEmbedded(t)
+	t.Setenv("KEYORIX_PROJECT", "envproj")
+	out := captureStdout(t, func() { require.NoError(t, runCurrent(nil, nil)) })
+	assert.Contains(t, out, "envproj (from KEYORIX_PROJECT)")
+}
+
+func TestRunDescribe_Embedded(t *testing.T) {
+	setupEmbedded(t)
+	_, err := embeddedCore(t).CreateProjectWithEnvs(context.Background(), "web", "the web project", []string{"dev", "prod"})
+	require.NoError(t, err)
+
+	out := captureStdout(t, func() { require.NoError(t, runDescribe(nil, []string{"web"})) })
+	assert.Contains(t, out, "Project:      web")
+	assert.Contains(t, out, "the web project")
+	assert.Contains(t, out, "dev")
+	assert.Contains(t, out, "Secrets:")
+
+	err = runDescribe(nil, []string{"ghost"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/cli/project/describe.go
+++ b/internal/cli/project/describe.go
@@ -42,22 +42,21 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 }
 
 func describeViaRemote(ctx context.Context, rc *common.RemoteClient, name string) error {
-	// List projects to find the ID.
+	// List projects to find the ID. rc.Get already strips the {"data":…} envelope —
+	// decode the inner payload directly (a nested Data wrapper would double-strip).
 	var listResp struct {
-		Data struct {
-			Projects []struct {
-				ID          uint   `json:"id"`
-				Name        string `json:"name"`
-				Description string `json:"description"`
-			} `json:"projects"`
-		} `json:"data"`
+		Projects []struct {
+			ID          uint   `json:"id"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+		} `json:"projects"`
 	}
 	if err := rc.Get(ctx, "/api/v1/projects", &listResp); err != nil {
 		return fmt.Errorf("failed to list projects: %w", err)
 	}
 	var projectID uint
 	var description string
-	for _, p := range listResp.Data.Projects {
+	for _, p := range listResp.Projects {
 		if p.Name == name {
 			projectID = p.ID
 			description = p.Description
@@ -70,16 +69,14 @@ func describeViaRemote(ctx context.Context, rc *common.RemoteClient, name string
 
 	// Environments.
 	var envResp struct {
-		Data struct {
-			Environments []*models.Environment `json:"environments"`
-		} `json:"data"`
+		Environments []*models.Environment `json:"environments"`
 	}
 	envPath := "/api/v1/projects/" + strconv.Itoa(int(projectID)) + "/environments"
 	if err := rc.Get(ctx, envPath, &envResp); err != nil {
 		return fmt.Errorf("failed to list environments: %w", err)
 	}
 
-	printProjectDetails(name, description, projectID, envResp.Data.Environments)
+	printProjectDetails(name, description, projectID, envResp.Environments)
 	return nil
 }
 

--- a/internal/cli/project/env.go
+++ b/internal/cli/project/env.go
@@ -36,16 +36,15 @@ func runEnvList(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	if rc, ok := common.NewRemoteClient(); ok {
+		// rc.Get already strips the {"data":…} envelope — decode the inner payload directly.
 		var resp struct {
-			Data struct {
-				Environments []*models.Environment `json:"environments"`
-			} `json:"data"`
+			Environments []*models.Environment `json:"environments"`
 		}
 		path := fmt.Sprintf("/api/v1/projects/%d/environments", projectID)
 		if err := rc.Get(ctx, path, &resp); err != nil {
 			return fmt.Errorf("failed to list environments: %w", err)
 		}
-		printEnvironmentTable(resp.Data.Environments, name)
+		printEnvironmentTable(resp.Environments, name)
 		return nil
 	}
 
@@ -156,18 +155,17 @@ func resolveProjectContext(flagValue string) (string, uint, error) {
 	}
 	ctx := context.Background()
 	if rc, ok := common.NewRemoteClient(); ok {
+		// rc.Get already strips the {"data":…} envelope — decode the inner payload directly.
 		var resp struct {
-			Data struct {
-				Projects []struct {
-					ID   uint   `json:"id"`
-					Name string `json:"name"`
-				} `json:"projects"`
-			} `json:"data"`
+			Projects []struct {
+				ID   uint   `json:"id"`
+				Name string `json:"name"`
+			} `json:"projects"`
 		}
 		if err := rc.Get(ctx, "/api/v1/projects", &resp); err != nil {
 			return "", 0, fmt.Errorf("failed to list projects: %w", err)
 		}
-		for _, p := range resp.Data.Projects {
+		for _, p := range resp.Projects {
 			if p.Name == name {
 				return name, p.ID, nil
 			}

--- a/internal/cli/project/environments.go
+++ b/internal/cli/project/environments.go
@@ -26,16 +26,15 @@ func runEnvironments(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	if rc, ok := common.NewRemoteClient(); ok {
+		// rc.Get already strips the {"data":…} envelope — decode the inner payload directly.
 		var resp struct {
-			Data struct {
-				Environments []*models.Environment `json:"environments"`
-			} `json:"data"`
+			Environments []*models.Environment `json:"environments"`
 		}
 		path := fmt.Sprintf("/api/v1/projects/%d/environments", projectID)
 		if err := rc.Get(ctx, path, &resp); err != nil {
 			return fmt.Errorf("failed to list environments: %w", err)
 		}
-		printEnvironments(resp.Data.Environments, projectID)
+		printEnvironments(resp.Environments, projectID)
 		return nil
 	}
 

--- a/internal/cli/project/list.go
+++ b/internal/cli/project/list.go
@@ -18,15 +18,16 @@ var listCmd = &cobra.Command{
 func runList(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	if rc, ok := common.NewRemoteClient(); ok {
+		// rc.Get already strips the {"data":…} envelope, so decode the inner payload
+		// directly (a nested Data wrapper here would double-strip and always yield an
+		// empty list — the remote-mode bug this shape previously had).
 		var resp struct {
-			Data struct {
-				Projects []*models.Project `json:"projects"`
-			} `json:"data"`
+			Projects []*models.Project `json:"projects"`
 		}
 		if err := rc.Get(ctx, "/api/v1/projects", &resp); err != nil {
 			return fmt.Errorf("failed to list projects: %w", err)
 		}
-		printProjects(resp.Data.Projects)
+		printProjects(resp.Projects)
 		return nil
 	}
 

--- a/internal/cli/project/print_test.go
+++ b/internal/cli/project/print_test.go
@@ -1,0 +1,143 @@
+package project
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureStdout redirects os.Stdout for the duration of fn and returns everything
+// written to it — the print* helpers all write to stdout via fmt.Printf.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func TestSplitEnvNames(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"simple", "dev,staging,prod", []string{"dev", "staging", "prod"}},
+		{"trims whitespace", " dev , staging ,prod ", []string{"dev", "staging", "prod"}},
+		{"drops empty segments", "dev,,prod,", []string{"dev", "prod"}},
+		{"all empty/whitespace yields none", " , , ", []string{}},
+		{"single", "dev", []string{"dev"}},
+		{"empty string yields none", "", []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitEnvNames(tt.in)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPrintProjects(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		out := captureStdout(t, func() { printProjects(nil) })
+		assert.Equal(t, "No projects found.\n", out)
+	})
+
+	t.Run("lists rows with header", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			printProjects([]*models.Project{
+				{ID: 1, Name: "web", Description: "frontend"},
+				{ID: 2, Name: "api", Description: ""},
+			})
+		})
+		assert.Contains(t, out, "ID")
+		assert.Contains(t, out, "NAME")
+		assert.Contains(t, out, "web")
+		assert.Contains(t, out, "frontend")
+		assert.Contains(t, out, "api")
+	})
+
+	t.Run("truncates a long description", func(t *testing.T) {
+		long := strings.Repeat("x", 50)
+		out := captureStdout(t, func() {
+			printProjects([]*models.Project{{ID: 1, Name: "p", Description: long}})
+		})
+		assert.Contains(t, out, strings.Repeat("x", 37)+"...")
+		assert.NotContains(t, out, strings.Repeat("x", 41))
+	})
+}
+
+func TestPrintProjectDetails(t *testing.T) {
+	t.Run("with description and envs", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			printProjectDetails("web", "the frontend", 7, []*models.Environment{
+				{ID: 1, Name: "dev"}, {ID: 2, Name: "prod"},
+			})
+		})
+		assert.Contains(t, out, "Project:      web (id=7)")
+		assert.Contains(t, out, "Description:  the frontend")
+		assert.Contains(t, out, "Environments: 2")
+		assert.Contains(t, out, "- dev (id=1)")
+		assert.Contains(t, out, "- prod (id=2)")
+	})
+
+	t.Run("omits the description line when empty", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			printProjectDetails("web", "", 7, nil)
+		})
+		assert.NotContains(t, out, "Description:")
+		assert.Contains(t, out, "Environments: 0")
+	})
+}
+
+func TestPrintEnvironments(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		out := captureStdout(t, func() { printEnvironments(nil, 3) })
+		assert.Equal(t, "No environments found for project 3.\n", out)
+	})
+	t.Run("populated", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			printEnvironments([]*models.Environment{{ID: 5, Name: "dev"}}, 3)
+		})
+		assert.Contains(t, out, "Environments for project 3:")
+		assert.Contains(t, out, "dev")
+	})
+}
+
+func TestPrintEnvironmentTable(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		out := captureStdout(t, func() { printEnvironmentTable(nil, "web") })
+		assert.Equal(t, "No environments found for project \"web\".\n", out)
+	})
+	t.Run("populated", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			printEnvironmentTable([]*models.Environment{{ID: 5, Name: "prod"}}, "web")
+		})
+		assert.Contains(t, out, `Environments for project "web":`)
+		assert.Contains(t, out, "prod")
+	})
+}
+
+func TestPrintCreateResult(t *testing.T) {
+	t.Run("with explicit envs flag", func(t *testing.T) {
+		out := captureStdout(t, func() { printCreateResult(9, "web", "dev,prod") })
+		assert.Contains(t, out, `Project created: id=9 name="web"`)
+		assert.Contains(t, out, "Environments seeded: dev,prod")
+	})
+	t.Run("defaults when no envs flag", func(t *testing.T) {
+		out := captureStdout(t, func() { printCreateResult(9, "web", "") })
+		assert.Contains(t, out, "Default environments (development, staging, production)")
+	})
+}

--- a/internal/cli/project/remote_test.go
+++ b/internal/cli/project/remote_test.go
@@ -1,0 +1,101 @@
+package project
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupRemote points the commands at a mock server via KEYORIX_SERVER/KEYORIX_TOKEN,
+// so common.NewRemoteClient returns true and the remote code paths run. The handler
+// returns responses in the REAL server envelope shape (sendSuccess: {"success":...,
+// "data":<payload>}), so these tests exercise the exact wire contract.
+func setupRemote(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	t.Setenv("KEYORIX_PROJECT", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() {
+		createName, createDescription, createEnvs = "", "", ""
+		envProjectFlag, envCreateName = "", ""
+	})
+}
+
+// TestRunList_Remote drives `project list` in remote mode against the real
+// sendSuccess envelope and asserts the returned project is actually printed. If the
+// remote response struct double-wraps the {"data":…} envelope (which decodeEnvelope
+// already strips), the project list decodes empty and this fails — surfacing that bug.
+func TestRunList_Remote(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/projects", r.URL.Path)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web","description":"the web project"}]}}`))
+	})
+
+	out := captureStdout(t, func() { require.NoError(t, runList(nil, nil)) })
+	assert.Contains(t, out, "web", "remote project list must print the project returned by the server")
+	assert.Contains(t, out, "the web project")
+}
+
+// projectsAndEnvsHandler serves the two endpoints the read commands hit, in the real
+// sendSuccess envelope: a single project "web" (id=1) with two environments.
+func projectsAndEnvsHandler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web","description":"the web project"}]}}`))
+		case "/api/v1/projects/1/environments":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"environments":[{"id":10,"name":"dev"},{"id":11,"name":"prod"}]}}`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func TestRunEnvironments_Remote(t *testing.T) {
+	setupRemote(t, projectsAndEnvsHandler(t))
+	out := captureStdout(t, func() { require.NoError(t, runEnvironments(nil, []string{"1"})) })
+	assert.Contains(t, out, "dev")
+	assert.Contains(t, out, "prod")
+}
+
+func TestRunEnvList_Remote(t *testing.T) {
+	setupRemote(t, projectsAndEnvsHandler(t))
+	envProjectFlag = "web" // resolveProjectContext resolves this to id=1 via the remote list
+	out := captureStdout(t, func() { require.NoError(t, runEnvList(nil, nil)) })
+	assert.Contains(t, out, `Environments for project "web":`)
+	assert.Contains(t, out, "dev")
+	assert.Contains(t, out, "prod")
+}
+
+func TestRunDescribe_Remote(t *testing.T) {
+	setupRemote(t, projectsAndEnvsHandler(t))
+	out := captureStdout(t, func() { require.NoError(t, runDescribe(nil, []string{"web"})) })
+	assert.Contains(t, out, "Project:      web (id=1)")
+	assert.Contains(t, out, "the web project")
+	assert.Contains(t, out, "dev")
+	assert.Contains(t, out, "prod")
+
+	err := runDescribe(nil, []string{"ghost"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRunUse_Remote(t *testing.T) {
+	setupRemote(t, projectsAndEnvsHandler(t))
+	out := captureStdout(t, func() { require.NoError(t, runUse(nil, []string{"web"})) })
+	assert.Contains(t, out, `Active project set to "web"`)
+
+	err := runUse(nil, []string{"ghost"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/cli/project/use.go
+++ b/internal/cli/project/use.go
@@ -26,18 +26,17 @@ func runUse(cmd *cobra.Command, args []string) error {
 
 	// Validate the project exists (remote or local).
 	if rc, ok := common.NewRemoteClient(); ok {
+		// rc.Get already strips the {"data":…} envelope — decode the inner payload directly.
 		var resp struct {
-			Data struct {
-				Projects []struct {
-					Name string `json:"name"`
-				} `json:"projects"`
-			} `json:"data"`
+			Projects []struct {
+				Name string `json:"name"`
+			} `json:"projects"`
 		}
 		if err := rc.Get(ctx, "/api/v1/projects", &resp); err != nil {
 			return fmt.Errorf("failed to list projects: %w", err)
 		}
 		found := false
-		for _, p := range resp.Data.Projects {
+		for _, p := range resp.Projects {
 			if p.Name == name {
 				found = true
 				break

--- a/internal/cli/secret/list.go
+++ b/internal/cli/secret/list.go
@@ -68,19 +68,19 @@ func runListRemote(ctx context.Context, rc *common.RemoteClient) error {
 	// ResolveProject ignores the error when nothing is set (project scope is optional for list).
 	projectName, _ := common.ResolveProject(listProjectName)
 	if projectName != "" {
+		// rc.Get already strips the {"data":…} envelope — decode the inner payload
+		// directly (a nested Data wrapper would double-strip and never match a project).
 		var resp struct {
-			Data struct {
-				Projects []struct {
-					ID   uint   `json:"id"`
-					Name string `json:"name"`
-				} `json:"projects"`
-			} `json:"data"`
+			Projects []struct {
+				ID   uint   `json:"id"`
+				Name string `json:"name"`
+			} `json:"projects"`
 		}
 		if err := rc.Get(ctx, "/api/v1/projects", &resp); err != nil {
 			return fmt.Errorf("failed to list projects: %w", err)
 		}
 		var projectID uint
-		for _, p := range resp.Data.Projects {
+		for _, p := range resp.Projects {
 			if strings.EqualFold(p.Name, projectName) {
 				projectID = p.ID
 				break

--- a/internal/cli/secret/list_project_resolve_remote_test.go
+++ b/internal/cli/secret/list_project_resolve_remote_test.go
@@ -1,0 +1,48 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunListRemote_ResolvesProjectScope is the regression for the double-{"data":…}
+// envelope bug in `secret list --project <name>` (remote mode): rc.Get already strips
+// the envelope, so the project lookup must decode {"projects":[…]} directly. With the
+// old nested Data wrapper the list decoded empty, resolution failed, and the command
+// errored "project not found" before ever reaching the secrets endpoint. Here the name
+// must resolve to id=1 and scope the secrets query with project_id=1.
+func TestRunListRemote_ResolvesProjectScope(t *testing.T) {
+	var secretsQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		case "/api/v1/secrets":
+			secretsQuery = r.URL.RawQuery
+			_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[],"total":0}}`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	t.Setenv("KEYORIX_PROJECT", "")
+
+	listProjectName, listLimit, listOffset, listEnv, listFormat = "web", 50, 0, 0, "table"
+	t.Cleanup(func() { listProjectName, listLimit, listOffset, listEnv, listFormat = "", 0, 0, 0, "" })
+
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runListRemote(context.Background(), rc))
+	assert.Contains(t, secretsQuery, "project_id=1",
+		"the --project name must resolve to its ID and scope the secrets query")
+}


### PR DESCRIPTION
## fix(cli): decode remote list responses correctly (+ project coverage)

Found while raising test coverage on `internal/cli/project`.

`RemoteClient.Get/Post/Put` strip the `{"data":…}` envelope and decode the **inner** payload into the caller's struct. Several remote-mode commands, though, unmarshalled into a struct that wrapped the payload in **another** `{"data":…}`. The double-strip left the inner field empty, so in **client mode** these silently returned nothing:

- `project list / describe / use / env *` → "No projects found" / "project not found"
- `secret list --project <name>` → failed to resolve the project scope
- `machine` commands → failed to resolve the project / list identities

### Fix
Decode the inner payload directly at every affected site: **project ×6, `secret/list` ×1, `machine` ×2**. The `Post` paths (which already decode bare models, relying on the same envelope strip) were correct and are unchanged. Verified the non-buggy lookalikes (`run.go`'s own decoder, `source_vault.go`'s Vault `data`/`data.data` format, and the `connect`/`rotate`/`system-init` manual full-body decoders) are correct and left alone.

### Tests
Regression tests hit each fixed path against the **real `sendSuccess` envelope** (a test that printed `"No projects found."` before the fix now passes). Plus formatting + embedded-core command tests:

- `internal/cli/project`: **7.1% → 77.2%**
- `internal/cli/machine`, `internal/cli/secret`: added remote regression coverage on the fixed paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
