### PR TITLE
feat(rbac): permission matrix export

### DIFF
--- a/internal/cli/rbac/export_matrix.go
+++ b/internal/cli/rbac/export_matrix.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"text/tabwriter"
 	"time"
 
@@ -68,11 +69,11 @@ func runExportMatrix(cmd *cobra.Command, args []string) error {
 
 	out := io.Writer(os.Stdout)
 	if exportMatrixOutput != "" {
-		f, err := os.Create(exportMatrixOutput)
+		f, err := os.Create(filepath.Clean(exportMatrixOutput))
 		if err != nil {
 			return fmt.Errorf("failed to open output file: %w", err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		out = f
 	}
 
@@ -192,38 +193,46 @@ func writeMatrixEmbedded(out io.Writer, rows []*core.PermissionMatrixRow, format
 
 func writeEmbeddedTable(out io.Writer, rows []*core.PermissionMatrixRow) error {
 	if len(rows) == 0 {
-		fmt.Fprintln(out, "No permission grants found.")
-		return nil
+		_, err := fmt.Fprintln(out, "No permission grants found.")
+		return err
 	}
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "USERNAME\tEMAIL\tROLE\tPERMISSION\tSCOPE\tPROJECT\tEXPIRES")
+	if _, err := fmt.Fprintln(tw, "USERNAME\tEMAIL\tROLE\tPERMISSION\tSCOPE\tPROJECT\tEXPIRES"); err != nil {
+		return err
+	}
 	for _, r := range rows {
 		expiresAt := "never"
 		if r.ExpiresAt != nil {
 			expiresAt = r.ExpiresAt.UTC().Format(time.RFC3339)
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			r.Username, r.Email, r.RoleName, r.PermissionName,
-			r.Scope, r.ProjectName, expiresAt)
+			r.Scope, r.ProjectName, expiresAt); err != nil {
+			return err
+		}
 	}
 	return tw.Flush()
 }
 
 func writeRemoteTable(out io.Writer, rows []remoteMatrixRow) error {
 	if len(rows) == 0 {
-		fmt.Fprintln(out, "No permission grants found.")
-		return nil
+		_, err := fmt.Fprintln(out, "No permission grants found.")
+		return err
 	}
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "USERNAME\tEMAIL\tROLE\tPERMISSION\tSCOPE\tPROJECT\tEXPIRES")
+	if _, err := fmt.Fprintln(tw, "USERNAME\tEMAIL\tROLE\tPERMISSION\tSCOPE\tPROJECT\tEXPIRES"); err != nil {
+		return err
+	}
 	for _, r := range rows {
 		expiresAt := "never"
 		if r.ExpiresAt != nil {
 			expiresAt = r.ExpiresAt.UTC().Format(time.RFC3339)
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			r.Username, r.Email, r.RoleName, r.PermissionName,
-			r.Scope, r.ProjectName, expiresAt)
+			r.Scope, r.ProjectName, expiresAt); err != nil {
+			return err
+		}
 	}
 	return tw.Flush()
 }

