### PR TITLE
harden: replace sentinel error == comparisons with errors.Is (go:S1065)

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -367,7 +367,7 @@ func streamBundleComponents(tr *tar.Reader, pinned map[string]Component, dest st
 	seen := make(map[string]bool, len(pinned))
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/crypto/exec_provider.go
+++ b/internal/crypto/exec_provider.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -109,7 +110,7 @@ func (p *ExecKeyProvider) KEK() ([]byte, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return nil, fmt.Errorf("exec key provider: command %q timed out after %s", p.command[0], execKeyTimeout)
 		}
 		// stderr can carry the helper's own diagnostic, but may also echo the

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -11,6 +11,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -50,7 +51,7 @@ func (ls *LocalStorage) CreateRole(ctx context.Context, role *models.Role) (*mod
 func (ls *LocalStorage) GetRole(ctx context.Context, id uint) (*models.Role, error) {
 	var role models.Role
 	if err := ls.db.WithContext(ctx).First(&role, id).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("%s", i18n.T("ErrorRoleNotFound", nil))
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -61,7 +62,7 @@ func (ls *LocalStorage) GetRole(ctx context.Context, id uint) (*models.Role, err
 func (ls *LocalStorage) GetRoleByName(ctx context.Context, name string) (*models.Role, error) {
 	var role models.Role
 	if err := ls.db.WithContext(ctx).Where("name = ?", name).First(&role).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("%s", i18n.T("ErrorRoleNotFound", nil))
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -536,7 +537,7 @@ func (ls *LocalStorage) ListPermissions(ctx context.Context) ([]*models.Permissi
 func (ls *LocalStorage) GetPermission(ctx context.Context, id uint) (*models.Permission, error) {
 	var permission models.Permission
 	if err := ls.db.WithContext(ctx).First(&permission, id).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/internal/storage/store/local_rotation_policies.go
+++ b/internal/storage/store/local_rotation_policies.go
@@ -9,6 +9,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -22,7 +23,7 @@ func (ls *LocalStorage) CreateRotationPolicy(ctx context.Context, p *models.Rota
 func (ls *LocalStorage) GetRotationPolicy(ctx context.Context, id uint) (*models.RotationPolicy, error) {
 	var policy models.RotationPolicy
 	if err := ls.db.WithContext(ctx).First(&policy, id).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("rotation policy not found")
 		}
 		return nil, fmt.Errorf("failed to get rotation policy: %w", err)

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -12,6 +12,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -134,7 +135,7 @@ func (ls *LocalStorage) ListProjectsWithCounts(ctx context.Context, includeDelet
 func (ls *LocalStorage) GetProject(ctx context.Context, id uint) (*models.Project, error) {
 	var project models.Project
 	if err := ls.db.WithContext(ctx).First(&project, id).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("project not found")
 		}
 		return nil, fmt.Errorf("failed to get project: %w", err)
@@ -339,7 +340,7 @@ func (ls *LocalStorage) ListEnvironmentsByProjectIncludingDeleted(ctx context.Co
 func (ls *LocalStorage) GetEnvironment(ctx context.Context, id uint) (*models.Environment, error) {
 	var env models.Environment
 	if err := ls.db.WithContext(ctx).First(&env, id).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("environment not found")
 		}
 		return nil, fmt.Errorf("failed to get environment: %w", err)
@@ -408,7 +409,7 @@ func (ls *LocalStorage) CreateSecret(ctx context.Context, secret *models.SecretN
 func (ls *LocalStorage) GetSecret(ctx context.Context, id uint) (*models.SecretNode, error) {
 	var secret models.SecretNode
 	if err := ls.db.WithContext(ctx).First(&secret, id).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("%s", i18n.T("ErrorSecretNotFound", nil))
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -440,7 +441,7 @@ func (ls *LocalStorage) GetSecretByName(ctx context.Context, name string, projec
 		name, projectID, environmentID,
 	).First(&secret).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("%s", i18n.T("ErrorSecretNotFound", nil))
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -804,7 +805,7 @@ func (ls *LocalStorage) GetSecretVersions(ctx context.Context, secretID uint) ([
 func (ls *LocalStorage) GetLatestSecretVersion(ctx context.Context, secretID uint) (*models.SecretVersion, error) {
 	var version models.SecretVersion
 	if err := ls.db.WithContext(ctx).Where("secret_node_id = ?", secretID).Order("version_number DESC").First(&version).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("%s", i18n.T("ErrorVersionNotFound", nil))
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -12,6 +12,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -106,7 +107,7 @@ func (ls *LocalStorage) CreateUserWithRoleGrants(ctx context.Context, user *mode
 func (ls *LocalStorage) GetUser(ctx context.Context, id uint) (*models.User, error) {
 	var user models.User
 	if err := ls.db.WithContext(ctx).First(&user, id).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			// Wrap the typed sentinel so callers can distinguish "absent" from a
 			// transient failure (e.g. ownership-transfer recovery must fail closed).
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
@@ -128,7 +129,7 @@ func (ls *LocalStorage) LockUserForUpdate(ctx context.Context, id uint) (*models
 	}
 	var user models.User
 	if err := q.First(&user, id).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -143,7 +144,7 @@ func (ls *LocalStorage) GetUserByEmail(ctx context.Context, email string) (*mode
 	// evaded by case (Bob@x vs bob@x), minting a duplicate identity. LOWER() on both
 	// sides matches regardless of stored casing (covers legacy mixed-case rows).
 	if err := ls.db.WithContext(ctx).Where("LOWER(email) = LOWER(?)", email).First(&user).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			// Wrap the typed sentinel (matching GetUser/LockUserForUpdate, #504) so
 			// callers can detect "genuinely absent" via
 			// errors.Is/storage.IsUserNotFound instead of matching this i18n text,
@@ -158,7 +159,7 @@ func (ls *LocalStorage) GetUserByEmail(ctx context.Context, email string) (*mode
 func (ls *LocalStorage) GetUserByUsername(ctx context.Context, username string) (*models.User, error) {
 	var user models.User
 	if err := ls.db.WithContext(ctx).Where("username = ?", username).First(&user).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -169,7 +170,7 @@ func (ls *LocalStorage) GetUserByUsername(ctx context.Context, username string) 
 func (ls *LocalStorage) GetUserByExternalID(ctx context.Context, externalID string) (*models.User, error) {
 	var user models.User
 	if err := ls.db.WithContext(ctx).Where("external_id = ?", externalID).First(&user).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -368,7 +369,7 @@ func (ls *LocalStorage) CreateGroup(ctx context.Context, group *models.Group) (*
 func (ls *LocalStorage) GetGroup(ctx context.Context, id uint) (*models.Group, error) {
 	var group models.Group
 	if err := ls.db.WithContext(ctx).First(&group, id).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("%s", i18n.T("ErrorGroupNotFound", nil))
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)


### PR DESCRIPTION
## Summary

- Replaces 16 direct `== gorm.ErrRecordNotFound` comparisons with `errors.Is()` in storage layer (`local_rbac.go`, `local_rotation_policies.go`, `local_users.go`, `local_secrets.go`)
- Replaces `err == io.EOF` with `errors.Is(err, io.EOF)` in `internal/bundle/bundle.go`
- Replaces `ctx.Err() == context.DeadlineExceeded` with `errors.Is(ctx.Err(), context.DeadlineExceeded)` in `internal/crypto/exec_provider.go`
- Adds `"errors"` import to 5 files that were missing it

Fixes SonarCloud go:S1065 — sentinel error comparisons should use `errors.Is()` to correctly handle wrapped errors.

## Test plan

- [ ] `go build ./internal/storage/store/ ./internal/bundle/ ./internal/crypto/` passes
- [ ] CI build-and-test passes
- [ ] No logic changes — only comparison form changed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)