### PR TITLE
feat(cli): machine token issue/revoke/list commands

### DIFF
--- a/internal/cli/machine/token.go
+++ b/internal/cli/machine/token.go
@@ -1,0 +1,294 @@
+// token.go — machine identity token management commands (ADR-030).
+//
+// Commands:
+//
+//	keyorix machine token issue  <name|id> --name <label> [--expires-in-days N] [--classification C] [--project P]
+//	keyorix machine token revoke <name|id> <token-id>     [--project P] [--force]
+//	keyorix machine token list   <name|id>                [--project P]
+package machine
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// tokenCmd is the parent "machine token" subcommand group.
+var tokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Manage machine identity tokens",
+	Long:  "Issue, list, and revoke bearer tokens for a machine identity (ADR-030).",
+}
+
+// ── flag variables ────────────────────────────────────────────────────────────
+
+var (
+	tokenProjectName    string
+	tokenIssueName       string
+	tokenIssueExpiryDays int
+	tokenIssueClass      string
+	tokenRevokeForce     bool
+)
+
+// ── issue ─────────────────────────────────────────────────────────────────────
+
+var issueCmd = &cobra.Command{
+	Use:          "issue <name|id>",
+	Short:        "Issue a new bearer token for a machine identity",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE:         runTokenIssue,
+}
+
+func runTokenIssue(cmd *cobra.Command, args []string) error {
+	if tokenIssueName == "" {
+		return fmt.Errorf("--name is required")
+	}
+	ctx := context.Background()
+	_, projectID, err := resolveProjectContext(tokenProjectName)
+	if err != nil {
+		return err
+	}
+	m, err := findMachineByRef(ctx, projectID, args[0])
+	if err != nil {
+		return err
+	}
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		body := map[string]interface{}{
+			"name":           tokenIssueName,
+			"expires_in_days": tokenIssueExpiryDays,
+			"classification": tokenIssueClass,
+		}
+		var resp struct {
+			Token     string  `json:"token"`
+			ID        uint    `json:"id"`
+			Prefix    string  `json:"prefix"`
+			ExpiresAt *string `json:"expires_at"`
+		}
+		path := fmt.Sprintf("/api/v1/projects/%d/machine-identities/%d/tokens", projectID, m.ID)
+		if err := rc.Post(ctx, path, body, &resp); err != nil {
+			return fmt.Errorf("failed to issue machine token: %w", err)
+		}
+		printIssuedToken(resp.Token, resp.ID, resp.Prefix, resp.ExpiresAt)
+		return nil
+	}
+
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	var expiresAt *time.Time
+	if tokenIssueExpiryDays > 0 {
+		t := time.Now().AddDate(0, 0, tokenIssueExpiryDays)
+		expiresAt = &t
+	}
+	result, err := svc.IssueMachineToken(ctx, projectID, m.ID, tokenIssueName, expiresAt, tokenIssueClass, 0)
+	if err != nil {
+		return fmt.Errorf("failed to issue machine token: %w", err)
+	}
+	var expiresStr *string
+	if result.Credential.ExpiresAt != nil {
+		s := result.Credential.ExpiresAt.Format("2006-01-02")
+		expiresStr = &s
+	}
+	printIssuedToken(result.PlainToken, result.Credential.ID, result.Credential.TokenPrefix, expiresStr)
+	return nil
+}
+
+func printIssuedToken(token string, id uint, prefix string, expiresAt *string) {
+	fmt.Println("Machine token issued. Copy it now — it will not be shown again.")
+	fmt.Println()
+	fmt.Printf("Token:   %s\n", token)
+	fmt.Printf("ID:      %d\n", id)
+	fmt.Printf("Prefix:  %s\n", prefix)
+	if expiresAt != nil && *expiresAt != "" {
+		fmt.Printf("Expires: %s\n", *expiresAt)
+	} else {
+		fmt.Println("Expires: never")
+	}
+}
+
+// ── list ──────────────────────────────────────────────────────────────────────
+
+var listTokensCmd = &cobra.Command{
+	Use:          "list <name|id>",
+	Short:        "List tokens for a machine identity",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE:         runTokenList,
+}
+
+// tokenListRow is the DTO shape returned by the server for each token entry.
+type tokenListRow struct {
+	ID         uint    `json:"id"`
+	Name       string  `json:"name"`
+	Prefix     string  `json:"prefix"`
+	LastUsedAt *string `json:"last_used_at"`
+	ExpiresAt  *string `json:"expires_at"`
+	Revoked    bool    `json:"revoked"`
+}
+
+func runTokenList(_ *cobra.Command, args []string) error {
+	ctx := context.Background()
+	_, projectID, err := resolveProjectContext(tokenProjectName)
+	if err != nil {
+		return err
+	}
+	m, err := findMachineByRef(ctx, projectID, args[0])
+	if err != nil {
+		return err
+	}
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		var resp struct {
+			Tokens []tokenListRow `json:"tokens"`
+		}
+		path := fmt.Sprintf("/api/v1/projects/%d/machine-identities/%d/tokens", projectID, m.ID)
+		if err := rc.Get(ctx, path, &resp); err != nil {
+			return fmt.Errorf("failed to list machine tokens: %w", err)
+		}
+		printTokenTable(resp.Tokens)
+		return nil
+	}
+
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	creds, err := svc.ListMachineTokens(ctx, projectID, m.ID)
+	if err != nil {
+		return fmt.Errorf("failed to list machine tokens: %w", err)
+	}
+	rows := make([]tokenListRow, 0, len(creds))
+	for _, c := range creds {
+		row := tokenListRow{
+			ID:      c.ID,
+			Name:    c.Name,
+			Prefix:  c.TokenPrefix,
+			Revoked: c.Revoked,
+		}
+		if c.LastUsedAt != nil {
+			s := c.LastUsedAt.Format("2006-01-02 15:04")
+			row.LastUsedAt = &s
+		}
+		if c.ExpiresAt != nil {
+			s := c.ExpiresAt.Format("2006-01-02")
+			row.ExpiresAt = &s
+		}
+		rows = append(rows, row)
+	}
+	printTokenTable(rows)
+	return nil
+}
+
+func printTokenTable(rows []tokenListRow) {
+	if len(rows) == 0 {
+		fmt.Println("No tokens found.")
+		return
+	}
+	fmt.Printf("%-6s %-22s %-20s %-18s %-12s %s\n", "ID", "NAME", "PREFIX", "LAST USED", "EXPIRES", "REVOKED")
+	for _, r := range rows {
+		lastUsed := "-"
+		if r.LastUsedAt != nil && *r.LastUsedAt != "" {
+			lastUsed = *r.LastUsedAt
+		}
+		expires := "never"
+		if r.ExpiresAt != nil && *r.ExpiresAt != "" {
+			expires = *r.ExpiresAt
+		}
+		revoked := "false"
+		if r.Revoked {
+			revoked = "true"
+		}
+		fmt.Printf("%-6d %-22s %-20s %-18s %-12s %s\n", r.ID, r.Name, r.Prefix, lastUsed, expires, revoked)
+	}
+}
+
+// ── revoke ────────────────────────────────────────────────────────────────────
+
+var revokeTokenCmd = &cobra.Command{
+	Use:          "revoke <name|id> <token-id>",
+	Short:        "Revoke a machine identity token",
+	Args:         cobra.ExactArgs(2),
+	SilenceUsage: true,
+	RunE:         runTokenRevoke,
+}
+
+func runTokenRevoke(cmd *cobra.Command, args []string) error {
+	tokenIDStr := args[1]
+	tokenID, err := strconv.ParseUint(tokenIDStr, 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid token ID %q: must be a numeric ID", tokenIDStr)
+	}
+
+	ctx := context.Background()
+	_, projectID, err := resolveProjectContext(tokenProjectName)
+	if err != nil {
+		return err
+	}
+	m, err := findMachineByRef(ctx, projectID, args[0])
+	if err != nil {
+		return err
+	}
+
+	if !tokenRevokeForce {
+		fmt.Printf("Revoke token %d? [y/N]: ", tokenID)
+		reader := bufio.NewReader(cmd.InOrStdin())
+		input, _ := reader.ReadString('\n')
+		if strings.ToLower(strings.TrimSpace(input)) != "y" {
+			fmt.Println("Revoke aborted.")
+			return nil
+		}
+	}
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		path := fmt.Sprintf("/api/v1/projects/%d/machine-identities/%d/tokens/%d", projectID, m.ID, tokenID)
+		if err := rc.Delete(ctx, path); err != nil {
+			return fmt.Errorf("failed to revoke machine token: %w", err)
+		}
+		fmt.Println("Machine token revoked.")
+		return nil
+	}
+
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	if _, err := svc.RevokeMachineToken(ctx, projectID, m.ID, uint(tokenID), 0); err != nil {
+		return fmt.Errorf("failed to revoke machine token: %w", err)
+	}
+	fmt.Println("Machine token revoked.")
+	return nil
+}
+
+// ── init ──────────────────────────────────────────────────────────────────────
+
+func init() {
+	// issue flags
+	issueCmd.Flags().StringVar(&tokenProjectName, "project", "", "Project name (defaults to the active project)")
+	issueCmd.Flags().StringVar(&tokenIssueName, "name", "", "Token label (required)")
+	issueCmd.Flags().IntVar(&tokenIssueExpiryDays, "expires-in-days", 0, "Token lifetime in days (0 = never expires)")
+	issueCmd.Flags().StringVar(&tokenIssueClass, "classification", "", "Data classification: public | internal | confidential | restricted")
+
+	// list flags
+	listTokensCmd.Flags().StringVar(&tokenProjectName, "project", "", "Project name (defaults to the active project)")
+
+	// revoke flags
+	revokeTokenCmd.Flags().StringVar(&tokenProjectName, "project", "", "Project name (defaults to the active project)")
+	revokeTokenCmd.Flags().BoolVar(&tokenRevokeForce, "force", false, "Skip the confirmation prompt")
+
+	// register subcommands under "machine token"
+	tokenCmd.AddCommand(issueCmd)
+	tokenCmd.AddCommand(listTokensCmd)
+	tokenCmd.AddCommand(revokeTokenCmd)
+
+	// register "machine token" under the root "machine" command
+	MachineCmd.AddCommand(tokenCmd)
+}

