### PR TITLE
feat(encryption): rotate-kek — passphrase change without DEK re-encryption

### DIFF
--- a/internal/cli/encryption/rotate_kek.go
+++ b/internal/cli/encryption/rotate_kek.go
@@ -1,0 +1,128 @@
+// rotate_kek.go — `keyorix encryption rotate-kek`.
+//
+// Changes the master passphrase by re-wrapping the current DEK under a new KEK
+// derived from the new passphrase + a freshly generated salt. Unlike
+// `encryption rotate`, no database rows are re-encrypted and no database
+// connection is required — only the key files are updated.
+package encryption
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/spf13/cobra"
+)
+
+// newMasterPasswordEnvKEK is the env var that carries the new master passphrase
+// for KEK rotation. Intentionally the same constant as migrate_provider.go uses
+// so the two commands share the same "new password" convention, but we reference
+// it by name here to keep the compile dependency explicit.
+const newMasterPasswordEnvKEK = "KEYORIX_NEW_MASTER_PASSWORD" // #nosec G101 -- env var name, not a credential
+
+var rotateKEKCmd = &cobra.Command{
+	Use:   "rotate-kek",
+	Short: "Change the master passphrase (re-wraps DEK, no database re-encryption)",
+	Long: `Derives a new KEK from a new master passphrase and re-wraps the existing
+Data Encryption Key (DEK) under it. Unlike 'encryption rotate', this does NOT
+re-encrypt any database rows — the DEK itself is unchanged. The server must be
+stopped before running this command.
+
+The new passphrase is read from KEYORIX_NEW_MASTER_PASSWORD (required).
+The old passphrase is read from KEYORIX_MASTER_PASSWORD (required).
+
+After this command succeeds, update KEYORIX_MASTER_PASSWORD in your deployment
+configuration to the new passphrase before restarting the server.
+
+Note: the evidence-signing key fingerprint (esk-...) and audit-checkpoint key
+fingerprint (ack-...) will change, because both are derived from the KEK.`,
+	RunE: runRotateKEK,
+}
+
+var rotateKEKConfirm bool
+
+func init() {
+	EncryptionCmd.AddCommand(rotateKEKCmd)
+	rotateKEKCmd.Flags().BoolVar(&rotateKEKConfirm, "confirm", false,
+		"required acknowledgement that the master passphrase will be changed")
+}
+
+func runRotateKEK(cmd *cobra.Command, args []string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	return rotateKEKWithConfig(cfg, rotateKEKConfirm)
+}
+
+// rotateKEKWithConfig is the testable core of runRotateKEK. It does no config
+// loading and no flag parsing — callers pass an explicit confirm bool. All
+// validation gates (encryption disabled, remote storage, missing env vars,
+// --confirm) return before any key-file work so tests don't need real key files.
+func rotateKEKWithConfig(cfg *config.Config, confirm bool) error {
+	if !cfg.Storage.Encryption.Enabled {
+		return fmt.Errorf("encryption is disabled in configuration")
+	}
+	if cfg.Storage.Type == "remote" {
+		return fmt.Errorf("KEK rotation must run on the server host. Current storage type is 'remote' — connect to the server and run this command there")
+	}
+	if !confirm {
+		return fmt.Errorf("this changes the master passphrase and re-wraps the DEK. Re-run with --confirm")
+	}
+
+	oldPassphrase, err := masterPassphrase(cfg)
+	if err != nil {
+		return err
+	}
+
+	newPassphrase := os.Getenv(newMasterPasswordEnvKEK)
+	if newPassphrase == "" {
+		return fmt.Errorf("%s environment variable is not set — set it to the new master passphrase", newMasterPasswordEnvKEK)
+	}
+	if oldPassphrase == newPassphrase {
+		return fmt.Errorf("new passphrase must differ from the old passphrase")
+	}
+
+	baseDir, _ := os.Getwd()
+	service := encryption.NewService(&cfg.Storage.Encryption, baseDir)
+
+	service.CleanPendingDEK()
+	if err := service.Initialize(oldPassphrase); err != nil {
+		return fmt.Errorf("failed to initialize encryption (wrong old passphrase?): %w", err)
+	}
+	defer service.Shutdown()
+
+	// Acquire the exclusive key lock to prevent a concurrent server or rotation
+	// from interfering. RotateKEKPassphrase also acquires the lock internally
+	// (cross-process flock), but we call AcquireExclusiveKeyLock here first so
+	// a live server fails fast with a clear message rather than silently waiting.
+	if err := service.AcquireExclusiveKeyLock(); err != nil {
+		return fmt.Errorf("refusing to rotate KEK: %w — stop the running server before rotating", err)
+	}
+
+	fmt.Println("Rotating KEK — re-wrapping DEK under new passphrase...")
+	if err := service.RotateKEKPassphrase(oldPassphrase, newPassphrase); err != nil {
+		return fmt.Errorf("KEK rotation failed: %w", err)
+	}
+
+	_, eskID, ok := service.EvidenceSignKey()
+	if !ok {
+		eskID = "(unavailable)"
+	}
+	_, ackID, ok := service.AuditCheckpointKey()
+	if !ok {
+		ackID = "(unavailable)"
+	}
+
+	fmt.Println("KEK rotation complete.")
+	fmt.Println()
+	fmt.Printf("  Evidence-signing key fingerprint:      %s\n", eskID)
+	fmt.Printf("  Audit-checkpoint key fingerprint:      %s\n", ackID)
+	fmt.Println()
+	fmt.Println("Update KEYORIX_MASTER_PASSWORD to the new value before restarting the server.")
+	fmt.Println()
+	fmt.Println("Note: evidence packs and audit checkpoints signed before this rotation will")
+	fmt.Println("report as 'superseded key version' (not tampered) under `keyorix compliance verify`.")
+	return nil
+}

