### PR TITLE
feat(secrets): bulk rotation

### DIFF
--- a/internal/cli/secret/bulk_rotate.go
+++ b/internal/cli/secret/bulk_rotate.go
@@ -1,0 +1,166 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// bulkRotateResultDTO mirrors the core.BulkRotateResult JSON shape the API returns.
+type bulkRotateResultDTO struct {
+	Triggered []uint              `json:"triggered"`
+	Failed    []bulkRotateErrDTO  `json:"failed"`
+	Total     int                 `json:"total"`
+}
+
+// bulkRotateErrDTO mirrors core.BulkRotateError.
+type bulkRotateErrDTO struct {
+	SecretID uint   `json:"secret_id"`
+	Name     string `json:"name"`
+	Error    string `json:"error"`
+}
+
+var (
+	bulkRotateProject        uint
+	bulkRotateEnv            uint
+	bulkRotateClassification string
+	bulkRotateNames          string
+	bulkRotateConfirm        bool
+)
+
+var bulkRotateCmd = &cobra.Command{
+	Use:   "bulk-rotate",
+	Short: "Trigger rotation for multiple secrets at once",
+	Long: `Trigger rotation for all matching secrets in a project — the CLI surface for
+incident response ("rotate everything tagged confidential in project X").
+
+Secrets without auto-rotate configured are skipped (reported in the failure list,
+not treated as errors) so the operation is always best-effort.
+
+Without --names the command rotates every matching secret in the project; use
+--env and/or --classification to narrow the scope.
+
+--confirm is required (or pass --names to rotate a named subset): this is a bulk
+destructive operation and an accidental wide rotation cannot be undone.
+
+  keyorix secret bulk-rotate --project 7 --classification confidential --confirm
+  keyorix secret bulk-rotate --project 7 --env 3 --confirm
+  keyorix secret bulk-rotate --project 7 --names db-password,api-key --confirm`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if bulkRotateProject == 0 {
+			return fmt.Errorf("--project is required")
+		}
+		if !bulkRotateConfirm {
+			return fmt.Errorf("--confirm is required to proceed with bulk rotation (this is a destructive bulk operation)")
+		}
+
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+
+		// Resolve --names to a list of secret IDs if provided.
+		var secretIDs []uint
+		if bulkRotateNames != "" {
+			ids, err := resolveSecretNamesToIDs(context.Background(), c, bulkRotateProject, bulkRotateEnv, splitNames(bulkRotateNames))
+			if err != nil {
+				return fmt.Errorf("resolve secret names: %w", err)
+			}
+			secretIDs = ids
+		}
+
+		result, err := postBulkRotate(context.Background(), c, bulkRotateProject, secretIDs, bulkRotateEnv, bulkRotateClassification)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Bulk rotation triggered: %d scheduled, %d failed\n", len(result.Triggered), len(result.Failed))
+		if len(result.Failed) > 0 {
+			fmt.Println("\nFailed:")
+			for _, f := range result.Failed {
+				label := f.Name
+				if label == "" {
+					label = fmt.Sprintf("id:%d", f.SecretID)
+				}
+				fmt.Printf("  %-30s %s\n", label+":", f.Error)
+			}
+		}
+		return nil
+	},
+}
+
+// splitNames splits a comma-separated name list, trimming whitespace.
+func splitNames(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// resolveSecretNamesToIDs resolves a list of secret names to IDs by listing secrets
+// in the given project (and optionally environment). Names not found are skipped
+// with a warning.
+func resolveSecretNamesToIDs(ctx context.Context, c *common.RemoteClient, projectID, envID uint, names []string) ([]uint, error) {
+	path := fmt.Sprintf("/api/v1/secrets?project_id=%d", projectID)
+	if envID != 0 {
+		path += fmt.Sprintf("&environment_id=%d", envID)
+	}
+
+	var resp struct {
+		Secrets []struct {
+			ID   uint   `json:"ID"`
+			Name string `json:"Name"`
+		} `json:"secrets"`
+	}
+	if err := c.Get(ctx, path, &resp); err != nil {
+		return nil, err
+	}
+
+	nameToID := make(map[string]uint, len(resp.Secrets))
+	for _, s := range resp.Secrets {
+		nameToID[s.Name] = s.ID
+	}
+
+	ids := make([]uint, 0, len(names))
+	for _, n := range names {
+		id, ok := nameToID[n]
+		if !ok {
+			fmt.Printf("warning: secret %q not found — skipping\n", n)
+			continue
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// postBulkRotate POSTs the bulk-rotate request (split out for httptest tests).
+func postBulkRotate(ctx context.Context, c *common.RemoteClient, projectID uint, secretIDs []uint, envID uint, classification string) (bulkRotateResultDTO, error) {
+	path := fmt.Sprintf("/api/v1/projects/%d/secrets/bulk-rotate", projectID)
+	body := map[string]interface{}{
+		"secret_ids":      secretIDs,
+		"environment_id":  envID,
+		"classification":  classification,
+	}
+	var result bulkRotateResultDTO
+	if err := c.Post(ctx, path, body, &result); err != nil {
+		return bulkRotateResultDTO{}, err
+	}
+	return result, nil
+}
+
+func init() {
+	bulkRotateCmd.Flags().UintVar(&bulkRotateProject, "project", 0, "Project ID (required)")
+	bulkRotateCmd.Flags().UintVar(&bulkRotateEnv, "env", 0, "Environment ID (optional filter)")
+	bulkRotateCmd.Flags().StringVar(&bulkRotateClassification, "classification", "", "Classification label filter (e.g. confidential)")
+	bulkRotateCmd.Flags().StringVar(&bulkRotateNames, "names", "", "Comma-separated secret names to rotate (omit to rotate all matching)")
+	bulkRotateCmd.Flags().BoolVar(&bulkRotateConfirm, "confirm", false, "Required: confirm you want to trigger bulk rotation")
+	SecretCmd.AddCommand(bulkRotateCmd)
+}

--- a/internal/cli/secret/bulk_rotate_test.go
+++ b/internal/cli/secret/bulk_rotate_test.go
@@ -1,0 +1,85 @@
+package secret
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bulkRotateStub builds a test HTTP server that handles POST
+// /api/v1/projects/7/secrets/bulk-rotate. When capture is non-nil it records the
+// decoded request body there.
+func bulkRotateStub(t *testing.T, status int, responseBody string, capture *map[string]interface{}) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/7/secrets/bulk-rotate" {
+			if capture != nil {
+				b, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(b, capture)
+			}
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(responseBody))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestBulkRotate_Remote_Success(t *testing.T) {
+	const body = `{"data":{"triggered":[1,2,3],"total":3}}`
+	var got map[string]interface{}
+	rc, done := bulkRotateStub(t, http.StatusOK, body, &got)
+	defer done()
+
+	result, err := postBulkRotate(context.Background(), rc, 7, []uint{1, 2, 3}, 0, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, len(result.Triggered))
+	assert.Empty(t, result.Failed)
+	assert.Equal(t, 3, result.Total)
+
+	// Verify the request body contained the secret IDs.
+	ids, ok := got["secret_ids"].([]interface{})
+	require.True(t, ok, "secret_ids should be present in the request body")
+	assert.Len(t, ids, 3)
+}
+
+func TestBulkRotate_Remote_PartialFailure(t *testing.T) {
+	const body = `{"data":{"triggered":[1],"failed":[{"secret_id":2,"name":"broken","error":"no rotation config"}],"total":2}}`
+	rc, done := bulkRotateStub(t, http.StatusOK, body, nil)
+	defer done()
+
+	result, err := postBulkRotate(context.Background(), rc, 7, []uint{1, 2}, 0, "")
+	require.NoError(t, err)
+
+	assert.Len(t, result.Triggered, 1)
+	assert.Equal(t, uint(1), result.Triggered[0])
+	require.Len(t, result.Failed, 1)
+	assert.Equal(t, uint(2), result.Failed[0].SecretID)
+	assert.Equal(t, "broken", result.Failed[0].Name)
+	assert.Contains(t, result.Failed[0].Error, "no rotation config")
+}
+
+func TestBulkRotate_Remote_RequiresConfirm(t *testing.T) {
+	// Reset global flag so it is not set from a previous test run.
+	bulkRotateConfirm = false
+	bulkRotateProject = 7
+
+	err := bulkRotateCmd.RunE(bulkRotateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--confirm")
+
+	// No HTTP call is made (the stub is not even created — we expect an early return).
+}

--- a/internal/core/bulk_rotate.go
+++ b/internal/core/bulk_rotate.go
@@ -1,0 +1,200 @@
+// bulk_rotate.go — BulkRotateSecrets: trigger rotation for multiple secrets in one call.
+// Incident response: "rotate everything tagged confidential in project X" in a single
+// operation instead of one call per secret. Secrets without auto-rotate configured are
+// skipped (reported in Failed with reason "no rotation config") — they never silently
+// block the rest. Returns partial results; never returns a top-level error unless the
+// ENTIRE operation cannot begin (e.g. invalid arguments or DB connectivity failure on
+// the initial load).
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// BulkRotateRequest describes a bulk rotation request. SecretIDs is an explicit list;
+// if empty the operation rotates every matching secret in ProjectID (with optional EnvID
+// and Classification filters). ProjectID is required in all cases.
+type BulkRotateRequest struct {
+	// SecretIDs: explicit list of secret IDs to rotate. When non-empty, ProjectID is
+	// still required as a cross-project guard — only secrets that actually belong to
+	// ProjectID are rotated; others are reported as failures.
+	SecretIDs []uint
+	// ProjectID scopes the operation. Required.
+	ProjectID uint
+	// EnvID optionally restricts a project-wide rotation to one environment.
+	// Ignored when SecretIDs is non-empty.
+	EnvID uint
+	// Classification optionally restricts a project-wide rotation to secrets with
+	// a specific classification label (e.g. "confidential"). Empty = all.
+	// Ignored when SecretIDs is non-empty.
+	Classification string
+	// RotatedBy is the actor string recorded on each rotation (username, "system:", etc.).
+	RotatedBy string
+}
+
+// BulkRotateResult summarises the outcome. Triggered contains every secret ID for
+// which rotation was successfully scheduled; Failed lists the rest with per-entry
+// reasons. Never nil.
+type BulkRotateResult struct {
+	Triggered []uint           `json:"triggered"`
+	Failed    []BulkRotateError `json:"failed,omitempty"`
+	Total     int              `json:"total"`
+}
+
+// BulkRotateError is a per-secret failure entry in BulkRotateResult.
+type BulkRotateError struct {
+	SecretID uint   `json:"secret_id"`
+	Name     string `json:"name,omitempty"`
+	Error    string `json:"error"`
+}
+
+// BulkRotateSecrets schedules rotation for all matching secrets.
+//
+// When req.SecretIDs is non-empty, only those secrets are processed. Each is
+// checked against req.ProjectID so a project-scoped caller cannot rotate another
+// project's secrets by guessing IDs.
+//
+// When req.SecretIDs is empty, every live secret in req.ProjectID is processed,
+// with optional req.EnvID and req.Classification filters.
+//
+// For each secret: if AutoRotate is not enabled, the secret is reported in
+// BulkRotateResult.Failed with reason "no rotation config" — it is never treated
+// as a fatal error. Otherwise, rotation is triggered via RotateSecretOnDemand.
+//
+// Returns partial results; individual secret failures do not abort the run.
+// Returns an error only if the request is structurally invalid or the initial
+// secret load fails entirely.
+func (c *KeyorixCore) BulkRotateSecrets(ctx context.Context, req BulkRotateRequest) (*BulkRotateResult, error) {
+	if req.ProjectID == 0 {
+		return nil, fmt.Errorf("project ID is required")
+	}
+	if req.RotatedBy == "" {
+		req.RotatedBy = "system:bulk-rotate"
+	}
+
+	result := &BulkRotateResult{
+		Triggered: []uint{},
+		Failed:    []BulkRotateError{},
+	}
+
+	if len(req.SecretIDs) > 0 {
+		// Explicit ID list — load all in one batch query.
+		secrets, err := c.storage.GetSecretsByIDs(ctx, req.SecretIDs)
+		if err != nil {
+			return nil, fmt.Errorf("load secrets: %w", err)
+		}
+		// Build a set for fast lookup.
+		found := make(map[uint]bool, len(secrets))
+		for _, s := range secrets {
+			found[s.ID] = true
+		}
+		// Report IDs that were not found.
+		for _, id := range req.SecretIDs {
+			if !found[id] {
+				result.Failed = append(result.Failed, BulkRotateError{
+					SecretID: id,
+					Error:    "secret not found",
+				})
+				result.Total++
+			}
+		}
+		// Process found secrets.
+		for _, s := range secrets {
+			result.Total++
+			if s.ProjectID != req.ProjectID {
+				result.Failed = append(result.Failed, BulkRotateError{
+					SecretID: s.ID,
+					Name:     s.Name,
+					Error:    "secret does not belong to this project",
+				})
+				continue
+			}
+			if !s.IsSecret {
+				result.Failed = append(result.Failed, BulkRotateError{
+					SecretID: s.ID,
+					Name:     s.Name,
+					Error:    "not a secret (folder nodes cannot be rotated)",
+				})
+				continue
+			}
+			if !s.AutoRotate {
+				result.Failed = append(result.Failed, BulkRotateError{
+					SecretID: s.ID,
+					Name:     s.Name,
+					Error:    "no rotation config",
+				})
+				continue
+			}
+			if err := c.bulkRotateOne(ctx, s.ID, s.RotationLength, s.RotationCharset, req.RotatedBy, result); err != nil {
+				// bulkRotateOne already appended to result.Failed; err signals a
+				// generate-value failure (very unlikely) which is still per-secret.
+				_ = err
+				continue
+			}
+		}
+		return result, nil
+	}
+
+	// Project-wide: list all matching secrets. Use the storage ceiling page size (10 000)
+	// so we get all secrets in one shot; Page=1 with a large PageSize is the established
+	// pattern for trusted internal callers (see inventory/csv export callers in this repo).
+	const bulkRotatePageSize = 10000
+	filter := &storage.SecretFilter{
+		ProjectID: &req.ProjectID,
+		Page:      1,
+		PageSize:  bulkRotatePageSize,
+	}
+	if req.EnvID != 0 {
+		filter.EnvironmentID = &req.EnvID
+	}
+	if req.Classification != "" {
+		filter.Classification = &req.Classification
+	}
+	isSecret := true
+	filter.IsSecret = &isSecret
+
+	secrets, _, err := c.storage.ListSecrets(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("list secrets for project %d: %w", req.ProjectID, err)
+	}
+
+	for _, s := range secrets {
+		result.Total++
+		if !s.AutoRotate {
+			result.Failed = append(result.Failed, BulkRotateError{
+				SecretID: s.ID,
+				Name:     s.Name,
+				Error:    "no rotation config",
+			})
+			continue
+		}
+		_ = c.bulkRotateOne(ctx, s.ID, s.RotationLength, s.RotationCharset, req.RotatedBy, result)
+	}
+	return result, nil
+}
+
+// bulkRotateOne generates a fresh value and rotates a single secret via RotateSecretOnDemand.
+// On success it appends the secret ID to result.Triggered; on failure it appends to
+// result.Failed. Returns a non-nil error only when value generation itself fails.
+func (c *KeyorixCore) bulkRotateOne(ctx context.Context, secretID uint, rotationLength int, rotationCharset, rotatedBy string, result *BulkRotateResult) error {
+	val, err := generateRotatedValueSpec(rotationLength, rotationCharset)
+	if err != nil {
+		result.Failed = append(result.Failed, BulkRotateError{
+			SecretID: secretID,
+			Error:    fmt.Sprintf("generate value: %v", err),
+		})
+		return err
+	}
+	if _, err := c.RotateSecretOnDemand(ctx, secretID, []byte(val), rotatedBy); err != nil {
+		result.Failed = append(result.Failed, BulkRotateError{
+			SecretID: secretID,
+			Error:    err.Error(),
+		})
+		return nil // rotation error is per-secret, not fatal
+	}
+	result.Triggered = append(result.Triggered, secretID)
+	return nil
+}

--- a/internal/core/bulk_rotate_test.go
+++ b/internal/core/bulk_rotate_test.go
@@ -1,0 +1,221 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// bulkRotateDB sets up an in-memory SQLite DB with the tables needed for bulk rotation
+// tests and returns a core + a helper to create test secrets.
+func bulkRotateDB(t *testing.T) (*KeyorixCore, func(name, classification string, autoRotate bool) uint) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_journal_mode=WAL"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{},
+		&models.SecretNode{}, &models.SecretVersion{},
+		&models.AuditEvent{}, &models.SecretAccessLog{},
+	))
+
+	ctx := context.Background()
+	ls := store.NewLocalStorage(db)
+
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "bulk-rotate-proj"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	c := &KeyorixCore{storage: ls, now: time.Now}
+
+	mk := func(name, classification string, autoRotate bool) uint {
+		s, err := ls.CreateSecret(ctx, &models.SecretNode{
+			Name: name, ProjectID: p.ID, EnvironmentID: env.ID,
+			Type: "password", IsSecret: true, Status: "active",
+			Classification: classification,
+			AutoRotate:     autoRotate,
+			OwnerID:        1, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		})
+		require.NoError(t, err)
+		// Seed an initial version so RotateSecret can get the latest version.
+		_, err = ls.CreateSecretVersion(ctx, &models.SecretVersion{
+			SecretNodeID: s.ID, VersionNumber: 1,
+			EncryptedValue:     []byte("initial-value"),
+			EncryptionMetadata: []byte("{}"),
+			CreatedAt:          time.Now(),
+		})
+		require.NoError(t, err)
+		return s.ID
+	}
+
+	return c, mk
+}
+
+func TestBulkRotateSecrets_ByIDs(t *testing.T) {
+	c, mk := bulkRotateDB(t)
+	ctx := context.Background()
+
+	id1 := mk("secret-alpha", "", true)
+	id2 := mk("secret-beta", "", true)
+	id3 := mk("secret-gamma", "", true)
+
+	// Determine project ID from one of the secrets.
+	s, err := c.storage.GetSecret(ctx, id1)
+	require.NoError(t, err)
+	projectID := s.ProjectID
+
+	result, err := c.BulkRotateSecrets(ctx, BulkRotateRequest{
+		ProjectID: projectID,
+		SecretIDs: []uint{id1, id2, id3},
+		RotatedBy: "alice",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.Total)
+	assert.Len(t, result.Triggered, 3)
+	assert.Empty(t, result.Failed)
+	assert.Contains(t, result.Triggered, id1)
+	assert.Contains(t, result.Triggered, id2)
+	assert.Contains(t, result.Triggered, id3)
+
+	// Each secret now has version 2.
+	for _, id := range []uint{id1, id2, id3} {
+		latest, err := c.storage.GetLatestSecretVersion(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, 2, latest.VersionNumber, "secret %d should have been rotated to version 2", id)
+	}
+}
+
+func TestBulkRotateSecrets_ByProject(t *testing.T) {
+	c, mk := bulkRotateDB(t)
+	ctx := context.Background()
+
+	id1 := mk("proj-secret-a", "", true)
+	id2 := mk("proj-secret-b", "", true)
+
+	s, err := c.storage.GetSecret(ctx, id1)
+	require.NoError(t, err)
+	projectID := s.ProjectID
+
+	// No SecretIDs — rotate all in the project.
+	result, err := c.BulkRotateSecrets(ctx, BulkRotateRequest{
+		ProjectID: projectID,
+		RotatedBy: "ops",
+	})
+	require.NoError(t, err)
+	// Total includes all secrets in the project from this and the parent test helpers
+	// (each helper call creates its own DB, so total here is exactly 2).
+	assert.Equal(t, 2, result.Total)
+	assert.Len(t, result.Triggered, 2)
+	assert.Empty(t, result.Failed)
+	assert.Contains(t, result.Triggered, id1)
+	assert.Contains(t, result.Triggered, id2)
+}
+
+func TestBulkRotateSecrets_ByClassification(t *testing.T) {
+	c, mk := bulkRotateDB(t)
+	ctx := context.Background()
+
+	confID := mk("conf-secret", "confidential", true)
+	_ = mk("public-secret", "public", true)
+
+	s, err := c.storage.GetSecret(ctx, confID)
+	require.NoError(t, err)
+	projectID := s.ProjectID
+
+	// Filter by classification — only "confidential" should be rotated.
+	result, err := c.BulkRotateSecrets(ctx, BulkRotateRequest{
+		ProjectID:      projectID,
+		Classification: "confidential",
+		RotatedBy:      "incident-response",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Total, "only the confidential secret matches the filter")
+	assert.Len(t, result.Triggered, 1)
+	assert.Equal(t, confID, result.Triggered[0])
+	assert.Empty(t, result.Failed)
+
+	// The public secret is still on version 1.
+}
+
+func TestBulkRotateSecrets_SkipsNoConfig(t *testing.T) {
+	c, mk := bulkRotateDB(t)
+	ctx := context.Background()
+
+	withRotation := mk("has-rotation", "", true)
+	noRotation := mk("no-rotation", "", false)
+
+	s, err := c.storage.GetSecret(ctx, withRotation)
+	require.NoError(t, err)
+	projectID := s.ProjectID
+
+	result, err := c.BulkRotateSecrets(ctx, BulkRotateRequest{
+		ProjectID: projectID,
+		RotatedBy: "ops",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Total)
+	assert.Len(t, result.Triggered, 1)
+	assert.Equal(t, withRotation, result.Triggered[0])
+	require.Len(t, result.Failed, 1)
+	assert.Equal(t, noRotation, result.Failed[0].SecretID)
+	assert.Contains(t, result.Failed[0].Error, "no rotation config")
+
+	// The no-rotation secret is still on version 1 — not an error, just a skip.
+	latest, err := c.storage.GetLatestSecretVersion(ctx, noRotation)
+	require.NoError(t, err)
+	assert.Equal(t, 1, latest.VersionNumber)
+}
+
+func TestBulkRotateSecrets_PartialFailure(t *testing.T) {
+	c, mk := bulkRotateDB(t)
+	ctx := context.Background()
+
+	valid1 := mk("valid-one", "", true)
+	valid2 := mk("valid-two", "", true)
+	noconf := mk("no-conf", "", false)
+
+	s, err := c.storage.GetSecret(ctx, valid1)
+	require.NoError(t, err)
+	projectID := s.ProjectID
+
+	// Mix of valid IDs + an ID that doesn't exist + one with no rotation config.
+	const missingID = uint(99999)
+	result, err := c.BulkRotateSecrets(ctx, BulkRotateRequest{
+		ProjectID: projectID,
+		SecretIDs: []uint{valid1, valid2, noconf, missingID},
+		RotatedBy: "responder",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 4, result.Total)
+	// 2 succeeded, 2 failed (no-conf + missing).
+	assert.Len(t, result.Triggered, 2)
+	assert.Len(t, result.Failed, 2)
+
+	failedIDs := make(map[uint]string, len(result.Failed))
+	for _, f := range result.Failed {
+		failedIDs[f.SecretID] = f.Error
+	}
+	assert.Contains(t, failedIDs[noconf], "no rotation config")
+	assert.Contains(t, failedIDs[missingID], "not found")
+
+	// valid1 and valid2 were rotated to version 2.
+	for _, id := range []uint{valid1, valid2} {
+		latest, err := c.storage.GetLatestSecretVersion(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, 2, latest.VersionNumber)
+	}
+	// no-conf stays at version 1.
+	latest, err := c.storage.GetLatestSecretVersion(ctx, noconf)
+	require.NoError(t, err)
+	assert.Equal(t, 1, latest.VersionNumber)
+}

--- a/server/http/bulk_rotate_handler_test.go
+++ b/server/http/bulk_rotate_handler_test.go
@@ -1,0 +1,205 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createBulkTestSecret creates a secret via the API and returns its ID from the response.
+func createBulkTestSecret(t *testing.T, client *http.Client, baseURL, token, name string, projectID, envID uint) uint {
+	t.Helper()
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":           name,
+		"value":          "bulk-rotate-test-value",
+		"project_id":     projectID,
+		"environment_id": envID,
+		"type":           "password",
+	})
+	req, err := http.NewRequest("POST", baseURL+"/api/v1/secrets", bytes.NewBuffer(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	data, ok := out["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object in create-secret response: %v", out)
+	id, ok := data["ID"].(float64)
+	require.True(t, ok, "expected numeric ID in create-secret response data: %v", data)
+	return uint(id)
+}
+
+// newBulkRotateTestEnv bootstraps a core + token + server and returns the bootstrapped
+// project and environment IDs (both are created by BootstrapSystem).
+func newBulkRotateTestEnv(t *testing.T) (c *core.KeyorixCore, token string, srv *httptest.Server, projectID, envID uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	c = newTestCore(t)
+	token = createTestToken(t, c)
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv = httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+
+	// Discover the project and environment IDs created by BootstrapSystem.
+	ctx := context.Background()
+	projects, err := c.ListProjects(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, projects)
+	projectID = projects[0].ID
+
+	envs, err := c.ListEnvironmentsByProject(ctx, projectID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+	envID = envs[0].ID
+
+	return
+}
+
+// doBulkRotate posts a bulk-rotate request and returns the HTTP status + decoded body.
+func doBulkRotate(t *testing.T, client *http.Client, baseURL, token string, projectID uint, body string) (int, map[string]interface{}) {
+	t.Helper()
+	url := fmt.Sprintf("%s/api/v1/projects/%d/secrets/bulk-rotate", baseURL, projectID)
+	req, err := http.NewRequest("POST", url, strings.NewReader(body))
+	require.NoError(t, err)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	var out map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	return resp.StatusCode, out
+}
+
+// TestBulkRotate_Unauthenticated verifies that the endpoint rejects requests without a token.
+func TestBulkRotate_Unauthenticated(t *testing.T) {
+	_, _, srv, projectID, _ := newBulkRotateTestEnv(t)
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	code, _ := doBulkRotate(t, client, srv.URL, "" /* no token */, projectID, `{}`)
+	assert.Equal(t, http.StatusUnauthorized, code)
+}
+
+// TestBulkRotate_EmptyIDs posts an explicit empty secret_ids list. The handler forwards
+// to core.BulkRotateSecrets with an empty list, which then falls through to the
+// project-wide path — returning 200 with total == 0 (no secrets seeded yet).
+func TestBulkRotate_EmptyIDs(t *testing.T) {
+	_, token, srv, projectID, _ := newBulkRotateTestEnv(t)
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	code, out := doBulkRotate(t, client, srv.URL, token, projectID, `{"secret_ids":[]}`)
+	assert.Equal(t, http.StatusOK, code)
+
+	data, ok := out["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object: %v", out)
+	// When secret_ids is empty the core falls through to the project-wide path.
+	// No secrets have been created, so total should be 0.
+	total, ok := data["total"].(float64)
+	require.True(t, ok, "expected numeric total in response: %v", data)
+	assert.Equal(t, float64(0), total)
+}
+
+// TestBulkRotate_BySecretIDs posts an explicit list of secret IDs and confirms the
+// response envelope contains the expected fields. Secrets without auto-rotation
+// configured are reported in failed (not triggered), which is the documented
+// "partial-results, never fatal" contract.
+func TestBulkRotate_BySecretIDs(t *testing.T) {
+	_, token, srv, projectID, envID := newBulkRotateTestEnv(t)
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	id1 := createBulkTestSecret(t, client, srv.URL, token, "bulk-id-secret-1", projectID, envID)
+	id2 := createBulkTestSecret(t, client, srv.URL, token, "bulk-id-secret-2", projectID, envID)
+
+	bodyJSON := fmt.Sprintf(`{"secret_ids":[%d,%d]}`, id1, id2)
+	code, out := doBulkRotate(t, client, srv.URL, token, projectID, bodyJSON)
+	assert.Equal(t, http.StatusOK, code)
+
+	data, ok := out["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object: %v", out)
+	assert.Contains(t, data, "triggered", "response must contain triggered field")
+	assert.Contains(t, data, "total", "response must contain total field")
+
+	// total must equal the number of IDs we submitted.
+	total, ok := data["total"].(float64)
+	require.True(t, ok, "expected numeric total: %v", data)
+	assert.Equal(t, float64(2), total, "total must match the number of submitted IDs")
+}
+
+// TestBulkRotate_ByProject posts with no secret_ids, relying on the project-wide path.
+// The response must contain both triggered and failed arrays.
+func TestBulkRotate_ByProject(t *testing.T) {
+	_, token, srv, projectID, envID := newBulkRotateTestEnv(t)
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	createBulkTestSecret(t, client, srv.URL, token, "proj-rotate-secret-1", projectID, envID)
+	createBulkTestSecret(t, client, srv.URL, token, "proj-rotate-secret-2", projectID, envID)
+
+	code, out := doBulkRotate(t, client, srv.URL, token, projectID, `{}`)
+	assert.Equal(t, http.StatusOK, code)
+
+	data, ok := out["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object: %v", out)
+	assert.Contains(t, data, "triggered", "response must contain triggered field")
+	assert.Contains(t, data, "total", "response must contain total field")
+	// failed is omitempty but the key should be present when there are failures;
+	// secrets without auto_rotate will land there — just confirm the envelope.
+	total, ok := data["total"].(float64)
+	require.True(t, ok, "expected numeric total: %v", data)
+	assert.GreaterOrEqual(t, total, float64(2), "total must reflect both seeded secrets")
+}
+
+// TestBulkRotate_WrongProject submits secret IDs that belong to a different project.
+// The cross-project guard must report them in failed, not triggered.
+func TestBulkRotate_WrongProject(t *testing.T) {
+	c, token, srv, projectID, envID := newBulkRotateTestEnv(t)
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	// Seed two secrets in the real project.
+	id1 := createBulkTestSecret(t, client, srv.URL, token, "cross-proj-secret-1", projectID, envID)
+	id2 := createBulkTestSecret(t, client, srv.URL, token, "cross-proj-secret-2", projectID, envID)
+
+	// Create a second project via the core API and submit the first project's secret
+	// IDs scoped to the second project — the cross-project guard must reject them.
+	ctx := context.Background()
+	otherProject, err := c.CreateProject(ctx, "other-project", "")
+	require.NoError(t, err)
+
+	bodyJSON := fmt.Sprintf(`{"secret_ids":[%d,%d]}`, id1, id2)
+	code, out := doBulkRotate(t, client, srv.URL, token, otherProject.ID, bodyJSON)
+	assert.Equal(t, http.StatusOK, code)
+
+	data, ok := out["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object: %v", out)
+
+	// All submitted IDs belong to the first project; rotated under a different
+	// project they must all land in failed.
+	failed, hasFailed := data["failed"]
+	require.True(t, hasFailed, "response must contain failed field when cross-project IDs are submitted: %v", data)
+	failedSlice, ok := failed.([]interface{})
+	require.True(t, ok, "failed must be an array: %v", failed)
+	assert.Len(t, failedSlice, 2, "both cross-project secrets must appear in failed")
+}

--- a/server/http/handlers/secrets_bulk_rotate.go
+++ b/server/http/handlers/secrets_bulk_rotate.go
@@ -1,0 +1,69 @@
+// secrets_bulk_rotate.go — BulkRotateSecrets handler: trigger rotation for multiple
+// secrets in a single project call — the HTTP transport for core.BulkRotateSecrets.
+// Scoped secrets.write (project) is enforced by the router.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// BulkRotateSecrets handles POST /api/v1/projects/{id}/secrets/bulk-rotate.
+//
+// Request body (all fields optional):
+//
+//	{
+//	  "secret_ids":       [1, 2, 3],       // explicit list; if omitted, rotate all matching
+//	  "environment_id":   4,               // optional env filter (ignored when secret_ids set)
+//	  "classification":   "confidential"   // optional classification filter (ignored when secret_ids set)
+//	}
+//
+// Returns a BulkRotateResult JSON object with triggered/failed counts. Individual secret
+// failures never abort the run — partial results are always returned.
+func (h *SecretHandler) BulkRotateSecrets(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	var reqBody struct {
+		SecretIDs      []uint `json:"secret_ids"`
+		EnvironmentID  uint   `json:"environment_id"`
+		Classification string `json:"classification"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+
+	req := core.BulkRotateRequest{
+		ProjectID:      uint(id),
+		SecretIDs:      reqBody.SecretIDs,
+		EnvID:          reqBody.EnvironmentID,
+		Classification: strings.TrimSpace(reqBody.Classification),
+		RotatedBy:      userCtx.Username,
+	}
+
+	result, err := h.coreService.BulkRotateSecrets(r.Context(), req)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "required") {
+			status = http.StatusBadRequest
+		}
+		h.sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+	h.sendSuccess(w, result, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -463,6 +463,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, projectScope)).Post("/projects/{id}/secrets/extend-expiring", secretHandler.ExtendExpiringSecrets)
 		// Bulk rename toward naming-policy conformance — remediation for name-conformance.
 		r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, projectScope)).Post("/projects/{id}/secrets/bulk-rename", secretHandler.BulkRenameSecrets)
+		// Bulk rotation — trigger rotation for multiple secrets at once (incident response).
+		r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, projectScope)).Post("/projects/{id}/secrets/bulk-rotate", secretHandler.BulkRotateSecrets)
 		// Bulk copy also requires secrets.read on the SOURCE environment (resolved from
 		// the envId path param, not attacker-supplied input) — mirroring the single-secret
 		// copy route below, which gates secrets.read on the source in addition to


### PR DESCRIPTION
POST /projects/{id}/secrets/bulk-rotate — trigger rotation by IDs or project/classification filter. CLI: keyorix secret bulk-rotate --project <p> --confirm. Calls existing RotateSecretOnDemand per secret. 8 tests.