### PR TITLE
feat(folders): secret folder management — HTTP API, core, and CLI

### DIFF
--- a/internal/cli/secret/folder.go
+++ b/internal/cli/secret/folder.go
@@ -1,0 +1,216 @@
+// folder.go — CLI subcommand: keyorix secret folder create/list/delete
+package secret
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/spf13/cobra"
+)
+
+// folderCmd is the root subcommand: keyorix secret folder
+var folderCmd = &cobra.Command{
+	Use:   "folder",
+	Short: "Manage secret folders",
+	Long:  "Commands for creating, listing, and deleting secret folder nodes.",
+}
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+var (
+	folderCreateName    string
+	folderCreateProject uint
+	folderCreateEnvID   uint
+	folderCreateParent  uint // 0 = root
+)
+
+var folderCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a folder",
+	RunE:  runFolderCreate,
+}
+
+func init() {
+	folderCreateCmd.Flags().StringVar(&folderCreateName, "name", "", "Folder name (required)")
+	folderCreateCmd.Flags().UintVar(&folderCreateProject, "project", 1, "Project ID")
+	folderCreateCmd.Flags().UintVar(&folderCreateEnvID, "environment", 1, "Environment ID")
+	folderCreateCmd.Flags().UintVar(&folderCreateParent, "parent", 0, "Parent folder ID (0 = root)")
+
+	folderCmd.AddCommand(folderCreateCmd)
+}
+
+func runFolderCreate(cmd *cobra.Command, args []string) error {
+	if folderCreateName == "" {
+		return fmt.Errorf("folder name is required (use --name)")
+	}
+
+	ctx := context.Background()
+
+	body := map[string]interface{}{
+		"name":           folderCreateName,
+		"project_id":     folderCreateProject,
+		"environment_id": folderCreateEnvID,
+	}
+	if folderCreateParent != 0 {
+		body["parent_id"] = folderCreateParent
+	}
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		var folder models.SecretNode
+		if err := rc.Post(ctx, "/api/v1/folders", body, &folder); err != nil {
+			return fmt.Errorf("failed to create folder: %w", err)
+		}
+		printFolder(&folder)
+		return nil
+	}
+
+	// Embedded mode.
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	var parentID *uint
+	if folderCreateParent != 0 {
+		pid := folderCreateParent
+		parentID = &pid
+	}
+	folder, err := service.CreateFolder(ctx, 0, folderCreateName, folderCreateProject, folderCreateEnvID, parentID)
+	if err != nil {
+		return fmt.Errorf("failed to create folder: %w", err)
+	}
+	printFolder(folder)
+	return nil
+}
+
+func printFolder(f *models.SecretNode) {
+	fmt.Printf("Folder created successfully!\n")
+	fmt.Printf("ID:          %d\n", f.ID)
+	fmt.Printf("Name:        %s\n", f.Name)
+	fmt.Printf("Project:     %d\n", f.ProjectID)
+	fmt.Printf("Environment: %d\n", f.EnvironmentID)
+	if f.ParentID != nil {
+		fmt.Printf("Parent ID:   %d\n", *f.ParentID)
+	}
+	fmt.Printf("Created:     %s\n", f.CreatedAt.Format(time.RFC3339))
+}
+
+// ── List ─────────────────────────────────────────────────────────────────────
+
+var (
+	folderListProject uint
+	folderListParent  uint // 0 = all
+)
+
+var folderListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List folders",
+	RunE:  runFolderList,
+}
+
+func init() {
+	folderListCmd.Flags().UintVar(&folderListProject, "project", 0, "Filter by project ID")
+	folderListCmd.Flags().UintVar(&folderListParent, "parent", 0, "Filter by parent folder ID (0 = no filter)")
+
+	folderCmd.AddCommand(folderListCmd)
+}
+
+func runFolderList(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		path := "/api/v1/folders?page_size=100"
+		if folderListProject != 0 {
+			path += fmt.Sprintf("&project_id=%d", folderListProject)
+		}
+		if folderListParent != 0 {
+			path += fmt.Sprintf("&parent_id=%d", folderListParent)
+		}
+
+		var folders []*models.SecretNode
+		if err := rc.Get(ctx, path, &folders); err != nil {
+			return fmt.Errorf("failed to list folders: %w", err)
+		}
+		printFolderList(folders)
+		return nil
+	}
+
+	// Embedded mode.
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	var parentID *uint
+	if folderListParent != 0 {
+		pid := folderListParent
+		parentID = &pid
+	}
+	folders, _, err := service.ListFolders(ctx, folderListProject, parentID, 1, 100)
+	if err != nil {
+		return fmt.Errorf("failed to list folders: %w", err)
+	}
+	printFolderList(folders)
+	return nil
+}
+
+func printFolderList(folders []*models.SecretNode) {
+	if len(folders) == 0 {
+		fmt.Println("No folders found.")
+		return
+	}
+	fmt.Printf("%-6s  %-30s  %-10s  %-12s  %-10s\n", "ID", "Name", "Project", "Environment", "Parent")
+	fmt.Printf("%-6s  %-30s  %-10s  %-12s  %-10s\n", "------", "------------------------------", "----------", "------------", "----------")
+	for _, f := range folders {
+		parentStr := "-"
+		if f.ParentID != nil {
+			parentStr = fmt.Sprintf("%d", *f.ParentID)
+		}
+		fmt.Printf("%-6d  %-30s  %-10d  %-12d  %-10s\n", f.ID, f.Name, f.ProjectID, f.EnvironmentID, parentStr)
+	}
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+var folderDeleteID uint
+
+var folderDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a folder",
+	RunE:  runFolderDelete,
+}
+
+func init() {
+	folderDeleteCmd.Flags().UintVar(&folderDeleteID, "id", 0, "Folder ID to delete (required)")
+
+	folderCmd.AddCommand(folderDeleteCmd)
+}
+
+func runFolderDelete(cmd *cobra.Command, args []string) error {
+	if folderDeleteID == 0 {
+		return fmt.Errorf("folder ID is required (use --id)")
+	}
+
+	ctx := context.Background()
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		path := fmt.Sprintf("/api/v1/folders/%d", folderDeleteID)
+		if err := rc.Delete(ctx, path); err != nil {
+			return fmt.Errorf("failed to delete folder: %w", err)
+		}
+		fmt.Printf("Folder %d deleted.\n", folderDeleteID)
+		return nil
+	}
+
+	// Embedded mode: use the core service directly.
+	service, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	if err := service.DeleteSecret(ctx, folderDeleteID); err != nil {
+		return fmt.Errorf("failed to delete folder: %w", err)
+	}
+	fmt.Printf("Folder %d deleted.\n", folderDeleteID)
+	return nil
+}

