### PR TITLE
feat(deps): audit dependency invalidation on secret soft-delete and restore

### DIFF
--- a/internal/core/core_s24_test.go
+++ b/internal/core/core_s24_test.go
@@ -300,8 +300,10 @@ func TestDeleteSecret_NotFound(t *testing.T) {
 
 func TestDeleteSecret_Success(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("GetSecret", mock.Anything, uint(3)).Return(&models.SecretNode{ID: 3}, nil)
+	ms.On("GetSecret", mock.Anything, uint(3)).Return(&models.SecretNode{ID: 3, ProjectID: 1}, nil)
 	ms.On("DeleteSecret", mock.Anything, uint(3)).Return(nil)
+	// emitDependencyLifecycleEvents lists the project's edges after delete.
+	ms.On("ListSecretDependenciesForProject", mock.Anything, uint(1)).Return([]*models.SecretDependency{}, nil)
 	c := NewKeyorixCore(ms)
 	require.NoError(t, c.DeleteSecret(context.Background(), 3))
 }
@@ -337,6 +339,8 @@ func TestRestoreSecret_ZeroID(t *testing.T) {
 
 func TestRestoreSecret_StorageError(t *testing.T) {
 	ms := new(MockStorage)
+	// GetSecretIncludingDeleted is called before RestoreSecret to obtain name+projectID.
+	ms.On("GetSecretIncludingDeleted", mock.Anything, uint(5)).Return(&models.SecretNode{ID: 5, ProjectID: 1}, nil)
 	ms.On("RestoreSecret", mock.Anything, uint(5)).Return(errors.New("not found"))
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 	c := NewKeyorixCore(ms)
@@ -346,8 +350,12 @@ func TestRestoreSecret_StorageError(t *testing.T) {
 
 func TestRestoreSecret_Success(t *testing.T) {
 	ms := new(MockStorage)
+	// GetSecretIncludingDeleted is called before RestoreSecret to obtain name+projectID.
+	ms.On("GetSecretIncludingDeleted", mock.Anything, uint(5)).Return(&models.SecretNode{ID: 5, ProjectID: 1}, nil)
 	ms.On("RestoreSecret", mock.Anything, uint(5)).Return(nil)
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	// emitDependencyLifecycleEvents lists the project's edges after restore.
+	ms.On("ListSecretDependenciesForProject", mock.Anything, uint(1)).Return([]*models.SecretDependency{}, nil)
 	c := NewKeyorixCore(ms)
 	require.NoError(t, c.RestoreSecret(context.Background(), 1, 5))
 }

--- a/internal/core/secret_dependencies.go
+++ b/internal/core/secret_dependencies.go
@@ -22,8 +22,10 @@ import (
 
 // Secret-dependency audit event types.
 const (
-	EventSecretDependencyAdded   = "secret.dependency_added"   // #nosec G101 -- audit event type, not a credential
-	EventSecretDependencyRemoved = "secret.dependency_removed" // #nosec G101 -- audit event type, not a credential
+	EventSecretDependencyAdded        = "secret.dependency_added"        // #nosec G101 -- audit event type, not a credential
+	EventSecretDependencyRemoved      = "secret.dependency_removed"      // #nosec G101 -- audit event type, not a credential
+	EventSecretDependencyInvalidated  = "secret.dependency_invalidated"  // #nosec G101 -- emitted when a soft-delete breaks a dependency edge
+	EventSecretDependencyRestored     = "secret.dependency_restored"     // #nosec G101 -- emitted when a restore re-activates a broken dependency edge
 )
 
 // SecretRef is a secret identified for a dependency view (id + name; never a value).
@@ -247,6 +249,44 @@ func (c *KeyorixCore) requireSecret(ctx context.Context, id uint) (*models.Secre
 		return nil, fmt.Errorf("%s: %d is not a secret", i18n.T("ErrorValidation", nil), id)
 	}
 	return node, nil
+}
+
+// emitDependencyLifecycleEvents emits one audit event per dependency edge that is
+// incident to secretID (either as the dependent or the depended-on target).
+// eventType is EventSecretDependencyInvalidated on soft-delete or
+// EventSecretDependencyRestored on restore. projectID is used to load the full edge
+// list; secretName is included in the human-readable description. Errors from the
+// edge list query are logged but never surface to the caller — the delete/restore
+// already succeeded and the audit emission is best-effort.
+func (c *KeyorixCore) emitDependencyLifecycleEvents(ctx context.Context, eventType string, actorID, secretID, projectID uint, secretName string) {
+	edges, err := c.storage.ListSecretDependenciesForProject(ctx, projectID)
+	if err != nil {
+		return // best-effort; the primary operation already succeeded
+	}
+	for _, e := range edges {
+		switch secretID {
+		case e.DependsOnSecretID:
+			// secretID is the "depends-on" target — its dependent loses its upstream.
+			dep := e.DependentSecretID
+			c.writeAuditEvent(ctx, eventType, actorPtr(actorID), &dep,
+				fmt.Sprintf("dependency of secret %d on %q (id %d) %s due to secret lifecycle event",
+					e.DependentSecretID, secretName, secretID, lifecycleVerb(eventType)))
+		case e.DependentSecretID:
+			// secretID is the dependent — the edge it owns is now unresolvable.
+			src := e.DependentSecretID
+			c.writeAuditEvent(ctx, eventType, actorPtr(actorID), &src,
+				fmt.Sprintf("dependency of %q (id %d) on secret %d %s due to secret lifecycle event",
+					secretName, secretID, e.DependsOnSecretID, lifecycleVerb(eventType)))
+		}
+	}
+}
+
+// lifecycleVerb returns a short past-tense word for an audit description.
+func lifecycleVerb(eventType string) string {
+	if eventType == EventSecretDependencyRestored {
+		return "restored"
+	}
+	return "invalidated"
 }
 
 // secretInfo is the per-secret metadata the views need: its name and the environment

--- a/internal/core/secret_dependencies_cascade_test.go
+++ b/internal/core/secret_dependencies_cascade_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -82,4 +83,96 @@ func TestGetSecretImpact_CascadesSoftDeleteAndRestore(t *testing.T) {
 
 	require.NoError(t, c.RestoreSecret(ctx, 0, appTok))
 	assert.ElementsMatch(t, []string{"app-token", "cache-key"}, impactNames(), "restore brings it back")
+}
+
+// --- audit event emission tests ---
+
+// DeleteSecret emits secret.dependency_invalidated for each incident edge.
+func TestDeleteSecret_EmitsDependencyInvalidatedAuditEvents(t *testing.T) {
+	ctx := context.Background()
+	c, db := newDepCore(t)
+
+	dbPass := mkSecret(t, db, 1, "db-password")
+	appTok := mkSecret(t, db, 1, "app-token")
+	cacheKey := mkSecret(t, db, 1, "cache-key")
+	// appTok and cacheKey both depend on dbPass.
+	_, err := c.AddSecretDependency(ctx, 10, appTok, dbPass, "")
+	require.NoError(t, err)
+	_, err = c.AddSecretDependency(ctx, 10, cacheKey, dbPass, "")
+	require.NoError(t, err)
+
+	// Soft-delete the dependency target (dbPass). Both edges become invalid.
+	require.NoError(t, c.DeleteSecret(ctx, dbPass))
+
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventSecretDependencyInvalidated).Find(&events).Error)
+	assert.Len(t, events, 2, "one invalidation event per incident edge")
+
+	// All events reference a dependent secret (not dbPass itself), because dbPass is
+	// the depends-on target and both appTok and cacheKey lose their upstream.
+	secretIDs := make(map[uint]bool)
+	for _, e := range events {
+		if e.SecretNodeID != nil {
+			secretIDs[*e.SecretNodeID] = true
+		}
+	}
+	assert.True(t, secretIDs[appTok], "app-token dependent must be referenced")
+	assert.True(t, secretIDs[cacheKey], "cache-key dependent must be referenced")
+}
+
+// RestoreSecret emits secret.dependency_restored for each incident edge.
+func TestRestoreSecret_EmitsDependencyRestoredAuditEvents(t *testing.T) {
+	ctx := context.Background()
+	c, db := newDepCore(t)
+
+	dbPass := mkSecret(t, db, 1, "db-password")
+	appTok := mkSecret(t, db, 1, "app-token")
+	cacheKey := mkSecret(t, db, 1, "cache-key")
+	_, err := c.AddSecretDependency(ctx, 10, appTok, dbPass, "")
+	require.NoError(t, err)
+	_, err = c.AddSecretDependency(ctx, 10, cacheKey, dbPass, "")
+	require.NoError(t, err)
+
+	require.NoError(t, c.DeleteSecret(ctx, dbPass))
+	require.NoError(t, c.RestoreSecret(ctx, 42, dbPass))
+
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventSecretDependencyRestored).Find(&events).Error)
+	assert.Len(t, events, 2, "one restore event per incident edge")
+}
+
+// No dependency audit events are emitted when the secret has no dependency edges.
+func TestDeleteSecret_NoDependencyEventsWhenNoEdges(t *testing.T) {
+	ctx := context.Background()
+	c, db := newDepCore(t)
+
+	isolated := mkSecret(t, db, 1, "isolated")
+	require.NoError(t, c.DeleteSecret(ctx, isolated))
+
+	var count int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", EventSecretDependencyInvalidated).Count(&count).Error)
+	assert.Zero(t, count, "no dependency events for a secret with no edges")
+}
+
+// DeleteSecret emits an event for the edge where the deleted secret is the dependent
+// (not just where it is the depends-on target).
+func TestDeleteSecret_EmitsEventWhenDeletedSecretIsDependent(t *testing.T) {
+	ctx := context.Background()
+	c, db := newDepCore(t)
+
+	upstream := mkSecret(t, db, 1, "upstream")
+	downstream := mkSecret(t, db, 1, "downstream")
+	// downstream depends on upstream.
+	_, err := c.AddSecretDependency(ctx, 10, downstream, upstream, "")
+	require.NoError(t, err)
+
+	// Delete the dependent (downstream). The edge is incident to it, so one event
+	// is expected with SecretNodeID = downstream.
+	require.NoError(t, c.DeleteSecret(ctx, downstream))
+
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventSecretDependencyInvalidated).Find(&events).Error)
+	require.Len(t, events, 1)
+	require.NotNil(t, events[0].SecretNodeID)
+	assert.Equal(t, downstream, *events[0].SecretNodeID)
 }

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -374,12 +374,18 @@ func (c *KeyorixCore) DeleteSecret(ctx context.Context, id uint) error {
 	if id == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret ID is required")
 	}
