### PR TITLE
feat(project): stats endpoint

### DIFF
--- a/internal/cli/project/project.go
+++ b/internal/cli/project/project.go
@@ -22,6 +22,7 @@ func init() {
 	ProjectCmd.AddCommand(useCmd)
 	ProjectCmd.AddCommand(currentCmd)
 	ProjectCmd.AddCommand(describeCmd)
+	ProjectCmd.AddCommand(statsCmd)
 
 	// env subcommand tree: project env list/create/delete/clone
 	envCmd.AddCommand(envListCmd)

--- a/internal/cli/project/stats.go
+++ b/internal/cli/project/stats.go
@@ -1,0 +1,208 @@
+// stats.go — keyorix project stats <name>
+//
+// Shows rich per-project statistics: secret counts, rotation health, access
+// metrics, and a classification breakdown.
+package project
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var statsFormat string
+
+var statsCmd = &cobra.Command{
+	Use:   "stats <name>",
+	Short: "Show rich statistics for a project",
+	Long: `Print per-project statistics: secret counts, rotation health, unique
+accessors, open anomalies, and a classification breakdown.
+
+In remote mode the project name is resolved to an ID via the list endpoint,
+then GET /api/v1/projects/{id}/stats is called.
+
+Examples:
+  keyorix project stats my-project
+  keyorix project stats my-project --format json`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE:         runStats,
+}
+
+func init() {
+	statsCmd.Flags().StringVar(&statsFormat, "format", "table", "Output format (table, json)")
+}
+
+// ── Wire types (remote API response shape) ─────────────────────────────────
+
+type projectStats struct {
+	ProjectID   uint   `json:"project_id"`
+	ProjectName string `json:"project_name"`
+
+	TotalSecrets     int `json:"total_secrets"`
+	ActiveSecrets    int `json:"active_secrets"`
+	ExpiredSecrets   int `json:"expired_secrets"`
+	ExpiringIn30Days int `json:"expiring_in_30_days"`
+
+	RotationEnabled int        `json:"rotation_enabled"`
+	OverdueRotation int        `json:"overdue_rotation"`
+	LastRotationAt  *time.Time `json:"last_rotation_at,omitempty"`
+
+	UniqueAccessors int `json:"unique_accessors"`
+	OpenAnomalies   int `json:"open_anomalies"`
+
+	ClassificationCounts map[string]int `json:"classification_counts"`
+
+	ComputedAt time.Time `json:"computed_at"`
+}
+
+// ── Command runner ──────────────────────────────────────────────────────────
+
+func runStats(_ *cobra.Command, args []string) error {
+	name := args[0]
+	ctx := context.Background()
+
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runStatsRemote(ctx, rc, name)
+	}
+	return runStatsEmbedded(ctx, name)
+}
+
+// ── Remote mode ─────────────────────────────────────────────────────────────
+
+func runStatsRemote(ctx context.Context, rc *common.RemoteClient, name string) error {
+	// Resolve project name → ID.
+	var listResp struct {
+		Projects []struct {
+			ID   uint   `json:"id"`
+			Name string `json:"name"`
+		} `json:"projects"`
+	}
+	if err := rc.Get(ctx, "/api/v1/projects", &listResp); err != nil {
+		return fmt.Errorf("failed to list projects: %w", err)
+	}
+	var projectID uint
+	for _, p := range listResp.Projects {
+		if strings.EqualFold(p.Name, name) {
+			projectID = p.ID
+			break
+		}
+	}
+	if projectID == 0 {
+		return fmt.Errorf("project %q not found", name)
+	}
+
+	path := "/api/v1/projects/" + strconv.Itoa(int(projectID)) + "/stats"
+	var stats projectStats
+	if err := rc.Get(ctx, path, &stats); err != nil {
+		return fmt.Errorf("failed to get project stats: %w", err)
+	}
+
+	return printStats(name, &stats)
+}
+
+// ── Embedded mode ───────────────────────────────────────────────────────────
+
+func runStatsEmbedded(ctx context.Context, name string) error {
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+
+	projectID, err := common.LookupProjectIDByName(ctx, svc.Storage(), name)
+	if err != nil {
+		return err
+	}
+
+	result, err := svc.GetProjectStats(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to compute project stats: %w", err)
+	}
+
+	// Convert core type to display shape (same JSON tags, safe to copy field by field).
+	stats := &projectStats{
+		ProjectID:            result.ProjectID,
+		ProjectName:          result.ProjectName,
+		TotalSecrets:         result.TotalSecrets,
+		ActiveSecrets:        result.ActiveSecrets,
+		ExpiredSecrets:       result.ExpiredSecrets,
+		ExpiringIn30Days:     result.ExpiringIn30Days,
+		RotationEnabled:      result.RotationEnabled,
+		OverdueRotation:      result.OverdueRotation,
+		LastRotationAt:       result.LastRotationAt,
+		UniqueAccessors:      result.UniqueAccessors,
+		OpenAnomalies:        result.OpenAnomalies,
+		ClassificationCounts: result.ClassificationCounts,
+		ComputedAt:           result.ComputedAt,
+	}
+	return printStats(name, stats)
+}
+
+// ── Display ─────────────────────────────────────────────────────────────────
+
+func printStats(projectName string, s *projectStats) error {
+	switch statsFormat {
+	case "json":
+		return printStatsJSON(s)
+	case "table":
+		printStatsTable(projectName, s)
+		return nil
+	default:
+		return fmt.Errorf("unsupported format: %s (use 'table' or 'json')", statsFormat)
+	}
+}
+
+func printStatsJSON(s *projectStats) error {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("failed to marshal stats: %w", err)
+	}
+	fmt.Println(string(b))
+	return nil
+}
+
+func printStatsTable(projectName string, s *projectStats) {
+	fmt.Printf("Project: %s\n\n", projectName)
+
+	fmt.Println("Secrets")
+	fmt.Printf("  %-22s %d\n", "Total:", s.TotalSecrets)
+	fmt.Printf("  %-22s %d\n", "Active:", s.ActiveSecrets)
+	fmt.Printf("  %-22s %d\n", "Expired:", s.ExpiredSecrets)
+	fmt.Printf("  %-22s %d\n", "Expiring (30d):", s.ExpiringIn30Days)
+	fmt.Println()
+
+	fmt.Println("Rotation")
+	fmt.Printf("  %-22s %d\n", "With config:", s.RotationEnabled)
+	fmt.Printf("  %-22s %d\n", "Overdue:", s.OverdueRotation)
+	lastRot := "never"
+	if s.LastRotationAt != nil {
+		lastRot = s.LastRotationAt.Format("2006-01-02")
+	}
+	fmt.Printf("  %-22s %s\n", "Last rotation:", lastRot)
+	fmt.Println()
+
+	fmt.Println("Access")
+	fmt.Printf("  %-22s %d\n", "Unique accessors:", s.UniqueAccessors)
+	fmt.Printf("  %-22s %d\n", "Open anomalies:", s.OpenAnomalies)
+	fmt.Println()
+
+	if len(s.ClassificationCounts) > 0 {
+		fmt.Println("Classification")
+		// Sort keys for deterministic output.
+		keys := make([]string, 0, len(s.ClassificationCounts))
+		for k := range s.ClassificationCounts {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Printf("  %-22s %d\n", k+":", s.ClassificationCounts[k])
+		}
+	}
+}

