### PR TITLE
feat(finops): per-project usage report — GET /api/v1/admin/usage + keyorix usage show

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/status"
 	"github.com/keyorixhq/keyorix/internal/cli/system"
 	trustcli "github.com/keyorixhq/keyorix/internal/cli/trust"
+	"github.com/keyorixhq/keyorix/internal/cli/usage"
 	"github.com/keyorixhq/keyorix/internal/cli/user"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -84,6 +85,7 @@ func init() {
 	rootCmd.AddCommand(trustcli.TrustCmd)
 	rootCmd.AddCommand(bundlecli.BundleCmd)
 	rootCmd.AddCommand(licensecli.LicenseCmd)
+	rootCmd.AddCommand(usage.UsageCmd)
 }
 
 // bootstrapI18n initializes i18n with the user's actual configured locale

--- a/internal/cli/usage/usage.go
+++ b/internal/cli/usage/usage.go
@@ -103,16 +103,22 @@ func printReport(report *storage.UsageReport) error {
 		report.WindowDays, report.GeneratedAt.Format("2006-01-02 15:04:05 UTC"))
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "PROJECT\tSECRETS\tREADS\tUNIQUE READERS")
+	if _, err := fmt.Fprintln(w, "PROJECT\tSECRETS\tREADS\tUNIQUE READERS"); err != nil {
+		return err
+	}
 	for _, p := range report.Projects {
 		name := p.ProjectName
 		if name == "" {
 			name = fmt.Sprintf("(project %d)", p.ProjectID)
 		}
-		fmt.Fprintf(w, "%s\t%d\t%d\t%d\n", name, p.SecretCount, p.ReadsInWindow, p.UniqueReaders)
+		if _, err := fmt.Fprintf(w, "%s\t%d\t%d\t%d\n", name, p.SecretCount, p.ReadsInWindow, p.UniqueReaders); err != nil {
+			return err
+		}
 	}
 	if len(report.Projects) == 0 {
-		fmt.Fprintln(w, "(no data)")
+		if _, err := fmt.Fprintln(w, "(no data)"); err != nil {
+			return err
+		}
 	}
 	return w.Flush()
 }

--- a/internal/cli/usage/usage.go
+++ b/internal/cli/usage/usage.go
@@ -1,0 +1,118 @@
+// Package usage provides the `keyorix usage` CLI command and its `show`
+// subcommand, which prints a per-project secret usage report.
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/spf13/cobra"
+)
+
+// UsageCmd is the top-level `keyorix usage` command.
+var UsageCmd = &cobra.Command{
+	Use:   "usage",
+	Short: "View usage and activity reports",
+}
+
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show per-project secret usage for a time window",
+	RunE:  runShow,
+}
+
+var (
+	flagDays      int
+	flagProjectID uint
+	flagFormat    string
+)
+
+func init() {
+	showCmd.Flags().IntVar(&flagDays, "days", 30, "Reporting window in days (1-365)")
+	showCmd.Flags().UintVar(&flagProjectID, "project-id", 0, "Scope to a single project (0 = all)")
+	showCmd.Flags().StringVar(&flagFormat, "format", "table", "Output format: table or json")
+	UsageCmd.AddCommand(showCmd)
+}
+
+func runShow(_ *cobra.Command, _ []string) error {
+	ctx := context.Background()
+
+	// Remote mode: proxy to GET /api/v1/admin/usage
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runShowRemote(ctx, rc)
+	}
+
+	// Local/embedded mode: query the database directly
+	st, err := common.InitializeStorage()
+	if err != nil {
+		return err
+	}
+	svc := core.NewKeyorixCore(st)
+
+	var projectID *uint
+	if flagProjectID != 0 {
+		id := flagProjectID
+		projectID = &id
+	}
+
+	report, err := svc.GetUsageReport(ctx, flagDays, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to generate usage report: %w", err)
+	}
+
+	return printReport(report)
+}
+
+// runShowRemote proxies the report fetch to the connected server.
+func runShowRemote(ctx context.Context, rc *common.RemoteClient) error {
+	path := fmt.Sprintf("/api/v1/admin/usage?days=%d", flagDays)
+	if flagProjectID != 0 {
+		path += fmt.Sprintf("&project_id=%d", flagProjectID)
+	}
+
+	var report storage.UsageReport
+	if err := rc.Get(ctx, path, &report); err != nil {
+		return fmt.Errorf("failed to fetch usage report: %w", err)
+	}
+	return printReport(&report)
+}
+
+func printReport(report *storage.UsageReport) error {
+	if flagFormat == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+
+	// Sort projects by name for stable output
+	sort.Slice(report.Projects, func(i, j int) bool {
+		if report.Projects[i].ProjectName != report.Projects[j].ProjectName {
+			return report.Projects[i].ProjectName < report.Projects[j].ProjectName
+		}
+		return report.Projects[i].ProjectID < report.Projects[j].ProjectID
+	})
+
+	fmt.Printf("Usage report — last %d days (generated %s)\n\n",
+		report.WindowDays, report.GeneratedAt.Format("2006-01-02 15:04:05 UTC"))
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "PROJECT\tSECRETS\tREADS\tUNIQUE READERS")
+	for _, p := range report.Projects {
+		name := p.ProjectName
+		if name == "" {
+			name = fmt.Sprintf("(project %d)", p.ProjectID)
+		}
+		fmt.Fprintf(w, "%s\t%d\t%d\t%d\n", name, p.SecretCount, p.ReadsInWindow, p.UniqueReaders)
+	}
+	if len(report.Projects) == 0 {
+		fmt.Fprintln(w, "(no data)")
+	}
+	return w.Flush()
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1535,6 +1535,14 @@ func (m *MockStorage) GetStats(ctx context.Context) (*storage.StorageStats, erro
 	return args.Get(0).(*storage.StorageStats), args.Error(1)
 }
 
