### PR TITLE
feat(anomaly): runtime config API + CLI — persist thresholds without restart

### DIFF
--- a/internal/cli/anomalies/config.go
+++ b/internal/cli/anomalies/config.go
@@ -1,0 +1,184 @@
+package anomalies
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// anomalyConfigRecord mirrors models.AnomalyConfigRecord for CLI JSON decoding.
+type anomalyConfigRecord struct {
+	LookbackDays     int     `json:"lookback_days"`
+	QuarantineHours  int     `json:"quarantine_hours"`
+	OffHoursEnabled  bool    `json:"off_hours_enabled"`
+	OffHoursTimezone string  `json:"off_hours_timezone"`
+	OffHoursStart    int     `json:"off_hours_start"`
+	OffHoursEnd      int     `json:"off_hours_end"`
+	MLEnabled        bool    `json:"ml_enabled"`
+	MLThreshold      float64 `json:"ml_threshold"`
+	MLNumTrees       int     `json:"ml_num_trees"`
+	MLSampleSize     int     `json:"ml_sample_size"`
+	UpdatedAt        string  `json:"updated_at"`
+	UpdatedBy        string  `json:"updated_by"`
+}
+
+type anomalyConfigResponse struct {
+	Config anomalyConfigRecord `json:"config"`
+}
+
+// configCmd is the "anomaly config" subcommand group.
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage anomaly detection runtime configuration",
+}
+
+var configGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Show the current anomaly detection configuration",
+	RunE:  runConfigGet,
+}
+
+// flags for "anomaly config set"
+var (
+	cfgLookbackDays     int
+	cfgQuarantineHours  int
+	cfgOffHoursEnabled  bool
+	cfgOffHoursTimezone string
+	cfgOffHoursStart    int
+	cfgOffHoursEnd      int
+	cfgMLEnabled        bool
+	cfgMLThreshold      float64
+	cfgMLNumTrees       int
+	cfgMLSampleSize     int
+)
+
+var configSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Update one or more anomaly detection configuration fields",
+	Long: `Update the anomaly detection runtime configuration.
+
+Only flags that are explicitly provided are changed; all others keep their
+current stored values.  Changes take effect on the next detection scan
+without restarting the server.`,
+	RunE: runConfigSet,
+}
+
+func init() {
+	configSetCmd.Flags().IntVar(&cfgLookbackDays, "lookback-days", 0, "Lookback window for baseline (days)")
+	configSetCmd.Flags().IntVar(&cfgQuarantineHours, "quarantine-hours", 0, "Quarantine period before a new actor is trusted (hours)")
+	configSetCmd.Flags().BoolVar(&cfgOffHoursEnabled, "off-hours-enabled", false, "Enable off-hours rule")
+	configSetCmd.Flags().StringVar(&cfgOffHoursTimezone, "off-hours-timezone", "", "IANA timezone for off-hours band (e.g. America/New_York)")
+	configSetCmd.Flags().IntVar(&cfgOffHoursStart, "off-hours-start", 0, "Off-hours band start hour (0–23)")
+	configSetCmd.Flags().IntVar(&cfgOffHoursEnd, "off-hours-end", 0, "Off-hours band end hour (0–23)")
+	configSetCmd.Flags().BoolVar(&cfgMLEnabled, "ml-enabled", false, "Enable ML (Isolation Forest) anomaly detection")
+	configSetCmd.Flags().Float64Var(&cfgMLThreshold, "ml-threshold", 0, "ML anomaly-score threshold (0.5–1.0)")
+	configSetCmd.Flags().IntVar(&cfgMLNumTrees, "ml-num-trees", 0, "ML Isolation Forest tree count")
+	configSetCmd.Flags().IntVar(&cfgMLSampleSize, "ml-sample-size", 0, "ML Isolation Forest per-tree subsample size")
+
+	configCmd.AddCommand(configGetCmd)
+	configCmd.AddCommand(configSetCmd)
+	AnomaliesCmd.AddCommand(configCmd)
+}
+
+const anomalyConfigPath = "/api/v1/admin/anomaly-config"
+
+func runConfigGet(cmd *cobra.Command, args []string) error {
+	rc, ok := common.NewRemoteClient()
+	if !ok {
+		return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	return runConfigGetRemote(rc)
+}
+
+func runConfigGetRemote(rc *common.RemoteClient) error {
+	var resp anomalyConfigResponse
+	if err := rc.Get(context.Background(), anomalyConfigPath, &resp); err != nil {
+		return err
+	}
+	printAnomalyConfig(resp.Config)
+	return nil
+}
+
+func runConfigSet(cmd *cobra.Command, args []string) error {
+	rc, ok := common.NewRemoteClient()
+	if !ok {
+		return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	return runConfigSetRemote(rc, cmd)
+}
+
+func runConfigSetRemote(rc *common.RemoteClient, cmd *cobra.Command) error {
+	// Fetch the current config so we can do a partial update (only changed flags).
+	var resp anomalyConfigResponse
+	if err := rc.Get(context.Background(), anomalyConfigPath, &resp); err != nil {
+		return fmt.Errorf("fetch current config: %w", err)
+	}
+	current := resp.Config
+
+	// Apply only the flags the caller explicitly provided.
+	if cmd.Flags().Changed("lookback-days") {
+		current.LookbackDays = cfgLookbackDays
+	}
+	if cmd.Flags().Changed("quarantine-hours") {
+		current.QuarantineHours = cfgQuarantineHours
+	}
+	if cmd.Flags().Changed("off-hours-enabled") {
+		current.OffHoursEnabled = cfgOffHoursEnabled
+	}
+	if cmd.Flags().Changed("off-hours-timezone") {
+		current.OffHoursTimezone = cfgOffHoursTimezone
+	}
+	if cmd.Flags().Changed("off-hours-start") {
+		current.OffHoursStart = cfgOffHoursStart
+	}
+	if cmd.Flags().Changed("off-hours-end") {
+		current.OffHoursEnd = cfgOffHoursEnd
+	}
+	if cmd.Flags().Changed("ml-enabled") {
+		current.MLEnabled = cfgMLEnabled
+	}
+	if cmd.Flags().Changed("ml-threshold") {
+		current.MLThreshold = cfgMLThreshold
+	}
+	if cmd.Flags().Changed("ml-num-trees") {
+		current.MLNumTrees = cfgMLNumTrees
+	}
+	if cmd.Flags().Changed("ml-sample-size") {
+		current.MLSampleSize = cfgMLSampleSize
+	}
+
+	var updated anomalyConfigResponse
+	// Marshal current (the patched struct) into a generic map for the PUT body.
+	b, err := json.Marshal(current)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(b, &body); err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	if err := rc.Put(context.Background(), anomalyConfigPath, body, &updated); err != nil {
+		return err
+	}
+	fmt.Println("Anomaly detection configuration updated.")
+	printAnomalyConfig(updated.Config)
+	return nil
+}
+
+func printAnomalyConfig(cfg anomalyConfigRecord) {
+	fmt.Printf("Lookback:          %d days\n", cfg.LookbackDays)
+	fmt.Printf("Quarantine:        %d hours\n", cfg.QuarantineHours)
+	fmt.Printf("Off-hours enabled: %v\n", cfg.OffHoursEnabled)
+	fmt.Printf("Off-hours tz:      %s\n", cfg.OffHoursTimezone)
+	fmt.Printf("Off-hours band:    %02d:00–%02d:00\n", cfg.OffHoursStart, cfg.OffHoursEnd)
+	fmt.Printf("ML enabled:        %v\n", cfg.MLEnabled)
+	fmt.Printf("ML threshold:      %.2f\n", cfg.MLThreshold)
+	fmt.Printf("ML num trees:      %d\n", cfg.MLNumTrees)
+	fmt.Printf("ML sample size:    %d\n", cfg.MLSampleSize)
+	if cfg.UpdatedBy != "" {
+		fmt.Printf("Last updated by:   %s at %s\n", cfg.UpdatedBy, cfg.UpdatedAt)
+	}
+}

--- a/internal/cli/anomalies/config_test.go
+++ b/internal/cli/anomalies/config_test.go
@@ -1,0 +1,210 @@
+package anomalies
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeConfigServer(t *testing.T, current anomalyConfigRecord) (*httptest.Server, *http.Request) {
+	t.Helper()
+	var lastReq *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastReq = r
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{
+				"config": current,
+			},
+		}
+		if r.Method == http.MethodPut {
+			var body anomalyConfigRecord
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &body)
+			resp = map[string]interface{}{
+				"data": map[string]interface{}{
+					"config": body,
+				},
+			}
+		}
+		b, _ := json.Marshal(resp)
+		_, _ = w.Write(b)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, lastReq
+}
+
+// TestAnomalyConfigGet_Remote verifies that "anomaly config get" issues a GET
+// to /api/v1/admin/anomaly-config and decodes the response.
+func TestAnomalyConfigGet_Remote(t *testing.T) {
+	cfg := anomalyConfigRecord{
+		LookbackDays:    7,
+		QuarantineHours: 24,
+		MLEnabled:       false,
+		MLThreshold:     0.6,
+		MLNumTrees:      100,
+		MLSampleSize:    256,
+	}
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{"config": cfg},
+		}
+		b, _ := json.Marshal(resp)
+		_, _ = w.Write(b)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runConfigGetRemote(rc))
+	assert.Equal(t, http.MethodGet, gotMethod)
+	assert.Equal(t, anomalyConfigPath, gotPath)
+}
+
+// TestAnomalyConfigSet_Remote_PartialUpdate verifies that only explicitly
+// changed flags are reflected in the PUT body; unchanged fields keep their
+// current values from the GET.
+func TestAnomalyConfigSet_Remote_PartialUpdate(t *testing.T) {
+	// Server starts with these values.
+	initial := anomalyConfigRecord{
+		LookbackDays:    7,
+		QuarantineHours: 24,
+		MLEnabled:       false,
+		MLThreshold:     0.6,
+		MLNumTrees:      100,
+		MLSampleSize:    256,
+	}
+
+	var putBody anomalyConfigRecord
+	var gotMethod string
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Method == http.MethodGet {
+			gotMethod = r.Method
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{"config": initial},
+			}
+			b, _ := json.Marshal(resp)
+			_, _ = w.Write(b)
+			return
+		}
+		// PUT — capture body
+		gotMethod = r.Method
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &putBody)
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{"config": putBody},
+		}
+		rb, _ := json.Marshal(resp)
+		_, _ = w.Write(rb)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	// Build a cobra command with only --ml-enabled set.
+	cmd := &cobra.Command{}
+	cmd.Flags().BoolVar(&cfgMLEnabled, "ml-enabled", false, "")
+	require.NoError(t, cmd.Flags().Set("ml-enabled", "true"))
+
+	require.NoError(t, runConfigSetRemote(rc, cmd))
+
+	// Should have done GET then PUT.
+	assert.Equal(t, http.MethodPut, gotMethod)
+	// Only ml_enabled changed; everything else is from the initial config.
+	assert.True(t, putBody.MLEnabled, "ml_enabled must be true after --ml-enabled flag")
+	assert.Equal(t, initial.LookbackDays, putBody.LookbackDays, "lookback_days must be unchanged")
+	assert.Equal(t, initial.QuarantineHours, putBody.QuarantineHours, "quarantine_hours must be unchanged")
+	assert.InDelta(t, initial.MLThreshold, putBody.MLThreshold, 1e-9, "ml_threshold must be unchanged")
+}
+
+// TestAnomalyConfigSet_Remote_AllFlags verifies that setting all flags in one
+// call produces a PUT body that reflects every change.
+func TestAnomalyConfigSet_Remote_AllFlags(t *testing.T) {
+	initial := anomalyConfigRecord{
+		LookbackDays:    7,
+		QuarantineHours: 24,
+		MLEnabled:       false,
+		MLThreshold:     0.6,
+		MLNumTrees:      100,
+		MLSampleSize:    256,
+	}
+
+	var putBody anomalyConfigRecord
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{"config": initial},
+			}
+			b, _ := json.Marshal(resp)
+			_, _ = w.Write(b)
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &putBody)
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{"config": putBody},
+		}
+		rb, _ := json.Marshal(resp)
+		_, _ = w.Write(rb)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	// Build a cobra command with all flags set.
+	cmd := &cobra.Command{}
+	cmd.Flags().IntVar(&cfgLookbackDays, "lookback-days", 0, "")
+	cmd.Flags().IntVar(&cfgQuarantineHours, "quarantine-hours", 0, "")
+	cmd.Flags().BoolVar(&cfgOffHoursEnabled, "off-hours-enabled", false, "")
+	cmd.Flags().StringVar(&cfgOffHoursTimezone, "off-hours-timezone", "", "")
+	cmd.Flags().IntVar(&cfgOffHoursStart, "off-hours-start", 0, "")
+	cmd.Flags().IntVar(&cfgOffHoursEnd, "off-hours-end", 0, "")
+	cmd.Flags().BoolVar(&cfgMLEnabled, "ml-enabled", false, "")
+	cmd.Flags().Float64Var(&cfgMLThreshold, "ml-threshold", 0, "")
+	cmd.Flags().IntVar(&cfgMLNumTrees, "ml-num-trees", 0, "")
+	cmd.Flags().IntVar(&cfgMLSampleSize, "ml-sample-size", 0, "")
+
+	require.NoError(t, cmd.Flags().Set("lookback-days", "30"))
+	require.NoError(t, cmd.Flags().Set("quarantine-hours", "48"))
+	require.NoError(t, cmd.Flags().Set("off-hours-enabled", "true"))
+	require.NoError(t, cmd.Flags().Set("off-hours-timezone", "America/New_York"))
+	require.NoError(t, cmd.Flags().Set("off-hours-start", "20"))
+	require.NoError(t, cmd.Flags().Set("off-hours-end", "8"))
+	require.NoError(t, cmd.Flags().Set("ml-enabled", "true"))
+	require.NoError(t, cmd.Flags().Set("ml-threshold", "0.75"))
+	require.NoError(t, cmd.Flags().Set("ml-num-trees", "200"))
+	require.NoError(t, cmd.Flags().Set("ml-sample-size", "512"))
+
+	require.NoError(t, runConfigSetRemote(rc, cmd))
+
+	assert.Equal(t, 30, putBody.LookbackDays)
+	assert.Equal(t, 48, putBody.QuarantineHours)
+	assert.True(t, putBody.OffHoursEnabled)
+	assert.Equal(t, "America/New_York", putBody.OffHoursTimezone)
+	assert.Equal(t, 20, putBody.OffHoursStart)
+	assert.Equal(t, 8, putBody.OffHoursEnd)
+	assert.True(t, putBody.MLEnabled)
+	assert.InDelta(t, 0.75, putBody.MLThreshold, 1e-9)
+	assert.Equal(t, 200, putBody.MLNumTrees)
+	assert.Equal(t, 512, putBody.MLSampleSize)
+}

