### PR TITLE
feat(cli): show KEK provider type in encryption status

### DIFF
--- a/internal/cli/encryption/encryption.go
+++ b/internal/cli/encryption/encryption.go
@@ -213,8 +213,48 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Initialized: ✅\n")
 	fmt.Printf("Key Version: %s\n", service.GetKeyVersion())
+	printProviderStatus(cfg.Storage.Encryption.KeyProvider)
 
 	return nil
+}
+
+func printProviderStatus(kp config.KeyProviderConfig) {
+	provType := kp.Type
+	if provType == "" {
+		provType = "password"
+	}
+	fmt.Printf("Key Provider: %s\n", provType)
+	switch provType {
+	case "password":
+		fmt.Println("  (passphrase-derived KEK; use `keyorix encryption migrate-provider` to change)")
+	case "file":
+		fmt.Printf("  File: %s\n", kp.FilePath)
+		if _, err := os.Stat(kp.FilePath); err == nil {
+			fmt.Println("  Status: file accessible ✅")
+		} else {
+			fmt.Printf("  Status: file not accessible ❌ (%v)\n", err)
+		}
+	case "env":
+		fmt.Printf("  Env var: %s\n", kp.EnvVar)
+		if os.Getenv(kp.EnvVar) != "" {
+			fmt.Println("  Status: env var set ✅")
+		} else {
+			fmt.Println("  Status: env var not set ❌")
+		}
+	case "exec":
+		fmt.Printf("  Command: %v\n", kp.ExecCommand)
+	case "shamir":
+		fmt.Printf("  Share files: %d configured\n", len(kp.ShamirShareFiles))
+	case "tpm":
+		fmt.Printf("  TPM device: %s\n", kp.TPMDevice)
+		fmt.Printf("  Wrapped key: %s\n", kp.WrappedKeyPath)
+	case "aws-kms", "gcp-kms", "azure-kms":
+		fmt.Printf("  KMS key: %s\n", kp.KMSKeyID)
+		if kp.WrappedKeyPath != "" {
+			fmt.Printf("  Wrapped key: %s\n", kp.WrappedKeyPath)
+		}
+		fmt.Println("  (connectivity not checked; verify credentials separately)")
+	}
 }
 
 func runRotate(cmd *cobra.Command, args []string) error {

--- a/internal/cli/encryption/provider_status_test.go
+++ b/internal/cli/encryption/provider_status_test.go
@@ -8,22 +8,26 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func captureProviderStatusOutput(fn func()) string {
+func captureProviderStatusOutput(t *testing.T, fn func()) string {
+	t.Helper()
 	old := os.Stdout
-	r, w, _ := os.Pipe()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
 	os.Stdout = w
 	fn()
-	w.Close()
+	require.NoError(t, w.Close())
 	os.Stdout = old
 	var buf bytes.Buffer
-	io.Copy(&buf, r) //nolint:errcheck
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
 	return buf.String()
 }
 
 func TestPrintProviderStatus_Password(t *testing.T) {
-	out := captureProviderStatusOutput(func() {
+	out := captureProviderStatusOutput(t, func() {
 		printProviderStatus(config.KeyProviderConfig{Type: "password"})
 	})
 	assert.Contains(t, out, "Key Provider: password")
@@ -31,16 +35,17 @@ func TestPrintProviderStatus_Password(t *testing.T) {
 }
 
 func TestPrintProviderStatus_EmptyTypeDefaultsToPassword(t *testing.T) {
-	out := captureProviderStatusOutput(func() {
+	out := captureProviderStatusOutput(t, func() {
 		printProviderStatus(config.KeyProviderConfig{})
 	})
 	assert.Contains(t, out, "Key Provider: password")
 }
 
 func TestPrintProviderStatus_FileExists(t *testing.T) {
-	f, _ := os.CreateTemp(t.TempDir(), "kek")
-	f.Close()
-	out := captureProviderStatusOutput(func() {
+	f, err := os.CreateTemp(t.TempDir(), "kek")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	out := captureProviderStatusOutput(t, func() {
 		printProviderStatus(config.KeyProviderConfig{Type: "file", FilePath: f.Name()})
 	})
 	assert.Contains(t, out, "Key Provider: file")
@@ -49,7 +54,7 @@ func TestPrintProviderStatus_FileExists(t *testing.T) {
 }
 
 func TestPrintProviderStatus_FileMissing(t *testing.T) {
-	out := captureProviderStatusOutput(func() {
+	out := captureProviderStatusOutput(t, func() {
 		printProviderStatus(config.KeyProviderConfig{Type: "file", FilePath: "/nonexistent/kek.key"})
 	})
 	assert.Contains(t, out, "not accessible ❌")
@@ -57,7 +62,7 @@ func TestPrintProviderStatus_FileMissing(t *testing.T) {
 
 func TestPrintProviderStatus_EnvSet(t *testing.T) {
 	t.Setenv("_TEST_KEYORIX_KEK", "val")
-	out := captureProviderStatusOutput(func() {
+	out := captureProviderStatusOutput(t, func() {
 		printProviderStatus(config.KeyProviderConfig{Type: "env", EnvVar: "_TEST_KEYORIX_KEK"})
 	})
 	assert.Contains(t, out, "Key Provider: env")
@@ -65,15 +70,15 @@ func TestPrintProviderStatus_EnvSet(t *testing.T) {
 }
 
 func TestPrintProviderStatus_EnvNotSet(t *testing.T) {
-	os.Unsetenv("_TEST_KEYORIX_KEK_MISSING") //nolint:errcheck
-	out := captureProviderStatusOutput(func() {
+	t.Setenv("_TEST_KEYORIX_KEK_MISSING", "")
+	out := captureProviderStatusOutput(t, func() {
 		printProviderStatus(config.KeyProviderConfig{Type: "env", EnvVar: "_TEST_KEYORIX_KEK_MISSING"})
 	})
 	assert.Contains(t, out, "not set ❌")
 }
 
 func TestPrintProviderStatus_AWSKMS(t *testing.T) {
-	out := captureProviderStatusOutput(func() {
+	out := captureProviderStatusOutput(t, func() {
 		printProviderStatus(config.KeyProviderConfig{
 			Type:     "aws-kms",
 			KMSKeyID: "arn:aws:kms:eu-west-1:123:key/abc",

--- a/internal/cli/encryption/provider_status_test.go
+++ b/internal/cli/encryption/provider_status_test.go
@@ -1,0 +1,84 @@
+package encryption
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func captureProviderStatusOutput(fn func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+	return buf.String()
+}
+
+func TestPrintProviderStatus_Password(t *testing.T) {
+	out := captureProviderStatusOutput(func() {
+		printProviderStatus(config.KeyProviderConfig{Type: "password"})
+	})
+	assert.Contains(t, out, "Key Provider: password")
+	assert.Contains(t, out, "passphrase-derived")
+}
+
+func TestPrintProviderStatus_EmptyTypeDefaultsToPassword(t *testing.T) {
+	out := captureProviderStatusOutput(func() {
+		printProviderStatus(config.KeyProviderConfig{})
+	})
+	assert.Contains(t, out, "Key Provider: password")
+}
+
+func TestPrintProviderStatus_FileExists(t *testing.T) {
+	f, _ := os.CreateTemp(t.TempDir(), "kek")
+	f.Close()
+	out := captureProviderStatusOutput(func() {
+		printProviderStatus(config.KeyProviderConfig{Type: "file", FilePath: f.Name()})
+	})
+	assert.Contains(t, out, "Key Provider: file")
+	assert.Contains(t, out, f.Name())
+	assert.Contains(t, out, "accessible ✅")
+}
+
+func TestPrintProviderStatus_FileMissing(t *testing.T) {
+	out := captureProviderStatusOutput(func() {
+		printProviderStatus(config.KeyProviderConfig{Type: "file", FilePath: "/nonexistent/kek.key"})
+	})
+	assert.Contains(t, out, "not accessible ❌")
+}
+
+func TestPrintProviderStatus_EnvSet(t *testing.T) {
+	t.Setenv("_TEST_KEYORIX_KEK", "val")
+	out := captureProviderStatusOutput(func() {
+		printProviderStatus(config.KeyProviderConfig{Type: "env", EnvVar: "_TEST_KEYORIX_KEK"})
+	})
+	assert.Contains(t, out, "Key Provider: env")
+	assert.Contains(t, out, "set ✅")
+}
+
+func TestPrintProviderStatus_EnvNotSet(t *testing.T) {
+	os.Unsetenv("_TEST_KEYORIX_KEK_MISSING") //nolint:errcheck
+	out := captureProviderStatusOutput(func() {
+		printProviderStatus(config.KeyProviderConfig{Type: "env", EnvVar: "_TEST_KEYORIX_KEK_MISSING"})
+	})
+	assert.Contains(t, out, "not set ❌")
+}
+
+func TestPrintProviderStatus_AWSKMS(t *testing.T) {
+	out := captureProviderStatusOutput(func() {
+		printProviderStatus(config.KeyProviderConfig{
+			Type:     "aws-kms",
+			KMSKeyID: "arn:aws:kms:eu-west-1:123:key/abc",
+		})
+	})
+	assert.Contains(t, out, "Key Provider: aws-kms")
+	assert.Contains(t, out, "arn:aws:kms")
+}


### PR DESCRIPTION
## Summary
- `keyorix encryption status` now prints `Key Provider: <type>` with provider-specific details
- File provider: checks if key file is accessible (✅/❌)
- Env provider: checks if env var is set (✅/❌)
- KMS providers (aws-kms/gcp-kms/azure-kms): prints key ID, skips live connectivity check
- Password, exec, shamir, tpm: prints relevant config info

## Test plan
- [ ] `go test ./internal/cli/encryption/...` green (7 new tests in `provider_status_test.go`)
- [ ] `go build ./...` green