### PR TITLE
harden: resolve all 19 SonarCloud Security C issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,12 @@ jobs:
 
       - name: govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 # NOSONAR -- go:S8545: version is pinned
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 # NOSONAR githubactions:S8545 -- version is pinned to v1.1.4
           govulncheck ./...
 
       - name: gosec
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION} # NOSONAR -- go:S8545: version is pinned via GOSEC_VERSION env
+          go install github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION} # NOSONAR githubactions:S8545 -- version is pinned via GOSEC_VERSION env var
           # -exclude-generated skips files with the "DO NOT EDIT" header
           # (generated protobuf code), whose *_FullMethodName string constants
           # otherwise trip G101 (hardcoded-credential) false positives.
@@ -126,7 +126,7 @@ jobs:
 
       - name: gosec
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION} # NOSONAR -- go:S8545: version is pinned via GOSEC_VERSION env
+          go install github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION} # NOSONAR githubactions:S8545 -- version is pinned via GOSEC_VERSION env var
           gosec -severity medium -exclude-generated ./...
 
   # scripts/fuzzing/targets.conf is a hand-maintained list consumed by the

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,8 +13,8 @@ on:
 # Workflow-level default: read-only, except the one permission CodeQL's own
 # upload step needs (security-events: write, to publish SARIF results to the
 # repo's Security tab). Mirrors ci.yml's least-privilege convention (#115).
-permissions: # NOSONAR -- githubactions:S8264: workflow-level permissions are intentional; job-level permissions refine further
-  contents: read
+permissions:
+  contents: read # NOSONAR githubactions:S8264 -- workflow-level read is intentional; job-level permissions further restrict (security-events:write only for the upload step)
 
 env:
   GO_VERSION: '1.26.5'

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run Semgrep (community rules, no account required)
         run: |
-          pip install semgrep --quiet --only-binary :all: # NOSONAR -- githubactions:S8544: version unpinned intentionally to track latest community rules
+          pip install semgrep --quiet --only-binary :all: # NOSONAR githubactions:S8544 -- intentionally unpinned to track latest community rules
           semgrep scan --config=auto --sarif --output=semgrep.sarif . || true
 
       - name: Upload results

--- a/deploy/helm/keyorix-operator/values.yaml
+++ b/deploy/helm/keyorix-operator/values.yaml
@@ -36,7 +36,13 @@ serviceAccount:
   # name overrides the generated ServiceAccount name.
   name: ""
 
-resources: {}
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/deploy/helm/keyorix/templates/tests/test-connection.yaml
+++ b/deploy/helm/keyorix/templates/tests/test-connection.yaml
@@ -30,3 +30,10 @@ spec:
         readOnlyRootFilesystem: true
         capabilities:
           drop: ["ALL"]
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+        limits:
+          cpu: 100m
+          memory: 32Mi

--- a/deploy/helm/keyorix/values.yaml
+++ b/deploy/helm/keyorix/values.yaml
@@ -49,9 +49,11 @@ server:
     requests:
       cpu: 100m
       memory: 128Mi
+      ephemeral-storage: 64Mi
     limits:
       cpu: 1
       memory: 512Mi
+      ephemeral-storage: 256Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -121,9 +123,11 @@ postgresql:
     requests:
       cpu: 100m
       memory: 256Mi
+      ephemeral-storage: 64Mi
     limits:
       cpu: 1
       memory: 1Gi
+      ephemeral-storage: 512Mi
 
 # Used when postgresql.enabled is false.
 externalDatabase:

--- a/internal/cli/secret/explain.go
+++ b/internal/cli/secret/explain.go
@@ -65,7 +65,7 @@ var explanations = []secretExplanation{
 		RiskSummary: "Database password hardcoded in source code or config file",
 		Impact:      "Direct database access. An attacker can read, modify, or delete all data. Often reused across environments.",
 		Fix: []string{
-			"Move to environment variable: DB_PASSWORD=os.getenv(\"DB_PASSWORD\")",
+			"Move to environment variable: DB_PASSWORD=os.getenv(\"DB_PASSWORD\")", // NOSONAR go:S2068 -- user-facing fix-suggestion string, not a credential
 			"Store in Keyorix: keyorix secret create db-password --value <password>",
 			helpInjectAtRuntime,
 			"Rotate the database password after removing from code",

--- a/internal/cli/secret/scan.go
+++ b/internal/cli/secret/scan.go
@@ -112,7 +112,7 @@ func runScan(cmd *cobra.Command, args []string) error { // NOSONAR -- cognitive 
 
 	var stagedFiles map[string]bool
 	if scanStaged {
-		out, err := exec.Command("git", "-C", absPath, "diff", "--cached", "--name-only").Output() // #nosec G204
+		out, err := exec.Command("git", "-C", absPath, "diff", "--cached", "--name-only").Output() // #nosec G204 // NOSONAR go:S4036
 		if err == nil && len(out) > 0 {
 			stagedFiles = map[string]bool{}
 			for _, f := range strings.Split(strings.TrimSpace(string(out)), "\n") {
@@ -137,7 +137,7 @@ func runScan(cmd *cobra.Command, args []string) error { // NOSONAR -- cognitive 
 		if strings.HasPrefix(scanCommit, "-") {
 			return fmt.Errorf("invalid --commit value %q: must not start with '-'", scanCommit)
 		}
-		out, err := exec.Command("git", "-C", absPath, "diff-tree", "--no-commit-id", "-r", "--name-only", scanCommit).Output() // #nosec G204
+		out, err := exec.Command("git", "-C", absPath, "diff-tree", "--no-commit-id", "-r", "--name-only", scanCommit).Output() // #nosec G204 // NOSONAR go:S4036
 		if err == nil && len(out) > 0 {
 			stagedFiles = map[string]bool{}
 			for _, f := range strings.Split(strings.TrimSpace(string(out)), "\n") {

--- a/server/tools/test_runner.go
+++ b/server/tools/test_runner.go
@@ -121,7 +121,7 @@ func (tr *TestRunner) runTestSuite(path, name string) error {
 	args = append(args, "-cover") // Enable coverage
 	args = append(args, path)
 
-	cmd := exec.Command("go", args...) // #nosec G204 -- path is validated by validateTestPath above
+	cmd := exec.Command("go", args...) // #nosec G204 -- path is validated by validateTestPath above // NOSONAR go:S4036
 	cmd.Dir = "."                      // Run from server directory
 
 	// Capture output
@@ -212,7 +212,7 @@ func (tr *TestRunner) RunBenchmarks() error {
 
 		// Use fixed command structure with validated paths
 		args := []string{"test", "-bench=.", "-benchmem", bench.path}
-		cmd := exec.Command("go", args...) // #nosec G204 -- Path is validated by validateTestPath function
+		cmd := exec.Command("go", args...) // #nosec G204 -- Path is validated by validateTestPath function // NOSONAR go:S4036
 		cmd.Dir = "."
 
 		output, err := cmd.CombinedOutput()
@@ -233,7 +233,7 @@ func (tr *TestRunner) RunCoverageReport() error {
 	fmt.Println("=" + strings.Repeat("=", 30))
 
 	// Run tests with coverage
-	cmd := exec.Command("go", "test", "-coverprofile=coverage.out", "./...")
+	cmd := exec.Command("go", "test", "-coverprofile=coverage.out", "./...") // NOSONAR go:S4036
 	cmd.Dir = "."
 
 	output, err := cmd.CombinedOutput()
@@ -242,7 +242,7 @@ func (tr *TestRunner) RunCoverageReport() error {
 	}
 
 	// Generate HTML coverage report
-	cmd = exec.Command("go", "tool", "cover", "-html=coverage.out", "-o", "coverage.html")
+	cmd = exec.Command("go", "tool", "cover", "-html=coverage.out", "-o", "coverage.html") // NOSONAR go:S4036
 	cmd.Dir = "."
 
 	if err := cmd.Run(); err != nil {
@@ -252,7 +252,7 @@ func (tr *TestRunner) RunCoverageReport() error {
 	}
 
 	// Show coverage summary
-	cmd = exec.Command("go", "tool", "cover", "-func=coverage.out")
+	cmd = exec.Command("go", "tool", "cover", "-func=coverage.out") // NOSONAR go:S4036
 	cmd.Dir = "."
 
 	output, err = cmd.CombinedOutput()

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,8 +5,11 @@ sonar.organization=keyorixhq
 # Go const declarations are not executable and always show 0% coverage.
 sonar.coverage.exclusions=**/*_gen.go,**/constants.go,**/*.pb.go
 
-# Exclude generated and constant-only files from duplication detection.
-sonar.cpd.exclusions=**/*_gen.go,**/*.pb.go,**/constants.go
+# Exclude generated, constant-only, and test files from duplication detection.
+# Go test files (*_test.go) have inherently repetitive structure — table-driven
+# test boilerplate, setup/teardown helpers, and assertion blocks repeat by design;
+# flagging them as CPD adds noise without actionable findings in test code.
+sonar.cpd.exclusions=**/*_gen.go,**/*.pb.go,**/constants.go,**/*_test.go
 
 # gosec v2.26.1 requires "#nosec GXXX" to be the first token in a comment,
 # while SonarCloud requires "NOSONAR" to be first — both can't be first in the
@@ -17,7 +20,7 @@ sonar.cpd.exclusions=**/*_gen.go,**/*.pb.go,**/constants.go
 # go:S5527 — InsecureSkipVerify disables hostname verification
 # All four files use InsecureSkipVerify as an explicit operator opt-in,
 # guarded by a config flag and a loud WARNING log at startup.
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S4830
 sonar.issue.ignore.multicriteria.e1.resourceKey=internal/evidencesink/webhook.go
 sonar.issue.ignore.multicriteria.e2.ruleKey=go:S5527
@@ -47,3 +50,11 @@ sonar.issue.ignore.multicriteria.e11.resourceKey=internal/evidencesink/evidences
 # go:S2077 — dynamic SQL; all call sites are guarded by assertSafeUsername
 sonar.issue.ignore.multicriteria.e12.ruleKey=go:S2077
 sonar.issue.ignore.multicriteria.e12.resourceKey=internal/dynamic/mysql.go
+# kubernetes:S5849 — web container adds NET_BIND_SERVICE to bind port 80;
+# nginx requires this capability and explicitly drops all others.
+sonar.issue.ignore.multicriteria.e13.ruleKey=kubernetes:S5849
+sonar.issue.ignore.multicriteria.e13.resourceKey=deploy/helm/keyorix/templates/web-deployment.yaml
+# kubernetes:S5332 — test-connection pod uses http:// to reach the internal
+# cluster service health endpoint; TLS is not available on the pod-to-pod path.
+sonar.issue.ignore.multicriteria.e14.ruleKey=kubernetes:S5332
+sonar.issue.ignore.multicriteria.e14.resourceKey=deploy/helm/keyorix/templates/tests/test-connection.yaml


### PR DESCRIPTION
## Summary

- **15 false positives** suppressed via inline `NOSONAR` annotations and `sonar-project.properties` multicriteria entries (e13–e14 for Kubernetes rules)
- **4 real fixes**: Kubernetes resource limits that were genuinely missing (`ephemeral-storage` on server/postgresql, `cpu`/`memory` on operator, resource block on test-connection pod)
- Also carries forward the `sonar.cpd.exclusions=**/*_test.go` addition from PR #980 (was absent from the base branch cut from local main)

### False positives suppressed

| Rule | File | Reason |
|------|------|--------|
| `go:S2068` | `internal/cli/secret/explain.go` | User-facing fix-suggestion string, not a credential |
| `go:S4036` ×5 | `server/tools/test_runner.go` | Calls Go toolchain by name; already `#nosec G204` |
| `go:S4036` ×2 | `internal/cli/secret/scan.go` | Calls git by name; already `#nosec G204` |
| `githubactions:S8545` ×3 | `.github/workflows/ci.yml` | govulncheck/gosec versions are pinned; corrected rule-key prefix |
| `githubactions:S8264` | `.github/workflows/codeql.yml` | Workflow-level `read` is intentional; job-level permissions further restrict |
| `githubactions:S8544` | `.github/workflows/semgrep.yml` | Unpinned by design to track latest community rules |
| `kubernetes:S5849` | `web-deployment.yaml` | `NET_BIND_SERVICE` required for nginx port 80; all others dropped |
| `kubernetes:S5332` | `test-connection.yaml` | Health check uses `http://` (internal pod-to-pod, no TLS available) |

### Real fixes

| Rule | Fix |
|------|-----|
| `kubernetes:S6870` (ephemeral-storage limit) | Added `ephemeral-storage` requests/limits to `values.yaml` server + postgresql |
| `kubernetes:S6864` (memory limit) | Replaced `resources: {}` with real limits in `keyorix-operator/values.yaml` |
| `kubernetes:S6864` (missing resources block) | Added `resources` block to test-connection pod template |

## Test plan

- [ ] CI passes (lint, gosec, build-and-test, gitleaks)
- [ ] SonarCloud scan clears the 19 open Security issues after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)