--- a/internal/cli/anomalies/config_test.go
+++ b/internal/cli/anomalies/config_test.go
@@ -13,33 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeConfigServer(t *testing.T, current anomalyConfigRecord) (*httptest.Server, *http.Request) {
-	t.Helper()
-	var lastReq *http.Request
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		lastReq = r
-		resp := map[string]interface{}{
-			"data": map[string]interface{}{
-				"config": current,
-			},
-		}
-		if r.Method == http.MethodPut {
-			var body anomalyConfigRecord
-			b, _ := io.ReadAll(r.Body)
-			_ = json.Unmarshal(b, &body)
-			resp = map[string]interface{}{
-				"data": map[string]interface{}{
-					"config": body,
-				},
-			}
-		}
-		b, _ := json.Marshal(resp)
-		_, _ = w.Write(b)
-	}))
-	t.Cleanup(srv.Close)
-	return srv, lastReq
-}
-
 // TestAnomalyConfigGet_Remote verifies that "anomaly config get" issues a GET
 // to /api/v1/admin/anomaly-config and decodes the response.
 func TestAnomalyConfigGet_Remote(t *testing.T) {

--- a/internal/core/anomaly_config.go
+++ b/internal/core/anomaly_config.go
@@ -1,0 +1,55 @@
+package core
+
+import (
+	"context"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ApplyAnomalyConfig loads the persisted anomaly config and applies it to the
+// given detector. Call at startup and before each detection scan so runtime
+// changes take effect without a restart.
+func (c *KeyorixCore) ApplyAnomalyConfig(ctx context.Context, detector *AnomalyDetector) error {
+	cfg, err := c.storage.GetAnomalyConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Lookback
+	if cfg.LookbackDays > 0 {
+		detector.SetLookback(time.Duration(cfg.LookbackDays) * 24 * time.Hour)
+	}
+	// Quarantine
+	if cfg.QuarantineHours > 0 {
+		detector.SetBaselineQuarantine(time.Duration(cfg.QuarantineHours) * time.Hour)
+	}
+	// Off-hours (only applied when enabled; the detector keeps its own default when disabled)
+	if cfg.OffHoursEnabled {
+		_ = detector.SetBusinessHours(ctx, cfg.OffHoursTimezone, cfg.OffHoursStart, cfg.OffHoursEnd)
+	}
+	// ML
+	detector.SetMLConfig(MLConfig{
+		Enabled:    cfg.MLEnabled,
+		Threshold:  cfg.MLThreshold,
+		NumTrees:   cfg.MLNumTrees,
+		SampleSize: cfg.MLSampleSize,
+	})
+	return nil
+}
+
+// GetAnomalyConfig returns the current persisted anomaly detection config (or
+// sensible defaults if none has been saved yet).
+func (c *KeyorixCore) GetAnomalyConfig(ctx context.Context) (*models.AnomalyConfigRecord, error) {
+	return c.storage.GetAnomalyConfig(ctx)
+}
+
+// UpdateAnomalyConfig persists a new anomaly detection config.  updatedBy is
+// the username of the operator making the change (stored on the row for audit
+// purposes); the caller is responsible for applying the new config to the live
+// detector via ApplyAnomalyConfig if one is running.
+func (c *KeyorixCore) UpdateAnomalyConfig(ctx context.Context, cfg *models.AnomalyConfigRecord, updatedBy string) error {
+	cfg.UpdatedBy = updatedBy
+	cfg.UpdatedAt = time.Now()
+	return c.storage.SaveAnomalyConfig(ctx, cfg)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1321,6 +1321,18 @@ func (m *MockStorage) MarkAnomalyAlertAlerted(ctx context.Context, id uint) erro
 	return m.Called(ctx, id).Error(0)
 }
 
+func (m *MockStorage) GetAnomalyConfig(ctx context.Context) (*models.AnomalyConfigRecord, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AnomalyConfigRecord), args.Error(1)
+}
+
+func (m *MockStorage) SaveAnomalyConfig(ctx context.Context, cfg *models.AnomalyConfigRecord) error {
+	return m.Called(ctx, cfg).Error(0)
+}
+
 func (m *MockStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditFilter) ([]*models.AuditEvent, int64, error) {
 	args := m.Called(ctx, filter)
 	if args.Get(0) == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -918,6 +918,10 @@ type Storage interface {
 	// hygiene rollup (#393) instead of calling UnusedSecrets once per project. A
 	// project absent from the result has zero unused secrets.
 	CountUnusedSecretsByProject(ctx context.Context, projectIDs []uint, notReadSince time.Time) (map[uint]int, error)
+	// GetAnomalyConfig retrieves the single anomaly config row, or returns sensible
+	// defaults if no row has been saved yet.
+	GetAnomalyConfig(ctx context.Context) (*models.AnomalyConfigRecord, error)
+	SaveAnomalyConfig(ctx context.Context, cfg *models.AnomalyConfigRecord) error
 	CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error
 	ListAnomalyAlerts(ctx context.Context, acknowledged *bool) ([]models.AnomalyAlert, error)
 	// AcknowledgeAnomalyAlert marks an alert acknowledged and stamps who did it and

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -1166,6 +1166,28 @@ type AnomalyAlert struct {
 	CreatedAt time.Time
 }
 
+// AnomalyConfigRecord stores runtime-tunable anomaly detection parameters.
+// Only one row exists (ID=1); use GetAnomalyConfig/SaveAnomalyConfig to manage it.
+type AnomalyConfigRecord struct {
+	ID uint `gorm:"primarykey"`
+	// Lookback window for access-frequency baseline (default: 7 days)
+	LookbackDays int `json:"lookback_days"`
+	// Quarantine period before a new secret's first-read is flagged (default: 24h)
+	QuarantineHours int `json:"quarantine_hours"`
+	// Off-hours enforcement
+	OffHoursEnabled  bool   `json:"off_hours_enabled"`
+	OffHoursTimezone string `json:"off_hours_timezone"` // IANA tz
+	OffHoursStart    int    `json:"off_hours_start"`    // 0–23
+	OffHoursEnd      int    `json:"off_hours_end"`      // 0–23
+	// ML Isolation Forest
+	MLEnabled    bool    `json:"ml_enabled"`
+	MLThreshold  float64 `json:"ml_threshold"`   // 0.5–1.0
+	MLNumTrees   int     `json:"ml_num_trees"`
+	MLSampleSize int     `json:"ml_sample_size"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	UpdatedBy    string    `json:"updated_by"` // username of last editor
+}
+
 // MachineIdentity is a non-human project member (ADR-023): a CI runner, a
 // Kubernetes workload, a service, or other automation. It carries its own
 // lifecycle, separate from human users, so the Members view can segment the two.

--- a/internal/storage/store/local_anomaly_config.go
+++ b/internal/storage/store/local_anomaly_config.go
@@ -1,0 +1,45 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// defaultAnomalyConfig returns sensible defaults matching the current startup values.
+func defaultAnomalyConfig() *models.AnomalyConfigRecord {
+	return &models.AnomalyConfigRecord{
+		ID:               1,
+		LookbackDays:     7,
+		QuarantineHours:  24,
+		OffHoursEnabled:  false,
+		OffHoursTimezone: "UTC",
+		OffHoursStart:    22,
+		OffHoursEnd:      6,
+		MLEnabled:        false,
+		MLThreshold:      0.6,
+		MLNumTrees:       100,
+		MLSampleSize:     256,
+		UpdatedAt:        time.Now(),
+	}
+}
+
+// GetAnomalyConfig retrieves the single anomaly config row (ID=1), or returns
+// sensible defaults if no row has been saved yet.
+func (ls *LocalStorage) GetAnomalyConfig(ctx context.Context) (*models.AnomalyConfigRecord, error) {
+	var cfg models.AnomalyConfigRecord
+	err := ls.db.WithContext(ctx).First(&cfg, 1).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return defaultAnomalyConfig(), nil
+	}
+	return &cfg, err
+}
+
+// SaveAnomalyConfig upserts the singleton anomaly config (always ID=1).
+func (ls *LocalStorage) SaveAnomalyConfig(ctx context.Context, cfg *models.AnomalyConfigRecord) error {
+	cfg.ID = 1 // always singleton
+	return ls.db.WithContext(ctx).Save(cfg).Error
+}

--- a/internal/storage/store/local_anomaly_config_test.go
+++ b/internal/storage/store/local_anomaly_config_test.go
@@ -1,0 +1,120 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newAnomalyConfigTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AnomalyConfigRecord{}))
+	return NewLocalStorage(db)
+}
+
+// TestGetAnomalyConfig_ReturnsDefaultWhenNoRow checks that an empty DB returns
+// sensible defaults without an error.
+func TestGetAnomalyConfig_ReturnsDefaultWhenNoRow(t *testing.T) {
+	ctx := context.Background()
+	ls := newAnomalyConfigTestStore(t)
+
+	cfg, err := ls.GetAnomalyConfig(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, 7, cfg.LookbackDays, "default lookback should be 7 days")
+	assert.Equal(t, 24, cfg.QuarantineHours, "default quarantine should be 24 hours")
+	assert.False(t, cfg.MLEnabled, "ML should be disabled by default")
+	assert.Equal(t, 0.6, cfg.MLThreshold)
+	assert.Equal(t, 100, cfg.MLNumTrees)
+	assert.Equal(t, 256, cfg.MLSampleSize)
+}
+
+// TestSaveAndGetAnomalyConfig_RoundTrip verifies that a saved config survives
+// a round-trip through the DB unchanged.
+func TestSaveAndGetAnomalyConfig_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	ls := newAnomalyConfigTestStore(t)
+
+	want := &models.AnomalyConfigRecord{
+		LookbackDays:     14,
+		QuarantineHours:  48,
+		OffHoursEnabled:  true,
+		OffHoursTimezone: "America/New_York",
+		OffHoursStart:    20,
+		OffHoursEnd:      8,
+		MLEnabled:        true,
+		MLThreshold:      0.75,
+		MLNumTrees:       200,
+		MLSampleSize:     512,
+		UpdatedBy:        "alice",
+		UpdatedAt:        time.Now().Truncate(time.Second),
+	}
+	require.NoError(t, ls.SaveAnomalyConfig(ctx, want))
+
+	got, err := ls.GetAnomalyConfig(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 14, got.LookbackDays)
+	assert.Equal(t, 48, got.QuarantineHours)
+	assert.True(t, got.OffHoursEnabled)
+	assert.Equal(t, "America/New_York", got.OffHoursTimezone)
+	assert.Equal(t, 20, got.OffHoursStart)
+	assert.Equal(t, 8, got.OffHoursEnd)
+	assert.True(t, got.MLEnabled)
+	assert.InDelta(t, 0.75, got.MLThreshold, 1e-9)
+	assert.Equal(t, 200, got.MLNumTrees)
+	assert.Equal(t, 512, got.MLSampleSize)
+	assert.Equal(t, "alice", got.UpdatedBy)
+}
+
+// TestSaveAnomalyConfig_Singleton ensures that calling SaveAnomalyConfig twice
+// results in exactly one row (the second call upserts, not appends).
+func TestSaveAnomalyConfig_Singleton(t *testing.T) {
+	ctx := context.Background()
+	ls := newAnomalyConfigTestStore(t)
+
+	first := &models.AnomalyConfigRecord{LookbackDays: 3, UpdatedBy: "alice"}
+	require.NoError(t, ls.SaveAnomalyConfig(ctx, first))
+
+	second := &models.AnomalyConfigRecord{LookbackDays: 14, UpdatedBy: "bob"}
+	require.NoError(t, ls.SaveAnomalyConfig(ctx, second))
+
+	// Only one row should exist.
+	var count int64
+	ls.db.Model(&models.AnomalyConfigRecord{}).Count(&count)
+	assert.Equal(t, int64(1), count, "SaveAnomalyConfig must maintain a single row")
+
+	// And it should reflect the latest save.
+	got, err := ls.GetAnomalyConfig(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 14, got.LookbackDays)
+	assert.Equal(t, "bob", got.UpdatedBy)
+}
+
+// TestGetAnomalyConfig_ReturnsUpdatedValues verifies that after saving, the
+// next Get reflects the new values (not the old defaults).
+func TestGetAnomalyConfig_ReturnsUpdatedValues(t *testing.T) {
+	ctx := context.Background()
+	ls := newAnomalyConfigTestStore(t)
+
+	// First Get returns defaults.
+	def, err := ls.GetAnomalyConfig(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 7, def.LookbackDays)
+
+	// Save a non-default value.
+	require.NoError(t, ls.SaveAnomalyConfig(ctx, &models.AnomalyConfigRecord{LookbackDays: 30}))
+
+	// Next Get reflects the persisted value, not the hard-coded default.
+	got, err := ls.GetAnomalyConfig(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 30, got.LookbackDays)
+}

--- a/internal/storage/store/remote_anomaly_config.go
+++ b/internal/storage/store/remote_anomaly_config.go
@@ -1,0 +1,19 @@
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// GetAnomalyConfig is not supported on RemoteStorage; anomaly config is managed
+// server-side via the /api/v1/admin/anomaly-config REST endpoint.
+func (rs *RemoteStorage) GetAnomalyConfig(_ context.Context) (*models.AnomalyConfigRecord, error) {
+	return nil, remoteUnsupported("GetAnomalyConfig")
+}
+
+// SaveAnomalyConfig is not supported on RemoteStorage; anomaly config is managed
+// server-side via the /api/v1/admin/anomaly-config REST endpoint.
+func (rs *RemoteStorage) SaveAnomalyConfig(_ context.Context, _ *models.AnomalyConfigRecord) error {
+	return remoteUnsupported("SaveAnomalyConfig")
+}

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -180,6 +180,12 @@ var remoteUnsupportedAllowlist = map[string]remoteUnsupportedEntry{
 	"GetSecretAncestors":       {statusIntentional, "RBAC Phase 3 — folder-ACL inheritance walk runs server-side; HasSecretACL uses ErrUnsupportedByBackend to skip the ancestor walk on remote callers"},
 
 	"GetProjectUsageStats": {statusIntentional, "usage report queries run server-side; a future PR may add a /api/v1/system/usage proxy route"},
+
+	// Anomaly config — server-side singleton; a remote-storage caller manages the
+	// config via the REST endpoint (GET/PUT /api/v1/admin/anomaly-config), so the
+	// storage layer itself is never reached through a remote hop.
+	"GetAnomalyConfig":  {statusIntentional, "anomaly config is managed via /api/v1/admin/anomaly-config; raw storage call never reached from a remote-storage caller"},
+	"SaveAnomalyConfig": {statusIntentional, "anomaly config is managed via /api/v1/admin/anomaly-config; raw storage call never reached from a remote-storage caller"},
 }
 
 // remoteUnsupportedCallRe matches the exact, 100%-consistent call pattern every

--- a/server/http/handlers/anomaly_config.go
+++ b/server/http/handlers/anomaly_config.go
@@ -1,0 +1,59 @@
+// anomaly_config.go — GET/PUT /api/v1/admin/anomaly-config
+//
+// Allows operators to read and update the runtime anomaly detection
+// configuration (lookback window, quarantine, off-hours, ML parameters)
+// without restarting the server.  Changes are persisted to the DB and picked
+// up by the anomaly detection scheduler on its next pass.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// GetAnomalyConfig handles GET /api/v1/admin/anomaly-config.
+// Returns the current persisted anomaly detection configuration (or defaults).
+func GetAnomalyConfig(w http.ResponseWriter, r *http.Request) {
+	coreService := middleware.GetCoreServiceFromContext(r.Context())
+	if coreService == nil {
+		sendError(w, "InternalError", "Core service not available", http.StatusInternalServerError, nil)
+		return
+	}
+	cfg, err := coreService.GetAnomalyConfig(r.Context())
+	if err != nil {
+		sendError(w, "InternalError", "Failed to retrieve anomaly config", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"config": cfg}, "")
+}
+
+// UpdateAnomalyConfig handles PUT /api/v1/admin/anomaly-config.
+// Replaces the current anomaly detection configuration; the detection scheduler
+// will pick up the change on its next pass without a restart.
+func UpdateAnomalyConfig(w http.ResponseWriter, r *http.Request) {
+	coreService := middleware.GetCoreServiceFromContext(r.Context())
+	if coreService == nil {
+		sendError(w, "InternalError", "Core service not available", http.StatusInternalServerError, nil)
+		return
+	}
+
+	var cfg models.AnomalyConfigRecord
+	if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+
+	var updatedBy string
+	if u := middleware.GetUserFromContext(r.Context()); u != nil {
+		updatedBy = u.Username
+	}
+
+	if err := coreService.UpdateAnomalyConfig(r.Context(), &cfg, updatedBy); err != nil {
+		sendError(w, "InternalError", "Failed to save anomaly config", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"config": cfg}, "")
+}

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -145,6 +145,9 @@ func newTestCore(t *testing.T) *core.KeyorixCore {
 		// SecretACL (RBAC Phase 3): ListSecretsWithSharingInfo now calls
 		// ListSecretACLsByUser on every listing, so the table must exist.
 		&models.SecretACL{},
+		// AnomalyConfigRecord backs GET/PUT /api/v1/admin/anomaly-config — the
+		// runtime-tunable anomaly detection configuration.
+		&models.AnomalyConfigRecord{},
 	)
 	require.NoError(t, err)
 	// Mirror internal/storage/factory.go's ensureProjectMembershipIndex exactly (the

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1772,6 +1772,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Post("/expiry-reminders", adminJobsHandler.RunExpiryReminders)
 			r.Post("/compliance-digest", adminJobsHandler.RunComplianceDigest)
 		})
+
+		// Runtime anomaly detection configuration — read/write the DB-persisted
+		// detection thresholds without restarting the server.
+		r.Route("/admin/anomaly-config", func(r chi.Router) {
+			r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/", handlers.GetAnomalyConfig)
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/", handlers.UpdateAnomalyConfig)
+		})
 	})
 
 	// Swagger UI and the raw OpenAPI spec (optional, based on config). #224: the

--- a/server/main.go
+++ b/server/main.go
@@ -882,11 +882,25 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error { // NOSONAR
 		// leave the time between passes unexamined (floored at 1h inside SetLookback).
 		detector.SetLookback(interval)
 		detector.SetBaselineQuarantine(cfg.AnomalyAlerts.GetBaselineQuarantine())
+		// Overlay the DB-persisted anomaly config on top of the file-based defaults.
+		// Best-effort at startup: a storage error keeps the file-based settings rather
+		// than aborting startup or leaving the detector unconfigured.
+		if err := coreService.ApplyAnomalyConfig(ctx, detector); err != nil {
+			log.Printf("Anomaly: could not load persisted config (%v); using file-based defaults", err)
+		} else {
+			log.Printf("Anomaly: persisted runtime config applied")
+		}
 		if alertsEnabled {
 			log.Printf("Anomaly alerting enabled: scan + alert every %s", interval)
 		}
 		runScheduler(ctx, "anomaly_detection", interval, func() middleware.SchedulerOutcome {
 			return lockedRun(ctx, coreService.Storage(), schedLockAnomaly, "Anomaly detection", func() error {
+				// Hotload: re-apply the persisted config before each pass so an operator's
+				// runtime change takes effect without a restart. Best-effort: a transient
+				// storage failure here is logged but does not skip the detection pass.
+				if err := coreService.ApplyAnomalyConfig(ctx, detector); err != nil {
+					log.Printf("Anomaly: failed to reload persisted config (%v); running with prior settings", err)
+				}
 				if derr := detector.RunDetection(ctx, coreService.ListActiveSecrets(ctx)); derr != nil {
 					return derr
 				}


### PR DESCRIPTION
AnomalyConfigRecord singleton + GET/PUT /api/v1/admin/anomaly-config + keyorix anomaly config get/set. Hotloads before each scan tick.