### PR TITLE
harden: exclude mysql.go from Semgrep + dismiss pinned-deps Scorecard alert

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -22,6 +22,14 @@ internal/evidencesink/webhook.go
 internal/notifychan/webhook.go
 internal/storage/remote/client.go
 
+# MySQL dynamic-credential DDL (CREATE USER, DROP USER) — MySQL DDL cannot use
+# parameterized query placeholders; values are validated by assertSafeUsername
+# ([a-z0-9_]@%) before interpolation, and passwords come from randString (no
+# quoting-sensitive characters). Suppressed by //nolint:gosec for gosec;
+# covered by CodeQL + SonarCloud NOSONAR. nosemgrep inline comments present
+# but ineffective (tool-compatibility constraint documented in the file header).
+internal/dynamic/mysql.go
+
 # Cookie Secure/HttpOnly attributes — Secure is threaded from the runtime TLS
 # config (cfg.Server.HTTP.TLS.Enabled), not statically false; HttpOnly:false
 # is intentional for the CSRF double-submit cookie pattern.


### PR DESCRIPTION
## Summary

- Add `internal/dynamic/mysql.go` to `.semgrepignore`. MySQL DDL statements (`CREATE USER`, `DROP USER`) cannot use parameterized placeholders — the driver's `?` syntax only works for DML values, not DDL identifiers. Values are validated by `assertSafeUsername([a-z0-9_]@%)` before interpolation and passwords come from `randString` (no quoting-sensitive characters). gosec is already suppressed via `//nolint:gosec` and SonarCloud via `NOSONAR` on each line; inline `// nosemgrep:` comments are also present but ineffective (the tool-compatibility constraint is documented in `.semgrepignore`). **Closes Semgrep alerts #122, #124, #125.**

- Dismiss Scorecard alert #159 (`PinnedDependenciesID` — `pip install semgrep` version unpinned) as "Won't fix" via the code-scanning API. The version is intentionally unpinned to always run against the latest community rules; a pinned version would silently drift behind new detections. The `NOSONAR` annotation is already present on the line.

## Test plan

- [ ] `Semgrep OSS` CI passes (mysql.go excluded from SARIF → GitHub auto-closes #122, #124, #125)
- [ ] `build-and-test` CI passes (no code changes)
- [ ] GitHub Security tab: 0 open code-scanning alerts after merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)