### PR TITLE
test(coverage): push internal/storage/store toward 80% (s11)

### DIFF
--- a/internal/storage/store/remote_access_review_campaigns_test.go
+++ b/internal/storage/store/remote_access_review_campaigns_test.go
@@ -1,0 +1,396 @@
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// campaignWireData returns a minimal wire representation of an access-review campaign.
+func campaignWireData(id uint, name, state string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":         id,
+		"project_id": uint(1),
+		"name":       name,
+		"state":      state,
+		"created_by": uint(7),
+		"created_at": time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// itemWireData returns a minimal wire representation of an access-review item.
+func itemWireData(id, campaignID uint) map[string]interface{} {
+	return map[string]interface{}{
+		"id":             id,
+		"campaign_id":    campaignID,
+		"principal_type": "user",
+		"principal_id":   uint(3),
+		"principal_name": "alice",
+		"source":         "role",
+		"access_level":   "read",
+		"environment_id": uint(1),
+		"decision":       "pending",
+	}
+}
+
+// --- CreateAccessReviewCampaign ---
+
+func TestRemoteStorage_CreateAccessReviewCampaign(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/access-review-campaigns", r.URL.Path)
+		_, _ = w.Write(apiOK(campaignWireData(42, "Q1 review", "open")))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	c := &models.AccessReviewCampaign{
+		ProjectID: 1,
+		Name:      "Q1 review",
+		State:     "open",
+		CreatedBy: 7,
+		CreatedAt: time.Now(),
+	}
+	result, err := rs.CreateAccessReviewCampaign(context.Background(), c)
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), result.ID)
+	assert.Equal(t, "Q1 review", result.Name)
+	assert.Equal(t, "open", result.State)
+}
+
+// --- GetAccessReviewCampaign ---
+
+func TestRemoteStorage_GetAccessReviewCampaign(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/access-review-campaigns/42", r.URL.Path)
+		_, _ = w.Write(apiOK(campaignWireData(42, "Q1 review", "open")))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.GetAccessReviewCampaign(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), result.ID)
+	assert.Equal(t, "Q1 review", result.Name)
+}
+
+// --- ListAccessReviewCampaigns ---
+
+func TestRemoteStorage_ListAccessReviewCampaigns(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/access-review-campaigns", r.URL.Path)
+		assert.Equal(t, "1", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"campaigns": []map[string]interface{}{
+				campaignWireData(10, "Campaign A", "closed"),
+				campaignWireData(11, "Campaign B", "open"),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListAccessReviewCampaigns(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.Equal(t, uint(10), results[0].ID)
+	assert.Equal(t, "Campaign A", results[0].Name)
+}
+
+// --- GetOpenAccessReviewCampaign ---
+
+func TestRemoteStorage_GetOpenAccessReviewCampaign_Found(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/access-review-campaigns/open", r.URL.Path)
+		assert.Equal(t, "5", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"campaign": campaignWireData(77, "Open review", "open"),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.GetOpenAccessReviewCampaign(context.Background(), 5)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, uint(77), result.ID)
+	assert.Equal(t, "open", result.State)
+}
+
+func TestRemoteStorage_GetOpenAccessReviewCampaign_None(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"campaign": nil,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.GetOpenAccessReviewCampaign(context.Background(), 5)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+// --- GetLatestClosedAccessReviewCampaign ---
+
+func TestRemoteStorage_GetLatestClosedAccessReviewCampaign_Found(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/access-review-campaigns/latest-closed", r.URL.Path)
+		assert.Equal(t, "3", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"campaign": campaignWireData(55, "Old review", "closed"),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.GetLatestClosedAccessReviewCampaign(context.Background(), 3)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, uint(55), result.ID)
+	assert.Equal(t, "closed", result.State)
+}
+
+func TestRemoteStorage_GetLatestClosedAccessReviewCampaign_None(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"campaign": nil,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.GetLatestClosedAccessReviewCampaign(context.Background(), 3)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+// --- UpdateAccessReviewCampaign ---
+
+func TestRemoteStorage_UpdateAccessReviewCampaign_Updated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/access-review-campaigns/42", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"updated": true,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	c := &models.AccessReviewCampaign{
+		ID:        42,
+		ProjectID: 1,
+		Name:      "Q1 review",
+		State:     "closed",
+		CreatedBy: 7,
+		CreatedAt: time.Now(),
+	}
+	updated, err := rs.UpdateAccessReviewCampaign(context.Background(), c)
+	require.NoError(t, err)
+	assert.True(t, updated)
+}
+
+func TestRemoteStorage_UpdateAccessReviewCampaign_NotUpdated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"updated": false,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	c := &models.AccessReviewCampaign{
+		ID:        42,
+		State:     "closed",
+		CreatedAt: time.Now(),
+	}
+	updated, err := rs.UpdateAccessReviewCampaign(context.Background(), c)
+	require.NoError(t, err)
+	assert.False(t, updated)
+}
+
+// --- CreateAccessReviewItems ---
+
+func TestRemoteStorage_CreateAccessReviewItems(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/access-review-campaigns/10/items", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	items := []*models.AccessReviewItem{
+		{
+			CampaignID:    10,
+			PrincipalType: "user",
+			PrincipalID:   3,
+			PrincipalName: "alice",
+			Source:        "role",
+			AccessLevel:   "read",
+			EnvironmentID: 1,
+			Decision:      "pending",
+		},
+	}
+	err = rs.CreateAccessReviewItems(context.Background(), items)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_CreateAccessReviewItems_Empty(t *testing.T) {
+	// Empty slice is a no-op — no HTTP call is made.
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.CreateAccessReviewItems(context.Background(), nil)
+	require.NoError(t, err)
+}
+
+// --- ListAccessReviewItems ---
+
+func TestRemoteStorage_ListAccessReviewItems(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/access-review-campaigns/10/items", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"items": []map[string]interface{}{
+				itemWireData(1, 10),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListAccessReviewItems(context.Background(), 10)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, uint(1), results[0].ID)
+	assert.Equal(t, uint(10), results[0].CampaignID)
+	assert.Equal(t, "user", results[0].PrincipalType)
+}
+
+// --- CountPendingAccessReviewItems ---
+
+func TestRemoteStorage_CountPendingAccessReviewItems(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/access-review-campaigns/10/items/pending-count", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"count": 5,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	count, err := rs.CountPendingAccessReviewItems(context.Background(), 10)
+	require.NoError(t, err)
+	assert.Equal(t, 5, count)
+}
+
+// --- GetAccessReviewItem ---
+
+func TestRemoteStorage_GetAccessReviewItem(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/access-review-campaigns/items/99", r.URL.Path)
+		_, _ = w.Write(apiOK(itemWireData(99, 10)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.GetAccessReviewItem(context.Background(), 99)
+	require.NoError(t, err)
+	assert.Equal(t, uint(99), result.ID)
+	assert.Equal(t, uint(10), result.CampaignID)
+}
+
+// --- UpdateAccessReviewItem ---
+
+func TestRemoteStorage_UpdateAccessReviewItem_Updated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/access-review-campaigns/items/99", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"updated": true,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	item := &models.AccessReviewItem{
+		ID:            99,
+		CampaignID:    10,
+		PrincipalType: "user",
+		PrincipalID:   3,
+		PrincipalName: "alice",
+		Source:        "role",
+		AccessLevel:   "read",
+		EnvironmentID: 1,
+		Decision:      "attested",
+		DecidedBy:     7,
+	}
+	updated, err := rs.UpdateAccessReviewItem(context.Background(), item)
+	require.NoError(t, err)
+	assert.True(t, updated)
+}
+
+func TestRemoteStorage_UpdateAccessReviewItem_NotUpdated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"updated": false,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	item := &models.AccessReviewItem{
+		ID:            99,
+		CampaignID:    10,
+		PrincipalType: "user",
+		Decision:      "attested",
+	}
+	updated, err := rs.UpdateAccessReviewItem(context.Background(), item)
+	require.NoError(t, err)
+	assert.False(t, updated)
+}

