### PR TITLE
harden: fix SonarCloud findings (TOCTOU in init, automountServiceAccountToken in Helm)

### DIFF
--- a/deploy/helm/keyorix/templates/postgresql.yaml
+++ b/deploy/helm/keyorix/templates/postgresql.yaml
@@ -63,6 +63,7 @@ spec:
         {{- include "keyorix.labels" . | nindent 8 }}
         app.kubernetes.io/component: postgresql
     spec:
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/keyorix/templates/server-deployment.yaml
+++ b/deploy/helm/keyorix/templates/server-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/server-config.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/keyorix/templates/tests/test-connection.yaml
+++ b/deploy/helm/keyorix/templates/tests/test-connection.yaml
@@ -9,6 +9,7 @@ metadata:
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 spec:
   restartPolicy: Never
+  automountServiceAccountToken: false
   securityContext:
     # A plain `wget --spider` needs no elevated privileges at all -- matches the
     # same hardening baseline as the application's own containers (#helm-chart-security).

--- a/deploy/helm/keyorix/templates/web-deployment.yaml
+++ b/deploy/helm/keyorix/templates/web-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/web-config.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/internal/cli/system/init.go
+++ b/internal/cli/system/init.go
@@ -155,14 +155,15 @@ func initializeDatabase(cfg *config.Config) error {
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0750); err != nil {
 		return fmt.Errorf("failed to create database directory: %w", err)
 	}
-	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		file, err := os.OpenFile(dbPath, os.O_CREATE|os.O_WRONLY, 0600)
-		if err != nil {
-			return fmt.Errorf("failed to create database file: %w", err)
-		}
+	// O_EXCL makes the create atomic: no TOCTOU window between stat and open.
+	// If the file already exists, OpenFile returns an error we treat as "ok".
+	file, err := os.OpenFile(dbPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err == nil {
 		if cerr := file.Close(); cerr != nil {
 			return fmt.Errorf("failed to close database file: %w", cerr)
 		}
+	} else if !os.IsExist(err) {
+		return fmt.Errorf("failed to create database file: %w", err)
 	}
 	return nil
 }
@@ -186,14 +187,13 @@ func initializeLogging() error {
 	if err := os.MkdirAll(filepath.Dir(logPath), 0750); err != nil {
 		return fmt.Errorf("failed to create logging directory: %w", err)
 	}
-	if _, err := os.Stat(logPath); os.IsNotExist(err) {
-		file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY, 0600)
-		if err != nil {
-			return fmt.Errorf("failed to create log file: %w", err)
-		}
+	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err == nil {
 		if cerr := file.Close(); cerr != nil {
 			return fmt.Errorf("failed to close log file: %w", cerr)
 		}
+	} else if !os.IsExist(err) {
+		return fmt.Errorf("failed to create log file: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- **`internal/cli/system/init.go`**: Replace `os.Stat` + `os.OpenFile(O_CREATE|O_WRONLY)` TOCTOU pattern with a single atomic `os.OpenFile(O_CREATE|O_EXCL|O_WRONLY)` in both `initializeDatabase()` and `initializeLogging()`. `O_EXCL` makes the create atomic — EEXIST means the file already exists (fine), any other error is a real failure. Fixes SonarCloud MAJOR findings at lines 159 and 190.

- **Helm templates** (`server-deployment.yaml`, `web-deployment.yaml`, `postgresql.yaml`, `tests/test-connection.yaml`): Add `automountServiceAccountToken: false` to each pod spec. None of these pods need the Kubernetes API, so mounting the SA token is unnecessary attack surface. The operator deployment is intentionally excluded — it is a controller-runtime controller that needs the SA token to watch/update Kubernetes Secrets. Fixes SonarCloud MAJOR findings.

## Not fixed (false positives)

- **TLS `InsecureSkipVerify` (8 CRITICAL)**: Operator opt-in behind `cfg.InsecureSkipVerify`, annotated `#nosec G402`, already dismissed in Semgrep/Trivy/CodeQL.
- **`auth.go` "compromised secret" (BLOCKER)**: `dummyBcryptHash` is a timing-equalization dummy seeded from a constant string, not a credential.
- **`evidencesink_extra_test.go` redirect (BLOCKER)**: Test code that deliberately issues an HTTP redirect to verify `refuseRedirect()` refuses it.
- **Resource limits in Helm**: Already defined in `values.yaml` with defaults; SonarCloud cannot render Helm templates so it can't see the `{{- with .Values.*.resources }}` blocks.
- **`isolation_forest.go` math/rand**: ML algorithm requiring reproducible pseudo-randomness, not security-sensitive.

## Test plan

- [ ] CI passes (build-and-test, helm-chart, helm-chart-security, kubeconform)
- [ ] `go build ./internal/cli/...` compiles cleanly
- [ ] SonarCloud re-scan shows TOCTOU + automount findings resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)