### PR TITLE
test(coverage): error-path + malformed-JSON tests for remote campaigns/dynamic/invitations

### DIFF
--- a/internal/storage/store/remote_coverage_campaigns_dynamic_invitations_test.go
+++ b/internal/storage/store/remote_coverage_campaigns_dynamic_invitations_test.go
@@ -1,0 +1,687 @@
+// remote_coverage_campaigns_dynamic_invitations_test.go — error-path and
+// malformed-JSON coverage for remote_access_review_campaigns.go,
+// remote_dynamic.go, and remote_invitations.go.
+//
+// Every error path uses HTTP 200 + {"success":false,"error":{...}} because the
+// remote client converts 4xx/5xx responses into a network-level error before
+// the store's resp.Success check is ever reached (see remote/client.go:280).
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// apiNotOK returns a 200-body whose success field is false, together with an
+// error object carrying the given code and message.  This is the only way to
+// exercise the `if !resp.Success` branches in RemoteStorage methods; the
+// remote client turns real 4xx/5xx responses into a network-level error before
+// those branches are reached.
+func apiNotOK(code, message string) []byte {
+	type errObj struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	type resp struct {
+		Success bool   `json:"success"`
+		Error   errObj `json:"error"`
+	}
+	b, _ := json.Marshal(resp{Success: false, Error: errObj{Code: code, Message: message}})
+	return b
+}
+
+// ============================================================================
+// remote_access_review_campaigns.go — error paths
+// ============================================================================
+
+func TestRemoteCov_CreateAccessReviewCampaign_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "create failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateAccessReviewCampaign(context.Background(), &models.AccessReviewCampaign{
+		ProjectID: 1, Name: "Q1", State: "open", CreatedBy: 1, CreatedAt: time.Now(),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "create access-review campaign failed")
+}
+
+func TestRemoteCov_CreateAccessReviewCampaign_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad json}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateAccessReviewCampaign(context.Background(), &models.AccessReviewCampaign{
+		ProjectID: 1, Name: "Q1", State: "open", CreatedBy: 1, CreatedAt: time.Now(),
+	})
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_GetAccessReviewCampaign_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("NOT_FOUND", "campaign not found"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetAccessReviewCampaign(context.Background(), 99)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "get access-review campaign failed")
+}
+
+func TestRemoteCov_GetAccessReviewCampaign_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetAccessReviewCampaign(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_UpdateAccessReviewCampaign_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("CONFLICT", "update failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateAccessReviewCampaign(context.Background(), &models.AccessReviewCampaign{
+		ID: 1, State: "closed", CreatedAt: time.Now(),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "update access-review campaign failed")
+}
+
+func TestRemoteCov_UpdateAccessReviewCampaign_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{broken"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateAccessReviewCampaign(context.Background(), &models.AccessReviewCampaign{
+		ID: 1, State: "closed", CreatedAt: time.Now(),
+	})
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_CountPendingAccessReviewItems_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "count failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountPendingAccessReviewItems(context.Background(), 10)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "count pending access-review items failed")
+}
+
+func TestRemoteCov_CountPendingAccessReviewItems_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountPendingAccessReviewItems(context.Background(), 10)
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_GetAccessReviewItem_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("NOT_FOUND", "item not found"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetAccessReviewItem(context.Background(), 55)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "get access-review item failed")
+}
+
+func TestRemoteCov_GetAccessReviewItem_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetAccessReviewItem(context.Background(), 55)
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_UpdateAccessReviewItem_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "item update failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateAccessReviewItem(context.Background(), &models.AccessReviewItem{
+		ID: 99, CampaignID: 10, Decision: "attested",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "update access-review item failed")
+}
+
+func TestRemoteCov_UpdateAccessReviewItem_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateAccessReviewItem(context.Background(), &models.AccessReviewItem{
+		ID: 99, CampaignID: 10, Decision: "attested",
+	})
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_ListAccessReviewItems_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "list failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListAccessReviewItems(context.Background(), 10)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list access-review items failed")
+}
+
+func TestRemoteCov_ListAccessReviewItems_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListAccessReviewItems(context.Background(), 10)
+	assert.Error(t, err)
+}
+
+// ============================================================================
+// remote_dynamic.go — error paths
+// ============================================================================
+
+func TestRemoteCov_CreateDynamicSecretConfig_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "create config failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateDynamicSecretConfig(context.Background(), &models.DynamicSecretConfig{
+		Name: "pg", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
+		CreatedBy: "admin", CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "create dynamic-secret config failed")
+}
+
+func TestRemoteCov_CreateDynamicSecretConfig_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateDynamicSecretConfig(context.Background(), &models.DynamicSecretConfig{
+		Name: "pg", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
+		CreatedBy: "admin", CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_CountDynamicSecretConfigsByClassification_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "count failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountDynamicSecretConfigsByClassification(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "count dynamic-secret configs by classification failed")
+}
+
+func TestRemoteCov_CountDynamicSecretConfigsByClassification_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountDynamicSecretConfigsByClassification(context.Background())
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_CreateDynamicSecretLease_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "create lease failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateDynamicSecretLease(context.Background(), &models.DynamicSecretLease{
+		ConfigID: 1, LeaseID: "lease-xyz", ProjectID: 1, EnvironmentID: 2,
+		RoleName: "reader", Status: "active",
+		IssuedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "create dynamic-secret lease failed")
+}
+
+func TestRemoteCov_CreateDynamicSecretLease_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateDynamicSecretLease(context.Background(), &models.DynamicSecretLease{
+		ConfigID: 1, LeaseID: "lease-xyz", ProjectID: 1, EnvironmentID: 2,
+		RoleName: "reader", Status: "active",
+		IssuedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
+	})
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_GetDynamicSecretConfig_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("NOT_FOUND", "config not found"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetDynamicSecretConfig(context.Background(), 99)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "get dynamic-secret config failed")
+}
+
+func TestRemoteCov_GetDynamicSecretConfig_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetDynamicSecretConfig(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_UpdateDynamicSecretConfig_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "update config failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.UpdateDynamicSecretConfig(context.Background(), &models.DynamicSecretConfig{
+		ID: 1, Name: "pg", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
+		CreatedBy: "admin", CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "update dynamic-secret config failed")
+}
+
+func TestRemoteCov_GetDynamicSecretLease_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("NOT_FOUND", "lease not found"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetDynamicSecretLease(context.Background(), "lease-xyz")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "get dynamic-secret lease failed")
+}
+
+func TestRemoteCov_GetDynamicSecretLease_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetDynamicSecretLease(context.Background(), "lease-xyz")
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_UpdateDynamicSecretLease_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "update lease failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.UpdateDynamicSecretLease(context.Background(), &models.DynamicSecretLease{
+		ID: 1, ConfigID: 1, LeaseID: "lease-xyz", ProjectID: 1, EnvironmentID: 2,
+		RoleName: "reader", Status: "revoked", RevokeReason: "expired",
+		IssuedAt: time.Now().Add(-2 * time.Hour), ExpiresAt: time.Now().Add(-time.Hour),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "update dynamic-secret lease failed")
+}
+
+func TestRemoteCov_CountActiveLeases_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "count failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountActiveLeases(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "count active dynamic-secret leases failed")
+}
+
+func TestRemoteCov_CountActiveLeases_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountActiveLeases(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+// ============================================================================
+// remote_invitations.go — error paths
+// ============================================================================
+
+func TestRemoteCov_CreateProjectInvitation_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("CONFLICT", "invitation already exists"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateProjectInvitation(context.Background(), &models.ProjectInvitation{
+		ProjectID: 10, Email: "bob@example.com", Role: "viewer",
+		State: "pending", InvitedBy: 5,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "create invitation failed")
+}
+
+func TestRemoteCov_CreateProjectInvitation_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateProjectInvitation(context.Background(), &models.ProjectInvitation{
+		ProjectID: 10, Email: "bob@example.com", Role: "viewer",
+		State: "pending", InvitedBy: 5,
+	})
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_GetProjectInvitation_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("NOT_FOUND", "invitation not found"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetProjectInvitation(context.Background(), 99)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "get invitation failed")
+}
+
+func TestRemoteCov_GetProjectInvitation_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetProjectInvitation(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_UpdateProjectInvitation_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("CONFLICT", "already accepted"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateProjectInvitation(context.Background(), &models.ProjectInvitation{
+		ID: 1, State: "accepted",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "update invitation failed")
+}
+
+func TestRemoteCov_UpdateProjectInvitation_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateProjectInvitation(context.Background(), &models.ProjectInvitation{
+		ID: 1, State: "accepted",
+	})
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_CreateAccessRequest_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "create access request failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateAccessRequest(context.Background(), &models.AccessRequest{
+		ProjectID: 10, UserID: 3, SuggestedRole: "editor", State: "pending",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "create access request failed")
+}
+
+func TestRemoteCov_CreateAccessRequest_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateAccessRequest(context.Background(), &models.AccessRequest{
+		ProjectID: 10, UserID: 3, SuggestedRole: "editor", State: "pending",
+	})
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_GetAccessRequest_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("NOT_FOUND", "request not found"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetAccessRequest(context.Background(), 99)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "get access request failed")
+}
+
+func TestRemoteCov_GetAccessRequest_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetAccessRequest(context.Background(), 50)
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_UpdateAccessRequest_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("CONFLICT", "update failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateAccessRequest(context.Background(), &models.AccessRequest{
+		ID: 50, State: "approved",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "update access request failed")
+}
+
+func TestRemoteCov_UpdateAccessRequest_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateAccessRequest(context.Background(), &models.AccessRequest{
+		ID: 50, State: "approved",
+	})
+	assert.Error(t, err)
+}
+
+func TestRemoteCov_CreateAccessRequestApproval_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "approval create failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateAccessRequestApproval(context.Background(), &models.AccessRequestApproval{
+		RequestID: 50, ApproverID: 2,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "create access request approval failed")
+}
+
+func TestRemoteCov_ListAccessRequestApprovals_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "list approvals failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListAccessRequestApprovals(context.Background(), 50)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list access request approvals failed")
+}
+
+func TestRemoteCov_ListAccessRequestApprovals_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListAccessRequestApprovals(context.Background(), 50)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- Adds `TestRemoteCov_` error-path tests (HTTP 200 + `success:false`) for every low-coverage function in `remote_access_review_campaigns.go`, `remote_dynamic.go`, and `remote_invitations.go`
- Adds malformed-JSON tests (HTTP 200 + `apiOK("{bad}")`) for all decode-path branches
- Defines a local `apiNotOK` helper in the new file; reuses the existing `apiOK` and `testConfig` from `remote_storage_test.go`