+func (m *MockStorage) GetProjectUsageStats(ctx context.Context, projectIDs []uint, windowDays int) ([]storage.ProjectUsageStat, error) {
+	args := m.Called(ctx, projectIDs, windowDays)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]storage.ProjectUsageStat), args.Error(1)
+}
+
 func (m *MockStorage) SaveStatsSnapshot(ctx context.Context, snapshot *models.StatsSnapshot) error {
 	args := m.Called(ctx, snapshot)
 	return args.Error(0)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1153,6 +1153,11 @@ type Storage interface {
 	HealthCheck(ctx context.Context) error
 	GetStats(ctx context.Context) (*StorageStats, error)
 
+	// GetProjectUsageStats returns per-project usage stats for the given projects
+	// over the past windowDays days. Passing nil for projectIDs returns stats for
+	// ALL projects. The result may omit projects with zero activity and zero secrets.
+	GetProjectUsageStats(ctx context.Context, projectIDs []uint, windowDays int) ([]ProjectUsageStat, error)
+
 }
 
 // SecretFilter defines filtering options for secret queries
@@ -1334,6 +1339,23 @@ type RBACAuditLog struct {
 	IPAddress  string    `json:"ip_address"`
 	Success    bool      `json:"success"`
 	Timestamp  time.Time `json:"timestamp"`
+}
+
+// ProjectUsageStat is one row in a usage report, aggregating all metrics for
+// one project over the reporting window.
+type ProjectUsageStat struct {
+	ProjectID     uint   `json:"project_id"`
+	ProjectName   string `json:"project_name"`
+	SecretCount   int64  `json:"secret_count"`   // active leaf secrets (is_secret=true, not deleted)
+	ReadsInWindow int64  `json:"reads_in_window"` // audit_events: event_type="secret.read", success=true, in window
+	UniqueReaders int    `json:"unique_readers"`  // distinct user_id values in those audit events
+}
+
+// UsageReport is the full usage response.
+type UsageReport struct {
+	WindowDays  int                `json:"window_days"`
+	GeneratedAt time.Time          `json:"generated_at"`
+	Projects    []ProjectUsageStat `json:"projects"`
 }
 
 // StorageStats provides statistics about the storage system

--- a/internal/core/usage_report.go
+++ b/internal/core/usage_report.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"context"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// GetUsageReport returns a per-project usage report for the given window.
+// If projectID is non-nil, the report is scoped to that project only.
+// windowDays is clamped to [1, 365]; values outside that range default to 30.
+func (c *KeyorixCore) GetUsageReport(ctx context.Context, windowDays int, projectID *uint) (*storage.UsageReport, error) {
+	if windowDays <= 0 || windowDays > 365 {
+		windowDays = 30
+	}
+	var projectIDs []uint
+	if projectID != nil {
+		projectIDs = []uint{*projectID}
+	}
+	stats, err := c.storage.GetProjectUsageStats(ctx, projectIDs, windowDays)
+	if err != nil {
+		return nil, err
+	}
+	if stats == nil {
+		stats = []storage.ProjectUsageStat{}
+	}
+	return &storage.UsageReport{
+		WindowDays:  windowDays,
+		GeneratedAt: time.Now().UTC(),
+		Projects:    stats,
+	}, nil
+}

--- a/internal/core/usage_report_test.go
+++ b/internal/core/usage_report_test.go
@@ -1,0 +1,99 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- helpers ----
+
+func newUsageReportCore(t *testing.T) (*KeyorixCore, *MockStorage) {
+	t.Helper()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	return c, ms
+}
+
+// ---- tests ----
+
+// TestGetUsageReport_AllProjects verifies that when no projectID is given,
+// GetProjectUsageStats is called with a nil slice and both projects appear in
+// the returned report.
+func TestGetUsageReport_AllProjects(t *testing.T) {
+	c, ms := newUsageReportCore(t)
+
+	stats := []storage.ProjectUsageStat{
+		{ProjectID: 1, ProjectName: "alpha", SecretCount: 5, ReadsInWindow: 20, UniqueReaders: 3},
+		{ProjectID: 2, ProjectName: "beta", SecretCount: 2, ReadsInWindow: 7, UniqueReaders: 1},
+	}
+	ms.On("GetProjectUsageStats", mock.Anything, []uint(nil), 30).Return(stats, nil)
+
+	report, err := c.GetUsageReport(context.Background(), 30, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 30, report.WindowDays)
+	assert.Len(t, report.Projects, 2)
+	assert.Equal(t, uint(1), report.Projects[0].ProjectID)
+	assert.Equal(t, uint(2), report.Projects[1].ProjectID)
+	ms.AssertExpectations(t)
+}
+
+// TestGetUsageReport_SingleProject verifies that a non-nil projectID is
+// forwarded as a single-element slice to GetProjectUsageStats.
+func TestGetUsageReport_SingleProject(t *testing.T) {
+	c, ms := newUsageReportCore(t)
+
+	id := uint(7)
+	stats := []storage.ProjectUsageStat{
+		{ProjectID: 7, ProjectName: "gamma", SecretCount: 1, ReadsInWindow: 3, UniqueReaders: 1},
+	}
+	ms.On("GetProjectUsageStats", mock.Anything, []uint{7}, 14).Return(stats, nil)
+
+	report, err := c.GetUsageReport(context.Background(), 14, &id)
+	require.NoError(t, err)
+	assert.Equal(t, 14, report.WindowDays)
+	require.Len(t, report.Projects, 1)
+	assert.Equal(t, uint(7), report.Projects[0].ProjectID)
+	ms.AssertExpectations(t)
+}
+
+// TestGetUsageReport_DefaultsInvalidDays verifies that out-of-range windowDays
+// values are clamped to 30 before the storage call.
+func TestGetUsageReport_DefaultsInvalidDays(t *testing.T) {
+	cases := []struct {
+		name string
+		days int
+	}{
+		{"zero", 0},
+		{"negative", -5},
+		{"too large", 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, ms := newUsageReportCore(t)
+			ms.On("GetProjectUsageStats", mock.Anything, []uint(nil), 30).Return([]storage.ProjectUsageStat{}, nil)
+
+			report, err := c.GetUsageReport(context.Background(), tc.days, nil)
+			require.NoError(t, err)
+			assert.Equal(t, 30, report.WindowDays, "invalid days %d should default to 30", tc.days)
+			ms.AssertExpectations(t)
+		})
+	}
+}
+
+// TestGetUsageReport_EmptyStats verifies that a nil slice from storage is
+// coerced to an empty non-nil slice in the returned report.
+func TestGetUsageReport_EmptyStats(t *testing.T) {
+	c, ms := newUsageReportCore(t)
+	ms.On("GetProjectUsageStats", mock.Anything, []uint(nil), 30).Return(nil, nil)
+
+	report, err := c.GetUsageReport(context.Background(), 30, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, report.Projects)
+	assert.Empty(t, report.Projects)
+	ms.AssertExpectations(t)
+}

