### PR TITLE
harden: fix all 16 CodeQL HIGH alerts (#1–#16)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,3 +65,21 @@ jobs:
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: '/language:go-${{ matrix.name }}'
+
+  # Fan-in job that satisfies the "CodeQL" required status check in branch
+  # protection. The matrix jobs above are each required too (Analyze (server)
+  # and Analyze (operator)), but branch protection also requires a "CodeQL"
+  # context which this single-name job provides.
+  summary:
+    name: CodeQL
+    needs: [analyze]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check analysis results
+        run: |
+          if [ "${{ needs.analyze.result }}" != "success" ]; then
+            echo "CodeQL analysis failed or was cancelled"
+            exit 1
+          fi
+          echo "All CodeQL analyses passed"

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -35,7 +35,7 @@ func ResolveActorID() uint {
 	if raw == "" {
 		return 0
 	}
-	id, err := strconv.ParseUint(raw, 10, 64)
+	id, err := strconv.ParseUint(raw, 10, 32)
 	if err != nil {
 		return 0
 	}
@@ -202,5 +202,5 @@ func PrintOneTimePasswordResult(otp *core.OneTimePasswordResult) {
 	if otp == nil {
 		return
 	}
-	fmt.Printf("One-time password for %s (relay securely — it must be changed on first login):\n  %s\n", otp.Email, otp.OneTimePassword)
+	fmt.Printf("One-time password for %s (relay securely — it must be changed on first login):\n  %s\n", otp.Email, otp.OneTimePassword) // lgtm[go/clear-text-logging]
 }

--- a/internal/cli/dynamic/dynamic.go
+++ b/internal/cli/dynamic/dynamic.go
@@ -203,7 +203,7 @@ var issueCmd = &cobra.Command{
 			fmt.Printf("  username: %s\n", lease.Username)
 		}
 		if lease.Password != "" {
-			fmt.Printf("  password: %s\n", lease.Password)
+			fmt.Printf("  password: %s\n", lease.Password) // lgtm[go/clear-text-logging]
 		}
 		// Cloud-IAM backends (AWS STS) return their credential as fields.
 		for _, k := range sortedKeys(lease.Fields) {

--- a/internal/cli/encryption/encryption.go
+++ b/internal/cli/encryption/encryption.go
@@ -329,7 +329,7 @@ func dryRunRotation(cfg *config.Config) error {
 // dynamic_secret_configs, and dynamic_secret_leases, the exact three tables
 // #422's sweep-gap fix added.
 func printSweepResult(result *encryption.SweepResult) {
-	fmt.Printf("📋 secret_versions: %d, sessions: %d, api_tokens: %d, api_clients: %d, password_resets: %d, mfa_secrets: %d, dynamic_secret_configs: %d, dynamic_secret_leases: %d (legacy AAD upgraded: %d)\n",
+	fmt.Printf("📋 secret_versions: %d, sessions: %d, api_tokens: %d, api_clients: %d, password_resets: %d, mfa_secrets: %d, dynamic_secret_configs: %d, dynamic_secret_leases: %d (legacy AAD upgraded: %d)\n", // lgtm[go/clear-text-logging]
 		result.SecretVersionsSwept, result.SessionsSwept, result.APITokensSwept, result.APIClientsSwept,
 		result.PasswordResetsSwept, result.MFASecretsSwept, result.DynamicSecretConfigsSwept, result.DynamicSecretLeasesSwept,
 		result.LegacyAADUpgraded)

--- a/internal/cli/project/hygiene.go
+++ b/internal/cli/project/hygiene.go
@@ -52,7 +52,7 @@ identities. Requires secrets.read at the project scope.`,
 // fetchHygiene GETs the project hygiene summary (split out for httptest tests).
 func fetchHygiene(ctx context.Context, c *common.RemoteClient, projectID uint) (*hygieneSummary, error) {
 	var out hygieneSummary
-	if err := c.Get(ctx, "/api/v1/projects/"+strconv.Itoa(int(projectID))+"/hygiene", &out); err != nil {
+	if err := c.Get(ctx, "/api/v1/projects/"+strconv.FormatUint(uint64(projectID), 10)+"/hygiene", &out); err != nil {
 		return nil, err
 	}
 	return &out, nil

--- a/internal/cli/secret/create.go
+++ b/internal/cli/secret/create.go
@@ -203,8 +203,8 @@ func interactiveCreate() (*core.CreateSecretRequest, error) {
 	askUint := func(prompt string, defaultVal uint) uint {
 		for {
 			input := ask(prompt, fmt.Sprint(defaultVal))
-			val, err := strconv.ParseUint(input, 10, 64)
-			if err != nil || val > uint64(^uint(0)) {
+			val, err := strconv.ParseUint(input, 10, 32)
+			if err != nil {
 				fmt.Println("Invalid number, please enter a valid positive integer.")
 				continue
 			}

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -443,7 +443,7 @@ func parseAuditHighWater(val string) (cp *models.AuditCheckpoint, sig string, ok
 		return nil, "", false
 	}
 	chained, err1 := strconv.ParseInt(parts[1], 10, 64)
-	headID, err2 := strconv.ParseUint(parts[2], 10, 64)
+	headID, err2 := strconv.ParseUint(parts[2], 10, 32)
 	if err1 != nil || err2 != nil {
 		return nil, "", false
 	}

--- a/internal/encryption/service_rotation.go
+++ b/internal/encryption/service_rotation.go
@@ -67,7 +67,7 @@ func (s *Service) RotateDEKWithSweep(passphrase string, db *gorm.DB) (*SweepResu
 		// dynamic_secret_leases) are exactly the tables #422's sweep-gap fix added;
 		// silently under-reporting them left an operator with no visibility into
 		// whether that fix's own sweeps ran, even after the data itself was safe.
-		log.Printf("✅ Sweep committed: %d secret_versions, %d sessions, %d api_tokens, %d api_clients, %d password_resets, %d mfa_secrets, %d dynamic_secret_configs, %d dynamic_secret_leases re-encrypted (%d legacy AAD upgraded)",
+		log.Printf("✅ Sweep committed: %d secret_versions, %d sessions, %d api_tokens, %d api_clients, %d password_resets, %d mfa_secrets, %d dynamic_secret_configs, %d dynamic_secret_leases re-encrypted (%d legacy AAD upgraded)", // lgtm[go/clear-text-logging]
 			result.SecretVersionsSwept, result.SessionsSwept, result.APITokensSwept,
 			result.APIClientsSwept, result.PasswordResetsSwept, result.MFASecretsSwept,
 			result.DynamicSecretConfigsSwept, result.DynamicSecretLeasesSwept, result.LegacyAADUpgraded)

--- a/internal/rotation/mysql.go
+++ b/internal/rotation/mysql.go
@@ -17,7 +17,7 @@ import (
 // mysqlConn is the slice of a MySQL connection the executor uses — an interface seam so
 // the driver stays contained here and tests inject a fake.
 type mysqlConn interface {
-	Exec(ctx context.Context, query string) error
+	Exec(ctx context.Context, query string, args ...interface{}) error
 	Close() error
 }
 
@@ -83,14 +83,14 @@ func (e *MySQLExecutor) Rotate(ctx context.Context, ref, newValue string) error 
 		host = "%"
 	}
 	// ALTER USER 'user'@'host' IDENTIFIED BY 'pw' — every component a quoted literal
-	// with internal quotes/backslashes doubled, so none can escape the statement.
-	q := fmt.Sprintf("ALTER USER %s@%s IDENTIFIED BY %s",
-		quoteMySQLString(user), quoteMySQLString(host), quoteMySQLString(newValue))
-	if err := c.Exec(ctx, q); err != nil {
-		// The new password is a quoted literal in q; a driver error can echo the
-		// failing statement verbatim. Redact before wrapping so the live credential
-		// never egresses via the rotation-failure SIEM audit / notification
-		// broadcast (#132).
+	// Account names are quoted literals (MySQL DDL cannot parameterise identifiers);
+	// the new password is passed as a ? placeholder so it never appears in the
+	// statement string and cannot break out via string interpolation.
+	q := fmt.Sprintf("ALTER USER %s@%s IDENTIFIED BY ?",
+		quoteMySQLString(user), quoteMySQLString(host))
+	if err := c.Exec(ctx, q, newValue); err != nil {
+		// Redact before wrapping so the live credential never egresses via the
+		// rotation-failure SIEM audit / notification broadcast (#132).
 		return redactSQLError("mysql", ref, err)
 	}
 	return nil
@@ -114,8 +114,8 @@ func quoteMySQLString(s string) string {
 // mysqlDBConn adapts *sql.DB to the mysqlConn seam.
 type mysqlDBConn struct{ db *sql.DB }
 
-func (m *mysqlDBConn) Exec(ctx context.Context, query string) error {
-	_, err := m.db.ExecContext(ctx, query)
+func (m *mysqlDBConn) Exec(ctx context.Context, query string, args ...interface{}) error {
+	_, err := m.db.ExecContext(ctx, query, args...)
 	return err
 }
 func (m *mysqlDBConn) Close() error { return m.db.Close() }

--- a/internal/rotation/mysql_test.go
+++ b/internal/rotation/mysql_test.go
@@ -11,13 +11,15 @@ import (
 
 type fakeMySQL struct {
 	query  string
+	args   []interface{}
 	called bool
 	err    error
 }
 
-func (f *fakeMySQL) Exec(_ context.Context, q string) error {
+func (f *fakeMySQL) Exec(_ context.Context, q string, args ...interface{}) error {
 	f.called = true
 	f.query = q
+	f.args = args
 	return f.err
 }
 func (f *fakeMySQL) Close() error { return nil }
@@ -39,20 +41,25 @@ func TestMySQL_RotateBuildsAlterUser(t *testing.T) {
 	// bare user → default host '%'
 	require.NoError(t, myWith(fake, "app_").Rotate(context.Background(), "app_svc", "n3wp4ss"))
 	assert.True(t, fake.called)
-	assert.Equal(t, `ALTER USER 'app_svc'@'%' IDENTIFIED BY 'n3wp4ss'`, fake.query)
+	assert.Equal(t, `ALTER USER 'app_svc'@'%' IDENTIFIED BY ?`, fake.query)
+	assert.Equal(t, []interface{}{"n3wp4ss"}, fake.args)
 }
 
 func TestMySQL_RotateWithExplicitHost(t *testing.T) {
 	fake := &fakeMySQL{}
 	require.NoError(t, myWith(fake, "app_").Rotate(context.Background(), "app_svc@10.0.0.5", "pw"))
-	assert.Equal(t, `ALTER USER 'app_svc'@'10.0.0.5' IDENTIFIED BY 'pw'`, fake.query)
+	assert.Equal(t, `ALTER USER 'app_svc'@'10.0.0.5' IDENTIFIED BY ?`, fake.query)
+	assert.Equal(t, []interface{}{"pw"}, fake.args)
 }
 
 // A crafted account/password cannot break out: internal quotes and backslashes doubled.
 func TestMySQL_RotateEscapesInjection(t *testing.T) {
 	fake := &fakeMySQL{}
 	require.NoError(t, myWith(fake, "ro").Rotate(context.Background(), `ro'le`, `pa\'ss`))
-	assert.Equal(t, `ALTER USER 'ro''le'@'%' IDENTIFIED BY 'pa\\''ss'`, fake.query)
+	// Account names are still quoted (DDL identifiers can't be parameterised);
+	// the password is a ? placeholder so no escaping is needed there.
+	assert.Equal(t, `ALTER USER 'ro''le'@'%' IDENTIFIED BY ?`, fake.query)
+	assert.Equal(t, []interface{}{`pa\'ss`}, fake.args)
 }
 
 func TestMySQL_RotateFailsClosedWithoutAllowedRefs(t *testing.T) {

--- a/server/http/handlers/audit_anomaly.go
+++ b/server/http/handlers/audit_anomaly.go
@@ -50,7 +50,7 @@ func AcknowledgeAnomalyAlert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	idStr := chi.URLParam(r, "id")
-	id, err := strconv.ParseUint(idStr, 10, 64)
+	id, err := strconv.ParseUint(idStr, 10, 32)
 	if err != nil {
 		sendError(w, "BadRequest", "Invalid alert ID", http.StatusBadRequest, nil)
 		return

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -557,7 +557,7 @@ func (h *AuthHandler) RevokeSession(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
-	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 64)
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
 		sendError(w, "BadRequest", "Invalid session ID", http.StatusBadRequest, nil)
 		return

--- a/server/http/handlers/connect.go
+++ b/server/http/handlers/connect.go
@@ -168,7 +168,7 @@ func (h *ConnectHandler) DeleteRefGrant(w http.ResponseWriter, r *http.Request) 
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
-	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 64)
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
 		sendError(w, "InvalidParameter", "invalid grant id", http.StatusBadRequest, nil)
 		return

--- a/server/http/handlers/pat_handler.go
+++ b/server/http/handlers/pat_handler.go
@@ -195,7 +195,7 @@ func (h *PATHandler) RevokePAT(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
-	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 64)
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
 		sendError(w, "BadRequest", "Invalid token ID", http.StatusBadRequest, nil)
 		return

--- a/server/http/handlers/secrets_versions.go
+++ b/server/http/handlers/secrets_versions.go
@@ -68,7 +68,7 @@ func (h *SecretHandler) RotateSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	idStr := chi.URLParam(r, "id")
-	id, err := strconv.ParseUint(idStr, 10, 64)
+	id, err := strconv.ParseUint(idStr, 10, 32)
 	if err != nil {
 		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
 		return
@@ -133,7 +133,7 @@ func (h *SecretHandler) RollbackSecret(w http.ResponseWriter, r *http.Request) {
 		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
-	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 64)
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
 		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
 		return


### PR DESCRIPTION
## Summary

Fixes all 16 HIGH-severity CodeQL alerts currently open on main.

**Integer conversions (#1–#11)** — 9 files  
`ParseUint` bitSize changed from `64` to `32` everywhere the result is cast to `uint`. With a 32-bit parse the value is provably ≤ 2³²−1, which fits in `uint` on every Go platform, eliminating the narrowing-cast risk. `strconv.Itoa(int(projectID))` in `hygiene.go` replaced with `strconv.FormatUint` for the same reason.

**SQL injection (#16)** — `internal/rotation/mysql.go`  
The new password in `ALTER USER … IDENTIFIED BY` is now a `?` placeholder instead of a quoted string literal. Account name and host must remain quoted (MySQL DDL cannot parameterise identifiers) but the user-controlled `newValue` now flows through the driver's prepared-statement path and never appears in the query string. Test fake and assertions updated accordingly.

**Clear-text logging (#12–#15)** — 4 files  
`// lgtm[go/clear-text-logging]` suppressions on four intentional outputs:
- Two log lines reporting integer re-encryption *counts* (no secrets)
- One CLI line displaying a dynamic-secret password to the requesting user (designed behaviour)
- One CLI line displaying a one-time password to the provisioning admin (designed behaviour)

## Test plan
- [ ] `go build ./...` passes (verified locally)
- [ ] `go test ./internal/rotation/...` — all MySQL tests pass with updated assertions
- [ ] CI build-and-test, lint, CodeQL green

🤖 Generated with [Claude Code](https://claude.ai/claude-code)