### PR TITLE
feat(secret): health score CLI + project health summary endpoint

### DIFF
--- a/internal/cli/project/health.go
+++ b/internal/cli/project/health.go
@@ -1,0 +1,229 @@
+// health.go — keyorix project health <name>
+//
+// Shows a health summary for a project: total secrets, band counts, and a
+// ranked table of the highest-risk secrets.
+package project
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	healthLimit  int
+	healthFormat string
+)
+
+var healthCmd = &cobra.Command{
+	Use:   "health <name>",
+	Short: "Show the secret health summary for a project",
+	Long: `Print a ranked list of the highest-risk secrets in a project together with
+overall band counts (HIGH / MEDIUM / LOW).
+
+In remote mode the project name is resolved to an ID via the list endpoint, then
+GET /api/v1/projects/{id}/health is called.
+
+Examples:
+  keyorix project health my-project
+  keyorix project health my-project --limit 10
+  keyorix project health my-project --format json`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE:         runHealth,
+}
+
+func init() {
+	healthCmd.Flags().IntVar(&healthLimit, "limit", 20, "Maximum number of secrets to display (1-100)")
+	healthCmd.Flags().StringVar(&healthFormat, "format", "table", "Output format (table, json)")
+	ProjectCmd.AddCommand(healthCmd)
+}
+
+// ── Wire types (remote API response shape) ────────────────────────────────
+
+type healthRiskFactor struct {
+	Key    string  `json:"key"`
+	Label  string  `json:"label"`
+	Score  int     `json:"score"`
+	Weight float64 `json:"weight"`
+	Detail string  `json:"detail"`
+}
+
+type healthSecretScore struct {
+	SecretID   uint               `json:"secret_id"`
+	SecretName string             `json:"secret_name"`
+	Score      int                `json:"score"`
+	Band       string             `json:"band"`
+	Factors    []healthRiskFactor `json:"factors"`
+}
+
+type healthSummary struct {
+	ProjectID       uint                `json:"project_id"`
+	TotalSecrets    int                 `json:"total_secrets"`
+	HighRiskCount   int                 `json:"high_risk_count"`
+	MediumRiskCount int                 `json:"medium_risk_count"`
+	LowRiskCount    int                 `json:"low_risk_count"`
+	TopRiskSecrets  []healthSecretScore `json:"secrets"`
+}
+
+// ── Command runner ─────────────────────────────────────────────────────────
+
+func runHealth(_ *cobra.Command, args []string) error {
+	name := args[0]
+	ctx := context.Background()
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runHealthRemote(ctx, rc, name)
+	}
+	return runHealthEmbedded(ctx, name)
+}
+
+// ── Remote mode ────────────────────────────────────────────────────────────
+
+func runHealthRemote(ctx context.Context, rc *common.RemoteClient, name string) error {
+	// Resolve project name → ID.
+	var listResp struct {
+		Projects []struct {
+			ID   uint   `json:"id"`
+			Name string `json:"name"`
+		} `json:"projects"`
+	}
+	if err := rc.Get(ctx, "/api/v1/projects", &listResp); err != nil {
+		return fmt.Errorf("failed to list projects: %w", err)
+	}
+	var projectID uint
+	for _, p := range listResp.Projects {
+		if strings.EqualFold(p.Name, name) {
+			projectID = p.ID
+			break
+		}
+	}
+	if projectID == 0 {
+		return fmt.Errorf("project %q not found", name)
+	}
+
+	path := "/api/v1/projects/" + strconv.Itoa(int(projectID)) + "/health"
+	if healthLimit != 20 {
+		path += fmt.Sprintf("?limit=%d", healthLimit)
+	}
+
+	var summary healthSummary
+	if err := rc.Get(ctx, path, &summary); err != nil {
+		return fmt.Errorf("failed to get project health: %w", err)
+	}
+
+	return printHealth(name, &summary)
+}
+
+// ── Embedded mode ──────────────────────────────────────────────────────────
+
+func runHealthEmbedded(ctx context.Context, name string) error {
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+
+	projectID, err := common.LookupProjectIDByName(ctx, svc.Storage(), name)
+	if err != nil {
+		return err
+	}
+
+	result, err := svc.GetProjectHealthSummary(ctx, projectID, healthLimit)
+	if err != nil {
+		return fmt.Errorf("failed to compute project health: %w", err)
+	}
+
+	// Convert core types to display shape.
+	secrets := make([]healthSecretScore, len(result.TopRiskSecrets))
+	for i, rs := range result.TopRiskSecrets {
+		factors := make([]healthRiskFactor, len(rs.Factors))
+		for j, f := range rs.Factors {
+			factors[j] = healthRiskFactor{
+				Key: f.Key, Label: f.Label, Score: f.Score, Weight: f.Weight, Detail: f.Detail,
+			}
+		}
+		secrets[i] = healthSecretScore{
+			SecretID:   rs.SecretID,
+			SecretName: rs.SecretName,
+			Score:      rs.Score,
+			Band:       rs.Band,
+			Factors:    factors,
+		}
+	}
+
+	summary := &healthSummary{
+		ProjectID:       result.ProjectID,
+		TotalSecrets:    result.TotalSecrets,
+		HighRiskCount:   result.HighRiskCount,
+		MediumRiskCount: result.MediumRiskCount,
+		LowRiskCount:    result.LowRiskCount,
+		TopRiskSecrets:  secrets,
+	}
+	return printHealth(name, summary)
+}
+
+// ── Display ────────────────────────────────────────────────────────────────
+
+func printHealth(projectName string, s *healthSummary) error {
+	switch healthFormat {
+	case "json":
+		return printHealthJSON(s)
+	case "table":
+		printHealthTable(projectName, s)
+		return nil
+	default:
+		return fmt.Errorf("unsupported format: %s (use 'table' or 'json')", healthFormat)
+	}
+}
+
+func printHealthJSON(s *healthSummary) error {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("failed to marshal health summary: %w", err)
+	}
+	fmt.Println(string(b))
+	return nil
+}
+
+func printHealthTable(projectName string, s *healthSummary) {
+	fmt.Printf("Project: %s  (%d secrets: %d HIGH · %d MEDIUM · %d LOW)\n\n",
+		projectName, s.TotalSecrets, s.HighRiskCount, s.MediumRiskCount, s.LowRiskCount)
+
+	if len(s.TopRiskSecrets) == 0 {
+		fmt.Println("No secrets found.")
+		return
+	}
+
+	fmt.Printf("%-30s  %5s  %-8s  %s\n", "SECRET NAME", "SCORE", "BAND", "TOP FACTOR")
+	fmt.Printf("%-30s  %5s  %-8s  %s\n",
+		strings.Repeat("-", 30), "-----", "--------", strings.Repeat("-", 30))
+
+	for _, rs := range s.TopRiskSecrets {
+		topFactor := topFactorDetail(rs.Factors)
+		name := rs.SecretName
+		if len(name) > 30 {
+			name = name[:27] + "..."
+		}
+		fmt.Printf("%-30s  %5d  %-8s  %s\n",
+			name, rs.Score, strings.ToUpper(rs.Band), topFactor)
+	}
+}
+
+// topFactorDetail returns the Detail of the highest-scoring factor.
+func topFactorDetail(factors []healthRiskFactor) string {
+	if len(factors) == 0 {
+		return ""
+	}
+	best := factors[0]
+	for _, f := range factors[1:] {
+		if f.Score > best.Score {
+			best = f
+		}
+	}
+	return best.Detail
+}

