### PR TITLE
fix(lint): suppress SA1019 on intentional chimw.RealIP usage in test

### DIFF
--- a/server/middleware/pat_cidr_bypass_test.go
+++ b/server/middleware/pat_cidr_bypass_test.go
@@ -45,7 +45,7 @@ func serveWithChain(clientIPMW func(http.Handler) http.Handler, remoteAddr strin
 // in-allowlist address (10.1.2.3) is INCORRECTLY authorized — concretely proving the
 // backlog's "very likely" claim for #302 was correct.
 func TestPATCIDRAllowlist_UnconditionalRealIP_WasBypassable(t *testing.T) {
-	status := serveWithChain(chimw.RealIP, "203.0.113.9:5555", map[string]string{
+	status := serveWithChain(chimw.RealIP, "203.0.113.9:5555", map[string]string{ //nolint:staticcheck // intentional: testing the pre-fix vulnerable behavior
 		"X-Forwarded-For": "10.1.2.3",
 	})
 	assert.Equal(t, http.StatusOK, status,


### PR DESCRIPTION
## Summary

- chi v5.3.1 (Dependabot PR #958) deprecated `chimw.RealIP`, triggering `SA1019` in lint CI
- The affected test (`TestPATCIDRAllowlist_UnconditionalRealIP_WasBypassable`) deliberately uses the deprecated middleware to prove the pre-#302 vulnerability was real — not an accidental usage
- Adds an inline `//nolint:staticcheck` directive with an explanatory comment so the intent is preserved and lint passes

## Test plan

- [ ] `lint` CI passes on this branch
- [ ] After this merges, Dependabot PR #958 can rebase on `main` and its lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)