## Functions covered

**remote_access_review_campaigns.go:** `CreateAccessReviewCampaign`, `decodeAccessReviewCampaignResponse`, `UpdateAccessReviewCampaign`, `GetAccessReviewCampaign`, `CountPendingAccessReviewItems`, `GetAccessReviewItem`, `UpdateAccessReviewItem`, `ListAccessReviewItems`, `decodeAccessReviewItemResponse`

**remote_dynamic.go:** `CreateDynamicSecretConfig`, `CountDynamicSecretConfigsByClassification`, `CreateDynamicSecretLease`, `decodeDynamicSecretConfigResponse`, `decodeDynamicSecretLeaseResponse`, `GetDynamicSecretConfig`, `UpdateDynamicSecretConfig`, `GetDynamicSecretLease`, `UpdateDynamicSecretLease`, `CountActiveLeases`

**remote_invitations.go:** `CreateProjectInvitation`, `CreateAccessRequest`, `decodeInvitationResponse`, `decodeAccessRequestResponse`, `UpdateProjectInvitation`, `GetProjectInvitation`, `UpdateAccessRequest`, `GetAccessRequest`, `CreateAccessRequestApproval`, `ListAccessRequestApprovals`

## Test plan

- [x] `go test ./internal/storage/store/ -run "TestRemoteCov_" -count=1` passes
- [x] `go vet ./internal/storage/store/` clean