--- a/internal/cli/project/stats_test.go
+++ b/internal/cli/project/stats_test.go
@@ -1,0 +1,145 @@
+package project
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupStatsRemote creates a mock HTTP server backed by handler, configures the
+// KEYORIX_* env vars so common.NewRemoteClient returns true, and returns the
+// RemoteClient plus a cleanup function.
+func setupStatsRemote(t *testing.T, handler http.HandlerFunc) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	t.Setenv("KEYORIX_PROJECT", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() {
+		statsFormat = "table"
+	})
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+// captureStatsStdout captures os.Stdout output from fn.
+func captureStatsStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	fn()
+	require.NoError(t, w.Close())
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+// projectsAndStatsHandler serves /api/v1/projects and /api/v1/projects/1/stats
+// in the standard sendSuccess envelope shape.
+func projectsAndStatsHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/api/v1/projects":
+		_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"acme","description":"test project"}]}}`))
+	case "/api/v1/projects/1/stats":
+		_, _ = w.Write([]byte(`{"success":true,"data":{` +
+			`"project_id":1,` +
+			`"project_name":"acme",` +
+			`"total_secrets":42,` +
+			`"active_secrets":39,` +
+			`"expired_secrets":1,` +
+			`"expiring_in_30_days":2,` +
+			`"rotation_enabled":28,` +
+			`"overdue_rotation":3,` +
+			`"last_rotation_at":"2026-07-15T00:00:00Z",` +
+			`"unique_accessors":7,` +
+			`"open_anomalies":1,` +
+			`"classification_counts":{"confidential":12,"internal":24,"public":3,"unclassified":3},` +
+			`"computed_at":"2026-07-19T12:00:00Z"` +
+			`}}`))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func TestProjectStats_Remote_TableFormat(t *testing.T) {
+	rc, done := setupStatsRemote(t, projectsAndStatsHandler)
+	defer done()
+
+	statsFormat = "table"
+	out := captureStatsStdout(t, func() {
+		require.NoError(t, runStatsRemote(t.Context(), rc, "acme"))
+	})
+
+	// Header
+	assert.Contains(t, out, "acme")
+
+	// Secrets section
+	assert.Contains(t, out, "Secrets")
+	assert.Contains(t, out, "42")
+	assert.Contains(t, out, "39")
+	assert.Contains(t, out, "Expired")
+	assert.Contains(t, out, "Expiring")
+
+	// Rotation section
+	assert.Contains(t, out, "Rotation")
+	assert.Contains(t, out, "28")
+	assert.Contains(t, out, "3")
+	assert.Contains(t, out, "2026-07-15")
+
+	// Access section
+	assert.Contains(t, out, "Access")
+	assert.Contains(t, out, "7")
+	assert.Contains(t, out, "Open anomalies")
+
+	// Classification section
+	assert.Contains(t, out, "Classification")
+	assert.Contains(t, out, "confidential")
+	assert.Contains(t, out, "12")
+	assert.Contains(t, out, "internal")
+	assert.Contains(t, out, "24")
+}
+
+func TestProjectStats_Remote_JSONFormat(t *testing.T) {
+	rc, done := setupStatsRemote(t, projectsAndStatsHandler)
+	defer done()
+
+	statsFormat = "json"
+	out := captureStatsStdout(t, func() {
+		require.NoError(t, runStatsRemote(t.Context(), rc, "acme"))
+	})
+
+	// Output must be valid JSON with the expected fields.
+	assert.Contains(t, out, `"project_id":1`)
+	assert.Contains(t, out, `"project_name":"acme"`)
+	assert.Contains(t, out, `"total_secrets":42`)
+	assert.Contains(t, out, `"active_secrets":39`)
+	assert.Contains(t, out, `"expired_secrets":1`)
+	assert.Contains(t, out, `"expiring_in_30_days":2`)
+	assert.Contains(t, out, `"rotation_enabled":28`)
+	assert.Contains(t, out, `"overdue_rotation":3`)
+	assert.Contains(t, out, `"unique_accessors":7`)
+	assert.Contains(t, out, `"open_anomalies":1`)
+	assert.Contains(t, out, `"confidential":12`)
+}
+
+func TestProjectStats_Remote_NotFound(t *testing.T) {
+	rc, done := setupStatsRemote(t, projectsAndStatsHandler)
+	defer done()
+
+	statsFormat = "table"
+	err := runStatsRemote(t.Context(), rc, "nonexistent-project")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/core/project_stats.go
+++ b/internal/core/project_stats.go
@@ -1,0 +1,185 @@
+// project_stats.go — rich per-project statistics for dashboards and the CLI.
+//
+// GET /api/v1/projects/{id}/stats
+// keyorix project stats <name>
+//
+// Derives all statistics from existing data — no new DB model. Counts are
+// computed sequentially from the storage layer; no net-new queries are added
+// beyond what the existing hygiene/rotation/anomaly paths already use.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// ProjectStats holds rich per-project statistics for a dashboard or CLI summary.
+type ProjectStats struct {
+	ProjectID   uint   `json:"project_id"`
+	ProjectName string `json:"project_name"`
+
+	// Secret counts
+	TotalSecrets     int `json:"total_secrets"`
+	ActiveSecrets    int `json:"active_secrets"`
+	ExpiredSecrets   int `json:"expired_secrets"`     // expiration < now
+	ExpiringIn30Days int `json:"expiring_in_30_days"` // expiration in [now, now+30d)
+
+	// Rotation health
+	RotationEnabled int        `json:"rotation_enabled"` // secrets covered by an active rotation policy
+	OverdueRotation int        `json:"overdue_rotation"` // of those, past their rotation interval
+	LastRotationAt  *time.Time `json:"last_rotation_at,omitempty"`
+
+	// Access
+	UniqueAccessors int `json:"unique_accessors"` // distinct users with a project-scoped role grant
+	OpenAnomalies   int `json:"open_anomalies"`   // unacknowledged anomaly alerts for project secrets
+
+	// ClassificationCounts is a breakdown by data-sensitivity label,
+	// e.g. {"confidential":3,"internal":8,"unclassified":2}.
+	ClassificationCounts map[string]int `json:"classification_counts"`
+
+	ComputedAt time.Time `json:"computed_at"`
+}
+
+// GetProjectStats computes statistics for a project by querying existing storage
+// methods. All queries run sequentially; the function is cheap for typical
+// projects (< a few thousand secrets).
+func (c *KeyorixCore) GetProjectStats(ctx context.Context, projectID uint) (*ProjectStats, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("project ID is required")
+	}
+
+	// Resolve project name.
+	proj, err := c.storage.GetProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("get project: %w", err)
+	}
+
+	now := c.now()
+	out := &ProjectStats{
+		ProjectID:            projectID,
+		ProjectName:          proj.Name,
+		ClassificationCounts: make(map[string]int),
+		ComputedAt:           now,
+	}
+
+	// ── Secret counts via lightweight name rows ───────────────────────────────
+
+	// ListLiveSecretNamesByProject returns one row per live secret with enough
+	// metadata for classification bucketing and ID cross-referencing (anomaly
+	// lookup). Cap at 50 000 to bound memory on very large projects.
+	nameRows, _, err := c.storage.ListLiveSecretNamesByProject(ctx, []uint{projectID}, 50_000)
+	if err != nil {
+		return nil, fmt.Errorf("list project secret names: %w", err)
+	}
+
+	out.TotalSecrets = len(nameRows)
+	projectSecretIDs := make(map[uint]bool, len(nameRows))
+	for _, r := range nameRows {
+		projectSecretIDs[r.ID] = true
+		label := r.Classification
+		if label == "" {
+			label = "unclassified"
+		}
+		out.ClassificationCounts[label]++
+	}
+
+	// Expired: secrets whose expiration is before now.
+	isSecret := true
+	expiredCutoff := now
+	_, expiredCount, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+		ProjectID:     &projectID,
+		IsSecret:      &isSecret,
+		ExpiresBefore: &expiredCutoff,
+		Page:          1,
+		PageSize:      1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("expired secrets count: %w", err)
+	}
+	out.ExpiredSecrets = int(expiredCount)
+
+	// Expiring in 30 days: secrets whose expiration is before now+30d (includes
+	// already-expired rows); subtract expired to get the upcoming window.
+	expiring30Cutoff := now.Add(30 * 24 * time.Hour)
+	_, expiring30Count, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+		ProjectID:     &projectID,
+		IsSecret:      &isSecret,
+		ExpiresBefore: &expiring30Cutoff,
+		Page:          1,
+		PageSize:      1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("expiring-in-30d count: %w", err)
+	}
+	out.ExpiringIn30Days = int(expiring30Count) - out.ExpiredSecrets
+	if out.ExpiringIn30Days < 0 {
+		out.ExpiringIn30Days = 0
+	}
+
+	out.ActiveSecrets = out.TotalSecrets - out.ExpiredSecrets
+	if out.ActiveSecrets < 0 {
+		out.ActiveSecrets = 0
+	}
+
+	// ── Rotation health ───────────────────────────────────────────────────────
+
+	statuses, err := c.GetRotationStatus(ctx, &projectID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("rotation status: %w", err)
+	}
+	// Deduplicate by SecretID: a secret covered by multiple overlapping policies
+	// must not inflate RotationEnabled or OverdueRotation.
+	seenRotation := make(map[uint]bool)
+	var latestRotation *time.Time
+	for _, s := range statuses {
+		if seenRotation[s.SecretID] {
+			continue
+		}
+		seenRotation[s.SecretID] = true
+		out.RotationEnabled++
+		if s.Status == RotationStatusOverdue {
+			out.OverdueRotation++
+		}
+		if s.LastRotatedAt != nil {
+			if latestRotation == nil || s.LastRotatedAt.After(*latestRotation) {
+				ts := *s.LastRotatedAt
+				latestRotation = &ts
+			}
+		}
+	}
+	out.LastRotationAt = latestRotation
+
+	// ── Unique accessors ──────────────────────────────────────────────────────
+
+	assignments, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("list project role assignments: %w", err)
+	}
+	uniqueUsers := make(map[uint]bool)
+	for _, a := range assignments {
+		if a.PrincipalType == "user" && a.PrincipalID != 0 {
+			uniqueUsers[a.PrincipalID] = true
+		}
+	}
+	out.UniqueAccessors = len(uniqueUsers)
+
+	// ── Open anomalies ────────────────────────────────────────────────────────
+
+	// ListAnomalyAlerts has no project filter; cross-reference with project's
+	// secret IDs to count only this project's unacknowledged alerts.
+	ackFalse := false
+	anomalies, err := c.storage.ListAnomalyAlerts(ctx, &ackFalse)
+	if err != nil {
+		return nil, fmt.Errorf("list anomaly alerts: %w", err)
+	}
+	for _, a := range anomalies {
+		if projectSecretIDs[a.SecretNodeID] {
+			out.OpenAnomalies++
+		}
+	}
+
+	return out, nil
+}

--- a/internal/core/project_stats.go
+++ b/internal/core/project_stats.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // ProjectStats holds rich per-project statistics for a dashboard or CLI summary.
@@ -51,7 +52,6 @@ func (c *KeyorixCore) GetProjectStats(ctx context.Context, projectID uint) (*Pro
 		return nil, fmt.Errorf("project ID is required")
 	}
 
-	// Resolve project name.
 	proj, err := c.storage.GetProject(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("get project: %w", err)
@@ -59,10 +59,9 @@ func (c *KeyorixCore) GetProjectStats(ctx context.Context, projectID uint) (*Pro
 
 	now := c.now()
 	out := &ProjectStats{
-		ProjectID:            projectID,
-		ProjectName:          proj.Name,
-		ClassificationCounts: make(map[string]int),
-		ComputedAt:           now,
+		ProjectID:   projectID,
+		ProjectName: proj.Name,
+		ComputedAt:  now,
 	}
 
 	// ── Secret counts via lightweight name rows ───────────────────────────────
@@ -74,19 +73,10 @@ func (c *KeyorixCore) GetProjectStats(ctx context.Context, projectID uint) (*Pro
 	if err != nil {
 		return nil, fmt.Errorf("list project secret names: %w", err)
 	}
-
 	out.TotalSecrets = len(nameRows)
-	projectSecretIDs := make(map[uint]bool, len(nameRows))
-	for _, r := range nameRows {
-		projectSecretIDs[r.ID] = true
-		label := r.Classification
-		if label == "" {
-			label = "unclassified"
-		}
-		out.ClassificationCounts[label]++
-	}
+	classCounts, secretIDs := buildClassificationCounts(nameRows)
+	out.ClassificationCounts = classCounts
 
-	// Expired: secrets whose expiration is before now.
 	isSecret := true
 	expiredCutoff := now
 	_, expiredCount, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
@@ -101,8 +91,8 @@ func (c *KeyorixCore) GetProjectStats(ctx context.Context, projectID uint) (*Pro
 	}
 	out.ExpiredSecrets = int(expiredCount)
 
-	// Expiring in 30 days: secrets whose expiration is before now+30d (includes
-	// already-expired rows); subtract expired to get the upcoming window.
+	// Expiring in 30 days: expiration before now+30d includes already-expired;
+	// subtract expired to get only the upcoming window.
 	expiring30Cutoff := now.Add(30 * 24 * time.Hour)
 	_, expiring30Count, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
 		ProjectID:     &projectID,
@@ -114,15 +104,8 @@ func (c *KeyorixCore) GetProjectStats(ctx context.Context, projectID uint) (*Pro
 	if err != nil {
 		return nil, fmt.Errorf("expiring-in-30d count: %w", err)
 	}
-	out.ExpiringIn30Days = int(expiring30Count) - out.ExpiredSecrets
-	if out.ExpiringIn30Days < 0 {
-		out.ExpiringIn30Days = 0
-	}
-
-	out.ActiveSecrets = out.TotalSecrets - out.ExpiredSecrets
-	if out.ActiveSecrets < 0 {
-		out.ActiveSecrets = 0
-	}
+	out.ExpiringIn30Days = max(0, int(expiring30Count)-out.ExpiredSecrets)
+	out.ActiveSecrets = max(0, out.TotalSecrets-out.ExpiredSecrets)
 
 	// ── Rotation health ───────────────────────────────────────────────────────
 
@@ -130,27 +113,7 @@ func (c *KeyorixCore) GetProjectStats(ctx context.Context, projectID uint) (*Pro
 	if err != nil {
 		return nil, fmt.Errorf("rotation status: %w", err)
 	}
-	// Deduplicate by SecretID: a secret covered by multiple overlapping policies
-	// must not inflate RotationEnabled or OverdueRotation.
-	seenRotation := make(map[uint]bool)
-	var latestRotation *time.Time
-	for _, s := range statuses {
-		if seenRotation[s.SecretID] {
-			continue
-		}
-		seenRotation[s.SecretID] = true
-		out.RotationEnabled++
-		if s.Status == RotationStatusOverdue {
-			out.OverdueRotation++
-		}
-		if s.LastRotatedAt != nil {
-			if latestRotation == nil || s.LastRotatedAt.After(*latestRotation) {
-				ts := *s.LastRotatedAt
-				latestRotation = &ts
-			}
-		}
-	}
-	out.LastRotationAt = latestRotation
+	out.RotationEnabled, out.OverdueRotation, out.LastRotationAt = aggregateRotationStats(statuses)
 
 	// ── Unique accessors ──────────────────────────────────────────────────────
 
@@ -158,28 +121,82 @@ func (c *KeyorixCore) GetProjectStats(ctx context.Context, projectID uint) (*Pro
 	if err != nil {
 		return nil, fmt.Errorf("list project role assignments: %w", err)
 	}
-	uniqueUsers := make(map[uint]bool)
-	for _, a := range assignments {
-		if a.PrincipalType == "user" && a.PrincipalID != 0 {
-			uniqueUsers[a.PrincipalID] = true
-		}
-	}
-	out.UniqueAccessors = len(uniqueUsers)
+	out.UniqueAccessors = countUniqueUserAccessors(assignments)
 
 	// ── Open anomalies ────────────────────────────────────────────────────────
 
-	// ListAnomalyAlerts has no project filter; cross-reference with project's
+	// ListAnomalyAlerts has no project filter; cross-reference with the project's
 	// secret IDs to count only this project's unacknowledged alerts.
 	ackFalse := false
 	anomalies, err := c.storage.ListAnomalyAlerts(ctx, &ackFalse)
 	if err != nil {
 		return nil, fmt.Errorf("list anomaly alerts: %w", err)
 	}
-	for _, a := range anomalies {
-		if projectSecretIDs[a.SecretNodeID] {
-			out.OpenAnomalies++
-		}
-	}
+	out.OpenAnomalies = countProjectAnomalies(anomalies, secretIDs)
 
 	return out, nil
+}
+
+// buildClassificationCounts returns a label→count map and a set of secret IDs
+// from the given name rows. Labels default to "unclassified" when empty.
+func buildClassificationCounts(rows []storage.SecretNameRow) (map[string]int, map[uint]bool) {
+	counts := make(map[string]int, 4)
+	ids := make(map[uint]bool, len(rows))
+	for _, r := range rows {
+		ids[r.ID] = true
+		label := r.Classification
+		if label == "" {
+			label = "unclassified"
+		}
+		counts[label]++
+	}
+	return counts, ids
+}
+
+// aggregateRotationStats collapses rotation-status entries into per-project
+// enabled/overdue counts and the most-recent rotation timestamp.
+// Secrets covered by multiple overlapping policies are counted only once.
+func aggregateRotationStats(statuses []*RotationStatusEntry) (enabled, overdue int, lastAt *time.Time) {
+	seen := make(map[uint]bool)
+	for _, s := range statuses {
+		if seen[s.SecretID] {
+			continue
+		}
+		seen[s.SecretID] = true
+		enabled++
+		if s.Status == RotationStatusOverdue {
+			overdue++
+		}
+		if s.LastRotatedAt != nil {
+			if lastAt == nil || s.LastRotatedAt.After(*lastAt) {
+				ts := *s.LastRotatedAt
+				lastAt = &ts
+			}
+		}
+	}
+	return enabled, overdue, lastAt
+}
+
+// countUniqueUserAccessors returns the number of distinct users with at least
+// one direct role grant on the project.
+func countUniqueUserAccessors(assignments []storage.RoleAssignment) int {
+	seen := make(map[uint]bool)
+	for _, a := range assignments {
+		if a.PrincipalType == "user" && a.PrincipalID != 0 {
+			seen[a.PrincipalID] = true
+		}
+	}
+	return len(seen)
+}
+
+// countProjectAnomalies returns the number of alerts whose secret belongs to
+// the given project (identified by secretIDs).
+func countProjectAnomalies(alerts []models.AnomalyAlert, secretIDs map[uint]bool) int {
+	n := 0
+	for _, a := range alerts {
+		if secretIDs[a.SecretNodeID] {
+			n++
+		}
+	}
+	return n
 }

--- a/internal/core/project_stats_test.go
+++ b/internal/core/project_stats_test.go
@@ -1,0 +1,222 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newStatsTestCore returns a KeyorixCore backed by a migrated, isolated
+// in-memory SQLite database suitable for project-stats tests.
+func newStatsTestCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{},
+		&models.Environment{},
+		&models.SecretNode{},
+		&models.SecretVersion{},
+		&models.User{},
+		&models.UserRole{},
+		&models.Role{},
+		&models.Group{},
+		&models.GroupRole{},
+		&models.AnomalyAlert{},
+		&models.RotationPolicy{},
+		&models.SecretAccessLog{},
+		&models.MachineIdentity{},
+		&models.AuditEvent{},
+	))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	return c, db
+}
+
+// TestGetProjectStats_Empty verifies that a project with no secrets returns
+// zero counts.
+func TestGetProjectStats_Empty(t *testing.T) {
+	c, _ := newStatsTestCore(t)
+	ctx := context.Background()
+
+	proj, err := c.storage.CreateProject(ctx, &models.Project{Name: "empty-proj"})
+	require.NoError(t, err)
+
+	stats, err := c.GetProjectStats(ctx, proj.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, proj.ID, stats.ProjectID)
+	assert.Equal(t, "empty-proj", stats.ProjectName)
+	assert.Equal(t, 0, stats.TotalSecrets)
+	assert.Equal(t, 0, stats.ActiveSecrets)
+	assert.Equal(t, 0, stats.ExpiredSecrets)
+	assert.Equal(t, 0, stats.ExpiringIn30Days)
+	assert.Equal(t, 0, stats.RotationEnabled)
+	assert.Equal(t, 0, stats.OverdueRotation)
+	assert.Nil(t, stats.LastRotationAt)
+	assert.Equal(t, 0, stats.UniqueAccessors)
+	assert.Equal(t, 0, stats.OpenAnomalies)
+	assert.NotNil(t, stats.ClassificationCounts)
+	assert.NotZero(t, stats.ComputedAt)
+}
+
+// TestGetProjectStats_SecretCounts seeds 3 active + 1 expired + 1 expiring-soon
+// secret and verifies the secret-count breakdown.
+func TestGetProjectStats_SecretCounts(t *testing.T) {
+	c, _ := newStatsTestCore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	proj, err := c.storage.CreateProject(ctx, &models.Project{Name: "counts-proj"})
+	require.NoError(t, err)
+	env, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: proj.ID})
+	require.NoError(t, err)
+
+	mkSecret := func(name string, expiration *time.Time) {
+		_, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name:          name,
+			ProjectID:     proj.ID,
+			EnvironmentID: env.ID,
+			Type:          "password",
+			IsSecret:      true,
+			Expiration:    expiration,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		})
+		require.NoError(t, err)
+	}
+
+	// 3 active (no expiration)
+	mkSecret("active-1", nil)
+	mkSecret("active-2", nil)
+	mkSecret("active-3", nil)
+
+	// 1 expired (expiration in the past)
+	past := now.Add(-24 * time.Hour)
+	mkSecret("expired-1", &past)
+
+	// 1 expiring soon (expiration 10 days from now, inside the 30-day window)
+	soon := now.Add(10 * 24 * time.Hour)
+	mkSecret("expiring-soon", &soon)
+
+	stats, err := c.GetProjectStats(ctx, proj.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, 5, stats.TotalSecrets)
+	assert.Equal(t, 1, stats.ExpiredSecrets)
+	assert.Equal(t, 1, stats.ExpiringIn30Days)
+	assert.Equal(t, 4, stats.ActiveSecrets, "5 total - 1 expired")
+}
+
+// TestGetProjectStats_ClassificationBreakdown seeds secrets with different
+// classification labels and verifies the ClassificationCounts map.
+func TestGetProjectStats_ClassificationBreakdown(t *testing.T) {
+	c, _ := newStatsTestCore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	proj, err := c.storage.CreateProject(ctx, &models.Project{Name: "classif-proj"})
+	require.NoError(t, err)
+	env, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: proj.ID})
+	require.NoError(t, err)
+
+	labels := []string{"confidential", "confidential", "internal", "internal", "internal", "public", ""}
+	for i, lbl := range labels {
+		_, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name:           "sec-" + string(rune('a'+i)),
+			ProjectID:      proj.ID,
+			EnvironmentID:  env.ID,
+			Type:           "password",
+			IsSecret:       true,
+			Classification: lbl,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		})
+		require.NoError(t, err)
+	}
+
+	stats, err := c.GetProjectStats(ctx, proj.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, stats.ClassificationCounts["confidential"])
+	assert.Equal(t, 3, stats.ClassificationCounts["internal"])
+	assert.Equal(t, 1, stats.ClassificationCounts["public"])
+	assert.Equal(t, 1, stats.ClassificationCounts["unclassified"]) // empty label → unclassified
+	assert.Equal(t, 7, stats.TotalSecrets)
+}
+
+// TestGetProjectStats_RotationHealth seeds secrets with a rotation policy,
+// marks one as overdue (last rotated long ago), and verifies rotation counts.
+func TestGetProjectStats_RotationHealth(t *testing.T) {
+	c, _ := newStatsTestCore(t)
+	ctx := context.Background()
+
+	fixed := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return fixed }
+
+	proj, err := c.storage.CreateProject(ctx, &models.Project{Name: "rotation-proj"})
+	require.NoError(t, err)
+	env, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: proj.ID})
+	require.NoError(t, err)
+
+	// Create two secrets: one recently rotated (ok), one long-overdue.
+	recentRotatedAt := fixed.Add(-5 * 24 * time.Hour) // 5 days ago
+	overdueRotatedAt := fixed.Add(-200 * 24 * time.Hour) // 200 days ago
+
+	_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "recent", ProjectID: proj.ID, EnvironmentID: env.ID,
+		Type: "password", IsSecret: true,
+		LastRotatedAt: &recentRotatedAt,
+		CreatedAt: recentRotatedAt, UpdatedAt: fixed,
+	})
+	require.NoError(t, err)
+	_, err = c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "overdue", ProjectID: proj.ID, EnvironmentID: env.ID,
+		Type: "password", IsSecret: true,
+		LastRotatedAt: &overdueRotatedAt,
+		CreatedAt: overdueRotatedAt, UpdatedAt: fixed,
+	})
+	require.NoError(t, err)
+
+	// A 90-day project-scoped rotation policy covering both secrets.
+	pID := proj.ID
+	require.NoError(t, c.storage.CreateRotationPolicy(ctx, &models.RotationPolicy{
+		Name:            "90d policy",
+		Scope:           "project",
+		ProjectID:       &pID,
+		IntervalDays:    90,
+		AlertDaysBefore: 7,
+		IsActive:        true,
+		CreatedBy:       "test",
+	}))
+
+	stats, err := c.GetProjectStats(ctx, proj.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, stats.RotationEnabled, "both secrets are covered")
+	assert.Equal(t, 1, stats.OverdueRotation, "only the 200-day-old one is overdue")
+	require.NotNil(t, stats.LastRotationAt)
+	assert.Equal(t, recentRotatedAt.UTC().Truncate(time.Second),
+		stats.LastRotationAt.UTC().Truncate(time.Second),
+		"LastRotationAt should be the most recent rotation")
+}
+
+// TestGetProjectStats_WrongProject verifies that a nonexistent project ID
+// returns an error.
+func TestGetProjectStats_WrongProject(t *testing.T) {
+	c, _ := newStatsTestCore(t)
+	ctx := context.Background()
+
+	_, err := c.GetProjectStats(ctx, 99999)
+	require.Error(t, err)
+}

--- a/internal/storage/models/all_models.go
+++ b/internal/storage/models/all_models.go
@@ -62,6 +62,7 @@ func AllTestModels() []any {
 		&SSOLoginState{},
 		&SchedulerLockLease{},
 		&SecretACL{},
+		&RotationPolicy{},
 		&AnomalyConfigRecord{},
 		&StatsSnapshot{},
 		&DeploymentStatsSnapshot{},

--- a/server/http/handlers/project_stats.go
+++ b/server/http/handlers/project_stats.go
@@ -1,0 +1,40 @@
+// project_stats.go — GET /api/v1/projects/{id}/stats handler.
+//
+// Returns rich per-project statistics derived from existing data:
+// secret counts, rotation health, unique accessors, open anomalies, and a
+// classification breakdown. Requires secrets.read at the project scope.
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// GetProjectStats handles GET /api/v1/projects/{id}/stats.
+//
+// Requires secrets.read scoped to the project (enforced by the route
+// middleware in router.go). Returns a ProjectStats JSON object.
+func (h *SecretHandler) GetProjectStats(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	stats, err := h.coreService.GetProjectStats(r.Context(), uint(id))
+	if err != nil {
+		h.sendError(w, "InternalError", "Failed to compute project stats", http.StatusInternalServerError, nil)
+		return
+	}
+
+	h.sendSuccess(w, stats, "")
+}

--- a/server/http/project_stats_handler_test.go
+++ b/server/http/project_stats_handler_test.go
@@ -1,0 +1,180 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetProjectStats_EmptyProject(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/projects/1/stats", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object in response")
+	assert.Contains(t, data, "total_secrets")
+	assert.Contains(t, data, "active_secrets")
+	assert.Contains(t, data, "classification_counts")
+}
+
+func TestGetProjectStats_WithSecrets(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	client := &http.Client{}
+	createSecret := func(name string) {
+		t.Helper()
+		payload, _ := json.Marshal(map[string]interface{}{
+			"name":           name,
+			"value":          "secret-value",
+			"project_id":     1,
+			"environment_id": 1,
+			"type":           "password",
+		})
+		req, err := http.NewRequest("POST", srv.URL+"/api/v1/secrets", bytes.NewReader(payload))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	}
+
+	createSecret("stats-secret-1")
+	createSecret("stats-secret-2")
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/projects/1/stats", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object in response")
+
+	totalSecrets, ok := data["total_secrets"].(float64)
+	require.True(t, ok, "total_secrets must be a number")
+	assert.GreaterOrEqual(t, int(totalSecrets), 2, "expected at least 2 secrets after creation")
+}
+
+func TestGetProjectStats_ResponseShape(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/projects/1/stats", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object in response")
+
+	expectedFields := []string{
+		"total_secrets",
+		"active_secrets",
+		"expired_secrets",
+		"expiring_in_30_days",
+		"rotation_enabled",
+		"overdue_rotation",
+		"unique_accessors",
+		"open_anomalies",
+		"classification_counts",
+		"computed_at",
+	}
+	for _, field := range expectedFields {
+		assert.Containsf(t, data, field, "response data must contain field %q", field)
+	}
+}
+
+func TestGetProjectStats_Unauthenticated(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/projects/1/stats", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestGetProjectStats_NotFound(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	// Project 999999 does not exist; GetProjectStats will fail on GetProject,
+	// which causes the handler to return 500 (InternalError).
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/projects/999999/stats", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}

--- a/server/http/project_stats_handler_test.go
+++ b/server/http/project_stats_handler_test.go
@@ -29,7 +29,7 @@ func TestGetProjectStats_EmptyProject(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -69,7 +69,7 @@ func TestGetProjectStats_WithSecrets(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := client.Do(req)
 		require.NoError(t, err)
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 	}
 
@@ -81,7 +81,7 @@ func TestGetProjectStats_WithSecrets(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -111,7 +111,7 @@ func TestGetProjectStats_ResponseShape(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -151,7 +151,7 @@ func TestGetProjectStats_Unauthenticated(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
@@ -174,7 +174,7 @@ func TestGetProjectStats_NotFound(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 }

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -367,6 +367,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission(permSecretsRead, projectScope)).Get("/projects/{id}/rotation-order", secretHandler.GetProjectRotationOrder)
 		r.With(customMiddleware.RequireScopedPermission(permSecretsRead, projectScope)).Get("/projects/{id}/rotation-plan", secretHandler.GetProjectRotationPlan)
 		r.With(customMiddleware.RequireScopedPermission(permSecretsRead, projectScope)).Get("/projects/{id}/health", secretHandler.GetProjectHealth)
+		r.With(customMiddleware.RequireScopedPermission(permSecretsRead, projectScope)).Get("/projects/{id}/stats", secretHandler.GetProjectStats)
 		// Deployment-wide rotation plan (ADR-053): aggregates every project. Gated by
 		// GLOBAL secrets.read — the same access level as listing all projects — so it
 		// reveals no project the caller cannot already see.


### PR DESCRIPTION
GET /projects/{id}/stats — secret counts, rotation health, unique accessors, open anomalies, classification breakdown. CLI: keyorix project stats <name>. No new model. 8 tests.