### PR TITLE
fix(lint): resolve pre-existing static analysis warnings in core

### DIFF
--- a/internal/core/invitation_accept_test.go
+++ b/internal/core/invitation_accept_test.go
@@ -19,7 +19,7 @@ func TestCompleteInvitationAccept(t *testing.T) {
 	hash := sha256Hex(raw)
 	iid := uint(11)
 
-	pendingInvite := func(c *KeyorixCore, mode string) *models.SetupToken {
+	pendingInvite := func(c *KeyorixCore, _ string) *models.SetupToken {
 		return &models.SetupToken{
 			ID: 3, State: SetupTokenActive, Purpose: SetupPurposeInvitationAccept,
 			SubjectEmail: "bob@acme.io", InvitationID: &iid, ExpiresAt: c.now().Add(time.Hour),

--- a/internal/core/secret_listing_query.go
+++ b/internal/core/secret_listing_query.go
@@ -195,7 +195,7 @@ func (c *KeyorixCore) getOwnedSecretsWithSharingInfo(ctx context.Context, userID
 	return result, nil
 }
 
-func (c *KeyorixCore) getSharedSecretsWithSharingInfo(ctx context.Context, userID uint, filter *models.SecretListFilter) ([]*models.SecretWithSharingInfo, error) {
+func (c *KeyorixCore) getSharedSecretsWithSharingInfo(ctx context.Context, userID uint, _ *models.SecretListFilter) ([]*models.SecretWithSharingInfo, error) {
 	shares, err := c.storage.ListSharesByUser(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/internal/core/secret_listing_sharing.go
+++ b/internal/core/secret_listing_sharing.go
@@ -167,7 +167,7 @@ func (c *KeyorixCore) GetUserSecretPermission(ctx context.Context, secretID, use
 }
 
 // buildSharingIndicators creates UI indicators for a secret based on sharing information.
-func (c *KeyorixCore) buildSharingIndicators(secret *models.SecretNode, shares []*models.ShareRecord, isOwner bool, userPermission string) *models.SharingIndicators {
+func (c *KeyorixCore) buildSharingIndicators(_ *models.SecretNode, shares []*models.ShareRecord, isOwner bool, userPermission string) *models.SharingIndicators {
 	indicators := &models.SharingIndicators{
 		CanRead:   true,
 		CanWrite:  isOwner || userPermission == string(PermissionWrite),

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -43,7 +43,6 @@ const (
 	EventSSOGroupsSynced = "auth.sso_groups_synced"
 	EventSSORolesSynced  = "auth.sso_roles_synced"
 	ssoClockSkew         = 60 * time.Second
-	ssoCompleteSuffix    = "/auth/sso/complete"
 	ssoDefaultRole       = "system_viewer"
 	ssoDefaultGroupClaim = "groups"
 )

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -269,7 +269,7 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 	if req.Username != "" && req.Username != user.Username {
 		if _, err := c.storage.GetUserByUsername(ctx, req.Username); err == nil {
 			return nil, fmt.Errorf("%w: username already exists", ErrUserAlreadyExists)
-		} else if err != nil && !storage.IsUserNotFound(err) {
+		} else if !storage.IsUserNotFound(err) {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 		}
 		user.Username = req.Username


### PR DESCRIPTION
Fixes 5 diagnostic warnings flagged by gopls/staticcheck that existed in `main`:

| File | Issue | Fix |
|------|-------|-----|
| `internal/core/invitation_accept_test.go:22` | unused param `mode string` | renamed to `_` |
| `internal/core/users.go:272` | tautological `err != nil` in `else if` branch | removed redundant check |
| `internal/core/secret_listing_sharing.go:170` | unused param `secret *models.SecretNode` | renamed to `_` |
| `internal/core/secret_listing_query.go:198` | unused param `filter *models.SecretListFilter` | renamed to `_` |
| `internal/core/sso.go:46` | unused const `ssoCompleteSuffix` | removed |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)