### PR TITLE
fix(ci): suppress Semgrep false positive on SONAR_TOKEN secret reference

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Analyze with SonarCloud
         uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # nosemgrep: generic.secrets.security.detected-sonarqube-docs-api-key
         with:
           args: >
             -Dsonar.projectKey=keyorixhq_keyorix


### PR DESCRIPTION
## Summary

- Semgrep finding #119 flags `SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}` as a "SonarQube Docs API Key detected"
- This is a false positive: `${{ secrets.SONAR_TOKEN }}` is a GitHub Actions secret reference, not a hardcoded credential
- Added `# nosemgrep: generic.secrets.security.detected-sonarqube-docs-api-key` inline directive to suppress the rule at this line

## Test plan
- [ ] Semgrep scan no longer reports finding #119 on `sonarcloud.yml`
- [ ] SonarCloud analysis workflow continues to function (the comment is in YAML, not passed to the action)

🤖 Generated with [Claude Code](https://claude.ai/code)