### PR TITLE
harden: scan test files in CodeQL by compiling them without running

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,9 @@ jobs:
         working-directory: ${{ matrix.working-directory }}
         env:
           GOWORK: ${{ matrix.gowork }}
-        run: go build ./...
+        run: |
+          go build ./...
+          go test -run=^$ ./...
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0


### PR DESCRIPTION
## Summary

- CodeQL was only scanning **44% of Go files** (615/1.41k) because `go build ./...` skips `_test.go` files entirely
- Adds `go test -run=^$ ./...` to the manual build step — compiles every test package with a never-matching regex so zero tests run, but all test files are compiled and indexed by CodeQL
- Expected result: coverage jumps from ~44% to ~100% across both matrix jobs (server + operator)

## Test plan

- [ ] Verify CodeQL workflow completes successfully on this PR
- [ ] Check the "Scanned files" count on the Security → Code scanning page after merge — should be close to 1.41k

🤖 Generated with [Claude Code](https://claude.com/claude-code)