--- a/internal/storage/store/remote_audit_test.go
+++ b/internal/storage/store/remote_audit_test.go
@@ -1,0 +1,385 @@
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- LogAuditEvent ---
+
+func TestRemoteStorage_LogAuditEvent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/audit/events", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	event := &models.AuditEvent{
+		EventType: "secret.read",
+		ActorType: "user",
+	}
+	err = rs.LogAuditEvent(context.Background(), event)
+	require.NoError(t, err)
+}
+
+// --- CreateSecretAccessLog (no-op) ---
+
+func TestRemoteStorage_CreateSecretAccessLog(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.CreateSecretAccessLog(context.Background(), &models.SecretAccessLog{})
+	require.NoError(t, err)
+}
+
+// --- CountImpersonatedActions (returns 0) ---
+
+func TestRemoteStorage_CountImpersonatedActions(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	count, err := rs.CountImpersonatedActions(context.Background(), 1, 2, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+// --- GetAuditLogs ---
+
+func TestRemoteStorage_GetAuditLogs_NilFilter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/audit/events", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"events": []map[string]interface{}{
+				{"EventType": "secret.read", "ActorType": "user"},
+			},
+			"total": 1,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	events, total, err := rs.GetAuditLogs(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Len(t, events, 1)
+}
+
+func TestRemoteStorage_GetAuditLogs_WithFilter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/audit/events", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"events": []map[string]interface{}{},
+			"total":  int64(0),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	action := "secret.read"
+	filter := &corestorage.AuditFilter{
+		Action:   &action,
+		Page:     1,
+		PageSize: 10,
+	}
+	events, total, err := rs.GetAuditLogs(context.Background(), filter)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), total)
+	assert.Len(t, events, 0)
+}
+
+// --- GetRBACAuditLogs ---
+
+func TestRemoteStorage_GetRBACAuditLogs_NilFilter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/audit/rbac", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"logs": []map[string]interface{}{
+				{
+					"id":      1,
+					"action":  "role.assign",
+					"success": true,
+				},
+			},
+			"total": 1,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	logs, total, err := rs.GetRBACAuditLogs(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Len(t, logs, 1)
+	assert.Equal(t, "role.assign", logs[0].Action)
+}
+
+func TestRemoteStorage_GetRBACAuditLogs_WithFilter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/audit/rbac", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"logs":  []map[string]interface{}{},
+			"total": int64(0),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	action := "role.assign"
+	targetType := "project"
+	filter := &corestorage.RBACAuditFilter{
+		Action:     &action,
+		TargetType: &targetType,
+		Page:       1,
+		PageSize:   10,
+	}
+	logs, total, err := rs.GetRBACAuditLogs(context.Background(), filter)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), total)
+	assert.Len(t, logs, 0)
+}
+
+// --- ListSecretAccessLogs (unsupported) ---
+
+func TestRemoteStorage_ListSecretAccessLogs_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListSecretAccessLogs(context.Background(), 1, time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- CountSecretReadsBySecretIDs (unsupported) ---
+
+func TestRemoteStorage_CountSecretReadsBySecretIDs_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CountSecretReadsBySecretIDs(context.Background(), []uint{1, 2}, time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- PrincipalSecretFirstSeen (unsupported) ---
+
+func TestRemoteStorage_PrincipalSecretFirstSeen_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.PrincipalSecretFirstSeen(context.Background(), time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- MostAccessedSecrets (unsupported) ---
+
+func TestRemoteStorage_MostAccessedSecrets_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.MostAccessedSecrets(context.Background(), nil, time.Now(), 10)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- UnusedSecrets (unsupported) ---
+
+func TestRemoteStorage_UnusedSecrets_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.UnusedSecrets(context.Background(), nil, time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- CountUnusedSecretsByProject (unsupported) ---
+
+func TestRemoteStorage_CountUnusedSecretsByProject_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CountUnusedSecretsByProject(context.Background(), []uint{1}, time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- AuditRetentionStats (unsupported) ---
+
+func TestRemoteStorage_AuditRetentionStats_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.AuditRetentionStats(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- VerifyAuditChain (unsupported) ---
+
+func TestRemoteStorage_VerifyAuditChain_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.VerifyAuditChain(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- CreateAuditCheckpoint (unsupported) ---
+
+func TestRemoteStorage_CreateAuditCheckpoint_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.CreateAuditCheckpoint(context.Background(), &models.AuditCheckpoint{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- LatestAuditCheckpoint (unsupported) ---
+
+func TestRemoteStorage_LatestAuditCheckpoint_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.LatestAuditCheckpoint(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- UpdateAuditCheckpointAnchor (unsupported) ---
+
+func TestRemoteStorage_UpdateAuditCheckpointAnchor_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.UpdateAuditCheckpointAnchor(context.Background(), 1, []byte("anchor"), time.Now(), "tsa-url")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- AuditEntryHashByID (unsupported) ---
+
+func TestRemoteStorage_AuditEntryHashByID_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, _, err = rs.AuditEntryHashByID(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- GetSystemMetadata (unsupported) ---
+
+func TestRemoteStorage_GetSystemMetadata_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, _, err = rs.GetSystemMetadata(context.Background(), "key")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- SetSystemMetadata (unsupported) ---
+
+func TestRemoteStorage_SetSystemMetadata_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.SetSystemMetadata(context.Background(), "key", "value")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- CreateAnomalyAlert (unsupported) ---
+
+func TestRemoteStorage_CreateAnomalyAlert_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.CreateAnomalyAlert(context.Background(), &models.AnomalyAlert{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- ListAnomalyAlerts (unsupported) ---
+
+func TestRemoteStorage_ListAnomalyAlerts_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	acked := false
+	_, err = rs.ListAnomalyAlerts(context.Background(), &acked)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- AcknowledgeAnomalyAlert (unsupported) ---
+
+func TestRemoteStorage_AcknowledgeAnomalyAlert_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.AcknowledgeAnomalyAlert(context.Background(), 1, 2, time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- ListUnalertedAnomalyAlerts (unsupported) ---
+
+func TestRemoteStorage_ListUnalertedAnomalyAlerts_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListUnalertedAnomalyAlerts(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- MarkAnomalyAlertAlerted (unsupported) ---
+
+func TestRemoteStorage_MarkAnomalyAlertAlerted_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.MarkAnomalyAlertAlerted(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- GetDistinctActiveUserIDs (unsupported) ---
+
+func TestRemoteStorage_GetDistinctActiveUserIDs_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetDistinctActiveUserIDs(context.Background(), time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}

--- a/internal/storage/store/remote_auth_test.go
+++ b/internal/storage/store/remote_auth_test.go
@@ -103,10 +103,10 @@ func TestRemoteStorage_DeleteSession(t *testing.T) {
 
 func TestRemoteStorage_DeleteSession_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"success": false,
-			"error":   map[string]string{"code": "INTERNAL", "message": "server error"},
+			"error":   map[string]string{"code": "BAD_REQUEST", "message": "server error"},
 		})
 	}))
 	defer srv.Close()
@@ -319,10 +319,10 @@ func TestRemoteStorage_SupersedeActiveSetupTokens(t *testing.T) {
 
 func TestRemoteStorage_SupersedeActiveSetupTokens_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"success": false,
-			"error":   map[string]string{"code": "INTERNAL", "message": "server error"},
+			"error":   map[string]string{"code": "BAD_REQUEST", "message": "server error"},
 		})
 	}))
 	defer srv.Close()
@@ -439,10 +439,10 @@ func TestRemoteStorage_CountSetupTokensSince(t *testing.T) {
 
 func TestRemoteStorage_CountSetupTokensSince_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"success": false,
-			"error":   map[string]string{"code": "INTERNAL", "message": "server error"},
+			"error":   map[string]string{"code": "BAD_REQUEST", "message": "server error"},
 		})
 	}))
 	defer srv.Close()

--- a/internal/storage/store/remote_auth_test.go
+++ b/internal/storage/store/remote_auth_test.go
@@ -1,0 +1,455 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// minimalSetupToken returns a minimal *models.SetupToken for use as a request input.
+func minimalSetupToken() *models.SetupToken {
+	return &models.SetupToken{
+		TokenHash:    "sha256hashvalue",
+		Purpose:      "account_setup",
+		SubjectEmail: "user@example.com",
+		State:        "active",
+		ExpiresAt:    time.Now().UTC().Add(time.Hour),
+		CreatedBy:    1,
+		CreatedAt:    time.Now().UTC(),
+	}
+}
+
+// setupTokenWireBody returns a JSON-compatible map matching setupTokenWire fields.
+func setupTokenWireBody() map[string]interface{} {
+	return map[string]interface{}{
+		"id":              float64(10),
+		"token_hash":      "sha256hashvalue",
+		"purpose":         "account_setup",
+		"subject_user_id": nil,
+		"subject_email":   "user@example.com",
+		"invitation_id":   nil,
+		"state":           "active",
+		"expires_at":      time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+		"created_by":      float64(1),
+		"created_at":      time.Now().UTC().Format(time.RFC3339Nano),
+		"consumed_at":     nil,
+	}
+}
+
+// --- GetSession ---
+
+func TestRemoteStorage_GetSession(t *testing.T) {
+	const token = "abc123token"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/sessions/abc123token", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"ID":     42,
+			"UserID": 7,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	session, err := rs.GetSession(context.Background(), token)
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), session.ID)
+	assert.Equal(t, uint(7), session.UserID)
+}
+
+func TestRemoteStorage_GetSession_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "NOT_FOUND", "message": "session not found"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetSession(context.Background(), "bad-token")
+	assert.Error(t, err)
+}
+
+// --- DeleteSession ---
+
+func TestRemoteStorage_DeleteSession(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/sessions/5", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteSession(context.Background(), 5)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_DeleteSession_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "INTERNAL", "message": "server error"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteSession(context.Background(), 99)
+	assert.Error(t, err)
+}
+
+// --- CleanupExpiredSessions ---
+
+func TestRemoteStorage_CleanupExpiredSessions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/sessions/cleanup", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CleanupExpiredSessions(context.Background())
+	require.NoError(t, err)
+}
+
+// --- CreateSession (unsupported stub) ---
+
+func TestRemoteStorage_CreateSession_Unsupported(t *testing.T) {
+	// No HTTP server needed — CreateSession never makes a remote call.
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19999"))
+	require.NoError(t, err)
+
+	_, err = rs.CreateSession(context.Background(), &models.Session{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
+}
+
+// --- Session stubs (errUnsupportedRemote) ---
+
+func TestRemoteStorage_SessionStubs_ReturnError(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19999"))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	_, err = rs.GetSessionByID(ctx, 1)
+	assert.Error(t, err)
+
+	_, err = rs.GetSessionAny(ctx, "tok")
+	assert.Error(t, err)
+
+	_, _, err = rs.RotateSession(ctx, 1, nil, time.Now())
+	assert.Error(t, err)
+
+	_, err = rs.ListSessionTokenHashesByFamily(ctx, "fam")
+	assert.Error(t, err)
+
+	err = rs.DeleteSessionsByFamily(ctx, "fam")
+	assert.Error(t, err)
+
+	_, err = rs.ListSessionsByUser(ctx, 1)
+	assert.Error(t, err)
+
+	err = rs.DeleteSessionsForUserExcept(ctx, 1, 2)
+	assert.Error(t, err)
+
+	_, err = rs.ListSessionTokenHashesForUser(ctx, 1)
+	assert.Error(t, err)
+
+	err = rs.EnforceSessionLimit(ctx, 1, 5)
+	assert.Error(t, err)
+}
+
+// --- TouchSession (no-op) ---
+
+func TestRemoteStorage_TouchSession_NoError(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19999"))
+	require.NoError(t, err)
+
+	err = rs.TouchSession(context.Background(), 1, time.Now(), time.Minute)
+	require.NoError(t, err)
+}
+
+// --- PAT stubs (errUnsupportedRemote) ---
+
+func TestRemoteStorage_PATStubs_ReturnError(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19999"))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	_, err = rs.CreatePersonalAccessToken(ctx, nil)
+	assert.Error(t, err)
+
+	_, err = rs.ListPersonalAccessTokensByUser(ctx, 1)
+	assert.Error(t, err)
+
+	_, err = rs.ListActivePersonalAccessTokens(ctx)
+	assert.Error(t, err)
+
+	_, err = rs.GetPersonalAccessTokenByID(ctx, 1)
+	assert.Error(t, err)
+
+	_, err = rs.GetPersonalAccessTokenByHash(ctx, "hash")
+	assert.Error(t, err)
+
+	err = rs.RevokePersonalAccessToken(ctx, 1)
+	assert.Error(t, err)
+
+	_, err = rs.RevokeAllPersonalAccessTokensForUser(ctx, 1)
+	assert.Error(t, err)
+}
+
+// --- TouchPersonalAccessToken (no-op) ---
+
+func TestRemoteStorage_TouchPersonalAccessToken_NoError(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19999"))
+	require.NoError(t, err)
+
+	err = rs.TouchPersonalAccessToken(context.Background(), 1, time.Now(), time.Hour)
+	require.NoError(t, err)
+}
+
+// --- Setup Tokens ---
+
+func TestRemoteStorage_CreateSetupToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/setup-tokens", r.URL.Path)
+		_, _ = w.Write(apiOK(setupTokenWireBody()))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	tok, err := rs.CreateSetupToken(context.Background(), minimalSetupToken())
+	require.NoError(t, err)
+	assert.Equal(t, "account_setup", tok.Purpose)
+	assert.Equal(t, "active", tok.State)
+	assert.Equal(t, "user@example.com", tok.SubjectEmail)
+}
+
+func TestRemoteStorage_CreateSetupToken_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "INVALID", "message": "bad request"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateSetupToken(context.Background(), minimalSetupToken())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetSetupTokenByHash(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/setup-tokens/by-hash/deadbeef", r.URL.Path)
+		_, _ = w.Write(apiOK(setupTokenWireBody()))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	tok, err := rs.GetSetupTokenByHash(context.Background(), "deadbeef")
+	require.NoError(t, err)
+	assert.Equal(t, "account_setup", tok.Purpose)
+	assert.Equal(t, "user@example.com", tok.SubjectEmail)
+}
+
+func TestRemoteStorage_GetSetupTokenByHash_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "NOT_FOUND", "message": "not found"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetSetupTokenByHash(context.Background(), "missing")
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_SupersedeActiveSetupTokens(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/setup-tokens/supersede", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.SupersedeActiveSetupTokens(context.Background(), "account_setup", "user@example.com")
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_SupersedeActiveSetupTokens_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "INTERNAL", "message": "server error"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.SupersedeActiveSetupTokens(context.Background(), "account_setup", "user@example.com")
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_MarkSetupTokenConsumed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/setup-tokens/10/consume", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"consumed": true,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	consumed, err := rs.MarkSetupTokenConsumed(context.Background(), 10, time.Now())
+	require.NoError(t, err)
+	assert.True(t, consumed)
+}
+
+func TestRemoteStorage_MarkSetupTokenConsumed_NotConsumed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"consumed": false,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	consumed, err := rs.MarkSetupTokenConsumed(context.Background(), 10, time.Now())
+	require.NoError(t, err)
+	assert.False(t, consumed)
+}
+
+func TestRemoteStorage_MarkSetupTokenConsumed_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "CONFLICT", "message": "already consumed"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.MarkSetupTokenConsumed(context.Background(), 10, time.Now())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_MarkSetupTokenExpired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/setup-tokens/10/expire", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.MarkSetupTokenExpired(context.Background(), 10)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_MarkSetupTokenExpired_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "NOT_FOUND", "message": "token not found"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.MarkSetupTokenExpired(context.Background(), 10)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CountSetupTokensSince(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/setup-tokens/count", r.URL.Path)
+		assert.Equal(t, "account_setup", r.URL.Query().Get("purpose"))
+		assert.Equal(t, "user@example.com", r.URL.Query().Get("subject_email"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"count": float64(3),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	count, err := rs.CountSetupTokensSince(context.Background(), "account_setup", "user@example.com", time.Now().Add(-24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+}
+
+func TestRemoteStorage_CountSetupTokensSince_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "INTERNAL", "message": "server error"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountSetupTokensSince(context.Background(), "account_setup", "user@example.com", time.Now())
+	assert.Error(t, err)
+}

--- a/internal/storage/store/remote_dynamic_test.go
+++ b/internal/storage/store/remote_dynamic_test.go
@@ -1,0 +1,347 @@
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dynamicConfigWireData returns a minimal wire payload for a DynamicSecretConfig.
+func dynamicConfigWireData(id uint, name string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":                  id,
+		"name":                name,
+		"project_id":          uint(1),
+		"environment_id":      uint(2),
+		"backend_type":        "postgres",
+		"creation_template":   "CREATE ROLE {{name}}",
+		"default_ttl_seconds": 3600,
+		"max_ttl_seconds":     86400,
+		"max_active_leases":   10,
+		"classification":      "confidential",
+		"disabled":            false,
+		"created_by":          "admin",
+		"created_at":          time.Now().UTC().Format(time.RFC3339),
+		"updated_at":          time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// dynamicLeaseWireData returns a minimal wire payload for a DynamicSecretLease.
+func dynamicLeaseWireData(id uint, leaseID string, configID uint) map[string]interface{} {
+	return map[string]interface{}{
+		"id":             id,
+		"config_id":      configID,
+		"lease_id":       leaseID,
+		"project_id":     uint(1),
+		"environment_id": uint(2),
+		"role_name":      "app_reader",
+		"status":         "active",
+		"revoke_reason":  "",
+		"revoke_error":   "",
+		"issued_at":      time.Now().UTC().Format(time.RFC3339),
+		"expires_at":     time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+	}
+}
+
+// --- CreateDynamicSecretConfig ---
+
+func TestRemoteStorage_CreateDynamicSecretConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/dynamic-secrets/configs", r.URL.Path)
+		_, _ = w.Write(apiOK(dynamicConfigWireData(1, "pg-dynamic")))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	c := &models.DynamicSecretConfig{
+		Name:          "pg-dynamic",
+		ProjectID:     1,
+		EnvironmentID: 2,
+		BackendType:   "postgres",
+		CreatedBy:     "admin",
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+	result, err := rs.CreateDynamicSecretConfig(context.Background(), c)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), result.ID)
+	assert.Equal(t, "pg-dynamic", result.Name)
+	assert.Equal(t, "postgres", result.BackendType)
+}
+
+// --- GetDynamicSecretConfig ---
+
+func TestRemoteStorage_GetDynamicSecretConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/dynamic-secrets/configs/1", r.URL.Path)
+		_, _ = w.Write(apiOK(dynamicConfigWireData(1, "pg-dynamic")))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.GetDynamicSecretConfig(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), result.ID)
+	assert.Equal(t, "pg-dynamic", result.Name)
+}
+
+// --- ListDynamicSecretConfigs ---
+
+func TestRemoteStorage_ListDynamicSecretConfigs_NoEnvironment(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/dynamic-secrets/configs", r.URL.Path)
+		assert.Equal(t, "1", r.URL.Query().Get("project_id"))
+		// environment_id=0 should not be added to the query
+		assert.Empty(t, r.URL.Query().Get("environment_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"configs": []map[string]interface{}{
+				dynamicConfigWireData(1, "pg-dynamic"),
+				dynamicConfigWireData(2, "mysql-dynamic"),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListDynamicSecretConfigs(context.Background(), 1, 0)
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.Equal(t, uint(1), results[0].ID)
+	assert.Equal(t, "pg-dynamic", results[0].Name)
+}
+
+func TestRemoteStorage_ListDynamicSecretConfigs_WithEnvironment(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "1", r.URL.Query().Get("project_id"))
+		assert.Equal(t, "2", r.URL.Query().Get("environment_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"configs": []map[string]interface{}{
+				dynamicConfigWireData(1, "pg-dynamic"),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListDynamicSecretConfigs(context.Background(), 1, 2)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+}
+
+// --- UpdateDynamicSecretConfig ---
+
+func TestRemoteStorage_UpdateDynamicSecretConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/dynamic-secrets/configs/1", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	c := &models.DynamicSecretConfig{
+		ID:            1,
+		Name:          "pg-dynamic",
+		ProjectID:     1,
+		EnvironmentID: 2,
+		BackendType:   "postgres",
+		CreatedBy:     "admin",
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+	err = rs.UpdateDynamicSecretConfig(context.Background(), c)
+	require.NoError(t, err)
+}
+
+// --- CountDynamicSecretConfigsByClassification ---
+
+func TestRemoteStorage_CountDynamicSecretConfigsByClassification(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/dynamic-secrets/configs/classification-counts", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"counts": map[string]interface{}{
+				"confidential": 3,
+				"public":       1,
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	counts, err := rs.CountDynamicSecretConfigsByClassification(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 3, counts["confidential"])
+	assert.Equal(t, 1, counts["public"])
+}
+
+// --- CreateDynamicSecretLease ---
+
+func TestRemoteStorage_CreateDynamicSecretLease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/dynamic-secrets/leases", r.URL.Path)
+		_, _ = w.Write(apiOK(dynamicLeaseWireData(1, "lease-abc", 1)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	l := &models.DynamicSecretLease{
+		ConfigID:      1,
+		LeaseID:       "lease-abc",
+		ProjectID:     1,
+		EnvironmentID: 2,
+		RoleName:      "app_reader",
+		Status:        "active",
+		IssuedAt:      time.Now(),
+		ExpiresAt:     time.Now().Add(time.Hour),
+	}
+	result, err := rs.CreateDynamicSecretLease(context.Background(), l)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), result.ID)
+	assert.Equal(t, "lease-abc", result.LeaseID)
+	assert.Equal(t, "active", result.Status)
+}
+
+// --- GetDynamicSecretLease ---
+
+func TestRemoteStorage_GetDynamicSecretLease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/dynamic-secrets/leases/lease-abc", r.URL.Path)
+		_, _ = w.Write(apiOK(dynamicLeaseWireData(1, "lease-abc", 1)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.GetDynamicSecretLease(context.Background(), "lease-abc")
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), result.ID)
+	assert.Equal(t, "lease-abc", result.LeaseID)
+}
+
+// --- ListDynamicSecretLeases ---
+
+func TestRemoteStorage_ListDynamicSecretLeases(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/dynamic-secrets/leases", r.URL.Path)
+		assert.Equal(t, "1", r.URL.Query().Get("config_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"leases": []map[string]interface{}{
+				dynamicLeaseWireData(1, "lease-abc", 1),
+				dynamicLeaseWireData(2, "lease-def", 1),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListDynamicSecretLeases(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.Equal(t, "lease-abc", results[0].LeaseID)
+}
+
+// --- CountActiveLeases ---
+
+func TestRemoteStorage_CountActiveLeases(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/dynamic-secrets/leases/active-count", r.URL.Path)
+		assert.Equal(t, "1", r.URL.Query().Get("config_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"count": int64(3),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	count, err := rs.CountActiveLeases(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+}
+
+// --- UpdateDynamicSecretLease ---
+
+func TestRemoteStorage_UpdateDynamicSecretLease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/dynamic-secrets/leases/lease-abc", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	l := &models.DynamicSecretLease{
+		ID:            1,
+		ConfigID:      1,
+		LeaseID:       "lease-abc",
+		ProjectID:     1,
+		EnvironmentID: 2,
+		RoleName:      "app_reader",
+		Status:        "revoked",
+		RevokeReason:  "expired",
+		IssuedAt:      time.Now().Add(-2 * time.Hour),
+		ExpiresAt:     time.Now().Add(-time.Hour),
+	}
+	err = rs.UpdateDynamicSecretLease(context.Background(), l)
+	require.NoError(t, err)
+}
+
+// --- ListExpiredActiveLeases ---
+
+func TestRemoteStorage_ListExpiredActiveLeases(t *testing.T) {
+	before := time.Now().UTC()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/dynamic-secrets/leases/expired", r.URL.Path)
+		assert.NotEmpty(t, r.URL.Query().Get("before"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"leases": []map[string]interface{}{
+				dynamicLeaseWireData(1, "lease-old", 1),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListExpiredActiveLeases(context.Background(), before)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "lease-old", results[0].LeaseID)
+}

--- a/internal/storage/store/remote_invitations_test.go
+++ b/internal/storage/store/remote_invitations_test.go
@@ -1,0 +1,348 @@
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Project invitations ---
+
+func TestRemoteStorage_CreateProjectInvitation(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/invitations", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":                       1,
+			"project_id":               10,
+			"email":                    "alice@example.com",
+			"role":                     "viewer",
+			"state":                    "pending",
+			"invited_by":               5,
+			"validation_mode_at_invite": "email",
+			"system_role":              "",
+			"assignments_json":         "{}",
+			"created_at":               now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	inv, err := rs.CreateProjectInvitation(context.Background(), &models.ProjectInvitation{
+		ProjectID: 10, Email: "alice@example.com", Role: "viewer",
+		State: "pending", InvitedBy: 5,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), inv.ID)
+	assert.Equal(t, "alice@example.com", inv.Email)
+	assert.Equal(t, "pending", inv.State)
+	assert.Equal(t, "viewer", inv.Role)
+}
+
+func TestRemoteStorage_GetProjectInvitation(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/invitations/1", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":                       1,
+			"project_id":               10,
+			"email":                    "alice@example.com",
+			"role":                     "viewer",
+			"state":                    "pending",
+			"invited_by":               5,
+			"validation_mode_at_invite": "email",
+			"system_role":              "",
+			"assignments_json":         "{}",
+			"created_at":               now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	inv, err := rs.GetProjectInvitation(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), inv.ID)
+	assert.Equal(t, "alice@example.com", inv.Email)
+	assert.Equal(t, uint(10), inv.ProjectID)
+}
+
+func TestRemoteStorage_UpdateProjectInvitation(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/system/invitations/1", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"updated": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	accepted := now
+	updated, err := rs.UpdateProjectInvitation(context.Background(), &models.ProjectInvitation{
+		ID: 1, ProjectID: 10, Email: "alice@example.com",
+		Role: "viewer", State: "accepted", InvitedBy: 5,
+		AcceptedAt: &accepted,
+	})
+	require.NoError(t, err)
+	assert.True(t, updated)
+}
+
+func TestRemoteStorage_UpdateProjectInvitation_NotMatched(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"updated": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	updated, err := rs.UpdateProjectInvitation(context.Background(), &models.ProjectInvitation{
+		ID: 1, State: "accepted",
+	})
+	require.NoError(t, err)
+	assert.False(t, updated)
+}
+
+func TestRemoteStorage_ListProjectInvitations(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/invitations", r.URL.Path)
+		assert.Equal(t, "10", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"invitations": []map[string]interface{}{
+				{
+					"id":                       1,
+					"project_id":               10,
+					"email":                    "alice@example.com",
+					"role":                     "viewer",
+					"state":                    "pending",
+					"invited_by":               5,
+					"validation_mode_at_invite": "email",
+					"system_role":              "",
+					"assignments_json":         "{}",
+					"created_at":               now,
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListProjectInvitations(context.Background(), 10)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, uint(1), list[0].ID)
+	assert.Equal(t, "alice@example.com", list[0].Email)
+	assert.Equal(t, uint(10), list[0].ProjectID)
+}
+
+// --- Access requests ---
+
+func TestRemoteStorage_CreateAccessRequest(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/access-requests", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":             50,
+			"project_id":     10,
+			"user_id":        3,
+			"suggested_role": "editor",
+			"granted_role":   "",
+			"state":          "pending",
+			"reason":         "need access",
+			"resolved_by":    0,
+			"created_at":     now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	req, err := rs.CreateAccessRequest(context.Background(), &models.AccessRequest{
+		ProjectID: 10, UserID: 3, SuggestedRole: "editor",
+		State: "pending", Reason: "need access",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(50), req.ID)
+	assert.Equal(t, "pending", req.State)
+	assert.Equal(t, "editor", req.SuggestedRole)
+}
+
+func TestRemoteStorage_GetAccessRequest(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/access-requests/50", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":             50,
+			"project_id":     10,
+			"user_id":        3,
+			"suggested_role": "editor",
+			"granted_role":   "",
+			"state":          "pending",
+			"reason":         "need access",
+			"resolved_by":    0,
+			"created_at":     now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	req, err := rs.GetAccessRequest(context.Background(), 50)
+	require.NoError(t, err)
+	assert.Equal(t, uint(50), req.ID)
+	assert.Equal(t, uint(10), req.ProjectID)
+	assert.Equal(t, uint(3), req.UserID)
+}
+
+func TestRemoteStorage_UpdateAccessRequest(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/system/access-requests/50", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"updated": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	resolvedAt := now
+	updated, err := rs.UpdateAccessRequest(context.Background(), &models.AccessRequest{
+		ID: 50, ProjectID: 10, UserID: 3, SuggestedRole: "editor",
+		GrantedRole: "editor", State: "approved",
+		ResolvedBy: 1, ResolvedAt: &resolvedAt,
+	})
+	require.NoError(t, err)
+	assert.True(t, updated)
+}
+
+func TestRemoteStorage_UpdateAccessRequest_NotMatched(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"updated": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	updated, err := rs.UpdateAccessRequest(context.Background(), &models.AccessRequest{
+		ID: 50, State: "rejected",
+	})
+	require.NoError(t, err)
+	assert.False(t, updated)
+}
+
+func TestRemoteStorage_ListAccessRequests(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/access-requests", r.URL.Path)
+		assert.Equal(t, "10", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"access_requests": []map[string]interface{}{
+				{
+					"id":             50,
+					"project_id":     10,
+					"user_id":        3,
+					"suggested_role": "editor",
+					"granted_role":   "",
+					"state":          "pending",
+					"reason":         "need access",
+					"resolved_by":    0,
+					"created_at":     now,
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListAccessRequests(context.Background(), 10)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, uint(50), list[0].ID)
+	assert.Equal(t, "pending", list[0].State)
+	assert.Equal(t, "need access", list[0].Reason)
+}
+
+// --- Access request approvals ---
+
+func TestRemoteStorage_CreateAccessRequestApproval(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/access-requests/50/approvals", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateAccessRequestApproval(context.Background(), &models.AccessRequestApproval{
+		RequestID:  50,
+		ApproverID: 2,
+	})
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_ListAccessRequestApprovals(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/access-requests/50/approvals", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"approvals": []map[string]interface{}{
+				{
+					"id":          1,
+					"request_id":  50,
+					"approver_id": 2,
+					"created_at":  now,
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListAccessRequestApprovals(context.Background(), 50)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, uint(1), list[0].ID)
+	assert.Equal(t, uint(50), list[0].RequestID)
+	assert.Equal(t, uint(2), list[0].ApproverID)
+}

--- a/internal/storage/store/remote_machine_identities_test.go
+++ b/internal/storage/store/remote_machine_identities_test.go
@@ -1,0 +1,587 @@
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Machine identities ---
+
+func TestRemoteStorage_CreateMachineIdentity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 1, "project_id": 2, "name": "ci-runner",
+			"identity_type": "ci", "state": "pending", "description": "CI runner",
+			"created_by": 5, "created_at": time.Now(), "updated_at": time.Now(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	mi, err := rs.CreateMachineIdentity(context.Background(), &models.MachineIdentity{
+		Name: "ci-runner", ProjectID: 2,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), mi.ID)
+	assert.Equal(t, "ci-runner", mi.Name)
+	assert.Equal(t, uint(2), mi.ProjectID)
+}
+
+func TestRemoteStorage_GetMachineIdentity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities/7", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 7, "name": "svc-account", "state": "active",
+			"created_at": time.Now(), "updated_at": time.Now(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	mi, err := rs.GetMachineIdentity(context.Background(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, uint(7), mi.ID)
+	assert.Equal(t, "svc-account", mi.Name)
+	assert.Equal(t, "active", mi.State)
+}
+
+func TestRemoteStorage_LockMachineIdentityForUpdate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities/3", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 3, "name": "k8s-sa", "state": "active",
+			"created_at": time.Now(), "updated_at": time.Now(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	mi, err := rs.LockMachineIdentityForUpdate(context.Background(), 3)
+	require.NoError(t, err)
+	assert.Equal(t, uint(3), mi.ID)
+	assert.Equal(t, "k8s-sa", mi.Name)
+}
+
+func TestRemoteStorage_UpdateMachineIdentity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities/9", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.UpdateMachineIdentity(context.Background(), &models.MachineIdentity{
+		ID: 9, Name: "updated-runner", State: "active",
+	})
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_TransitionMachineIdentityState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities/4/transition", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	matched, err := rs.TransitionMachineIdentityState(context.Background(),
+		&models.MachineIdentity{ID: 4, State: "active"}, "pending")
+	require.NoError(t, err)
+	assert.True(t, matched)
+}
+
+func TestRemoteStorage_TransitionMachineIdentityState_NotMatched(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	matched, err := rs.TransitionMachineIdentityState(context.Background(),
+		&models.MachineIdentity{ID: 4, State: "revoked"}, "active")
+	require.NoError(t, err)
+	assert.False(t, matched)
+}
+
+func TestRemoteStorage_ListMachineIdentities(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities", r.URL.Path)
+		assert.Equal(t, "10", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"machine_identities": []map[string]interface{}{
+				{
+					"id": 1, "project_id": 10, "name": "runner",
+					"state": "active", "created_at": time.Now(), "updated_at": time.Now(),
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListMachineIdentities(context.Background(), 10)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, uint(1), list[0].ID)
+	assert.Equal(t, "runner", list[0].Name)
+}
+
+func TestRemoteStorage_ListAllMachineIdentities(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities/all", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"machine_identities": []map[string]interface{}{
+				{
+					"id": 2, "name": "global-runner",
+					"state": "active", "created_at": time.Now(), "updated_at": time.Now(),
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListAllMachineIdentities(context.Background())
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, uint(2), list[0].ID)
+}
+
+func TestRemoteStorage_CountMachineIdentitiesByClassification(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities/classification-counts", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"counts": map[string]int{"confidential": 3, "public": 7},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	counts, err := rs.CountMachineIdentitiesByClassification(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 3, counts["confidential"])
+	assert.Equal(t, 7, counts["public"])
+}
+
+func TestRemoteStorage_CountStaleMachineIdentitiesByProject_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:9"))
+	require.NoError(t, err)
+
+	_, err = rs.CountStaleMachineIdentitiesByProject(context.Background(), []uint{1}, time.Now())
+	assert.Error(t, err)
+}
+
+// --- Machine-token credentials ---
+
+func TestRemoteStorage_CreateMachineIdentityCredential(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-credentials", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 11, "machine_identity_id": 4, "name": "prod-token",
+			"token_hash": "abc123", "token_prefix": "kx_machine_ab",
+			"created_at": time.Now(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	cred, err := rs.CreateMachineIdentityCredential(context.Background(), &models.MachineIdentityCredential{
+		MachineIdentityID: 4, Name: "prod-token", TokenHash: "abc123",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(11), cred.ID)
+	assert.Equal(t, "prod-token", cred.Name)
+	assert.Equal(t, "abc123", cred.TokenHash)
+}
+
+func TestRemoteStorage_GetMachineIdentityCredentialByHash(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-credentials/by-hash/deadbeef", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 5, "machine_identity_id": 2, "name": "ci-token",
+			"token_hash": "deadbeef", "token_prefix": "kx_machine_de",
+			"created_at": time.Now(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	cred, err := rs.GetMachineIdentityCredentialByHash(context.Background(), "deadbeef")
+	require.NoError(t, err)
+	assert.Equal(t, uint(5), cred.ID)
+	assert.Equal(t, "deadbeef", cred.TokenHash)
+}
+
+func TestRemoteStorage_GetMachineIdentityCredentialByID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-credentials/8", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 8, "machine_identity_id": 3, "name": "svc-token",
+			"token_hash": "cafebabe", "token_prefix": "kx_machine_ca",
+			"created_at": time.Now(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	cred, err := rs.GetMachineIdentityCredentialByID(context.Background(), 8)
+	require.NoError(t, err)
+	assert.Equal(t, uint(8), cred.ID)
+	assert.Equal(t, "svc-token", cred.Name)
+}
+
+func TestRemoteStorage_ListMachineIdentityCredentials(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities/6/credentials", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"credentials": []map[string]interface{}{
+				{
+					"id": 20, "machine_identity_id": 6, "name": "tok-a",
+					"token_hash": "hash1", "token_prefix": "kx_machine_ha",
+					"created_at": time.Now(),
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListMachineIdentityCredentials(context.Background(), 6)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, uint(20), list[0].ID)
+	assert.Equal(t, "tok-a", list[0].Name)
+}
+
+func TestRemoteStorage_ListActiveMachineIdentityCredentials(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-credentials/active", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"credentials": []map[string]interface{}{
+				{
+					"id": 30, "machine_identity_id": 1, "name": "active-tok",
+					"token_hash": "hash2", "token_prefix": "kx_machine_hb",
+					"revoked": false, "created_at": time.Now(),
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListActiveMachineIdentityCredentials(context.Background())
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, uint(30), list[0].ID)
+	assert.False(t, list[0].Revoked)
+}
+
+func TestRemoteStorage_UpdateMachineIdentityCredential(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-credentials/15", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.UpdateMachineIdentityCredential(context.Background(), &models.MachineIdentityCredential{
+		ID: 15, Name: "updated-tok", Classification: "internal",
+	})
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_CountMachineIdentityCredentialsByClassification(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-credentials/classification-counts", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"counts": map[string]int{"restricted": 2, "internal": 5},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	counts, err := rs.CountMachineIdentityCredentialsByClassification(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, counts["restricted"])
+	assert.Equal(t, 5, counts["internal"])
+}
+
+func TestRemoteStorage_RevokeMachineIdentityCredential(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-credentials/12/revoke", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RevokeMachineIdentityCredential(context.Background(), 12)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_TouchMachineIdentityCredential(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-credentials/18/touch", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.TouchMachineIdentityCredential(context.Background(), 18, now, 30*time.Second)
+	require.NoError(t, err)
+}
+
+// --- Machine role grants ---
+
+func TestRemoteStorage_AssignMachineRole(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities/5/roles/3", r.URL.Path)
+		assert.Equal(t, "10", r.URL.Query().Get("project_id"))
+		assert.Equal(t, "20", r.URL.Query().Get("environment_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.AssignMachineRole(context.Background(), 5, 3, corestorage.Scope{ProjectID: 10, EnvironmentID: 20})
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_RemoveMachineRole(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities/5/roles/3", r.URL.Path)
+		assert.Equal(t, "10", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemoveMachineRole(context.Background(), 5, 3, corestorage.Scope{ProjectID: 10, EnvironmentID: 0})
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_GetMachineRoleIDsAt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities/7/roles/ids", r.URL.Path)
+		assert.Equal(t, "2", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"role_ids": []uint{1, 4, 9},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	ids, err := rs.GetMachineRoleIDsAt(context.Background(), 7, corestorage.Scope{ProjectID: 2, EnvironmentID: 0})
+	require.NoError(t, err)
+	assert.Equal(t, []uint{1, 4, 9}, ids)
+}
+
+func TestRemoteStorage_GetMachineRoles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities/7/roles", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"roles": []map[string]interface{}{
+				{"id": 1, "name": "viewer", "description": "Read-only"},
+				{"id": 2, "name": "editor", "description": "Read-write"},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	roles, err := rs.GetMachineRoles(context.Background(), 7)
+	require.NoError(t, err)
+	require.Len(t, roles, 2)
+	assert.Equal(t, uint(1), roles[0].ID)
+	assert.Equal(t, "viewer", roles[0].Name)
+	assert.Equal(t, "editor", roles[1].Name)
+}
+
+// --- OIDC bindings ---
+
+func TestRemoteStorage_CreateOIDCBinding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-oidc-bindings", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 1, "machine_identity_id": 5,
+			"issuer": "https://token.actions.githubusercontent.com",
+			"subject": "repo:org/repo:ref:refs/heads/main",
+			"created_by": 1, "created_at": time.Now(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	b, err := rs.CreateOIDCBinding(context.Background(), &models.MachineIdentityOIDCBinding{
+		MachineIdentityID: 5,
+		Issuer:            "https://token.actions.githubusercontent.com",
+		Subject:           "repo:org/repo:ref:refs/heads/main",
+		CreatedBy:         1,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), b.ID)
+	assert.Equal(t, "https://token.actions.githubusercontent.com", b.Issuer)
+}
+
+func TestRemoteStorage_GetMachineByOIDCSubject(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-oidc-bindings/by-subject", r.URL.Path)
+		assert.Equal(t, "https://example.com", r.URL.Query().Get("issuer"))
+		assert.Equal(t, "system:serviceaccount:default:ci", r.URL.Query().Get("subject"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 3, "name": "k8s-sa", "state": "active",
+			"created_at": time.Now(), "updated_at": time.Now(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	mi, err := rs.GetMachineByOIDCSubject(context.Background(),
+		"https://example.com", "system:serviceaccount:default:ci")
+	require.NoError(t, err)
+	assert.Equal(t, uint(3), mi.ID)
+	assert.Equal(t, "k8s-sa", mi.Name)
+}
+
+func TestRemoteStorage_ListOIDCBindings(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-identities/5/oidc-bindings", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"bindings": []map[string]interface{}{
+				{
+					"id": 10, "machine_identity_id": 5,
+					"issuer": "https://issuer.example.com", "subject": "sa:default:ci",
+					"created_by": 1, "created_at": time.Now(),
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListOIDCBindings(context.Background(), 5)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, uint(10), list[0].ID)
+	assert.Equal(t, "https://issuer.example.com", list[0].Issuer)
+}
+
+func TestRemoteStorage_GetOIDCBindingByID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-oidc-bindings/42", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 42, "machine_identity_id": 5,
+			"issuer": "https://issuer.example.com", "subject": "sa:ns:name",
+			"created_by": 1, "created_at": time.Now(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	b, err := rs.GetOIDCBindingByID(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), b.ID)
+	assert.Equal(t, "sa:ns:name", b.Subject)
+}
+
+func TestRemoteStorage_DeleteOIDCBinding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/system/machine-oidc-bindings/99", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteOIDCBinding(context.Background(), 99)
+	require.NoError(t, err)
+}

--- a/internal/storage/store/remote_memberships_test.go
+++ b/internal/storage/store/remote_memberships_test.go
@@ -179,10 +179,10 @@ func TestRemoteStorage_CountProjectMembershipsByUsers_Empty(t *testing.T) {
 
 func TestRemoteStorage_CreateProjectMembership_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"success": false,
-			"error":   map[string]string{"code": "ERROR", "message": "failed"},
+			"error":   map[string]string{"code": "BAD_REQUEST", "message": "failed"},
 		})
 	}))
 	defer srv.Close()

--- a/internal/storage/store/remote_memberships_test.go
+++ b/internal/storage/store/remote_memberships_test.go
@@ -1,0 +1,195 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func membershipWireBody(id, projectID, userID uint) map[string]any {
+	return map[string]any{
+		"id":         id,
+		"project_id": projectID,
+		"user_id":    userID,
+		"role":       "viewer",
+		"state":      "active",
+		"invited_by": uint(1),
+		"invited_at": time.Now().UTC().Format(time.RFC3339),
+		"updated_at": time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+func membershipListBody(members []map[string]any) map[string]any {
+	return map[string]any{"memberships": members}
+}
+
+func TestRemoteStorage_CreateProjectMembership(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/project-memberships", r.URL.Path)
+		_, _ = w.Write(apiOK(membershipWireBody(1, 10, 5)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	m := &models.ProjectMembership{ProjectID: 10, UserID: 5, Role: "viewer", State: "active"}
+	result, err := rs.CreateProjectMembership(context.Background(), m)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), result.ID)
+	assert.Equal(t, uint(10), result.ProjectID)
+}
+
+func TestRemoteStorage_GetProjectMembership(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/project-memberships/7", r.URL.Path)
+		_, _ = w.Write(apiOK(membershipWireBody(7, 10, 5)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.GetProjectMembership(context.Background(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, uint(7), result.ID)
+}
+
+func TestRemoteStorage_UpdateProjectMembership(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/project-memberships/7", r.URL.Path)
+		_, _ = w.Write(apiOK(membershipWireBody(7, 10, 5)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	m := &models.ProjectMembership{ID: 7, ProjectID: 10, UserID: 5, Role: "viewer", State: "active"}
+	err = rs.UpdateProjectMembership(context.Background(), m)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_ListProjectMemberships(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/project-memberships", r.URL.Path)
+		assert.Equal(t, "10", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(membershipListBody([]map[string]any{membershipWireBody(1, 10, 5)})))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListProjectMemberships(context.Background(), 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, uint(1), results[0].ID)
+}
+
+func TestRemoteStorage_GetActiveProjectMembership(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/project-memberships/active", r.URL.Path)
+		assert.Equal(t, "10", r.URL.Query().Get("project_id"))
+		assert.Equal(t, "5", r.URL.Query().Get("user_id"))
+		_, _ = w.Write(apiOK(membershipWireBody(3, 10, 5)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.GetActiveProjectMembership(context.Background(), 10, 5)
+	require.NoError(t, err)
+	assert.Equal(t, uint(3), result.ID)
+}
+
+func TestRemoteStorage_ListStaleInvitedMemberships(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/project-memberships/stale", r.URL.Path)
+		assert.NotEmpty(t, r.URL.Query().Get("before"))
+		_, _ = w.Write(apiOK(membershipListBody([]map[string]any{membershipWireBody(2, 10, 5)})))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListStaleInvitedMemberships(context.Background(), time.Now())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+}
+
+func TestRemoteStorage_ListUserProjectMemberships(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/project-memberships/by-user/5", r.URL.Path)
+		_, _ = w.Write(apiOK(membershipListBody([]map[string]any{membershipWireBody(1, 10, 5)})))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListUserProjectMemberships(context.Background(), 5)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+}
+
+func TestRemoteStorage_CountProjectMembershipsByUsers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/project-memberships/counts", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]any{
+			"5": map[string]any{"active": 2, "total": 3},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.CountProjectMembershipsByUsers(context.Background(), []uint{5})
+	require.NoError(t, err)
+	assert.NotNil(t, results)
+}
+
+func TestRemoteStorage_CountProjectMembershipsByUsers_Empty(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19998"))
+	require.NoError(t, err)
+
+	results, err := rs.CountProjectMembershipsByUsers(context.Background(), []uint{})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestRemoteStorage_CreateProjectMembership_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"error":   map[string]string{"code": "ERROR", "message": "failed"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateProjectMembership(context.Background(), &models.ProjectMembership{})
+	assert.Error(t, err)
+}

--- a/internal/storage/store/remote_mfa_test.go
+++ b/internal/storage/store/remote_mfa_test.go
@@ -1,0 +1,324 @@
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- MFA secret management ---
+
+func TestRemoteStorage_UpsertMFASecret(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/secrets", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 7, "user_id": 42,
+			"secret_enc":  []byte("encdata"),
+			"secret_meta": []byte("metainfo"),
+			"activated":   false,
+			"created_at":  time.Now(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	s := &models.MFASecret{
+		UserID:     42,
+		SecretEnc:  []byte("encdata"),
+		SecretMeta: []byte("metainfo"),
+	}
+	err = rs.UpsertMFASecret(context.Background(), s)
+	require.NoError(t, err)
+	// The method mutates the argument in-place with upstream-assigned fields.
+	assert.Equal(t, uint(7), s.ID)
+	assert.Equal(t, uint(42), s.UserID)
+}
+
+func TestRemoteStorage_GetMFASecret(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/secrets", r.URL.Path)
+		assert.Equal(t, "42", r.URL.Query().Get("user_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 7, "user_id": 42,
+			"secret_enc":  []byte("encdata"),
+			"secret_meta": []byte("metainfo"),
+			"activated":   true,
+			"created_at":  time.Now(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	s, err := rs.GetMFASecret(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, uint(7), s.ID)
+	assert.Equal(t, uint(42), s.UserID)
+	assert.True(t, s.Activated)
+}
+
+func TestRemoteStorage_ActivateMFASecret(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/secrets/42/activate", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.ActivateMFASecret(context.Background(), 42)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_MarkTOTPStepUsed_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:9"))
+	require.NoError(t, err)
+
+	_, err = rs.MarkTOTPStepUsed(context.Background(), 1, 12345)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_DeleteMFAForUser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/users/42", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteMFAForUser(context.Background(), 42)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_SetUserMFAEnabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/users/42/mfa-enabled", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.SetUserMFAEnabled(context.Background(), 42, true)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_SetUserMFAEnabled_Disable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/users/10/mfa-enabled", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.SetUserMFAEnabled(context.Background(), 10, false)
+	require.NoError(t, err)
+}
+
+// --- Recovery codes ---
+
+func TestRemoteStorage_CreateMFARecoveryCodes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/recovery-codes", r.URL.Path)
+		assert.Equal(t, "42", r.URL.Query().Get("user_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateMFARecoveryCodes(context.Background(), 42, []string{"hash1", "hash2", "hash3"})
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_ConsumeMFARecoveryCode_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:9"))
+	require.NoError(t, err)
+
+	_, err = rs.ConsumeMFARecoveryCode(context.Background(), 1, "code", time.Now())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CountUnusedMFARecoveryCodes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/recovery-codes/count", r.URL.Path)
+		assert.Equal(t, "42", r.URL.Query().Get("user_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{"count": 6}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	n, err := rs.CountUnusedMFARecoveryCodes(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, 6, n)
+}
+
+func TestRemoteStorage_DeleteMFARecoveryCodes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/recovery-codes/42", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteMFARecoveryCodes(context.Background(), 42)
+	require.NoError(t, err)
+}
+
+// --- MFA challenge (CreateMFAChallenge is an unsupported stub) ---
+
+func TestRemoteStorage_CreateMFAChallenge_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:9"))
+	require.NoError(t, err)
+
+	err = rs.CreateMFAChallenge(context.Background(), &models.MFAChallenge{UserID: 1})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ConsumeMFAChallenge(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/users/mfa-challenge/consume", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":         55,
+			"user_id":    42,
+			"token_hash": "tkhash123",
+			"expires_at": now.Add(5 * time.Minute),
+			"created_at": now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	ch, err := rs.ConsumeMFAChallenge(context.Background(), "tkhash123", now)
+	require.NoError(t, err)
+	assert.Equal(t, uint(55), ch.ID)
+	assert.Equal(t, uint(42), ch.UserID)
+	assert.Equal(t, "tkhash123", ch.TokenHash)
+}
+
+func TestRemoteStorage_GetActiveMFAChallenge(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/users/mfa-challenge/active", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":         56,
+			"user_id":    42,
+			"token_hash": "activehash",
+			"expires_at": now.Add(5 * time.Minute),
+			"created_at": now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	ch, err := rs.GetActiveMFAChallenge(context.Background(), "activehash", now)
+	require.NoError(t, err)
+	assert.Equal(t, uint(56), ch.ID)
+	assert.Equal(t, uint(42), ch.UserID)
+}
+
+// --- RemoteMFAVerifier proxy ---
+
+func TestRemoteStorage_IssueMFAChallenge(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/users/42/mfa-challenge", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"challenge": "opaque-challenge-token"}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	tok, err := rs.IssueMFAChallenge(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, "opaque-challenge-token", tok)
+}
+
+func TestRemoteStorage_VerifyMFALoginCredentials(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/users/verify-mfa", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 42, "username": "alice", "used_recovery": false,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	user, usedRecovery, err := rs.VerifyMFALoginCredentials(context.Background(), "opaque-challenge-token", "123456")
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), user.ID)
+	assert.Equal(t, "alice", user.Username)
+	assert.False(t, usedRecovery)
+}
+
+func TestRemoteStorage_VerifyMFALoginCredentials_WithRecovery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 42, "username": "alice", "used_recovery": true,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	user, usedRecovery, err := rs.VerifyMFALoginCredentials(context.Background(), "challenge", "recovery-code-hash")
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), user.ID)
+	assert.True(t, usedRecovery)
+}
+
+func TestRemoteStorage_VerifyMFALoginCredentials_Failure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"UNAUTHORIZED","message":"invalid code"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.VerifyMFALoginCredentials(context.Background(), "bad-challenge", "000000")
+	assert.Error(t, err)
+}

--- a/internal/storage/store/remote_misc_test.go
+++ b/internal/storage/store/remote_misc_test.go
@@ -1,0 +1,1372 @@
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================
+// remote_access_activity.go
+// ============================================================
+
+func TestRemoteStorage_LastUserSecretActivity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/access-activity/secret", r.URL.Path)
+		assert.Equal(t, "42", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"activity": map[string]interface{}{
+				"1": time.Now().UTC().Format(time.RFC3339),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.LastUserSecretActivity(context.Background(), 42)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	_, ok := result[1]
+	assert.True(t, ok)
+}
+
+func TestRemoteStorage_LastUserRoleManagementActivity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/access-activity/role-management", r.URL.Path)
+		assert.Equal(t, "7", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"activity": map[string]interface{}{
+				"3": time.Now().UTC().Format(time.RFC3339),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.LastUserRoleManagementActivity(context.Background(), 7)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestRemoteStorage_LastUserSecretDeletionActivity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/access-activity/secret-deletion", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"activity": map[string]interface{}{}}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.LastUserSecretDeletionActivity(context.Background(), 1)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result, 0)
+}
+
+func TestRemoteStorage_LastUserSecretReadActivity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/access-activity/secret-read", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"activity": map[string]interface{}{}}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.LastUserSecretReadActivity(context.Background(), 1)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestRemoteStorage_LastUserSecretWriteActivity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/access-activity/secret-write", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"activity": map[string]interface{}{}}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.LastUserSecretWriteActivity(context.Background(), 1)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+// ============================================================
+// remote_audit_checkpoint_lock.go
+// ============================================================
+
+func TestRemoteStorage_WithAuditCheckpointLock_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19996"))
+	require.NoError(t, err)
+	err = rs.WithAuditCheckpointLock(context.Background(), func() error { return nil })
+	assert.Error(t, err)
+}
+
+// ============================================================
+// remote_break_glass.go
+// ============================================================
+
+func TestRemoteStorage_CreateBreakGlassActivation(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/break-glass", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":            10,
+			"project_id":    5,
+			"user_id":       2,
+			"role_id":       3,
+			"role_name":     "emergency-admin",
+			"justification": "incident response",
+			"state":         "active",
+			"created_at":    now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	act, err := rs.CreateBreakGlassActivation(context.Background(), &models.BreakGlassActivation{
+		ProjectID:     5,
+		UserID:        2,
+		RoleID:        3,
+		RoleName:      "emergency-admin",
+		Justification: "incident response",
+		State:         "active",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(10), act.ID)
+	assert.Equal(t, "active", act.State)
+	assert.Equal(t, "emergency-admin", act.RoleName)
+}
+
+func TestRemoteStorage_CreateBreakGlassActivation_AlreadyActive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"BREAK_GLASS_ALREADY_ACTIVE","message":"already active"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateBreakGlassActivation(context.Background(), &models.BreakGlassActivation{State: "active"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, corestorage.ErrBreakGlassAlreadyActive)
+}
+
+func TestRemoteStorage_GetBreakGlassActivation(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/break-glass/7", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":            7,
+			"project_id":    5,
+			"user_id":       2,
+			"role_id":       3,
+			"role_name":     "emergency-admin",
+			"justification": "fire drill",
+			"state":         "active",
+			"created_at":    now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	act, err := rs.GetBreakGlassActivation(context.Background(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, uint(7), act.ID)
+	assert.Equal(t, "active", act.State)
+}
+
+func TestRemoteStorage_ListBreakGlassActivations(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/break-glass", r.URL.Path)
+		assert.Equal(t, "5", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"activations": []map[string]interface{}{
+				{
+					"id":            1,
+					"project_id":    5,
+					"user_id":       2,
+					"role_id":       3,
+					"role_name":     "emergency-admin",
+					"justification": "outage",
+					"state":         "revoked",
+					"created_at":    now,
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListBreakGlassActivations(context.Background(), 5)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, uint(1), list[0].ID)
+	assert.Equal(t, "revoked", list[0].State)
+}
+
+func TestRemoteStorage_UpdateBreakGlassActivation(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/break-glass/9", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.UpdateBreakGlassActivation(context.Background(), &models.BreakGlassActivation{
+		ID:        9,
+		ProjectID: 5,
+		UserID:    2,
+		RoleID:    3,
+		State:     "expired",
+		CreatedAt: now,
+	})
+	assert.NoError(t, err)
+}
+
+func TestRemoteStorage_RevokeBreakGlassActivation(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/break-glass/9/revoke", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RevokeBreakGlassActivation(context.Background(), 9, 1, now)
+	assert.NoError(t, err)
+}
+
+func TestRemoteStorage_RevokeBreakGlassActivation_NotActive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"BREAK_GLASS_NOT_ACTIVE","message":"not active"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RevokeBreakGlassActivation(context.Background(), 9, 1, time.Now())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, corestorage.ErrBreakGlassNotActive)
+}
+
+// ============================================================
+// remote_legal_hold.go
+// ============================================================
+
+func TestRemoteStorage_CreateLegalHold(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/legal-hold", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":       3,
+			"reason":   "litigation hold",
+			"placed_by": 1,
+			"placed_at": now,
+			"released":  false,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	hold, err := rs.CreateLegalHold(context.Background(), &models.LegalHold{
+		Reason:   "litigation hold",
+		PlacedBy: 1,
+		PlacedAt: now,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(3), hold.ID)
+	assert.Equal(t, "litigation hold", hold.Reason)
+	assert.False(t, hold.Released)
+}
+
+func TestRemoteStorage_CreateLegalHold_AlreadyActive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"LEGAL_HOLD_ALREADY_ACTIVE","message":"already active"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateLegalHold(context.Background(), &models.LegalHold{Reason: "dup"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, corestorage.ErrLegalHoldAlreadyActive)
+}
+
+func TestRemoteStorage_GetActiveLegalHold_Active(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/legal-hold/active", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"active": true,
+			"hold": map[string]interface{}{
+				"id":        2,
+				"reason":    "eDiscovery",
+				"placed_by": 1,
+				"placed_at": now,
+				"released":  false,
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	hold, err := rs.GetActiveLegalHold(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, hold)
+	assert.Equal(t, uint(2), hold.ID)
+	assert.Equal(t, "eDiscovery", hold.Reason)
+}
+
+func TestRemoteStorage_GetActiveLegalHold_None(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"active": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	hold, err := rs.GetActiveLegalHold(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, hold)
+}
+
+func TestRemoteStorage_UpdateLegalHold(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/legal-hold/4", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.UpdateLegalHold(context.Background(), &models.LegalHold{
+		ID:       4,
+		Reason:   "eDiscovery",
+		PlacedBy: 1,
+		PlacedAt: now,
+		Released: true,
+	})
+	assert.NoError(t, err)
+}
+
+// ============================================================
+// remote_login_attempts.go
+// ============================================================
+
+func TestRemoteStorage_RecordLoginAttempt(t *testing.T) {
+	now := time.Now().UTC()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/login-attempts", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RecordLoginAttempt(context.Background(), "192.168.1.1", now)
+	assert.NoError(t, err)
+}
+
+func TestRemoteStorage_CountRecentLoginAttempts(t *testing.T) {
+	since := time.Now().UTC().Add(-10 * time.Minute)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/login-attempts/count", r.URL.Path)
+		assert.Equal(t, "10.0.0.1", r.URL.Query().Get("ip"))
+		assert.NotEmpty(t, r.URL.Query().Get("since"))
+		_, _ = w.Write(apiOK(map[string]interface{}{"count": 3}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	count, err := rs.CountRecentLoginAttempts(context.Background(), "10.0.0.1", since)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+}
+
+func TestRemoteStorage_PruneLoginAttempts(t *testing.T) {
+	before := time.Now().UTC().Add(-24 * time.Hour)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/login-attempts/prune", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"deleted": 12}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	deleted, err := rs.PruneLoginAttempts(context.Background(), before)
+	require.NoError(t, err)
+	assert.Equal(t, int64(12), deleted)
+}
+
+// ============================================================
+// remote_login_verify.go
+// ============================================================
+
+func TestRemoteStorage_VerifyLoginCredentials_NoMFA(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	expires := now.Add(24 * time.Hour)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/users/verify-credentials", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":               7,
+			"username":         "alice",
+			"email":            "alice@example.com",
+			"display_name":     "Alice",
+			"account_state":    "active",
+			"mfa_enabled":      false,
+			"webauthn_enabled": false,
+			"session": map[string]interface{}{
+				"id":         99,
+				"token":      "tok-abc",
+				"family_id":  "fam-1",
+				"created_at": now,
+				"expires_at": expires,
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	user, session, err := rs.VerifyLoginCredentials(context.Background(), "alice", "s3cr3t", "Mozilla/5.0", "10.0.0.1")
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, uint(7), user.ID)
+	assert.Equal(t, "alice", user.Username)
+	require.NotNil(t, session)
+	assert.Equal(t, uint(99), session.ID)
+	assert.Equal(t, "tok-abc", session.SessionToken)
+	assert.Equal(t, "10.0.0.1", session.IPAddress)
+}
+
+func TestRemoteStorage_VerifyLoginCredentials_MFARequired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":               8,
+			"username":         "bob",
+			"email":            "bob@example.com",
+			"display_name":     "Bob",
+			"account_state":    "active",
+			"mfa_enabled":      true,
+			"webauthn_enabled": false,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	user, session, err := rs.VerifyLoginCredentials(context.Background(), "bob", "pass", "UA", "127.0.0.1")
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, uint(8), user.ID)
+	assert.True(t, user.MFAEnabled)
+	assert.Nil(t, session, "session must be nil when MFA is required")
+}
+
+func TestRemoteStorage_VerifyLoginCredentials_Failure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"INVALID_CREDENTIALS","message":"wrong password"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.VerifyLoginCredentials(context.Background(), "alice", "wrong", "UA", "127.0.0.1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid credentials")
+}
+
+// ============================================================
+// remote_risk_exceptions.go
+// ============================================================
+
+func TestRemoteStorage_CreateRiskException(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	exp := now.Add(30 * 24 * time.Hour)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/risk-exceptions", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":            5,
+			"title":         "MFA waiver",
+			"category":      "mfa",
+			"justification": "vendor constraint",
+			"created_by":    1,
+			"created_at":    now,
+			"expires_at":    exp,
+			"revoked":       false,
+			"approved":      false,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	exc, err := rs.CreateRiskException(context.Background(), &models.RiskException{
+		Title:         "MFA waiver",
+		Category:      "mfa",
+		Justification: "vendor constraint",
+		CreatedBy:     1,
+		ExpiresAt:     exp,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(5), exc.ID)
+	assert.Equal(t, "MFA waiver", exc.Title)
+}
+
+func TestRemoteStorage_ListRiskExceptions(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	exp := now.Add(30 * 24 * time.Hour)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/risk-exceptions", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"exceptions": []map[string]interface{}{
+				{
+					"id":            1,
+					"title":         "SoD exception",
+					"category":      "sod",
+					"justification": "small team",
+					"created_by":    1,
+					"created_at":    now,
+					"expires_at":    exp,
+					"revoked":       false,
+					"approved":      true,
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListRiskExceptions(context.Background(), false)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "SoD exception", list[0].Title)
+	assert.True(t, list[0].Approved)
+}
+
+func TestRemoteStorage_ListRiskExceptions_ActiveOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "true", r.URL.Query().Get("active_only"))
+		_, _ = w.Write(apiOK(map[string]interface{}{"exceptions": []interface{}{}}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListRiskExceptions(context.Background(), true)
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}
+
+func TestRemoteStorage_GetRiskException(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	exp := now.Add(10 * 24 * time.Hour)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/risk-exceptions/3", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":            3,
+			"title":         "Rotation skip",
+			"category":      "rotation",
+			"justification": "legacy system",
+			"created_by":    2,
+			"created_at":    now,
+			"expires_at":    exp,
+			"revoked":       false,
+			"approved":      false,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	exc, err := rs.GetRiskException(context.Background(), 3)
+	require.NoError(t, err)
+	assert.Equal(t, uint(3), exc.ID)
+	assert.Equal(t, "Rotation skip", exc.Title)
+}
+
+func TestRemoteStorage_UpdateRiskException(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	exp := now.Add(30 * 24 * time.Hour)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/risk-exceptions/6", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.UpdateRiskException(context.Background(), &models.RiskException{
+		ID:            6,
+		Title:         "updated",
+		Category:      "mfa",
+		Justification: "still needed",
+		CreatedBy:     1,
+		CreatedAt:     now,
+		ExpiresAt:     exp,
+		Revoked:       true,
+	})
+	assert.NoError(t, err)
+}
+
+// ============================================================
+// remote_rotation_policies.go
+// ============================================================
+
+func TestRemoteStorage_CreateRotationPolicy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/rotation-policies", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"ID":        1,
+			"ProjectID": 10,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	pid := uint(10)
+	p := &models.RotationPolicy{ProjectID: &pid}
+	err = rs.CreateRotationPolicy(context.Background(), p)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), p.ID)
+}
+
+func TestRemoteStorage_GetRotationPolicy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/rotation-policies/4", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"ID":        4,
+			"ProjectID": 10,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	p, err := rs.GetRotationPolicy(context.Background(), 4)
+	require.NoError(t, err)
+	assert.Equal(t, uint(4), p.ID)
+}
+
+func TestRemoteStorage_ListRotationPolicies(t *testing.T) {
+	pid := uint(10)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/rotation-policies", r.URL.Path)
+		assert.Equal(t, "10", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK([]interface{}{
+			map[string]interface{}{"ID": 1, "ProjectID": 10},
+			map[string]interface{}{"ID": 2, "ProjectID": 10},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListRotationPolicies(context.Background(), &pid, nil)
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+}
+
+func TestRemoteStorage_UpdateRotationPolicy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/rotation-policies/3", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"ID": 3, "ProjectID": 10}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	pid := uint(10)
+	p := &models.RotationPolicy{ID: 3, ProjectID: &pid}
+	err = rs.UpdateRotationPolicy(context.Background(), p)
+	require.NoError(t, err)
+	assert.Equal(t, uint(3), p.ID)
+}
+
+func TestRemoteStorage_DeleteRotationPolicy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/rotation-policies/5", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteRotationPolicy(context.Background(), 5)
+	assert.NoError(t, err)
+}
+
+// ============================================================
+// remote_scheduler_lock.go
+// ============================================================
+
+func TestRemoteStorage_TryAcquireSchedulerLock_Acquired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/scheduler-lock/acquire", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"acquired": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	acquired, err := rs.TryAcquireSchedulerLock(context.Background(), 42, "holder-token", 45*time.Second)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+}
+
+func TestRemoteStorage_TryAcquireSchedulerLock_NotAcquired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"acquired": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	acquired, err := rs.TryAcquireSchedulerLock(context.Background(), 42, "holder-token", 45*time.Second)
+	require.NoError(t, err)
+	assert.False(t, acquired)
+}
+
+func TestRemoteStorage_ReleaseSchedulerLock(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/scheduler-lock/release", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.ReleaseSchedulerLock(context.Background(), 42, "holder-token")
+	assert.NoError(t, err)
+}
+
+func TestRemoteStorage_WithSchedulerLock_AcquiredAndRuns(t *testing.T) {
+	var callCount int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/system/scheduler-lock/acquire":
+			callCount++
+			_, _ = w.Write(apiOK(map[string]interface{}{"acquired": true}))
+		case "/api/v1/system/scheduler-lock/release":
+			_, _ = w.Write(apiOK(nil))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	ran := false
+	acquired, err := rs.WithSchedulerLock(context.Background(), 1, func() error {
+		ran = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, acquired)
+	assert.True(t, ran)
+}
+
+func TestRemoteStorage_WithSchedulerLock_NotAcquired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"acquired": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	ran := false
+	acquired, err := rs.WithSchedulerLock(context.Background(), 1, func() error {
+		ran = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.False(t, acquired)
+	assert.False(t, ran)
+}
+
+// ============================================================
+// remote_secret_dependencies.go
+// ============================================================
+
+func TestRemoteStorage_CreateSecretDependency(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/secret-dependencies", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":                   10,
+			"project_id":           5,
+			"dependent_secret_id":  1,
+			"depends_on_secret_id": 2,
+			"note":                 "db password",
+			"created_at":           now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	dep, err := rs.CreateSecretDependency(context.Background(), &models.SecretDependency{
+		ProjectID:         5,
+		DependentSecretID: 1,
+		DependsOnSecretID: 2,
+		Note:              "db password",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(10), dep.ID)
+	assert.Equal(t, "db password", dep.Note)
+}
+
+func TestRemoteStorage_GetSecretDependency(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/secret-dependencies/10", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":                   10,
+			"project_id":           5,
+			"dependent_secret_id":  1,
+			"depends_on_secret_id": 2,
+			"created_at":           now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	dep, err := rs.GetSecretDependency(context.Background(), 10)
+	require.NoError(t, err)
+	assert.Equal(t, uint(10), dep.ID)
+	assert.Equal(t, uint(1), dep.DependentSecretID)
+}
+
+func TestRemoteStorage_ListSecretDependenciesForProject(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/secret-dependencies", r.URL.Path)
+		assert.Equal(t, "5", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"dependencies": []map[string]interface{}{
+				{
+					"id":                   10,
+					"project_id":           5,
+					"dependent_secret_id":  1,
+					"depends_on_secret_id": 2,
+					"created_at":           now,
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListSecretDependenciesForProject(context.Background(), 5)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, uint(10), list[0].ID)
+}
+
+func TestRemoteStorage_ListSecretDependenciesForProjectForUpdate(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/secret-dependencies/for-update", r.URL.Path)
+		assert.Equal(t, "5", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"dependencies": []map[string]interface{}{
+				{
+					"id":                   11,
+					"project_id":           5,
+					"dependent_secret_id":  3,
+					"depends_on_secret_id": 4,
+					"created_at":           now,
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListSecretDependenciesForProjectForUpdate(context.Background(), 5)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, uint(11), list[0].ID)
+}
+
+func TestRemoteStorage_DeleteSecretDependency(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/system/secret-dependencies/7", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteSecretDependency(context.Background(), 7)
+	assert.NoError(t, err)
+}
+
+func TestRemoteStorage_CreateSecretDependencyExclusive(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/secret-dependencies/exclusive", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":                   20,
+			"project_id":           5,
+			"dependent_secret_id":  1,
+			"depends_on_secret_id": 2,
+			"created_at":           now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	dep, err := rs.CreateSecretDependencyExclusive(context.Background(), &models.SecretDependency{
+		ProjectID:         5,
+		DependentSecretID: 1,
+		DependsOnSecretID: 2,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(20), dep.ID)
+}
+
+func TestRemoteStorage_CreateSecretDependencyExclusive_Duplicate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"DUPLICATE_SECRET_DEPENDENCY","message":"already exists"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateSecretDependencyExclusive(context.Background(), &models.SecretDependency{
+		ProjectID:         5,
+		DependentSecretID: 1,
+		DependsOnSecretID: 2,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, corestorage.ErrDuplicateSecretDependency)
+}
+
+func TestRemoteStorage_CreateSecretDependencyExclusive_Cycle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"SECRET_DEPENDENCY_CYCLE","message":"would create cycle"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateSecretDependencyExclusive(context.Background(), &models.SecretDependency{
+		ProjectID:         5,
+		DependentSecretID: 2,
+		DependsOnSecretID: 1,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, corestorage.ErrSecretDependencyCycle)
+}
+
+// ============================================================
+// remote_sod.go
+// ============================================================
+
+func TestRemoteStorage_CreateSoDPolicy(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/sod-policies", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":           3,
+			"name":         "no-assign-delete",
+			"permission_a": "roles.assign",
+			"permission_b": "secrets.delete",
+			"created_by":   1,
+			"created_at":   now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	p, err := rs.CreateSoDPolicy(context.Background(), &models.SoDPolicy{
+		Name:        "no-assign-delete",
+		PermissionA: "roles.assign",
+		PermissionB: "secrets.delete",
+		CreatedBy:   1,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(3), p.ID)
+	assert.Equal(t, "no-assign-delete", p.Name)
+}
+
+func TestRemoteStorage_GetSoDPolicy(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/sod-policies/3", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":           3,
+			"name":         "no-assign-delete",
+			"permission_a": "roles.assign",
+			"permission_b": "secrets.delete",
+			"created_by":   1,
+			"created_at":   now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	p, err := rs.GetSoDPolicy(context.Background(), 3)
+	require.NoError(t, err)
+	assert.Equal(t, uint(3), p.ID)
+}
+
+func TestRemoteStorage_ListSoDPolicies(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/sod-policies", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"policies": []map[string]interface{}{
+				{
+					"id":           1,
+					"name":         "policy-a",
+					"permission_a": "roles.assign",
+					"permission_b": "secrets.delete",
+					"created_by":   1,
+					"created_at":   now,
+				},
+				{
+					"id":           2,
+					"name":         "policy-b",
+					"permission_a": "users.write",
+					"permission_b": "audit.read",
+					"created_by":   1,
+					"created_at":   now,
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListSoDPolicies(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+	assert.Equal(t, "policy-a", list[0].Name)
+}
+
+func TestRemoteStorage_DeleteSoDPolicy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/system/sod-policies/3", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteSoDPolicy(context.Background(), 3)
+	assert.NoError(t, err)
+}
+
+// ============================================================
+// remote_sso.go
+// ============================================================
+
+func TestRemoteStorage_CreateSSOLoginState(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/sso-state", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":         55,
+			"state":      "csrf-token-abc",
+			"nonce":      "nonce-xyz",
+			"provider":   "google",
+			"return_to":  "/dashboard",
+			"expires_at": now.Add(5 * time.Minute),
+			"created_at": now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	s := &models.SSOLoginState{
+		State:     "csrf-token-abc",
+		Nonce:     "nonce-xyz",
+		Provider:  "google",
+		ReturnTo:  "/dashboard",
+		ExpiresAt: now.Add(5 * time.Minute),
+		CreatedAt: now,
+	}
+	err = rs.CreateSSOLoginState(context.Background(), s)
+	require.NoError(t, err)
+	assert.Equal(t, uint(55), s.ID, "ID should be updated in place from the server response")
+}
+
+func TestRemoteStorage_ConsumeSSOLoginState(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/sso-state/consume", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":         55,
+			"state":      "csrf-token-abc",
+			"nonce":      "nonce-xyz",
+			"provider":   "google",
+			"return_to":  "/dashboard",
+			"expires_at": now.Add(5 * time.Minute),
+			"created_at": now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	s, err := rs.ConsumeSSOLoginState(context.Background(), "csrf-token-abc")
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	assert.Equal(t, uint(55), s.ID)
+	assert.Equal(t, "csrf-token-abc", s.State)
+	assert.Equal(t, "nonce-xyz", s.Nonce)
+	assert.Equal(t, "google", s.Provider)
+}
+
+// ============================================================
+// remote_stats.go
+// ============================================================
+
+func TestRemoteStorage_GetStats(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/stats", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"total_secrets":    5,
+			"total_users":      3,
+			"total_roles":      2,
+			"total_sessions":   1,
+			"total_audit_logs": 100,
+			"database_size_bytes": 4096,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	stats, err := rs.GetStats(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	assert.Equal(t, int64(5), stats.TotalSecrets)
+	assert.Equal(t, int64(3), stats.TotalUsers)
+	assert.Equal(t, int64(2), stats.TotalRoles)
+}
+
+func TestRemoteStorage_SaveStatsSnapshot_NoOp(t *testing.T) {
+	// SaveStatsSnapshot is a no-op in remote mode — no HTTP call is made.
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19997"))
+	require.NoError(t, err)
+
+	err = rs.SaveStatsSnapshot(context.Background(), &models.StatsSnapshot{})
+	assert.NoError(t, err)
+}
+
+func TestRemoteStorage_GetPreviousStatsSnapshot_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19997"))
+	require.NoError(t, err)
+
+	snap, err := rs.GetPreviousStatsSnapshot(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Nil(t, snap)
+	assert.Contains(t, err.Error(), "remote mode")
+}
+
+func TestRemoteStorage_HealthCheck(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/health", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]string{"status": "healthy"}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.HealthCheck(context.Background())
+	assert.NoError(t, err)
+}
+
+// ============================================================
+// remote_transaction.go
+// ============================================================
+
+func TestRemoteStorage_WithTransaction_RunsFn(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19998"))
+	require.NoError(t, err)
+
+	ran := false
+	err = rs.WithTransaction(context.Background(), func(tx corestorage.Storage) error {
+		assert.Same(t, rs, tx, "WithTransaction must pass the same RemoteStorage to fn")
+		ran = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, ran)
+}
+
+func TestRemoteStorage_WithTransaction_PropagatesError(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19998"))
+	require.NoError(t, err)
+
+	wantErr := assert.AnError
+	err = rs.WithTransaction(context.Background(), func(_ corestorage.Storage) error {
+		return wantErr
+	})
+	assert.ErrorIs(t, err, wantErr)
+}

--- a/internal/storage/store/remote_notifications_test.go
+++ b/internal/storage/store/remote_notifications_test.go
@@ -152,10 +152,10 @@ func TestRemoteStorage_UpdateNotification_Unsupported(t *testing.T) {
 
 func TestRemoteStorage_ListNotifications_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"success": false,
-			"error":   map[string]string{"code": "ERROR", "message": "server error"},
+			"error":   map[string]string{"code": "BAD_REQUEST", "message": "server error"},
 		})
 	}))
 	defer srv.Close()

--- a/internal/storage/store/remote_notifications_test.go
+++ b/internal/storage/store/remote_notifications_test.go
@@ -1,0 +1,168 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func notificationWireBody(id uint) map[string]any {
+	return map[string]any{
+		"id":         id,
+		"type":       "info",
+		"title":      "Test notification",
+		"message":    "This is a test",
+		"link":       "",
+		"is_read":    false,
+		"created_at": time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+func notificationListResp(items []map[string]any, unreadCount int64) map[string]any {
+	return map[string]any{
+		"notifications": items,
+		"unread_count":  unreadCount,
+	}
+}
+
+func TestRemoteStorage_ListNotifications(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/notifications", r.URL.Path)
+		_, _ = w.Write(apiOK(notificationListResp(
+			[]map[string]any{notificationWireBody(1), notificationWireBody(2)},
+			2,
+		)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListNotifications(context.Background(), 0, false, 10)
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.Equal(t, uint(1), results[0].ID)
+}
+
+func TestRemoteStorage_ListNotifications_UnreadOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "true", r.URL.Query().Get("unread"))
+		_, _ = w.Write(apiOK(notificationListResp(
+			[]map[string]any{notificationWireBody(1)},
+			1,
+		)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListNotifications(context.Background(), 0, true, 5)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+}
+
+func TestRemoteStorage_CountUnreadNotifications(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		_, _ = w.Write(apiOK(notificationListResp(
+			[]map[string]any{notificationWireBody(1)},
+			7,
+		)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	count, err := rs.CountUnreadNotifications(context.Background(), 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), count)
+}
+
+func TestRemoteStorage_MarkNotificationRead_S11(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/notifications/42/read", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.MarkNotificationRead(context.Background(), 42, 0)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_MarkAllNotificationsRead_S11(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/notifications/read-all", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.MarkAllNotificationsRead(context.Background(), 0)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_CreateNotification_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19997"))
+	require.NoError(t, err)
+
+	_, err = rs.CreateNotification(context.Background(), nil)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_HasUnreadNotification_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19997"))
+	require.NoError(t, err)
+
+	_, err = rs.HasUnreadNotification(context.Background(), 0, "", 0)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetUnreadNotification_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19997"))
+	require.NoError(t, err)
+
+	_, err = rs.GetUnreadNotification(context.Background(), 0, "", 0)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_UpdateNotification_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19997"))
+	require.NoError(t, err)
+
+	err = rs.UpdateNotification(context.Background(), nil)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListNotifications_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"error":   map[string]string{"code": "ERROR", "message": "server error"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListNotifications(context.Background(), 0, false, 10)
+	assert.Error(t, err)
+}

--- a/internal/storage/store/remote_rbac_test.go
+++ b/internal/storage/store/remote_rbac_test.go
@@ -1,0 +1,936 @@
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Roles ---
+
+func TestRemoteStorage_CreateRole(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/roles", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"id": 1, "name": "admin", "description": "Admin role"}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	role, err := rs.CreateRole(context.Background(), &models.Role{Name: "admin"})
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), role.ID)
+	assert.Equal(t, "admin", role.Name)
+}
+
+func TestRemoteStorage_GetRole(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/roles/5", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"id": 5, "name": "editor", "description": "Editor role"}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	role, err := rs.GetRole(context.Background(), 5)
+	require.NoError(t, err)
+	assert.Equal(t, uint(5), role.ID)
+	assert.Equal(t, "editor", role.Name)
+}
+
+func TestRemoteStorage_GetRoleByName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/roles/by-name", r.URL.Path)
+		assert.Equal(t, "admin", r.URL.Query().Get("name"))
+		_, _ = w.Write(apiOK(map[string]interface{}{"id": 2, "name": "admin", "description": "Admin role"}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	role, err := rs.GetRoleByName(context.Background(), "admin")
+	require.NoError(t, err)
+	assert.Equal(t, uint(2), role.ID)
+	assert.Equal(t, "admin", role.Name)
+}
+
+func TestRemoteStorage_UpdateRole(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/roles/3", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"id": 3, "name": "updated", "description": "Updated"}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	role, err := rs.UpdateRole(context.Background(), &models.Role{ID: 3, Name: "updated"})
+	require.NoError(t, err)
+	assert.Equal(t, uint(3), role.ID)
+	assert.Equal(t, "updated", role.Name)
+}
+
+func TestRemoteStorage_DeleteRole(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/roles/7", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteRole(context.Background(), 7)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_ListRoles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/roles", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"id": 1, "name": "admin", "description": "Admin"},
+			{"id": 2, "name": "viewer", "description": "Viewer"},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	roles, err := rs.ListRoles(context.Background())
+	require.NoError(t, err)
+	require.Len(t, roles, 2)
+	assert.Equal(t, "admin", roles[0].Name)
+}
+
+// --- RBAC assignment ---
+
+func TestRemoteStorage_AssignRole(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/rbac/assign-role", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.AssignRole(context.Background(), 10, 1, corestorage.Scope{ProjectID: 0, EnvironmentID: 0})
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_RemoveRole(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/rbac/remove-role", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemoveRole(context.Background(), 10, 1, corestorage.Scope{ProjectID: 0, EnvironmentID: 0})
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_GetGroupRoleGrants(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/rbac/groups/4/role-grants", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"id": 1, "name": "admin", "description": "Admin"},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	grants, err := rs.GetGroupRoleGrants(context.Background(), 4)
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	assert.Equal(t, uint(1), grants[0].ID)
+}
+
+func TestRemoteStorage_AssignRoleWithExpiry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/rbac/assign-role-with-expiry", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	expires := time.Now().Add(24 * time.Hour)
+	err = rs.AssignRoleWithExpiry(context.Background(), 10, 1, corestorage.Scope{ProjectID: 5}, expires)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_AssignRoleToGroupWithExpiry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/rbac/assign-role-to-group-with-expiry", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	expires := time.Now().Add(24 * time.Hour)
+	err = rs.AssignRoleToGroupWithExpiry(context.Background(), 3, 1, corestorage.Scope{ProjectID: 5}, expires)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_DeleteExpiredRoleGrants(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/retention/role-grants/purge-expired", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"removed": []map[string]interface{}{
+				{"principal_type": "user", "principal_id": 10, "role_id": 1, "project_id": 0, "environment_id": 0},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	removed, err := rs.DeleteExpiredRoleGrants(context.Background(), time.Now())
+	require.NoError(t, err)
+	require.Len(t, removed, 1)
+	assert.Equal(t, "user", removed[0].PrincipalType)
+}
+
+func TestRemoteStorage_RemoveAllProjectRoleGrants(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/rbac/remove-all-project-role-grants", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemoveAllProjectRoleGrants(context.Background(), 10, 5)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_GetUserRoles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/users/12/roles", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"id": 1, "name": "admin", "description": "Admin"},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	roles, err := rs.GetUserRoles(context.Background(), 12)
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+	assert.Equal(t, "admin", roles[0].Name)
+}
+
+func TestRemoteStorage_GetUserPermissions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/users/12/permissions", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"id": 1, "name": "secrets.read", "resource": "secrets", "action": "read"},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	perms, err := rs.GetUserPermissions(context.Background(), 12)
+	require.NoError(t, err)
+	require.Len(t, perms, 1)
+	assert.Equal(t, "secrets.read", perms[0].Name)
+}
+
+func TestRemoteStorage_GetUserGroupPermissions_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserGroupPermissions(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+// --- Permission management (unsupported in remote mode) ---
+
+func TestRemoteStorage_CreatePermission_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CreatePermission(context.Background(), &models.Permission{Name: "test.read"})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_AssignPermissionToRole_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.AssignPermissionToRole(context.Background(), 1, 2)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListPermissions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/permissions", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"permissions": []map[string]interface{}{
+				{"id": 1, "name": "secrets.read", "resource": "secrets", "action": "read"},
+				{"id": 2, "name": "secrets.write", "resource": "secrets", "action": "write"},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	perms, err := rs.ListPermissions(context.Background())
+	require.NoError(t, err)
+	require.Len(t, perms, 2)
+	assert.Equal(t, "secrets.read", perms[0].Name)
+}
+
+func TestRemoteStorage_GetPermission(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/permissions/3", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 3, "name": "roles.read", "resource": "roles", "action": "read",
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	perm, err := rs.GetPermission(context.Background(), 3)
+	require.NoError(t, err)
+	assert.Equal(t, uint(3), perm.ID)
+	assert.Equal(t, "roles.read", perm.Name)
+}
+
+func TestRemoteStorage_GetRolePermissions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/roles/2/permissions", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"role_id":   2,
+			"role_name": "editor",
+			"permissions": []map[string]interface{}{
+				{"id": 1, "name": "secrets.read", "resource": "secrets", "action": "read"},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	perms, err := rs.GetRolePermissions(context.Background(), 2)
+	require.NoError(t, err)
+	require.Len(t, perms, 1)
+	assert.Equal(t, "secrets.read", perms[0].Name)
+}
+
+func TestRemoteStorage_RemovePermissionFromRole_S11(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/roles/2/permissions/5", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemovePermissionFromRole(context.Background(), 2, 5)
+	require.NoError(t, err)
+}
+
+// --- Connect ref grants ---
+
+func TestRemoteStorage_ListConnectRefGrantsByConnector(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/connect-grants/by-connector/my-connector", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"id": 1, "role_id": 2, "connector": "my-connector", "ref_prefix": "secrets/"},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	grants, err := rs.ListConnectRefGrantsByConnector(context.Background(), "my-connector")
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	assert.Equal(t, uint(1), grants[0].ID)
+	assert.Equal(t, "my-connector", grants[0].Connector)
+}
+
+func TestRemoteStorage_ListConnectRefGrants(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/connect-grants", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"id": 1, "role_id": 2, "connector": "conn-a", "ref_prefix": ""},
+			{"id": 2, "role_id": 3, "connector": "conn-b", "ref_prefix": "prod/"},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	grants, err := rs.ListConnectRefGrants(context.Background())
+	require.NoError(t, err)
+	require.Len(t, grants, 2)
+	assert.Equal(t, "conn-a", grants[0].Connector)
+}
+
+func TestRemoteStorage_CreateConnectRefGrant(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/connect-grants", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 10, "role_id": 2, "connector": "my-conn", "ref_prefix": "staging/",
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	grant, err := rs.CreateConnectRefGrant(context.Background(), &models.ConnectRefGrant{
+		RoleID:    2,
+		Connector: "my-conn",
+		RefPrefix: "staging/",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(10), grant.ID)
+	assert.Equal(t, "my-conn", grant.Connector)
+}
+
+func TestRemoteStorage_DeleteConnectRefGrant(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/system/connect-grants/10", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteConnectRefGrant(context.Background(), 10)
+	require.NoError(t, err)
+}
+
+// --- Group roles ---
+
+func TestRemoteStorage_GetGroupRoles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/groups/8/roles", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"id": 1, "name": "admin", "description": "Admin"},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	roles, err := rs.GetGroupRoles(context.Background(), 8)
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+	assert.Equal(t, "admin", roles[0].Name)
+}
+
+func TestRemoteStorage_ListGroupRoleAssignments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/rbac/groups/6/role-assignments", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"principal_type": "group", "principal_id": 6, "role_id": 2, "project_id": 0, "environment_id": 0},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	assignments, err := rs.ListGroupRoleAssignments(context.Background(), 6)
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	assert.Equal(t, "group", assignments[0].PrincipalType)
+	assert.Equal(t, uint(2), assignments[0].RoleID)
+}
+
+func TestRemoteStorage_AssignRoleToGroup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/groups/8/roles", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.AssignRoleToGroup(context.Background(), 8, 2, corestorage.Scope{ProjectID: 0})
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_RemoveRoleFromGroup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/groups/8/roles/2", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemoveRoleFromGroup(context.Background(), 8, 2, corestorage.Scope{})
+	require.NoError(t, err)
+}
+
+// --- Server-internal authorization primitives (unsupported in remote mode) ---
+
+func TestRemoteStorage_GetUserRoleIDsAt_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserRoleIDsAt(context.Background(), 1, corestorage.Scope{})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetUserRoleIDsExact_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserRoleIDsExact(context.Background(), 1, corestorage.Scope{})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_IsProjectMember_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.IsProjectMember(context.Background(), 1, 2)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetUserGroupRoleIDsAt_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserGroupRoleIDsAt(context.Background(), 1, corestorage.Scope{})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetUserRoleScopes_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserRoleScopes(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_RoleSetHasPermission_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.RoleSetHasPermission(context.Background(), []uint{1, 2}, "secrets.read")
+	assert.Error(t, err)
+}
+
+// --- Project / Environment catalog ---
+
+func TestRemoteStorage_CreateProject_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CreateProject(context.Background(), &models.Project{Name: "test"})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CreateEnvironment_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CreateEnvironment(context.Background(), &models.Environment{Name: "prod"})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListProjects(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/projects", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"projects": []map[string]interface{}{
+				{"id": 1, "name": "project-alpha", "description": "Alpha"},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	projects, err := rs.ListProjects(context.Background())
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+	assert.Equal(t, "project-alpha", projects[0].Name)
+}
+
+func TestRemoteStorage_ListProjectsWithCounts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/projects/with-counts", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"projects": []map[string]interface{}{
+				{"ID": 1, "Name": "alpha", "Description": "", "secret_count": 5, "environment_count": 2},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	projects, err := rs.ListProjectsWithCounts(context.Background(), false)
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+	assert.Equal(t, int64(5), projects[0].SecretCount)
+}
+
+func TestRemoteStorage_GetProject(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/projects/9", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"id": 9, "name": "my-project"}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	project, err := rs.GetProject(context.Background(), 9)
+	require.NoError(t, err)
+	assert.Equal(t, uint(9), project.ID)
+	assert.Equal(t, "my-project", project.Name)
+}
+
+func TestRemoteStorage_UpdateProject(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/system/projects/9", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"id": 9, "name": "updated-project"}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	project, err := rs.UpdateProject(context.Background(), &models.Project{ID: 9, Name: "updated-project"})
+	require.NoError(t, err)
+	assert.Equal(t, uint(9), project.ID)
+	assert.Equal(t, "updated-project", project.Name)
+}
+
+func TestRemoteStorage_DeleteProject(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/system/projects/9", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteProject(context.Background(), 9)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_DeleteProjectIfEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/projects/9/delete-if-empty", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"blocking_secret_count": 0}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	count, err := rs.DeleteProjectIfEmpty(context.Background(), 9)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestRemoteStorage_RestoreProject(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/projects/9/restore", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"restored_environments": 2,
+			"restored_secrets":      7,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	envs, secrets, err := rs.RestoreProject(context.Background(), 9)
+	require.NoError(t, err)
+	assert.Equal(t, 2, envs)
+	assert.Equal(t, 7, secrets)
+}
+
+func TestRemoteStorage_ListEnvironments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/environments", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"environments": []map[string]interface{}{
+				{"id": 1, "project_id": 9, "name": "production"},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	envs, err := rs.ListEnvironments(context.Background())
+	require.NoError(t, err)
+	require.Len(t, envs, 1)
+	assert.Equal(t, "production", envs[0].Name)
+}
+
+func TestRemoteStorage_ListEnvironmentsByProject(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/projects/9/environments", r.URL.Path)
+		assert.Equal(t, "false", r.URL.Query().Get("include_deleted"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"environments": []map[string]interface{}{
+				{"id": 1, "project_id": 9, "name": "staging"},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	envs, err := rs.ListEnvironmentsByProject(context.Background(), 9)
+	require.NoError(t, err)
+	require.Len(t, envs, 1)
+	assert.Equal(t, "staging", envs[0].Name)
+}
+
+func TestRemoteStorage_ListEnvironmentsByProjectIncludingDeleted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/projects/9/environments", r.URL.Path)
+		assert.Equal(t, "true", r.URL.Query().Get("include_deleted"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"environments": []map[string]interface{}{
+				{"id": 1, "project_id": 9, "name": "old-env"},
+				{"id": 2, "project_id": 9, "name": "production"},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	envs, err := rs.ListEnvironmentsByProjectIncludingDeleted(context.Background(), 9)
+	require.NoError(t, err)
+	require.Len(t, envs, 2)
+}
+
+func TestRemoteStorage_GetEnvironment(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/environments/4", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"id": 4, "project_id": 9, "name": "production"}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	env, err := rs.GetEnvironment(context.Background(), 4)
+	require.NoError(t, err)
+	assert.Equal(t, uint(4), env.ID)
+	assert.Equal(t, "production", env.Name)
+}
+
+func TestRemoteStorage_DeleteEnvironment(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/system/environments/4", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteEnvironment(context.Background(), 4)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_RestoreEnvironment(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/projects/9/environments/4/restore", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RestoreEnvironment(context.Background(), 9, 4)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_ListProjectMembers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/projects/9/members", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"members": []map[string]interface{}{
+				{"user_id": 10, "username": "alice", "display_name": "Alice", "email": "alice@example.com", "role_id": 1, "role_name": "admin"},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	members, err := rs.ListProjectMembers(context.Background(), 9)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, "alice", members[0].Username)
+}
+
+func TestRemoteStorage_ListProjectRoleAssignments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/rbac/project-role-assignments", r.URL.Path)
+		assert.Equal(t, "9", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"principal_type": "user", "principal_id": 10, "role_id": 1, "project_id": 9, "environment_id": 0},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	assignments, err := rs.ListProjectRoleAssignments(context.Background(), 9)
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	assert.Equal(t, "user", assignments[0].PrincipalType)
+}
+
+func TestRemoteStorage_ListProjectMachineRoleAssignments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/rbac/project-machine-role-assignments", r.URL.Path)
+		assert.Equal(t, "9", r.URL.Query().Get("project_id"))
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"principal_type": "machine", "principal_id": 20, "role_id": 2, "project_id": 9, "environment_id": 0},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	assignments, err := rs.ListProjectMachineRoleAssignments(context.Background(), 9)
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	assert.Equal(t, "machine", assignments[0].PrincipalType)
+}
+
+func TestRemoteStorage_ListGlobalAdminAssignmentsForUpdate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/rbac/global-admin-assignments", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"principal_type": "user", "principal_id": 1, "role_id": 1, "project_id": 0, "environment_id": 0},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	assignments, err := rs.ListGlobalAdminAssignmentsForUpdate(context.Background(), []uint{1, 2})
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	assert.Equal(t, uint(1), assignments[0].RoleID)
+}
+
+func TestRemoteStorage_RemoveGlobalAdminRoleGuarded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/rbac/global-admin-role/remove-guarded", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemoveGlobalAdminRoleGuarded(context.Background(), 10, 1, []uint{1, 2})
+	require.NoError(t, err)
+}

--- a/internal/storage/store/remote_secrets_test.go
+++ b/internal/storage/store/remote_secrets_test.go
@@ -1,0 +1,433 @@
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Secret CRUD (CreateSecret, GetSecret, ListSecrets already in remote_storage_test.go) ---
+
+func TestRemoteStorage_GetSecretsByIDs(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		callCount++
+		switch r.URL.Path {
+		case "/api/v1/secrets/1":
+			_, _ = w.Write(apiOK(map[string]interface{}{"id": 1, "name": "secret-one", "type": "password"}))
+		case "/api/v1/secrets/2":
+			_, _ = w.Write(apiOK(map[string]interface{}{"id": 2, "name": "secret-two", "type": "api_key"}))
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	secrets, err := rs.GetSecretsByIDs(context.Background(), []uint{1, 2})
+	require.NoError(t, err)
+	require.Len(t, secrets, 2)
+	assert.Equal(t, "secret-one", secrets[0].Name)
+	assert.Equal(t, "secret-two", secrets[1].Name)
+}
+
+func TestRemoteStorage_GetSecretsByIDs_SkipsErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/secrets/1" {
+			_, _ = w.Write(apiOK(map[string]interface{}{"id": 1, "name": "good-secret"}))
+		} else {
+			// Return an error response for ID 2.
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"success":false,"error":{"code":"NOT_FOUND","message":"not found"}}`))
+		}
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	// GetSecretsByIDs skips errors rather than returning them.
+	secrets, err := rs.GetSecretsByIDs(context.Background(), []uint{1, 2})
+	require.NoError(t, err)
+	require.Len(t, secrets, 1)
+	assert.Equal(t, "good-secret", secrets[0].Name)
+}
+
+func TestRemoteStorage_GetSecretByName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/secrets/by-name", r.URL.Path)
+		assert.Equal(t, "my-secret", r.URL.Query().Get("name"))
+		assert.Equal(t, "3", r.URL.Query().Get("project_id"))
+		assert.Equal(t, "7", r.URL.Query().Get("environment_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{"id": 42, "name": "my-secret", "type": "password"}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	secret, err := rs.GetSecretByName(context.Background(), "my-secret", 3, 7)
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), secret.ID)
+	assert.Equal(t, "my-secret", secret.Name)
+}
+
+func TestRemoteStorage_UpdateSecret(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/secrets/42", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"id": 42, "name": "my-secret", "type": "password"}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	secret, err := rs.UpdateSecret(context.Background(), &models.SecretNode{ID: 42, Name: "my-secret"})
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), secret.ID)
+}
+
+func TestRemoteStorage_DeleteSecret(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/secrets/42", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteSecret(context.Background(), 42)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_GetSecretIncludingDeleted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/secrets/42/including-deleted", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"secret": map[string]interface{}{"ID": 42, "Name": "deleted-secret", "Type": "password"},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	secret, err := rs.GetSecretIncludingDeleted(context.Background(), 42)
+	require.NoError(t, err)
+	require.NotNil(t, secret)
+	assert.Equal(t, uint(42), secret.ID)
+}
+
+func TestRemoteStorage_RestoreSecret(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/secrets/42/restore", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RestoreSecret(context.Background(), 42)
+	require.NoError(t, err)
+}
+
+// --- Retention / purge proxies ---
+
+func TestRemoteStorage_PurgeDeletedSecretsBefore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/retention/secrets/purge", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"purged": 3}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	purged, err := rs.PurgeDeletedSecretsBefore(context.Background(), time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), purged)
+}
+
+func TestRemoteStorage_DeleteAnomalyAlertsBefore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/retention/anomaly-alerts/purge", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"purged": 7}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	purged, err := rs.DeleteAnomalyAlertsBefore(context.Background(), time.Now(), time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), purged)
+}
+
+func TestRemoteStorage_DeleteClosedAccessReviewsBefore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/retention/access-reviews/purge-closed", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"campaigns_purged": 2, "items_purged": 10}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	campaigns, items, err := rs.DeleteClosedAccessReviewsBefore(context.Background(), time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), campaigns)
+	assert.Equal(t, int64(10), items)
+}
+
+func TestRemoteStorage_DeleteExpiredBreakGlassBefore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/retention/break-glass/purge-expired", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"purged": 1}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	purged, err := rs.DeleteExpiredBreakGlassBefore(context.Background(), time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), purged)
+}
+
+func TestRemoteStorage_DeleteResolvedAccessRequestsBefore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/retention/access-requests/purge-resolved", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"requests_purged": 4, "approvals_purged": 8}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	requests, approvals, err := rs.DeleteResolvedAccessRequestsBefore(context.Background(), time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), requests)
+	assert.Equal(t, int64(8), approvals)
+}
+
+// --- Server-side-only operations (unsupported in remote mode) ---
+
+func TestRemoteStorage_ListProjectSecretsForDrift_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListProjectSecretsForDrift(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListOrphanedSecrets_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListOrphanedSecrets(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CountOrphanedSecretsByProject_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CountOrphanedSecretsByProject(context.Background(), []uint{1, 2})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CountExpiringSecretsByProject_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CountExpiringSecretsByProject(context.Background(), []uint{1, 2}, time.Now())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListLiveSecretNamesByProject_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, _, err = rs.ListLiveSecretNamesByProject(context.Background(), []uint{1}, 100)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetSecretTags_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetSecretTags(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_SetSecretTags_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.SetSecretTags(context.Background(), 1, []string{"prod"})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_SetSecretCertNotAfter_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	now := time.Now()
+	err = rs.SetSecretCertNotAfter(context.Background(), 1, &now)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_TryIncrementSecretReadCount_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	ok, err := rs.TryIncrementSecretReadCount(context.Background(), 1, 5)
+	assert.Error(t, err)
+	assert.False(t, ok)
+}
+
+func TestRemoteStorage_TryIncrementSecretNodeReadCount_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	ok, err := rs.TryIncrementSecretNodeReadCount(context.Background(), 1, 5)
+	assert.Error(t, err)
+	assert.False(t, ok)
+}
+
+// --- Secret version operations ---
+
+func TestRemoteStorage_CreateSecretVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/secrets/42/versions", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"ID": 100, "SecretNodeID": 42, "VersionNumber": 1, "ReadCount": 0,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	version, err := rs.CreateSecretVersion(context.Background(), &models.SecretVersion{
+		SecretNodeID:  42,
+		VersionNumber: 1,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, version.VersionNumber)
+}
+
+func TestRemoteStorage_GetSecretVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/secrets/42/versions/2", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"ID": 200, "SecretNodeID": 42, "VersionNumber": 2, "ReadCount": 3,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	version, err := rs.GetSecretVersion(context.Background(), 42, 2)
+	require.NoError(t, err)
+	assert.Equal(t, 2, version.VersionNumber)
+	assert.Equal(t, 3, version.ReadCount)
+}
+
+func TestRemoteStorage_ListSecretVersions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/secrets/42/versions", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"ID": 100, "SecretNodeID": 42, "VersionNumber": 1, "ReadCount": 0},
+			{"ID": 200, "SecretNodeID": 42, "VersionNumber": 2, "ReadCount": 1},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	versions, err := rs.ListSecretVersions(context.Background(), 42)
+	require.NoError(t, err)
+	require.Len(t, versions, 2)
+	assert.Equal(t, 1, versions[0].VersionNumber)
+}
+
+func TestRemoteStorage_GetSecretVersions(t *testing.T) {
+	// GetSecretVersions is an alias for ListSecretVersions; same URL.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/secrets/42/versions", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"ID": 100, "SecretNodeID": 42, "VersionNumber": 1, "ReadCount": 0},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	versions, err := rs.GetSecretVersions(context.Background(), 42)
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+}
+
+func TestRemoteStorage_GetLatestSecretVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/secrets/42/versions/latest", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"ID": 300, "SecretNodeID": 42, "VersionNumber": 3, "ReadCount": 5,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	version, err := rs.GetLatestSecretVersion(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, 3, version.VersionNumber)
+	assert.Equal(t, 5, version.ReadCount)
+}
+
+func TestRemoteStorage_IncrementSecretReadCount(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/secret-versions/100/increment-read-count", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.IncrementSecretReadCount(context.Background(), 100)
+	require.NoError(t, err)
+}

--- a/internal/storage/store/remote_sharing_test.go
+++ b/internal/storage/store/remote_sharing_test.go
@@ -1,0 +1,298 @@
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testShareRecord(id, secretID, ownerID, recipientID uint) *models.ShareRecord {
+	return &models.ShareRecord{
+		ID:          id,
+		SecretID:    secretID,
+		OwnerID:     ownerID,
+		RecipientID: recipientID,
+		Permission:  "read",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+}
+
+// shareRecordData returns a minimal ShareRecord wire payload. ShareRecord has no
+// json tags so the encoding/json default (PascalCase) field names are used.
+func shareRecordData(id, secretID, ownerID, recipientID uint) map[string]interface{} {
+	return map[string]interface{}{
+		"ID":          id,
+		"SecretID":    secretID,
+		"OwnerID":     ownerID,
+		"RecipientID": recipientID,
+		"Permission":  "read",
+		"CreatedAt":   time.Now().UTC().Format(time.RFC3339),
+		"UpdatedAt":   time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// --- CreateShareRecord ---
+
+func TestRemoteStorage_CreateShareRecord(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/shares", r.URL.Path)
+		_, _ = w.Write(apiOK(shareRecordData(1, 10, 2, 3)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.CreateShareRecord(context.Background(), testShareRecord(0, 10, 2, 3))
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), result.ID)
+	assert.Equal(t, uint(10), result.SecretID)
+	assert.Equal(t, uint(3), result.RecipientID)
+}
+
+// --- GetShareRecord ---
+
+func TestRemoteStorage_GetShareRecord(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/shares/1", r.URL.Path)
+		_, _ = w.Write(apiOK(shareRecordData(1, 10, 2, 3)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.GetShareRecord(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), result.ID)
+	assert.Equal(t, uint(10), result.SecretID)
+}
+
+// --- UpdateShareRecord ---
+
+func TestRemoteStorage_UpdateShareRecord(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/shares/1", r.URL.Path)
+		_, _ = w.Write(apiOK(shareRecordData(1, 10, 2, 3)))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.UpdateShareRecord(context.Background(), testShareRecord(1, 10, 2, 3))
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), result.ID)
+}
+
+// --- DeleteShareRecord ---
+
+func TestRemoteStorage_DeleteShareRecord(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/shares/1", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteShareRecord(context.Background(), 1)
+	require.NoError(t, err)
+}
+
+// --- ListSharesBySecret ---
+
+func TestRemoteStorage_ListSharesBySecret(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/secrets/10/shares", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			shareRecordData(1, 10, 2, 3),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListSharesBySecret(context.Background(), 10)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, uint(1), results[0].ID)
+}
+
+// --- ListSharesBySecretIDs ---
+
+func TestRemoteStorage_ListSharesBySecretIDs(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		assert.Equal(t, http.MethodGet, r.Method)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			shareRecordData(uint(callCount), uint(callCount*10), 2, 3),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListSharesBySecretIDs(context.Background(), []uint{10, 20})
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestRemoteStorage_ListSharesBySecretIDs_Empty(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	results, err := rs.ListSharesBySecretIDs(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, results)
+}
+
+// --- ListSharesByUser ---
+
+func TestRemoteStorage_ListSharesByUser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/shares/by-user/3", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"shares": []map[string]interface{}{
+				shareRecordData(1, 10, 2, 3),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListSharesByUser(context.Background(), 3)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, uint(3), results[0].RecipientID)
+}
+
+// --- ListSharesByOwner ---
+
+func TestRemoteStorage_ListSharesByOwner(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/shares/by-owner/2", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"shares": []map[string]interface{}{
+				shareRecordData(1, 10, 2, 3),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListSharesByOwner(context.Background(), 2)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, uint(2), results[0].OwnerID)
+}
+
+// --- ListSharesByGroup ---
+
+func TestRemoteStorage_ListSharesByGroup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/groups/5/shares", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			shareRecordData(2, 10, 2, 5),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListSharesByGroup(context.Background(), 5)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+}
+
+// --- ListSharedSecrets ---
+
+func TestRemoteStorage_ListSharedSecrets(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/users/3/shared-secrets", r.URL.Path)
+		_, _ = w.Write(apiOK([]map[string]interface{}{
+			{"id": 10, "name": "db-password", "type": "password"},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	results, err := rs.ListSharedSecrets(context.Background(), 3)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "db-password", results[0].Name)
+}
+
+// --- CheckSharePermission ---
+
+func TestRemoteStorage_CheckSharePermission(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/secrets/10/permissions", r.URL.Path)
+		assert.Equal(t, "3", r.URL.Query().Get("user_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"permission": "write",
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	perm, err := rs.CheckSharePermission(context.Background(), 10, 3)
+	require.NoError(t, err)
+	assert.Equal(t, "write", perm)
+}
+
+// --- DeleteExpiredShareRecords ---
+
+func TestRemoteStorage_DeleteExpiredShareRecords(t *testing.T) {
+	before := time.Now().UTC()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/retention/share-records/purge-expired", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"removed": []map[string]interface{}{
+				shareRecordData(7, 10, 2, 3),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	removed, err := rs.DeleteExpiredShareRecords(context.Background(), before)
+	require.NoError(t, err)
+	assert.Len(t, removed, 1)
+	assert.Equal(t, uint(7), removed[0].ID)
+}

--- a/internal/storage/store/remote_users_test.go
+++ b/internal/storage/store/remote_users_test.go
@@ -397,7 +397,7 @@ func TestRemoteStorage_PurgeDeletedUsersBefore(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/api/v1/system/retention/users/purge", r.URL.Path)
-		_, _ = w.Write(apiOK(map[string]interface{}{"count": float64(5)}))
+		_, _ = w.Write(apiOK(map[string]interface{}{"purged": float64(5)}))
 	}))
 	defer srv.Close()
 
@@ -413,7 +413,7 @@ func TestRemoteStorage_PurgeDeletedProjectsBefore(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/api/v1/system/retention/projects/purge", r.URL.Path)
-		_, _ = w.Write(apiOK(map[string]interface{}{"count": float64(2)}))
+		_, _ = w.Write(apiOK(map[string]interface{}{"purged": float64(2)}))
 	}))
 	defer srv.Close()
 
@@ -429,7 +429,7 @@ func TestRemoteStorage_PurgeDeletedEnvironmentsBefore(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/api/v1/system/retention/environments/purge", r.URL.Path)
-		_, _ = w.Write(apiOK(map[string]interface{}{"count": float64(0)}))
+		_, _ = w.Write(apiOK(map[string]interface{}{"purged": float64(0)}))
 	}))
 	defer srv.Close()
 
@@ -496,10 +496,10 @@ func TestRemoteStorage_ListUsers_WithFilter(t *testing.T) {
 
 func TestRemoteStorage_ListUsers_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"success": false,
-			"error":   map[string]string{"code": "INTERNAL", "message": "server error"},
+			"error":   map[string]string{"code": "BAD_REQUEST", "message": "server error"},
 		})
 	}))
 	defer srv.Close()
@@ -764,10 +764,10 @@ func TestRemoteStorage_ListGroups(t *testing.T) {
 
 func TestRemoteStorage_ListGroups_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"success": false,
-			"error":   map[string]string{"code": "INTERNAL", "message": "server error"},
+			"error":   map[string]string{"code": "BAD_REQUEST", "message": "server error"},
 		})
 	}))
 	defer srv.Close()

--- a/internal/storage/store/remote_users_test.go
+++ b/internal/storage/store/remote_users_test.go
@@ -1,0 +1,959 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// minimalUserWire returns a JSON-compatible map matching userWireResponse fields.
+func minimalUserWire(id int, username, email string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":                   float64(id),
+		"username":             username,
+		"email":                email,
+		"display_name":         "Test User",
+		"active":               true,
+		"account_state":        "active",
+		"external_id":          "",
+		"mfa_enabled":          false,
+		"created_at":           time.Now().UTC().Format(time.RFC3339Nano),
+		"updated_at":           time.Now().UTC().Format(time.RFC3339Nano),
+		"last_login_at":        nil,
+		"deleted_at":           nil,
+		"failed_login_attempts": 0,
+		"login_lockout_count":  0,
+		"last_failed_login_at": nil,
+	}
+}
+
+// minimalGroupWire returns a JSON-compatible map matching groupWire fields.
+func minimalGroupWire(id int, name string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":          float64(id),
+		"name":        name,
+		"description": "A test group",
+		"created_at":  time.Now().UTC().Format(time.RFC3339Nano),
+		"updated_at":  time.Now().UTC().Format(time.RFC3339Nano),
+		"deleted_at":  nil,
+	}
+}
+
+// --- CreateUser ---
+
+func TestRemoteStorage_CreateUser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/users", r.URL.Path)
+		_, _ = w.Write(apiOK(minimalUserWire(1, "alice", "alice@example.com")))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	user, err := rs.CreateUser(context.Background(), &models.User{
+		Username:    "alice",
+		Email:       "alice@example.com",
+		DisplayName: "Alice",
+		IsActive:    true,
+	}, "plaintext-pw")
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), user.ID)
+	assert.Equal(t, "alice", user.Username)
+	assert.Equal(t, "alice@example.com", user.Email)
+	assert.True(t, user.IsActive)
+}
+
+func TestRemoteStorage_CreateUser_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "CONFLICT", "message": "user already exists"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateUser(context.Background(), &models.User{Username: "alice", Email: "alice@example.com"})
+	assert.Error(t, err)
+}
+
+// --- GetUser ---
+
+func TestRemoteStorage_GetUser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/users/1", r.URL.Path)
+		_, _ = w.Write(apiOK(minimalUserWire(1, "alice", "alice@example.com")))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	user, err := rs.GetUser(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), user.ID)
+	assert.Equal(t, "alice", user.Username)
+}
+
+func TestRemoteStorage_GetUser_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "NOT_FOUND", "message": "user not found"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetUser(context.Background(), 999)
+	assert.Error(t, err)
+}
+
+// --- LockUserForUpdate ---
+
+func TestRemoteStorage_LockUserForUpdate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/users/2", r.URL.Path)
+		wire := minimalUserWire(2, "bob", "bob@example.com")
+		wire["failed_login_attempts"] = float64(3)
+		wire["login_lockout_count"] = float64(1)
+		_, _ = w.Write(apiOK(wire))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	user, err := rs.LockUserForUpdate(context.Background(), 2)
+	require.NoError(t, err)
+	assert.Equal(t, uint(2), user.ID)
+	assert.Equal(t, "bob", user.Username)
+	assert.Equal(t, 3, user.FailedLoginAttempts)
+	assert.Equal(t, 1, user.LoginLockoutCount)
+}
+
+// --- GetUserByEmail ---
+
+func TestRemoteStorage_GetUserByEmail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/users/by-email", r.URL.Path)
+		assert.Equal(t, "alice@example.com", r.URL.Query().Get("email"))
+		_, _ = w.Write(apiOK(minimalUserWire(1, "alice", "alice@example.com")))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	user, err := rs.GetUserByEmail(context.Background(), "alice@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "alice@example.com", user.Email)
+}
+
+func TestRemoteStorage_GetUserByEmail_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "NOT_FOUND", "message": "user not found"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserByEmail(context.Background(), "nobody@example.com")
+	assert.Error(t, err)
+}
+
+// --- GetUserByUsername ---
+
+func TestRemoteStorage_GetUserByUsername(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/users/by-username", r.URL.Path)
+		assert.Equal(t, "alice", r.URL.Query().Get("username"))
+		_, _ = w.Write(apiOK(minimalUserWire(1, "alice", "alice@example.com")))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	user, err := rs.GetUserByUsername(context.Background(), "alice")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", user.Username)
+}
+
+func TestRemoteStorage_GetUserByUsername_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "NOT_FOUND", "message": "user not found"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserByUsername(context.Background(), "nobody")
+	assert.Error(t, err)
+}
+
+// --- GetUserByExternalID ---
+
+func TestRemoteStorage_GetUserByExternalID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/users/by-external-id", r.URL.Path)
+		assert.Equal(t, "ext-123", r.URL.Query().Get("external_id"))
+		wire := minimalUserWire(1, "alice", "alice@example.com")
+		wire["external_id"] = "ext-123"
+		_, _ = w.Write(apiOK(wire))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	user, err := rs.GetUserByExternalID(context.Background(), "ext-123")
+	require.NoError(t, err)
+	assert.Equal(t, "ext-123", user.ExternalID)
+}
+
+// --- UpdateUser ---
+
+func TestRemoteStorage_UpdateUser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/users/1", r.URL.Path)
+		wire := minimalUserWire(1, "alice-updated", "alice@example.com")
+		wire["display_name"] = "Alice Updated"
+		_, _ = w.Write(apiOK(wire))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	user, err := rs.UpdateUser(context.Background(), &models.User{
+		ID:          1,
+		Username:    "alice-updated",
+		Email:       "alice@example.com",
+		DisplayName: "Alice Updated",
+		IsActive:    true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "alice-updated", user.Username)
+	assert.Equal(t, "Alice Updated", user.DisplayName)
+}
+
+func TestRemoteStorage_UpdateUser_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "NOT_FOUND", "message": "user not found"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateUser(context.Background(), &models.User{ID: 999, Username: "ghost"})
+	assert.Error(t, err)
+}
+
+// --- UpdateLastLogin (unsupported in remote mode) ---
+
+func TestRemoteStorage_UpdateLastLogin_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19999"))
+	require.NoError(t, err)
+
+	err = rs.UpdateLastLogin(context.Background(), 1, time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
+// --- SetAccountState (returns ErrRemoteUnsupported) ---
+
+func TestRemoteStorage_SetAccountState_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19999"))
+	require.NoError(t, err)
+
+	err = rs.SetAccountState(context.Background(), 1, "suspended", time.Now())
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, store.ErrRemoteUnsupported)
+}
+
+// --- SetPasswordHash (returns ErrRemoteUnsupported) ---
+
+func TestRemoteStorage_SetPasswordHash_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19999"))
+	require.NoError(t, err)
+
+	err = rs.SetPasswordHash(context.Background(), 1, "newhash", time.Now())
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, store.ErrRemoteUnsupported)
+}
+
+// --- UpdateLoginLockoutState ---
+
+func TestRemoteStorage_UpdateLoginLockoutState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/users/1/login-lockout", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	now := time.Now()
+	lockedUntil := now.Add(15 * time.Minute)
+	err = rs.UpdateLoginLockoutState(context.Background(), 1, 3, &now, &lockedUntil, 1)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_UpdateLoginLockoutState_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "NOT_FOUND", "message": "user not found"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.UpdateLoginLockoutState(context.Background(), 999, 0, nil, nil, 0)
+	assert.Error(t, err)
+}
+
+// --- DeleteUser ---
+
+func TestRemoteStorage_DeleteUser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/users/1", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteUser(context.Background(), 1)
+	require.NoError(t, err)
+}
+
+// --- RestoreUser ---
+
+func TestRemoteStorage_RestoreUser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/users/1/restore", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RestoreUser(context.Background(), 1)
+	require.NoError(t, err)
+}
+
+// --- Purge retention ---
+
+func TestRemoteStorage_PurgeDeletedUsersBefore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/retention/users/purge", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"count": float64(5)}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	count, err := rs.PurgeDeletedUsersBefore(context.Background(), time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), count)
+}
+
+func TestRemoteStorage_PurgeDeletedProjectsBefore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/retention/projects/purge", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"count": float64(2)}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	count, err := rs.PurgeDeletedProjectsBefore(context.Background(), time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+}
+
+func TestRemoteStorage_PurgeDeletedEnvironmentsBefore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/retention/environments/purge", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"count": float64(0)}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	count, err := rs.PurgeDeletedEnvironmentsBefore(context.Background(), time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+// --- ListUsers ---
+
+func TestRemoteStorage_ListUsers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/users", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"users": []interface{}{
+				minimalUserWire(1, "alice", "alice@example.com"),
+				minimalUserWire(2, "bob", "bob@example.com"),
+			},
+			"total": float64(2),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	users, total, err := rs.ListUsers(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Len(t, users, 2)
+	assert.Equal(t, int64(2), total)
+	assert.Equal(t, "alice", users[0].Username)
+	assert.Equal(t, "bob", users[1].Username)
+}
+
+func TestRemoteStorage_ListUsers_WithFilter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/users", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"users": []interface{}{
+				minimalUserWire(1, "alice", "alice@example.com"),
+			},
+			"total": float64(1),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	username := "alice"
+	users, total, err := rs.ListUsers(context.Background(), &corestorage.UserFilter{
+		Username: &username,
+		Page:     1,
+		PageSize: 10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, users, 1)
+	assert.Equal(t, int64(1), total)
+}
+
+func TestRemoteStorage_ListUsers_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "INTERNAL", "message": "server error"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.ListUsers(context.Background(), nil)
+	assert.Error(t, err)
+}
+
+// --- ListUsersInStateBefore ---
+
+func TestRemoteStorage_ListUsersInStateBefore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/retention/users/stale", r.URL.Path)
+		assert.Equal(t, "inactive", r.URL.Query().Get("state"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"users": []interface{}{
+				minimalUserWire(3, "stale-user", "stale@example.com"),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	users, err := rs.ListUsersInStateBefore(context.Background(), "inactive", time.Now())
+	require.NoError(t, err)
+	assert.Len(t, users, 1)
+	assert.Equal(t, "stale-user", users[0].Username)
+}
+
+// --- CreateUserWithRoleGrants ---
+
+func TestRemoteStorage_CreateUserWithRoleGrants(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/users/with-role-grants", r.URL.Path)
+		_, _ = w.Write(apiOK(minimalUserWire(10, "newuser", "new@example.com")))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	grants := []corestorage.RoleGrant{
+		{RoleID: 1, Scope: corestorage.Scope{ProjectID: 0, EnvironmentID: 0}},
+	}
+	user, err := rs.CreateUserWithRoleGrants(context.Background(), &models.User{
+		Username:    "newuser",
+		Email:       "new@example.com",
+		DisplayName: "New User",
+		IsActive:    true,
+		AccountState: "active",
+	}, grants)
+	require.NoError(t, err)
+	assert.Equal(t, uint(10), user.ID)
+	assert.Equal(t, "newuser", user.Username)
+}
+
+// --- GetUserGroups ---
+
+func TestRemoteStorage_GetUserGroups(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/users/1/groups", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"groups": []interface{}{
+				minimalGroupWire(1, "admins"),
+				minimalGroupWire(2, "developers"),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	groups, err := rs.GetUserGroups(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Len(t, groups, 2)
+	assert.Equal(t, "admins", groups[0].Name)
+	assert.Equal(t, "developers", groups[1].Name)
+}
+
+func TestRemoteStorage_GetUserGroups_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"groups": []interface{}{},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	groups, err := rs.GetUserGroups(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Empty(t, groups)
+}
+
+// --- CreateGroup ---
+
+func TestRemoteStorage_CreateGroup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/groups", r.URL.Path)
+		_, _ = w.Write(apiOK(minimalGroupWire(5, "engineering")))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	group, err := rs.CreateGroup(context.Background(), &models.Group{
+		Name:        "engineering",
+		Description: "Engineering team",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(5), group.ID)
+	assert.Equal(t, "engineering", group.Name)
+}
+
+func TestRemoteStorage_CreateGroup_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "CONFLICT", "message": "group already exists"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateGroup(context.Background(), &models.Group{Name: "engineering"})
+	assert.Error(t, err)
+}
+
+// --- GetGroup ---
+
+func TestRemoteStorage_GetGroup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/groups/5", r.URL.Path)
+		_, _ = w.Write(apiOK(minimalGroupWire(5, "engineering")))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	group, err := rs.GetGroup(context.Background(), 5)
+	require.NoError(t, err)
+	assert.Equal(t, uint(5), group.ID)
+	assert.Equal(t, "engineering", group.Name)
+}
+
+func TestRemoteStorage_GetGroup_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "NOT_FOUND", "message": "group not found"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetGroup(context.Background(), 999)
+	assert.Error(t, err)
+}
+
+// --- UpdateGroup ---
+
+func TestRemoteStorage_UpdateGroup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/groups/5", r.URL.Path)
+		wire := minimalGroupWire(5, "engineering-updated")
+		wire["description"] = "Updated description"
+		_, _ = w.Write(apiOK(wire))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	group, err := rs.UpdateGroup(context.Background(), &models.Group{
+		ID:          5,
+		Name:        "engineering-updated",
+		Description: "Updated description",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "engineering-updated", group.Name)
+	assert.Equal(t, "Updated description", group.Description)
+}
+
+// --- DeleteGroup ---
+
+func TestRemoteStorage_DeleteGroup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/system/groups/5", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteGroup(context.Background(), 5)
+	require.NoError(t, err)
+}
+
+// --- RestoreGroup ---
+
+func TestRemoteStorage_RestoreGroup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/groups/5/restore", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RestoreGroup(context.Background(), 5)
+	require.NoError(t, err)
+}
+
+// --- ListGroups ---
+
+func TestRemoteStorage_ListGroups(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/groups", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"groups": []interface{}{
+				minimalGroupWire(1, "admins"),
+				minimalGroupWire(2, "developers"),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	groups, err := rs.ListGroups(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, groups, 2)
+	assert.Equal(t, "admins", groups[0].Name)
+}
+
+func TestRemoteStorage_ListGroups_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "INTERNAL", "message": "server error"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListGroups(context.Background())
+	assert.Error(t, err)
+}
+
+// --- ListGroupsPage ---
+
+func TestRemoteStorage_ListGroupsPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/groups/page", r.URL.Path)
+		assert.Equal(t, "0", r.URL.Query().Get("offset"))
+		assert.Equal(t, "10", r.URL.Query().Get("limit"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"groups": []interface{}{
+				minimalGroupWire(1, "admins"),
+			},
+			"total": float64(1),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	groups, total, err := rs.ListGroupsPage(context.Background(), 0, 10)
+	require.NoError(t, err)
+	assert.Len(t, groups, 1)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, "admins", groups[0].Name)
+}
+
+// --- AddUserToGroup ---
+
+func TestRemoteStorage_AddUserToGroup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/groups/5/members", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	// AddUserToGroup(ctx, userID, groupID)
+	err = rs.AddUserToGroup(context.Background(), 1, 5)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_AddUserToGroup_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "CONFLICT", "message": "already member"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.AddUserToGroup(context.Background(), 1, 5)
+	assert.Error(t, err)
+}
+
+// --- RemoveUserFromGroup ---
+
+func TestRemoteStorage_RemoveUserFromGroup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/system/groups/5/members/1", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	// RemoveUserFromGroup(ctx, userID, groupID)
+	err = rs.RemoveUserFromGroup(context.Background(), 1, 5)
+	require.NoError(t, err)
+}
+
+// --- ListGroupMembers ---
+
+func TestRemoteStorage_ListGroupMembers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/groups/5/members", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"members": []interface{}{
+				minimalUserWire(1, "alice", "alice@example.com"),
+				minimalUserWire(2, "bob", "bob@example.com"),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	members, err := rs.ListGroupMembers(context.Background(), 5)
+	require.NoError(t, err)
+	assert.Len(t, members, 2)
+	assert.Equal(t, "alice", members[0].Username)
+	assert.Equal(t, "bob", members[1].Username)
+}
+
+func TestRemoteStorage_ListGroupMembers_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "NOT_FOUND", "message": "group not found"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListGroupMembers(context.Background(), 999)
+	assert.Error(t, err)
+}
+
+// --- ListGroupMembersByGroupIDs ---
+
+func TestRemoteStorage_ListGroupMembersByGroupIDs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/system/groups/members-by-ids", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"1": []interface{}{
+				minimalUserWire(10, "alice", "alice@example.com"),
+			},
+			"2": []interface{}{
+				minimalUserWire(11, "bob", "bob@example.com"),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.ListGroupMembersByGroupIDs(context.Background(), []uint{1, 2})
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Len(t, result[1], 1)
+	assert.Equal(t, "alice", result[1][0].Username)
+	assert.Len(t, result[2], 1)
+	assert.Equal(t, "bob", result[2][0].Username)
+}
+
+func TestRemoteStorage_ListGroupMembersByGroupIDs_Empty(t *testing.T) {
+	// No HTTP server needed — the function short-circuits on empty input.
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19999"))
+	require.NoError(t, err)
+
+	result, err := rs.ListGroupMembersByGroupIDs(context.Background(), []uint{})
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+// --- Password history stubs (no-ops) ---
+
+func TestRemoteStorage_PasswordHistoryStubs_NoError(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19999"))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	err = rs.AddPasswordHistory(ctx, 1, "hashvalue", time.Now())
+	require.NoError(t, err)
+
+	hashes, err := rs.RecentPasswordHashes(ctx, 1, 5)
+	require.NoError(t, err)
+	assert.Nil(t, hashes)
+
+	err = rs.PrunePasswordHistory(ctx, 1, 10)
+	require.NoError(t, err)
+}

--- a/internal/storage/store/remote_webauthn_test.go
+++ b/internal/storage/store/remote_webauthn_test.go
@@ -1,0 +1,329 @@
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- WebAuthn credentials ---
+
+func TestRemoteStorage_CreateWebAuthnCredential(t *testing.T) {
+	credID := []byte{0x01, 0x02, 0x03, 0x04}
+	blob := []byte(`{"id":"AQIDBA=="}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/webauthn/credentials", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":              99,
+			"user_id":         7,
+			"credential_id":   credID,
+			"name":            "YubiKey 5C",
+			"credential_blob": blob,
+			"created_at":      time.Now(),
+			"disabled":        false,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	c := &models.WebAuthnCredential{
+		UserID:         7,
+		CredentialID:   credID,
+		Name:           "YubiKey 5C",
+		CredentialBlob: blob,
+	}
+	err = rs.CreateWebAuthnCredential(context.Background(), c)
+	require.NoError(t, err)
+	// The method mutates the argument in-place with upstream-assigned fields.
+	assert.Equal(t, uint(99), c.ID)
+	assert.Equal(t, "YubiKey 5C", c.Name)
+}
+
+func TestRemoteStorage_ListWebAuthnCredentials(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/webauthn/credentials", r.URL.Path)
+		assert.Equal(t, "7", r.URL.Query().Get("user_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"credentials": []map[string]interface{}{
+				{
+					"id": 99, "user_id": 7, "name": "YubiKey 5C",
+					"credential_id":   []byte{0x01, 0x02},
+					"credential_blob": []byte(`{}`),
+					"created_at":      time.Now(), "disabled": false,
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	list, err := rs.ListWebAuthnCredentials(context.Background(), 7)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, uint(99), list[0].ID)
+	assert.Equal(t, "YubiKey 5C", list[0].Name)
+}
+
+func TestRemoteStorage_GetWebAuthnCredentialByCredID(t *testing.T) {
+	credID := []byte{0xAB, 0xCD}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/webauthn/credentials/lookup", r.URL.Path)
+		assert.Equal(t, "7", r.URL.Query().Get("user_id"))
+		// credential_id is base64-encoded on the wire
+		assert.NotEmpty(t, r.URL.Query().Get("credential_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 100, "user_id": 7, "name": "MacBook Touch ID",
+			"credential_id":   credID,
+			"credential_blob": []byte(`{}`),
+			"created_at":      time.Now(), "disabled": false,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	c, err := rs.GetWebAuthnCredentialByCredID(context.Background(), credID, 7)
+	require.NoError(t, err)
+	assert.Equal(t, uint(100), c.ID)
+	assert.Equal(t, "MacBook Touch ID", c.Name)
+}
+
+// LockWebAuthnCredentialForUpdate delegates to GetWebAuthnCredentialByCredID.
+func TestRemoteStorage_LockWebAuthnCredentialForUpdate(t *testing.T) {
+	credID := []byte{0x11, 0x22}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/webauthn/credentials/lookup", r.URL.Path)
+		assert.Equal(t, "5", r.URL.Query().Get("user_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 101, "user_id": 5, "name": "Locked Key",
+			"credential_id":   credID,
+			"credential_blob": []byte(`{}`),
+			"created_at":      time.Now(), "disabled": false,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	c, err := rs.LockWebAuthnCredentialForUpdate(context.Background(), credID, 5)
+	require.NoError(t, err)
+	assert.Equal(t, uint(101), c.ID)
+	assert.Equal(t, "Locked Key", c.Name)
+}
+
+func TestRemoteStorage_UpdateWebAuthnCredential(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/system/webauthn/credentials/99", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.UpdateWebAuthnCredential(context.Background(), &models.WebAuthnCredential{
+		ID: 99, UserID: 7, Name: "Updated Key", Disabled: true,
+	})
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_AdvanceWebAuthnCredentialCounter(t *testing.T) {
+	credID := []byte{0xBE, 0xEF}
+	newBlob := []byte(`{"signCount":42}`)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method)
+		assert.Equal(t, "/api/v1/system/webauthn/credentials/advance-counter", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"advanced": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	advanced, err := rs.AdvanceWebAuthnCredentialCounter(context.Background(),
+		credID, 7, newBlob, 42, now)
+	require.NoError(t, err)
+	assert.True(t, advanced)
+}
+
+func TestRemoteStorage_AdvanceWebAuthnCredentialCounter_NotAdvanced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method)
+		_, _ = w.Write(apiOK(map[string]interface{}{"advanced": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	advanced, err := rs.AdvanceWebAuthnCredentialCounter(context.Background(),
+		[]byte{0x01}, 7, []byte(`{}`), 1, time.Now())
+	require.NoError(t, err)
+	assert.False(t, advanced)
+}
+
+func TestRemoteStorage_DeleteWebAuthnCredential(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/system/webauthn/users/7/credentials/99", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteWebAuthnCredential(context.Background(), 7, 99)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_CountWebAuthnCredentials(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/system/webauthn/credentials/count", r.URL.Path)
+		assert.Equal(t, "7", r.URL.Query().Get("user_id"))
+		_, _ = w.Write(apiOK(map[string]interface{}{"count": int64(3)}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	n, err := rs.CountWebAuthnCredentials(context.Background(), 7)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), n)
+}
+
+func TestRemoteStorage_SetUserWebAuthnEnabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/system/webauthn/users/7/webauthn-enabled", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.SetUserWebAuthnEnabled(context.Background(), 7, true)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_SetUserWebAuthnEnabled_Disable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/system/webauthn/users/3/webauthn-enabled", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.SetUserWebAuthnEnabled(context.Background(), 3, false)
+	require.NoError(t, err)
+}
+
+// --- WebAuthn sessions ---
+
+func TestRemoteStorage_CreateWebAuthnSession(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/webauthn/sessions", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":         200,
+			"user_id":    7,
+			"token_hash": "sess-hash",
+			"purpose":    "register",
+			"data":       []byte(`{}`),
+			"expires_at": now.Add(10 * time.Minute),
+			"created_at": now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	s := &models.WebAuthnSession{
+		UserID:    7,
+		TokenHash: "sess-hash",
+		Purpose:   "register",
+		Data:      []byte(`{}`),
+		ExpiresAt: now.Add(10 * time.Minute),
+	}
+	err = rs.CreateWebAuthnSession(context.Background(), s)
+	require.NoError(t, err)
+	// The method mutates the argument in-place with upstream-assigned fields.
+	assert.Equal(t, uint(200), s.ID)
+	assert.Equal(t, "register", s.Purpose)
+}
+
+func TestRemoteStorage_ConsumeWebAuthnSession(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/webauthn/sessions/consume", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":         200,
+			"user_id":    7,
+			"token_hash": "sess-hash",
+			"purpose":    "login",
+			"data":       []byte(`{}`),
+			"expires_at": now.Add(5 * time.Minute),
+			"used_at":    now,
+			"created_at": now.Add(-1 * time.Minute),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	sess, err := rs.ConsumeWebAuthnSession(context.Background(), "sess-hash", now)
+	require.NoError(t, err)
+	assert.Equal(t, uint(200), sess.ID)
+	assert.Equal(t, uint(7), sess.UserID)
+	assert.Equal(t, "login", sess.Purpose)
+	assert.NotNil(t, sess.UsedAt)
+}
+
+func TestRemoteStorage_ConsumeWebAuthnSession_Failure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"NOT_FOUND","message":"not found"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ConsumeWebAuthnSession(context.Background(), "nonexistent-hash", time.Now())
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- Add `httptest.NewServer`-based tests for **all RemoteStorage methods** that proxy to real HTTP endpoints
- Previously only 5 remote functions were tested; this sprint adds ~530 tests across 15 new files
- Covers every `RemoteStorage` method in 27 remote implementation files
- Functions returning `remoteUnsupported()` are tested for the error sentinel; all others use per-test HTTP servers that assert method + path + return minimal valid responses
- Fixes one pre-existing duplicate test name collision with `remote_unsupported_test.go`

## Test plan

- [ ] `go test ./internal/storage/store/...` passes locally (compile-verified)
- [ ] No duplicate test function names (verified with `grep | sort | uniq -d`)
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)