--- a/internal/cli/encryption/rotate_kek_test.go
+++ b/internal/cli/encryption/rotate_kek_test.go
@@ -1,0 +1,178 @@
+package encryption
+
+// rotate_kek_test.go — integration tests for the rotate-kek CLI command.
+//
+// Exercises rotateKEKWithConfig — the testable core of runRotateKEK — directly,
+// using real temp key directories so the file I/O (read salt, write .pending
+// files, atomic rename) is fully exercised without a running server or database.
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+)
+
+// enabledLocalCfgKEK returns a minimal EncryptionConfig with encryption
+// enabled and local storage, pointing at default relative key paths (resolved
+// under the test's cwd / temp dir).
+func enabledLocalCfgKEK() *config.Config {
+	return &config.Config{
+		Storage: config.StorageConfig{
+			Type: "local",
+			Encryption: config.EncryptionConfig{
+				Enabled:  true,
+				DEKPath:  "dek.key",
+				SaltPath: "kek.salt",
+			},
+		},
+	}
+}
+
+// TestRotateKEKCommand_RequiresConfirm verifies that missing --confirm causes
+// an early error before any key-file work.
+func TestRotateKEKCommand_RequiresConfirm(t *testing.T) {
+	err := rotateKEKWithConfig(enabledLocalCfgKEK(), false /*confirm=false*/)
+	if err == nil || !strings.Contains(err.Error(), "--confirm") {
+		t.Fatalf("expected --confirm gate, got: %v", err)
+	}
+}
+
+// TestRotateKEKCommand_RejectsDisabledEncryption verifies that the command
+// returns an error when encryption is disabled in config.
+func TestRotateKEKCommand_RejectsDisabledEncryption(t *testing.T) {
+	cfg := enabledLocalCfgKEK()
+	cfg.Storage.Encryption.Enabled = false
+	err := rotateKEKWithConfig(cfg, true)
+	if err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Fatalf("expected disabled-encryption rejection, got: %v", err)
+	}
+}
+
+// TestRotateKEKCommand_RejectsRemoteStorage verifies that the command refuses
+// to run when the storage type is "remote" (must run on the server host).
+func TestRotateKEKCommand_RejectsRemoteStorage(t *testing.T) {
+	cfg := enabledLocalCfgKEK()
+	cfg.Storage.Type = "remote"
+	err := rotateKEKWithConfig(cfg, true)
+	if err == nil || !strings.Contains(err.Error(), "server host") {
+		t.Fatalf("expected remote-storage rejection, got: %v", err)
+	}
+}
+
+// TestRotateKEKCommand_RequiresNewPassphraseEnv verifies that missing
+// KEYORIX_NEW_MASTER_PASSWORD causes an error.
+func TestRotateKEKCommand_RequiresNewPassphraseEnv(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "old-passphrase")
+	t.Setenv("KEYORIX_NEW_MASTER_PASSWORD", "") // explicitly unset
+
+	// We need actual key files so we get past the Initialize step; alternatively
+	// we can init the keys first.
+	cfg := enabledLocalCfgKEK()
+	svc := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := svc.Initialize("old-passphrase"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	svc.Shutdown()
+
+	err := rotateKEKWithConfig(cfg, true)
+	if err == nil || !strings.Contains(err.Error(), "KEYORIX_NEW_MASTER_PASSWORD") {
+		t.Fatalf("expected missing-env-var rejection, got: %v", err)
+	}
+}
+
+// TestRotateKEKCommand_RejectsSamePassphrase verifies that using the same
+// value for old and new passphrase is rejected.
+func TestRotateKEKCommand_RejectsSamePassphrase(t *testing.T) {
+	const pass = "same-old-same-new"
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	t.Setenv("KEYORIX_MASTER_PASSWORD", pass)
+	t.Setenv("KEYORIX_NEW_MASTER_PASSWORD", pass)
+
+	cfg := enabledLocalCfgKEK()
+	svc := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := svc.Initialize(pass); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	svc.Shutdown()
+
+	err := rotateKEKWithConfig(cfg, true)
+	if err == nil || !strings.Contains(err.Error(), "differ") {
+		t.Fatalf("expected same-passphrase rejection, got: %v", err)
+	}
+}
+
+// TestRotateKEKCommand_Success_OldPassphraseNoLongerWorks is the full
+// end-to-end CLI test:
+//  1. Init keys with old passphrase.
+//  2. Run rotate-kek via rotateKEKWithConfig.
+//  3. Verify old passphrase is rejected.
+//  4. Verify new passphrase opens the DEK (and can decrypt pre-rotation data).
+func TestRotateKEKCommand_Success_OldPassphraseNoLongerWorks(t *testing.T) {
+	const (
+		oldPass = "e2e-old-master-passphrase-correct"
+		newPass = "e2e-new-master-passphrase-different"
+		secret  = "super-secret-value-to-survive-kek-rotation"
+	)
+
+	dir := t.TempDir()
+	t.Chdir(dir) // rotateKEKWithConfig resolves key paths under cwd via os.Getwd()
+
+	t.Setenv("KEYORIX_MASTER_PASSWORD", oldPass)
+	t.Setenv("KEYORIX_NEW_MASTER_PASSWORD", newPass)
+
+	cfg := enabledLocalCfgKEK()
+
+	// 1. Init keys and encrypt a value.
+	svc := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := svc.Initialize(oldPass); err != nil {
+		t.Fatalf("init with old passphrase: %v", err)
+	}
+	ciphertext, _, err := svc.EncryptSecret([]byte(secret))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	svc.Shutdown()
+
+	// 2. Run rotate-kek.
+	if err := rotateKEKWithConfig(cfg, true); err != nil {
+		t.Fatalf("rotateKEKWithConfig: %v", err)
+	}
+
+	// 3. Old passphrase must be rejected.
+	svcOld := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := svcOld.Initialize(oldPass); err == nil {
+		svcOld.Shutdown()
+		t.Fatal("old passphrase still accepted after KEK rotation — expected failure")
+	}
+
+	// 4. New passphrase must work and decrypt the pre-rotation ciphertext.
+	svcNew := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := svcNew.Initialize(newPass); err != nil {
+		t.Fatalf("new passphrase rejected after KEK rotation: %v", err)
+	}
+	defer svcNew.Shutdown()
+
+	plaintext, err := svcNew.DecryptSecret(ciphertext)
+	if err != nil {
+		t.Fatalf("decrypt pre-rotation ciphertext with new passphrase: %v", err)
+	}
+	if string(plaintext) != secret {
+		t.Fatalf("plaintext mismatch: got %q want %q", plaintext, secret)
+	}
+
+	// Confirm no leftover pending files.
+	if _, err := os.Stat("dek.key.pending"); !os.IsNotExist(err) {
+		t.Errorf("dek.key.pending still exists after successful rotation")
+	}
+	if _, err := os.Stat("kek.salt.pending"); !os.IsNotExist(err) {
+		t.Errorf("kek.salt.pending still exists after successful rotation")
+	}
+}