--- a/internal/cli/rbac/export_matrix.go
+++ b/internal/cli/rbac/export_matrix.go
@@ -1,0 +1,240 @@
+package rbac
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/spf13/cobra"
+)
+
+var exportMatrixCmd = &cobra.Command{
+	Use:   "export-matrix",
+	Short: "Export the deployment-wide RBAC permission matrix",
+	Long: `Export every (user, role, permission, scope) tuple in the deployment.
+
+Used by auditors for SOC2/ISO27001 access reviews. Output includes who holds
+what role/permission in what scope (global, project, or environment).
+
+Supports table (default), JSON, and CSV output formats.
+
+Examples:
+  keyorix rbac export-matrix
+  keyorix rbac export-matrix --format csv --output access-review.csv
+  keyorix rbac export-matrix --format json --project production`,
+	RunE: runExportMatrix,
+}
+
+var (
+	exportMatrixFormat  string
+	exportMatrixProject string
+	exportMatrixOutput  string
+)
+
+func init() {
+	exportMatrixCmd.Flags().StringVar(&exportMatrixFormat, "format", "table", "Output format: table, csv, or json")
+	exportMatrixCmd.Flags().StringVar(&exportMatrixProject, "project", "", "Filter by project name (optional)")
+	exportMatrixCmd.Flags().StringVar(&exportMatrixOutput, "output", "", "Write output to this file (default: stdout)")
+}
+
+// remoteMatrixRow is the JSON shape the server's GET /api/v1/rbac/permission-matrix
+// endpoint returns for each entry in the "rows" array.
+type remoteMatrixRow struct {
+	UserID          uint       `json:"user_id"`
+	Username        string     `json:"username"`
+	Email           string     `json:"email"`
+	RoleID          uint       `json:"role_id"`
+	RoleName        string     `json:"role_name"`
+	PermissionName  string     `json:"permission_name"`
+	Resource        string     `json:"resource"`
+	Action          string     `json:"action"`
+	Scope           string     `json:"scope"`
+	ProjectID       uint       `json:"project_id"`
+	ProjectName     string     `json:"project_name"`
+	EnvironmentID   uint       `json:"environment_id"`
+	EnvironmentName string     `json:"environment_name"`
+	ExpiresAt       *time.Time `json:"expires_at"`
+}
+
+func runExportMatrix(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	out := io.Writer(os.Stdout)
+	if exportMatrixOutput != "" {
+		f, err := os.Create(exportMatrixOutput)
+		if err != nil {
+			return fmt.Errorf("failed to open output file: %w", err)
+		}
+		defer f.Close()
+		out = f
+	}
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runExportMatrixRemote(ctx, rc, out)
+	}
+
+	// Embedded (direct-DB) mode.
+	st, err := common.InitializeStorage()
+	if err != nil {
+		return err
+	}
+	coreService := core.NewKeyorixCore(st)
+
+	projectID := uint(0)
+	if exportMatrixProject != "" {
+		projectID, err = common.LookupProjectIDByName(ctx, st, exportMatrixProject)
+		if err != nil {
+			return fmt.Errorf("failed to resolve project: %w", err)
+		}
+	}
+
+	rows, err := coreService.GetPermissionMatrix(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to build permission matrix: %w", err)
+	}
+
+	return writeMatrixEmbedded(out, rows, exportMatrixFormat)
+}
+
+func runExportMatrixRemote(ctx context.Context, rc *common.RemoteClient, out io.Writer) error {
+	path := "/api/v1/rbac/permission-matrix"
+	if exportMatrixProject != "" {
+		projectID, err := resolveProjectIDByName(ctx, rc, exportMatrixProject)
+		if err != nil {
+			return err
+		}
+		if exportMatrixFormat == "csv" {
+			// Request CSV directly from the server to avoid double-serialisation.
+			data, err := rc.GetRaw(ctx, fmt.Sprintf("%s?project_id=%d&format=csv", path, projectID))
+			if err != nil {
+				return fmt.Errorf("failed to fetch permission matrix (CSV): %w", err)
+			}
+			_, err = out.Write(data)
+			return err
+		}
+		path = fmt.Sprintf("%s?project_id=%d", path, projectID)
+	} else if exportMatrixFormat == "csv" {
+		data, err := rc.GetRaw(ctx, path+"?format=csv")
+		if err != nil {
+			return fmt.Errorf("failed to fetch permission matrix (CSV): %w", err)
+		}
+		_, err = out.Write(data)
+		return err
+	}
+
+	var resp struct {
+		Rows  []remoteMatrixRow `json:"rows"`
+		Total int               `json:"total"`
+	}
+	if err := rc.Get(ctx, path, &resp); err != nil {
+		return fmt.Errorf("failed to fetch permission matrix: %w", err)
+	}
+	return writeMatrixRemote(out, resp.Rows, exportMatrixFormat)
+}
+
+func writeMatrixRemote(out io.Writer, rows []remoteMatrixRow, format string) error {
+	switch format {
+	case "json":
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(rows)
+	case "csv":
+		w := csv.NewWriter(out)
+		_ = w.Write([]string{
+			"username", "email", "role", "permission", "resource", "action",
+			"scope", "project", "environment", "expires_at",
+		})
+		for _, r := range rows {
+			_ = w.Write(remoteRowToCSV(r))
+		}
+		w.Flush()
+		return w.Error()
+	default:
+		return writeRemoteTable(out, rows)
+	}
+}
+
+func writeMatrixEmbedded(out io.Writer, rows []*core.PermissionMatrixRow, format string) error {
+	switch format {
+	case "json":
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(rows)
+	case "csv":
+		w := csv.NewWriter(out)
+		_ = w.Write([]string{
+			"username", "email", "role", "permission", "resource", "action",
+			"scope", "project", "environment", "expires_at",
+		})
+		for _, r := range rows {
+			expiresAt := "never"
+			if r.ExpiresAt != nil {
+				expiresAt = r.ExpiresAt.UTC().Format(time.RFC3339)
+			}
+			_ = w.Write([]string{
+				r.Username, r.Email, r.RoleName, r.PermissionName,
+				r.Resource, r.Action, r.Scope, r.ProjectName, r.EnvironmentName, expiresAt,
+			})
+		}
+		w.Flush()
+		return w.Error()
+	default:
+		return writeEmbeddedTable(out, rows)
+	}
+}
+
+func writeEmbeddedTable(out io.Writer, rows []*core.PermissionMatrixRow) error {
+	if len(rows) == 0 {
+		fmt.Fprintln(out, "No permission grants found.")
+		return nil
+	}
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "USERNAME\tEMAIL\tROLE\tPERMISSION\tSCOPE\tPROJECT\tEXPIRES")
+	for _, r := range rows {
+		expiresAt := "never"
+		if r.ExpiresAt != nil {
+			expiresAt = r.ExpiresAt.UTC().Format(time.RFC3339)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.Username, r.Email, r.RoleName, r.PermissionName,
+			r.Scope, r.ProjectName, expiresAt)
+	}
+	return tw.Flush()
+}
+
+func writeRemoteTable(out io.Writer, rows []remoteMatrixRow) error {
+	if len(rows) == 0 {
+		fmt.Fprintln(out, "No permission grants found.")
+		return nil
+	}
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "USERNAME\tEMAIL\tROLE\tPERMISSION\tSCOPE\tPROJECT\tEXPIRES")
+	for _, r := range rows {
+		expiresAt := "never"
+		if r.ExpiresAt != nil {
+			expiresAt = r.ExpiresAt.UTC().Format(time.RFC3339)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.Username, r.Email, r.RoleName, r.PermissionName,
+			r.Scope, r.ProjectName, expiresAt)
+	}
+	return tw.Flush()
+}
+
+func remoteRowToCSV(r remoteMatrixRow) []string {
+	expiresAt := "never"
+	if r.ExpiresAt != nil {
+		expiresAt = r.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+	return []string{
+		r.Username, r.Email, r.RoleName, r.PermissionName,
+		r.Resource, r.Action, r.Scope, r.ProjectName, r.EnvironmentName, expiresAt,
+	}
+}

--- a/internal/cli/rbac/export_matrix_test.go
+++ b/internal/cli/rbac/export_matrix_test.go
@@ -1,0 +1,166 @@
+package rbac
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// matrixPayload is the JSON body the fake server returns.
+const matrixPayload = `{"data":{
+	"rows":[
+		{
+			"user_id":1,"username":"alice","email":"alice@example.com",
+			"role_id":10,"role_name":"admin",
+			"permission_name":"secrets.read","resource":"secrets","action":"read",
+			"scope":"global","project_id":0,"project_name":"","environment_id":0,"environment_name":"",
+			"expires_at":null
+		},
+		{
+			"user_id":2,"username":"bob","email":"bob@example.com",
+			"role_id":20,"role_name":"viewer",
+			"permission_name":"secrets.read","resource":"secrets","action":"read",
+			"scope":"project","project_id":5,"project_name":"project-a","environment_id":0,"environment_name":"",
+			"expires_at":null
+		}
+	],
+	"total":2
+}}`
+
+func fakeMatrixServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/rbac/permission-matrix", func(w http.ResponseWriter, r *http.Request) {
+		// Echo the project_id query param in a simple way; format=csv returns CSV.
+		if r.URL.Query().Get("format") == "csv" {
+			w.Header().Set("Content-Type", "text/csv")
+			_, _ = w.Write([]byte(
+				"username,email,role,permission,resource,action,scope,project,environment,expires_at\n" +
+					"alice,alice@example.com,admin,secrets.read,secrets,read,global,,,never\n",
+			))
+			return
+		}
+		_, _ = w.Write([]byte(matrixPayload))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"project-a"}]}}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestExportMatrix_RemoteJSON — happy-path: JSON output from remote.
+func TestExportMatrix_RemoteJSON(t *testing.T) {
+	srv := fakeMatrixServer(t)
+	rc := remoteClientFor(t, srv)
+	ctx := context.Background()
+
+	// reset flags
+	exportMatrixFormat = "json"
+	exportMatrixProject = ""
+
+	var buf bytes.Buffer
+	err := runExportMatrixRemote(ctx, rc, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "alice")
+	assert.Contains(t, out, "bob")
+	assert.Contains(t, out, "secrets.read")
+}
+
+// TestExportMatrix_RemoteCSV — happy-path: CSV output delegated to server.
+func TestExportMatrix_RemoteCSV(t *testing.T) {
+	srv := fakeMatrixServer(t)
+	rc := remoteClientFor(t, srv)
+	ctx := context.Background()
+
+	exportMatrixFormat = "csv"
+	exportMatrixProject = ""
+
+	var buf bytes.Buffer
+	err := runExportMatrixRemote(ctx, rc, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.True(t, strings.HasPrefix(out, "username,"), "expected CSV header")
+	assert.Contains(t, out, "alice")
+}
+
+// TestExportMatrix_RemoteProjectFilter — project filter is passed to the server URL.
+func TestExportMatrix_RemoteProjectFilter(t *testing.T) {
+	var capturedPath string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/rbac/permission-matrix", func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":{"rows":[],"total":0}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"project-a"}]}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	rc := remoteClientFor(t, srv)
+	ctx := context.Background()
+
+	exportMatrixFormat = "json"
+	exportMatrixProject = "project-a"
+
+	var buf bytes.Buffer
+	err := runExportMatrixRemote(ctx, rc, &buf)
+	require.NoError(t, err)
+
+	// Verify the project_id=5 was forwarded to the server.
+	assert.Contains(t, capturedPath, "project_id=5", "server should receive project_id filter")
+}
+
+// TestExportMatrix_RemoteTable — table format (default) renders without error.
+func TestExportMatrix_RemoteTable(t *testing.T) {
+	srv := fakeMatrixServer(t)
+	rc := remoteClientFor(t, srv)
+	ctx := context.Background()
+
+	exportMatrixFormat = "table"
+	exportMatrixProject = ""
+
+	var buf bytes.Buffer
+	err := runExportMatrixRemote(ctx, rc, &buf)
+	require.NoError(t, err)
+
+	out := buf.String()
+	// Header row and at least one data row expected.
+	assert.Contains(t, out, "USERNAME")
+	assert.Contains(t, out, "alice")
+}
+
+// TestWriteMatrixRemote_EmptyRows — empty result prints "No permission grants found."
+func TestWriteMatrixRemote_EmptyRows(t *testing.T) {
+	var buf bytes.Buffer
+	err := writeMatrixRemote(&buf, []remoteMatrixRow{}, "table")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "No permission grants found.")
+}
+
+// TestWriteMatrixRemote_ExpiresAt — a time-bound row formats the expiry correctly.
+func TestWriteMatrixRemote_ExpiresAt(t *testing.T) {
+	exp := time.Date(2027, 1, 15, 12, 0, 0, 0, time.UTC)
+	rows := []remoteMatrixRow{{
+		Username: "eve", Email: "eve@example.com", RoleName: "jit",
+		PermissionName: "secrets.read", Resource: "secrets", Action: "read",
+		Scope: "global", ExpiresAt: &exp,
+	}}
+	var buf bytes.Buffer
+	err := writeMatrixRemote(&buf, rows, "csv")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "2027-01-15T12:00:00Z")
+}

