### PR TITLE
fix(sonar): reduce MoveSecret cognitive complexity + suppress dast.yml S6437

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -40,7 +40,7 @@ jobs:
           done
 
       - name: Install Nuclei
-        run: go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.3.9
+        run: go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.3.9 # NOSONAR githubactions:S6437 -- pinned to v3.3.9; go.sum not applicable for standalone DAST tool binaries outside the module graph
 
       - name: Update Nuclei templates
         run: nuclei -update-templates -silent

--- a/internal/core/secret_move.go
+++ b/internal/core/secret_move.go
@@ -65,8 +65,8 @@ func (c *KeyorixCore) MoveSecret(ctx context.Context, actorID, secretID uint, ne
 
 	uid, sid := actorID, secretID
 	parentDesc := "root"
-	if newParentID != nil && *newParentID != 0 {
-		parentDesc = fmt.Sprintf("folder %d", *newParentID)
+	if secret.ParentID != nil {
+		parentDesc = fmt.Sprintf("folder %d", *secret.ParentID)
 	}
 	c.writeAuditEvent(ctx, EventSecretMoved, &uid, &sid,
 		fmt.Sprintf("moved secret/folder %q to %s", updated.Name, parentDesc))


### PR DESCRIPTION
## Summary

**`internal/core/secret_move.go` — SonarCloud S3776 (Cognitive Complexity)**
- The audit-section condition `if newParentID != nil && *newParentID != 0` was a duplicate of the parent-validation guard above it
- After that validation block, `secret.ParentID` is already normalised (`= newParentID` or `= nil`)
- Replaced with `if secret.ParentID != nil` — eliminates the `&&` compound boolean, cutting cognitive complexity from 16 → 15

**`.github/workflows/dast.yml` — SonarCloud githubactions:S6437 (L43)**
- `go install` without a `go.sum`-backed lockfile triggers "Dependency versions are not predictable"
- The Nuclei install is already pinned to `@v3.3.9` and is a standalone DAST scanning tool outside the application module graph — `go.sum` enforcement is not applicable here
- Added `# NOSONAR githubactions:S6437` suppression, consistent with the same pattern in `osv-scanner.yml`

## Test plan

- [ ] CI lint + build-and-test green
- [ ] SonarCloud shows S3776 resolved for `MoveSecret`
- [ ] SonarCloud shows S6437 suppressed for `dast.yml:43`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)