--- a/internal/encryption/keymanager_kek_rotation.go
+++ b/internal/encryption/keymanager_kek_rotation.go
@@ -1,0 +1,202 @@
+// keymanager_kek_rotation.go — passphrase-only KEK rotation (rotate-kek).
+//
+// RotateKEKPassphrase re-wraps the current DEK under a new KEK derived from a
+// new passphrase + a freshly generated salt, without touching the database or
+// changing the DEK value. Evidence-signing and audit-checkpoint keys change
+// because they are KEK-derived.
+//
+// Unlike RotateDEKWithSweep (new DEK, full re-encryption sweep) and
+// RewrapDEK (new KEK provider, no passphrase), this operation stays entirely
+// within the password/passphrase KEK provider and is the intended path for
+// an operator who needs to rotate the master passphrase.
+package encryption
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/keyorixhq/keyorix/internal/securefiles"
+)
+
+// RotateKEKPassphrase re-wraps the current DEK under a new KEK derived from
+// newPassphrase + a freshly generated salt, without touching the database.
+// The old passphrase must match what the manager was initialized with (verified
+// by attempting an unwrap before any file is modified). Evidence-signing and
+// audit-checkpoint keys change because they are KEK-derived.
+//
+// Both oldPassphrase and newPassphrase must be non-empty. The same value for
+// both is allowed and simply re-derives the KEK with a new random salt.
+//
+// The manager must already be Initialized (currentDEK in memory).
+func (km *KeyManager) RotateKEKPassphrase(oldPassphrase, newPassphrase string) error {
+	km.mu.Lock()
+	defer km.mu.Unlock()
+
+	if km.currentDEK == nil {
+		return fmt.Errorf("key manager not initialized — cannot rotate KEK")
+	}
+	if oldPassphrase == "" {
+		return fmt.Errorf("rotate KEK: old passphrase must not be empty")
+	}
+	if newPassphrase == "" {
+		return fmt.Errorf("rotate KEK: new passphrase must not be empty")
+	}
+
+	// Acquire the same cross-process exclusive DEK lock that RewrapDEK and
+	// RotateDEKWithSweep use — we write to the same dek.key.pending → dek.key
+	// path and must never interleave with a concurrent rotation.
+	lock, err := km.acquireExclusiveKeyLock()
+	if err != nil {
+		return fmt.Errorf("rotate KEK: %w", err)
+	}
+	defer lock.release()
+
+	// Re-read the on-disk wrapped DEK under the exclusive lock and compare it
+	// against the snapshot taken when currentDEK was last set. If another
+	// process rotated the DEK in the meantime, our in-memory currentDEK is now
+	// stale — abort rather than overwriting the newer key (mirrors
+	// RewrapDEK's staleness check, #195).
+	onDisk, err := securefiles.SafeReadFile(km.baseDir, km.dekPath)
+	if err != nil {
+		return fmt.Errorf("rotate KEK: re-read active DEK under lock: %w", err)
+	}
+	if !bytes.Equal(onDisk, km.dekSnapshot) {
+		return fmt.Errorf("rotate KEK: the on-disk DEK changed since this process started — a concurrent DEK rotation likely completed in the meantime; re-run rotate-kek now that the rotation has finished")
+	}
+
+	// Read the current salt from disk so we can derive the current KEK and
+	// verify oldPassphrase is correct before touching any file.
+	currentSalt, err := securefiles.SafeReadFile(km.baseDir, km.saltPath)
+	if err != nil {
+		return fmt.Errorf("rotate KEK: read current salt: %w", err)
+	}
+	if len(currentSalt) != 32 {
+		return fmt.Errorf("rotate KEK: invalid current salt size: expected 32 bytes, got %d", len(currentSalt))
+	}
+
+	// Derive the current KEK from the old passphrase and verify it unwraps the
+	// on-disk DEK. This confirms the passphrase is correct BEFORE modifying any
+	// file — fail closed rather than writing an unwrappable DEK on disk.
+	currentKEK := GenerateKEK(oldPassphrase, currentSalt, DefaultKEKIterations)
+	defer wipeBytes(currentKEK)
+
+	if _, err := unwrapKey(onDisk, currentKEK); err != nil {
+		return fmt.Errorf("rotate KEK: old passphrase is incorrect — aborting without modifying any file: %w", err)
+	}
+
+	// Generate a fresh 32-byte salt for the new KEK.
+	newSalt := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, newSalt); err != nil {
+		return fmt.Errorf("rotate KEK: generate new salt: %w", err)
+	}
+
+	// Derive the new KEK from newPassphrase + newSalt.
+	newKEK := GenerateKEK(newPassphrase, newSalt, DefaultKEKIterations)
+	defer wipeBytes(newKEK)
+
+	// Wrap the current (unchanged) DEK with the new KEK.
+	newWrappedDEK, err := wrapKey(km.currentDEK, newKEK)
+	if err != nil {
+		return fmt.Errorf("rotate KEK: wrap DEK with new KEK: %w", err)
+	}
+
+	// Write pending files. On any failure here the original files are untouched:
+	//   salt:    saltPath.pending → saltPath   (atomic rename)
+	//   dek.key: dekPath.pending  → dekPath    (atomic rename, matches RewrapDEK)
+	//
+	// We write the salt pending first so that if we crash between the two renames,
+	// the DEK pending file doesn't exist yet and the original DEK is still valid
+	// under the original salt.
+	pendingSaltPath := km.saltPath + ".pending"
+	if err := securefiles.SecureWriteFileSync(km.baseDir, pendingSaltPath, newSalt, 0600); err != nil {
+		return fmt.Errorf("rotate KEK: write pending salt: %w", err)
+	}
+
+	pendingDEKPath := km.dekPath + ".pending"
+	if err := securefiles.SecureWriteFileSync(km.baseDir, pendingDEKPath, newWrappedDEK, 0600); err != nil {
+		_ = os.Remove(filepath.Join(km.baseDir, pendingSaltPath))
+		return fmt.Errorf("rotate KEK: write pending DEK: %w", err)
+	}
+
+	// Atomic rename: salt first, then DEK. A crash between the two renames leaves
+	// the new salt on disk with the OLD wrapped DEK — the old passphrase still
+	// unwraps it (old salt was renamed away but the old DEK is still under the old
+	// KEK). To allow recovery, we keep the old salt in .bak until after the DEK
+	// rename succeeds.
+	//
+	// Actually: safer approach — rename salt.pending → salt, then DEK.pending → DEK.
+	// If we crash after the salt rename but before the DEK rename, the new salt is
+	// on disk but the DEK is still wrapped under the OLD KEK (which uses the OLD
+	// salt). The operator would be stuck. To avoid this, we rename DEK first, then
+	// salt — if we crash after the DEK rename but before the salt rename, the DEK is
+	// wrapped under the new KEK derived from the new salt, but the new salt hasn't
+	// been written. However, the pending salt file still exists and the operator can
+	// recover by completing the rename.
+	//
+	// The safest ordering for durability is:
+	//   1. pending salt written and fsynced
+	//   2. pending DEK written and fsynced
+	//   3. rename DEK.pending → DEK  (DEK is now wrapped under new KEK; old salt still active)
+	//   4. fsync dir (make rename durable)
+	//   5. rename salt.pending → salt (now both files are consistent under new KEK)
+	//   6. fsync dir
+	//
+	// If we crash at step 3 or 4: the new DEK is active but wrapped under new KEK.
+	// The old salt file is still there. The operator runs rotate-kek again with the
+	// same new passphrase to complete. The pending salt file is still on disk.
+	//
+	// This is the same as what RewrapDEK does for the DEK: write pending, rename,
+	// fsync dir. We apply the same pattern for both files, DEK first.
+	pendingDEKFull := filepath.Join(km.baseDir, pendingDEKPath)
+	activeDEKFull := filepath.Join(km.baseDir, km.dekPath)
+	if err := os.Rename(pendingDEKFull, activeDEKFull); err != nil {
+		_ = os.Remove(filepath.Join(km.baseDir, pendingSaltPath))
+		_ = os.Remove(pendingDEKFull)
+		return fmt.Errorf("rotate KEK: promote pending DEK to active: %w", err)
+	}
+	if err := securefiles.SyncDir(filepath.Dir(activeDEKFull)); err != nil {
+		// DEK rename is durable; log the sync failure but continue to salt rename.
+		// The system is in a safe (if not fully durable) state.
+		_ = err // best-effort; continue
+	}
+
+	pendingSaltFull := filepath.Join(km.baseDir, pendingSaltPath)
+	activeSaltFull := filepath.Join(km.baseDir, km.saltPath)
+	if err := os.Rename(pendingSaltFull, activeSaltFull); err != nil {
+		// DEK is already renamed (wrapped under new KEK derived from newSalt).
+		// The salt file is still old — the operator must complete the rename manually.
+		return fmt.Errorf("rotate KEK: promote pending salt to active (DEK rename already succeeded — manually rename %s to %s to complete): %w", pendingSaltPath, km.saltPath, err)
+	}
+	if err := securefiles.SyncDir(filepath.Dir(activeSaltFull)); err != nil {
+		_ = err // best-effort
+	}
+
+	// Derive new evidence-signing and audit-checkpoint keys from the new KEK,
+	// matching Initialize's derivation exactly, before wiping the new KEK.
+	newESK, newESKID, err := deriveEvidenceSignKey(newKEK)
+	if err != nil {
+		return fmt.Errorf("rotate KEK: re-derive evidence-signing key: %w", err)
+	}
+	newACK, newACKID, err := deriveAuditCheckpointKey(newKEK)
+	if err != nil {
+		wipeBytes(newESK)
+		return fmt.Errorf("rotate KEK: re-derive audit-checkpoint key: %w", err)
+	}
+
+	// Update in-memory state under the already-held mu.Lock.
+	wipeBytes(km.evidenceSignKey)
+	km.evidenceSignKey = newESK
+	km.evidenceSignKeyID = newESKID
+
+	wipeBytes(km.auditCheckpointKey)
+	km.auditCheckpointKey = newACK
+	km.auditCheckpointKeyID = newACKID
+
+	km.dekSnapshot = append([]byte(nil), newWrappedDEK...)
+
+	return nil
+}

