### PR TITLE
feat(env): environment clone

### DIFF
--- a/internal/cli/project/env_clone.go
+++ b/internal/cli/project/env_clone.go
@@ -1,0 +1,130 @@
+// env_clone.go — keyorix project env clone <src-env-name> <dst-env-name>
+// Copies all secrets from a source environment to a destination environment
+// within the same project (staging → production promotion).
+package project
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/spf13/cobra"
+)
+
+var envCloneProjectFlag string
+
+var envCloneCmd = &cobra.Command{
+	Use:   "clone <src-env-name> <dst-env-name>",
+	Short: "Clone all secrets from one environment to another in the same project",
+	Long: `Copies every secret from the source environment into the destination environment
+within the same project. Secrets that already exist by name in the destination are
+skipped (not overwritten). Only the latest version of each secret is copied.`,
+	Args: cobra.ExactArgs(2),
+	RunE: runEnvClone,
+}
+
+func init() {
+	envCloneCmd.Flags().StringVar(&envCloneProjectFlag, "project", "", descOverrideProject)
+}
+
+func runEnvClone(cmd *cobra.Command, args []string) error {
+	srcName := args[0]
+	dstName := args[1]
+
+	_, projectID, err := resolveProjectContext(envCloneProjectFlag)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runEnvCloneRemote(ctx, rc, projectID, srcName, dstName)
+	}
+
+	return runEnvCloneEmbedded(ctx, projectID, srcName, dstName)
+}
+
+func runEnvCloneRemote(ctx context.Context, rc *common.RemoteClient, projectID uint, srcName, dstName string) error {
+	// Resolve environment names → IDs via the project's environment list.
+	var resp struct {
+		Environments []struct {
+			ID   uint   `json:"id"`
+			Name string `json:"name"`
+		} `json:"environments"`
+	}
+	path := fmt.Sprintf("/api/v1/projects/%d/environments", projectID)
+	if err := rc.Get(ctx, path, &resp); err != nil {
+		return fmt.Errorf("failed to list environments: %w", err)
+	}
+
+	var srcID, dstID uint
+	for _, e := range resp.Environments {
+		switch e.Name {
+		case srcName:
+			srcID = e.ID
+		case dstName:
+			dstID = e.ID
+		}
+	}
+	if srcID == 0 {
+		return fmt.Errorf("source environment %q not found in project", srcName)
+	}
+	if dstID == 0 {
+		return fmt.Errorf("destination environment %q not found in project", dstName)
+	}
+
+	var result core.EnvCloneResult
+	clonePath := fmt.Sprintf("/api/v1/projects/%d/environments/%d/clone", projectID, srcID)
+	body := map[string]interface{}{"destination_environment_id": dstID}
+	if err := rc.Post(ctx, clonePath, body, &result); err != nil {
+		return fmt.Errorf("failed to clone environment: %w", err)
+	}
+
+	printCloneResult(srcName, dstName, &result)
+	return nil
+}
+
+func runEnvCloneEmbedded(ctx context.Context, projectID uint, srcName, dstName string) error {
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+
+	envs, err := svc.ListEnvironmentsByProject(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to list environments: %w", err)
+	}
+
+	var srcID, dstID uint
+	for _, e := range envs {
+		switch e.Name {
+		case srcName:
+			srcID = e.ID
+		case dstName:
+			dstID = e.ID
+		}
+	}
+	if srcID == 0 {
+		return fmt.Errorf("source environment %q not found in project", srcName)
+	}
+	if dstID == 0 {
+		return fmt.Errorf("destination environment %q not found in project", dstName)
+	}
+
+	result, err := svc.CloneEnvironment(ctx, projectID, srcID, dstID, "cli", 0)
+	if err != nil {
+		return fmt.Errorf("failed to clone environment: %w", err)
+	}
+
+	printCloneResult(srcName, dstName, result)
+	return nil
+}
+
+func printCloneResult(srcName, dstName string, result *core.EnvCloneResult) {
+	fmt.Printf("Cloned environment %q → %q\n", srcName, dstName)
+	fmt.Printf("  Secrets cloned:  %d\n", result.SecretsCloned)
+	if result.SecretsSkipped > 0 {
+		fmt.Printf("  Secrets skipped: %d  (already exist in destination)\n", result.SecretsSkipped)
+	}
+}

