### PR TITLE
fix(test): add missing Name field to project_viewer mock in invitations_test

### DIFF
--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -106,7 +106,7 @@ func TestApproveAccessRequest_FallsBackToSuggestedRole(t *testing.T) {
 		ID: 3, ProjectID: 1, UserID: 2, SuggestedRole: "project_viewer", State: AccessRequestPending,
 	}, nil)
 	store.On("GetProject", ctx, uint(1)).Return(&models.Project{ID: 1}, nil)
-	store.On("GetRoleByName", ctx, "project_viewer").Return(&models.Role{ID: 6}, nil)
+	store.On("GetRoleByName", ctx, "project_viewer").Return(&models.Role{ID: 6, Name: "project_viewer"}, nil)
 	store.On("AssignRole", ctx, uint(2), uint(6), storage.Scope{ProjectID: 1}).Return(nil)
 	store.On("UpdateAccessRequest", ctx, mock.Anything).Return(true, nil)
 	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)


### PR DESCRIPTION
## Summary

- `41a1861d` fixed the same missing-`Name` pattern for `project_developer` mocks but missed `TestApproveAccessRequest_FallsBackToSuggestedRole`, which mocks `GetRoleByName` returning `Role{ID: 6}` without `Name`
- `finalizeAccessRequestApproval` sets `req.GrantedRole = roleModel.Name`, so an empty `Name` produces `GrantedRole == ""` — failing `assert.Equal(t, "project_viewer", out.GrantedRole)`

One-character change: `&models.Role{ID: 6}` → `&models.Role{ID: 6, Name: "project_viewer"}`

## Test plan

- [ ] `go test ./internal/core/` passes
- [ ] `build-and-test` CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)