### PR TITLE
test(coverage): bump connect/project/pat/rotation/core to >=80%

### DIFF
--- a/internal/cli/connect/connect_s2_test.go
+++ b/internal/cli/connect/connect_s2_test.go
@@ -1,0 +1,186 @@
+// connect_s2_test.go — sprint-2 coverage for the login flow, empty-token response,
+// runStatus connection failure, and runConnect save-config error paths.
+package connect
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoginWithCredentials_EmptyToken verifies that a well-formed 200 response
+// with an empty token field is treated as an error (no token in response).
+func TestLoginWithCredentials_EmptyToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 200 OK but token is blank.
+		_, _ = w.Write([]byte(`{"data":{"token":""}}`))
+	}))
+	defer srv.Close()
+
+	_, err := loginWithCredentials(srv.URL, "alice", "pw", 5*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no token in response")
+}
+
+// TestLoginWithCredentials_InvalidJSON verifies that a non-JSON body returns
+// a "failed to parse response" error.
+func TestLoginWithCredentials_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not-json`))
+	}))
+	defer srv.Close()
+
+	_, err := loginWithCredentials(srv.URL, "alice", "pw", 5*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// TestRunConnect_WithLogin exercises the username+password flow in runConnect:
+// KEYORIX_PASSWORD is set so that resolveConnectPassword returns it without
+// prompting, loginWithCredentials succeeds, and the config is saved.
+func TestRunConnect_WithLogin(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/login":
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			assert.Equal(t, "alice", body["username"])
+			_, _ = w.Write([]byte(`{"data":{"token":"login-token"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	t.Setenv("KEYORIX_PASSWORD", "s3cr3t")
+	t.Setenv("KEYORIX_API_KEY", "")
+
+	require.NoError(t, ConnectCmd.Flags().Set("username", "alice"))
+	require.NoError(t, ConnectCmd.Flags().Set("insecure", "true"))
+	require.NoError(t, ConnectCmd.Flags().Set("timeout", "5s"))
+	require.NoError(t, ConnectCmd.Flags().Set("test", "false"))
+	t.Cleanup(func() {
+		_ = ConnectCmd.Flags().Set("username", "")
+		_ = ConnectCmd.Flags().Set("insecure", "false")
+		_ = ConnectCmd.Flags().Set("timeout", "30s")
+		_ = ConnectCmd.Flags().Set("test", "false")
+	})
+
+	require.NoError(t, runConnect(ConnectCmd, []string{srv.URL}))
+}
+
+// TestRunConnect_LoginFails verifies that a failed loginWithCredentials call
+// is propagated as a "login failed" error.
+func TestRunConnect_LoginFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_PASSWORD", "wrong")
+	t.Setenv("KEYORIX_API_KEY", "")
+
+	require.NoError(t, ConnectCmd.Flags().Set("username", "alice"))
+	require.NoError(t, ConnectCmd.Flags().Set("insecure", "true"))
+	require.NoError(t, ConnectCmd.Flags().Set("timeout", "5s"))
+	require.NoError(t, ConnectCmd.Flags().Set("test", "false"))
+	t.Cleanup(func() {
+		_ = ConnectCmd.Flags().Set("username", "")
+		_ = ConnectCmd.Flags().Set("insecure", "false")
+		_ = ConnectCmd.Flags().Set("timeout", "30s")
+		_ = ConnectCmd.Flags().Set("test", "false")
+	})
+
+	err := runConnect(ConnectCmd, []string{srv.URL})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "login failed")
+}
+
+// TestRunConnect_EmptyPassword verifies that an empty resolved password
+// (no KEYORIX_PASSWORD and no --password flag) triggers a clear error when a
+// username is supplied.
+func TestRunConnect_EmptyPassword(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	// Clear both sources so resolveConnectPassword gets "" from env and
+	// cannot fall through to a terminal read (Stdin is not a tty in tests,
+	// so term.ReadPassword would error, but we want the password=="" path).
+	t.Setenv("KEYORIX_PASSWORD", "")
+
+	require.NoError(t, ConnectCmd.Flags().Set("username", "alice"))
+	require.NoError(t, ConnectCmd.Flags().Set("insecure", "true"))
+	require.NoError(t, ConnectCmd.Flags().Set("timeout", "5s"))
+	require.NoError(t, ConnectCmd.Flags().Set("test", "false"))
+	t.Cleanup(func() {
+		_ = ConnectCmd.Flags().Set("username", "")
+		_ = ConnectCmd.Flags().Set("insecure", "false")
+		_ = ConnectCmd.Flags().Set("timeout", "30s")
+		_ = ConnectCmd.Flags().Set("test", "false")
+	})
+
+	err := runConnect(ConnectCmd, []string{srv.URL})
+	// Either the "password is required" branch fires (no tty) or term.ReadPassword
+	// returns an error because Stdin is a pipe. Both are valid failures here.
+	require.Error(t, err)
+}
+
+// TestRunStatus_ClientMode_FailedConnection verifies the runStatus path where
+// the server is not reachable (connection fails) — the status command still
+// returns nil (it prints the error instead of returning it).
+func TestRunStatus_ClientMode_FailedConnection(t *testing.T) {
+	// Point cli.yaml at a server that is guaranteed to refuse connections.
+	dir := t.TempDir()
+	t.Chdir(dir)
+	configDir := filepath.Join(dir, "config", "keyorix")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+
+	require.NoError(t, os.MkdirAll(configDir, 0750))
+	// Use an address that will immediately refuse — port 0 is not listened on.
+	cliYAML := "mode: client\nclient:\n  endpoint: http://127.0.0.1:1\n  auth:\n    type: api_key\n    api_key: tok\n  timeout: 1s\n"
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "cli.yaml"), []byte(cliYAML), 0600))
+
+	// runStatus handles a failed test-connection by printing the error, not
+	// returning it.
+	require.NoError(t, runStatus(nil, nil))
+}
+
+// TestTestServerConnection_NoAPIKey verifies that testServerConnection works
+// even when the API key is empty (no Authorization header is sent).
+func TestTestServerConnection_NoAPIKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/health", r.URL.Path)
+		assert.Equal(t, "", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	require.NoError(t, testServerConnection(srv.URL, "", 5*time.Second))
+}
+
+// TestRequireSecureEndpoint_InvalidURL verifies that a completely unparseable
+// URL returns an "invalid endpoint" error.
+func TestRequireSecureEndpoint_InvalidURL(t *testing.T) {
+	err := requireSecureEndpoint("://bad-url", false)
+	require.Error(t, err)
+}
+
+// TestResolveConnectPassword_FlagWins verifies that a --password flag value
+// is returned without reading from env or stdin.
+func TestResolveConnectPassword_FlagWins(t *testing.T) {
+	c := cmdWithFlags()
+	require.NoError(t, c.Flags().Set("password", "flag-password"))
+	pw, err := resolveConnectPassword(c, "bob")
+	require.NoError(t, err)
+	assert.Equal(t, "flag-password", pw)
+}

