### PR TITLE
test(cli): add remote/validation coverage for 9 CLI packages

### DIFF
--- a/internal/cli/accessreview/accessreview_remote_test.go
+++ b/internal/cli/accessreview/accessreview_remote_test.go
@@ -1,0 +1,395 @@
+package accessreview
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccessReview_EmptyResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"entries":[],"count":0}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject := flagProject
+	defer func() { flagProject = origProject }()
+	flagProject = 3
+	require.NoError(t, AccessReviewCmd.RunE(AccessReviewCmd, nil))
+}
+
+func TestAccessReview_WithSourceEntry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"entries":[
+			{"principal_type":"user","principal_name":"bob","email":"bob@x.io","source":"direct_share","access_level":"read","secret_name":"db-pass"},
+			{"principal_type":"group","principal_name":"devs","source":"group_share","access_level":"write","secret_name":"api-key"}
+		],"count":2}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject := flagProject
+	defer func() { flagProject = origProject }()
+	flagProject = 5
+	require.NoError(t, AccessReviewCmd.RunE(AccessReviewCmd, nil))
+}
+
+func TestAccessReview_WithRoleEntry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"entries":[
+			{"principal_type":"user","principal_name":"alice","email":"a@x.io","source":"role","role_name":"editor","access_level":"write","environment_id":2}
+		],"count":1}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject := flagProject
+	defer func() { flagProject = origProject }()
+	flagProject = 7
+	require.NoError(t, AccessReviewCmd.RunE(AccessReviewCmd, nil))
+}
+
+func TestRunDecision_Revoke_WithStubServer(t *testing.T) {
+	var gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject, origSource, origPrincipalID, origRoleID, origPrincipalType :=
+		dProject, dSource, dPrincipalID, dRoleID, dPrincipalType
+	defer func() {
+		dProject = origProject
+		dSource = origSource
+		dPrincipalID = origPrincipalID
+		dRoleID = origRoleID
+		dPrincipalType = origPrincipalType
+	}()
+	dProject = 4
+	dSource = "role"
+	dPrincipalType = "user"
+	dPrincipalID = 10
+	dRoleID = 5
+
+	require.NoError(t, runDecision("revoke"))
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v1/projects/4/access-review/revoke", gotPath)
+}
+
+func TestRunDecision_Attest_WithStubServer(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject, origSource, origPrincipalID, origRoleID, origPrincipalType :=
+		dProject, dSource, dPrincipalID, dRoleID, dPrincipalType
+	defer func() {
+		dProject = origProject
+		dSource = origSource
+		dPrincipalID = origPrincipalID
+		dRoleID = origRoleID
+		dPrincipalType = origPrincipalType
+	}()
+	dProject = 4
+	dSource = "role"
+	dPrincipalType = "group"
+	dPrincipalID = 7
+	dRoleID = 3
+
+	require.NoError(t, runDecision("attest"))
+	assert.Equal(t, "/api/v1/projects/4/access-review/attest", gotPath)
+}
+
+func TestRunDecision_ShareSource_WithSecretID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject, origSource, origPrincipalID, origSecretID, origRoleID :=
+		dProject, dSource, dPrincipalID, dSecretID, dRoleID
+	defer func() {
+		dProject = origProject
+		dSource = origSource
+		dPrincipalID = origPrincipalID
+		dSecretID = origSecretID
+		dRoleID = origRoleID
+	}()
+	dProject = 4
+	dSource = "direct_share"
+	dPrincipalID = 8
+	dSecretID = 12
+	dRoleID = 0
+
+	require.NoError(t, runDecision("revoke"))
+}
+
+func TestRunDecision_NoServerConnection(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	origProject, origSource, origPrincipalID, origRoleID :=
+		dProject, dSource, dPrincipalID, dRoleID
+	defer func() {
+		dProject = origProject
+		dSource = origSource
+		dPrincipalID = origPrincipalID
+		dRoleID = origRoleID
+	}()
+	dProject = 4
+	dSource = "role"
+	dPrincipalID = 1
+	dRoleID = 2
+
+	err := runDecision("revoke")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+// Campaign subcommand tests
+
+func TestCampaignListCmd_RequiresProjectID(t *testing.T) {
+	origProject := cProject
+	defer func() { cProject = origProject }()
+	cProject = 0
+
+	err := campaignListCmd.RunE(campaignListCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project-id is required")
+}
+
+func TestCampaignListCmd_WithStubServer(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"campaigns":[{"campaign":{"id":1,"project_id":5,"name":"Q1 Review","state":"open"},"progress":{"total":5,"pending":3,"attested":1,"revoked":1}}],"count":1}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject := cProject
+	defer func() { cProject = origProject }()
+	cProject = 5
+
+	require.NoError(t, campaignListCmd.RunE(campaignListCmd, nil))
+	assert.Equal(t, "/api/v1/projects/5/access-review/campaigns", gotPath)
+}
+
+func TestCampaignListCmd_EmptyResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"campaigns":[],"count":0}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject := cProject
+	defer func() { cProject = origProject }()
+	cProject = 5
+
+	require.NoError(t, campaignListCmd.RunE(campaignListCmd, nil))
+}
+
+func TestCampaignShowCmd_RequiresBothIDs(t *testing.T) {
+	origProject, origCampaign := cProject, cCampaign
+	defer func() { cProject = origProject; cCampaign = origCampaign }()
+
+	cProject = 0
+	cCampaign = 0
+	err := campaignShowCmd.RunE(campaignShowCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project-id and --campaign-id are required")
+
+	cProject = 5
+	cCampaign = 0
+	err = campaignShowCmd.RunE(campaignShowCmd, nil)
+	require.Error(t, err)
+}
+
+func TestCampaignShowCmd_WithStubServer(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"campaign":{"id":3,"project_id":5,"name":"Q1","state":"open"},"items":[{"id":1,"principal_type":"user","principal_name":"alice","source":"role","role_name":"editor","access_level":"write","decision":"pending"}],"progress":{"total":1,"pending":1}}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject, origCampaign := cProject, cCampaign
+	defer func() { cProject = origProject; cCampaign = origCampaign }()
+	cProject = 5
+	cCampaign = 3
+
+	require.NoError(t, campaignShowCmd.RunE(campaignShowCmd, nil))
+	assert.Equal(t, "/api/v1/projects/5/access-review/campaigns/3", gotPath)
+}
+
+func TestCampaignOpenCmd_RequiresProjectID(t *testing.T) {
+	origProject := cProject
+	defer func() { cProject = origProject }()
+	cProject = 0
+
+	err := campaignOpenCmd.RunE(campaignOpenCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project-id is required")
+}
+
+func TestCampaignOpenCmd_WithStubServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		_, _ = w.Write([]byte(`{"data":{"campaign":{"id":10,"project_id":5,"name":"Test Campaign","state":"open"},"progress":{"total":3,"pending":3,"attested":0,"revoked":0}}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject, origName := cProject, cName
+	defer func() { cProject = origProject; cName = origName }()
+	cProject = 5
+	cName = "Test Campaign"
+
+	require.NoError(t, campaignOpenCmd.RunE(campaignOpenCmd, nil))
+}
+
+func TestCampaignDecideCmd_RequiresAllIDs(t *testing.T) {
+	origProject, origCampaign, origItem, origAction :=
+		cProject, cCampaign, cItem, cAction
+	defer func() {
+		cProject = origProject
+		cCampaign = origCampaign
+		cItem = origItem
+		cAction = origAction
+	}()
+
+	cProject = 0
+	cCampaign = 1
+	cItem = 1
+	cAction = "attest"
+	err := campaignDecideCmd.RunE(campaignDecideCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project-id, --campaign-id and --item-id are required")
+}
+
+func TestCampaignDecideCmd_BadAction(t *testing.T) {
+	origProject, origCampaign, origItem, origAction :=
+		cProject, cCampaign, cItem, cAction
+	defer func() {
+		cProject = origProject
+		cCampaign = origCampaign
+		cItem = origItem
+		cAction = origAction
+	}()
+	cProject = 5
+	cCampaign = 3
+	cItem = 1
+	cAction = "approve" // invalid
+
+	err := campaignDecideCmd.RunE(campaignDecideCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--action must be attest or revoke")
+}
+
+func TestCampaignDecideCmd_WithStubServer(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject, origCampaign, origItem, origAction, origReason :=
+		cProject, cCampaign, cItem, cAction, cReason
+	defer func() {
+		cProject = origProject
+		cCampaign = origCampaign
+		cItem = origItem
+		cAction = origAction
+		cReason = origReason
+	}()
+	cProject = 5
+	cCampaign = 3
+	cItem = 7
+	cAction = "attest"
+	cReason = "reviewed and approved"
+
+	require.NoError(t, campaignDecideCmd.RunE(campaignDecideCmd, nil))
+	assert.Equal(t, "/api/v1/projects/5/access-review/campaigns/3/items/7/decide", gotPath)
+}
+
+func TestCampaignCloseCmd_RequiresBothIDs(t *testing.T) {
+	origProject, origCampaign := cProject, cCampaign
+	defer func() { cProject = origProject; cCampaign = origCampaign }()
+	cProject = 0
+	cCampaign = 0
+
+	err := campaignCloseCmd.RunE(campaignCloseCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project-id and --campaign-id are required")
+}
+
+func TestCampaignCloseCmd_WithStubServer(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"campaign":{"id":3,"project_id":5,"name":"Q1","state":"closed"},"progress":{"total":3,"pending":0,"attested":2,"revoked":1}}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject, origCampaign, origForce := cProject, cCampaign, cForce
+	defer func() { cProject = origProject; cCampaign = origCampaign; cForce = origForce }()
+	cProject = 5
+	cCampaign = 3
+	cForce = false
+
+	require.NoError(t, campaignCloseCmd.RunE(campaignCloseCmd, nil))
+	assert.Equal(t, "/api/v1/projects/5/access-review/campaigns/3/close", gotPath)
+}
+
+func TestCampaignListCmd_DegradedFlagRendered(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"campaigns":[
+			{"campaign":{"id":1,"project_id":5,"name":"Q1","state":"open","degraded":true,"degraded_reasons":["secret 42 unreadable"]},"progress":{"total":2,"pending":2}}
+		],"count":1}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject := cProject
+	defer func() { cProject = origProject }()
+	cProject = 5
+	require.NoError(t, campaignListCmd.RunE(campaignListCmd, nil))
+}
+
+func TestProgressStr(t *testing.T) {
+	p := progressView{Total: 10, Pending: 5, Attested: 3, Revoked: 2}
+	got := progressStr(p)
+	assert.Contains(t, got, "10 total")
+	assert.Contains(t, got, "5 pending")
+	assert.Contains(t, got, "3 attested")
+	assert.Contains(t, got, "2 revoked")
+}

--- a/internal/cli/auth/auth_remote_test.go
+++ b/internal/cli/auth/auth_remote_test.go
@@ -1,0 +1,126 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunLogin_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Set the API key via env so no interactive prompt is triggered.
+	t.Setenv("KEYORIX_API_KEY", "kx_env_secret")
+
+	require.NoError(t, loginCmd.Flags().Set("server", "https://keyorix.example.com"))
+	t.Cleanup(func() {
+		_ = loginCmd.Flags().Set("server", "")
+		loginCmd.Flags().Lookup("server").Changed = false
+	})
+
+	require.NoError(t, runLogin(loginCmd, nil))
+
+	// A keyorix.yaml should have been written.
+	_, err := os.Stat(filepath.Join(dir, "keyorix.yaml"))
+	assert.NoError(t, err, "keyorix.yaml should be created by runLogin")
+}
+
+func TestRunLogin_NoAPIKeyNoServer(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_API_KEY", "")
+
+	err := runLogin(loginCmd, nil)
+	// Should fail: either "API key is required" or "server URL is required" depending
+	// on whether a config with remote settings exists.
+	require.Error(t, err)
+}
+
+func TestRunLogin_ServerFromExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Pre-write a keyorix.yaml with a remote section so runLogin can pick up the server.
+	yaml := "storage:\n  type: remote\n  remote:\n    base_url: https://keyorix.example.com\n    tls_verify: true\n    timeout_seconds: 30\n"
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(yaml), 0600))
+
+	t.Setenv("KEYORIX_API_KEY", "kx_env_key")
+	require.NoError(t, runLogin(loginCmd, nil))
+}
+
+func TestRunLogout_WritesLocalConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Start with a remote config.
+	yaml := "storage:\n  type: remote\n  remote:\n    base_url: https://keyorix.example.com\n"
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(yaml), 0600))
+
+	require.NoError(t, runLogout(logoutCmd, nil))
+
+	// Should have written a local-mode config.
+	data, err := os.ReadFile("keyorix.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "local")
+}
+
+func TestRunLogout_NoExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	// No keyorix.yaml — runLogout should fail because config.Load returns an error
+	// when no file is present.
+	err := runLogout(logoutCmd, nil)
+	require.Error(t, err)
+}
+
+func TestRunStatus_LocalStorage(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	yaml := "storage:\n  type: local\n  database:\n    path: ./secrets.db\n"
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(yaml), 0600))
+
+	require.NoError(t, runStatus(statusCmd, nil))
+}
+
+func TestRunStatus_RemoteStorage(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	yaml := "storage:\n  type: remote\n  remote:\n    base_url: https://keyorix.example.com\n    api_key: kx_tok\n"
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(yaml), 0600))
+
+	require.NoError(t, runStatus(statusCmd, nil))
+}
+
+func TestRunStatus_RemoteStorage_NoAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	yaml := "storage:\n  type: remote\n  remote:\n    base_url: https://keyorix.example.com\n"
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(yaml), 0600))
+
+	require.NoError(t, runStatus(statusCmd, nil))
+}
+
+func TestRunStatus_RemoteStorage_NilRemote(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// type=remote but no remote section — exercises the nil-remote branch.
+	yaml := "storage:\n  type: remote\n"
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(yaml), 0600))
+
+	require.NoError(t, runStatus(statusCmd, nil))
+}
+
+func TestRunStatus_MissingConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	// No config file — runStatus prints "No configuration found" and returns nil.
+	require.NoError(t, runStatus(statusCmd, nil))
+}

--- a/internal/cli/bundle/bundle_remote_test.go
+++ b/internal/cli/bundle/bundle_remote_test.go
@@ -1,0 +1,110 @@
+package bundle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildCmd_MissingSrcFile verifies that after the --src/--out flag guards
+// pass, a missing src directory is caught when the build tries to scan it.
+func TestBuildCmd_MissingSrcFile(t *testing.T) {
+	origS, origO, origV, origK, origSK, origR :=
+		buildSrc, buildOut, buildVersion, buildKeyID, buildSignKey, buildReleased
+	defer func() {
+		buildSrc = origS
+		buildOut = origO
+		buildVersion = origV
+		buildKeyID = origK
+		buildSignKey = origSK
+		buildReleased = origR
+	}()
+	buildSrc = "/definitely/does/not/exist"
+	buildOut = filepath.Join(t.TempDir(), "out.tar.gz")
+	buildVersion = "v0.99.0"
+	buildKeyID = "key-2026"
+	buildReleased = ""
+
+	// buildSignKey points to a non-existent file — the error should be about
+	// reading the signing key.
+	buildSignKey = "/does/not/exist/key.pem"
+
+	err := buildCmd.RunE(buildCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read signing key")
+}
+
+// TestBuildCmd_ValidReleasedAt verifies that a valid --released-at parses without
+// error (further errors come from missing sign-key, which is expected).
+func TestBuildCmd_ValidReleasedAt(t *testing.T) {
+	origS, origO, origV, origK, origSK, origR :=
+		buildSrc, buildOut, buildVersion, buildKeyID, buildSignKey, buildReleased
+	defer func() {
+		buildSrc = origS
+		buildOut = origO
+		buildVersion = origV
+		buildKeyID = origK
+		buildSignKey = origSK
+		buildReleased = origR
+	}()
+	buildSrc = "/does/not/matter"
+	buildOut = filepath.Join(t.TempDir(), "out.tar.gz")
+	buildVersion = "v0.99.0"
+	buildKeyID = "key-2026"
+	buildSignKey = "/missing-key.pem"
+	buildReleased = "2026-07-01T00:00:00Z"
+
+	err := buildCmd.RunE(buildCmd, nil)
+	require.Error(t, err)
+	// The RFC3339 date was valid — error is about reading the key, not parsing the date.
+	assert.NotContains(t, err.Error(), "--released-at must be RFC3339")
+}
+
+// TestVerifyCmd_MissingBundle verifies that opening a nonexistent bundle path
+// produces an error.
+func TestVerifyCmd_MissingBundle(t *testing.T) {
+	origV := verifyInstalled
+	defer func() { verifyInstalled = origV }()
+	verifyInstalled = ""
+
+	err := verifyCmd.RunE(verifyCmd, []string{"/nonexistent/bundle.tar.gz"})
+	require.Error(t, err)
+	// Could be "load trusted keys" or "open bundle" depending on DefaultRegistry.
+	assert.Error(t, err)
+}
+
+// TestImportCmd_MissingBundleFile verifies that --dest passes the guard but a
+// missing bundle file is caught next (after the license gate).
+func TestImportCmd_MissingLicensePath(t *testing.T) {
+	origD, origL := importDest, importLicense
+	defer func() { importDest = origD; importLicense = origL }()
+	importDest = t.TempDir()
+	importLicense = "/nonexistent/license.tok"
+
+	err := importCmd.RunE(importCmd, []string{"/some/bundle.tar.gz"})
+	require.Error(t, err)
+	// Error is about reading the license file, not about --dest.
+	assert.Contains(t, err.Error(), "read license")
+}
+
+// TestConfiguredDeploymentID_NoConfig verifies that configuredDeploymentID returns
+// "" when no config file is present.
+func TestConfiguredDeploymentID_NoConfig(t *testing.T) {
+	t.Setenv("KEYORIX_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.yaml"))
+	assert.Equal(t, "", configuredDeploymentID())
+}
+
+// TestConfiguredDeploymentID_FromConfig verifies that configuredDeploymentID
+// picks up license.deployment_id from a real config file.
+func TestConfiguredDeploymentID_FromConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	yaml := "license:\n  deployment_id: \"test-deploy-123\"\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(yaml), 0600))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+
+	assert.Equal(t, "test-deploy-123", configuredDeploymentID())
+}

--- a/internal/cli/config/config_remote_test.go
+++ b/internal/cli/config/config_remote_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	appconfig "github.com/keyorixhq/keyorix/internal/config"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cfgForLocal(dbPath string) appconfig.Config {
+	var c appconfig.Config
+	c.Storage.Type = "local"
+	c.Storage.Database.Path = dbPath
+	return c
+}
+
+// newSetRemoteCmd builds a minimal cobra.Command with the set-remote flags wired.
+func newSetRemoteCmd(url, apiKey string) *cobra.Command {
+	cmd := &cobra.Command{Use: "set-remote"}
+	cmd.Flags().String("url", url, "")
+	cmd.Flags().String("api-key", apiKey, "")
+	cmd.Flags().Int("timeout", 30, "")
+	return cmd
+}
+
+func TestRunSetRemote_WritesConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := newSetRemoteCmd("https://keyorix.example.com", "")
+	t.Setenv("KEYORIX_API_KEY", "")
+	require.NoError(t, runSetRemote(cmd, nil))
+
+	_, err := os.Stat(filepath.Join(dir, "keyorix.yaml"))
+	assert.NoError(t, err, "keyorix.yaml should be created by set-remote")
+}
+
+func TestRunSetRemote_WithAPIKeyFlag(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := newSetRemoteCmd("https://keyorix.example.com", "kx_secret")
+	require.NoError(t, runSetRemote(cmd, nil))
+}
+
+func TestRunUseLocal_WritesConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := &cobra.Command{}
+	require.NoError(t, runUseLocal(cmd, nil))
+
+	_, err := os.Stat(filepath.Join(dir, "keyorix.yaml"))
+	assert.NoError(t, err, "keyorix.yaml should be created by use-local")
+}
+
+func TestRunStatus_LocalConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	yamlContent := "storage:\n  type: local\n  database:\n    path: ./test.db\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keyorix.yaml"), []byte(yamlContent), 0600))
+
+	cmd := &cobra.Command{}
+	require.NoError(t, runStatus(cmd, nil))
+}
+
+func TestRunStatus_RemoteConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	yamlContent := "storage:\n  type: remote\n  remote:\n    base_url: https://keyorix.example.com\n    api_key: kx_secret\n    timeout_seconds: 30\n    tls_verify: true\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keyorix.yaml"), []byte(yamlContent), 0600))
+
+	cmd := &cobra.Command{}
+	require.NoError(t, runStatus(cmd, nil))
+}
+
+func TestRunStatus_MissingConfig_DefaultsApply(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	// No keyorix.yaml — runStatus falls back to defaults, should not error.
+	cmd := &cobra.Command{}
+	_ = runStatus(cmd, nil)
+}
+
+func TestRunTestConnection_LocalExistingDB(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	dbPath := filepath.Join(dir, "secrets.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte{}, 0600))
+
+	yaml := "storage:\n  type: local\n  database:\n    path: " + dbPath + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keyorix.yaml"), []byte(yaml), 0600))
+
+	cmd := &cobra.Command{}
+	require.NoError(t, runTestConnection(cmd, nil))
+}
+
+func TestRunTestConnection_LocalMissingDB(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	yaml := "storage:\n  type: local\n  database:\n    path: /nonexistent/secrets.db\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keyorix.yaml"), []byte(yaml), 0600))
+
+	cmd := &cobra.Command{}
+	// Missing DB is a warning, not an error from testLocalConnection.
+	require.NoError(t, runTestConnection(cmd, nil))
+}
+
+func TestTestRemoteConnection_NilRemoteConfig(t *testing.T) {
+	c := &appconfig.Config{}
+	c.Storage.Type = "remote"
+	// c.Storage.Remote is nil intentionally
+	err := testRemoteConnection(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote configuration not found")
+}
+
+func TestTestLocalConnection_EmptyPath(t *testing.T) {
+	c := cfgForLocal("")
+	// Empty DB path falls back to ./secrets.db — should not error.
+	require.NoError(t, testLocalConnection(&c))
+}
+
+func TestMaskAPIKey_ExactlyEight(t *testing.T) {
+	// len == 8: the <= 8 branch returns "***"
+	assert.Equal(t, "***", maskAPIKey("12345678"))
+}
+
+func TestMaskAPIKey_NineChars(t *testing.T) {
+	// 9 chars: first4 + "..." + last4
+	assert.Equal(t, "1234...6789", maskAPIKey("123456789"))
+}

--- a/internal/cli/connect/connect_remote_test.go
+++ b/internal/cli/connect/connect_remote_test.go
@@ -1,0 +1,126 @@
+package connect
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunConnect_WithAPIKeyAndHealthCheck(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	t.Setenv("KEYORIX_API_KEY", "test-key")
+
+	require.NoError(t, ConnectCmd.Flags().Set("test", "true"))
+	require.NoError(t, ConnectCmd.Flags().Set("insecure", "true"))
+	t.Cleanup(func() {
+		_ = ConnectCmd.Flags().Set("test", "true")
+		_ = ConnectCmd.Flags().Set("insecure", "false")
+	})
+
+	require.NoError(t, runConnect(ConnectCmd, []string{srv.URL}))
+}
+
+func TestRunConnect_RefusesNonHTTPS(t *testing.T) {
+	require.NoError(t, ConnectCmd.Flags().Set("insecure", "false"))
+	t.Cleanup(func() { _ = ConnectCmd.Flags().Set("insecure", "false") })
+
+	err := runConnect(ConnectCmd, []string{"http://external.example.com"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-HTTPS")
+}
+
+func TestRunConnect_InvalidTimeout(t *testing.T) {
+	require.NoError(t, ConnectCmd.Flags().Set("timeout", "notaduration"))
+	t.Cleanup(func() { _ = ConnectCmd.Flags().Set("timeout", "30s") })
+
+	err := runConnect(ConnectCmd, []string{"https://keyorix.example.com"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid timeout")
+}
+
+func TestRunConnect_HealthCheckFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	t.Setenv("KEYORIX_API_KEY", "test-key")
+
+	require.NoError(t, ConnectCmd.Flags().Set("test", "true"))
+	require.NoError(t, ConnectCmd.Flags().Set("insecure", "true"))
+	require.NoError(t, ConnectCmd.Flags().Set("timeout", "5s"))
+	t.Cleanup(func() {
+		_ = ConnectCmd.Flags().Set("test", "true")
+		_ = ConnectCmd.Flags().Set("insecure", "false")
+		_ = ConnectCmd.Flags().Set("timeout", "30s")
+	})
+
+	err := runConnect(ConnectCmd, []string{srv.URL})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection test failed")
+}
+
+func TestRunDisconnect_WhenEmbedded(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+
+	// With no config file, LoadCLIConfig returns a default (embedded) config.
+	require.NoError(t, runDisconnect(nil, nil))
+}
+
+func TestRunDisconnect_FromClientMode(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	configDir := filepath.Join(dir, "config", "keyorix")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+
+	require.NoError(t, os.MkdirAll(configDir, 0750))
+	cliYAML := "mode: client\nclient:\n  endpoint: https://keyorix.example.com\n"
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "cli.yaml"), []byte(cliYAML), 0600))
+
+	require.NoError(t, runDisconnect(nil, nil))
+}
+
+func TestRunStatus_EmbeddedMode(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	// No cli.yaml → defaults to embedded mode, runStatus should succeed.
+	require.NoError(t, runStatus(nil, nil))
+}
+
+func TestRunStatus_ClientMode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	configDir := filepath.Join(dir, "config", "keyorix")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+
+	require.NoError(t, os.MkdirAll(configDir, 0750))
+	cliYAML := "mode: client\nclient:\n  endpoint: " + srv.URL + "\n  auth:\n    type: api_key\n    api_key: tok\n  timeout: 5s\n"
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "cli.yaml"), []byte(cliYAML), 0600))
+
+	require.NoError(t, runStatus(nil, nil))
+}

--- a/internal/cli/encryption/encryption_remote_test.go
+++ b/internal/cli/encryption/encryption_remote_test.go
@@ -1,0 +1,142 @@
+package encryption
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func encryptionEnabledLocalCfg() *config.Config {
+	return &config.Config{
+		Storage: config.StorageConfig{
+			Type: "local",
+			Encryption: config.EncryptionConfig{
+				Enabled: true,
+			},
+		},
+	}
+}
+
+// TestRotateWithConfig_DryRunSkipsConfirm verifies that --dry-run does not
+// require --confirm (it returns a different error about missing env/key, not
+// about --confirm).
+func TestRotateWithConfig_DryRunSkipsConfirmGate(t *testing.T) {
+	cfg := encryptionEnabledLocalCfg()
+	// dry-run=true skips the --confirm gate; it will then fail on key init
+	// (no KEYORIX_MASTER_PASSWORD / no real key files) — but NOT on --confirm.
+	err := rotateWithConfig(cfg, false, true)
+	if err != nil {
+		assert.NotContains(t, err.Error(), "--confirm",
+			"dry-run should not require --confirm; got: %v", err)
+	}
+}
+
+// TestMasterPassphrase_PasswordProviderRequiresEnvVar verifies the default
+// (password) provider path of masterPassphrase.
+func TestMasterPassphrase_PasswordProviderRequiresEnvVar(t *testing.T) {
+	cfg := &config.Config{
+		Storage: config.StorageConfig{
+			Encryption: config.EncryptionConfig{
+				Enabled: true,
+				// KeyProvider.Type is zero-value "" → treated as "password".
+			},
+		},
+	}
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "")
+	_, err := masterPassphrase(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "KEYORIX_MASTER_PASSWORD")
+}
+
+func TestMasterPassphrase_PasswordProviderReturnsValue(t *testing.T) {
+	cfg := &config.Config{
+		Storage: config.StorageConfig{
+			Encryption: config.EncryptionConfig{
+				Enabled: true,
+			},
+		},
+	}
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "supersecret")
+	pw, err := masterPassphrase(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "supersecret", pw)
+}
+
+func TestMasterPassphrase_NonPasswordProviderReturnsEmpty(t *testing.T) {
+	cfg := &config.Config{
+		Storage: config.StorageConfig{
+			Encryption: config.EncryptionConfig{
+				Enabled: true,
+				KeyProvider: config.KeyProviderConfig{
+					Type: "file",
+				},
+			},
+		},
+	}
+	// Should return ("", nil) without reading KEYORIX_MASTER_PASSWORD.
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "should-not-be-used")
+	pw, err := masterPassphrase(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "", pw)
+}
+
+func TestEncryptionCmdStructure(t *testing.T) {
+	names := make(map[string]bool)
+	for _, c := range EncryptionCmd.Commands() {
+		names[c.Name()] = true
+	}
+	for _, expected := range []string{"init", "status", "rotate", "upgrade-aad", "validate", "fix-perms"} {
+		assert.True(t, names[expected], "expected subcommand %q to be registered", expected)
+	}
+}
+
+func TestRotateCmd_HasExpectedFlags(t *testing.T) {
+	for _, f := range []string{"confirm", "dry-run"} {
+		assert.NotNil(t, rotateCmd.Flags().Lookup(f), "rotate should have --%s flag", f)
+	}
+}
+
+// TestRunInit_EncryptionDisabled verifies that `encryption init` exits cleanly
+// (without error) when encryption is disabled in config — it only prints a message.
+func TestRunInit_EncryptionDisabled(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Write a config with encryption disabled.
+	yaml := "storage:\n  type: local\n  encryption:\n    enabled: false\n"
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(yaml), 0600))
+
+	err := initCmd.RunE(initCmd, nil)
+	require.NoError(t, err)
+}
+
+// TestRunStatus_EncryptionDisabled verifies that `encryption status` exits
+// cleanly when encryption is disabled.
+func TestRunStatus_EncryptionDisabled(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	yaml := "storage:\n  type: local\n  encryption:\n    enabled: false\n"
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(yaml), 0600))
+
+	err := statusCmd.RunE(statusCmd, nil)
+	require.NoError(t, err)
+}
+
+// TestRunStatus_EncryptionEnabled_NoPassword verifies that `encryption status`
+// with encryption enabled returns nil (it logs the error, does not propagate it).
+func TestRunStatus_EncryptionEnabled_NoPassword(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "")
+
+	yaml := "storage:\n  type: local\n  encryption:\n    enabled: true\n    dek_path: ./dek.key\n    salt_path: ./salt.bin\n"
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(yaml), 0600))
+
+	// runStatus with encryption enabled but no password logs a warning and returns nil.
+	err := statusCmd.RunE(statusCmd, nil)
+	require.NoError(t, err)
+}

--- a/internal/cli/migrate/migrate_remote_test.go
+++ b/internal/cli/migrate/migrate_remote_test.go
@@ -1,0 +1,64 @@
+package migrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigrateCmdWiring verifies the MigrateCmd wiring — already covered by
+// migrate_test.go; this file adds additional flag-validation paths that are
+// not yet exercised.
+
+// TestUserToMachineCmd_TypeFlagDefault verifies the default value for --type.
+func TestUserToMachineCmd_TypeFlagDefault(t *testing.T) {
+	f := userToMachineCmd.Flags().Lookup("type")
+	require.NotNil(t, f)
+	assert.Equal(t, "service", f.DefValue)
+}
+
+// TestUserToMachineCmd_KeepUserFlagDefault verifies --keep-user defaults to false.
+func TestUserToMachineCmd_KeepUserFlagDefault(t *testing.T) {
+	f := userToMachineCmd.Flags().Lookup("keep-user")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+// TestUserToMachineCmd_ProjectFlagEmpty verifies --project default is "".
+func TestUserToMachineCmd_ProjectFlagDefault(t *testing.T) {
+	f := userToMachineCmd.Flags().Lookup("project")
+	require.NotNil(t, f)
+	assert.Equal(t, "", f.DefValue)
+}
+
+// TestRunUserToMachine_ByRequired_CobraBypassPath re-exercises the guard via the
+// package-level var (already covered by migrate_extra_test.go; included here for
+// package-level isolation clarity).
+func TestRunUserToMachine_ByRequiredGuard(t *testing.T) {
+	orig := u2mBy
+	defer func() { u2mBy = orig }()
+	u2mBy = ""
+
+	err := runUserToMachine(userToMachineCmd, []string{"service-account"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "acting admin email is required")
+}
+
+// TestMigrateCmd_UseField checks the Use field to guard against accidental renames.
+func TestMigrateCmd_UseField(t *testing.T) {
+	assert.Equal(t, "migrate", MigrateCmd.Use)
+}
+
+// TestUserToMachineCmd_UseField verifies the sub-command Use text.
+func TestUserToMachineCmd_UseField(t *testing.T) {
+	assert.Equal(t, "user-to-machine <username>", userToMachineCmd.Use)
+}
+
+// TestUserToMachineCmd_ByFlagIsRequired verifies cobra marks --by as required.
+func TestUserToMachineCmd_ByFlagIsRequired(t *testing.T) {
+	const cobraRequired = "cobra_annotation_bash_completion_one_required_flag"
+	f := userToMachineCmd.Flags().Lookup("by")
+	require.NotNil(t, f)
+	assert.NotEmpty(t, f.Annotations[cobraRequired])
+}

--- a/internal/cli/secret/secret_remote_test.go
+++ b/internal/cli/secret/secret_remote_test.go
@@ -1,0 +1,143 @@
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunGet_NoSelector(t *testing.T) {
+	origID, origName, origRef := getID, getName, getRef
+	defer func() { getID = origID; getName = origName; getRef = origRef }()
+	getID = 0
+	getName = ""
+	getRef = ""
+
+	err := runGet(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "one of --id, --name, or --ref is required")
+}
+
+func TestRunGet_MultipleSelectors(t *testing.T) {
+	origID, origName, origRef := getID, getName, getRef
+	defer func() { getID = origID; getName = origName; getRef = origRef }()
+	getID = 1
+	getName = "db-pass"
+	getRef = ""
+
+	err := runGet(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestRunGet_ByIDRemote(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"id":5,"name":"db-pass","type":"password","project_id":1,"environment_id":1,"created_by":"admin","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	origID, origName, origRef, origShow := getID, getName, getRef, getShowValue
+	defer func() { getID = origID; getName = origName; getRef = origRef; getShowValue = origShow }()
+	getID = 5
+	getName = ""
+	getRef = ""
+	getShowValue = false
+
+	require.NoError(t, runGet(nil, nil))
+	assert.Equal(t, "/api/v1/secrets/5", gotPath)
+}
+
+func TestRunGet_ByRefRemote(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		// Return a minimal secret + value so displaySecret does not nil-deref.
+		_, _ = w.Write([]byte(`{"data":{"secret":{"id":1,"name":"db-pass","type":"password","project_id":1,"environment_id":1,"created_by":"admin","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"},"value":"supersecret"}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	origID, origName, origRef, origShow := getID, getName, getRef, getShowValue
+	defer func() { getID = origID; getName = origName; getRef = origRef; getShowValue = origShow }()
+	getID = 0
+	getName = ""
+	getRef = "myproject/prod/db-pass"
+	getShowValue = false
+
+	require.NoError(t, runGet(nil, nil))
+	// The ref is passed as a query param to /api/v1/secrets/value
+	assert.Equal(t, "/api/v1/secrets/value", gotPath)
+}
+
+func TestRunDelete_NoIDOrName(t *testing.T) {
+	origID, origName := deleteID, deleteName
+	defer func() { deleteID = origID; deleteName = origName }()
+	deleteID = 0
+	deleteName = ""
+
+	err := runDelete(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "either --id or --name is required")
+}
+
+func TestRunList_RemoteMode(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"secrets":[],"total":0,"page":1,"page_size":50}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	origProject, origEnv, origLimit, origOffset, origFormat :=
+		listProjectName, listEnv, listLimit, listOffset, listFormat
+	defer func() {
+		listProjectName = origProject
+		listEnv = origEnv
+		listLimit = origLimit
+		listOffset = origOffset
+		listFormat = origFormat
+	}()
+	listProjectName = ""
+	listEnv = 0
+	listLimit = 50
+	listOffset = 0
+	listFormat = "table" // must be set; TestRunListRemote_ResolvesProjectScope leaves it ""
+
+	require.NoError(t, runList(nil, nil))
+	assert.Equal(t, "/api/v1/secrets", gotPath)
+}
+
+func TestBuildCreateRequest_NameRequired(t *testing.T) {
+	// Test buildCreateRequest validation directly — avoids cobra cmd nil issue.
+	origName, origValue, origInteractive := createName, createValue, createInteractive
+	defer func() { createName = origName; createValue = origValue; createInteractive = origInteractive }()
+	createName = ""
+	createValue = ""
+	createInteractive = false
+
+	_, err := buildCreateRequest()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret name is required")
+}
+
+func TestBuildCreateRequest_ValueRequired(t *testing.T) {
+	origName, origValue, origFile := createName, createValue, createFromFile
+	defer func() { createName = origName; createValue = origValue; createFromFile = origFile }()
+	createName = "my-secret"
+	createValue = ""
+	createFromFile = ""
+
+	_, err := buildCreateRequest()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret value is required")
+}

--- a/internal/cli/share/share_remote_test.go
+++ b/internal/cli/share/share_remote_test.go
@@ -1,0 +1,136 @@
+package share
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunListRemote_EmptyResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"shares":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runListRemote(rc, 5))
+}
+
+func TestRunListRemote_WithExpiry(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"shares":[
+			{"ID":2,"SecretID":5,"OwnerID":1,"RecipientID":3,"IsGroup":false,"Permission":"write","CreatedAt":"2026-06-01T10:00:00Z","ExpiresAt":"2027-06-01T10:00:00Z"}
+		]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runListRemote(rc, 5))
+	assert.Equal(t, "/api/v1/secrets/5/shares", gotPath)
+}
+
+func TestRunSharedSecretsRemote_EmptyResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"secrets":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runSharedSecretsRemote(rc))
+}
+
+func TestRunList_Remote_RoutesThroughRemoteClient(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"shares":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origID := listSecretID
+	defer func() { listSecretID = origID }()
+	listSecretID = 9
+
+	require.NoError(t, runList(nil, nil))
+	assert.Equal(t, "/api/v1/secrets/9/shares", gotPath)
+}
+
+func TestRunSharedSecrets_Remote_RoutesThroughRemoteClient(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"secrets":[
+			{"ID":1,"Name":"s","Type":"password","ProjectID":2,"EnvironmentID":1,"CreatedBy":"admin","CreatedAt":"2026-01-01T00:00:00Z"}
+		]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	require.NoError(t, runSharedSecrets(nil, nil))
+	assert.Equal(t, "/api/v1/shared-secrets", gotPath)
+}
+
+func TestRunUpdate_PermissionValidation(t *testing.T) {
+	origPerm, origID := updatePermission, updateShareID
+	defer func() { updatePermission = origPerm; updateShareID = origID }()
+	updatePermission = "admin"
+	updateShareID = 1
+
+	err := runUpdate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid permission")
+}
+
+func TestRunUpdate_ClearExpiryWithExpires(t *testing.T) {
+	origPerm, origID, origClear, origExpires := updatePermission, updateShareID, updateClearExpiry, updateExpires
+	defer func() {
+		updatePermission = origPerm
+		updateShareID = origID
+		updateClearExpiry = origClear
+		updateExpires = origExpires
+	}()
+	updatePermission = "read"
+	updateShareID = 1
+	updateClearExpiry = true
+	updateExpires = "2026-12-01T00:00:00Z"
+
+	err := runUpdate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--clear-expiry cannot be combined")
+}
+
+func TestRunUpdate_ClearExpiryWithTTL(t *testing.T) {
+	origPerm, origID, origClear, origTTL := updatePermission, updateShareID, updateClearExpiry, updateTTL
+	defer func() {
+		updatePermission = origPerm
+		updateShareID = origID
+		updateClearExpiry = origClear
+		updateTTL = origTTL
+	}()
+	updatePermission = "write"
+	updateShareID = 1
+	updateClearExpiry = true
+	updateTTL = "24h"
+
+	err := runUpdate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--clear-expiry cannot be combined")
+}


### PR DESCRIPTION
## Summary

- Adds `*_remote_test.go` files for 9 CLI packages using httptest stubs to drive network paths
- Covers: `accessreview` (campaign CRUD, decide/revoke/attest), `share` (list/update guards), `bundle` (bad key/path/license, deploymentID), `config` (setRemote/useLocal/status/testConnection), `connect` (happy/error/disconnect/status), `encryption` (passphrase branches, init/status/rotate gates), `secret` (create guards, get by-id/by-ref, delete, list), `migrate` (flag defaults), `auth` (login/logout/status)
- All hermetic via httptest; no external dependencies

## Test plan

- [ ] `go test ./internal/cli/accessreview/... ./internal/cli/auth/... ./internal/cli/bundle/... ./internal/cli/config/... ./internal/cli/connect/... ./internal/cli/encryption/... ./internal/cli/migrate/... ./internal/cli/secret/... ./internal/cli/share/...` passes
- [ ] CI build-and-test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)