### PR TITLE
test(cli): cover run secret-injection and connect helpers

### DIFF
--- a/internal/cli/connect/connect_extra_test.go
+++ b/internal/cli/connect/connect_extra_test.go
@@ -1,0 +1,103 @@
+package connect
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLoopbackHost(t *testing.T) {
+	loopback := []string{"localhost", "127.0.0.1", "127.0.0.5", "::1"}
+	for _, h := range loopback {
+		assert.True(t, isLoopbackHost(h), "%s should be loopback", h)
+	}
+	notLoopback := []string{"example.com", "10.0.0.1", "8.8.8.8", "0.0.0.0", ""}
+	for _, h := range notLoopback {
+		assert.False(t, isLoopbackHost(h), "%s should NOT be loopback", h)
+	}
+}
+
+func cmdWithFlags() *cobra.Command {
+	c := &cobra.Command{}
+	c.Flags().String("api-key", "", "")
+	c.Flags().String("password", "", "")
+	return c
+}
+
+func TestResolveAPIKey(t *testing.T) {
+	t.Run("flag wins", func(t *testing.T) {
+		c := cmdWithFlags()
+		require.NoError(t, c.Flags().Set("api-key", "from-flag"))
+		assert.Equal(t, "from-flag", resolveAPIKey(c))
+	})
+	t.Run("env fallback", func(t *testing.T) {
+		t.Setenv("KEYORIX_API_KEY", "from-env")
+		assert.Equal(t, "from-env", resolveAPIKey(cmdWithFlags()))
+	})
+	t.Run("empty when neither set", func(t *testing.T) {
+		t.Setenv("KEYORIX_API_KEY", "")
+		assert.Equal(t, "", resolveAPIKey(cmdWithFlags()))
+	})
+}
+
+func TestResolveConnectPassword(t *testing.T) {
+	t.Run("flag wins", func(t *testing.T) {
+		c := cmdWithFlags()
+		require.NoError(t, c.Flags().Set("password", "flagpw"))
+		pw, err := resolveConnectPassword(c, "alice")
+		require.NoError(t, err)
+		assert.Equal(t, "flagpw", pw)
+	})
+	t.Run("env fallback", func(t *testing.T) {
+		t.Setenv("KEYORIX_PASSWORD", "envpw")
+		pw, err := resolveConnectPassword(cmdWithFlags(), "alice")
+		require.NoError(t, err)
+		assert.Equal(t, "envpw", pw)
+	})
+}
+
+func TestLoginWithCredentials(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/auth/login", r.URL.Path)
+		_, _ = w.Write([]byte(`{"data":{"token":"session-token-xyz"}}`))
+	}))
+	defer srv.Close()
+
+	tok, err := loginWithCredentials(srv.URL, "alice", "pw", 5*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "session-token-xyz", tok)
+}
+
+func TestLoginWithCredentials_BadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := loginWithCredentials(srv.URL, "alice", "wrong", 5*time.Second)
+	require.Error(t, err)
+}
+
+func TestTestServerConnection(t *testing.T) {
+	t.Run("healthy", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/health", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+		require.NoError(t, testServerConnection(srv.URL, "key", 5*time.Second))
+	})
+	t.Run("unhealthy status is an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+		require.Error(t, testServerConnection(srv.URL, "key", 5*time.Second))
+	})
+}

--- a/internal/cli/run/run_fetch_test.go
+++ b/internal/cli/run/run_fetch_test.go
@@ -1,0 +1,104 @@
+package run
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToEnvKey(t *testing.T) {
+	cases := map[string]string{
+		"db-password": "DB_PASSWORD",
+		"api.key!":    "API_KEY_",
+		"already_ok":  "ALREADY_OK",
+		"MixedCase":   "MIXEDCASE",
+		"1two":        "1TWO",
+		"":            "",
+		"a b/c":       "A_B_C",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, toEnvKey(in), "toEnvKey(%q)", in)
+	}
+}
+
+// TestFetchSecretsRemote drives the remote secret-injection path against the real
+// sendSuccess envelope: resolve project → env → list secrets → fetch each value,
+// keyed by toEnvKey(name).
+func TestFetchSecretsRemote(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		case "/api/v1/environments":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"environments":[{"id":2,"name":"dev"}]}}`))
+		case "/api/v1/secrets":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[{"id":9,"name":"db-password"}]}}`))
+		case "/api/v1/secrets/9":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"value":"s3cr3t"}}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	got, err := fetchSecretsRemote(context.Background(), srv.URL, "tok", "web", "dev")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"DB_PASSWORD": "s3cr3t"}, got)
+}
+
+func TestFetchSecretsRemote_ProjectNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[]}}`))
+	}))
+	defer srv.Close()
+
+	_, err := fetchSecretsRemote(context.Background(), srv.URL, "tok", "ghost", "dev")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `project "ghost" not found on server`)
+}
+
+func TestFetchSecretsEmbedded(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "s.db")}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	ctx := context.Background()
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	project, err := svc.CreateProjectWithEnvs(ctx, "web", "", []string{"dev"})
+	require.NoError(t, err)
+	envs, err := svc.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+	_, err = svc.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "db-password", Value: []byte("s3cr3t"), ProjectID: project.ID,
+		EnvironmentID: envs[0].ID, Type: "password", CreatedBy: "test",
+	})
+	require.NoError(t, err)
+
+	got, err := fetchSecretsEmbedded(ctx, "web", "dev")
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3t", got["DB_PASSWORD"])
+
+	_, err = fetchSecretsEmbedded(ctx, "ghost", "dev")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}


### PR DESCRIPTION
## test(cli): cover run secret-injection and connect helpers

Next coverage tier.

### internal/cli/run  16.9% → **70.1%**
- `toEnvKey` name→env-var mapping (edge cases: punctuation, leading digit, empty).
- `fetchSecretsRemote`: the full project→env→list-secrets→fetch-value flow against the real `sendSuccess` envelope, plus project-not-found.
- `fetchSecretsEmbedded`: embedded core → injected env map, plus not-found.

(The existing tests already cover `buildChildEnv`/`filterSensitiveEnv`/`isSensitiveKeyorixEnv` — the credential-leak-prevention core.)

### internal/cli/connect  17.1% → **43.2%**
- `isLoopbackHost` edge cases (IPv6 `::1`, non-loopback IPs, empty).
- `resolveAPIKey` / `resolveConnectPassword` flag-vs-env resolution.
- `loginWithCredentials` token exchange (+ bad-status error), `testServerConnection` health check.

No production changes. Verified `run`’s own `apiClient` and `connect`’s manual login decode are both correct (not the #890 double-envelope bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
