### PR TITLE
test(cli): cover the five 0%-coverage command packages

### DIFF
--- a/internal/cli/breakglass/breakglass_test.go
+++ b/internal/cli/breakglass/breakglass_test.go
@@ -1,0 +1,107 @@
+package breakglass
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	fn()
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func setupRemote(t *testing.T, h http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+}
+
+func TestBgBase(t *testing.T) {
+	assert.Equal(t, "/api/v1/projects/5/break-glass", bgBase(5))
+	assert.Equal(t, "/api/v1/projects/0/break-glass", bgBase(0))
+}
+
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, "short", truncate("short", 16))
+	assert.Equal(t, "a…", truncate("abcdef", 2))
+	assert.Equal(t, "a", truncate("abc", 1))
+	assert.Equal(t, "", truncate("abc", 0))
+}
+
+func TestActivate_RequiredFlags(t *testing.T) {
+	bgProject, bgJustify = 0, ""
+	t.Cleanup(func() { bgProject, bgJustify = 0, "" })
+	require.ErrorContains(t, activateCmd.RunE(nil, nil), "--project-id is required")
+
+	bgProject = 3
+	require.ErrorContains(t, activateCmd.RunE(nil, nil), "--justification is required")
+}
+
+func TestActivate_Remote(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/projects/3/break-glass", r.URL.Path)
+		_, _ = w.Write([]byte(`{"success":true,"data":{"activation":{"id":7,"role_name":"break-glass-editor","expires_at":"2026-07-11T00:00:00Z"}}}`))
+	})
+	bgProject, bgJustify, bgTTL = 3, "prod outage #42", "2h"
+	t.Cleanup(func() { bgProject, bgJustify, bgTTL = 0, "", "" })
+
+	out := captureStdout(t, func() { require.NoError(t, activateCmd.RunE(nil, nil)) })
+	assert.Contains(t, out, "Emergency access activated (id=7)")
+	assert.Contains(t, out, `role "break-glass-editor"`)
+}
+
+func TestList_Remote(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"success":true,"data":{"activations":[],"count":0}}`))
+		})
+		bgProject = 3
+		t.Cleanup(func() { bgProject = 0 })
+		out := captureStdout(t, func() { require.NoError(t, listCmd.RunE(nil, nil)) })
+		assert.Contains(t, out, "No break-glass activations for project 3.")
+	})
+
+	t.Run("populated", func(t *testing.T) {
+		setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"success":true,"data":{"count":1,"activations":[{"id":9,"user_id":2,"role_name":"break-glass-editor","state":"active","expires_at":"2026-07-11T00:00:00Z","justification":"incident"}]}}`))
+		})
+		bgProject = 3
+		t.Cleanup(func() { bgProject = 0 })
+		out := captureStdout(t, func() { require.NoError(t, listCmd.RunE(nil, nil)) })
+		assert.Contains(t, out, "Break-glass activations — project 3")
+		assert.Contains(t, out, "incident")
+		assert.Contains(t, out, "active")
+	})
+}
+
+func TestRevoke_RequiredFlagsAndRemote(t *testing.T) {
+	bgProject, bgActivation = 0, 0
+	require.ErrorContains(t, revokeCmd.RunE(nil, nil), "required")
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/projects/3/break-glass/9/revoke", r.URL.Path)
+		_, _ = w.Write([]byte(`{"success":true,"data":{}}`))
+	})
+	bgProject, bgActivation = 3, 9
+	t.Cleanup(func() { bgProject, bgActivation = 0, 0 })
+	out := captureStdout(t, func() { require.NoError(t, revokeCmd.RunE(nil, nil)) })
+	assert.Contains(t, out, "Revoked break-glass activation 9 in project 3.")
+}

