### PR TITLE
harden: fix SonarCloud S8193/S8209/S8196/S8184 and NOSONAR false positives

### DIFF
--- a/internal/audit/siem/forwarder.go
+++ b/internal/audit/siem/forwarder.go
@@ -131,7 +131,7 @@ func newForwarder(cfg Config, baseBackoff time.Duration) (*Forwarder, error) {
 	transport := &http.Transport{}
 	if cfg.InsecureSkipVerify {
 		log.Printf("WARNING: SIEM forwarder %q has TLS verification disabled (insecure_skip_verify); do not use in production", cfg.Endpoint)
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 — operator opt-in for self-signed SIEM
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 — operator opt-in for self-signed SIEM NOSONAR
 	}
 	f := &Forwarder{
 		cfg:         cfg,

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -506,7 +506,7 @@ func streamComponent(tr io.Reader, comp Component, destDir string) error {
 		removeBundleTemp(tmpPath)
 		return fmt.Errorf("%w: %s (size %d, want %d)", ErrDigestMismatch, comp.Path, n, comp.Size)
 	}
-	if got := hex.EncodeToString(h.Sum(nil)); got != comp.SHA256 {
+	if hex.EncodeToString(h.Sum(nil)) != comp.SHA256 {
 		removeBundleTemp(tmpPath)
 		return fmt.Errorf("%w: %s", ErrDigestMismatch, comp.Path)
 	}

--- a/internal/cli/secret/explain.go
+++ b/internal/cli/secret/explain.go
@@ -55,7 +55,7 @@ var explanations = []secretExplanation{
 		Example: "AWS_SECRET_ACCESS_KEY=os.getenv(\"AWS_SECRET_ACCESS_KEY\")",
 	},
 	{
-		KeyPattern:  "db_password",
+		KeyPattern:  "db_password", // NOSONAR
 		RiskLevel:   "HIGH",
 		RiskSummary: "Database password hardcoded in source code or config file",
 		Impact:      "Direct database access. An attacker can read, modify, or delete all data. Often reused across environments.",

--- a/internal/connect/awssm.go
+++ b/internal/connect/awssm.go
@@ -15,9 +15,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 )
 
-// smGetAPI is the slice of the Secrets Manager client the connector uses — an
+// smSecretGetter is the slice of the Secrets Manager client the connector uses — an
 // interface seam so it is unit-tested with a fake and the SDK stays contained here.
-type smGetAPI interface {
+type smSecretGetter interface {
 	GetSecretValue(ctx context.Context, in *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
 }
 
@@ -28,7 +28,7 @@ type AWSSecretsManagerConnector struct {
 	allowedRefs []string
 	// newClient builds an SM client for the region; nil uses the real AWS client
 	// (the standard credential chain). Tests inject a fake.
-	newClient func(ctx context.Context, region string) (smGetAPI, error)
+	newClient func(ctx context.Context, region string) (smSecretGetter, error)
 }
 
 // NewAWSSecretsManagerConnector builds an AWS Secrets Manager connector. allowedRefs,
@@ -41,7 +41,7 @@ func NewAWSSecretsManagerConnector(name, region string, allowedRefs []string) *A
 func (c *AWSSecretsManagerConnector) Name() string { return c.name }
 func (c *AWSSecretsManagerConnector) Type() string { return "aws-secrets-manager" }
 
-func (c *AWSSecretsManagerConnector) client(ctx context.Context) (smGetAPI, error) {
+func (c *AWSSecretsManagerConnector) client(ctx context.Context) (smSecretGetter, error) {
 	if c.newClient != nil {
 		return c.newClient(ctx, c.region)
 	}

--- a/internal/connect/awssm_test.go
+++ b/internal/connect/awssm_test.go
@@ -25,7 +25,7 @@ func (f *fakeSM) GetSecretValue(_ context.Context, in *secretsmanager.GetSecretV
 
 func connectorWith(name string, fake *fakeSM) *AWSSecretsManagerConnector {
 	c := NewAWSSecretsManagerConnector(name, "eu-west-1", nil)
-	c.newClient = func(_ context.Context, _ string) (smGetAPI, error) { return fake, nil }
+	c.newClient = func(_ context.Context, _ string) (smSecretGetter, error) { return fake, nil }
 	return c
 }
 
@@ -38,7 +38,7 @@ func TestAWSSM_TypeAndName(t *testing.T) {
 func TestAWSSM_AllowedRefsGuardrail(t *testing.T) {
 	fake := &fakeSM{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String("ok")}}
 	c := NewAWSSecretsManagerConnector("aws", "eu-west-1", []string{"keyorix/", "shared/"})
-	c.newClient = func(_ context.Context, _ string) (smGetAPI, error) { return fake, nil }
+	c.newClient = func(_ context.Context, _ string) (smSecretGetter, error) { return fake, nil }
 
 	// A ref matching an allowed prefix passes.
 	val, err := c.GetSecret(context.Background(), "keyorix/prod/db")

--- a/internal/connect/azurekv.go
+++ b/internal/connect/azurekv.go
@@ -15,9 +15,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 )
 
-// azKVGetAPI is the slice of the Key Vault secrets client the connector uses — an
+// azSecretGetter is the slice of the Key Vault secrets client the connector uses — an
 // interface seam so it is unit-tested with a fake and the SDK stays contained here.
-type azKVGetAPI interface {
+type azSecretGetter interface {
 	GetSecret(ctx context.Context, name, version string, options *azsecrets.GetSecretOptions) (azsecrets.GetSecretResponse, error)
 }
 
@@ -28,7 +28,7 @@ type AzureKeyVaultConnector struct {
 	allowedRefs []string
 	// newClient builds a Key Vault client for vaultURL; nil uses the real client with
 	// DefaultAzureCredential. Tests inject a fake.
-	newClient func(ctx context.Context) (azKVGetAPI, error)
+	newClient func(ctx context.Context) (azSecretGetter, error)
 }
 
 // NewAzureKeyVaultConnector builds an Azure Key Vault connector. vaultURL is the vault
@@ -42,7 +42,7 @@ func NewAzureKeyVaultConnector(name, vaultURL string, allowedRefs []string) *Azu
 func (c *AzureKeyVaultConnector) Name() string { return c.name }
 func (c *AzureKeyVaultConnector) Type() string { return "azure-key-vault" }
 
-func (c *AzureKeyVaultConnector) client(ctx context.Context) (azKVGetAPI, error) {
+func (c *AzureKeyVaultConnector) client(ctx context.Context) (azSecretGetter, error) {
 	if c.newClient != nil {
 		return c.newClient(ctx)
 	}

--- a/internal/connect/azurekv_test.go
+++ b/internal/connect/azurekv_test.go
@@ -30,7 +30,7 @@ func (f *fakeAzKV) GetSecret(_ context.Context, name, version string, _ *azsecre
 
 func azKVConnectorWith(name, vaultURL string, fake *fakeAzKV, allowed ...string) *AzureKeyVaultConnector {
 	c := NewAzureKeyVaultConnector(name, vaultURL, allowed)
-	c.newClient = func(_ context.Context) (azKVGetAPI, error) { return fake, nil }
+	c.newClient = func(_ context.Context) (azSecretGetter, error) { return fake, nil }
 	return c
 }
 

--- a/internal/core/audit_context.go
+++ b/internal/core/audit_context.go
@@ -66,7 +66,7 @@ func impersonatorFromContext(ctx context.Context) (uint, bool) {
 // impersonation tag from parent. Audit writes run in goroutines that must
 // outlive the request, but still need to record the impersonating admin.
 func DetachedAuditContext(parent context.Context) context.Context {
-	ctx := context.Background()
+	ctx := context.Background() // NOSONAR
 	if adminID, ok := impersonatorFromContext(parent); ok {
 		ctx = WithImpersonation(ctx, adminID)
 	}

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -41,7 +41,7 @@ type LoginRequest struct {
 // dummyBcryptHash is a fixed bcrypt hash (DefaultCost) used to equalize the timing of
 // the user-not-found login path with the wrong-password path, so /auth/login can't be
 // used as a username-existence oracle. Computed once at package load.
-var dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), bcrypt.DefaultCost)
+var dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), bcrypt.DefaultCost) // NOSONAR -- not a credential; this is a timing-equalization sentinel to prevent username-existence oracle attacks
 
 // RemoteLoginVerifier is implemented by storage backends that cannot themselves
 // supply a real password hash for VerifyPasswordCredentials to compare against

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -486,7 +486,7 @@ func (c *KeyorixCore) RevokeLeasesForConfig(ctx context.Context, configID, userI
 		if l.Status != "active" && l.Status != "revoke_failed" {
 			continue
 		}
-		if rerr := c.RevokeLease(ctx, l.LeaseID, userID, reason); rerr != nil {
+		if c.RevokeLease(ctx, l.LeaseID, userID, reason) != nil {
 			failed++
 		} else {
 			revoked++

--- a/internal/core/isolation_forest.go
+++ b/internal/core/isolation_forest.go
@@ -96,7 +96,7 @@ func subsample(data [][]float64, k int, rng *rand.Rand) [][]float64 {
 		k = n
 	}
 	for i := 0; i < k; i++ {
-		j := i + rng.Intn(n-i)
+		j := i + rng.Intn(n-i) // NOSONAR -- PRNG intentional for isolation forest ML algorithm
 		idx[i], idx[j] = idx[j], idx[i]
 	}
 	out := make([][]float64, k)
@@ -121,7 +121,7 @@ func buildITree(samples [][]float64, depth, heightLimit int, rng *rand.Rand) *iT
 	if !ok {
 		return &iTreeNode{external: true, size: len(samples)}
 	}
-	split := minV + rng.Float64()*(maxV-minV)
+	split := minV + rng.Float64()*(maxV-minV) // NOSONAR -- PRNG intentional for isolation forest ML algorithm
 
 	left := make([][]float64, 0, len(samples))
 	right := make([][]float64, 0, len(samples))
@@ -169,7 +169,7 @@ func pickSplitFeature(samples [][]float64, rng *rand.Rand) (feat int, minV, maxV
 	if len(varying) == 0 {
 		return 0, 0, 0, false
 	}
-	feat = varying[rng.Intn(len(varying))]
+	feat = varying[rng.Intn(len(varying))] // NOSONAR -- PRNG intentional for isolation forest ML algorithm
 	return feat, ranges[feat].lo, ranges[feat].hi, true
 }
 

--- a/internal/core/isolation_forest_test.go
+++ b/internal/core/isolation_forest_test.go
@@ -66,10 +66,10 @@ func TestIsolationForestDeterministic(t *testing.T) {
 }
 
 func TestIsolationForestTooLittleData(t *testing.T) {
-	if f := newIsolationForest([][]float64{{1, 2, 3}}, 100, 256, rand.New(rand.NewSource(1))); f != nil {
+	if newIsolationForest([][]float64{{1, 2, 3}}, 100, 256, rand.New(rand.NewSource(1))) != nil {
 		t.Fatal("a single-row dataset should yield no forest")
 	}
-	if f := newIsolationForest(nil, 100, 256, rand.New(rand.NewSource(1))); f != nil {
+	if newIsolationForest(nil, 100, 256, rand.New(rand.NewSource(1))) != nil {
 		t.Fatal("empty data should yield no forest")
 	}
 }

--- a/internal/core/rate_limit.go
+++ b/internal/core/rate_limit.go
@@ -102,7 +102,7 @@ func (c *KeyorixCore) PruneLoginAttempts(ctx context.Context) (int64, error) {
 // rate-limiting of any kind before this; composing the key this way (rather
 // than a second table/migration) matches the codebase's existing convention
 // for "per-IP request budget" and needs no schema change.
-const passwordResetRateLimitPrefix = "pwreset:"
+const passwordResetRateLimitPrefix = "pwreset:" // NOSONAR
 
 const (
 	// PasswordResetMaxAttempts is the request budget per IP within

--- a/internal/dynamic/awssts.go
+++ b/internal/dynamic/awssts.go
@@ -45,9 +45,9 @@ import (
 // stsMinDurationSeconds is the AWS AssumeRole minimum (15 minutes).
 const stsMinDurationSeconds int32 = 900
 
-// stsAssumeAPI is the slice of the STS client the engine uses — an interface seam so
+// stsRoleAssumer is the slice of the STS client the engine uses — an interface seam so
 // the engine is unit-tested with a fake and the SDK stays contained here.
-type stsAssumeAPI interface {
+type stsRoleAssumer interface {
 	AssumeRole(ctx context.Context, in *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
 }
 
@@ -55,7 +55,7 @@ type stsAssumeAPI interface {
 type AWSSTSEngine struct {
 	// newClient builds an STS client for a region; nil uses the real AWS client
 	// (the standard credential chain). Tests inject a fake.
-	newClient func(ctx context.Context, region string) (stsAssumeAPI, error)
+	newClient func(ctx context.Context, region string) (stsRoleAssumer, error)
 }
 
 func (e *AWSSTSEngine) BackendType() string        { return "aws-sts" }
@@ -69,7 +69,7 @@ type awsSTSConfig struct {
 	DurationSeconds int32  `json:"duration_seconds,omitempty"`
 }
 
-func (e *AWSSTSEngine) client(ctx context.Context, region string) (stsAssumeAPI, error) {
+func (e *AWSSTSEngine) client(ctx context.Context, region string) (stsRoleAssumer, error) {
 	if e.newClient != nil {
 		return e.newClient(ctx, region)
 	}

--- a/internal/dynamic/awssts_test.go
+++ b/internal/dynamic/awssts_test.go
@@ -25,7 +25,7 @@ func (f *fakeSTS) AssumeRole(_ context.Context, in *sts.AssumeRoleInput, _ ...fu
 }
 
 func newFakeSTSEngine(fake *fakeSTS) *AWSSTSEngine {
-	return &AWSSTSEngine{newClient: func(_ context.Context, _ string) (stsAssumeAPI, error) { return fake, nil }}
+	return &AWSSTSEngine{newClient: func(_ context.Context, _ string) (stsRoleAssumer, error) { return fake, nil }}
 }
 
 func TestAWSSTSEngine_Issue(t *testing.T) {

--- a/internal/dynamic/dynamic_s3_test.go
+++ b/internal/dynamic/dynamic_s3_test.go
@@ -331,7 +331,7 @@ func TestAWSSTSEngine_Issue_ExternalID(t *testing.T) {
 
 func TestAWSSTSEngine_Issue_ClientError(t *testing.T) {
 	eng := &AWSSTSEngine{
-		newClient: func(_ context.Context, _ string) (stsAssumeAPI, error) {
+		newClient: func(_ context.Context, _ string) (stsRoleAssumer, error) {
 			return nil, fmt.Errorf("cannot build STS client")
 		},
 	}

--- a/internal/encryption/auth_encryption.go
+++ b/internal/encryption/auth_encryption.go
@@ -58,7 +58,7 @@ func (ae *AuthEncryption) GetAuthEncryptionStatus() map[string]interface{} {
 }
 
 // ValidateEncryptedToken decrypts storedToken and compares to plainToken using constant-time compare.
-func (ae *AuthEncryption) ValidateEncryptedToken(encryptedToken []byte, metadata []byte, plainToken string) (bool, error) {
+func (ae *AuthEncryption) ValidateEncryptedToken(encryptedToken, metadata []byte, plainToken string) (bool, error) {
 	storedToken, err := ae.DecryptSessionToken(encryptedToken, metadata)
 	if err != nil {
 		return false, fmt.Errorf("failed to decrypt stored token: %w", err)
@@ -79,7 +79,7 @@ func (ae *AuthEncryption) EncryptClientSecret(plainSecret string) ([]byte, []byt
 }
 
 // DecryptClientSecret decrypts an API client secret.
-func (ae *AuthEncryption) DecryptClientSecret(encryptedData []byte, metadata []byte) (string, error) {
+func (ae *AuthEncryption) DecryptClientSecret(encryptedData, metadata []byte) (string, error) {
 	if !ae.service.IsEnabled() {
 		return string(encryptedData), nil
 	}
@@ -103,7 +103,7 @@ func (ae *AuthEncryption) EncryptSessionToken(plainToken string) ([]byte, []byte
 }
 
 // DecryptSessionToken decrypts a session token.
-func (ae *AuthEncryption) DecryptSessionToken(encryptedData []byte, metadata []byte) (string, error) {
+func (ae *AuthEncryption) DecryptSessionToken(encryptedData, metadata []byte) (string, error) {
 	if !ae.service.IsEnabled() {
 		return string(encryptedData), nil
 	}
@@ -127,7 +127,7 @@ func (ae *AuthEncryption) EncryptAPIToken(plainToken string) ([]byte, []byte, er
 }
 
 // DecryptAPIToken decrypts an API token.
-func (ae *AuthEncryption) DecryptAPIToken(encryptedData []byte, metadata []byte) (string, error) {
+func (ae *AuthEncryption) DecryptAPIToken(encryptedData, metadata []byte) (string, error) {
 	if !ae.service.IsEnabled() {
 		return string(encryptedData), nil
 	}
@@ -151,7 +151,7 @@ func (ae *AuthEncryption) EncryptPasswordResetToken(plainToken string) ([]byte, 
 }
 
 // DecryptPasswordResetToken decrypts a password reset token.
-func (ae *AuthEncryption) DecryptPasswordResetToken(encryptedData []byte, metadata []byte) (string, error) {
+func (ae *AuthEncryption) DecryptPasswordResetToken(encryptedData, metadata []byte) (string, error) {
 	if !ae.service.IsEnabled() {
 		return string(encryptedData), nil
 	}

--- a/internal/encryption/service_rotation.go
+++ b/internal/encryption/service_rotation.go
@@ -47,7 +47,7 @@ func (s *Service) RotateDEKWithSweep(passphrase string, db *gorm.DB) (*SweepResu
 			return fmt.Errorf("failed to begin transaction: %w", tx.Error)
 		}
 		defer func() {
-			if r := recover(); r != nil {
+			if recover() != nil {
 				tx.Rollback()
 			}
 		}()
@@ -119,7 +119,7 @@ func (s *Service) PreviewRotationSweep(db *gorm.DB) (*SweepResult, error) {
 	// Always rolled back — a dry run must never persist anything, no matter what.
 	defer tx.Rollback()
 	defer func() {
-		if r := recover(); r != nil {
+		if recover() != nil {
 			tx.Rollback()
 		}
 	}()
@@ -160,7 +160,7 @@ func (s *Service) UpgradeAuthAAD(db *gorm.DB) (*SweepResult, error) {
 		return nil, fmt.Errorf("failed to begin transaction: %w", tx.Error)
 	}
 	defer func() {
-		if r := recover(); r != nil {
+		if recover() != nil {
 			tx.Rollback()
 		}
 	}()

--- a/internal/evidencesink/webhook.go
+++ b/internal/evidencesink/webhook.go
@@ -66,7 +66,7 @@ func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*Webhook, error) 
 	transport := &http.Transport{}
 	if cfg.InsecureSkipVerify {
 		log.Printf("WARNING: evidencesink webhook %q has TLS verification disabled (insecure_skip_verify); do not use in production", cfg.Endpoint)
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints NOSONAR
 	}
 	return &Webhook{cfg: cfg, client: &http.Client{Timeout: webhookTimeout, Transport: transport, CheckRedirect: refuseRedirect}, baseBackoff: baseBackoff}, nil
 }

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -73,7 +73,7 @@ func TestGetLocalizer(t *testing.T) {
 
 	// Test panic when not initialized
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Error("GetLocalizer() should panic when not initialized")
 		}
 	}()
@@ -205,7 +205,7 @@ func TestMustLocalize(t *testing.T) {
 
 	t.Run("non-existing message panics", func(t *testing.T) {
 		defer func() {
-			if r := recover(); r == nil {
+			if recover() == nil {
 				t.Error("MustLocalize() should panic for non-existing message")
 			}
 		}()
@@ -302,7 +302,7 @@ func TestMustTFunction(t *testing.T) {
 
 	t.Run("non-existing message panics", func(t *testing.T) {
 		defer func() {
-			if r := recover(); r == nil {
+			if recover() == nil {
 				t.Error("MustT() should panic for non-existing message")
 			}
 		}()

--- a/internal/notifychan/webhook.go
+++ b/internal/notifychan/webhook.go
@@ -74,7 +74,7 @@ func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*WebhookSink, err
 	transport := &http.Transport{}
 	if cfg.InsecureSkipVerify {
 		log.Printf("WARNING: notifychan webhook %q has TLS verification disabled (insecure_skip_verify); do not use in production", cfg.Endpoint)
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- opt-in for self-signed endpoints NOSONAR
 	}
 	s := &WebhookSink{
 		cfg:    cfg,

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -84,8 +84,8 @@ func (ls *LocalStorage) CreateShareRecord(ctx context.Context, share *models.Sha
 		// updating the row that won the race, preserving CreateShareRecord's upsert
 		// contract instead of surfacing a raw constraint error to the caller.
 		if isUniqueConstraintErr(err) {
-			if rerr := ls.db.Where("secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL",
-				share.SecretID, share.RecipientID, share.IsGroup).First(&existing).Error; rerr == nil {
+			if ls.db.Where("secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL",
+				share.SecretID, share.RecipientID, share.IsGroup).First(&existing).Error == nil {
 				existing.Permission = share.Permission
 				existing.UpdatedAt = time.Now()
 				if serr := ls.db.Save(&existing).Error; serr != nil {

--- a/internal/storage/store/remote_scheduler_lock.go
+++ b/internal/storage/store/remote_scheduler_lock.go
@@ -64,7 +64,7 @@ func (rs *RemoteStorage) WithSchedulerLock(ctx context.Context, key int64, fn fu
 		return false, nil
 	}
 
-	heartbeatCtx, stopHeartbeat := context.WithCancel(context.Background())
+	heartbeatCtx, stopHeartbeat := context.WithCancel(context.Background()) // NOSONAR
 	heartbeatDone := make(chan struct{})
 	go func() {
 		defer close(heartbeatDone)

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "github.com/mattn/go-sqlite3" // registers the sqlite3 driver with database/sql
 )
 
 // openTestDB opens a fresh, file-backed (not shared in-memory) SQLite

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -165,7 +165,7 @@ func blockedUnderImpersonation(fullMethod string) bool {
 // wrappedServerStream wraps grpc.ServerStream to override context
 type wrappedServerStream struct {
 	grpc.ServerStream
-	ctx context.Context
+	ctx context.Context // NOSONAR
 }
 
 func (w *wrappedServerStream) Context() context.Context {

--- a/server/http/handlers/secrets_copy.go
+++ b/server/http/handlers/secrets_copy.go
@@ -66,7 +66,7 @@ func (h *SecretHandler) CopySecret(w http.ResponseWriter, r *http.Request) {
 		case strings.Contains(msg, "permission") || strings.Contains(msg, "not authorized"):
 			status = http.StatusForbidden
 		default:
-			log.Printf("Error copying secret %d to environment %d: %v", id, reqBody.EnvironmentID, err)
+			log.Printf("Error copying secret %d to environment %d: %v", id, reqBody.EnvironmentID, err) // NOSONAR
 			msg = clientSafe(err)
 		}
 		h.sendError(w, "Error", msg, status, nil)

--- a/server/http/handlers/secrets_copy_environment.go
+++ b/server/http/handlers/secrets_copy_environment.go
@@ -52,7 +52,7 @@ func (h *SecretHandler) CopyEnvironmentSecrets(w http.ResponseWriter, r *http.Re
 		if strings.Contains(msg, "must ") || strings.Contains(msg, "required") || strings.Contains(msg, "belong") || strings.Contains(msg, "validation") {
 			status = http.StatusBadRequest
 		} else {
-			log.Printf("Error copying secrets from environment %d to %d (project %d): %v", sourceEnvID, reqBody.TargetEnvironmentID, projectID, err)
+			log.Printf("Error copying secrets from environment %d to %d (project %d): %v", sourceEnvID, reqBody.TargetEnvironmentID, projectID, err) // NOSONAR
 			msg = clientSafe(err)
 		}
 		h.sendError(w, "Error", msg, status, nil)

--- a/server/http/handlers/swagger.go
+++ b/server/http/handlers/swagger.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	_ "embed"
+	_ "embed" // required for //go:embed directives in this file
 	"net/http"
 	"strings"
 )

--- a/server/main.go
+++ b/server/main.go
@@ -1349,7 +1349,7 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error {
 	<-ctx.Done()
 
 	// Graceful shutdown
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second) // NOSONAR
 	defer cancel()
 
 	log.Println("Shutting down HTTP server...")
@@ -1607,9 +1607,9 @@ func buildAutoCertTLSConfig(domains []string, tlsCfg config.TLSConfig) (*tls.Con
 
 // resolveOutboundIP returns the machine's preferred outbound IP address.
 func resolveOutboundIP() string {
-	conn, err := net.Dial("udp", "8.8.8.8:80")
+	conn, err := net.Dial("udp", "8.8.8.8:80") // NOSONAR -- well-known UDP probe target; no data is sent, used only to resolve the local outbound interface
 	if err != nil {
-		return "127.0.0.1"
+		return "127.0.0.1" // NOSONAR -- default bind address, not sensitive
 	}
 	defer conn.Close() //nolint:errcheck
 	return conn.LocalAddr().(*net.UDPAddr).IP.String()

--- a/server/middleware/session_cookie.go
+++ b/server/middleware/session_cookie.go
@@ -52,13 +52,13 @@ func SetSessionCookie(w http.ResponseWriter, token string, expiresAt *time.Time,
 	if expiresAt != nil {
 		cookie.Expires = *expiresAt
 	}
-	http.SetCookie(w, cookie)
+	http.SetCookie(w, cookie) // NOSONAR -- Secure flag comes from runtime TLS config
 }
 
 // ClearSessionCookie expires the session cookie immediately (logout, or the
 // gone-original-session case when ending impersonation).
 func ClearSessionCookie(w http.ResponseWriter, secure bool) {
-	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure is threaded from cfg.Server.HTTP.TLS.Enabled; hardcoding true would break local HTTP dev
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure is threaded from cfg.Server.HTTP.TLS.Enabled; hardcoding true would break local HTTP dev NOSONAR
 		Name:     SessionCookieName,
 		Value:    "",
 		Path:     "/",
@@ -75,7 +75,7 @@ func ClearSessionCookie(w http.ResponseWriter, secure bool) {
 // custom header on a request to this origin (no third-party origin is
 // allowlisted by this app's CORS config), not from the cookie being secret.
 func SetCSRFCookie(w http.ResponseWriter, token string, secure bool) {
-	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- HttpOnly:false is intentional (double-submit pattern requires JS to read it); Secure is threaded from cfg.Server.HTTP.TLS.Enabled
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- HttpOnly:false is intentional (double-submit pattern requires JS to read it); Secure is threaded from cfg.Server.HTTP.TLS.Enabled NOSONAR
 		Name:     CSRFCookieName,
 		Value:    token,
 		Path:     "/",
@@ -87,7 +87,7 @@ func SetCSRFCookie(w http.ResponseWriter, token string, secure bool) {
 
 // ClearCSRFCookie expires the CSRF cookie (logout).
 func ClearCSRFCookie(w http.ResponseWriter, secure bool) {
-	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- HttpOnly:false is intentional (double-submit pattern requires JS to read it); Secure is threaded from cfg.Server.HTTP.TLS.Enabled
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- HttpOnly:false is intentional (double-submit pattern requires JS to read it); Secure is threaded from cfg.Server.HTTP.TLS.Enabled NOSONAR
 		Name:     CSRFCookieName,
 		Value:    "",
 		Path:     "/",


### PR DESCRIPTION
## Summary

- **S8193** – Remove unnecessary `if r := recover(); ...` init variables in 6 files (service_rotation, bundle, dynamic_secrets, local_sharing, isolation_forest_test, i18n_test)
- **S8209** – Group consecutive `[]byte` params in `auth_encryption.go` (`DecryptClientSecret`, `DecryptSessionToken`, `DecryptAPIToken`)
- **S8196** – Rename single-method interfaces to the Go `-er` convention: `azSecretGetter`, `smSecretGetter`, `stsRoleAssumer`; update 4 test mocks
- **S8184** – Add explanatory comments to blank `_ "embed"` imports in `migrations_test.go` and `swagger.go`
- **NOSONAR suppressions** for confirmed false positives: S2092/S3330 (cookie flags driven by runtime TLS config), S4830/S5527 (operator-configured InsecureSkipVerify), S5145 (integer IDs in logs), S8239 (intentional detached/shutdown/heartbeat contexts), S8242 (gRPC interface struct field), S2245 (intentional PRNG for ML), S2068/S6437 (password/secret variable names), S1313 (loopback default and UDP probe)

## Test plan

- [ ] `build-and-test` CI passes
- [ ] `lint` CI passes
- [ ] `gitleaks` CI passes
- [ ] SonarCloud shows reduced issues for the addressed rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)