--- a/internal/cli/project/env_clone_test.go
+++ b/internal/cli/project/env_clone_test.go
@@ -1,0 +1,114 @@
+package project
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// envAndProjectsHandler returns an http.HandlerFunc that serves the three
+// endpoints exercised by runEnvClone in remote mode:
+//   - GET /api/v1/projects      → one project "web" (id=1)
+//   - GET /api/v1/projects/1/environments → two environments: staging(id=10), production(id=11)
+//   - POST /api/v1/projects/1/environments/10/clone → customisable via cloneResp/cloneStatus
+func envAndProjectsForCloneHandler(t *testing.T, cloneStatus int, cloneResp interface{}) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		case r.URL.Path == "/api/v1/projects/1/environments":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"environments":[{"id":10,"name":"staging"},{"id":11,"name":"production"}]}}`))
+		case r.URL.Path == "/api/v1/projects/1/environments/10/clone" && r.Method == http.MethodPost:
+			w.WriteHeader(cloneStatus)
+			if cloneResp != nil {
+				enc, _ := json.Marshal(cloneResp)
+				_, _ = w.Write(enc)
+			}
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+// setupCloneRemote spins up a test server and points the CLI at it via env vars.
+func setupCloneRemote(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	t.Setenv("KEYORIX_PROJECT", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() {
+		envCloneProjectFlag = ""
+	})
+}
+
+func TestEnvClone_Remote_Success(t *testing.T) {
+	result := map[string]interface{}{
+		"success": true,
+		"data": core.EnvCloneResult{
+			SourceEnv:      "staging",
+			DestEnv:        "production",
+			SecretsCloned:  5,
+			SecretsSkipped: 0,
+		},
+	}
+	setupCloneRemote(t, envAndProjectsForCloneHandler(t, http.StatusOK, result))
+	envCloneProjectFlag = "web"
+
+	out := captureStdout(t, func() {
+		require.NoError(t, runEnvClone(nil, []string{"staging", "production"}))
+	})
+	assert.Contains(t, out, `Cloned environment "staging" → "production"`)
+	assert.Contains(t, out, "Secrets cloned:  5")
+}
+
+func TestEnvClone_Remote_PartialSkip(t *testing.T) {
+	result := map[string]interface{}{
+		"success": true,
+		"data": core.EnvCloneResult{
+			SourceEnv:      "staging",
+			DestEnv:        "production",
+			SecretsCloned:  3,
+			SecretsSkipped: 2,
+		},
+	}
+	setupCloneRemote(t, envAndProjectsForCloneHandler(t, http.StatusOK, result))
+	envCloneProjectFlag = "web"
+
+	out := captureStdout(t, func() {
+		require.NoError(t, runEnvClone(nil, []string{"staging", "production"}))
+	})
+	assert.Contains(t, out, "Secrets cloned:  3")
+	assert.Contains(t, out, "Secrets skipped: 2")
+	assert.Contains(t, out, "already exist in destination")
+}
+
+func TestEnvClone_Remote_NotFound(t *testing.T) {
+	setupCloneRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		case "/api/v1/projects/1/environments":
+			// Only returns staging, no production.
+			_, _ = w.Write([]byte(`{"success":true,"data":{"environments":[{"id":10,"name":"staging"}]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	envCloneProjectFlag = "web"
+
+	err := runEnvClone(nil, []string{"staging", "production"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `destination environment "production" not found`)
+}

--- a/internal/cli/project/project.go
+++ b/internal/cli/project/project.go
@@ -23,10 +23,11 @@ func init() {
 	ProjectCmd.AddCommand(currentCmd)
 	ProjectCmd.AddCommand(describeCmd)
 
-	// env subcommand tree: project env list/create/delete
+	// env subcommand tree: project env list/create/delete/clone
 	envCmd.AddCommand(envListCmd)
 	envCmd.AddCommand(envCreateCmd)
 	envCmd.AddCommand(envDeleteCmd)
+	envCmd.AddCommand(envCloneCmd)
 	ProjectCmd.AddCommand(envCmd)
 
 	// Keep legacy 'environments' alias for backwards compat.

--- a/internal/core/env_clone.go
+++ b/internal/core/env_clone.go
@@ -1,0 +1,88 @@
+// env_clone.go — CloneEnvironment: copy every active secret from one environment
+// into another within the same project (staging → production promotion). Secrets
+// that already exist by name in the destination are skipped; only the latest
+// version of each source secret is copied.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+const cloneEnvPageSize = 500
+
+// EnvCloneResult summarises the outcome of a CloneEnvironment call.
+type EnvCloneResult struct {
+	SourceEnv      string
+	DestEnv        string
+	SecretsCloned  int
+	SecretsSkipped int   // secrets that already exist in dest (skipped, not overwritten)
+	Errors         []string
+}
+
+// CloneEnvironment copies all active secrets from srcEnvID to dstEnvID.
+// Both environments must belong to the same project (projectID).
+// Secrets that already exist by name in dstEnvID are skipped (not overwritten).
+// Only the latest version of each secret is copied. clonedBy is the username
+// credited in audit events; actorID is the user's numeric ID (used for the
+// per-secret read permission check).
+func (c *KeyorixCore) CloneEnvironment(ctx context.Context, projectID, srcEnvID, dstEnvID uint, clonedBy string, actorID uint) (*EnvCloneResult, error) {
+	if projectID == 0 || srcEnvID == 0 || dstEnvID == 0 {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project, source and destination environment IDs are required")
+	}
+	if srcEnvID == dstEnvID {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "source and destination environments must differ")
+	}
+
+	// Verify both environments belong to the authorised project.
+	srcEnv, err := c.storage.GetEnvironment(ctx, srcEnvID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: source environment: %w", i18n.T("ErrorValidation", nil), err)
+	}
+	dstEnv, err := c.storage.GetEnvironment(ctx, dstEnvID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: destination environment: %w", i18n.T("ErrorValidation", nil), err)
+	}
+	if srcEnv.ProjectID != projectID || dstEnv.ProjectID != projectID {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "both environments must belong to the given project")
+	}
+
+	result := &EnvCloneResult{
+		SourceEnv: srcEnv.Name,
+		DestEnv:   dstEnv.Name,
+	}
+
+	// Page through the source environment's secrets.
+	trueVal := true
+	for page := 1; ; page++ {
+		secrets, total, lerr := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+			EnvironmentID: &srcEnvID,
+			IsSecret:      &trueVal, // only real secrets, not folders
+			Page:          page,
+			PageSize:      cloneEnvPageSize,
+		})
+		if lerr != nil {
+			return result, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), lerr)
+		}
+
+		for _, s := range secrets {
+			// CopySecret handles name-clash detection internally (CreateSecret fails if
+			// the name already exists in dstEnvID) and records read + create audit events.
+			if _, cerr := c.CopySecret(ctx, s.ID, dstEnvID, "", clonedBy, actorID, "", ""); cerr != nil {
+				result.SecretsSkipped++
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", s.Name, cerr))
+				continue
+			}
+			result.SecretsCloned++
+		}
+
+		if len(secrets) < cloneEnvPageSize || int64(page*cloneEnvPageSize) >= total {
+			break
+		}
+	}
+
+	return result, nil
+}

