### PR TITLE
harden: bump operator Go to 1.26.5 (CVE-2026-39822, CVE-2026-42505)

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/keyorixhq/keyorix/operator
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## Summary

- Bumps `operator/go.mod` from `go 1.26.4` to `go 1.26.5` to align with the root module
- Fixes two stdlib CVEs flagged by osv-scanner on the operator module:
  - **CVE-2026-39822** (GO-2026-4970): root escape via symlink + trailing slash in `os`
  - **CVE-2026-42505** (GO-2026-5856): ECH privacy leak in `crypto/tls`

The CI `operator` job already uses Go 1.26.5 (`go-version: '1.26.5'` in ci.yml) so no workflow changes are needed.

## Test plan

- [ ] `operator` CI job passes (builds + tests with Go 1.26.5)
- [ ] osv-scanner alerts #93 and #94 close as fixed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)