--- a/internal/cli/rbac/rbac.go
+++ b/internal/cli/rbac/rbac.go
@@ -20,4 +20,5 @@ func init() {
 	RbacCmd.AddCommand(assignRoleToGroupCmd)
 	RbacCmd.AddCommand(removeRoleFromGroupCmd)
 	RbacCmd.AddCommand(listGroupRolesCmd)
+	RbacCmd.AddCommand(exportMatrixCmd)
 }

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -2029,6 +2029,10 @@ func (m *MockStorage) ConsumeWebAuthnSession(_ context.Context, _ string, _ time
 	return nil, nil
 }
 
+func (m *MockStorage) ListAllUserRoleGrants(_ context.Context) ([]*models.UserRole, error) {
+	return nil, nil
+}
+
 // Per-secret / per-folder ACL stubs (ADR-058).
 func (m *MockStorage) CreateOrUpdateSecretACL(_ context.Context, _ *models.SecretACL) error {
 	return nil

--- a/internal/core/permission_matrix.go
+++ b/internal/core/permission_matrix.go
@@ -1,0 +1,188 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// PermissionMatrixRow is one row in the audit permission matrix:
+// one user × one permission × one scope (global, project, or environment).
+type PermissionMatrixRow struct {
+	UserID          uint       `json:"user_id"`
+	Username        string     `json:"username"`
+	Email           string     `json:"email"`
+	RoleID          uint       `json:"role_id"`
+	RoleName        string     `json:"role_name"`
+	PermissionName  string     `json:"permission_name"`
+	Resource        string     `json:"resource"`
+	Action          string     `json:"action"`
+	Scope           string     `json:"scope"`            // "global" | "project" | "environment"
+	ProjectID       uint       `json:"project_id"`
+	ProjectName     string     `json:"project_name"`
+	EnvironmentID   uint       `json:"environment_id"`
+	EnvironmentName string     `json:"environment_name"`
+	ExpiresAt       *time.Time `json:"expires_at"` // nil = permanent
+}
+
+// GetPermissionMatrix returns every (user, role, permission, scope) tuple in the
+// deployment. If projectID > 0, only grants scoped to that project are included
+// (plus global grants with project_id = 0).
+func (c *KeyorixCore) GetPermissionMatrix(ctx context.Context, projectID uint) ([]*PermissionMatrixRow, error) {
+	// 1. Fetch all user→role grant rows.
+	grants, err := c.storage.ListAllUserRoleGrants(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("permission matrix: list grants: %w", err)
+	}
+
+	// 2. Build user lookup map (user_id → User).
+	type userInfo struct {
+		Username string
+		Email    string
+	}
+	userCache := map[uint]userInfo{}
+	getUserInfo := func(userID uint) (userInfo, error) {
+		if u, ok := userCache[userID]; ok {
+			return u, nil
+		}
+		u, err := c.storage.GetUser(ctx, userID)
+		if err != nil {
+			return userInfo{}, fmt.Errorf("get user %d: %w", userID, err)
+		}
+		info := userInfo{Username: u.Username, Email: u.Email}
+		userCache[userID] = info
+		return info, nil
+	}
+
+	// 3. Build role permissions cache (role_id → []Permission).
+	type permInfo struct {
+		Name     string
+		Resource string
+		Action   string
+	}
+	rolePermsCache := map[uint][]permInfo{}
+	getRolePerms := func(roleID uint) ([]permInfo, error) {
+		if perms, ok := rolePermsCache[roleID]; ok {
+			return perms, nil
+		}
+		perms, err := c.storage.GetRolePermissions(ctx, roleID)
+		if err != nil {
+			return nil, fmt.Errorf("get permissions for role %d: %w", roleID, err)
+		}
+		var result []permInfo
+		for _, p := range perms {
+			result = append(result, permInfo{Name: p.Name, Resource: p.Resource, Action: p.Action})
+		}
+		rolePermsCache[roleID] = result
+		return result, nil
+	}
+
+	// 4. Build role name cache.
+	roleNameCache := map[uint]string{}
+	getRoleName := func(roleID uint) (string, error) {
+		if name, ok := roleNameCache[roleID]; ok {
+			return name, nil
+		}
+		role, err := c.storage.GetRole(ctx, roleID)
+		if err != nil {
+			return "", fmt.Errorf("get role %d: %w", roleID, err)
+		}
+		roleNameCache[roleID] = role.Name
+		return role.Name, nil
+	}
+
+	// 5. Build project name cache.
+	projectNameCache := map[uint]string{}
+	getProjectName := func(projID uint) (string, error) {
+		if projID == 0 {
+			return "", nil
+		}
+		if name, ok := projectNameCache[projID]; ok {
+			return name, nil
+		}
+		proj, err := c.storage.GetProject(ctx, projID)
+		if err != nil {
+			// Soft-deleted projects may still have grants; return ID-as-name rather than failing.
+			name := fmt.Sprintf("project-%d", projID)
+			projectNameCache[projID] = name
+			return name, nil
+		}
+		projectNameCache[projID] = proj.Name
+		return proj.Name, nil
+	}
+
+	// 6. Build environment name cache.
+	envNameCache := map[uint]string{}
+	getEnvName := func(envID uint) (string, error) {
+		if envID == 0 {
+			return "", nil
+		}
+		if name, ok := envNameCache[envID]; ok {
+			return name, nil
+		}
+		env, err := c.storage.GetEnvironment(ctx, envID)
+		if err != nil {
+			name := fmt.Sprintf("env-%d", envID)
+			envNameCache[envID] = name
+			return name, nil
+		}
+		envNameCache[envID] = env.Name
+		return env.Name, nil
+	}
+
+	// 7. Cross-join: for each grant × each permission → one row.
+	var rows []*PermissionMatrixRow
+	for _, grant := range grants {
+		// Apply project filter: include global (project_id=0) and same-project grants.
+		if projectID > 0 && grant.ProjectID != 0 && grant.ProjectID != projectID {
+			continue
+		}
+
+		uInfo, err := getUserInfo(grant.UserID)
+		if err != nil {
+			// Unknown/deleted user — skip silently; the row may be a stale JIT grant.
+			continue
+		}
+
+		roleName, err := getRoleName(grant.RoleID)
+		if err != nil {
+			continue
+		}
+
+		perms, err := getRolePerms(grant.RoleID)
+		if err != nil {
+			continue
+		}
+
+		projName, _ := getProjectName(grant.ProjectID)
+		envName, _ := getEnvName(grant.EnvironmentID)
+
+		scope := "global"
+		if grant.ProjectID != 0 && grant.EnvironmentID != 0 {
+			scope = "environment"
+		} else if grant.ProjectID != 0 {
+			scope = "project"
+		}
+
+		for _, perm := range perms {
+			rows = append(rows, &PermissionMatrixRow{
+				UserID:          grant.UserID,
+				Username:        uInfo.Username,
+				Email:           uInfo.Email,
+				RoleID:          grant.RoleID,
+				RoleName:        roleName,
+				PermissionName:  perm.Name,
+				Resource:        perm.Resource,
+				Action:          perm.Action,
+				Scope:           scope,
+				ProjectID:       grant.ProjectID,
+				ProjectName:     projName,
+				EnvironmentID:   grant.EnvironmentID,
+				EnvironmentName: envName,
+				ExpiresAt:       grant.ExpiresAt,
+			})
+		}
+	}
+
+	return rows, nil
+}

--- a/internal/core/permission_matrix_test.go
+++ b/internal/core/permission_matrix_test.go
@@ -1,0 +1,191 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newMatrixCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.User{},
+	))
+	return NewKeyorixCore(store.NewLocalStorage(db)), db
+}
+
+// seed helpers
+func seedMatrixUser(t *testing.T, db *gorm.DB, id uint, username, email string) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.User{ID: id, Username: username, Email: email}).Error)
+}
+
+func seedMatrixRole(t *testing.T, db *gorm.DB, id uint, name string) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.Role{ID: id, Name: name}).Error)
+}
+
+func seedMatrixPerm(t *testing.T, db *gorm.DB, id uint, name, resource, action string) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.Permission{ID: id, Name: name, Resource: resource, Action: action}).Error)
+}
+
+func seedMatrixRolePerm(t *testing.T, db *gorm.DB, roleID, permID uint) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: roleID, PermissionID: permID}).Error)
+}
+
+// TestGetPermissionMatrix_GlobalGrant — a user with a global role (project_id=0)
+// yields a row with Scope="global" and no project/environment name.
+func TestGetPermissionMatrix_GlobalGrant(t *testing.T) {
+	c, db := newMatrixCore(t)
+	ctx := context.Background()
+
+	seedMatrixUser(t, db, 1, "alice", "alice@example.com")
+	seedMatrixRole(t, db, 10, "admin")
+	seedMatrixPerm(t, db, 100, "secrets.read", "secrets", "read")
+	seedMatrixRolePerm(t, db, 10, 100)
+	// global grant: project_id=0, environment_id=0
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 10, ProjectID: 0, EnvironmentID: 0}).Error)
+
+	rows, err := c.GetPermissionMatrix(ctx, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	r := rows[0]
+	assert.Equal(t, uint(1), r.UserID)
+	assert.Equal(t, "alice", r.Username)
+	assert.Equal(t, "alice@example.com", r.Email)
+	assert.Equal(t, uint(10), r.RoleID)
+	assert.Equal(t, "admin", r.RoleName)
+	assert.Equal(t, "secrets.read", r.PermissionName)
+	assert.Equal(t, "secrets", r.Resource)
+	assert.Equal(t, "read", r.Action)
+	assert.Equal(t, "global", r.Scope)
+	assert.Zero(t, r.ProjectID)
+	assert.Empty(t, r.ProjectName)
+	assert.Nil(t, r.ExpiresAt)
+}
+
+// TestGetPermissionMatrix_ProjectScoped — a project-scoped grant appears with the
+// project's name in the row.
+func TestGetPermissionMatrix_ProjectScoped(t *testing.T) {
+	c, db := newMatrixCore(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Project{ID: 5, Name: "project-a"}).Error)
+	seedMatrixUser(t, db, 2, "bob", "bob@example.com")
+	seedMatrixRole(t, db, 20, "viewer")
+	seedMatrixPerm(t, db, 200, "secrets.read", "secrets", "read")
+	seedMatrixRolePerm(t, db, 20, 200)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 20, ProjectID: 5, EnvironmentID: 0}).Error)
+
+	rows, err := c.GetPermissionMatrix(ctx, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	r := rows[0]
+	assert.Equal(t, "bob", r.Username)
+	assert.Equal(t, "project", r.Scope)
+	assert.Equal(t, uint(5), r.ProjectID)
+	assert.Equal(t, "project-a", r.ProjectName)
+	assert.Zero(t, r.EnvironmentID)
+	assert.Nil(t, r.ExpiresAt)
+}
+
+// TestGetPermissionMatrix_FilterByProject — projectID filter excludes grants for
+// other projects while including global grants (project_id=0).
+func TestGetPermissionMatrix_FilterByProject(t *testing.T) {
+	c, db := newMatrixCore(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj-alpha"}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "proj-beta"}).Error)
+
+	seedMatrixUser(t, db, 10, "carol", "carol@example.com")
+	seedMatrixRole(t, db, 30, "editor")
+	seedMatrixPerm(t, db, 300, "secrets.write", "secrets", "write")
+	seedMatrixRolePerm(t, db, 30, 300)
+
+	// grant in project-1
+	require.NoError(t, db.Create(&models.UserRole{UserID: 10, RoleID: 30, ProjectID: 1, EnvironmentID: 0}).Error)
+	// grant in project-2 (should be excluded when filtering by project 1)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 10, RoleID: 30, ProjectID: 2, EnvironmentID: 0}).Error)
+	// global grant (should be included even with project filter)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 10, RoleID: 30, ProjectID: 0, EnvironmentID: 0}).Error)
+
+	rows, err := c.GetPermissionMatrix(ctx, 1)
+	require.NoError(t, err)
+	// project-1 grant + global grant = 2 rows; project-2 grant excluded
+	require.Len(t, rows, 2)
+
+	scopes := make(map[string]bool)
+	for _, r := range rows {
+		scopes[r.Scope] = true
+		assert.NotEqual(t, uint(2), r.ProjectID, "project-2 grant must be excluded")
+	}
+	assert.True(t, scopes["project"], "project-scoped row expected")
+	assert.True(t, scopes["global"], "global row must be included in project filter")
+}
+
+// TestGetPermissionMatrix_MultiplePermissions — a role with 2 permissions produces
+// 2 rows per grant.
+func TestGetPermissionMatrix_MultiplePermissions(t *testing.T) {
+	c, db := newMatrixCore(t)
+	ctx := context.Background()
+
+	seedMatrixUser(t, db, 3, "dave", "dave@example.com")
+	seedMatrixRole(t, db, 40, "poweruser")
+	seedMatrixPerm(t, db, 400, "secrets.read", "secrets", "read")
+	seedMatrixPerm(t, db, 401, "secrets.write", "secrets", "write")
+	seedMatrixRolePerm(t, db, 40, 400)
+	seedMatrixRolePerm(t, db, 40, 401)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 40, ProjectID: 0, EnvironmentID: 0}).Error)
+
+	rows, err := c.GetPermissionMatrix(ctx, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 2, "2 permissions × 1 grant = 2 rows")
+
+	permNames := map[string]bool{}
+	for _, r := range rows {
+		permNames[r.PermissionName] = true
+		assert.Equal(t, "dave", r.Username)
+		assert.Equal(t, "poweruser", r.RoleName)
+		assert.Equal(t, "global", r.Scope)
+	}
+	assert.True(t, permNames["secrets.read"])
+	assert.True(t, permNames["secrets.write"])
+
+	// Confirm time-bound: seed a JIT grant for project_id=1 and verify ExpiresAt is set.
+	// Filtering by project_id=1 also includes global grants (project_id=0), so we get
+	// 4 rows total (2 from the existing global grant + 2 from the JIT project-scoped grant).
+	exp := time.Now().Add(2 * time.Hour)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 40, ProjectID: 1, EnvironmentID: 0, ExpiresAt: &exp}).Error)
+
+	rows, err = c.GetPermissionMatrix(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, rows, 4, "2 global rows + 2 project-scoped JIT rows")
+
+	var timedRows []*PermissionMatrixRow
+	for _, r := range rows {
+		if r.ExpiresAt != nil {
+			timedRows = append(timedRows, r)
+		}
+	}
+	require.Len(t, timedRows, 2, "2 JIT rows expected")
+	for _, r := range timedRows {
+		assert.True(t, r.ExpiresAt.After(time.Now()))
+		assert.Equal(t, "project", r.Scope)
+	}
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -813,6 +813,10 @@ type Storage interface {
 	// the project admin who performed the offboarding (#232).
 	RemoveAllProjectRoleGrants(ctx context.Context, userID, projectID uint) error
 	GetUserRoles(ctx context.Context, userID uint) ([]*models.Role, error)
+	// ListAllUserRoleGrants returns every user→role grant row in the deployment,
+	// including scoped (project/environment) and global (project_id=0) grants.
+	// Includes time-bound (JIT) grants; callers filter by ExpiresAt if needed.
+	ListAllUserRoleGrants(ctx context.Context) ([]*models.UserRole, error)
 	GetUserRoleIDsAt(ctx context.Context, userID uint, scope Scope) ([]uint, error)
 	GetUserRoleIDsExact(ctx context.Context, userID uint, scope Scope) ([]uint, error)
 	// IsProjectMember reports whether the user holds a LIVE role grant scoped to the

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -780,3 +780,11 @@ func (ls *LocalStorage) GetUserGroupPermissions(ctx context.Context, userID uint
 	}
 	return permissions, nil
 }