-	if _, err := c.storage.GetSecret(ctx, id); err != nil {
+	secret, err := c.storage.GetSecret(ctx, id)
+	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
 	}
 	if err := c.storage.DeleteSecret(ctx, id); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	// Emit an audit event for every dependency edge incident to this secret so
+	// operators know which rotation plans are affected (best-effort; the delete
+	// already succeeded). actorID 0 here because DeleteSecret itself has no actor
+	// context — the HTTP handler's LogSecretDeleted carries the authenticated user.
+	c.emitDependencyLifecycleEvents(ctx, EventSecretDependencyInvalidated, 0, id, secret.ProjectID, secret.Name)
 	return nil
 }
 
@@ -402,11 +408,24 @@ func (c *KeyorixCore) RestoreSecret(ctx context.Context, actorID, id uint) error
 	if id == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret ID is required")
 	}
+	// Fetch before restoring so we have name + projectID even though the row is
+	// still soft-deleted at this point (GetSecretIncludingDeleted ignores deleted_at).
+	secret, err := c.storage.GetSecretIncludingDeleted(ctx, id)
+	if err != nil {
+		// Fall back gracefully: the storage.RestoreSecret call will re-validate the
+		// row and return a proper error if the id is unknown.
+		secret = nil
+	}
 	if err := c.storage.RestoreSecret(ctx, id); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	sid := id
 	c.writeAuditEvent(ctx, "secret.restored", actorPtr(actorID), &sid, fmt.Sprintf("secret %d restored", id))
