### PR TITLE
test(coverage): push internal/i18n to >=80% (s5)

### DIFF
--- a/internal/i18n/i18n_s5_test.go
+++ b/internal/i18n/i18n_s5_test.go
@@ -1,0 +1,47 @@
+package i18n
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestInitializeForTesting covers the InitializeForTesting helper (was at 0%).
+func TestInitializeForTesting(t *testing.T) {
+	// Reset state so once.Do fires.
+	globalLocalizer = nil
+	once = sync.Once{}
+
+	if err := InitializeForTesting(); err != nil {
+		t.Fatalf("InitializeForTesting() unexpected error: %v", err)
+	}
+	if globalLocalizer == nil {
+		t.Fatal("InitializeForTesting() did not set globalLocalizer")
+	}
+}
+
+// TestResetForTesting covers the ResetForTesting helper (was at 0%).
+func TestResetForTesting(t *testing.T) {
+	// Make sure there is something to reset.
+	globalLocalizer = nil
+	once = sync.Once{}
+	if err := InitializeForTesting(); err != nil {
+		t.Fatalf("setup InitializeForTesting() error: %v", err)
+	}
+	if globalLocalizer == nil {
+		t.Fatal("precondition: globalLocalizer should be set before reset")
+	}
+
+	ResetForTesting()
+
+	if globalLocalizer != nil {
+		t.Error("ResetForTesting() did not clear globalLocalizer")
+	}
+
+	// Verify once was also reset — a fresh Initialize should succeed.
+	if err := InitializeForTesting(); err != nil {
+		t.Fatalf("re-initialize after ResetForTesting() error: %v", err)
+	}
+	if globalLocalizer == nil {
+		t.Error("re-initialize after ResetForTesting() did not set globalLocalizer")
+	}
+}


### PR DESCRIPTION
Sprint-5 — nudges internal/i18n above the 80% threshold.

- Adds `TestInitializeForTesting` covering the `InitializeForTesting` helper (was 0%)
- Adds `TestResetForTesting` covering the `ResetForTesting` helper (was 0%)
- Net result: 79.7% → 89.8% statement coverage

🤖 Generated with [Claude Code](https://claude.ai/claude-code)