--- a/internal/encryption/keymanager_kek_rotation_test.go
+++ b/internal/encryption/keymanager_kek_rotation_test.go
@@ -1,0 +1,316 @@
+package encryption
+
+// keymanager_kek_rotation_test.go — unit tests for RotateKEKPassphrase.
+//
+// All tests use real temp directories (t.TempDir()) since the feature exercises
+// file I/O: reading the current salt, writing .pending files, and atomically
+// renaming them into place.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+)
+
+// newPassphraseService creates an initialized Service with a password provider
+// in a fresh temp directory and returns both the service and the directory.
+func newPassphraseService(t *testing.T, passphrase string) (*Service, string) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "kek.salt",
+	}
+	svc := NewService(cfg, dir)
+	if err := svc.Initialize(passphrase); err != nil {
+		t.Fatalf("initialize service: %v", err)
+	}
+	return svc, dir
+}
+
+// TestRotateKEKPassphrase_SuccessChangesSalt verifies that after KEK rotation:
+//  1. The salt file on disk is different from the original salt.
+//  2. The old passphrase no longer unwraps the DEK (new KEK = new salt + new passphrase).
+//  3. The new passphrase correctly unwraps the DEK from a fresh service.
+func TestRotateKEKPassphrase_SuccessChangesSalt(t *testing.T) {
+	const (
+		oldPass = "old-correct-horse-battery-staple"
+		newPass = "new-tr0ub4dor&3"
+	)
+
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "kek.salt",
+	}
+	svc := NewService(cfg, dir)
+	if err := svc.Initialize(oldPass); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	defer svc.Shutdown()
+
+	// Capture the salt before rotation.
+	saltBefore, err := os.ReadFile(filepath.Join(dir, "kek.salt"))
+	if err != nil {
+		t.Fatalf("read salt before: %v", err)
+	}
+
+	if err := svc.RotateKEKPassphrase(oldPass, newPass); err != nil {
+		t.Fatalf("RotateKEKPassphrase: %v", err)
+	}
+
+	// Salt file must have changed.
+	saltAfter, err := os.ReadFile(filepath.Join(dir, "kek.salt"))
+	if err != nil {
+		t.Fatalf("read salt after: %v", err)
+	}
+	if bytes.Equal(saltBefore, saltAfter) {
+		t.Fatal("salt did not change after KEK rotation")
+	}
+
+	// Old passphrase must no longer unwrap the DEK.
+	svcOld := NewService(cfg, dir)
+	if err := svcOld.Initialize(oldPass); err == nil {
+		svcOld.Shutdown()
+		t.Fatal("old passphrase still unwraps DEK after KEK rotation — expected failure")
+	}
+
+	// New passphrase must successfully unwrap the DEK.
+	svcNew := NewService(cfg, dir)
+	if err := svcNew.Initialize(newPass); err != nil {
+		t.Fatalf("new passphrase failed to open DEK after KEK rotation: %v", err)
+	}
+	defer svcNew.Shutdown()
+}
+
+// TestRotateKEKPassphrase_WrongOldPassphrase_Fails verifies that an incorrect
+// old passphrase is rejected before any file is modified.
+func TestRotateKEKPassphrase_WrongOldPassphrase_Fails(t *testing.T) {
+	const correctPass = "correct-passphrase"
+	svc, dir := newPassphraseService(t, correctPass)
+	defer svc.Shutdown()
+
+	saltBefore, _ := os.ReadFile(filepath.Join(dir, "kek.salt"))
+	dekBefore, _ := os.ReadFile(filepath.Join(dir, "dek.key"))
+
+	err := svc.RotateKEKPassphrase("wrong-passphrase", "new-passphrase")
+	if err == nil {
+		t.Fatal("expected error for wrong old passphrase, got nil")
+	}
+
+	// Neither file must have changed.
+	saltAfter, _ := os.ReadFile(filepath.Join(dir, "kek.salt"))
+	dekAfter, _ := os.ReadFile(filepath.Join(dir, "dek.key"))
+
+	if !bytes.Equal(saltBefore, saltAfter) {
+		t.Error("salt changed even though old passphrase was wrong")
+	}
+	if !bytes.Equal(dekBefore, dekAfter) {
+		t.Error("dek.key changed even though old passphrase was wrong")
+	}
+}
+
+// TestRotateKEKPassphrase_EmptyNewPassphrase_Fails verifies that an empty new
+// passphrase is rejected immediately (input validation, no file access).
+func TestRotateKEKPassphrase_EmptyNewPassphrase_Fails(t *testing.T) {
+	svc, _ := newPassphraseService(t, "correct-passphrase")
+	defer svc.Shutdown()
+
+	if err := svc.RotateKEKPassphrase("correct-passphrase", ""); err == nil {
+		t.Fatal("expected error for empty new passphrase, got nil")
+	}
+}
+
+// TestRotateKEKPassphrase_EmptyOldPassphrase_Fails verifies that an empty old
+// passphrase is rejected immediately.
+func TestRotateKEKPassphrase_EmptyOldPassphrase_Fails(t *testing.T) {
+	svc, _ := newPassphraseService(t, "correct-passphrase")
+	defer svc.Shutdown()
+
+	if err := svc.RotateKEKPassphrase("", "new-passphrase"); err == nil {
+		t.Fatal("expected error for empty old passphrase, got nil")
+	}
+}
+
+// TestRotateKEKPassphrase_SamePassphrase_Allowed verifies that rotating to the
+// same passphrase is allowed (salt is regenerated, so the wrapping genuinely
+// changes; this is a valid idempotency / re-salt operation).
+func TestRotateKEKPassphrase_SamePassphrase_Allowed(t *testing.T) {
+	const pass = "same-passphrase"
+	svc, dir := newPassphraseService(t, pass)
+	defer svc.Shutdown()
+
+	saltBefore, _ := os.ReadFile(filepath.Join(dir, "kek.salt"))
+
+	if err := svc.RotateKEKPassphrase(pass, pass); err != nil {
+		t.Fatalf("same-passphrase KEK rotation failed: %v", err)
+	}
+
+	saltAfter, _ := os.ReadFile(filepath.Join(dir, "kek.salt"))
+	// Salt must change even for same passphrase (fresh random salt).
+	if bytes.Equal(saltBefore, saltAfter) {
+		t.Error("salt did not change for same-passphrase rotation")
+	}
+
+	// Verify the passphrase still works after re-salting.
+	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
+	svcNew := NewService(cfg, dir)
+	if err := svcNew.Initialize(pass); err != nil {
+		t.Fatalf("passphrase failed after same-passphrase rotation: %v", err)
+	}
+	defer svcNew.Shutdown()
+}
+
+// TestRotateKEKPassphrase_EvidenceKeyChanges verifies that the evidence-signing
+// key fingerprint differs after KEK rotation (because it is KEK-derived).
+func TestRotateKEKPassphrase_EvidenceKeyChanges(t *testing.T) {
+	const (
+		oldPass = "old-evidence-test-pass"
+		newPass = "new-evidence-test-pass"
+	)
+	svc, _ := newPassphraseService(t, oldPass)
+	defer svc.Shutdown()
+
+	_, eskIDBefore, ok := svc.EvidenceSignKey()
+	if !ok {
+		t.Fatal("EvidenceSignKey unavailable before KEK rotation")
+	}
+
+	if err := svc.RotateKEKPassphrase(oldPass, newPass); err != nil {
+		t.Fatalf("RotateKEKPassphrase: %v", err)
+	}
+
+	_, eskIDAfter, ok := svc.EvidenceSignKey()
+	if !ok {
+		t.Fatal("EvidenceSignKey unavailable after KEK rotation")
+	}
+	if eskIDBefore == eskIDAfter {
+		t.Fatalf("evidence-signing key fingerprint did not change after KEK rotation: %q", eskIDAfter)
+	}
+}
+
+// TestRotateKEKPassphrase_AuditCheckpointKeyChanges verifies that the
+// audit-checkpoint key fingerprint differs after KEK rotation.
+func TestRotateKEKPassphrase_AuditCheckpointKeyChanges(t *testing.T) {
+	const (
+		oldPass = "old-audit-test-pass"
+		newPass = "new-audit-test-pass"
+	)
+	svc, _ := newPassphraseService(t, oldPass)
+	defer svc.Shutdown()
+
+	_, ackIDBefore, ok := svc.AuditCheckpointKey()
+	if !ok {
+		t.Fatal("AuditCheckpointKey unavailable before KEK rotation")
+	}
+
+	if err := svc.RotateKEKPassphrase(oldPass, newPass); err != nil {
+		t.Fatalf("RotateKEKPassphrase: %v", err)
+	}
+
+	_, ackIDAfter, ok := svc.AuditCheckpointKey()
+	if !ok {
+		t.Fatal("AuditCheckpointKey unavailable after KEK rotation")
+	}
+	if ackIDBefore == ackIDAfter {
+		t.Fatalf("audit-checkpoint key fingerprint did not change after KEK rotation: %q", ackIDAfter)
+	}
+}
+
+// TestRotateKEKPassphrase_DEKValueUnchanged verifies that the plaintext DEK
+// value is identical before and after KEK rotation: data encrypted before the
+// rotation must still decrypt successfully after it.
+func TestRotateKEKPassphrase_DEKValueUnchanged(t *testing.T) {
+	const (
+		oldPass  = "old-dek-unchanged-pass"
+		newPass  = "new-dek-unchanged-pass"
+		secret   = "plaintext-that-must-survive-kek-rotation"
+	)
+
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "kek.salt",
+	}
+
+	// Initialize and encrypt a value before rotation.
+	svc := NewService(cfg, dir)
+	if err := svc.Initialize(oldPass); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	ciphertext, _, err := svc.EncryptSecret([]byte(secret))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	// Capture DEK bytes before rotation.
+	dekBefore := captureCurrentDEK(t, svc)
+
+	if err := svc.RotateKEKPassphrase(oldPass, newPass); err != nil {
+		svc.Shutdown()
+		t.Fatalf("RotateKEKPassphrase: %v", err)
+	}
+	svc.Shutdown()
+
+	// Open a fresh service with the new passphrase (simulates server restart).
+	svcNew := NewService(cfg, dir)
+	if err := svcNew.Initialize(newPass); err != nil {
+		t.Fatalf("open with new passphrase: %v", err)
+	}
+	defer svcNew.Shutdown()
+
+	// DEK value must be identical (re-derived from the on-disk key).
+	dekAfter := captureCurrentDEK(t, svcNew)
+	if !bytes.Equal(dekBefore, dekAfter) {
+		t.Fatalf("DEK value changed across KEK rotation: before=%x after=%x", dekBefore, dekAfter)
+	}
+
+	// Pre-rotation ciphertext must still decrypt successfully.
+	plaintext, err := svcNew.DecryptSecret(ciphertext)
+	if err != nil {
+		t.Fatalf("decrypt pre-rotation ciphertext with new passphrase: %v", err)
+	}
+	if string(plaintext) != secret {
+		t.Fatalf("plaintext mismatch: got %q want %q", plaintext, secret)
+	}
+}
+
+// TestRotateKEKPassphrase_RequiresInitializedManager verifies that calling
+// RotateKEKPassphrase on an uninitialized KeyManager returns an error.
+func TestRotateKEKPassphrase_RequiresInitializedManager(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	if err := km.RotateKEKPassphrase("old", "new"); err == nil {
+		t.Fatal("expected error for uninitialized manager, got nil")
+	}
+}
+
+// TestRotateKEKPassphrase_NoPendingFilesLeft verifies that no .pending files
+// remain on disk after a successful rotation.
+func TestRotateKEKPassphrase_NoPendingFilesLeft(t *testing.T) {
+	const (
+		oldPass = "old-pending-test"
+		newPass = "new-pending-test"
+	)
+	svc, dir := newPassphraseService(t, oldPass)
+	defer svc.Shutdown()
+
+	if err := svc.RotateKEKPassphrase(oldPass, newPass); err != nil {
+		t.Fatalf("RotateKEKPassphrase: %v", err)
+	}
+
+	// dek.key.pending must not exist.
+	if _, err := os.Stat(filepath.Join(dir, "dek.key.pending")); !os.IsNotExist(err) {
+		t.Errorf("dek.key.pending still exists after successful rotation (stat err: %v)", err)
+	}
+	// kek.salt.pending must not exist.
+	if _, err := os.Stat(filepath.Join(dir, "kek.salt.pending")); !os.IsNotExist(err) {
+		t.Errorf("kek.salt.pending still exists after successful rotation (stat err: %v)", err)
+	}
+}

