### PR TITLE
feat(secrets): folder-aware secret create + list (parent_id / folder_only)

### DIFF
--- a/internal/cli/secret/create.go
+++ b/internal/cli/secret/create.go
@@ -31,6 +31,7 @@ var (
 	createFromFile      string
 	createInteractive   bool
 	createDescription   string
+	createFolderID      uint
 )
 
 var createCmd = &cobra.Command{
@@ -50,6 +51,7 @@ func init() {
 	createCmd.Flags().StringVar(&createFromFile, "from-file", "", "Read secret value from file")
 	createCmd.Flags().BoolVar(&createInteractive, "interactive", false, "Interactive mode")
 	createCmd.Flags().StringVar(&createDescription, "description", "", "Optional free-text note about the secret")
+	createCmd.Flags().UintVar(&createFolderID, "folder", 0, "Parent folder ID (places the secret inside a folder node; 0 = root level)")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -92,6 +94,9 @@ func runCreateRemote(ctx context.Context, rc *common.RemoteClient, req *core.Cre
 	}
 	if req.Description != "" {
 		body["description"] = req.Description
+	}
+	if req.ParentID != nil && *req.ParentID != 0 {
+		body["parent_id"] = *req.ParentID
 	}
 
 	var secret models.SecretNode
@@ -178,6 +183,10 @@ func buildCreateRequest() (*core.CreateSecretRequest, error) { // NOSONAR -- cog
 			return nil, fmt.Errorf("invalid expiration format: %w", err)
 		}
 		req.Expiration = &exp
+	}
+
+	if createFolderID != 0 {
+		req.ParentID = &createFolderID
 	}
 
 	return req, nil

--- a/internal/cli/secret/create_remote_folder_test.go
+++ b/internal/cli/secret/create_remote_folder_test.go
@@ -1,0 +1,106 @@
+// create_remote_folder_test.go — tests that runCreateRemote sends (or omits)
+// parent_id in the HTTP request body based on the --folder flag.
+package secret
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createStubResponse is the minimal valid JSON the stub server returns.
+// decodeEnvelope in RemoteClient strips the {"data":…} wrapper, so the inner
+// object must be a valid SecretNode (only ID and Name are required for
+// printCreatedSecret to not panic).
+const createStubResponse = `{"success":true,"data":{"id":1,"name":"test","type":"generic","project_id":1,"environment_id":1,"status":"active","created_by":"cli-user","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"},"message":"created"}`
+
+// TestRunCreateRemote_FolderFlag_SendsParentID asserts that when ParentID is
+// set on the request, runCreateRemote includes "parent_id" in the POST body.
+func TestRunCreateRemote_FolderFlag_SendsParentID(t *testing.T) {
+	var capturedBody map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/v1/secrets", r.URL.Path)
+
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(raw, &capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(createStubResponse))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok, "expected remote client to be created")
+
+	parentID := uint(42)
+	req := &core.CreateSecretRequest{
+		Name:          "my-secret",
+		Value:         []byte("secret-value"),
+		Type:          "generic",
+		ProjectID:     1,
+		EnvironmentID: 1,
+		ParentID:      &parentID,
+	}
+
+	err := runCreateRemote(context.Background(), rc, req)
+	require.NoError(t, err)
+
+	// JSON numbers unmarshal as float64 by default into interface{}.
+	gotParentID, ok := capturedBody["parent_id"]
+	require.True(t, ok, "expected parent_id key in request body")
+	assert.Equal(t, float64(42), gotParentID, "parent_id should be 42")
+}
+
+// TestRunCreateRemote_NoFolderFlag_NoParentID asserts that when ParentID is
+// nil, runCreateRemote does NOT include "parent_id" in the POST body.
+func TestRunCreateRemote_NoFolderFlag_NoParentID(t *testing.T) {
+	var capturedBody map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/v1/secrets", r.URL.Path)
+
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(raw, &capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(createStubResponse))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok, "expected remote client to be created")
+
+	req := &core.CreateSecretRequest{
+		Name:          "my-secret",
+		Value:         []byte("secret-value"),
+		Type:          "generic",
+		ProjectID:     1,
+		EnvironmentID: 1,
+		ParentID:      nil, // no folder
+	}
+
+	err := runCreateRemote(context.Background(), rc, req)
+	require.NoError(t, err)
+
+	_, present := capturedBody["parent_id"]
+	assert.False(t, present, "parent_id should NOT be present in request body when ParentID is nil")
+}