--- a/internal/storage/store/local_usage.go
+++ b/internal/storage/store/local_usage.go
@@ -1,0 +1,121 @@
+// local_usage.go — Per-project usage report query for LocalStorage.
+//
+// Covers: GetProjectUsageStats
+//
+// All operations use direct GORM queries.
+// For the remote (HTTP) equivalent see remote_usage.go.
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// GetProjectUsageStats returns per-project usage stats over the past windowDays
+// days. When projectIDs is nil or empty, stats are returned for ALL projects
+// that have at least one active secret or at least one secret.read audit event
+// in the window.
+func (ls *LocalStorage) GetProjectUsageStats(ctx context.Context, projectIDs []uint, windowDays int) ([]storage.ProjectUsageStat, error) {
+	since := time.Now().UTC().AddDate(0, 0, -windowDays)
+	allProjects := len(projectIDs) == 0
+
+	// --- Query 1: active secret counts per project ---
+	type secretRow struct {
+		ProjectID uint
+		Count     int64
+	}
+	var secretRows []secretRow
+	q := ls.db.WithContext(ctx).
+		Table("secret_nodes").
+		Select("project_id, COUNT(*) AS count").
+		Where("deleted_at IS NULL AND is_secret = ?", true)
+	if !allProjects {
+		q = q.Where("project_id IN ?", projectIDs)
+	}
+	if err := q.Group("project_id").Scan(&secretRows).Error; err != nil {
+		return nil, err
+	}
+
+	// --- Query 2: read counts + unique reader counts per project ---
+	type readRow struct {
+		ProjectID uint
+		Reads     int64
+		Readers   int
+	}
+	var readRows []readRow
+	rq := ls.db.WithContext(ctx).
+		Table("audit_events").
+		Select("project_id, COUNT(*) AS reads, COUNT(DISTINCT COALESCE(user_id, 0)) AS readers").
+		Where("event_type = ? AND (success = ? OR success IS NULL) AND event_time >= ?", "secret.read", true, since).
+		Where("project_id IS NOT NULL")
+	if !allProjects {
+		rq = rq.Where("project_id IN ?", projectIDs)
+	}
+	if err := rq.Group("project_id").Scan(&readRows).Error; err != nil {
+		return nil, err
+	}
+
+	// Merge results into a map keyed by project_id
+	type merged struct {
+		secrets int64
+		reads   int64
+		readers int
+	}
+	statsMap := make(map[uint]*merged)
+	for _, r := range secretRows {
+		if statsMap[r.ProjectID] == nil {
+			statsMap[r.ProjectID] = &merged{}
+		}
+		statsMap[r.ProjectID].secrets = r.Count
+	}
+	for _, r := range readRows {
+		if statsMap[r.ProjectID] == nil {
+			statsMap[r.ProjectID] = &merged{}
+		}
+		statsMap[r.ProjectID].reads = r.Reads
+		statsMap[r.ProjectID].readers = r.Readers
+	}
+
+	if len(statsMap) == 0 {
+		return nil, nil
+	}
+
+	// Collect project IDs we need names for
+	ids := make([]uint, 0, len(statsMap))
+	for id := range statsMap {
+		ids = append(ids, id)
+	}
+
+	// --- Query 3: project names ---
+	type projectRow struct {
+		ID   uint
+		Name string
+	}
+	var projRows []projectRow
+	if err := ls.db.WithContext(ctx).
+		Table("projects").
+		Select("id, name").
+		Where("id IN ?", ids).
+		Scan(&projRows).Error; err != nil {
+		return nil, err
+	}
+	nameMap := make(map[uint]string, len(projRows))
+	for _, p := range projRows {
+		nameMap[p.ID] = p.Name
+	}
+
+	// Build result slice
+	result := make([]storage.ProjectUsageStat, 0, len(statsMap))
+	for id, m := range statsMap {
+		result = append(result, storage.ProjectUsageStat{
+			ProjectID:     id,
+			ProjectName:   nameMap[id],
+			SecretCount:   m.secrets,
+			ReadsInWindow: m.reads,
+			UniqueReaders: m.readers,
+		})
+	}
+	return result, nil
+}