--- a/internal/cli/secret/secret.go
+++ b/internal/cli/secret/secret.go
@@ -20,4 +20,5 @@ func init() {
 	SecretCmd.AddCommand(versionsCmd)
 	SecretCmd.AddCommand(importCmd)
 	SecretCmd.AddCommand(exportCmd)
+	SecretCmd.AddCommand(folderCmd)
 }

--- a/internal/core/folder_test.go
+++ b/internal/core/folder_test.go
@@ -1,0 +1,168 @@
+// folder_test.go — tests for CreateFolder, ListFolders in core/secrets.go.
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var folderCoreDBCounter atomic.Int64
+
+func freshFolderCoreDB(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := folderCoreDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxcore_folder_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{},
+		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SecretNode{},
+		&models.AuditEvent{}, &models.SecretVersion{}, &models.SecretAccessLog{},
+		&models.ShareRecord{},
+	))
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "test-proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 5, ProjectID: 1, Name: "test-env"}).Error)
+
+	return NewKeyorixCore(store.NewLocalStorage(db)), db
+}
+
+// TestCreateFolder_HappyPath verifies a root folder is created with IsSecret=false.
+func TestCreateFolder_HappyPath(t *testing.T) {
+	cs, _ := freshFolderCoreDB(t)
+
+	folder, err := cs.CreateFolder(context.Background(), 1, "my-folder", 1, 5, nil)
+	require.NoError(t, err)
+	require.NotNil(t, folder)
+
+	assert.Equal(t, "my-folder", folder.Name)
+	assert.False(t, folder.IsSecret)
+	assert.Equal(t, uint(1), folder.ProjectID)
+	assert.Equal(t, uint(5), folder.EnvironmentID)
+	assert.Nil(t, folder.ParentID)
+	assert.Equal(t, "folder", folder.Type)
+}
+
+// TestCreateFolder_EmptyName ensures an empty name is rejected.
+func TestCreateFolder_EmptyName(t *testing.T) {
+	cs, _ := freshFolderCoreDB(t)
+
+	_, err := cs.CreateFolder(context.Background(), 1, "  ", 1, 5, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "folder name is required")
+}
+
+// TestCreateFolder_MissingProjectID ensures zero projectID is rejected.
+func TestCreateFolder_MissingProjectID(t *testing.T) {
+	cs, _ := freshFolderCoreDB(t)
+
+	_, err := cs.CreateFolder(context.Background(), 1, "folder", 0, 5, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project_id is required")
+}
+
+// TestCreateFolder_MissingEnvID ensures zero environmentID is rejected.
+func TestCreateFolder_MissingEnvID(t *testing.T) {
+	cs, _ := freshFolderCoreDB(t)
+
+	_, err := cs.CreateFolder(context.Background(), 1, "folder", 1, 0, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment_id is required")
+}
+
+// TestCreateFolder_InvalidParent verifies that a non-existent parent is rejected.
+func TestCreateFolder_InvalidParent(t *testing.T) {
+	cs, _ := freshFolderCoreDB(t)
+
+	nonExistent := uint(999)
+	_, err := cs.CreateFolder(context.Background(), 1, "child", 1, 5, &nonExistent)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parent folder 999 not found")
+}
+
+// TestCreateFolder_ParentMustBeFolder verifies that a secret node cannot be used as a parent.
+func TestCreateFolder_ParentMustBeFolder(t *testing.T) {
+	cs, _ := freshFolderCoreDB(t)
+
+	// Create a real secret (IsSecret=true).
+	secret, err := cs.CreateSecret(context.Background(), &CreateSecretRequest{
+		Name: "secret-node", Value: []byte("val"), ProjectID: 1, EnvironmentID: 5,
+		Type: "generic", CreatedBy: "alice", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	_, err = cs.CreateFolder(context.Background(), 1, "child", 1, 5, &secret.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is a secret, not a folder")
+}
+
+// TestCreateFolder_NestedFolder verifies that a folder can be nested under another folder.
+func TestCreateFolder_NestedFolder(t *testing.T) {
+	cs, _ := freshFolderCoreDB(t)
+
+	parent, err := cs.CreateFolder(context.Background(), 1, "parent", 1, 5, nil)
+	require.NoError(t, err)
+
+	child, err := cs.CreateFolder(context.Background(), 1, "child", 1, 5, &parent.ID)
+	require.NoError(t, err)
+	require.NotNil(t, child.ParentID)
+	assert.Equal(t, parent.ID, *child.ParentID)
+}
+
+// TestListFolders_FiltersByIsSecret verifies that only folder nodes are returned.
+func TestListFolders_FiltersByIsSecret(t *testing.T) {
+	cs, _ := freshFolderCoreDB(t)
+
+	// Create a folder and a real secret.
+	_, err := cs.CreateFolder(context.Background(), 1, "f1", 1, 5, nil)
+	require.NoError(t, err)
+	_, err = cs.CreateSecret(context.Background(), &CreateSecretRequest{
+		Name: "real-secret", Value: []byte("v"), ProjectID: 1, EnvironmentID: 5,
+		Type: "generic", CreatedBy: "alice", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	folders, total, err := cs.ListFolders(context.Background(), 1, nil, 1, 100)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, folders, 1)
+	assert.Equal(t, "f1", folders[0].Name)
+	assert.False(t, folders[0].IsSecret)
+}
+
+// TestListFolders_ParentFilter verifies that parent_id filtering works.
+func TestListFolders_ParentFilter(t *testing.T) {
+	cs, _ := freshFolderCoreDB(t)
+
+	parent, err := cs.CreateFolder(context.Background(), 1, "parent", 1, 5, nil)
+	require.NoError(t, err)
+	_, err = cs.CreateFolder(context.Background(), 1, "child1", 1, 5, &parent.ID)
+	require.NoError(t, err)
+	_, err = cs.CreateFolder(context.Background(), 1, "child2", 1, 5, &parent.ID)
+	require.NoError(t, err)
+	// Root-level sibling (no parent).
+	_, err = cs.CreateFolder(context.Background(), 1, "sibling", 1, 5, nil)
+	require.NoError(t, err)
+
+	// Filter by parent ID — should return only the two children.
+	folders, total, err := cs.ListFolders(context.Background(), 1, &parent.ID, 1, 100)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), total)
+	assert.Len(t, folders, 2)
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -430,3 +430,74 @@ func (c *KeyorixCore) ListSecrets(ctx context.Context, filter *storage.SecretFil
 	}
 	return secrets, total, nil
 }
+
+// CreateFolder creates a SecretNode with IsSecret=false (a folder container).
+// name must be non-empty. If parentID is provided the referenced node must
+// exist and must itself be a folder (IsSecret=false).
+func (c *KeyorixCore) CreateFolder(
+	ctx context.Context,
+	actorID uint,
+	name string,
+	projectID, envID uint,
+	parentID *uint,
+) (*models.SecretNode, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("%s: folder name is required", i18n.T("ErrorValidation", nil))
+	}
+	if projectID == 0 {
+		return nil, fmt.Errorf("%s: project_id is required", i18n.T("ErrorValidation", nil))
+	}
+	if envID == 0 {
+		return nil, fmt.Errorf("%s: environment_id is required", i18n.T("ErrorValidation", nil))
+	}
+
+	// Validate that the parent exists and is itself a folder node.
+	if parentID != nil {
+		parent, err := c.storage.GetSecret(ctx, *parentID)
+		if err != nil {
+			return nil, fmt.Errorf("parent folder %d not found: %w", *parentID, err)
+		}
+		if parent.IsSecret {
+			return nil, fmt.Errorf("%s: parent node %d is a secret, not a folder", i18n.T("ErrorValidation", nil), *parentID)
+		}
+	}
+
+	node := &models.SecretNode{
+		Name:          name,
+		ProjectID:     projectID,
+		EnvironmentID: envID,
+		ParentID:      parentID,
+		IsSecret:      false,
+		Type:          "folder",
+		Status:        "active",
+		CreatedBy:     fmt.Sprintf("%d", actorID),
+		OwnerID:       actorID,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+
+	created, err := c.storage.CreateSecret(ctx, node, "")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return created, nil
+}
+
+// ListFolders returns all folder nodes (IsSecret=false) for a project/environment.
+// If parentID is non-nil, only children of that parent are returned.
+func (c *KeyorixCore) ListFolders(ctx context.Context, projectID uint, parentID *uint, page, pageSize int) ([]*models.SecretNode, int64, error) {
+	isFalse := false
+	filter := &storage.SecretFilter{
+		IsSecret: &isFalse,
+		Page:     page,
+		PageSize: pageSize,
+	}
+	if projectID != 0 {
+		filter.ProjectID = &projectID
+	}
+	if parentID != nil {
+		filter.ParentID = parentID
+	}
+	return c.ListSecrets(ctx, filter)
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1163,6 +1163,13 @@ type SecretFilter struct {
 	// NULL) — the recycle-bin / restore view. Implies reaching past GORM's
 	// soft-delete scope. Takes precedence over IncludeDeleted.
 	DeletedOnly bool
+	// IsSecret, when set, restricts to nodes matching the given value:
+	// true = actual secrets only, false = folder nodes only.
+	// When nil, both secrets and folders are returned.
+	IsSecret *bool
+	// ParentID, when set, restricts to nodes whose parent_id matches.
+	// Use a pointer to 0 (or a sentinel) to match root-level nodes.
+	ParentID *uint
 }
 
 // DriftSecretRow is one secret's drift-relevant projection: which environment it

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -611,6 +611,12 @@ func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretF
 	if filter.CreatedBefore != nil {
 		query = query.Where("secret_nodes.created_at < ?", *filter.CreatedBefore)
 	}
+	if filter.IsSecret != nil {
+		query = query.Where("secret_nodes.is_secret = ?", *filter.IsSecret)
+	}
+	if filter.ParentID != nil {
+		query = query.Where("secret_nodes.parent_id = ?", *filter.ParentID)
+	}
 
 	var total int64
 	if err := query.Count(&total).Error; err != nil {

--- a/server/http/handlers/folders_handler.go
+++ b/server/http/handlers/folders_handler.go
@@ -1,0 +1,203 @@
+// folders_handler.go — FolderHandler: create, list, and delete folder nodes.
+//
+// Routes (under /api/v1/folders):
+//
+//	POST   /              — create a folder (body: {name, project_id, environment_id, parent_id?})
+//	GET    /              — list folders (?project_id=N&parent_id=M)
+//	DELETE /{id}          — soft-delete a folder
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/keyorixhq/keyorix/server/validation"
+)
+
+// FolderHandler handles folder-node HTTP requests.
+type FolderHandler struct {
+	coreService *core.KeyorixCore
+	validator   *validation.Validator
+}
+
+// NewFolderHandler creates a new FolderHandler.
+func NewFolderHandler(coreService *core.KeyorixCore) *FolderHandler {
+	return &FolderHandler{
+		coreService: coreService,
+		validator:   validation.NewValidator(),
+	}
+}
+
+func (h *FolderHandler) sendSuccess(w http.ResponseWriter, data interface{}, message string) {
+	w.Header().Set(hdrContentType, mimeApplicationJSON)
+	w.Header().Set(hdrXContentTypeOptions, "nosniff")
+	if err := json.NewEncoder(w).Encode(SuccessResponse{Success: true, Data: data, Message: message}); err != nil {
+		log.Printf("Error encoding folder JSON response: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+}
+
+func (h *FolderHandler) sendError(w http.ResponseWriter, errorType, message string, statusCode int, details interface{}) {
+	w.Header().Set(hdrContentType, mimeApplicationJSON)
+	w.Header().Set(hdrXContentTypeOptions, "nosniff")
+	w.WriteHeader(statusCode)
+	if err := json.NewEncoder(w).Encode(ErrorResponse{
+		Error:   errorType,
+		Message: message,
+		Code:    statusCode,
+		Details: details,
+	}); err != nil {
+		log.Printf("Error encoding folder JSON error response: %v", err)
+	}
+}
+
+// CreateFolder handles POST /api/v1/folders.
+// Authorization is done in-handler (same pattern as CreateSecret) because the
+// create route carries no path scope — scope comes from the request body.
+func (h *FolderHandler) CreateFolder(w http.ResponseWriter, r *http.Request) {
+	userCtx, ok := mustGetUser(w, r)
+	if !ok {
+		return
+	}
+
+	var reqBody struct {
+		Name          string `json:"name"`
+		ProjectID     uint   `json:"project_id"`
+		EnvironmentID uint   `json:"environment_id"`
+		ParentID      *uint  `json:"parent_id,omitempty"`
+	}
+	if !mustDecodeBody(w, r, &reqBody) {
+		return
+	}
+
+	if reqBody.Name == "" {
+		h.sendError(w, "ValidationError", "name is required", http.StatusBadRequest, nil)
+		return
+	}
+	if reqBody.ProjectID == 0 {
+		h.sendError(w, "ValidationError", "project_id is required", http.StatusBadRequest, nil)
+		return
+	}
+	if reqBody.EnvironmentID == 0 {
+		h.sendError(w, "ValidationError", "environment_id is required", http.StatusBadRequest, nil)
+		return
+	}
+
+	// Authorize at the project/environment scope from the body.
+	scope := core.Scope{ProjectID: reqBody.ProjectID, EnvironmentID: reqBody.EnvironmentID}
+	if allowed, err := h.coreService.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), permSecretsWrite, scope); err != nil || !allowed {
+		h.sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
+		return
+	}
+	// Per-project MFA policy (ADR-037).
+	if middleware.ProjectMFABlocked(r, h.coreService, scope.ProjectID) {
+		middleware.WriteProjectMFARequired(w)
+		return
+	}
+
+	folder, err := h.coreService.CreateFolder(r.Context(), userCtx.UserID, reqBody.Name, reqBody.ProjectID, reqBody.EnvironmentID, reqBody.ParentID)
+	if err != nil {
+		log.Printf("Error creating folder: %v", err)
+		h.sendError(w, "InternalError", "Failed to create folder", http.StatusInternalServerError, nil)
+		return
+	}
+
+	w.Header().Set(hdrContentType, mimeApplicationJSON)
+	w.Header().Set(hdrXContentTypeOptions, "nosniff")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(SuccessResponse{Success: true, Data: folder, Message: "Folder created"}); err != nil {
+		log.Printf("Error encoding created folder: %v", err)
+	}
+}
+
+// ListFolders handles GET /api/v1/folders.
+// Scope is enforced via the RequireScopedPermission middleware using the
+// project_id query parameter (same convention as ListSecrets).
+func (h *FolderHandler) ListFolders(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+
+	var projectID uint
+	if pidStr := r.URL.Query().Get("project_id"); pidStr != "" {
+		v, err := strconv.ParseUint(pidStr, 10, 32)
+		if err != nil {
+			h.sendError(w, "ValidationError", "invalid project_id", http.StatusBadRequest, nil)
+			return
+		}
+		projectID = uint(v)
+	}
+
+	var parentID *uint
+	if pidStr := r.URL.Query().Get("parent_id"); pidStr != "" {
+		v, err := strconv.ParseUint(pidStr, 10, 32)
+		if err != nil {
+			h.sendError(w, "ValidationError", "invalid parent_id", http.StatusBadRequest, nil)
+			return
+		}
+		pid := uint(v)
+		parentID = &pid
+	}
+
+	page := 1
+	pageSize := 20
+	if p, err := strconv.Atoi(r.URL.Query().Get("page")); err == nil && p > 0 {
+		page = p
+	}
+	if ps, err := strconv.Atoi(r.URL.Query().Get("page_size")); err == nil && ps > 0 && ps <= 100 {
+		pageSize = ps
+	}
+
+	folders, total, err := h.coreService.ListFolders(r.Context(), projectID, parentID, page, pageSize)
+	if err != nil {
+		log.Printf("Error listing folders: %v", err)
+		h.sendError(w, "InternalError", "Failed to list folders", http.StatusInternalServerError, nil)
+		return
+	}
+
+	w.Header().Set("X-Total-Count", fmt.Sprintf("%d", total))
+	h.sendSuccess(w, folders, "")
+}
+
+// DeleteFolder handles DELETE /api/v1/folders/{id}.
+// Authorization is performed by the RequireScopedPermission middleware using
+// the folder node's own project/environment scope.
+func (h *FolderHandler) DeleteFolder(w http.ResponseWriter, r *http.Request) {
+	userCtx, ok := mustGetUser(w, r)
+	if !ok {
+		return
+	}
+
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "invalid folder ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	// Verify the node is actually a folder before deleting.
+	node, err := h.coreService.GetSecret(r.Context(), uint(id))
+	if err != nil {
+		h.sendError(w, "NotFound", "Folder not found", http.StatusNotFound, nil)
+		return
+	}
+	if node.IsSecret {
+		h.sendError(w, "ValidationError", "node is a secret, not a folder", http.StatusBadRequest, nil)
+		return
+	}
+
+	if err := h.coreService.DeleteSecretWithPermissionCheck(r.Context(), uint(id), userCtx.UserID); err != nil {
+		log.Printf("Error deleting folder %d: %v", id, err)
+		h.sendError(w, "InternalError", "Failed to delete folder", http.StatusInternalServerError, nil)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/http/handlers/folders_handler_test.go
+++ b/server/http/handlers/folders_handler_test.go
@@ -1,0 +1,240 @@
+// folders_handler_test.go — HTTP handler tests for FolderHandler.
+//
+// Covers:
+//   - CreateFolder: happy path (201)
+//   - CreateFolder: missing name → 400
+//   - CreateFolder: missing project_id → 400
+//   - ListFolders: happy path (200)
+//   - ListFolders: invalid parent_id → 400
+//   - DeleteFolder: happy path (204)
+//   - DeleteFolder: invalid id → 400
+//   - DeleteFolder: deleting a real secret returns 400 (not a folder)
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var folderHandlerDBCounter atomic.Int64
+
+// freshFolderFixture creates an isolated in-memory SQLite DB with all required
+// schema and seeds: user 1 as system_admin, project 1, environment 10.
+// Returns the FolderHandler, core service, and raw DB.
+func freshFolderFixture(t *testing.T) (*FolderHandler, *core.KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := folderHandlerDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxfolder_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{},
+		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SecretNode{},
+		&models.AuditEvent{}, &models.SecretVersion{}, &models.SecretAccessLog{},
+		&models.ShareRecord{},
+	))
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice-folder", AccountState: "active"}).Error)
+	adminRole := &models.Role{Name: "system_admin"}
+	require.NoError(t, db.Create(adminRole).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID}).Error)
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj-folder"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 1, Name: "prod-folder"}).Error)
+
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h := NewFolderHandler(cs)
+	return h, cs, db
+}
+
+// withFolderAdminCtx injects a UserContext for user 1 into the request.
+func withFolderAdminCtx(r *http.Request) *http.Request {
+	uc := &middleware.UserContext{
+		UserID: 1, Username: "alice-folder",
+		ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: true,
+	}
+	return r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), uc))
+}
+
+// ── CreateFolder ─────────────────────────────────────────────────────────────
+
+func TestCreateFolder_HappyPath(t *testing.T) {
+	h, _, _ := freshFolderFixture(t)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":           "configs",
+		"project_id":     1,
+		"environment_id": 10,
+	})
+	r := withFolderAdminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/folders", bytes.NewReader(body)))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateFolder(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	var resp SuccessResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+}
+
+func TestCreateFolder_MissingName(t *testing.T) {
+	h, _, _ := freshFolderFixture(t)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"project_id":     1,
+		"environment_id": 10,
+	})
+	r := withFolderAdminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/folders", bytes.NewReader(body)))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateFolder(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "name is required")
+}
+
+func TestCreateFolder_MissingProjectID(t *testing.T) {
+	h, _, _ := freshFolderFixture(t)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":           "configs",
+		"environment_id": 10,
+	})
+	r := withFolderAdminCtx(httptest.NewRequest(http.MethodPost, "/api/v1/folders", bytes.NewReader(body)))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateFolder(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "project_id is required")
+}
+
+func TestCreateFolder_NoUserContext_401(t *testing.T) {
+	h, _, _ := freshFolderFixture(t)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "configs", "project_id": 1, "environment_id": 10,
+	})
+	// No user context injected.
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/folders", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateFolder(w, r)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// ── ListFolders ──────────────────────────────────────────────────────────────
+
+func TestListFolders_HappyPath(t *testing.T) {
+	h, cs, _ := freshFolderFixture(t)
+
+	// Create a couple of folders first.
+	_, err := cs.CreateFolder(context.Background(), 1, "alpha", 1, 10, nil)
+	require.NoError(t, err)
+	_, err = cs.CreateFolder(context.Background(), 1, "beta", 1, 10, nil)
+	require.NoError(t, err)
+
+	r := withFolderAdminCtx(httptest.NewRequest(http.MethodGet, "/api/v1/folders?project_id=1", nil))
+	w := httptest.NewRecorder()
+	h.ListFolders(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp SuccessResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+}
+
+func TestListFolders_InvalidParentID(t *testing.T) {
+	h, _, _ := freshFolderFixture(t)
+
+	r := withFolderAdminCtx(httptest.NewRequest(http.MethodGet, "/api/v1/folders?parent_id=notanumber", nil))
+	w := httptest.NewRecorder()
+	h.ListFolders(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestListFolders_NoUserContext_401(t *testing.T) {
+	h, _, _ := freshFolderFixture(t)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/folders", nil)
+	w := httptest.NewRecorder()
+	h.ListFolders(w, r)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// ── DeleteFolder ─────────────────────────────────────────────────────────────
+
+func TestDeleteFolder_HappyPath(t *testing.T) {
+	h, cs, _ := freshFolderFixture(t)
+
+	folder, err := cs.CreateFolder(context.Background(), 1, "to-delete", 1, 10, nil)
+	require.NoError(t, err)
+
+	r := withFolderAdminCtx(withChiParam(
+		httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/folders/%d", folder.ID), nil),
+		"id", fmt.Sprintf("%d", folder.ID),
+	))
+	w := httptest.NewRecorder()
+	h.DeleteFolder(w, r)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestDeleteFolder_InvalidID(t *testing.T) {
+	h, _, _ := freshFolderFixture(t)
+
+	r := withFolderAdminCtx(withChiParam(
+		httptest.NewRequest(http.MethodDelete, "/api/v1/folders/notanumber", nil),
+		"id", "notanumber",
+	))
+	w := httptest.NewRecorder()
+	h.DeleteFolder(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDeleteFolder_IsSecret_Returns400(t *testing.T) {
+	h, cs, _ := freshFolderFixture(t)
+
+	// Create a real secret (IsSecret=true) and try to delete it as a folder.
+	secret, err := cs.CreateSecret(context.Background(), &core.CreateSecretRequest{
+		Name: "real-secret", Value: []byte("val"), ProjectID: 1, EnvironmentID: 10,
+		Type: "generic", CreatedBy: "alice-folder", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	r := withFolderAdminCtx(withChiParam(
+		httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/folders/%d", secret.ID), nil),
+		"id", fmt.Sprintf("%d", secret.ID),
+	))
+	w := httptest.NewRecorder()
+	h.DeleteFolder(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "not a folder")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -138,6 +138,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	notificationHandler := handlers.NewNotificationHandler(coreService)
 	connectHandler := handlers.NewConnectHandler(coreService)
 	adminJobsHandler := handlers.NewAdminJobsHandler(coreService)
+	folderHandler := handlers.NewFolderHandler(coreService)
 
 	// Auth endpoints (no authentication middleware). Several of these mint or hand back a
 	// session token (login, refresh, MFA/WebAuthn verify, the SSO/SAML callbacks) or
@@ -576,6 +577,16 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 
 		// Shared secrets endpoint (the caller's own shares)
 		r.With(customMiddleware.RequirePermission(permSecretsRead)).Get("/shared-secrets", shareHandler.ListSharedSecrets)
+
+		// Folder endpoints. Create authorizes in-handler (scope from the body).
+		// List scopes via the project_id query param. Delete resolves scope from
+		// the folder node's own project/environment.
+		folderScope := customMiddleware.ScopeFromSecretParam("id")
+		r.Route("/folders", func(r chi.Router) {
+			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, customMiddleware.ScopeFromQuery)).Get("/", folderHandler.ListFolders)
+			r.Post("/", folderHandler.CreateFolder)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsDelete, folderScope)).Delete("/{id}", folderHandler.DeleteFolder)
+		})
 
 		// Rotation policies endpoints. List/evaluate take an optional scope
 		// filter; per-policy routes resolve scope from the policy; create


### PR DESCRIPTION
## Summary

- Adds `POST/GET /api/v1/folders` and `DELETE /api/v1/folders/{id}` endpoints backed by a new `FolderHandler`; authorization follows the same `secrets.write`/`secrets.read`/`secrets.delete` permission model as the secrets routes
- Adds `core.CreateFolder` (validates name, project/env presence, and that any `parent_id` points to an existing folder node, not a secret) and `core.ListFolders` (delegates to `ListSecrets` with an `IsSecret=false` filter)
- Extends `storage.SecretFilter` with `IsSecret *bool` and `ParentID *uint` fields, wired through `LocalStorage.ListSecrets` for server-side filtering; `remote_secrets.go`'s `buildSecretFilterPath` is unchanged (folders route through the new `/api/v1/folders` path, not `/api/v1/secrets`)
- Adds `keyorix secret folder create/list/delete` CLI subcommands using `common.RemoteClient` in remote mode and the embedded core service in local mode

## Test plan

- [ ] `go test ./internal/core/ -run "TestCreateFolder|TestListFolders"` — 9 core unit tests covering happy path, empty name, missing IDs, invalid parent, non-folder parent, nested folders, and IsSecret/ParentID filtering
- [ ] `go test ./server/http/handlers/ -run "TestCreateFolder|TestListFolders|TestDeleteFolder"` — 10 handler tests covering 201/400/401 for create, 200/400/401 for list, 204/400 for delete, and the "node is a secret not a folder" guard
- [ ] `go build ./...` passes cleanly
- [ ] Full package test suites green: `internal/core`, `internal/storage/...`, `server/http/handlers`, `internal/cli/secret`