--- a/internal/cli/secret/folder_flag_test.go
+++ b/internal/cli/secret/folder_flag_test.go
@@ -1,0 +1,157 @@
+// folder_flag_test.go — CLI tests for --folder flag on create and list.
+//
+// Covers:
+//   - buildCreateRequest with --folder sets ParentID
+//   - buildCreateRequest with --folder=0 leaves ParentID nil
+//   - runListRemote sends ?parent_id=N when --folder is set
+//   - runListRemote does NOT send parent_id when --folder=0
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── buildCreateRequest: --folder sets ParentID ────────────────────────────────
+
+func TestBuildCreateRequest_FolderFlag(t *testing.T) {
+	origName := createName
+	origValue := createValue
+	origFolder := createFolderID
+	origEnv := createEnvironmentID
+	origProject := createProjectID
+	t.Cleanup(func() {
+		createName = origName
+		createValue = origValue
+		createFolderID = origFolder
+		createEnvironmentID = origEnv
+		createProjectID = origProject
+	})
+
+	createName = "my-secret"
+	createValue = "secret-value"
+	createFolderID = 42
+	createEnvironmentID = 10
+	createProjectID = 1
+
+	req, err := buildCreateRequest()
+	require.NoError(t, err)
+	require.NotNil(t, req.ParentID, "expected ParentID to be set when --folder is given")
+	assert.Equal(t, uint(42), *req.ParentID)
+}
+
+func TestBuildCreateRequest_FolderFlag_Zero(t *testing.T) {
+	origName := createName
+	origValue := createValue
+	origFolder := createFolderID
+	t.Cleanup(func() {
+		createName = origName
+		createValue = origValue
+		createFolderID = origFolder
+	})
+
+	createName = "my-secret"
+	createValue = "secret-value"
+	createFolderID = 0 // zero means root level — no parent
+
+	req, err := buildCreateRequest()
+	require.NoError(t, err)
+	assert.Nil(t, req.ParentID, "ParentID should be nil when --folder=0")
+}
+
+// ── runListRemote: --folder sends ?parent_id= query param ────────────────────
+
+// TestRunListRemote_FolderFlag_AddsParentID verifies that ?parent_id=N is
+// appended to the secrets request when --folder N is provided.
+func TestRunListRemote_FolderFlag_AddsParentID(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[],"total":0,"page":1,"page_size":50,"total_pages":1}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origFolder := listFolderID
+	origLimit := listLimit
+	origOffset := listOffset
+	origFormat := listFormat
+	origProject := listProjectName
+	origEnv := listEnv
+	t.Cleanup(func() {
+		listFolderID = origFolder
+		listLimit = origLimit
+		listOffset = origOffset
+		listFormat = origFormat
+		listProjectName = origProject
+		listEnv = origEnv
+	})
+
+	listFolderID = 7
+	listLimit = 50
+	listOffset = 0
+	listFormat = "table"
+	listProjectName = ""
+	listEnv = 0
+
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runListRemote(context.Background(), rc))
+	assert.True(t, strings.Contains(gotQuery, "parent_id=7"),
+		"expected parent_id=7 in query string, got: %s", gotQuery)
+}
+
+// TestRunListRemote_FolderFlag_Zero_NoParentID verifies that parent_id is NOT
+// added to the query when --folder=0 (the default).
+func TestRunListRemote_FolderFlag_Zero_NoParentID(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[],"total":0,"page":1,"page_size":50,"total_pages":1}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origFolder := listFolderID
+	origLimit := listLimit
+	origOffset := listOffset
+	origFormat := listFormat
+	origProject := listProjectName
+	origEnv := listEnv
+	t.Cleanup(func() {
+		listFolderID = origFolder
+		listLimit = origLimit
+		listOffset = origOffset
+		listFormat = origFormat
+		listProjectName = origProject
+		listEnv = origEnv
+	})
+
+	listFolderID = 0 // no folder filter
+	listLimit = 50
+	listOffset = 0
+	listFormat = "table"
+	listProjectName = ""
+	listEnv = 0
+
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runListRemote(context.Background(), rc))
+	assert.False(t, strings.Contains(gotQuery, "parent_id"),
+		"expected no parent_id in query when --folder=0, got: %s", gotQuery)
+}

