### PR TITLE
feat(secrets): temporal access policies — per-secret time-window enforcement

### DIFF
--- a/internal/cli/secret/schedule.go
+++ b/internal/cli/secret/schedule.go
@@ -1,0 +1,176 @@
+// schedule.go — the `keyorix secret schedule` CLI: manage per-secret temporal access policies.
+//
+// Commands:
+//
+//	keyorix secret set-schedule <name> --days mon,tue,wed,thu,fri --start-hour 9 --end-hour 17 [--timezone UTC]
+//	keyorix secret get-schedule <name>
+//	keyorix secret clear-schedule <name>
+//
+// All three commands talk to the server's REST API under
+// /api/v1/secrets/{id}/schedule, requiring secrets.manage permission server-side.
+//
+// Day names ("mon", "tue", …, "sun") are converted to ISO weekday numbers before
+// being sent; integers ("1"–"7") are passed through as-is.
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/spf13/cobra"
+)
+
+// dayNameToISO maps 3-letter English day abbreviations to ISO weekday numbers (Mon=1…Sun=7).
+var dayNameToISO = map[string]int{
+	"mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6, "sun": 7,
+}
+
+// convertDayNames converts a comma-separated list of day names or numbers
+// (e.g. "mon,fri" or "1,5" or "*") to a canonical comma-separated ISO integer string.
+func convertDayNames(days string) (string, error) {
+	if days == "*" {
+		return "*", nil
+	}
+	var parts []string
+	for _, raw := range strings.Split(days, ",") {
+		s := strings.TrimSpace(strings.ToLower(raw))
+		if iso, ok := dayNameToISO[s]; ok {
+			parts = append(parts, strconv.Itoa(iso))
+			continue
+		}
+		// Try numeric.
+		d, err := strconv.Atoi(s)
+		if err != nil || d < 1 || d > 7 {
+			return "", fmt.Errorf("invalid day %q: must be mon–sun or 1–7 (or \"*\")", raw)
+		}
+		parts = append(parts, strconv.Itoa(d))
+	}
+	return strings.Join(parts, ","), nil
+}
+
+var (
+	schedDays      string
+	schedStartHour int
+	schedEndHour   int
+	schedTimezone  string
+)
+
+var setScheduleCmd = &cobra.Command{
+	Use:          "set-schedule <secret-name>",
+	Short:        "Set a temporal access schedule for a secret",
+	Long: `Restrict read access to a secret to a specific day-of-week + hour window.
+
+The schedule applies to all permission-checked reads (human users); admin/machine
+reads bypass it.
+
+Examples:
+  keyorix secret set-schedule db-prod-password --days mon,tue,wed,thu,fri --start-hour 9 --end-hour 17
+  keyorix secret set-schedule db-prod-password --days 1,2,3,4,5 --start-hour 9 --end-hour 17 --timezone America/New_York
+  keyorix secret set-schedule db-prod-password --days "*" --start-hour 0 --end-hour 24`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := parseSecretArg(args[0])
+		if err != nil {
+			return err
+		}
+		isoDays, err := convertDayNames(schedDays)
+		if err != nil {
+			return err
+		}
+		tz := schedTimezone
+		if tz == "" {
+			tz = "UTC"
+		}
+		c, err := scheduleClient()
+		if err != nil {
+			return err
+		}
+		body := map[string]interface{}{
+			"allowed_days": isoDays,
+			"start_hour":   schedStartHour,
+			"end_hour":     schedEndHour,
+			"timezone":     tz,
+		}
+		var out models.SecretAccessSchedule
+		if err := c.Put(context.Background(), fmt.Sprintf("/api/v1/secrets/%d/schedule", id), body, &out); err != nil {
+			return err
+		}
+		fmt.Printf("Schedule set: secret %d is readable on days %q, %02d:00–%02d:00 %s\n",
+			id, out.AllowedDays, out.StartHour, out.EndHour, out.Timezone)
+		return nil
+	},
+}
+
+var getScheduleCmd = &cobra.Command{
+	Use:          "get-schedule <secret-name>",
+	Short:        "Show the temporal access schedule for a secret",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		id, err := parseSecretArg(args[0])
+		if err != nil {
+			return err
+		}
+		c, err := scheduleClient()
+		if err != nil {
+			return err
+		}
+		var out models.SecretAccessSchedule
+		if err := c.Get(context.Background(), fmt.Sprintf("/api/v1/secrets/%d/schedule", id), &out); err != nil {
+			return err
+		}
+		fmt.Printf("Secret %d schedule:\n", id)
+		fmt.Printf("  Days:       %s\n", out.AllowedDays)
+		fmt.Printf("  Start hour: %d:00\n", out.StartHour)
+		fmt.Printf("  End hour:   %d:00\n", out.EndHour)
+		fmt.Printf("  Timezone:   %s\n", out.Timezone)
+		return nil
+	},
+}
+
+var clearScheduleCmd = &cobra.Command{
+	Use:          "clear-schedule <secret-name>",
+	Short:        "Remove the temporal access schedule for a secret (idempotent)",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		id, err := parseSecretArg(args[0])
+		if err != nil {
+			return err
+		}
+		c, err := scheduleClient()
+		if err != nil {
+			return err
+		}
+		if err := c.Delete(context.Background(), fmt.Sprintf("/api/v1/secrets/%d/schedule", id)); err != nil {
+			return err
+		}
+		fmt.Printf("Schedule cleared for secret %d.\n", id)
+		return nil
+	},
+}
+
+func scheduleClient() (*common.RemoteClient, error) {
+	c, ok := common.NewRemoteClient()
+	if !ok {
+		return nil, fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	return c, nil
+}
+
+func init() {
+	setScheduleCmd.Flags().StringVar(&schedDays, "days", "", "Allowed days: comma-separated day names (mon,tue,…) or ISO numbers (1–7), or \"*\" for all days (required)")
+	setScheduleCmd.Flags().IntVar(&schedStartHour, "start-hour", 0, "Start hour of the read window (0–23, inclusive)")
+	setScheduleCmd.Flags().IntVar(&schedEndHour, "end-hour", 24, "End hour of the read window (1–24, exclusive)")
+	setScheduleCmd.Flags().StringVar(&schedTimezone, "timezone", "UTC", "IANA timezone name (default: UTC)")
+	_ = setScheduleCmd.MarkFlagRequired("days")
+
+	SecretCmd.AddCommand(setScheduleCmd)
+	SecretCmd.AddCommand(getScheduleCmd)
+	SecretCmd.AddCommand(clearScheduleCmd)
+}

--- a/internal/cli/secret/schedule_test.go
+++ b/internal/cli/secret/schedule_test.go
@@ -1,0 +1,134 @@
+package secret
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scheduleStub sets up an httptest server that stubs the /schedule routes.
+func scheduleStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	sched := models.SecretAccessSchedule{
+		ID:           1,
+		SecretNodeID: 42,
+		AllowedDays:  "1,2,3,4,5",
+		StartHour:    9,
+		EndHour:      17,
+		Timezone:     "UTC",
+	}
+	schedJSON, _ := json.Marshal(sched)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/secrets/42/schedule":
+			_, _ = w.Write([]byte(`{"success":true,"data":` + string(schedJSON) + `}`))
+
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v1/secrets/42/schedule":
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			// Echo back what was sent, merged with our fixture IDs.
+			resp := map[string]interface{}{
+				"success": true,
+				"data": map[string]interface{}{
+					"id":             1,
+					"secret_node_id": 42,
+					"allowed_days":   body["allowed_days"],
+					"start_hour":     body["start_hour"],
+					"end_hour":       body["end_hour"],
+					"timezone":       body["timezone"],
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/secrets/42/schedule":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"deleted":true}}`))
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+// TestSetSecretSchedule_Remote verifies PUT /api/v1/secrets/{id}/schedule.
+func TestSetSecretSchedule_Remote(t *testing.T) {
+	rc, done := scheduleStub(t)
+	defer done()
+
+	var out models.SecretAccessSchedule
+	err := rc.Put(context.Background(), "/api/v1/secrets/42/schedule", map[string]interface{}{
+		"allowed_days": "1,2,3,4,5",
+		"start_hour":   9,
+		"end_hour":     17,
+		"timezone":     "UTC",
+	}, &out)
+	require.NoError(t, err)
+	assert.Equal(t, "1,2,3,4,5", out.AllowedDays)
+	assert.Equal(t, 9, out.StartHour)
+	assert.Equal(t, 17, out.EndHour)
+	assert.Equal(t, "UTC", out.Timezone)
+}
+
+// TestGetSecretSchedule_Remote verifies GET /api/v1/secrets/{id}/schedule.
+func TestGetSecretSchedule_Remote(t *testing.T) {
+	rc, done := scheduleStub(t)
+	defer done()
+
+	var out models.SecretAccessSchedule
+	err := rc.Get(context.Background(), "/api/v1/secrets/42/schedule", &out)
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), out.SecretNodeID)
+	assert.Equal(t, "1,2,3,4,5", out.AllowedDays)
+	assert.Equal(t, 9, out.StartHour)
+	assert.Equal(t, 17, out.EndHour)
+}
+
+// TestClearSecretSchedule_Remote verifies DELETE /api/v1/secrets/{id}/schedule.
+func TestClearSecretSchedule_Remote(t *testing.T) {
+	rc, done := scheduleStub(t)
+	defer done()
+
+	err := rc.Delete(context.Background(), "/api/v1/secrets/42/schedule")
+	require.NoError(t, err)
+}
+
+// TestDayNameConversion covers the convertDayNames helper.
+func TestDayNameConversion(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"mon,fri", "1,5", false},
+		{"mon,tue,wed,thu,fri", "1,2,3,4,5", false},
+		{"1,2,3", "1,2,3", false},
+		{"*", "*", false},
+		{"sun", "7", false},
+		{"sat,sun", "6,7", false},
+		{"0", "", true},  // 0 is not a valid ISO weekday
+		{"8", "", true},  // 8 is out of range
+		{"abc", "", true}, // unrecognised name
+	}
+	for _, tc := range tests {
+		got, err := convertDayNames(tc.input)
+		if tc.wantErr {
+			assert.Error(t, err, "input=%q", tc.input)
+		} else {
+			require.NoError(t, err, "input=%q", tc.input)
+			assert.Equal(t, tc.want, got, "input=%q", tc.input)
+		}
+	}
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -2109,3 +2109,15 @@ func (m *MockStorage) SaveCompliancePostureSnapshot(_ context.Context, _ *models
 func (m *MockStorage) GetPreviousCompliancePostureSnapshot(_ context.Context) (*models.CompliancePostureSnapshot, error) {
 	return nil, nil
 }
+
+// Temporal access schedule — stubs return no schedule (nil, nil) by default,
+// which enforces no restriction (fail-open on the check side).
+func (m *MockStorage) GetSecretAccessSchedule(_ context.Context, _ uint) (*models.SecretAccessSchedule, error) {
+	return nil, nil
+}
+func (m *MockStorage) SetSecretAccessSchedule(_ context.Context, _ *models.SecretAccessSchedule) error {
+	return nil
+}
+func (m *MockStorage) DeleteSecretAccessSchedule(_ context.Context, _ uint) error {
+	return nil
+}

--- a/internal/core/secret_schedule.go
+++ b/internal/core/secret_schedule.go
@@ -1,0 +1,128 @@
+// secret_schedule.go — temporal access policy enforcement for secrets.
+//
+// A SecretAccessSchedule row pins a secret's read window to specific days of
+// the week and hours of the day (expressed in a configurable IANA timezone).
+// When a schedule exists, reads outside the window are rejected with
+// ErrAccessOutsideSchedule (HTTP 403 at the handler layer).
+//
+// Intentional fail-open rule: an unrecognised timezone name is treated as "no
+// restriction" rather than blanket denial, so a misconfigured timezone does not
+// permanently lock out every operator. The mismatch is logged by the caller.
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ErrAccessOutsideSchedule is returned when a permission-checked secret read
+// occurs outside the secret's configured temporal access window.
+var ErrAccessOutsideSchedule = errors.New("secret access is not permitted outside the configured time window")
+
+// checkSecretAccessSchedule returns ErrAccessOutsideSchedule when the secret
+// has a schedule and the current time falls outside the allowed window.
+// Returns nil if no schedule is configured or the current time is within it.
+func (c *KeyorixCore) checkSecretAccessSchedule(ctx context.Context, secretNodeID uint) error {
+	sched, err := c.storage.GetSecretAccessSchedule(ctx, secretNodeID)
+	if err != nil || sched == nil {
+		return err // nil schedule = no restriction
+	}
+	return enforceSchedule(sched, time.Now())
+}
+
+// enforceSchedule is the pure time-check logic (separated for unit testing).
+func enforceSchedule(sched *models.SecretAccessSchedule, now time.Time) error {
+	loc, err := time.LoadLocation(sched.Timezone)
+	if err != nil {
+		// Misconfigured timezone — fail open rather than locking out all access.
+		return nil
+	}
+	local := now.In(loc)
+
+	// Check day of week.
+	if sched.AllowedDays != "*" {
+		weekday := int(local.Weekday()) // 0=Sun, 1=Mon, …, 6=Sat
+		// Convert to ISO 8601: Mon=1 … Sun=7
+		isoDay := weekday
+		if isoDay == 0 {
+			isoDay = 7
+		}
+		allowed := false
+		for _, part := range strings.Split(sched.AllowedDays, ",") {
+			d, _ := strconv.Atoi(strings.TrimSpace(part))
+			if d == isoDay {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return ErrAccessOutsideSchedule
+		}
+	}
+
+	// Check hour window [StartHour, EndHour).
+	hour := local.Hour()
+	if hour < sched.StartHour || hour >= sched.EndHour {
+		return ErrAccessOutsideSchedule
+	}
+	return nil
+}
+
+// GetSecretSchedule returns the access schedule for secretID, or nil if none exists.
+func (c *KeyorixCore) GetSecretSchedule(ctx context.Context, secretID uint) (*models.SecretAccessSchedule, error) {
+	return c.storage.GetSecretAccessSchedule(ctx, secretID)
+}
+
+// SetSecretSchedule validates and upserts a temporal access schedule for secretID.
+func (c *KeyorixCore) SetSecretSchedule(ctx context.Context, secretID uint, days string, startHour, endHour int, timezone string) (*models.SecretAccessSchedule, error) {
+	if err := validateScheduleParams(days, startHour, endHour, timezone); err != nil {
+		return nil, err
+	}
+	sched := &models.SecretAccessSchedule{
+		SecretNodeID: secretID,
+		AllowedDays:  days,
+		StartHour:    startHour,
+		EndHour:      endHour,
+		Timezone:     timezone,
+	}
+	if err := c.storage.SetSecretAccessSchedule(ctx, sched); err != nil {
+		return nil, err
+	}
+	return sched, nil
+}
+
+// DeleteSecretSchedule removes the temporal access schedule for secretID (idempotent).
+func (c *KeyorixCore) DeleteSecretSchedule(ctx context.Context, secretID uint) error {
+	return c.storage.DeleteSecretAccessSchedule(ctx, secretID)
+}
+
+// validateScheduleParams checks the schedule parameters before persistence.
+func validateScheduleParams(days string, startHour, endHour int, timezone string) error {
+	if startHour < 0 || startHour > 23 {
+		return fmt.Errorf("start_hour must be in [0, 23], got %d", startHour)
+	}
+	if endHour < 1 || endHour > 24 {
+		return fmt.Errorf("end_hour must be in [1, 24], got %d", endHour)
+	}
+	if endHour <= startHour {
+		return fmt.Errorf("end_hour (%d) must be greater than start_hour (%d)", endHour, startHour)
+	}
+	if _, err := time.LoadLocation(timezone); err != nil {
+		return fmt.Errorf("invalid timezone %q: %w", timezone, err)
+	}
+	if days != "*" {
+		for _, part := range strings.Split(days, ",") {
+			d, err := strconv.Atoi(strings.TrimSpace(part))
+			if err != nil || d < 1 || d > 7 {
+				return fmt.Errorf("invalid day %q in days %q: must be integers 1–7 or \"*\"", strings.TrimSpace(part), days)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/core/secret_schedule_test.go
+++ b/internal/core/secret_schedule_test.go
@@ -1,0 +1,220 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// ── enforceSchedule pure unit tests ─────────────────────────────────────────
+
+func monFridaySched() *models.SecretAccessSchedule {
+	return &models.SecretAccessSchedule{
+		AllowedDays: "1,2,3,4,5",
+		StartHour:   9,
+		EndHour:     17,
+		Timezone:    "UTC",
+	}
+}
+
+func TestEnforceSchedule_WithinWindow(t *testing.T) {
+	// Wednesday 14:00 UTC — within Mon–Fri 09–17
+	now := time.Date(2026, 7, 15, 14, 0, 0, 0, time.UTC) // Wednesday
+	assert.NoError(t, enforceSchedule(monFridaySched(), now))
+}
+
+func TestEnforceSchedule_BeforeStartHour(t *testing.T) {
+	// Wednesday 08:00 UTC — before start hour
+	now := time.Date(2026, 7, 15, 8, 0, 0, 0, time.UTC)
+	assert.ErrorIs(t, enforceSchedule(monFridaySched(), now), ErrAccessOutsideSchedule)
+}
+
+func TestEnforceSchedule_AtEndHour(t *testing.T) {
+	// Wednesday 17:00 UTC — end hour is exclusive
+	now := time.Date(2026, 7, 15, 17, 0, 0, 0, time.UTC)
+	assert.ErrorIs(t, enforceSchedule(monFridaySched(), now), ErrAccessOutsideSchedule)
+}
+
+func TestEnforceSchedule_AfterEndHour(t *testing.T) {
+	now := time.Date(2026, 7, 15, 20, 0, 0, 0, time.UTC)
+	assert.ErrorIs(t, enforceSchedule(monFridaySched(), now), ErrAccessOutsideSchedule)
+}
+
+func TestEnforceSchedule_OutsideDays(t *testing.T) {
+	// Saturday (ISO 6) — not in Mon–Fri schedule
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC) // Saturday
+	assert.ErrorIs(t, enforceSchedule(monFridaySched(), now), ErrAccessOutsideSchedule)
+}
+
+func TestEnforceSchedule_Sunday(t *testing.T) {
+	// Sunday is ISO 7 — not in Mon–Fri (1,2,3,4,5)
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC) // Sunday
+	assert.ErrorIs(t, enforceSchedule(monFridaySched(), now), ErrAccessOutsideSchedule)
+}
+
+func TestEnforceSchedule_StarDaysAlwaysPass(t *testing.T) {
+	sched := &models.SecretAccessSchedule{
+		AllowedDays: "*",
+		StartHour:   0,
+		EndHour:     24,
+		Timezone:    "UTC",
+	}
+	// Saturday midnight — days check must pass because AllowedDays == "*"
+	now := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	assert.NoError(t, enforceSchedule(sched, now))
+}
+
+func TestEnforceSchedule_UnknownTimezone_FailOpen(t *testing.T) {
+	sched := &models.SecretAccessSchedule{
+		AllowedDays: "1,2,3,4,5",
+		StartHour:   9,
+		EndHour:     17,
+		Timezone:    "Galaxy/Andromeda", // invalid IANA name
+	}
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC) // Saturday, would be denied on UTC schedule
+	// Fail-open: unrecognised timezone returns nil
+	assert.NoError(t, enforceSchedule(sched, now))
+}
+
+// ── checkSecretAccessSchedule integration tests ──────────────────────────────
+
+// newScheduleCore creates a KeyorixCore backed by an isolated in-memory SQLite for schedule tests.
+func newScheduleCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{},
+		&models.SecretAccessSchedule{},
+		&models.AuditEvent{},
+		&models.Project{},
+		&models.Environment{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 10, Name: "p"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 10, Name: "e"}).Error)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	return c, db
+}
+
+func TestCheckSecretAccessSchedule_NoSchedule(t *testing.T) {
+	c, _ := newScheduleCore(t)
+	// secretNodeID 999 has no schedule row — must return nil (no restriction)
+	err := c.checkSecretAccessSchedule(context.Background(), 999)
+	assert.NoError(t, err)
+}
+
+func TestCheckSecretAccessSchedule_WithSchedule_InWindow(t *testing.T) {
+	c, db := newScheduleCore(t)
+	s := &models.SecretNode{ProjectID: 10, EnvironmentID: 10, Name: "sched-in", IsSecret: true, Status: "active"}
+	require.NoError(t, db.Create(s).Error)
+
+	require.NoError(t, db.Create(&models.SecretAccessSchedule{
+		SecretNodeID: s.ID,
+		AllowedDays:  "*",
+		StartHour:    0,
+		EndHour:      24,
+		Timezone:     "UTC",
+	}).Error)
+
+	// Any time should pass (all-day, all-hours)
+	err := c.checkSecretAccessSchedule(context.Background(), s.ID)
+	assert.NoError(t, err)
+}
+
+func TestCheckSecretAccessSchedule_Denied(t *testing.T) {
+	_, db := newScheduleCore(t)
+	s := &models.SecretNode{ProjectID: 10, EnvironmentID: 10, Name: "sched-deny", IsSecret: true, Status: "active"}
+	require.NoError(t, db.Create(s).Error)
+
+	// Schedule that allows ONLY hour 23 on Sundays (ISO 7)
+	require.NoError(t, db.Create(&models.SecretAccessSchedule{
+		SecretNodeID: s.ID,
+		AllowedDays:  "7",
+		StartHour:    23,
+		EndHour:      24,
+		Timezone:     "UTC",
+	}).Error)
+
+	ls := store.NewLocalStorage(db)
+	// Swap storage to use a fixed "now" outside the window (Monday 12:00)
+	frozenMonday := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC) // Monday
+
+	sched, err := ls.GetSecretAccessSchedule(context.Background(), s.ID)
+	require.NoError(t, err)
+	require.NotNil(t, sched)
+	assert.ErrorIs(t, enforceSchedule(sched, frozenMonday), ErrAccessOutsideSchedule)
+}
+
+// ── SetSecretSchedule / GetSecretSchedule / DeleteSecretSchedule ─────────────
+
+func TestSetAndGetSecretSchedule(t *testing.T) {
+	c, db := newScheduleCore(t)
+	s := &models.SecretNode{ProjectID: 10, EnvironmentID: 10, Name: "sched-set", IsSecret: true, Status: "active"}
+	require.NoError(t, db.Create(s).Error)
+
+	got, err := c.SetSecretSchedule(context.Background(), s.ID, "1,2,3,4,5", 9, 17, "UTC")
+	require.NoError(t, err)
+	assert.Equal(t, "1,2,3,4,5", got.AllowedDays)
+	assert.Equal(t, 9, got.StartHour)
+	assert.Equal(t, 17, got.EndHour)
+	assert.Equal(t, "UTC", got.Timezone)
+
+	retrieved, err := c.GetSecretSchedule(context.Background(), s.ID)
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "1,2,3,4,5", retrieved.AllowedDays)
+}
+
+func TestDeleteSecretSchedule(t *testing.T) {
+	c, db := newScheduleCore(t)
+	s := &models.SecretNode{ProjectID: 10, EnvironmentID: 10, Name: "sched-del", IsSecret: true, Status: "active"}
+	require.NoError(t, db.Create(s).Error)
+
+	_, err := c.SetSecretSchedule(context.Background(), s.ID, "*", 0, 24, "UTC")
+	require.NoError(t, err)
+
+	require.NoError(t, c.DeleteSecretSchedule(context.Background(), s.ID))
+
+	retrieved, err := c.GetSecretSchedule(context.Background(), s.ID)
+	require.NoError(t, err)
+	assert.Nil(t, retrieved)
+}
+
+// ── validateScheduleParams ───────────────────────────────────────────────────
+
+func TestValidateScheduleParams_Valid(t *testing.T) {
+	assert.NoError(t, validateScheduleParams("1,2,3,4,5", 9, 17, "UTC"))
+	assert.NoError(t, validateScheduleParams("*", 0, 24, "America/New_York"))
+}
+
+func TestValidateScheduleParams_BadStartHour(t *testing.T) {
+	assert.Error(t, validateScheduleParams("*", -1, 17, "UTC"))
+	assert.Error(t, validateScheduleParams("*", 24, 25, "UTC"))
+}
+
+func TestValidateScheduleParams_BadEndHour(t *testing.T) {
+	assert.Error(t, validateScheduleParams("*", 9, 0, "UTC"))
+	assert.Error(t, validateScheduleParams("*", 9, 25, "UTC"))
+}
+
+func TestValidateScheduleParams_EndNotAfterStart(t *testing.T) {
+	assert.Error(t, validateScheduleParams("*", 17, 9, "UTC"))
+	assert.Error(t, validateScheduleParams("*", 9, 9, "UTC"))
+}
+
+func TestValidateScheduleParams_BadTimezone(t *testing.T) {
+	assert.Error(t, validateScheduleParams("*", 9, 17, "Not/A/Timezone"))
+}
+
+func TestValidateScheduleParams_BadDayValue(t *testing.T) {
+	assert.Error(t, validateScheduleParams("0,1,2", 9, 17, "UTC")) // 0 is invalid
+	assert.Error(t, validateScheduleParams("1,8", 9, 17, "UTC"))   // 8 is invalid
+	assert.Error(t, validateScheduleParams("mon", 9, 17, "UTC"))   // string, not number
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -219,6 +219,9 @@ func (c *KeyorixCore) GetSecretWithPermissionCheck(ctx context.Context, id, user
 	if _, err := c.EnforceSecretReadPermission(ctx, id, userID); err != nil {
 		return nil, err
 	}
+	if err := c.checkSecretAccessSchedule(ctx, id); err != nil {
+		return nil, err
+	}
 	return c.GetSecret(ctx, id)
 }
 
@@ -246,6 +249,9 @@ func (c *KeyorixCore) GetSecretByNameWithPermissionCheck(ctx context.Context, na
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
 	}
 	if _, err := c.EnforceSecretReadPermission(ctx, secret.ID, userID); err != nil {
+		return nil, err
+	}
+	if err := c.checkSecretAccessSchedule(ctx, secret.ID); err != nil {
 		return nil, err
 	}
 	return c.GetSecret(ctx, secret.ID)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -352,6 +352,13 @@ type Storage interface {
 	// folder-ACL enforcement runs server-side on the remote deployment.
 	GetSecretAncestors(ctx context.Context, nodeID uint) ([]uint, error)
 
+	// Temporal access schedule — restricts a secret's reads to a configured
+	// time window (day-of-week + hour range). GetSecretAccessSchedule returns
+	// nil, nil when no schedule has been configured for the secret.
+	GetSecretAccessSchedule(ctx context.Context, secretNodeID uint) (*models.SecretAccessSchedule, error)
+	SetSecretAccessSchedule(ctx context.Context, schedule *models.SecretAccessSchedule) error
+	DeleteSecretAccessSchedule(ctx context.Context, secretNodeID uint) error
+
 	// Legal hold (ISO 27001 A.5.34 / eDiscovery) — a deployment-wide hold that
 	// blocks the purge jobs from hard-deleting records while active.
 	CreateLegalHold(ctx context.Context, h *models.LegalHold) (*models.LegalHold, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -809,6 +809,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	connectRefGrantExists := tableExists(db, "connect_ref_grants")
 	groupsExists := tableExists(db, "groups")
 	secretACLExists := tableExists(db, "secret_acls")
+	scheduleExists := tableExists(db, "secret_access_schedules")
 
 	// Create rotation_policies if missing (additive, safe on existing DBs).
 	if !rotationExists {
@@ -1085,6 +1086,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	if !secretACLExists {
 		if err := db.AutoMigrate(&models.SecretACL{}); err != nil {
 			return fmt.Errorf("failed to migrate secret_acls table: %w", err)
+		}
+	}
+
+	// Create secret_access_schedules if missing (temporal access policies, additive).
+	if !scheduleExists {
+		if err := db.AutoMigrate(&models.SecretAccessSchedule{}); err != nil {
+			return fmt.Errorf("failed to migrate secret_access_schedules table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -661,6 +661,21 @@ type SecretACL struct {
 	UpdatedAt   time.Time
 }
 
+// SecretAccessSchedule enforces temporal read-access controls on a secret.
+// A secret with a schedule is readable ONLY during the allowed window.
+// Days uses ISO weekday numbers: 1=Mon, 2=Tue, ..., 7=Sun. "*" = all days.
+type SecretAccessSchedule struct {
+	ID           uint      `gorm:"primarykey" json:"id"`
+	SecretNodeID uint      `gorm:"uniqueIndex;not null" json:"secret_node_id"`
+	// AllowedDays is a comma-separated ISO weekday list, e.g. "1,2,3,4,5" or "*"
+	AllowedDays string    `json:"allowed_days"`
+	StartHour   int       `json:"start_hour"` // 0–23 inclusive
+	EndHour     int       `json:"end_hour"`   // 1–24; EndHour > StartHour
+	Timezone    string    `json:"timezone"`   // IANA, e.g. "UTC" or "America/New_York"
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
 type SecretVersion struct {
 	ID                 uint `gorm:"primaryKey"`
 	SecretNodeID       uint

--- a/internal/storage/store/local_secret_schedule.go
+++ b/internal/storage/store/local_secret_schedule.go
@@ -1,0 +1,61 @@
+// local_secret_schedule.go — SecretAccessSchedule persistence (temporal access policies).
+// Each row constrains read access to a secret within a day-of-week + hour window.
+// For the remote equivalent see remote_secret_schedule.go.
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// GetSecretAccessSchedule returns the schedule for secretNodeID, or nil, nil if none exists.
+func (ls *LocalStorage) GetSecretAccessSchedule(ctx context.Context, secretNodeID uint) (*models.SecretAccessSchedule, error) {
+	var row models.SecretAccessSchedule
+	err := ls.db.WithContext(ctx).Where("secret_node_id = ?", secretNodeID).First(&row).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return &row, nil
+}
+
+// SetSecretAccessSchedule upserts the schedule for schedule.SecretNodeID.
+func (ls *LocalStorage) SetSecretAccessSchedule(ctx context.Context, schedule *models.SecretAccessSchedule) error {
+	result := ls.db.WithContext(ctx).
+		Where(models.SecretAccessSchedule{SecretNodeID: schedule.SecretNodeID}).
+		Assign(models.SecretAccessSchedule{
+			AllowedDays: schedule.AllowedDays,
+			StartHour:   schedule.StartHour,
+			EndHour:     schedule.EndHour,
+			Timezone:    schedule.Timezone,
+		}).
+		FirstOrCreate(schedule)
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	// If the row already existed (RowsAffected == 0 from FirstOrCreate), persist the Assign'd fields.
+	if result.RowsAffected == 0 {
+		if err := ls.db.WithContext(ctx).Save(schedule).Error; err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+	}
+	return nil
+}
+
+// DeleteSecretAccessSchedule removes the schedule for secretNodeID.
+// Returns nil if no schedule exists (idempotent).
+func (ls *LocalStorage) DeleteSecretAccessSchedule(ctx context.Context, secretNodeID uint) error {
+	result := ls.db.WithContext(ctx).
+		Where("secret_node_id = ?", secretNodeID).
+		Delete(&models.SecretAccessSchedule{})
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	return nil
+}

--- a/internal/storage/store/remote_secret_schedule.go
+++ b/internal/storage/store/remote_secret_schedule.go
@@ -1,0 +1,23 @@
+// remote_secret_schedule.go — SecretAccessSchedule stubs for RemoteStorage (temporal access policies).
+// The schedule check runs server-side; a CLI remote caller never invokes these directly.
+// Schedule management routes (GET/PUT/DELETE /api/v1/secrets/{id}/schedule) are
+// reached via the HTTP handlers in server/http/handlers/secret_schedule.go.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) GetSecretAccessSchedule(_ context.Context, _ uint) (*models.SecretAccessSchedule, error) {
+	return nil, remoteUnsupported("GetSecretAccessSchedule")
+}
+
+func (rs *RemoteStorage) SetSecretAccessSchedule(_ context.Context, _ *models.SecretAccessSchedule) error {
+	return remoteUnsupported("SetSecretAccessSchedule")
+}
+
+func (rs *RemoteStorage) DeleteSecretAccessSchedule(_ context.Context, _ uint) error {
+	return remoteUnsupported("DeleteSecretAccessSchedule")
+}

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -172,6 +172,14 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	// boundary owns authorization; HasSecretACL/AuthorizeSecret run on the server).
 	"ListAllUserRoleGrants": {statusIntentional, "permission matrix is server-aggregated via GET /api/v1/rbac/permission-matrix; direct grant enumeration runs server-side"},
 
+	// Temporal access schedule — schedule enforcement runs server-side inside
+	// checkSecretAccessSchedule; a remote CLI caller never invokes these storage
+	// primitives directly. Schedule management is exposed via HTTP handlers
+	// (server/http/handlers/secret_schedule.go) under /api/v1/secrets/{id}/schedule.
+	"GetSecretAccessSchedule":    {statusIntentional, "temporal schedule check runs server-side; schedule management routes are HTTP-proxied via secret_schedule.go"},
+	"SetSecretAccessSchedule":    {statusIntentional, "temporal schedule check runs server-side; schedule management routes are HTTP-proxied via secret_schedule.go"},
+	"DeleteSecretAccessSchedule": {statusIntentional, "temporal schedule check runs server-side; schedule management routes are HTTP-proxied via secret_schedule.go"},
+
 	"CreateOrUpdateSecretACL":  {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
 	"ListSecretACLs":           {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
 	"ListSecretACLsByUser":     {statusIntentional, "RBAC Phase 3 — listing ACL-granted secrets for a user runs server-side in ListSecretsWithSharingInfo; the core function calls LocalStorage on the server, not RemoteStorage"},

--- a/internal/testhelper/rbac_test_helper.go
+++ b/internal/testhelper/rbac_test_helper.go
@@ -86,6 +86,8 @@ func NewRBACTestHelper(t *testing.T) *RBACTestHelper {
 		// here so any test exercising a grant path gets a real (empty-by-default)
 		// sod_policies table instead of a "no such table" storage error.
 		&models.SoDPolicy{},
+		// GetSecret now queries secret_access_schedules for temporal-access enforcement.
+		&models.SecretAccessSchedule{},
 	)
 	require.NoError(t, err)
 

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -47,7 +47,7 @@ func newSecretTestRig(t *testing.T) *secretTestRig {
 		&models.SecretVersion{}, &models.User{}, &models.Role{}, &models.ShareRecord{},
 		&models.Permission{}, &models.RolePermission{}, &models.UserRole{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.DynamicSecretConfig{}, &models.SecretACL{},
+		&models.DynamicSecretConfig{}, &models.SecretACL{}, &models.SecretAccessSchedule{},
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "default"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "development"}).Error)

--- a/server/http/handlers/handlers_s12_test.go
+++ b/server/http/handlers/handlers_s12_test.go
@@ -71,6 +71,7 @@ func freshCoreS12(t *testing.T) *core.KeyorixCore {
 		&models.SystemMetadata{},
 		&models.PasswordHistory{},
 		&models.SecretVersion{},
+		&models.SecretACL{}, &models.SecretAccessSchedule{},
 	)
 	require.NoError(t, err)
 	return core.NewKeyorixCore(store.NewLocalStorage(db))
@@ -112,7 +113,7 @@ func freshCoreS12WithAdmin(t *testing.T) (*core.KeyorixCore, *gorm.DB) {
 		&models.SystemMetadata{},
 		&models.PasswordHistory{},
 		&models.SecretVersion{},
-		&models.SecretACL{},
+		&models.SecretACL{}, &models.SecretAccessSchedule{},
 	)
 	require.NoError(t, err)
 

--- a/server/http/handlers/secret_schedule.go
+++ b/server/http/handlers/secret_schedule.go
@@ -1,0 +1,90 @@
+// secret_schedule.go — temporal access schedule handlers.
+//
+// Routes (under /api/v1/secrets/{id}/schedule):
+//
+//	GET    /{id}/schedule — return the current schedule; 404 when none set
+//	PUT    /{id}/schedule — set/replace the schedule; body: {allowed_days, start_hour, end_hour, timezone}
+//	DELETE /{id}/schedule — remove the schedule (idempotent)
+//
+// All three routes require secrets.manage at the secret's project scope.
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+// GetSecretSchedule handles GET /api/v1/secrets/{id}/schedule.
+func (h *SecretHandler) GetSecretSchedule(w http.ResponseWriter, r *http.Request) {
+	secretID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
+		return
+	}
+	sched, err := h.coreService.GetSecretSchedule(r.Context(), uint(secretID))
+	if err != nil {
+		h.sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	if sched == nil {
+		h.sendError(w, "NotFound", "no schedule configured for this secret", http.StatusNotFound, nil)
+		return
+	}
+	h.sendSuccess(w, sched, "")
+}
+
+// SetSecretSchedule handles PUT /api/v1/secrets/{id}/schedule.
+func (h *SecretHandler) SetSecretSchedule(w http.ResponseWriter, r *http.Request) {
+	secretID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
+		return
+	}
+	var body struct {
+		AllowedDays string `json:"allowed_days"`
+		StartHour   int    `json:"start_hour"`
+		EndHour     int    `json:"end_hour"`
+		Timezone    string `json:"timezone"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		h.sendError(w, "InvalidJSON", errInvalidJSON, http.StatusBadRequest, nil)
+		return
+	}
+	if body.Timezone == "" {
+		body.Timezone = "UTC"
+	}
+	sched, err := h.coreService.SetSecretSchedule(r.Context(), uint(secretID), body.AllowedDays, body.StartHour, body.EndHour, body.Timezone)
+	if err != nil {
+		status := http.StatusBadRequest
+		if !isScheduleValidationError(err) {
+			status = http.StatusInternalServerError
+		}
+		h.sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	h.sendSuccess(w, sched, "schedule set")
+}
+
+// DeleteSecretSchedule handles DELETE /api/v1/secrets/{id}/schedule.
+func (h *SecretHandler) DeleteSecretSchedule(w http.ResponseWriter, r *http.Request) {
+	secretID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.DeleteSecretSchedule(r.Context(), uint(secretID)); err != nil {
+		h.sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	h.sendSuccess(w, map[string]bool{"deleted": true}, "schedule removed")
+}
+
+// isScheduleValidationError returns true when err originates from validateScheduleParams.
+func isScheduleValidationError(err error) bool {
+	return err != nil && !errors.Is(err, core.ErrAccessOutsideSchedule)
+}

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -226,7 +226,9 @@ func (h *SecretHandler) GetSecret(w http.ResponseWriter, r *http.Request) { // N
 	}
 	if err != nil {
 		log.Printf("Error getting secret: %v", err)
-		if strings.Contains(err.Error(), errNotFound) {
+		if errors.Is(err, core.ErrAccessOutsideSchedule) {
+			h.sendError(w, "Forbidden", err.Error(), http.StatusForbidden, nil)
+		} else if strings.Contains(err.Error(), errNotFound) {
 			h.sendError(w, "NotFound", errSecretNotFound, http.StatusNotFound, nil)
 		} else if strings.Contains(err.Error(), errPermissionDenied) {
 			h.sendError(w, "Forbidden", errAccessDenied, http.StatusForbidden, nil)

--- a/server/http/handlers/secrets_crud_goroutine_panic_test.go
+++ b/server/http/handlers/secrets_crud_goroutine_panic_test.go
@@ -69,7 +69,8 @@ func newPanicTestHandler(t *testing.T) (*SecretHandler, *gorm.DB) {
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{},
 		&models.Permission{}, &models.RolePermission{}, &models.Group{}, &models.GroupRole{},
 		&models.UserGroup{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{},
-		&models.SecretNode{}, &models.SecretVersion{}, &models.SecretAccessLog{}, &models.ShareRecord{}))
+		&models.SecretNode{}, &models.SecretVersion{}, &models.SecretAccessLog{}, &models.ShareRecord{},
+		&models.SecretACL{}, &models.SecretAccessSchedule{}))
 
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", AccountState: "active"}).Error)
 	adminRole := &models.Role{Name: "admin"}

--- a/server/http/handlers/secrets_crud_s13_test.go
+++ b/server/http/handlers/secrets_crud_s13_test.go
@@ -86,6 +86,7 @@ func freshSecretFixtureS13(t *testing.T) (*SecretHandler, *core.KeyorixCore, *mo
 		&models.SystemMetadata{},
 		&models.PasswordHistory{},
 		&models.SecretVersion{},
+		&models.SecretACL{}, &models.SecretAccessSchedule{},
 	))
 
 	// Seed user 1 as system_admin so in-handler authorization passes.

--- a/server/http/handlers/secrets_crud_s15_test.go
+++ b/server/http/handlers/secrets_crud_s15_test.go
@@ -57,7 +57,7 @@ func freshSecretFixtureS15(t *testing.T) (*SecretHandler, *core.KeyorixCore, *mo
 		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.Project{}, &models.Environment{}, &models.SecretNode{},
 		&models.AuditEvent{}, &models.SecretVersion{}, &models.SecretAccessLog{},
-		&models.ShareRecord{},
+		&models.ShareRecord{}, &models.SecretACL{}, &models.SecretAccessSchedule{},
 	))
 
 	// Seed the user context user (UserID=1) as a global admin bypass.

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -156,6 +156,10 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		// GetCompliancePosture on every call; the table must exist for posture
 		// handler tests that go through the real router.
 		&models.CompliancePostureSnapshot{},
+		// temporal access policies: SecretAccessSchedule enforces time-window
+		// read restrictions on secrets; the schedule check runs server-side
+		// in checkSecretAccessSchedule, called from GetSecretWithPermissionCheck.
+		&models.SecretAccessSchedule{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -543,6 +543,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Post("/{id}/acl", secretHandler.GrantSecretACL)
 			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Delete("/{id}/acl/{aclId}", secretHandler.RevokeSecretACL)
 
+			// Temporal access schedule: restrict a secret's reads to a time window.
+			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Get("/{id}/schedule", secretHandler.GetSecretSchedule)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Put("/{id}/schedule", secretHandler.SetSecretSchedule)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Delete("/{id}/schedule", secretHandler.DeleteSecretSchedule)
+
 			// Certificate inspection (ADR-054) — public X.509 metadata, no value/key.
 			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/certificate", secretHandler.GetSecretCertificate)
 


### PR DESCRIPTION
SecretAccessSchedule model + GET/PUT/DELETE /api/v1/secrets/{id}/schedule + keyorix secret set-schedule/get-schedule/clear-schedule. 403 outside configured day+hour window.