--- a/internal/encryption/service_rotation.go
+++ b/internal/encryption/service_rotation.go
@@ -219,6 +219,24 @@ func (s *Service) RotateDEK(passphrase string) error {
 	return nil
 }
 
+// RotateKEKPassphrase changes the master passphrase without re-encrypting the
+// database. It re-wraps the current DEK under a new KEK derived from
+// newPassphrase + a fresh random salt. The DEK value is unchanged, so all
+// existing ciphertext stays valid. Evidence-signing and audit-checkpoint key
+// fingerprints will change because those keys are KEK-derived.
+//
+// The old passphrase is verified against the on-disk wrapped DEK before any
+// file is modified. The server must be stopped (exclusive key lock must not
+// be held by another process) before running this command.
+func (s *Service) RotateKEKPassphrase(oldPassphrase, newPassphrase string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.initialized {
+		return fmt.Errorf("encryption service not initialized")
+	}
+	return s.keyManager.RotateKEKPassphrase(oldPassphrase, newPassphrase)
+}
+
 // RewrapDEKWithProvider re-wraps the in-memory DEK with a KEK from newProvider and
 // atomically replaces the on-disk wrapped DEK (ADR-041 KEK-provider migration). The
 // DEK value is unchanged, so every existing ciphertext stays valid — only the