--- a/internal/cli/pat/pat_s2_test.go
+++ b/internal/cli/pat/pat_s2_test.go
@@ -1,0 +1,112 @@
+// pat_s2_test.go — sprint-2 coverage for hygieneCmd.RunE (table and empty
+// branches), normalizeExpiry RFC3339 invalid path, describeScope CIDRs-only,
+// and client() error path.
+package pat
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHygieneCmd_Empty verifies the "No stale or expired tokens" branch of
+// hygieneCmd.RunE via a server that returns an empty list.
+func TestHygieneCmd_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/pat-hygiene", r.URL.Path)
+		_, _ = w.Write([]byte(`{"data":{"tokens":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	hygieneDays = 0
+
+	out := captureStdout(t, func() {
+		require.NoError(t, hygieneCmd.RunE(hygieneCmd, nil))
+	})
+	assert.Contains(t, out, "No stale or expired tokens")
+}
+
+// TestHygieneCmd_WithResults verifies the table-rendering branch of
+// hygieneCmd.RunE via a server that returns both a stale and an expired token.
+func TestHygieneCmd_WithResults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"tokens":[
+			{"id":1,"name":"ci","token_prefix":"kx_ci","user_id":5,"last_used_at":"","expired":false,"stale":true},
+			{"id":2,"name":"old","token_prefix":"kx_old","user_id":9,"last_used_at":"2026-01-01T00:00:00Z","expired":true,"stale":false}
+		]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	hygieneDays = 0
+
+	out := captureStdout(t, func() {
+		require.NoError(t, hygieneCmd.RunE(hygieneCmd, nil))
+	})
+	assert.Contains(t, out, "ci")
+	assert.Contains(t, out, "kx_ci")
+	assert.Contains(t, out, "stale")
+	assert.Contains(t, out, "old")
+	assert.Contains(t, out, "expired")
+}
+
+// TestHygieneCmd_WithDays verifies that hygieneDays > 0 appends the query param.
+func TestHygieneCmd_WithDays(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.RequestURI()
+		_, _ = w.Write([]byte(`{"data":{"tokens":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	hygieneDays = 60
+	t.Cleanup(func() { hygieneDays = 0 })
+
+	out := captureStdout(t, func() {
+		require.NoError(t, hygieneCmd.RunE(hygieneCmd, nil))
+	})
+	assert.Contains(t, gotPath, "days=60")
+	assert.Contains(t, out, "No stale")
+}
+
+// TestHygieneCmd_NotConnected verifies that hygieneCmd returns an error when
+// no server is configured (the client() helper path).
+func TestHygieneCmd_NotConnected(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := hygieneCmd.RunE(hygieneCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+// TestNormalizeExpiry_InvalidRFC3339 verifies the "invalid --expires" error
+// path when the value contains "T" but is not a valid RFC3339 timestamp.
+func TestNormalizeExpiry_InvalidRFC3339(t *testing.T) {
+	_, err := normalizeExpiry("2026-13-01T25:00:00Z")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --expires")
+}
+
+// TestDescribeScope_CIDRsOnly verifies that a token with only AllowedCIDRs
+// (no scopes, no project/env scope) renders just the "from=…" part.
+func TestDescribeScope_CIDRsOnly(t *testing.T) {
+	result := describeScope(patView{AllowedCIDRs: []string{"10.0.0.0/8", "192.168.0.0/16"}})
+	assert.Equal(t, "from=10.0.0.0/8,192.168.0.0/16", result)
+}
+
+// TestClient_NotConnected verifies that the client() helper returns an error
+// when KEYORIX_SERVER is not set (XDG_CONFIG_HOME points at an empty dir so
+// there is no cli.yaml in client mode either).
+func TestClient_NotConnected(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	_, err := client()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}

--- a/internal/cli/project/project_s2_test.go
+++ b/internal/cli/project/project_s2_test.go
@@ -1,0 +1,150 @@
+// project_s2_test.go — sprint-2 coverage for the project CLI:
+// runCreate (no envs / default / dup-name), runDescribe no-arg, remote
+// env create/delete, and resolveProjectContext local project-not-found paths.
+package project
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── runCreate – no-envs path ──────────────────────────────────────────────────
+
+// TestRunCreate_Embedded_NoEnvs verifies that runCreate with no --envs flag
+// goes through svc.CreateProject (not CreateProjectWithEnvs) and prints the
+// default-environments message.
+func TestRunCreate_Embedded_NoEnvs(t *testing.T) {
+	setupEmbedded(t)
+	createName = "backend"
+	createEnvs = ""
+	createDescription = "back-end service"
+
+	out := captureStdout(t, func() { require.NoError(t, runCreate(nil, nil)) })
+	assert.Contains(t, out, "Project created: id=")
+	assert.Contains(t, out, `name="backend"`)
+	assert.Contains(t, out, "Default environments")
+
+	svc := embeddedCore(t)
+	projects, err := svc.ListProjects(context.Background())
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+	assert.Equal(t, "backend", projects[0].Name)
+}
+
+// TestRunCreate_Embedded_DupName verifies that creating two projects with the
+// same name returns an error on the second attempt.
+func TestRunCreate_Embedded_DupName(t *testing.T) {
+	setupEmbedded(t)
+	svc := embeddedCore(t)
+	_, err := svc.CreateProject(context.Background(), "dupe", "")
+	require.NoError(t, err)
+
+	createName = "dupe"
+	createEnvs = ""
+	err = runCreate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project")
+}
+
+// ── runDescribe – no-arg path ────────────────────────────────────────────────
+
+// TestRunDescribe_Embedded_NoArgs verifies that runDescribe with no positional
+// argument and no active project returns an error.
+func TestRunDescribe_Embedded_NoArgs(t *testing.T) {
+	setupEmbedded(t)
+	err := runDescribe(nil, []string{})
+	require.Error(t, err)
+}
+
+// TestRunDescribe_Embedded_NoArgs_WithEnv verifies that runDescribe picks up
+// the active project from KEYORIX_PROJECT when no arg is given.
+func TestRunDescribe_Embedded_NoArgs_WithEnv(t *testing.T) {
+	setupEmbedded(t)
+	_, err := embeddedCore(t).CreateProjectWithEnvs(context.Background(), "api", "the api", []string{"prod"})
+	require.NoError(t, err)
+	t.Setenv("KEYORIX_PROJECT", "api")
+
+	out := captureStdout(t, func() { require.NoError(t, runDescribe(nil, []string{})) })
+	assert.Contains(t, out, "Project:      api")
+}
+
+// ── resolveProjectContext – local project-not-found ───────────────────────────
+
+// TestResolveProjectContext_LocalNotFound verifies that resolveProjectContext
+// returns an error when the named project doesn't exist in the local store.
+func TestResolveProjectContext_LocalNotFound(t *testing.T) {
+	setupEmbedded(t)
+	_, _, err := resolveProjectContext("myproj")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// ── remote env create / delete ────────────────────────────────────────────────
+
+// TestRunEnvCreate_Remote verifies the remote-mode env create path.
+func TestRunEnvCreate_Remote(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		case "/api/v1/projects/1/environments":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"id":5,"name":"qa","project_id":1}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	envProjectFlag = "web"
+	envCreateName = "qa"
+
+	out := captureStdout(t, func() { require.NoError(t, runEnvCreate(nil, nil)) })
+	assert.Contains(t, out, `"qa" created`)
+}
+
+// TestRunEnvDelete_Remote verifies the remote-mode env delete path.
+func TestRunEnvDelete_Remote(t *testing.T) {
+	var deleteCalled bool
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && r.URL.Path == "/api/v1/environments/3" {
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	out := captureStdout(t, func() { require.NoError(t, runEnvDelete(nil, []string{"3"})) })
+	assert.True(t, deleteCalled)
+	assert.Contains(t, out, "deleted")
+}
+
+// TestRunEnvList_Remote_Empty verifies the empty-environment message in remote mode.
+func TestRunEnvList_Remote_Empty(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		case "/api/v1/projects/1/environments":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"environments":[]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	envProjectFlag = "web"
+
+	out := captureStdout(t, func() { require.NoError(t, runEnvList(nil, nil)) })
+	assert.Contains(t, out, "No environments")
+}
+
+// TestRunList_Remote_Empty verifies the "No projects found" message in remote mode.
+func TestRunList_Remote_Empty(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[]}}`))
+	})
+
+	out := captureStdout(t, func() { require.NoError(t, runList(nil, nil)) })
+	assert.Contains(t, out, "No projects found")
+}

--- a/internal/cli/rotation/rotation_s2_test.go
+++ b/internal/cli/rotation/rotation_s2_test.go
@@ -1,0 +1,184 @@
+// rotation_s2_test.go — sprint-2 coverage for printProjectPlan, printDeploymentPlan,
+// autoRotateLabel false path, and order/plan print output not covered by existing tests.
+package rotation
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureRotationOutput redirects os.Stdout for the duration of fn and returns
+// the captured bytes. Named differently from other capture helpers to avoid
+// redeclaration across files in this package.
+func captureRotationOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	old := os.Stdout
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+// TestPrintProjectPlan_Empty verifies printProjectPlan prints a header even
+// with zero waves.
+func TestPrintProjectPlan_Empty(t *testing.T) {
+	plan := &rotationPlanView{ProjectID: 7, TotalSecrets: 0, Waves: nil}
+	out := captureRotationOutput(t, func() { printProjectPlan(plan, "") })
+	assert.Contains(t, out, "project 7")
+	assert.Contains(t, out, "0 to rotate")
+}
+
+// TestPrintProjectPlan_WithWaves verifies header and per-secret output for a
+// multi-wave plan.
+func TestPrintProjectPlan_WithWaves(t *testing.T) {
+	plan := &rotationPlanView{
+		ProjectID:    3,
+		TotalSecrets: 2,
+		OverdueCount: 1,
+		DueSoonCount: 1,
+		Waves: []rotationWave{
+			{
+				Index: 0,
+				Secrets: []plannedRotation{
+					{SecretID: 10, SecretName: "root-ca", Status: "overdue", DaysOverdue: 30, RiskBand: "high", AutoRotate: false, Reasons: []string{"30 days overdue"}},
+				},
+			},
+			{
+				Index: 1,
+				Secrets: []plannedRotation{
+					{SecretID: 11, SecretName: "app-cert", Status: "due_soon", DaysOverdue: -5, RiskBand: "", AutoRotate: true},
+				},
+			},
+		},
+	}
+	out := captureRotationOutput(t, func() { printProjectPlan(plan, "") })
+	assert.Contains(t, out, "project 3")
+	assert.Contains(t, out, "2 to rotate")
+	assert.Contains(t, out, "Wave 1")
+	assert.Contains(t, out, "root-ca")
+	assert.Contains(t, out, "high risk")
+	assert.Contains(t, out, "30 days overdue")
+	assert.Contains(t, out, "self-rotating")
+}
+
+// TestPrintProjectPlan_WithIndent verifies the indent prefix is applied.
+func TestPrintProjectPlan_WithIndent(t *testing.T) {
+	plan := &rotationPlanView{ProjectID: 1, Waves: nil}
+	out := captureRotationOutput(t, func() { printProjectPlan(plan, "  ") })
+	assert.Contains(t, out, "  Rotation plan")
+}
+
+// TestPrintDeploymentPlan_NoWork verifies the "nothing to rotate" fast-path.
+func TestPrintDeploymentPlan_NoWork(t *testing.T) {
+	plan := &deploymentPlanView{ProjectsScanned: 5, ProjectsWithWork: 0}
+	out := captureRotationOutput(t, func() { printDeploymentPlan(plan) })
+	assert.Contains(t, out, "Nothing to rotate")
+	assert.Contains(t, out, "5 project")
+}
+
+// TestPrintDeploymentPlan_WithProjects verifies the multi-project roll-up header.
+func TestPrintDeploymentPlan_WithProjects(t *testing.T) {
+	plan := &deploymentPlanView{
+		ProjectsScanned:  3,
+		ProjectsWithWork: 2,
+		TotalSecrets:     4,
+		OverdueCount:     2,
+		DueSoonCount:     2,
+		Projects: []rotationPlanView{
+			{ProjectID: 7, TotalSecrets: 2, OverdueCount: 2, Waves: []rotationWave{
+				{Index: 0, Secrets: []plannedRotation{
+					{SecretID: 1, SecretName: "cert-a", Status: "overdue", DaysOverdue: 10, AutoRotate: false},
+				}},
+			}},
+			{ProjectID: 2, TotalSecrets: 2, DueSoonCount: 2, Waves: nil},
+		},
+	}
+	out := captureRotationOutput(t, func() { printDeploymentPlan(plan) })
+	assert.Contains(t, out, "Deployment rotation plan")
+	assert.Contains(t, out, "4 to rotate")
+	assert.Contains(t, out, "project 7")
+	assert.Contains(t, out, "cert-a")
+}
+
+// TestAutoRotateLabel_False verifies that autoRotateLabel returns "" for false.
+func TestAutoRotateLabel_False(t *testing.T) {
+	assert.Equal(t, "", autoRotateLabel(false))
+}
+
+// TestOrderCmd_EmptyOrder verifies the "secrets can rotate in any order" branch.
+func TestOrderCmd_EmptyOrder(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"project_id":1,"order":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	out := captureRotationOutput(t, func() {
+		require.NoError(t, orderCmd.RunE(orderCmd, []string{"1"}))
+	})
+	assert.Contains(t, out, "any order")
+}
+
+// TestOrderCmd_WithDeps verifies the numbered list output when dependencies exist.
+func TestOrderCmd_WithDeps(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"project_id":5,"order":[{"secret_id":1,"secret_name":"root-ca"},{"secret_id":2,"secret_name":"leaf-cert"}]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	out := captureRotationOutput(t, func() {
+		require.NoError(t, orderCmd.RunE(orderCmd, []string{"5"}))
+	})
+	assert.Contains(t, out, "project 5")
+	assert.Contains(t, out, "root-ca")
+	assert.Contains(t, out, "leaf-cert")
+}
+
+// TestPlanCmd_WithWaves verifies that a non-empty plan prints wave output.
+func TestPlanCmd_WithWaves(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"project_id":1,"total_secrets":1,"overdue_count":1,"due_soon_count":0,"waves":[{"index":0,"secrets":[{"secret_id":5,"secret_name":"api-key","status":"overdue","days_overdue":15,"risk_band":"low","auto_rotate":false,"reasons":["15 days overdue"]}]}]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	planAllProjects = false
+	t.Cleanup(func() { planAllProjects = false })
+
+	out := captureRotationOutput(t, func() {
+		require.NoError(t, planCmd.RunE(planCmd, []string{"1"}))
+	})
+	assert.Contains(t, out, "api-key")
+}
+
+// TestPlanCmd_AllProjectsWithWork verifies the deployment-wide plan is printed
+// when --all-projects is set and projects have work.
+func TestPlanCmd_AllProjectsWithWork(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects_scanned":2,"projects_with_work":1,"total_secrets":1,"overdue_count":1,"due_soon_count":0,"projects":[{"project_id":3,"total_secrets":1,"overdue_count":1,"due_soon_count":0,"waves":[{"index":0,"secrets":[{"secret_id":9,"secret_name":"db-pw","status":"overdue","days_overdue":5,"risk_band":"medium","auto_rotate":false,"reasons":["5 days overdue"]}]}]}]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	planAllProjects = true
+	t.Cleanup(func() { planAllProjects = false })
+
+	out := captureRotationOutput(t, func() {
+		require.NoError(t, planCmd.RunE(planCmd, []string{}))
+	})
+	assert.Contains(t, out, "Deployment rotation plan")
+	assert.Contains(t, out, "db-pw")
+}

--- a/internal/core/core_s2_test.go
+++ b/internal/core/core_s2_test.go
@@ -1,0 +1,389 @@
+// core_s2_test.go — sprint-2 coverage: account sessions, catalog, connect,
+// dashboard helpers, group permission, and anomaly detector edge paths.
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/connect"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// ── account.go ────────────────────────────────────────────────────────────────
+
+func TestCurrentSessionID_EmptyToken(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	// An empty token must return 0 without any storage call.
+	id := c.CurrentSessionID(context.Background(), "")
+	assert.Equal(t, uint(0), id)
+	ms.AssertNotCalled(t, "GetSession", mock.Anything, mock.Anything)
+}
+
+func TestCurrentSessionID_StorageError(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	ms.On("GetSession", mock.Anything, "bad-token").Return(nil, errors.New("not found"))
+	// Storage error → return 0.
+	id := c.CurrentSessionID(context.Background(), "bad-token")
+	assert.Equal(t, uint(0), id)
+}
+
+func TestCurrentSessionID_Valid(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	sess := &models.Session{ID: 42, SessionToken: "tok"}
+	ms.On("GetSession", mock.Anything, "tok").Return(sess, nil)
+	id := c.CurrentSessionID(context.Background(), "tok")
+	assert.Equal(t, uint(42), id)
+}
+
+func TestListOwnSessions_ZeroUserID(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	_, err := c.ListOwnSessions(context.Background(), 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user ID is required")
+}
+
+func TestRevokeOwnSession_WrongOwner(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	// Session belongs to user 2, caller is user 1.
+	sess := &models.Session{ID: 5, UserID: 2, SessionToken: "t"}
+	ms.On("GetSessionByID", mock.Anything, uint(5)).Return(sess, nil)
+	err := c.RevokeOwnSession(context.Background(), 1, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session not found")
+	ms.AssertNotCalled(t, "DeleteSession", mock.Anything, mock.Anything)
+}
+
+func TestRevokeOwnSession_ZeroIDs(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	err := c.RevokeOwnSession(context.Background(), 0, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+// ── catalog.go ────────────────────────────────────────────────────────────────
+
+func TestGetProject_Delegated(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetProject", mock.Anything, uint(7)).Return(&models.Project{ID: 7, Name: "web"}, nil)
+	c := NewKeyorixCore(ms)
+	p, err := c.GetProject(context.Background(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, uint(7), p.ID)
+}
+
+func TestGetProject_NotFound(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetProject", mock.Anything, uint(99)).Return(nil, errors.New("not found"))
+	c := NewKeyorixCore(ms)
+	_, err := c.GetProject(context.Background(), 99)
+	require.Error(t, err)
+}
+
+func TestListProjectsWithCounts_Delegated(t *testing.T) {
+	// MockStorage.ListProjectsWithCounts is a fixed stub returning (nil, nil).
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	result, err := c.ListProjectsWithCounts(context.Background(), false)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestDeleteEnvironment_Delegated(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	// MockStorage.DeleteEnvironment returns nil.
+	require.NoError(t, c.DeleteEnvironment(context.Background(), 1))
+}
+
+func TestGetEnvironment_Delegated(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	// MockStorage.GetEnvironment returns &models.Environment{}.
+	env, err := c.GetEnvironment(context.Background(), 1)
+	require.NoError(t, err)
+	assert.NotNil(t, env)
+}
+
+func TestListEnvironments_Delegated(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	// MockStorage.ListEnvironments returns nil, nil.
+	envs, err := c.ListEnvironments(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, envs)
+}
+
+func TestCreateEnvironment_EmptyName(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	_, err := c.CreateEnvironment(context.Background(), 1, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment name is required")
+}
+
+func TestCreateEnvironment_TooLongName(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	long := make([]byte, 201)
+	for i := range long {
+		long[i] = 'a'
+	}
+	_, err := c.CreateEnvironment(context.Background(), 1, string(long))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+func TestCreateEnvironment_Success(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	// MockStorage.CreateEnvironment returns the passed env back.
+	env, err := c.CreateEnvironment(context.Background(), 1, "staging")
+	require.NoError(t, err)
+	assert.Equal(t, "staging", env.Name)
+	assert.Equal(t, uint(1), env.ProjectID)
+}
+
+// ── connect.go ────────────────────────────────────────────────────────────────
+
+func TestConnectConnectorNames_NoManager(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	names := c.ConnectConnectorNames()
+	assert.Nil(t, names)
+}
+
+func TestConnectConnectorNames_WithManager(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	c := &KeyorixCore{storage: ms}
+	c.SetConnectManager(connect.NewManager([]connect.Connector{fakeConnector{name: "aws"}}))
+	names := c.ConnectConnectorNames()
+	assert.Equal(t, []string{"aws"}, names)
+}
+
+func TestListConnectRefGrants_Delegated(t *testing.T) {
+	ms := new(MockStorage)
+	// MockStorage.ListConnectRefGrants is a fixed stub returning (nil, nil).
+	c := NewKeyorixCore(ms)
+	grants, err := c.ListConnectRefGrants(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, grants)
+}
+
+func TestDeleteConnectRefGrant_Success(t *testing.T) {
+	// DeleteConnectRefGrant mock is a fixed stub (returns nil, no m.Called).
+	// LogAuditEvent is called via writeAuditEvent — mock it to avoid panics.
+	ms := new(MockStorage)
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	c := NewKeyorixCore(ms)
+	// Fixed stub returns nil — success path.
+	require.NoError(t, c.DeleteConnectRefGrant(context.Background(), 1, 3))
+}
+
+// ── catalog.go – extra helpers ────────────────────────────────────────────────
+
+func TestListEnvironmentsByProjectIncludingDeleted(t *testing.T) {
+	ms := new(MockStorage)
+	// MockStorage.ListEnvironmentsByProjectIncludingDeleted is a fixed stub.
+	c := NewKeyorixCore(ms)
+	envs, err := c.ListEnvironmentsByProjectIncludingDeleted(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Nil(t, envs)
+}
+
+func TestTranslateProjectNameError_DuplicateName(t *testing.T) {
+	// Call CreateProject with a duplicate-name storage error so translateProjectNameError
+	// is exercised on the non-duplicate path via the mock.
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	// Use CreateProjectWithEnvs with an empty envNames to hit validateProjectName
+	// then storage.CreateProject (which won't be called because mock returns nil
+	// on fixed stub). Instead trigger it via CreateProject which goes through
+	// validateProjectName then storage.CreateProject. Stub returns ErrDuplicateProjectName.
+	_, err := c.CreateProject(context.Background(), "", "")
+	// Empty name triggers validateProjectName error — translateProjectNameError is
+	// exercised only when CreateProject succeeds validation but storage fails.
+	require.Error(t, err)
+	// Exercise translateProjectNameError directly via a non-duplicate error.
+	nonDup := errors.New("some other error")
+	out := translateProjectNameError(nonDup)
+	assert.Equal(t, nonDup, out)
+	// And with the actual duplicate sentinel.
+	dup := translateProjectNameError(storage.ErrDuplicateProjectName)
+	assert.Contains(t, dup.Error(), "already exists")
+}
+
+// ── dashboard.go helpers ──────────────────────────────────────────────────────
+
+func TestComputeTrend_BothZero(t *testing.T) {
+	assert.Nil(t, computeTrend(0, 0))
+}
+
+func TestComputeTrend_PrevZeroCurrentNonZero(t *testing.T) {
+	trend := computeTrend(0, 10)
+	require.NotNil(t, trend)
+	assert.Equal(t, 100.0, trend.Value)
+	assert.True(t, trend.IsPositive)
+}
+
+func TestComputeTrend_NoChange(t *testing.T) {
+	assert.Nil(t, computeTrend(10, 10))
+}
+
+func TestComputeTrend_Increase(t *testing.T) {
+	trend := computeTrend(100, 150)
+	require.NotNil(t, trend)
+	assert.Equal(t, 50.0, trend.Value)
+	assert.True(t, trend.IsPositive)
+}
+
+func TestComputeTrend_Decrease(t *testing.T) {
+	trend := computeTrend(100, 80)
+	require.NotNil(t, trend)
+	assert.Equal(t, 20.0, trend.Value)
+	assert.False(t, trend.IsPositive)
+}
+
+func TestLastIndex_EmptySubstr(t *testing.T) {
+	assert.Equal(t, 5, lastIndex("hello", ""))
+}
+
+func TestLastIndex_NotFound(t *testing.T) {
+	assert.Equal(t, -1, lastIndex("hello", "xyz"))
+}
+
+func TestLastIndex_LastOccurrence(t *testing.T) {
+	// "aXbXc" — second X is at index 3.
+	assert.Equal(t, 3, lastIndex("aXbXc", "X"))
+}
+
+func TestExtractSecretName_Found(t *testing.T) {
+	assert.Equal(t, "prod-db", extractSecretName("User admin deleted secret prod-db"))
+}
+
+func TestExtractSecretName_NotFound(t *testing.T) {
+	assert.Equal(t, "", extractSecretName("User admin logged in"))
+}
+
+func TestMapAuditEventToActivity_SecretRead(t *testing.T) {
+	e := &models.AuditEvent{ID: 1, EventType: "secret.read", Description: "User alice read secret api-key", EventTime: time.Now()}
+	item := mapAuditEventToActivity(e, "alice")
+	assert.Equal(t, "accessed", item.Type)
+	assert.Equal(t, "api-key", item.SecretName)
+}
+
+func TestMapAuditEventToActivity_AuthLogin(t *testing.T) {
+	e := &models.AuditEvent{ID: 2, EventType: "auth.login", Description: "User bob logged in"}
+	item := mapAuditEventToActivity(e, "bob")
+	assert.Equal(t, "login", item.Type)
+	assert.Equal(t, "", item.SecretName)
+}
+
+func TestMapAuditEventToActivity_Fallback(t *testing.T) {
+	e := &models.AuditEvent{ID: 3, EventType: "rbac.role_assigned", Description: "role assigned"}
+	item := mapAuditEventToActivity(e, "admin")
+	assert.Equal(t, "rbac.role_assigned", item.Type)
+	assert.Equal(t, "", item.SecretName)
+}
+
+func TestGetActivityFeed_StorageError(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetAuditLogs", mock.Anything, mock.Anything).Return(nil, int64(0), errors.New("db down"))
+	c := NewKeyorixCore(ms)
+	feed, err := c.GetActivityFeed(context.Background(), 1, "alice", -1, 0)
+	require.NoError(t, err) // storage error is swallowed; returns empty feed
+	assert.Empty(t, feed.Items)
+	assert.Equal(t, 1, feed.Page)
+	assert.Equal(t, 10, feed.PageSize)
+}
+
+func TestGetActivityFeed_WithEvents(t *testing.T) {
+	ms := new(MockStorage)
+	events := []*models.AuditEvent{
+		{ID: 1, EventType: "secret.read", Description: "User alice read secret db-pw", EventTime: time.Now()},
+	}
+	ms.On("GetAuditLogs", mock.Anything, mock.Anything).Return(events, int64(1), nil)
+	c := NewKeyorixCore(ms)
+	feed, err := c.GetActivityFeed(context.Background(), 1, "alice", 1, 10)
+	require.NoError(t, err)
+	require.Len(t, feed.Items, 1)
+	assert.Equal(t, "accessed", feed.Items[0].Type)
+}
+
+// ── group_sharing.go ──────────────────────────────────────────────────────────
+
+func TestCheckUserGroupPermission_ZeroSecretID(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	_, _, err := c.CheckUserGroupPermission(context.Background(), 0, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret ID is required")
+}
+
+func TestCheckUserGroupPermission_ZeroUserID(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	_, _, err := c.CheckUserGroupPermission(context.Background(), 1, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user ID is required")
+}
+
+func TestCheckUserGroupPermission_Valid(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	ok, perm, err := c.CheckUserGroupPermission(context.Background(), 1, 1)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, "", perm)
+}
+
+// ── groups.go ────────────────────────────────────────────────────────────────
+
+func TestListGroups_Success(t *testing.T) {
+	ms := new(MockStorage)
+	grps := []*models.Group{{ID: 1, Name: "admins"}}
+	ms.On("ListGroups", mock.Anything).Return(grps, nil)
+	c := NewKeyorixCore(ms)
+	result, err := c.ListGroups(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "admins", result[0].Name)
+}
+
+func TestListGroups_Error(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("ListGroups", mock.Anything).Return(nil, errors.New("db error"))
+	c := NewKeyorixCore(ms)
+	_, err := c.ListGroups(context.Background())
+	require.Error(t, err)
+}
+
+// ── anomaly.go ────────────────────────────────────────────────────────────────
+
+func TestSetBaselineQuarantine(t *testing.T) {
+	ms := new(MockStorage)
+	d := NewAnomalyDetector(ms)
+	d.SetBaselineQuarantine(48 * time.Hour)
+	assert.Equal(t, 48*time.Hour, d.quarantine)
+}
+
+func TestSetMLConfig(t *testing.T) {
+	ms := new(MockStorage)
+	d := NewAnomalyDetector(ms)
+	cfg := MLConfig{Enabled: true}
+	d.SetMLConfig(cfg)
+	assert.True(t, d.ml.Enabled)
+}


### PR DESCRIPTION
Sprint-2 coverage tests - adds _s2_test.go files targeting multiple packages toward >=80% coverage.