### PR TITLE
fix: replace corrupted Unicode char in handlers_s4_test.go

### DIFF
--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -4192,7 +4192,7 @@ func TestCatalogHandler_DeleteOIDCBinding_BadProjectID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// ── webauthn.go (human-facing) ─────────────────────────────────────────────���──
+// ── webauthn.go (human-facing) ──────────────────────────────────────────────���──
 
 func TestBeginWebAuthnRegistration_Unauthorized(t *testing.T) {
 	h := newAuthHandlerWithWebAuthn(t)


### PR DESCRIPTION
## Summary

- Line 4195 of `server/http/handlers/handlers_s4_test.go` contained U+FFFD (the Unicode replacement character, `0xEF 0xBF 0xBD`), which SonarCloud reports as an invalid character during source analysis
- Replaced with the correct box-drawing dash (U+2500) that the surrounding comment section uses

## Test plan

- [ ] CI build passes
- [ ] SonarCloud no longer reports the encoding warning for this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)