### PR TITLE
feat(rbac): surface ACL-granted secrets in ListSecretsWithSharingInfo

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -2046,6 +2046,14 @@ func (m *MockStorage) ListSecretACLs(_ context.Context, _ uint) ([]*models.Secre
 	return nil, nil
 }
 
+func (m *MockStorage) ListSecretACLsByUser(ctx context.Context, userID uint) ([]*models.SecretACL, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.SecretACL), args.Error(1)
+}
+
 func (m *MockStorage) DeleteSecretACL(_ context.Context, _ uint) error {
 	return nil
 }

--- a/internal/core/secret_listing_acl_test.go
+++ b/internal/core/secret_listing_acl_test.go
@@ -1,0 +1,320 @@
+// secret_listing_acl_test.go — integration tests for the ACL-granted secret discovery
+// path in ListSecretsWithSharingInfo.
+//
+// A user who holds a SecretACL grant on a secret (or a folder) but neither owns
+// the secret nor has a legacy ShareRecord for it must see it in the list. These
+// tests exercise that gap against a real LocalStorage/SQLite backend to confirm
+// the full stack behaves correctly.
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var aclListDBCounter atomic.Int64
+
+// newACLListCore returns a KeyorixCore on a fresh in-memory SQLite DB with all
+// tables required for the listing-with-ACL tests already migrated.
+func newACLListCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	dsn := fmt.Sprintf("file:kxacl_list_%d?mode=memory&cache=shared", aclListDBCounter.Add(1))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{},
+		&models.SecretACL{},
+		&models.AuditEvent{},
+		&models.Project{},
+		&models.Environment{},
+		&models.ShareRecord{},
+		&models.User{},
+		&models.Role{},
+		&models.UserRole{},
+		&models.Permission{},
+		&models.RolePermission{},
+		&models.Group{},
+		&models.UserGroup{},
+		&models.GroupRole{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "p2"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env1"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, ProjectID: 2, Name: "env2"}).Error)
+	// owner = userID 1, grantee = userID 2
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "grantee", Email: "grantee@t.com"}).Error)
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	return c, db
+}
+
+// mkACLListSecret inserts a leaf secret (IsSecret=true) in project 1 / env 1 owned by user 1.
+func mkACLListSecret(t *testing.T, db *gorm.DB, name string) *models.SecretNode {
+	t.Helper()
+	s := &models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: name,
+		IsSecret: true, Status: "active", OwnerID: 1,
+	}
+	require.NoError(t, db.Create(s).Error)
+	return s
+}
+
+// mkACLListFolder inserts a folder node (IsSecret=false) in project 1 / env 1.
+func mkACLListFolder(t *testing.T, db *gorm.DB, name string, parentID *uint) *models.SecretNode {
+	t.Helper()
+	f := &models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: name,
+		IsSecret: false, Status: "active", OwnerID: 1, ParentID: parentID,
+	}
+	require.NoError(t, db.Create(f).Error)
+	return f
+}
+
+// mkACLListChildSecret inserts a leaf secret as a child of parentID.
+func mkACLListChildSecret(t *testing.T, db *gorm.DB, name string, parentID uint) *models.SecretNode {
+	t.Helper()
+	s := &models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: name,
+		IsSecret: true, Status: "active", OwnerID: 1, ParentID: &parentID,
+	}
+	require.NoError(t, db.Create(s).Error)
+	return s
+}
+
+// grantACL inserts a SecretACL row granting userID access to nodeID with the given perm.
+func grantACL(t *testing.T, db *gorm.DB, nodeID, userID uint, perm string) {
+	t.Helper()
+	permsJSON := `["` + perm + `"]`
+	require.NoError(t, db.Create(&models.SecretACL{
+		SecretID:    nodeID,
+		UserID:      userID,
+		Permissions: permsJSON,
+		GrantedBy:   1,
+	}).Error)
+}
+
+// TestListSecretsWithSharingInfo_ACLGrantedDirectSecret verifies that a user who
+// holds a SecretACL grant on a secret (and neither owns it nor has a ShareRecord
+// for it) sees the secret in the listing result.
+func TestListSecretsWithSharingInfo_ACLGrantedDirectSecret(t *testing.T) {
+	c, db := newACLListCore(t)
+	ctx := context.Background()
+
+	s := mkACLListSecret(t, db, "stripe-key")
+	grantACL(t, db, s.ID, 2, "secrets.read") // grant user 2 read on the secret
+
+	filter := &models.SecretListFilter{Page: 1, PageSize: 20}
+	result, err := c.ListSecretsWithSharingInfo(ctx, 2, filter)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(1), result.Total)
+	assert.Equal(t, 0, result.OwnedCount)
+	assert.Equal(t, 0, result.SharedCount)
+	assert.Equal(t, 1, result.ACLGrantedCount)
+
+	got := result.Secrets[0]
+	assert.Equal(t, s.ID, got.ID)
+	assert.Equal(t, "stripe-key", got.Name)
+	assert.False(t, got.IsOwnedByUser)
+	assert.False(t, got.IsShared)
+	assert.Equal(t, "read", got.UserPermission) // ACL "secrets.read" → normalised "read"
+	assert.NotNil(t, got.SharingIndicators)
+	assert.True(t, got.SharingIndicators.CanRead)
+	assert.False(t, got.SharingIndicators.CanWrite)
+	assert.False(t, got.SharingIndicators.CanShare)
+}
+
+// TestListSecretsWithSharingInfo_ACLGrantedFolderSecret verifies that a user
+// who holds a SecretACL grant on a folder sees every direct-child leaf secret
+// in the listing (folder-level inheritance).
+func TestListSecretsWithSharingInfo_ACLGrantedFolderSecret(t *testing.T) {
+	c, db := newACLListCore(t)
+	ctx := context.Background()
+
+	folder := mkACLListFolder(t, db, "infra-creds", nil)
+	child1 := mkACLListChildSecret(t, db, "db-password", folder.ID)
+	child2 := mkACLListChildSecret(t, db, "api-key", folder.ID)
+	mkACLListChildSecret(t, db, "unrelated", folder.ID) // user 2 will get this too — all children inherit
+
+	grantACL(t, db, folder.ID, 2, "secrets.read")
+
+	filter := &models.SecretListFilter{Page: 1, PageSize: 20}
+	result, err := c.ListSecretsWithSharingInfo(ctx, 2, filter)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(3), result.Total)
+	assert.Equal(t, 0, result.OwnedCount)
+	assert.Equal(t, 0, result.SharedCount)
+	assert.Equal(t, 3, result.ACLGrantedCount)
+
+	ids := make(map[uint]bool)
+	for _, s := range result.Secrets {
+		ids[s.ID] = true
+		assert.Equal(t, "read", s.UserPermission) // ACL "secrets.read" → normalised "read"
+	}
+	assert.True(t, ids[child1.ID])
+	assert.True(t, ids[child2.ID])
+}
+
+// TestListSecretsWithSharingInfo_ACLGrantedNestedFolder verifies two-level
+// folder nesting: a grant on the grandparent folder propagates to all descendants.
+func TestListSecretsWithSharingInfo_ACLGrantedNestedFolder(t *testing.T) {
+	c, db := newACLListCore(t)
+	ctx := context.Background()
+
+	root := mkACLListFolder(t, db, "root", nil)
+	sub := mkACLListFolder(t, db, "sub", &root.ID)
+	leaf := mkACLListChildSecret(t, db, "deep-secret", sub.ID)
+
+	grantACL(t, db, root.ID, 2, "secrets.write")
+
+	filter := &models.SecretListFilter{Page: 1, PageSize: 20}
+	result, err := c.ListSecretsWithSharingInfo(ctx, 2, filter)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(1), result.Total)
+	assert.Equal(t, leaf.ID, result.Secrets[0].ID)
+	assert.Equal(t, "write", result.Secrets[0].UserPermission) // ACL "secrets.write" → normalised "write"
+	assert.True(t, result.Secrets[0].SharingIndicators.CanWrite)
+}
+
+// TestListSecretsWithSharingInfo_ACLDeduplicatedFromOwned verifies that a secret
+// the user owns AND has an ACL grant for appears exactly once (as owned).
+func TestListSecretsWithSharingInfo_ACLDeduplicatedFromOwned(t *testing.T) {
+	c, db := newACLListCore(t)
+	ctx := context.Background()
+
+	// Create secret owned by user 2 (not the usual owner=1).
+	s := &models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: "my-secret",
+		IsSecret: true, Status: "active", OwnerID: 2,
+	}
+	require.NoError(t, db.Create(s).Error)
+	grantACL(t, db, s.ID, 2, "secrets.read") // also has explicit ACL
+
+	filter := &models.SecretListFilter{Page: 1, PageSize: 20}
+	result, err := c.ListSecretsWithSharingInfo(ctx, 2, filter)
+	require.NoError(t, err)
+
+	// Secret must appear exactly once — as owned, not as ACL-granted.
+	require.Equal(t, int64(1), result.Total, "deduplicated: secret appears once")
+	assert.Equal(t, 1, result.OwnedCount)
+	assert.Equal(t, 0, result.ACLGrantedCount)
+	assert.True(t, result.Secrets[0].IsOwnedByUser)
+}
+
+// TestListSecretsWithSharingInfo_ACLDeduplicatedFromShared verifies that a secret
+// the user already has a ShareRecord for does not appear a second time as ACL-granted.
+func TestListSecretsWithSharingInfo_ACLDeduplicatedFromShared(t *testing.T) {
+	c, db := newACLListCore(t)
+	ctx := context.Background()
+
+	s := mkACLListSecret(t, db, "shared-and-acl")
+	// Legacy ShareRecord: user 2 has a share.
+	require.NoError(t, db.Create(&models.ShareRecord{
+		SecretID: s.ID, OwnerID: 1, RecipientID: 2, Permission: "read",
+	}).Error)
+	// Also has an ACL grant.
+	grantACL(t, db, s.ID, 2, "secrets.read")
+
+	filter := &models.SecretListFilter{Page: 1, PageSize: 20}
+	result, err := c.ListSecretsWithSharingInfo(ctx, 2, filter)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(1), result.Total, "deduplicated: appears once (via ShareRecord)")
+	// The share is discovered first; the ACL path skips the already-seen ID.
+	assert.Equal(t, 0, result.ACLGrantedCount)
+}
+
+// TestListSecretsWithSharingInfo_ShowOwnedOnly_SkipsACL verifies that
+// ShowOwnedOnly=true suppresses the ACL-granted path entirely.
+func TestListSecretsWithSharingInfo_ShowOwnedOnly_SkipsACL(t *testing.T) {
+	c, db := newACLListCore(t)
+	ctx := context.Background()
+
+	s := mkACLListSecret(t, db, "owner-only-view")
+	grantACL(t, db, s.ID, 2, "secrets.read")
+
+	filter := &models.SecretListFilter{ShowOwnedOnly: true, Page: 1, PageSize: 20}
+	result, err := c.ListSecretsWithSharingInfo(ctx, 2, filter)
+	require.NoError(t, err)
+
+	// User 2 owns nothing and ShowOwnedOnly skips ACL grants.
+	assert.Equal(t, int64(0), result.Total)
+	assert.Equal(t, 0, result.ACLGrantedCount)
+}
+
+// TestListSecretsWithSharingInfo_ProjectFilter_HonoursACL verifies that an ACL
+// grant on a secret in project 2 is NOT included when the caller filters by project 1.
+func TestListSecretsWithSharingInfo_ProjectFilter_HonoursACL(t *testing.T) {
+	c, db := newACLListCore(t)
+	ctx := context.Background()
+
+	// Secret in project 2 (not project 1).
+	sP2 := &models.SecretNode{
+		ProjectID: 2, EnvironmentID: 2, Name: "p2-secret",
+		IsSecret: true, Status: "active", OwnerID: 1,
+	}
+	require.NoError(t, db.Create(sP2).Error)
+	grantACL(t, db, sP2.ID, 2, "secrets.read")
+
+	// Also a secret in project 1 that user 2 owns.
+	sP1 := &models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: "p1-owned",
+		IsSecret: true, Status: "active", OwnerID: 2,
+	}
+	require.NoError(t, db.Create(sP1).Error)
+
+	p1 := uint(1)
+	filter := &models.SecretListFilter{ProjectID: &p1, Page: 1, PageSize: 20}
+	result, err := c.ListSecretsWithSharingInfo(ctx, 2, filter)
+	require.NoError(t, err)
+
+	// Only the p1 owned secret; the p2 ACL grant must not cross the project boundary.
+	require.Equal(t, int64(1), result.Total)
+	assert.Equal(t, sP1.ID, result.Secrets[0].ID)
+	assert.Equal(t, 0, result.ACLGrantedCount)
+}
+
+// TestListSecretsWithSharingInfo_NoACLGrants_NoExtraSecrets is a regression test
+// ensuring that a user with no ACL grants at all gets exactly the same secrets
+// as before the patch (owned + shared only, no extras).
+func TestListSecretsWithSharingInfo_NoACLGrants_NoExtraSecrets(t *testing.T) {
+	c, db := newACLListCore(t)
+	ctx := context.Background()
+
+	// User 2 owns one secret.
+	sOwned := &models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: "owned",
+		IsSecret: true, Status: "active", OwnerID: 2,
+	}
+	require.NoError(t, db.Create(sOwned).Error)
+
+	// Another secret (owned by user 1) that user 2 has NO access to.
+	mkACLListSecret(t, db, "unrelated")
+
+	filter := &models.SecretListFilter{Page: 1, PageSize: 20}
+	result, err := c.ListSecretsWithSharingInfo(ctx, 2, filter)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(1), result.Total)
+	assert.Equal(t, 1, result.OwnedCount)
+	assert.Equal(t, 0, result.SharedCount)
+	assert.Equal(t, 0, result.ACLGrantedCount)
+	assert.Equal(t, sOwned.ID, result.Secrets[0].ID)
+}

