### PR TITLE
fix(test): deduplicate apiNotOK helper in remote store coverage tests

### DIFF
--- a/internal/storage/store/remote_coverage_campaigns_dynamic_invitations_test.go
+++ b/internal/storage/store/remote_coverage_campaigns_dynamic_invitations_test.go
@@ -9,7 +9,6 @@ package store_test
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,24 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// apiNotOK returns a 200-body whose success field is false, together with an
-// error object carrying the given code and message.  This is the only way to
-// exercise the `if !resp.Success` branches in RemoteStorage methods; the
-// remote client turns real 4xx/5xx responses into a network-level error before
-// those branches are reached.
-func apiNotOK(code, message string) []byte {
-	type errObj struct {
-		Code    string `json:"code"`
-		Message string `json:"message"`
-	}
-	type resp struct {
-		Success bool   `json:"success"`
-		Error   errObj `json:"error"`
-	}
-	b, _ := json.Marshal(resp{Success: false, Error: errObj{Code: code, Message: message}})
-	return b
-}
 
 // ============================================================================
 // remote_access_review_campaigns.go — error paths

--- a/internal/storage/store/remote_coverage_mfa_rbac_secrets_test.go
+++ b/internal/storage/store/remote_coverage_mfa_rbac_secrets_test.go
@@ -9,7 +9,6 @@ package store_test
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,21 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// apiNotOK returns an HTTP-200 body whose success=false, mirroring the shape
-// the Keyorix client library parses for application-level errors.
-func apiNotOK(code, message string) []byte {
-	type errObj struct {
-		Code    string `json:"code"`
-		Message string `json:"message"`
-	}
-	type resp struct {
-		Success bool   `json:"success"`
-		Error   errObj `json:"error"`
-	}
-	b, _ := json.Marshal(resp{Success: false, Error: errObj{Code: code, Message: message}})
-	return b
-}
 
 // --------------------------------------------------------------------------
 // remote_mfa.go — error paths

--- a/internal/storage/store/remote_coverage_policies_memberships_auth_test.go
+++ b/internal/storage/store/remote_coverage_policies_memberships_auth_test.go
@@ -14,7 +14,6 @@ package store_test
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -25,25 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// apiNotOK returns a 200-status JSON body with success:false. Using HTTP 200
-// ensures the remote client does NOT convert the response into an HTTPError,
-// which means the !resp.Success branch inside each method is reached.
-func apiNotOK(code, message string) []byte {
-	type errBody struct {
-		Code    string `json:"code"`
-		Message string `json:"message"`
-	}
-	type resp struct {
-		Success bool    `json:"success"`
-		Error   errBody `json:"error"`
-	}
-	b, _ := json.Marshal(resp{
-		Success: false,
-		Error:   errBody{Code: code, Message: message},
-	})
-	return b
-}
 
 // ============================================================
 // remote_break_glass.go — !resp.Success branches


### PR DESCRIPTION
## Summary
- `apiNotOK` was declared independently in four `store_test` package files that were merged in sequence across two coverage blitzes (#1025, #1027, #1028, #1029)
- The duplicate declarations cause a `DuplicateDecl` compile error on any PR that merges on top of main
- Removes the three duplicate declarations; the canonical copy in `remote_coverage_test.go` serves all four files (same `store_test` package)
- Drops the now-unused `encoding/json` import from the three files that no longer need it

## Test plan
- [ ] `go vet ./internal/storage/store/` passes (no DuplicateDecl)
- [ ] CI build-and-test passes