### PR TITLE
ci(trivy): drop redundant vuln+secret scanners, keep misconfig only

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,12 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
 
-      - name: Run Trivy (deps + Dockerfile misconfigs + secrets)
+      - name: Run Trivy (Dockerfile / Helm / k8s misconfigs)
         uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
-          scanners: vuln,misconfig,secret
+          scanners: misconfig
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH


### PR DESCRIPTION
## Summary

- `vuln` scanner is fully redundant: osv-scanner already covers Go module and container CVEs with SBOM attestation
- `secret` scanner is fully redundant: gitleaks is a superset (broader ruleset, all branches/history)
- `misconfig` scanner is the only scanner with unique value: Dockerfile, Helm chart, and k8s manifest checks that neither osv-scanner nor gitleaks perform

Keeps Trivy focused on what it's uniquely good at; zero coverage loss.

## Test plan

- [ ] Trivy CI job runs on PR and main pushes with `scanners: misconfig`
- [ ] osv-scanner and gitleaks jobs continue to cover vuln/secret surface
- [ ] SARIF upload to Security tab still works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)