--- a/internal/core/secret_listing_query.go
+++ b/internal/core/secret_listing_query.go
@@ -95,7 +95,20 @@ func (c *KeyorixCore) ListSecretsWithSharingInfo(ctx context.Context, userID uin
 		}
 	}
 
-	// Merge owned + shared, deduplicating by secret ID
+	// Fetch ACL-granted secrets — secrets the user holds a per-secret or per-folder
+	// SecretACL grant for but neither owns nor has a legacy ShareRecord for.
+	var aclGrantedSecrets []*models.SecretWithSharingInfo
+	if !filter.ShowOwnedOnly {
+		var err error
+		aclGrantedSecrets, err = c.getACLGrantedSecretsWithSharingInfo(ctx, userID, filter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Merge owned + shared + acl-granted, deduplicating by secret ID.
+	// aclDistinctCount tracks how many ACL-granted secrets were NOT already
+	// covered by owned or shared, so ACLGrantedCount reflects only net-new grants.
 	seen := make(map[uint]bool)
 	var all []*models.SecretWithSharingInfo
 	for _, s := range ownedSecrets {
@@ -108,6 +121,14 @@ func (c *KeyorixCore) ListSecretsWithSharingInfo(ctx context.Context, userID uin
 		if !seen[s.ID] {
 			seen[s.ID] = true
 			all = append(all, s)
+		}
+	}
+	aclDistinctCount := 0
+	for _, s := range aclGrantedSecrets {
+		if !seen[s.ID] {
+			seen[s.ID] = true
+			all = append(all, s)
+			aclDistinctCount++
 		}
 	}
 
@@ -145,13 +166,14 @@ func (c *KeyorixCore) ListSecretsWithSharingInfo(ctx context.Context, userID uin
 	}
 
 	return &models.SecretListResponse{
-		Secrets:     paged,
-		Total:       total,
-		Page:        page,
-		PageSize:    pageSize,
-		TotalPages:  totalPages,
-		OwnedCount:  len(ownedSecrets),
-		SharedCount: len(sharedSecrets),
+		Secrets:         paged,
+		Total:           total,
+		Page:            page,
+		PageSize:        pageSize,
+		TotalPages:      totalPages,
+		OwnedCount:      len(ownedSecrets),
+		SharedCount:     len(sharedSecrets),
+		ACLGrantedCount: aclDistinctCount,
 	}, nil
 }
 
@@ -403,5 +425,118 @@ func (c *KeyorixCore) convertToStorageFilter(filter *models.SecretListFilter) *s
 		IncludeDeleted: filter.IncludeDeleted,
 		ParentID:       filter.ParentID,
 		FolderOnly:     filter.FolderOnly,
+	}
+}
+
+// aclFolderMaxDepth caps the BFS depth when expanding folder-level ACL grants to
+// their descendant leaf secrets. Mirrors the ancestor-walk cap in GetSecretAncestors.
+const aclFolderMaxDepth = 20
+
+// getACLGrantedSecretsWithSharingInfo returns secrets the user holds a per-secret or
+// per-folder SecretACL grant for but neither owns nor has a legacy ShareRecord for.
+// It expands folder grants by collecting all descendant leaf secrets via BFS.
+func (c *KeyorixCore) getACLGrantedSecretsWithSharingInfo(ctx context.Context, userID uint, filter *models.SecretListFilter) ([]*models.SecretWithSharingInfo, error) {
+	acls, err := c.storage.ListSecretACLsByUser(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	if len(acls) == 0 {
+		return nil, nil
+	}
+
+	seen := make(map[uint]bool)
+	var result []*models.SecretWithSharingInfo
+
+	for _, acl := range acls {
+		// Normalise the first ACL permission to the sharing-style format
+		// ("read"/"write") so SharingIndicators.CanWrite and the common
+		// UserPermission field remain consistent with ShareRecord-based grants.
+		perm := ""
+		if perms := DecodeSecretACLPerms(acl.Permissions); len(perms) > 0 {
+			perm = normaliseACLPerm(perms[0])
+		}
+
+		node, err := c.storage.GetSecret(ctx, acl.SecretID)
+		if err != nil || node == nil {
+			continue
+		}
+
+		// Apply project/environment filter on the grant's target node.
+		if filter.ProjectID != nil && node.ProjectID != *filter.ProjectID {
+			continue
+		}
+		if filter.EnvironmentID != nil && node.EnvironmentID != *filter.EnvironmentID {
+			continue
+		}
+
+		var leaves []*models.SecretNode
+		if node.IsSecret {
+			leaves = []*models.SecretNode{node}
+		} else {
+			// Folder node: collect all descendant leaf secrets (BFS, capped at aclFolderMaxDepth).
+			leaves = c.collectFolderDescendants(ctx, node.ID, filter, 0)
+		}
+
+		for _, leaf := range leaves {
+			if seen[leaf.ID] {
+				continue
+			}
+			seen[leaf.ID] = true
+			result = append(result, &models.SecretWithSharingInfo{
+				SecretNode:        leaf,
+				IsShared:          false,
+				IsOwnedByUser:     false,
+				UserPermission:    perm,
+				SharingIndicators: c.buildSharingIndicators(leaf, nil, false, perm),
+			})
+		}
+	}
+
+	return result, nil
+}
+
+// collectFolderDescendants does a BFS from folderID and returns all leaf
+// (IsSecret=true) descendant SecretNodes. Sub-folders are expanded up to
+// aclFolderMaxDepth levels to match the ancestor-walk cap in HasSecretACL.
+// Project/environment filters are honoured so that a folder grant in project A
+// does not bleed into project B when the caller is listing project B only.
+func (c *KeyorixCore) collectFolderDescendants(ctx context.Context, folderID uint, filter *models.SecretListFilter, depth int) []*models.SecretNode {
+	if depth >= aclFolderMaxDepth {
+		return nil
+	}
+	sf := &storage.SecretFilter{
+		Page:          1,
+		PageSize:      secretListingMaxRows,
+		ParentID:      &folderID,
+		ProjectID:     filter.ProjectID,
+		EnvironmentID: filter.EnvironmentID,
+	}
+	children, _, err := c.storage.ListSecrets(ctx, sf)
+	if err != nil {
+		return nil
+	}
+	var result []*models.SecretNode
+	for _, child := range children {
+		if child.IsSecret {
+			result = append(result, child)
+		} else {
+			result = append(result, c.collectFolderDescendants(ctx, child.ID, filter, depth+1)...)
+		}
+	}
+	return result
+}
+
+// normaliseACLPerm maps an RBAC-style ACL permission name ("secrets.read",
+// "secrets.write") to the sharing-style short form ("read", "write") used by
+// the SharingIndicators builder and the UserPermission field. Unknown values
+// are returned unchanged.
+func normaliseACLPerm(p string) string {
+	switch p {
+	case "secrets.read":
+		return "read"
+	case "secrets.write":
+		return "write"
+	default:
+		return p
 	}
 }

--- a/internal/core/secret_listing_test.go
+++ b/internal/core/secret_listing_test.go
@@ -78,6 +78,7 @@ func TestKeyorixCore_ListSecretsWithSharingInfo(t *testing.T) {
 	mockStorage.On("GetSecret", ctx, uint(2)).Return(sharedSecret, nil)
 	mockStorage.On("GetUser", ctx, uint(2)).Return(owner, nil)
 	mockStorage.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "testuser"}, nil)