--- a/internal/cli/license/license_test.go
+++ b/internal/cli/license/license_test.go
@@ -1,0 +1,180 @@
+package license
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	ilicense "github.com/keyorixhq/keyorix/internal/license"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	fn()
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+// writeSigningKey generates an ed25519 key and writes it as a PKCS#8 PEM file,
+// the format `license issue` expects.
+func writeSigningKey(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "sign.pem")
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600))
+	return path
+}
+
+func TestGraceOf(t *testing.T) {
+	assert.Equal(t, 14*24*time.Hour, graceOf(0))
+	assert.Equal(t, 14*24*time.Hour, graceOf(-3))
+	assert.Equal(t, 24*time.Hour, graceOf(24))
+}
+
+func TestReadToken(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "tok")
+	require.NoError(t, os.WriteFile(p, []byte("  the-token \n"), 0o600))
+	got, err := readToken(p)
+	require.NoError(t, err)
+	assert.Equal(t, "the-token", got)
+
+	_, err = readToken(filepath.Join(dir, "does-not-exist"))
+	require.Error(t, err)
+}
+
+func TestPrintStatus(t *testing.T) {
+	t.Run("granting", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			printStatus(ilicense.Status{
+				State: ilicense.StateActive, Licensee: "acme", Plan: "enterprise",
+				Features: []string{"airgap_updates"}, NotAfter: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+			})
+		})
+		assert.Contains(t, out, "state:    active")
+		assert.Contains(t, out, "licensee: acme")
+		assert.Contains(t, out, "plan:     enterprise")
+		assert.Contains(t, out, "features: airgap_updates")
+		assert.Contains(t, out, "expires:  2030-01-01T00:00:00Z")
+	})
+
+	t.Run("baseline shows no commercial features", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			printStatus(ilicense.Status{State: ilicense.StateNone, Reason: "no license installed"})
+		})
+		assert.Contains(t, out, "state:    none")
+		assert.Contains(t, out, "community baseline")
+		assert.Contains(t, out, "note:     no license installed")
+	})
+}
+
+func TestIssue_HappyPath(t *testing.T) {
+	issueLicensee = "acme"
+	issuePlan = "enterprise-airgap"
+	issueFeatures = "airgap_updates, extra"
+	issueNotAfter = time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	issueKeyID = "test-key"
+	issueSignKey = writeSigningKey(t)
+	t.Cleanup(func() {
+		issueLicensee, issuePlan, issueFeatures, issueNotAfter, issueKeyID, issueSignKey = "", "", "", "", "", ""
+	})
+
+	out := captureStdout(t, func() { require.NoError(t, issueCmd.RunE(nil, nil)) })
+	assert.NotEmpty(t, strings.TrimSpace(out), "issue must print a token")
+}
+
+func TestIssue_ErrorPaths(t *testing.T) {
+	t.Run("bad not-after", func(t *testing.T) {
+		issueNotAfter = "not-a-date"
+		issueSignKey = writeSigningKey(t)
+		t.Cleanup(func() { issueNotAfter, issueSignKey = "", "" })
+		err := issueCmd.RunE(nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--not-after must be RFC3339")
+	})
+
+	t.Run("missing signing key file", func(t *testing.T) {
+		issueNotAfter = time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+		issueSignKey = filepath.Join(t.TempDir(), "nope.pem")
+		t.Cleanup(func() { issueNotAfter, issueSignKey = "", "" })
+		err := issueCmd.RunE(nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read signing key")
+	})
+}
+
+func TestInstall_RequiresDest(t *testing.T) {
+	installDest = ""
+	err := installCmd.RunE(nil, []string{"whatever"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--dest is required")
+}
+
+func TestInstall_RefusesInvalidToken(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "bad.token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("this-is-not-a-valid-token"), 0o600))
+
+	installDest = filepath.Join(dir, "installed.token")
+	installDeployment = ""
+	installGraceHours = 0
+	t.Cleanup(func() { installDest, installDeployment, installGraceHours = "", "", 0 })
+
+	err := installCmd.RunE(nil, []string{tokenFile})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to install an invalid license")
+	_, statErr := os.Stat(installDest)
+	assert.True(t, os.IsNotExist(statErr), "an invalid token must not be written")
+}
+
+func TestInstall_EmptyTokenBaselineWritesFile(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "empty.token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte(""), 0o600))
+
+	installDest = filepath.Join(dir, "installed.token")
+	t.Cleanup(func() { installDest = "" })
+
+	out := captureStdout(t, func() { require.NoError(t, installCmd.RunE(nil, []string{tokenFile})) })
+	assert.Contains(t, out, "Installed license")
+	_, err := os.Stat(installDest)
+	require.NoError(t, err, "a baseline (empty) token still installs")
+}
+
+func TestStatus_Baseline(t *testing.T) {
+	statusFile = ""
+	statusDeployment = ""
+	statusGraceHours = 0
+	out := captureStdout(t, func() { require.NoError(t, statusCmd.RunE(nil, nil)) })
+	assert.Contains(t, out, "state:    none")
+	assert.Contains(t, out, "community baseline")
+}
+
+func TestStatus_GarbageTokenFileIsFailSafe(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "garbage.token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("garbage"), 0o600))
+	statusFile = tokenFile
+	t.Cleanup(func() { statusFile = "" })
+
+	out := captureStdout(t, func() { require.NoError(t, statusCmd.RunE(nil, nil)) })
+	assert.Contains(t, out, "state:    invalid", "a garbage token degrades to invalid, never errors the tool")
+}

--- a/internal/cli/risk/risk_test.go
+++ b/internal/cli/risk/risk_test.go
@@ -1,0 +1,112 @@
+package risk
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	fn()
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func setupRemote(t *testing.T, h http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+}
+
+func TestList_Remote(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"success":true,"data":{"exceptions":[]}}`))
+		})
+		listAll = false
+		out := captureStdout(t, func() { require.NoError(t, listCmd.RunE(nil, nil)) })
+		assert.Contains(t, out, "No risk exceptions.")
+	})
+	t.Run("populated with --all", func(t *testing.T) {
+		setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "all=true", r.URL.RawQuery)
+			_, _ = w.Write([]byte(`{"success":true,"data":{"exceptions":[{"id":3,"title":"legacy MFA gap","category":"mfa","reference":"user:9","justification":"migration in flight","status":"active","expires_at":"2026-12-31T00:00:00Z","approved":true}]}}`))
+		})
+		listAll = true
+		t.Cleanup(func() { listAll = false })
+		out := captureStdout(t, func() { require.NoError(t, listCmd.RunE(nil, nil)) })
+		assert.Contains(t, out, "#3 legacy MFA gap")
+		assert.Contains(t, out, "approved")
+		assert.Contains(t, out, "migration in flight")
+	})
+}
+
+func TestAdd_Validation(t *testing.T) {
+	addTitle, addJustification, addExpires = "", "", ""
+	require.ErrorContains(t, addCmd.RunE(nil, nil), "--title and --justification are required")
+
+	addTitle, addJustification = "t", "j"
+	addExpires = ""
+	require.ErrorContains(t, addCmd.RunE(nil, nil), "--expires is required")
+
+	addExpires = "not-a-date"
+	require.ErrorContains(t, addCmd.RunE(nil, nil), "--expires must be RFC3339")
+	t.Cleanup(func() { addTitle, addJustification, addExpires = "", "", "" })
+}
+
+func TestAdd_Remote(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		_, _ = w.Write([]byte(`{"success":true,"data":{"exception":{"id":11}}}`))
+	})
+	addTitle, addJustification = "gap", "accepted for Q3"
+	addExpires = time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	t.Cleanup(func() { addTitle, addJustification, addExpires = "", "", "" })
+	out := captureStdout(t, func() { require.NoError(t, addCmd.RunE(nil, nil)) })
+	assert.Contains(t, out, "Risk exception recorded (id=11)")
+}
+
+func TestApprove_RequiredIDAndRemote(t *testing.T) {
+	approveID = 0
+	require.ErrorContains(t, approveCmd.RunE(nil, nil), "--id is required")
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/risk-exceptions/4/approve", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	})
+	approveID = 4
+	t.Cleanup(func() { approveID = 0 })
+	out := captureStdout(t, func() { require.NoError(t, approveCmd.RunE(nil, nil)) })
+	assert.Contains(t, out, "Risk exception 4 approved.")
+}
+
+func TestRevoke_RequiredIDAndRemote(t *testing.T) {
+	revokeID = 0
+	require.ErrorContains(t, revokeCmd.RunE(nil, nil), "--id is required")
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/risk-exceptions/4", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	})
+	revokeID = 4
+	t.Cleanup(func() { revokeID = 0 })
+	out := captureStdout(t, func() { require.NoError(t, revokeCmd.RunE(nil, nil)) })
+	assert.Contains(t, out, "Risk exception 4 revoked.")
+}

--- a/internal/cli/sod/sod_test.go
+++ b/internal/cli/sod/sod_test.go
@@ -1,0 +1,110 @@
+package sod
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	fn()
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func setupRemote(t *testing.T, h http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+}
+
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, "short", truncate("short", 26))
+	assert.Equal(t, "abcde…", truncate("abcdefghij", 6))
+	assert.Equal(t, "x", truncate("xyz", 1))
+}
+
+func TestPolicyList_Remote(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"success":true,"data":{"policies":[],"count":0}}`))
+		})
+		out := captureStdout(t, func() { require.NoError(t, policyListCmd.RunE(nil, nil)) })
+		assert.Contains(t, out, "No separation-of-duties policies defined.")
+	})
+	t.Run("populated", func(t *testing.T) {
+		setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/v1/sod/policies", r.URL.Path)
+			_, _ = w.Write([]byte(`{"success":true,"data":{"count":1,"policies":[{"id":2,"name":"assign-vs-delete","permission_a":"roles.assign","permission_b":"secrets.delete"}]}}`))
+		})
+		out := captureStdout(t, func() { require.NoError(t, policyListCmd.RunE(nil, nil)) })
+		assert.Contains(t, out, "assign-vs-delete")
+		assert.Contains(t, out, "roles.assign")
+		assert.Contains(t, out, "secrets.delete")
+	})
+}
+
+func TestPolicyCreate_RequiredFlagsAndRemote(t *testing.T) {
+	sName, sPermA, sPermB = "", "", ""
+	require.ErrorContains(t, policyCreateCmd.RunE(nil, nil), "are required")
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		_, _ = w.Write([]byte(`{"success":true,"data":{"policy":{"id":5,"name":"p","permission_a":"a","permission_b":"b"}}}`))
+	})
+	sName, sPermA, sPermB, sDesc = "p", "roles.assign", "secrets.delete", "toxic combo"
+	t.Cleanup(func() { sName, sPermA, sPermB, sDesc = "", "", "", "" })
+	out := captureStdout(t, func() { require.NoError(t, policyCreateCmd.RunE(nil, nil)) })
+	assert.Contains(t, out, "Created SoD policy 5")
+	assert.Contains(t, out, "must not be held together")
+}
+
+func TestPolicyDelete_RequiredIDAndRemote(t *testing.T) {
+	sID = 0
+	require.ErrorContains(t, policyDeleteCmd.RunE(nil, nil), "--id is required")
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/sod/policies/5", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	})
+	sID = 5
+	t.Cleanup(func() { sID = 0 })
+	out := captureStdout(t, func() { require.NoError(t, policyDeleteCmd.RunE(nil, nil)) })
+	assert.Contains(t, out, "Deleted SoD policy 5.")
+}
+
+func TestViolations_Remote(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"success":true,"data":{"violations":[],"count":0}}`))
+		})
+		out := captureStdout(t, func() { require.NoError(t, violationsCmd.RunE(nil, nil)) })
+		assert.Contains(t, out, "No separation-of-duties violations.")
+	})
+	t.Run("degraded with a violation", func(t *testing.T) {
+		setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"success":true,"data":{"count":1,"degraded":true,"degraded_reasons":["principal 9 unreadable"],"violations":[{"policy_name":"assign-vs-delete","username":"alice","email":"a@x.io","permission_a":"roles.assign","permission_b":"secrets.delete"}]}}`))
+		})
+		out := captureStdout(t, func() { require.NoError(t, violationsCmd.RunE(nil, nil)) })
+		assert.Contains(t, out, "DEGRADED SCAN")
+		assert.Contains(t, out, "principal 9 unreadable")
+		assert.Contains(t, out, "1 violation(s):")
+		assert.Contains(t, out, "alice <a@x.io>")
+	})
+}