--- a/internal/core/env_clone_test.go
+++ b/internal/core/env_clone_test.go
@@ -1,0 +1,139 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newCloneTestCore builds a minimal KeyorixCore backed by an isolated in-memory
+// SQLite DB for environment-clone integration tests. Each call gets its own DSN
+// keyed by test name to prevent cross-test DB collisions.
+func newCloneTestCore(t *testing.T) *KeyorixCore {
+	t.Helper()
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=private", t.Name())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{},
+		&models.SecretVersion{},
+		&models.Project{},
+		&models.Environment{},
+		&models.AuditEvent{},
+		&models.SecretAccessLog{},
+	))
+	return &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+}
+
+func TestCloneEnvironment_Basic(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	c := newCloneTestCore(t)
+	ctx := context.Background()
+
+	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p-clone-basic"})
+	src, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "staging", ProjectID: p.ID})
+	dst, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+
+	// Create 3 secrets in src.
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		_, err := c.CreateSecret(ctx, &CreateSecretRequest{
+			Name: name, Value: []byte("val-" + name),
+			ProjectID: p.ID, EnvironmentID: src.ID,
+			Type: "generic", CreatedBy: "owner", OwnerID: 1,
+		})
+		require.NoError(t, err)
+	}
+
+	result, err := c.CloneEnvironment(ctx, p.ID, src.ID, dst.ID, "owner", 1)
+	require.NoError(t, err)
+	assert.Equal(t, "staging", result.SourceEnv)
+	assert.Equal(t, "production", result.DestEnv)
+	assert.Equal(t, 3, result.SecretsCloned)
+	assert.Equal(t, 0, result.SecretsSkipped)
+}
+
+func TestCloneEnvironment_SkipsExisting(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	c := newCloneTestCore(t)
+	ctx := context.Background()
+
+	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p-clone-skip"})
+	src, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "staging", ProjectID: p.ID})
+	dst, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+
+	// 3 secrets in src.
+	for _, name := range []string{"db", "api", "secret3"} {
+		_, err := c.CreateSecret(ctx, &CreateSecretRequest{
+			Name: name, Value: []byte("v"),
+			ProjectID: p.ID, EnvironmentID: src.ID,
+			Type: "generic", CreatedBy: "owner", OwnerID: 1,
+		})
+		require.NoError(t, err)
+	}
+	// "db" already exists in dst.
+	_, err := c.CreateSecret(ctx, &CreateSecretRequest{
+		Name: "db", Value: []byte("prod-val"),
+		ProjectID: p.ID, EnvironmentID: dst.ID,
+		Type: "generic", CreatedBy: "owner", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	result, err := c.CloneEnvironment(ctx, p.ID, src.ID, dst.ID, "owner", 1)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.SecretsCloned, "api and secret3 are new")
+	assert.Equal(t, 1, result.SecretsSkipped, "db already exists in dst")
+	assert.Len(t, result.Errors, 1)
+}
+
+func TestCloneEnvironment_EmptySource(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	c := newCloneTestCore(t)
+	ctx := context.Background()
+
+	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p-clone-empty"})
+	src, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "staging", ProjectID: p.ID})
+	dst, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+
+	result, err := c.CloneEnvironment(ctx, p.ID, src.ID, dst.ID, "owner", 1)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.SecretsCloned)
+	assert.Equal(t, 0, result.SecretsSkipped)
+}
+
+func TestCloneEnvironment_DifferentProject(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	c := newCloneTestCore(t)
+	ctx := context.Background()
+
+	p1, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p-clone-diff-1"})
+	p2, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p-clone-diff-2"})
+	src, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "staging", ProjectID: p1.ID})
+	dst, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+
+	_, err := c.CloneEnvironment(ctx, p1.ID, src.ID, dst.ID, "owner", 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must belong to the given project")
+}
+
+func TestCloneEnvironment_DestNotFound(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	c := newCloneTestCore(t)
+	ctx := context.Background()
+
+	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p-clone-notfound"})
+	src, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "staging", ProjectID: p.ID})
+
+	_, err := c.CloneEnvironment(ctx, p.ID, src.ID, 99999, "owner", 1)
+	require.Error(t, err)
+}