+	// Emit an audit event for every dependency edge that is now re-active so
+	// operators know which rotation plans are unblocked (best-effort).
+	if secret != nil {
+		c.emitDependencyLifecycleEvents(ctx, EventSecretDependencyRestored, actorID, id, secret.ProjectID, secret.Name)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- When a secret is soft-deleted, emit a `secret.dependency_invalidated` audit event for every dependency edge incident to it (whether it is the depends-on target or the dependent side), so operators can see which rotation plans are broken.
- When a secret is restored, emit `secret.dependency_restored` for the same edges so the unblocking is also audited.
- No DB schema changes — edge rows are never mutated; the rotation planner already handles soft-deleted secrets implicitly via `edgesBetweenLiveSecrets`/`edgesWithinEnvironment`.

## Changes

- `secret_dependencies.go`: add `EventSecretDependencyInvalidated` + `EventSecretDependencyRestored` constants; add `emitDependencyLifecycleEvents` helper (best-effort, one event per incident edge) and `lifecycleVerb` helper.
- `secrets.go` `DeleteSecret`: retain the `GetSecret` result (was discarded) to get `name` + `projectID`, then call `emitDependencyLifecycleEvents` after the soft-delete succeeds.
- `secrets.go` `RestoreSecret`: call `GetSecretIncludingDeleted` before restoring (the row is hidden while still soft-deleted), then call `emitDependencyLifecycleEvents` after restore succeeds.
- `secret_dependencies_cascade_test.go`: four new tests — invalidation on delete, restoration on restore, no events for an isolated secret, event when the deleted secret is the dependent.
- `core_s24_test.go`: update two existing mock-based unit tests to expect the new storage calls.

## Test plan

- [ ] `go test ./internal/core/...` passes (all 4 new tests + existing cascade + all other core tests)
- [ ] `go build ./...` clean
- [ ] `TestDeleteSecret_EmitsDependencyInvalidatedAuditEvents`: deleting the depends-on target emits 2 `secret.dependency_invalidated` events, one referencing each dependent
- [ ] `TestRestoreSecret_EmitsDependencyRestoredAuditEvents`: restoring after delete emits 2 `secret.dependency_restored` events
- [ ] `TestDeleteSecret_NoDependencyEventsWhenNoEdges`: no events for a secret with no edges
- [ ] `TestDeleteSecret_EmitsEventWhenDeletedSecretIsDependent`: deleting the dependent itself emits 1 event referencing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)