### PR TITLE
feat(storage): rebuild user_roles/group_roles composite PK on upgrade

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -10,6 +10,15 @@ _(nothing claimed)_
 
 ## Done
 
+- **RBAC PK rebuild migration** — `migrateDatabase` now detects when
+  `user_roles`/`group_roles` carry the old `(user_id, role_id)` or
+  `(user_id, role_id, project_id)` primary key (from GORM-created pre-Phase-2
+  installs) and rebuilds it to the full four-column composite PK
+  `(user_id/group_id, role_id, project_id, environment_id)`. SQLite uses a
+  CREATE/INSERT/DROP/RENAME recreation; Postgres uses DROP CONSTRAINT / ADD
+  PRIMARY KEY. Runs after the Phase 2 NULL-normalise block; idempotent on every
+  subsequent boot. Added in `internal/storage/factory.go`
+  (`rebuildRolePKIfNeeded`, `rebuildRolePKSQLite`, `rebuildRolePKPostgres`).
 - **RBAC Phase 2 — environment-scoped enforcement.** Permissions are resolved
   per-request against the target project/environment (`core.Authorize`), with
   group inheritance and a global `admin`/`super_admin` bypass. `UserRole`/
@@ -29,12 +38,6 @@ _(nothing claimed)_
 - **OpenAPI sync** — document the new optional `project_id` / `environment_id`
   fields on `POST /user-roles`, `PUT /users/{id}/roles`, and
   `POST /groups/{id}/roles`.
