### PR TITLE
harden: fix 6 remaining SonarCloud Maintainability + Reliability issues

### DIFF
--- a/deploy/helm/keyorix-operator/templates/deployment.yaml
+++ b/deploy/helm/keyorix-operator/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             requests:
               cpu: 10m
               memory: 64Mi
-              ephemeralStorage: 64Mi
+              ephemeral-storage: 64Mi
             limits:
               cpu: 500m
               memory: 256Mi

--- a/deploy/helm/keyorix-operator/values.yaml
+++ b/deploy/helm/keyorix-operator/values.yaml
@@ -40,9 +40,11 @@ resources:
   requests:
     cpu: 50m
     memory: 64Mi
+    ephemeral-storage: 64Mi
   limits:
     cpu: 500m
     memory: 256Mi
+    ephemeral-storage: 256Mi
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/deploy/helm/keyorix/templates/server-deployment.yaml
+++ b/deploy/helm/keyorix/templates/server-deployment.yaml
@@ -98,7 +98,7 @@ spec:
             requests:
               cpu: 50m
               memory: 128Mi
-              ephemeralStorage: 64Mi
+              ephemeral-storage: 64Mi
             limits:
               cpu: 1000m
               memory: 512Mi

--- a/deploy/helm/keyorix/templates/tests/test-connection.yaml
+++ b/deploy/helm/keyorix/templates/tests/test-connection.yaml
@@ -34,7 +34,7 @@ spec:
         requests:
           cpu: 10m
           memory: 16Mi
-          ephemeralStorage: 8Mi
+          ephemeral-storage: 8Mi
         limits:
           cpu: 100m
           memory: 32Mi

--- a/deploy/helm/keyorix/templates/web-deployment.yaml
+++ b/deploy/helm/keyorix/templates/web-deployment.yaml
@@ -76,7 +76,7 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
-              ephemeralStorage: 32Mi
+              ephemeral-storage: 32Mi
             limits:
               cpu: 500m
               memory: 128Mi

--- a/deploy/helm/keyorix/values.yaml
+++ b/deploy/helm/keyorix/values.yaml
@@ -77,9 +77,11 @@ web:
     requests:
       cpu: 50m
       memory: 64Mi
+      ephemeral-storage: 32Mi
     limits:
       cpu: 500m
       memory: 128Mi
+      ephemeral-storage: 128Mi
   # corsAllowedOrigins allowlists origins (exact scheme+host+port, e.g.
   # "https://app.example.com") the nginx-proxied /api, /auth, /system endpoints will
   # accept CREDENTIALED cross-origin requests from. The bundled web UI's own JS calls

--- a/server/http/handlers/helpers.go
+++ b/server/http/handlers/helpers.go
@@ -10,6 +10,12 @@ import (
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
+const (
+	hdrContentType           = "Content-Type"
+	hdrXContentTypeOptions   = "X-Content-Type-Options"
+	mimeApplicationJSON      = "application/json"
+)
+
 // sendSuccess sends a successful JSON response
 //
 // The envelope always carries "success": true (in addition to the implicit 2xx
@@ -23,8 +29,8 @@ import (
 // failure. This is a purely additive JSON key: existing consumers of the
 // "data"/"message" keys are unaffected.
 func sendSuccess(w http.ResponseWriter, data interface{}, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set(hdrContentType, mimeApplicationJSON)
+	w.Header().Set(hdrXContentTypeOptions, "nosniff")
 
 	response := map[string]interface{}{
 		"success": true,
@@ -45,8 +51,8 @@ func sendSuccess(w http.ResponseWriter, data interface{}, message string) {
 // sendSuccess's Header().Set() calls to be silently ignored), this function sets
 // Content-Type and X-Content-Type-Options before WriteHeader.
 func sendCreated(w http.ResponseWriter, data interface{}, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set(hdrContentType, mimeApplicationJSON)
+	w.Header().Set(hdrXContentTypeOptions, "nosniff")
 	w.WriteHeader(http.StatusCreated)
 	response := map[string]interface{}{
 		"success": true,
@@ -153,8 +159,8 @@ func mustDecodeBody(w http.ResponseWriter, r *http.Request, v interface{}) bool 
 // match APIError) — writing the field explicitly here means the error path no
 // longer depends on that coincidence.
 func sendError(w http.ResponseWriter, errorType, message string, statusCode int, details interface{}) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set(hdrContentType, mimeApplicationJSON)
+	w.Header().Set(hdrXContentTypeOptions, "nosniff")
 	w.WriteHeader(statusCode)
 
 	response := map[string]interface{}{


### PR DESCRIPTION
## Summary

Closes all 6 open SonarCloud issues (3 Maintainability + 3 Reliability).

### go:S1192 — 3 Maintainability issues (`helpers.go`)

The `sendCreated` helper added in the previous PR duplicated `"Content-Type"`, `"X-Content-Type-Options"`, and `"application/json"` across `sendSuccess` / `sendCreated` / `sendError`. Fix: extract three package-level constants (`hdrContentType`, `hdrXContentTypeOptions`, `mimeApplicationJSON`).

### kubernetes:S6897 — 3 Reliability+Maintainability issues (Helm charts)

Root cause: the prior fix used `ephemeralStorage` (camelCase) but Kubernetes and SonarCloud's rule require `ephemeral-storage` (kebab-case). The camelCase field is silently ignored by Kubernetes, so no valid storage request existed.

Two-part fix per affected chart:
1. **Template else-branch**: rename `ephemeralStorage` → `ephemeral-storage`
2. **`values.yaml`**: add `ephemeral-storage` to the default resources block — without this, `if .Values.web.resources` / `if .Values.resources` is always true (values are populated), so the else-branch with the fix was never reached

Files changed:
- `deploy/helm/keyorix/templates/tests/test-connection.yaml` — unconditional block, rename only
- `deploy/helm/keyorix/templates/web-deployment.yaml` + `values.yaml`
- `deploy/helm/keyorix-operator/templates/deployment.yaml` + `values.yaml`
- `deploy/helm/keyorix/templates/server-deployment.yaml` — else-branch consistency fix (issue already closed since `server.values.yaml` had the correct spelling)

## Test plan

- [ ] `helm lint deploy/helm/keyorix` passes
- [ ] `helm lint deploy/helm/keyorix-operator` passes
- [ ] `go vet ./server/http/handlers/` passes
- [ ] SonarCloud analysis after merge shows 0 open Reliability + 0 open Maintainability issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)