### PR TITLE
harden: exclude Go test files from Semgrep + fix ErrMFARequired check order

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -7,6 +7,13 @@
 # co-located gosec `// #nosec` directives that these same lines require, because
 # both tools require their own directive to appear first in the comment.
 
+# All Go test files — hardcoded test credentials (JWT keys, AWS key IDs, bcrypt
+# hashes, OAuth tokens), cookies without Secure/HttpOnly, raw ResponseWriter
+# writes, and exec/SQL calls in test helpers are intentional test fixtures, not
+# production vulnerabilities. Real security coverage for these patterns is
+# provided by CodeQL and gosec on the production code paths.
+*_test.go
+
 # InsecureSkipVerify=true — an explicit operator opt-in, guarded by a config
 # flag (insecure_skip_verify: true) and a loud WARNING log at startup.
 # Suppressed by // #nosec G402 for gosec; covered by CodeQL + SonarCloud.

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -243,27 +243,29 @@ func (h *AuthHandler) ConsumeSetup(w http.ResponseWriter, r *http.Request) {
 	if idx := strings.LastIndex(ip, ":"); idx != -1 {
 		ip = ip[:idx]
 	}
-	result, err := h.coreService.CompleteSetup(r.Context(), body.Token, body.Password, r.Header.Get(hdrUserAgent), ip) // nosemgrep: trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable -- ErrMFARequired is a sentinel that carries a valid result.User
-	if err != nil {
-		// The new password was accepted, but the account has MFA (TOTP) or a passkey
-		// enrolled — mirror Login's ErrMFARequired handling exactly (see Login above)
-		// so a password reset cannot be used to silently bypass the second factor.
-		// Issue a short-lived challenge instead of a session; the client completes
-		// VerifyMFALogin (or the WebAuthn ceremony) to get a real session.
-		if errors.Is(err, core.ErrMFARequired) {
-			challenge, cerr := h.coreService.CreateMFAChallenge(r.Context(), result.User.ID)
-			if cerr != nil {
-				sendError(w, "Internal", "failed to start MFA challenge", http.StatusInternalServerError, nil)
-				return
-			}
-			sendSuccess(w, map[string]interface{}{
-				"mfa_required":       true,
-				"mfa_challenge":      challenge,
-				"totp_available":     result.User.MFAEnabled,
-				"webauthn_available": result.User.WebAuthnEnabled,
-			}, "MFA required")
+	result, err := h.coreService.CompleteSetup(r.Context(), body.Token, body.Password, r.Header.Get(hdrUserAgent), ip)
+	// The new password was accepted, but the account has MFA (TOTP) or a passkey
+	// enrolled — mirror Login's ErrMFARequired handling exactly (see Login above)
+	// so a password reset cannot be used to silently bypass the second factor.
+	// Issue a short-lived challenge instead of a session; the client completes
+	// VerifyMFALogin (or the WebAuthn ceremony) to get a real session.
+	// ErrMFARequired is checked before the generic err != nil block because
+	// CompleteSetup returns a valid result.User alongside this sentinel.
+	if errors.Is(err, core.ErrMFARequired) {
+		challenge, cerr := h.coreService.CreateMFAChallenge(r.Context(), result.User.ID)
+		if cerr != nil {
+			sendError(w, "Internal", "failed to start MFA challenge", http.StatusInternalServerError, nil)
 			return
 		}
+		sendSuccess(w, map[string]interface{}{
+			"mfa_required":       true,
+			"mfa_challenge":      challenge,
+			"totp_available":     result.User.MFAEnabled,
+			"webauthn_available": result.User.WebAuthnEnabled,
+		}, "MFA required")
+		return
+	}
+	if err != nil {
 		// Only a password-policy failure surfaces its reason (the link is still live,
 		// so the user can fix the password and retry). Every other failure — dead/used
 		// token, missing or already-existing account, internal error — is reported


### PR DESCRIPTION
## Summary

- Add `*_test.go` to `.semgrepignore`. Go test files intentionally contain patterns Semgrep flags as security issues — hardcoded test credentials (JWT keys, AWS key IDs, bcrypt hashes, OAuth tokens), cookies without `Secure`/`HttpOnly`, raw `ResponseWriter` writes, exec/SQL calls in test helpers. These are test fixtures, not production vulnerabilities. Production coverage for the same patterns is already provided by CodeQL and gosec. **Closes ~346 open Semgrep code-scanning alerts** (293 `no-direct-write-to-responsewriter`, 28 cookie/SQL/secrets, and other test-only findings).

- Restructure `ConsumeSetup` in `auth.go` to check `errors.Is(err, core.ErrMFARequired)` *before* the generic `if err \!= nil` block. `CompleteSetup` returns a valid `result.User` alongside the `ErrMFARequired` sentinel, so the logic is semantically identical but avoids the TrailOfBits `invalid-usage-of-modified-variable` pattern (accessing `result` inside `err \!= nil`). The previous nosemgrep inline comment was not effective. **Closes Semgrep alert #123.**

## Remaining open alert

Scorecard `PinnedDependenciesID` #159 (`.github/workflows/semgrep.yml` — `pip install semgrep` unpinned) requires a manual "Won't fix" dismissal in the GitHub Security UI, or pinning to a specific semgrep version. The version is left unpinned intentionally to track latest community rules.

## Test plan

- [ ] `build-and-test` CI passes (auth.go change compiles; semantics preserved)
- [ ] `Semgrep OSS` CI passes (test files excluded from SARIF → GitHub auto-closes ~346 alerts)
- [ ] `CodeQL` and `gosec` continue to scan `*_test.go` files (`.semgrepignore` only affects Semgrep)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)