### PR TITLE
feat(secrets): add secret move/reparent — POST /{id}/move + CLI

### DIFF
--- a/internal/cli/secret/move.go
+++ b/internal/cli/secret/move.go
@@ -1,0 +1,62 @@
+// move.go — keyorix secret move: re-parent a secret or folder.
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	moveID uint
+	moveTo uint
+)
+
+var moveCmd = &cobra.Command{
+	Use:   "move",
+	Short: "Move a secret or folder to a different parent folder",
+	Long: `Move a secret or folder to a different parent folder.
+
+Use --to 0 (or omit --to) to move the node to the root (no parent).
+
+Examples:
+  keyorix secret move --id 42 --to 7     # move secret 42 into folder 7
+  keyorix secret move --id 42 --to 0     # move secret 42 to the root
+
+Requires secrets.write at the secret's scope.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if moveID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		if err := moveSecret(context.Background(), c, moveID, moveTo); err != nil {
+			return err
+		}
+		dest := "root"
+		if moveTo != 0 {
+			dest = "folder " + strconv.Itoa(int(moveTo))
+		}
+		fmt.Printf("Secret %d moved to %s\n", moveID, dest)
+		return nil
+	},
+}
+
+// moveSecret POSTs the move request to the server. Exported (lowercase) for test access.
+func moveSecret(ctx context.Context, c *common.RemoteClient, id, parentID uint) error {
+	body := map[string]uint{"parent_id": parentID}
+	var ignored struct{}
+	return c.Post(ctx, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/move", body, &ignored)
+}
+
+func init() {
+	moveCmd.Flags().UintVar(&moveID, "id", 0, "Secret or folder ID to move (required)")
+	moveCmd.Flags().UintVar(&moveTo, "to", 0, "Target parent folder ID (0 = root)")
+	SecretCmd.AddCommand(moveCmd)
+}

--- a/internal/cli/secret/move_cmd_test.go
+++ b/internal/cli/secret/move_cmd_test.go
@@ -38,7 +38,7 @@ func TestMoveCmd_ToRoot_PrintsRootMessage(t *testing.T) {
 	t.Cleanup(func() { moveID = origID; moveTo = origTo })
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"success":true,"data":{}}`))
+		_, _ = w.Write([]byte(`{"success":true,"data":{}}`))
 	}))
 	defer srv.Close()
 	t.Setenv("KEYORIX_SERVER", srv.URL)
