### PR TITLE
feat(grpc): GetDeploymentRotationPlan RPC (ADR-053 vertical completion)

### DIFF
--- a/server/grpc/services/conversions.go
+++ b/server/grpc/services/conversions.go
@@ -261,6 +261,26 @@ func rotationPlanToProto(p *core.RotationPlan) *pb.RotationPlan {
 	return out
 }
 
+func deploymentRotationPlanToProto(d *core.DeploymentRotationPlan) *pb.DeploymentRotationPlan {
+	out := &pb.DeploymentRotationPlan{
+		ProjectsScanned:  intToI32(d.ProjectsScanned),
+		ProjectsWithWork: intToI32(d.ProjectsWithWork),
+		TotalSecrets:     intToI32(d.TotalSecrets),
+		OverdueCount:     intToI32(d.OverdueCount),
+		DueSoonCount:     intToI32(d.DueSoonCount),
+	}
+	for i := range d.Projects {
+		out.Projects = append(out.Projects, rotationPlanToProto(&d.Projects[i]))
+	}
+	for _, bp := range d.BrokenProjects {
+		out.BrokenProjects = append(out.BrokenProjects, &pb.BrokenRotationProject{
+			ProjectId: intToU32(int(bp.ProjectID)),
+			Error:     bp.Error,
+		})
+	}
+	return out
+}
+
 func rotationOrderToProto(o *core.RotationOrder) *pb.RotationOrder {
 	out := &pb.RotationOrder{ProjectId: intToU32(int(o.ProjectID))}
 	for _, s := range o.Order {

--- a/server/grpc/services/project_service.go
+++ b/server/grpc/services/project_service.go
@@ -120,6 +120,22 @@ func (s *ProjectGRPCService) GetProjectRotationPlan(ctx context.Context, req *pb
 	return rotationPlanToProto(plan), nil
 }
 
+// GetDeploymentRotationPlan returns the install-wide rotation plan (ADR-053).
+func (s *ProjectGRPCService) GetDeploymentRotationPlan(ctx context.Context, _ *emptypb.Empty) (*pb.DeploymentRotationPlan, error) {
+	user, err := requireUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := authorizeGlobal(ctx, s.core, user, permSecretsRead); err != nil {
+		return nil, err
+	}
+	plan, err := s.core.GenerateDeploymentRotationPlan(ctx)
+	if err != nil {
+		return nil, mapProjectError(err)
+	}
+	return deploymentRotationPlanToProto(plan), nil
+}
+
 func (s *ProjectGRPCService) CreateProject(ctx context.Context, req *pb.CreateProjectRequest) (*pb.Project, error) {
 	user, err := requireUser(ctx)
 	if err != nil {

--- a/server/grpc/services/rotation_plan_service_test.go
+++ b/server/grpc/services/rotation_plan_service_test.go
@@ -84,3 +84,17 @@ func TestGRPC_GetDeploymentRotationPlanRequiresAuth(t *testing.T) {
 	_, err := svc.GetDeploymentRotationPlan(t.Context(), &emptypb.Empty{})
 	require.Error(t, err)
 }
+
+func TestDeploymentRotationPlanToProto_BrokenProjects(t *testing.T) {
+	d := &core.DeploymentRotationPlan{
+		ProjectsScanned:  2,
+		ProjectsWithWork: 0,
+		BrokenProjects: []core.BrokenRotationProject{
+			{ProjectID: 42, Error: "connection reset"},
+		},
+	}
+	result := deploymentRotationPlanToProto(d)
+	require.Len(t, result.GetBrokenProjects(), 1)
+	assert.Equal(t, uint32(42), result.GetBrokenProjects()[0].GetProjectId())
+	assert.Equal(t, "connection reset", result.GetBrokenProjects()[0].GetError())
+}

--- a/server/grpc/services/rotation_plan_service_test.go
+++ b/server/grpc/services/rotation_plan_service_test.go
@@ -10,6 +10,7 @@ import (
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // newRotationPlanRig reuses the secret rig (i18n + RBAC graph + project 1 / env 1 /
@@ -63,5 +64,23 @@ func TestGRPC_GetProjectRotationPlan(t *testing.T) {
 func TestGRPC_GetProjectRotationPlanRequiresAuth(t *testing.T) {
 	svc := newRotationPlanRig(t)
 	_, err := svc.GetProjectRotationPlan(t.Context(), &pb.GetProjectRequest{Id: 1})
+	require.Error(t, err)
+}
+
+func TestGRPC_GetDeploymentRotationPlan(t *testing.T) {
+	svc := newRotationPlanRig(t)
+	resp, err := svc.GetDeploymentRotationPlan(authCtx(1, "owner", "secrets.read"), &emptypb.Empty{})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), resp.GetProjectsScanned())
+	assert.Equal(t, int32(1), resp.GetProjectsWithWork())
+	assert.Equal(t, int32(2), resp.GetTotalSecrets())
+	assert.Equal(t, int32(2), resp.GetOverdueCount())
+	require.Len(t, resp.GetProjects(), 1, "one project has work")
+	assert.Empty(t, resp.GetBrokenProjects())
+}
+
+func TestGRPC_GetDeploymentRotationPlanRequiresAuth(t *testing.T) {
+	svc := newRotationPlanRig(t)
+	_, err := svc.GetDeploymentRotationPlan(t.Context(), &emptypb.Empty{})
 	require.Error(t, err)
 }

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -332,6 +332,23 @@ message RotationOrder {
 
 // --- Automated rotation plan (ADR-053) ---
 
+// BrokenRotationProject names a project whose rotation plan could not be computed.
+message BrokenRotationProject {
+  uint32 project_id = 1;
+  string error = 2;
+}
+
+// DeploymentRotationPlan is the install-wide rotation plan roll-up (ADR-053).
+message DeploymentRotationPlan {
+  int32 projects_scanned = 1;
+  int32 projects_with_work = 2;
+  int32 total_secrets = 3;
+  int32 overdue_count = 4;
+  int32 due_soon_count = 5;
+  repeated RotationPlan projects = 6;
+  repeated BrokenRotationProject broken_projects = 7;
+}
+
 message PlannedRotation {
   uint32 secret_id = 1;
   string secret_name = 2;
@@ -903,6 +920,9 @@ service ProjectService {
   // The project's automated rotation plan (ADR-053): overdue/due-soon secrets
   // batched into dependency-safe waves, prioritised by urgency. Scoped secrets.read.
   rpc GetProjectRotationPlan(GetProjectRequest) returns (RotationPlan);
+
+  // GetDeploymentRotationPlan returns the install-wide rotation plan (ADR-053).
+  rpc GetDeploymentRotationPlan(google.protobuf.Empty) returns (DeploymentRotationPlan);
 
   // List a project's environments.
   rpc ListEnvironments(ListEnvironmentsRequest) returns (ListEnvironmentsResponse);

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -1371,6 +1371,152 @@ func (x *RotationOrder) GetOrder() []*RotationStep {
 	return nil
 }
 
+// BrokenRotationProject names a project whose rotation plan could not be computed.
+type BrokenRotationProject struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ProjectId     uint32                 `protobuf:"varint,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BrokenRotationProject) Reset() {
+	*x = BrokenRotationProject{}
+	mi := &file_keyorix_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BrokenRotationProject) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BrokenRotationProject) ProtoMessage() {}
+
+func (x *BrokenRotationProject) ProtoReflect() protoreflect.Message {
+	mi := &file_keyorix_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BrokenRotationProject.ProtoReflect.Descriptor instead.
+func (*BrokenRotationProject) Descriptor() ([]byte, []int) {
+	return file_keyorix_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *BrokenRotationProject) GetProjectId() uint32 {
+	if x != nil {
+		return x.ProjectId
+	}
+	return 0
+}
+
+func (x *BrokenRotationProject) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+// DeploymentRotationPlan is the install-wide rotation plan roll-up (ADR-053).
+type DeploymentRotationPlan struct {
+	state            protoimpl.MessageState   `protogen:"open.v1"`
+	ProjectsScanned  int32                    `protobuf:"varint,1,opt,name=projects_scanned,json=projectsScanned,proto3" json:"projects_scanned,omitempty"`
+	ProjectsWithWork int32                    `protobuf:"varint,2,opt,name=projects_with_work,json=projectsWithWork,proto3" json:"projects_with_work,omitempty"`
+	TotalSecrets     int32                    `protobuf:"varint,3,opt,name=total_secrets,json=totalSecrets,proto3" json:"total_secrets,omitempty"`
+	OverdueCount     int32                    `protobuf:"varint,4,opt,name=overdue_count,json=overdueCount,proto3" json:"overdue_count,omitempty"`
+	DueSoonCount     int32                    `protobuf:"varint,5,opt,name=due_soon_count,json=dueSoonCount,proto3" json:"due_soon_count,omitempty"`
+	Projects         []*RotationPlan          `protobuf:"bytes,6,rep,name=projects,proto3" json:"projects,omitempty"`
+	BrokenProjects   []*BrokenRotationProject `protobuf:"bytes,7,rep,name=broken_projects,json=brokenProjects,proto3" json:"broken_projects,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *DeploymentRotationPlan) Reset() {
+	*x = DeploymentRotationPlan{}
+	mi := &file_keyorix_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeploymentRotationPlan) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeploymentRotationPlan) ProtoMessage() {}
+
+func (x *DeploymentRotationPlan) ProtoReflect() protoreflect.Message {
+	mi := &file_keyorix_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeploymentRotationPlan.ProtoReflect.Descriptor instead.
+func (*DeploymentRotationPlan) Descriptor() ([]byte, []int) {
+	return file_keyorix_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *DeploymentRotationPlan) GetProjectsScanned() int32 {
+	if x != nil {
+		return x.ProjectsScanned
+	}
+	return 0
+}
+
+func (x *DeploymentRotationPlan) GetProjectsWithWork() int32 {
+	if x != nil {
+		return x.ProjectsWithWork
+	}
+	return 0
+}
+
+func (x *DeploymentRotationPlan) GetTotalSecrets() int32 {
+	if x != nil {
+		return x.TotalSecrets
+	}
+	return 0
+}
+
+func (x *DeploymentRotationPlan) GetOverdueCount() int32 {
+	if x != nil {
+		return x.OverdueCount
+	}
+	return 0
+}
+
+func (x *DeploymentRotationPlan) GetDueSoonCount() int32 {
+	if x != nil {
+		return x.DueSoonCount
+	}
+	return 0
+}
+
+func (x *DeploymentRotationPlan) GetProjects() []*RotationPlan {
+	if x != nil {
+		return x.Projects
+	}
+	return nil
+}
+
+func (x *DeploymentRotationPlan) GetBrokenProjects() []*BrokenRotationProject {
+	if x != nil {
+		return x.BrokenProjects
+	}
+	return nil
+}
+
 type PlannedRotation struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	SecretId       uint32                 `protobuf:"varint,1,opt,name=secret_id,json=secretId,proto3" json:"secret_id,omitempty"`
@@ -1389,7 +1535,7 @@ type PlannedRotation struct {
 
 func (x *PlannedRotation) Reset() {
 	*x = PlannedRotation{}
-	mi := &file_keyorix_proto_msgTypes[18]
+	mi := &file_keyorix_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1401,7 +1547,7 @@ func (x *PlannedRotation) String() string {
 func (*PlannedRotation) ProtoMessage() {}
 
 func (x *PlannedRotation) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[18]
+	mi := &file_keyorix_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1414,7 +1560,7 @@ func (x *PlannedRotation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlannedRotation.ProtoReflect.Descriptor instead.
 func (*PlannedRotation) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{18}
+	return file_keyorix_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *PlannedRotation) GetSecretId() uint32 {
@@ -1497,7 +1643,7 @@ type RotationWave struct {
 
 func (x *RotationWave) Reset() {
 	*x = RotationWave{}
-	mi := &file_keyorix_proto_msgTypes[19]
+	mi := &file_keyorix_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1509,7 +1655,7 @@ func (x *RotationWave) String() string {
 func (*RotationWave) ProtoMessage() {}
 
 func (x *RotationWave) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[19]
+	mi := &file_keyorix_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1522,7 +1668,7 @@ func (x *RotationWave) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotationWave.ProtoReflect.Descriptor instead.
 func (*RotationWave) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{19}
+	return file_keyorix_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *RotationWave) GetIndex() int32 {
@@ -1552,7 +1698,7 @@ type RotationPlan struct {
 
 func (x *RotationPlan) Reset() {
 	*x = RotationPlan{}
-	mi := &file_keyorix_proto_msgTypes[20]
+	mi := &file_keyorix_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1564,7 +1710,7 @@ func (x *RotationPlan) String() string {
 func (*RotationPlan) ProtoMessage() {}
 
 func (x *RotationPlan) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[20]
+	mi := &file_keyorix_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1577,7 +1723,7 @@ func (x *RotationPlan) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotationPlan.ProtoReflect.Descriptor instead.
 func (*RotationPlan) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{20}
+	return file_keyorix_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *RotationPlan) GetProjectId() uint32 {
@@ -1634,7 +1780,7 @@ type User struct {
 
 func (x *User) Reset() {
 	*x = User{}
-	mi := &file_keyorix_proto_msgTypes[21]
+	mi := &file_keyorix_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1646,7 +1792,7 @@ func (x *User) String() string {
 func (*User) ProtoMessage() {}
 
 func (x *User) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[21]
+	mi := &file_keyorix_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1659,7 +1805,7 @@ func (x *User) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use User.ProtoReflect.Descriptor instead.
 func (*User) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{21}
+	return file_keyorix_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *User) GetId() uint32 {
@@ -1750,7 +1896,7 @@ type ProjectAssignment struct {
 
 func (x *ProjectAssignment) Reset() {
 	*x = ProjectAssignment{}
-	mi := &file_keyorix_proto_msgTypes[22]
+	mi := &file_keyorix_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1762,7 +1908,7 @@ func (x *ProjectAssignment) String() string {
 func (*ProjectAssignment) ProtoMessage() {}
 
 func (x *ProjectAssignment) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[22]
+	mi := &file_keyorix_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1775,7 +1921,7 @@ func (x *ProjectAssignment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProjectAssignment.ProtoReflect.Descriptor instead.
 func (*ProjectAssignment) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{22}
+	return file_keyorix_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ProjectAssignment) GetProjectId() uint32 {
@@ -1813,7 +1959,7 @@ type CreateUserRequest struct {
 
 func (x *CreateUserRequest) Reset() {
 	*x = CreateUserRequest{}
-	mi := &file_keyorix_proto_msgTypes[23]
+	mi := &file_keyorix_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1825,7 +1971,7 @@ func (x *CreateUserRequest) String() string {
 func (*CreateUserRequest) ProtoMessage() {}
 
 func (x *CreateUserRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[23]
+	mi := &file_keyorix_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1838,7 +1984,7 @@ func (x *CreateUserRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateUserRequest.ProtoReflect.Descriptor instead.
 func (*CreateUserRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{23}
+	return file_keyorix_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *CreateUserRequest) GetUsername() string {
@@ -1923,7 +2069,7 @@ type CreateUserResponse struct {
 
 func (x *CreateUserResponse) Reset() {
 	*x = CreateUserResponse{}
-	mi := &file_keyorix_proto_msgTypes[24]
+	mi := &file_keyorix_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1935,7 +2081,7 @@ func (x *CreateUserResponse) String() string {
 func (*CreateUserResponse) ProtoMessage() {}
 
 func (x *CreateUserResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[24]
+	mi := &file_keyorix_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1948,7 +2094,7 @@ func (x *CreateUserResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateUserResponse.ProtoReflect.Descriptor instead.
 func (*CreateUserResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{24}
+	return file_keyorix_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *CreateUserResponse) GetUser() *User {
@@ -1981,7 +2127,7 @@ type GetUserRequest struct {
 
 func (x *GetUserRequest) Reset() {
 	*x = GetUserRequest{}
-	mi := &file_keyorix_proto_msgTypes[25]
+	mi := &file_keyorix_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1993,7 +2139,7 @@ func (x *GetUserRequest) String() string {
 func (*GetUserRequest) ProtoMessage() {}
 
 func (x *GetUserRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[25]
+	mi := &file_keyorix_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2006,7 +2152,7 @@ func (x *GetUserRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserRequest.ProtoReflect.Descriptor instead.
 func (*GetUserRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{25}
+	return file_keyorix_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetUserRequest) GetId() uint32 {
@@ -2029,7 +2175,7 @@ type UpdateUserRequest struct {
 
 func (x *UpdateUserRequest) Reset() {
 	*x = UpdateUserRequest{}
-	mi := &file_keyorix_proto_msgTypes[26]
+	mi := &file_keyorix_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2041,7 +2187,7 @@ func (x *UpdateUserRequest) String() string {
 func (*UpdateUserRequest) ProtoMessage() {}
 
 func (x *UpdateUserRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[26]
+	mi := &file_keyorix_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2054,7 +2200,7 @@ func (x *UpdateUserRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserRequest.ProtoReflect.Descriptor instead.
 func (*UpdateUserRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{26}
+	return file_keyorix_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *UpdateUserRequest) GetId() uint32 {
@@ -2101,7 +2247,7 @@ type DeleteUserRequest struct {
 
 func (x *DeleteUserRequest) Reset() {
 	*x = DeleteUserRequest{}
-	mi := &file_keyorix_proto_msgTypes[27]
+	mi := &file_keyorix_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2113,7 +2259,7 @@ func (x *DeleteUserRequest) String() string {
 func (*DeleteUserRequest) ProtoMessage() {}
 
 func (x *DeleteUserRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[27]
+	mi := &file_keyorix_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2126,7 +2272,7 @@ func (x *DeleteUserRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteUserRequest.ProtoReflect.Descriptor instead.
 func (*DeleteUserRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{27}
+	return file_keyorix_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *DeleteUserRequest) GetId() uint32 {
@@ -2151,7 +2297,7 @@ type ListUsersRequest struct {
 
 func (x *ListUsersRequest) Reset() {
 	*x = ListUsersRequest{}
-	mi := &file_keyorix_proto_msgTypes[28]
+	mi := &file_keyorix_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2163,7 +2309,7 @@ func (x *ListUsersRequest) String() string {
 func (*ListUsersRequest) ProtoMessage() {}
 
 func (x *ListUsersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[28]
+	mi := &file_keyorix_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2176,7 +2322,7 @@ func (x *ListUsersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUsersRequest.ProtoReflect.Descriptor instead.
 func (*ListUsersRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{28}
+	return file_keyorix_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ListUsersRequest) GetPage() uint32 {
@@ -2234,7 +2380,7 @@ type ListUsersResponse struct {
 
 func (x *ListUsersResponse) Reset() {
 	*x = ListUsersResponse{}
-	mi := &file_keyorix_proto_msgTypes[29]
+	mi := &file_keyorix_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2246,7 +2392,7 @@ func (x *ListUsersResponse) String() string {
 func (*ListUsersResponse) ProtoMessage() {}
 
 func (x *ListUsersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[29]
+	mi := &file_keyorix_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2259,7 +2405,7 @@ func (x *ListUsersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUsersResponse.ProtoReflect.Descriptor instead.
 func (*ListUsersResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{29}
+	return file_keyorix_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ListUsersResponse) GetUsers() []*User {
@@ -2310,7 +2456,7 @@ type Permission struct {
 
 func (x *Permission) Reset() {
 	*x = Permission{}
-	mi := &file_keyorix_proto_msgTypes[30]
+	mi := &file_keyorix_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2322,7 +2468,7 @@ func (x *Permission) String() string {
 func (*Permission) ProtoMessage() {}
 
 func (x *Permission) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[30]
+	mi := &file_keyorix_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2335,7 +2481,7 @@ func (x *Permission) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Permission.ProtoReflect.Descriptor instead.
 func (*Permission) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{30}
+	return file_keyorix_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *Permission) GetId() uint32 {
@@ -2387,7 +2533,7 @@ type Role struct {
 
 func (x *Role) Reset() {
 	*x = Role{}
-	mi := &file_keyorix_proto_msgTypes[31]
+	mi := &file_keyorix_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2399,7 +2545,7 @@ func (x *Role) String() string {
 func (*Role) ProtoMessage() {}
 
 func (x *Role) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[31]
+	mi := &file_keyorix_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2412,7 +2558,7 @@ func (x *Role) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Role.ProtoReflect.Descriptor instead.
 func (*Role) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{31}
+	return file_keyorix_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *Role) GetId() uint32 {
@@ -2469,7 +2615,7 @@ type CreateRoleRequest struct {
 
 func (x *CreateRoleRequest) Reset() {
 	*x = CreateRoleRequest{}
-	mi := &file_keyorix_proto_msgTypes[32]
+	mi := &file_keyorix_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2481,7 +2627,7 @@ func (x *CreateRoleRequest) String() string {
 func (*CreateRoleRequest) ProtoMessage() {}
 
 func (x *CreateRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[32]
+	mi := &file_keyorix_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2494,7 +2640,7 @@ func (x *CreateRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateRoleRequest.ProtoReflect.Descriptor instead.
 func (*CreateRoleRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{32}
+	return file_keyorix_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *CreateRoleRequest) GetName() string {
@@ -2527,7 +2673,7 @@ type GetRoleRequest struct {
 
 func (x *GetRoleRequest) Reset() {
 	*x = GetRoleRequest{}
-	mi := &file_keyorix_proto_msgTypes[33]
+	mi := &file_keyorix_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2539,7 +2685,7 @@ func (x *GetRoleRequest) String() string {
 func (*GetRoleRequest) ProtoMessage() {}
 
 func (x *GetRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[33]
+	mi := &file_keyorix_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2552,7 +2698,7 @@ func (x *GetRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoleRequest.ProtoReflect.Descriptor instead.
 func (*GetRoleRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{33}
+	return file_keyorix_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GetRoleRequest) GetId() uint32 {
@@ -2574,7 +2720,7 @@ type UpdateRoleRequest struct {
 
 func (x *UpdateRoleRequest) Reset() {
 	*x = UpdateRoleRequest{}
-	mi := &file_keyorix_proto_msgTypes[34]
+	mi := &file_keyorix_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2586,7 +2732,7 @@ func (x *UpdateRoleRequest) String() string {
 func (*UpdateRoleRequest) ProtoMessage() {}
 
 func (x *UpdateRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[34]
+	mi := &file_keyorix_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2599,7 +2745,7 @@ func (x *UpdateRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateRoleRequest.ProtoReflect.Descriptor instead.
 func (*UpdateRoleRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{34}
+	return file_keyorix_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *UpdateRoleRequest) GetId() uint32 {
@@ -2632,7 +2778,7 @@ type DeleteRoleRequest struct {
 
 func (x *DeleteRoleRequest) Reset() {
 	*x = DeleteRoleRequest{}
-	mi := &file_keyorix_proto_msgTypes[35]
+	mi := &file_keyorix_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2644,7 +2790,7 @@ func (x *DeleteRoleRequest) String() string {
 func (*DeleteRoleRequest) ProtoMessage() {}
 
 func (x *DeleteRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[35]
+	mi := &file_keyorix_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2657,7 +2803,7 @@ func (x *DeleteRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRoleRequest.ProtoReflect.Descriptor instead.
 func (*DeleteRoleRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{35}
+	return file_keyorix_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *DeleteRoleRequest) GetId() uint32 {
@@ -2677,7 +2823,7 @@ type ListRolesRequest struct {
 
 func (x *ListRolesRequest) Reset() {
 	*x = ListRolesRequest{}
-	mi := &file_keyorix_proto_msgTypes[36]
+	mi := &file_keyorix_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2689,7 +2835,7 @@ func (x *ListRolesRequest) String() string {
 func (*ListRolesRequest) ProtoMessage() {}
 
 func (x *ListRolesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[36]
+	mi := &file_keyorix_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2702,7 +2848,7 @@ func (x *ListRolesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRolesRequest.ProtoReflect.Descriptor instead.
 func (*ListRolesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{36}
+	return file_keyorix_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ListRolesRequest) GetPage() uint32 {
@@ -2732,7 +2878,7 @@ type ListRolesResponse struct {
 
 func (x *ListRolesResponse) Reset() {
 	*x = ListRolesResponse{}
-	mi := &file_keyorix_proto_msgTypes[37]
+	mi := &file_keyorix_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2744,7 +2890,7 @@ func (x *ListRolesResponse) String() string {
 func (*ListRolesResponse) ProtoMessage() {}
 
 func (x *ListRolesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[37]
+	mi := &file_keyorix_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2757,7 +2903,7 @@ func (x *ListRolesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRolesResponse.ProtoReflect.Descriptor instead.
 func (*ListRolesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{37}
+	return file_keyorix_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ListRolesResponse) GetRoles() []*Role {
@@ -2809,7 +2955,7 @@ type AssignRoleRequest struct {
 
 func (x *AssignRoleRequest) Reset() {
 	*x = AssignRoleRequest{}
-	mi := &file_keyorix_proto_msgTypes[38]
+	mi := &file_keyorix_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2821,7 +2967,7 @@ func (x *AssignRoleRequest) String() string {
 func (*AssignRoleRequest) ProtoMessage() {}
 
 func (x *AssignRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[38]
+	mi := &file_keyorix_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2834,7 +2980,7 @@ func (x *AssignRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssignRoleRequest.ProtoReflect.Descriptor instead.
 func (*AssignRoleRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{38}
+	return file_keyorix_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *AssignRoleRequest) GetUserId() uint32 {
@@ -2877,7 +3023,7 @@ type RoleAssignment struct {
 
 func (x *RoleAssignment) Reset() {
 	*x = RoleAssignment{}
-	mi := &file_keyorix_proto_msgTypes[39]
+	mi := &file_keyorix_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2889,7 +3035,7 @@ func (x *RoleAssignment) String() string {
 func (*RoleAssignment) ProtoMessage() {}
 
 func (x *RoleAssignment) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[39]
+	mi := &file_keyorix_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2902,7 +3048,7 @@ func (x *RoleAssignment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoleAssignment.ProtoReflect.Descriptor instead.
 func (*RoleAssignment) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{39}
+	return file_keyorix_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *RoleAssignment) GetUserId() uint32 {
@@ -2945,7 +3091,7 @@ type RemoveRoleRequest struct {
 
 func (x *RemoveRoleRequest) Reset() {
 	*x = RemoveRoleRequest{}
-	mi := &file_keyorix_proto_msgTypes[40]
+	mi := &file_keyorix_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2957,7 +3103,7 @@ func (x *RemoveRoleRequest) String() string {
 func (*RemoveRoleRequest) ProtoMessage() {}
 
 func (x *RemoveRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[40]
+	mi := &file_keyorix_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2970,7 +3116,7 @@ func (x *RemoveRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveRoleRequest.ProtoReflect.Descriptor instead.
 func (*RemoveRoleRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{40}
+	return file_keyorix_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *RemoveRoleRequest) GetUserId() uint32 {
@@ -3010,7 +3156,7 @@ type GetUserRolesRequest struct {
 
 func (x *GetUserRolesRequest) Reset() {
 	*x = GetUserRolesRequest{}
-	mi := &file_keyorix_proto_msgTypes[41]
+	mi := &file_keyorix_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3022,7 +3168,7 @@ func (x *GetUserRolesRequest) String() string {
 func (*GetUserRolesRequest) ProtoMessage() {}
 
 func (x *GetUserRolesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[41]
+	mi := &file_keyorix_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3035,7 +3181,7 @@ func (x *GetUserRolesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserRolesRequest.ProtoReflect.Descriptor instead.
 func (*GetUserRolesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{41}
+	return file_keyorix_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *GetUserRolesRequest) GetUserId() uint32 {
@@ -3057,7 +3203,7 @@ type GetUserRolesResponse struct {
 
 func (x *GetUserRolesResponse) Reset() {
 	*x = GetUserRolesResponse{}
-	mi := &file_keyorix_proto_msgTypes[42]
+	mi := &file_keyorix_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3069,7 +3215,7 @@ func (x *GetUserRolesResponse) String() string {
 func (*GetUserRolesResponse) ProtoMessage() {}
 
 func (x *GetUserRolesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[42]
+	mi := &file_keyorix_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3082,7 +3228,7 @@ func (x *GetUserRolesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserRolesResponse.ProtoReflect.Descriptor instead.
 func (*GetUserRolesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{42}
+	return file_keyorix_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *GetUserRolesResponse) GetUserId() uint32 {
@@ -3138,7 +3284,7 @@ type AuditLog struct {
 
 func (x *AuditLog) Reset() {
 	*x = AuditLog{}
-	mi := &file_keyorix_proto_msgTypes[43]
+	mi := &file_keyorix_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3150,7 +3296,7 @@ func (x *AuditLog) String() string {
 func (*AuditLog) ProtoMessage() {}
 
 func (x *AuditLog) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[43]
+	mi := &file_keyorix_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3163,7 +3309,7 @@ func (x *AuditLog) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditLog.ProtoReflect.Descriptor instead.
 func (*AuditLog) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{43}
+	return file_keyorix_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *AuditLog) GetId() uint32 {
@@ -3287,7 +3433,7 @@ type GetAuditLogsRequest struct {
 
 func (x *GetAuditLogsRequest) Reset() {
 	*x = GetAuditLogsRequest{}
-	mi := &file_keyorix_proto_msgTypes[44]
+	mi := &file_keyorix_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3299,7 +3445,7 @@ func (x *GetAuditLogsRequest) String() string {
 func (*GetAuditLogsRequest) ProtoMessage() {}
 
 func (x *GetAuditLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[44]
+	mi := &file_keyorix_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3312,7 +3458,7 @@ func (x *GetAuditLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAuditLogsRequest.ProtoReflect.Descriptor instead.
 func (*GetAuditLogsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{44}
+	return file_keyorix_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *GetAuditLogsRequest) GetEventType() string {
@@ -3384,7 +3530,7 @@ type GetAuditLogsResponse struct {
 
 func (x *GetAuditLogsResponse) Reset() {
 	*x = GetAuditLogsResponse{}
-	mi := &file_keyorix_proto_msgTypes[45]
+	mi := &file_keyorix_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3396,7 +3542,7 @@ func (x *GetAuditLogsResponse) String() string {
 func (*GetAuditLogsResponse) ProtoMessage() {}
 
 func (x *GetAuditLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[45]
+	mi := &file_keyorix_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3409,7 +3555,7 @@ func (x *GetAuditLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAuditLogsResponse.ProtoReflect.Descriptor instead.
 func (*GetAuditLogsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{45}
+	return file_keyorix_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *GetAuditLogsResponse) GetLogs() []*AuditLog {
@@ -3469,7 +3615,7 @@ type RBACAuditLog struct {
 
 func (x *RBACAuditLog) Reset() {
 	*x = RBACAuditLog{}
-	mi := &file_keyorix_proto_msgTypes[46]
+	mi := &file_keyorix_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3481,7 +3627,7 @@ func (x *RBACAuditLog) String() string {
 func (*RBACAuditLog) ProtoMessage() {}
 
 func (x *RBACAuditLog) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[46]
+	mi := &file_keyorix_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3494,7 +3640,7 @@ func (x *RBACAuditLog) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RBACAuditLog.ProtoReflect.Descriptor instead.
 func (*RBACAuditLog) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{46}
+	return file_keyorix_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *RBACAuditLog) GetId() uint32 {
@@ -3580,7 +3726,7 @@ type GetRBACAuditLogsRequest struct {
 
 func (x *GetRBACAuditLogsRequest) Reset() {
 	*x = GetRBACAuditLogsRequest{}
-	mi := &file_keyorix_proto_msgTypes[47]
+	mi := &file_keyorix_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3592,7 +3738,7 @@ func (x *GetRBACAuditLogsRequest) String() string {
 func (*GetRBACAuditLogsRequest) ProtoMessage() {}
 
 func (x *GetRBACAuditLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[47]
+	mi := &file_keyorix_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3605,7 +3751,7 @@ func (x *GetRBACAuditLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRBACAuditLogsRequest.ProtoReflect.Descriptor instead.
 func (*GetRBACAuditLogsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{47}
+	return file_keyorix_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *GetRBACAuditLogsRequest) GetAction() string {
@@ -3656,7 +3802,7 @@ type GetRBACAuditLogsResponse struct {
 
 func (x *GetRBACAuditLogsResponse) Reset() {
 	*x = GetRBACAuditLogsResponse{}
-	mi := &file_keyorix_proto_msgTypes[48]
+	mi := &file_keyorix_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3668,7 +3814,7 @@ func (x *GetRBACAuditLogsResponse) String() string {
 func (*GetRBACAuditLogsResponse) ProtoMessage() {}
 
 func (x *GetRBACAuditLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[48]
+	mi := &file_keyorix_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3681,7 +3827,7 @@ func (x *GetRBACAuditLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRBACAuditLogsResponse.ProtoReflect.Descriptor instead.
 func (*GetRBACAuditLogsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{48}
+	return file_keyorix_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *GetRBACAuditLogsResponse) GetLogs() []*RBACAuditLog {
@@ -3735,7 +3881,7 @@ type StreamAuditLogsRequest struct {
 
 func (x *StreamAuditLogsRequest) Reset() {
 	*x = StreamAuditLogsRequest{}
-	mi := &file_keyorix_proto_msgTypes[49]
+	mi := &file_keyorix_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3747,7 +3893,7 @@ func (x *StreamAuditLogsRequest) String() string {
 func (*StreamAuditLogsRequest) ProtoMessage() {}
 
 func (x *StreamAuditLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[49]
+	mi := &file_keyorix_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3760,7 +3906,7 @@ func (x *StreamAuditLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamAuditLogsRequest.ProtoReflect.Descriptor instead.
 func (*StreamAuditLogsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{49}
+	return file_keyorix_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *StreamAuditLogsRequest) GetEventType() string {
@@ -3811,7 +3957,7 @@ type VerifyAuditChainResponse struct {
 
 func (x *VerifyAuditChainResponse) Reset() {
 	*x = VerifyAuditChainResponse{}
-	mi := &file_keyorix_proto_msgTypes[50]
+	mi := &file_keyorix_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3823,7 +3969,7 @@ func (x *VerifyAuditChainResponse) String() string {
 func (*VerifyAuditChainResponse) ProtoMessage() {}
 
 func (x *VerifyAuditChainResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[50]
+	mi := &file_keyorix_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3836,7 +3982,7 @@ func (x *VerifyAuditChainResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VerifyAuditChainResponse.ProtoReflect.Descriptor instead.
 func (*VerifyAuditChainResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{50}
+	return file_keyorix_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *VerifyAuditChainResponse) GetValid() bool {
@@ -3918,7 +4064,7 @@ type WriteAuditCheckpointResponse struct {
 
 func (x *WriteAuditCheckpointResponse) Reset() {
 	*x = WriteAuditCheckpointResponse{}
-	mi := &file_keyorix_proto_msgTypes[51]
+	mi := &file_keyorix_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3930,7 +4076,7 @@ func (x *WriteAuditCheckpointResponse) String() string {
 func (*WriteAuditCheckpointResponse) ProtoMessage() {}
 
 func (x *WriteAuditCheckpointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[51]
+	mi := &file_keyorix_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3943,7 +4089,7 @@ func (x *WriteAuditCheckpointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteAuditCheckpointResponse.ProtoReflect.Descriptor instead.
 func (*WriteAuditCheckpointResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{51}
+	return file_keyorix_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *WriteAuditCheckpointResponse) GetId() uint32 {
@@ -4010,7 +4156,7 @@ type GetAuditRetentionResponse struct {
 
 func (x *GetAuditRetentionResponse) Reset() {
 	*x = GetAuditRetentionResponse{}
-	mi := &file_keyorix_proto_msgTypes[52]
+	mi := &file_keyorix_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4022,7 +4168,7 @@ func (x *GetAuditRetentionResponse) String() string {
 func (*GetAuditRetentionResponse) ProtoMessage() {}
 
 func (x *GetAuditRetentionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[52]
+	mi := &file_keyorix_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4035,7 +4181,7 @@ func (x *GetAuditRetentionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAuditRetentionResponse.ProtoReflect.Descriptor instead.
 func (*GetAuditRetentionResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{52}
+	return file_keyorix_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *GetAuditRetentionResponse) GetRetentionPolicy() string {
@@ -4100,7 +4246,7 @@ type BreakGlassActivation struct {
 
 func (x *BreakGlassActivation) Reset() {
 	*x = BreakGlassActivation{}
-	mi := &file_keyorix_proto_msgTypes[53]
+	mi := &file_keyorix_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4112,7 +4258,7 @@ func (x *BreakGlassActivation) String() string {
 func (*BreakGlassActivation) ProtoMessage() {}
 
 func (x *BreakGlassActivation) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[53]
+	mi := &file_keyorix_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4125,7 +4271,7 @@ func (x *BreakGlassActivation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BreakGlassActivation.ProtoReflect.Descriptor instead.
 func (*BreakGlassActivation) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{53}
+	return file_keyorix_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *BreakGlassActivation) GetId() uint32 {
@@ -4216,7 +4362,7 @@ type ActivateBreakGlassRequest struct {
 
 func (x *ActivateBreakGlassRequest) Reset() {
 	*x = ActivateBreakGlassRequest{}
-	mi := &file_keyorix_proto_msgTypes[54]
+	mi := &file_keyorix_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4228,7 +4374,7 @@ func (x *ActivateBreakGlassRequest) String() string {
 func (*ActivateBreakGlassRequest) ProtoMessage() {}
 
 func (x *ActivateBreakGlassRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[54]
+	mi := &file_keyorix_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4241,7 +4387,7 @@ func (x *ActivateBreakGlassRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActivateBreakGlassRequest.ProtoReflect.Descriptor instead.
 func (*ActivateBreakGlassRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{54}
+	return file_keyorix_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *ActivateBreakGlassRequest) GetProjectId() uint32 {
@@ -4274,7 +4420,7 @@ type ListBreakGlassActivationsRequest struct {
 
 func (x *ListBreakGlassActivationsRequest) Reset() {
 	*x = ListBreakGlassActivationsRequest{}
-	mi := &file_keyorix_proto_msgTypes[55]
+	mi := &file_keyorix_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4286,7 +4432,7 @@ func (x *ListBreakGlassActivationsRequest) String() string {
 func (*ListBreakGlassActivationsRequest) ProtoMessage() {}
 
 func (x *ListBreakGlassActivationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[55]
+	mi := &file_keyorix_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4299,7 +4445,7 @@ func (x *ListBreakGlassActivationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBreakGlassActivationsRequest.ProtoReflect.Descriptor instead.
 func (*ListBreakGlassActivationsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{55}
+	return file_keyorix_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *ListBreakGlassActivationsRequest) GetProjectId() uint32 {
@@ -4318,7 +4464,7 @@ type ListBreakGlassActivationsResponse struct {
 
 func (x *ListBreakGlassActivationsResponse) Reset() {
 	*x = ListBreakGlassActivationsResponse{}
-	mi := &file_keyorix_proto_msgTypes[56]
+	mi := &file_keyorix_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4330,7 +4476,7 @@ func (x *ListBreakGlassActivationsResponse) String() string {
 func (*ListBreakGlassActivationsResponse) ProtoMessage() {}
 
 func (x *ListBreakGlassActivationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[56]
+	mi := &file_keyorix_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4343,7 +4489,7 @@ func (x *ListBreakGlassActivationsResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ListBreakGlassActivationsResponse.ProtoReflect.Descriptor instead.
 func (*ListBreakGlassActivationsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{56}
+	return file_keyorix_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ListBreakGlassActivationsResponse) GetActivations() []*BreakGlassActivation {
@@ -4363,7 +4509,7 @@ type RevokeBreakGlassRequest struct {
 
 func (x *RevokeBreakGlassRequest) Reset() {
 	*x = RevokeBreakGlassRequest{}
-	mi := &file_keyorix_proto_msgTypes[57]
+	mi := &file_keyorix_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4375,7 +4521,7 @@ func (x *RevokeBreakGlassRequest) String() string {
 func (*RevokeBreakGlassRequest) ProtoMessage() {}
 
 func (x *RevokeBreakGlassRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[57]
+	mi := &file_keyorix_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4388,7 +4534,7 @@ func (x *RevokeBreakGlassRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeBreakGlassRequest.ProtoReflect.Descriptor instead.
 func (*RevokeBreakGlassRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{57}
+	return file_keyorix_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *RevokeBreakGlassRequest) GetProjectId() uint32 {
@@ -4420,7 +4566,7 @@ type Group struct {
 
 func (x *Group) Reset() {
 	*x = Group{}
-	mi := &file_keyorix_proto_msgTypes[58]
+	mi := &file_keyorix_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4432,7 +4578,7 @@ func (x *Group) String() string {
 func (*Group) ProtoMessage() {}
 
 func (x *Group) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[58]
+	mi := &file_keyorix_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4445,7 +4591,7 @@ func (x *Group) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Group.ProtoReflect.Descriptor instead.
 func (*Group) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{58}
+	return file_keyorix_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *Group) GetId() uint32 {
@@ -4497,7 +4643,7 @@ type GroupMember struct {
 
 func (x *GroupMember) Reset() {
 	*x = GroupMember{}
-	mi := &file_keyorix_proto_msgTypes[59]
+	mi := &file_keyorix_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4509,7 +4655,7 @@ func (x *GroupMember) String() string {
 func (*GroupMember) ProtoMessage() {}
 
 func (x *GroupMember) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[59]
+	mi := &file_keyorix_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4522,7 +4668,7 @@ func (x *GroupMember) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupMember.ProtoReflect.Descriptor instead.
 func (*GroupMember) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{59}
+	return file_keyorix_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *GroupMember) GetId() uint32 {
@@ -4569,7 +4715,7 @@ type GetGroupRequest struct {
 
 func (x *GetGroupRequest) Reset() {
 	*x = GetGroupRequest{}
-	mi := &file_keyorix_proto_msgTypes[60]
+	mi := &file_keyorix_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4581,7 +4727,7 @@ func (x *GetGroupRequest) String() string {
 func (*GetGroupRequest) ProtoMessage() {}
 
 func (x *GetGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[60]
+	mi := &file_keyorix_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4594,7 +4740,7 @@ func (x *GetGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGroupRequest.ProtoReflect.Descriptor instead.
 func (*GetGroupRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{60}
+	return file_keyorix_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *GetGroupRequest) GetId() uint32 {
@@ -4614,7 +4760,7 @@ type CreateGroupRequest struct {
 
 func (x *CreateGroupRequest) Reset() {
 	*x = CreateGroupRequest{}
-	mi := &file_keyorix_proto_msgTypes[61]
+	mi := &file_keyorix_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4626,7 +4772,7 @@ func (x *CreateGroupRequest) String() string {
 func (*CreateGroupRequest) ProtoMessage() {}
 
 func (x *CreateGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[61]
+	mi := &file_keyorix_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4639,7 +4785,7 @@ func (x *CreateGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateGroupRequest.ProtoReflect.Descriptor instead.
 func (*CreateGroupRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{61}
+	return file_keyorix_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *CreateGroupRequest) GetName() string {
@@ -4667,7 +4813,7 @@ type UpdateGroupRequest struct {
 
 func (x *UpdateGroupRequest) Reset() {
 	*x = UpdateGroupRequest{}
-	mi := &file_keyorix_proto_msgTypes[62]
+	mi := &file_keyorix_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4679,7 +4825,7 @@ func (x *UpdateGroupRequest) String() string {
 func (*UpdateGroupRequest) ProtoMessage() {}
 
 func (x *UpdateGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[62]
+	mi := &file_keyorix_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4692,7 +4838,7 @@ func (x *UpdateGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateGroupRequest.ProtoReflect.Descriptor instead.
 func (*UpdateGroupRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{62}
+	return file_keyorix_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *UpdateGroupRequest) GetId() uint32 {
@@ -4725,7 +4871,7 @@ type DeleteGroupRequest struct {
 
 func (x *DeleteGroupRequest) Reset() {
 	*x = DeleteGroupRequest{}
-	mi := &file_keyorix_proto_msgTypes[63]
+	mi := &file_keyorix_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4737,7 +4883,7 @@ func (x *DeleteGroupRequest) String() string {
 func (*DeleteGroupRequest) ProtoMessage() {}
 
 func (x *DeleteGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[63]
+	mi := &file_keyorix_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4750,7 +4896,7 @@ func (x *DeleteGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteGroupRequest.ProtoReflect.Descriptor instead.
 func (*DeleteGroupRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{63}
+	return file_keyorix_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *DeleteGroupRequest) GetId() uint32 {
@@ -4769,7 +4915,7 @@ type RestoreGroupRequest struct {
 
 func (x *RestoreGroupRequest) Reset() {
 	*x = RestoreGroupRequest{}
-	mi := &file_keyorix_proto_msgTypes[64]
+	mi := &file_keyorix_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4781,7 +4927,7 @@ func (x *RestoreGroupRequest) String() string {
 func (*RestoreGroupRequest) ProtoMessage() {}
 
 func (x *RestoreGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[64]
+	mi := &file_keyorix_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4794,7 +4940,7 @@ func (x *RestoreGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreGroupRequest.ProtoReflect.Descriptor instead.
 func (*RestoreGroupRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{64}
+	return file_keyorix_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *RestoreGroupRequest) GetId() uint32 {
@@ -4813,7 +4959,7 @@ type ListGroupsResponse struct {
 
 func (x *ListGroupsResponse) Reset() {
 	*x = ListGroupsResponse{}
-	mi := &file_keyorix_proto_msgTypes[65]
+	mi := &file_keyorix_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4825,7 +4971,7 @@ func (x *ListGroupsResponse) String() string {
 func (*ListGroupsResponse) ProtoMessage() {}
 
 func (x *ListGroupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[65]
+	mi := &file_keyorix_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4838,7 +4984,7 @@ func (x *ListGroupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGroupsResponse.ProtoReflect.Descriptor instead.
 func (*ListGroupsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{65}
+	return file_keyorix_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *ListGroupsResponse) GetGroups() []*Group {
@@ -4857,7 +5003,7 @@ type GetGroupMembersRequest struct {
 
 func (x *GetGroupMembersRequest) Reset() {
 	*x = GetGroupMembersRequest{}
-	mi := &file_keyorix_proto_msgTypes[66]
+	mi := &file_keyorix_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4869,7 +5015,7 @@ func (x *GetGroupMembersRequest) String() string {
 func (*GetGroupMembersRequest) ProtoMessage() {}
 
 func (x *GetGroupMembersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[66]
+	mi := &file_keyorix_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4882,7 +5028,7 @@ func (x *GetGroupMembersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGroupMembersRequest.ProtoReflect.Descriptor instead.
 func (*GetGroupMembersRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{66}
+	return file_keyorix_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *GetGroupMembersRequest) GetId() uint32 {
@@ -4901,7 +5047,7 @@ type GetGroupMembersResponse struct {
 
 func (x *GetGroupMembersResponse) Reset() {
 	*x = GetGroupMembersResponse{}
-	mi := &file_keyorix_proto_msgTypes[67]
+	mi := &file_keyorix_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4913,7 +5059,7 @@ func (x *GetGroupMembersResponse) String() string {
 func (*GetGroupMembersResponse) ProtoMessage() {}
 
 func (x *GetGroupMembersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[67]
+	mi := &file_keyorix_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4926,7 +5072,7 @@ func (x *GetGroupMembersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGroupMembersResponse.ProtoReflect.Descriptor instead.
 func (*GetGroupMembersResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{67}
+	return file_keyorix_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *GetGroupMembersResponse) GetMembers() []*GroupMember {
@@ -4947,7 +5093,7 @@ type GroupMemberRequest struct {
 
 func (x *GroupMemberRequest) Reset() {
 	*x = GroupMemberRequest{}
-	mi := &file_keyorix_proto_msgTypes[68]
+	mi := &file_keyorix_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4959,7 +5105,7 @@ func (x *GroupMemberRequest) String() string {
 func (*GroupMemberRequest) ProtoMessage() {}
 
 func (x *GroupMemberRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[68]
+	mi := &file_keyorix_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4972,7 +5118,7 @@ func (x *GroupMemberRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupMemberRequest.ProtoReflect.Descriptor instead.
 func (*GroupMemberRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{68}
+	return file_keyorix_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *GroupMemberRequest) GetGroupId() uint32 {
@@ -5005,7 +5151,7 @@ type ShareRecord struct {
 
 func (x *ShareRecord) Reset() {
 	*x = ShareRecord{}
-	mi := &file_keyorix_proto_msgTypes[69]
+	mi := &file_keyorix_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5017,7 +5163,7 @@ func (x *ShareRecord) String() string {
 func (*ShareRecord) ProtoMessage() {}
 
 func (x *ShareRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[69]
+	mi := &file_keyorix_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5030,7 +5176,7 @@ func (x *ShareRecord) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShareRecord.ProtoReflect.Descriptor instead.
 func (*ShareRecord) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{69}
+	return file_keyorix_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *ShareRecord) GetId() uint32 {
@@ -5101,7 +5247,7 @@ type ShareSecretRequest struct {
 
 func (x *ShareSecretRequest) Reset() {
 	*x = ShareSecretRequest{}
-	mi := &file_keyorix_proto_msgTypes[70]
+	mi := &file_keyorix_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5113,7 +5259,7 @@ func (x *ShareSecretRequest) String() string {
 func (*ShareSecretRequest) ProtoMessage() {}
 
 func (x *ShareSecretRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[70]
+	mi := &file_keyorix_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5126,7 +5272,7 @@ func (x *ShareSecretRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShareSecretRequest.ProtoReflect.Descriptor instead.
 func (*ShareSecretRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{70}
+	return file_keyorix_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *ShareSecretRequest) GetSecretId() uint32 {
@@ -5166,7 +5312,7 @@ type ListSecretSharesRequest struct {
 
 func (x *ListSecretSharesRequest) Reset() {
 	*x = ListSecretSharesRequest{}
-	mi := &file_keyorix_proto_msgTypes[71]
+	mi := &file_keyorix_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5178,7 +5324,7 @@ func (x *ListSecretSharesRequest) String() string {
 func (*ListSecretSharesRequest) ProtoMessage() {}
 
 func (x *ListSecretSharesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[71]
+	mi := &file_keyorix_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5191,7 +5337,7 @@ func (x *ListSecretSharesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSecretSharesRequest.ProtoReflect.Descriptor instead.
 func (*ListSecretSharesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{71}
+	return file_keyorix_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *ListSecretSharesRequest) GetSecretId() uint32 {
@@ -5211,7 +5357,7 @@ type ListUserSharesRequest struct {
 
 func (x *ListUserSharesRequest) Reset() {
 	*x = ListUserSharesRequest{}
-	mi := &file_keyorix_proto_msgTypes[72]
+	mi := &file_keyorix_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5223,7 +5369,7 @@ func (x *ListUserSharesRequest) String() string {
 func (*ListUserSharesRequest) ProtoMessage() {}
 
 func (x *ListUserSharesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[72]
+	mi := &file_keyorix_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5236,7 +5382,7 @@ func (x *ListUserSharesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUserSharesRequest.ProtoReflect.Descriptor instead.
 func (*ListUserSharesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{72}
+	return file_keyorix_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *ListUserSharesRequest) GetPage() uint32 {
@@ -5263,7 +5409,7 @@ type ListSharedSecretsRequest struct {
 
 func (x *ListSharedSecretsRequest) Reset() {
 	*x = ListSharedSecretsRequest{}
-	mi := &file_keyorix_proto_msgTypes[73]
+	mi := &file_keyorix_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5275,7 +5421,7 @@ func (x *ListSharedSecretsRequest) String() string {
 func (*ListSharedSecretsRequest) ProtoMessage() {}
 
 func (x *ListSharedSecretsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[73]
+	mi := &file_keyorix_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5288,7 +5434,7 @@ func (x *ListSharedSecretsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSharedSecretsRequest.ProtoReflect.Descriptor instead.
 func (*ListSharedSecretsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{73}
+	return file_keyorix_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *ListSharedSecretsRequest) GetPage() uint32 {
@@ -5318,7 +5464,7 @@ type ListSharesResponse struct {
 
 func (x *ListSharesResponse) Reset() {
 	*x = ListSharesResponse{}
-	mi := &file_keyorix_proto_msgTypes[74]
+	mi := &file_keyorix_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5330,7 +5476,7 @@ func (x *ListSharesResponse) String() string {
 func (*ListSharesResponse) ProtoMessage() {}
 
 func (x *ListSharesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[74]
+	mi := &file_keyorix_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5343,7 +5489,7 @@ func (x *ListSharesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSharesResponse.ProtoReflect.Descriptor instead.
 func (*ListSharesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{74}
+	return file_keyorix_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *ListSharesResponse) GetShares() []*ShareRecord {
@@ -5391,7 +5537,7 @@ type UpdateSharePermissionRequest struct {
 
 func (x *UpdateSharePermissionRequest) Reset() {
 	*x = UpdateSharePermissionRequest{}
-	mi := &file_keyorix_proto_msgTypes[75]
+	mi := &file_keyorix_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5403,7 +5549,7 @@ func (x *UpdateSharePermissionRequest) String() string {
 func (*UpdateSharePermissionRequest) ProtoMessage() {}
 
 func (x *UpdateSharePermissionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[75]
+	mi := &file_keyorix_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5416,7 +5562,7 @@ func (x *UpdateSharePermissionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSharePermissionRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSharePermissionRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{75}
+	return file_keyorix_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *UpdateSharePermissionRequest) GetShareId() uint32 {
@@ -5442,7 +5588,7 @@ type RevokeShareRequest struct {
 
 func (x *RevokeShareRequest) Reset() {
 	*x = RevokeShareRequest{}
-	mi := &file_keyorix_proto_msgTypes[76]
+	mi := &file_keyorix_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5454,7 +5600,7 @@ func (x *RevokeShareRequest) String() string {
 func (*RevokeShareRequest) ProtoMessage() {}
 
 func (x *RevokeShareRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[76]
+	mi := &file_keyorix_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5467,7 +5613,7 @@ func (x *RevokeShareRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeShareRequest.ProtoReflect.Descriptor instead.
 func (*RevokeShareRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{76}
+	return file_keyorix_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *RevokeShareRequest) GetShareId() uint32 {
@@ -5489,7 +5635,7 @@ type HealthResponse struct {
 
 func (x *HealthResponse) Reset() {
 	*x = HealthResponse{}
-	mi := &file_keyorix_proto_msgTypes[77]
+	mi := &file_keyorix_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5501,7 +5647,7 @@ func (x *HealthResponse) String() string {
 func (*HealthResponse) ProtoMessage() {}
 
 func (x *HealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[77]
+	mi := &file_keyorix_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5514,7 +5660,7 @@ func (x *HealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponse.ProtoReflect.Descriptor instead.
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{77}
+	return file_keyorix_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *HealthResponse) GetStatus() string {
@@ -5562,7 +5708,7 @@ type SystemInfo struct {
 
 func (x *SystemInfo) Reset() {
 	*x = SystemInfo{}
-	mi := &file_keyorix_proto_msgTypes[78]
+	mi := &file_keyorix_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5574,7 +5720,7 @@ func (x *SystemInfo) String() string {
 func (*SystemInfo) ProtoMessage() {}
 
 func (x *SystemInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[78]
+	mi := &file_keyorix_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5587,7 +5733,7 @@ func (x *SystemInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemInfo.ProtoReflect.Descriptor instead.
 func (*SystemInfo) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{78}
+	return file_keyorix_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *SystemInfo) GetVersion() string {
@@ -5665,7 +5811,7 @@ type DatabaseInfo struct {
 
 func (x *DatabaseInfo) Reset() {
 	*x = DatabaseInfo{}
-	mi := &file_keyorix_proto_msgTypes[79]
+	mi := &file_keyorix_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5677,7 +5823,7 @@ func (x *DatabaseInfo) String() string {
 func (*DatabaseInfo) ProtoMessage() {}
 
 func (x *DatabaseInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[79]
+	mi := &file_keyorix_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5690,7 +5836,7 @@ func (x *DatabaseInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DatabaseInfo.ProtoReflect.Descriptor instead.
 func (*DatabaseInfo) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{79}
+	return file_keyorix_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *DatabaseInfo) GetStatus() string {
@@ -5732,7 +5878,7 @@ type EncryptionInfo struct {
 
 func (x *EncryptionInfo) Reset() {
 	*x = EncryptionInfo{}
-	mi := &file_keyorix_proto_msgTypes[80]
+	mi := &file_keyorix_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5744,7 +5890,7 @@ func (x *EncryptionInfo) String() string {
 func (*EncryptionInfo) ProtoMessage() {}
 
 func (x *EncryptionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[80]
+	mi := &file_keyorix_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5757,7 +5903,7 @@ func (x *EncryptionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EncryptionInfo.ProtoReflect.Descriptor instead.
 func (*EncryptionInfo) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{80}
+	return file_keyorix_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *EncryptionInfo) GetStatus() string {
@@ -5794,7 +5940,7 @@ type Metrics struct {
 
 func (x *Metrics) Reset() {
 	*x = Metrics{}
-	mi := &file_keyorix_proto_msgTypes[81]
+	mi := &file_keyorix_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5806,7 +5952,7 @@ func (x *Metrics) String() string {
 func (*Metrics) ProtoMessage() {}
 
 func (x *Metrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[81]
+	mi := &file_keyorix_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5819,7 +5965,7 @@ func (x *Metrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Metrics.ProtoReflect.Descriptor instead.
 func (*Metrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{81}
+	return file_keyorix_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *Metrics) GetRequests() *RequestMetrics {
@@ -5869,7 +6015,7 @@ type RequestMetrics struct {
 
 func (x *RequestMetrics) Reset() {
 	*x = RequestMetrics{}
-	mi := &file_keyorix_proto_msgTypes[82]
+	mi := &file_keyorix_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5881,7 +6027,7 @@ func (x *RequestMetrics) String() string {
 func (*RequestMetrics) ProtoMessage() {}
 
 func (x *RequestMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[82]
+	mi := &file_keyorix_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5894,7 +6040,7 @@ func (x *RequestMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequestMetrics.ProtoReflect.Descriptor instead.
 func (*RequestMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{82}
+	return file_keyorix_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *RequestMetrics) GetTotal() uint64 {
@@ -5937,7 +6083,7 @@ type SecretMetrics struct {
 
 func (x *SecretMetrics) Reset() {
 	*x = SecretMetrics{}
-	mi := &file_keyorix_proto_msgTypes[83]
+	mi := &file_keyorix_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5949,7 +6095,7 @@ func (x *SecretMetrics) String() string {
 func (*SecretMetrics) ProtoMessage() {}
 
 func (x *SecretMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[83]
+	mi := &file_keyorix_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5962,7 +6108,7 @@ func (x *SecretMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecretMetrics.ProtoReflect.Descriptor instead.
 func (*SecretMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{83}
+	return file_keyorix_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *SecretMetrics) GetTotal() uint64 {
@@ -6004,7 +6150,7 @@ type UserMetrics struct {
 
 func (x *UserMetrics) Reset() {
 	*x = UserMetrics{}
-	mi := &file_keyorix_proto_msgTypes[84]
+	mi := &file_keyorix_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6016,7 +6162,7 @@ func (x *UserMetrics) String() string {
 func (*UserMetrics) ProtoMessage() {}
 
 func (x *UserMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[84]
+	mi := &file_keyorix_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6029,7 +6175,7 @@ func (x *UserMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserMetrics.ProtoReflect.Descriptor instead.
 func (*UserMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{84}
+	return file_keyorix_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *UserMetrics) GetTotal() uint64 {
@@ -6065,7 +6211,7 @@ type PerformanceMetrics struct {
 
 func (x *PerformanceMetrics) Reset() {
 	*x = PerformanceMetrics{}
-	mi := &file_keyorix_proto_msgTypes[85]
+	mi := &file_keyorix_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6077,7 +6223,7 @@ func (x *PerformanceMetrics) String() string {
 func (*PerformanceMetrics) ProtoMessage() {}
 
 func (x *PerformanceMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[85]
+	mi := &file_keyorix_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6090,7 +6236,7 @@ func (x *PerformanceMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PerformanceMetrics.ProtoReflect.Descriptor instead.
 func (*PerformanceMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{85}
+	return file_keyorix_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *PerformanceMetrics) GetAvgResponseTimeMs() float64 {
@@ -6133,7 +6279,7 @@ type SystemMetrics struct {
 
 func (x *SystemMetrics) Reset() {
 	*x = SystemMetrics{}
-	mi := &file_keyorix_proto_msgTypes[86]
+	mi := &file_keyorix_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6145,7 +6291,7 @@ func (x *SystemMetrics) String() string {
 func (*SystemMetrics) ProtoMessage() {}
 
 func (x *SystemMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[86]
+	mi := &file_keyorix_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6158,7 +6304,7 @@ func (x *SystemMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemMetrics.ProtoReflect.Descriptor instead.
 func (*SystemMetrics) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{86}
+	return file_keyorix_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *SystemMetrics) GetCpuUsagePercent() float64 {
@@ -6203,7 +6349,7 @@ type Project struct {
 
 func (x *Project) Reset() {
 	*x = Project{}
-	mi := &file_keyorix_proto_msgTypes[87]
+	mi := &file_keyorix_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6215,7 +6361,7 @@ func (x *Project) String() string {
 func (*Project) ProtoMessage() {}
 
 func (x *Project) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[87]
+	mi := &file_keyorix_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6228,7 +6374,7 @@ func (x *Project) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Project.ProtoReflect.Descriptor instead.
 func (*Project) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{87}
+	return file_keyorix_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *Project) GetId() uint32 {
@@ -6286,7 +6432,7 @@ type Environment struct {
 
 func (x *Environment) Reset() {
 	*x = Environment{}
-	mi := &file_keyorix_proto_msgTypes[88]
+	mi := &file_keyorix_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6298,7 +6444,7 @@ func (x *Environment) String() string {
 func (*Environment) ProtoMessage() {}
 
 func (x *Environment) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[88]
+	mi := &file_keyorix_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6311,7 +6457,7 @@ func (x *Environment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Environment.ProtoReflect.Descriptor instead.
 func (*Environment) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{88}
+	return file_keyorix_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *Environment) GetId() uint32 {
@@ -6358,7 +6504,7 @@ type ListProjectsResponse struct {
 
 func (x *ListProjectsResponse) Reset() {
 	*x = ListProjectsResponse{}
-	mi := &file_keyorix_proto_msgTypes[89]
+	mi := &file_keyorix_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6370,7 +6516,7 @@ func (x *ListProjectsResponse) String() string {
 func (*ListProjectsResponse) ProtoMessage() {}
 
 func (x *ListProjectsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[89]
+	mi := &file_keyorix_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6383,7 +6529,7 @@ func (x *ListProjectsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListProjectsResponse.ProtoReflect.Descriptor instead.
 func (*ListProjectsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{89}
+	return file_keyorix_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *ListProjectsResponse) GetProjects() []*Project {
@@ -6402,7 +6548,7 @@ type GetProjectRequest struct {
 
 func (x *GetProjectRequest) Reset() {
 	*x = GetProjectRequest{}
-	mi := &file_keyorix_proto_msgTypes[90]
+	mi := &file_keyorix_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6414,7 +6560,7 @@ func (x *GetProjectRequest) String() string {
 func (*GetProjectRequest) ProtoMessage() {}
 
 func (x *GetProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[90]
+	mi := &file_keyorix_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6427,7 +6573,7 @@ func (x *GetProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProjectRequest.ProtoReflect.Descriptor instead.
 func (*GetProjectRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{90}
+	return file_keyorix_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *GetProjectRequest) GetId() uint32 {
@@ -6447,7 +6593,7 @@ type CreateProjectRequest struct {
 
 func (x *CreateProjectRequest) Reset() {
 	*x = CreateProjectRequest{}
-	mi := &file_keyorix_proto_msgTypes[91]
+	mi := &file_keyorix_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6459,7 +6605,7 @@ func (x *CreateProjectRequest) String() string {
 func (*CreateProjectRequest) ProtoMessage() {}
 
 func (x *CreateProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[91]
+	mi := &file_keyorix_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6472,7 +6618,7 @@ func (x *CreateProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateProjectRequest.ProtoReflect.Descriptor instead.
 func (*CreateProjectRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{91}
+	return file_keyorix_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *CreateProjectRequest) GetName() string {
@@ -6501,7 +6647,7 @@ type UpdateProjectRequest struct {
 
 func (x *UpdateProjectRequest) Reset() {
 	*x = UpdateProjectRequest{}
-	mi := &file_keyorix_proto_msgTypes[92]
+	mi := &file_keyorix_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6513,7 +6659,7 @@ func (x *UpdateProjectRequest) String() string {
 func (*UpdateProjectRequest) ProtoMessage() {}
 
 func (x *UpdateProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[92]
+	mi := &file_keyorix_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6526,7 +6672,7 @@ func (x *UpdateProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProjectRequest.ProtoReflect.Descriptor instead.
 func (*UpdateProjectRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{92}
+	return file_keyorix_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *UpdateProjectRequest) GetId() uint32 {
@@ -6567,7 +6713,7 @@ type DeleteProjectRequest struct {
 
 func (x *DeleteProjectRequest) Reset() {
 	*x = DeleteProjectRequest{}
-	mi := &file_keyorix_proto_msgTypes[93]
+	mi := &file_keyorix_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6579,7 +6725,7 @@ func (x *DeleteProjectRequest) String() string {
 func (*DeleteProjectRequest) ProtoMessage() {}
 
 func (x *DeleteProjectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[93]
+	mi := &file_keyorix_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6592,7 +6738,7 @@ func (x *DeleteProjectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProjectRequest.ProtoReflect.Descriptor instead.
 func (*DeleteProjectRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{93}
+	return file_keyorix_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *DeleteProjectRequest) GetId() uint32 {
@@ -6618,7 +6764,7 @@ type ListEnvironmentsRequest struct {
 
 func (x *ListEnvironmentsRequest) Reset() {
 	*x = ListEnvironmentsRequest{}
-	mi := &file_keyorix_proto_msgTypes[94]
+	mi := &file_keyorix_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6630,7 +6776,7 @@ func (x *ListEnvironmentsRequest) String() string {
 func (*ListEnvironmentsRequest) ProtoMessage() {}
 
 func (x *ListEnvironmentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[94]
+	mi := &file_keyorix_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6643,7 +6789,7 @@ func (x *ListEnvironmentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListEnvironmentsRequest.ProtoReflect.Descriptor instead.
 func (*ListEnvironmentsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{94}
+	return file_keyorix_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *ListEnvironmentsRequest) GetProjectId() uint32 {
@@ -6662,7 +6808,7 @@ type ListEnvironmentsResponse struct {
 
 func (x *ListEnvironmentsResponse) Reset() {
 	*x = ListEnvironmentsResponse{}
-	mi := &file_keyorix_proto_msgTypes[95]
+	mi := &file_keyorix_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6674,7 +6820,7 @@ func (x *ListEnvironmentsResponse) String() string {
 func (*ListEnvironmentsResponse) ProtoMessage() {}
 
 func (x *ListEnvironmentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[95]
+	mi := &file_keyorix_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6687,7 +6833,7 @@ func (x *ListEnvironmentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListEnvironmentsResponse.ProtoReflect.Descriptor instead.
 func (*ListEnvironmentsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{95}
+	return file_keyorix_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *ListEnvironmentsResponse) GetEnvironments() []*Environment {
@@ -6717,7 +6863,7 @@ type MachineIdentity struct {
 
 func (x *MachineIdentity) Reset() {
 	*x = MachineIdentity{}
-	mi := &file_keyorix_proto_msgTypes[96]
+	mi := &file_keyorix_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6729,7 +6875,7 @@ func (x *MachineIdentity) String() string {
 func (*MachineIdentity) ProtoMessage() {}
 
 func (x *MachineIdentity) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[96]
+	mi := &file_keyorix_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6742,7 +6888,7 @@ func (x *MachineIdentity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineIdentity.ProtoReflect.Descriptor instead.
 func (*MachineIdentity) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{96}
+	return file_keyorix_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *MachineIdentity) GetId() uint32 {
@@ -6845,7 +6991,7 @@ type MachineToken struct {
 
 func (x *MachineToken) Reset() {
 	*x = MachineToken{}
-	mi := &file_keyorix_proto_msgTypes[97]
+	mi := &file_keyorix_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6857,7 +7003,7 @@ func (x *MachineToken) String() string {
 func (*MachineToken) ProtoMessage() {}
 
 func (x *MachineToken) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[97]
+	mi := &file_keyorix_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6870,7 +7016,7 @@ func (x *MachineToken) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineToken.ProtoReflect.Descriptor instead.
 func (*MachineToken) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{97}
+	return file_keyorix_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *MachineToken) GetId() uint32 {
@@ -6938,7 +7084,7 @@ type ListMachineIdentitiesRequest struct {
 
 func (x *ListMachineIdentitiesRequest) Reset() {
 	*x = ListMachineIdentitiesRequest{}
-	mi := &file_keyorix_proto_msgTypes[98]
+	mi := &file_keyorix_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6950,7 +7096,7 @@ func (x *ListMachineIdentitiesRequest) String() string {
 func (*ListMachineIdentitiesRequest) ProtoMessage() {}
 
 func (x *ListMachineIdentitiesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[98]
+	mi := &file_keyorix_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6963,7 +7109,7 @@ func (x *ListMachineIdentitiesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMachineIdentitiesRequest.ProtoReflect.Descriptor instead.
 func (*ListMachineIdentitiesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{98}
+	return file_keyorix_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *ListMachineIdentitiesRequest) GetProjectId() uint32 {
@@ -6982,7 +7128,7 @@ type ListMachineIdentitiesResponse struct {
 
 func (x *ListMachineIdentitiesResponse) Reset() {
 	*x = ListMachineIdentitiesResponse{}
-	mi := &file_keyorix_proto_msgTypes[99]
+	mi := &file_keyorix_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6994,7 +7140,7 @@ func (x *ListMachineIdentitiesResponse) String() string {
 func (*ListMachineIdentitiesResponse) ProtoMessage() {}
 
 func (x *ListMachineIdentitiesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[99]
+	mi := &file_keyorix_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7007,7 +7153,7 @@ func (x *ListMachineIdentitiesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMachineIdentitiesResponse.ProtoReflect.Descriptor instead.
 func (*ListMachineIdentitiesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{99}
+	return file_keyorix_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *ListMachineIdentitiesResponse) GetMachineIdentities() []*MachineIdentity {
@@ -7030,7 +7176,7 @@ type CreateMachineIdentityRequest struct {
 
 func (x *CreateMachineIdentityRequest) Reset() {
 	*x = CreateMachineIdentityRequest{}
-	mi := &file_keyorix_proto_msgTypes[100]
+	mi := &file_keyorix_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7042,7 +7188,7 @@ func (x *CreateMachineIdentityRequest) String() string {
 func (*CreateMachineIdentityRequest) ProtoMessage() {}
 
 func (x *CreateMachineIdentityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[100]
+	mi := &file_keyorix_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7055,7 +7201,7 @@ func (x *CreateMachineIdentityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateMachineIdentityRequest.ProtoReflect.Descriptor instead.
 func (*CreateMachineIdentityRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{100}
+	return file_keyorix_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *CreateMachineIdentityRequest) GetProjectId() uint32 {
@@ -7104,7 +7250,7 @@ type TransitionMachineIdentityRequest struct {
 
 func (x *TransitionMachineIdentityRequest) Reset() {
 	*x = TransitionMachineIdentityRequest{}
-	mi := &file_keyorix_proto_msgTypes[101]
+	mi := &file_keyorix_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7116,7 +7262,7 @@ func (x *TransitionMachineIdentityRequest) String() string {
 func (*TransitionMachineIdentityRequest) ProtoMessage() {}
 
 func (x *TransitionMachineIdentityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[101]
+	mi := &file_keyorix_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7129,7 +7275,7 @@ func (x *TransitionMachineIdentityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransitionMachineIdentityRequest.ProtoReflect.Descriptor instead.
 func (*TransitionMachineIdentityRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{101}
+	return file_keyorix_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *TransitionMachineIdentityRequest) GetProjectId() uint32 {
@@ -7164,7 +7310,7 @@ type ClassifyMachineIdentityRequest struct {
 
 func (x *ClassifyMachineIdentityRequest) Reset() {
 	*x = ClassifyMachineIdentityRequest{}
-	mi := &file_keyorix_proto_msgTypes[102]
+	mi := &file_keyorix_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7176,7 +7322,7 @@ func (x *ClassifyMachineIdentityRequest) String() string {
 func (*ClassifyMachineIdentityRequest) ProtoMessage() {}
 
 func (x *ClassifyMachineIdentityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[102]
+	mi := &file_keyorix_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7189,7 +7335,7 @@ func (x *ClassifyMachineIdentityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassifyMachineIdentityRequest.ProtoReflect.Descriptor instead.
 func (*ClassifyMachineIdentityRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{102}
+	return file_keyorix_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *ClassifyMachineIdentityRequest) GetProjectId() uint32 {
@@ -7226,7 +7372,7 @@ type IssueMachineTokenRequest struct {
 
 func (x *IssueMachineTokenRequest) Reset() {
 	*x = IssueMachineTokenRequest{}
-	mi := &file_keyorix_proto_msgTypes[103]
+	mi := &file_keyorix_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7238,7 +7384,7 @@ func (x *IssueMachineTokenRequest) String() string {
 func (*IssueMachineTokenRequest) ProtoMessage() {}
 
 func (x *IssueMachineTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[103]
+	mi := &file_keyorix_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7251,7 +7397,7 @@ func (x *IssueMachineTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssueMachineTokenRequest.ProtoReflect.Descriptor instead.
 func (*IssueMachineTokenRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{103}
+	return file_keyorix_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *IssueMachineTokenRequest) GetProjectId() uint32 {
@@ -7302,7 +7448,7 @@ type IssueMachineTokenResponse struct {
 
 func (x *IssueMachineTokenResponse) Reset() {
 	*x = IssueMachineTokenResponse{}
-	mi := &file_keyorix_proto_msgTypes[104]
+	mi := &file_keyorix_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7314,7 +7460,7 @@ func (x *IssueMachineTokenResponse) String() string {
 func (*IssueMachineTokenResponse) ProtoMessage() {}
 
 func (x *IssueMachineTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[104]
+	mi := &file_keyorix_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7327,7 +7473,7 @@ func (x *IssueMachineTokenResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssueMachineTokenResponse.ProtoReflect.Descriptor instead.
 func (*IssueMachineTokenResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{104}
+	return file_keyorix_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *IssueMachineTokenResponse) GetToken() string {
@@ -7375,7 +7521,7 @@ type ListMachineTokensRequest struct {
 
 func (x *ListMachineTokensRequest) Reset() {
 	*x = ListMachineTokensRequest{}
-	mi := &file_keyorix_proto_msgTypes[105]
+	mi := &file_keyorix_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7387,7 +7533,7 @@ func (x *ListMachineTokensRequest) String() string {
 func (*ListMachineTokensRequest) ProtoMessage() {}
 
 func (x *ListMachineTokensRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[105]
+	mi := &file_keyorix_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7400,7 +7546,7 @@ func (x *ListMachineTokensRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMachineTokensRequest.ProtoReflect.Descriptor instead.
 func (*ListMachineTokensRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{105}
+	return file_keyorix_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *ListMachineTokensRequest) GetProjectId() uint32 {
@@ -7426,7 +7572,7 @@ type ListMachineTokensResponse struct {
 
 func (x *ListMachineTokensResponse) Reset() {
 	*x = ListMachineTokensResponse{}
-	mi := &file_keyorix_proto_msgTypes[106]
+	mi := &file_keyorix_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7438,7 +7584,7 @@ func (x *ListMachineTokensResponse) String() string {
 func (*ListMachineTokensResponse) ProtoMessage() {}
 
 func (x *ListMachineTokensResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[106]
+	mi := &file_keyorix_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7451,7 +7597,7 @@ func (x *ListMachineTokensResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMachineTokensResponse.ProtoReflect.Descriptor instead.
 func (*ListMachineTokensResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{106}
+	return file_keyorix_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *ListMachineTokensResponse) GetTokens() []*MachineToken {
@@ -7472,7 +7618,7 @@ type RevokeMachineTokenRequest struct {
 
 func (x *RevokeMachineTokenRequest) Reset() {
 	*x = RevokeMachineTokenRequest{}
-	mi := &file_keyorix_proto_msgTypes[107]
+	mi := &file_keyorix_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7484,7 +7630,7 @@ func (x *RevokeMachineTokenRequest) String() string {
 func (*RevokeMachineTokenRequest) ProtoMessage() {}
 
 func (x *RevokeMachineTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[107]
+	mi := &file_keyorix_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7497,7 +7643,7 @@ func (x *RevokeMachineTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeMachineTokenRequest.ProtoReflect.Descriptor instead.
 func (*RevokeMachineTokenRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{107}
+	return file_keyorix_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *RevokeMachineTokenRequest) GetProjectId() uint32 {
@@ -7533,7 +7679,7 @@ type ClassifyMachineTokenRequest struct {
 
 func (x *ClassifyMachineTokenRequest) Reset() {
 	*x = ClassifyMachineTokenRequest{}
-	mi := &file_keyorix_proto_msgTypes[108]
+	mi := &file_keyorix_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7545,7 +7691,7 @@ func (x *ClassifyMachineTokenRequest) String() string {
 func (*ClassifyMachineTokenRequest) ProtoMessage() {}
 
 func (x *ClassifyMachineTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[108]
+	mi := &file_keyorix_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7558,7 +7704,7 @@ func (x *ClassifyMachineTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassifyMachineTokenRequest.ProtoReflect.Descriptor instead.
 func (*ClassifyMachineTokenRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{108}
+	return file_keyorix_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *ClassifyMachineTokenRequest) GetProjectId() uint32 {
@@ -7608,7 +7754,7 @@ type DynamicSecretConfig struct {
 
 func (x *DynamicSecretConfig) Reset() {
 	*x = DynamicSecretConfig{}
-	mi := &file_keyorix_proto_msgTypes[109]
+	mi := &file_keyorix_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7620,7 +7766,7 @@ func (x *DynamicSecretConfig) String() string {
 func (*DynamicSecretConfig) ProtoMessage() {}
 
 func (x *DynamicSecretConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[109]
+	mi := &file_keyorix_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7633,7 +7779,7 @@ func (x *DynamicSecretConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DynamicSecretConfig.ProtoReflect.Descriptor instead.
 func (*DynamicSecretConfig) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{109}
+	return file_keyorix_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *DynamicSecretConfig) GetId() uint32 {
@@ -7730,7 +7876,7 @@ type DynamicSecretLease struct {
 
 func (x *DynamicSecretLease) Reset() {
 	*x = DynamicSecretLease{}
-	mi := &file_keyorix_proto_msgTypes[110]
+	mi := &file_keyorix_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7742,7 +7888,7 @@ func (x *DynamicSecretLease) String() string {
 func (*DynamicSecretLease) ProtoMessage() {}
 
 func (x *DynamicSecretLease) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[110]
+	mi := &file_keyorix_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7755,7 +7901,7 @@ func (x *DynamicSecretLease) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DynamicSecretLease.ProtoReflect.Descriptor instead.
 func (*DynamicSecretLease) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{110}
+	return file_keyorix_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *DynamicSecretLease) GetLeaseId() string {
@@ -7836,7 +7982,7 @@ type IssuedCredential struct {
 
 func (x *IssuedCredential) Reset() {
 	*x = IssuedCredential{}
-	mi := &file_keyorix_proto_msgTypes[111]
+	mi := &file_keyorix_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7848,7 +7994,7 @@ func (x *IssuedCredential) String() string {
 func (*IssuedCredential) ProtoMessage() {}
 
 func (x *IssuedCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[111]
+	mi := &file_keyorix_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7861,7 +8007,7 @@ func (x *IssuedCredential) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssuedCredential.ProtoReflect.Descriptor instead.
 func (*IssuedCredential) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{111}
+	return file_keyorix_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *IssuedCredential) GetLeaseId() string {
@@ -7909,7 +8055,7 @@ type ListDynamicConfigsRequest struct {
 
 func (x *ListDynamicConfigsRequest) Reset() {
 	*x = ListDynamicConfigsRequest{}
-	mi := &file_keyorix_proto_msgTypes[112]
+	mi := &file_keyorix_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7921,7 +8067,7 @@ func (x *ListDynamicConfigsRequest) String() string {
 func (*ListDynamicConfigsRequest) ProtoMessage() {}
 
 func (x *ListDynamicConfigsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[112]
+	mi := &file_keyorix_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7934,7 +8080,7 @@ func (x *ListDynamicConfigsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDynamicConfigsRequest.ProtoReflect.Descriptor instead.
 func (*ListDynamicConfigsRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{112}
+	return file_keyorix_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *ListDynamicConfigsRequest) GetProjectId() uint32 {
@@ -7960,7 +8106,7 @@ type ListDynamicConfigsResponse struct {
 
 func (x *ListDynamicConfigsResponse) Reset() {
 	*x = ListDynamicConfigsResponse{}
-	mi := &file_keyorix_proto_msgTypes[113]
+	mi := &file_keyorix_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7972,7 +8118,7 @@ func (x *ListDynamicConfigsResponse) String() string {
 func (*ListDynamicConfigsResponse) ProtoMessage() {}
 
 func (x *ListDynamicConfigsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[113]
+	mi := &file_keyorix_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7985,7 +8131,7 @@ func (x *ListDynamicConfigsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDynamicConfigsResponse.ProtoReflect.Descriptor instead.
 func (*ListDynamicConfigsResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{113}
+	return file_keyorix_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *ListDynamicConfigsResponse) GetConfigs() []*DynamicSecretConfig {
@@ -8004,7 +8150,7 @@ type GetDynamicConfigRequest struct {
 
 func (x *GetDynamicConfigRequest) Reset() {
 	*x = GetDynamicConfigRequest{}
-	mi := &file_keyorix_proto_msgTypes[114]
+	mi := &file_keyorix_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8016,7 +8162,7 @@ func (x *GetDynamicConfigRequest) String() string {
 func (*GetDynamicConfigRequest) ProtoMessage() {}
 
 func (x *GetDynamicConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[114]
+	mi := &file_keyorix_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8029,7 +8175,7 @@ func (x *GetDynamicConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDynamicConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetDynamicConfigRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{114}
+	return file_keyorix_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *GetDynamicConfigRequest) GetId() uint32 {
@@ -8056,7 +8202,7 @@ type CreateDynamicConfigRequest struct {
 
 func (x *CreateDynamicConfigRequest) Reset() {
 	*x = CreateDynamicConfigRequest{}
-	mi := &file_keyorix_proto_msgTypes[115]
+	mi := &file_keyorix_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8068,7 +8214,7 @@ func (x *CreateDynamicConfigRequest) String() string {
 func (*CreateDynamicConfigRequest) ProtoMessage() {}
 
 func (x *CreateDynamicConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[115]
+	mi := &file_keyorix_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8081,7 +8227,7 @@ func (x *CreateDynamicConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDynamicConfigRequest.ProtoReflect.Descriptor instead.
 func (*CreateDynamicConfigRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{115}
+	return file_keyorix_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *CreateDynamicConfigRequest) GetName() string {
@@ -8157,7 +8303,7 @@ type ClassifyDynamicConfigRequest struct {
 
 func (x *ClassifyDynamicConfigRequest) Reset() {
 	*x = ClassifyDynamicConfigRequest{}
-	mi := &file_keyorix_proto_msgTypes[116]
+	mi := &file_keyorix_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8169,7 +8315,7 @@ func (x *ClassifyDynamicConfigRequest) String() string {
 func (*ClassifyDynamicConfigRequest) ProtoMessage() {}
 
 func (x *ClassifyDynamicConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[116]
+	mi := &file_keyorix_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8182,7 +8328,7 @@ func (x *ClassifyDynamicConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassifyDynamicConfigRequest.ProtoReflect.Descriptor instead.
 func (*ClassifyDynamicConfigRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{116}
+	return file_keyorix_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *ClassifyDynamicConfigRequest) GetId() uint32 {
@@ -8209,7 +8355,7 @@ type IssueLeaseRequest struct {
 
 func (x *IssueLeaseRequest) Reset() {
 	*x = IssueLeaseRequest{}
-	mi := &file_keyorix_proto_msgTypes[117]
+	mi := &file_keyorix_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8221,7 +8367,7 @@ func (x *IssueLeaseRequest) String() string {
 func (*IssueLeaseRequest) ProtoMessage() {}
 
 func (x *IssueLeaseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[117]
+	mi := &file_keyorix_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8234,7 +8380,7 @@ func (x *IssueLeaseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssueLeaseRequest.ProtoReflect.Descriptor instead.
 func (*IssueLeaseRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{117}
+	return file_keyorix_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *IssueLeaseRequest) GetConfigId() uint32 {
@@ -8260,7 +8406,7 @@ type ListLeasesRequest struct {
 
 func (x *ListLeasesRequest) Reset() {
 	*x = ListLeasesRequest{}
-	mi := &file_keyorix_proto_msgTypes[118]
+	mi := &file_keyorix_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8272,7 +8418,7 @@ func (x *ListLeasesRequest) String() string {
 func (*ListLeasesRequest) ProtoMessage() {}
 
 func (x *ListLeasesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[118]
+	mi := &file_keyorix_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8285,7 +8431,7 @@ func (x *ListLeasesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListLeasesRequest.ProtoReflect.Descriptor instead.
 func (*ListLeasesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{118}
+	return file_keyorix_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *ListLeasesRequest) GetConfigId() uint32 {
@@ -8304,7 +8450,7 @@ type ListLeasesResponse struct {
 
 func (x *ListLeasesResponse) Reset() {
 	*x = ListLeasesResponse{}
-	mi := &file_keyorix_proto_msgTypes[119]
+	mi := &file_keyorix_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8316,7 +8462,7 @@ func (x *ListLeasesResponse) String() string {
 func (*ListLeasesResponse) ProtoMessage() {}
 
 func (x *ListLeasesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[119]
+	mi := &file_keyorix_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8329,7 +8475,7 @@ func (x *ListLeasesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListLeasesResponse.ProtoReflect.Descriptor instead.
 func (*ListLeasesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{119}
+	return file_keyorix_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *ListLeasesResponse) GetLeases() []*DynamicSecretLease {
@@ -8348,7 +8494,7 @@ type RevokeLeaseRequest struct {
 
 func (x *RevokeLeaseRequest) Reset() {
 	*x = RevokeLeaseRequest{}
-	mi := &file_keyorix_proto_msgTypes[120]
+	mi := &file_keyorix_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8360,7 +8506,7 @@ func (x *RevokeLeaseRequest) String() string {
 func (*RevokeLeaseRequest) ProtoMessage() {}
 
 func (x *RevokeLeaseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[120]
+	mi := &file_keyorix_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8373,7 +8519,7 @@ func (x *RevokeLeaseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeLeaseRequest.ProtoReflect.Descriptor instead.
 func (*RevokeLeaseRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{120}
+	return file_keyorix_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *RevokeLeaseRequest) GetLeaseId() string {
@@ -8393,7 +8539,7 @@ type RenewLeaseRequest struct {
 
 func (x *RenewLeaseRequest) Reset() {
 	*x = RenewLeaseRequest{}
-	mi := &file_keyorix_proto_msgTypes[121]
+	mi := &file_keyorix_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8405,7 +8551,7 @@ func (x *RenewLeaseRequest) String() string {
 func (*RenewLeaseRequest) ProtoMessage() {}
 
 func (x *RenewLeaseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[121]
+	mi := &file_keyorix_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8418,7 +8564,7 @@ func (x *RenewLeaseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewLeaseRequest.ProtoReflect.Descriptor instead.
 func (*RenewLeaseRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{121}
+	return file_keyorix_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *RenewLeaseRequest) GetLeaseId() string {
@@ -8445,7 +8591,7 @@ type RenewLeaseResponse struct {
 
 func (x *RenewLeaseResponse) Reset() {
 	*x = RenewLeaseResponse{}
-	mi := &file_keyorix_proto_msgTypes[122]
+	mi := &file_keyorix_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8457,7 +8603,7 @@ func (x *RenewLeaseResponse) String() string {
 func (*RenewLeaseResponse) ProtoMessage() {}
 
 func (x *RenewLeaseResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[122]
+	mi := &file_keyorix_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8470,7 +8616,7 @@ func (x *RenewLeaseResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewLeaseResponse.ProtoReflect.Descriptor instead.
 func (*RenewLeaseResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{122}
+	return file_keyorix_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *RenewLeaseResponse) GetLeaseId() string {
@@ -8496,7 +8642,7 @@ type RevokeAllLeasesRequest struct {
 
 func (x *RevokeAllLeasesRequest) Reset() {
 	*x = RevokeAllLeasesRequest{}
-	mi := &file_keyorix_proto_msgTypes[123]
+	mi := &file_keyorix_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8508,7 +8654,7 @@ func (x *RevokeAllLeasesRequest) String() string {
 func (*RevokeAllLeasesRequest) ProtoMessage() {}
 
 func (x *RevokeAllLeasesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[123]
+	mi := &file_keyorix_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8521,7 +8667,7 @@ func (x *RevokeAllLeasesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeAllLeasesRequest.ProtoReflect.Descriptor instead.
 func (*RevokeAllLeasesRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{123}
+	return file_keyorix_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *RevokeAllLeasesRequest) GetConfigId() uint32 {
@@ -8541,7 +8687,7 @@ type RevokeAllLeasesResponse struct {
 
 func (x *RevokeAllLeasesResponse) Reset() {
 	*x = RevokeAllLeasesResponse{}
-	mi := &file_keyorix_proto_msgTypes[124]
+	mi := &file_keyorix_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8553,7 +8699,7 @@ func (x *RevokeAllLeasesResponse) String() string {
 func (*RevokeAllLeasesResponse) ProtoMessage() {}
 
 func (x *RevokeAllLeasesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[124]
+	mi := &file_keyorix_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8566,7 +8712,7 @@ func (x *RevokeAllLeasesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeAllLeasesResponse.ProtoReflect.Descriptor instead.
 func (*RevokeAllLeasesResponse) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{124}
+	return file_keyorix_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *RevokeAllLeasesResponse) GetRevoked() uint32 {
@@ -8595,7 +8741,7 @@ type AuditIntegrityPosture struct {
 
 func (x *AuditIntegrityPosture) Reset() {
 	*x = AuditIntegrityPosture{}
-	mi := &file_keyorix_proto_msgTypes[125]
+	mi := &file_keyorix_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8607,7 +8753,7 @@ func (x *AuditIntegrityPosture) String() string {
 func (*AuditIntegrityPosture) ProtoMessage() {}
 
 func (x *AuditIntegrityPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[125]
+	mi := &file_keyorix_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8620,7 +8766,7 @@ func (x *AuditIntegrityPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditIntegrityPosture.ProtoReflect.Descriptor instead.
 func (*AuditIntegrityPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{125}
+	return file_keyorix_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *AuditIntegrityPosture) GetChainVerified() bool {
@@ -8667,7 +8813,7 @@ type AccessGovernancePosture struct {
 
 func (x *AccessGovernancePosture) Reset() {
 	*x = AccessGovernancePosture{}
-	mi := &file_keyorix_proto_msgTypes[126]
+	mi := &file_keyorix_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8679,7 +8825,7 @@ func (x *AccessGovernancePosture) String() string {
 func (*AccessGovernancePosture) ProtoMessage() {}
 
 func (x *AccessGovernancePosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[126]
+	mi := &file_keyorix_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8692,7 +8838,7 @@ func (x *AccessGovernancePosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessGovernancePosture.ProtoReflect.Descriptor instead.
 func (*AccessGovernancePosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{126}
+	return file_keyorix_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *AccessGovernancePosture) GetProjects() int32 {
@@ -8762,7 +8908,7 @@ type RotationPosture struct {
 
 func (x *RotationPosture) Reset() {
 	*x = RotationPosture{}
-	mi := &file_keyorix_proto_msgTypes[127]
+	mi := &file_keyorix_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8774,7 +8920,7 @@ func (x *RotationPosture) String() string {
 func (*RotationPosture) ProtoMessage() {}
 
 func (x *RotationPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[127]
+	mi := &file_keyorix_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8787,7 +8933,7 @@ func (x *RotationPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotationPosture.ProtoReflect.Descriptor instead.
 func (*RotationPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{127}
+	return file_keyorix_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *RotationPosture) GetCoveredSecrets() int32 {
@@ -8822,7 +8968,7 @@ type IdentityPosture struct {
 
 func (x *IdentityPosture) Reset() {
 	*x = IdentityPosture{}
-	mi := &file_keyorix_proto_msgTypes[128]
+	mi := &file_keyorix_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8834,7 +8980,7 @@ func (x *IdentityPosture) String() string {
 func (*IdentityPosture) ProtoMessage() {}
 
 func (x *IdentityPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[128]
+	mi := &file_keyorix_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8847,7 +8993,7 @@ func (x *IdentityPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IdentityPosture.ProtoReflect.Descriptor instead.
 func (*IdentityPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{128}
+	return file_keyorix_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *IdentityPosture) GetActiveUsers() int32 {
@@ -8881,7 +9027,7 @@ type EmergencyAccessPosture struct {
 
 func (x *EmergencyAccessPosture) Reset() {
 	*x = EmergencyAccessPosture{}
-	mi := &file_keyorix_proto_msgTypes[129]
+	mi := &file_keyorix_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8893,7 +9039,7 @@ func (x *EmergencyAccessPosture) String() string {
 func (*EmergencyAccessPosture) ProtoMessage() {}
 
 func (x *EmergencyAccessPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[129]
+	mi := &file_keyorix_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8906,7 +9052,7 @@ func (x *EmergencyAccessPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EmergencyAccessPosture.ProtoReflect.Descriptor instead.
 func (*EmergencyAccessPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{129}
+	return file_keyorix_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *EmergencyAccessPosture) GetActiveActivations() int32 {
@@ -8937,7 +9083,7 @@ type ClassificationCounts struct {
 
 func (x *ClassificationCounts) Reset() {
 	*x = ClassificationCounts{}
-	mi := &file_keyorix_proto_msgTypes[130]
+	mi := &file_keyorix_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8949,7 +9095,7 @@ func (x *ClassificationCounts) String() string {
 func (*ClassificationCounts) ProtoMessage() {}
 
 func (x *ClassificationCounts) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[130]
+	mi := &file_keyorix_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8962,7 +9108,7 @@ func (x *ClassificationCounts) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassificationCounts.ProtoReflect.Descriptor instead.
 func (*ClassificationCounts) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{130}
+	return file_keyorix_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *ClassificationCounts) GetTotal() int32 {
@@ -9024,7 +9170,7 @@ type ClassificationPosture struct {
 
 func (x *ClassificationPosture) Reset() {
 	*x = ClassificationPosture{}
-	mi := &file_keyorix_proto_msgTypes[131]
+	mi := &file_keyorix_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9036,7 +9182,7 @@ func (x *ClassificationPosture) String() string {
 func (*ClassificationPosture) ProtoMessage() {}
 
 func (x *ClassificationPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[131]
+	mi := &file_keyorix_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9049,7 +9195,7 @@ func (x *ClassificationPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClassificationPosture.ProtoReflect.Descriptor instead.
 func (*ClassificationPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{131}
+	return file_keyorix_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *ClassificationPosture) GetTotalSecrets() int32 {
@@ -9125,7 +9271,7 @@ type AnomaliesPosture struct {
 
 func (x *AnomaliesPosture) Reset() {
 	*x = AnomaliesPosture{}
-	mi := &file_keyorix_proto_msgTypes[132]
+	mi := &file_keyorix_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9137,7 +9283,7 @@ func (x *AnomaliesPosture) String() string {
 func (*AnomaliesPosture) ProtoMessage() {}
 
 func (x *AnomaliesPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[132]
+	mi := &file_keyorix_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9150,7 +9296,7 @@ func (x *AnomaliesPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AnomaliesPosture.ProtoReflect.Descriptor instead.
 func (*AnomaliesPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{132}
+	return file_keyorix_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *AnomaliesPosture) GetUnacknowledged() int32 {
@@ -9178,7 +9324,7 @@ type LegalHoldPosture struct {
 
 func (x *LegalHoldPosture) Reset() {
 	*x = LegalHoldPosture{}
-	mi := &file_keyorix_proto_msgTypes[133]
+	mi := &file_keyorix_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9190,7 +9336,7 @@ func (x *LegalHoldPosture) String() string {
 func (*LegalHoldPosture) ProtoMessage() {}
 
 func (x *LegalHoldPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[133]
+	mi := &file_keyorix_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9203,7 +9349,7 @@ func (x *LegalHoldPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LegalHoldPosture.ProtoReflect.Descriptor instead.
 func (*LegalHoldPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{133}
+	return file_keyorix_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *LegalHoldPosture) GetActive() bool {
@@ -9240,7 +9386,7 @@ type RetentionPosture struct {
 
 func (x *RetentionPosture) Reset() {
 	*x = RetentionPosture{}
-	mi := &file_keyorix_proto_msgTypes[134]
+	mi := &file_keyorix_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9252,7 +9398,7 @@ func (x *RetentionPosture) String() string {
 func (*RetentionPosture) ProtoMessage() {}
 
 func (x *RetentionPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[134]
+	mi := &file_keyorix_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9265,7 +9411,7 @@ func (x *RetentionPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RetentionPosture.ProtoReflect.Descriptor instead.
 func (*RetentionPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{134}
+	return file_keyorix_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *RetentionPosture) GetEnabled() bool {
@@ -9313,7 +9459,7 @@ type RiskPosture struct {
 
 func (x *RiskPosture) Reset() {
 	*x = RiskPosture{}
-	mi := &file_keyorix_proto_msgTypes[135]
+	mi := &file_keyorix_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9325,7 +9471,7 @@ func (x *RiskPosture) String() string {
 func (*RiskPosture) ProtoMessage() {}
 
 func (x *RiskPosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[135]
+	mi := &file_keyorix_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9338,7 +9484,7 @@ func (x *RiskPosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RiskPosture.ProtoReflect.Descriptor instead.
 func (*RiskPosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{135}
+	return file_keyorix_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *RiskPosture) GetActiveExceptions() int32 {
@@ -9380,7 +9526,7 @@ type CompliancePosture struct {
 
 func (x *CompliancePosture) Reset() {
 	*x = CompliancePosture{}
-	mi := &file_keyorix_proto_msgTypes[136]
+	mi := &file_keyorix_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9392,7 +9538,7 @@ func (x *CompliancePosture) String() string {
 func (*CompliancePosture) ProtoMessage() {}
 
 func (x *CompliancePosture) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[136]
+	mi := &file_keyorix_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9405,7 +9551,7 @@ func (x *CompliancePosture) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompliancePosture.ProtoReflect.Descriptor instead.
 func (*CompliancePosture) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{136}
+	return file_keyorix_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *CompliancePosture) GetGeneratedAt() *timestamppb.Timestamp {
@@ -9513,7 +9659,7 @@ type FrameworkRefs struct {
 
 func (x *FrameworkRefs) Reset() {
 	*x = FrameworkRefs{}
-	mi := &file_keyorix_proto_msgTypes[137]
+	mi := &file_keyorix_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9525,7 +9671,7 @@ func (x *FrameworkRefs) String() string {
 func (*FrameworkRefs) ProtoMessage() {}
 
 func (x *FrameworkRefs) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[137]
+	mi := &file_keyorix_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9538,7 +9684,7 @@ func (x *FrameworkRefs) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FrameworkRefs.ProtoReflect.Descriptor instead.
 func (*FrameworkRefs) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{137}
+	return file_keyorix_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *FrameworkRefs) GetIso_27001() []string {
@@ -9590,7 +9736,7 @@ type ControlState struct {
 
 func (x *ControlState) Reset() {
 	*x = ControlState{}
-	mi := &file_keyorix_proto_msgTypes[138]
+	mi := &file_keyorix_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9602,7 +9748,7 @@ func (x *ControlState) String() string {
 func (*ControlState) ProtoMessage() {}
 
 func (x *ControlState) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[138]
+	mi := &file_keyorix_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9615,7 +9761,7 @@ func (x *ControlState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ControlState.ProtoReflect.Descriptor instead.
 func (*ControlState) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{138}
+	return file_keyorix_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *ControlState) GetId() string {
@@ -9675,7 +9821,7 @@ type ControlsSummary struct {
 
 func (x *ControlsSummary) Reset() {
 	*x = ControlsSummary{}
-	mi := &file_keyorix_proto_msgTypes[139]
+	mi := &file_keyorix_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9687,7 +9833,7 @@ func (x *ControlsSummary) String() string {
 func (*ControlsSummary) ProtoMessage() {}
 
 func (x *ControlsSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[139]
+	mi := &file_keyorix_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9700,7 +9846,7 @@ func (x *ControlsSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ControlsSummary.ProtoReflect.Descriptor instead.
 func (*ControlsSummary) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{139}
+	return file_keyorix_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *ControlsSummary) GetTotal() int32 {
@@ -9749,7 +9895,7 @@ type ComplianceControls struct {
 
 func (x *ComplianceControls) Reset() {
 	*x = ComplianceControls{}
-	mi := &file_keyorix_proto_msgTypes[140]
+	mi := &file_keyorix_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9761,7 +9907,7 @@ func (x *ComplianceControls) String() string {
 func (*ComplianceControls) ProtoMessage() {}
 
 func (x *ComplianceControls) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[140]
+	mi := &file_keyorix_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9774,7 +9920,7 @@ func (x *ComplianceControls) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComplianceControls.ProtoReflect.Descriptor instead.
 func (*ComplianceControls) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{140}
+	return file_keyorix_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *ComplianceControls) GetGeneratedAt() *timestamppb.Timestamp {
@@ -9807,7 +9953,7 @@ type ConnectorList struct {
 
 func (x *ConnectorList) Reset() {
 	*x = ConnectorList{}
-	mi := &file_keyorix_proto_msgTypes[141]
+	mi := &file_keyorix_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9819,7 +9965,7 @@ func (x *ConnectorList) String() string {
 func (*ConnectorList) ProtoMessage() {}
 
 func (x *ConnectorList) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[141]
+	mi := &file_keyorix_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9832,7 +9978,7 @@ func (x *ConnectorList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectorList.ProtoReflect.Descriptor instead.
 func (*ConnectorList) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{141}
+	return file_keyorix_proto_rawDescGZIP(), []int{143}
 }
 
 func (x *ConnectorList) GetConnectors() []string {
@@ -9852,7 +9998,7 @@ type ReadFederatedSecretRequest struct {
 
 func (x *ReadFederatedSecretRequest) Reset() {
 	*x = ReadFederatedSecretRequest{}
-	mi := &file_keyorix_proto_msgTypes[142]
+	mi := &file_keyorix_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9864,7 +10010,7 @@ func (x *ReadFederatedSecretRequest) String() string {
 func (*ReadFederatedSecretRequest) ProtoMessage() {}
 
 func (x *ReadFederatedSecretRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[142]
+	mi := &file_keyorix_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9877,7 +10023,7 @@ func (x *ReadFederatedSecretRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadFederatedSecretRequest.ProtoReflect.Descriptor instead.
 func (*ReadFederatedSecretRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{142}
+	return file_keyorix_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *ReadFederatedSecretRequest) GetConnector() string {
@@ -9905,7 +10051,7 @@ type FederatedSecretValue struct {
 
 func (x *FederatedSecretValue) Reset() {
 	*x = FederatedSecretValue{}
-	mi := &file_keyorix_proto_msgTypes[143]
+	mi := &file_keyorix_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9917,7 +10063,7 @@ func (x *FederatedSecretValue) String() string {
 func (*FederatedSecretValue) ProtoMessage() {}
 
 func (x *FederatedSecretValue) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[143]
+	mi := &file_keyorix_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9930,7 +10076,7 @@ func (x *FederatedSecretValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FederatedSecretValue.ProtoReflect.Descriptor instead.
 func (*FederatedSecretValue) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{143}
+	return file_keyorix_proto_rawDescGZIP(), []int{145}
 }
 
 func (x *FederatedSecretValue) GetConnector() string {
@@ -9967,7 +10113,7 @@ type ConnectRefGrant struct {
 
 func (x *ConnectRefGrant) Reset() {
 	*x = ConnectRefGrant{}
-	mi := &file_keyorix_proto_msgTypes[144]
+	mi := &file_keyorix_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9979,7 +10125,7 @@ func (x *ConnectRefGrant) String() string {
 func (*ConnectRefGrant) ProtoMessage() {}
 
 func (x *ConnectRefGrant) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[144]
+	mi := &file_keyorix_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9992,7 +10138,7 @@ func (x *ConnectRefGrant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectRefGrant.ProtoReflect.Descriptor instead.
 func (*ConnectRefGrant) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{144}
+	return file_keyorix_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *ConnectRefGrant) GetId() uint32 {
@@ -10039,7 +10185,7 @@ type ConnectRefGrantList struct {
 
 func (x *ConnectRefGrantList) Reset() {
 	*x = ConnectRefGrantList{}
-	mi := &file_keyorix_proto_msgTypes[145]
+	mi := &file_keyorix_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10051,7 +10197,7 @@ func (x *ConnectRefGrantList) String() string {
 func (*ConnectRefGrantList) ProtoMessage() {}
 
 func (x *ConnectRefGrantList) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[145]
+	mi := &file_keyorix_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10064,7 +10210,7 @@ func (x *ConnectRefGrantList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectRefGrantList.ProtoReflect.Descriptor instead.
 func (*ConnectRefGrantList) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{145}
+	return file_keyorix_proto_rawDescGZIP(), []int{147}
 }
 
 func (x *ConnectRefGrantList) GetGrants() []*ConnectRefGrant {
@@ -10086,7 +10232,7 @@ type CreateConnectRefGrantRequest struct {
 
 func (x *CreateConnectRefGrantRequest) Reset() {
 	*x = CreateConnectRefGrantRequest{}
-	mi := &file_keyorix_proto_msgTypes[146]
+	mi := &file_keyorix_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10098,7 +10244,7 @@ func (x *CreateConnectRefGrantRequest) String() string {
 func (*CreateConnectRefGrantRequest) ProtoMessage() {}
 
 func (x *CreateConnectRefGrantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[146]
+	mi := &file_keyorix_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10111,7 +10257,7 @@ func (x *CreateConnectRefGrantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateConnectRefGrantRequest.ProtoReflect.Descriptor instead.
 func (*CreateConnectRefGrantRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{146}
+	return file_keyorix_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *CreateConnectRefGrantRequest) GetRoleId() uint32 {
@@ -10151,7 +10297,7 @@ type DeleteConnectRefGrantRequest struct {
 
 func (x *DeleteConnectRefGrantRequest) Reset() {
 	*x = DeleteConnectRefGrantRequest{}
-	mi := &file_keyorix_proto_msgTypes[147]
+	mi := &file_keyorix_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10163,7 +10309,7 @@ func (x *DeleteConnectRefGrantRequest) String() string {
 func (*DeleteConnectRefGrantRequest) ProtoMessage() {}
 
 func (x *DeleteConnectRefGrantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_keyorix_proto_msgTypes[147]
+	mi := &file_keyorix_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10176,7 +10322,7 @@ func (x *DeleteConnectRefGrantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteConnectRefGrantRequest.ProtoReflect.Descriptor instead.
 func (*DeleteConnectRefGrantRequest) Descriptor() ([]byte, []int) {
-	return file_keyorix_proto_rawDescGZIP(), []int{147}
+	return file_keyorix_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *DeleteConnectRefGrantRequest) GetId() uint32 {
@@ -10349,7 +10495,19 @@ const file_keyorix_proto_rawDesc = "" +
 	"\rRotationOrder\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\rR\tprojectId\x12.\n" +
-	"\x05order\x18\x02 \x03(\v2\x18.keyorix.v1.RotationStepR\x05order\"\xc5\x02\n" +
+	"\x05order\x18\x02 \x03(\v2\x18.keyorix.v1.RotationStepR\x05order\"L\n" +
+	"\x15BrokenRotationProject\x12\x1d\n" +
+	"\n" +
+	"project_id\x18\x01 \x01(\rR\tprojectId\x12\x14\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"\xe3\x02\n" +
+	"\x16DeploymentRotationPlan\x12)\n" +
+	"\x10projects_scanned\x18\x01 \x01(\x05R\x0fprojectsScanned\x12,\n" +
+	"\x12projects_with_work\x18\x02 \x01(\x05R\x10projectsWithWork\x12#\n" +
+	"\rtotal_secrets\x18\x03 \x01(\x05R\ftotalSecrets\x12#\n" +
+	"\roverdue_count\x18\x04 \x01(\x05R\foverdueCount\x12$\n" +
+	"\x0edue_soon_count\x18\x05 \x01(\x05R\fdueSoonCount\x124\n" +
+	"\bprojects\x18\x06 \x03(\v2\x18.keyorix.v1.RotationPlanR\bprojects\x12J\n" +
+	"\x0fbroken_projects\x18\a \x03(\v2!.keyorix.v1.BrokenRotationProjectR\x0ebrokenProjects\"\xc5\x02\n" +
 	"\x0fPlannedRotation\x12\x1b\n" +
 	"\tsecret_id\x18\x01 \x01(\rR\bsecretId\x12\x1f\n" +
 	"\vsecret_name\x18\x02 \x01(\tR\n" +
@@ -11265,7 +11423,7 @@ const file_keyorix_proto_rawDesc = "" +
 	"\fRestoreGroup\x12\x1f.keyorix.v1.RestoreGroupRequest\x1a\x11.keyorix.v1.Group\x12Z\n" +
 	"\x0fGetGroupMembers\x12\".keyorix.v1.GetGroupMembersRequest\x1a#.keyorix.v1.GetGroupMembersResponse\x12H\n" +
 	"\x0eAddGroupMember\x12\x1e.keyorix.v1.GroupMemberRequest\x1a\x16.google.protobuf.Empty\x12K\n" +
-	"\x11RemoveGroupMember\x12\x1e.keyorix.v1.GroupMemberRequest\x1a\x16.google.protobuf.Empty2\xfe\x04\n" +
+	"\x11RemoveGroupMember\x12\x1e.keyorix.v1.GroupMemberRequest\x1a\x16.google.protobuf.Empty2\xd7\x05\n" +
 	"\x0eProjectService\x12H\n" +
 	"\fListProjects\x12\x16.google.protobuf.Empty\x1a .keyorix.v1.ListProjectsResponse\x12@\n" +
 	"\n" +
@@ -11274,7 +11432,8 @@ const file_keyorix_proto_rawDesc = "" +
 	"\rUpdateProject\x12 .keyorix.v1.UpdateProjectRequest\x1a\x13.keyorix.v1.Project\x12I\n" +
 	"\rDeleteProject\x12 .keyorix.v1.DeleteProjectRequest\x1a\x16.google.protobuf.Empty\x12S\n" +
 	"\x17GetProjectRotationOrder\x12\x1d.keyorix.v1.GetProjectRequest\x1a\x19.keyorix.v1.RotationOrder\x12Q\n" +
-	"\x16GetProjectRotationPlan\x12\x1d.keyorix.v1.GetProjectRequest\x1a\x18.keyorix.v1.RotationPlan\x12]\n" +
+	"\x16GetProjectRotationPlan\x12\x1d.keyorix.v1.GetProjectRequest\x1a\x18.keyorix.v1.RotationPlan\x12W\n" +
+	"\x19GetDeploymentRotationPlan\x12\x16.google.protobuf.Empty\x1a\".keyorix.v1.DeploymentRotationPlan\x12]\n" +
 	"\x10ListEnvironments\x12#.keyorix.v1.ListEnvironmentsRequest\x1a$.keyorix.v1.ListEnvironmentsResponse2\xa6\x06\n" +
 	"\x16MachineIdentityService\x12l\n" +
 	"\x15ListMachineIdentities\x12(.keyorix.v1.ListMachineIdentitiesRequest\x1a).keyorix.v1.ListMachineIdentitiesResponse\x12^\n" +
@@ -11321,7 +11480,7 @@ func file_keyorix_proto_rawDescGZIP() []byte {
 	return file_keyorix_proto_rawDescData
 }
 
-var file_keyorix_proto_msgTypes = make([]protoimpl.MessageInfo, 154)
+var file_keyorix_proto_msgTypes = make([]protoimpl.MessageInfo, 156)
 var file_keyorix_proto_goTypes = []any{
 	(*Secret)(nil),                            // 0: keyorix.v1.Secret
 	(*SecretValue)(nil),                       // 1: keyorix.v1.SecretValue
@@ -11341,420 +11500,426 @@ var file_keyorix_proto_goTypes = []any{
 	(*SecretImpact)(nil),                      // 15: keyorix.v1.SecretImpact
 	(*RotationStep)(nil),                      // 16: keyorix.v1.RotationStep
 	(*RotationOrder)(nil),                     // 17: keyorix.v1.RotationOrder
-	(*PlannedRotation)(nil),                   // 18: keyorix.v1.PlannedRotation
-	(*RotationWave)(nil),                      // 19: keyorix.v1.RotationWave
-	(*RotationPlan)(nil),                      // 20: keyorix.v1.RotationPlan
-	(*User)(nil),                              // 21: keyorix.v1.User
-	(*ProjectAssignment)(nil),                 // 22: keyorix.v1.ProjectAssignment
-	(*CreateUserRequest)(nil),                 // 23: keyorix.v1.CreateUserRequest
-	(*CreateUserResponse)(nil),                // 24: keyorix.v1.CreateUserResponse
-	(*GetUserRequest)(nil),                    // 25: keyorix.v1.GetUserRequest
-	(*UpdateUserRequest)(nil),                 // 26: keyorix.v1.UpdateUserRequest
-	(*DeleteUserRequest)(nil),                 // 27: keyorix.v1.DeleteUserRequest
-	(*ListUsersRequest)(nil),                  // 28: keyorix.v1.ListUsersRequest
-	(*ListUsersResponse)(nil),                 // 29: keyorix.v1.ListUsersResponse
-	(*Permission)(nil),                        // 30: keyorix.v1.Permission
-	(*Role)(nil),                              // 31: keyorix.v1.Role
-	(*CreateRoleRequest)(nil),                 // 32: keyorix.v1.CreateRoleRequest
-	(*GetRoleRequest)(nil),                    // 33: keyorix.v1.GetRoleRequest
-	(*UpdateRoleRequest)(nil),                 // 34: keyorix.v1.UpdateRoleRequest
-	(*DeleteRoleRequest)(nil),                 // 35: keyorix.v1.DeleteRoleRequest
-	(*ListRolesRequest)(nil),                  // 36: keyorix.v1.ListRolesRequest
-	(*ListRolesResponse)(nil),                 // 37: keyorix.v1.ListRolesResponse
-	(*AssignRoleRequest)(nil),                 // 38: keyorix.v1.AssignRoleRequest
-	(*RoleAssignment)(nil),                    // 39: keyorix.v1.RoleAssignment
-	(*RemoveRoleRequest)(nil),                 // 40: keyorix.v1.RemoveRoleRequest
-	(*GetUserRolesRequest)(nil),               // 41: keyorix.v1.GetUserRolesRequest
-	(*GetUserRolesResponse)(nil),              // 42: keyorix.v1.GetUserRolesResponse
-	(*AuditLog)(nil),                          // 43: keyorix.v1.AuditLog
-	(*GetAuditLogsRequest)(nil),               // 44: keyorix.v1.GetAuditLogsRequest
-	(*GetAuditLogsResponse)(nil),              // 45: keyorix.v1.GetAuditLogsResponse
-	(*RBACAuditLog)(nil),                      // 46: keyorix.v1.RBACAuditLog
-	(*GetRBACAuditLogsRequest)(nil),           // 47: keyorix.v1.GetRBACAuditLogsRequest
-	(*GetRBACAuditLogsResponse)(nil),          // 48: keyorix.v1.GetRBACAuditLogsResponse
-	(*StreamAuditLogsRequest)(nil),            // 49: keyorix.v1.StreamAuditLogsRequest
-	(*VerifyAuditChainResponse)(nil),          // 50: keyorix.v1.VerifyAuditChainResponse
-	(*WriteAuditCheckpointResponse)(nil),      // 51: keyorix.v1.WriteAuditCheckpointResponse
-	(*GetAuditRetentionResponse)(nil),         // 52: keyorix.v1.GetAuditRetentionResponse
-	(*BreakGlassActivation)(nil),              // 53: keyorix.v1.BreakGlassActivation
-	(*ActivateBreakGlassRequest)(nil),         // 54: keyorix.v1.ActivateBreakGlassRequest
-	(*ListBreakGlassActivationsRequest)(nil),  // 55: keyorix.v1.ListBreakGlassActivationsRequest
-	(*ListBreakGlassActivationsResponse)(nil), // 56: keyorix.v1.ListBreakGlassActivationsResponse
-	(*RevokeBreakGlassRequest)(nil),           // 57: keyorix.v1.RevokeBreakGlassRequest
-	(*Group)(nil),                             // 58: keyorix.v1.Group
-	(*GroupMember)(nil),                       // 59: keyorix.v1.GroupMember
-	(*GetGroupRequest)(nil),                   // 60: keyorix.v1.GetGroupRequest
-	(*CreateGroupRequest)(nil),                // 61: keyorix.v1.CreateGroupRequest
-	(*UpdateGroupRequest)(nil),                // 62: keyorix.v1.UpdateGroupRequest
-	(*DeleteGroupRequest)(nil),                // 63: keyorix.v1.DeleteGroupRequest
-	(*RestoreGroupRequest)(nil),               // 64: keyorix.v1.RestoreGroupRequest
-	(*ListGroupsResponse)(nil),                // 65: keyorix.v1.ListGroupsResponse
-	(*GetGroupMembersRequest)(nil),            // 66: keyorix.v1.GetGroupMembersRequest
-	(*GetGroupMembersResponse)(nil),           // 67: keyorix.v1.GetGroupMembersResponse
-	(*GroupMemberRequest)(nil),                // 68: keyorix.v1.GroupMemberRequest
-	(*ShareRecord)(nil),                       // 69: keyorix.v1.ShareRecord
-	(*ShareSecretRequest)(nil),                // 70: keyorix.v1.ShareSecretRequest
-	(*ListSecretSharesRequest)(nil),           // 71: keyorix.v1.ListSecretSharesRequest
-	(*ListUserSharesRequest)(nil),             // 72: keyorix.v1.ListUserSharesRequest
-	(*ListSharedSecretsRequest)(nil),          // 73: keyorix.v1.ListSharedSecretsRequest
-	(*ListSharesResponse)(nil),                // 74: keyorix.v1.ListSharesResponse
-	(*UpdateSharePermissionRequest)(nil),      // 75: keyorix.v1.UpdateSharePermissionRequest
-	(*RevokeShareRequest)(nil),                // 76: keyorix.v1.RevokeShareRequest
-	(*HealthResponse)(nil),                    // 77: keyorix.v1.HealthResponse
-	(*SystemInfo)(nil),                        // 78: keyorix.v1.SystemInfo
-	(*DatabaseInfo)(nil),                      // 79: keyorix.v1.DatabaseInfo
-	(*EncryptionInfo)(nil),                    // 80: keyorix.v1.EncryptionInfo
-	(*Metrics)(nil),                           // 81: keyorix.v1.Metrics
-	(*RequestMetrics)(nil),                    // 82: keyorix.v1.RequestMetrics
-	(*SecretMetrics)(nil),                     // 83: keyorix.v1.SecretMetrics
-	(*UserMetrics)(nil),                       // 84: keyorix.v1.UserMetrics
-	(*PerformanceMetrics)(nil),                // 85: keyorix.v1.PerformanceMetrics
-	(*SystemMetrics)(nil),                     // 86: keyorix.v1.SystemMetrics
-	(*Project)(nil),                           // 87: keyorix.v1.Project
-	(*Environment)(nil),                       // 88: keyorix.v1.Environment
-	(*ListProjectsResponse)(nil),              // 89: keyorix.v1.ListProjectsResponse
-	(*GetProjectRequest)(nil),                 // 90: keyorix.v1.GetProjectRequest
-	(*CreateProjectRequest)(nil),              // 91: keyorix.v1.CreateProjectRequest
-	(*UpdateProjectRequest)(nil),              // 92: keyorix.v1.UpdateProjectRequest
-	(*DeleteProjectRequest)(nil),              // 93: keyorix.v1.DeleteProjectRequest
-	(*ListEnvironmentsRequest)(nil),           // 94: keyorix.v1.ListEnvironmentsRequest
-	(*ListEnvironmentsResponse)(nil),          // 95: keyorix.v1.ListEnvironmentsResponse
-	(*MachineIdentity)(nil),                   // 96: keyorix.v1.MachineIdentity
-	(*MachineToken)(nil),                      // 97: keyorix.v1.MachineToken
-	(*ListMachineIdentitiesRequest)(nil),      // 98: keyorix.v1.ListMachineIdentitiesRequest
-	(*ListMachineIdentitiesResponse)(nil),     // 99: keyorix.v1.ListMachineIdentitiesResponse
-	(*CreateMachineIdentityRequest)(nil),      // 100: keyorix.v1.CreateMachineIdentityRequest
-	(*TransitionMachineIdentityRequest)(nil),  // 101: keyorix.v1.TransitionMachineIdentityRequest
-	(*ClassifyMachineIdentityRequest)(nil),    // 102: keyorix.v1.ClassifyMachineIdentityRequest
-	(*IssueMachineTokenRequest)(nil),          // 103: keyorix.v1.IssueMachineTokenRequest
-	(*IssueMachineTokenResponse)(nil),         // 104: keyorix.v1.IssueMachineTokenResponse
-	(*ListMachineTokensRequest)(nil),          // 105: keyorix.v1.ListMachineTokensRequest
-	(*ListMachineTokensResponse)(nil),         // 106: keyorix.v1.ListMachineTokensResponse
-	(*RevokeMachineTokenRequest)(nil),         // 107: keyorix.v1.RevokeMachineTokenRequest
-	(*ClassifyMachineTokenRequest)(nil),       // 108: keyorix.v1.ClassifyMachineTokenRequest
-	(*DynamicSecretConfig)(nil),               // 109: keyorix.v1.DynamicSecretConfig
-	(*DynamicSecretLease)(nil),                // 110: keyorix.v1.DynamicSecretLease
-	(*IssuedCredential)(nil),                  // 111: keyorix.v1.IssuedCredential
-	(*ListDynamicConfigsRequest)(nil),         // 112: keyorix.v1.ListDynamicConfigsRequest
-	(*ListDynamicConfigsResponse)(nil),        // 113: keyorix.v1.ListDynamicConfigsResponse
-	(*GetDynamicConfigRequest)(nil),           // 114: keyorix.v1.GetDynamicConfigRequest
-	(*CreateDynamicConfigRequest)(nil),        // 115: keyorix.v1.CreateDynamicConfigRequest
-	(*ClassifyDynamicConfigRequest)(nil),      // 116: keyorix.v1.ClassifyDynamicConfigRequest
-	(*IssueLeaseRequest)(nil),                 // 117: keyorix.v1.IssueLeaseRequest
-	(*ListLeasesRequest)(nil),                 // 118: keyorix.v1.ListLeasesRequest
-	(*ListLeasesResponse)(nil),                // 119: keyorix.v1.ListLeasesResponse
-	(*RevokeLeaseRequest)(nil),                // 120: keyorix.v1.RevokeLeaseRequest
-	(*RenewLeaseRequest)(nil),                 // 121: keyorix.v1.RenewLeaseRequest
-	(*RenewLeaseResponse)(nil),                // 122: keyorix.v1.RenewLeaseResponse
-	(*RevokeAllLeasesRequest)(nil),            // 123: keyorix.v1.RevokeAllLeasesRequest
-	(*RevokeAllLeasesResponse)(nil),           // 124: keyorix.v1.RevokeAllLeasesResponse
-	(*AuditIntegrityPosture)(nil),             // 125: keyorix.v1.AuditIntegrityPosture
-	(*AccessGovernancePosture)(nil),           // 126: keyorix.v1.AccessGovernancePosture
-	(*RotationPosture)(nil),                   // 127: keyorix.v1.RotationPosture
-	(*IdentityPosture)(nil),                   // 128: keyorix.v1.IdentityPosture
-	(*EmergencyAccessPosture)(nil),            // 129: keyorix.v1.EmergencyAccessPosture
-	(*ClassificationCounts)(nil),              // 130: keyorix.v1.ClassificationCounts
-	(*ClassificationPosture)(nil),             // 131: keyorix.v1.ClassificationPosture
-	(*AnomaliesPosture)(nil),                  // 132: keyorix.v1.AnomaliesPosture
-	(*LegalHoldPosture)(nil),                  // 133: keyorix.v1.LegalHoldPosture
-	(*RetentionPosture)(nil),                  // 134: keyorix.v1.RetentionPosture
-	(*RiskPosture)(nil),                       // 135: keyorix.v1.RiskPosture
-	(*CompliancePosture)(nil),                 // 136: keyorix.v1.CompliancePosture
-	(*FrameworkRefs)(nil),                     // 137: keyorix.v1.FrameworkRefs
-	(*ControlState)(nil),                      // 138: keyorix.v1.ControlState
-	(*ControlsSummary)(nil),                   // 139: keyorix.v1.ControlsSummary
-	(*ComplianceControls)(nil),                // 140: keyorix.v1.ComplianceControls
-	(*ConnectorList)(nil),                     // 141: keyorix.v1.ConnectorList
-	(*ReadFederatedSecretRequest)(nil),        // 142: keyorix.v1.ReadFederatedSecretRequest
-	(*FederatedSecretValue)(nil),              // 143: keyorix.v1.FederatedSecretValue
-	(*ConnectRefGrant)(nil),                   // 144: keyorix.v1.ConnectRefGrant
-	(*ConnectRefGrantList)(nil),               // 145: keyorix.v1.ConnectRefGrantList
-	(*CreateConnectRefGrantRequest)(nil),      // 146: keyorix.v1.CreateConnectRefGrantRequest
-	(*DeleteConnectRefGrantRequest)(nil),      // 147: keyorix.v1.DeleteConnectRefGrantRequest
-	nil,                                       // 148: keyorix.v1.Secret.MetadataEntry
-	nil,                                       // 149: keyorix.v1.CreateSecretRequest.MetadataEntry
-	nil,                                       // 150: keyorix.v1.UpdateSecretRequest.MetadataEntry
-	nil,                                       // 151: keyorix.v1.HealthResponse.ServicesEntry
-	nil,                                       // 152: keyorix.v1.SystemInfo.FeaturesEntry
-	nil,                                       // 153: keyorix.v1.IssuedCredential.FieldsEntry
-	(*timestamppb.Timestamp)(nil),             // 154: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                     // 155: google.protobuf.Empty
+	(*BrokenRotationProject)(nil),             // 18: keyorix.v1.BrokenRotationProject
+	(*DeploymentRotationPlan)(nil),            // 19: keyorix.v1.DeploymentRotationPlan
+	(*PlannedRotation)(nil),                   // 20: keyorix.v1.PlannedRotation
+	(*RotationWave)(nil),                      // 21: keyorix.v1.RotationWave
+	(*RotationPlan)(nil),                      // 22: keyorix.v1.RotationPlan
+	(*User)(nil),                              // 23: keyorix.v1.User
+	(*ProjectAssignment)(nil),                 // 24: keyorix.v1.ProjectAssignment
+	(*CreateUserRequest)(nil),                 // 25: keyorix.v1.CreateUserRequest
+	(*CreateUserResponse)(nil),                // 26: keyorix.v1.CreateUserResponse
+	(*GetUserRequest)(nil),                    // 27: keyorix.v1.GetUserRequest
+	(*UpdateUserRequest)(nil),                 // 28: keyorix.v1.UpdateUserRequest
+	(*DeleteUserRequest)(nil),                 // 29: keyorix.v1.DeleteUserRequest
+	(*ListUsersRequest)(nil),                  // 30: keyorix.v1.ListUsersRequest
+	(*ListUsersResponse)(nil),                 // 31: keyorix.v1.ListUsersResponse
+	(*Permission)(nil),                        // 32: keyorix.v1.Permission
+	(*Role)(nil),                              // 33: keyorix.v1.Role
+	(*CreateRoleRequest)(nil),                 // 34: keyorix.v1.CreateRoleRequest
+	(*GetRoleRequest)(nil),                    // 35: keyorix.v1.GetRoleRequest
+	(*UpdateRoleRequest)(nil),                 // 36: keyorix.v1.UpdateRoleRequest
+	(*DeleteRoleRequest)(nil),                 // 37: keyorix.v1.DeleteRoleRequest
+	(*ListRolesRequest)(nil),                  // 38: keyorix.v1.ListRolesRequest
+	(*ListRolesResponse)(nil),                 // 39: keyorix.v1.ListRolesResponse
+	(*AssignRoleRequest)(nil),                 // 40: keyorix.v1.AssignRoleRequest
+	(*RoleAssignment)(nil),                    // 41: keyorix.v1.RoleAssignment
+	(*RemoveRoleRequest)(nil),                 // 42: keyorix.v1.RemoveRoleRequest
+	(*GetUserRolesRequest)(nil),               // 43: keyorix.v1.GetUserRolesRequest
+	(*GetUserRolesResponse)(nil),              // 44: keyorix.v1.GetUserRolesResponse
+	(*AuditLog)(nil),                          // 45: keyorix.v1.AuditLog
+	(*GetAuditLogsRequest)(nil),               // 46: keyorix.v1.GetAuditLogsRequest
+	(*GetAuditLogsResponse)(nil),              // 47: keyorix.v1.GetAuditLogsResponse
+	(*RBACAuditLog)(nil),                      // 48: keyorix.v1.RBACAuditLog
+	(*GetRBACAuditLogsRequest)(nil),           // 49: keyorix.v1.GetRBACAuditLogsRequest
+	(*GetRBACAuditLogsResponse)(nil),          // 50: keyorix.v1.GetRBACAuditLogsResponse
+	(*StreamAuditLogsRequest)(nil),            // 51: keyorix.v1.StreamAuditLogsRequest
+	(*VerifyAuditChainResponse)(nil),          // 52: keyorix.v1.VerifyAuditChainResponse
+	(*WriteAuditCheckpointResponse)(nil),      // 53: keyorix.v1.WriteAuditCheckpointResponse
+	(*GetAuditRetentionResponse)(nil),         // 54: keyorix.v1.GetAuditRetentionResponse
+	(*BreakGlassActivation)(nil),              // 55: keyorix.v1.BreakGlassActivation
+	(*ActivateBreakGlassRequest)(nil),         // 56: keyorix.v1.ActivateBreakGlassRequest
+	(*ListBreakGlassActivationsRequest)(nil),  // 57: keyorix.v1.ListBreakGlassActivationsRequest
+	(*ListBreakGlassActivationsResponse)(nil), // 58: keyorix.v1.ListBreakGlassActivationsResponse
+	(*RevokeBreakGlassRequest)(nil),           // 59: keyorix.v1.RevokeBreakGlassRequest
+	(*Group)(nil),                             // 60: keyorix.v1.Group
+	(*GroupMember)(nil),                       // 61: keyorix.v1.GroupMember
+	(*GetGroupRequest)(nil),                   // 62: keyorix.v1.GetGroupRequest
+	(*CreateGroupRequest)(nil),                // 63: keyorix.v1.CreateGroupRequest
+	(*UpdateGroupRequest)(nil),                // 64: keyorix.v1.UpdateGroupRequest
+	(*DeleteGroupRequest)(nil),                // 65: keyorix.v1.DeleteGroupRequest
+	(*RestoreGroupRequest)(nil),               // 66: keyorix.v1.RestoreGroupRequest
+	(*ListGroupsResponse)(nil),                // 67: keyorix.v1.ListGroupsResponse
+	(*GetGroupMembersRequest)(nil),            // 68: keyorix.v1.GetGroupMembersRequest
+	(*GetGroupMembersResponse)(nil),           // 69: keyorix.v1.GetGroupMembersResponse
+	(*GroupMemberRequest)(nil),                // 70: keyorix.v1.GroupMemberRequest
+	(*ShareRecord)(nil),                       // 71: keyorix.v1.ShareRecord
+	(*ShareSecretRequest)(nil),                // 72: keyorix.v1.ShareSecretRequest
+	(*ListSecretSharesRequest)(nil),           // 73: keyorix.v1.ListSecretSharesRequest
+	(*ListUserSharesRequest)(nil),             // 74: keyorix.v1.ListUserSharesRequest
+	(*ListSharedSecretsRequest)(nil),          // 75: keyorix.v1.ListSharedSecretsRequest
+	(*ListSharesResponse)(nil),                // 76: keyorix.v1.ListSharesResponse
+	(*UpdateSharePermissionRequest)(nil),      // 77: keyorix.v1.UpdateSharePermissionRequest
+	(*RevokeShareRequest)(nil),                // 78: keyorix.v1.RevokeShareRequest
+	(*HealthResponse)(nil),                    // 79: keyorix.v1.HealthResponse
+	(*SystemInfo)(nil),                        // 80: keyorix.v1.SystemInfo
+	(*DatabaseInfo)(nil),                      // 81: keyorix.v1.DatabaseInfo
+	(*EncryptionInfo)(nil),                    // 82: keyorix.v1.EncryptionInfo
+	(*Metrics)(nil),                           // 83: keyorix.v1.Metrics
+	(*RequestMetrics)(nil),                    // 84: keyorix.v1.RequestMetrics
+	(*SecretMetrics)(nil),                     // 85: keyorix.v1.SecretMetrics
+	(*UserMetrics)(nil),                       // 86: keyorix.v1.UserMetrics
+	(*PerformanceMetrics)(nil),                // 87: keyorix.v1.PerformanceMetrics
+	(*SystemMetrics)(nil),                     // 88: keyorix.v1.SystemMetrics
+	(*Project)(nil),                           // 89: keyorix.v1.Project
+	(*Environment)(nil),                       // 90: keyorix.v1.Environment
+	(*ListProjectsResponse)(nil),              // 91: keyorix.v1.ListProjectsResponse
+	(*GetProjectRequest)(nil),                 // 92: keyorix.v1.GetProjectRequest
+	(*CreateProjectRequest)(nil),              // 93: keyorix.v1.CreateProjectRequest
+	(*UpdateProjectRequest)(nil),              // 94: keyorix.v1.UpdateProjectRequest
+	(*DeleteProjectRequest)(nil),              // 95: keyorix.v1.DeleteProjectRequest
+	(*ListEnvironmentsRequest)(nil),           // 96: keyorix.v1.ListEnvironmentsRequest
+	(*ListEnvironmentsResponse)(nil),          // 97: keyorix.v1.ListEnvironmentsResponse
+	(*MachineIdentity)(nil),                   // 98: keyorix.v1.MachineIdentity
+	(*MachineToken)(nil),                      // 99: keyorix.v1.MachineToken
+	(*ListMachineIdentitiesRequest)(nil),      // 100: keyorix.v1.ListMachineIdentitiesRequest
+	(*ListMachineIdentitiesResponse)(nil),     // 101: keyorix.v1.ListMachineIdentitiesResponse
+	(*CreateMachineIdentityRequest)(nil),      // 102: keyorix.v1.CreateMachineIdentityRequest
+	(*TransitionMachineIdentityRequest)(nil),  // 103: keyorix.v1.TransitionMachineIdentityRequest
+	(*ClassifyMachineIdentityRequest)(nil),    // 104: keyorix.v1.ClassifyMachineIdentityRequest
+	(*IssueMachineTokenRequest)(nil),          // 105: keyorix.v1.IssueMachineTokenRequest
+	(*IssueMachineTokenResponse)(nil),         // 106: keyorix.v1.IssueMachineTokenResponse
+	(*ListMachineTokensRequest)(nil),          // 107: keyorix.v1.ListMachineTokensRequest
+	(*ListMachineTokensResponse)(nil),         // 108: keyorix.v1.ListMachineTokensResponse
+	(*RevokeMachineTokenRequest)(nil),         // 109: keyorix.v1.RevokeMachineTokenRequest
+	(*ClassifyMachineTokenRequest)(nil),       // 110: keyorix.v1.ClassifyMachineTokenRequest
+	(*DynamicSecretConfig)(nil),               // 111: keyorix.v1.DynamicSecretConfig
+	(*DynamicSecretLease)(nil),                // 112: keyorix.v1.DynamicSecretLease
+	(*IssuedCredential)(nil),                  // 113: keyorix.v1.IssuedCredential
+	(*ListDynamicConfigsRequest)(nil),         // 114: keyorix.v1.ListDynamicConfigsRequest
+	(*ListDynamicConfigsResponse)(nil),        // 115: keyorix.v1.ListDynamicConfigsResponse
+	(*GetDynamicConfigRequest)(nil),           // 116: keyorix.v1.GetDynamicConfigRequest
+	(*CreateDynamicConfigRequest)(nil),        // 117: keyorix.v1.CreateDynamicConfigRequest
+	(*ClassifyDynamicConfigRequest)(nil),      // 118: keyorix.v1.ClassifyDynamicConfigRequest
+	(*IssueLeaseRequest)(nil),                 // 119: keyorix.v1.IssueLeaseRequest
+	(*ListLeasesRequest)(nil),                 // 120: keyorix.v1.ListLeasesRequest
+	(*ListLeasesResponse)(nil),                // 121: keyorix.v1.ListLeasesResponse
+	(*RevokeLeaseRequest)(nil),                // 122: keyorix.v1.RevokeLeaseRequest
+	(*RenewLeaseRequest)(nil),                 // 123: keyorix.v1.RenewLeaseRequest
+	(*RenewLeaseResponse)(nil),                // 124: keyorix.v1.RenewLeaseResponse
+	(*RevokeAllLeasesRequest)(nil),            // 125: keyorix.v1.RevokeAllLeasesRequest
+	(*RevokeAllLeasesResponse)(nil),           // 126: keyorix.v1.RevokeAllLeasesResponse
+	(*AuditIntegrityPosture)(nil),             // 127: keyorix.v1.AuditIntegrityPosture
+	(*AccessGovernancePosture)(nil),           // 128: keyorix.v1.AccessGovernancePosture
+	(*RotationPosture)(nil),                   // 129: keyorix.v1.RotationPosture
+	(*IdentityPosture)(nil),                   // 130: keyorix.v1.IdentityPosture
+	(*EmergencyAccessPosture)(nil),            // 131: keyorix.v1.EmergencyAccessPosture
+	(*ClassificationCounts)(nil),              // 132: keyorix.v1.ClassificationCounts
+	(*ClassificationPosture)(nil),             // 133: keyorix.v1.ClassificationPosture
+	(*AnomaliesPosture)(nil),                  // 134: keyorix.v1.AnomaliesPosture
+	(*LegalHoldPosture)(nil),                  // 135: keyorix.v1.LegalHoldPosture
+	(*RetentionPosture)(nil),                  // 136: keyorix.v1.RetentionPosture
+	(*RiskPosture)(nil),                       // 137: keyorix.v1.RiskPosture
+	(*CompliancePosture)(nil),                 // 138: keyorix.v1.CompliancePosture
+	(*FrameworkRefs)(nil),                     // 139: keyorix.v1.FrameworkRefs
+	(*ControlState)(nil),                      // 140: keyorix.v1.ControlState
+	(*ControlsSummary)(nil),                   // 141: keyorix.v1.ControlsSummary
+	(*ComplianceControls)(nil),                // 142: keyorix.v1.ComplianceControls
+	(*ConnectorList)(nil),                     // 143: keyorix.v1.ConnectorList
+	(*ReadFederatedSecretRequest)(nil),        // 144: keyorix.v1.ReadFederatedSecretRequest
+	(*FederatedSecretValue)(nil),              // 145: keyorix.v1.FederatedSecretValue
+	(*ConnectRefGrant)(nil),                   // 146: keyorix.v1.ConnectRefGrant
+	(*ConnectRefGrantList)(nil),               // 147: keyorix.v1.ConnectRefGrantList
+	(*CreateConnectRefGrantRequest)(nil),      // 148: keyorix.v1.CreateConnectRefGrantRequest
+	(*DeleteConnectRefGrantRequest)(nil),      // 149: keyorix.v1.DeleteConnectRefGrantRequest
+	nil,                                       // 150: keyorix.v1.Secret.MetadataEntry
+	nil,                                       // 151: keyorix.v1.CreateSecretRequest.MetadataEntry
+	nil,                                       // 152: keyorix.v1.UpdateSecretRequest.MetadataEntry
+	nil,                                       // 153: keyorix.v1.HealthResponse.ServicesEntry
+	nil,                                       // 154: keyorix.v1.SystemInfo.FeaturesEntry
+	nil,                                       // 155: keyorix.v1.IssuedCredential.FieldsEntry
+	(*timestamppb.Timestamp)(nil),             // 156: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                     // 157: google.protobuf.Empty
 }
 var file_keyorix_proto_depIdxs = []int32{
-	154, // 0: keyorix.v1.Secret.expiration:type_name -> google.protobuf.Timestamp
-	148, // 1: keyorix.v1.Secret.metadata:type_name -> keyorix.v1.Secret.MetadataEntry
-	154, // 2: keyorix.v1.Secret.created_at:type_name -> google.protobuf.Timestamp
-	154, // 3: keyorix.v1.Secret.updated_at:type_name -> google.protobuf.Timestamp
-	154, // 4: keyorix.v1.CreateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
-	149, // 5: keyorix.v1.CreateSecretRequest.metadata:type_name -> keyorix.v1.CreateSecretRequest.MetadataEntry
-	154, // 6: keyorix.v1.UpdateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
-	150, // 7: keyorix.v1.UpdateSecretRequest.metadata:type_name -> keyorix.v1.UpdateSecretRequest.MetadataEntry
+	156, // 0: keyorix.v1.Secret.expiration:type_name -> google.protobuf.Timestamp
+	150, // 1: keyorix.v1.Secret.metadata:type_name -> keyorix.v1.Secret.MetadataEntry
+	156, // 2: keyorix.v1.Secret.created_at:type_name -> google.protobuf.Timestamp
+	156, // 3: keyorix.v1.Secret.updated_at:type_name -> google.protobuf.Timestamp
+	156, // 4: keyorix.v1.CreateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
+	151, // 5: keyorix.v1.CreateSecretRequest.metadata:type_name -> keyorix.v1.CreateSecretRequest.MetadataEntry
+	156, // 6: keyorix.v1.UpdateSecretRequest.expiration:type_name -> google.protobuf.Timestamp
+	152, // 7: keyorix.v1.UpdateSecretRequest.metadata:type_name -> keyorix.v1.UpdateSecretRequest.MetadataEntry
 	0,   // 8: keyorix.v1.ListSecretsResponse.secrets:type_name -> keyorix.v1.Secret
-	154, // 9: keyorix.v1.SecretVersion.created_at:type_name -> google.protobuf.Timestamp
+	156, // 9: keyorix.v1.SecretVersion.created_at:type_name -> google.protobuf.Timestamp
 	10,  // 10: keyorix.v1.GetSecretVersionsResponse.versions:type_name -> keyorix.v1.SecretVersion
 	12,  // 11: keyorix.v1.SecretDependencies.depends_on:type_name -> keyorix.v1.DependencyEdge
 	12,  // 12: keyorix.v1.SecretDependencies.dependents:type_name -> keyorix.v1.DependencyEdge
 	14,  // 13: keyorix.v1.SecretImpact.affected:type_name -> keyorix.v1.ImpactedSecret
 	16,  // 14: keyorix.v1.RotationOrder.order:type_name -> keyorix.v1.RotationStep
-	18,  // 15: keyorix.v1.RotationWave.secrets:type_name -> keyorix.v1.PlannedRotation
-	19,  // 16: keyorix.v1.RotationPlan.waves:type_name -> keyorix.v1.RotationWave
-	154, // 17: keyorix.v1.User.last_login_at:type_name -> google.protobuf.Timestamp
-	154, // 18: keyorix.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	154, // 19: keyorix.v1.User.updated_at:type_name -> google.protobuf.Timestamp
-	22,  // 20: keyorix.v1.CreateUserRequest.project_assignments:type_name -> keyorix.v1.ProjectAssignment
-	21,  // 21: keyorix.v1.CreateUserResponse.user:type_name -> keyorix.v1.User
-	21,  // 22: keyorix.v1.ListUsersResponse.users:type_name -> keyorix.v1.User
-	30,  // 23: keyorix.v1.Role.permissions:type_name -> keyorix.v1.Permission
-	154, // 24: keyorix.v1.Role.created_at:type_name -> google.protobuf.Timestamp
-	154, // 25: keyorix.v1.Role.updated_at:type_name -> google.protobuf.Timestamp
-	31,  // 26: keyorix.v1.ListRolesResponse.roles:type_name -> keyorix.v1.Role
-	31,  // 27: keyorix.v1.GetUserRolesResponse.roles:type_name -> keyorix.v1.Role
-	154, // 28: keyorix.v1.AuditLog.event_time:type_name -> google.protobuf.Timestamp
-	154, // 29: keyorix.v1.GetAuditLogsRequest.start_time:type_name -> google.protobuf.Timestamp
-	154, // 30: keyorix.v1.GetAuditLogsRequest.end_time:type_name -> google.protobuf.Timestamp
-	43,  // 31: keyorix.v1.GetAuditLogsResponse.logs:type_name -> keyorix.v1.AuditLog
-	154, // 32: keyorix.v1.RBACAuditLog.created_at:type_name -> google.protobuf.Timestamp
-	46,  // 33: keyorix.v1.GetRBACAuditLogsResponse.logs:type_name -> keyorix.v1.RBACAuditLog
-	154, // 34: keyorix.v1.WriteAuditCheckpointResponse.anchored_at:type_name -> google.protobuf.Timestamp
-	154, // 35: keyorix.v1.GetAuditRetentionResponse.oldest_event:type_name -> google.protobuf.Timestamp
-	154, // 36: keyorix.v1.GetAuditRetentionResponse.newest_event:type_name -> google.protobuf.Timestamp
-	154, // 37: keyorix.v1.BreakGlassActivation.expires_at:type_name -> google.protobuf.Timestamp
-	154, // 38: keyorix.v1.BreakGlassActivation.created_at:type_name -> google.protobuf.Timestamp
-	154, // 39: keyorix.v1.BreakGlassActivation.revoked_at:type_name -> google.protobuf.Timestamp
-	53,  // 40: keyorix.v1.ListBreakGlassActivationsResponse.activations:type_name -> keyorix.v1.BreakGlassActivation
-	154, // 41: keyorix.v1.Group.created_at:type_name -> google.protobuf.Timestamp
-	154, // 42: keyorix.v1.Group.updated_at:type_name -> google.protobuf.Timestamp
-	58,  // 43: keyorix.v1.ListGroupsResponse.groups:type_name -> keyorix.v1.Group
-	59,  // 44: keyorix.v1.GetGroupMembersResponse.members:type_name -> keyorix.v1.GroupMember
-	154, // 45: keyorix.v1.ShareRecord.created_at:type_name -> google.protobuf.Timestamp
-	154, // 46: keyorix.v1.ShareRecord.updated_at:type_name -> google.protobuf.Timestamp
-	69,  // 47: keyorix.v1.ListSharesResponse.shares:type_name -> keyorix.v1.ShareRecord
-	154, // 48: keyorix.v1.HealthResponse.timestamp:type_name -> google.protobuf.Timestamp
-	151, // 49: keyorix.v1.HealthResponse.services:type_name -> keyorix.v1.HealthResponse.ServicesEntry
-	152, // 50: keyorix.v1.SystemInfo.features:type_name -> keyorix.v1.SystemInfo.FeaturesEntry
-	79,  // 51: keyorix.v1.SystemInfo.database:type_name -> keyorix.v1.DatabaseInfo
-	80,  // 52: keyorix.v1.SystemInfo.encryption:type_name -> keyorix.v1.EncryptionInfo
-	82,  // 53: keyorix.v1.Metrics.requests:type_name -> keyorix.v1.RequestMetrics
-	83,  // 54: keyorix.v1.Metrics.secrets:type_name -> keyorix.v1.SecretMetrics
-	84,  // 55: keyorix.v1.Metrics.users:type_name -> keyorix.v1.UserMetrics
-	85,  // 56: keyorix.v1.Metrics.performance:type_name -> keyorix.v1.PerformanceMetrics
-	86,  // 57: keyorix.v1.Metrics.system:type_name -> keyorix.v1.SystemMetrics
-	154, // 58: keyorix.v1.Project.created_at:type_name -> google.protobuf.Timestamp
-	154, // 59: keyorix.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
-	154, // 60: keyorix.v1.Environment.created_at:type_name -> google.protobuf.Timestamp
-	154, // 61: keyorix.v1.Environment.updated_at:type_name -> google.protobuf.Timestamp
-	87,  // 62: keyorix.v1.ListProjectsResponse.projects:type_name -> keyorix.v1.Project
-	88,  // 63: keyorix.v1.ListEnvironmentsResponse.environments:type_name -> keyorix.v1.Environment
-	154, // 64: keyorix.v1.MachineIdentity.created_at:type_name -> google.protobuf.Timestamp
-	154, // 65: keyorix.v1.MachineIdentity.updated_at:type_name -> google.protobuf.Timestamp
-	154, // 66: keyorix.v1.MachineIdentity.last_seen_at:type_name -> google.protobuf.Timestamp
-	154, // 67: keyorix.v1.MachineIdentity.revoked_at:type_name -> google.protobuf.Timestamp
-	154, // 68: keyorix.v1.MachineToken.last_used_at:type_name -> google.protobuf.Timestamp
-	154, // 69: keyorix.v1.MachineToken.expires_at:type_name -> google.protobuf.Timestamp
-	154, // 70: keyorix.v1.MachineToken.created_at:type_name -> google.protobuf.Timestamp
-	96,  // 71: keyorix.v1.ListMachineIdentitiesResponse.machine_identities:type_name -> keyorix.v1.MachineIdentity
-	154, // 72: keyorix.v1.IssueMachineTokenResponse.expires_at:type_name -> google.protobuf.Timestamp
-	97,  // 73: keyorix.v1.ListMachineTokensResponse.tokens:type_name -> keyorix.v1.MachineToken
-	154, // 74: keyorix.v1.DynamicSecretConfig.created_at:type_name -> google.protobuf.Timestamp
-	154, // 75: keyorix.v1.DynamicSecretLease.issued_at:type_name -> google.protobuf.Timestamp
-	154, // 76: keyorix.v1.DynamicSecretLease.expires_at:type_name -> google.protobuf.Timestamp
-	154, // 77: keyorix.v1.DynamicSecretLease.revoked_at:type_name -> google.protobuf.Timestamp
-	154, // 78: keyorix.v1.IssuedCredential.expires_at:type_name -> google.protobuf.Timestamp
-	153, // 79: keyorix.v1.IssuedCredential.fields:type_name -> keyorix.v1.IssuedCredential.FieldsEntry
-	109, // 80: keyorix.v1.ListDynamicConfigsResponse.configs:type_name -> keyorix.v1.DynamicSecretConfig
-	110, // 81: keyorix.v1.ListLeasesResponse.leases:type_name -> keyorix.v1.DynamicSecretLease
-	154, // 82: keyorix.v1.RenewLeaseResponse.expires_at:type_name -> google.protobuf.Timestamp
-	130, // 83: keyorix.v1.ClassificationPosture.dynamic_configs:type_name -> keyorix.v1.ClassificationCounts
-	130, // 84: keyorix.v1.ClassificationPosture.machine_identities:type_name -> keyorix.v1.ClassificationCounts
-	130, // 85: keyorix.v1.ClassificationPosture.machine_credentials:type_name -> keyorix.v1.ClassificationCounts
-	154, // 86: keyorix.v1.LegalHoldPosture.placed_at:type_name -> google.protobuf.Timestamp
-	154, // 87: keyorix.v1.CompliancePosture.generated_at:type_name -> google.protobuf.Timestamp
-	125, // 88: keyorix.v1.CompliancePosture.audit_integrity:type_name -> keyorix.v1.AuditIntegrityPosture
-	126, // 89: keyorix.v1.CompliancePosture.access_governance:type_name -> keyorix.v1.AccessGovernancePosture
-	127, // 90: keyorix.v1.CompliancePosture.rotation:type_name -> keyorix.v1.RotationPosture
-	128, // 91: keyorix.v1.CompliancePosture.identity:type_name -> keyorix.v1.IdentityPosture
-	129, // 92: keyorix.v1.CompliancePosture.emergency_access:type_name -> keyorix.v1.EmergencyAccessPosture
-	131, // 93: keyorix.v1.CompliancePosture.classification:type_name -> keyorix.v1.ClassificationPosture
-	132, // 94: keyorix.v1.CompliancePosture.anomalies:type_name -> keyorix.v1.AnomaliesPosture
-	133, // 95: keyorix.v1.CompliancePosture.legal_hold:type_name -> keyorix.v1.LegalHoldPosture
-	134, // 96: keyorix.v1.CompliancePosture.retention:type_name -> keyorix.v1.RetentionPosture
-	135, // 97: keyorix.v1.CompliancePosture.risk:type_name -> keyorix.v1.RiskPosture
-	137, // 98: keyorix.v1.ControlState.frameworks:type_name -> keyorix.v1.FrameworkRefs
-	154, // 99: keyorix.v1.ComplianceControls.generated_at:type_name -> google.protobuf.Timestamp
-	138, // 100: keyorix.v1.ComplianceControls.controls:type_name -> keyorix.v1.ControlState
-	139, // 101: keyorix.v1.ComplianceControls.summary:type_name -> keyorix.v1.ControlsSummary
-	154, // 102: keyorix.v1.ConnectRefGrant.expires_at:type_name -> google.protobuf.Timestamp
-	144, // 103: keyorix.v1.ConnectRefGrantList.grants:type_name -> keyorix.v1.ConnectRefGrant
-	154, // 104: keyorix.v1.CreateConnectRefGrantRequest.expires_at:type_name -> google.protobuf.Timestamp
-	2,   // 105: keyorix.v1.SecretService.CreateSecret:input_type -> keyorix.v1.CreateSecretRequest
-	3,   // 106: keyorix.v1.SecretService.GetSecret:input_type -> keyorix.v1.GetSecretRequest
-	3,   // 107: keyorix.v1.SecretService.GetSecretValue:input_type -> keyorix.v1.GetSecretRequest
-	4,   // 108: keyorix.v1.SecretService.UpdateSecret:input_type -> keyorix.v1.UpdateSecretRequest
-	5,   // 109: keyorix.v1.SecretService.DeleteSecret:input_type -> keyorix.v1.DeleteSecretRequest
-	6,   // 110: keyorix.v1.SecretService.ListSecrets:input_type -> keyorix.v1.ListSecretsRequest
-	8,   // 111: keyorix.v1.SecretService.GetSecretVersions:input_type -> keyorix.v1.GetSecretVersionsRequest
-	9,   // 112: keyorix.v1.SecretService.SetSecretAutoRotate:input_type -> keyorix.v1.SetSecretAutoRotateRequest
-	3,   // 113: keyorix.v1.SecretService.ListSecretDependencies:input_type -> keyorix.v1.GetSecretRequest
-	3,   // 114: keyorix.v1.SecretService.GetSecretImpact:input_type -> keyorix.v1.GetSecretRequest
-	70,  // 115: keyorix.v1.ShareService.ShareSecret:input_type -> keyorix.v1.ShareSecretRequest
-	71,  // 116: keyorix.v1.ShareService.ListSecretShares:input_type -> keyorix.v1.ListSecretSharesRequest
-	72,  // 117: keyorix.v1.ShareService.ListUserShares:input_type -> keyorix.v1.ListUserSharesRequest
-	73,  // 118: keyorix.v1.ShareService.ListSharedSecrets:input_type -> keyorix.v1.ListSharedSecretsRequest
-	75,  // 119: keyorix.v1.ShareService.UpdateSharePermission:input_type -> keyorix.v1.UpdateSharePermissionRequest
-	76,  // 120: keyorix.v1.ShareService.RevokeShare:input_type -> keyorix.v1.RevokeShareRequest
-	23,  // 121: keyorix.v1.UserService.CreateUser:input_type -> keyorix.v1.CreateUserRequest
-	25,  // 122: keyorix.v1.UserService.GetUser:input_type -> keyorix.v1.GetUserRequest
-	26,  // 123: keyorix.v1.UserService.UpdateUser:input_type -> keyorix.v1.UpdateUserRequest
-	27,  // 124: keyorix.v1.UserService.DeleteUser:input_type -> keyorix.v1.DeleteUserRequest
-	28,  // 125: keyorix.v1.UserService.ListUsers:input_type -> keyorix.v1.ListUsersRequest
-	32,  // 126: keyorix.v1.RoleService.CreateRole:input_type -> keyorix.v1.CreateRoleRequest
-	33,  // 127: keyorix.v1.RoleService.GetRole:input_type -> keyorix.v1.GetRoleRequest
-	34,  // 128: keyorix.v1.RoleService.UpdateRole:input_type -> keyorix.v1.UpdateRoleRequest
-	35,  // 129: keyorix.v1.RoleService.DeleteRole:input_type -> keyorix.v1.DeleteRoleRequest
-	36,  // 130: keyorix.v1.RoleService.ListRoles:input_type -> keyorix.v1.ListRolesRequest
-	38,  // 131: keyorix.v1.RoleService.AssignRole:input_type -> keyorix.v1.AssignRoleRequest
-	40,  // 132: keyorix.v1.RoleService.RemoveRole:input_type -> keyorix.v1.RemoveRoleRequest
-	41,  // 133: keyorix.v1.RoleService.GetUserRoles:input_type -> keyorix.v1.GetUserRolesRequest
-	44,  // 134: keyorix.v1.AuditService.GetAuditLogs:input_type -> keyorix.v1.GetAuditLogsRequest
-	47,  // 135: keyorix.v1.AuditService.GetRBACAuditLogs:input_type -> keyorix.v1.GetRBACAuditLogsRequest
-	49,  // 136: keyorix.v1.AuditService.StreamAuditLogs:input_type -> keyorix.v1.StreamAuditLogsRequest
-	155, // 137: keyorix.v1.AuditService.VerifyAuditChain:input_type -> google.protobuf.Empty
-	155, // 138: keyorix.v1.AuditService.WriteAuditCheckpoint:input_type -> google.protobuf.Empty
-	155, // 139: keyorix.v1.AuditService.GetAuditRetention:input_type -> google.protobuf.Empty
-	155, // 140: keyorix.v1.SystemService.HealthCheck:input_type -> google.protobuf.Empty
-	155, // 141: keyorix.v1.SystemService.GetSystemInfo:input_type -> google.protobuf.Empty
-	155, // 142: keyorix.v1.SystemService.GetMetrics:input_type -> google.protobuf.Empty
-	54,  // 143: keyorix.v1.BreakGlassService.ActivateBreakGlass:input_type -> keyorix.v1.ActivateBreakGlassRequest
-	55,  // 144: keyorix.v1.BreakGlassService.ListBreakGlassActivations:input_type -> keyorix.v1.ListBreakGlassActivationsRequest
-	57,  // 145: keyorix.v1.BreakGlassService.RevokeBreakGlass:input_type -> keyorix.v1.RevokeBreakGlassRequest
-	155, // 146: keyorix.v1.GroupService.ListGroups:input_type -> google.protobuf.Empty
-	60,  // 147: keyorix.v1.GroupService.GetGroup:input_type -> keyorix.v1.GetGroupRequest
-	61,  // 148: keyorix.v1.GroupService.CreateGroup:input_type -> keyorix.v1.CreateGroupRequest
-	62,  // 149: keyorix.v1.GroupService.UpdateGroup:input_type -> keyorix.v1.UpdateGroupRequest
-	63,  // 150: keyorix.v1.GroupService.DeleteGroup:input_type -> keyorix.v1.DeleteGroupRequest
-	64,  // 151: keyorix.v1.GroupService.RestoreGroup:input_type -> keyorix.v1.RestoreGroupRequest
-	66,  // 152: keyorix.v1.GroupService.GetGroupMembers:input_type -> keyorix.v1.GetGroupMembersRequest
-	68,  // 153: keyorix.v1.GroupService.AddGroupMember:input_type -> keyorix.v1.GroupMemberRequest
-	68,  // 154: keyorix.v1.GroupService.RemoveGroupMember:input_type -> keyorix.v1.GroupMemberRequest
-	155, // 155: keyorix.v1.ProjectService.ListProjects:input_type -> google.protobuf.Empty
-	90,  // 156: keyorix.v1.ProjectService.GetProject:input_type -> keyorix.v1.GetProjectRequest
-	91,  // 157: keyorix.v1.ProjectService.CreateProject:input_type -> keyorix.v1.CreateProjectRequest
-	92,  // 158: keyorix.v1.ProjectService.UpdateProject:input_type -> keyorix.v1.UpdateProjectRequest
-	93,  // 159: keyorix.v1.ProjectService.DeleteProject:input_type -> keyorix.v1.DeleteProjectRequest
-	90,  // 160: keyorix.v1.ProjectService.GetProjectRotationOrder:input_type -> keyorix.v1.GetProjectRequest
-	90,  // 161: keyorix.v1.ProjectService.GetProjectRotationPlan:input_type -> keyorix.v1.GetProjectRequest
-	94,  // 162: keyorix.v1.ProjectService.ListEnvironments:input_type -> keyorix.v1.ListEnvironmentsRequest
-	98,  // 163: keyorix.v1.MachineIdentityService.ListMachineIdentities:input_type -> keyorix.v1.ListMachineIdentitiesRequest
-	100, // 164: keyorix.v1.MachineIdentityService.CreateMachineIdentity:input_type -> keyorix.v1.CreateMachineIdentityRequest
-	101, // 165: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:input_type -> keyorix.v1.TransitionMachineIdentityRequest
-	102, // 166: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:input_type -> keyorix.v1.ClassifyMachineIdentityRequest
-	103, // 167: keyorix.v1.MachineIdentityService.IssueMachineToken:input_type -> keyorix.v1.IssueMachineTokenRequest
-	105, // 168: keyorix.v1.MachineIdentityService.ListMachineTokens:input_type -> keyorix.v1.ListMachineTokensRequest
-	107, // 169: keyorix.v1.MachineIdentityService.RevokeMachineToken:input_type -> keyorix.v1.RevokeMachineTokenRequest
-	108, // 170: keyorix.v1.MachineIdentityService.ClassifyMachineToken:input_type -> keyorix.v1.ClassifyMachineTokenRequest
-	112, // 171: keyorix.v1.DynamicSecretService.ListConfigs:input_type -> keyorix.v1.ListDynamicConfigsRequest
-	114, // 172: keyorix.v1.DynamicSecretService.GetConfig:input_type -> keyorix.v1.GetDynamicConfigRequest
-	115, // 173: keyorix.v1.DynamicSecretService.CreateConfig:input_type -> keyorix.v1.CreateDynamicConfigRequest
-	116, // 174: keyorix.v1.DynamicSecretService.ClassifyConfig:input_type -> keyorix.v1.ClassifyDynamicConfigRequest
-	117, // 175: keyorix.v1.DynamicSecretService.IssueLease:input_type -> keyorix.v1.IssueLeaseRequest
-	118, // 176: keyorix.v1.DynamicSecretService.ListLeases:input_type -> keyorix.v1.ListLeasesRequest
-	120, // 177: keyorix.v1.DynamicSecretService.RevokeLease:input_type -> keyorix.v1.RevokeLeaseRequest
-	121, // 178: keyorix.v1.DynamicSecretService.RenewLease:input_type -> keyorix.v1.RenewLeaseRequest
-	123, // 179: keyorix.v1.DynamicSecretService.RevokeAllLeases:input_type -> keyorix.v1.RevokeAllLeasesRequest
-	155, // 180: keyorix.v1.ComplianceService.GetCompliancePosture:input_type -> google.protobuf.Empty
-	155, // 181: keyorix.v1.ComplianceService.GetComplianceControls:input_type -> google.protobuf.Empty
-	155, // 182: keyorix.v1.ConnectService.ListConnectors:input_type -> google.protobuf.Empty
-	142, // 183: keyorix.v1.ConnectService.ReadSecret:input_type -> keyorix.v1.ReadFederatedSecretRequest
-	155, // 184: keyorix.v1.ConnectService.ListRefGrants:input_type -> google.protobuf.Empty
-	146, // 185: keyorix.v1.ConnectService.CreateRefGrant:input_type -> keyorix.v1.CreateConnectRefGrantRequest
-	147, // 186: keyorix.v1.ConnectService.DeleteRefGrant:input_type -> keyorix.v1.DeleteConnectRefGrantRequest
-	0,   // 187: keyorix.v1.SecretService.CreateSecret:output_type -> keyorix.v1.Secret
-	0,   // 188: keyorix.v1.SecretService.GetSecret:output_type -> keyorix.v1.Secret
-	1,   // 189: keyorix.v1.SecretService.GetSecretValue:output_type -> keyorix.v1.SecretValue
-	0,   // 190: keyorix.v1.SecretService.UpdateSecret:output_type -> keyorix.v1.Secret
-	155, // 191: keyorix.v1.SecretService.DeleteSecret:output_type -> google.protobuf.Empty
-	7,   // 192: keyorix.v1.SecretService.ListSecrets:output_type -> keyorix.v1.ListSecretsResponse
-	11,  // 193: keyorix.v1.SecretService.GetSecretVersions:output_type -> keyorix.v1.GetSecretVersionsResponse
-	155, // 194: keyorix.v1.SecretService.SetSecretAutoRotate:output_type -> google.protobuf.Empty
-	13,  // 195: keyorix.v1.SecretService.ListSecretDependencies:output_type -> keyorix.v1.SecretDependencies
-	15,  // 196: keyorix.v1.SecretService.GetSecretImpact:output_type -> keyorix.v1.SecretImpact
-	69,  // 197: keyorix.v1.ShareService.ShareSecret:output_type -> keyorix.v1.ShareRecord
-	74,  // 198: keyorix.v1.ShareService.ListSecretShares:output_type -> keyorix.v1.ListSharesResponse
-	74,  // 199: keyorix.v1.ShareService.ListUserShares:output_type -> keyorix.v1.ListSharesResponse
-	7,   // 200: keyorix.v1.ShareService.ListSharedSecrets:output_type -> keyorix.v1.ListSecretsResponse
-	69,  // 201: keyorix.v1.ShareService.UpdateSharePermission:output_type -> keyorix.v1.ShareRecord
-	155, // 202: keyorix.v1.ShareService.RevokeShare:output_type -> google.protobuf.Empty
-	24,  // 203: keyorix.v1.UserService.CreateUser:output_type -> keyorix.v1.CreateUserResponse
-	21,  // 204: keyorix.v1.UserService.GetUser:output_type -> keyorix.v1.User
-	21,  // 205: keyorix.v1.UserService.UpdateUser:output_type -> keyorix.v1.User
-	155, // 206: keyorix.v1.UserService.DeleteUser:output_type -> google.protobuf.Empty
-	29,  // 207: keyorix.v1.UserService.ListUsers:output_type -> keyorix.v1.ListUsersResponse
-	31,  // 208: keyorix.v1.RoleService.CreateRole:output_type -> keyorix.v1.Role
-	31,  // 209: keyorix.v1.RoleService.GetRole:output_type -> keyorix.v1.Role
-	31,  // 210: keyorix.v1.RoleService.UpdateRole:output_type -> keyorix.v1.Role
-	155, // 211: keyorix.v1.RoleService.DeleteRole:output_type -> google.protobuf.Empty
-	37,  // 212: keyorix.v1.RoleService.ListRoles:output_type -> keyorix.v1.ListRolesResponse
-	39,  // 213: keyorix.v1.RoleService.AssignRole:output_type -> keyorix.v1.RoleAssignment
-	155, // 214: keyorix.v1.RoleService.RemoveRole:output_type -> google.protobuf.Empty
-	42,  // 215: keyorix.v1.RoleService.GetUserRoles:output_type -> keyorix.v1.GetUserRolesResponse
-	45,  // 216: keyorix.v1.AuditService.GetAuditLogs:output_type -> keyorix.v1.GetAuditLogsResponse
-	48,  // 217: keyorix.v1.AuditService.GetRBACAuditLogs:output_type -> keyorix.v1.GetRBACAuditLogsResponse
-	43,  // 218: keyorix.v1.AuditService.StreamAuditLogs:output_type -> keyorix.v1.AuditLog
-	50,  // 219: keyorix.v1.AuditService.VerifyAuditChain:output_type -> keyorix.v1.VerifyAuditChainResponse
-	51,  // 220: keyorix.v1.AuditService.WriteAuditCheckpoint:output_type -> keyorix.v1.WriteAuditCheckpointResponse
-	52,  // 221: keyorix.v1.AuditService.GetAuditRetention:output_type -> keyorix.v1.GetAuditRetentionResponse
-	77,  // 222: keyorix.v1.SystemService.HealthCheck:output_type -> keyorix.v1.HealthResponse
-	78,  // 223: keyorix.v1.SystemService.GetSystemInfo:output_type -> keyorix.v1.SystemInfo
-	81,  // 224: keyorix.v1.SystemService.GetMetrics:output_type -> keyorix.v1.Metrics
-	53,  // 225: keyorix.v1.BreakGlassService.ActivateBreakGlass:output_type -> keyorix.v1.BreakGlassActivation
-	56,  // 226: keyorix.v1.BreakGlassService.ListBreakGlassActivations:output_type -> keyorix.v1.ListBreakGlassActivationsResponse
-	155, // 227: keyorix.v1.BreakGlassService.RevokeBreakGlass:output_type -> google.protobuf.Empty
-	65,  // 228: keyorix.v1.GroupService.ListGroups:output_type -> keyorix.v1.ListGroupsResponse
-	58,  // 229: keyorix.v1.GroupService.GetGroup:output_type -> keyorix.v1.Group
-	58,  // 230: keyorix.v1.GroupService.CreateGroup:output_type -> keyorix.v1.Group
-	58,  // 231: keyorix.v1.GroupService.UpdateGroup:output_type -> keyorix.v1.Group
-	155, // 232: keyorix.v1.GroupService.DeleteGroup:output_type -> google.protobuf.Empty
-	58,  // 233: keyorix.v1.GroupService.RestoreGroup:output_type -> keyorix.v1.Group
-	67,  // 234: keyorix.v1.GroupService.GetGroupMembers:output_type -> keyorix.v1.GetGroupMembersResponse
-	155, // 235: keyorix.v1.GroupService.AddGroupMember:output_type -> google.protobuf.Empty
-	155, // 236: keyorix.v1.GroupService.RemoveGroupMember:output_type -> google.protobuf.Empty
-	89,  // 237: keyorix.v1.ProjectService.ListProjects:output_type -> keyorix.v1.ListProjectsResponse
-	87,  // 238: keyorix.v1.ProjectService.GetProject:output_type -> keyorix.v1.Project
-	87,  // 239: keyorix.v1.ProjectService.CreateProject:output_type -> keyorix.v1.Project
-	87,  // 240: keyorix.v1.ProjectService.UpdateProject:output_type -> keyorix.v1.Project
-	155, // 241: keyorix.v1.ProjectService.DeleteProject:output_type -> google.protobuf.Empty
-	17,  // 242: keyorix.v1.ProjectService.GetProjectRotationOrder:output_type -> keyorix.v1.RotationOrder
-	20,  // 243: keyorix.v1.ProjectService.GetProjectRotationPlan:output_type -> keyorix.v1.RotationPlan
-	95,  // 244: keyorix.v1.ProjectService.ListEnvironments:output_type -> keyorix.v1.ListEnvironmentsResponse
-	99,  // 245: keyorix.v1.MachineIdentityService.ListMachineIdentities:output_type -> keyorix.v1.ListMachineIdentitiesResponse
-	96,  // 246: keyorix.v1.MachineIdentityService.CreateMachineIdentity:output_type -> keyorix.v1.MachineIdentity
-	96,  // 247: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:output_type -> keyorix.v1.MachineIdentity
-	96,  // 248: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:output_type -> keyorix.v1.MachineIdentity
-	104, // 249: keyorix.v1.MachineIdentityService.IssueMachineToken:output_type -> keyorix.v1.IssueMachineTokenResponse
-	106, // 250: keyorix.v1.MachineIdentityService.ListMachineTokens:output_type -> keyorix.v1.ListMachineTokensResponse
-	155, // 251: keyorix.v1.MachineIdentityService.RevokeMachineToken:output_type -> google.protobuf.Empty
-	97,  // 252: keyorix.v1.MachineIdentityService.ClassifyMachineToken:output_type -> keyorix.v1.MachineToken
-	113, // 253: keyorix.v1.DynamicSecretService.ListConfigs:output_type -> keyorix.v1.ListDynamicConfigsResponse
-	109, // 254: keyorix.v1.DynamicSecretService.GetConfig:output_type -> keyorix.v1.DynamicSecretConfig
-	109, // 255: keyorix.v1.DynamicSecretService.CreateConfig:output_type -> keyorix.v1.DynamicSecretConfig
-	109, // 256: keyorix.v1.DynamicSecretService.ClassifyConfig:output_type -> keyorix.v1.DynamicSecretConfig
-	111, // 257: keyorix.v1.DynamicSecretService.IssueLease:output_type -> keyorix.v1.IssuedCredential
-	119, // 258: keyorix.v1.DynamicSecretService.ListLeases:output_type -> keyorix.v1.ListLeasesResponse
-	155, // 259: keyorix.v1.DynamicSecretService.RevokeLease:output_type -> google.protobuf.Empty
-	122, // 260: keyorix.v1.DynamicSecretService.RenewLease:output_type -> keyorix.v1.RenewLeaseResponse
-	124, // 261: keyorix.v1.DynamicSecretService.RevokeAllLeases:output_type -> keyorix.v1.RevokeAllLeasesResponse
-	136, // 262: keyorix.v1.ComplianceService.GetCompliancePosture:output_type -> keyorix.v1.CompliancePosture
-	140, // 263: keyorix.v1.ComplianceService.GetComplianceControls:output_type -> keyorix.v1.ComplianceControls
-	141, // 264: keyorix.v1.ConnectService.ListConnectors:output_type -> keyorix.v1.ConnectorList
-	143, // 265: keyorix.v1.ConnectService.ReadSecret:output_type -> keyorix.v1.FederatedSecretValue
-	145, // 266: keyorix.v1.ConnectService.ListRefGrants:output_type -> keyorix.v1.ConnectRefGrantList
-	144, // 267: keyorix.v1.ConnectService.CreateRefGrant:output_type -> keyorix.v1.ConnectRefGrant
-	155, // 268: keyorix.v1.ConnectService.DeleteRefGrant:output_type -> google.protobuf.Empty
-	187, // [187:269] is the sub-list for method output_type
-	105, // [105:187] is the sub-list for method input_type
-	105, // [105:105] is the sub-list for extension type_name
-	105, // [105:105] is the sub-list for extension extendee
-	0,   // [0:105] is the sub-list for field type_name
+	22,  // 15: keyorix.v1.DeploymentRotationPlan.projects:type_name -> keyorix.v1.RotationPlan
+	18,  // 16: keyorix.v1.DeploymentRotationPlan.broken_projects:type_name -> keyorix.v1.BrokenRotationProject
+	20,  // 17: keyorix.v1.RotationWave.secrets:type_name -> keyorix.v1.PlannedRotation
+	21,  // 18: keyorix.v1.RotationPlan.waves:type_name -> keyorix.v1.RotationWave
+	156, // 19: keyorix.v1.User.last_login_at:type_name -> google.protobuf.Timestamp
+	156, // 20: keyorix.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	156, // 21: keyorix.v1.User.updated_at:type_name -> google.protobuf.Timestamp
+	24,  // 22: keyorix.v1.CreateUserRequest.project_assignments:type_name -> keyorix.v1.ProjectAssignment
+	23,  // 23: keyorix.v1.CreateUserResponse.user:type_name -> keyorix.v1.User
+	23,  // 24: keyorix.v1.ListUsersResponse.users:type_name -> keyorix.v1.User
+	32,  // 25: keyorix.v1.Role.permissions:type_name -> keyorix.v1.Permission
+	156, // 26: keyorix.v1.Role.created_at:type_name -> google.protobuf.Timestamp
+	156, // 27: keyorix.v1.Role.updated_at:type_name -> google.protobuf.Timestamp
+	33,  // 28: keyorix.v1.ListRolesResponse.roles:type_name -> keyorix.v1.Role
+	33,  // 29: keyorix.v1.GetUserRolesResponse.roles:type_name -> keyorix.v1.Role
+	156, // 30: keyorix.v1.AuditLog.event_time:type_name -> google.protobuf.Timestamp
+	156, // 31: keyorix.v1.GetAuditLogsRequest.start_time:type_name -> google.protobuf.Timestamp
+	156, // 32: keyorix.v1.GetAuditLogsRequest.end_time:type_name -> google.protobuf.Timestamp
+	45,  // 33: keyorix.v1.GetAuditLogsResponse.logs:type_name -> keyorix.v1.AuditLog
+	156, // 34: keyorix.v1.RBACAuditLog.created_at:type_name -> google.protobuf.Timestamp
+	48,  // 35: keyorix.v1.GetRBACAuditLogsResponse.logs:type_name -> keyorix.v1.RBACAuditLog
+	156, // 36: keyorix.v1.WriteAuditCheckpointResponse.anchored_at:type_name -> google.protobuf.Timestamp
+	156, // 37: keyorix.v1.GetAuditRetentionResponse.oldest_event:type_name -> google.protobuf.Timestamp
+	156, // 38: keyorix.v1.GetAuditRetentionResponse.newest_event:type_name -> google.protobuf.Timestamp
+	156, // 39: keyorix.v1.BreakGlassActivation.expires_at:type_name -> google.protobuf.Timestamp
+	156, // 40: keyorix.v1.BreakGlassActivation.created_at:type_name -> google.protobuf.Timestamp
+	156, // 41: keyorix.v1.BreakGlassActivation.revoked_at:type_name -> google.protobuf.Timestamp
+	55,  // 42: keyorix.v1.ListBreakGlassActivationsResponse.activations:type_name -> keyorix.v1.BreakGlassActivation
+	156, // 43: keyorix.v1.Group.created_at:type_name -> google.protobuf.Timestamp
+	156, // 44: keyorix.v1.Group.updated_at:type_name -> google.protobuf.Timestamp
+	60,  // 45: keyorix.v1.ListGroupsResponse.groups:type_name -> keyorix.v1.Group
+	61,  // 46: keyorix.v1.GetGroupMembersResponse.members:type_name -> keyorix.v1.GroupMember
+	156, // 47: keyorix.v1.ShareRecord.created_at:type_name -> google.protobuf.Timestamp
+	156, // 48: keyorix.v1.ShareRecord.updated_at:type_name -> google.protobuf.Timestamp
+	71,  // 49: keyorix.v1.ListSharesResponse.shares:type_name -> keyorix.v1.ShareRecord
+	156, // 50: keyorix.v1.HealthResponse.timestamp:type_name -> google.protobuf.Timestamp
+	153, // 51: keyorix.v1.HealthResponse.services:type_name -> keyorix.v1.HealthResponse.ServicesEntry
+	154, // 52: keyorix.v1.SystemInfo.features:type_name -> keyorix.v1.SystemInfo.FeaturesEntry
+	81,  // 53: keyorix.v1.SystemInfo.database:type_name -> keyorix.v1.DatabaseInfo
+	82,  // 54: keyorix.v1.SystemInfo.encryption:type_name -> keyorix.v1.EncryptionInfo
+	84,  // 55: keyorix.v1.Metrics.requests:type_name -> keyorix.v1.RequestMetrics
+	85,  // 56: keyorix.v1.Metrics.secrets:type_name -> keyorix.v1.SecretMetrics
+	86,  // 57: keyorix.v1.Metrics.users:type_name -> keyorix.v1.UserMetrics
+	87,  // 58: keyorix.v1.Metrics.performance:type_name -> keyorix.v1.PerformanceMetrics
+	88,  // 59: keyorix.v1.Metrics.system:type_name -> keyorix.v1.SystemMetrics
+	156, // 60: keyorix.v1.Project.created_at:type_name -> google.protobuf.Timestamp
+	156, // 61: keyorix.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
+	156, // 62: keyorix.v1.Environment.created_at:type_name -> google.protobuf.Timestamp
+	156, // 63: keyorix.v1.Environment.updated_at:type_name -> google.protobuf.Timestamp
+	89,  // 64: keyorix.v1.ListProjectsResponse.projects:type_name -> keyorix.v1.Project
+	90,  // 65: keyorix.v1.ListEnvironmentsResponse.environments:type_name -> keyorix.v1.Environment
+	156, // 66: keyorix.v1.MachineIdentity.created_at:type_name -> google.protobuf.Timestamp
+	156, // 67: keyorix.v1.MachineIdentity.updated_at:type_name -> google.protobuf.Timestamp
+	156, // 68: keyorix.v1.MachineIdentity.last_seen_at:type_name -> google.protobuf.Timestamp
+	156, // 69: keyorix.v1.MachineIdentity.revoked_at:type_name -> google.protobuf.Timestamp
+	156, // 70: keyorix.v1.MachineToken.last_used_at:type_name -> google.protobuf.Timestamp
+	156, // 71: keyorix.v1.MachineToken.expires_at:type_name -> google.protobuf.Timestamp
+	156, // 72: keyorix.v1.MachineToken.created_at:type_name -> google.protobuf.Timestamp
+	98,  // 73: keyorix.v1.ListMachineIdentitiesResponse.machine_identities:type_name -> keyorix.v1.MachineIdentity
+	156, // 74: keyorix.v1.IssueMachineTokenResponse.expires_at:type_name -> google.protobuf.Timestamp
+	99,  // 75: keyorix.v1.ListMachineTokensResponse.tokens:type_name -> keyorix.v1.MachineToken
+	156, // 76: keyorix.v1.DynamicSecretConfig.created_at:type_name -> google.protobuf.Timestamp
+	156, // 77: keyorix.v1.DynamicSecretLease.issued_at:type_name -> google.protobuf.Timestamp
+	156, // 78: keyorix.v1.DynamicSecretLease.expires_at:type_name -> google.protobuf.Timestamp
+	156, // 79: keyorix.v1.DynamicSecretLease.revoked_at:type_name -> google.protobuf.Timestamp
+	156, // 80: keyorix.v1.IssuedCredential.expires_at:type_name -> google.protobuf.Timestamp
+	155, // 81: keyorix.v1.IssuedCredential.fields:type_name -> keyorix.v1.IssuedCredential.FieldsEntry
+	111, // 82: keyorix.v1.ListDynamicConfigsResponse.configs:type_name -> keyorix.v1.DynamicSecretConfig
+	112, // 83: keyorix.v1.ListLeasesResponse.leases:type_name -> keyorix.v1.DynamicSecretLease
+	156, // 84: keyorix.v1.RenewLeaseResponse.expires_at:type_name -> google.protobuf.Timestamp
+	132, // 85: keyorix.v1.ClassificationPosture.dynamic_configs:type_name -> keyorix.v1.ClassificationCounts
+	132, // 86: keyorix.v1.ClassificationPosture.machine_identities:type_name -> keyorix.v1.ClassificationCounts
+	132, // 87: keyorix.v1.ClassificationPosture.machine_credentials:type_name -> keyorix.v1.ClassificationCounts
+	156, // 88: keyorix.v1.LegalHoldPosture.placed_at:type_name -> google.protobuf.Timestamp
+	156, // 89: keyorix.v1.CompliancePosture.generated_at:type_name -> google.protobuf.Timestamp
+	127, // 90: keyorix.v1.CompliancePosture.audit_integrity:type_name -> keyorix.v1.AuditIntegrityPosture
+	128, // 91: keyorix.v1.CompliancePosture.access_governance:type_name -> keyorix.v1.AccessGovernancePosture
+	129, // 92: keyorix.v1.CompliancePosture.rotation:type_name -> keyorix.v1.RotationPosture
+	130, // 93: keyorix.v1.CompliancePosture.identity:type_name -> keyorix.v1.IdentityPosture
+	131, // 94: keyorix.v1.CompliancePosture.emergency_access:type_name -> keyorix.v1.EmergencyAccessPosture
+	133, // 95: keyorix.v1.CompliancePosture.classification:type_name -> keyorix.v1.ClassificationPosture
+	134, // 96: keyorix.v1.CompliancePosture.anomalies:type_name -> keyorix.v1.AnomaliesPosture
+	135, // 97: keyorix.v1.CompliancePosture.legal_hold:type_name -> keyorix.v1.LegalHoldPosture
+	136, // 98: keyorix.v1.CompliancePosture.retention:type_name -> keyorix.v1.RetentionPosture
+	137, // 99: keyorix.v1.CompliancePosture.risk:type_name -> keyorix.v1.RiskPosture
+	139, // 100: keyorix.v1.ControlState.frameworks:type_name -> keyorix.v1.FrameworkRefs
+	156, // 101: keyorix.v1.ComplianceControls.generated_at:type_name -> google.protobuf.Timestamp
+	140, // 102: keyorix.v1.ComplianceControls.controls:type_name -> keyorix.v1.ControlState
+	141, // 103: keyorix.v1.ComplianceControls.summary:type_name -> keyorix.v1.ControlsSummary
+	156, // 104: keyorix.v1.ConnectRefGrant.expires_at:type_name -> google.protobuf.Timestamp
+	146, // 105: keyorix.v1.ConnectRefGrantList.grants:type_name -> keyorix.v1.ConnectRefGrant
+	156, // 106: keyorix.v1.CreateConnectRefGrantRequest.expires_at:type_name -> google.protobuf.Timestamp
+	2,   // 107: keyorix.v1.SecretService.CreateSecret:input_type -> keyorix.v1.CreateSecretRequest
+	3,   // 108: keyorix.v1.SecretService.GetSecret:input_type -> keyorix.v1.GetSecretRequest
+	3,   // 109: keyorix.v1.SecretService.GetSecretValue:input_type -> keyorix.v1.GetSecretRequest
+	4,   // 110: keyorix.v1.SecretService.UpdateSecret:input_type -> keyorix.v1.UpdateSecretRequest
+	5,   // 111: keyorix.v1.SecretService.DeleteSecret:input_type -> keyorix.v1.DeleteSecretRequest
+	6,   // 112: keyorix.v1.SecretService.ListSecrets:input_type -> keyorix.v1.ListSecretsRequest
+	8,   // 113: keyorix.v1.SecretService.GetSecretVersions:input_type -> keyorix.v1.GetSecretVersionsRequest
+	9,   // 114: keyorix.v1.SecretService.SetSecretAutoRotate:input_type -> keyorix.v1.SetSecretAutoRotateRequest
+	3,   // 115: keyorix.v1.SecretService.ListSecretDependencies:input_type -> keyorix.v1.GetSecretRequest
+	3,   // 116: keyorix.v1.SecretService.GetSecretImpact:input_type -> keyorix.v1.GetSecretRequest
+	72,  // 117: keyorix.v1.ShareService.ShareSecret:input_type -> keyorix.v1.ShareSecretRequest
+	73,  // 118: keyorix.v1.ShareService.ListSecretShares:input_type -> keyorix.v1.ListSecretSharesRequest
+	74,  // 119: keyorix.v1.ShareService.ListUserShares:input_type -> keyorix.v1.ListUserSharesRequest
+	75,  // 120: keyorix.v1.ShareService.ListSharedSecrets:input_type -> keyorix.v1.ListSharedSecretsRequest
+	77,  // 121: keyorix.v1.ShareService.UpdateSharePermission:input_type -> keyorix.v1.UpdateSharePermissionRequest
+	78,  // 122: keyorix.v1.ShareService.RevokeShare:input_type -> keyorix.v1.RevokeShareRequest
+	25,  // 123: keyorix.v1.UserService.CreateUser:input_type -> keyorix.v1.CreateUserRequest
+	27,  // 124: keyorix.v1.UserService.GetUser:input_type -> keyorix.v1.GetUserRequest
+	28,  // 125: keyorix.v1.UserService.UpdateUser:input_type -> keyorix.v1.UpdateUserRequest
+	29,  // 126: keyorix.v1.UserService.DeleteUser:input_type -> keyorix.v1.DeleteUserRequest
+	30,  // 127: keyorix.v1.UserService.ListUsers:input_type -> keyorix.v1.ListUsersRequest
+	34,  // 128: keyorix.v1.RoleService.CreateRole:input_type -> keyorix.v1.CreateRoleRequest
+	35,  // 129: keyorix.v1.RoleService.GetRole:input_type -> keyorix.v1.GetRoleRequest
+	36,  // 130: keyorix.v1.RoleService.UpdateRole:input_type -> keyorix.v1.UpdateRoleRequest
+	37,  // 131: keyorix.v1.RoleService.DeleteRole:input_type -> keyorix.v1.DeleteRoleRequest
+	38,  // 132: keyorix.v1.RoleService.ListRoles:input_type -> keyorix.v1.ListRolesRequest
+	40,  // 133: keyorix.v1.RoleService.AssignRole:input_type -> keyorix.v1.AssignRoleRequest
+	42,  // 134: keyorix.v1.RoleService.RemoveRole:input_type -> keyorix.v1.RemoveRoleRequest
+	43,  // 135: keyorix.v1.RoleService.GetUserRoles:input_type -> keyorix.v1.GetUserRolesRequest
+	46,  // 136: keyorix.v1.AuditService.GetAuditLogs:input_type -> keyorix.v1.GetAuditLogsRequest
+	49,  // 137: keyorix.v1.AuditService.GetRBACAuditLogs:input_type -> keyorix.v1.GetRBACAuditLogsRequest
+	51,  // 138: keyorix.v1.AuditService.StreamAuditLogs:input_type -> keyorix.v1.StreamAuditLogsRequest
+	157, // 139: keyorix.v1.AuditService.VerifyAuditChain:input_type -> google.protobuf.Empty
+	157, // 140: keyorix.v1.AuditService.WriteAuditCheckpoint:input_type -> google.protobuf.Empty
+	157, // 141: keyorix.v1.AuditService.GetAuditRetention:input_type -> google.protobuf.Empty
+	157, // 142: keyorix.v1.SystemService.HealthCheck:input_type -> google.protobuf.Empty
+	157, // 143: keyorix.v1.SystemService.GetSystemInfo:input_type -> google.protobuf.Empty
+	157, // 144: keyorix.v1.SystemService.GetMetrics:input_type -> google.protobuf.Empty
+	56,  // 145: keyorix.v1.BreakGlassService.ActivateBreakGlass:input_type -> keyorix.v1.ActivateBreakGlassRequest
+	57,  // 146: keyorix.v1.BreakGlassService.ListBreakGlassActivations:input_type -> keyorix.v1.ListBreakGlassActivationsRequest
+	59,  // 147: keyorix.v1.BreakGlassService.RevokeBreakGlass:input_type -> keyorix.v1.RevokeBreakGlassRequest
+	157, // 148: keyorix.v1.GroupService.ListGroups:input_type -> google.protobuf.Empty
+	62,  // 149: keyorix.v1.GroupService.GetGroup:input_type -> keyorix.v1.GetGroupRequest
+	63,  // 150: keyorix.v1.GroupService.CreateGroup:input_type -> keyorix.v1.CreateGroupRequest
+	64,  // 151: keyorix.v1.GroupService.UpdateGroup:input_type -> keyorix.v1.UpdateGroupRequest
+	65,  // 152: keyorix.v1.GroupService.DeleteGroup:input_type -> keyorix.v1.DeleteGroupRequest
+	66,  // 153: keyorix.v1.GroupService.RestoreGroup:input_type -> keyorix.v1.RestoreGroupRequest
+	68,  // 154: keyorix.v1.GroupService.GetGroupMembers:input_type -> keyorix.v1.GetGroupMembersRequest
+	70,  // 155: keyorix.v1.GroupService.AddGroupMember:input_type -> keyorix.v1.GroupMemberRequest
+	70,  // 156: keyorix.v1.GroupService.RemoveGroupMember:input_type -> keyorix.v1.GroupMemberRequest
+	157, // 157: keyorix.v1.ProjectService.ListProjects:input_type -> google.protobuf.Empty
+	92,  // 158: keyorix.v1.ProjectService.GetProject:input_type -> keyorix.v1.GetProjectRequest
+	93,  // 159: keyorix.v1.ProjectService.CreateProject:input_type -> keyorix.v1.CreateProjectRequest
+	94,  // 160: keyorix.v1.ProjectService.UpdateProject:input_type -> keyorix.v1.UpdateProjectRequest
+	95,  // 161: keyorix.v1.ProjectService.DeleteProject:input_type -> keyorix.v1.DeleteProjectRequest
+	92,  // 162: keyorix.v1.ProjectService.GetProjectRotationOrder:input_type -> keyorix.v1.GetProjectRequest
+	92,  // 163: keyorix.v1.ProjectService.GetProjectRotationPlan:input_type -> keyorix.v1.GetProjectRequest
+	157, // 164: keyorix.v1.ProjectService.GetDeploymentRotationPlan:input_type -> google.protobuf.Empty
+	96,  // 165: keyorix.v1.ProjectService.ListEnvironments:input_type -> keyorix.v1.ListEnvironmentsRequest
+	100, // 166: keyorix.v1.MachineIdentityService.ListMachineIdentities:input_type -> keyorix.v1.ListMachineIdentitiesRequest
+	102, // 167: keyorix.v1.MachineIdentityService.CreateMachineIdentity:input_type -> keyorix.v1.CreateMachineIdentityRequest
+	103, // 168: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:input_type -> keyorix.v1.TransitionMachineIdentityRequest
+	104, // 169: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:input_type -> keyorix.v1.ClassifyMachineIdentityRequest
+	105, // 170: keyorix.v1.MachineIdentityService.IssueMachineToken:input_type -> keyorix.v1.IssueMachineTokenRequest
+	107, // 171: keyorix.v1.MachineIdentityService.ListMachineTokens:input_type -> keyorix.v1.ListMachineTokensRequest
+	109, // 172: keyorix.v1.MachineIdentityService.RevokeMachineToken:input_type -> keyorix.v1.RevokeMachineTokenRequest
+	110, // 173: keyorix.v1.MachineIdentityService.ClassifyMachineToken:input_type -> keyorix.v1.ClassifyMachineTokenRequest
+	114, // 174: keyorix.v1.DynamicSecretService.ListConfigs:input_type -> keyorix.v1.ListDynamicConfigsRequest
+	116, // 175: keyorix.v1.DynamicSecretService.GetConfig:input_type -> keyorix.v1.GetDynamicConfigRequest
+	117, // 176: keyorix.v1.DynamicSecretService.CreateConfig:input_type -> keyorix.v1.CreateDynamicConfigRequest
+	118, // 177: keyorix.v1.DynamicSecretService.ClassifyConfig:input_type -> keyorix.v1.ClassifyDynamicConfigRequest
+	119, // 178: keyorix.v1.DynamicSecretService.IssueLease:input_type -> keyorix.v1.IssueLeaseRequest
+	120, // 179: keyorix.v1.DynamicSecretService.ListLeases:input_type -> keyorix.v1.ListLeasesRequest
+	122, // 180: keyorix.v1.DynamicSecretService.RevokeLease:input_type -> keyorix.v1.RevokeLeaseRequest
+	123, // 181: keyorix.v1.DynamicSecretService.RenewLease:input_type -> keyorix.v1.RenewLeaseRequest
+	125, // 182: keyorix.v1.DynamicSecretService.RevokeAllLeases:input_type -> keyorix.v1.RevokeAllLeasesRequest
+	157, // 183: keyorix.v1.ComplianceService.GetCompliancePosture:input_type -> google.protobuf.Empty
+	157, // 184: keyorix.v1.ComplianceService.GetComplianceControls:input_type -> google.protobuf.Empty
+	157, // 185: keyorix.v1.ConnectService.ListConnectors:input_type -> google.protobuf.Empty
+	144, // 186: keyorix.v1.ConnectService.ReadSecret:input_type -> keyorix.v1.ReadFederatedSecretRequest
+	157, // 187: keyorix.v1.ConnectService.ListRefGrants:input_type -> google.protobuf.Empty
+	148, // 188: keyorix.v1.ConnectService.CreateRefGrant:input_type -> keyorix.v1.CreateConnectRefGrantRequest
+	149, // 189: keyorix.v1.ConnectService.DeleteRefGrant:input_type -> keyorix.v1.DeleteConnectRefGrantRequest
+	0,   // 190: keyorix.v1.SecretService.CreateSecret:output_type -> keyorix.v1.Secret
+	0,   // 191: keyorix.v1.SecretService.GetSecret:output_type -> keyorix.v1.Secret
+	1,   // 192: keyorix.v1.SecretService.GetSecretValue:output_type -> keyorix.v1.SecretValue
+	0,   // 193: keyorix.v1.SecretService.UpdateSecret:output_type -> keyorix.v1.Secret
+	157, // 194: keyorix.v1.SecretService.DeleteSecret:output_type -> google.protobuf.Empty
+	7,   // 195: keyorix.v1.SecretService.ListSecrets:output_type -> keyorix.v1.ListSecretsResponse
+	11,  // 196: keyorix.v1.SecretService.GetSecretVersions:output_type -> keyorix.v1.GetSecretVersionsResponse
+	157, // 197: keyorix.v1.SecretService.SetSecretAutoRotate:output_type -> google.protobuf.Empty
+	13,  // 198: keyorix.v1.SecretService.ListSecretDependencies:output_type -> keyorix.v1.SecretDependencies
+	15,  // 199: keyorix.v1.SecretService.GetSecretImpact:output_type -> keyorix.v1.SecretImpact
+	71,  // 200: keyorix.v1.ShareService.ShareSecret:output_type -> keyorix.v1.ShareRecord
+	76,  // 201: keyorix.v1.ShareService.ListSecretShares:output_type -> keyorix.v1.ListSharesResponse
+	76,  // 202: keyorix.v1.ShareService.ListUserShares:output_type -> keyorix.v1.ListSharesResponse
+	7,   // 203: keyorix.v1.ShareService.ListSharedSecrets:output_type -> keyorix.v1.ListSecretsResponse
+	71,  // 204: keyorix.v1.ShareService.UpdateSharePermission:output_type -> keyorix.v1.ShareRecord
+	157, // 205: keyorix.v1.ShareService.RevokeShare:output_type -> google.protobuf.Empty
+	26,  // 206: keyorix.v1.UserService.CreateUser:output_type -> keyorix.v1.CreateUserResponse
+	23,  // 207: keyorix.v1.UserService.GetUser:output_type -> keyorix.v1.User
+	23,  // 208: keyorix.v1.UserService.UpdateUser:output_type -> keyorix.v1.User
+	157, // 209: keyorix.v1.UserService.DeleteUser:output_type -> google.protobuf.Empty
+	31,  // 210: keyorix.v1.UserService.ListUsers:output_type -> keyorix.v1.ListUsersResponse
+	33,  // 211: keyorix.v1.RoleService.CreateRole:output_type -> keyorix.v1.Role
+	33,  // 212: keyorix.v1.RoleService.GetRole:output_type -> keyorix.v1.Role
+	33,  // 213: keyorix.v1.RoleService.UpdateRole:output_type -> keyorix.v1.Role
+	157, // 214: keyorix.v1.RoleService.DeleteRole:output_type -> google.protobuf.Empty
+	39,  // 215: keyorix.v1.RoleService.ListRoles:output_type -> keyorix.v1.ListRolesResponse
+	41,  // 216: keyorix.v1.RoleService.AssignRole:output_type -> keyorix.v1.RoleAssignment
+	157, // 217: keyorix.v1.RoleService.RemoveRole:output_type -> google.protobuf.Empty
+	44,  // 218: keyorix.v1.RoleService.GetUserRoles:output_type -> keyorix.v1.GetUserRolesResponse
+	47,  // 219: keyorix.v1.AuditService.GetAuditLogs:output_type -> keyorix.v1.GetAuditLogsResponse
+	50,  // 220: keyorix.v1.AuditService.GetRBACAuditLogs:output_type -> keyorix.v1.GetRBACAuditLogsResponse
+	45,  // 221: keyorix.v1.AuditService.StreamAuditLogs:output_type -> keyorix.v1.AuditLog
+	52,  // 222: keyorix.v1.AuditService.VerifyAuditChain:output_type -> keyorix.v1.VerifyAuditChainResponse
+	53,  // 223: keyorix.v1.AuditService.WriteAuditCheckpoint:output_type -> keyorix.v1.WriteAuditCheckpointResponse
+	54,  // 224: keyorix.v1.AuditService.GetAuditRetention:output_type -> keyorix.v1.GetAuditRetentionResponse
+	79,  // 225: keyorix.v1.SystemService.HealthCheck:output_type -> keyorix.v1.HealthResponse
+	80,  // 226: keyorix.v1.SystemService.GetSystemInfo:output_type -> keyorix.v1.SystemInfo
+	83,  // 227: keyorix.v1.SystemService.GetMetrics:output_type -> keyorix.v1.Metrics
+	55,  // 228: keyorix.v1.BreakGlassService.ActivateBreakGlass:output_type -> keyorix.v1.BreakGlassActivation
+	58,  // 229: keyorix.v1.BreakGlassService.ListBreakGlassActivations:output_type -> keyorix.v1.ListBreakGlassActivationsResponse
+	157, // 230: keyorix.v1.BreakGlassService.RevokeBreakGlass:output_type -> google.protobuf.Empty
+	67,  // 231: keyorix.v1.GroupService.ListGroups:output_type -> keyorix.v1.ListGroupsResponse
+	60,  // 232: keyorix.v1.GroupService.GetGroup:output_type -> keyorix.v1.Group
+	60,  // 233: keyorix.v1.GroupService.CreateGroup:output_type -> keyorix.v1.Group
+	60,  // 234: keyorix.v1.GroupService.UpdateGroup:output_type -> keyorix.v1.Group
+	157, // 235: keyorix.v1.GroupService.DeleteGroup:output_type -> google.protobuf.Empty
+	60,  // 236: keyorix.v1.GroupService.RestoreGroup:output_type -> keyorix.v1.Group
+	69,  // 237: keyorix.v1.GroupService.GetGroupMembers:output_type -> keyorix.v1.GetGroupMembersResponse
+	157, // 238: keyorix.v1.GroupService.AddGroupMember:output_type -> google.protobuf.Empty
+	157, // 239: keyorix.v1.GroupService.RemoveGroupMember:output_type -> google.protobuf.Empty
+	91,  // 240: keyorix.v1.ProjectService.ListProjects:output_type -> keyorix.v1.ListProjectsResponse
+	89,  // 241: keyorix.v1.ProjectService.GetProject:output_type -> keyorix.v1.Project
+	89,  // 242: keyorix.v1.ProjectService.CreateProject:output_type -> keyorix.v1.Project
+	89,  // 243: keyorix.v1.ProjectService.UpdateProject:output_type -> keyorix.v1.Project
+	157, // 244: keyorix.v1.ProjectService.DeleteProject:output_type -> google.protobuf.Empty
+	17,  // 245: keyorix.v1.ProjectService.GetProjectRotationOrder:output_type -> keyorix.v1.RotationOrder
+	22,  // 246: keyorix.v1.ProjectService.GetProjectRotationPlan:output_type -> keyorix.v1.RotationPlan
+	19,  // 247: keyorix.v1.ProjectService.GetDeploymentRotationPlan:output_type -> keyorix.v1.DeploymentRotationPlan
+	97,  // 248: keyorix.v1.ProjectService.ListEnvironments:output_type -> keyorix.v1.ListEnvironmentsResponse
+	101, // 249: keyorix.v1.MachineIdentityService.ListMachineIdentities:output_type -> keyorix.v1.ListMachineIdentitiesResponse
+	98,  // 250: keyorix.v1.MachineIdentityService.CreateMachineIdentity:output_type -> keyorix.v1.MachineIdentity
+	98,  // 251: keyorix.v1.MachineIdentityService.TransitionMachineIdentity:output_type -> keyorix.v1.MachineIdentity
+	98,  // 252: keyorix.v1.MachineIdentityService.ClassifyMachineIdentity:output_type -> keyorix.v1.MachineIdentity
+	106, // 253: keyorix.v1.MachineIdentityService.IssueMachineToken:output_type -> keyorix.v1.IssueMachineTokenResponse
+	108, // 254: keyorix.v1.MachineIdentityService.ListMachineTokens:output_type -> keyorix.v1.ListMachineTokensResponse
+	157, // 255: keyorix.v1.MachineIdentityService.RevokeMachineToken:output_type -> google.protobuf.Empty
+	99,  // 256: keyorix.v1.MachineIdentityService.ClassifyMachineToken:output_type -> keyorix.v1.MachineToken
+	115, // 257: keyorix.v1.DynamicSecretService.ListConfigs:output_type -> keyorix.v1.ListDynamicConfigsResponse
+	111, // 258: keyorix.v1.DynamicSecretService.GetConfig:output_type -> keyorix.v1.DynamicSecretConfig
+	111, // 259: keyorix.v1.DynamicSecretService.CreateConfig:output_type -> keyorix.v1.DynamicSecretConfig
+	111, // 260: keyorix.v1.DynamicSecretService.ClassifyConfig:output_type -> keyorix.v1.DynamicSecretConfig
+	113, // 261: keyorix.v1.DynamicSecretService.IssueLease:output_type -> keyorix.v1.IssuedCredential
+	121, // 262: keyorix.v1.DynamicSecretService.ListLeases:output_type -> keyorix.v1.ListLeasesResponse
+	157, // 263: keyorix.v1.DynamicSecretService.RevokeLease:output_type -> google.protobuf.Empty
+	124, // 264: keyorix.v1.DynamicSecretService.RenewLease:output_type -> keyorix.v1.RenewLeaseResponse
+	126, // 265: keyorix.v1.DynamicSecretService.RevokeAllLeases:output_type -> keyorix.v1.RevokeAllLeasesResponse
+	138, // 266: keyorix.v1.ComplianceService.GetCompliancePosture:output_type -> keyorix.v1.CompliancePosture
+	142, // 267: keyorix.v1.ComplianceService.GetComplianceControls:output_type -> keyorix.v1.ComplianceControls
+	143, // 268: keyorix.v1.ConnectService.ListConnectors:output_type -> keyorix.v1.ConnectorList
+	145, // 269: keyorix.v1.ConnectService.ReadSecret:output_type -> keyorix.v1.FederatedSecretValue
+	147, // 270: keyorix.v1.ConnectService.ListRefGrants:output_type -> keyorix.v1.ConnectRefGrantList
+	146, // 271: keyorix.v1.ConnectService.CreateRefGrant:output_type -> keyorix.v1.ConnectRefGrant
+	157, // 272: keyorix.v1.ConnectService.DeleteRefGrant:output_type -> google.protobuf.Empty
+	190, // [190:273] is the sub-list for method output_type
+	107, // [107:190] is the sub-list for method input_type
+	107, // [107:107] is the sub-list for extension type_name
+	107, // [107:107] is the sub-list for extension extendee
+	0,   // [0:107] is the sub-list for field type_name
 }
 
 func init() { file_keyorix_proto_init() }
@@ -11766,38 +11931,38 @@ func file_keyorix_proto_init() {
 	file_keyorix_proto_msgTypes[2].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[4].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[6].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[21].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[23].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[24].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[25].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[26].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[28].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[34].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[38].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[30].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[36].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[40].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[43].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[44].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[42].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[45].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[46].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[47].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[48].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[49].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[50].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[51].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[52].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[53].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[92].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[96].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[97].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[104].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[110].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[111].OneofWrappers = []any{}
-	file_keyorix_proto_msgTypes[144].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[54].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[55].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[94].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[98].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[99].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[106].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[112].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[113].OneofWrappers = []any{}
 	file_keyorix_proto_msgTypes[146].OneofWrappers = []any{}
+	file_keyorix_proto_msgTypes[148].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_keyorix_proto_rawDesc), len(file_keyorix_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   154,
+			NumMessages:   156,
 			NumExtensions: 0,
 			NumServices:   13,
 		},

--- a/server/proto/pb/keyorix_grpc.pb.go
+++ b/server/proto/pb/keyorix_grpc.pb.go
@@ -2580,14 +2580,15 @@ var GroupService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	ProjectService_ListProjects_FullMethodName            = "/keyorix.v1.ProjectService/ListProjects"
-	ProjectService_GetProject_FullMethodName              = "/keyorix.v1.ProjectService/GetProject"
-	ProjectService_CreateProject_FullMethodName           = "/keyorix.v1.ProjectService/CreateProject"
-	ProjectService_UpdateProject_FullMethodName           = "/keyorix.v1.ProjectService/UpdateProject"
-	ProjectService_DeleteProject_FullMethodName           = "/keyorix.v1.ProjectService/DeleteProject"
-	ProjectService_GetProjectRotationOrder_FullMethodName = "/keyorix.v1.ProjectService/GetProjectRotationOrder"
-	ProjectService_GetProjectRotationPlan_FullMethodName  = "/keyorix.v1.ProjectService/GetProjectRotationPlan"
-	ProjectService_ListEnvironments_FullMethodName        = "/keyorix.v1.ProjectService/ListEnvironments"
+	ProjectService_ListProjects_FullMethodName              = "/keyorix.v1.ProjectService/ListProjects"
+	ProjectService_GetProject_FullMethodName                = "/keyorix.v1.ProjectService/GetProject"
+	ProjectService_CreateProject_FullMethodName             = "/keyorix.v1.ProjectService/CreateProject"
+	ProjectService_UpdateProject_FullMethodName             = "/keyorix.v1.ProjectService/UpdateProject"
+	ProjectService_DeleteProject_FullMethodName             = "/keyorix.v1.ProjectService/DeleteProject"
+	ProjectService_GetProjectRotationOrder_FullMethodName   = "/keyorix.v1.ProjectService/GetProjectRotationOrder"
+	ProjectService_GetProjectRotationPlan_FullMethodName    = "/keyorix.v1.ProjectService/GetProjectRotationPlan"
+	ProjectService_GetDeploymentRotationPlan_FullMethodName = "/keyorix.v1.ProjectService/GetDeploymentRotationPlan"
+	ProjectService_ListEnvironments_FullMethodName          = "/keyorix.v1.ProjectService/ListEnvironments"
 )
 
 // ProjectServiceClient is the client API for ProjectService service.
@@ -2614,6 +2615,8 @@ type ProjectServiceClient interface {
 	// The project's automated rotation plan (ADR-053): overdue/due-soon secrets
 	// batched into dependency-safe waves, prioritised by urgency. Scoped secrets.read.
 	GetProjectRotationPlan(ctx context.Context, in *GetProjectRequest, opts ...grpc.CallOption) (*RotationPlan, error)
+	// GetDeploymentRotationPlan returns the install-wide rotation plan (ADR-053).
+	GetDeploymentRotationPlan(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*DeploymentRotationPlan, error)
 	// List a project's environments.
 	ListEnvironments(ctx context.Context, in *ListEnvironmentsRequest, opts ...grpc.CallOption) (*ListEnvironmentsResponse, error)
 }
@@ -2696,6 +2699,16 @@ func (c *projectServiceClient) GetProjectRotationPlan(ctx context.Context, in *G
 	return out, nil
 }
 
+func (c *projectServiceClient) GetDeploymentRotationPlan(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*DeploymentRotationPlan, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeploymentRotationPlan)
+	err := c.cc.Invoke(ctx, ProjectService_GetDeploymentRotationPlan_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *projectServiceClient) ListEnvironments(ctx context.Context, in *ListEnvironmentsRequest, opts ...grpc.CallOption) (*ListEnvironmentsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListEnvironmentsResponse)
@@ -2730,6 +2743,8 @@ type ProjectServiceServer interface {
 	// The project's automated rotation plan (ADR-053): overdue/due-soon secrets
 	// batched into dependency-safe waves, prioritised by urgency. Scoped secrets.read.
 	GetProjectRotationPlan(context.Context, *GetProjectRequest) (*RotationPlan, error)
+	// GetDeploymentRotationPlan returns the install-wide rotation plan (ADR-053).
+	GetDeploymentRotationPlan(context.Context, *emptypb.Empty) (*DeploymentRotationPlan, error)
 	// List a project's environments.
 	ListEnvironments(context.Context, *ListEnvironmentsRequest) (*ListEnvironmentsResponse, error)
 	mustEmbedUnimplementedProjectServiceServer()
@@ -2762,6 +2777,9 @@ func (UnimplementedProjectServiceServer) GetProjectRotationOrder(context.Context
 }
 func (UnimplementedProjectServiceServer) GetProjectRotationPlan(context.Context, *GetProjectRequest) (*RotationPlan, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetProjectRotationPlan not implemented")
+}
+func (UnimplementedProjectServiceServer) GetDeploymentRotationPlan(context.Context, *emptypb.Empty) (*DeploymentRotationPlan, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetDeploymentRotationPlan not implemented")
 }
 func (UnimplementedProjectServiceServer) ListEnvironments(context.Context, *ListEnvironmentsRequest) (*ListEnvironmentsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListEnvironments not implemented")
@@ -2913,6 +2931,24 @@ func _ProjectService_GetProjectRotationPlan_Handler(srv interface{}, ctx context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ProjectService_GetDeploymentRotationPlan_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ProjectServiceServer).GetDeploymentRotationPlan(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ProjectService_GetDeploymentRotationPlan_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ProjectServiceServer).GetDeploymentRotationPlan(ctx, req.(*emptypb.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ProjectService_ListEnvironments_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ListEnvironmentsRequest)
 	if err := dec(in); err != nil {
@@ -2965,6 +3001,10 @@ var ProjectService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetProjectRotationPlan",
 			Handler:    _ProjectService_GetProjectRotationPlan_Handler,
+		},
+		{
+			MethodName: "GetDeploymentRotationPlan",
+			Handler:    _ProjectService_GetDeploymentRotationPlan_Handler,
 		},
 		{
 			MethodName: "ListEnvironments",


### PR DESCRIPTION
## Summary
- Adds `GetDeploymentRotationPlan(google.protobuf.Empty) returns (DeploymentRotationPlan)` to `ProjectService`
- New proto messages: `DeploymentRotationPlan` and `BrokenRotationProject`
- Mirrors the HTTP `GET /api/v1/rotation-plan` endpoint — same global `secrets.read` gate
- Converter `deploymentRotationPlanToProto` in `conversions.go`
- Two gRPC tests: happy-path + no-auth rejection

## Test plan
- [ ] `go test ./server/grpc/services/...` green
- [ ] `go build ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)