--- a/internal/cli/project/health_test.go
+++ b/internal/cli/project/health_test.go
@@ -1,0 +1,115 @@
+package project
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupHealthRemote creates a mock HTTP server backed by handler, sets the
+// KEYORIX_* env vars so common.NewRemoteClient returns true, and returns the
+// client plus a cleanup function.
+func setupHealthRemote(t *testing.T, handler http.HandlerFunc) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	t.Setenv("KEYORIX_PROJECT", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() {
+		healthLimit = 20
+		healthFormat = "table"
+	})
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+// captureHealthStdout captures os.Stdout output from fn.
+func captureHealthStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	fn()
+	require.NoError(t, w.Close())
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+// projectsAndHealthHandler serves /api/v1/projects and /api/v1/projects/1/health
+// in the real sendSuccess envelope shape.
+func projectsAndHealthHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/api/v1/projects":
+		_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web","description":"the web project"}]}}`))
+	case "/api/v1/projects/1/health":
+		_, _ = w.Write([]byte(`{"success":true,"data":{` +
+			`"project_id":1,` +
+			`"total_secrets":42,` +
+			`"high_risk_count":3,` +
+			`"medium_risk_count":11,` +
+			`"low_risk_count":28,` +
+			`"secrets":[` +
+			`{"secret_id":5,"secret_name":"prod-db-password","score":91,"band":"high","factors":[{"key":"rotation","label":"Rotation age","score":100,"weight":0.3,"detail":"not rotated in 180 days"}]},` +
+			`{"secret_id":8,"secret_name":"api-key-external","score":72,"band":"high","factors":[{"key":"exposure","label":"Exposure","score":90,"weight":0.2,"detail":"shared with 6 principals"}]},` +
+			`{"secret_id":3,"secret_name":"stripe-webhook","score":68,"band":"medium","factors":[{"key":"expiry","label":"Expiry","score":40,"weight":0.3,"detail":"no expiry set"}]}` +
+			`]}}`))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func TestProjectHealth_Remote_TableFormat(t *testing.T) {
+	rc, done := setupHealthRemote(t, projectsAndHealthHandler)
+	defer done()
+
+	healthFormat = "table"
+	out := captureHealthStdout(t, func() {
+		require.NoError(t, runHealthRemote(t.Context(), rc, "web"))
+	})
+
+	// Header line with project and counts.
+	assert.Contains(t, out, "web")
+	assert.Contains(t, out, "42 secrets")
+	assert.Contains(t, out, "3 HIGH")
+	assert.Contains(t, out, "11 MEDIUM")
+	assert.Contains(t, out, "28 LOW")
+
+	// Table rows.
+	assert.Contains(t, out, "prod-db-password")
+	assert.Contains(t, out, "91")
+	assert.Contains(t, out, "HIGH")
+	assert.Contains(t, out, "api-key-external")
+	assert.Contains(t, out, "stripe-webhook")
+	assert.Contains(t, out, "MEDIUM")
+}
+
+func TestProjectHealth_Remote_JSONFormat(t *testing.T) {
+	rc, done := setupHealthRemote(t, projectsAndHealthHandler)
+	defer done()
+
+	healthFormat = "json"
+	out := captureHealthStdout(t, func() {
+		require.NoError(t, runHealthRemote(t.Context(), rc, "web"))
+	})
+
+	// Output must be valid JSON containing the expected fields.
+	assert.Contains(t, out, `"project_id":1`)
+	assert.Contains(t, out, `"total_secrets":42`)
+	assert.Contains(t, out, `"high_risk_count":3`)
+	assert.Contains(t, out, `"medium_risk_count":11`)
+	assert.Contains(t, out, `"low_risk_count":28`)
+	assert.Contains(t, out, `"prod-db-password"`)
+	assert.Contains(t, out, `"score":91`)
+}

