### PR TITLE
harden: suppress remaining SonarCloud false positives (S2092, S8239, S5146, S8242)

### DIFF
--- a/internal/evidencesink/evidencesink_extra_test.go
+++ b/internal/evidencesink/evidencesink_extra_test.go
@@ -25,7 +25,7 @@ func TestWebhook_RefuseRedirect_CrossHost(t *testing.T) {
 			// tweaked hostname to look like a cross-host redirect — we can't actually
 			// route to a different host in a unit test, but the CheckRedirect fires
 			// before the connection is established).
-			http.Redirect(w, r, "http://evil.example.com/steal", http.StatusFound)
+			http.Redirect(w, r, "http://evil.example.com/steal", http.StatusFound) // NOSONAR -- test server intentionally redirects to evil host to verify refuseRedirect refuses it; gosecurity:S5146 false positive
 			return
 		}
 		w.WriteHeader(http.StatusOK)

--- a/internal/storage/store/remote_scheduler_lock.go
+++ b/internal/storage/store/remote_scheduler_lock.go
@@ -85,7 +85,7 @@ func (rs *RemoteStorage) WithSchedulerLock(ctx context.Context, key int64, fn fu
 		stopHeartbeat()
 		<-heartbeatDone
 		// Best-effort: see the doc comment above for why this must not fail the tick.
-		if err := rs.ReleaseSchedulerLock(context.Background(), key, holder); err != nil {
+		if err := rs.ReleaseSchedulerLock(context.Background(), key, holder); err != nil { // NOSONAR -- cleanup must proceed even if caller's ctx is cancelled; go:S8239
 			log.Printf("scheduler lock %d: release failed (holder %s), relying on TTL expiry: %v", key, holder, err)
 		}
 	}()

--- a/server/grpc/interceptors/interceptors_s2_test.go
+++ b/server/grpc/interceptors/interceptors_s2_test.go
@@ -126,7 +126,7 @@ func TestPrincipalID_User(t *testing.T) {
 }
 
 // fakeStream is a minimal grpc.ServerStream for stream-interceptor tests.
-type fakeStream struct {
+type fakeStream struct { // NOSONAR -- test-only struct; storing context.Context in a field is intentional here; godre:S8242
 	grpc.ServerStream
 	ctx context.Context
 }

--- a/server/middleware/session_cookie.go
+++ b/server/middleware/session_cookie.go
@@ -114,13 +114,13 @@ func SetAdminSessionCookie(w http.ResponseWriter, token string, expiresAt *time.
 	if expiresAt != nil {
 		cookie.Expires = *expiresAt
 	}
-	http.SetCookie(w, cookie)
+	http.SetCookie(w, cookie) // NOSONAR -- Secure flag comes from runtime TLS config; go:S2092 false positive
 }
 
 // ClearAdminSessionCookie removes the stashed admin session cookie once
 // impersonation ends (restored or not).
 func ClearAdminSessionCookie(w http.ResponseWriter, secure bool) {
-	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure is threaded from cfg.Server.HTTP.TLS.Enabled; hardcoding true would break local HTTP dev
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure is threaded from cfg.Server.HTTP.TLS.Enabled; hardcoding true would break local HTTP dev NOSONAR -- go:S2092 false positive
 		Name:     AdminSessionCookieName,
 		Value:    "",
 		Path:     "/",


### PR DESCRIPTION
## Summary

Suppresses the last cluster of SonarCloud false positives on main:

- **go:S2092** (`session_cookie.go`) — `SetAdminSessionCookie` and `ClearAdminSessionCookie` were missing `// NOSONAR` on their `http.SetCookie` calls. The `Secure` flag is threaded from runtime TLS config (`cfg.Server.HTTP.TLS.Enabled`), not hardcoded `false`. The other four cookie functions already had `// NOSONAR`.
- **go:S8239** (`remote_scheduler_lock.go`) — Lock-release cleanup call uses `context.Background()` intentionally: cleanup must proceed even when the caller's context is cancelled (e.g. the protected fn timed out). Line 67 (`heartbeatCtx`) already had `// NOSONAR`; line 88 did not.
- **gosecurity:S5146** (`evidencesink_extra_test.go`) — Test server handler redirects to `http://evil.example.com/steal` to verify that `refuseRedirect` refuses cross-host redirects. The redirect is in the test setup, not production code.
- **godre:S8242** (`interceptors_s2_test.go`) — `fakeStream` test helper stores `context.Context` as a struct field; this is intentional in a test double for `grpc.ServerStream`.

## Test plan

- [ ] CI build-and-test passes
- [ ] SonarCloud Quality Gate passes (no new issues introduced)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)