### PR TITLE
fix(sonar): remove U+FFFD replacement chars from handlers_s4_test.go section divider

### DIFF
--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -4259,7 +4259,7 @@ func TestBeginWebAuthnPasswordlessLogin_BadBody(t *testing.T) {
 	assert.NotEqual(t, http.StatusOK, w.Code)
 }
 
-// ── rotation_policies_handler.go ��────────────────────────────────────────────
+// ── rotation_policies_handler.go ──────────────────────────────────────────────
 
 func TestRotationPolicyHandler_List_Unauthorized(t *testing.T) {
 	h := NewRotationPolicyHandler(newHandlerCore(t))


### PR DESCRIPTION
## Summary

- Two `U+FFFD` (Unicode replacement character, bytes `EF BF BD`) were embedded in the `rotation_policies_handler.go` section-divider comment at line 4262 of `server/http/handlers/handlers_s4_test.go`
- SonarCloud's scanner treats `U+FFFD` as a broken-encoding marker and raises the **"There are problems with file encoding in the source code"** dashboard warning, even though the file is otherwise valid UTF-8
- Replaced both with `U+2500` (BOX DRAWINGS LIGHT HORIZONTAL, `─`) to match every other section divider in the file

Root cause: bad copy-paste of the divider template when the rotation-policies handler section was added; the source had invalid bytes that were transcoded to replacement characters.

## Test plan

- [ ] SonarCloud analysis on this PR passes with no encoding warning
- [ ] `go build ./...` passes (comment-only change, no logic affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)