--- a/internal/cli/secret/score.go
+++ b/internal/cli/secret/score.go
@@ -1,0 +1,213 @@
+// score.go — keyorix secret score <name>
+//
+// Shows the risk score for a named secret. In remote mode it resolves the name
+// to an ID via the list endpoint, then calls GET /api/v1/secrets/{id}/risk. In
+// embedded mode it calls coreService.ComputeSecretRiskScore directly.
+package secret
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/spf13/cobra"
+)
+
+var (
+	scoreProject string
+	scoreEnv     uint
+)
+
+var scoreCmd = &cobra.Command{
+	Use:   "score <name>",
+	Short: "Show the risk score for a secret",
+	Long: `Print the composite risk score for a named secret.
+
+The score is 0-100 (higher = riskier) and is broken down into four weighted
+factors: rotation age (30%), expiry (30%), usage (20%), and exposure (20%).
+
+In remote mode the secret name is resolved to an ID via the list endpoint, then
+GET /api/v1/secrets/{id}/risk is called.
+
+Examples:
+  keyorix secret score my-api-key
+  keyorix secret score my-api-key --project web
+  keyorix secret score my-api-key --project web --env 2`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE:         runScore,
+}
+
+func init() {
+	scoreCmd.Flags().StringVar(&scoreProject, "project", "", "Project name (overrides KEYORIX_PROJECT and active project)")
+	scoreCmd.Flags().UintVar(&scoreEnv, "env", 0, "Environment ID filter (optional)")
+	SecretCmd.AddCommand(scoreCmd)
+}
+
+func runScore(_ *cobra.Command, args []string) error {
+	name := args[0]
+	ctx := context.Background()
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runScoreRemote(ctx, rc, name)
+	}
+	return runScoreEmbedded(ctx, name)
+}
+
+// ── Remote mode ────────────────────────────────────────────────────────────
+
+// scoreRiskFactor is the wire shape of one risk factor returned by the API.
+type scoreRiskFactor struct {
+	Key    string  `json:"key"`
+	Label  string  `json:"label"`
+	Score  int     `json:"score"`
+	Weight float64 `json:"weight"`
+	Detail string  `json:"detail"`
+}
+
+// scoreRiskResult is the wire shape of the GET /api/v1/secrets/{id}/risk response.
+type scoreRiskResult struct {
+	SecretID   uint              `json:"secret_id"`
+	SecretName string            `json:"secret_name"`
+	Score      int               `json:"score"`
+	Band       string            `json:"band"`
+	Factors    []scoreRiskFactor `json:"factors"`
+	Degraded   bool              `json:"degraded"`
+}
+
+func runScoreRemote(ctx context.Context, rc *common.RemoteClient, name string) error {
+	// 1. Resolve name → ID via list endpoint.
+	secretID, err := resolveSecretIDByName(ctx, rc, name)
+	if err != nil {
+		return err
+	}
+
+	// 2. Fetch the risk score.
+	var result scoreRiskResult
+	path := fmt.Sprintf("/api/v1/secrets/%d/risk", secretID)
+	if err := rc.Get(ctx, path, &result); err != nil {
+		return fmt.Errorf("failed to get risk score: %w", err)
+	}
+
+	printRiskScore(result.SecretName, result.Score, result.Band, result.Factors, result.Degraded)
+	return nil
+}
+
+// resolveSecretIDByName finds the ID of a secret by its name via the list endpoint.
+func resolveSecretIDByName(ctx context.Context, rc *common.RemoteClient, name string) (uint, error) {
+	path := "/api/v1/secrets?page=1&page_size=500"
+
+	projectName, _ := common.ResolveProject(scoreProject)
+	if projectName != "" {
+		param, err := resolveProjectIDParam(ctx, rc, projectName)
+		if err != nil {
+			return 0, err
+		}
+		path += param
+	}
+	if scoreEnv != 0 {
+		path += fmt.Sprintf("&environment_id=%d", scoreEnv)
+	}
+
+	// The list endpoint returns SecretWithSharingInfo whose SecretNode fields are
+	// PascalCase JSON (same as GET /api/v1/secrets/{id}).
+	var resp struct {
+		Secrets []struct {
+			ID   uint   `json:"ID"`
+			Name string `json:"Name"`
+		} `json:"secrets"`
+	}
+	if err := rc.Get(ctx, path, &resp); err != nil {
+		return 0, fmt.Errorf("failed to list secrets: %w", err)
+	}
+
+	for _, s := range resp.Secrets {
+		if strings.EqualFold(s.Name, name) {
+			return s.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("secret %q not found", name)
+}
+
+// ── Embedded mode ──────────────────────────────────────────────────────────
+
+func runScoreEmbedded(ctx context.Context, name string) error {
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+
+	filter := &coreStorage.SecretFilter{
+		Page:     1,
+		PageSize: 500,
+	}
+	projectName, _ := common.ResolveProject(scoreProject)
+	if projectName != "" {
+		projectID, err := common.LookupProjectIDByName(ctx, svc.Storage(), projectName)
+		if err != nil {
+			return err
+		}
+		filter.ProjectID = &projectID
+	}
+	if scoreEnv != 0 {
+		filter.EnvironmentID = &scoreEnv
+	}
+
+	secrets, _, err := svc.ListSecrets(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("failed to list secrets: %w", err)
+	}
+
+	var secretID uint
+	for _, s := range secrets {
+		if strings.EqualFold(s.Name, name) {
+			secretID = s.ID
+			break
+		}
+	}
+	if secretID == 0 {
+		return fmt.Errorf("secret %q not found", name)
+	}
+
+	rs, err := svc.ComputeSecretRiskScore(ctx, secretID)
+	if err != nil {
+		return fmt.Errorf("failed to compute risk score: %w", err)
+	}
+
+	// Convert core types to the display shape.
+	factors := make([]scoreRiskFactor, len(rs.Factors))
+	for i, f := range rs.Factors {
+		factors[i] = scoreRiskFactor{
+			Key:    f.Key,
+			Label:  f.Label,
+			Score:  f.Score,
+			Weight: f.Weight,
+			Detail: f.Detail,
+		}
+	}
+	printRiskScore(rs.SecretName, rs.Score, rs.Band, factors, rs.Degraded)
+	return nil
+}
+
+// ── Display ────────────────────────────────────────────────────────────────
+
+func printRiskScore(secretName string, score int, band string, factors []scoreRiskFactor, degraded bool) {
+	fmt.Printf("Secret: %s\n", secretName)
+	fmt.Printf("Score:  %d/100  band: %s\n", score, strings.ToUpper(band))
+	if degraded {
+		fmt.Println("  (exposure data incomplete — score is a lower bound)")
+	}
+	fmt.Println()
+	fmt.Println("Factors:")
+	for _, f := range factors {
+		fmt.Printf("  %-14s score=%-3d  weight=%-4s  detail=%s\n",
+			f.Key, f.Score, fmt.Sprintf("%.0f%%", f.Weight*100), f.Detail)
+	}
+
+	if strings.EqualFold(band, "high") {
+		fmt.Fprintln(os.Stderr, "⚠ This secret is HIGH risk. Consider rotating or restricting access.")
+	}
+}

--- a/internal/cli/secret/score_test.go
+++ b/internal/cli/secret/score_test.go
@@ -1,0 +1,155 @@
+package secret
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scoreSetup creates a test HTTP server driven by handler and points the CLI at
+// it via env vars. It returns the RemoteClient and a cleanup function.
+func scoreSetup(t *testing.T, handler http.HandlerFunc) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	t.Setenv("KEYORIX_PROJECT", "")
+	// Reset package-level flag vars so tests don't bleed into each other.
+	t.Cleanup(func() {
+		scoreProject = ""
+		scoreEnv = 0
+	})
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+// captureScoreOutput captures both stdout and stderr produced by fn.
+func captureScoreOutput(t *testing.T, fn func()) (stdout, stderr string) {
+	t.Helper()
+
+	// Capture stdout.
+	origOut := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = wOut
+
+	// Capture stderr.
+	origErr := os.Stderr
+	rErr, wErr, err2 := os.Pipe()
+	require.NoError(t, err2)
+	os.Stderr = wErr
+
+	defer func() {
+		os.Stdout = origOut
+		os.Stderr = origErr
+	}()
+
+	fn()
+
+	require.NoError(t, wOut.Close())
+	require.NoError(t, wErr.Close())
+
+	outBytes, _ := io.ReadAll(rOut)
+	errBytes, _ := io.ReadAll(rErr)
+
+	var buf bytes.Buffer
+	buf.Write(outBytes)
+	stdout = buf.String()
+	stderr = string(errBytes)
+	return
+}
+
+// highRiskHandler serves:
+//   - GET /api/v1/secrets?...  → list with one secret named "prod-db"
+//   - GET /api/v1/secrets/5/risk → high-risk score
+func highRiskHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/api/v1/secrets":
+		_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[{"ID":5,"Name":"prod-db"}],"total":1,"page":1,"page_size":500,"total_pages":1}}`))
+	case "/api/v1/secrets/5/risk":
+		_, _ = w.Write([]byte(`{"success":true,"data":{"secret_id":5,"secret_name":"prod-db","score":85,"band":"high","factors":[{"key":"rotation","label":"Rotation age","score":100,"weight":0.3,"detail":"Last created 400 day(s) ago (never rotated)"},{"key":"expiry","label":"Expiry","score":100,"weight":0.3,"detail":"Expired 10 day(s) ago"},{"key":"usage","label":"Usage","score":80,"weight":0.2,"detail":"No reads in the last 30 days"},{"key":"exposure","label":"Exposure","score":10,"weight":0.2,"detail":"Only the owner has access"}],"degraded":false}}`))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func TestSecretScore_Remote_HighRisk(t *testing.T) {
+	rc, done := scoreSetup(t, highRiskHandler)
+	defer done()
+
+	var runErr error
+	stdout, stderr := captureScoreOutput(t, func() {
+		runErr = runScoreRemote(t.Context(), rc, "prod-db")
+	})
+	require.NoError(t, runErr)
+
+	// Output should show the secret name, score, and band.
+	assert.Contains(t, stdout, "prod-db")
+	assert.Contains(t, stdout, "85/100")
+	assert.Contains(t, stdout, "HIGH")
+	assert.Contains(t, stdout, "Factors:")
+	assert.Contains(t, stdout, "rotation")
+
+	// HIGH risk warning must go to stderr.
+	assert.Contains(t, stderr, "HIGH risk")
+	assert.Contains(t, stderr, "Consider rotating")
+}
+
+// lowRiskHandler serves a low-risk score for secret "jwt-key" (id=3).
+func lowRiskHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/api/v1/secrets":
+		_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[{"ID":3,"Name":"jwt-key"}],"total":1,"page":1,"page_size":500,"total_pages":1}}`))
+	case "/api/v1/secrets/3/risk":
+		_, _ = w.Write([]byte(`{"success":true,"data":{"secret_id":3,"secret_name":"jwt-key","score":12,"band":"low","factors":[{"key":"rotation","label":"Rotation age","score":10,"weight":0.3,"detail":"Last rotated 5 day(s) ago"},{"key":"expiry","label":"Expiry","score":10,"weight":0.3,"detail":"Expires in 200 day(s)"},{"key":"usage","label":"Usage","score":10,"weight":0.2,"detail":"12 reads in the last 30 days"},{"key":"exposure","label":"Exposure","score":10,"weight":0.2,"detail":"Only the owner has access"}],"degraded":false}}`))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func TestSecretScore_Remote_LowRisk(t *testing.T) {
+	rc, done := scoreSetup(t, lowRiskHandler)
+	defer done()
+
+	var runErr error
+	stdout, stderr := captureScoreOutput(t, func() {
+		runErr = runScoreRemote(t.Context(), rc, "jwt-key")
+	})
+	require.NoError(t, runErr)
+
+	assert.Contains(t, stdout, "jwt-key")
+	assert.Contains(t, stdout, "12/100")
+	assert.Contains(t, stdout, "LOW")
+
+	// No HIGH-risk warning for a low-risk secret.
+	assert.NotContains(t, stderr, "HIGH risk")
+}
+
+// notFoundHandler responds to all requests with 404.
+func notFoundHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/api/v1/secrets":
+		// Return an empty list so name resolution fails gracefully.
+		_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[],"total":0,"page":1,"page_size":500,"total_pages":1}}`))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"success":false,"error":"NotFound","message":"not found","code":404}`))
+	}
+}
+
+func TestSecretScore_Remote_NotFound(t *testing.T) {
+	rc, done := scoreSetup(t, notFoundHandler)
+	defer done()
+
+	err := runScoreRemote(t.Context(), rc, "ghost-secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/core/project_health.go
+++ b/internal/core/project_health.go
@@ -1,0 +1,99 @@
+// project_health.go — per-project secret health summary.
+//
+// GetProjectHealthSummary aggregates ComputeSecretRiskScoresBatch across all
+// secrets in a project and returns band counts plus the top-N riskiest secrets.
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// ProjectHealthSummary is the result of GetProjectHealthSummary.
+type ProjectHealthSummary struct {
+	ProjectID       uint               `json:"project_id"`
+	TotalSecrets    int                `json:"total_secrets"`
+	HighRiskCount   int                `json:"high_risk_count"`
+	MediumRiskCount int                `json:"medium_risk_count"`
+	LowRiskCount    int                `json:"low_risk_count"`
+	TopRiskSecrets  []*SecretRiskScore `json:"secrets"`
+}
+
+const (
+	defaultHealthLimit = 20
+	maxHealthLimit     = 100
+)
+
+// GetProjectHealthSummary lists all secrets in projectID, scores them in batch,
+// counts by risk band, and returns the top `limit` secrets sorted by Score desc.
+// limit is clamped: if <= 0 or > 100 it defaults to 20.
+func (c *KeyorixCore) GetProjectHealthSummary(ctx context.Context, projectID uint, limit int) (*ProjectHealthSummary, error) {
+	if limit <= 0 || limit > maxHealthLimit {
+		limit = defaultHealthLimit
+	}
+
+	// Fetch ALL secrets for the project (no paging — admin function).
+	trueVal := true
+	secrets, _, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+		ProjectID: &projectID,
+		IsSecret:  &trueVal,
+		PageSize:  maxHealthLimit * 10, // generous upper bound; health is a bounded admin view
+		Page:      1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list secrets: %w", err)
+	}
+
+	// Collect all IDs in one pass.
+	ids := make([]uint, 0, len(secrets))
+	for _, s := range secrets {
+		ids = append(ids, s.ID)
+	}
+
+	// Score the whole batch with one set of queries.
+	scoreMap, err := c.ComputeSecretRiskScoresBatch(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("compute risk scores: %w", err)
+	}
+
+	// Build the ordered slice and band counts.
+	all := make([]*SecretRiskScore, 0, len(scoreMap))
+	var highN, medN, lowN int
+	for _, s := range scoreMap {
+		all = append(all, s)
+		switch s.Band {
+		case RiskBandHigh:
+			highN++
+		case RiskBandMedium:
+			medN++
+		default:
+			lowN++
+		}
+	}
+
+	// Sort by Score descending; break ties by SecretID for determinism.
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].Score != all[j].Score {
+			return all[i].Score > all[j].Score
+		}
+		return all[i].SecretID < all[j].SecretID
+	})
+
+	// Return only the top `limit`.
+	top := all
+	if len(top) > limit {
+		top = top[:limit]
+	}
+
+	return &ProjectHealthSummary{
+		ProjectID:       projectID,
+		TotalSecrets:    len(secrets),
+		HighRiskCount:   highN,
+		MediumRiskCount: medN,
+		LowRiskCount:    lowN,
+		TopRiskSecrets:  top,
+	}, nil
+}

