### PR TITLE
feat(secret): encrypted export/import — RSA-OAEP+AES-256-GCM for airgap transfer

### DIFF
--- a/internal/cli/secret/export.go
+++ b/internal/cli/secret/export.go
@@ -16,10 +16,11 @@ import (
 )
 
 var (
-	exportFormat  string
-	exportOutput  string
-	exportEnv     string
-	exportProject string
+	exportFormat     string
+	exportOutput     string
+	exportEnv        string
+	exportProject    string
+	exportEncryptFor string
 )
 
 // createExportFile opens path for a fresh plaintext-secrets export. O_EXCL
@@ -37,17 +38,24 @@ func createExportFile(path string) (*os.File, error) {
 var exportCmd = &cobra.Command{
 	Use:   "export",
 	Short: "Export secrets to a file or stdout",
-	Long: `Export secrets from Keyorix to dotenv, JSON, or Vault YAML format.
+	Long: `Export secrets from Keyorix to dotenv, JSON, Vault YAML, or encrypted-json format.
 
 Examples:
   keyorix secret export --env production --format dotenv
   keyorix secret export --env production --format json --output secrets.json
   keyorix secret export --env staging --format vault --output vault-export.yaml
+  keyorix secret export --env production --format encrypted-json --encrypt-for recipient.pub.pem --output secrets.enc.json
+  keyorix secret export --env production --encrypt-for recipient.pub.pem --output secrets.enc.json
 
 Supported formats:
-  dotenv  .env files (KEY=VALUE)
-  json    Flat key-value JSON object
-  vault   Medusa/Vault YAML (importable back via 'keyorix secret import --format vault')
+  dotenv         .env files (KEY=VALUE)
+  json           Flat key-value JSON object
+  vault          Medusa/Vault YAML (importable back via 'keyorix secret import --format vault')
+  encrypted-json RSA-OAEP-SHA256 + AES-256-GCM encrypted envelope (safe for airgap transfer)
+
+The encrypted-json format wraps the standard JSON export in a hybrid encryption
+envelope. Provide the recipient's RSA public key via --encrypt-for. Decrypt and
+import with: keyorix secret import --file secrets.enc.json --decrypt-with private.pem
 
 Output goes to stdout unless --output is specified.
 Warnings and summary are always printed to stderr.`,
@@ -55,10 +63,11 @@ Warnings and summary are always printed to stderr.`,
 }
 
 func init() {
-	exportCmd.Flags().StringVar(&exportFormat, "format", "dotenv", "Output format: dotenv, json, vault")
+	exportCmd.Flags().StringVar(&exportFormat, "format", "dotenv", "Output format: dotenv, json, vault, encrypted-json")
 	exportCmd.Flags().StringVar(&exportOutput, "output", "", "Output file path (default: stdout)")
 	exportCmd.Flags().StringVar(&exportEnv, "env", "development", "Environment name (e.g. production)")
 	exportCmd.Flags().StringVar(&exportProject, "project", "default", "Project name")
+	exportCmd.Flags().StringVar(&exportEncryptFor, "encrypt-for", "", "Path to RSA public key PEM (switches format to encrypted-json)")
 }
 
 // exportedSecret holds a secret's name and decrypted value.
@@ -101,6 +110,13 @@ func runExport(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 
+	// If --encrypt-for is set and format was not explicitly chosen as
+	// encrypted-json, auto-switch and inform the operator.
+	if exportEncryptFor != "" && strings.ToLower(exportFormat) != "encrypted-json" {
+		fmt.Fprintf(os.Stderr, "NOTE: --encrypt-for is set; switching format to encrypted-json.\n")
+		exportFormat = "encrypted-json"
+	}
+
 	var out io.Writer = os.Stdout
 	if exportOutput != "" {
 		f, err := createExportFile(exportOutput)
@@ -115,7 +131,9 @@ func runExport(cmd *cobra.Command, args []string) (retErr error) {
 		out = f
 	}
 
-	fmt.Fprintln(os.Stderr, "WARNING: exported secrets are in plaintext. Handle with care.")
+	if strings.ToLower(exportFormat) != "encrypted-json" {
+		fmt.Fprintln(os.Stderr, "WARNING: exported secrets are in plaintext. Handle with care.")
+	}
 
 	switch strings.ToLower(exportFormat) {
 	case "dotenv", "env":
@@ -124,8 +142,13 @@ func runExport(cmd *cobra.Command, args []string) (retErr error) {
 		err = writeExportJSON(out, fetched)
 	case "vault":
 		err = writeVault(out, fetched, exportEnv)
+	case "encrypted-json":
+		if exportEncryptFor == "" {
+			return fmt.Errorf("--encrypt-for <pubkey.pem> is required for the encrypted-json format")
+		}
+		err = writeEncryptedJSON(out, fetched, exportEncryptFor)
 	default:
-		return fmt.Errorf("unknown format %q (supported: dotenv, json, vault)", exportFormat)
+		return fmt.Errorf("unknown format %q (supported: dotenv, json, vault, encrypted-json)", exportFormat)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to write output: %w", err)
@@ -209,6 +232,21 @@ func writeExportJSON(w io.Writer, secrets []exportedSecret) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(m)
+}
+
+// writeEncryptedJSON produces the RSA-OAEP + AES-256-GCM envelope JSON on w.
+func writeEncryptedJSON(w io.Writer, secrets []exportedSecret, pubKeyPath string) error {
+	// Reuse the existing JSON serialisation logic via a bytes buffer.
+	var buf strings.Builder
+	if err := writeExportJSON(&buf, secrets); err != nil {
+		return err
+	}
+	envelope, err := encryptExport([]byte(buf.String()), pubKeyPath)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(envelope)
+	return err
 }
 
 func writeVault(w io.Writer, secrets []exportedSecret, envName string) error {

--- a/internal/cli/secret/export_encrypt.go
+++ b/internal/cli/secret/export_encrypt.go
@@ -1,0 +1,159 @@
+package secret
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+)
+
+// encryptedExportEnvelope is the JSON shape of an encrypted export file.
+type encryptedExportEnvelope struct {
+	Format       string `json:"format"`
+	Algorithm    string `json:"algorithm"`
+	EncryptedKey string `json:"encrypted_key"` // base64(RSA-OAEP-SHA256(aesKey))
+	Nonce        string `json:"nonce"`          // base64(12-byte nonce)
+	Ciphertext   string `json:"ciphertext"`     // base64(AES-256-GCM(payload))
+}
+
+const (
+	encryptedExportFormat    = "keyorix-encrypted-export-v1"
+	encryptedExportAlgorithm = "RSA-OAEP-SHA256+AES-256-GCM"
+)
+
+// encryptExport encrypts plainJSON bytes with the RSA public key at pubKeyPath.
+// Returns the JSON-encoded encryptedExportEnvelope bytes.
+func encryptExport(plainJSON []byte, pubKeyPath string) ([]byte, error) {
+	// 1. Load PEM public key
+	pemBytes, err := os.ReadFile(pubKeyPath) // #nosec G304 — operator-supplied CLI path
+	if err != nil {
+		return nil, fmt.Errorf("read public key %q: %w", pubKeyPath, err)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in %q", pubKeyPath)
+	}
+
+	// Try PKCS1 first, then PKIX (SubjectPublicKeyInfo).
+	pub, err := x509.ParsePKCS1PublicKey(block.Bytes)
+	if err != nil {
+		key, err2 := x509.ParsePKIXPublicKey(block.Bytes)
+		if err2 != nil {
+			return nil, fmt.Errorf("cannot parse public key (tried PKCS1: %v; PKIX: %v)", err, err2)
+		}
+		rsaKey, ok := key.(*rsa.PublicKey)
+		if !ok {
+			return nil, fmt.Errorf("public key in %q is not an RSA key", pubKeyPath)
+		}
+		pub = rsaKey
+	}
+
+	// 2. Generate random 32-byte AES key.
+	aesKey := make([]byte, 32)
+	if _, err := rand.Read(aesKey); err != nil {
+		return nil, fmt.Errorf("generate AES key: %w", err)
+	}
+
+	// 3. RSA-OAEP-SHA256 encrypt the AES key.
+	encKey, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, pub, aesKey, nil)
+	if err != nil {
+		return nil, fmt.Errorf("RSA-OAEP encrypt AES key: %w", err)
+	}
+
+	// 4. AES-256-GCM encrypt the payload.
+	block2, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, fmt.Errorf("create AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block2)
+	if err != nil {
+		return nil, fmt.Errorf("create GCM: %w", err)
+	}
+	nonce := make([]byte, gcm.NonceSize()) // 12 bytes
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+	ciphertext := gcm.Seal(nil, nonce, plainJSON, nil)
+
+	// 5. Build envelope.
+	env := encryptedExportEnvelope{
+		Format:       encryptedExportFormat,
+		Algorithm:    encryptedExportAlgorithm,
+		EncryptedKey: base64.StdEncoding.EncodeToString(encKey),
+		Nonce:        base64.StdEncoding.EncodeToString(nonce),
+		Ciphertext:   base64.StdEncoding.EncodeToString(ciphertext),
+	}
+	return json.MarshalIndent(env, "", "  ")
+}
+
+// decryptExport reverses encryptExport, returning the plaintext JSON bytes.
+func decryptExport(envelopeBytes []byte, privKeyPath string) ([]byte, error) {
+	var env encryptedExportEnvelope
+	if err := json.Unmarshal(envelopeBytes, &env); err != nil {
+		return nil, fmt.Errorf("parse encrypted envelope: %w", err)
+	}
+	if env.Format != encryptedExportFormat {
+		return nil, fmt.Errorf("unexpected envelope format %q (want %q)", env.Format, encryptedExportFormat)
+	}
+
+	// Load private key (try PKCS1 then PKCS8).
+	pemBytes, err := os.ReadFile(privKeyPath) // #nosec G304 — operator-supplied CLI path
+	if err != nil {
+		return nil, fmt.Errorf("read private key %q: %w", privKeyPath, err)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in %q", privKeyPath)
+	}
+	priv, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		key, err2 := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err2 != nil {
+			return nil, fmt.Errorf("cannot parse private key (tried PKCS1: %v; PKCS8: %v)", err, err2)
+		}
+		rsaKey, ok := key.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("private key in %q is not an RSA key", privKeyPath)
+		}
+		priv = rsaKey
+	}
+
+	encKey, err := base64.StdEncoding.DecodeString(env.EncryptedKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode encrypted_key: %w", err)
+	}
+	nonce, err := base64.StdEncoding.DecodeString(env.Nonce)
+	if err != nil {
+		return nil, fmt.Errorf("decode nonce: %w", err)
+	}
+	ciphertextBytes, err := base64.StdEncoding.DecodeString(env.Ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("decode ciphertext: %w", err)
+	}
+
+	aesKey, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, priv, encKey, nil)
+	if err != nil {
+		return nil, fmt.Errorf("RSA-OAEP decrypt AES key: %w", err)
+	}
+
+	block2, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, fmt.Errorf("create AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block2)
+	if err != nil {
+		return nil, fmt.Errorf("create GCM: %w", err)
+	}
+	plain, err := gcm.Open(nil, nonce, ciphertextBytes, nil)
+	if err != nil {
+		return nil, fmt.Errorf("AES-GCM decrypt: %w", err)
+	}
+	return plain, nil
+}

--- a/internal/cli/secret/export_encrypt_test.go
+++ b/internal/cli/secret/export_encrypt_test.go
@@ -1,0 +1,241 @@
+package secret
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// generateTestKeyPair returns a fresh 2048-bit RSA key pair.
+func generateTestKeyPair(t *testing.T) (*rsa.PrivateKey, *rsa.PublicKey) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	return priv, &priv.PublicKey
+}
+
+// writePKCS1PubKey writes an RSA public key in PKCS1 PEM format to a temp file
+// and returns its path.
+func writePKCS1PubKey(t *testing.T, pub *rsa.PublicKey) string {
+	t.Helper()
+	der := x509.MarshalPKCS1PublicKey(pub)
+	block := &pem.Block{Type: "RSA PUBLIC KEY", Bytes: der}
+	path := filepath.Join(t.TempDir(), "pub.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("write pub key: %v", err)
+	}
+	return path
+}
+
+// writePKIXPubKey writes an RSA public key in PKIX (SubjectPublicKeyInfo) PEM
+// format to a temp file and returns its path.
+func writePKIXPubKey(t *testing.T, pub *rsa.PublicKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey: %v", err)
+	}
+	block := &pem.Block{Type: "PUBLIC KEY", Bytes: der}
+	path := filepath.Join(t.TempDir(), "pub_pkix.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("write pkix pub key: %v", err)
+	}
+	return path
+}
+
+// writePKCS1PrivKey writes an RSA private key in PKCS1 PEM format to a temp
+// file and returns its path.
+func writePKCS1PrivKey(t *testing.T, priv *rsa.PrivateKey) string {
+	t.Helper()
+	der := x509.MarshalPKCS1PrivateKey(priv)
+	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}
+	path := filepath.Join(t.TempDir(), "priv.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("write priv key: %v", err)
+	}
+	return path
+}
+
+// writePKCS8PrivKey writes an RSA private key in PKCS8 PEM format to a temp
+// file and returns its path.
+func writePKCS8PrivKey(t *testing.T, priv *rsa.PrivateKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	block := &pem.Block{Type: "PRIVATE KEY", Bytes: der}
+	path := filepath.Join(t.TempDir(), "priv_pkcs8.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("write pkcs8 priv key: %v", err)
+	}
+	return path
+}
+
+// TestEncryptDecryptRoundTrip verifies that a message encrypted with a public
+// key can be decrypted with the corresponding private key.
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	plaintext := []byte(`{"DB_PASSWORD":"supersecret","API_KEY":"sk_live_abc123"}`)
+
+	envelope, err := encryptExport(plaintext, pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	got, err := decryptExport(envelope, privPath)
+	if err != nil {
+		t.Fatalf("decryptExport: %v", err)
+	}
+
+	if string(got) != string(plaintext) {
+		t.Errorf("round-trip mismatch:\n  want: %s\n  got:  %s", plaintext, got)
+	}
+}
+
+// TestEncryptExport_WrongKey verifies that decryption with a different private
+// key fails.
+func TestEncryptExport_WrongKey(t *testing.T) {
+	_, pub := generateTestKeyPair(t)
+	wrongPriv, _ := generateTestKeyPair(t)
+
+	pubPath := writePKCS1PubKey(t, pub)
+	wrongPrivPath := writePKCS1PrivKey(t, wrongPriv)
+
+	envelope, err := encryptExport([]byte(`{"KEY":"value"}`), pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	_, err = decryptExport(envelope, wrongPrivPath)
+	if err == nil {
+		t.Fatal("expected error when decrypting with wrong private key, got nil")
+	}
+}
+
+// TestEncryptExport_TamperedCiphertext verifies that GCM authentication catches
+// a tampered ciphertext.
+func TestEncryptExport_TamperedCiphertext(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	envelope, err := encryptExport([]byte(`{"KEY":"value"}`), pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	// Parse the envelope, flip a byte in Ciphertext, re-encode.
+	var env encryptedExportEnvelope
+	if err := json.Unmarshal(envelope, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	// Corrupt the last base64 character if it's not a padding '='.
+	ct := []byte(env.Ciphertext)
+	for i := len(ct) - 1; i >= 0; i-- {
+		if ct[i] != '=' {
+			ct[i] ^= 0xff
+			break
+		}
+	}
+	env.Ciphertext = string(ct)
+	tampered, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal tampered envelope: %v", err)
+	}
+
+	_, err = decryptExport(tampered, privPath)
+	if err == nil {
+		t.Fatal("expected GCM authentication error for tampered ciphertext, got nil")
+	}
+}
+
+// TestDecryptExport_PKCS8Key verifies that a PKCS8-encoded private key works.
+func TestDecryptExport_PKCS8Key(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	privPath := writePKCS8PrivKey(t, priv)
+
+	plaintext := []byte(`{"SECRET":"pkcs8-works"}`)
+
+	envelope, err := encryptExport(plaintext, pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	got, err := decryptExport(envelope, privPath)
+	if err != nil {
+		t.Fatalf("decryptExport with PKCS8 key: %v", err)
+	}
+
+	if string(got) != string(plaintext) {
+		t.Errorf("PKCS8 round-trip mismatch:\n  want: %s\n  got:  %s", plaintext, got)
+	}
+}
+
+// TestDecryptExport_PKIXPublicKey verifies that a PKIX (SubjectPublicKeyInfo)
+// encoded public key works for encryption.
+func TestDecryptExport_PKIXPublicKey(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKIXPubKey(t, pub)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	plaintext := []byte(`{"SECRET":"pkix-pub-works"}`)
+
+	envelope, err := encryptExport(plaintext, pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport with PKIX public key: %v", err)
+	}
+
+	got, err := decryptExport(envelope, privPath)
+	if err != nil {
+		t.Fatalf("decryptExport: %v", err)
+	}
+
+	if string(got) != string(plaintext) {
+		t.Errorf("PKIX round-trip mismatch:\n  want: %s\n  got:  %s", plaintext, got)
+	}
+}
+
+// TestEncryptedExportFormat verifies that the envelope JSON has the expected
+// top-level fields and correct constant values.
+func TestEncryptedExportFormat(t *testing.T) {
+	_, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+
+	envelopeBytes, err := encryptExport([]byte(`{"KEY":"val"}`), pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	var env encryptedExportEnvelope
+	if err := json.Unmarshal(envelopeBytes, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+
+	if env.Format != encryptedExportFormat {
+		t.Errorf("Format = %q, want %q", env.Format, encryptedExportFormat)
+	}
+	if env.Algorithm != encryptedExportAlgorithm {
+		t.Errorf("Algorithm = %q, want %q", env.Algorithm, encryptedExportAlgorithm)
+	}
+	if env.EncryptedKey == "" {
+		t.Error("EncryptedKey is empty")
+	}
+	if env.Nonce == "" {
+		t.Error("Nonce is empty")
+	}
+	if env.Ciphertext == "" {
+		t.Error("Ciphertext is empty")
+	}
+}

--- a/internal/cli/secret/import.go
+++ b/internal/cli/secret/import.go
@@ -4,6 +4,7 @@
 package secret
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -23,6 +24,7 @@ var (
 	importProject      string
 	importDryRun       bool
 	importSkipExisting bool
+	importDecryptWith  string
 )
 
 var importCmd = &cobra.Command{
@@ -35,6 +37,7 @@ File mode (--file):
   keyorix secret import --file vault-export.yaml --format vault --env production
   keyorix secret import --file secrets.json --format json --env staging
   keyorix secret import --file .env --format dotenv --env development --dry-run
+  keyorix secret import --file secrets.enc.json --decrypt-with private.pem --env production
 
 Live-source mode (--source) — reads directly from a running provider using your
 local credentials and never sends them to the Keyorix server:
@@ -47,6 +50,12 @@ Supported file formats (--format):
   dotenv  .env files (KEY=VALUE, comments and blank lines ignored)
   vault   Medusa/Vault YAML export (path hierarchy, last two segments become name)
   json    Flat key-value JSON object
+
+Encrypted imports (--decrypt-with):
+  When the file is a keyorix-encrypted-export-v1 envelope (produced by
+  'keyorix secret export --format encrypted-json'), pass the RSA private key
+  with --decrypt-with. The file is decrypted transparently and then imported
+  as a standard JSON payload.
 
 Live sources (--source):
   vault   HashiCorp Vault KV engine (VAULT_ADDR / VAULT_TOKEN or --vault-* flags)
@@ -66,6 +75,7 @@ func init() {
 	importCmd.Flags().StringVar(&importProject, "project", "default", "Project name")
 	importCmd.Flags().BoolVar(&importDryRun, "dry-run", false, "Show what would be imported without creating anything")
 	importCmd.Flags().BoolVar(&importSkipExisting, "skip-existing", true, "Skip secrets that already exist instead of failing")
+	importCmd.Flags().StringVar(&importDecryptWith, "decrypt-with", "", "Path to RSA private key PEM to decrypt an encrypted-json export")
 
 	// Live-source flags (mutually exclusive with --file).
 	importCmd.Flags().StringVar(&importSource, "source", "", "Live source: vault, aws, azure, gcp (instead of --file)")
@@ -171,6 +181,20 @@ func collectEntries(ctx context.Context) ([]secretEntry, error) {
 		clean := filepath.Clean(importFile)
 		if _, err := os.Stat(clean); err != nil {
 			return nil, fmt.Errorf("cannot open file %q: %w", importFile, err)
+		}
+		// Detect encrypted-json envelope and decrypt transparently.
+		if importDecryptWith != "" {
+			fileBytes, err := os.ReadFile(clean) // #nosec G304 — path already cleaned
+			if err != nil {
+				return nil, fmt.Errorf("read file %q: %w", clean, err)
+			}
+			if bytes.HasPrefix(bytes.TrimSpace(fileBytes), []byte(`{"format":"`+encryptedExportFormat)) {
+				plain, err := decryptExport(fileBytes, importDecryptWith)
+				if err != nil {
+					return nil, fmt.Errorf("decrypt %q: %w", clean, err)
+				}
+				return parseJSONBytes(plain)
+			}
 		}
 		entries, err := parseFile(clean, importFormat)
 		if err != nil {

--- a/internal/cli/secret/import_parsers.go
+++ b/internal/cli/secret/import_parsers.go
@@ -107,6 +107,30 @@ func parseFile(path, format string) ([]secretEntry, error) {
 	}
 }
 
+// parseJSONBytes parses a flat key-value JSON object from already-read bytes.
+// This is used by the encrypted-json import path where the bytes have already
+// been decrypted in memory; the file-size limit is enforced before decryption.
+func parseJSONBytes(data []byte) ([]secretEntry, error) {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	var entries []secretEntry
+	for k, v := range raw {
+		val := fmt.Sprintf("%v", v)
+		if k == "" || val == "" {
+			continue
+		}
+		entry := secretEntry{Name: k, Value: val}
+		if err := validateImportedEntry(entry); err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
 // parseDotenv reads a standard .env file.
 // Rules:
 //   - Lines starting with # are comments — skipped.


### PR DESCRIPTION
Adds --encrypt-for <pubkey.pem> to keyorix secret export and --decrypt-with <privkey.pem> to import. Stdlib only, self-describing JSON envelope.