### PR TITLE
feat(crypto): MultiKeyProvider KEK fallback chain (ADR-038 follow-up)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -552,6 +552,8 @@ type KeyProviderConfig struct {
 	// TPMDevice is the TPM 2.0 device for type "tpm" (default /dev/tpmrm0). The KEK
 	// is sealed to this TPM and the sealed blob stored at WrappedKeyPath.
 	TPMDevice string `yaml:"tpm_device"`
+	// Fallbacks is an ordered list of providers tried when the primary fails.
+	Fallbacks []KeyProviderConfig `yaml:"fallbacks,omitempty"`
 }
 
 type SecretsConfig struct {

--- a/internal/crypto/multi_provider.go
+++ b/internal/crypto/multi_provider.go
@@ -1,0 +1,48 @@
+package crypto
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+// MultiKeyProvider tries its providers in order, returning the KEK from the
+// first that succeeds. If all fail it returns a wrapped error. An empty list
+// is a configuration error.
+type MultiKeyProvider struct {
+	providers []KeyProvider
+}
+
+// NewMultiKeyProvider creates a MultiKeyProvider. Returns error if list is empty.
+func NewMultiKeyProvider(providers []KeyProvider) (*MultiKeyProvider, error) {
+	if len(providers) == 0 {
+		return nil, fmt.Errorf("multi key provider: at least one provider is required")
+	}
+	return &MultiKeyProvider{providers: providers}, nil
+}
+
+// Name returns "multi(p1,p2,...)" for logging/status output.
+func (m *MultiKeyProvider) Name() string {
+	names := make([]string, len(m.providers))
+	for i, p := range m.providers {
+		names[i] = p.Name()
+	}
+	return "multi(" + strings.Join(names, ",") + ")"
+}
+
+// KEK tries each provider in order. The first successful result is returned.
+func (m *MultiKeyProvider) KEK() ([]byte, error) {
+	var errs []string
+	for _, p := range m.providers {
+		key, err := p.KEK()
+		if err == nil {
+			if len(m.providers) > 1 {
+				log.Printf("key provider: %s succeeded", p.Name())
+			}
+			return key, nil
+		}
+		log.Printf("key provider: %s failed (%v), trying next", p.Name(), err)
+		errs = append(errs, fmt.Sprintf("%s: %v", p.Name(), err))
+	}
+	return nil, fmt.Errorf("all key providers failed: %s", strings.Join(errs, "; "))
+}

--- a/internal/crypto/multi_provider_test.go
+++ b/internal/crypto/multi_provider_test.go
@@ -1,0 +1,75 @@
+package crypto_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubProvider struct {
+	name string
+	key  []byte
+	err  error
+}
+
+func (s *stubProvider) Name() string         { return s.name }
+func (s *stubProvider) KEK() ([]byte, error) { return s.key, s.err }
+
+func goodProvider(name string) *stubProvider {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	return &stubProvider{name: name, key: key}
+}
+
+func badProvider(name string) *stubProvider {
+	return &stubProvider{name: name, err: errors.New("provider unavailable")}
+}
+
+func TestMultiKeyProvider_EmptyListError(t *testing.T) {
+	_, err := crypto.NewMultiKeyProvider(nil)
+	require.Error(t, err)
+}
+
+func TestMultiKeyProvider_PrimarySucceeds(t *testing.T) {
+	good := goodProvider("primary")
+	bad := badProvider("fallback")
+	m, err := crypto.NewMultiKeyProvider([]crypto.KeyProvider{good, bad})
+	require.NoError(t, err)
+	key, err := m.KEK()
+	require.NoError(t, err)
+	assert.Equal(t, good.key, key)
+}
+
+func TestMultiKeyProvider_FallsBackOnPrimaryFailure(t *testing.T) {
+	fbKey := make([]byte, 32)
+	for i := range fbKey {
+		fbKey[i] = 0xff
+	}
+	m, err := crypto.NewMultiKeyProvider([]crypto.KeyProvider{
+		badProvider("primary"),
+		&stubProvider{name: "fallback", key: fbKey},
+	})
+	require.NoError(t, err)
+	key, err := m.KEK()
+	require.NoError(t, err)
+	assert.Equal(t, fbKey, key)
+}
+
+func TestMultiKeyProvider_AllFail(t *testing.T) {
+	m, err := crypto.NewMultiKeyProvider([]crypto.KeyProvider{badProvider("a"), badProvider("b")})
+	require.NoError(t, err)
+	_, err = m.KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all key providers failed")
+}
+
+func TestMultiKeyProvider_Name(t *testing.T) {
+	m, err := crypto.NewMultiKeyProvider([]crypto.KeyProvider{goodProvider("aws-kms"), goodProvider("file")})
+	require.NoError(t, err)
+	assert.Equal(t, "multi(aws-kms,file)", m.Name())
+}

--- a/internal/encryption/multi_provider_config_test.go
+++ b/internal/encryption/multi_provider_config_test.go
@@ -1,0 +1,62 @@
+package encryption_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewKeyProviderFromConfig_Fallback(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "salt",
+		KeyProvider: config.KeyProviderConfig{
+			Type:     "file",
+			FilePath: filepath.Join(dir, "nonexistent.key"),
+			Fallbacks: []config.KeyProviderConfig{
+				{Type: "password"},
+			},
+		},
+	}
+	p, err := encryption.NewKeyProviderFromConfig(cfg, dir, "test-passphrase")
+	require.NoError(t, err)
+	assert.Contains(t, p.Name(), "multi(")
+	key, err := p.KEK()
+	require.NoError(t, err)
+	assert.Len(t, key, 32)
+}
+
+func TestNewKeyProviderFromConfig_NoFallback(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "salt",
+		KeyProvider: config.KeyProviderConfig{Type: "password"},
+	}
+	p, err := encryption.NewKeyProviderFromConfig(cfg, dir, "pass")
+	require.NoError(t, err)
+	assert.NotContains(t, p.Name(), "multi(")
+}
+
+func TestNewKeyProviderFromConfig_BadFallbackType(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "salt",
+		KeyProvider: config.KeyProviderConfig{
+			Type: "password",
+			Fallbacks: []config.KeyProviderConfig{{Type: "invalid-type"}},
+		},
+	}
+	_, err := encryption.NewKeyProviderFromConfig(cfg, dir, "pass")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown")
+}

