### PR TITLE
feat(rbac): --project/--environment scope flags on assign-role and remove-role CLI commands

### DIFF
--- a/internal/cli/rbac/assign_role.go
+++ b/internal/cli/rbac/assign_role.go
@@ -3,10 +3,12 @@ package rbac
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +16,10 @@ var assignRoleCmd = &cobra.Command{
 	Use:   "assign-role",
 	Short: "Assign a role to a user",
 	Long: `Assign a role to a user by email address.
+
+With --project, the grant is scoped to that project only (rather than globally).
+With --environment, the grant is further narrowed to a single environment within
+that project (--project must also be supplied).
 
 With --ttl, the grant is time-bound (just-in-time access): it stops authorizing
 once the window passes and is swept automatically. Useful for emergency or
@@ -24,15 +30,19 @@ Time-bound grants require a server connection (run 'keyorix connect <server>').`
 }
 
 var (
-	userEmail string
-	roleName  string
-	roleTTL   time.Duration
+	userEmail        string
+	roleName         string
+	roleTTL          time.Duration
+	assignProjectFlag string
+	assignEnvFlag     string
 )
 
 func init() {
 	assignRoleCmd.Flags().StringVar(&userEmail, "user", "", "User email address (required)")
 	assignRoleCmd.Flags().StringVar(&roleName, "role", "", "Role name to assign (required)")
 	assignRoleCmd.Flags().DurationVar(&roleTTL, "ttl", 0, "Time-bound grant lifetime (e.g. 4h, 30m); omit for a permanent grant")
+	assignRoleCmd.Flags().StringVar(&assignProjectFlag, "project", "", "Scope the grant to this project (optional)")
+	assignRoleCmd.Flags().StringVar(&assignEnvFlag, "environment", "", "Scope the grant to this environment within --project (optional; requires --project)")
 
 	_ = assignRoleCmd.MarkFlagRequired("user")
 	_ = assignRoleCmd.MarkFlagRequired("role")
@@ -43,8 +53,11 @@ func runAssignRole(cmd *cobra.Command, args []string) error {
 	if roleTTL < 0 {
 		return fmt.Errorf("--ttl must be positive")
 	}
+	if assignEnvFlag != "" && assignProjectFlag == "" {
+		return fmt.Errorf("--environment requires --project")
+	}
 	if rc, ok := common.NewRemoteClient(); ok {
-		return runAssignRoleRemote(ctx, rc, userEmail, roleName, roleTTL)
+		return runAssignRoleRemote(ctx, rc, userEmail, roleName, roleTTL, assignProjectFlag, assignEnvFlag)
 	}
 
 	// Embedded (direct-DB) mode has no time-bound path — the JIT expiry sweep runs
@@ -59,15 +72,55 @@ func runAssignRole(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Resolve scope.
+	scope := storage.Scope{}
+	if assignProjectFlag != "" {
+		projectID, err := common.LookupProjectIDByName(ctx, st, assignProjectFlag)
+		if err != nil {
+			return fmt.Errorf("failed to resolve project: %w", err)
+		}
+		scope.ProjectID = projectID
+
+		if assignEnvFlag != "" {
+			envs, err := st.ListEnvironmentsByProject(ctx, projectID)
+			if err != nil {
+				return fmt.Errorf("failed to list environments: %w", err)
+			}
+			found := false
+			for _, e := range envs {
+				if strings.EqualFold(e.Name, assignEnvFlag) {
+					scope.EnvironmentID = e.ID
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("environment %q not found in project %q", assignEnvFlag, assignProjectFlag)
+			}
+		}
+	}
+
 	// Create core service
 	coreService := core.NewKeyorixCore(st)
 
-	// Use core service to assign role
-	err = coreService.AssignRoleToUser(ctx, userEmail, roleName)
+	// Use core service to assign role at the resolved scope.
+	err = coreService.AssignUserRoleScoped(ctx, userEmail, roleName, scope)
 	if err != nil {
 		return fmt.Errorf("failed to assign role: %w", err)
 	}
 
-	fmt.Printf("✅ Successfully assigned role '%s' to user '%s'\n", roleName, userEmail)
+	suffix := scopeSuffix(assignProjectFlag, assignEnvFlag)
+	fmt.Printf("Successfully assigned role '%s' to user '%s'%s\n", roleName, userEmail, suffix)
 	return nil
+}
+
+// scopeSuffix returns a human-readable scope qualifier for display messages.
+func scopeSuffix(project, env string) string {
+	if project == "" {
+		return ""
+	}
+	if env != "" {
+		return fmt.Sprintf(" in project '%s' / environment '%s'", project, env)
+	}
+	return fmt.Sprintf(" in project '%s'", project)
 }

--- a/internal/cli/rbac/rbac_s24_test.go
+++ b/internal/cli/rbac/rbac_s24_test.go
@@ -186,7 +186,7 @@ func TestRunAssignRoleRemote_PostFails(t *testing.T) {
 	defer srv.Close()
 
 	rc := remoteClientFor(t, srv)
-	err := runAssignRoleRemote(context.Background(), rc, "alice@test.com", "admin", 0)
+	err := runAssignRoleRemote(context.Background(), rc, "alice@test.com", "admin", 0, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to assign role")
 }

--- a/internal/cli/rbac/rbac_s2_test.go
+++ b/internal/cli/rbac/rbac_s2_test.go
@@ -366,7 +366,7 @@ func TestRemoveRoleRemote_DeleteFails(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 	rc := remoteClientFor(t, srv)
-	err := runRemoveRoleRemote(context.Background(), rc, "alice@test.com", "viewer")
+	err := runRemoveRoleRemote(context.Background(), rc, "alice@test.com", "viewer", "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to remove role")
 }

--- a/internal/cli/rbac/rbac_scope_test.go
+++ b/internal/cli/rbac/rbac_scope_test.go
@@ -1,0 +1,261 @@
+package rbac
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── Local-mode (direct-DB) scope tests ───────────────────────────────────────
+
+// TestAssignUserRoleScoped_ProjectScope verifies that AssignUserRoleScoped stores
+// the grant with the correct ProjectID and zero EnvironmentID.
+func TestAssignUserRoleScoped_ProjectScope(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+
+	user := h.CreateTestUser(t, "scopeuser", 20)
+	user.Email = "scopeuser@test.com"
+	h.DB.Save(user)
+
+	ctx := context.Background()
+
+	// Assign role scoped to project 2 ("production" seeded in seedTestData).
+	scope := storage.Scope{ProjectID: 2}
+	svc := core.NewKeyorixCore(h.Storage)
+	err := svc.AssignUserRoleScoped(ctx, user.Email, "editor", scope)
+	require.NoError(t, err)
+
+	// Verify the stored grant has the expected scope.
+	rows := h.QueryRawSQL(t, `
+		SELECT ur.project_id, ur.environment_id
+		FROM user_roles ur
+		JOIN roles r ON ur.role_id = r.id
+		WHERE ur.user_id = ? AND r.name = 'editor'`, user.ID)
+	defer rows.Close() //nolint:errcheck
+
+	require.True(t, rows.Next(), "expected one user_role row")
+	var projectID, environmentID uint
+	require.NoError(t, rows.Scan(&projectID, &environmentID))
+	assert.Equal(t, uint(2), projectID)
+	assert.Equal(t, uint(0), environmentID)
+}
+
+// TestAssignUserRoleScoped_ProjectAndEnvScope verifies that AssignUserRoleScoped
+// stores the grant with both ProjectID and EnvironmentID set.
+func TestAssignUserRoleScoped_ProjectAndEnvScope(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+
+	user := h.CreateTestUser(t, "scopeuser2", 21)
+	user.Email = "scopeuser2@test.com"
+	h.DB.Save(user)
+
+	ctx := context.Background()
+
+	// Assign role scoped to project 2 / environment 1.
+	scope := storage.Scope{ProjectID: 2, EnvironmentID: 1}
+	svc := core.NewKeyorixCore(h.Storage)
+	err := svc.AssignUserRoleScoped(ctx, user.Email, "viewer", scope)
+	require.NoError(t, err)
+
+	rows := h.QueryRawSQL(t, `
+		SELECT ur.project_id, ur.environment_id
+		FROM user_roles ur
+		JOIN roles r ON ur.role_id = r.id
+		WHERE ur.user_id = ? AND r.name = 'viewer'`, user.ID)
+	defer rows.Close() //nolint:errcheck
+
+	require.True(t, rows.Next(), "expected one user_role row")
+	var projectID, environmentID uint
+	require.NoError(t, rows.Scan(&projectID, &environmentID))
+	assert.Equal(t, uint(2), projectID)
+	assert.Equal(t, uint(1), environmentID)
+}
+
+// TestAssignUserRoleScoped_GlobalFallback verifies that passing Scope{} (the zero
+// value) still assigns globally (ProjectID == 0).
+func TestAssignUserRoleScoped_GlobalFallback(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+
+	user := h.CreateTestUser(t, "globaluser", 22)
+	user.Email = "globaluser@test.com"
+	h.DB.Save(user)
+
+	ctx := context.Background()
+
+	svc := core.NewKeyorixCore(h.Storage)
+	err := svc.AssignUserRoleScoped(ctx, user.Email, "viewer", storage.Scope{})
+	require.NoError(t, err)
+
+	rows := h.QueryRawSQL(t, `
+		SELECT ur.project_id, ur.environment_id
+		FROM user_roles ur
+		JOIN roles r ON ur.role_id = r.id
+		WHERE ur.user_id = ? AND r.name = 'viewer'`, user.ID)
+	defer rows.Close() //nolint:errcheck
+
+	require.True(t, rows.Next(), "expected one user_role row for global grant")
+	var projectID, environmentID uint
+	require.NoError(t, rows.Scan(&projectID, &environmentID))
+	assert.Equal(t, uint(0), projectID, "global grant must have ProjectID == 0")
+	assert.Equal(t, uint(0), environmentID)
+}
+
+// TestRemoveUserRoleScoped_ProjectScope verifies that a scoped grant can be
+// removed by the matching scope.
+func TestRemoveUserRoleScoped_ProjectScope(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+
+	user := h.CreateTestUser(t, "removeuser", 23)
+	user.Email = "removeuser@test.com"
+	h.DB.Save(user)
+
+	ctx := context.Background()
+	scope := storage.Scope{ProjectID: 2}
+	svc := core.NewKeyorixCore(h.Storage)
+
+	require.NoError(t, svc.AssignUserRoleScoped(ctx, user.Email, "editor", scope))
+	require.NoError(t, svc.RemoveUserRoleScoped(ctx, user.Email, "editor", scope))
+
+	rows := h.QueryRawSQL(t, `
+		SELECT COUNT(*) FROM user_roles ur
+		JOIN roles r ON ur.role_id = r.id
+		WHERE ur.user_id = ? AND r.name = 'editor'`, user.ID)
+	defer rows.Close() //nolint:errcheck
+
+	require.True(t, rows.Next())
+	var count int
+	require.NoError(t, rows.Scan(&count))
+	assert.Equal(t, 0, count, "scoped grant should be removed")
+}
+
+// ── Scope flag CLI-layer tests (assign-role / remove-role flags) ──────────────
+
+// TestAssignRoleCmd_ScopeFlags verifies that --project and --environment flags
+// exist on the assign-role command.
+func TestAssignRoleCmd_ScopeFlags(t *testing.T) {
+	projectFlag := assignRoleCmd.Flags().Lookup("project")
+	require.NotNil(t, projectFlag, "--project flag should exist on assign-role")
+
+	envFlag := assignRoleCmd.Flags().Lookup("environment")
+	require.NotNil(t, envFlag, "--environment flag should exist on assign-role")
+}
+
+// TestRemoveRoleCmd_ScopeFlags verifies that --project and --environment flags
+// exist on the remove-role command.
+func TestRemoveRoleCmd_ScopeFlags(t *testing.T) {
+	projectFlag := removeRoleCmd.Flags().Lookup("project")
+	require.NotNil(t, projectFlag, "--project flag should exist on remove-role")
+
+	envFlag := removeRoleCmd.Flags().Lookup("environment")
+	require.NotNil(t, envFlag, "--environment flag should exist on remove-role")
+}
+
+// ── Remote-mode scope tests ───────────────────────────────────────────────────
+
+// TestRunAssignRoleRemote_WithProject verifies that project_id is included in the
+// POST body when --project is supplied in remote mode.
+func TestRunAssignRoleRemote_WithProject(t *testing.T) {
+	var gotBody map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":1,"name":"editor","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":3,"name":"staging"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/user-roles", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"user_id":5,"role_id":1}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runAssignRoleRemote(context.Background(), rc, "alice@test.com", "editor", 0, "staging", "")
+	require.NoError(t, err)
+	assert.Equal(t, float64(3), gotBody["project_id"], "project_id must be resolved and sent")
+	assert.Nil(t, gotBody["environment_id"], "environment_id must be absent when --environment is not set")
+}
+
+// TestRunAssignRoleRemote_WithProjectAndEnv verifies that both project_id and
+// environment_id appear in the POST body when both flags are supplied.
+func TestRunAssignRoleRemote_WithProjectAndEnv(t *testing.T) {
+	var gotBody map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":1,"name":"editor","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":3,"name":"staging"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":2,"name":"dev"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/user-roles", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"user_id":5,"role_id":1}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runAssignRoleRemote(context.Background(), rc, "alice@test.com", "editor", 0, "staging", "dev")
+	require.NoError(t, err)
+	assert.Equal(t, float64(3), gotBody["project_id"])
+	assert.Equal(t, float64(2), gotBody["environment_id"])
+}
+
+// TestRunRemoveRoleRemote_WithProject verifies that project_id is included in the
+// DELETE body when --project is supplied in remote mode.
+func TestRunRemoveRoleRemote_WithProject(t *testing.T) {
+	var gotBody map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":1,"name":"editor","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":3,"name":"staging"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/user-roles", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runRemoveRoleRemote(context.Background(), rc, "alice@test.com", "editor", "staging", "")
+	require.NoError(t, err)
+	assert.Equal(t, float64(3), gotBody["project_id"])
+	assert.Nil(t, gotBody["environment_id"])
+}
+
+// TestScopeSuffix verifies scopeSuffix helper produces expected strings.
+func TestScopeSuffix(t *testing.T) {
+	assert.Equal(t, "", scopeSuffix("", ""))
+	assert.Equal(t, " in project 'myproj'", scopeSuffix("myproj", ""))
+	assert.Equal(t, " in project 'myproj' / environment 'prod'", scopeSuffix("myproj", "prod"))
+}

--- a/internal/cli/rbac/remote.go
+++ b/internal/cli/rbac/remote.go
@@ -23,6 +23,44 @@ import (
 
 // ── shared resolution helpers ───────────────────────────────────────────────
 
+// resolveProjectIDByName finds a project's ID by name via GET /api/v1/projects.
+func resolveProjectIDByName(ctx context.Context, rc *common.RemoteClient, name string) (uint, error) {
+	var resp struct {
+		Projects []struct {
+			ID   uint   `json:"id"`
+			Name string `json:"name"`
+		} `json:"projects"`
+	}
+	if err := rc.Get(ctx, "/api/v1/projects", &resp); err != nil {
+		return 0, fmt.Errorf("failed to list projects: %w", err)
+	}
+	for _, p := range resp.Projects {
+		if strings.EqualFold(p.Name, name) {
+			return p.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("project %q not found — run 'keyorix project list' to see available projects", name)
+}
+
+// resolveEnvironmentIDByName finds an environment's ID by name via GET /api/v1/environments.
+func resolveEnvironmentIDByName(ctx context.Context, rc *common.RemoteClient, name string) (uint, error) {
+	var resp struct {
+		Environments []struct {
+			ID   uint   `json:"id"`
+			Name string `json:"name"`
+		} `json:"environments"`
+	}
+	if err := rc.Get(ctx, "/api/v1/environments", &resp); err != nil {
+		return 0, fmt.Errorf("failed to list environments: %w", err)
+	}
+	for _, e := range resp.Environments {
+		if strings.EqualFold(e.Name, name) {
+			return e.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("environment %q not found", name)
+}
+
 // resolveUserIDByEmail finds a user's ID by email via GET /api/v1/users.
 func resolveUserIDByEmail(ctx context.Context, rc *common.RemoteClient, email string) (uint, error) {
 	var resp struct {
@@ -196,7 +234,7 @@ func runCheckPermissionRemote(ctx context.Context, rc *common.RemoteClient, emai
 	return nil
 }
 
-func runAssignRoleRemote(ctx context.Context, rc *common.RemoteClient, email, role string, ttl time.Duration) error {
+func runAssignRoleRemote(ctx context.Context, rc *common.RemoteClient, email, role string, ttl time.Duration, project, env string) error {
 	userID, err := resolveUserIDByEmail(ctx, rc, email)
 	if err != nil {
 		return err
@@ -209,19 +247,34 @@ func runAssignRoleRemote(ctx context.Context, rc *common.RemoteClient, email, ro
 	if ttl > 0 {
 		body["expires_at"] = time.Now().Add(ttl).UTC().Format(time.RFC3339)
 	}
+	if project != "" {
+		projectID, err := resolveProjectIDByName(ctx, rc, project)
+		if err != nil {
+			return err
+		}
+		body["project_id"] = projectID
+		if env != "" {
+			envID, err := resolveEnvironmentIDByName(ctx, rc, env)
+			if err != nil {
+				return err
+			}
+			body["environment_id"] = envID
+		}
+	}
 	var out map[string]interface{}
 	if err := rc.Post(ctx, "/api/v1/user-roles", body, &out); err != nil {
 		return fmt.Errorf("failed to assign role: %w", err)
 	}
+	suffix := scopeSuffix(project, env)
 	if ttl > 0 {
-		fmt.Printf("✅ Assigned role '%s' to user '%s' for %s (time-bound)\n", role, email, ttl)
+		fmt.Printf("Assigned role '%s' to user '%s'%s for %s (time-bound)\n", role, email, suffix, ttl)
 	} else {
-		fmt.Printf("✅ Successfully assigned role '%s' to user '%s'\n", role, email)
+		fmt.Printf("Successfully assigned role '%s' to user '%s'%s\n", role, email, suffix)
 	}
 	return nil
 }
 
-func runRemoveRoleRemote(ctx context.Context, rc *common.RemoteClient, email, role string) error {
+func runRemoveRoleRemote(ctx context.Context, rc *common.RemoteClient, email, role string, project, env string) error {
 	userID, err := resolveUserIDByEmail(ctx, rc, email)
 	if err != nil {
 		return err
@@ -230,10 +283,25 @@ func runRemoveRoleRemote(ctx context.Context, rc *common.RemoteClient, email, ro
 	if err != nil {
 		return err
 	}
-	body := map[string]uint{"user_id": userID, "role_id": roleID}
+	body := map[string]interface{}{"user_id": userID, "role_id": roleID}
+	if project != "" {
+		projectID, err := resolveProjectIDByName(ctx, rc, project)
+		if err != nil {
+			return err
+		}
+		body["project_id"] = projectID
+		if env != "" {
+			envID, err := resolveEnvironmentIDByName(ctx, rc, env)
+			if err != nil {
+				return err
+			}
+			body["environment_id"] = envID
+		}
+	}
 	if err := rc.DeleteWithBody(ctx, "/api/v1/user-roles", body); err != nil {
 		return fmt.Errorf("failed to remove role: %w", err)
 	}
-	fmt.Printf("✅ Successfully removed role '%s' from user '%s'\n", role, email)
+	suffix := scopeSuffix(project, env)
+	fmt.Printf("Successfully removed role '%s' from user '%s'%s\n", role, email, suffix)
 	return nil
 }

--- a/internal/cli/rbac/remote_test.go
+++ b/internal/cli/rbac/remote_test.go
@@ -108,8 +108,8 @@ func TestRemoteCommandWrappers(t *testing.T) {
 	require.NoError(t, runListPermissionsRemote(ctx, rc, "alice@test.com"))
 	require.NoError(t, runCheckPermissionRemote(ctx, rc, "alice@test.com", "secrets.read"))
 	require.NoError(t, runCheckPermissionRemote(ctx, rc, "alice@test.com", "secrets.write")) // not held → ❌, still nil err
-	require.NoError(t, runAssignRoleRemote(ctx, rc, "alice@test.com", "admin", 0))
-	require.NoError(t, runRemoveRoleRemote(ctx, rc, "alice@test.com", "admin"))
+	require.NoError(t, runAssignRoleRemote(ctx, rc, "alice@test.com", "admin", 0, "", ""))
+	require.NoError(t, runRemoveRoleRemote(ctx, rc, "alice@test.com", "admin", "", ""))
 
 	// A malformed permission name is rejected before any request.
 	require.Error(t, runCheckPermissionRemote(ctx, rc, "alice@test.com", "notvalid"))
@@ -136,14 +136,14 @@ func TestRunAssignRoleRemote_TimeBound(t *testing.T) {
 	rc := remoteClientFor(t, srv)
 	ctx := context.Background()
 
-	require.NoError(t, runAssignRoleRemote(ctx, rc, "alice@test.com", "admin", 4*time.Hour))
+	require.NoError(t, runAssignRoleRemote(ctx, rc, "alice@test.com", "admin", 4*time.Hour, "", ""))
 	require.Contains(t, lastBody, "expires_at")
 	exp, err := time.Parse(time.RFC3339, lastBody["expires_at"].(string))
 	require.NoError(t, err)
 	assert.True(t, exp.After(time.Now()), "expiry must be in the future")
 
 	lastBody = nil
-	require.NoError(t, runAssignRoleRemote(ctx, rc, "alice@test.com", "admin", 0))
+	require.NoError(t, runAssignRoleRemote(ctx, rc, "alice@test.com", "admin", 0, "", ""))
 	assert.NotContains(t, lastBody, "expires_at", "a permanent grant omits expires_at")
 }
 

--- a/internal/cli/rbac/remove_role.go
+++ b/internal/cli/rbac/remove_role.go
@@ -3,27 +3,37 @@ package rbac
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/spf13/cobra"
 )
 
 var removeRoleCmd = &cobra.Command{
 	Use:   "remove-role",
 	Short: "Remove a role from a user",
-	Long:  "Remove a role assignment from a user by email address",
-	RunE:  runRemoveRole,
+	Long: `Remove a role assignment from a user by email address.
+
+With --project, removes only the grant scoped to that project.
+With --environment, removes only the grant scoped to that environment within
+the project (--project must also be supplied).`,
+	RunE: runRemoveRole,
 }
 
 var (
-	removeUserEmail string
-	removeRoleName  string
+	removeUserEmail   string
+	removeRoleName    string
+	removeProjectFlag string
+	removeEnvFlag     string
 )
 
 func init() {
 	removeRoleCmd.Flags().StringVar(&removeUserEmail, "user", "", "User email address (required)")
 	removeRoleCmd.Flags().StringVar(&removeRoleName, "role", "", "Role name to remove (required)")
+	removeRoleCmd.Flags().StringVar(&removeProjectFlag, "project", "", "Remove the grant scoped to this project (optional)")
+	removeRoleCmd.Flags().StringVar(&removeEnvFlag, "environment", "", "Remove the grant scoped to this environment within --project (optional; requires --project)")
 
 	_ = removeRoleCmd.MarkFlagRequired("user")
 	_ = removeRoleCmd.MarkFlagRequired("role")
@@ -31,8 +41,11 @@ func init() {
 
 func runRemoveRole(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
+	if removeEnvFlag != "" && removeProjectFlag == "" {
+		return fmt.Errorf("--environment requires --project")
+	}
 	if rc, ok := common.NewRemoteClient(); ok {
-		return runRemoveRoleRemote(ctx, rc, removeUserEmail, removeRoleName)
+		return runRemoveRoleRemote(ctx, rc, removeUserEmail, removeRoleName, removeProjectFlag, removeEnvFlag)
 	}
 
 	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
@@ -41,15 +54,44 @@ func runRemoveRole(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Resolve scope.
+	scope := storage.Scope{}
+	if removeProjectFlag != "" {
+		projectID, err := common.LookupProjectIDByName(ctx, st, removeProjectFlag)
+		if err != nil {
+			return fmt.Errorf("failed to resolve project: %w", err)
+		}
+		scope.ProjectID = projectID
+
+		if removeEnvFlag != "" {
+			envs, err := st.ListEnvironmentsByProject(ctx, projectID)
+			if err != nil {
+				return fmt.Errorf("failed to list environments: %w", err)
+			}
+			found := false
+			for _, e := range envs {
+				if strings.EqualFold(e.Name, removeEnvFlag) {
+					scope.EnvironmentID = e.ID
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("environment %q not found in project %q", removeEnvFlag, removeProjectFlag)
+			}
+		}
+	}
+
 	// Create core service
 	coreService := core.NewKeyorixCore(st)
 
-	// Use core service to remove role
-	err = coreService.RemoveRoleFromUser(ctx, removeUserEmail, removeRoleName)
+	// Use core service to remove role at the resolved scope.
+	err = coreService.RemoveUserRoleScoped(ctx, removeUserEmail, removeRoleName, scope)
 	if err != nil {
 		return fmt.Errorf("failed to remove role: %w", err)
 	}
 
-	fmt.Printf("✅ Successfully removed role '%s' from user '%s'\n", removeRoleName, removeUserEmail)
+	suffix := scopeSuffix(removeProjectFlag, removeEnvFlag)
+	fmt.Printf("Successfully removed role '%s' from user '%s'%s\n", removeRoleName, removeUserEmail, suffix)
 	return nil
 }

--- a/internal/core/rbac.go
+++ b/internal/core/rbac.go
@@ -9,8 +9,14 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-// AssignRoleToUser assigns a role to a user by email and role name.
+// AssignRoleToUser assigns a role to a user by email and role name (global scope).
 func (c *KeyorixCore) AssignRoleToUser(ctx context.Context, userEmail, roleName string) error {
+	return c.AssignUserRoleScoped(ctx, userEmail, roleName, Scope{})
+}
+
+// AssignUserRoleScoped assigns a role to a user at an explicit scope (project/environment).
+// Pass Scope{} for a global grant. actorID 0 = local CLI/system (no authenticated session).
+func (c *KeyorixCore) AssignUserRoleScoped(ctx context.Context, userEmail, roleName string, scope Scope) error {
 	user, err := c.storage.GetUserByEmail(ctx, userEmail)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
@@ -19,15 +25,20 @@ func (c *KeyorixCore) AssignRoleToUser(ctx context.Context, userEmail, roleName 
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
-	// actorID 0: invoked without an authenticated session (local CLI/system).
-	if err := c.AssignUserRole(ctx, 0, user.ID, role.ID, Scope{}); err != nil {
+	if err := c.AssignUserRole(ctx, 0, user.ID, role.ID, scope); err != nil {
 		return err
 	}
 	return nil
 }
 
-// RemoveRoleFromUser removes a role from a user by email and role name.
+// RemoveRoleFromUser removes a role from a user by email and role name (global scope).
 func (c *KeyorixCore) RemoveRoleFromUser(ctx context.Context, userEmail, roleName string) error {
+	return c.RemoveUserRoleScoped(ctx, userEmail, roleName, Scope{})
+}
+
+// RemoveUserRoleScoped removes a role from a user at an explicit scope (project/environment).
+// Pass Scope{} for a global grant. actorID 0 = local CLI/system (no authenticated session).
+func (c *KeyorixCore) RemoveUserRoleScoped(ctx context.Context, userEmail, roleName string, scope Scope) error {
 	user, err := c.storage.GetUserByEmail(ctx, userEmail)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
@@ -36,8 +47,7 @@ func (c *KeyorixCore) RemoveRoleFromUser(ctx context.Context, userEmail, roleNam
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
-	// actorID 0: invoked without an authenticated session (local CLI/system).
-	if err := c.RemoveUserRole(ctx, 0, user.ID, role.ID, Scope{}); err != nil {
+	if err := c.RemoveUserRole(ctx, 0, user.ID, role.ID, scope); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Add optional `--project` and `--environment` flags to `keyorix rbac assign-role` and `keyorix rbac remove-role`.
- When `--project` is given, the role grant is scoped to that project (sets `project_id` on the stored `user_role`). When `--environment` is also given, the grant is further narrowed to that environment (`environment_id` set). Omitting both flags preserves the existing global-grant behaviour.
- Closes the "CLI scope flags" backlog item — the HTTP API already accepted `project_id`/`environment_id` in the POST/DELETE `/api/v1/user-roles` body; only the CLI surface was missing.

## How it works

**Local (direct-DB) mode:**
- Project name is resolved to an ID via `common.LookupProjectIDByName`.
- Environment name is resolved via `st.ListEnvironmentsByProject` filtered by name.
- Two new core helpers (`AssignUserRoleScoped` / `RemoveUserRoleScoped`) accept an explicit `storage.Scope`; the existing `AssignRoleToUser` / `RemoveRoleFromUser` now delegate to them with `Scope{}` for backward compatibility.

**Remote (server) mode:**
- Project/environment names are resolved via `GET /api/v1/projects` and `GET /api/v1/environments`.
- `project_id` and `environment_id` are included in the POST/DELETE body already consumed by the server.

## Test plan

- [ ] `go test ./internal/cli/rbac/...` passes (includes new `rbac_scope_test.go`).
- [ ] New tests cover: scoped assign stores correct `project_id`/`environment_id`; global fallback when no flags; scoped remove clears the grant; `--project`/`--environment` flags present on both commands; remote mode sends correct IDs in request body.
- [ ] Existing tests in `remote_test.go`, `rbac_s2_test.go`, `rbac_s24_test.go` updated to match new function signatures.
- [ ] `go build ./...` and `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)