### PR TITLE
fix: address GitHub code-review findings + pin SonarCloud UTF-8 encoding

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -34,4 +34,5 @@ jobs:
             -Dsonar.projectKey=keyorixhq_keyorix
             -Dsonar.organization=keyorixhq
             -Dsonar.go.coverage.reportPaths=coverage.out
+            -Dsonar.sourceEncoding=UTF-8
           projectBaseDir: .

--- a/internal/cli/secret/scan.go
+++ b/internal/cli/secret/scan.go
@@ -110,6 +110,10 @@ func runScan(cmd *cobra.Command, args []string) error { // NOSONAR -- cognitive 
 		return fmt.Errorf("invalid path: %w", err)
 	}
 
+	if scanSeverity != "" && scanSeverity != "low" && scanSeverity != "medium" && scanSeverity != "high" {
+		return fmt.Errorf("invalid --severity value %q (expected one of: low, medium, high)", scanSeverity)
+	}
+
 	var stagedFiles map[string]bool
 	if scanStaged {
 		out, err := exec.Command("git", "-C", absPath, "diff", "--cached", "--name-only").Output() // #nosec G204 -- NOSONAR go:S4036
@@ -156,16 +160,15 @@ func runScan(cmd *cobra.Command, args []string) error { // NOSONAR -- cognitive 
 		if err != nil {
 			return nil
 		}
-		// Never follow symlinks (#153). filepath.Walk reports a symlink's own Lstat
-		// info (info.Mode()&os.ModeSymlink is set) and doesn't itself descend into a
-		// symlinked directory — but a symlinked *file* still reaches this callback,
-		// and the per-type scanners below open the path with os.ReadFile, which DOES
-		// follow symlinks. A malicious repo could commit one pointing outside the
-		// scanned tree (e.g. at the scanning user's own ~/.aws/credentials or
-		// /etc/shadow); reading through it would leak the SCANNING USER's own files
-		// into the report. Skip every symlink encountered rather than trying to
-		// validate where it resolves to.
-		if info.Mode()&os.ModeSymlink != 0 {
+		// Never follow symlinks — a malicious repo could commit a symlink pointing
+		// outside the scanned tree (e.g. ~/.aws/credentials); reading through it
+		// would leak the scanning user's own files into the report. Use os.Lstat
+		// explicitly rather than relying on the info parameter from filepath.Walk.
+		lstatInfo, lerr := os.Lstat(path)
+		if lerr != nil {
+			return nil
+		}
+		if lstatInfo.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
 		if info.IsDir() {
@@ -247,7 +250,10 @@ func runScan(cmd *cobra.Command, args []string) error { // NOSONAR -- cognitive 
 	}
 
 	if scanReport != "" {
-		data, _ := json.MarshalIndent(report, "", "  ")
+		data, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal report: %w", err)
+		}
 		if err := os.WriteFile(scanReport, data, 0600); err != nil {
 			return fmt.Errorf("failed to save report: %w", err)
 		}

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -39,7 +39,7 @@ func (c *KeyorixCore) UpdateOwnProfile(ctx context.Context, userID uint, display
 		}
 		if email != user.Email {
 			if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(currentPassword)); err != nil {
-				return nil, fmt.Errorf("%s: current password is incorrect", i18n.T("ErrorValidation", nil))
+				return nil, fmt.Errorf("%w: current password is incorrect", ErrIncorrectCurrentPassword)
 			}
 		}
 	}
@@ -65,7 +65,7 @@ func (c *KeyorixCore) ChangePassword(ctx context.Context, userID uint, current, 
 		return fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(current)); err != nil {
-		return fmt.Errorf("%s: current password is incorrect", i18n.T("ErrorValidation", nil))
+		return fmt.Errorf("%w: current password is incorrect", ErrIncorrectCurrentPassword)
 	}
 	// Enforce policy + history after the current-password check so an attacker can't
 	// probe the policy without already holding valid credentials (ADR-025).

--- a/internal/core/auth_bootstrap.go
+++ b/internal/core/auth_bootstrap.go
@@ -216,10 +216,10 @@ func (c *KeyorixCore) BootstrapSystem(ctx context.Context, req *BootstrapRequest
 	// unauthenticated, first-caller-wins admin seizure on any fresh, network-reachable
 	// instance. An unset server token disables API bootstrap entirely (fail closed).
 	if c.bootstrapToken == "" {
-		return nil, fmt.Errorf("system initialisation over the API is disabled: no bootstrap token is configured")
+		return nil, fmt.Errorf("system initialisation over the API is disabled: %w", ErrInvalidBootstrapToken)
 	}
 	if subtle.ConstantTimeCompare([]byte(req.Token), []byte(c.bootstrapToken)) != 1 {
-		return nil, fmt.Errorf("invalid bootstrap token")
+		return nil, ErrInvalidBootstrapToken
 	}
 	// The initial admin is the most privileged account; enforce the password policy
 	// here too (plain CreateUser does not), so it can't be seeded with a weak password.

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -1,0 +1,19 @@
+package core
+
+import "errors"
+
+// Sentinel errors for common failure modes. Use errors.Is to test for these
+// across wrapped error chains.
+var (
+	// ErrIncorrectCurrentPassword is returned when a password-change or profile-update
+	// request supplies the wrong current password.
+	ErrIncorrectCurrentPassword = errors.New("incorrect current password")
+
+	// ErrUserAlreadyExists is returned when a user-creation or update request
+	// collides with an existing username or email.
+	ErrUserAlreadyExists = errors.New("user already exists")
+
+	// ErrInvalidBootstrapToken is returned when the supplied bootstrap token is
+	// missing, empty, or does not match the server's configured token.
+	ErrInvalidBootstrapToken = errors.New("invalid bootstrap token")
+)

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -50,7 +50,7 @@ func (c *KeyorixCore) buildUserForCreate(ctx context.Context, req *CreateUserReq
 	}
 
 	if _, err := c.storage.GetUserByUsername(ctx, req.Username); err == nil {
-		return nil, "", fmt.Errorf("%s: username already exists", i18n.T("ErrorValidation", nil))
+		return nil, "", fmt.Errorf("%w: username already exists", ErrUserAlreadyExists)
 	} else if !errors.Is(err, storage.ErrUnsupportedByBackend) && !storage.IsUserNotFound(err) {
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
@@ -64,7 +64,7 @@ func (c *KeyorixCore) buildUserForCreate(ctx context.Context, req *CreateUserReq
 
 	existing, err := c.storage.GetUserByEmail(ctx, req.Email)
 	if err == nil && existing != nil {
-		return nil, "", fmt.Errorf("%s: user with email already exists", i18n.T("ErrorValidation", nil))
+		return nil, "", fmt.Errorf("%w: user with email already exists", ErrUserAlreadyExists)
 	}
 	if err != nil && !storage.IsUserNotFound(err) {
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -115,7 +115,7 @@ func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*
 		// produced, instead of a raw constraint-violation message or an ambiguous
 		// duplicate-email row.
 		if errors.Is(err, storage.ErrDuplicateEmail) {
-			return nil, fmt.Errorf("%s: user with email already exists", i18n.T("ErrorValidation", nil))
+			return nil, fmt.Errorf("%w: user with email already exists", ErrUserAlreadyExists)
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
@@ -202,7 +202,7 @@ func (c *KeyorixCore) CreateUserWithAssignments(ctx context.Context, req *Create
 	if err != nil {
 		// #117: same race/translation as CreateUser above — see its comment.
 		if errors.Is(err, storage.ErrDuplicateEmail) {
-			return nil, fmt.Errorf("%s: user with email already exists", i18n.T("ErrorValidation", nil))
+			return nil, fmt.Errorf("%w: user with email already exists", ErrUserAlreadyExists)
 		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
@@ -268,7 +268,7 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 	}
 	if req.Username != "" && req.Username != user.Username {
 		if _, err := c.storage.GetUserByUsername(ctx, req.Username); err == nil {
-			return nil, fmt.Errorf("%s: username already exists", i18n.T("ErrorValidation", nil))
+			return nil, fmt.Errorf("%w: username already exists", ErrUserAlreadyExists)
 		} else if err != nil && !storage.IsUserNotFound(err) {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 		}
@@ -277,7 +277,7 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 	if req.Email != "" && req.Email != user.Email {
 		existing, err := c.storage.GetUserByEmail(ctx, req.Email)
 		if err == nil && existing != nil && existing.ID != user.ID {
-			return nil, fmt.Errorf("%s: user with email already exists", i18n.T("ErrorValidation", nil))
+			return nil, fmt.Errorf("%w: user with email already exists", ErrUserAlreadyExists)
 		}
 		if err != nil && !storage.IsUserNotFound(err) {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -142,9 +142,10 @@ fi
 
 # Build CLI Docker image
 log_info "Building CLI Docker image..."
-cat > Dockerfile.cli << 'EOF'
+CLI_GO_BUILDER_IMAGE="${CLI_GO_BUILDER_IMAGE:-golang:1.21-alpine}"
+cat > Dockerfile.cli << EOF
 # Multi-stage build for CLI
-FROM golang:1.21-alpine AS builder
+FROM ${CLI_GO_BUILDER_IMAGE} AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -154,7 +155,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o bin/keyorix ./cmd/keyorix
 
 # Production image
-FROM alpine:latest
+FROM alpine:3.24
 
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/

--- a/scripts/run-comprehensive-tests.sh
+++ b/scripts/run-comprehensive-tests.sh
@@ -82,8 +82,6 @@ if [[ -d "web" ]] && [[ -f "web/package.json" ]]; then
             npm ci > /dev/null 2>&1 # NOSONAR -- npm ci installs strictly from package-lock.json; postinstall hooks run for the frontend build pipeline
         else
             log_warning "npm not found - skipping web tests"
-            cd ..
-            continue
         fi
     fi
     
@@ -205,7 +203,7 @@ run_test "Production Config Exists" "[[ -f server/config/production.yaml ]]"
 # 11. Build Tests
 log_info "=== Running Build Tests ==="
 if command -v go &> /dev/null; then
-    run_test "Go Build Test" "go build -o test-binary ./cm./bin/keyorix && rm -f test-binary"
+    run_test "Go Build Test" "go build -o test-binary ./cmd/keyorix && rm -f test-binary"
 fi
 
 if [[ -d "web" ]] && command -v npm &> /dev/null; then

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -153,7 +153,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	h.setSessionCookies(w, session)
 
 	// Audit log + last-login stamp (both non-blocking)
-	ip, ua := r.RemoteAddr, r.Header.Get(hdrUserAgent)
+	ua := r.Header.Get(hdrUserAgent)
 	goSafe(func() { h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, ua) }) // #nosec G118
 	goSafe(func() { _ = h.coreService.RecordLogin(context.Background(), user.ID) })                     // #nosec G118
 
@@ -452,11 +452,11 @@ func (h *AuthHandler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
 
 	user, err := h.coreService.UpdateOwnProfile(r.Context(), userCtx.UserID, body.DisplayName, body.Email, body.CurrentPassword)
 	if err != nil {
-		if strings.Contains(err.Error(), "incorrect") {
+		if errors.Is(err, core.ErrIncorrectCurrentPassword) {
 			sendError(w, "Unauthorized", "Current password is incorrect", http.StatusUnauthorized, nil)
 			return
 		}
-		if strings.Contains(err.Error(), "already exists") {
+		if errors.Is(err, core.ErrUserAlreadyExists) {
 			sendError(w, "Conflict", "That email is already in use", http.StatusConflict, nil)
 			return
 		}
@@ -489,7 +489,7 @@ func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 	token := extractBearerToken(r)
 	err := h.coreService.ChangePassword(r.Context(), userCtx.UserID, body.CurrentPassword, body.NewPassword, token)
 	if err != nil {
-		if strings.Contains(err.Error(), "incorrect") {
+		if errors.Is(err, core.ErrIncorrectCurrentPassword) {
 			sendError(w, "Unauthorized", "Current password is incorrect", http.StatusUnauthorized, nil)
 			return
 		}
@@ -640,7 +640,7 @@ func (h *AuthHandler) InitSystem(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// A bad/missing token or a weak password is a client error, not a 500.
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "bootstrap token") || strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)) {
+		if errors.Is(err, core.ErrInvalidBootstrapToken) || strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)) {
 			status = http.StatusForbidden
 		}
 		sendError(w, "Error", err.Error(), status, nil)

--- a/server/http/handlers/helpers.go
+++ b/server/http/handlers/helpers.go
@@ -40,6 +40,26 @@ func sendSuccess(w http.ResponseWriter, data interface{}, message string) {
 	}
 }
 
+// sendCreated writes a 201 Created JSON success response with correctly ordered
+// headers. Unlike calling w.WriteHeader(201) before sendSuccess (which causes
+// sendSuccess's Header().Set() calls to be silently ignored), this function sets
+// Content-Type and X-Content-Type-Options before WriteHeader.
+func sendCreated(w http.ResponseWriter, data interface{}, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusCreated)
+	response := map[string]interface{}{
+		"success": true,
+		"data":    data,
+	}
+	if message != "" {
+		response["message"] = message
+	}
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("Error encoding JSON response: %v", err)
+	}
+}
+
 // clientSafe returns a generic, client-safe message in place of err's raw
 // Error() text. Use it at the fallback/default branch of an error path once
 // the caller has already carved out the small set of deliberately-crafted,

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -108,7 +108,7 @@ func (h *UserHandler) createUserWithOTP(w http.ResponseWriter, r *http.Request, 
 	created, otp, err := h.coreService.CreateUserWithOneTimePassword(r.Context(), req, actorID)
 	if err != nil {
 		log.Printf("Error creating user with one-time password: %v", err)
-		if strings.Contains(err.Error(), "already exists") {
+		if errors.Is(err, core.ErrUserAlreadyExists) {
 			sendError(w, "ConflictError", "User already exists", http.StatusConflict, nil)
 			return
 		}
@@ -119,8 +119,7 @@ func (h *UserHandler) createUserWithOTP(w http.ResponseWriter, r *http.Request, 
 		sendError(w, "InternalError", "Failed to create user", http.StatusInternalServerError, nil)
 		return
 	}
-	w.WriteHeader(http.StatusCreated)
-	sendSuccess(w, map[string]interface{}{
+	sendCreated(w, map[string]interface{}{
 		"user":              userToAPIResponse(created),
 		"one_time_password": otp,
 	}, i18n.T("SuccessUserCreated", nil))
@@ -130,7 +129,7 @@ func (h *UserHandler) createUserWithSetupLink(w http.ResponseWriter, r *http.Req
 	created, prov, err := h.coreService.CreateUserWithSetupLink(r.Context(), req, actorID)
 	if err != nil {
 		log.Printf("Error creating user with setup link: %v", err)
-		if strings.Contains(err.Error(), "already exists") {
+		if errors.Is(err, core.ErrUserAlreadyExists) {
 			sendError(w, "ConflictError", "User already exists", http.StatusConflict, nil)
 			return
 		}
@@ -145,8 +144,7 @@ func (h *UserHandler) createUserWithSetupLink(w http.ResponseWriter, r *http.Req
 		sendError(w, "InternalError", "Failed to create user", http.StatusInternalServerError, nil)
 		return
 	}
-	w.WriteHeader(http.StatusCreated)
-	sendSuccess(w, map[string]interface{}{
+	sendCreated(w, map[string]interface{}{
 		"user":       userToAPIResponse(created),
 		"setup_link": prov,
 	}, i18n.T("SuccessUserCreated", nil))
@@ -177,7 +175,7 @@ func (h *UserHandler) createUserClassic(w http.ResponseWriter, r *http.Request, 
 	if err != nil {
 		log.Printf("Error creating user: %v", err)
 		switch {
-		case strings.Contains(err.Error(), errAlreadyExists):
+		case errors.Is(err, core.ErrUserAlreadyExists):
 			sendError(w, "ConflictError", errUserAlreadyExists, http.StatusConflict, nil)
 		case strings.Contains(err.Error(), "only an administrator can grant"):
 			sendError(w, "Forbidden", err.Error(), http.StatusForbidden, nil)
@@ -190,8 +188,7 @@ func (h *UserHandler) createUserClassic(w http.ResponseWriter, r *http.Request, 
 		}
 		return
 	}
-	w.WriteHeader(http.StatusCreated)
-	sendSuccess(w, userToAPIResponse(created), i18n.T("SuccessUserCreated", nil))
+	sendCreated(w, userToAPIResponse(created), i18n.T("SuccessUserCreated", nil))
 }
 
 func (h *UserHandler) authorizeUserCreationAssignments(ctx context.Context, userCtx *middleware.UserContext, role string, projAssignments []projectAssignmentBody) error {
@@ -691,7 +688,7 @@ func (h *UserHandler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 			sendError(w, "NotFound", errUserNotFound, http.StatusNotFound, nil)
 			return
 		}
-		if strings.Contains(err.Error(), errAlreadyExists) {
+		if errors.Is(err, core.ErrUserAlreadyExists) {
 			sendError(w, "ConflictError", errUserAlreadyExists, http.StatusConflict, nil)
 			return
 		}
@@ -832,7 +829,7 @@ func (h *UserHandler) RevokeSessions(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InvalidParameter", errInvalidUserID, http.StatusBadRequest, nil)
 		return
 	}
-	// Mirrors accountStateAction's self-action guard (line 367): an admin must not be
+	// Mirrors accountStateAction's self-action guard: an admin must not be
 	// able to revoke their own active sessions out from under themselves mid-request.
 	if uint(id) == admin.UserID {
 		sendError(w, "BadRequest", "Cannot revoke your own sessions", http.StatusBadRequest, nil)


### PR DESCRIPTION
## Summary

- **Code review findings** (`internal/`, `scripts/`, `server/`): implements 16 GitHub automated code-review findings across five files — sentinel errors replacing `strings.Contains` checks, a `sendCreated` helper that correctly orders headers before `WriteHeader(201)`, symlink detection via `os.Lstat`, severity validation in `secret scan`, a handled `json.MarshalIndent` error, Docker image pinning, and shell-script fixes.
- **SonarCloud UTF-8 encoding** (`.github/workflows/sonarcloud.yml`): adds `-Dsonar.sourceEncoding=UTF-8` to the inline workflow args; `sonar-project.properties` already sets this but certain versions of the SonarSource Action may not honour the properties file when inline `-D` args are also present, causing the "problems with file encoding" scanner warning.

## Changes

**New sentinel errors** (`internal/core/errors.go`):
- `ErrIncorrectCurrentPassword`, `ErrUserAlreadyExists`, `ErrInvalidBootstrapToken`
- Wrapped with `%w` in `account.go`, `users.go`, `auth_bootstrap.go`
- Checked with `errors.Is` in `auth.go`, `users_crud.go` — replaces fragile `strings.Contains(err.Error(), …)` pattern

**HTTP 201 header ordering** (`server/http/handlers/helpers.go`, `users_crud.go`):
- New `sendCreated` helper sets `Content-Type` / `X-Content-Type-Options` **before** `WriteHeader(201)` — the prior pattern called `w.WriteHeader(201)` first, causing `sendSuccess`'s `Header().Set()` calls to be silently ignored

**`secret scan` fixes** (`internal/cli/secret/scan.go`):
- Explicit `os.Lstat` for symlink detection (more reliable than relying on `filepath.Walk`'s `info` parameter)
- Validate `--severity` flag value before running the walk
- Check and return `json.MarshalIndent` error

**Script fixes** (`scripts/`):
- `build-docker.sh`: pin base image via `CLI_GO_BUILDER_IMAGE` env var; pin runtime to `alpine:3.24`; allow variable expansion in heredoc
- `run-comprehensive-tests.sh`: remove invalid `continue` outside a loop + stale `cd ..`; fix malformed binary path `./cm./bin/keyorix` → `./cmd/keyorix`

**SonarCloud workflow** (`.github/workflows/sonarcloud.yml`):
- Add `-Dsonar.sourceEncoding=UTF-8` to inline `-D` args to guarantee UTF-8 regardless of action/properties-file interaction

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (pre-existing `TestApproveAccessRequest_FallsBackToSuggestedRole` flake is unrelated)
- [ ] SonarCloud scan on merge no longer reports "problems with file encoding"
- [ ] `errors.Is(err, core.ErrIncorrectCurrentPassword)` / `ErrUserAlreadyExists` / `ErrInvalidBootstrapToken` resolve correctly across all call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)