-- **Upgrade-path PK rebuild** — fresh installs get the full composite primary key
-  via AutoMigrate, but an existing GORM-created DB keeps its old
-  `(user_id, role_id)` PK, so the same role cannot be assigned at two scopes
-  there. Provide a one-off migration that rebuilds the `user_roles` /
-  `group_roles` primary key to include `project_id` / `environment_id`
-  (SQLite requires table recreation; Postgres an `ALTER`).
 - **Scoped list UX** — an unscoped `GET /secrets` by a non-global reader returns
   403; consider instead returning the union of secrets across the scopes they can
   read (requires a readable-scopes query + result filtering, with a log line when

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -368,6 +368,200 @@ func warnIfDuplicatesExist(db *gorm.DB, table, keyExpr, whereClause, remediation
 	return nil
 }
 
+// rolePKIsComplete reports whether the given role-assignment table already has the
+// full composite PK: (user_id/group_id, role_id, project_id, environment_id).
+// Detection is dialect-specific:
+//   - SQLite: parse the CREATE TABLE statement from sqlite_master and check whether
+//     the PRIMARY KEY clause mentions "project_id" and "environment_id".
+//   - Postgres: query information_schema.key_column_usage for the table's PK and
+//     check that both columns appear among the PK members.
+func rolePKIsComplete(db *gorm.DB, table string) bool {
+	if db.Dialector.Name() == "postgres" {
+		var count int64
+		db.Raw(`
+			SELECT COUNT(*) FROM information_schema.key_column_usage
+			WHERE table_schema = 'public'
+			  AND table_name   = ?
+			  AND constraint_name IN (
+				SELECT constraint_name
+				FROM   information_schema.table_constraints
+				WHERE  table_schema     = 'public'
+				  AND  table_name       = ?
+				  AND  constraint_type  = 'PRIMARY KEY'
+			  )
+			  AND column_name IN ('project_id', 'environment_id')`,
+			table, table).Scan(&count)
+		return count >= 2
+	}
+	// SQLite: read the CREATE TABLE SQL and look for project_id in the PK clause.
+	var createSQL string
+	db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&createSQL)
+	lower := strings.ToLower(createSQL)
+	pkStart := strings.Index(lower, "primary key")
+	if pkStart == -1 {
+		return false
+	}
+	pkClause := lower[pkStart:]
+	return strings.Contains(pkClause, "project_id") && strings.Contains(pkClause, "environment_id")
+}
+
+// rebuildRolePKIfNeeded detects whether user_roles / group_roles still carry the
+// old (user_id, role_id) or (user_id, role_id, project_id) primary key and, if so,
+// rebuilds the table with the correct four-column composite PK
+// (user_id/group_id, role_id, project_id, environment_id). By the time this runs,
+// the Phase 2 block above has already added environment_id (if absent) and
+// normalised NULL project_id values to 0, so all data is clean.
+//
+// SQLite does not support ALTER TABLE DROP/ADD CONSTRAINT, so the rebuild is done
+// via CREATE TABLE … AS SELECT / DROP / RENAME, wrapped in a transaction.
+// Postgres supports DROP CONSTRAINT / ADD CONSTRAINT in a single DDL statement.
+//
+// Idempotent: if the PK is already correct, nothing is done.
+func rebuildRolePKIfNeeded(db *gorm.DB) error {
+	type tableSpec struct {
+		name    string // table name
+		idCol   string // first PK column (user_id or group_id)
+		pkCols  string // full new PK column list for CREATE TABLE
+		oldPK   string // old PK constraint name on Postgres (heuristic)
+	}
+	tables := []tableSpec{
+		{
+			name:   "user_roles",
+			idCol:  "user_id",
+			pkCols: "user_id, role_id, project_id, environment_id",
+			oldPK:  "user_roles_pkey",
+		},
+		{
+			name:   "group_roles",
+			idCol:  "group_id",
+			pkCols: "group_id, role_id, project_id, environment_id",
+			oldPK:  "group_roles_pkey",
+		},
+	}
+
+	for _, spec := range tables {
+		if !tableExists(db, spec.name) {
+			continue
+		}
+		if rolePKIsComplete(db, spec.name) {
+			continue
+		}
+
+		if db.Dialector.Name() == "postgres" {
+			if err := rebuildRolePKPostgres(db, spec.name, spec.idCol, spec.pkCols, spec.oldPK); err != nil {
+				return fmt.Errorf("PK rebuild for %s (postgres): %w", spec.name, err)
+			}
+		} else {
+			if err := rebuildRolePKSQLite(db, spec.name, spec.idCol, spec.pkCols); err != nil {
+				return fmt.Errorf("PK rebuild for %s (sqlite): %w", spec.name, err)
+			}
+		}
+	}
+	return nil
+}
+
+// rebuildRolePKSQLite recreates table on SQLite with the correct composite PK.
+// SQLite does not support DROP/ADD CONSTRAINT, so a CREATE/INSERT/DROP/RENAME
+// sequence is used. The Phase 2 column-add block runs before this, but we guard
+// defensively: if project_id or environment_id are absent (truly ancient schemas)
+// we substitute the literal 0, so the rebuild is self-contained regardless of
+// what prior migration steps managed to run.
+func rebuildRolePKSQLite(db *gorm.DB, table, idCol, pkCols string) error {
+	newTable := table + "_new"
+	hasExpiresAt := columnExists(db, table, "expires_at")
+	hasProjectID := columnExists(db, table, "project_id")
+	hasEnvID := columnExists(db, table, "environment_id")
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		// Build column list for SELECT: substitute 0 for columns not yet present.
+		projectExpr := "0"
+		if hasProjectID {
+			projectExpr = "COALESCE(project_id, 0)"
+		}
+		envExpr := "0"
+		if hasEnvID {
+			envExpr = "COALESCE(environment_id, 0)"
+		}
+		selectCols := fmt.Sprintf(
+			"COALESCE(%s, 0), COALESCE(role_id, 0), %s, %s",
+			idCol, projectExpr, envExpr,
+		)
+		createExpiresCol := ""
+		if hasExpiresAt {
+			selectCols += ", expires_at"
+			createExpiresCol = ",\n\t\texpires_at TIMESTAMP WITH TIME ZONE"
+		}
+
+		createSQL := fmt.Sprintf(`CREATE TABLE %s (
+		%s INTEGER NOT NULL,
+		role_id INTEGER NOT NULL,
+		project_id INTEGER NOT NULL DEFAULT 0,
+		environment_id INTEGER NOT NULL DEFAULT 0%s,
+		PRIMARY KEY (%s)
+	)`, newTable, idCol, createExpiresCol, pkCols)
+
+		if err := tx.Exec(createSQL).Error; err != nil {
+			return fmt.Errorf("create %s: %w", newTable, err)
+		}
+
+		insertSQL := fmt.Sprintf("INSERT INTO %s SELECT %s FROM %s", newTable, selectCols, table)
+		if err := tx.Exec(insertSQL).Error; err != nil {
+			return fmt.Errorf("copy rows into %s: %w", newTable, err)
+		}
+
+		if err := tx.Exec(fmt.Sprintf("DROP TABLE %s", table)).Error; err != nil {
+			return fmt.Errorf("drop old %s: %w", table, err)
+		}
+
+		if err := tx.Exec(fmt.Sprintf("ALTER TABLE %s RENAME TO %s", newTable, table)).Error; err != nil {
+			return fmt.Errorf("rename %s to %s: %w", newTable, table, err)
+		}
+
+		return nil
+	})
+}
+
+// rebuildRolePKPostgres rebuilds the PK on Postgres by ensuring project_id /
+// environment_id columns exist (with default 0 if not yet present — belt-and-
+// suspenders after the Phase 2 block), then dropping the old constraint and adding
+// the new four-column one.
+func rebuildRolePKPostgres(db *gorm.DB, table, idCol, pkCols, oldConstraint string) error {
+	return db.Transaction(func(tx *gorm.DB) error {
+		// Belt-and-suspenders: add missing columns (Phase 2 already did this,
+		// but guard here too so this function is self-contained).
+		for _, col := range []string{"project_id", "environment_id"} {
+			if !columnExists(tx, table, col) {
+				if err := tx.Exec(fmt.Sprintf(
+					"ALTER TABLE %s ADD COLUMN %s INTEGER NOT NULL DEFAULT 0", table, col,
+				)).Error; err != nil {
+					return fmt.Errorf("add %s.%s: %w", table, col, err)
+				}
+			}
+		}
+
+		// Normalise any remaining NULLs (should be 0 already after Phase 2).
+		tx.Exec(fmt.Sprintf("UPDATE %s SET project_id = 0 WHERE project_id IS NULL", table))
+		tx.Exec(fmt.Sprintf("UPDATE %s SET environment_id = 0 WHERE environment_id IS NULL", table))
+
+		// Drop the old PK constraint. Use IF EXISTS (Postgres 9.5+) so this is safe
+		// even if the constraint name was customised.
+		if err := tx.Exec(fmt.Sprintf(
+			"ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s", table, oldConstraint,
+		)).Error; err != nil {
+			return fmt.Errorf("drop old PK on %s: %w", table, err)
+		}
+
+		// Add the new four-column PK.
+		if err := tx.Exec(fmt.Sprintf(
+			"ALTER TABLE %s ADD PRIMARY KEY (%s)", table, pkCols,
+		)).Error; err != nil {
+			return fmt.Errorf("add new PK on %s (%s): %w", table, pkCols, err)
+		}
+
+		return nil
+	})
+}
+
 // migrateDatabase performs database migrations via GORM AutoMigrate.
 // Idempotent: safe to run on both fresh and existing databases.
 // On a fresh DB, AutoMigrate creates all tables. On an existing DB,
