### PR TITLE
test(grpc): add PermissionDenied coverage for GetDeploymentRotationPlan

### DIFF
--- a/server/grpc/services/rotation_plan_service_test.go
+++ b/server/grpc/services/rotation_plan_service_test.go
@@ -10,6 +10,8 @@ import (
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -83,6 +85,19 @@ func TestGRPC_GetDeploymentRotationPlanRequiresAuth(t *testing.T) {
 	svc := newRotationPlanRig(t)
 	_, err := svc.GetDeploymentRotationPlan(t.Context(), &emptypb.Empty{})
 	require.Error(t, err)
+}
+
+// TestGRPC_GetDeploymentRotationPlanPermissionDenied verifies that an authenticated
+// user without a secrets.read RBAC grant cannot access the deployment-wide rotation plan.
+// User 2 is not granted any role in the rig so AuthorizePrincipal denies the call.
+func TestGRPC_GetDeploymentRotationPlanPermissionDenied(t *testing.T) {
+	svc := newRotationPlanRig(t)
+	// User 2 claims "secrets.read" in the flat context, but has no RBAC role
+	// binding — AuthorizePrincipal will deny the call.
+	ctx := authCtx(2, "nobody", "secrets.read")
+	_, err := svc.GetDeploymentRotationPlan(ctx, &emptypb.Empty{})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }
 
 func TestDeploymentRotationPlanToProto_BrokenProjects(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds the missing `PermissionDenied` test case for `GetDeploymentRotationPlan` in `rotation_plan_service_test.go`.
- The core implementation (`GetDeploymentRotationPlan` RPC, `DeploymentRotationPlan` + `BrokenRotationProject` proto messages, `GenerateDeploymentRotationPlan` in the core, and `deploymentRotationPlanToProto` converter) was shipped in PR #1006.
- This PR completes the three-case test matrix required by ADR-053: unauthenticated → `Unauthenticated`, authenticated without RBAC grant → `PermissionDenied`, authenticated with `secrets.read` → valid `DeploymentRotationPlan`.

## Test plan

- [x] `TestGRPC_GetDeploymentRotationPlan` — authenticated with `secrets.read`, returns a valid plan
- [x] `TestGRPC_GetDeploymentRotationPlanRequiresAuth` — unauthenticated call returns an error
- [x] `TestGRPC_GetDeploymentRotationPlanPermissionDenied` (new) — authenticated user 2 without RBAC role binding receives `codes.PermissionDenied`
- [x] `go vet ./server/grpc/...` passes
- [x] `go test ./server/grpc/services/ -run DeploymentRotationPlan` — 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)