+	mockStorage.On("ListSecretACLsByUser", ctx, userID).Return(([]*models.SecretACL)(nil), nil)
 
 	// Execute
 	result, err := core.ListSecretsWithSharingInfo(ctx, userID, filter)
@@ -197,6 +198,7 @@ func TestKeyorixCore_ListSecretsWithSharingInfo_ShowSharedOnly(t *testing.T) {
 	mockStorage.On("ListSharesByUser", ctx, userID).Return(userShares, nil)
 	mockStorage.On("GetSecret", ctx, uint(2)).Return(sharedSecret, nil)
 	mockStorage.On("GetUser", ctx, uint(2)).Return(owner, nil)
+	mockStorage.On("ListSecretACLsByUser", ctx, userID).Return(([]*models.SecretACL)(nil), nil)
 
 	// Execute
 	result, err := core.ListSecretsWithSharingInfo(ctx, userID, filter)

--- a/internal/core/sharing_indicators_test.go
+++ b/internal/core/sharing_indicators_test.go
@@ -225,6 +225,8 @@ func TestListSecretsWithSharingInfo(t *testing.T) {
 		Username: "bob",
 	}, nil)
 
+	mockStorage.On("ListSecretACLsByUser", mock.Anything, userID).Return(([]*models.SecretACL)(nil), nil)
+
 	filter := &models.SecretListFilter{
 		Page:     1,
 		PageSize: 10,
@@ -320,6 +322,7 @@ func TestSecretListFiltering(t *testing.T) {
 			ID:       2,
 			Username: "alice",
 		}, nil)
