### PR TITLE
ci: preflight fast-gate before build-and-test, lint, fuzz, licenses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,11 @@ env:
   COVERAGE_FLOOR: '80'
 
 jobs:
-  build-and-test:
+  # Fast compile gate (~30s). Catches redeclarations, type errors, and build
+  # failures before any expensive job starts. Jobs that require the main module
+  # to compile declare `needs: [preflight]`; unrelated jobs (operator, gitleaks,
+  # helm-*, openapi-lint) keep running in parallel.
+  preflight:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -49,6 +53,17 @@ jobs:
 
       - name: go build
         run: go build ./...
+
+  build-and-test:
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.26.5'
 
       - name: go test
         run: |
@@ -86,6 +101,7 @@ jobs:
           gosec -severity medium -exclude-generated ./...
 
   lint:
+    needs: [preflight]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -156,6 +172,7 @@ jobs:
   #     entry (e.g. after a rename/removal) that run-rotation.sh would fail
   #     to run every cycle.
   fuzz-targets:
+    needs: [preflight]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -253,6 +270,7 @@ jobs:
   # program. No GPL/AGPL/LGPL/SSPL/BSL/Commons-Clause/Elastic/Unknown licenses
   # were found in either module's real dependency tree.
   licenses:
+    needs: [preflight]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

- Adds a `preflight` job (~30s) that runs `go vet ./...` + `go build ./...` before any expensive work starts
- `build-and-test`, `lint`, `fuzz-targets`, and `licenses` all declare `needs: [preflight]`, so a compile error (redeclaration, type mismatch) fails fast without burning CI minutes on the test suite, govulncheck, gosec, or golangci-lint
- Jobs that don't require the main module to compile (`operator`, `gitleaks`, `helm-chart`, `helm-chart-security`, `openapi-lint`) remain fully parallel — no change in their behavior or latency
- Removes the now-redundant `go vet` and `go build` steps from `build-and-test` since preflight already guarantees them

## What this changes

**Green path:** +~30s overhead (preflight must finish before tests/lint start). Total wall-clock stays similar because `go vet + go build` was already the first thing `build-and-test` did.

**Red path (compile error):** fails at ~30s. Previously the test suite, govulncheck, gosec, and golangci-lint all started in parallel and burned minutes before failing on the same root error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)