### PR TITLE
test(coverage): RBAC/ACL handler and store coverage blitz

### DIFF
--- a/internal/core/groups_membership_s38_test.go
+++ b/internal/core/groups_membership_s38_test.go
@@ -1,0 +1,148 @@
+// groups_membership_s38_test.go — coverage top-up for groups.go membership
+// functions. Targets branches not yet exercised by groups_audit_test.go and
+// authz_admin_ceiling_group_test.go:
+//   - AddUserToGroup: zero userID or groupID returns validation error
+//   - RemoveUserFromGroup: zero userID or groupID returns validation error
+//   - GetGroupMembers: groupID == 0 returns validation error
+//   - GetGroupMembers: happy path returns members
+//   - GetGroup: ID == 0 returns validation error
+//   - ListGroups: returns all groups
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newGroupsS38Core returns a KeyorixCore backed by an isolated in-memory SQLite
+// DB with all tables needed for group membership tests.
+func newGroupsS38Core(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Role{},
+		&models.User{}, &models.UserRole{}, &models.AuditEvent{},
+	))
+	return &KeyorixCore{storage: store.NewLocalStorage(db)}, db
+}
+
+// ── AddUserToGroup validation ─────────────────────────────────────────────────
+
+// TestAddUserToGroup_ZeroUserID verifies a zero userID is rejected.
+func TestAddUserToGroup_ZeroUserID(t *testing.T) {
+	c, db := newGroupsS38Core(t)
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "dev"}).Error)
+	err := c.AddUserToGroup(context.Background(), 1, 0, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+// TestAddUserToGroup_ZeroGroupID verifies a zero groupID is rejected.
+func TestAddUserToGroup_ZeroGroupID(t *testing.T) {
+	c, db := newGroupsS38Core(t)
+	require.NoError(t, db.Create(&models.User{ID: 7, Username: "bob", Email: "bob@example.com"}).Error)
+	err := c.AddUserToGroup(context.Background(), 1, 7, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+// TestAddUserToGroup_CLIActor_ZeroActorID verifies the CLI actor (actorID=0) path
+// bypasses role-check and succeeds when user+group are valid.
+func TestAddUserToGroup_CLIActor_ZeroActorID(t *testing.T) {
+	c, db := newGroupsS38Core(t)
+	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "cli-group"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 20, Username: "cli-user", Email: "cli@example.com"}).Error)
+	err := c.AddUserToGroup(context.Background(), 0, 20, 10)
+	require.NoError(t, err)
+}
+
+// ── RemoveUserFromGroup validation ────────────────────────────────────────────
+
+// TestRemoveUserFromGroup_ZeroUserID verifies a zero userID is rejected.
+func TestRemoveUserFromGroup_ZeroUserID(t *testing.T) {
+	c, db := newGroupsS38Core(t)
+	require.NoError(t, db.Create(&models.Group{ID: 15, Name: "ops"}).Error)
+	err := c.RemoveUserFromGroup(context.Background(), 1, 0, 15)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+// TestRemoveUserFromGroup_ZeroGroupID verifies a zero groupID is rejected.
+func TestRemoveUserFromGroup_ZeroGroupID(t *testing.T) {
+	c, db := newGroupsS38Core(t)
+	require.NoError(t, db.Create(&models.User{ID: 25, Username: "alice", Email: "alice@example.com"}).Error)
+	err := c.RemoveUserFromGroup(context.Background(), 1, 25, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+// ── GetGroupMembers ───────────────────────────────────────────────────────────
+
+// TestGetGroupMembers_ZeroGroupID verifies a zero groupID returns a validation error.
+func TestGetGroupMembers_ZeroGroupID(t *testing.T) {
+	c, _ := newGroupsS38Core(t)
+	_, err := c.GetGroupMembers(context.Background(), 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+// TestGetGroupMembers_HappyPath verifies GetGroupMembers returns the correct members.
+func TestGetGroupMembers_HappyPath(t *testing.T) {
+	c, db := newGroupsS38Core(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Group{ID: 30, Name: "platform"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 40, Username: "member1", Email: "m1@example.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 41, Username: "member2", Email: "m2@example.com"}).Error)
+
+	// Add members directly via store (bypasses guard that checks last admin).
+	require.NoError(t, c.AddUserToGroup(ctx, 0, 40, 30))
+	require.NoError(t, c.AddUserToGroup(ctx, 0, 41, 30))
+
+	members, err := c.GetGroupMembers(ctx, 30)
+	require.NoError(t, err)
+	require.Len(t, members, 2)
+	ids := make([]uint, 0, 2)
+	for _, m := range members {
+		ids = append(ids, m.ID)
+	}
+	assert.ElementsMatch(t, []uint{40, 41}, ids)
+}
+
+// ── GetGroup ──────────────────────────────────────────────────────────────────
+
+// TestGetGroup_ZeroID verifies a zero ID returns a validation error.
+func TestGetGroup_ZeroID(t *testing.T) {
+	c, _ := newGroupsS38Core(t)
+	_, err := c.GetGroup(context.Background(), 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+// ── ListGroups ────────────────────────────────────────────────────────────────
+
+// TestListGroups_ReturnsAll verifies that ListGroups returns all created groups.
+func TestListGroups_ReturnsAll(t *testing.T) {
+	c, db := newGroupsS38Core(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Group{ID: 50, Name: "alpha"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 51, Name: "beta"}).Error)
+
+	groups, err := c.ListGroups(ctx)
+	require.NoError(t, err)
+	assert.Len(t, groups, 2)
+}

--- a/internal/core/groups_membership_s38_test.go
+++ b/internal/core/groups_membership_s38_test.go
@@ -45,7 +45,7 @@ func newGroupsS38Core(t *testing.T) (*KeyorixCore, *gorm.DB) {
 func TestAddUserToGroup_ZeroUserID(t *testing.T) {
 	c, db := newGroupsS38Core(t)
 	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "dev"}).Error)
-	err := c.AddUserToGroup(context.Background(), 1, 0, 5)
+	err := c.AddUserToGroupGlobal(context.Background(), 1, 0, 5)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required")
 }
@@ -54,7 +54,7 @@ func TestAddUserToGroup_ZeroUserID(t *testing.T) {
 func TestAddUserToGroup_ZeroGroupID(t *testing.T) {
 	c, db := newGroupsS38Core(t)
 	require.NoError(t, db.Create(&models.User{ID: 7, Username: "bob", Email: "bob@example.com"}).Error)
-	err := c.AddUserToGroup(context.Background(), 1, 7, 0)
+	err := c.AddUserToGroupGlobal(context.Background(), 1, 7, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required")
 }
@@ -65,7 +65,7 @@ func TestAddUserToGroup_CLIActor_ZeroActorID(t *testing.T) {
 	c, db := newGroupsS38Core(t)
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "cli-group"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 20, Username: "cli-user", Email: "cli@example.com"}).Error)
-	err := c.AddUserToGroup(context.Background(), 0, 20, 10)
+	err := c.AddUserToGroupGlobal(context.Background(), 0, 20, 10)
 	require.NoError(t, err)
 }
 
@@ -75,7 +75,7 @@ func TestAddUserToGroup_CLIActor_ZeroActorID(t *testing.T) {
 func TestRemoveUserFromGroup_ZeroUserID(t *testing.T) {
 	c, db := newGroupsS38Core(t)
 	require.NoError(t, db.Create(&models.Group{ID: 15, Name: "ops"}).Error)
-	err := c.RemoveUserFromGroup(context.Background(), 1, 0, 15)
+	err := c.RemoveUserFromGroupGlobal(context.Background(), 1, 0, 15)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required")
 }
@@ -84,7 +84,7 @@ func TestRemoveUserFromGroup_ZeroUserID(t *testing.T) {
 func TestRemoveUserFromGroup_ZeroGroupID(t *testing.T) {
 	c, db := newGroupsS38Core(t)
 	require.NoError(t, db.Create(&models.User{ID: 25, Username: "alice", Email: "alice@example.com"}).Error)
-	err := c.RemoveUserFromGroup(context.Background(), 1, 25, 0)
+	err := c.RemoveUserFromGroupGlobal(context.Background(), 1, 25, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required")
 }
@@ -109,8 +109,8 @@ func TestGetGroupMembers_HappyPath(t *testing.T) {
 	require.NoError(t, db.Create(&models.User{ID: 41, Username: "member2", Email: "m2@example.com"}).Error)
 
 	// Add members directly via store (bypasses guard that checks last admin).
-	require.NoError(t, c.AddUserToGroup(ctx, 0, 40, 30))
-	require.NoError(t, c.AddUserToGroup(ctx, 0, 41, 30))
+	require.NoError(t, c.AddUserToGroupGlobal(ctx, 0, 40, 30))
+	require.NoError(t, c.AddUserToGroupGlobal(ctx, 0, 41, 30))
 
 	members, err := c.GetGroupMembers(ctx, 30)
 	require.NoError(t, err)

--- a/internal/storage/store/local_secret_acl_test.go
+++ b/internal/storage/store/local_secret_acl_test.go
@@ -1,0 +1,193 @@
+// local_secret_acl_test.go — unit tests for LocalStorage SecretACL persistence.
+//
+// These tests exercise CreateOrUpdateSecretACL, GetSecretACL, ListSecretACLs,
+// and DeleteSecretACL directly at the store layer, independent of the core
+// business-logic wrappers.
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newACLStore returns an isolated LocalStorage backed by an in-memory SQLite
+// database with the SecretACL table migrated and a seed secret inserted.
+func newACLStore(t *testing.T) (*LocalStorage, uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretACL{}))
+
+	// Seed one secret so the store tests don't need a FK violation guard.
+	s := &models.SecretNode{ProjectID: 1, EnvironmentID: 1, Name: "acl-store-secret", IsSecret: true, Status: "active"}
+	require.NoError(t, db.Create(s).Error)
+
+	return NewLocalStorage(db), s.ID
+}
+
+// ── CreateOrUpdateSecretACL ────────────────────────────────────────────────────
+
+// TestLocalACL_Create verifies that a new SecretACL row is inserted correctly.
+func TestLocalACL_Create(t *testing.T) {
+	ls, secretID := newACLStore(t)
+	ctx := context.Background()
+
+	acl := &models.SecretACL{
+		SecretID:    secretID,
+		UserID:      10,
+		Permissions: `["secrets.read"]`,
+		GrantedBy:   1,
+	}
+	require.NoError(t, ls.CreateOrUpdateSecretACL(ctx, acl))
+	assert.NotZero(t, acl.ID, "ID should be populated after insert")
+
+	// Verify it is retrievable.
+	got, err := ls.GetSecretACL(ctx, secretID, 10)
+	require.NoError(t, err)
+	assert.Equal(t, uint(10), got.UserID)
+	assert.Equal(t, `["secrets.read"]`, got.Permissions)
+}
+
+// TestLocalACL_Update verifies that a second call with the same (secret, user) pair
+// updates the existing row rather than inserting a duplicate.
+func TestLocalACL_Update(t *testing.T) {
+	ls, secretID := newACLStore(t)
+	ctx := context.Background()
+
+	acl := &models.SecretACL{
+		SecretID:    secretID,
+		UserID:      20,
+		Permissions: `["secrets.read"]`,
+		GrantedBy:   1,
+	}
+	require.NoError(t, ls.CreateOrUpdateSecretACL(ctx, acl))
+
+	// Second call — update permissions.
+	acl2 := &models.SecretACL{
+		SecretID:    secretID,
+		UserID:      20,
+		Permissions: `["secrets.read","secrets.write"]`,
+		GrantedBy:   1,
+	}
+	require.NoError(t, ls.CreateOrUpdateSecretACL(ctx, acl2))
+
+	// Must still be exactly one row.
+	rows, err := ls.ListSecretACLs(ctx, secretID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, `["secrets.read","secrets.write"]`, rows[0].Permissions)
+}
+
+// ── GetSecretACL ──────────────────────────────────────────────────────────────
+
+// TestLocalACL_GetExisting verifies GetSecretACL returns the correct row.
+func TestLocalACL_GetExisting(t *testing.T) {
+	ls, secretID := newACLStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, ls.CreateOrUpdateSecretACL(ctx, &models.SecretACL{
+		SecretID: secretID, UserID: 30, Permissions: `["secrets.read"]`, GrantedBy: 1,
+	}))
+
+	got, err := ls.GetSecretACL(ctx, secretID, 30)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, uint(30), got.UserID)
+	assert.Equal(t, secretID, got.SecretID)
+}
+
+// TestLocalACL_GetMissing verifies GetSecretACL returns an error for a non-existent record.
+func TestLocalACL_GetMissing(t *testing.T) {
+	ls, secretID := newACLStore(t)
+	ctx := context.Background()
+
+	_, err := ls.GetSecretACL(ctx, secretID, 9999)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// ── ListSecretACLs ────────────────────────────────────────────────────────────
+
+// TestLocalACL_ListReturnsAll verifies ListSecretACLs returns all rows for a secret.
+func TestLocalACL_ListReturnsAll(t *testing.T) {
+	ls, secretID := newACLStore(t)
+	ctx := context.Background()
+
+	for _, uid := range []uint{41, 42, 43} {
+		require.NoError(t, ls.CreateOrUpdateSecretACL(ctx, &models.SecretACL{
+			SecretID: secretID, UserID: uid, Permissions: `["secrets.read"]`, GrantedBy: 1,
+		}))
+	}
+
+	rows, err := ls.ListSecretACLs(ctx, secretID)
+	require.NoError(t, err)
+	assert.Len(t, rows, 3)
+}
+
+// TestLocalACL_ListEmpty verifies ListSecretACLs returns an empty slice when no grants exist.
+func TestLocalACL_ListEmpty(t *testing.T) {
+	ls, secretID := newACLStore(t)
+	ctx := context.Background()
+
+	rows, err := ls.ListSecretACLs(ctx, secretID)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+// TestLocalACL_ListOnlyOwnSecret verifies ListSecretACLs scopes to the requested secret.
+func TestLocalACL_ListOnlyOwnSecret(t *testing.T) {
+	ls, secretID := newACLStore(t)
+	ctx := context.Background()
+
+	// Insert a second secret.
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretACL{}))
+
+	// Grant on secretID; don't grant on secret 9999.
+	require.NoError(t, ls.CreateOrUpdateSecretACL(ctx, &models.SecretACL{
+		SecretID: secretID, UserID: 50, Permissions: `["secrets.read"]`, GrantedBy: 1,
+	}))
+
+	rows, err := ls.ListSecretACLs(ctx, 9999)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "listing for a different secret must return nothing")
+}
+
+// ── DeleteSecretACL ───────────────────────────────────────────────────────────
+
+// TestLocalACL_Delete verifies that DeleteSecretACL removes the row.
+func TestLocalACL_Delete(t *testing.T) {
+	ls, secretID := newACLStore(t)
+	ctx := context.Background()
+
+	acl := &models.SecretACL{
+		SecretID: secretID, UserID: 60, Permissions: `["secrets.read"]`, GrantedBy: 1,
+	}
+	require.NoError(t, ls.CreateOrUpdateSecretACL(ctx, acl))
+	require.NotZero(t, acl.ID)
+
+	require.NoError(t, ls.DeleteSecretACL(ctx, acl.ID))
+
+	// Confirm deletion.
+	_, err := ls.GetSecretACL(ctx, secretID, 60)
+	require.Error(t, err, "row must be absent after deletion")
+}
+
+// TestLocalACL_DeleteMissing verifies that deleting a non-existent row returns an error.
+func TestLocalACL_DeleteMissing(t *testing.T) {
+	ls, _ := newACLStore(t)
+	ctx := context.Background()
+
+	err := ls.DeleteSecretACL(ctx, 9999)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/server/http/handlers/secret_acl_handler_test.go
+++ b/server/http/handlers/secret_acl_handler_test.go
@@ -296,6 +296,149 @@ func TestRevokeSecretACL_NotFound(t *testing.T) {
 	assert.NotEqual(t, http.StatusOK, w.Code)
 }
 
+// TestGrantSecretACL_EmptyPermissions returns 400 when permissions slice is empty.
+func TestGrantSecretACL_EmptyPermissions(t *testing.T) {
+	t.Parallel()
+	cs, db := freshCoreACL(t)
+	sid := mkACLHandlerSecret(t, db, "grant-emptyperms")
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 55, "permissions": []string{}})
+	req := withUserCtxACL(withChiParam(
+		httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/secrets/%d/acl", sid), bytes.NewReader(body)),
+		"id", fmt.Sprintf("%d", sid),
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.GrantSecretACL(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "permissions")
+}
+
+// TestGrantSecretACL_InvalidPermission returns an error when an unrecognised permission is used.
+func TestGrantSecretACL_InvalidPermission(t *testing.T) {
+	t.Parallel()
+	cs, db := freshCoreACL(t)
+	sid := mkACLHandlerSecret(t, db, "grant-invalidperm")
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 66, "permissions": []string{"secrets.admin"}})
+	req := withUserCtxACL(withChiParam(
+		httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/secrets/%d/acl", sid), bytes.NewReader(body)),
+		"id", fmt.Sprintf("%d", sid),
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.GrantSecretACL(w, req)
+	// Core rejects invalid permissions — expect 4xx.
+	assert.NotEqual(t, http.StatusOK, w.Code)
+}
+
+// TestRevokeSecretACL_HappyPath is a standalone targeted test for the revoke success branch.
+func TestRevokeSecretACL_HappyPath(t *testing.T) {
+	t.Parallel()
+	cs, db := freshCoreACL(t)
+	sid := mkACLHandlerSecret(t, db, "revoke-happy")
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+
+	// Grant first.
+	grantBody, _ := json.Marshal(map[string]interface{}{"user_id": 99, "permissions": []string{"secrets.read"}})
+	req := withUserCtxACL(withChiParam(
+		httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/secrets/%d/acl", sid), bytes.NewReader(grantBody)),
+		"id", fmt.Sprintf("%d", sid),
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.GrantSecretACL(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Fetch the ACL ID.
+	req2 := withUserCtxACL(withChiParam(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/secrets/%d/acl", sid), nil),
+		"id", fmt.Sprintf("%d", sid),
+	))
+	w2 := httptest.NewRecorder()
+	h.ListSecretACLs(w2, req2)
+	require.Equal(t, http.StatusOK, w2.Code)
+	var listResp struct {
+		Data []struct {
+			ID uint `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &listResp))
+	require.Len(t, listResp.Data, 1)
+	aclID := listResp.Data[0].ID
+
+	// Revoke.
+	req3 := withUserCtxACL(withChiParam2ACL(
+		httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/secrets/%d/acl/%d", sid, aclID), nil),
+		"id", fmt.Sprintf("%d", sid), "aclId", fmt.Sprintf("%d", aclID),
+	))
+	w3 := httptest.NewRecorder()
+	h.RevokeSecretACL(w3, req3)
+	assert.Equal(t, http.StatusOK, w3.Code)
+	assert.Contains(t, w3.Body.String(), "revoked")
+}
+
+// TestListSecretACLs_WithACLs returns 200 with ACL data when grants exist.
+func TestListSecretACLs_WithACLs(t *testing.T) {
+	t.Parallel()
+	cs, db := freshCoreACL(t)
+	sid := mkACLHandlerSecret(t, db, "list-with-acls")
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+
+	// Grant first.
+	grantBody, _ := json.Marshal(map[string]interface{}{"user_id": 123, "permissions": []string{"secrets.read"}})
+	req := withUserCtxACL(withChiParam(
+		httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/secrets/%d/acl", sid), bytes.NewReader(grantBody)),
+		"id", fmt.Sprintf("%d", sid),
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.GrantSecretACL(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// List.
+	req2 := withUserCtxACL(withChiParam(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/secrets/%d/acl", sid), nil),
+		"id", fmt.Sprintf("%d", sid),
+	))
+	w2 := httptest.NewRecorder()
+	h.ListSecretACLs(w2, req2)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	body := w2.Body.String()
+	assert.Contains(t, body, "success")
+	assert.Contains(t, body, "123")
+}
+
+// TestAclErrorStatus_Forbidden verifies the 403 branch of aclErrorStatus.
+func TestAclErrorStatus_Forbidden(t *testing.T) {
+	code := aclErrorStatus("not authorized to perform this action")
+	assert.Equal(t, http.StatusForbidden, code)
+}
+
+// TestAclErrorStatus_NotFound verifies the 404 branch of aclErrorStatus.
+func TestAclErrorStatus_NotFound(t *testing.T) {
+	code := aclErrorStatus("record not found")
+	assert.Equal(t, http.StatusNotFound, code)
+}
+
+// TestAclErrorStatus_BadRequest verifies the 400 branch of aclErrorStatus.
+func TestAclErrorStatus_BadRequest(t *testing.T) {
+	code := aclErrorStatus("invalid permission value provided")
+	assert.Equal(t, http.StatusBadRequest, code)
+}
+
+// TestAclErrorStatus_InternalServerError verifies the 500 default branch of aclErrorStatus.
+func TestAclErrorStatus_InternalServerError(t *testing.T) {
+	code := aclErrorStatus("database connection failed")
+	assert.Equal(t, http.StatusInternalServerError, code)
+}
+
 // TestGrantRevokeACL_RoundTrip verifies the full grant → list → revoke → list cycle.
 func TestGrantRevokeACL_RoundTrip(t *testing.T) {
 	t.Parallel()

--- a/server/http/handlers/secrets_list_s38_test.go
+++ b/server/http/handlers/secrets_list_s38_test.go
@@ -1,0 +1,189 @@
+// secrets_list_s38_test.go — coverage top-up for secrets_list.go.
+//
+// Covers ListSecrets branches not yet exercised: 401 unauthorized, pagination
+// parameter parsing, page-size clamping, the machine-identity dispatch path,
+// and the sorting/filter query parameters.
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var s38ListCounter atomic.Uint64
+
+// freshListFixtureS38 returns a SecretHandler backed by an isolated in-memory
+// SQLite DB with a project, environment, and one active secret.
+func freshListFixtureS38(t *testing.T) (*SecretHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := s38ListCounter.Add(1)
+	dsn := fmt.Sprintf("file:kx_list_s38_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{},
+		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SecretNode{},
+		&models.AuditEvent{}, &models.AnomalyAlert{},
+		&models.ShareRecord{}, &models.SecretACL{},
+		&models.SecretVersion{},
+	))
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj-list"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env-list"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: "list-target", IsSecret: true, Status: "active",
+	}).Error)
+	// Seed user 1 so ListSecretsWithSharingInfo can resolve the listing user.
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "list-user", Email: "list@example.com", AccountState: "active"}).Error)
+
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	return h, db
+}
+
+// userCtxS38 returns a UserContext for a regular (non-machine) user.
+func userCtxS38(userID uint) *middleware.UserContext {
+	return &middleware.UserContext{
+		UserID:    userID,
+		Username:  fmt.Sprintf("user-%d", userID),
+		ActorType: core.ActorTypeUser,
+	}
+}
+
+func withUserCtxS38(r *http.Request, userID uint) *http.Request {
+	uc := userCtxS38(userID)
+	return r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), uc))
+}
+
+// TestListSecrets_NoAuth_S38 verifies 401 when no user context is present.
+func TestListSecrets_NoAuth_S38(t *testing.T) {
+	t.Parallel()
+	h, _ := freshListFixtureS38(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestListSecrets_HappyPath_S38 verifies 200 with user context set.
+func TestListSecrets_HappyPath_S38(t *testing.T) {
+	t.Parallel()
+	h, _ := freshListFixtureS38(t)
+	req := withUserCtxS38(httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil), 1)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "success")
+}
+
+// TestListSecrets_PageParam_S38 verifies pagination query params are accepted.
+func TestListSecrets_PageParam_S38(t *testing.T) {
+	t.Parallel()
+	h, _ := freshListFixtureS38(t)
+	req := withUserCtxS38(
+		httptest.NewRequest(http.MethodGet, "/api/v1/secrets?page=2&page_size=5", nil), 1)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestListSecrets_PageSizeAltParam_S38 verifies the legacy pageSize query param is accepted.
+func TestListSecrets_PageSizeAltParam_S38(t *testing.T) {
+	t.Parallel()
+	h, _ := freshListFixtureS38(t)
+	req := withUserCtxS38(
+		httptest.NewRequest(http.MethodGet, "/api/v1/secrets?pageSize=10", nil), 1)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestListSecrets_LargePageClamped_S38 verifies that a very large page number is clamped.
+func TestListSecrets_LargePageClamped_S38(t *testing.T) {
+	t.Parallel()
+	h, _ := freshListFixtureS38(t)
+	req := withUserCtxS38(
+		httptest.NewRequest(http.MethodGet, "/api/v1/secrets?page=99999999", nil), 1)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	// Must not error out even with a huge page; response should be 200 (empty result).
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestListSecrets_FilterParams_S38 exercises all optional query parameters in one request.
+func TestListSecrets_FilterParams_S38(t *testing.T) {
+	t.Parallel()
+	h, _ := freshListFixtureS38(t)
+	req := withUserCtxS38(
+		httptest.NewRequest(http.MethodGet,
+			"/api/v1/secrets?search=foo&include_deleted=true&show_owned_only=true"+
+				"&show_shared_only=true&permission=secrets.read&type=static"+
+				"&classification=internal&tag=env:prod&tag=team:platform"+
+				"&project_id=1&environment_id=1&sort_by=name&sort_order=asc",
+			nil,
+		), 1)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestListSecrets_ExpiresBeforeParam_S38 exercises the expires_before RFC3339 filter.
+func TestListSecrets_ExpiresBeforeParam_S38(t *testing.T) {
+	t.Parallel()
+	h, _ := freshListFixtureS38(t)
+	req := withUserCtxS38(
+		httptest.NewRequest(http.MethodGet,
+			"/api/v1/secrets?expires_before=2030-01-01T00:00:00Z", nil), 1)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestListSecrets_MachineIdentityPath_S38 exercises the machine-identity dispatch branch
+// (ListSecretsInScope rather than ListSecretsWithSharingInfo).
+func TestListSecrets_MachineIdentityPath_S38(t *testing.T) {
+	t.Parallel()
+	h, _ := freshListFixtureS38(t)
+
+	machineID := uint(42)
+	uc := &middleware.UserContext{
+		UserID:            0,
+		ActorType:         core.ActorTypeMachine,
+		MachineIdentityID: &machineID,
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil)
+	req = req.WithContext(context.WithValue(req.Context(), middleware.GetUserContextKey(), uc))
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	// Machine identity path uses ListSecretsInScope — must return 200.
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestListSecrets_TagCommaList_S38 exercises the comma-separated tag syntax.
+func TestListSecrets_TagCommaList_S38(t *testing.T) {
+	t.Parallel()
+	h, _ := freshListFixtureS38(t)
+	req := withUserCtxS38(
+		httptest.NewRequest(http.MethodGet, "/api/v1/secrets?tag=a,b,c", nil), 1)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/server/http/handlers/secrets_list_s38_test.go
+++ b/server/http/handlers/secrets_list_s38_test.go
@@ -129,6 +129,8 @@ func TestListSecrets_LargePageClamped_S38(t *testing.T) {
 }
 
 // TestListSecrets_FilterParams_S38 exercises all optional query parameters in one request.
+// Note: project_id/environment_id are omitted here to avoid the scope-auth check
+// (user 1 has no role grants); those URL params are covered by TestListSecrets_ScopeFilter_403_S38.
 func TestListSecrets_FilterParams_S38(t *testing.T) {
 	t.Parallel()
 	h, _ := freshListFixtureS38(t)
@@ -137,12 +139,25 @@ func TestListSecrets_FilterParams_S38(t *testing.T) {
 			"/api/v1/secrets?search=foo&include_deleted=true&show_owned_only=true"+
 				"&show_shared_only=true&permission=secrets.read&type=static"+
 				"&classification=internal&tag=env:prod&tag=team:platform"+
-				"&project_id=1&environment_id=1&sort_by=name&sort_order=asc",
+				"&sort_by=name&sort_order=asc",
 			nil,
 		), 1)
 	w := httptest.NewRecorder()
 	h.ListSecrets(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestListSecrets_ScopeFilter_403_S38 verifies that a scope filter with an unauthorized
+// user returns 403 (exercises the project_id/environment_id parse + scope-auth check).
+func TestListSecrets_ScopeFilter_403_S38(t *testing.T) {
+	t.Parallel()
+	h, _ := freshListFixtureS38(t)
+	req := withUserCtxS38(
+		httptest.NewRequest(http.MethodGet,
+			"/api/v1/secrets?project_id=1&environment_id=1", nil), 1)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 // TestListSecrets_ExpiresBeforeParam_S38 exercises the expires_before RFC3339 filter.


### PR DESCRIPTION
## Summary

- Add 9 tests for `ListSecrets` handler branches (401, machine-identity path, pagination clamping, all filter query params, tag comma-split, `expires_before`)
- Add 9 tests for `local_secret_acl.go` store layer: create, upsert update, get hit/miss, list (all/empty/scope-isolation), delete success/not-found
- Add 9 tests for `groups.go` membership validation: zero-ID branches in `AddUserToGroup`, `RemoveUserFromGroup`, `GetGroupMembers`, `GetGroup`, plus `GetGroupMembers` happy path and `ListGroups`
- Add 8 tests to the existing `secret_acl_handler_test.go`: empty-permissions 400, invalid-permission rejection, standalone `RevokeSecretACL` happy-path, `ListSecretACLs` with data present, and all four `aclErrorStatus` branches (403/404/400/500)

Total: **35 new tests**, all green.

## Test plan

- [x] `go test ./server/http/handlers/... ./internal/core/... ./internal/storage/store/... -count=1` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)