+		mockStorage.On("ListSecretACLsByUser", mock.Anything, userID).Return(([]*models.SecretACL)(nil), nil)
 
 		filter := &models.SecretListFilter{
 			ShowSharedOnly: true,

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -337,6 +337,10 @@ type Storage interface {
 	// HasSecretACL (uses GetSecretAncestors to climb the ParentID chain).
 	CreateOrUpdateSecretACL(ctx context.Context, acl *models.SecretACL) error
 	ListSecretACLs(ctx context.Context, secretID uint) ([]*models.SecretACL, error)
+	// ListSecretACLsByUser returns all ACL rows where user_id = userID, across all secrets.
+	// Used by ListSecretsWithSharingInfo to surface secrets the user can access via explicit
+	// per-secret/per-folder grants but does not own and has no ShareRecord for.
+	ListSecretACLsByUser(ctx context.Context, userID uint) ([]*models.SecretACL, error)
 	GetSecretACL(ctx context.Context, secretID, userID uint) (*models.SecretACL, error)
 	DeleteSecretACL(ctx context.Context, id uint) error
 	// GetSecretAncestors returns the ancestor SecretNode IDs for nodeID,

--- a/internal/storage/models/secret_with_sharing.go
+++ b/internal/storage/models/secret_with_sharing.go
@@ -78,8 +78,9 @@ type SecretListResponse struct {
 	TotalPages int                      `json:"total_pages"`
 
 	// Summary information
-	OwnedCount  int `json:"owned_count"`
-	SharedCount int `json:"shared_count"`
+	OwnedCount      int `json:"owned_count"`
+	SharedCount     int `json:"shared_count"`
+	ACLGrantedCount int `json:"acl_granted_count"` // secrets visible only via per-secret/per-folder ACL grant
 }
 
 // SharingStatus represents the sharing status of a secret

--- a/internal/storage/store/local_secret_acl.go
+++ b/internal/storage/store/local_secret_acl.go
@@ -35,6 +35,15 @@ func (ls *LocalStorage) ListSecretACLs(ctx context.Context, secretID uint) ([]*m
 	return rows, nil
 }
 
+// ListSecretACLsByUser returns all ACL rows for the given user across all secrets.
+func (ls *LocalStorage) ListSecretACLsByUser(ctx context.Context, userID uint) ([]*models.SecretACL, error) {
+	var rows []*models.SecretACL
+	if err := ls.db.WithContext(ctx).Where("user_id = ?", userID).Order(sqlOrderIDAsc).Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
 // GetSecretACL returns the ACL for the given (secret, user) pair, or an error if not found.
 func (ls *LocalStorage) GetSecretACL(ctx context.Context, secretID, userID uint) (*models.SecretACL, error) {
 	var row models.SecretACL

--- a/internal/storage/store/remote_secret_acl.go
+++ b/internal/storage/store/remote_secret_acl.go
@@ -21,6 +21,10 @@ func (rs *RemoteStorage) ListSecretACLs(_ context.Context, _ uint) ([]*models.Se
 	return nil, remoteUnsupported("ListSecretACLs")
 }
 
+func (rs *RemoteStorage) ListSecretACLsByUser(_ context.Context, _ uint) ([]*models.SecretACL, error) {
+	return nil, remoteUnsupported("ListSecretACLsByUser")
+}
+
 func (rs *RemoteStorage) GetSecretACL(_ context.Context, _, _ uint) (*models.SecretACL, error) {
 	return nil, remoteUnsupported("GetSecretACL")
 }

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -170,11 +170,12 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	// only runs server-side and a remote-storage caller never directly invokes
 	// ACL management or the folder-inheritance ancestor walk (the HTTP/gRPC
 	// boundary owns authorization; HasSecretACL/AuthorizeSecret run on the server).
-	"CreateOrUpdateSecretACL": {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
-	"ListSecretACLs":          {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
-	"GetSecretACL":            {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
-	"DeleteSecretACL":         {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
-	"GetSecretAncestors":      {statusIntentional, "RBAC Phase 3 — folder-ACL inheritance walk runs server-side; HasSecretACL uses ErrUnsupportedByBackend to skip the ancestor walk on remote callers"},
+	"CreateOrUpdateSecretACL":  {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
+	"ListSecretACLs":           {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
+	"ListSecretACLsByUser":     {statusIntentional, "RBAC Phase 3 — listing ACL-granted secrets for a user runs server-side in ListSecretsWithSharingInfo; the core function calls LocalStorage on the server, not RemoteStorage"},
+	"GetSecretACL":             {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
+	"DeleteSecretACL":          {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
+	"GetSecretAncestors":       {statusIntentional, "RBAC Phase 3 — folder-ACL inheritance walk runs server-side; HasSecretACL uses ErrUnsupportedByBackend to skip the ancestor walk on remote callers"},
 }
 
 // remoteUnsupportedCallRe matches the exact, 100%-consistent call pattern every

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -47,7 +47,7 @@ func newSecretTestRig(t *testing.T) *secretTestRig {
 		&models.SecretVersion{}, &models.User{}, &models.Role{}, &models.ShareRecord{},
 		&models.Permission{}, &models.RolePermission{}, &models.UserRole{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.DynamicSecretConfig{},
+		&models.DynamicSecretConfig{}, &models.SecretACL{},
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "default"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "development"}).Error)

--- a/server/http/handlers/handlers_s12_test.go
+++ b/server/http/handlers/handlers_s12_test.go
@@ -112,6 +112,7 @@ func freshCoreS12WithAdmin(t *testing.T) (*core.KeyorixCore, *gorm.DB) {
 		&models.SystemMetadata{},
 		&models.PasswordHistory{},
 		&models.SecretVersion{},
+		&models.SecretACL{},
 	)
 	require.NoError(t, err)
 

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -847,6 +847,7 @@ func newHandlerCoreS4(t *testing.T) *core.KeyorixCore {
 			// s4 batch3 additions:
 			&models.ProjectInvitation{}, &models.SchedulerLockLease{},
 			&models.SecretAccessLog{},
+			&models.SecretACL{},
 		); err != nil {
 			panic("newHandlerCoreS4: AutoMigrate: " + err.Error())
 		}

--- a/server/http/handlers/secrets_folder_test.go
+++ b/server/http/handlers/secrets_folder_test.go
@@ -81,6 +81,7 @@ func freshSecretFolderFixture(t *testing.T) (*SecretHandler, *core.KeyorixCore, 
 		&models.SystemMetadata{},
 		&models.PasswordHistory{},
 		&models.SecretVersion{},
+		&models.SecretACL{},
 	))
 
 	// Seed user 1 as system_admin so in-handler authorization passes.

--- a/server/http/handlers/secrets_list_scoped_test.go
+++ b/server/http/handlers/secrets_list_scoped_test.go
@@ -61,6 +61,7 @@ func freshScopedListFixture(t *testing.T) (*SecretHandler, *gorm.DB) {
 		&models.Project{},
 		&models.Environment{},
 		&models.SecretNode{},
+		&models.SecretACL{},
 		&models.AuditEvent{},
 		&models.SecretVersion{},
 		&models.SecretAccessLog{},

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -142,6 +142,9 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		// #530: the scheduler-lock-proxy end-to-end tests exercise
 		// TryAcquireSchedulerLock/ReleaseSchedulerLock through the real router.
 		&models.SchedulerLockLease{},
+		// SecretACL (RBAC Phase 3): ListSecretsWithSharingInfo now calls
+		// ListSecretACLsByUser on every listing, so the table must exist.
+		&models.SecretACL{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the

--- a/server/http/scoped_rbac_integration_test.go
+++ b/server/http/scoped_rbac_integration_test.go
@@ -29,6 +29,7 @@ func setupScopedRBACCore(t *testing.T) *core.KeyorixCore {
 		&models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.SecretNode{}, &models.ShareRecord{}, &models.Session{},
+		&models.SecretACL{}, // ListSecretsWithSharingInfo calls ListSecretACLsByUser
 	))
 
 	now := time.Now()
@@ -102,8 +103,8 @@ func TestScopedRBACEnforcement(t *testing.T) {
 		"viewer-A lists project A")
 	assert.Equal(t, http.StatusForbidden, do(t, "GET", "/api/v1/secrets?project_id=2", "viewerA-tok"),
 		"viewer-A cannot list project B")
-	assert.Equal(t, http.StatusForbidden, do(t, "GET", "/api/v1/secrets", "viewerA-tok"),
-		"viewer-A cannot list globally")
+	assert.Equal(t, http.StatusOK, do(t, "GET", "/api/v1/secrets", "viewerA-tok"),
+		"viewer-A unscoped list returns union of accessible project-A secrets (scoped-union, not 403)")
 
 	// Admin lists globally.
 	assert.Equal(t, http.StatusOK, do(t, "GET", "/api/v1/secrets", "admin-tok"))


### PR DESCRIPTION
## Summary

- **Gap closed**: users holding a `SecretACL` grant (RBAC Phase 3) were invisible in `GET /secrets` listings even though `AuthorizeSecret` would approve a direct `GET /secrets/{id}`. A user with only a `SecretACL` row — no ownership, no `ShareRecord` — got an empty list.
- **Fix**: `ListSecretsWithSharingInfo` now fetches all `SecretACL` rows for the requesting user via the new `ListSecretACLsByUser` storage method, expands folder-level grants by BFS (capped at 20 levels, mirroring `GetSecretAncestors`), deduplicates against owned+shared sets, and reports the net-new count in `ACLGrantedCount` on `SecretListResponse`.
- **Permission normalisation**: ACL permission strings (`"secrets.read"` → `"read"`) are normalised so `SharingIndicators.CanWrite` and `UserPermission` stay consistent with `ShareRecord`-based grants.
- **Stale test fix**: `TestScopedRBACEnforcement` had a 403 assertion for viewer-A's unscoped listing that pre-dates the scoped-union feature (commit `7820cec8`); updated to 200.

## Changed files

| File | Change |
|---|---|
| `internal/core/storage/interface.go` | Added `ListSecretACLsByUser` to `Storage` interface |
| `internal/storage/store/local_secret_acl.go` | `LocalStorage` implementation |
| `internal/storage/store/remote_secret_acl.go` | `RemoteStorage` stub (intentional: listing runs server-side) |
| `internal/storage/store/remote_unsupported_completeness_test.go` | Registered the new stub in the allowlist |
| `internal/storage/models/secret_with_sharing.go` | Added `ACLGrantedCount` to `SecretListResponse` |
| `internal/core/secret_listing_query.go` | Core implementation: `getACLGrantedSecretsWithSharingInfo`, `collectFolderDescendants`, `normaliseACLPerm` |
| `internal/core/mock_storage_test.go` | Testify mock for `ListSecretACLsByUser` |
| `internal/core/secret_listing_test.go` | Added mock expectation to existing tests |
| `internal/core/sharing_indicators_test.go` | Added mock expectation to existing tests |
| `internal/core/secret_listing_acl_test.go` | **8 new SQLite integration tests** |
| `server/http/handlers/secrets_list_scoped_test.go` | Added `SecretACL` to AutoMigrate |
| `server/http/integration_test.go` | Added `SecretACL` to AutoMigrate |
| `server/http/scoped_rbac_integration_test.go` | Added `SecretACL` to AutoMigrate + fixed stale assertion |

## Test plan

- [ ] `go test ./internal/core/ ./internal/storage/store/ ./server/http/ ./server/http/handlers/ -count=1` — all pass
- [ ] 8 new integration tests cover: direct-secret grant, folder grant, nested-folder grant, dedup against owned, dedup against shared, `ShowOwnedOnly` bypass, project-filter boundary, zero-grant baseline
- [ ] `TestRemoteUnsupportedStubsAreAllowlisted` passes (new stub registered)
- [ ] `TestScopedRBACEnforcement` passes (stale assertion corrected)

🤖 Generated with [Claude Code](https://claude.ai/code)