### PR TITLE
test(coverage): bump server/grpc, interceptors, middleware, startup to >=80%

### DIFF
--- a/internal/startup/validation_s2_test.go
+++ b/internal/startup/validation_s2_test.go
@@ -1,0 +1,144 @@
+package startup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// minimalConfigYAML returns a valid Keyorix config with:
+//   - no HTTP/gRPC servers enabled (avoids port-required validation)
+//   - local sqlite storage pointing at absDBPath
+//   - encryption disabled (avoids key file requirements)
+//   - file permission checks disabled (avoids chmod on the temp files)
+func minimalConfigYAML(absDBPath string) string {
+	return fmt.Sprintf(`
+storage:
+  type: local
+  database:
+    path: %q
+  encryption:
+    enabled: false
+
+server:
+  http:
+    enabled: false
+  grpc:
+    enabled: false
+
+security:
+  enable_file_permission_check: false
+`, absDBPath)
+}
+
+// writeConfig writes content to configPath.
+func writeConfig(t *testing.T, configPath, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0600))
+}
+
+// TestValidateStartup_MissingConfigFile returns an error when the config file
+// does not exist.
+func TestValidateStartup_MissingConfigFile(t *testing.T) {
+	_, err := ValidateStartup("/nonexistent/path/keyorix.yaml", false)
+	require.Error(t, err)
+}
+
+// TestValidateStartup_ValidConfig returns a fully-OK result for a well-formed
+// config (no encryption, no TLS, sqlite storage, file-perm checks off).
+func TestValidateStartup_ValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "secrets.db")
+	// The DB file doesn't have to exist — a missing file is a warning, not error.
+	configPath := filepath.Join(dir, "keyorix.yaml")
+	writeConfig(t, configPath, minimalConfigYAML(dbPath))
+
+	result, err := ValidateStartup(configPath, false)
+	require.NoError(t, err)
+	assert.True(t, result.ConfigValid, "ConfigValid must be true")
+	assert.True(t, result.PermissionsOK, "PermissionsOK must be true (checks disabled)")
+	assert.True(t, result.EncryptionOK, "EncryptionOK must be true (encryption disabled)")
+	assert.True(t, result.DatabaseOK, "DatabaseOK must be true")
+}
+
+// TestValidateStartup_ExistingDB verifies ValidateStartup accepts an existing,
+// readable database file.
+func TestValidateStartup_ExistingDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "secrets.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("SQLite3 header"), 0600))
+	configPath := filepath.Join(dir, "keyorix.yaml")
+	writeConfig(t, configPath, minimalConfigYAML(dbPath))
+
+	result, err := ValidateStartup(configPath, false)
+	require.NoError(t, err)
+	assert.True(t, result.DatabaseOK)
+}
+
+// TestValidateStartup_BadConfigSchema returns an error when the config content is
+// structurally valid YAML but fails schema validation (e.g. HTTP server enabled
+// without a port).
+func TestValidateStartup_BadConfigSchema(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "keyorix.yaml")
+	// HTTP enabled but no port → Validate() returns an error.
+	writeConfig(t, configPath, `
+server:
+  http:
+    enabled: true
+`)
+	_, err := ValidateStartup(configPath, false)
+	require.Error(t, err, "a config that fails Validate() must return an error")
+}
+
+// TestValidateDatabase_TraversalPath verifies that a path containing ".." after
+// Clean is rejected.
+func TestValidateDatabase_TraversalPath(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Storage.Type = ""
+	// "/../foo" after Clean is still absolute ("/foo") — use a relative traversal
+	// to land on a non-absolute path after Clean.
+	cfg.Storage.Database.Path = "../../relative.db"
+	result := &ValidationResult{}
+	err := validateDatabase(cfg, result)
+	require.Error(t, err)
+}
+
+// TestValidateStartup_EncryptionEnabledMissingKeys returns an error when
+// encryption is enabled but the key files don't exist.
+func TestValidateStartup_EncryptionEnabledMissingKeys(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "secrets.db")
+	configPath := filepath.Join(dir, "keyorix.yaml")
+	// Use absolute paths for missing key files so validateEncryption path is reached.
+	saltPath := filepath.Join(dir, "absent.salt")
+	dekPath := filepath.Join(dir, "absent.dek")
+	content := fmt.Sprintf(`
+storage:
+  type: local
+  database:
+    path: %q
+  encryption:
+    enabled: true
+    salt_path: %q
+    dek_path: %q
+
+server:
+  http:
+    enabled: false
+  grpc:
+    enabled: false
+
+security:
+  enable_file_permission_check: false
+`, dbPath, saltPath, dekPath)
+	writeConfig(t, configPath, content)
+
+	_, err := ValidateStartup(configPath, false)
+	require.Error(t, err, "missing encryption key files must result in an error")
+}