--- a/internal/core/project_health_test.go
+++ b/internal/core/project_health_test.go
@@ -1,0 +1,200 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newHealthTestDB opens a fresh in-memory SQLite DB with all required tables
+// migrated. Each call produces a fully isolated database.
+func newHealthTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1) // required for :memory: isolation
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{},
+		&models.SecretVersion{},
+		&models.User{},
+		&models.Project{},
+		&models.Environment{},
+		&models.SecretAccessLog{},
+		&models.MachineIdentity{},
+		&models.AuditEvent{},
+		&models.RotationPolicy{},
+		&models.ShareRecord{},
+		&models.UserGroup{},
+	))
+	return db
+}
+
+// makeSecret creates a SecretNode in the given project/environment. Pinning a
+// recent CreatedAt keeps rotation scores low so tests can be deterministic.
+func makeHealthSecret(t *testing.T, c *KeyorixCore, name string, projectID, envID, ownerID uint) uint {
+	t.Helper()
+	s, err := c.storage.CreateSecret(context.Background(), &models.SecretNode{
+		Name:          name,
+		ProjectID:     projectID,
+		EnvironmentID: envID,
+		Type:          "password",
+		OwnerID:       ownerID,
+		IsSecret:      true,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	})
+	require.NoError(t, err)
+	return s.ID
+}
+
+func TestGetProjectHealthSummary_Empty(t *testing.T) {
+	db := newHealthTestDB(t)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "empty-project"})
+	require.NoError(t, err)
+
+	summary, err := c.GetProjectHealthSummary(ctx, p.ID, 20)
+	require.NoError(t, err)
+	assert.Equal(t, p.ID, summary.ProjectID)
+	assert.Equal(t, 0, summary.TotalSecrets)
+	assert.Equal(t, 0, summary.HighRiskCount)
+	assert.Equal(t, 0, summary.MediumRiskCount)
+	assert.Equal(t, 0, summary.LowRiskCount)
+	assert.Empty(t, summary.TopRiskSecrets)
+}
+
+func TestGetProjectHealthSummary_Counts(t *testing.T) {
+	db := newHealthTestDB(t)
+	ctx := context.Background()
+	now := time.Now()
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "counts-project"})
+	require.NoError(t, err)
+	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	// HIGH secret: expired 10d ago + old (400d, never rotated) + no reads + owner only.
+	// expiry=100*0.30=30, rotation=100*0.30=30, usage=80*0.20=16, exposure=10*0.20=2 → 78 ≥ 67 → HIGH
+	oldCreated := now.AddDate(0, 0, -400)
+	expired := now.AddDate(0, 0, -10)
+	_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "expired-secret", ProjectID: p.ID, EnvironmentID: e.ID,
+		Type: "password", OwnerID: 1, IsSecret: true,
+		Expiration: &expired,
+		CreatedAt:  oldCreated, UpdatedAt: oldCreated,
+	})
+	require.NoError(t, err)
+
+	// MEDIUM secret: old (400d) but has many reads (usage=10) and no expiry (40) and owner only.
+	// expiry=40*0.30=12, rotation=100*0.30=30, usage=10*0.20=2, exposure=10*0.20=2 → 46 → MEDIUM
+	medS, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "old-active-secret", ProjectID: p.ID, EnvironmentID: e.ID,
+		Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: oldCreated, UpdatedAt: oldCreated,
+	})
+	require.NoError(t, err)
+	for i := 0; i < 12; i++ {
+		require.NoError(t, c.storage.CreateSecretAccessLog(ctx, &models.SecretAccessLog{
+			SecretNodeID: medS.ID, AccessedBy: "owner", Action: "read", AccessTime: now,
+		}))
+	}
+
+	// LOW secret: expires far in the future, freshly created, many reads.
+	// expiry=10*0.30=3, rotation=10*0.30=3, usage=10*0.20=2, exposure=10*0.20=2 → 10 → LOW
+	future := now.AddDate(1, 0, 0)
+	lowS, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "fresh-secret", ProjectID: p.ID, EnvironmentID: e.ID,
+		Type: "password", OwnerID: 1, IsSecret: true,
+		Expiration: &future,
+		CreatedAt:  now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+	for i := 0; i < 12; i++ {
+		require.NoError(t, c.storage.CreateSecretAccessLog(ctx, &models.SecretAccessLog{
+			SecretNodeID: lowS.ID, AccessedBy: "owner", Action: "read", AccessTime: now,
+		}))
+	}
+
+	summary, err := c.GetProjectHealthSummary(ctx, p.ID, 20)
+	require.NoError(t, err)
+	assert.Equal(t, 3, summary.TotalSecrets)
+	// Band counts must add up to total.
+	assert.Equal(t, summary.TotalSecrets, summary.HighRiskCount+summary.MediumRiskCount+summary.LowRiskCount)
+	// We expect exactly 1 HIGH, 1 MEDIUM, 1 LOW.
+	assert.Equal(t, 1, summary.HighRiskCount, "expired-secret should be HIGH")
+	assert.Equal(t, 1, summary.MediumRiskCount, "old-active-secret should be MEDIUM")
+	assert.Equal(t, 1, summary.LowRiskCount, "fresh-secret should be LOW")
+	// All 3 secrets must appear in TopRiskSecrets (limit=20 > 3).
+	assert.Len(t, summary.TopRiskSecrets, 3)
+	// Must be sorted descending.
+	for i := 1; i < len(summary.TopRiskSecrets); i++ {
+		assert.GreaterOrEqual(t, summary.TopRiskSecrets[i-1].Score, summary.TopRiskSecrets[i].Score)
+	}
+}
+
+func TestGetProjectHealthSummary_Limit(t *testing.T) {
+	db := newHealthTestDB(t)
+	ctx := context.Background()
+	now := time.Now()
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "limit-project"})
+	require.NoError(t, err)
+	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	// Create 5 secrets.
+	for i := 0; i < 5; i++ {
+		makeHealthSecret(t, c, fmt.Sprintf("s%d", i), p.ID, e.ID, 1)
+	}
+
+	summary, err := c.GetProjectHealthSummary(ctx, p.ID, 2)
+	require.NoError(t, err)
+	assert.Equal(t, 5, summary.TotalSecrets)
+	// Only the top 2 should be returned.
+	assert.Len(t, summary.TopRiskSecrets, 2)
+	// They must be in descending order.
+	require.Equal(t, 2, len(summary.TopRiskSecrets))
+	assert.GreaterOrEqual(t, summary.TopRiskSecrets[0].Score, summary.TopRiskSecrets[1].Score)
+}
+
+func TestGetProjectHealthSummary_WrongProject(t *testing.T) {
+	db := newHealthTestDB(t)
+	ctx := context.Background()
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+
+	// Create two projects; put secrets only in p1.
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	p1, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	p2, err := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
+	require.NoError(t, err)
+	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: p1.ID})
+	require.NoError(t, err)
+	makeHealthSecret(t, c, "only-in-p1", p1.ID, e.ID, 1)
+
+	// Querying p2 must return empty, not p1's secrets.
+	summary, err := c.GetProjectHealthSummary(ctx, p2.ID, 20)
+	require.NoError(t, err)
+	assert.Equal(t, p2.ID, summary.ProjectID)
+	assert.Equal(t, 0, summary.TotalSecrets)
+	assert.Empty(t, summary.TopRiskSecrets)
+}

