### PR TITLE
fix(security): restrict DAST workflow permissions + eliminate string-formatted SQL

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -6,6 +6,8 @@ on:
     - cron: '0 3 * * 1'  # weekly Monday 3am UTC
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   nuclei:
     name: Nuclei DAST

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -740,15 +740,18 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	// RBAC Phase 2: scope role assignments by environment as well as project.
 	// project_id already exists (nullable on pre-008 DBs); add environment_id and
 	// normalise NULL project_id rows to the 0 = global sentinel the queries expect.
-	for _, tbl := range []string{"user_roles", "group_roles"} {
-		if !tableExists(db, tbl) {
+	for _, m := range []struct{ tbl, addEnvID, nullPID string }{
+		{"user_roles", "ALTER TABLE user_roles ADD COLUMN environment_id INTEGER NOT NULL DEFAULT 0", "UPDATE user_roles SET project_id = 0 WHERE project_id IS NULL"},
+		{"group_roles", "ALTER TABLE group_roles ADD COLUMN environment_id INTEGER NOT NULL DEFAULT 0", "UPDATE group_roles SET project_id = 0 WHERE project_id IS NULL"},
+	} {
+		if !tableExists(db, m.tbl) {
 			continue
 		}
-		if !columnExists(db, tbl, "environment_id") {
-			db.Exec(fmt.Sprintf("ALTER TABLE %s ADD COLUMN environment_id INTEGER NOT NULL DEFAULT 0", tbl))
+		if !columnExists(db, m.tbl, "environment_id") {
+			db.Exec(m.addEnvID)
 		}
-		if columnExists(db, tbl, "project_id") {
-			db.Exec(fmt.Sprintf("UPDATE %s SET project_id = 0 WHERE project_id IS NULL", tbl))
+		if columnExists(db, m.tbl, "project_id") {
+			db.Exec(m.nullPID)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Closes two GitHub Security alerts:

**#541 — Token-Permissions (Scorecard) in `dast.yml`**
- Added `permissions: {}` at the workflow level so any future jobs added to the file don't silently inherit the repo's default write-all GITHUB_TOKEN
- The `nuclei` job already had correct minimal per-job grants (`security-events: write`, `contents: read`) — this just locks down the workflow-level default

**#538 — Semgrep `string-formatted-query` in `factory.go:751`**
- Replaced `fmt.Sprintf("UPDATE %s ...", tbl)` in the RBAC Phase 2 migration loop with a literal struct slice (`[]struct{ tbl, addEnvID, nullPID string }`)
- Table names were already from a hardcoded `[]string` so there was no real injection risk; using literal SQL strings per entry makes the safety obvious to static analysis without any `// nosemgrep` suppression

## Test plan

- [ ] CI lint + build-and-test green
- [ ] DAST workflow continues to run correctly (job permissions unchanged)
- [ ] Scorecard Token-Permissions alert #541 dismissed on merge
- [ ] Semgrep alert #538 dismissed on merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)