@@ -556,6 +750,18 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 		if columnExists(db, tbl, "project_id") {
 			db.Exec(fmt.Sprintf("UPDATE %s SET project_id = 0 WHERE project_id IS NULL", tbl))
 		}
+	}
+
+	// RBAC PK rebuild: fresh installs get the full composite PK (user_id, role_id,
+	// project_id, environment_id) via AutoMigrate, but existing GORM-created DBs
+	// keep their old (user_id, role_id) or (user_id, role_id, project_id) PK — so
+	// the same role cannot be assigned at two different project/environment scopes
+	// on an upgraded install. Detect the old PK and rebuild it (SQLite requires a
+	// table recreation; Postgres can drop + add the constraint in-place), run after
+	// the Phase 2 ADD COLUMN / NULL-normalise so the data is clean before we touch
+	// the PK.
+	if err := rebuildRolePKIfNeeded(db); err != nil {
+		return err
 	}
 
 	// Snapshot all table-existence checks UP FRONT, before any AutoMigrate runs.

--- a/internal/storage/factory_rbac_pk_rebuild_test.go
+++ b/internal/storage/factory_rbac_pk_rebuild_test.go
@@ -1,0 +1,274 @@
+package storage
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRolePKIsComplete_SQLite_OldTwoColumnPK verifies that rolePKIsComplete
+// returns false when the table has the old two-column PK (user_id, role_id).
+func TestRolePKIsComplete_SQLite_OldTwoColumnPK(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "pk-detect-old.db"))
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id   INTEGER NOT NULL,
+		role_id   INTEGER NOT NULL,
+		PRIMARY KEY (user_id, role_id)
+	)`).Error)
+
+	assert.False(t, rolePKIsComplete(db, "user_roles"),
+		"old two-column PK must be detected as incomplete")
+}
+
+// TestRolePKIsComplete_SQLite_OldThreeColumnPK verifies that rolePKIsComplete
+// returns false when the table has the three-column PK (user_id, role_id,
+// project_id) that the RBAC Phase 1 migration could produce — project_id is
+// present but environment_id is missing from the PK.
+func TestRolePKIsComplete_SQLite_OldThreeColumnPK(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "pk-detect-three.db"))
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id    INTEGER NOT NULL,
+		role_id    INTEGER NOT NULL,
+		project_id INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY (user_id, role_id, project_id)
+	)`).Error)
+
+	assert.False(t, rolePKIsComplete(db, "user_roles"),
+		"three-column PK without environment_id must be detected as incomplete")
+}
+
+// TestRolePKIsComplete_SQLite_NewFourColumnPK verifies that rolePKIsComplete
+// returns true when the table already has the correct four-column composite PK.
+func TestRolePKIsComplete_SQLite_NewFourColumnPK(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "pk-detect-new.db"))
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id        INTEGER NOT NULL,
+		role_id        INTEGER NOT NULL,
+		project_id     INTEGER NOT NULL DEFAULT 0,
+		environment_id INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY (user_id, role_id, project_id, environment_id)
+	)`).Error)
+
+	assert.True(t, rolePKIsComplete(db, "user_roles"),
+		"four-column composite PK must be detected as complete")
+}
+
+// TestRebuildRolePKSQLite_OldTwoColumnPK_UserRoles exercises the full
+// upgrade path for user_roles when the table has only a (user_id, role_id) PK.
+// After the rebuild, the table must:
+//   - carry the four-column composite PK
+//   - preserve all pre-existing rows
+//   - accept a new row that shares role_id with an existing row but has a
+//     different project_id/environment_id scope (which would have violated the
+//     old two-column PK).
+func TestRebuildRolePKSQLite_OldTwoColumnPK_UserRoles(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "pk-rebuild-user-old.db"))
+	require.NoError(t, err)
+
+	// Old schema: two-column PK.
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id   INTEGER NOT NULL,
+		role_id   INTEGER NOT NULL,
+		PRIMARY KEY (user_id, role_id)
+	)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO user_roles (user_id, role_id) VALUES (1, 10)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO user_roles (user_id, role_id) VALUES (2, 10)`).Error)
+
+	// Add the missing columns that Phase 2 would add, so rebuildRolePKSQLite
+	// can include them in the CREATE TABLE statement.
+	require.NoError(t, db.Exec(`ALTER TABLE user_roles ADD COLUMN project_id     INTEGER NOT NULL DEFAULT 0`).Error)
+	require.NoError(t, db.Exec(`ALTER TABLE user_roles ADD COLUMN environment_id INTEGER NOT NULL DEFAULT 0`).Error)
+
+	require.NoError(t, rebuildRolePKSQLite(db, "user_roles", "user_id", "user_id, role_id, project_id, environment_id"))
+
+	// PK is now complete.
+	assert.True(t, rolePKIsComplete(db, "user_roles"), "PK must be complete after rebuild")
+
+	// Pre-existing data preserved.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	var count int
+	require.NoError(t, sqlDB.QueryRow(`SELECT COUNT(*) FROM user_roles`).Scan(&count))
+	assert.Equal(t, 2, count, "both pre-existing rows must be preserved after PK rebuild")
+
+	var roleID int
+	require.NoError(t, sqlDB.QueryRow(`SELECT role_id FROM user_roles WHERE user_id = 1`).Scan(&roleID))
+	assert.Equal(t, 10, roleID)
+
+	// Can now insert the same role at a different scope — this would have violated
+	// the old (user_id, role_id) PK.
+	require.NoError(t, db.Exec(`INSERT INTO user_roles (user_id, role_id, project_id, environment_id) VALUES (1, 10, 5, 0)`).Error,
+		"inserting the same role at a different project scope must succeed after PK rebuild")
+
+	require.NoError(t, sqlDB.QueryRow(`SELECT COUNT(*) FROM user_roles`).Scan(&count))
+	assert.Equal(t, 3, count)
+}
+
+// TestRebuildRolePKSQLite_OldTwoColumnPK_GroupRoles mirrors the user_roles test
+// for group_roles, confirming the rebuild works for both tables.
+func TestRebuildRolePKSQLite_OldTwoColumnPK_GroupRoles(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "pk-rebuild-group-old.db"))
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE group_roles (
+		group_id INTEGER NOT NULL,
+		role_id  INTEGER NOT NULL,
+		PRIMARY KEY (group_id, role_id)
+	)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO group_roles (group_id, role_id) VALUES (3, 20)`).Error)
+
+	require.NoError(t, db.Exec(`ALTER TABLE group_roles ADD COLUMN project_id     INTEGER NOT NULL DEFAULT 0`).Error)
+	require.NoError(t, db.Exec(`ALTER TABLE group_roles ADD COLUMN environment_id INTEGER NOT NULL DEFAULT 0`).Error)
+
+	require.NoError(t, rebuildRolePKSQLite(db, "group_roles", "group_id", "group_id, role_id, project_id, environment_id"))
+
+	assert.True(t, rolePKIsComplete(db, "group_roles"), "PK must be complete after rebuild")
+
+	// Can now insert the same role for the same group at a different scope.
+	require.NoError(t, db.Exec(`INSERT INTO group_roles (group_id, role_id, project_id, environment_id) VALUES (3, 20, 7, 0)`).Error,
+		"same role at different project scope must succeed after PK rebuild")
+}
+
+// TestRebuildRolePKSQLite_WithExpiresAt confirms that optional expires_at rows
+// are copied across correctly during the SQLite table recreation.
+func TestRebuildRolePKSQLite_WithExpiresAt(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "pk-rebuild-expires.db"))
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id    INTEGER NOT NULL,
+		role_id    INTEGER NOT NULL,
+		expires_at TIMESTAMP WITH TIME ZONE,
+		PRIMARY KEY (user_id, role_id)
+	)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO user_roles (user_id, role_id, expires_at) VALUES (1, 5, '2030-01-01 00:00:00')`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO user_roles (user_id, role_id, expires_at) VALUES (2, 5, NULL)`).Error)
+
+	require.NoError(t, db.Exec(`ALTER TABLE user_roles ADD COLUMN project_id     INTEGER NOT NULL DEFAULT 0`).Error)
+	require.NoError(t, db.Exec(`ALTER TABLE user_roles ADD COLUMN environment_id INTEGER NOT NULL DEFAULT 0`).Error)
+
+	require.NoError(t, rebuildRolePKSQLite(db, "user_roles", "user_id", "user_id, role_id, project_id, environment_id"))
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	var expiresAt *string
+	require.NoError(t, sqlDB.QueryRow(`SELECT expires_at FROM user_roles WHERE user_id = 1 AND role_id = 5`).Scan(&expiresAt))
+	require.NotNil(t, expiresAt, "expires_at must be preserved for the timed row")
+	assert.True(t, strings.Contains(*expiresAt, "2030"), "expires_at value must be retained")
+
+	require.NoError(t, sqlDB.QueryRow(`SELECT expires_at FROM user_roles WHERE user_id = 2 AND role_id = 5`).Scan(&expiresAt))
+	assert.Nil(t, expiresAt, "NULL expires_at must remain NULL after rebuild")
+}
+
+// TestRebuildRolePKIfNeeded_SQLite_EndToEnd exercises the full migrateDatabase
+// upgrade path: seed old-schema tables, run migrateDatabase, verify that the PK
+// is rebuilt and data is preserved — the same contract the real field upgrade path
+// delivers.
+func TestRebuildRolePKIfNeeded_SQLite_EndToEnd(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pk-rebuild-e2e.db")
+	db, err := gormOpenForTest(t, dbPath)
+	require.NoError(t, err)
+
+	// Simulate a GORM-created DB from before the composite PK: two-column PK only.
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id   INTEGER NOT NULL,
+		role_id   INTEGER NOT NULL,
+		PRIMARY KEY (user_id, role_id)
+	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE group_roles (
+		group_id INTEGER NOT NULL,
+		role_id  INTEGER NOT NULL,
+		PRIMARY KEY (group_id, role_id)
+	)`).Error)
+
+	// Seed data (use distinct role IDs per table to avoid accidental collision).
+	require.NoError(t, db.Exec(`INSERT INTO user_roles  (user_id,  role_id) VALUES (1, 1)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO user_roles  (user_id,  role_id) VALUES (2, 2)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO group_roles (group_id, role_id) VALUES (1, 3)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO group_roles (group_id, role_id) VALUES (2, 4)`).Error)
+
+	f := &DefaultStorageFactory{}
+	require.NoError(t, f.migrateDatabase(db))
+
+	// Both tables must now carry the full four-column composite PK.
+	assert.True(t, rolePKIsComplete(db, "user_roles"),
+		"user_roles must have the four-column composite PK after migrateDatabase")
+	assert.True(t, rolePKIsComplete(db, "group_roles"),
+		"group_roles must have the four-column composite PK after migrateDatabase")
+
+	// All pre-existing rows must survive the rebuild.
+	sqlDB, rawErr := db.DB()
+	require.NoError(t, rawErr)
+
+	var cnt int
+	require.NoError(t, sqlDB.QueryRow(`SELECT COUNT(*) FROM user_roles`).Scan(&cnt))
+	assert.Equal(t, 2, cnt, "both user_roles rows must survive the PK rebuild")
+
+	require.NoError(t, sqlDB.QueryRow(`SELECT COUNT(*) FROM group_roles`).Scan(&cnt))
+	assert.Equal(t, 2, cnt, "both group_roles rows must survive the PK rebuild")
+
+	// Post-rebuild: the same role can now be assigned at two different project
+	// scopes (the core invariant this migration restores).
+	require.NoError(t, db.Exec(
+		`INSERT INTO user_roles (user_id, role_id, project_id, environment_id) VALUES (1, 1, 5, 0)`,
+	).Error, "same role at a different project scope must succeed after PK rebuild")
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO group_roles (group_id, role_id, project_id, environment_id) VALUES (1, 3, 7, 2)`,
+	).Error, "same role at a different environment scope must succeed after PK rebuild")
+
+	// migrateDatabase is idempotent: re-running must succeed without error.
+	require.NoError(t, f.migrateDatabase(db),
+		"migrateDatabase must be idempotent — re-running must succeed")
+}
+
+// TestRebuildRolePKIfNeeded_SQLite_AlreadyComplete confirms that
+// rebuildRolePKIfNeeded is a no-op when both tables already have the correct
+// four-column PK (i.e. a fresh install — the common case on every boot after
+// the first).
+func TestRebuildRolePKIfNeeded_SQLite_AlreadyComplete(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pk-rebuild-noop.db")
+	db, err := gormOpenForTest(t, dbPath)
+	require.NoError(t, err)
+
+	// Tables with the correct PK already — no rebuild should be needed.
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id        INTEGER NOT NULL,
+		role_id        INTEGER NOT NULL,
+		project_id     INTEGER NOT NULL DEFAULT 0,
+		environment_id INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY (user_id, role_id, project_id, environment_id)
+	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE group_roles (
+		group_id       INTEGER NOT NULL,
+		role_id        INTEGER NOT NULL,
+		project_id     INTEGER NOT NULL DEFAULT 0,
+		environment_id INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY (group_id, role_id, project_id, environment_id)
+	)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO user_roles  VALUES (1, 1, 0, 0)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO group_roles VALUES (1, 1, 0, 0)`).Error)
+
+	require.NoError(t, rebuildRolePKIfNeeded(db))
+
+	// Data must be untouched.
+	sqlDB, rawErr := db.DB()
+	require.NoError(t, rawErr)
+
+	var cnt int
+	require.NoError(t, sqlDB.QueryRow(`SELECT COUNT(*) FROM user_roles`).Scan(&cnt))
+	assert.Equal(t, 1, cnt, "no-op path must leave existing rows in place")
+	require.NoError(t, sqlDB.QueryRow(`SELECT COUNT(*) FROM group_roles`).Scan(&cnt))
+	assert.Equal(t, 1, cnt)
+}


### PR DESCRIPTION
## What

Adds a database migration that detects when `user_roles` and `group_roles` tables still carry the old Phase 1 composite primary key `(user_id, role_id)` and rebuilds it to the full four-column composite `(user_id, role_id, project_id, environment_id)`.

## Why

Users who upgraded from RBAC Phase 1 have a narrower PK on these tables. Without this migration, attempting to assign the same role at more than one project/environment scope fails with a unique-constraint violation, making per-scope RBAC assignments impossible on upgraded installations.

## How

- **SQLite**: recreates each table via the standard rename-create-copy-drop dance (SQLite cannot `ALTER TABLE … DROP CONSTRAINT`).
- **Postgres**: drops the old primary key constraint and re-adds it with the full column list in a single transaction.
- Both paths are guarded by an introspection query that checks the existing PK columns before doing any DDL, so the migration is a no-op on fresh installs where the correct PK is already in place.

## Tests

`migration_pk_rebuild_test.go` exercises the upgrade path end-to-end: it provisions a database with the old narrow PK, runs the migration, then verifies that assigning the same role at two different project/environment scopes succeeds without constraint errors.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)