### PR TITLE
fix(quality): address SonarCloud issues

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -38,7 +38,7 @@ jobs:
           done
 
       - name: Install Nuclei
-        run: go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest
+        run: go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.3.9
 
       - name: Update Nuclei templates
         run: nuclei -update-templates -silent

--- a/internal/cli/rbac/assign_role.go
+++ b/internal/cli/rbac/assign_role.go
@@ -72,46 +72,45 @@ func runAssignRole(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Resolve scope.
-	scope := storage.Scope{}
-	if assignProjectFlag != "" {
-		projectID, err := common.LookupProjectIDByName(ctx, st, assignProjectFlag)
-		if err != nil {
-			return fmt.Errorf("failed to resolve project: %w", err)
-		}
-		scope.ProjectID = projectID
-
-		if assignEnvFlag != "" {
-			envs, err := st.ListEnvironmentsByProject(ctx, projectID)
-			if err != nil {
-				return fmt.Errorf("failed to list environments: %w", err)
-			}
-			found := false
-			for _, e := range envs {
-				if strings.EqualFold(e.Name, assignEnvFlag) {
-					scope.EnvironmentID = e.ID
-					found = true
-					break
-				}
-			}
-			if !found {
-				return fmt.Errorf("environment %q not found in project %q", assignEnvFlag, assignProjectFlag)
-			}
-		}
+	scope, err := resolveScope(ctx, st, assignProjectFlag, assignEnvFlag)
+	if err != nil {
+		return err
 	}
 
-	// Create core service
 	coreService := core.NewKeyorixCore(st)
-
-	// Use core service to assign role at the resolved scope.
-	err = coreService.AssignUserRoleScoped(ctx, userEmail, roleName, scope)
-	if err != nil {
+	if err = coreService.AssignUserRoleScoped(ctx, userEmail, roleName, scope); err != nil {
 		return fmt.Errorf("failed to assign role: %w", err)
 	}
 
 	suffix := scopeSuffix(assignProjectFlag, assignEnvFlag)
 	fmt.Printf("Successfully assigned role '%s' to user '%s'%s\n", roleName, userEmail, suffix)
 	return nil
+}
+
+// resolveScope looks up the project and environment IDs for scope-scoped role grants.
+func resolveScope(ctx context.Context, st storage.Storage, project, env string) (storage.Scope, error) {
+	if project == "" {
+		return storage.Scope{}, nil
+	}
+	projectID, err := common.LookupProjectIDByName(ctx, st, project)
+	if err != nil {
+		return storage.Scope{}, fmt.Errorf("failed to resolve project: %w", err)
+	}
+	scope := storage.Scope{ProjectID: projectID}
+	if env == "" {
+		return scope, nil
+	}
+	envs, err := st.ListEnvironmentsByProject(ctx, projectID)
+	if err != nil {
+		return storage.Scope{}, fmt.Errorf("failed to list environments: %w", err)
+	}
+	for _, e := range envs {
+		if strings.EqualFold(e.Name, env) {
+			scope.EnvironmentID = e.ID
+			return scope, nil
+		}
+	}
+	return storage.Scope{}, fmt.Errorf("environment %q not found in project %q", env, project)
 }
 
 // scopeSuffix returns a human-readable scope qualifier for display messages.

--- a/internal/cli/rbac/remove_role.go
+++ b/internal/cli/rbac/remove_role.go
@@ -3,11 +3,9 @@ package rbac
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/spf13/cobra"
 )
 
@@ -48,46 +46,18 @@ func runRemoveRole(cmd *cobra.Command, args []string) error {
 		return runRemoveRoleRemote(ctx, rc, removeUserEmail, removeRoleName, removeProjectFlag, removeEnvFlag)
 	}
 
-	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
 	st, err := common.InitializeStorage()
 	if err != nil {
 		return err
 	}
 
-	// Resolve scope.
-	scope := storage.Scope{}
-	if removeProjectFlag != "" {
-		projectID, err := common.LookupProjectIDByName(ctx, st, removeProjectFlag)
-		if err != nil {
-			return fmt.Errorf("failed to resolve project: %w", err)
-		}
-		scope.ProjectID = projectID
-
-		if removeEnvFlag != "" {
-			envs, err := st.ListEnvironmentsByProject(ctx, projectID)
-			if err != nil {
-				return fmt.Errorf("failed to list environments: %w", err)
-			}
-			found := false
-			for _, e := range envs {
-				if strings.EqualFold(e.Name, removeEnvFlag) {
-					scope.EnvironmentID = e.ID
-					found = true
-					break
-				}
-			}
-			if !found {
-				return fmt.Errorf("environment %q not found in project %q", removeEnvFlag, removeProjectFlag)
-			}
-		}
+	scope, err := resolveScope(ctx, st, removeProjectFlag, removeEnvFlag)
+	if err != nil {
+		return err
 	}
 
-	// Create core service
 	coreService := core.NewKeyorixCore(st)
-
-	// Use core service to remove role at the resolved scope.
-	err = coreService.RemoveUserRoleScoped(ctx, removeUserEmail, removeRoleName, scope)
-	if err != nil {
+	if err = coreService.RemoveUserRoleScoped(ctx, removeUserEmail, removeRoleName, scope); err != nil {
 		return fmt.Errorf("failed to remove role: %w", err)
 	}
 

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -27,6 +27,8 @@ type SecretGRPCService struct {
 // Compile-time assertion that the service satisfies the generated interface.
 var _ pb.SecretServiceServer = (*SecretGRPCService)(nil)
 
+const errSecretIDRequired = "secret_id is required"
+
 // NewSecretService creates a secret gRPC service backed by the shared core.
 func NewSecretService(coreService *core.KeyorixCore) *SecretGRPCService {
 	return &SecretGRPCService{core: coreService}
@@ -369,7 +371,7 @@ func (s *SecretGRPCService) GrantSecretACL(ctx context.Context, req *pb.GrantSec
 		return nil, err
 	}
 	if req.GetSecretId() == 0 {
-		return nil, status.Error(codes.InvalidArgument, "secret_id is required")
+		return nil, status.Error(codes.InvalidArgument, errSecretIDRequired)
 	}
 	if req.GetUserId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "user_id is required")
@@ -404,7 +406,7 @@ func (s *SecretGRPCService) RevokeSecretACL(ctx context.Context, req *pb.RevokeS
 		return nil, err
 	}
 	if req.GetSecretId() == 0 {
-		return nil, status.Error(codes.InvalidArgument, "secret_id is required")
+		return nil, status.Error(codes.InvalidArgument, errSecretIDRequired)
 	}
 	if req.GetAclId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "acl_id is required")
@@ -426,7 +428,7 @@ func (s *SecretGRPCService) ListSecretACLs(ctx context.Context, req *pb.ListSecr
 		return nil, err
 	}
 	if req.GetSecretId() == 0 {
-		return nil, status.Error(codes.InvalidArgument, "secret_id is required")
+		return nil, status.Error(codes.InvalidArgument, errSecretIDRequired)
 	}
 	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetSecretId()), permSecretsManage); err != nil {
 		return nil, err

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -27,7 +27,7 @@ type SecretGRPCService struct {
 // Compile-time assertion that the service satisfies the generated interface.
 var _ pb.SecretServiceServer = (*SecretGRPCService)(nil)
 
-const errSecretIDRequired = "secret_id is required"
+const errSecretIDRequired = "secret_id is required" // #nosec G101 -- error message string, not a hardcoded credential
 
 // NewSecretService creates a secret gRPC service backed by the shared core.
 func NewSecretService(coreService *core.KeyorixCore) *SecretGRPCService {

--- a/server/http/handlers/constants.go
+++ b/server/http/handlers/constants.go
@@ -6,6 +6,7 @@ const (
 	errFailedCreateUser = "Failed to create user"
 	errFailedGetRole = "Failed to get role"
 	errFailedGetUser = "Failed to get user"
+	errFailedToListSecrets = "Failed to list secrets"
 	errGroupNotFound = "Group not found"
 	errGroupNotFoundLower = "group not found"
 	errInvalidAccessRequestID = "invalid access request ID"

--- a/server/http/handlers/constants.go
+++ b/server/http/handlers/constants.go
@@ -6,7 +6,7 @@ const (
 	errFailedCreateUser = "Failed to create user"
 	errFailedGetRole = "Failed to get role"
 	errFailedGetUser = "Failed to get user"
-	errFailedToListSecrets = "Failed to list secrets"
+	errFailedToListSecrets = "Failed to list secrets" // #nosec G101 -- error message string, not a hardcoded credential
 	errGroupNotFound = "Group not found"
 	errGroupNotFoundLower = "group not found"
 	errInvalidAccessRequestID = "invalid access request ID"

--- a/server/http/handlers/secret_acl_handler.go
+++ b/server/http/handlers/secret_acl_handler.go
@@ -25,7 +25,7 @@ func (h *SecretHandler) ListSecretACLs(w http.ResponseWriter, r *http.Request) {
 	}
 	secretID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
-		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
 		return
 	}
 	acls, err := h.coreService.ListSecretACLs(r.Context(), uint(secretID))
@@ -45,7 +45,7 @@ func (h *SecretHandler) GrantSecretACL(w http.ResponseWriter, r *http.Request) {
 	}
 	secretID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
-		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
 		return
 	}
 	var body struct {
@@ -80,7 +80,7 @@ func (h *SecretHandler) RevokeSecretACL(w http.ResponseWriter, r *http.Request) 
 	}
 	secretID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
-		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
 		return
 	}
 	aclID, err := strconv.ParseUint(chi.URLParam(r, "aclId"), 10, 32)

--- a/server/http/handlers/secrets_list.go
+++ b/server/http/handlers/secrets_list.go
@@ -132,7 +132,7 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) { //
 		response, err = h.coreService.ListSecretsInScope(r.Context(), filter)
 		if err != nil {
 			log.Printf("Error listing secrets: %v", err)
-			h.sendError(w, "InternalError", "Failed to list secrets", http.StatusInternalServerError, nil)
+			h.sendError(w, "InternalError", errFailedToListSecrets, http.StatusInternalServerError, nil)
 			return
 		}
 		h.resolveSecretNames(r.Context(), response.Secrets)
@@ -155,7 +155,7 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) { //
 	if scopeRequested {
 		// Caller narrowed to a specific scope — enforce secrets.read there.
 		allowed, aerr := h.coreService.AuthorizePrincipal(
-			r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), "secrets.read", requestedScope,
+			r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), permSecretsRead, requestedScope,
 		)
 		if aerr != nil || !allowed {
 			h.sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
@@ -165,7 +165,7 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) { //
 		response, err = h.coreService.ListSecretsWithSharingInfo(r.Context(), userCtx.UserID, filter)
 		if err != nil {
 			log.Printf("Error listing secrets: %v", err)
-			h.sendError(w, "InternalError", "Failed to list secrets", http.StatusInternalServerError, nil)
+			h.sendError(w, "InternalError", errFailedToListSecrets, http.StatusInternalServerError, nil)
 			return
 		}
 		h.resolveSecretNames(r.Context(), response.Secrets)
@@ -175,14 +175,14 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) { //
 
 	// No scope filter — try global first.
 	globalOK, aerr := h.coreService.AuthorizePrincipal(
-		r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), "secrets.read", core.Scope{},
+		r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), permSecretsRead, core.Scope{},
 	)
 	if aerr == nil && globalOK {
 		// Global reader — original behaviour.
 		response, err = h.coreService.ListSecretsWithSharingInfo(r.Context(), userCtx.UserID, filter)
 		if err != nil {
 			log.Printf("Error listing secrets: %v", err)
-			h.sendError(w, "InternalError", "Failed to list secrets", http.StatusInternalServerError, nil)
+			h.sendError(w, "InternalError", errFailedToListSecrets, http.StatusInternalServerError, nil)
 			return
 		}
 		h.resolveSecretNames(r.Context(), response.Secrets)
@@ -191,10 +191,10 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) { //
 	}
 
 	// Not a global reader — enumerate scopes and return the union.
-	scopes, serr := h.coreService.GetReadableScopes(r.Context(), userCtx.UserID, "secrets.read")
+	scopes, serr := h.coreService.GetReadableScopes(r.Context(), userCtx.UserID, permSecretsRead)
 	if serr != nil {
 		log.Printf("Error enumerating readable scopes for user %d: %v", userCtx.UserID, serr)
-		h.sendError(w, "InternalError", "Failed to list secrets", http.StatusInternalServerError, nil)
+		h.sendError(w, "InternalError", errFailedToListSecrets, http.StatusInternalServerError, nil)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- **dast.yml**: Pin `nuclei@latest` → `nuclei@v3.3.9` so DAST builds are reproducible (SonarCloud S6437)
- **assign_role.go / remove_role.go**: Extract inline project+environment lookup into `resolveScope()` helper — reduces cognitive complexity from 25/23 to ≤10 each (SonarCloud S3776)
- **secret_service.go**: Define `errSecretIDRequired` constant; replace 3 duplicate `"secret_id is required"` literals (SonarCloud S1192)
- **secret_acl_handler.go**: Use existing `errInvalidSecretID` constant from `constants.go` for the 3 `"Invalid secret ID"` occurrences (SonarCloud S1192)
- **secrets_list.go**: Add `errFailedToListSecrets` to `constants.go`; replace 4 `"Failed to list secrets"` and 3 `"secrets.read"` literals with existing `permSecretsRead` (SonarCloud S1192)

## Test plan
- [ ] `go vet ./...` passes
- [ ] lint passes
- [ ] build-and-test passes