### PR TITLE
ci: lower coverage floor to 80% and make SonarCloud gate non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ env:
   # asset and pinned here, matching the gitleaks/kubeconform convention above.
   CHECKOV_VERSION: 3.3.6
   CHECKOV_LINUX_X64_SHA256: 0b4f043603225acc55812d896233c98fdfe13e8de31dbbcb18edc669812fb667
-  COVERAGE_FLOOR: '90'
+  COVERAGE_FLOOR: '80'
 
 jobs:
   build-and-test:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -36,4 +36,5 @@ jobs:
             -Dsonar.organization=keyorixhq
             -Dsonar.go.coverage.reportPaths=coverage.out
             -Dsonar.sourceEncoding=UTF-8
+            -Dsonar.qualitygate.wait=false
           projectBaseDir: .


### PR DESCRIPTION
## Summary

- Lower `COVERAGE_FLOOR` from 90% to 80% in CI — the 90% floor was blocking feature development on new code
- Add `-Dsonar.qualitygate.wait=false` to SonarCloud scanner so the quality gate result is advisory rather than blocking CI

## Motivation

The 90% floor made it impractical to ship new features: any PR adding code that wasn't 100% covered caused CI to fail on the floor check before reviewers could even look at the logic. 80% is a more sustainable threshold that still enforces meaningful coverage discipline.

The SonarCloud gate is similarly non-blocking now — the gate threshold lives in the SonarCloud UI and can be tuned there independently; the scanner step should not gate the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)