--- a/server/http/env_clone_handler_test.go
+++ b/server/http/env_clone_handler_test.go
@@ -1,0 +1,233 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestEnvironment POSTs to POST /api/v1/projects/{projectID}/environments and
+// returns the newly created environment's ID. It fails the test immediately on any
+// non-201 response or decode error.
+func createTestEnvironment(t *testing.T, client *http.Client, baseURL, token string, projectID uint, name string) uint {
+	t.Helper()
+	body := fmt.Sprintf(`{"name":%q}`, name)
+	req, err := http.NewRequest("POST",
+		fmt.Sprintf("%s/api/v1/projects/%d/environments", baseURL, projectID),
+		strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equalf(t, http.StatusCreated, resp.StatusCode, "createTestEnvironment: unexpected status for %q", name)
+
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	data, ok := out["data"].(map[string]interface{})
+	require.True(t, ok, "createTestEnvironment: response missing data object")
+	id, ok := data["ID"].(float64)
+	require.True(t, ok, "createTestEnvironment: data.ID missing or not a number")
+	return uint(id)
+}
+
+// createTestSecret POSTs to POST /api/v1/secrets and returns the new secret ID.
+func createTestSecret(t *testing.T, client *http.Client, baseURL, token string, projectID, envID uint, name string) uint {
+	t.Helper()
+	payload := map[string]interface{}{
+		"name":           name,
+		"value":          "test-value",
+		"project_id":     projectID,
+		"environment_id": envID,
+		"type":           "generic",
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", baseURL+"/api/v1/secrets", bytes.NewBuffer(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equalf(t, http.StatusCreated, resp.StatusCode, "createTestSecret: unexpected status for %q", name)
+
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	data, ok := out["data"].(map[string]interface{})
+	require.True(t, ok, "createTestSecret: response missing data object")
+	id, ok := data["ID"].(float64)
+	require.True(t, ok, "createTestSecret: data.ID missing or not a number")
+	return uint(id)
+}
+
+// doClone calls POST /api/v1/projects/{projectID}/environments/{srcEnvID}/clone and
+// returns the raw *http.Response. The caller owns closing the body.
+func doClone(t *testing.T, client *http.Client, baseURL, token string, projectID, srcEnvID, dstEnvID uint) *http.Response {
+	t.Helper()
+	body := fmt.Sprintf(`{"destination_environment_id":%d}`, dstEnvID)
+	req, err := http.NewRequest("POST",
+		fmt.Sprintf("%s/api/v1/projects/%d/environments/%d/clone", baseURL, projectID, srcEnvID),
+		strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// TestCloneEnvironment_EmptySource clones environment 1 (no secrets) to a fresh
+// environment and expects 200 with secrets_cloned == 0.
+func TestCloneEnvironment_EmptySource(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	// BootstrapSystem creates project 1 with environments 1 (development), 2 (staging),
+	// 3 (production). Create an additional destination so we do not clone onto a shared
+	// built-in environment and risk cross-test state.
+	dstEnvID := createTestEnvironment(t, client, srv.URL, token, 1, "clone-dst-empty")
+
+	resp := doClone(t, client, srv.URL, token, 1, 1, dstEnvID)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	data, ok := out["data"].(map[string]interface{})
+	require.True(t, ok, "response must contain a data object")
+	assert.EqualValues(t, 0, data["SecretsCloned"])
+}
+
+// TestCloneEnvironment_WithSecrets creates 2 secrets in env 1, clones to a new env,
+// and expects 200 with secrets_cloned == 2.
+func TestCloneEnvironment_WithSecrets(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	createTestSecret(t, client, srv.URL, token, 1, 1, "clone-with-alpha")
+	createTestSecret(t, client, srv.URL, token, 1, 1, "clone-with-beta")
+
+	dstEnvID := createTestEnvironment(t, client, srv.URL, token, 1, "clone-dst-with")
+
+	resp := doClone(t, client, srv.URL, token, 1, 1, dstEnvID)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	data, ok := out["data"].(map[string]interface{})
+	require.True(t, ok, "response must contain a data object")
+	assert.EqualValues(t, 2, data["SecretsCloned"])
+}
+
+// TestCloneEnvironment_SkipsExisting creates "foo" in env 1, creates env 2 with
+// "foo" already in it, clones, and expects 200 with secrets_skipped >= 1.
+func TestCloneEnvironment_SkipsExisting(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	// Seed "foo" in the source (env 1).
+	createTestSecret(t, client, srv.URL, token, 1, 1, "clone-skip-foo")
+
+	// Create destination and pre-seed the same name so it gets skipped.
+	dstEnvID := createTestEnvironment(t, client, srv.URL, token, 1, "clone-dst-skip")
+	createTestSecret(t, client, srv.URL, token, 1, dstEnvID, "clone-skip-foo")
+
+	resp := doClone(t, client, srv.URL, token, 1, 1, dstEnvID)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	data, ok := out["data"].(map[string]interface{})
+	require.True(t, ok, "response must contain a data object")
+	skipped, _ := data["SecretsSkipped"].(float64)
+	assert.GreaterOrEqual(t, int(skipped), 1, "at least one secret must be skipped")
+}
+
+// TestCloneEnvironment_Unauthenticated verifies that an unauthenticated request
+// receives 401.
+func TestCloneEnvironment_Unauthenticated(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	_ = createTestToken(t, c) // seed system so the DB is initialised
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	body := `{"destination_environment_id":2}`
+	req, err := http.NewRequest("POST",
+		srv.URL+"/api/v1/projects/1/environments/1/clone",
+		strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	// No Authorization header.
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestCloneEnvironment_DestNotFound clones to a non-existent destination environment
+// and expects 404 or 400.
+func TestCloneEnvironment_DestNotFound(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	resp := doClone(t, client, srv.URL, token, 1, 1, 999999)
+	defer func() { _ = resp.Body.Close() }()
+	assert.True(t,
+		resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest,
+		"expected 404 or 400, got %d", resp.StatusCode)
+}

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -337,6 +337,57 @@ func (h *CatalogHandler) ListProjectEnvironments(w http.ResponseWriter, r *http.
 	sendSuccess(w, map[string]interface{}{"environments": environments}, "")
 }
 
+// CloneEnvironment handles POST /api/v1/projects/{id}/environments/{envId}/clone
+// Body: {"destination_environment_id": N}
+// Copies all active secrets from {envId} into the destination environment (same project).
+// Secrets already present by name in the destination are skipped.
+func (h *CatalogHandler) CloneEnvironment(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		sendError(w, "BadRequest", errInvalidProjectID, http.StatusBadRequest, nil)
+		return
+	}
+	srcEnvID, err := strconv.ParseUint(chi.URLParam(r, "envId"), 10, 32)
+	if err != nil {
+		sendError(w, "BadRequest", errInvalidEnvironmentID, http.StatusBadRequest, nil)
+		return
+	}
+	var reqBody struct {
+		DestinationEnvironmentID uint `json:"destination_environment_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	if reqBody.DestinationEnvironmentID == 0 {
+		sendError(w, "BadRequest", "destination_environment_id is required", http.StatusBadRequest, nil)
+		return
+	}
+
+	result, err := h.coreService.CloneEnvironment(r.Context(), uint(projectID), uint(srcEnvID), reqBody.DestinationEnvironmentID, userCtx.Username, userCtx.UserID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		msg := err.Error()
+		if strings.Contains(msg, "must ") || strings.Contains(msg, "required") ||
+			strings.Contains(msg, "belong") || strings.Contains(msg, "validation") {
+			status = http.StatusBadRequest
+		} else if strings.Contains(msg, errNotFound) {
+			status = http.StatusNotFound
+		} else {
+			log.Printf("Error cloning environment %d to %d (project %d): %v", srcEnvID, reqBody.DestinationEnvironmentID, projectID, err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "Error", msg, status, nil)
+		return
+	}
+	sendSuccess(w, result, "")
+}
+
 // RestoreEnvironment handles POST /api/v1/projects/{projectId}/environments/{id}/restore.
 // Nested under the project so the permission scope resolves from the project ID
 // (the environment row itself is soft-deleted and not loadable by the scope check).

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -474,6 +474,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			customMiddleware.RequireScopedPermission(permSecretsWrite, projectScope),
 			customMiddleware.RequireScopedPermission(permSecretsRead, customMiddleware.ScopeFromEnvParam("envId")),
 		).Post("/projects/{id}/environments/{envId}/copy-secrets", secretHandler.CopyEnvironmentSecrets)
+		// Environment clone: copies all secrets from one environment to another within the same
+		// project (staging → production promotion). Requires secrets.write on the project scope
+		// (creates in destination) AND secrets.read on the source environment (reads values).
+		r.With(
+			customMiddleware.RequireScopedPermission(permSecretsWrite, projectScope),
+			customMiddleware.RequireScopedPermission(permSecretsRead, customMiddleware.ScopeFromEnvParam("envId")),
+		).Post("/projects/{id}/environments/{envId}/clone", catalogHandler.CloneEnvironment)
 		r.With(customMiddleware.RequireScopedPermission(permSecretsRead, projectScope)).Get(pathProjectEnvs, catalogHandler.ListProjectEnvironments)
 		r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, projectScope)).Post(pathProjectEnvs, catalogHandler.CreateProjectEnvironment)
 		// Environment restore is nested under the project so the scope resolves


### PR DESCRIPTION
POST /projects/{id}/environments/{envId}/clone — copies all secrets to destination env, skipping existing names. CLI: keyorix project env clone <src> <dst> --project <name>. 8 tests.