--- a/server/grpc/interceptors/interceptors_s2_test.go
+++ b/server/grpc/interceptors/interceptors_s2_test.go
@@ -1,0 +1,134 @@
+package interceptors
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// TestStreamLoggingInterceptor_SuccessPath ensures StreamLoggingInterceptor passes
+// through the handler result on a successful stream.
+func TestStreamLoggingInterceptor_SuccessPath(t *testing.T) {
+	interceptor := StreamLoggingInterceptor()
+	info := &grpc.StreamServerInfo{FullMethod: "/keyorix.v1.AuditService/StreamAuditLogs"}
+
+	called := false
+	err := interceptor(nil, &fakeStream{ctx: context.Background()}, info,
+		func(_ interface{}, _ grpc.ServerStream) error {
+			called = true
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !called {
+		t.Fatal("handler was not called")
+	}
+}
+
+// TestStreamLoggingInterceptor_ErrorPath ensures StreamLoggingInterceptor propagates
+// handler errors.
+func TestStreamLoggingInterceptor_ErrorPath(t *testing.T) {
+	interceptor := StreamLoggingInterceptor()
+	info := &grpc.StreamServerInfo{FullMethod: "/keyorix.v1.AuditService/StreamAuditLogs"}
+	handlerErr := errors.New("stream failure")
+
+	err := interceptor(nil, &fakeStream{ctx: context.Background()}, info,
+		func(_ interface{}, _ grpc.ServerStream) error {
+			return handlerErr
+		})
+	if !errors.Is(err, handlerErr) {
+		t.Fatalf("expected original error to propagate, got %v", err)
+	}
+}
+
+// TestClientUserAgent_PresentInMetadata returns the user-agent when present.
+func TestClientUserAgent_PresentInMetadata(t *testing.T) {
+	md := metadata.Pairs("user-agent", "grpc-go/1.60.0")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	got := ClientUserAgent(ctx)
+	if got != "grpc-go/1.60.0" {
+		t.Errorf("ClientUserAgent = %q, want %q", got, "grpc-go/1.60.0")
+	}
+}
+
+// TestClientUserAgent_AbsentReturnsEmpty returns "" when user-agent is not set.
+func TestClientUserAgent_AbsentReturnsEmpty(t *testing.T) {
+	ctx := context.Background()
+	if got := ClientUserAgent(ctx); got != "" {
+		t.Errorf("ClientUserAgent with no metadata = %q, want empty", got)
+	}
+}
+
+// TestClientUserAgent_NoMetadataKey returns "" when metadata present but key missing.
+func TestClientUserAgent_NoMetadataKey(t *testing.T) {
+	md := metadata.Pairs("authorization", "Bearer tok")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	if got := ClientUserAgent(ctx); got != "" {
+		t.Errorf("ClientUserAgent without user-agent key = %q, want empty", got)
+	}
+}
+
+// TestGetUserContextKey returns the package-level context key.
+func TestGetUserContextKey(t *testing.T) {
+	k := GetUserContextKey()
+	if k != userContextKey {
+		t.Errorf("GetUserContextKey() = %v, want %v", k, userContextKey)
+	}
+}
+
+// TestWrappedServerStream_Context verifies wrappedServerStream.Context returns the
+// injected context, not the underlying stream's context.
+func TestWrappedServerStream_Context(t *testing.T) {
+	type key struct{}
+	inner := &fakeStream{ctx: context.Background()}
+	injected := context.WithValue(context.Background(), key{}, "marker")
+	ws := &wrappedServerStream{ServerStream: inner, ctx: injected}
+	if v := ws.Context().Value(key{}); v != "marker" {
+		t.Errorf("wrappedServerStream.Context() did not return injected context; got value %v", v)
+	}
+}
+
+// TestActorKind_MachineType verifies ActorKind returns "machine_identity" for
+// machine actor types.
+func TestActorKind_MachineType(t *testing.T) {
+	uc := &UserContext{ActorType: "machine_identity"}
+	if got := uc.ActorKind(); got != "machine_identity" {
+		t.Errorf("ActorKind() = %q, want %q", got, "machine_identity")
+	}
+}
+
+// TestActorKind_UserType verifies ActorKind defaults to "user" for non-machine types.
+func TestActorKind_UserType(t *testing.T) {
+	uc := &UserContext{ActorType: ""}
+	if got := uc.ActorKind(); got != "user" {
+		t.Errorf("ActorKind() = %q, want %q", got, "user")
+	}
+}
+
+// TestPrincipalID_Machine returns the MachineIdentityID for machine actors.
+func TestPrincipalID_Machine(t *testing.T) {
+	uc := &UserContext{ActorType: "machine_identity", MachineIdentityID: 42}
+	if got := uc.PrincipalID(); got != 42 {
+		t.Errorf("PrincipalID() = %d, want %d", got, 42)
+	}
+}
+
+// TestPrincipalID_User returns the UserID for user actors.
+func TestPrincipalID_User(t *testing.T) {
+	uc := &UserContext{UserID: 7}
+	if got := uc.PrincipalID(); got != 7 {
+		t.Errorf("PrincipalID() = %d, want %d", got, 7)
+	}
+}
+
+// fakeStream is a minimal grpc.ServerStream for stream-interceptor tests.
+type fakeStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (f *fakeStream) Context() context.Context { return f.ctx }

--- a/server/grpc/server_s2_test.go
+++ b/server/grpc/server_s2_test.go
@@ -1,0 +1,127 @@
+package grpc
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+)
+
+// writeSelfSignedCert generates a minimal self-signed ECDSA certificate and key
+// pair, writes them to dir/cert.pem and dir/key.pem, and returns their paths.
+func writeSelfSignedCert(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+
+	certFile, err := os.Create(certPath)
+	if err != nil {
+		t.Fatalf("create cert file: %v", err)
+	}
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		t.Fatalf("encode cert: %v", err)
+	}
+	if err := certFile.Close(); err != nil {
+		t.Fatalf("close cert file: %v", err)
+	}
+
+	keyFile, err := os.Create(keyPath)
+	if err != nil {
+		t.Fatalf("create key file: %v", err)
+	}
+	privDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	if err := pem.Encode(keyFile, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privDER}); err != nil {
+		t.Fatalf("encode key: %v", err)
+	}
+	if err := keyFile.Close(); err != nil {
+		t.Fatalf("close key file: %v", err)
+	}
+
+	return certPath, keyPath
+}
+
+// TestCreateGRPCTLSConfig_ManualCertAppliesHardening exercises the non-AutoCert
+// branch: certificate loaded from disk, TLS hardening still applied.
+func TestCreateGRPCTLSConfig_ManualCertAppliesHardening(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeSelfSignedCert(t, dir)
+
+	cfg := &config.Config{}
+	cfg.Server.GRPC.TLS.Enabled = true
+	cfg.Server.GRPC.TLS.AutoCert = false
+	cfg.Server.GRPC.TLS.CertFile = certPath
+	cfg.Server.GRPC.TLS.KeyFile = keyPath
+
+	tlsConfig, err := createGRPCTLSConfig(cfg)
+	if err != nil {
+		t.Fatalf("createGRPCTLSConfig: %v", err)
+	}
+	if tlsConfig.MinVersion != tls.VersionTLS12 {
+		t.Errorf("MinVersion = %v, want tls.VersionTLS12", tlsConfig.MinVersion)
+	}
+	if len(tlsConfig.CipherSuites) == 0 {
+		t.Fatal("CipherSuites must not be empty on the manual-cert branch")
+	}
+	if len(tlsConfig.Certificates) == 0 {
+		t.Fatal("Certificates must be populated when loading from disk")
+	}
+}
+
+// TestCreateGRPCTLSConfig_ManualCertMissingFile tests that a missing cert file
+// returns an error rather than silently succeeding.
+func TestCreateGRPCTLSConfig_ManualCertMissingFile(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Server.GRPC.TLS.Enabled = true
+	cfg.Server.GRPC.TLS.AutoCert = false
+	cfg.Server.GRPC.TLS.CertFile = "/nonexistent/cert.pem"
+	cfg.Server.GRPC.TLS.KeyFile = "/nonexistent/key.pem"
+
+	if _, err := createGRPCTLSConfig(cfg); err == nil {
+		t.Error("createGRPCTLSConfig must return an error for a missing certificate file")
+	}
+}
+
+// TestApplyTLSHardening_AllowedCiphersOverridesDefault verifies that an operator
+// can override the hardcoded cipher list via AllowedCiphers.
+func TestApplyTLSHardening_AllowedCiphersOverridesDefault(t *testing.T) {
+	tlsCfg := config.TLSConfig{
+		AllowedCiphers: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+	}
+	result := &tls.Config{}
+	if err := applyTLSHardening(result, tlsCfg); err != nil {
+		t.Fatalf("applyTLSHardening: %v", err)
+	}
+	if len(result.CipherSuites) != 1 || result.CipherSuites[0] != tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+		t.Errorf("CipherSuites = %v, want [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]", result.CipherSuites)
+	}
+}

