### PR TITLE
fix(test): use fresh isolated DB for TestDeleteSoDPolicyProxy_NotFound_S11

### DIFF
--- a/server/http/handlers/handlers_s11_test.go
+++ b/server/http/handlers/handlers_s11_test.go
@@ -1502,7 +1502,7 @@ func TestListSoDPoliciesProxy_HappyPath_S11(t *testing.T) {
 // TestDeleteSoDPolicyProxy_NotFound_S11 — nonexistent policy → 404.
 func TestDeleteSoDPolicyProxy_NotFound_S11(t *testing.T) {
 	t.Parallel()
-	h := newCatalogHandlerS8(t)
+	h := NewCatalogHandler(freshCoreS11(t))
 	r := httptest.NewRequest(http.MethodDelete, "/", nil)
 	r = withChiParamS8(r, "id", "99999")
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

- `TestDeleteSoDPolicyProxy_NotFound_S11` was using `newCatalogHandlerS8` which shares the `kxhandlers_s4` in-memory SQLite DB across 100+ parallel tests
- Under CI load this produces `database table is locked: sod_policies` on the DELETE, causing the handler to return 500 instead of 404/200 and failing the assertion
- Switches to `NewCatalogHandler(freshCoreS11(t))` so the test gets its own isolated connection — the same pattern already applied to other write-path tests in this suite

## Test plan

- [ ] `build-and-test` CI passes without the locked-table failure
- [ ] After this merges, Dependabot PRs #953 and #960 can rebase and their `build-and-test` check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)