--- a/internal/cli/status/status_test.go
+++ b/internal/cli/status/status_test.go
@@ -1,0 +1,80 @@
+package status
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	fn()
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+// chdirLocalConfig writes a local keyorix.yaml in a temp dir and chdirs there, so
+// both the status display (config.Load("keyorix.yaml")) and InitializeCoreService
+// (config.Load("")) resolve the same local backend.
+func chdirLocalConfig(t *testing.T) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, config.Save("keyorix.yaml", &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "s.db")}},
+	}))
+}
+
+func TestRunStatus_LocalHealthy(t *testing.T) {
+	chdirLocalConfig(t)
+	out := captureStdout(t, func() { require.NoError(t, runStatus(nil, nil)) })
+	assert.Contains(t, out, "System Status")
+	assert.Contains(t, out, "Storage Type: 💾 Local")
+	assert.Contains(t, out, "Healthy")
+}
+
+func TestRunStatus_NoConfigUsesDefaults(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dir := t.TempDir()
+	t.Chdir(dir) // no keyorix.yaml present
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	out := captureStdout(t, func() { require.NoError(t, runStatus(nil, nil)) })
+	assert.Contains(t, out, "No configuration found, using defaults")
+	assert.Contains(t, out, "Storage Type: 💾 Local")
+}
+
+func TestRunPing_LocalRejected(t *testing.T) {
+	chdirLocalConfig(t)
+	err := runPing(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ping command only works with remote storage")
+}
+
+func TestRunPing_NoConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir) // no keyorix.yaml
+	err := runPing(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load configuration")
+}


### PR DESCRIPTION
## test(cli): cover the five 0%%-coverage command packages

Adds test suites for `internal/cli/{breakglass,license,risk,sod,status}` — none had any tests before.

| package | before | after |
|---|---|---|
| license | 0%% | **92.0%%** |
| sod | 0%% | **88.2%%** |
| risk | 0%% | **86.9%%** |
| breakglass | 0%% | **86.8%%** |
| status | 0%% | **36.6%%** |

- **license** (local): `graceOf`/`readToken`/`printStatus` units; `issue` ed25519 key round-trip + RFC3339/missing-key errors; `install` dest-required / invalid-token refusal / baseline write; `status` baseline + fail-safe garbage token.
- **breakglass / sod / risk** (remote): pure helpers (`bgBase`, `truncate`) plus mock-server tests for every command against the real `sendSuccess` envelope, including required-flag guards and degraded-scan banners.
- **status**: `runStatus` local-health + no-config-defaults; `runPing` local and no-config guards. The slow 3-ping success loop (1s sleeps) is intentionally left uncovered.

No production changes. Verified none of these packages have the remote double-`{\"data\"}` envelope bug fixed for project/secret/machine in #890 — they decode bare payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