+
+// ListAllUserRoleGrants returns every user→role grant row in the deployment,
+// including scoped (project/environment) and global (project_id=0) grants.
+// Includes time-bound (JIT) grants; callers filter by ExpiresAt if needed.
+func (ls *LocalStorage) ListAllUserRoleGrants(ctx context.Context) ([]*models.UserRole, error) {
+	var grants []*models.UserRole
+	return grants, ls.db.WithContext(ctx).Find(&grants).Error
+}

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -315,6 +315,13 @@ func (rs *RemoteStorage) GetUserRoles(ctx context.Context, userID uint) ([]*mode
 	return result, nil
 }
 
+// ListAllUserRoleGrants is not supported in remote storage. The permission
+// matrix is server-aggregated via GET /api/v1/rbac/permission-matrix; direct
+// grant enumeration runs server-side against LocalStorage.
+func (rs *RemoteStorage) ListAllUserRoleGrants(_ context.Context) ([]*models.UserRole, error) {
+	return nil, remoteUnsupported("ListAllUserRoleGrants")
+}
+
 // GetUserPermissions retrieves all permissions for a user via remote API.
 func (rs *RemoteStorage) GetUserPermissions(ctx context.Context, userID uint) ([]*storage.Permission, error) {
 	path := fmt.Sprintf("/api/v1/users/%d/permissions", userID)

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -170,6 +170,8 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	// only runs server-side and a remote-storage caller never directly invokes
 	// ACL management or the folder-inheritance ancestor walk (the HTTP/gRPC
 	// boundary owns authorization; HasSecretACL/AuthorizeSecret run on the server).
+	"ListAllUserRoleGrants": {statusIntentional, "permission matrix is server-aggregated via GET /api/v1/rbac/permission-matrix; direct grant enumeration runs server-side"},
+
 	"CreateOrUpdateSecretACL":  {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
 	"ListSecretACLs":           {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
 	"ListSecretACLsByUser":     {statusIntentional, "RBAC Phase 3 — listing ACL-granted secrets for a user runs server-side in ListSecretsWithSharingInfo; the core function calls LocalStorage on the server, not RemoteStorage"},

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -10,6 +10,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -978,4 +979,53 @@ func queryUint(r *http.Request, key string) uint {
 		return uint(v)
 	}
 	return 0
+}
+
+// GetPermissionMatrix handles GET /api/v1/rbac/permission-matrix[?project_id=N&format=csv].
+// It returns a deployment-wide audit matrix of every (user, role, permission, scope)
+// tuple. Gated on roles.read permission.
+//
+// ?project_id=N  — optional project filter (0 = all projects, including global grants)
+// ?format=csv    — return CSV instead of JSON
+func (h *RBACHandler) GetPermissionMatrix(w http.ResponseWriter, r *http.Request) {
+	projectID := queryUint(r, "project_id")
+	format := r.URL.Query().Get("format")
+
+	rows, err := h.coreService.GetPermissionMatrix(r.Context(), projectID)
+	if err != nil {
+		sendError(w, "InternalError", "Failed to build permission matrix", http.StatusInternalServerError, nil)
+		return
+	}
+
+	if format == "csv" {
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Disposition", `attachment; filename="permission-matrix.csv"`)
+		cw := csv.NewWriter(w)
+		_ = cw.Write([]string{
+			"username", "email", "role", "permission", "resource", "action",
+			"scope", "project", "environment", "expires_at",
+		})
+		for _, row := range rows {
+			expiresAt := "never"
+			if row.ExpiresAt != nil {
+				expiresAt = row.ExpiresAt.UTC().Format(time.RFC3339)
+			}
+			_ = cw.Write([]string{
+				row.Username,
+				row.Email,
+				row.RoleName,
+				row.PermissionName,
+				row.Resource,
+				row.Action,
+				row.Scope,
+				row.ProjectName,
+				row.EnvironmentName,
+				expiresAt,
+			})
+		}
+		cw.Flush()
+		return
+	}
+
+	sendSuccess(w, map[string]interface{}{"rows": rows, "total": len(rows)}, "")
 }

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1560,6 +1560,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/rbac/project-role-assignments", rbacHandler.ListProjectRoleAssignmentsProxy)
 			r.Get("/rbac/project-machine-role-assignments", rbacHandler.ListProjectMachineRoleAssignmentsProxy)
 			r.Get("/rbac/global-admin-assignments", rbacHandler.ListGlobalAdminAssignmentsForUpdateProxy)
+			r.With(customMiddleware.RequirePermission(permRolesRead)).Get("/rbac/permission-matrix", rbacHandler.GetPermissionMatrix)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/rbac/assign-role-with-expiry", rbacHandler.AssignRoleWithExpiryProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/rbac/assign-role-to-group-with-expiry", rbacHandler.AssignRoleToGroupWithExpiryProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/rbac/remove-all-project-role-grants", rbacHandler.RemoveAllProjectRoleGrantsProxy)


### PR DESCRIPTION
Adds GET /api/v1/rbac/permission-matrix (CSV/JSON) + keyorix rbac export-matrix CLI. Full user×role×permission×scope audit matrix for SOC2 access reviews.