### PR TITLE
docs(encryption): fix stale rotate-dek references + add operator rotation runbook

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -63,8 +63,32 @@ Two ways to permanently lose every stored secret:
 
 1. **Changing `KEYORIX_MASTER_PASSWORD`** after first boot. The KEK no longer
    derives, the DEK can't be unwrapped. (To rotate it intentionally, use
-   `keyorix encryption rotate` — see ADR-010 — never by editing `.env`.)
+   `keyorix encryption rotate` — see below — never by editing `.env`.)
 2. **Losing the `keyorix_keys` volume.** Back it up (next section).
+
+### DEK rotation procedure
+
+To generate a new Data Encryption Key and re-encrypt every secret in the database:
+
+```sh
+# 1. Stop the server (rotation acquires an exclusive lock; it refuses if the
+#    server process is running and holding the key lock).
+docker compose stop keyorix
+
+# 2. Preview what will be re-encrypted — no changes made, no --confirm needed.
+docker compose run --rm keyorix keyorix encryption rotate --dry-run
+
+# 3. Perform the rotation.  --confirm is required (acknowledges write-lock).
+docker compose run --rm keyorix keyorix encryption rotate --confirm
+
+# 4. Restart the server.
+docker compose start keyorix
+```
+
+The rotation re-encrypts all secrets, credentials, and session tokens in a
+single transaction.  If the server crashes mid-sweep, the orphaned pending key
+file is detected and cleaned up automatically on the next `--confirm` run.
+Back up the `keyorix_keys` volume after a successful rotation.
 
 Store `KEYORIX_MASTER_PASSWORD` in your own password manager / secret store. It is
 not recoverable from the system.

--- a/docs/adr-010-kek-rotation-reencryption-sweep.md
+++ b/docs/adr-010-kek-rotation-reencryption-sweep.md
@@ -122,7 +122,7 @@ Alternatively exposed as a protected admin API endpoint (operator-only, no user-
 
 - **Downtime:** the sweep holds a long-running write transaction. For large installations, this will block concurrent secret reads/writes for the duration. Acceptable at v0.x scale (hundreds of secrets). Document in operator guide. Hot-swap streaming rotation is a v2 concern.
 - **Memory pressure:** batched sweep keeps at most 500 plaintext values in memory at once. Acceptable trade-off between memory pressure and transaction duration.
-- **Failure mode:** if the server crashes mid-sweep (after `keys/dek.key.pending` is written but before rename), the pending file is orphaned. Recovery: re-run `key rotate-dek`. The pending file is detected and cleaned up at startup.
+- **Failure mode:** if the server crashes mid-sweep (after `keys/dek.key.pending` is written but before rename), the pending file is orphaned. Recovery: re-run `keyorix encryption rotate --confirm`. The pending file is detected and cleaned up at startup.
 
 ### Not in scope for this ADR
 


### PR DESCRIPTION
## Summary

- Fixes the only stale `key rotate-dek` reference in the codebase — ADR-010 line 125 used the superseded server subcommand as a crash-recovery instruction; updated to `keyorix encryption rotate --confirm` (the actual shipped command).
- Expands SELF_HOSTING.md section 4 from a one-liner mention to a four-step operator runbook (stop → dry-run → rotate → restart) with the `--confirm` flag, crash-recovery behaviour, and a reminder to back up the keys volume after rotation.
- No code changes. The `keyorix encryption rotate` implementation (and its 40+ tests) shipped in the May 2026 ADR-010 addendum; this closes the backlog item that asked to verify and update docs before removing the open checkbox.

## Test plan

- [ ] Read ADR-010 Consequences section — `keyorix encryption rotate --confirm` appears where `key rotate-dek` used to be
- [ ] Read SELF_HOSTING.md section 4 — four-step rotation procedure is present and correct

🤖 Generated with [Claude Code](https://claude.ai/code)