### PR TITLE
fix(ci): suppress Semgrep false positives (#120-123)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Analyze with SonarCloud
         uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # nosemgrep: generic.secrets.security.detected-sonarqube-docs-api-key
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # nosemgrep: generic.secrets.security.detected-sonarqube-docs-api-key.detected-sonarqube-docs-api-key
         with:
           args: >
             -Dsonar.projectKey=keyorixhq_keyorix

--- a/internal/dynamic/mysql.go
+++ b/internal/dynamic/mysql.go
@@ -88,7 +88,7 @@ func (e *MySQLEngine) Issue(ctx context.Context, adminDSN, creationTemplate stri
 	}
 
 	ref := mysqlAccountRef(user)
-	if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE USER %s IDENTIFIED BY '%s'", ref, password)); err != nil { // NOSONAR -- ref passes assertSafeUsername ([a-z0-9_]); password is from randString (quote-free alphabet)
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE USER %s IDENTIFIED BY '%s'", ref, password)); err != nil { //nolint:gosec // nosemgrep: go.lang.security.audit.database.string-formatted-query.string-formatted-query // NOSONAR -- ref passes assertSafeUsername([a-z0-9_]), password is quote-free randString
 		return Credential{}, "", fmt.Errorf("create user: %w", err)
 	}
 
@@ -98,7 +98,7 @@ func (e *MySQLEngine) Issue(ctx context.Context, adminDSN, creationTemplate stri
 		grant := strings.ReplaceAll(tmpl, "{{name}}", ref)
 		if _, err := db.ExecContext(ctx, grant); err != nil { // NOSONAR -- grant is operator-authored (trusted config); ref passes assertSafeUsername
 			// Don't leak a half-provisioned account if the template fails.
-			_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP USER IF EXISTS %s", ref)) // NOSONAR -- ref passes assertSafeUsername ([a-z0-9_]@%)
+			_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP USER IF EXISTS %s", ref)) //nolint:gosec // nosemgrep: go.lang.security.audit.database.string-formatted-query.string-formatted-query // NOSONAR -- ref passes assertSafeUsername([a-z0-9_]@%)
 			return Credential{}, "", fmt.Errorf("run creation template: %w", err)
 		}
 	}
@@ -118,7 +118,7 @@ func (e *MySQLEngine) Revoke(ctx context.Context, adminDSN, roleName string) err
 	defer func() { _ = db.Close() }()
 
 	killUserConnections(ctx, db, roleName)
-	if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP USER IF EXISTS %s", mysqlAccountRef(roleName))); err != nil { // NOSONAR -- roleName passes assertSafeUsername guard above
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP USER IF EXISTS %s", mysqlAccountRef(roleName))); err != nil { //nolint:gosec // nosemgrep: go.lang.security.audit.database.string-formatted-query.string-formatted-query // NOSONAR -- roleName passes assertSafeUsername guard above
 		return fmt.Errorf("drop user %s: %w", roleName, err)
 	}
 	return nil

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -243,7 +243,7 @@ func (h *AuthHandler) ConsumeSetup(w http.ResponseWriter, r *http.Request) {
 	if idx := strings.LastIndex(ip, ":"); idx != -1 {
 		ip = ip[:idx]
 	}
-	result, err := h.coreService.CompleteSetup(r.Context(), body.Token, body.Password, r.Header.Get(hdrUserAgent), ip)
+	result, err := h.coreService.CompleteSetup(r.Context(), body.Token, body.Password, r.Header.Get(hdrUserAgent), ip) // nosemgrep: trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable -- ErrMFARequired is a sentinel that carries a valid result.User
 	if err != nil {
 		// The new password was accepted, but the account has MFA (TOTP) or a passkey
 		// enrolled — mirror Login's ErrMFARequired handling exactly (see Login above)


### PR DESCRIPTION
## Summary

Closes Semgrep code scanning alerts #120, #121, #122, #123. Alert #119 (SONAR_TOKEN) is already fixed on main via #972.

- **#120-122** `go.lang.security.audit.database.string-formatted-query` in `internal/dynamic/mysql.go` (lines 91, 101, 121): the three `fmt.Sprintf` SQL statements are injection-safe — account names pass `assertSafeUsername([a-z0-9_])`, passwords come from a quote-free `randString` alphabet, and the creation template is an operator-authored trust boundary. Added `nosemgrep` + `nolint:gosec` directives.

- **#123** `trailofbits.go.invalid-usage-of-modified-variable` in `server/http/handlers/auth.go` (line 246): `result` is intentionally used inside `if err != nil` because `core.ErrMFARequired` is a sentinel that signals "setup succeeded but MFA is required" and returns a valid `result.User` alongside the error. Added `nosemgrep` directive.

## Test plan
- [ ] Semgrep scan closes alerts #120, #121, #122, #123 after merge
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.ai/code)