### PR TITLE
harden: fix Scorecard workflow alerts (TokenPermissions, PinnedDeps, dependabot cooldown)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,19 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   # #478: without a gomod entry, Go dependency/toolchain-minimum drift (e.g. #477)
   # has no automated forcing function and depends on someone noticing manually.
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   - package-ecosystem: gomod
     directory: /operator
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
           govulncheck ./...
 
       - name: gosec

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
     tags: ['v*']
 
+# Lock down GITHUB_TOKEN defaults: no permissions at the top level; each job
+# below requests only what it needs (packages/id-token for image publish).
+permissions: {}
+
 env:
   # Pinned, checksum-verified (mirrors gitleaks in ci.yml) — the tool that scans
   # our images for vulnerabilities is itself a supply-chain surface.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
   push:
     tags: ['v*']
 
+# Lock down GITHUB_TOKEN defaults: no permissions at the top level; each job
+# below requests only what it needs (contents/packages/id-token for publish).
+permissions: {}
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- **release.yml, docker-publish.yml**: Add top-level `permissions: {}` to lock down GITHUB_TOKEN defaults. Each job already declares the minimum permissions it needs (`contents: write`, `packages: write`, `id-token: write`). Closes Scorecard **TokenPermissionsID** alerts #98 and #101.
- **ci.yml**: Pin `govulncheck` to `@v1.1.4` instead of `@latest`. Closes Scorecard **PinnedDependenciesID** alert #105.
- **dependabot.yml**: Add `cooldown: default-days: 7` to all three `package-ecosystem` entries. Prevents Dependabot from immediately proposing updates to newly-published package versions, providing a 7-day window for the community to detect supply-chain compromises. Closes Semgrep **dependabot-missing-cooldown** alerts #21, #22, #23.

## Test plan

- [ ] CI passes (build-and-test, lint, operator jobs)
- [ ] Release workflow syntax is valid (no top-level permissions removed from jobs)
- [ ] docker-publish workflow syntax is valid
- [ ] Scorecard re-scan shows TokenPermissionsID + PinnedDependenciesID cleared after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)