--- a/internal/storage/store/local_usage_test.go
+++ b/internal/storage/store/local_usage_test.go
@@ -1,0 +1,190 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newUsageStore opens a unique named in-memory SQLite DB, migrates the
+// tables needed for GetProjectUsageStats, and returns a LocalStorage.
+func newUsageStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	dsn := "file:" + t.Name() + "_usage?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{},
+		&models.SecretNode{},
+		&models.AuditEvent{},
+	))
+	return NewLocalStorage(db)
+}
+
+// seed inserts two projects and several secrets + audit events:
+//
+//	proj1 (id=1): 2 secrets, 3 reads in window by 2 distinct users
+//	proj2 (id=2): 1 secret,  1 read  in window by 1 user
+func seedUsageData(t *testing.T, ls *LocalStorage, now time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	tr := true
+
+	// Projects
+	p1 := &models.Project{Name: "proj1"}
+	p2 := &models.Project{Name: "proj2"}
+	require.NoError(t, ls.db.WithContext(ctx).Create(p1).Error)
+	require.NoError(t, ls.db.WithContext(ctx).Create(p2).Error)
+
+	// Secrets: 2 in proj1, 1 in proj2
+	uid1, uid2 := uint(1), uint(2)
+	sn1a := &models.SecretNode{ProjectID: p1.ID, Name: "sec1a", IsSecret: true}
+	sn1b := &models.SecretNode{ProjectID: p1.ID, Name: "sec1b", IsSecret: true}
+	sn2a := &models.SecretNode{ProjectID: p2.ID, Name: "sec2a", IsSecret: true}
+	for _, sn := range []*models.SecretNode{sn1a, sn1b, sn2a} {
+		require.NoError(t, ls.db.WithContext(ctx).Create(sn).Error)
+	}
+
+	// Audit events: 3 reads for proj1 (2 unique users), 1 read for proj2 (1 user)
+	inWindow := now.Add(-24 * time.Hour)
+	outOfWindow := now.Add(-40 * 24 * time.Hour) // 40 days ago — outside a 30-day window
+
+	events := []*models.AuditEvent{
+		// proj1 in-window reads
+		{EventType: "secret.read", ProjectID: &p1.ID, UserID: &uid1, EventTime: inWindow, Success: &tr, ActorType: "user"},
+		{EventType: "secret.read", ProjectID: &p1.ID, UserID: &uid1, EventTime: inWindow, Success: &tr, ActorType: "user"},
+		{EventType: "secret.read", ProjectID: &p1.ID, UserID: &uid2, EventTime: inWindow, Success: &tr, ActorType: "user"},
+		// proj2 in-window read
+		{EventType: "secret.read", ProjectID: &p2.ID, UserID: &uid1, EventTime: inWindow, Success: &tr, ActorType: "user"},
+		// proj1 out-of-window read — must NOT be counted for a 30-day window
+		{EventType: "secret.read", ProjectID: &p1.ID, UserID: &uid1, EventTime: outOfWindow, Success: &tr, ActorType: "user"},
+	}
+	for _, e := range events {
+		require.NoError(t, ls.db.WithContext(ctx).Create(e).Error)
+	}
+}
+
+// TestGetProjectUsageStats_SecretCounts verifies that active-secret counts are
+// correct per project and that soft-deleted secrets are excluded.
+func TestGetProjectUsageStats_SecretCounts(t *testing.T) {
+	ls := newUsageStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	seedUsageData(t, ls, now)
+
+	// Add a soft-deleted secret to proj1 — should NOT be counted
+	deleted := &models.SecretNode{ProjectID: 1, Name: "deleted", IsSecret: true}
+	require.NoError(t, ls.db.WithContext(ctx).Create(deleted).Error)
+	require.NoError(t, ls.db.WithContext(ctx).Delete(deleted).Error)
+
+	// Also add a non-leaf (folder) node — IsSecret=false, should be excluded
+	folder := &models.SecretNode{ProjectID: 1, Name: "folder", IsSecret: false}
+	require.NoError(t, ls.db.WithContext(ctx).Create(folder).Error)
+
+	stats, err := ls.GetProjectUsageStats(ctx, nil, 30)
+	require.NoError(t, err)
+
+	byProject := make(map[uint]int64)
+	for _, s := range stats {
+		byProject[s.ProjectID] = s.SecretCount
+	}
+	assert.Equal(t, int64(2), byProject[1], "proj1 should have 2 active secrets")
+	assert.Equal(t, int64(1), byProject[2], "proj2 should have 1 active secret")
+}
+
+// TestGetProjectUsageStats_ReadCounts verifies read counts and out-of-window
+// exclusion.
+func TestGetProjectUsageStats_ReadCounts(t *testing.T) {
+	ls := newUsageStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	seedUsageData(t, ls, now)
+
+	stats, err := ls.GetProjectUsageStats(ctx, nil, 30)
+	require.NoError(t, err)
+
+	byProject := make(map[uint]int64)
+	for _, s := range stats {
+		byProject[s.ProjectID] = s.ReadsInWindow
+	}
+	// proj1: 3 in-window reads (the 4th is 40 days ago, outside window)
+	assert.Equal(t, int64(3), byProject[1], "proj1 should have 3 reads in 30d window")
+	// proj2: 1 in-window read
+	assert.Equal(t, int64(1), byProject[2], "proj2 should have 1 read in 30d window")
+}
+
+// TestGetProjectUsageStats_UniqueReaders verifies that distinct user counts are
+// computed correctly.
+func TestGetProjectUsageStats_UniqueReaders(t *testing.T) {
+	ls := newUsageStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	seedUsageData(t, ls, now)
+
+	stats, err := ls.GetProjectUsageStats(ctx, nil, 30)
+	require.NoError(t, err)
+
+	byProject := make(map[uint]int)
+	for _, s := range stats {
+		byProject[s.ProjectID] = s.UniqueReaders
+	}
+	assert.Equal(t, 2, byProject[1], "proj1 should have 2 unique readers")
+	assert.Equal(t, 1, byProject[2], "proj2 should have 1 unique reader")
+}
+
+// TestGetProjectUsageStats_ProjectFilter verifies that passing a specific
+// project ID filters the result to that project only.
+func TestGetProjectUsageStats_ProjectFilter(t *testing.T) {
+	ls := newUsageStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	seedUsageData(t, ls, now)
+
+	stats, err := ls.GetProjectUsageStats(ctx, []uint{1}, 30)
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+	assert.Equal(t, uint(1), stats[0].ProjectID)
+	assert.Equal(t, "proj1", stats[0].ProjectName)
+}
+
+// TestGetProjectUsageStats_NoAuditEvents verifies that a project with secrets
+// but no reads still appears when queried directly.
+func TestGetProjectUsageStats_NoAuditEvents(t *testing.T) {
+	ls := newUsageStore(t)
+	ctx := context.Background()
+
+	// A project with no reads at all
+	p := &models.Project{Name: "silent"}
+	require.NoError(t, ls.db.WithContext(ctx).Create(p).Error)
+	sn := &models.SecretNode{ProjectID: p.ID, Name: "top-secret", IsSecret: true}
+	require.NoError(t, ls.db.WithContext(ctx).Create(sn).Error)
+
+	stats, err := ls.GetProjectUsageStats(ctx, []uint{p.ID}, 30)
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+	assert.Equal(t, int64(1), stats[0].SecretCount)
+	assert.Equal(t, int64(0), stats[0].ReadsInWindow)
+	assert.Equal(t, 0, stats[0].UniqueReaders)
+}
+
+// TestGetProjectUsageStats_EmptyDB verifies that an empty database returns nil
+// without error.
+func TestGetProjectUsageStats_EmptyDB(t *testing.T) {
+	ls := newUsageStore(t)
+	ctx := context.Background()
+
+	stats, err := ls.GetProjectUsageStats(ctx, nil, 30)
+	require.NoError(t, err)
+	assert.Nil(t, stats)
+}

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -176,6 +176,8 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"GetSecretACL":             {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
 	"DeleteSecretACL":          {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
 	"GetSecretAncestors":       {statusIntentional, "RBAC Phase 3 — folder-ACL inheritance walk runs server-side; HasSecretACL uses ErrUnsupportedByBackend to skip the ancestor walk on remote callers"},
+
+	"GetProjectUsageStats": {statusIntentional, "usage report queries run server-side; a future PR may add a /api/v1/system/usage proxy route"},
 }
 
 // remoteUnsupportedCallRe matches the exact, 100%-consistent call pattern every

--- a/internal/storage/store/remote_usage.go
+++ b/internal/storage/store/remote_usage.go
@@ -1,0 +1,19 @@
+// remote_usage.go — Per-project usage report stub for RemoteStorage.
+//
+// Usage report queries aggregate data from secret_nodes + audit_events, both
+// of which live server-side. A future PR may add a /api/v1/admin/usage proxy
+// route (mirroring the HTTP handler already wired on the server) so CLI users
+// in remote mode can pull reports without a direct DB connection.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// GetProjectUsageStats is not supported in remote mode; usage report queries
+// run server-side against the live database.
+func (rs *RemoteStorage) GetProjectUsageStats(_ context.Context, _ []uint, _ int) ([]storage.ProjectUsageStat, error) {
+	return nil, remoteUnsupported("GetProjectUsageStats")
+}

--- a/server/http/handlers/admin_usage.go
+++ b/server/http/handlers/admin_usage.go
@@ -1,0 +1,56 @@
+// admin_usage.go — GET /api/v1/admin/usage handler.
+//
+// Returns a per-project usage report (secret counts + read activity) for the
+// requested time window. Gated by system.read permission in the router.
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+// AdminUsageHandler serves GET /api/v1/admin/usage.
+type AdminUsageHandler struct {
+	coreService *core.KeyorixCore
+}
+
+// NewAdminUsageHandler constructs an AdminUsageHandler.
+func NewAdminUsageHandler(cs *core.KeyorixCore) *AdminUsageHandler {
+	return &AdminUsageHandler{coreService: cs}
+}
+
+// GetUsageReport handles GET /api/v1/admin/usage.
+//
+// Query params:
+//
+//	days       int   reporting window in days (1-365, default 30)
+//	project_id uint  scope to one project (omit for all projects)
+func (h *AdminUsageHandler) GetUsageReport(w http.ResponseWriter, r *http.Request) {
+	// Parse days param (default 30, max 365)
+	days := 30
+	if s := r.URL.Query().Get("days"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 && n <= 365 {
+			days = n
+		}
+	}
+
+	// Parse optional project_id param
+	var projectID *uint
+	if s := r.URL.Query().Get("project_id"); s != "" {
+		if n, err := strconv.ParseUint(s, 10, 64); err == nil {
+			id := uint(n)
+			projectID = &id
+		}
+	}
+
+	report, err := h.coreService.GetUsageReport(r.Context(), days, projectID)
+	if err != nil {
+		log.Printf("GetUsageReport: %v", err)
+		sendError(w, "InternalError", "Failed to generate usage report", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, report, "")
+}

--- a/server/http/handlers/admin_usage.go
+++ b/server/http/handlers/admin_usage.go
@@ -40,7 +40,7 @@ func (h *AdminUsageHandler) GetUsageReport(w http.ResponseWriter, r *http.Reques
 	// Parse optional project_id param
 	var projectID *uint
 	if s := r.URL.Query().Get("project_id"); s != "" {
-		if n, err := strconv.ParseUint(s, 10, 64); err == nil {
+		if n, err := strconv.ParseUint(s, 10, 32); err == nil {
 			id := uint(n)
 			projectID = &id
 		}

--- a/server/http/handlers/admin_usage_test.go
+++ b/server/http/handlers/admin_usage_test.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newUsageHandlerDB builds a LocalStorage-backed core service with the tables
+// needed by GetProjectUsageStats wired up.
+func newUsageHandlerDB(t *testing.T) *AdminUsageHandler {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{},
+		&models.SecretNode{},
+		&models.AuditEvent{},
+	))
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	return NewAdminUsageHandler(cs)
+}
+
+// get issues a GET request against the handler.
+func getUsage(h http.HandlerFunc, target string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+	return w
+}
+
+// TestAdminUsage_OK verifies that an empty DB returns a 200 with a valid
+// report envelope.
+func TestAdminUsage_OK(t *testing.T) {
+	h := newUsageHandlerDB(t)
+	w := getUsage(h.GetUsageReport, "/api/v1/admin/usage")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.True(t, body["success"].(bool))
+
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "data field should be an object")
+	assert.EqualValues(t, 30, data["window_days"])
+	assert.NotEmpty(t, data["generated_at"])
+}
+
+// TestAdminUsage_InvalidDays_DefaultsTo30 verifies that an invalid days value
+// is defaulted to 30 in the response.
+func TestAdminUsage_InvalidDays_DefaultsTo30(t *testing.T) {
+	h := newUsageHandlerDB(t)
+
+	for _, target := range []string{
+		"/api/v1/admin/usage?days=-1",
+		"/api/v1/admin/usage?days=0",
+		"/api/v1/admin/usage?days=999",
+		"/api/v1/admin/usage?days=notanumber",
+	} {
+		t.Run(target, func(t *testing.T) {
+			w := getUsage(h.GetUsageReport, target)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var body map[string]interface{}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			data := body["data"].(map[string]interface{})
+			assert.EqualValues(t, 30, data["window_days"])
+		})
+	}
+}
+
+// TestAdminUsage_ProjectFilter verifies that a valid project_id param is
+// accepted and the response reflects it (report is scoped to an empty project).
+func TestAdminUsage_ProjectFilter(t *testing.T) {
+	h := newUsageHandlerDB(t)
+	w := getUsage(h.GetUsageReport, "/api/v1/admin/usage?project_id=1&days=7")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.True(t, body["success"].(bool))
+	data := body["data"].(map[string]interface{})
+	// No secrets or events in DB, so projects slice is empty
+	assert.EqualValues(t, 7, data["window_days"])
+}
+
+// TestAdminUsage_ValidDays verifies that an explicit valid days value is
+// honored and returned in the response.
+func TestAdminUsage_ValidDays(t *testing.T) {
+	h := newUsageHandlerDB(t)
+	w := getUsage(h.GetUsageReport, "/api/v1/admin/usage?days=90")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	data := body["data"].(map[string]interface{})
+	assert.EqualValues(t, 90, data["window_days"])
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -129,6 +129,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 
 	catalogHandler := handlers.NewCatalogHandler(coreService)
 	dashboardHandler := handlers.NewDashboardHandler(coreService)
+	adminUsageHandler := handlers.NewAdminUsageHandler(coreService)
 	auditHandler := handlers.NewAuditHandler(coreService)
 	licenseHandler := handlers.NewLicenseHandler(coreService)
 	rotationPolicyHandler := handlers.NewRotationPolicyHandler(coreService)
@@ -1754,6 +1755,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/sod/policies", catalogHandler.CreateSoDPolicy)
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Delete("/sod/policies/{id}", catalogHandler.DeleteSoDPolicy)
 		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/sod/violations", catalogHandler.ListSoDViolations)
+
+		// Usage report — per-project secret counts + read activity over a time window.
+		// Deployment-wide aggregation, gated by system.read.
+		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/admin/usage", adminUsageHandler.GetUsageReport)
 
 		// On-demand triggers for the notification/alert jobs that otherwise run only on
 		// their background schedulers — dispatch immediately after an incident or config


### PR DESCRIPTION
## Summary

- **Storage**: `GetProjectUsageStats` on the `storage.Storage` interface — three-query implementation (active secret counts, read-event counts + unique reader counts, project name lookup) in `local_usage.go`; `remoteUnsupported` stub in `remote_usage.go` (added to the completeness allowlist with a reasoned citation)
- **Types**: `ProjectUsageStat` and `UsageReport` added to `internal/core/storage/interface.go` alongside the existing `StorageStats` / `SecretUsageStat` types
- **Core**: `KeyorixCore.GetUsageReport(ctx, windowDays, *projectID)` in `internal/core/usage_report.go` — clamps window to [1, 365], defaults invalid values to 30; nil projectIDs returns all projects
- **HTTP**: `AdminUsageHandler` serving `GET /api/v1/admin/usage` (query params: `days`, `project_id`) in `server/http/handlers/admin_usage.go`; route registered in `server/http/router.go` gated by `system.read` permission, adjacent to the existing `/admin/jobs` group
- **CLI**: `keyorix usage show` (flags: `--days`, `--project-id`, `--format table|json`) in `internal/cli/usage/usage.go`, supporting both local/embedded mode (direct DB) and remote mode (proxies to `/api/v1/admin/usage`); registered in `internal/cli/main.go`

## Test plan

- [x] `go build ./...` — clean
- [x] Core tests: `TestGetUsageReport_AllProjects`, `_SingleProject`, `_DefaultsInvalidDays`, `_EmptyStats` (mock storage)
- [x] Storage integration tests: `TestGetProjectUsageStats_SecretCounts` (soft-deleted + folder nodes excluded), `_ReadCounts` (out-of-window exclusion), `_UniqueReaders`, `_ProjectFilter`, `_NoAuditEvents`, `_EmptyDB` (real SQLite)
- [x] Handler tests: `TestAdminUsage_OK`, `_InvalidDays_DefaultsTo30`, `_ProjectFilter`, `_ValidDays`
- [x] `TestRemoteUnsupportedStubsAreAllowlisted` completeness guard — passes with new `GetProjectUsageStats` entry

🤖 Generated with [Claude Code](https://claude.ai/code)