### PR TITLE
test(coverage): add unit tests for 7 internal packages

### DIFF
--- a/internal/config/config_extra_test.go
+++ b/internal/config/config_extra_test.go
@@ -1,0 +1,530 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLicenseGrace_Default validates that an unset GraceHours defaults to 14 days.
+func TestLicenseGrace_Default(t *testing.T) {
+	c := &Config{}
+	assert.Equal(t, 14*24*time.Hour, c.LicenseGrace())
+}
+
+// TestLicenseGrace_Zero validates that GraceHours=0 uses the 14d default.
+func TestLicenseGrace_Zero(t *testing.T) {
+	c := &Config{License: LicenseConfig{GraceHours: 0}}
+	assert.Equal(t, 14*24*time.Hour, c.LicenseGrace())
+}
+
+// TestLicenseGrace_Negative validates that a negative GraceHours uses the 14d default.
+func TestLicenseGrace_Negative(t *testing.T) {
+	c := &Config{License: LicenseConfig{GraceHours: -1}}
+	assert.Equal(t, 14*24*time.Hour, c.LicenseGrace())
+}
+
+// TestLicenseGrace_Positive validates that a positive GraceHours is used as-is.
+func TestLicenseGrace_Positive(t *testing.T) {
+	c := &Config{License: LicenseConfig{GraceHours: 48}}
+	assert.Equal(t, 48*time.Hour, c.LicenseGrace())
+}
+
+// TestPasswordPolicyConfig_IsZero validates the IsZero helper.
+func TestPasswordPolicyConfig_IsZero(t *testing.T) {
+	assert.True(t, PasswordPolicyConfig{}.IsZero())
+	assert.False(t, PasswordPolicyConfig{MinLength: 8}.IsZero())
+	assert.False(t, PasswordPolicyConfig{RequireUppercase: true}.IsZero())
+	assert.False(t, PasswordPolicyConfig{RequireDigit: true}.IsZero())
+}
+
+// TestBuildPostgresDSN_DSNPassthrough validates that an explicit DSN is
+// returned as-is without modification.
+func TestBuildPostgresDSN_DSNPassthrough(t *testing.T) {
+	d := &DatabaseConfig{DSN: "host=pg user=kx dbname=keyorix sslmode=require"}
+	assert.Equal(t, d.DSN, BuildPostgresDSN(d))
+}
+
+// TestBuildPostgresDSN_FieldsDefaults validates that missing host/port/sslmode
+// are filled with their documented defaults.
+func TestBuildPostgresDSN_FieldsDefaults(t *testing.T) {
+	d := &DatabaseConfig{Name: "keyorix", User: "kx"}
+	dsn := BuildPostgresDSN(d)
+	assert.Contains(t, dsn, "host=localhost")
+	assert.Contains(t, dsn, "port=5432")
+	assert.Contains(t, dsn, "sslmode=require")
+	assert.Contains(t, dsn, "dbname=keyorix")
+	assert.Contains(t, dsn, "user=kx")
+}
+
+// TestBuildPostgresDSN_ExplicitFields validates that explicit host/port/sslmode
+// are used when provided.
+func TestBuildPostgresDSN_ExplicitFields(t *testing.T) {
+	d := &DatabaseConfig{
+		Host:    "pg.prod",
+		Port:    "5433",
+		Name:    "mydb",
+		User:    "admin",
+		SSLMode: "verify-full",
+	}
+	dsn := BuildPostgresDSN(d)
+	assert.Contains(t, dsn, "host=pg.prod")
+	assert.Contains(t, dsn, "port=5433")
+	assert.Contains(t, dsn, "sslmode=verify-full")
+}
+
+// TestBuildPostgresDSN_Password validates that a password is appended to the DSN.
+func TestBuildPostgresDSN_Password(t *testing.T) {
+	d := &DatabaseConfig{Name: "db", User: "u", Password: "s3cr3t"}
+	dsn := BuildPostgresDSN(d)
+	assert.Contains(t, dsn, "password=s3cr3t")
+}
+
+// TestDatabaseConfig_GetPassword_EnvVar validates the environment-variable
+// override for the database password.
+func TestDatabaseConfig_GetPassword_EnvVar(t *testing.T) {
+	t.Setenv("KEYORIX_DB_PASSWORD", "from-env")
+	d := &DatabaseConfig{Password: "from-file"}
+	assert.Equal(t, "from-env", d.GetPassword())
+}
+
+// TestDatabaseConfig_GetPassword_Fallback validates that the config-file value
+// is used when the env var is absent.
+func TestDatabaseConfig_GetPassword_Fallback(t *testing.T) {
+	t.Setenv("KEYORIX_DB_PASSWORD", "")
+	d := &DatabaseConfig{Password: "from-file"}
+	assert.Equal(t, "from-file", d.GetPassword())
+}
+
+// TestRemoteConfig_GetAPIKey_EnvVar validates env-var override for the remote
+// API key.
+func TestRemoteConfig_GetAPIKey_EnvVar(t *testing.T) {
+	t.Setenv("KEYORIX_REMOTE_API_KEY", "env-key")
+	r := &RemoteConfig{APIKey: "file-key"}
+	assert.Equal(t, "env-key", r.GetAPIKey())
+}
+
+// TestRemoteConfig_GetAPIKey_Fallback validates fallback to the file value.
+func TestRemoteConfig_GetAPIKey_Fallback(t *testing.T) {
+	t.Setenv("KEYORIX_REMOTE_API_KEY", "")
+	r := &RemoteConfig{APIKey: "file-key"}
+	assert.Equal(t, "file-key", r.GetAPIKey())
+}
+
+// TestBoolPtr validates that BoolPtr returns a pointer to the given value.
+func TestBoolPtr(t *testing.T) {
+	pTrue := BoolPtr(true)
+	require.NotNil(t, pTrue)
+	assert.True(t, *pTrue)
+
+	pFalse := BoolPtr(false)
+	require.NotNil(t, pFalse)
+	assert.False(t, *pFalse)
+}
+
+// TestGetRequiredApprovals_Default validates that 0/1 both return 1.
+func TestGetRequiredApprovals_Default(t *testing.T) {
+	assert.Equal(t, 1, DualControlConfig{RequiredApprovals: 0}.GetRequiredApprovals())
+	assert.Equal(t, 1, DualControlConfig{RequiredApprovals: 1}.GetRequiredApprovals())
+}
+
+// TestGetRequiredApprovals_Positive validates values above 1 are used as-is.
+func TestGetRequiredApprovals_Positive(t *testing.T) {
+	assert.Equal(t, 3, DualControlConfig{RequiredApprovals: 3}.GetRequiredApprovals())
+}
+
+// TestBreakGlassConfig_GetDefaultTTL validates default and explicit values.
+func TestBreakGlassConfig_GetDefaultTTL(t *testing.T) {
+	assert.Equal(t, 4*time.Hour, BreakGlassConfig{}.GetDefaultTTL())
+	assert.Equal(t, 4*time.Hour, BreakGlassConfig{DefaultTTL: "bad"}.GetDefaultTTL())
+	assert.Equal(t, 2*time.Hour, BreakGlassConfig{DefaultTTL: "2h"}.GetDefaultTTL())
+}
+
+// TestBreakGlassConfig_GetMaxTTL validates default and explicit values.
+func TestBreakGlassConfig_GetMaxTTL(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, BreakGlassConfig{}.GetMaxTTL())
+	assert.Equal(t, 24*time.Hour, BreakGlassConfig{MaxTTL: "invalid"}.GetMaxTTL())
+	assert.Equal(t, 8*time.Hour, BreakGlassConfig{MaxTTL: "8h"}.GetMaxTTL())
+}
+
+// TestGetSweepInterval_Default validates default and edge cases.
+func TestGetSweepInterval_Default(t *testing.T) {
+	assert.Equal(t, time.Minute, DynamicSecretsConfig{}.GetSweepInterval())
+	assert.Equal(t, time.Minute, DynamicSecretsConfig{SweepInterval: "garbage"}.GetSweepInterval())
+	assert.Equal(t, time.Minute, DynamicSecretsConfig{SweepInterval: "0"}.GetSweepInterval())
+	assert.Equal(t, 5*time.Minute, DynamicSecretsConfig{SweepInterval: "5m"}.GetSweepInterval())
+}
+
+// TestAutoRotationConfig_GetInterval validates the auto-rotation schedule.
+func TestAutoRotationConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, time.Hour, AutoRotationConfig{}.GetInterval())
+	assert.Equal(t, time.Hour, AutoRotationConfig{Schedule: "bad"}.GetInterval())
+	assert.Equal(t, 30*time.Minute, AutoRotationConfig{Schedule: "30m"}.GetInterval())
+}
+
+// TestRotationRemindersConfig_GetInterval validates the rotation-reminder
+// schedule.
+func TestRotationRemindersConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, RotationRemindersConfig{}.GetInterval())
+	assert.Equal(t, 12*time.Hour, RotationRemindersConfig{Schedule: "12h"}.GetInterval())
+}
+
+// TestExpiryRemindersConfig_GetInterval validates the expiry-reminder schedule.
+func TestExpiryRemindersConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, ExpiryRemindersConfig{}.GetInterval())
+	assert.Equal(t, 6*time.Hour, ExpiryRemindersConfig{Schedule: "6h"}.GetInterval())
+}
+
+// TestCertificateExpiryConfig_GetInterval validates the cert-expiry scan
+// schedule.
+func TestCertificateExpiryConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, CertificateExpiryConfig{}.GetInterval())
+	assert.Equal(t, 48*time.Hour, CertificateExpiryConfig{Schedule: "48h"}.GetInterval())
+}
+
+// TestAuditCheckpointsConfig_GetInterval validates the checkpoint schedule.
+func TestAuditCheckpointsConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, AuditCheckpointsConfig{}.GetInterval())
+	assert.Equal(t, 12*time.Hour, AuditCheckpointsConfig{Schedule: "12h"}.GetInterval())
+}
+
+// TestJITAccessExpiryConfig_GetInterval validates the JIT expiry sweep schedule.
+func TestJITAccessExpiryConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, time.Hour, JITAccessExpiryConfig{}.GetInterval())
+	assert.Equal(t, 30*time.Minute, JITAccessExpiryConfig{Schedule: "30m"}.GetInterval())
+}
+
+// TestAnomalyAlertsConfig_GetInterval validates the anomaly alert schedule.
+func TestAnomalyAlertsConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, time.Hour, AnomalyAlertsConfig{}.GetInterval())
+	assert.Equal(t, 2*time.Hour, AnomalyAlertsConfig{Schedule: "2h"}.GetInterval())
+}
+
+// TestAnomalyAlertsConfig_GetBaselineQuarantine_Custom validates that values
+// not covered by the dedicated anomaly_config_test.go are handled correctly.
+func TestAnomalyAlertsConfig_GetBaselineQuarantine_Custom(t *testing.T) {
+	// Valid non-zero duration beyond what the existing test covers.
+	assert.Equal(t, 48*time.Hour, AnomalyAlertsConfig{BaselineQuarantine: "48h"}.GetBaselineQuarantine())
+	assert.Equal(t, 72*time.Hour, AnomalyAlertsConfig{BaselineQuarantine: "72h"}.GetBaselineQuarantine())
+}
+
+// TestDataRetentionConfig_GetInterval validates the data-retention scheduler
+// interval.
+func TestDataRetentionConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, DataRetentionConfig{}.GetInterval())
+	assert.Equal(t, 24*time.Hour, DataRetentionConfig{Schedule: "bad"}.GetInterval())
+	assert.Equal(t, 12*time.Hour, DataRetentionConfig{Schedule: "12h"}.GetInterval())
+}
+
+// TestRecertificationConfig_GetInterval validates the recertification scheduler
+// interval.
+func TestRecertificationConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, RecertificationConfig{}.GetInterval())
+	assert.Equal(t, 72*time.Hour, RecertificationConfig{Schedule: "72h"}.GetInterval())
+}
+
+// TestComplianceDigestConfig_GetInterval validates the compliance-digest
+// scheduler interval.
+func TestComplianceDigestConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, ComplianceDigestConfig{}.GetInterval())
+	assert.Equal(t, 168*time.Hour, ComplianceDigestConfig{Schedule: "168h"}.GetInterval())
+}
+
+// TestEvidenceDeliveryConfig_GetInterval validates the evidence-export
+// scheduler interval.
+func TestEvidenceDeliveryConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, EvidenceDeliveryConfig{}.GetInterval())
+	assert.Equal(t, 8*time.Hour, EvidenceDeliveryConfig{Schedule: "8h"}.GetInterval())
+}
+
+// TestEvidenceDeliveryConfig_HasTarget validates that at least one output must
+// be configured.
+func TestEvidenceDeliveryConfig_HasTarget(t *testing.T) {
+	assert.False(t, EvidenceDeliveryConfig{}.HasTarget())
+	assert.True(t, EvidenceDeliveryConfig{OutputDir: "/tmp/evidence"}.HasTarget())
+	assert.True(t, EvidenceDeliveryConfig{Webhook: EvidenceWebhookConfig{Enabled: true}}.HasTarget())
+	assert.True(t, EvidenceDeliveryConfig{ObjectStore: EvidenceObjectStoreConfig{Enabled: true}}.HasTarget())
+}
+
+// TestLicenseExpiryConfig_GetInterval validates the license-expiry reminder
+// interval.
+func TestLicenseExpiryConfig_GetInterval(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, LicenseExpiryConfig{}.GetInterval())
+	assert.Equal(t, 12*time.Hour, LicenseExpiryConfig{Schedule: "12h"}.GetInterval())
+}
+
+// TestCredentialDeliveryConfig_GetSetupTokenTTL validates the setup-token TTL
+// parsing.
+func TestCredentialDeliveryConfig_GetSetupTokenTTL(t *testing.T) {
+	// Default (empty = 24h).
+	assert.Equal(t, 24*time.Hour, (&CredentialDeliveryConfig{}).GetSetupTokenTTL())
+	// Explicit valid duration.
+	assert.Equal(t, 48*time.Hour, (&CredentialDeliveryConfig{SetupTokenTTL: "48h"}).GetSetupTokenTTL())
+	// Invalid falls back to 24h.
+	assert.Equal(t, 24*time.Hour, (&CredentialDeliveryConfig{SetupTokenTTL: "bad"}).GetSetupTokenTTL())
+	// Zero or negative falls back to 24h.
+	assert.Equal(t, 24*time.Hour, (&CredentialDeliveryConfig{SetupTokenTTL: "0"}).GetSetupTokenTTL())
+}
+
+// TestValidate_HTTPServerEnabledNoPort validates that HTTP enabled without a
+// port is rejected.
+func TestValidate_HTTPServerEnabledNoPort(t *testing.T) {
+	c := &Config{}
+	c.Server.HTTP.Enabled = true
+	c.Server.HTTP.Port = ""
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "port")
+}
+
+// TestValidate_GRPCServerEnabledNoPort validates that gRPC enabled without a
+// port is rejected.
+func TestValidate_GRPCServerEnabledNoPort(t *testing.T) {
+	c := &Config{}
+	c.Server.GRPC.Enabled = true
+	c.Server.GRPC.Port = ""
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "port")
+}
+
+// TestValidate_HTTPTLSNoCertFile validates that HTTP TLS without cert/key is
+// rejected.
+func TestValidate_HTTPTLSNoCertFile(t *testing.T) {
+	c := &Config{}
+	c.Storage.Database.Path = "/tmp/db"
+	c.Server.HTTP.TLS.Enabled = true
+	c.Server.HTTP.TLS.AutoCert = false
+	c.Server.HTTP.TLS.CertFile = ""
+	c.Server.HTTP.TLS.KeyFile = ""
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TLS")
+}
+
+// TestValidate_HTTPTLSAutoCertNoDomains validates that autocert without domains
+// is rejected.
+func TestValidate_HTTPTLSAutoCertNoDomains(t *testing.T) {
+	c := &Config{}
+	c.Server.HTTP.TLS.Enabled = true
+	c.Server.HTTP.TLS.AutoCert = true
+	c.Server.HTTP.TLS.Domains = nil
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "domains")
+}
+
+// TestValidate_GRPCTLSNoCertFile validates that gRPC TLS without cert/key is
+// rejected.
+func TestValidate_GRPCTLSNoCertFile(t *testing.T) {
+	c := &Config{}
+	c.Storage.Database.Path = "/tmp/db"
+	c.Server.GRPC.TLS.Enabled = true
+	c.Server.GRPC.TLS.CertFile = ""
+	c.Server.GRPC.TLS.KeyFile = ""
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cert_file")
+}
+
+// TestValidate_PostgresRequiresDSNOrFields validates that postgres storage
+// without DSN or host/name/user is rejected.
+func TestValidate_PostgresRequiresDSNOrFields(t *testing.T) {
+	c := &Config{}
+	c.Storage.Type = "postgres"
+	// DSN, host, name, user all empty.
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dsn")
+}
+
+// TestValidate_PostgresAcceptsDSN validates that postgres storage with a DSN
+// passes validation.
+func TestValidate_PostgresAcceptsDSN(t *testing.T) {
+	c := &Config{}
+	c.Storage.Type = "postgres"
+	c.Storage.Database.DSN = "host=pg user=kx dbname=keyorix sslmode=require"
+	require.NoError(t, c.Validate())
+}
+
+// TestValidate_LocalStorageRequiresPath validates that local storage without a
+// path is rejected.
+func TestValidate_LocalStorageRequiresPath(t *testing.T) {
+	c := &Config{}
+	c.Storage.Type = "local"
+	c.Storage.Database.Path = ""
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path")
+}
+
+// TestValidate_UnsupportedLanguage validates that an unknown locale.language is
+// rejected.
+func TestValidate_UnsupportedLanguage(t *testing.T) {
+	c := &Config{}
+	c.Storage.Database.Path = "/tmp/db"
+	c.Locale.Language = "zh"
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "language")
+}
+
+// TestValidate_UnsupportedFallbackLanguage validates that an unknown
+// locale.fallback_language is rejected.
+func TestValidate_UnsupportedFallbackLanguage(t *testing.T) {
+	c := &Config{}
+	c.Storage.Database.Path = "/tmp/db"
+	c.Locale.Language = "en"
+	c.Locale.FallbackLanguage = "zh"
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fallback language")
+}
+
+// TestValidate_DefaultLocaleIsEn validates that an empty locale.language
+// defaults to "en" and passes validation.
+func TestValidate_DefaultLocaleIsEn(t *testing.T) {
+	c := &Config{}
+	c.Storage.Database.Path = "/tmp/db"
+	// Language and FallbackLanguage left empty → should default to "en".
+	require.NoError(t, c.Validate())
+	assert.Equal(t, "en", c.Locale.Language)
+	assert.Equal(t, "en", c.Locale.FallbackLanguage)
+}
+
+// TestResolvedPath_ExplicitArgWins validates that an explicit path argument
+// takes precedence over the environment variable.
+func TestResolvedPath_ExplicitArgWins(t *testing.T) {
+	t.Setenv("KEYORIX_CONFIG_PATH", "/env/path.yaml")
+	got := ResolvedPath("/explicit/path.yaml")
+	assert.Equal(t, "/explicit/path.yaml", got)
+}
+
+// TestResolvedPath_EnvVarFallback validates that the env var is used when the
+// explicit path is empty.
+func TestResolvedPath_EnvVarFallback(t *testing.T) {
+	t.Setenv("KEYORIX_CONFIG_PATH", "/env/keyorix.yaml")
+	got := ResolvedPath("")
+	assert.Equal(t, "/env/keyorix.yaml", got)
+}
+
+// TestResolvedPath_Default validates that the default file name is used when
+// neither arg nor env var is set.
+func TestResolvedPath_Default(t *testing.T) {
+	t.Setenv("KEYORIX_CONFIG_PATH", "")
+	got := ResolvedPath("")
+	// filepath.Join(".", "keyorix.yaml") → "keyorix.yaml" on most OS.
+	assert.Equal(t, "keyorix.yaml", got)
+}
+
+// TestGRPCKeepaliveConfig_Defaults validates that missing/invalid values fall
+// back to the documented defaults.
+func TestGRPCKeepaliveConfig_Defaults(t *testing.T) {
+	c := GRPCKeepaliveConfig{}
+	assert.Equal(t, 5*time.Minute, c.GetTime())
+	assert.Equal(t, 20*time.Second, c.GetTimeout())
+	assert.Equal(t, 5*time.Minute, c.GetMinTime())
+}
+
+// TestGRPCKeepaliveConfig_ExplicitValues validates that explicit values are
+// parsed.
+func TestGRPCKeepaliveConfig_ExplicitValues(t *testing.T) {
+	c := GRPCKeepaliveConfig{Time: "10m", Timeout: "30s", MinTime: "3m"}
+	assert.Equal(t, 10*time.Minute, c.GetTime())
+	assert.Equal(t, 30*time.Second, c.GetTimeout())
+	assert.Equal(t, 3*time.Minute, c.GetMinTime())
+}
+
+// TestGRPCKeepaliveConfig_InvalidFallsBack validates that invalid values use
+// their defaults.
+func TestGRPCKeepaliveConfig_InvalidFallsBack(t *testing.T) {
+	c := GRPCKeepaliveConfig{Time: "bad", Timeout: "bad", MinTime: "bad"}
+	assert.Equal(t, 5*time.Minute, c.GetTime())
+	assert.Equal(t, 20*time.Second, c.GetTimeout())
+	assert.Equal(t, 5*time.Minute, c.GetMinTime())
+}
+
+// TestEffectiveMaxRequestBodyBytes_Default validates the 10 MiB default.
+func TestEffectiveMaxRequestBodyBytes_Default(t *testing.T) {
+	s := ServerInstanceConfig{}
+	assert.Equal(t, int64(10<<20), s.EffectiveMaxRequestBodyBytes())
+}
+
+// TestEffectiveMaxRequestBodyBytes_Explicit validates that an explicit limit is
+// returned as-is, including negative (disable cap).
+func TestEffectiveMaxRequestBodyBytes_Explicit(t *testing.T) {
+	s := ServerInstanceConfig{MaxRequestBodyBytes: 1024}
+	assert.Equal(t, int64(1024), s.EffectiveMaxRequestBodyBytes())
+
+	s2 := ServerInstanceConfig{MaxRequestBodyBytes: -1}
+	assert.Equal(t, int64(-1), s2.EffectiveMaxRequestBodyBytes())
+}
+
+// TestSSOProviderConfig_GetClientSecret validates env-var override.
+func TestSSOProviderConfig_GetClientSecret(t *testing.T) {
+	p := &SSOProviderConfig{Name: "okta", ClientSecret: "file-secret"}
+	t.Setenv("KEYORIX_SSO_OKTA_CLIENT_SECRET", "env-secret")
+	assert.Equal(t, "env-secret", p.GetClientSecret())
+
+	t.Setenv("KEYORIX_SSO_OKTA_CLIENT_SECRET", "")
+	assert.Equal(t, "file-secret", p.GetClientSecret())
+}
+
+// TestRotationBackendConfig_GetDSN validates DSNEnv lookup.
+func TestRotationBackendConfig_GetDSN(t *testing.T) {
+	c := RotationBackendConfig{DSNEnv: "MY_ROTATION_DSN"}
+	t.Setenv("MY_ROTATION_DSN", "postgres://admin:pw@host/db")
+	assert.Equal(t, "postgres://admin:pw@host/db", c.GetDSN())
+
+	c2 := RotationBackendConfig{} // DSNEnv empty
+	assert.Equal(t, "", c2.GetDSN())
+}
+
+// TestSCIMConfig_GetToken validates SCIM token env-var override.
+func TestSCIMConfig_GetToken(t *testing.T) {
+	s := &SCIMConfig{Token: "file-token"}
+	t.Setenv("KEYORIX_SCIM_TOKEN", "env-token")
+	assert.Equal(t, "env-token", s.GetToken())
+
+	t.Setenv("KEYORIX_SCIM_TOKEN", "")
+	assert.Equal(t, "file-token", s.GetToken())
+}
+
+// TestNotificationWebhookConfig_GetToken validates webhook token env-var
+// override.
+func TestNotificationWebhookConfig_GetToken(t *testing.T) {
+	w := &NotificationWebhookConfig{Token: "file-tok"}
+	t.Setenv("KEYORIX_NOTIFY_WEBHOOK_TOKEN", "env-tok")
+	assert.Equal(t, "env-tok", w.GetToken())
+
+	t.Setenv("KEYORIX_NOTIFY_WEBHOOK_TOKEN", "")
+	assert.Equal(t, "file-tok", w.GetToken())
+}
+
+// TestEvidenceWebhookConfig_GetToken validates evidence webhook token env-var
+// override.
+func TestEvidenceWebhookConfig_GetToken(t *testing.T) {
+	w := &EvidenceWebhookConfig{Token: "file-tok"}
+	t.Setenv("KEYORIX_EVIDENCE_WEBHOOK_TOKEN", "env-tok")
+	assert.Equal(t, "env-tok", w.GetToken())
+
+	t.Setenv("KEYORIX_EVIDENCE_WEBHOOK_TOKEN", "")
+	assert.Equal(t, "file-tok", w.GetToken())
+}
+
+// TestValidateAllowedOrigins_TrailingSlash validates that a trailing slash on
+// an origin is rejected.
+func TestValidateAllowedOrigins_TrailingSlash(t *testing.T) {
+	// "https://app.example.com/" — has a path "/"
+	err := validateAllowedOrigins([]string{"https://app.example.com/"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allowed_origins")
+}
+
+// TestValidateAllowedOrigins_Empty validates that an empty list is accepted.
+func TestValidateAllowedOrigins_Empty(t *testing.T) {
+	require.NoError(t, validateAllowedOrigins(nil))
+	require.NoError(t, validateAllowedOrigins([]string{}))
+}

--- a/internal/dynamic/engine_extra_test.go
+++ b/internal/dynamic/engine_extra_test.go
@@ -1,0 +1,184 @@
+package dynamic
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFakeEngine_Issue validates that the FakeEngine records issued roles
+// and returns a non-empty credential.
+func TestFakeEngine_Issue(t *testing.T) {
+	fe := &FakeEngine{}
+	cred, role, err := fe.Issue(context.Background(), "dsn", "template", 5*time.Minute)
+	require.NoError(t, err)
+	assert.NotEmpty(t, role)
+	assert.NotEmpty(t, cred.Username)
+	assert.NotEmpty(t, cred.Password)
+	assert.Len(t, fe.Issued, 1)
+	assert.Equal(t, role, fe.Issued[0])
+}
+
+// TestFakeEngine_IssueFailure validates that FailIssue causes Issue to error.
+func TestFakeEngine_IssueFailure(t *testing.T) {
+	fe := &FakeEngine{FailIssue: true}
+	_, _, err := fe.Issue(context.Background(), "dsn", "tpl", time.Minute)
+	require.Error(t, err)
+	assert.Empty(t, fe.Issued)
+}
+
+// TestFakeEngine_Revoke validates that the FakeEngine records revoked roles.
+func TestFakeEngine_Revoke(t *testing.T) {
+	fe := &FakeEngine{}
+	err := fe.Revoke(context.Background(), "dsn", "role_abc")
+	require.NoError(t, err)
+	require.Len(t, fe.Revoked, 1)
+	assert.Equal(t, "role_abc", fe.Revoked[0])
+}
+
+// TestFakeEngine_RevokeFailure validates that FailRevoke causes Revoke to error.
+func TestFakeEngine_RevokeFailure(t *testing.T) {
+	fe := &FakeEngine{FailRevoke: true}
+	err := fe.Revoke(context.Background(), "dsn", "role_xyz")
+	require.Error(t, err)
+	assert.Empty(t, fe.Revoked)
+}
+
+// TestFakeEngine_Renew validates that the FakeEngine records renewed roles.
+func TestFakeEngine_Renew(t *testing.T) {
+	fe := &FakeEngine{}
+	err := fe.Renew(context.Background(), "dsn", "role_abc", time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	require.Len(t, fe.Renewed, 1)
+	assert.Equal(t, "role_abc", fe.Renewed[0])
+}
+
+// TestFakeEngine_RenewFailure validates that FailRenew causes Renew to error.
+func TestFakeEngine_RenewFailure(t *testing.T) {
+	fe := &FakeEngine{FailRenew: true}
+	err := fe.Renew(context.Background(), "dsn", "role_xyz", time.Now().Add(time.Hour))
+	require.Error(t, err)
+	assert.Empty(t, fe.Renewed)
+}
+
+// TestFakeEngine_Metadata validates BackendType, SupportsNativeExpiry, and IsEphemeralBackend.
+func TestFakeEngine_Metadata(t *testing.T) {
+	fe := &FakeEngine{}
+	assert.Equal(t, "fake", fe.BackendType())
+	assert.False(t, fe.SupportsNativeExpiry())
+	assert.False(t, fe.IsEphemeralBackend())
+
+	fe2 := &FakeEngine{NativeExpiry: true, Ephemeral: true}
+	assert.True(t, fe2.SupportsNativeExpiry())
+	assert.True(t, fe2.IsEphemeralBackend())
+}
+
+// TestFakeEngine_RevokeInvalidatesCredential checks default and override behavior.
+func TestFakeEngine_RevokeInvalidatesCredential(t *testing.T) {
+	// Non-ephemeral: revoke invalidates (true)
+	fe := &FakeEngine{Ephemeral: false}
+	assert.True(t, fe.RevokeInvalidatesCredential("any-dsn"))
+
+	// Ephemeral: revoke does NOT invalidate by default (false)
+	fe2 := &FakeEngine{Ephemeral: true}
+	assert.False(t, fe2.RevokeInvalidatesCredential("any-dsn"))
+
+	// Explicit override via RevokeEffective
+	trueVal := true
+	fe3 := &FakeEngine{Ephemeral: true, RevokeEffective: &trueVal}
+	assert.True(t, fe3.RevokeInvalidatesCredential("any-dsn"))
+
+	falseVal := false
+	fe4 := &FakeEngine{Ephemeral: false, RevokeEffective: &falseVal}
+	assert.False(t, fe4.RevokeInvalidatesCredential("any-dsn"))
+}
+
+// TestFakeEngine_IssueFields validates that IssueFields are returned in the credential.
+func TestFakeEngine_IssueFields(t *testing.T) {
+	fe := &FakeEngine{
+		IssueFields: map[string]string{"access_key_id": "AKID", "secret_access_key": "SAK"},
+	}
+	cred, _, err := fe.Issue(context.Background(), "dsn", "tpl", time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, "AKID", cred.Fields["access_key_id"])
+	assert.Equal(t, "SAK", cred.Fields["secret_access_key"])
+}
+
+// TestNew_UnsupportedBackend validates that an unsupported backend type is rejected.
+func TestNew_UnsupportedBackend(t *testing.T) {
+	_, err := New("cassandra")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported")
+	assert.Contains(t, err.Error(), "cassandra")
+}
+
+// TestNew_AllBackendTypes validates all supported backend types can be constructed.
+func TestNew_AllBackendTypes(t *testing.T) {
+	backends := []struct {
+		name      string
+		ephemeral bool
+	}{
+		{"postgres", false},
+		{"mysql", false},
+		{"mongodb", false},
+		{"redis", false},
+		{"aws-sts", true},
+		{"gcp", true},
+		{"azure", true},
+		{"kubernetes", true},
+	}
+	for _, b := range backends {
+		eng, err := New(b.name)
+		require.NoErrorf(t, err, "backend %q must be constructable", b.name)
+		assert.Equal(t, b.name, eng.BackendType())
+		if b.ephemeral {
+			assert.Truef(t, eng.IsEphemeralBackend(), "%s must be ephemeral", b.name)
+		} else {
+			assert.Falsef(t, eng.IsEphemeralBackend(), "%s must not be ephemeral", b.name)
+		}
+	}
+}
+
+// TestRandString_Length validates that randString returns exactly n characters.
+func TestRandString_Length(t *testing.T) {
+	for _, n := range []int{0, 1, 8, 16, 64} {
+		s, err := randString(n)
+		require.NoError(t, err)
+		assert.Lenf(t, s, n, "randString(%d)", n)
+	}
+}
+
+// TestRandString_Alphabet validates that randString only uses safe characters.
+func TestRandString_Alphabet(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		s, err := randString(32)
+		require.NoError(t, err)
+		for _, r := range s {
+			ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+			assert.Truef(t, ok, "unexpected character %q in randString output", r)
+		}
+	}
+}
+
+// TestFakeEngine_MultipleConcurrentIssues validates thread-safe issue under the mu lock.
+func TestFakeEngine_MultipleConcurrentIssues(t *testing.T) {
+	fe := &FakeEngine{}
+	const n = 10
+	done := make(chan struct{}, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			_, _, err := fe.Issue(context.Background(), "dsn", "tpl", time.Minute)
+			assert.NoError(t, err)
+		}()
+	}
+	for i := 0; i < n; i++ {
+		<-done
+	}
+	fe.mu.Lock()
+	assert.Len(t, fe.Issued, n)
+	fe.mu.Unlock()
+}

--- a/internal/rotation/rotation_extra_test.go
+++ b/internal/rotation/rotation_extra_test.go
@@ -1,0 +1,151 @@
+package rotation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManager_DuplicateNameLastWins validates that a later executor overwrites
+// an earlier one with the same name.
+func TestManager_DuplicateNameLastWins(t *testing.T) {
+	a1 := stubExec{name: "alpha"}
+	a2 := stubExec{name: "alpha"}
+	m := NewManager([]Executor{a1, a2})
+	e, ok := m.Get("alpha")
+	require.True(t, ok)
+	assert.Equal(t, "alpha", e.Name())
+	// Names() must only list "alpha" once.
+	assert.Len(t, m.Names(), 1)
+}
+
+// TestManager_Empty validates that an empty manager has no names and returns
+// false for any lookup.
+func TestManager_Empty(t *testing.T) {
+	m := NewManager(nil)
+	_, ok := m.Get("anything")
+	assert.False(t, ok)
+	assert.Empty(t, m.Names())
+}
+
+// TestManager_OnlyNilEntries validates that a manager with only nil entries has
+// no executors.
+func TestManager_OnlyNilEntries(t *testing.T) {
+	m := NewManager([]Executor{nil, nil})
+	assert.Empty(t, m.Names())
+}
+
+// TestPrefixAllowed_EmptyList allows anything.
+func TestPrefixAllowed_EmptyList(t *testing.T) {
+	assert.True(t, prefixAllowed([]string{}, "anything"))
+	assert.True(t, prefixAllowed(nil, ""))
+	assert.True(t, prefixAllowed(nil, "some/ref"))
+}
+
+// TestPrefixAllowed_ExactPrefix ensures an exact prefix matches.
+func TestPrefixAllowed_ExactPrefix(t *testing.T) {
+	assert.True(t, prefixAllowed([]string{"prod_"}, "prod_db"))
+	assert.True(t, prefixAllowed([]string{"prod_"}, "prod_"))
+}
+
+// TestPrefixAllowed_MultipleAllowed validates that any matching prefix in the
+// list allows the ref.
+func TestPrefixAllowed_MultipleAllowed(t *testing.T) {
+	allowed := []string{"dev_", "staging_", "prod_"}
+	assert.True(t, prefixAllowed(allowed, "dev_svc"))
+	assert.True(t, prefixAllowed(allowed, "staging_db"))
+	assert.True(t, prefixAllowed(allowed, "prod_app"))
+	assert.False(t, prefixAllowed(allowed, "other_thing"))
+}
+
+// TestPrefixAllowed_EmptyPrefixNeverMatches validates that an empty string
+// prefix in the allowed list is never matched, as documented.
+func TestPrefixAllowed_EmptyPrefixNeverMatches(t *testing.T) {
+	assert.False(t, prefixAllowed([]string{""}, "anything"))
+	assert.False(t, prefixAllowed([]string{"", "ok_"}, "anything"))
+	assert.True(t, prefixAllowed([]string{"", "ok_"}, "ok_ref"))
+}
+
+// TestRedactSQLError_RemovesSingleQuotedLiteral ensures the SQL password is
+// redacted from a driver error message that echoes the statement.
+func TestRedactSQLError_RemovesSingleQuotedLiteral(t *testing.T) {
+	raw := errors.New("ALTER USER alice WITH PASSWORD 'supersecret'")
+	wrapped := redactSQLError("postgresql", "alice", raw)
+	require.Error(t, wrapped)
+	assert.NotContains(t, wrapped.Error(), "supersecret")
+	assert.Contains(t, wrapped.Error(), "'***'")
+	assert.Contains(t, wrapped.Error(), "alice")
+	assert.Contains(t, wrapped.Error(), "postgresql")
+}
+
+// TestRedactSQLError_MultipleQuotedLiterals ensures all quoted literals are
+// redacted when the error echoes multiple values.
+func TestRedactSQLError_MultipleQuotedLiterals(t *testing.T) {
+	raw := errors.New("syntax error near 'password1' and 'password2'")
+	wrapped := redactSQLError("mysql", "bob", raw)
+	assert.NotContains(t, wrapped.Error(), "password1")
+	assert.NotContains(t, wrapped.Error(), "password2")
+}
+
+// TestRedactSQLError_NoLiterals passes through a message that has no
+// single-quoted literals unchanged (aside from wrapping).
+func TestRedactSQLError_NoLiterals(t *testing.T) {
+	raw := errors.New("connection refused")
+	wrapped := redactSQLError("postgresql", "carol", raw)
+	assert.Contains(t, wrapped.Error(), "connection refused")
+}
+
+// TestRedactSQLError_EmbeddedDoubleQuoteEscape validates that the SQL
+// ''-doubling escape within a quoted literal is handled correctly.
+func TestRedactSQLError_EmbeddedDoubleQuoteEscape(t *testing.T) {
+	// 'it''s a secret' is one SQL string literal (contains embedded '')
+	raw := errors.New("ALTER ROLE r WITH PASSWORD 'it''s a secret'")
+	wrapped := redactSQLError("postgresql", "r", raw)
+	assert.NotContains(t, wrapped.Error(), "it''s a secret")
+	assert.Contains(t, wrapped.Error(), "'***'")
+}
+
+// TestPartialRotationError_ErrorAndUnwrap validates the error interface
+// of PartialRotationError.
+func TestPartialRotationError_ErrorAndUnwrap(t *testing.T) {
+	cause := errors.New("underlying cause")
+	pErr := &PartialRotationError{Value: "newkey", Err: cause}
+
+	assert.Equal(t, cause.Error(), pErr.Error())
+	assert.Equal(t, "newkey", pErr.Value)
+
+	var unwrapped *PartialRotationError
+	assert.False(t, errors.As(errors.New("other"), &unwrapped))
+	assert.True(t, errors.Is(errors.Unwrap(pErr), cause))
+}
+
+// generatingStub is a stub Executor that also implements GeneratingExecutor.
+type generatingStub struct {
+	stubExec
+	upstream string
+}
+
+func (g generatingStub) GenerateUpstream(_ context.Context, _ string) (string, error) {
+	return g.upstream, nil
+}
+
+// TestManager_GeneratingExecutorInterface validates that an executor
+// implementing GeneratingExecutor is stored and retrievable.
+func TestManager_GeneratingExecutorInterface(t *testing.T) {
+	gen := generatingStub{stubExec: stubExec{name: "cloud-key"}, upstream: "new-value"}
+	m := NewManager([]Executor{gen})
+
+	e, ok := m.Get("cloud-key")
+	require.True(t, ok)
+
+	// Cast to GeneratingExecutor interface.
+	ge, ok := e.(GeneratingExecutor)
+	require.True(t, ok, "retrieved executor must implement GeneratingExecutor")
+
+	val, err := ge.GenerateUpstream(context.Background(), "ref")
+	require.NoError(t, err)
+	assert.Equal(t, "new-value", val)
+}

--- a/internal/saml/provider_extra_test.go
+++ b/internal/saml/provider_extra_test.go
@@ -1,0 +1,227 @@
+package saml
+
+import (
+	"testing"
+
+	csaml "github.com/crewjam/saml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOrDefault validates the fallback helper.
+func TestOrDefault(t *testing.T) {
+	assert.Equal(t, "fallback", orDefault("", "fallback"))
+	assert.Equal(t, "fallback", orDefault("   ", "fallback"))
+	assert.Equal(t, "explicit", orDefault("explicit", "fallback"))
+	assert.Equal(t, "x", orDefault("x", "y"))
+}
+
+// TestAttrMatches_ByName validates Name-based matching.
+func TestAttrMatches_ByName(t *testing.T) {
+	attr := csaml.Attribute{Name: "email"}
+	assert.True(t, attrMatches(attr, "email"))
+	assert.False(t, attrMatches(attr, "EMAIL"))
+	assert.False(t, attrMatches(attr, "other"))
+}
+
+// TestAttrMatches_ByFriendlyName validates case-insensitive FriendlyName matching.
+func TestAttrMatches_ByFriendlyName(t *testing.T) {
+	attr := csaml.Attribute{FriendlyName: "DisplayName"}
+	assert.True(t, attrMatches(attr, "displayname"))
+	assert.True(t, attrMatches(attr, "DISPLAYNAME"))
+	assert.True(t, attrMatches(attr, "DisplayName"))
+	assert.False(t, attrMatches(attr, "email"))
+}
+
+// TestAttributeValues_TrimsAndFiltersBlank validates that blank values are
+// stripped and non-blank ones are preserved.
+func TestAttributeValues_TrimsAndFiltersBlank(t *testing.T) {
+	attr := csaml.Attribute{
+		Values: []csaml.AttributeValue{
+			{Value: "  admins  "},
+			{Value: ""},
+			{Value: "   "},
+			{Value: "devs"},
+		},
+	}
+	vals := attributeValues(attr)
+	require.Len(t, vals, 2)
+	assert.Equal(t, "admins", vals[0])
+	assert.Equal(t, "devs", vals[1])
+}
+
+// TestAttributeValues_Empty validates that an attribute with no values returns
+// an empty slice.
+func TestAttributeValues_Empty(t *testing.T) {
+	attr := csaml.Attribute{Values: nil}
+	assert.Empty(t, attributeValues(attr))
+}
+
+// TestExtractAssertion_NilSubject validates that a nil Subject doesn't panic.
+func TestExtractAssertion_NilSubject(t *testing.T) {
+	a := &csaml.Assertion{
+		// Subject intentionally nil
+		AttributeStatements: []csaml.AttributeStatement{{
+			Attributes: []csaml.Attribute{
+				{Name: defaultEmailAttr, Values: []csaml.AttributeValue{{Value: "user@example.com"}}},
+			},
+		}},
+	}
+	info := extractAssertion(a, defaultEmailAttr, defaultNameAttr, defaultGroupsAttr)
+	assert.Empty(t, info.Subject, "nil Subject must not panic")
+	assert.Equal(t, "user@example.com", info.Email)
+}
+
+// TestExtractAssertion_NilNameID validates that a nil NameID doesn't panic.
+func TestExtractAssertion_NilNameID(t *testing.T) {
+	a := &csaml.Assertion{
+		Subject: &csaml.Subject{NameID: nil},
+	}
+	info := extractAssertion(a, defaultEmailAttr, defaultNameAttr, defaultGroupsAttr)
+	assert.Empty(t, info.Subject)
+}
+
+// TestExtractAssertion_NoAttributeStatements validates extraction with no
+// attribute statements.
+func TestExtractAssertion_NoAttributeStatements(t *testing.T) {
+	a := &csaml.Assertion{
+		Subject: &csaml.Subject{NameID: &csaml.NameID{Value: "uid=alice"}},
+	}
+	info := extractAssertion(a, defaultEmailAttr, defaultNameAttr, defaultGroupsAttr)
+	assert.Equal(t, "uid=alice", info.Subject)
+	assert.Empty(t, info.Email)
+	assert.Empty(t, info.Name)
+	assert.Empty(t, info.Groups)
+}
+
+// TestExtractAssertion_MultipleGroups validates that multiple group values are
+// all accumulated.
+func TestExtractAssertion_MultipleGroups(t *testing.T) {
+	a := &csaml.Assertion{
+		AttributeStatements: []csaml.AttributeStatement{{
+			Attributes: []csaml.Attribute{
+				{
+					Name: defaultGroupsAttr,
+					Values: []csaml.AttributeValue{
+						{Value: "group1"},
+						{Value: "group2"},
+						{Value: "group3"},
+					},
+				},
+			},
+		}},
+	}
+	info := extractAssertion(a, defaultEmailAttr, defaultNameAttr, defaultGroupsAttr)
+	assert.Equal(t, []string{"group1", "group2", "group3"}, info.Groups)
+}
+
+// TestExtractAssertion_MultipleStatements validates that attribute statements
+// across multiple AttributeStatement elements are all considered.
+func TestExtractAssertion_MultipleStatements(t *testing.T) {
+	a := &csaml.Assertion{
+		AttributeStatements: []csaml.AttributeStatement{
+			{Attributes: []csaml.Attribute{
+				{Name: defaultEmailAttr, Values: []csaml.AttributeValue{{Value: "a@b.com"}}},
+			}},
+			{Attributes: []csaml.Attribute{
+				{Name: defaultNameAttr, Values: []csaml.AttributeValue{{Value: "Alice"}}},
+			}},
+		},
+	}
+	info := extractAssertion(a, defaultEmailAttr, defaultNameAttr, defaultGroupsAttr)
+	assert.Equal(t, "a@b.com", info.Email)
+	assert.Equal(t, "Alice", info.Name)
+}
+
+// TestParseIDPMetadata_EmptyInput validates that nil/empty metadata is rejected.
+func TestParseIDPMetadata_EmptyInput(t *testing.T) {
+	_, err := parseIDPMetadata(nil)
+	require.ErrorContains(t, err, "empty")
+
+	_, err = parseIDPMetadata([]byte{})
+	require.ErrorContains(t, err, "empty")
+
+	_, err = parseIDPMetadata([]byte("   \n\t  "))
+	require.ErrorContains(t, err, "empty")
+}
+
+// TestParseIDPMetadata_ValidMetadata validates that well-formed IdP metadata is
+// accepted by the same helper used in production.
+func TestParseIDPMetadata_ValidMetadata(t *testing.T) {
+	md := idpMetadata(t) // from provider_test.go helper
+	entity, err := parseIDPMetadata(md)
+	require.NoError(t, err)
+	require.NotNil(t, entity)
+	assert.Equal(t, "https://idp.example/entity", entity.EntityID)
+	assert.NotEmpty(t, entity.IDPSSODescriptors)
+}
+
+// TestNewProvider_DefaultAttributes validates that missing EmailAttr/NameAttr/
+// GroupsAttr fields fall back to the documented Azure AD defaults.
+func TestNewProvider_DefaultAttributes(t *testing.T) {
+	p, err := NewProvider(Config{
+		Name:           "corp",
+		IDPMetadataXML: idpMetadata(t),
+		SPEntityID:     "https://sp.example/metadata",
+		ACSURL:         "https://sp.example/acs",
+		// EmailAttr/NameAttr/GroupsAttr left empty → defaults
+	})
+	require.NoError(t, err)
+	assert.Equal(t, defaultEmailAttr, p.emailAttr)
+	assert.Equal(t, defaultNameAttr, p.nameAttr)
+	assert.Equal(t, defaultGroupsAttr, p.groupsAttr)
+}
+
+// TestNewProvider_ExplicitAttributes validates that explicit attribute names
+// are used as-is.
+func TestNewProvider_ExplicitAttributes(t *testing.T) {
+	p, err := NewProvider(Config{
+		Name:           "corp2",
+		IDPMetadataXML: idpMetadata(t),
+		SPEntityID:     "https://sp.example/metadata2",
+		ACSURL:         "https://sp.example/acs2",
+		EmailAttr:      "mail",
+		NameAttr:       "cn",
+		GroupsAttr:     "memberOf",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "mail", p.emailAttr)
+	assert.Equal(t, "cn", p.nameAttr)
+	assert.Equal(t, "memberOf", p.groupsAttr)
+}
+
+// TestProvider_Name validates that the name accessor returns the configured name.
+func TestProvider_Name(t *testing.T) {
+	p := testProvider(t)
+	assert.Equal(t, "corp", p.Name())
+}
+
+// TestNewProvider_BlankACSURL validates that a blank ACSURL is rejected.
+func TestNewProvider_BlankACSURL(t *testing.T) {
+	_, err := NewProvider(Config{
+		IDPMetadataXML: idpMetadata(t),
+		SPEntityID:     "https://x",
+		ACSURL:         "   ",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "acs_url")
+}
+
+// TestNewProvider_BlankSPEntityID validates that a blank SPEntityID is rejected.
+func TestNewProvider_BlankSPEntityID(t *testing.T) {
+	_, err := NewProvider(Config{
+		IDPMetadataXML: idpMetadata(t),
+		SPEntityID:     "   ",
+		ACSURL:         "https://x/acs",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sp_entity_id")
+}
+
+// TestRequireAudienceRestriction_NilAssertion validates nil assertion is
+// rejected without panic.
+func TestRequireAudienceRestriction_NilAssertion(t *testing.T) {
+	fn := requireAudienceRestriction("https://sp.example")
+	err := fn(nil)
+	require.Error(t, err)
+}

--- a/internal/startup/validation_extra_test.go
+++ b/internal/startup/validation_extra_test.go
@@ -1,0 +1,269 @@
+package startup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSafeFilePermPath_CleanAbsolute validates that a safe absolute path is
+// returned unchanged (after Clean).
+func TestSafeFilePermPath_CleanAbsolute(t *testing.T) {
+	got, err := safeFilePermPath("label", "/app/keys/dek.key")
+	require.NoError(t, err)
+	assert.Equal(t, "/app/keys/dek.key", got)
+}
+
+// TestSafeFilePermPath_RejectsTraversal validates that paths with ".." are
+// rejected after filepath.Clean.
+func TestSafeFilePermPath_RejectsTraversal(t *testing.T) {
+	_, err := safeFilePermPath("test", "sub/../../outside")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "..")
+}
+
+// TestSafeFilePermPath_RejectsParentDirOnly validates that ".." alone is
+// rejected.
+func TestSafeFilePermPath_RejectsParentDirOnly(t *testing.T) {
+	_, err := safeFilePermPath("label", "..")
+	require.Error(t, err)
+}
+
+// TestSafeFilePermPath_SafeRelative validates that a safe relative path without
+// traversal is allowed.
+func TestSafeFilePermPath_SafeRelative(t *testing.T) {
+	got, err := safeFilePermPath("label", "keys/dek.key")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Clean("keys/dek.key"), got)
+}
+
+// TestValidateEncryption_UnsafeSaltPath validates that a ".." in the salt path
+// is caught by validateEncryption's own traversal check.
+func TestValidateEncryption_UnsafeSaltPath(t *testing.T) {
+	cfg := encCfg("../../outside/salt", "/tmp/dek")
+	err := validateEncryption(cfg, &ValidationResult{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsafe")
+}
+
+// TestValidateEncryption_UnsafeDEKPath validates that a ".." in the DEK path
+// is caught by validateEncryption's own traversal check.
+func TestValidateEncryption_UnsafeDEKPath(t *testing.T) {
+	dir := t.TempDir()
+	salt := writeKeyFile(t, dir, "kek.salt", 32)
+	cfg := encCfg(salt, "../../outside/dek.key")
+	err := validateEncryption(cfg, &ValidationResult{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsafe")
+}
+
+// TestValidateEncryption_MissingDEK validates that a missing DEK file is
+// detected.
+func TestValidateEncryption_MissingDEK(t *testing.T) {
+	dir := t.TempDir()
+	salt := writeKeyFile(t, dir, "kek.salt", 32)
+	dek := filepath.Join(dir, "absent.dek")
+
+	err := validateEncryption(encCfg(salt, dek), &ValidationResult{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DEK")
+}
+
+// TestValidateDatabase_LocalPathMustBeAbsolute validates that a relative
+// database path is rejected for local storage.
+func TestValidateDatabase_LocalPathMustBeAbsolute(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Database.Path = "relative/secrets.db"
+	err := validateDatabase(cfg, &ValidationResult{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "relative")
+}
+
+// TestValidateDatabase_LocalPathWithTraversal validates that a RELATIVE path
+// with ".." is rejected for local storage. Note: an absolute path like
+// /app/../../etc/secrets.db cleans to /etc/secrets.db (still absolute), which
+// passes the check — only paths that are relative (not absolute) after Clean
+// are caught by the is-abs guard here.
+func TestValidateDatabase_LocalPathWithTraversal(t *testing.T) {
+	cfg := &config.Config{}
+	// A relative path with ".." remains relative after Clean.
+	cfg.Storage.Database.Path = "../relative.db"
+	err := validateDatabase(cfg, &ValidationResult{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "relative")
+}
+
+// TestValidateDatabase_ExistingFile validates that an existing, readable file is
+// accepted.
+func TestValidateDatabase_ExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "secrets.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("SQLite data"), 0600))
+
+	cfg := &config.Config{}
+	cfg.Storage.Database.Path = dbPath
+	result := &ValidationResult{}
+	err := validateDatabase(cfg, result)
+	require.NoError(t, err)
+}
+
+// TestValidateDatabase_NonExistentFileIsWarning validates that a missing DB file
+// produces a warning (not an error) — it will be created on first use.
+func TestValidateDatabase_NonExistentFileIsWarning(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Storage.Database.Path = filepath.Join(dir, "not-yet-created.db")
+	result := &ValidationResult{}
+	err := validateDatabase(cfg, result)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.Warnings, "a missing DB file should produce a warning")
+}
+
+// TestValidateDatabase_RemoteStorageSkip validates the "remote" path skips the
+// local-file check and adds a warning.
+func TestValidateDatabase_RemoteStorageSkip(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Storage.Type = "remote"
+	result := &ValidationResult{}
+	err := validateDatabase(cfg, result)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.Warnings)
+}
+
+// TestValidateDatabase_PostgresSkip validates the "postgres" path skips the
+// local-file check and adds a warning.
+func TestValidateDatabase_PostgresSkip(t *testing.T) {
+	for _, typ := range []string{"postgres", "postgresql"} {
+		cfg := &config.Config{}
+		cfg.Storage.Type = typ
+		result := &ValidationResult{}
+		err := validateDatabase(cfg, result)
+		require.NoErrorf(t, err, "storage.type=%q must not require a local DB file", typ)
+		assert.NotEmptyf(t, result.Warnings, "storage.type=%q should add a skip warning", typ)
+	}
+}
+
+// TestResolveKeyPath_Absolute validates that absolute paths are returned as-is.
+func TestResolveKeyPath_Absolute(t *testing.T) {
+	got := resolveKeyPath("/etc/keys/dek.key")
+	assert.Equal(t, "/etc/keys/dek.key", got)
+}
+
+// TestResolveKeyPath_Relative validates that relative paths are resolved against
+// ".".
+func TestResolveKeyPath_Relative(t *testing.T) {
+	got := resolveKeyPath("keys/dek.key")
+	assert.Equal(t, filepath.Clean("keys/dek.key"), got)
+}
+
+// TestResolveKeyPath_Dot validates that "." resolves to ".".
+func TestResolveKeyPath_Dot(t *testing.T) {
+	got := resolveKeyPath(".")
+	assert.Equal(t, ".", got)
+}
+
+// TestValidateFilePermissions_EncryptionPathsChecked validates that when
+// encryption is enabled, the salt and DEK paths are added to the check list.
+// We use existing files with correct permissions so the check passes.
+func TestValidateFilePermissions_EncryptionPathsChecked(t *testing.T) {
+	dir := t.TempDir()
+	salt := writeKeyFile(t, dir, "kek.salt", 32)
+	dek := writeKeyFile(t, dir, "dek.key", 60)
+
+	cfg := &config.Config{}
+	cfg.Storage.Encryption.Enabled = true
+	cfg.Storage.Encryption.SaltPath = salt
+	cfg.Storage.Encryption.DEKPath = dek
+
+	result := &ValidationResult{}
+	err := validateFilePermissions(cfg, "", false, result)
+	require.NoError(t, err)
+}
+
+// TestValidateFilePermissions_TLSGRPCPathsChecked validates that when gRPC TLS
+// is enabled, cert and key paths are included.
+func TestValidateFilePermissions_TLSGRPCPathsChecked(t *testing.T) {
+	dir := t.TempDir()
+	cert := filepath.Join(dir, "server.crt")
+	key := filepath.Join(dir, "server.key")
+	require.NoError(t, os.WriteFile(cert, []byte("cert"), 0600))
+	require.NoError(t, os.WriteFile(key, []byte("key"), 0600))
+
+	cfg := &config.Config{}
+	cfg.Server.GRPC.TLS.Enabled = true
+	cfg.Server.GRPC.TLS.CertFile = cert
+	cfg.Server.GRPC.TLS.KeyFile = key
+
+	result := &ValidationResult{}
+	err := validateFilePermissions(cfg, "", false, result)
+	require.NoError(t, err)
+}
+
+// TestValidateFilePermissions_TLSHTTPPathsChecked validates that when HTTP TLS
+// is enabled, cert and key paths are included.
+func TestValidateFilePermissions_TLSHTTPPathsChecked(t *testing.T) {
+	dir := t.TempDir()
+	cert := filepath.Join(dir, "http.crt")
+	key := filepath.Join(dir, "http.key")
+	require.NoError(t, os.WriteFile(cert, []byte("cert"), 0600))
+	require.NoError(t, os.WriteFile(key, []byte("key"), 0600))
+
+	cfg := &config.Config{}
+	cfg.Server.HTTP.TLS.Enabled = true
+	cfg.Server.HTTP.TLS.CertFile = cert
+	cfg.Server.HTTP.TLS.KeyFile = key
+
+	result := &ValidationResult{}
+	err := validateFilePermissions(cfg, "", false, result)
+	require.NoError(t, err)
+}
+
+// TestValidateFilePermissions_DatabasePathIncluded validates that when storage
+// type is local and a non-empty database path is given, it is included in the
+// permission check.
+func TestValidateFilePermissions_DatabasePathIncluded(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "secrets.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("data"), 0600))
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Database.Path = dbPath
+
+	result := &ValidationResult{}
+	err := validateFilePermissions(cfg, "", false, result)
+	require.NoError(t, err)
+}
+
+// TestPrintValidationResult_AllPass exercises the print function with a fully
+// passing result (smoke test — no panic, no assertions on stdout).
+func TestPrintValidationResult_AllPass(t *testing.T) {
+	result := &ValidationResult{
+		ConfigValid:   true,
+		PermissionsOK: true,
+		EncryptionOK:  true,
+		DatabaseOK:    true,
+	}
+	// Must not panic.
+	PrintValidationResult(result)
+}
+
+// TestPrintValidationResult_WithWarningsAndErrors exercises the print function
+// with a failing result that has both warnings and errors.
+func TestPrintValidationResult_WithWarningsAndErrors(t *testing.T) {
+	result := &ValidationResult{
+		ConfigValid:   false,
+		PermissionsOK: false,
+		EncryptionOK:  false,
+		DatabaseOK:    false,
+		Warnings:      []string{"file permission check disabled"},
+		Errors:        []string{"failed to load config: file not found"},
+	}
+	// Must not panic.
+	PrintValidationResult(result)
+}

--- a/internal/storage/factory_routing_test.go
+++ b/internal/storage/factory_routing_test.go
@@ -1,0 +1,149 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSQLiteDSN_NoPriorParams validates that the DSN has the required pragmas
+// when no query params are present.
+func TestSQLiteDSN_NoPriorParams(t *testing.T) {
+	dsn := sqliteDSN("/data/secrets.db")
+	assert.Contains(t, dsn, "_foreign_keys=1")
+	assert.Contains(t, dsn, "_busy_timeout=")
+	assert.Contains(t, dsn, "_journal_mode=WAL")
+	assert.Contains(t, dsn, "?")
+}
+
+// TestSQLiteDSN_WithExistingParams validates that the DSN appends (not clobbers)
+// pragmas when the operator already includes query parameters.
+func TestSQLiteDSN_WithExistingParams(t *testing.T) {
+	dsn := sqliteDSN("/data/secrets.db?cache=shared")
+	// Must use "&" as separator, not "?" (which would duplicate the query start).
+	assert.Contains(t, dsn, "cache=shared")
+	assert.Contains(t, dsn, "_foreign_keys=1")
+	assert.Contains(t, dsn, "_journal_mode=WAL")
+}
+
+// TestCreateStorage_LocalStorage validates that a local SQLite storage is
+// constructed successfully.
+func TestCreateStorage_LocalStorage(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Database.Path = filepath.Join(dir, "test.db")
+
+	st, err := NewStorageFactory().CreateStorage(cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, st)
+}
+
+// TestCreateStorage_EmptyTypeIsLocal validates that an empty storage.type is
+// treated as "local" (backward-compat).
+func TestCreateStorage_EmptyTypeIsLocal(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Storage.Type = "" // explicitly empty
+	cfg.Storage.Database.Path = filepath.Join(dir, "empty-type.db")
+
+	st, err := NewStorageFactory().CreateStorage(cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, st)
+}
+
+// TestCreateStorage_InvalidType validates that any unrecognized type is
+// explicitly rejected rather than silently falling through to SQLite.
+func TestCreateStorage_InvalidType(t *testing.T) {
+	for _, invalid := range []string{"postgress", "localdb", "remot", "mysql", "cassandra"} {
+		cfg := &config.Config{}
+		cfg.Storage.Type = invalid
+		st, err := NewStorageFactory().CreateStorage(cfg)
+		require.Errorf(t, err, "storage.type=%q must be rejected", invalid)
+		assert.Nil(t, st)
+		assert.Contains(t, err.Error(), invalid)
+	}
+}
+
+// TestCreateStorage_PostgresRequiresDSNOrFields validates that creating
+// Postgres storage without any connection info is rejected.
+func TestCreateStorage_PostgresRequiresDSNOrFields(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Storage.Type = "postgres"
+	// DSN, host, name, user all empty → BuildPostgresDSN returns "" for host-only.
+	// The factory checks for empty DSN.
+	// Note: BuildPostgresDSN fills host/port defaults but the factory only checks
+	// when DSN is empty and name/user are empty. So we provide a host to still
+	// get an empty Name/User — which our factory rejects.
+	cfg.Storage.Database.DSN = ""
+	cfg.Storage.Database.Host = ""
+	cfg.Storage.Database.Name = ""
+	cfg.Storage.Database.User = ""
+
+	_, err := NewStorageFactory().CreateStorage(cfg)
+	require.Error(t, err)
+	// The factory rejects with "requires a DSN or host/name/user fields"
+	// because BuildPostgresDSN still returns a non-empty DSN even with empty fields.
+	// So just verify we can call it without panic.
+	_ = err
+}
+
+// TestOpenGormDB_RemoteStorageRejected validates that OpenGormDB refuses remote
+// storage since it has no local DB to open.
+func TestOpenGormDB_RemoteStorageRejected(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Storage.Type = "remote"
+	_, err := OpenGormDB(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote")
+}
+
+// TestOpenGormDB_InvalidTypeRejected validates that OpenGormDB rejects unknown
+// storage types (#463 defense-in-depth).
+func TestOpenGormDB_InvalidTypeRejected(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Storage.Type = "badtype"
+	_, err := OpenGormDB(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "badtype")
+}
+
+// TestOpenGormDB_LocalSQLite validates that OpenGormDB can open a local SQLite
+// database.
+func TestOpenGormDB_LocalSQLite(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Database.Path = filepath.Join(dir, "gormdb.db")
+
+	db, err := OpenGormDB(cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, db)
+}
+
+// TestOpenGormDB_EmptyPathUsesDefault validates that an empty path uses the
+// default "secrets.db" path (doesn't panic).
+func TestOpenGormDB_EmptyPathUsesDefault(t *testing.T) {
+	// This test only validates the logic routing, not the file creation.
+	// We use a TempDir-chdir trick to avoid writing to the test runner's cwd.
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Database.Path = "" // triggers default "./secrets.db"
+
+	db, err := OpenGormDB(cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, db)
+}

--- a/internal/storage/models/models_extra_test.go
+++ b/internal/storage/models/models_extra_test.go
@@ -1,0 +1,275 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- SecretNode helper methods ---
+
+// TestSecretNode_CanAccess validates that the owner always has access and a
+// non-owner without shares does not.
+func TestSecretNode_CanAccess(t *testing.T) {
+	s := &SecretNode{OwnerID: 1}
+	assert.True(t, s.CanAccess(1), "owner must always have access")
+	assert.False(t, s.CanAccess(2), "non-owner with no share must not have access")
+}
+
+// TestSecretNode_CanWrite validates that only the owner has write access in the
+// model-layer helper (shares are checked at the storage layer).
+func TestSecretNode_CanWrite(t *testing.T) {
+	s := &SecretNode{OwnerID: 10}
+	assert.True(t, s.CanWrite(10))
+	assert.False(t, s.CanWrite(99))
+}
+
+// --- Permission level helpers ---
+
+// TestValidatePermissionLevel_CaseSensitive validates that uppercase is not
+// accepted (ValidatePermissionLevel is case-sensitive).
+func TestValidatePermissionLevel_CaseSensitive(t *testing.T) {
+	// "READ" and "WRITE" must be rejected — only lowercase is valid.
+	require.Error(t, ValidatePermissionLevel("READ"))
+	require.Error(t, ValidatePermissionLevel("WRITE"))
+	require.Error(t, ValidatePermissionLevel("admin"))
+}
+
+// --- Group sharing helpers ---
+
+// TestGetGroupMembers_ZeroIDError validates the zero-ID guard.
+func TestGetGroupMembers_ZeroIDError(t *testing.T) {
+	_, err := GetGroupMembers(0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "zero")
+}
+
+// TestGetGroupMembers_NonZeroID validates a non-zero ID returns a non-nil
+// (but empty) slice without error.
+func TestGetGroupMembers_NonZeroID(t *testing.T) {
+	members, err := GetGroupMembers(1)
+	require.NoError(t, err)
+	assert.NotNil(t, members)
+}
+
+// TestValidateGroupExists_ZeroIDError validates the zero-ID guard.
+func TestValidateGroupExists_ZeroIDError(t *testing.T) {
+	err := ValidateGroupExists(0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "zero")
+}
+
+// TestValidateGroupExists_NonZeroID validates that a non-zero ID passes.
+func TestValidateGroupExists_NonZeroID(t *testing.T) {
+	// The placeholder always returns nil for non-zero.
+	require.NoError(t, ValidateGroupExists(1))
+}
+
+// TestCanAccessViaGroup_ZeroSecretID validates the secret-ID zero guard.
+func TestCanAccessViaGroup_ZeroSecretID(t *testing.T) {
+	_, _, err := CanAccessViaGroup(0, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret")
+}
+
+// TestCanAccessViaGroup_ZeroUserID validates the user-ID zero guard.
+func TestCanAccessViaGroup_ZeroUserID(t *testing.T) {
+	_, _, err := CanAccessViaGroup(1, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user")
+}
+
+// TestCanAccessViaGroup_NonZero validates that non-zero IDs return no error.
+func TestCanAccessViaGroup_NonZero(t *testing.T) {
+	ok, perm, err := CanAccessViaGroup(1, 2)
+	require.NoError(t, err)
+	assert.False(t, ok, "placeholder always returns false")
+	assert.Empty(t, perm)
+}
+
+// TestGetUserGroups_ZeroIDError validates the zero-ID guard.
+func TestGetUserGroups_ZeroIDError(t *testing.T) {
+	_, err := GetUserGroups(0)
+	require.Error(t, err)
+}
+
+// TestGetGroupShares_ZeroIDError validates the zero-ID guard.
+func TestGetGroupShares_ZeroIDError(t *testing.T) {
+	_, err := GetGroupShares(0)
+	require.Error(t, err)
+}
+
+// TestIsGroupMember_Placeholder validates that the placeholder always returns
+// false.
+func TestIsGroupMember_Placeholder(t *testing.T) {
+	assert.False(t, IsGroupMember(1, 1))
+}
+
+// --- JSON type ---
+
+// TestJSON_ValueNil validates that a nil JSON value returns (nil, nil).
+func TestJSON_ValueNil(t *testing.T) {
+	var j JSON
+	v, err := j.Value()
+	require.NoError(t, err)
+	assert.Nil(t, v)
+}
+
+// TestJSON_Value validates that a non-nil JSON returns its string representation.
+func TestJSON_Value(t *testing.T) {
+	j := JSON(`{"key":"val"}`)
+	v, err := j.Value()
+	require.NoError(t, err)
+	assert.Equal(t, `{"key":"val"}`, v)
+}
+
+// TestJSON_ScanNil validates that scanning nil sets j to nil.
+func TestJSON_ScanNil(t *testing.T) {
+	var j JSON
+	require.NoError(t, j.Scan(nil))
+	assert.Nil(t, j)
+}
+
+// TestJSON_ScanString validates scanning a string value.
+func TestJSON_ScanString(t *testing.T) {
+	var j JSON
+	require.NoError(t, j.Scan(`{"a":1}`))
+	assert.Equal(t, JSON(`{"a":1}`), j)
+}
+
+// TestJSON_ScanBytes validates scanning a []byte value.
+func TestJSON_ScanBytes(t *testing.T) {
+	var j JSON
+	require.NoError(t, j.Scan([]byte(`{"b":2}`)))
+	assert.Equal(t, JSON(`{"b":2}`), j)
+}
+
+// TestJSON_ScanUnsupportedType validates that scanning an unsupported type
+// returns an error.
+func TestJSON_ScanUnsupportedType(t *testing.T) {
+	var j JSON
+	err := j.Scan(42)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported scan type")
+}
+
+// TestJSON_MarshalJSON_Nil validates that a nil JSON marshals as "null".
+func TestJSON_MarshalJSON_Nil(t *testing.T) {
+	var j JSON
+	b, err := j.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(b))
+}
+
+// TestJSON_MarshalJSON_NonNil validates raw bytes are used directly.
+func TestJSON_MarshalJSON_NonNil(t *testing.T) {
+	j := JSON(`{"x":1}`)
+	b, err := j.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, `{"x":1}`, string(b))
+}
+
+// TestJSON_UnmarshalJSON validates that JSON is stored as raw bytes.
+func TestJSON_UnmarshalJSON(t *testing.T) {
+	var j JSON
+	require.NoError(t, j.UnmarshalJSON([]byte(`{"y":2}`)))
+	assert.Equal(t, JSON(`{"y":2}`), j)
+}
+
+// TestJSON_RoundTrip validates the full marshal/unmarshal cycle via encoding/json.
+func TestJSON_RoundTrip(t *testing.T) {
+	type wrapper struct {
+		Data JSON `json:"data"`
+	}
+	original := wrapper{Data: JSON(`{"hello":"world"}`)}
+	b, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded wrapper
+	require.NoError(t, json.Unmarshal(b, &decoded))
+	assert.Equal(t, original.Data, decoded.Data)
+}
+
+// TestJSON_RoundTrip_Null validates that a nil JSON field marshals as null and
+// round-trips correctly.
+func TestJSON_RoundTrip_Null(t *testing.T) {
+	type wrapper struct {
+		Data JSON `json:"data"`
+	}
+	original := wrapper{Data: nil}
+	b, err := json.Marshal(original)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "null")
+
+	var decoded wrapper
+	require.NoError(t, json.Unmarshal(b, &decoded))
+	// After round-trip, Data may be nil or JSON("null") depending on path.
+	// Both are acceptable; just ensure no error.
+}
+
+// --- NotificationSeverity ---
+
+// TestNotificationSeverity_Constants validates the ordered severity constants.
+func TestNotificationSeverity_Constants(t *testing.T) {
+	assert.Equal(t, NotificationSeverity(0), NotificationSeverityNone)
+	assert.Equal(t, NotificationSeverity(1), NotificationSeverityWarning)
+	assert.Equal(t, NotificationSeverity(2), NotificationSeverityCritical)
+
+	// Critical is strictly more severe than Warning.
+	assert.Greater(t, int(NotificationSeverityCritical), int(NotificationSeverityWarning))
+}
+
+// --- SoDPolicy TableName ---
+
+// TestSoDPolicy_TableName validates the custom table name.
+func TestSoDPolicy_TableName(t *testing.T) {
+	assert.Equal(t, "sod_policies", SoDPolicy{}.TableName())
+}
+
+// --- MachineIdentityOIDCBinding TableName ---
+
+// TestMachineIdentityOIDCBinding_TableName validates the custom table name.
+func TestMachineIdentityOIDCBinding_TableName(t *testing.T) {
+	assert.Equal(t, "machine_identity_oidc_bindings", MachineIdentityOIDCBinding{}.TableName())
+}
+
+// --- DynamicSecretLease ---
+
+// TestDynamicSecretLease_StatusTransitions validates that the model stores all
+// expected status values.
+func TestDynamicSecretLease_StatusTransitions(t *testing.T) {
+	for _, s := range []string{"active", "revoked", "expired", "revoke_failed"} {
+		l := DynamicSecretLease{Status: s}
+		assert.Equal(t, s, l.Status)
+	}
+}
+
+// TestDynamicSecretLease_ExpiresAt validates IssuedAt < ExpiresAt ordering.
+func TestDynamicSecretLease_ExpiresAt(t *testing.T) {
+	now := time.Now()
+	l := DynamicSecretLease{
+		IssuedAt:  now,
+		ExpiresAt: now.Add(time.Hour),
+	}
+	assert.True(t, l.ExpiresAt.After(l.IssuedAt))
+}
+
+// --- ShareRecord permission defaults ---
+
+// TestShareRecord_DefaultPermission validates that an empty Permission is set
+// to "read" by ValidateShareRecord.
+func TestShareRecord_DefaultPermission(t *testing.T) {
+	s := &ShareRecord{SecretID: 1, OwnerID: 2, RecipientID: 3}
+	require.NoError(t, ValidateShareRecord(s))
+	assert.Equal(t, "read", s.Permission)
+}
+
+// TestShareRecord_ExpiresAt validates that an expired share can be represented.
+func TestShareRecord_ExpiresAt(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	s := ShareRecord{ExpiresAt: &past}
+	assert.True(t, s.ExpiresAt.Before(time.Now()))
+}


### PR DESCRIPTION
## Summary

- Adds `*_extra_test.go` files covering previously untested paths in 7 internal packages
- `internal/dynamic`: FakeEngine lifecycle, all backend types, concurrency safety, randString
- `internal/rotation`: Manager duplicate/empty/nil, prefixAllowed, redactSQLError, PartialRotationError
- `internal/saml`: orDefault, attrMatches, attributeValues, extractAssertion, parseIDPMetadata, NewProvider
- `internal/startup`: safeFilePermPath, validateEncryption, validateDatabase, validateFilePermissions, PrintValidationResult
- `internal/config`: LicenseGrace, BuildPostgresDSN, env overrides for DB/Remote/SCIM, DualControl, BreakGlass, scheduler helpers, EvidenceDelivery, Validate HTTP/gRPC, SAML/Rotation accessors
- `internal/storage/models`: SecretNode.CanAccess/CanWrite, JSON round-trip, group sharing helpers, ValidatePermissionLevel
- `internal/storage`: sqliteDSN injection guard, CreateStorage, OpenGormDB routing

## Test plan

- [ ] `go test ./internal/dynamic/... ./internal/rotation/... ./internal/saml/... ./internal/startup/... ./internal/config/... ./internal/storage/...` passes
- [ ] CI build-and-test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)