@@ -57,7 +57,7 @@ func TestMoveCmd_ToFolder_PrintsFolderMessage(t *testing.T) {
 	t.Cleanup(func() { moveID = origID; moveTo = origTo })
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"success":true,"data":{}}`))
+		_, _ = w.Write([]byte(`{"success":true,"data":{}}`))
 	}))
 	defer srv.Close()
 	t.Setenv("KEYORIX_SERVER", srv.URL)

--- a/internal/cli/secret/move_cmd_test.go
+++ b/internal/cli/secret/move_cmd_test.go
@@ -1,0 +1,70 @@
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMoveCmd_MissingID returns an error when --id is not set.
+func TestMoveCmd_MissingID(t *testing.T) {
+	orig := moveID
+	t.Cleanup(func() { moveID = orig })
+	moveID = 0
+	err := moveCmd.RunE(moveCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id is required")
+}
+
+// TestMoveCmd_NotConnected returns an error when no server is configured.
+func TestMoveCmd_NotConnected(t *testing.T) {
+	orig := moveID
+	t.Cleanup(func() { moveID = orig })
+	moveID = 42
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := moveCmd.RunE(moveCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+// TestMoveCmd_ToRoot_PrintsRootMessage confirms that moving to root prints "root".
+func TestMoveCmd_ToRoot_PrintsRootMessage(t *testing.T) {
+	origID := moveID
+	origTo := moveTo
+	t.Cleanup(func() { moveID = origID; moveTo = origTo })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"success":true,"data":{}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	moveID = 42
+	moveTo = 0
+	err := moveCmd.RunE(moveCmd, nil)
+	require.NoError(t, err)
+}
+
+// TestMoveCmd_ToFolder_PrintsFolderMessage confirms "folder N" in output when moveTo != 0.
+func TestMoveCmd_ToFolder_PrintsFolderMessage(t *testing.T) {
+	origID := moveID
+	origTo := moveTo
+	t.Cleanup(func() { moveID = origID; moveTo = origTo })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"success":true,"data":{}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	moveID = 42
+	moveTo = 7
+	err := moveCmd.RunE(moveCmd, nil)
+	require.NoError(t, err)
+}

--- a/internal/cli/secret/move_remote_test.go
+++ b/internal/cli/secret/move_remote_test.go
@@ -1,0 +1,99 @@
+// move_remote_test.go — CLI-level tests for the secret move command.
+package secret
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// moveStub starts a minimal httptest server that accepts POST /api/v1/secrets/{id}/move.
+func moveStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/secrets/42/move" {
+			b, _ := io.ReadAll(r.Body)
+			capturedBody = b
+			_, _ = w.Write([]byte(`{"success":true,"data":{"ID":42,"ParentID":7},"message":"Secret moved"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(func() { _ = capturedBody })
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+// TestMoveSecret_SendsCorrectBody verifies that moveSecret POSTs {"parent_id": N}.
+func TestMoveSecret_SendsCorrectBody(t *testing.T) {
+	var captured map[string]uint
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/secrets/42/move" {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &captured)
+			_, _ = w.Write([]byte(`{"success":true,"data":{},"message":"Secret moved"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	err := moveSecret(context.Background(), rc, 42, 7)
+	require.NoError(t, err)
+	assert.Equal(t, uint(7), captured["parent_id"])
+}
+
+// TestMoveSecret_ToRoot_Body verifies that moveSecret sends parent_id=0 for root.
+func TestMoveSecret_ToRoot_Body(t *testing.T) {
+	var captured map[string]uint
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/secrets/10/move" {
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &captured)
+			_, _ = w.Write([]byte(`{"success":true,"data":{}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	err := moveSecret(context.Background(), rc, 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, uint(0), captured["parent_id"])
+}
+
+// TestMoveSecret_HappyPath verifies that moveSecret succeeds with a valid response.
+func TestMoveSecret_HappyPath(t *testing.T) {
+	rc, done := moveStub(t)
+	defer done()
+	err := moveSecret(context.Background(), rc, 42, 7)
+	require.NoError(t, err)
+}
+
+// TestMoveSecret_ServerError verifies that moveSecret returns an error on non-200.
+func TestMoveSecret_ServerError(t *testing.T) {
+	rc, done := moveStub(t)
+	defer done()
+	// ID 999 is not served by the stub — returns 404.
+	err := moveSecret(context.Background(), rc, 999, 7)
+	require.Error(t, err)
+}

--- a/internal/core/secret_move.go
+++ b/internal/core/secret_move.go
@@ -1,0 +1,74 @@
+// secret_move.go — move a secret or folder to a different parent folder.
+//
+// MoveSecret re-parents a SecretNode under a new parent (folder) or to the
+// root (parentID == nil). The caller (transport) must have enforced scoped
+// secrets.write; this function re-checks write access and validates that the
+// target parent, when set, is a folder (IsSecret == false).
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// EventSecretMoved is emitted when a secret or folder is moved to a new parent.
+const EventSecretMoved = "secret.moved"
+
+// MoveSecret changes the parent of secretID to newParentID.
+//
+//   - actorID must have secrets.write on the secret (via EnforceSecretWritePermission).
+//   - newParentID == nil moves the node to the root (no parent).
+//   - newParentID != nil validates that the target is a folder (IsSecret == false).
+func (c *KeyorixCore) MoveSecret(ctx context.Context, actorID, secretID uint, newParentID *uint) (*models.SecretNode, error) {
+	if secretID == 0 || actorID == 0 {
+		return nil, fmt.Errorf("%s: secret ID and actor ID are required", i18n.T("ErrorValidation", nil))
+	}
+
+	// Authorization: the actor must be able to write the secret.
+	if _, err := c.EnforceSecretWritePermission(ctx, secretID, actorID); err != nil {
+		return nil, err
+	}
+
+	// Load the target secret / folder.
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
+	}
+
+	// Validate the new parent when specified.
+	if newParentID != nil && *newParentID != 0 {
+		// Prevent moving a node into itself before the storage lookup.
+		if *newParentID == secretID {
+			return nil, fmt.Errorf("%s: cannot move a node into itself", i18n.T("ErrorValidation", nil))
+		}
+		parent, err := c.storage.GetSecret(ctx, *newParentID)
+		if err != nil {
+			return nil, fmt.Errorf("%s: parent %d not found", i18n.T("ErrorValidation", nil), *newParentID)
+		}
+		if parent.IsSecret {
+			return nil, fmt.Errorf("%s: target parent %d is a secret, not a folder", i18n.T("ErrorValidation", nil), *newParentID)
+		}
+		secret.ParentID = newParentID
+	} else {
+		// Move to root (no parent).
+		secret.ParentID = nil
+	}
+
+	secret.UpdatedAt = c.now()
+	updated, err := c.storage.UpdateSecret(ctx, secret)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+
+	uid, sid := actorID, secretID
+	parentDesc := "root"
+	if newParentID != nil && *newParentID != 0 {
+		parentDesc = fmt.Sprintf("folder %d", *newParentID)
+	}
+	c.writeAuditEvent(ctx, EventSecretMoved, &uid, &sid,
+		fmt.Sprintf("moved secret/folder %q to %s", updated.Name, parentDesc))
+	return updated, nil
+}

--- a/internal/core/secret_move_test.go
+++ b/internal/core/secret_move_test.go
@@ -215,3 +215,24 @@ func TestMoveSecret_ZeroSecretID(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required")
 }
+
+// TestMoveFolder_ToAnotherFolder moves a folder node into a sibling folder.
+func TestMoveFolder_ToAnotherFolder(t *testing.T) {
+	c, _, folderID, db := newMoveFixture(t)
+	ctx := context.Background()
+
+	// Create a second folder to be the target parent.
+	target, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "target-folder", ProjectID: 1, EnvironmentID: 1,
+		Type: "folder", OwnerID: 1, IsSecret: false, Status: "active",
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	_ = db
+
+	// Move the first folder into the target folder.
+	updated, err := c.MoveSecret(ctx, 1, folderID, &target.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.ParentID)
+	assert.Equal(t, target.ID, *updated.ParentID)
+}

--- a/internal/core/secret_move_test.go
+++ b/internal/core/secret_move_test.go
@@ -1,0 +1,217 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newMoveFixture opens a unique in-memory SQLite DB and seeds:
+//   - User 1 (actor / owner)
+//   - Project 1, Environment 1
+//   - A secret owned by user 1  (IsSecret=true)
+//   - A folder owned by user 1  (IsSecret=false)
+//
+// Returns the core, the secret ID, the folder ID, and the underlying DB.
+func newMoveFixture(t *testing.T) (c *KeyorixCore, secretID, folderID uint, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{},
+		&models.SecretVersion{},
+		&models.AuditEvent{},
+		&models.ShareRecord{},
+		&models.User{},
+		&models.Group{},
+		&models.UserGroup{},
+	))
+
+	// Seed a user so share-lookup JOIN does not hit a missing table.
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@test.com"}).Error)
+
+	c = &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+
+	secret, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name:          "db-password",
+		ProjectID:     1,
+		EnvironmentID: 1,
+		Type:          "password",
+		OwnerID:       1,
+		IsSecret:      true,
+		Status:        "active",
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	})
+	require.NoError(t, err)
+
+	folder, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name:          "infra",
+		ProjectID:     1,
+		EnvironmentID: 1,
+		Type:          "folder",
+		OwnerID:       1,
+		IsSecret:      false, // folder
+		Status:        "active",
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	})
+	require.NoError(t, err)
+
+	return c, secret.ID, folder.ID, db
+}
+
+// TestMoveSecret_ToFolder moves a secret into a valid folder.
+func TestMoveSecret_ToFolder(t *testing.T) {
+	c, secretID, folderID, _ := newMoveFixture(t)
+	ctx := context.Background()
+
+	updated, err := c.MoveSecret(ctx, 1, secretID, &folderID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.ParentID)
+	assert.Equal(t, folderID, *updated.ParentID)
+}
+
+// TestMoveSecret_ToRoot moves a secret to the root (nil parent).
+func TestMoveSecret_ToRoot(t *testing.T) {
+	c, secretID, folderID, _ := newMoveFixture(t)
+	ctx := context.Background()
+
+	// First move into a folder, then back to root.
+	_, err := c.MoveSecret(ctx, 1, secretID, &folderID)
+	require.NoError(t, err)
+
+	updated, err := c.MoveSecret(ctx, 1, secretID, nil)
+	require.NoError(t, err)
+	assert.Nil(t, updated.ParentID)
+}
+
+// TestMoveSecret_ToRoot_ZeroParentID treats parent_id=0 as root (nil parent).
+func TestMoveSecret_ToRoot_ZeroParentID(t *testing.T) {
+	c, secretID, _, _ := newMoveFixture(t)
+	ctx := context.Background()
+
+	zero := uint(0)
+	updated, err := c.MoveSecret(ctx, 1, secretID, &zero)
+	require.NoError(t, err)
+	assert.Nil(t, updated.ParentID)
+}
+
+// TestMoveSecret_NonFolderParent rejects moving into a secret (not a folder).
+func TestMoveSecret_NonFolderParent(t *testing.T) {
+	c, secretID, _, _ := newMoveFixture(t)
+	ctx := context.Background()
+
+	// The secret itself is IsSecret=true — trying to use it as a parent fails.
+	_, err := c.MoveSecret(ctx, 1, secretID, &secretID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "itself")
+}
+
+// TestMoveSecret_NonFolder_OtherSecret rejects using another secret as parent.
+func TestMoveSecret_NonFolder_OtherSecret(t *testing.T) {
+	c, secretID, _, db := newMoveFixture(t)
+	ctx := context.Background()
+
+	// Create a second secret (IsSecret=true) to use as an invalid parent.
+	other, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name:          "other-secret",
+		ProjectID:     1,
+		EnvironmentID: 1,
+		Type:          "password",
+		OwnerID:       1,
+		IsSecret:      true,
+		Status:        "active",
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	})
+	require.NoError(t, err)
+	_ = db
+
+	_, err = c.MoveSecret(ctx, 1, secretID, &other.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a folder")
+}
+
+// TestMoveSecret_SecretNotFound returns an error when the secret does not exist.
+func TestMoveSecret_SecretNotFound(t *testing.T) {
+	c, _, _, _ := newMoveFixture(t)
+	ctx := context.Background()
+
+	_, err := c.MoveSecret(ctx, 1, 9999, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestMoveSecret_ParentNotFound returns a validation error when the parent does not exist.
+func TestMoveSecret_ParentNotFound(t *testing.T) {
+	c, secretID, _, _ := newMoveFixture(t)
+	ctx := context.Background()
+
+	nonExistentParent := uint(9999)
+	_, err := c.MoveSecret(ctx, 1, secretID, &nonExistentParent)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestMoveSecret_AuditEvent verifies that an audit event is written after a successful move.
+func TestMoveSecret_AuditEvent(t *testing.T) {
+	c, secretID, folderID, db := newMoveFixture(t)
+	ctx := context.Background()
+
+	_, err := c.MoveSecret(ctx, 1, secretID, &folderID)
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).
+		Where("event_type = ?", EventSecretMoved).Count(&count).Error)
+	assert.EqualValues(t, 1, count)
+}
+
+// TestMoveSecret_AuditEvent_ToRoot verifies that moving to root is also audited.
+func TestMoveSecret_AuditEvent_ToRoot(t *testing.T) {
+	c, secretID, _, db := newMoveFixture(t)
+	ctx := context.Background()
+
+	_, err := c.MoveSecret(ctx, 1, secretID, nil)
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).
+		Where("event_type = ?", EventSecretMoved).Count(&count).Error)
+	assert.EqualValues(t, 1, count)
+}
+
+// TestMoveSecret_ZeroActorID rejects a zero actor ID (validation).
+func TestMoveSecret_ZeroActorID(t *testing.T) {
+	c, secretID, _, _ := newMoveFixture(t)
+	ctx := context.Background()
+
+	_, err := c.MoveSecret(ctx, 0, secretID, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+// TestMoveSecret_ZeroSecretID rejects a zero secret ID (validation).
+func TestMoveSecret_ZeroSecretID(t *testing.T) {
+	c, _, _, _ := newMoveFixture(t)
+	ctx := context.Background()
+
+	_, err := c.MoveSecret(ctx, 1, 0, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}

--- a/server/http/handlers/secrets_move.go
+++ b/server/http/handlers/secrets_move.go
@@ -1,0 +1,59 @@
+// secrets_move.go — MoveSecret handler: re-parent a secret or folder.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// MoveSecret handles POST /api/v1/secrets/{id}/move
+//
+// Request body: { "parent_id": N }  — N=0 means move to root.
+// Requires secrets.write at the secret's project scope (enforced by the route
+// middleware); core re-checks write access via EnforceSecretWritePermission.
+func (h *SecretHandler) MoveSecret(w http.ResponseWriter, r *http.Request) {
+	userCtx, ok := mustGetUser(w, r)
+	if !ok {
+		return
+	}
+
+	secretID, ok := mustParseUintParam(w, r, "id", "InvalidParameter", errInvalidSecretID)
+	if !ok {
+		return
+	}
+
+	var reqBody struct {
+		ParentID uint `json:"parent_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "InvalidJSON", errInvalidJSON, http.StatusBadRequest, nil)
+		return
+	}
+
+	// N=0 → root (nil parent); N>0 → pointer to that folder.
+	var parentID *uint
+	if reqBody.ParentID != 0 {
+		pid := reqBody.ParentID
+		parentID = &pid
+	}
+
+	updated, err := h.coreService.MoveSecret(r.Context(), userCtx.UserID, secretID, parentID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "not found"):
+			status = http.StatusNotFound
+		case strings.Contains(msg, "validation") ||
+			strings.Contains(msg, "not a folder") ||
+			strings.Contains(msg, "cannot move"):
+			status = http.StatusBadRequest
+		case strings.Contains(msg, "permission") || strings.Contains(msg, "not authorized"):
+			status = http.StatusForbidden
+		}
+		h.sendError(w, "Error", msg, status, nil)
+		return
+	}
+	h.sendSuccess(w, updated, "Secret moved")
+}

--- a/server/http/handlers/secrets_move_test.go
+++ b/server/http/handlers/secrets_move_test.go
@@ -1,0 +1,245 @@
+// secrets_move_test.go — HTTP-level tests for POST /api/v1/secrets/{id}/move.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	customMiddleware "github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// moveFixtureResult carries the created IDs for move handler tests.
+type moveFixtureResult struct {
+	handler  *SecretHandler
+	secretID uint
+	folderID uint
+}
+
+// freshMoveFixture opens a unique in-memory SQLite DB with all required models,
+// seeds user 1 (owner), a project, an environment, one secret and one folder.
+func freshMoveFixture(t *testing.T) moveFixtureResult {
+	t.Helper()
+
+	cfg := &config.Config{Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"}}
+	require.NoError(t, i18n.Initialize(cfg))
+
+	n := s12DBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhandlers_move_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{},
+		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{},
+		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.ShareRecord{},
+		&models.Tag{}, &models.SecretTag{},
+		&models.ProjectMembership{}, &models.SoDPolicy{},
+		&models.AnomalyAlert{}, &models.RotationPolicy{}, &models.Notification{},
+		&models.BreakGlassActivation{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{},
+		&models.LoginAttempt{},
+		&models.AccessRequest{}, &models.AccessRequestApproval{},
+		&models.WebAuthnCredential{}, &models.WebAuthnSession{},
+		&models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
+		&models.ConnectRefGrant{}, &models.Session{}, &models.SetupToken{},
+		&models.MFAChallenge{}, &models.SSOLoginState{},
+		&models.MachineIdentity{}, &models.MachineIdentityCredential{},
+		&models.MachineIdentityRole{}, &models.MachineIdentityOIDCBinding{},
+		&models.SecretDependency{}, &models.RiskException{},
+		&models.MFASecret{}, &models.MFARecoveryCode{},
+		&models.IdentityProvider{}, &models.ExternalIdentity{},
+		&models.LegalHold{},
+		&models.PersonalAccessToken{},
+		&models.ProjectInvitation{}, &models.SchedulerLockLease{},
+		&models.SystemMetadata{},
+		&models.PasswordHistory{},
+	))
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner_move", Email: "owner_move@test.com"}).Error)
+
+	st := store.NewLocalStorage(db)
+	cs := core.NewKeyorixCore(st)
+	ctx := context.Background()
+
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "proj-move"})
+	require.NoError(t, err)
+	env, err := st.CreateEnvironment(ctx, &models.Environment{Name: "env-move", ProjectID: proj.ID})
+	require.NoError(t, err)
+
+	secret, err := st.CreateSecret(ctx, &models.SecretNode{
+		Name:          "db-password-move",
+		ProjectID:     proj.ID,
+		EnvironmentID: env.ID,
+		Type:          "password",
+		OwnerID:       1,
+		IsSecret:      true,
+		Status:        "active",
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	})
+	require.NoError(t, err)
+
+	folder, err := st.CreateSecret(ctx, &models.SecretNode{
+		Name:          "infra-folder-move",
+		ProjectID:     proj.ID,
+		EnvironmentID: env.ID,
+		Type:          "folder",
+		OwnerID:       1,
+		IsSecret:      false,
+		Status:        "active",
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	})
+	require.NoError(t, err)
+
+	handler, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	return moveFixtureResult{handler: handler, secretID: secret.ID, folderID: folder.ID}
+}
+
+// withMoveUserCtx injects user 1 into the request context.
+func withMoveUserCtx(r *http.Request) *http.Request {
+	uctx := &customMiddleware.UserContext{UserID: 1, Username: "owner_move", Email: "owner_move@test.com"}
+	return r.WithContext(context.WithValue(r.Context(), customMiddleware.GetUserContextKey(), uctx))
+}
+
+// TestMoveSecret_HappyPath_ToFolder_HTTP verifies a successful move into a folder.
+func TestMoveSecret_HappyPath_ToFolder_HTTP(t *testing.T) {
+	fx := freshMoveFixture(t)
+
+	body, _ := json.Marshal(map[string]uint{"parent_id": fx.folderID})
+	req := withChiParamS14(
+		httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)),
+		"id", strconv.Itoa(int(fx.secretID)),
+	)
+	req = withMoveUserCtx(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	fx.handler.MoveSecret(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "moved")
+}
+
+// TestMoveSecret_ToRoot_HTTP verifies a successful move to root (parent_id=0).
+func TestMoveSecret_ToRoot_HTTP(t *testing.T) {
+	fx := freshMoveFixture(t)
+
+	body, _ := json.Marshal(map[string]uint{"parent_id": 0})
+	req := withChiParamS14(
+		httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)),
+		"id", strconv.Itoa(int(fx.secretID)),
+	)
+	req = withMoveUserCtx(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	fx.handler.MoveSecret(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestMoveSecret_NotFound_HTTP verifies a 404 for a non-existent secret.
+func TestMoveSecret_NotFound_HTTP(t *testing.T) {
+	fx := freshMoveFixture(t)
+
+	body, _ := json.Marshal(map[string]uint{"parent_id": 0})
+	req := withChiParamS14(
+		httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)),
+		"id", "99999",
+	)
+	req = withMoveUserCtx(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	fx.handler.MoveSecret(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestMoveSecret_NonFolderParent_HTTP verifies a 400 when target is not a folder.
+func TestMoveSecret_NonFolderParent_HTTP(t *testing.T) {
+	fx := freshMoveFixture(t)
+
+	// Use the secret's own ID as target (IsSecret=true → not a folder, and also self).
+	body, _ := json.Marshal(map[string]uint{"parent_id": fx.secretID})
+	req := withChiParamS14(
+		httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)),
+		"id", strconv.Itoa(int(fx.secretID)),
+	)
+	req = withMoveUserCtx(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	fx.handler.MoveSecret(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestMoveSecret_InvalidID_HTTP verifies a 400 for a non-numeric secret ID.
+func TestMoveSecret_InvalidID_HTTP(t *testing.T) {
+	fx := freshMoveFixture(t)
+
+	body, _ := json.Marshal(map[string]uint{"parent_id": 0})
+	req := withChiParamS14(
+		httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)),
+		"id", "notanumber",
+	)
+	req = withMoveUserCtx(req)
+
+	w := httptest.NewRecorder()
+	fx.handler.MoveSecret(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestMoveSecret_InvalidJSON_HTTP verifies a 400 for malformed JSON.
+func TestMoveSecret_InvalidJSON_HTTP(t *testing.T) {
+	fx := freshMoveFixture(t)
+
+	req := withChiParamS14(
+		httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte("{bad json"))),
+		"id", strconv.Itoa(int(fx.secretID)),
+	)
+	req = withMoveUserCtx(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	fx.handler.MoveSecret(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestMoveSecret_NoUserCtx_HTTP verifies a 401 when no user context is present.
+func TestMoveSecret_NoUserCtx_HTTP(t *testing.T) {
+	fx := freshMoveFixture(t)
+
+	body, _ := json.Marshal(map[string]uint{"parent_id": 0})
+	req := withChiParamS14(
+		httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)),
+		"id", strconv.Itoa(int(fx.secretID)),
+	)
+	// No user context injected.
+
+	w := httptest.NewRecorder()
+	fx.handler.MoveSecret(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -556,6 +556,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/rotate", secretHandler.RotateSecret)
 			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/rollback", secretHandler.RollbackSecret)
 			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/transfer-ownership", secretHandler.TransferOwnership)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/move", secretHandler.MoveSecret)
 			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/suspend", secretHandler.SuspendSecret)
 			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/resume", secretHandler.ResumeSecret)
 			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/share", shareHandler.ShareSecret)


### PR DESCRIPTION
## Summary

- **Core** (`internal/core/secret_move.go`): `MoveSecret(ctx, actorID, secretID, newParentID)` — enforces secrets.write, validates target is a folder (IsSecret=false), prevents self-reparent, updates ParentID via the existing `UpdateSecret` storage method, emits `secret.moved` audit event.
- **HTTP** (`server/http/handlers/secrets_move.go`): `POST /api/v1/secrets/{id}/move` with `{"parent_id": N}` (N=0 = root). Wired in `server/http/router.go` with `secrets.write` scope guard.
- **CLI** (`internal/cli/secret/move.go`): `keyorix secret move --id N --to M` (`--to 0` = root).

## Test plan

- [ ] `go test ./internal/core/ -run TestMoveSecret` — 11 cases: to folder, to root (nil and zero), self-reparent (400), non-folder parent (400), 404 secret, 404 parent, audit event written, zero actor/secret IDs rejected
- [ ] `go test ./server/http/handlers/ -run TestMoveSecret` — 7 cases: happy path to folder, to root, 404, 400 non-folder, bad ID, bad JSON, no auth context
- [ ] `go test ./internal/cli/secret/ -run TestMoveSecret` — 4 cases: correct body sent, root body, happy path, server error propagation
- [ ] Full package test suites pass: core, handlers, cli/secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)