### PR TITLE
fix(ci): skip SonarCloud for dependabot + fix evidence-dir cleanup race

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   Analysis:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
         with:

--- a/server/server_s4_test.go
+++ b/server/server_s4_test.go
@@ -2065,6 +2065,15 @@ func TestStartHTTPServer_ShortLive(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 
+	// The evidence-delivery scheduler fires at 1ms and may write a new file
+	// after startHTTPServer returns but before t.TempDir() cleanup runs,
+	// causing "directory not empty". Use a separate dir with ignored cleanup.
+	evidenceDir, errMkdir := os.MkdirTemp("", "kx-evidence-test-*")
+	if errMkdir != nil {
+		t.Fatalf("MkdirTemp: %v", errMkdir)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(evidenceDir) })
+
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("get free port: %v", err)
@@ -2132,7 +2141,7 @@ func TestStartHTTPServer_ShortLive(t *testing.T) {
 		},
 		EvidenceDelivery: config.EvidenceDeliveryConfig{
 			Enabled:   true,
-			OutputDir: dir,
+			OutputDir: evidenceDir,
 			Schedule:  "1ms",
 		},
 		JITAccessExpiry: config.JITAccessExpiryConfig{


### PR DESCRIPTION
## Summary

- **SonarCloud `Analysis` fails on every dependabot PR** — dependabot branches run without access to `SONAR_TOKEN` (GitHub security model). The scanner exits with code 3 (`Not authorized`). Fix: add `if: github.actor != 'dependabot[bot]'` to the `Analysis` job so it simply skips for dependency bumps.

- **`build-and-test` fails on the go-mail 0.8.1 PR (#995)** — `TestStartHTTPServer_ShortLive` sets `EvidenceDelivery.OutputDir = t.TempDir()`. The 1ms evidence scheduler fires after `startHTTPServer` returns, writing a new file between `os.RemoveAll`'s directory scan and its final `rmdir`, producing `"directory not empty"` which Go's `t.TempDir()` cleanup turns into a test failure. Fix: route evidence output to a separate `os.MkdirTemp` dir whose cleanup ignores errors.

## Test plan

- [ ] After merge, re-run CI on dependabot PRs #994–1000 — `Analysis` job should be skipped (neutral), all other checks green
- [ ] `build-and-test` on #995 (go-mail bump) should pass with the test fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)