### PR TITLE
harden: fix 17 SonarCloud shell script issues (S5332/S6505/S6506/S6573)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,9 +40,9 @@ info "Detected platform: ${OS}/${ARCH}"
 # Get latest version from GitHub
 info "Fetching latest release..."
 if command -v curl >/dev/null 2>&1; then
-    LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+    LATEST=$(curl --proto '=https' --tlsv1.2 -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
 elif command -v wget >/dev/null 2>&1; then
-    LATEST=$(wget -qO- "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+    LATEST=$(wget -qO- "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/') # NOSONAR -- wget lacks --https-only on BusyBox; URL is already https://
 else
     error "curl or wget is required to install Keyorix."
 fi
@@ -63,18 +63,18 @@ TMP_BIN="${TMP_DIR}/${BINARY}"
 
 info "Downloading ${BINARY_NAME}..."
 if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$DOWNLOAD_URL" -o "$TMP_BIN" || error "Download failed. Check https://github.com/${REPO}/releases/${LATEST}"
+    curl --proto '=https' --tlsv1.2 -fsSL "$DOWNLOAD_URL" -o "$TMP_BIN" || error "Download failed. Check https://github.com/${REPO}/releases/${LATEST}"
 else
-    wget -qO "$TMP_BIN" "$DOWNLOAD_URL" || error "Download failed. Check https://github.com/${REPO}/releases/${LATEST}"
+    wget -qO "$TMP_BIN" "$DOWNLOAD_URL" || error "Download failed. Check https://github.com/${REPO}/releases/${LATEST}" # NOSONAR -- wget lacks --https-only on BusyBox; URL is already https://
 fi
 
 # Verify SHA-256 checksum against the release's published checksums.txt.
 info "Verifying checksum..."
 CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${LATEST}/checksums.txt"
 if command -v curl >/dev/null 2>&1; then
-    EXPECTED=$(curl -fsSL "$CHECKSUMS_URL" | awk -v n="$BINARY_NAME" '$2==n {print $1}')
+    EXPECTED=$(curl --proto '=https' --tlsv1.2 -fsSL "$CHECKSUMS_URL" | awk -v n="$BINARY_NAME" '$2==n {print $1}')
 else
-    EXPECTED=$(wget -qO- "$CHECKSUMS_URL" | awk -v n="$BINARY_NAME" '$2==n {print $1}')
+    EXPECTED=$(wget -qO- "$CHECKSUMS_URL" | awk -v n="$BINARY_NAME" '$2==n {print $1}') # NOSONAR -- wget lacks --https-only on BusyBox; URL is already https://
 fi
 
 if [ -n "$EXPECTED" ]; then
@@ -118,7 +118,7 @@ rm -rf "$TMP_DIR"
 success "Keyorix ${LATEST} installed to ${INSTALL_DIR}/${BINARY}"
 echo ""
 echo "  Get started:"
-echo "  keyorix connect http://your-server --username admin --password your-password"
+echo "  keyorix connect http://your-server --username admin --password your-password" # NOSONAR -- documentation string, not a network connection
 echo "  keyorix secret list"
 echo ""
 echo "  Docs: https://github.com/${REPO}"

--- a/integrations/github-action/entrypoint.sh
+++ b/integrations/github-action/entrypoint.sh
@@ -84,7 +84,7 @@ install_cli() {
     # signal — this is required whether we end up reusing an existing binary
     # or downloading a fresh one.
     echo "Verifying checksum..."
-    expected="$(curl -fsSL "$checksums_url" | awk -v n="$binary_name" '$2==n {print $1}')"
+    expected="$(curl --proto '=https' --tlsv1.2 -fsSL "$checksums_url" | awk -v n="$binary_name" '$2==n {print $1}')"
     if [[ -z "$expected" ]]; then
       echo "error: no checksum published for ${binary_name} at ${VERSION}; refusing to install unverified binary" >&2
       exit 1
@@ -114,7 +114,7 @@ install_cli() {
     tmp_bin="${tmp_dir}/keyorix"
 
     echo "Downloading keyorix ${VERSION} (${os}/${arch})..."
-    curl -fsSL "$url" -o "$tmp_bin"
+    curl --proto '=https' --tlsv1.2 -fsSL "$url" -o "$tmp_bin"
 
     if ! actual="$(sha256_of "$tmp_bin")"; then
       echo "error: no sha256sum/shasum tool found; cannot verify checksum" >&2
@@ -138,7 +138,7 @@ install_cli() {
     # SHA (not the mutable `main` branch, and not a movable tag ref) so a
     # future main-branch or tag compromise can't alter the code piped into
     # `sh` here. Bump deliberately when install.sh's logic needs to change.
-    curl -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/6dd9e555125500e76b4e2035a867621e416585a3/install.sh | sh
+    curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/6dd9e555125500e76b4e2035a867621e416585a3/install.sh | sh
   fi
   keyorix --version
 }

--- a/scripts/build-all-platforms.sh
+++ b/scripts/build-all-platforms.sh
@@ -157,9 +157,9 @@ done
 log_info "Creating checksums..."
 cd "$DIST_DIR"
 if command -v sha256sum &> /dev/null; then
-    sha256sum *.zip *.tar.gz > checksums.txt 2>/dev/null || true
+    sha256sum ./*.zip ./*.tar.gz > checksums.txt 2>/dev/null || true
 elif command -v shasum &> /dev/null; then
-    shasum -a 256 *.zip *.tar.gz > checksums.txt 2>/dev/null || true
+    shasum -a 256 ./*.zip ./*.tar.gz > checksums.txt 2>/dev/null || true
 fi
 cd ..
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -128,7 +128,7 @@ if [[ -d "web" ]] && [[ -f "web/package.json" ]]; then
     if command -v npm &> /dev/null; then
         if [[ ! -d "node_modules" ]]; then
             log_info "Installing web dependencies..."
-            npm install
+            npm install # NOSONAR -- postinstall hooks are needed for frontend build; --ignore-scripts would break the asset pipeline
         fi
         log_info "Building web production bundle..."
         if npm run build; then

--- a/scripts/run-comprehensive-tests.sh
+++ b/scripts/run-comprehensive-tests.sh
@@ -75,7 +75,7 @@ if [[ -d "web" ]] && [[ -f "web/package.json" ]]; then
     if [[ ! -d "node_modules" ]]; then
         log_info "Installing web dependencies..."
         if command -v npm &> /dev/null; then
-            npm install > /dev/null 2>&1
+            npm install > /dev/null 2>&1 # NOSONAR -- postinstall hooks are needed for frontend build; --ignore-scripts would break the asset pipeline
         else
             log_warning "npm not found - skipping web tests"
             cd ..
@@ -217,6 +217,7 @@ run_test "Docker Files Exist" "[[ -f server/Dockerfile ]] || [[ -f Dockerfile ]]
 
 # Generate test report
 log_info "=== Generating Test Report ==="
+SUCCESS_RATE=$(( TOTAL_TESTS > 0 ? PASSED_TESTS * 100 / TOTAL_TESTS : 0 ))
 cat > TEST_REPORT.md << EOF
 # Comprehensive Test Report
 
@@ -224,7 +225,7 @@ cat > TEST_REPORT.md << EOF
 **Total Tests**: $TOTAL_TESTS
 **Passed**: $PASSED_TESTS
 **Failed**: $FAILED_TESTS
-**Success Rate**: $(( PASSED_TESTS * 100 / TOTAL_TESTS ))%
+**Success Rate**: ${SUCCESS_RATE}%
 
 ## Test Categories
 

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -33,7 +33,7 @@ if [ -n "$KEYORIX_ADMIN_PASSWORD" ]; then
     if [ -z "$KEYORIX_BOOTSTRAP_TOKEN" ]; then
         echo "KEYORIX_ADMIN_PASSWORD is set but KEYORIX_BOOTSTRAP_TOKEN is not — skipping"
         echo "auto-bootstrap (the server-generated random token can't be read back here)."
-        echo "Set KEYORIX_BOOTSTRAP_TOKEN, or initialise manually: keyorix system init --server http://<host>:8080"
+        echo "Set KEYORIX_BOOTSTRAP_TOKEN, or initialise manually: keyorix system init --server http://<host>:8080" # NOSONAR -- documentation string, not a network connection
     else
         echo "Bootstrapping admin user '$ADMIN_USER' (idempotent)..."
         # Write the POST body (which embeds the admin password) to a private temp
@@ -62,7 +62,7 @@ if [ -n "$KEYORIX_ADMIN_PASSWORD" ]; then
     fi
 else
     echo "KEYORIX_ADMIN_PASSWORD not set — skipping auto-bootstrap."
-    echo "Initialise manually: keyorix system init --server http://<host>:8080"
+    echo "Initialise manually: keyorix system init --server http://<host>:8080" # NOSONAR -- documentation string, not a network connection
 fi
 
 # Hand the server the foreground.


### PR DESCRIPTION
## Summary

Fixes all 17 new SonarCloud shell-script issues introduced by PR #951, restoring Security Rating A on new code.

- **shell:S6506** (9 issues) — curl calls in `install.sh` and `integrations/github-action/entrypoint.sh` lacked `--proto '=https' --tlsv1.2` flags to prevent protocol-downgrade on redirect. Added to all 6 curl calls. wget alternatives get `# NOSONAR` — BusyBox wget lacks `--https-only` and the URLs are already `https://`.
- **shell:S5332** (3 issues) — three `echo` strings in `install.sh` and `server/entrypoint.sh` containing `http://` as example CLI usage text (not actual network connections). Suppressed with `# NOSONAR -- documentation string`.
- **shell:S6505** (2 issues) — `npm install` in `scripts/build.sh` and `scripts/run-comprehensive-tests.sh` without `--ignore-scripts`. Suppressed with `# NOSONAR` — postinstall hooks are required for the frontend asset pipeline.
- **shell:S6573** (3 issues) — glob patterns without `./` prefix: changed `*.zip *.tar.gz` to `./*.zip ./*.tar.gz` in `scripts/build-all-platforms.sh`; pre-computed `SUCCESS_RATE` before the heredoc in `scripts/run-comprehensive-tests.sh` to remove the arithmetic `$((...))` expansion from inside the heredoc body (which SonarCloud's analyzer incorrectly flagged as a glob).

## Test plan

- [ ] CI build-and-test passes (no Go changes)
- [ ] gosec passes (no Go changes)
- [ ] SonarCloud Security Rating returns to A on new code (no more shell issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)