--- a/server/http/handlers/project_health.go
+++ b/server/http/handlers/project_health.go
@@ -1,0 +1,51 @@
+// project_health.go — project-level secret health summary handler.
+//
+// Route (under /api/v1/projects):
+//
+//	GET /{id}/health[?limit=N]  — top-N highest-risk secrets in the project
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// GetProjectHealth handles GET /api/v1/projects/{id}/health[?limit=N]
+//
+// Returns the top-N highest-risk secrets in the project together with band
+// counts. N defaults to 20 and is capped at 100 (clamping is done in core).
+// Requires secrets.read at the project scope (enforced by the route middleware).
+func (h *SecretHandler) GetProjectHealth(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	limit := 20
+	if lStr := r.URL.Query().Get("limit"); lStr != "" {
+		parsed, err := strconv.Atoi(lStr)
+		if err != nil || parsed <= 0 {
+			h.sendError(w, "InvalidParameter", "limit must be a positive integer", http.StatusBadRequest, nil)
+			return
+		}
+		limit = parsed
+	}
+
+	summary, err := h.coreService.GetProjectHealthSummary(r.Context(), uint(id), limit)
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to compute project health", http.StatusInternalServerError, nil)
+		return
+	}
+
+	h.sendSuccess(w, summary, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -365,6 +365,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission(permSecretsRead, projectScope)).Get("/projects/{id}/drift", catalogHandler.GetProjectDrift)
 		r.With(customMiddleware.RequireScopedPermission(permSecretsRead, projectScope)).Get("/projects/{id}/rotation-order", secretHandler.GetProjectRotationOrder)
 		r.With(customMiddleware.RequireScopedPermission(permSecretsRead, projectScope)).Get("/projects/{id}/rotation-plan", secretHandler.GetProjectRotationPlan)
+		r.With(customMiddleware.RequireScopedPermission(permSecretsRead, projectScope)).Get("/projects/{id}/health", secretHandler.GetProjectHealth)
 		// Deployment-wide rotation plan (ADR-053): aggregates every project. Gated by
 		// GLOBAL secrets.read — the same access level as listing all projects — so it
 		// reveals no project the caller cannot already see.


### PR DESCRIPTION
Adds keyorix secret score <name> + GET /api/v1/projects/{id}/health + keyorix project health <name>. Uses existing ComputeSecretRiskScoresBatch.