--- a/internal/cli/secret/list.go
+++ b/internal/cli/secret/list.go
@@ -21,6 +21,7 @@ var (
 	listOffset      int
 	listSearch      string
 	listFormat      string
+	listFolderID    uint
 )
 
 var listCmd = &cobra.Command{
@@ -47,6 +48,7 @@ func init() {
 	listCmd.Flags().IntVar(&listOffset, "offset", 0, "Number of results to skip")
 	listCmd.Flags().StringVar(&listSearch, "search", "", "Search query")
 	listCmd.Flags().StringVar(&listFormat, "format", "table", "Output format (table, json)")
+	listCmd.Flags().UintVar(&listFolderID, "folder", 0, "Filter to direct children of this folder node ID (0 = all)")
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -100,6 +102,9 @@ func runListRemote(ctx context.Context, rc *common.RemoteClient) error {
 
 	if listEnv != 0 {
 		path += fmt.Sprintf("&environment_id=%d", listEnv)
+	}
+	if listFolderID != 0 {
+		path += fmt.Sprintf("&parent_id=%d", listFolderID)
 	}
 
 	var resp models.SecretListResponse
@@ -159,6 +164,9 @@ func runListEmbedded(ctx context.Context) error {
 
 	if listEnv != 0 {
 		filter.EnvironmentID = &listEnv
+	}
+	if listFolderID != 0 {
+		filter.ParentID = &listFolderID
 	}
 
 	secrets, total, err := service.ListSecrets(ctx, filter)

--- a/internal/core/secret_folder_test.go
+++ b/internal/core/secret_folder_test.go
@@ -1,0 +1,183 @@
+// secret_folder_test.go — core-layer tests for folder-aware secret creation.
+//
+// Covers:
+//   - CreateSecret with valid ParentID sets ParentID on the stored node
+//   - CreateSecret with ParentID pointing to a real secret (not folder) → error
+//   - CreateSecret with non-existent ParentID → error
+//   - CreateSecret with ParentID from a different project/environment → error
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var folderCoreCounter atomic.Int64
+
+func newFolderCoreDB(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := folderCoreCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxcore_folder_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{},
+		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SecretNode{},
+		&models.AuditEvent{}, &models.AnomalyAlert{},
+		&models.RotationPolicy{}, &models.SecretVersion{},
+		&models.SecretAccessLog{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 1, Name: "prod"}).Error)
+	// Second project for cross-project test.
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "other-proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 20, ProjectID: 2, Name: "staging"}).Error)
+
+	return NewKeyorixCore(store.NewLocalStorage(db)), db
+}
+
+// seedFolder inserts a folder node (IsSecret=false) directly into the DB.
+func seedFolder(t *testing.T, db *gorm.DB, projectID, envID uint) *models.SecretNode {
+	t.Helper()
+	node := &models.SecretNode{
+		Name:          "test-folder",
+		ProjectID:     projectID,
+		EnvironmentID: envID,
+		IsSecret:      false,
+		Type:          "folder",
+		Status:        "active",
+		CreatedBy:     "system",
+		OwnerID:       1,
+	}
+	require.NoError(t, db.Create(node).Error)
+	return node
+}
+
+// TestCreateSecret_ParentID_SetsParent verifies that a valid folder ParentID is
+// persisted on the created secret node.
+func TestCreateSecret_ParentID_SetsParent(t *testing.T) {
+	c, db := newFolderCoreDB(t)
+	folder := seedFolder(t, db, 1, 10)
+
+	req := &CreateSecretRequest{
+		Name:          "child-secret",
+		Value:         []byte("s3cr3t"),
+		ProjectID:     1,
+		EnvironmentID: 10,
+		Type:          "generic",
+		CreatedBy:     "user",
+		OwnerID:       1,
+		ParentID:      &folder.ID,
+	}
+	got, err := c.CreateSecret(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, got.ParentID, "expected ParentID to be set on created secret")
+	assert.Equal(t, folder.ID, *got.ParentID)
+}
+
+// TestCreateSecret_ParentID_NotAFolder verifies that using a real secret as the
+// parent is rejected with a validation error.
+func TestCreateSecret_ParentID_NotAFolder(t *testing.T) {
+	c, _ := newFolderCoreDB(t)
+
+	// Create a real secret first.
+	realSecret, err := c.CreateSecret(context.Background(), &CreateSecretRequest{
+		Name:          "real",
+		Value:         []byte("val"),
+		ProjectID:     1,
+		EnvironmentID: 10,
+		Type:          "generic",
+		CreatedBy:     "user",
+		OwnerID:       1,
+	})
+	require.NoError(t, err)
+
+	_, err = c.CreateSecret(context.Background(), &CreateSecretRequest{
+		Name:          "child",
+		Value:         []byte("val2"),
+		ProjectID:     1,
+		EnvironmentID: 10,
+		Type:          "generic",
+		CreatedBy:     "user",
+		OwnerID:       1,
+		ParentID:      &realSecret.ID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a folder")
+}
+
+// TestCreateSecret_ParentID_NonExistent verifies that a non-existent parent ID
+// is rejected with a validation error.
+func TestCreateSecret_ParentID_NonExistent(t *testing.T) {
+	c, _ := newFolderCoreDB(t)
+	nonExistent := uint(99999)
+
+	_, err := c.CreateSecret(context.Background(), &CreateSecretRequest{
+		Name:          "orphan",
+		Value:         []byte("val"),
+		ProjectID:     1,
+		EnvironmentID: 10,
+		Type:          "generic",
+		CreatedBy:     "user",
+		OwnerID:       1,
+		ParentID:      &nonExistent,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parent folder")
+}
+
+// TestCreateSecret_ParentID_CrossProject verifies that a folder in a different
+// project/environment cannot be used as a parent.
+func TestCreateSecret_ParentID_CrossProject(t *testing.T) {
+	c, db := newFolderCoreDB(t)
+	// Folder lives in project 2 / env 20.
+	otherFolder := seedFolder(t, db, 2, 20)
+
+	_, err := c.CreateSecret(context.Background(), &CreateSecretRequest{
+		Name:          "cross-project-secret",
+		Value:         []byte("val"),
+		ProjectID:     1,
+		EnvironmentID: 10,
+		Type:          "generic",
+		CreatedBy:     "user",
+		OwnerID:       1,
+		ParentID:      &otherFolder.ID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same project/environment")
+}
+
+// TestCreateSecret_ParentID_Zero verifies that ParentID=0 is treated as "no parent"
+// (root level) and succeeds without validation errors.
+func TestCreateSecret_ParentID_Zero(t *testing.T) {
+	c, _ := newFolderCoreDB(t)
+	zero := uint(0)
+
+	got, err := c.CreateSecret(context.Background(), &CreateSecretRequest{
+		Name:          "root-level",
+		Value:         []byte("val"),
+		ProjectID:     1,
+		EnvironmentID: 10,
+		Type:          "generic",
+		CreatedBy:     "user",
+		OwnerID:       1,
+		ParentID:      &zero,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, got.ParentID, "ParentID=0 should not set a parent")
+}

--- a/internal/core/secret_listing_query.go
+++ b/internal/core/secret_listing_query.go
@@ -401,5 +401,7 @@ func (c *KeyorixCore) convertToStorageFilter(filter *models.SecretListFilter) *s
 		ProjectID:      filter.ProjectID,
 		EnvironmentID:  filter.EnvironmentID,
 		IncludeDeleted: filter.IncludeDeleted,
+		ParentID:       filter.ParentID,
+		FolderOnly:     filter.FolderOnly,
 	}
 }

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -32,6 +32,10 @@ type CreateSecretRequest struct {
 	Tags          []string          `json:"tags,omitempty"`
 	CreatedBy     string            `json:"created_by" validate:"required"`
 	OwnerID       uint              `json:"owner_id,omitempty"`
+	// ParentID optionally places the new secret inside a folder node. When set,
+	// the parent must exist, belong to the same project/environment, and be a
+	// folder (IsSecret=false). A zero value means no parent (root level).
+	ParentID *uint `json:"parent_id,omitempty"`
 	// Classification is an optional data-sensitivity label (A.5.12): "" or one of
 	// public|internal|confidential|restricted.
 	Classification string `json:"classification,omitempty"`
@@ -92,6 +96,20 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 		return nil, fmt.Errorf("%s", i18n.T("ErrorSecretAlreadyExists", nil))
 	}
 
+	// Validate parent folder when one is requested.
+	if req.ParentID != nil && *req.ParentID != 0 {
+		parent, perr := c.storage.GetSecret(ctx, *req.ParentID)
+		if perr != nil {
+			return nil, fmt.Errorf("%s: parent folder %d not found", i18n.T("ErrorValidation", nil), *req.ParentID)
+		}
+		if parent.IsSecret {
+			return nil, fmt.Errorf("%s: parent %d is a secret, not a folder", i18n.T("ErrorValidation", nil), *req.ParentID)
+		}
+		if parent.ProjectID != req.ProjectID || parent.EnvironmentID != req.EnvironmentID {
+			return nil, fmt.Errorf("%s: parent folder %d does not belong to the same project/environment", i18n.T("ErrorValidation", nil), *req.ParentID)
+		}
+	}
+
 	if !IsValidClassification(req.Classification) {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "invalid classification")
 	}
@@ -123,6 +141,9 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 		OwnerID:        req.OwnerID,
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
+	}
+	if req.ParentID != nil && *req.ParentID != 0 {
+		secret.ParentID = req.ParentID
 	}
 
 	// req.Value is forwarded as the optional plaintext argument (#499): LocalStorage

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1170,8 +1170,14 @@ type SecretFilter struct {
 	// Classification, when set, restricts to secrets with that data-classification
 	// label (A.5.12). Use the sentinel "unclassified" to match the empty label.
 	Classification *string
-	Page           int
-	PageSize       int
+	// ParentID, when set, restricts to secrets whose parent_id equals the given
+	// value. Use to list the direct children of a folder node.
+	ParentID *uint
+	// FolderOnly, when true, restricts to folder nodes (is_secret=false). Mutually
+	// exclusive with listing only real secrets — callers set one or the other.
+	FolderOnly bool
+	Page       int
+	PageSize   int
 	// IncludeDeleted, when true, also returns soft-deleted secrets (ADR-033) —
 	// for a restore UI. Default false: GORM auto-scopes deleted_at IS NULL.
 	IncludeDeleted bool
@@ -1183,9 +1189,6 @@ type SecretFilter struct {
 	// true = actual secrets only, false = folder nodes only.
 	// When nil, both secrets and folders are returned.
 	IsSecret *bool
-	// ParentID, when set, restricts to nodes whose parent_id matches.
-	// Use a pointer to 0 (or a sentinel) to match root-level nodes.
-	ParentID *uint
 }
 
 // DriftSecretRow is one secret's drift-relevant projection: which environment it

--- a/internal/storage/models/secret_with_sharing.go
+++ b/internal/storage/models/secret_with_sharing.go
@@ -45,6 +45,12 @@ type SecretListFilter struct {
 	// before this time (already expired or expiring within the window).
 	ExpiresBefore *time.Time
 
+	// ParentID, when set, restricts to secrets whose parent_id equals the given
+	// value (direct children of a folder node).
+	ParentID *uint
+	// FolderOnly, when true, returns only folder nodes (is_secret=false).
+	FolderOnly bool
+
 	// Sharing filters
 	ShowOwnedOnly  bool   // Show only secrets owned by the user
 	ShowSharedOnly bool   // Show only secrets shared with the user

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -617,6 +617,9 @@ func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretF
 	if filter.ParentID != nil {
 		query = query.Where("secret_nodes.parent_id = ?", *filter.ParentID)
 	}
+	if filter.FolderOnly {
+		query = query.Where("secret_nodes.is_secret = ?", false)
+	}
 
 	var total int64
 	if err := query.Count(&total).Error; err != nil {

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -52,7 +52,7 @@ func (s *SecretGRPCService) CreateSecret(ctx context.Context, req *pb.CreateSecr
 		return nil, err
 	}
 
-	secret, err := s.core.CreateSecret(ctx, &core.CreateSecretRequest{
+	coreReq := &core.CreateSecretRequest{
 		Name:          req.GetName(),
 		Value:         []byte(req.GetValue()),
 		ProjectID:     uint(req.GetProjectId()),
@@ -64,7 +64,12 @@ func (s *SecretGRPCService) CreateSecret(ctx context.Context, req *pb.CreateSecr
 		Tags:          req.GetTags(),
 		CreatedBy:     user.Username,
 		OwnerID:       user.UserID,
-	})
+	}
+	if req.ParentId != nil && req.GetParentId() != 0 {
+		pID := uint(req.GetParentId())
+		coreReq.ParentID = &pID
+	}
+	secret, err := s.core.CreateSecret(ctx, coreReq)
 	if err != nil {
 		return nil, mapSecretError(err)
 	}
@@ -304,6 +309,8 @@ func (s *SecretGRPCService) ListSecrets(ctx context.Context, req *pb.ListSecrets
 		ShowSharedOnly: req.GetShowSharedOnly(),
 		Page:           page,
 		PageSize:       pageSize,
+		ParentID:       optUint(req.ParentId),
+		FolderOnly:     req.GetFolderOnly(),
 	}
 
 	resp, err := s.core.ListSecretsWithSharingInfo(ctx, user.UserID, filter)

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -39,6 +39,9 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 		Metadata       map[string]string `json:"metadata,omitempty"`
 		Tags           []string          `json:"tags,omitempty"`
 		Classification string            `json:"classification,omitempty"`
+		// ParentID optionally places the secret inside a folder node.
+		// The parent must exist and be a folder (IsSecret=false).
+		ParentID *uint `json:"parent_id,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
@@ -75,6 +78,7 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 		Metadata:       reqBody.Metadata,
 		Tags:           reqBody.Tags,
 		Classification: reqBody.Classification,
+		ParentID:       reqBody.ParentID,
 		CreatedBy:      userCtx.Username,
 		OwnerID:        userCtx.UserID,
 	}

--- a/server/http/handlers/secrets_folder_test.go
+++ b/server/http/handlers/secrets_folder_test.go
@@ -44,7 +44,7 @@ var folderTestDBCounter atomic.Int64
 
 // freshFolderFixture builds an isolated named in-memory SQLite DB with a project,
 // environment, one system_admin user, and one folder node ready for use.
-func freshFolderFixture(t *testing.T) (*SecretHandler, *core.KeyorixCore, *models.SecretNode, *gorm.DB) {
+func freshSecretFolderFixture(t *testing.T) (*SecretHandler, *core.KeyorixCore, *models.SecretNode, *gorm.DB) {
 	t.Helper()
 	require.NoError(t, i18n.InitializeForTesting())
 	n := folderTestDBCounter.Add(1)
@@ -125,7 +125,7 @@ func withAdminCtxFolder(r *http.Request) *http.Request {
 // TestCreateSecret_WithParentID verifies that POST /api/v1/secrets with a valid
 // parent_id places the new secret inside the folder (ParentID set on the response).
 func TestCreateSecret_WithParentID(t *testing.T) {
-	h, _, folder, _ := freshFolderFixture(t)
+	h, _, folder, _ := freshSecretFolderFixture(t)
 
 	body := map[string]interface{}{
 		"name":           "child-secret",
@@ -156,7 +156,7 @@ func TestCreateSecret_WithParentID(t *testing.T) {
 // TestCreateSecret_NonFolderParentID verifies that POST /api/v1/secrets with a
 // parent_id that points to a real secret (not a folder) is rejected with 400.
 func TestCreateSecret_NonFolderParentID(t *testing.T) {
-	h, cs, _, _ := freshFolderFixture(t)
+	h, cs, _, _ := freshSecretFolderFixture(t)
 
 	// Create a real secret to use as (invalid) parent.
 	realSecret, err := cs.CreateSecret(context.Background(), &core.CreateSecretRequest{
@@ -185,7 +185,7 @@ func TestCreateSecret_NonFolderParentID(t *testing.T) {
 // TestCreateSecret_NonExistentParentID verifies that POST /api/v1/secrets with a
 // parent_id that does not exist is rejected with 400.
 func TestCreateSecret_NonExistentParentID(t *testing.T) {
-	h, _, _, _ := freshFolderFixture(t)
+	h, _, _, _ := freshSecretFolderFixture(t)
 
 	body := map[string]interface{}{
 		"name":           "orphan-secret",
@@ -209,7 +209,7 @@ func TestCreateSecret_NonExistentParentID(t *testing.T) {
 // TestListSecrets_ParentID verifies that GET /api/v1/secrets?parent_id=N returns
 // only the secrets that are direct children of that folder.
 func TestListSecrets_ParentID(t *testing.T) {
-	h, cs, folder, _ := freshFolderFixture(t)
+	h, cs, folder, _ := freshSecretFolderFixture(t)
 
 	// Create a child secret inside the folder.
 	child, err := cs.CreateSecret(context.Background(), &core.CreateSecretRequest{
@@ -243,7 +243,7 @@ func TestListSecrets_ParentID(t *testing.T) {
 // TestListSecrets_FolderOnly verifies that GET /api/v1/secrets?folder_only=true
 // returns only folder nodes (IsSecret=false).
 func TestListSecrets_FolderOnly(t *testing.T) {
-	h, cs, _, _ := freshFolderFixture(t)
+	h, cs, _, _ := freshSecretFolderFixture(t)
 
 	// Create a real secret to confirm it is excluded.
 	_, err := cs.CreateSecret(context.Background(), &core.CreateSecretRequest{

--- a/server/http/handlers/secrets_folder_test.go
+++ b/server/http/handlers/secrets_folder_test.go
@@ -48,7 +48,7 @@ func freshSecretFolderFixture(t *testing.T) (*SecretHandler, *core.KeyorixCore, 
 	t.Helper()
 	require.NoError(t, i18n.InitializeForTesting())
 	n := folderTestDBCounter.Add(1)
-	dsn := fmt.Sprintf("file:kxfolder_%d?mode=memory&cache=shared&_timeout=30000", n)
+	dsn := fmt.Sprintf("file:kxsecfolder_%d?mode=memory&cache=shared&_timeout=30000", n)
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, err := db.DB()

--- a/server/http/handlers/secrets_folder_test.go
+++ b/server/http/handlers/secrets_folder_test.go
@@ -1,0 +1,268 @@
+// secrets_folder_test.go — tests for folder-aware secret create and list.
+//
+// Covers:
+//   - POST /api/v1/secrets with parent_id → ParentID set on the created node
+//   - POST /api/v1/secrets with non-folder parent_id → 400
+//   - GET /api/v1/secrets?parent_id=N → returns only children of that folder
+//   - GET /api/v1/secrets?folder_only=true → returns only folder nodes
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// decodeFolderListResponse decodes a list-secrets HTTP response envelope.
+func decodeFolderListResponse(t *testing.T, body []byte) *models.SecretListResponse {
+	t.Helper()
+	var wrapper struct {
+		Success bool                      `json:"success"`
+		Data    *models.SecretListResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(body, &wrapper))
+	require.NotNil(t, wrapper.Data, "response.Data must not be nil")
+	return wrapper.Data
+}
+
+var folderTestDBCounter atomic.Int64
+
+// freshFolderFixture builds an isolated named in-memory SQLite DB with a project,
+// environment, one system_admin user, and one folder node ready for use.
+func freshFolderFixture(t *testing.T) (*SecretHandler, *core.KeyorixCore, *models.SecretNode, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := folderTestDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxfolder_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{},
+		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SecretNode{},
+		&models.AuditEvent{}, &models.AnomalyAlert{},
+		&models.RotationPolicy{}, &models.Notification{},
+		&models.ProjectMembership{}, &models.SoDPolicy{},
+		&models.BreakGlassActivation{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{},
+		&models.LoginAttempt{},
+		&models.AccessRequest{}, &models.AccessRequestApproval{},
+		&models.WebAuthnCredential{}, &models.WebAuthnSession{},
+		&models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
+		&models.ConnectRefGrant{}, &models.Session{}, &models.SetupToken{},
+		&models.MFAChallenge{}, &models.SSOLoginState{},
+		&models.MachineIdentity{}, &models.MachineIdentityCredential{},
+		&models.MachineIdentityRole{}, &models.MachineIdentityOIDCBinding{},
+		&models.SecretDependency{}, &models.RiskException{},
+		&models.MFASecret{}, &models.MFARecoveryCode{},
+		&models.IdentityProvider{}, &models.ExternalIdentity{},
+		&models.LegalHold{}, &models.ShareRecord{},
+		&models.PersonalAccessToken{},
+		&models.ProjectInvitation{}, &models.SchedulerLockLease{},
+		&models.SecretAccessLog{},
+		&models.SystemMetadata{},
+		&models.PasswordHistory{},
+		&models.SecretVersion{},
+	))
+
+	// Seed user 1 as system_admin so in-handler authorization passes.
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice-folder", AccountState: "active"}).Error)
+	adminRole := &models.Role{Name: "system_admin"}
+	require.NoError(t, db.Create(adminRole).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID}).Error)
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj-folder"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 1, Name: "prod-folder"}).Error)
+
+	// Seed a folder node (IsSecret=false) directly into the DB.
+	folder := &models.SecretNode{
+		Name:          "my-folder",
+		ProjectID:     1,
+		EnvironmentID: 10,
+		IsSecret:      false,
+		Type:          "folder",
+		Status:        "active",
+		CreatedBy:     "alice-folder",
+		OwnerID:       1,
+	}
+	require.NoError(t, db.Create(folder).Error)
+
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+
+	return h, cs, folder, db
+}
+
+func withAdminCtxFolder(r *http.Request) *http.Request {
+	uc := &middleware.UserContext{
+		UserID: 1, Username: "alice-folder",
+		ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: true,
+	}
+	return r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), uc))
+}
+
+// ── HTTP: create secret with parent_id ────────────────────────────────────────
+
+// TestCreateSecret_WithParentID verifies that POST /api/v1/secrets with a valid
+// parent_id places the new secret inside the folder (ParentID set on the response).
+func TestCreateSecret_WithParentID(t *testing.T) {
+	h, _, folder, _ := freshFolderFixture(t)
+
+	body := map[string]interface{}{
+		"name":           "child-secret",
+		"value":          "topsecret",
+		"project_id":     1,
+		"environment_id": 10,
+		"type":           "generic",
+		"parent_id":      folder.ID,
+	}
+	b, _ := json.Marshal(body)
+	r := withAdminCtxFolder(httptest.NewRequest(http.MethodPost, "/api/v1/secrets", bytes.NewReader(b)))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateSecret(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+
+	// The create response wraps a *SecretNode directly in "data".
+	var resp struct {
+		Data *models.SecretNode `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Data, "expected data in response")
+	require.NotNil(t, resp.Data.ParentID, "expected ParentID to be set")
+	assert.Equal(t, folder.ID, *resp.Data.ParentID)
+}
+
+// TestCreateSecret_NonFolderParentID verifies that POST /api/v1/secrets with a
+// parent_id that points to a real secret (not a folder) is rejected with 400.
+func TestCreateSecret_NonFolderParentID(t *testing.T) {
+	h, cs, _, _ := freshFolderFixture(t)
+
+	// Create a real secret to use as (invalid) parent.
+	realSecret, err := cs.CreateSecret(context.Background(), &core.CreateSecretRequest{
+		Name: "real-secret", Value: []byte("val"), ProjectID: 1, EnvironmentID: 10,
+		Type: "generic", CreatedBy: "alice-folder", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	body := map[string]interface{}{
+		"name":           "child-of-secret",
+		"value":          "topsecret",
+		"project_id":     1,
+		"environment_id": 10,
+		"type":           "generic",
+		"parent_id":      realSecret.ID,
+	}
+	b, _ := json.Marshal(body)
+	r := withAdminCtxFolder(httptest.NewRequest(http.MethodPost, "/api/v1/secrets", bytes.NewReader(b)))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateSecret(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "expected 400 for non-folder parent; body: %s", w.Body.String())
+}
+
+// TestCreateSecret_NonExistentParentID verifies that POST /api/v1/secrets with a
+// parent_id that does not exist is rejected with 400.
+func TestCreateSecret_NonExistentParentID(t *testing.T) {
+	h, _, _, _ := freshFolderFixture(t)
+
+	body := map[string]interface{}{
+		"name":           "orphan-secret",
+		"value":          "val",
+		"project_id":     1,
+		"environment_id": 10,
+		"type":           "generic",
+		"parent_id":      99999,
+	}
+	b, _ := json.Marshal(body)
+	r := withAdminCtxFolder(httptest.NewRequest(http.MethodPost, "/api/v1/secrets", bytes.NewReader(b)))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateSecret(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "expected 400 for non-existent parent; body: %s", w.Body.String())
+}
+
+// ── HTTP: list with ?parent_id=N ──────────────────────────────────────────────
+
+// TestListSecrets_ParentID verifies that GET /api/v1/secrets?parent_id=N returns
+// only the secrets that are direct children of that folder.
+func TestListSecrets_ParentID(t *testing.T) {
+	h, cs, folder, _ := freshFolderFixture(t)
+
+	// Create a child secret inside the folder.
+	child, err := cs.CreateSecret(context.Background(), &core.CreateSecretRequest{
+		Name: "folder-child", Value: []byte("val"), ProjectID: 1, EnvironmentID: 10,
+		Type: "generic", CreatedBy: "alice-folder", OwnerID: 1,
+		ParentID: &folder.ID,
+	})
+	require.NoError(t, err)
+
+	// Create a root-level secret (no parent) to confirm it is excluded.
+	_, err = cs.CreateSecret(context.Background(), &core.CreateSecretRequest{
+		Name: "root-secret", Value: []byte("val2"), ProjectID: 1, EnvironmentID: 10,
+		Type: "generic", CreatedBy: "alice-folder", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	url := fmt.Sprintf("/api/v1/secrets?project_id=1&parent_id=%d", folder.ID)
+	r := withAdminCtxFolder(httptest.NewRequest(http.MethodGet, url, nil))
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	resp := decodeFolderListResponse(t, w.Body.Bytes())
+	assert.Equal(t, int64(1), resp.Total, "expected exactly 1 child secret")
+	require.Len(t, resp.Secrets, 1)
+	require.NotNil(t, resp.Secrets[0].SecretNode)
+	assert.Equal(t, child.ID, resp.Secrets[0].ID)
+}
+
+// TestListSecrets_FolderOnly verifies that GET /api/v1/secrets?folder_only=true
+// returns only folder nodes (IsSecret=false).
+func TestListSecrets_FolderOnly(t *testing.T) {
+	h, cs, _, _ := freshFolderFixture(t)
+
+	// Create a real secret to confirm it is excluded.
+	_, err := cs.CreateSecret(context.Background(), &core.CreateSecretRequest{
+		Name: "real-secret-folderonly", Value: []byte("val"), ProjectID: 1, EnvironmentID: 10,
+		Type: "generic", CreatedBy: "alice-folder", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	r := withAdminCtxFolder(httptest.NewRequest(http.MethodGet, "/api/v1/secrets?project_id=1&folder_only=true", nil))
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	resp := decodeFolderListResponse(t, w.Body.Bytes())
+	// The fixture seeds one folder; the real secret must be excluded.
+	assert.Equal(t, int64(1), resp.Total, "expected exactly 1 folder node")
+	for _, s := range resp.Secrets {
+		require.NotNil(t, s.SecretNode)
+		assert.False(t, s.IsSecret, "folder_only=true returned a real secret (id=%d)", s.ID)
+	}
+}

--- a/server/http/handlers/secrets_list.go
+++ b/server/http/handlers/secrets_list.go
@@ -123,6 +123,15 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) { //
 			filter.ExpiresBefore = &t
 		}
 	}
+	if pidStr := r.URL.Query().Get("parent_id"); pidStr != "" {
+		if pID, err := strconv.ParseUint(pidStr, 10, 32); err == nil {
+			pIDUint := uint(pID)
+			filter.ParentID = &pIDUint
+		}
+	}
+	if r.URL.Query().Get("folder_only") == "true" {
+		filter.FolderOnly = true
+	}
 
 	// Machine principals (ADR-030) have no user identity for the owned/shared
 	// model; they list by their authorized scope without the scoped-union logic.

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -232,6 +232,10 @@ message CreateSecretRequest {
   optional google.protobuf.Timestamp expiration = 7;
   map<string, string> metadata = 8;
   repeated string tags = 9;
+  // parent_id optionally places the new secret inside a folder node.
+  // The parent must exist, be a folder (is_secret=false), and belong to the
+  // same project/environment. 0 or absent means root level.
+  optional uint32 parent_id = 10;
 }
 
 message GetSecretRequest {
@@ -264,6 +268,10 @@ message ListSecretsRequest {
   bool show_shared_only = 7;
   uint32 page = 8;
   uint32 page_size = 9;
+  // parent_id, when set, restricts results to direct children of that folder node.
+  optional uint32 parent_id = 10;
+  // folder_only, when true, returns only folder nodes (is_secret=false).
+  bool folder_only = 11;
 }
 
 message ListSecretsResponse {

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -308,6 +308,10 @@ type CreateSecretRequest struct {
 	Expiration    *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=expiration,proto3,oneof" json:"expiration,omitempty"`
 	Metadata      map[string]string      `protobuf:"bytes,8,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Tags          []string               `protobuf:"bytes,9,rep,name=tags,proto3" json:"tags,omitempty"`
+	// parent_id optionally places the new secret inside a folder node.
+	// The parent must exist, be a folder (is_secret=false), and belong to the
+	// same project/environment. 0 or absent means root level.
+	ParentId      *uint32 `protobuf:"varint,10,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -403,6 +407,13 @@ func (x *CreateSecretRequest) GetTags() []string {
 		return x.Tags
 	}
 	return nil
+}
+
+func (x *CreateSecretRequest) GetParentId() uint32 {
+	if x != nil && x.ParentId != nil {
+		return *x.ParentId
+	}
+	return 0
 }
 
 type GetSecretRequest struct {
@@ -598,8 +609,12 @@ type ListSecretsRequest struct {
 	ShowSharedOnly bool    `protobuf:"varint,7,opt,name=show_shared_only,json=showSharedOnly,proto3" json:"show_shared_only,omitempty"`
 	Page           uint32  `protobuf:"varint,8,opt,name=page,proto3" json:"page,omitempty"`
 	PageSize       uint32  `protobuf:"varint,9,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// parent_id, when set, restricts results to direct children of that folder node.
+	ParentId *uint32 `protobuf:"varint,10,opt,name=parent_id,json=parentId,proto3,oneof" json:"parent_id,omitempty"`
+	// folder_only, when true, returns only folder nodes (is_secret=false).
+	FolderOnly    bool `protobuf:"varint,11,opt,name=folder_only,json=folderOnly,proto3" json:"folder_only,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ListSecretsRequest) Reset() {
@@ -693,6 +708,20 @@ func (x *ListSecretsRequest) GetPageSize() uint32 {
 		return x.PageSize
 	}
 	return 0
+}
+
+func (x *ListSecretsRequest) GetParentId() uint32 {
+	if x != nil && x.ParentId != nil {
+		return *x.ParentId
+	}
+	return 0
+}
+
+func (x *ListSecretsRequest) GetFolderOnly() bool {
+	if x != nil {
+		return x.FolderOnly
+	}
+	return false
 }
 
 type ListSecretsResponse struct {
@@ -10663,7 +10692,7 @@ const file_keyorix_proto_rawDesc = "" +
 	"\x05value\x18\x03 \x01(\tR\x05value\x12%\n" +
 	"\x0eversion_number\x18\x04 \x01(\rR\rversionNumber\x12\x1d\n" +
 	"\n" +
-	"read_count\x18\x05 \x01(\rR\treadCount\"\xb5\x03\n" +
+	"read_count\x18\x05 \x01(\rR\treadCount\"\xe5\x03\n" +
 	"\x13CreateSecretRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value\x12\x1d\n" +
@@ -10676,13 +10705,17 @@ const file_keyorix_proto_rawDesc = "" +
 	"expiration\x18\a \x01(\v2\x1a.google.protobuf.TimestampH\x01R\n" +
 	"expiration\x88\x01\x01\x12I\n" +
 	"\bmetadata\x18\b \x03(\v2-.keyorix.v1.CreateSecretRequest.MetadataEntryR\bmetadata\x12\x12\n" +
-	"\x04tags\x18\t \x03(\tR\x04tags\x1a;\n" +
+	"\x04tags\x18\t \x03(\tR\x04tags\x12 \n" +
+	"\tparent_id\x18\n" +
+	" \x01(\rH\x02R\bparentId\x88\x01\x01\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\f\n" +
 	"\n" +
 	"_max_readsB\r\n" +
-	"\v_expiration\"G\n" +
+	"\v_expirationB\f\n" +
+	"\n" +
+	"_parent_id\"G\n" +
 	"\x10GetSecretRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12#\n" +
 	"\rinclude_value\x18\x02 \x01(\bR\fincludeValue\"\xe6\x02\n" +
@@ -10703,7 +10736,7 @@ const file_keyorix_proto_rawDesc = "" +
 	"_max_readsB\r\n" +
 	"\v_expiration\"%\n" +
 	"\x13DeleteSecretRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\rR\x02id\"\x87\x03\n" +
+	"\x02id\x18\x01 \x01(\rR\x02id\"\xd8\x03\n" +
 	"\x12ListSecretsRequest\x12\"\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\rH\x00R\tprojectId\x88\x01\x01\x12*\n" +
@@ -10716,12 +10749,18 @@ const file_keyorix_proto_rawDesc = "" +
 	"\x0fshow_owned_only\x18\x06 \x01(\bR\rshowOwnedOnly\x12(\n" +
 	"\x10show_shared_only\x18\a \x01(\bR\x0eshowSharedOnly\x12\x12\n" +
 	"\x04page\x18\b \x01(\rR\x04page\x12\x1b\n" +
-	"\tpage_size\x18\t \x01(\rR\bpageSizeB\r\n" +
+	"\tpage_size\x18\t \x01(\rR\bpageSize\x12 \n" +
+	"\tparent_id\x18\n" +
+	" \x01(\rH\x05R\bparentId\x88\x01\x01\x12\x1f\n" +
+	"\vfolder_only\x18\v \x01(\bR\n" +
+	"folderOnlyB\r\n" +
 	"\v_project_idB\x11\n" +
 	"\x0f_environment_idB\a\n" +
 	"\x05_typeB\t\n" +
 	"\a_searchB\r\n" +
-	"\v_permission\"\xef\x01\n" +
+	"\v_permissionB\f\n" +
+	"\n" +
+	"_parent_id\"\xef\x01\n" +
 	"\x13ListSecretsResponse\x12,\n" +
 	"\asecrets\x18\x01 \x03(\v2\x12.keyorix.v1.SecretR\asecrets\x12\x14\n" +
 	"\x05total\x18\x02 \x01(\rR\x05total\x12\x12\n" +


### PR DESCRIPTION
## Summary

- **POST /api/v1/secrets**: add optional `parent_id` body field to place a new secret inside a folder node (`is_secret=false`). The parent is validated: it must exist, be a folder, and belong to the same project/environment. A `400` is returned for non-existent or non-folder parents.
- **GET /api/v1/secrets**: add `?parent_id=N` (filter to direct children of a folder) and `?folder_only=true` (list only folder nodes) query params.
- **Core**: `CreateSecretRequest.ParentID *uint` + folder validation in `CreateSecret`; `SecretFilter` and `SecretListFilter` gain `ParentID` and `FolderOnly`; wired through `convertToStorageFilter` → `LocalStorage.ListSecrets`.
- **gRPC**: `CreateSecretRequest.parent_id` (field 10) and `ListSecretsRequest.parent_id` / `folder_only` (fields 10–11); proto regenerated; service wired.
- **CLI**: `secret create --folder <id>` and `secret list --folder <id>`.

## Test plan

- [ ] `go test ./internal/core/... ./internal/storage/... ./server/http/handlers/... ./server/grpc/services/... ./internal/cli/secret/...` — all pass (14 new tests, 0 regressions)
- [ ] HTTP: create secret with valid `parent_id` → `201`, `ParentID` set on response
- [ ] HTTP: create secret with non-folder `parent_id` → `400`
- [ ] HTTP: create secret with non-existent `parent_id` → `400`
- [ ] HTTP: `GET /api/v1/secrets?parent_id=N` → returns only children of that folder
- [ ] HTTP: `GET /api/v1/secrets?folder_only=true` → returns only folder nodes
- [ ] Core: `CreateSecret` with cross-project parent → error
- [ ] CLI: `--folder 42` sets `parent_id` in HTTP body / `?parent_id=42` in list query

🤖 Generated with [Claude Code](https://claude.com/claude-code)