### PR DESCRIPTION
## Summary

- Adds `keyorix encryption rotate-kek --confirm` — changes the master passphrase by re-wrapping the DEK under a new KEK (new passphrase + fresh salt), **without re-encrypting any database rows**. The DEK value is unchanged; only its wrapping changes.
- Old passphrase comes from `KEYORIX_MASTER_PASSWORD`; new passphrase from `KEYORIX_NEW_MASTER_PASSWORD` (never a CLI flag — keeps plaintext out of shell history).
- Uses the same cross-process exclusive flock and `dekSnapshot` staleness check as `RewrapDEK` (#195) to prevent concurrent rotation races.
- Evidence-signing and audit-checkpoint key fingerprints change (KEK-derived), with fingerprints printed on success so operators can update monitoring.

## Key files changed

- `internal/encryption/keymanager_kek_rotation.go` — `KeyManager.RotateKEKPassphrase`: verify old passphrase → generate new salt → wrap DEK under new KEK → atomic rename salt + DEK → update in-memory ESK/ACK.
- `internal/encryption/service_rotation.go` — `Service.RotateKEKPassphrase` thin wrapper.
- `internal/cli/encryption/rotate_kek.go` — cobra command registration, `rotateKEKWithConfig` testable core.
- `internal/encryption/keymanager_kek_rotation_test.go` — 9 unit tests (salt changes, wrong/empty passphrase rejects, same-passphrase re-salts, evidence/audit fingerprints change, DEK value unchanged, no pending files left).
- `internal/cli/encryption/rotate_kek_test.go` — 6 CLI tests (requires `--confirm`, disabled/remote/missing-env rejections, same-passphrase rejection, full end-to-end with old-passphrase rejection and ciphertext round-trip).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/encryption/ ./internal/cli/encryption/ -count=1` — 688 tests pass
- [ ] Operator workflow: set `KEYORIX_NEW_MASTER_PASSWORD`, run `keyorix encryption rotate-kek --confirm`, update `KEYORIX_MASTER_PASSWORD` in deployment config, restart server

🤖 Generated with [Claude Code](https://claude.ai/code)