--- a/internal/encryption/multi_provider_config_test.go
+++ b/internal/encryption/multi_provider_config_test.go
@@ -60,3 +60,52 @@ func TestNewKeyProviderFromConfig_BadFallbackType(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown")
 }
+
+// TestNewKeyProviderFromConfig_EnvProvider verifies the env case is constructed
+// without error even when the env var is absent (validation deferred to KEK()).
+func TestNewKeyProviderFromConfig_EnvProvider(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "salt",
+		KeyProvider: config.KeyProviderConfig{Type: "env", EnvVar: "_KEYORIX_TEST_KEK_ABSENT"},
+	}
+	p, err := encryption.NewKeyProviderFromConfig(cfg, dir, "")
+	require.NoError(t, err)
+	assert.Equal(t, "env", p.Name())
+}
+
+// TestNewKeyProviderFromConfig_ExecProvider verifies the exec case is constructed
+// without error (command execution is deferred to KEK()).
+func TestNewKeyProviderFromConfig_ExecProvider(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "salt",
+		KeyProvider: config.KeyProviderConfig{Type: "exec", ExecCommand: []string{"/bin/true"}},
+	}
+	p, err := encryption.NewKeyProviderFromConfig(cfg, dir, "")
+	require.NoError(t, err)
+	assert.Contains(t, p.Name(), "exec")
+}
+
+// TestNewKeyProviderFromConfig_AzureKMSContextError covers the azure-kms branch
+// when KMSEncryptionContext is set (unsupported for RSA-OAEP wrap).
+func TestNewKeyProviderFromConfig_AzureKMSContextError(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "salt",
+		KeyProvider: config.KeyProviderConfig{
+			Type:                 "azure-kms",
+			KMSKeyID:             "https://vault.azure.net/keys/mykey",
+			KMSEncryptionContext: map[string]string{"bound": "true"},
+		},
+	}
+	_, err := encryption.NewKeyProviderFromConfig(cfg, dir, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "azure-kms")
+}

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -85,15 +85,36 @@ func (s *Service) buildKeyProvider(passphrase string) (crypto.KeyProvider, error
 // provider, byte-identical to the historical derivation; file/env supply
 // externally-managed raw key material, exec fetches it from a resolver command,
 // shamir reconstructs it from K-of-N shares, and tpm seals it to the host TPM; the
-// *-kms providers envelope-wrap the KEK with a cloud KMS key. baseDir resolves
-// provider-relative paths (salt /
-// wrapped_key_path). Exported so the KEK-provider migration tool can build a
-// *target* provider from a different config than the running service's.
+// *-kms providers envelope-wrap the KEK with a cloud KMS key. When Fallbacks are
+// configured, wraps all providers in a MultiKeyProvider that tries them in order.
+// baseDir resolves provider-relative paths (salt / wrapped_key_path). Exported so
+// the KEK-provider migration tool can build a *target* provider from a different
+// config than the running service's.
 func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase string) (crypto.KeyProvider, error) {
-	kp := cfg.KeyProvider
+	primary, err := buildSingleProvider(&cfg.KeyProvider, baseDir, passphrase, cfg.SaltPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(cfg.KeyProvider.Fallbacks) == 0 {
+		return primary, nil
+	}
+	providers := []crypto.KeyProvider{primary}
+	for i := range cfg.KeyProvider.Fallbacks {
+		fb, err := buildSingleProvider(&cfg.KeyProvider.Fallbacks[i], baseDir, passphrase, cfg.SaltPath)
+		if err != nil {
+			return nil, fmt.Errorf("fallback provider [%d] (%s): %w", i, cfg.KeyProvider.Fallbacks[i].Type, err)
+		}
+		providers = append(providers, fb)
+	}
+	return crypto.NewMultiKeyProvider(providers)
+}
+
+// buildSingleProvider constructs a single KeyProvider from one KeyProviderConfig.
+// saltPath is the encryption config's salt file path (used by the password provider).
+func buildSingleProvider(kp *config.KeyProviderConfig, baseDir, passphrase, saltPath string) (crypto.KeyProvider, error) {
 	switch kp.Type {
 	case "", "password":
-		return crypto.NewPasswordKeyProvider(passphrase, baseDir, cfg.SaltPath), nil
+		return crypto.NewPasswordKeyProvider(passphrase, baseDir, saltPath), nil
 	case "file":
 		return crypto.NewFileKeyProvider(kp.FilePath), nil
 	case "env":


### PR DESCRIPTION
## Summary
- New `crypto.MultiKeyProvider`: tries providers in order, falls back on error, logs each attempt
- `config.KeyProviderConfig.Fallbacks []KeyProviderConfig` — ordered fallback list in YAML
- `NewKeyProviderFromConfig` transparently wraps in `MultiKeyProvider` when fallbacks configured
- No change to existing single-provider paths (zero-fallback fast path returns primary directly)

## Test plan
- [ ] `go test ./internal/crypto/...` — 5 unit tests (empty list error, primary wins, fallback on failure, all fail, Name format)
- [ ] `go test ./internal/encryption/...` — 3 config integration tests (fallback wiring, no-fallback path, bad fallback type)
- [ ] `go build ./...` green
- [ ] `go vet ./internal/crypto/... ./internal/encryption/... ./internal/config/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)