--- a/server/grpc/services/services_s2_test.go
+++ b/server/grpc/services/services_s2_test.go
@@ -1,0 +1,284 @@
+package services
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// --- mapDynamicError ---
+
+func TestMapDynamicError_NotFound(t *testing.T) {
+	err := mapDynamicError(errors.New("config not found in database"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.NotFound {
+		t.Errorf("expected NotFound, got %v", st.Code())
+	}
+}
+
+func TestMapDynamicError_InvalidArgument_CannotExceed(t *testing.T) {
+	err := mapDynamicError(errors.New("cannot exceed the allowed limit"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", st.Code())
+	}
+}
+
+func TestMapDynamicError_InvalidArgument_Required(t *testing.T) {
+	err := mapDynamicError(errors.New("name is required"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", st.Code())
+	}
+}
+
+func TestMapDynamicError_InvalidArgument_ClassificationMust(t *testing.T) {
+	err := mapDynamicError(errors.New("classification must be one of: restricted, confidential"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", st.Code())
+	}
+}
+
+func TestMapDynamicError_PermissionDenied(t *testing.T) {
+	err := mapDynamicError(errors.New("permission denied for this config"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
+	}
+}
+
+func TestMapDynamicError_Denied(t *testing.T) {
+	err := mapDynamicError(errors.New("access denied by policy"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
+	}
+}
+
+func TestMapDynamicError_Default_Unavailable(t *testing.T) {
+	err := mapDynamicError(errors.New("connection reset by peer"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Unavailable {
+		t.Errorf("expected Unavailable, got %v", st.Code())
+	}
+}
+
+// --- mapMachineError ---
+
+func TestMapMachineError_NotFound(t *testing.T) {
+	err := mapMachineError(errors.New("machine identity not found"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.NotFound {
+		t.Errorf("expected NotFound, got %v", st.Code())
+	}
+}
+
+func TestMapMachineError_CannotTransition(t *testing.T) {
+	err := mapMachineError(errors.New("cannot transition from active to active"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.FailedPrecondition {
+		t.Errorf("expected FailedPrecondition, got %v", st.Code())
+	}
+}
+
+func TestMapMachineError_MustBeActive(t *testing.T) {
+	err := mapMachineError(errors.New("must be active to issue a token"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.FailedPrecondition {
+		t.Errorf("expected FailedPrecondition, got %v", st.Code())
+	}
+}
+
+func TestMapMachineError_InvalidArgument(t *testing.T) {
+	err := mapMachineError(errors.New("invalid machine identity name"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", st.Code())
+	}
+}
+
+func TestMapMachineError_ClassificationMust(t *testing.T) {
+	err := mapMachineError(errors.New("classification must be one of: restricted"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", st.Code())
+	}
+}
+
+func TestMapMachineError_Required(t *testing.T) {
+	err := mapMachineError(errors.New("name is required"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", st.Code())
+	}
+}
+
+func TestMapMachineError_PermissionDenied(t *testing.T) {
+	err := mapMachineError(errors.New("permission denied"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
+	}
+}
+
+func TestMapMachineError_Denied(t *testing.T) {
+	err := mapMachineError(errors.New("access denied by RBAC"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
+	}
+}
+
+func TestMapMachineError_Default_Internal(t *testing.T) {
+	err := mapMachineError(errors.New("unexpected storage failure"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Internal {
+		t.Errorf("expected Internal, got %v", st.Code())
+	}
+}
+
+// --- mapRoleError ---
+
+func TestMapRoleError_NotFound(t *testing.T) {
+	err := mapRoleError(errors.New("role not found"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.NotFound {
+		t.Errorf("expected NotFound, got %v", st.Code())
+	}
+}
+
+func TestMapRoleError_AlreadyExists(t *testing.T) {
+	err := mapRoleError(errors.New("role already exists in the system"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.AlreadyExists {
+		t.Errorf("expected AlreadyExists, got %v", st.Code())
+	}
+}
+
+func TestMapRoleError_Duplicate(t *testing.T) {
+	err := mapRoleError(errors.New("duplicate role name"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.AlreadyExists {
+		t.Errorf("expected AlreadyExists, got %v", st.Code())
+	}
+}
+
+func TestMapRoleError_Default(t *testing.T) {
+	err := mapRoleError(errors.New("something unexpected went wrong"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Internal {
+		t.Errorf("expected Internal, got %v", st.Code())
+	}
+}
+
+// --- breakGlassError ---
+
+func TestBreakGlassError_NotFound(t *testing.T) {
+	err := breakGlassError(errors.New("activation not found"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.NotFound {
+		t.Errorf("expected NotFound, got %v", st.Code())
+	}
+}
+
+func TestBreakGlassError_Justification(t *testing.T) {
+	err := breakGlassError(errors.New("justification is required"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", st.Code())
+	}
+}
+
+func TestBreakGlassError_PermissionDenied(t *testing.T) {
+	err := breakGlassError(errors.New("permission denied to activate break-glass"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
+	}
+}
+
+func TestBreakGlassError_AlreadyRevoked(t *testing.T) {
+	err := breakGlassError(errors.New("already revoked"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.FailedPrecondition {
+		t.Errorf("expected FailedPrecondition, got %v", st.Code())
+	}
+}
+
+func TestBreakGlassError_Default(t *testing.T) {
+	err := breakGlassError(errors.New("unexpected backend error"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Internal {
+		t.Errorf("expected Internal, got %v", st.Code())
+	}
+}
+
+// --- resolveActor ---
+
+func TestResolveActor_NilUserIDSystemType(t *testing.T) {
+	e := &models.AuditEvent{ActorType: "system"}
+	got := resolveActor(e, nil)
+	if got != "system" {
+		t.Errorf("resolveActor with system actor = %q, want %q", got, "system")
+	}
+}
+
+func TestResolveActor_NilUserIDUnknownType(t *testing.T) {
+	e := &models.AuditEvent{ActorType: "job"}
+	got := resolveActor(e, nil)
+	if got != "unknown" {
+		t.Errorf("resolveActor with non-system actor = %q, want %q", got, "unknown")
+	}
+}
+
+func TestResolveActor_UserIDInMap(t *testing.T) {
+	uid := uint(5)
+	e := &models.AuditEvent{UserID: &uid}
+	got := resolveActor(e, map[uint]string{5: "alice"})
+	if got != "alice" {
+		t.Errorf("resolveActor with known user = %q, want %q", got, "alice")
+	}
+}
+
+func TestResolveActor_UserIDNotInMap(t *testing.T) {
+	uid := uint(99)
+	e := &models.AuditEvent{UserID: &uid}
+	got := resolveActor(e, map[uint]string{})
+	if got != "unknown" {
+		t.Errorf("resolveActor with unknown user = %q, want %q", got, "unknown")
+	}
+}
+
+// --- machineActionToState ---
+
+func TestMachineActionToState_Activate(t *testing.T) {
+	state, ok := machineActionToState("activate")
+	if !ok || state == "" {
+		t.Errorf("activate: ok=%v state=%q", ok, state)
+	}
+}
+
+func TestMachineActionToState_Suspend(t *testing.T) {
+	state, ok := machineActionToState("suspend")
+	if !ok || state == "" {
+		t.Errorf("suspend: ok=%v state=%q", ok, state)
+	}
+}
+
+func TestMachineActionToState_Revoke(t *testing.T) {
+	state, ok := machineActionToState("revoke")
+	if !ok || state == "" {
+		t.Errorf("revoke: ok=%v state=%q", ok, state)
+	}
+}
+
+func TestMachineActionToState_Unknown(t *testing.T) {
+	_, ok := machineActionToState("unknown-action")
+	if ok {
+		t.Error("expected ok=false for unknown action")
+	}
+}

--- a/server/middleware/middleware_s2_test.go
+++ b/server/middleware/middleware_s2_test.go
@@ -1,0 +1,264 @@
+package middleware
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// --- PrometheusMiddleware ---
+
+// TestPrometheusMiddleware_MatchedRoute verifies that PrometheusMiddleware calls the
+// handler and returns a 200 when the route is matched.
+func TestPrometheusMiddleware_MatchedRoute(t *testing.T) {
+	rctx := chi.NewRouteContext()
+	rctx.RoutePatterns = []string{"/api/v1/secrets/{id}"}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets/1", nil)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rec := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	PrometheusMiddleware(handler).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+// TestPrometheusMiddleware_UnmatchedRoute verifies that PrometheusMiddleware handles
+// requests without a matched route (empty pattern).
+func TestPrometheusMiddleware_UnmatchedRoute(t *testing.T) {
+	rctx := chi.NewRouteContext()
+	req := httptest.NewRequest(http.MethodGet, "/unknown/path", nil)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rec := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	PrometheusMiddleware(handler).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// --- ScopeFromProjectParam ---
+
+// TestScopeFromProjectParam_Valid verifies the resolver extracts a project ID from
+// a chi URL parameter.
+func TestScopeFromProjectParam_Valid(t *testing.T) {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("projectId", "42")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/42", nil)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	scope, err := ScopeFromProjectParam("projectId")(req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scope.ProjectID != 42 {
+		t.Errorf("ProjectID = %d, want 42", scope.ProjectID)
+	}
+}
+
+// TestScopeFromProjectParam_Invalid returns errInvalidTarget for a non-numeric param.
+func TestScopeFromProjectParam_Invalid(t *testing.T) {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("projectId", "notanumber")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/notanumber", nil)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	_, err := ScopeFromProjectParam("projectId")(req, nil)
+	if err == nil {
+		t.Error("expected error for non-numeric param, got nil")
+	}
+}
+
+// --- ScopeFromRoleAssignmentBody ---
+
+// TestScopeFromRoleAssignmentBody_ValidJSON parses project_id/environment_id from
+// the request body and returns the right scope.
+func TestScopeFromRoleAssignmentBody_ValidJSON(t *testing.T) {
+	body := `{"project_id":3,"environment_id":7}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/user-roles", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	scope, err := ScopeFromRoleAssignmentBody(req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scope.ProjectID != 3 || scope.EnvironmentID != 7 {
+		t.Errorf("scope = %+v, want {ProjectID:3 EnvironmentID:7}", scope)
+	}
+}
+
+// TestScopeFromRoleAssignmentBody_EmptyBody returns a global scope (both IDs = 0).
+func TestScopeFromRoleAssignmentBody_EmptyBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/user-roles", http.NoBody)
+	scope, err := ScopeFromRoleAssignmentBody(req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scope.ProjectID != 0 || scope.EnvironmentID != 0 {
+		t.Errorf("empty body scope = %+v, want global (0,0)", scope)
+	}
+}
+
+// TestScopeFromRoleAssignmentBody_InvalidJSON returns an error for malformed JSON.
+func TestScopeFromRoleAssignmentBody_InvalidJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/user-roles", strings.NewReader("{not-json"))
+	_, err := ScopeFromRoleAssignmentBody(req, nil)
+	if err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+// --- stripControl ---
+
+// TestStripControl_RemovesControlChars verifies that CR/LF and other control
+// bytes are stripped from log strings.
+func TestStripControl_RemovesControlChars(t *testing.T) {
+	input := "hello\rworld\nfoo\x00bar"
+	got := stripControl(input)
+	for _, bad := range []string{"\r", "\n", "\x00"} {
+		for _, r := range got {
+			if string(r) == bad {
+				t.Errorf("stripControl did not remove control char %q from %q; got %q", bad, input, got)
+			}
+		}
+	}
+	// Safe characters must be preserved.
+	for _, safe := range []string{"hello", "world", "foo", "bar"} {
+		found := false
+		for i := 0; i+len(safe) <= len(got); i++ {
+			if got[i:i+len(safe)] == safe {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("stripControl removed safe content %q from result %q", safe, got)
+		}
+	}
+}
+
+// TestStripControl_SafeString passes an already-safe string unchanged.
+func TestStripControl_SafeString(t *testing.T) {
+	input := "safe-log-entry-123"
+	got := stripControl(input)
+	if got != input {
+		t.Errorf("stripControl(%q) = %q, want %q", input, got, input)
+	}
+}
+
+// --- sweepLocked (rate limiter) ---
+
+// TestSweepLocked_ViaHighRequestCount exercises the sweepLocked path by
+// pre-seeding the request counter to just before the sweep boundary, then
+// calling allow() to cross it, invoking sweepLocked.
+func TestSweepLocked_ViaHighRequestCount(t *testing.T) {
+	rl := &principalRateLimiter{
+		rps:      1000,
+		burst:    10000,
+		limiters: make(map[string]*principalBucket),
+	}
+	rl.requests = principalLimiterSweepEvery - 1
+	_ = rl.allow("test-key") // triggers sweepLocked on this call
+}
+
+// --- Authentication public wrapper ---
+
+// TestAuthentication_PublicWrapper verifies that the Authentication function
+// (which wraps authenticationWithValidator) rejects requests without a token,
+// confirming the wrapper is wired correctly.
+func TestAuthentication_PublicWrapper(t *testing.T) {
+	// Build a real in-memory core for the wrapper (needed to avoid nil-deref
+	// in the validator path; any unauthenticated call is rejected before it
+	// reaches the core service).
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil)
+	rec := httptest.NewRecorder()
+
+	// Authentication(nil) should fail closed (no core service = reject everything).
+	mw := Authentication(nil)
+	mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("Authentication(nil): expected 401, got %d", rec.Code)
+	}
+}
+
+// --- RequireScopedPermission ---
+
+// TestRequireScopedPermission_NoUserContext returns 401 when there is no user context.
+func TestRequireScopedPermission_NoUserContext(t *testing.T) {
+	mw := RequireScopedPermission("secrets.read", ScopeGlobal)
+	rec := httptest.NewRecorder()
+	mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("no user context: expected 401, got %d", rec.Code)
+	}
+}
+
+// TestRequireScopedPermission_NoCoreService returns 403 when the core service
+// is absent from context.
+func TestRequireScopedPermission_NoCoreService(t *testing.T) {
+	mw := RequireScopedPermission("secrets.read", ScopeGlobal)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	uc := &UserContext{UserID: 1, Username: "admin"}
+	req = req.WithContext(context.WithValue(req.Context(), userContextKey, uc))
+	mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("no core service: expected 403, got %d", rec.Code)
+	}
+}
+
+// TestRequirePermission_NoUserContext returns 401 when there is no user context.
+func TestRequirePermission_NoUserContext(t *testing.T) {
+	mw := RequirePermission("secrets.read")
+	rec := httptest.NewRecorder()
+	mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("no user context: expected 401, got %d", rec.Code)
+	}
+}
+
+// --- GetCoreServiceFromContext with a value ---
+
+// TestGetCoreServiceFromContext_WithNilValue confirms nil is returned when the
+// key exists with a non-*core.KeyorixCore value.
+func TestGetCoreServiceFromContext_WithNilValue(t *testing.T) {
+	ctx := context.WithValue(context.Background(), coreServiceContextKey, "wrong type")
+	got := GetCoreServiceFromContext(ctx)
+	if got != nil {
+		t.Errorf("expected nil for wrong type, got %v", got)
+	}
+}
+
+// --- ScopeFromRefQuery ---
+
+// TestScopeFromRefQuery_MissingRef returns errTargetNotFound for an empty ref.
+func TestScopeFromRefQuery_MissingRef(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/?ref=", nil)
+	_, err := ScopeFromRefQuery(req, nil)
+	if err == nil {
+		t.Error("expected error for missing ref, got nil")
+	}
+}
+
+// _ ensures the io package import is used.
+var _ io.Reader = strings.NewReader("")


### PR DESCRIPTION
Sprint-2 coverage tests - adds _s2_test.go files targeting multiple packages toward >=80% coverage.