--- a/internal/cli/machine/token_test.go
+++ b/internal/cli/machine/token_test.go
@@ -1,0 +1,412 @@
+// token_test.go — tests for machine token issue/list/revoke commands.
+package machine
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── TestMachineTokenIssue_OutputsToken ────────────────────────────────────────
+
+// TestMachineTokenIssue_OutputsToken verifies that issue prints the raw token and
+// confirms it won't be shown again.
+func TestMachineTokenIssue_OutputsToken(t *testing.T) {
+	projectID, _, machineName := setupMachineLocalDB(t)
+	_ = projectID
+
+	origName := tokenIssueName
+	origProj := tokenProjectName
+	origDays := tokenIssueExpiryDays
+	origClass := tokenIssueClass
+	defer func() {
+		tokenIssueName = origName
+		tokenProjectName = origProj
+		tokenIssueExpiryDays = origDays
+		tokenIssueClass = origClass
+	}()
+
+	tokenIssueName = "deploy-key"
+	tokenProjectName = "testproject"
+	tokenIssueExpiryDays = 0
+	tokenIssueClass = ""
+
+	out := captureStdout(t, func() {
+		err := runTokenIssue(nil, []string{machineName})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "Machine token issued")
+	assert.Contains(t, out, "will not be shown again")
+	assert.Contains(t, out, "kx_machine_")
+	assert.Contains(t, out, "Token:")
+	assert.Contains(t, out, "ID:")
+	assert.Contains(t, out, "Prefix:")
+}
+
+// ── TestMachineTokenIssue_ExpiresInDays ──────────────────────────────────────
+
+// TestMachineTokenIssue_ExpiresInDays confirms that --expires-in-days 30 sets the
+// expiry and it appears in the output.
+func TestMachineTokenIssue_ExpiresInDays(t *testing.T) {
+	_, _, machineName := setupMachineLocalDB(t)
+
+	origName := tokenIssueName
+	origProj := tokenProjectName
+	origDays := tokenIssueExpiryDays
+	origClass := tokenIssueClass
+	defer func() {
+		tokenIssueName = origName
+		tokenProjectName = origProj
+		tokenIssueExpiryDays = origDays
+		tokenIssueClass = origClass
+	}()
+
+	tokenIssueName = "short-lived"
+	tokenProjectName = "testproject"
+	tokenIssueExpiryDays = 30
+	tokenIssueClass = ""
+
+	out := captureStdout(t, func() {
+		err := runTokenIssue(nil, []string{machineName})
+		require.NoError(t, err)
+	})
+
+	// expiry line should appear, not "never"
+	assert.Contains(t, out, "Expires:")
+	assert.NotContains(t, out, "Expires: never")
+}
+
+// ── TestMachineTokenList_ShowsExistingTokens ──────────────────────────────────
+
+// TestMachineTokenList_ShowsExistingTokens issues a token then lists it and checks
+// the table header and the token's name appear.
+func TestMachineTokenList_ShowsExistingTokens(t *testing.T) {
+	_, _, machineName := setupMachineLocalDB(t)
+
+	// issue a token first
+	origName := tokenIssueName
+	origProj := tokenProjectName
+	origDays := tokenIssueExpiryDays
+	origClass := tokenIssueClass
+	defer func() {
+		tokenIssueName = origName
+		tokenProjectName = origProj
+		tokenIssueExpiryDays = origDays
+		tokenIssueClass = origClass
+	}()
+
+	tokenIssueName = "list-test-token"
+	tokenProjectName = "testproject"
+	tokenIssueExpiryDays = 0
+	tokenIssueClass = ""
+
+	captureStdout(t, func() {
+		err := runTokenIssue(nil, []string{machineName})
+		require.NoError(t, err)
+	})
+
+	// now list
+	out := captureStdout(t, func() {
+		err := runTokenList(nil, []string{machineName})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "list-test-token")
+}
+
+// ── TestMachineTokenRevoke_RequiresForceOrConfirm ─────────────────────────────
+
+// TestMachineTokenRevoke_RequiresForceOrConfirm verifies that without --force and
+// when stdin sends "n", the token is NOT revoked (the DELETE is never called).
+func TestMachineTokenRevoke_RequiresForceOrConfirm(t *testing.T) {
+	var deleteCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleteCalls++
+		}
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects" {
+			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":10,"name":"proj"}]}}`))
+			return
+		}
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/machine-identities") {
+			_, _ = w.Write([]byte(`{"data":{"machine_identities":[{"id":20,"name":"ci-bot","state":"active"}]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":null}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origForce := tokenRevokeForce
+	origProj := tokenProjectName
+	defer func() {
+		tokenRevokeForce = origForce
+		tokenProjectName = origProj
+	}()
+
+	tokenRevokeForce = false
+	tokenProjectName = "proj"
+
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader("n\n"))
+
+	err := runTokenRevoke(cmd, []string{"ci-bot", "42"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleteCalls, "answering 'n' must not call DELETE")
+}
+
+// ── TestMachineTokenRevoke_Force_Succeeds ─────────────────────────────────────
+
+// TestMachineTokenRevoke_Force_Succeeds verifies that --force bypasses the
+// confirmation prompt and issues the DELETE.
+func TestMachineTokenRevoke_Force_Succeeds(t *testing.T) {
+	var deleteCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":10,"name":"proj"}]}}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/machine-identities"):
+			_, _ = w.Write([]byte(`{"data":{"machine_identities":[{"id":20,"name":"ci-bot","state":"active"}]}}`))
+		case r.Method == http.MethodDelete:
+			deleteCalls++
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":null}`))
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origForce := tokenRevokeForce
+	origProj := tokenProjectName
+	defer func() {
+		tokenRevokeForce = origForce
+		tokenProjectName = origProj
+	}()
+
+	tokenRevokeForce = true
+	tokenProjectName = "proj"
+
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader(""))
+
+	out := captureStdout(t, func() {
+		err := runTokenRevoke(cmd, []string{"ci-bot", "42"})
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, 1, deleteCalls, "--force must call DELETE")
+	assert.Contains(t, out, "Machine token revoked")
+}
+
+// ── TestTokenCmd_Registered ───────────────────────────────────────────────────
+
+func TestTokenCmd_Registered(t *testing.T) {
+	cmd, _, err := MachineCmd.Find([]string{"token"})
+	require.NoError(t, err)
+	assert.Equal(t, "token", cmd.Name())
+}
+
+func TestTokenIssueCmd_Registered(t *testing.T) {
+	cmd, _, err := MachineCmd.Find([]string{"token", "issue"})
+	require.NoError(t, err)
+	assert.Equal(t, "issue", cmd.Name())
+	assert.NotNil(t, cmd.Flags().Lookup("name"))
+	assert.NotNil(t, cmd.Flags().Lookup("expires-in-days"))
+	assert.NotNil(t, cmd.Flags().Lookup("classification"))
+	assert.NotNil(t, cmd.Flags().Lookup("project"))
+}
+
+func TestTokenListCmd_Registered(t *testing.T) {
+	cmd, _, err := MachineCmd.Find([]string{"token", "list"})
+	require.NoError(t, err)
+	assert.Equal(t, "list", cmd.Name())
+	assert.NotNil(t, cmd.Flags().Lookup("project"))
+}
+
+func TestTokenRevokeCmd_Registered(t *testing.T) {
+	cmd, _, err := MachineCmd.Find([]string{"token", "revoke"})
+	require.NoError(t, err)
+	assert.Equal(t, "revoke", cmd.Name())
+	assert.NotNil(t, cmd.Flags().Lookup("force"))
+	assert.NotNil(t, cmd.Flags().Lookup("project"))
+}
+
+// ── TestMachineTokenIssue_NameRequired ───────────────────────────────────────
+
+func TestMachineTokenIssue_NameRequired(t *testing.T) {
+	origName := tokenIssueName
+	defer func() { tokenIssueName = origName }()
+	tokenIssueName = ""
+
+	err := runTokenIssue(nil, []string{"ci-bot"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--name is required")
+}
+
+// ── TestMachineTokenRevoke_InvalidTokenID ────────────────────────────────────
+
+func TestMachineTokenRevoke_InvalidTokenID(t *testing.T) {
+	err := runTokenRevoke(&cobra.Command{}, []string{"ci-bot", "not-a-number"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid token ID")
+}
+
+// ── TestPrintTokenTable_Empty ─────────────────────────────────────────────────
+
+func TestPrintTokenTable_Empty(t *testing.T) {
+	out := captureStdout(t, func() {
+		printTokenTable(nil)
+	})
+	assert.Contains(t, out, "No tokens found")
+}
+
+// ── TestMachineTokenList_RemotePath ──────────────────────────────────────────
+
+func TestMachineTokenList_RemotePath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"myproj"}]}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/5/machine-identities":
+			_, _ = w.Write([]byte(`{"data":{"machine_identities":[{"id":11,"name":"worker","state":"active"}]}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/5/machine-identities/11/tokens":
+			_, _ = w.Write([]byte(`{"data":{"tokens":[{"id":99,"name":"ci-token","prefix":"kx_machine_ab12","revoked":false}]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	origProj := tokenProjectName
+	defer func() { tokenProjectName = origProj }()
+	tokenProjectName = "myproj"
+
+	out := captureStdout(t, func() {
+		err := runTokenList(nil, []string{"worker"})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "ci-token")
+	assert.Contains(t, out, "kx_machine_ab12")
+}
+
+// ── TestMachineTokenIssue_RemotePath ─────────────────────────────────────────
+
+func TestMachineTokenIssue_RemotePath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":7,"name":"remoteproj"}]}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/7/machine-identities":
+			_, _ = w.Write([]byte(`{"data":{"machine_identities":[{"id":33,"name":"bot","state":"active"}]}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/7/machine-identities/33/tokens":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"data":{"token":"kx_machine_therawtoken","id":55,"prefix":"kx_machine_th12","expires_at":null}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	origName := tokenIssueName
+	origProj := tokenProjectName
+	origDays := tokenIssueExpiryDays
+	defer func() {
+		tokenIssueName = origName
+		tokenProjectName = origProj
+		tokenIssueExpiryDays = origDays
+	}()
+
+	tokenIssueName = "remote-key"
+	tokenProjectName = "remoteproj"
+	tokenIssueExpiryDays = 0
+
+	out := captureStdout(t, func() {
+		err := runTokenIssue(nil, []string{"bot"})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "kx_machine_therawtoken")
+	assert.Contains(t, out, "55")
+}
+
+// ── TestMachineTokenRevoke_LocalPath ─────────────────────────────────────────
+
+func TestMachineTokenRevoke_LocalPath(t *testing.T) {
+	_, _, machineName := setupMachineLocalDB(t)
+
+	// issue a token so we have a credential ID to revoke
+	origIssueName := tokenIssueName
+	origIssueProj := tokenProjectName
+	origIssueDays := tokenIssueExpiryDays
+	origIssueClass := tokenIssueClass
+	defer func() {
+		tokenIssueName = origIssueName
+		tokenProjectName = origIssueProj
+		tokenIssueExpiryDays = origIssueDays
+		tokenIssueClass = origIssueClass
+	}()
+
+	tokenIssueName = "revoke-me"
+	tokenProjectName = "testproject"
+	tokenIssueExpiryDays = 0
+	tokenIssueClass = ""
+
+	var issuedIDStr string
+	captureStdout(t, func() {
+		// Capture the issued ID from the output — parse "ID:      N"
+		out := captureStdout(t, func() {
+			err := runTokenIssue(nil, []string{machineName})
+			require.NoError(t, err)
+		})
+		// Find "ID:      <num>" line
+		for _, line := range strings.Split(out, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "ID:") {
+				parts := strings.Fields(line)
+				if len(parts) >= 2 {
+					issuedIDStr = parts[1]
+				}
+			}
+		}
+	})
+
+	// If we didn't parse the ID, fall back to "1" (first issued credential in fresh DB)
+	if issuedIDStr == "" {
+		issuedIDStr = "1"
+	}
+
+	origForce := tokenRevokeForce
+	defer func() { tokenRevokeForce = origForce }()
+	tokenRevokeForce = true
+
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader(""))
+
+	out := captureStdout(t, func() {
+		err := runTokenRevoke(cmd, []string{machineName, issuedIDStr})
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, out, "Machine token revoked")
+}


### PR DESCRIPTION
## Summary

- Adds `keyorix machine token issue <machine> --name <label> [--expires-in-days N] [--classification C] [--project P]` — mints a bearer token and prints it once with a copy-now warning
- Adds `keyorix machine token list <machine> [--project P]` — tabular view of all tokens (ID, name, prefix, last used, expiry, revoked state)
- Adds `keyorix machine token revoke <machine> <token-id> [--project P] [--force]` — revokes a token with a y/N prompt unless `--force` is passed

Both remote (server API via `KEYORIX_SERVER`/`KEYORIX_TOKEN`) and local (embedded SQLite) paths are implemented; URL construction follows the existing project-scoped routes (`/api/v1/projects/{id}/machine-identities/{machineId}/tokens`). Project and machine name resolution reuse the existing `resolveProjectContext` / `findMachineByRef` helpers.

## Test plan

- [ ] `go test ./internal/cli/machine/ -count=1` — all 100 tests pass (15 new token tests)
- [ ] `go build ./...` — clean
- [ ] Remote path covered via httptest servers (issue, list, revoke with and without `--force`)
- [ ] Local path covered via `setupMachineLocalDB` with real SQLite core (issue output, expiry, list after issue, force-revoke)

🤖 Generated with [Claude Code](https://claude.ai/code)