### PR TITLE
fix: address GitHub code-quality findings

### DIFF
--- a/internal/cli/secret/export.go
+++ b/internal/cli/secret/export.go
@@ -68,7 +68,7 @@ type exportedSecret struct {
 	Value string
 }
 
-func runExport(cmd *cobra.Command, args []string) error {
+func runExport(cmd *cobra.Command, args []string) (retErr error) {
 	rc, ok := common.NewRemoteClient()
 	if !ok {
 		return fmt.Errorf("no remote server configured; set KEYORIX_SERVER and KEYORIX_TOKEN or run 'keyorix auth login'")
@@ -107,7 +107,11 @@ func runExport(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("cannot create output file %q (it may already exist — remove it or choose a different path): %w", exportOutput, err)
 		}
-		defer f.Close() //nolint:errcheck
+		defer func() {
+			if cerr := f.Close(); cerr != nil && retErr == nil {
+				retErr = fmt.Errorf("failed to close output file: %w", cerr)
+			}
+		}()
 		out = f
 	}
 

--- a/internal/cli/secret/secret_s8_test.go
+++ b/internal/cli/secret/secret_s8_test.go
@@ -676,7 +676,7 @@ func TestRunGetEmbedded_ByName_NotFound_Paged_S8(t *testing.T) {
 }
 
 // newS8ExportCmd creates a cobra.Command with a Background context for runExport tests.
-func newS8ExportCmdS8(t *testing.T) *cobra.Command {
+func newS8ExportCmd(t *testing.T) *cobra.Command {
 	t.Helper()
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
@@ -689,13 +689,13 @@ func TestRunExport_NoRemoteClient_S8(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
 
-	err := runExport(newS8ExportCmdS8(t), nil)
+	err := runExport(newS8ExportCmd(t), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no remote server configured")
 }
 
 // newS8ImportCmd creates a cobra.Command with a Background context for runImport tests.
-func newS8ImportCmdS8(t *testing.T) *cobra.Command {
+func newS8ImportCmd(t *testing.T) *cobra.Command {
 	t.Helper()
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
@@ -732,7 +732,7 @@ func TestRunImport_DryRun_S8(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
 
-	err := runImport(newS8ImportCmdS8(t), nil)
+	err := runImport(newS8ImportCmd(t), nil)
 	require.NoError(t, err)
 }
 
@@ -797,7 +797,7 @@ func TestRunImport_DryRunEmpty_S8(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
 
-	err := runImport(newS8ImportCmdS8(t), nil)
+	err := runImport(newS8ImportCmd(t), nil)
 	require.NoError(t, err)
 }
 
@@ -1714,7 +1714,7 @@ func TestRunExport_ProjectNotFound_S8(t *testing.T) {
 	t.Cleanup(func() { exportProject = origProject })
 	exportProject = "missing-project-s8"
 
-	err := runExport(newS8ExportCmdS8(t), nil)
+	err := runExport(newS8ExportCmd(t), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -1742,7 +1742,7 @@ func TestRunExport_EnvNotFound_S8(t *testing.T) {
 	exportProject = "default"
 	exportEnv = "missing-env-s8"
 
-	err := runExport(newS8ExportCmdS8(t), nil)
+	err := runExport(newS8ExportCmd(t), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -1772,7 +1772,7 @@ func TestRunExport_NoSecrets_S8(t *testing.T) {
 	exportEnv = "development"
 	exportFormat = "dotenv"
 
-	err := runExport(newS8ExportCmdS8(t), nil)
+	err := runExport(newS8ExportCmd(t), nil)
 	require.NoError(t, err)
 }
 
@@ -1803,7 +1803,7 @@ func TestRunExport_UnknownFormat_S8(t *testing.T) {
 	exportFormat = "badformat"
 	exportOutput = ""
 
-	err := runExport(newS8ExportCmdS8(t), nil)
+	err := runExport(newS8ExportCmd(t), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown format")
 }
@@ -1868,7 +1868,7 @@ func TestRunImport_SkipExisting_S8(t *testing.T) {
 	importSkipExisting = true
 	importSource = ""
 
-	err := runImport(newS8ImportCmdS8(t), nil)
+	err := runImport(newS8ImportCmd(t), nil)
 	// With skip-existing and a 409 response → no error.
 	require.NoError(t, err)
 }

--- a/internal/cli/secret/secret_s9_test.go
+++ b/internal/cli/secret/secret_s9_test.go
@@ -427,8 +427,8 @@ func TestExplodeValue_Compound_S9(t *testing.T) {
 	for _, e := range results {
 		byName[e.Name] = e.Value
 	}
-	assert.Equal(t, "localhost", byName["db.host"])
-	assert.Equal(t, "5432", byName["db.port"])
+	assert.Equal(t, "localhost", byName["db-host"])
+	assert.Equal(t, "5432", byName["db-port"])
 }
 
 func TestExplodeValue_Simple_S9(t *testing.T) {

--- a/internal/cli/secret/secret_s9_test.go
+++ b/internal/cli/secret/secret_s9_test.go
@@ -415,14 +415,20 @@ func TestRunExport_BadOutputPath_S9(t *testing.T) {
 	exportOutput = "/no/such/dir-s9/export.json"
 
 	err := runExport(exportCmd, nil)
-	_ = err
+	assert.Error(t, err)
 }
 
 // ── explodeValue: compound value ─────────────────────────────────────────────
 
 func TestExplodeValue_Compound_S9(t *testing.T) {
 	results := explodeValue("db", `{"host":"localhost","port":"5432"}`)
-	_ = results
+	assert.NotEmpty(t, results)
+	byName := make(map[string]string, len(results))
+	for _, e := range results {
+		byName[e.Name] = e.Value
+	}
+	assert.Equal(t, "localhost", byName["db.host"])
+	assert.Equal(t, "5432", byName["db.port"])
 }
 
 func TestExplodeValue_Simple_S9(t *testing.T) {

--- a/internal/cli/secret/secret_s9_test.go
+++ b/internal/cli/secret/secret_s9_test.go
@@ -421,6 +421,10 @@ func TestRunExport_BadOutputPath_S9(t *testing.T) {
 // ── explodeValue: compound value ─────────────────────────────────────────────
 
 func TestExplodeValue_Compound_S9(t *testing.T) {
+	orig := importNoExplode
+	importNoExplode = false
+	t.Cleanup(func() { importNoExplode = orig })
+
 	results := explodeValue("db", `{"host":"localhost","port":"5432"}`)
 	assert.NotEmpty(t, results)
 	byName := make(map[string]string, len(results))

--- a/internal/storage/store/remote_notifications_test.go
+++ b/internal/storage/store/remote_notifications_test.go
@@ -88,7 +88,7 @@ func TestRemoteStorage_CountUnreadNotifications(t *testing.T) {
 	assert.Equal(t, int64(7), count)
 }
 
-func TestRemoteStorage_MarkNotificationRead_S11(t *testing.T) {
+func TestRemoteStorage_MarkNotificationRead_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/api/v1/notifications/42/read", r.URL.Path)
@@ -103,7 +103,7 @@ func TestRemoteStorage_MarkNotificationRead_S11(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRemoteStorage_MarkAllNotificationsRead_S11(t *testing.T) {
+func TestRemoteStorage_MarkAllNotificationsRead_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/api/v1/notifications/read-all", r.URL.Path)

--- a/internal/storage/store/remote_rbac_test.go
+++ b/internal/storage/store/remote_rbac_test.go
@@ -367,7 +367,7 @@ func TestRemoteStorage_GetRolePermissions(t *testing.T) {
 	assert.Equal(t, "secrets.read", perms[0].Name)
 }
 
-func TestRemoteStorage_RemovePermissionFromRole_S11(t *testing.T) {
+func TestRemoteStorage_RemovePermissionFromRole_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "DELETE", r.Method)
 		assert.Equal(t, "/api/v1/roles/2/permissions/5", r.URL.Path)


### PR DESCRIPTION
## Summary

- **export.go** (CodeQL HIGH): `defer f.Close()` on a writable file handle now uses a named-return closure that propagates a close error when no earlier error occurred — data-loss on flush failure is no longer silently swallowed
- **secret_s8_test.go**: rename `newS8ExportCmdS8` → `newS8ExportCmd` and `newS8ImportCmdS8` → `newS8ImportCmd` (redundant `_S8` suffix appeared in both prefix and suffix)
- **secret_s9_test.go**: `TestRunExport_BadOutputPath_S9` now asserts `assert.Error`; `TestExplodeValue_Compound_S9` now verifies key-value pairs instead of discarding results
- **remote_notifications_test.go**: rename `_S11` → `_Success` on `MarkNotificationRead` and `MarkAllNotificationsRead` tests
- **remote_rbac_test.go**: rename `_S11` → `_Success` on `RemovePermissionFromRole` test

## Test plan

- [ ] CI build-and-test passes (all affected test functions still compile and run)
- [ ] CodeQL scan no longer flags export.go:110

🤖 Generated with [Claude Code](https://claude.com/claude-code)