### PR TITLE
feat(notifications): channel management CRUD

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -22,6 +22,7 @@ import (
 	licensecli "github.com/keyorixhq/keyorix/internal/cli/license"
 	"github.com/keyorixhq/keyorix/internal/cli/machine"
 	"github.com/keyorixhq/keyorix/internal/cli/migrate"
+	"github.com/keyorixhq/keyorix/internal/cli/notification"
 	"github.com/keyorixhq/keyorix/internal/cli/pat"
 	"github.com/keyorixhq/keyorix/internal/cli/project"
 	"github.com/keyorixhq/keyorix/internal/cli/rbac"
@@ -86,6 +87,7 @@ func init() {
 	rootCmd.AddCommand(bundlecli.BundleCmd)
 	rootCmd.AddCommand(licensecli.LicenseCmd)
 	rootCmd.AddCommand(usage.UsageCmd)
+	rootCmd.AddCommand(notification.NotificationCmd)
 }
 
 // bootstrapI18n initializes i18n with the user's actual configured locale

--- a/internal/cli/notification/channels.go
+++ b/internal/cli/notification/channels.go
@@ -1,0 +1,294 @@
+// Package notification provides CLI commands for managing notification channels.
+package notification
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// NotificationCmd is the top-level "notification" command.
+var NotificationCmd = &cobra.Command{
+	Use:   "notification",
+	Short: "Manage notifications and notification channels",
+}
+
+// channelCmd groups the "notification channel" sub-commands.
+var channelCmd = &cobra.Command{
+	Use:   "channel",
+	Short: "Manage runtime notification channel destinations",
+}
+
+var (
+	flagChannelType    string
+	flagChannelURL     string
+	flagChannelEmail   string
+	flagChannelEvents  string
+	flagChannelEnabled bool
+	flagChannelDisable bool
+	flagConfirm        bool
+)
+
+func init() {
+	// channel add flags
+	addCmd.Flags().StringVar(&flagChannelType, "type", "", "Channel type: webhook, slack, teams, or email (required)")
+	addCmd.Flags().StringVar(&flagChannelURL, "url", "", "Webhook URL (required for webhook/slack/teams)")
+	addCmd.Flags().StringVar(&flagChannelEmail, "email", "", "Email address (required for email type)")
+	addCmd.Flags().StringVar(&flagChannelEvents, "events", "", "Comma-separated event types, e.g. secret.rotated,anomaly.detected (empty = all)")
+	_ = addCmd.MarkFlagRequired("type")
+
+	// channel update flags
+	updateCmd.Flags().StringVar(&flagChannelURL, "url", "", "New webhook URL")
+	updateCmd.Flags().StringVar(&flagChannelEmail, "email", "", "New email address")
+	updateCmd.Flags().StringVar(&flagChannelEvents, "events", "", "New event filter (comma-separated)")
+	updateCmd.Flags().BoolVar(&flagChannelEnabled, "enabled", false, "Enable the channel")
+	updateCmd.Flags().BoolVar(&flagChannelDisable, "disabled", false, "Disable the channel")
+
+	// channel delete flags
+	deleteCmd.Flags().BoolVar(&flagConfirm, "confirm", false, "Confirm deletion without interactive prompt")
+
+	channelCmd.AddCommand(listCmd)
+	channelCmd.AddCommand(addCmd)
+	channelCmd.AddCommand(getCmd)
+	channelCmd.AddCommand(updateCmd)
+	channelCmd.AddCommand(deleteCmd)
+	NotificationCmd.AddCommand(channelCmd)
+}
+
+// notificationChannelWire is the API wire shape returned by the server.
+type notificationChannelWire struct {
+	ID        uint   `json:"id"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Enabled   bool   `json:"enabled"`
+	URL       string `json:"url"`
+	Email     string `json:"email"`
+	Events    string `json:"events"`
+	CreatedBy string `json:"created_by"`
+}
+
+type channelListResponse struct {
+	Channels []notificationChannelWire `json:"channels"`
+}
+
+const channelsBasePath = "/api/v1/notification-channels"
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all notification channels",
+	RunE:  runChannelList,
+}
+
+func runChannelList(cmd *cobra.Command, args []string) error {
+	rc, ok := common.NewRemoteClient()
+	if !ok {
+		return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	return runChannelListRemote(rc)
+}
+
+func runChannelListRemote(rc *common.RemoteClient) error {
+	var result channelListResponse
+	if err := rc.Get(context.Background(), channelsBasePath, &result); err != nil {
+		return err
+	}
+	if len(result.Channels) == 0 {
+		fmt.Println("No notification channels configured.")
+		return nil
+	}
+	fmt.Printf("%-5s %-24s %-8s %-8s %s\n", "ID", "NAME", "TYPE", "ENABLED", "EVENTS")
+	for _, ch := range result.Channels {
+		enabled := "no"
+		if ch.Enabled {
+			enabled = "yes"
+		}
+		events := ch.Events
+		if events == "" {
+			events = "*"
+		}
+		fmt.Printf("%-5d %-24s %-8s %-8s %s\n", ch.ID, ch.Name, ch.Type, enabled, events)
+	}
+	return nil
+}
+
+var addCmd = &cobra.Command{
+	Use:   "add <name>",
+	Short: "Add a notification channel",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runChannelAdd,
+}
+
+func runChannelAdd(cmd *cobra.Command, args []string) error {
+	rc, ok := common.NewRemoteClient()
+	if !ok {
+		return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	return runChannelAddRemote(rc, args[0], flagChannelType, flagChannelURL, flagChannelEmail, flagChannelEvents)
+}
+
+func runChannelAddRemote(rc *common.RemoteClient, name, chType, url, email, events string) error {
+	body := map[string]interface{}{
+		"name":    name,
+		"type":    chType,
+		"enabled": true,
+		"url":     url,
+		"email":   email,
+		"events":  events,
+	}
+	var result notificationChannelWire
+	if err := rc.Post(context.Background(), channelsBasePath, body, &result); err != nil {
+		return err
+	}
+	fmt.Printf("Notification channel %q (id=%d, type=%s) created.\n", result.Name, result.ID, result.Type)
+	return nil
+}
+
+var getCmd = &cobra.Command{
+	Use:   "get <name>",
+	Short: "Get details of a notification channel by name",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runChannelGet,
+}
+
+func runChannelGet(cmd *cobra.Command, args []string) error {
+	rc, ok := common.NewRemoteClient()
+	if !ok {
+		return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	return runChannelGetRemote(rc, args[0])
+}
+
+func runChannelGetRemote(rc *common.RemoteClient, name string) error {
+	// List all and find by name (no server-side name-lookup endpoint).
+	var result channelListResponse
+	if err := rc.Get(context.Background(), channelsBasePath, &result); err != nil {
+		return err
+	}
+	for _, ch := range result.Channels {
+		if strings.EqualFold(ch.Name, name) {
+			printChannel(ch)
+			return nil
+		}
+	}
+	return fmt.Errorf("notification channel %q not found", name)
+}
+
+func printChannel(ch notificationChannelWire) {
+	enabled := "no"
+	if ch.Enabled {
+		enabled = "yes"
+	}
+	events := ch.Events
+	if events == "" {
+		events = "*"
+	}
+	fmt.Printf("id:         %d\n", ch.ID)
+	fmt.Printf("name:       %s\n", ch.Name)
+	fmt.Printf("type:       %s\n", ch.Type)
+	fmt.Printf("enabled:    %s\n", enabled)
+	if ch.URL != "" {
+		fmt.Printf("url:        %s\n", ch.URL)
+	}
+	if ch.Email != "" {
+		fmt.Printf("email:      %s\n", ch.Email)
+	}
+	fmt.Printf("events:     %s\n", events)
+	fmt.Printf("created by: %s\n", ch.CreatedBy)
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update <name>",
+	Short: "Update a notification channel by name",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runChannelUpdate,
+}
+
+func buildUpdateBody(cmd *cobra.Command, url, email, events string, enable, disable bool) map[string]interface{} {
+	body := map[string]interface{}{}
+	if cmd.Flags().Changed("url") {
+		body["url"] = url
+	}
+	if cmd.Flags().Changed("email") {
+		body["email"] = email
+	}
+	if cmd.Flags().Changed("events") {
+		body["events"] = events
+	}
+	if enable {
+		body["enabled"] = true
+	}
+	if disable {
+		body["enabled"] = false
+	}
+	return body
+}
+
+func runChannelUpdate(cmd *cobra.Command, args []string) error {
+	rc, ok := common.NewRemoteClient()
+	if !ok {
+		return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	body := buildUpdateBody(cmd, flagChannelURL, flagChannelEmail, flagChannelEvents, flagChannelEnabled, flagChannelDisable)
+	return runChannelUpdateRemote(rc, args[0], body)
+}
+
+func runChannelUpdateRemote(rc *common.RemoteClient, name string, body map[string]interface{}) error {
+	// Resolve name → id.
+	id, err := resolveChannelID(rc, name)
+	if err != nil {
+		return err
+	}
+	var result notificationChannelWire
+	if err := rc.Put(context.Background(), fmt.Sprintf("%s/%d", channelsBasePath, id), body, &result); err != nil {
+		return err
+	}
+	fmt.Printf("Notification channel %q (id=%d) updated.\n", result.Name, result.ID)
+	return nil
+}
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete <name>",
+	Short: "Delete a notification channel by name",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runChannelDelete,
+}
+
+func runChannelDelete(cmd *cobra.Command, args []string) error {
+	if !flagConfirm {
+		return fmt.Errorf("add --confirm to confirm deletion of notification channel %q", args[0])
+	}
+	rc, ok := common.NewRemoteClient()
+	if !ok {
+		return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+	}
+	return runChannelDeleteRemote(rc, args[0])
+}
+
+func runChannelDeleteRemote(rc *common.RemoteClient, name string) error {
+	id, err := resolveChannelID(rc, name)
+	if err != nil {
+		return err
+	}
+	if err := rc.Delete(context.Background(), fmt.Sprintf("%s/%d", channelsBasePath, id)); err != nil {
+		return err
+	}
+	fmt.Printf("Notification channel %q deleted.\n", name)
+	return nil
+}
+
+// resolveChannelID lists all channels and returns the id for the given name.
+func resolveChannelID(rc *common.RemoteClient, name string) (uint, error) {
+	var result channelListResponse
+	if err := rc.Get(context.Background(), channelsBasePath, &result); err != nil {
+		return 0, err
+	}
+	for _, ch := range result.Channels {
+		if strings.EqualFold(ch.Name, name) {
+			return ch.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("notification channel %q not found", name)
+}

--- a/internal/cli/notification/channels_test.go
+++ b/internal/cli/notification/channels_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -105,4 +106,181 @@ func TestNotificationChannelList_Remote_ServerError(t *testing.T) {
 	err := runChannelListRemote(rc)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "403")
+}
+
+// ── runChannelGetRemote ───────────────────────────────────────────────────────
+
+func TestNotificationChannelGet_Remote_Found(t *testing.T) {
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(channelListBody))
+	})
+
+	err := runChannelGetRemote(rc, "slack-ops")
+	require.NoError(t, err)
+}
+
+func TestNotificationChannelGet_Remote_NameNotFound(t *testing.T) {
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(channelListBody))
+	})
+
+	err := runChannelGetRemote(rc, "nonexistent-channel")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestNotificationChannelGet_Remote_ServerError(t *testing.T) {
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := runChannelGetRemote(rc, "slack-ops")
+	require.Error(t, err)
+}
+
+// ── printChannel ──────────────────────────────────────────────────────────────
+
+func TestPrintChannel_WithURL(t *testing.T) {
+	ch := notificationChannelWire{
+		ID:        1,
+		Name:      "ops-hook",
+		Type:      "webhook",
+		Enabled:   true,
+		URL:       "https://hook.example.com",
+		Events:    "anomaly.detected",
+		CreatedBy: "admin",
+	}
+	// Just exercise without panicking; output goes to stdout.
+	printChannel(ch)
+}
+
+func TestPrintChannel_WithEmail(t *testing.T) {
+	ch := notificationChannelWire{
+		ID:        2,
+		Name:      "email-ops",
+		Type:      "email",
+		Enabled:   false,
+		Email:     "ops@example.com",
+		Events:    "", // empty → printed as "*"
+		CreatedBy: "admin",
+	}
+	printChannel(ch)
+}
+
+// ── buildUpdateBody ───────────────────────────────────────────────────────────
+
+func newUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "update <name>"}
+	var u, e, ev string
+	var enabled, disabled bool
+	cmd.Flags().StringVar(&u, "url", "", "")
+	cmd.Flags().StringVar(&e, "email", "", "")
+	cmd.Flags().StringVar(&ev, "events", "", "")
+	cmd.Flags().BoolVar(&enabled, "enabled", false, "")
+	cmd.Flags().BoolVar(&disabled, "disabled", false, "")
+	return cmd
+}
+
+func TestBuildUpdateBody_NoChanges(t *testing.T) {
+	cmd := newUpdateCmd()
+	body := buildUpdateBody(cmd, "", "", "", false, false)
+	assert.Empty(t, body)
+}
+
+func TestBuildUpdateBody_URLChanged(t *testing.T) {
+	cmd := newUpdateCmd()
+	require.NoError(t, cmd.ParseFlags([]string{"--url", "https://new.example.com"}))
+	url, _ := cmd.Flags().GetString("url")
+
+	body := buildUpdateBody(cmd, url, "", "", false, false)
+	assert.Equal(t, "https://new.example.com", body["url"])
+	assert.NotContains(t, body, "email")
+	assert.NotContains(t, body, "events")
+}
+
+func TestBuildUpdateBody_Enable(t *testing.T) {
+	cmd := newUpdateCmd()
+	body := buildUpdateBody(cmd, "", "", "", true, false)
+	require.Contains(t, body, "enabled")
+	assert.True(t, body["enabled"].(bool))
+}
+
+func TestBuildUpdateBody_Disable(t *testing.T) {
+	cmd := newUpdateCmd()
+	body := buildUpdateBody(cmd, "", "", "", false, true)
+	require.Contains(t, body, "enabled")
+	assert.False(t, body["enabled"].(bool))
+}
+
+func TestBuildUpdateBody_EmailAndEvents(t *testing.T) {
+	cmd := newUpdateCmd()
+	require.NoError(t, cmd.ParseFlags([]string{"--email", "ops@example.com", "--events", "secret.rotated"}))
+	email, _ := cmd.Flags().GetString("email")
+	events, _ := cmd.Flags().GetString("events")
+
+	body := buildUpdateBody(cmd, "", email, events, false, false)
+	assert.Equal(t, "ops@example.com", body["email"])
+	assert.Equal(t, "secret.rotated", body["events"])
+	assert.NotContains(t, body, "url")
+}
+
+// ── cobra entry-point coverage (no-server / no-confirm paths) ─────────────────
+
+func TestRunChannelList_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := runChannelList(listCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestRunChannelAdd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	// addCmd requires --type, so set the flag variable directly.
+	origType := flagChannelType
+	t.Cleanup(func() { flagChannelType = origType })
+	flagChannelType = "webhook"
+
+	err := runChannelAdd(addCmd, []string{"my-channel"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestRunChannelGet_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := runChannelGet(getCmd, []string{"my-channel"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestRunChannelUpdate_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := runChannelUpdate(updateCmd, []string{"my-channel"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestRunChannelDelete_NoConfirm(t *testing.T) {
+	origConfirm := flagConfirm
+	t.Cleanup(func() { flagConfirm = origConfirm })
+	flagConfirm = false
+
+	err := runChannelDelete(deleteCmd, []string{"my-channel"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "add --confirm")
+}
+
+func TestRunChannelDelete_NoServer(t *testing.T) {
+	origConfirm := flagConfirm
+	t.Cleanup(func() { flagConfirm = origConfirm })
+	flagConfirm = true
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	err := runChannelDelete(deleteCmd, []string{"my-channel"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
 }

--- a/internal/cli/notification/channels_test.go
+++ b/internal/cli/notification/channels_test.go
@@ -1,0 +1,108 @@
+package notification
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildTestServer builds an httptest.Server that handles notification-channel
+// routes with preconfigured JSON responses.
+func buildTestServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *common.RemoteClient) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return srv, rc
+}
+
+const channelListBody = `{"data":{"channels":[{"id":1,"name":"slack-ops","type":"slack","enabled":true,"url":"https://hooks.slack.com/abc","email":"","events":"anomaly.detected","created_by":"admin"}]}}`
+const channelSingleBody = `{"data":{"id":1,"name":"slack-ops","type":"slack","enabled":true,"url":"https://hooks.slack.com/abc","email":"","events":"anomaly.detected","created_by":"admin"}}`
+
+func TestNotificationChannelList_Remote(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(channelListBody))
+	})
+
+	require.NoError(t, runChannelListRemote(rc))
+	assert.Equal(t, http.MethodGet, gotMethod)
+	assert.Equal(t, "/api/v1/notification-channels", gotPath)
+	assert.Equal(t, "Bearer test-token", gotAuth)
+}
+
+func TestNotificationChannelAdd_Remote(t *testing.T) {
+	var gotMethod, gotPath string
+
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(channelSingleBody))
+	})
+
+	require.NoError(t, runChannelAddRemote(rc, "slack-ops", "slack", "https://hooks.slack.com/abc", "", "anomaly.detected"))
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v1/notification-channels", gotPath)
+}
+
+func TestNotificationChannelDelete_Remote(t *testing.T) {
+	var methods, paths []string
+
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method)
+		paths = append(paths, r.URL.Path)
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(channelListBody))
+		} else {
+			_, _ = w.Write([]byte(`{"data":{"id":1,"deleted":true}}`))
+		}
+	})
+
+	require.NoError(t, runChannelDeleteRemote(rc, "slack-ops"))
+	assert.Contains(t, methods, http.MethodGet)
+	assert.Contains(t, methods, http.MethodDelete)
+	assert.Contains(t, paths, "/api/v1/notification-channels")
+	assert.Contains(t, paths, "/api/v1/notification-channels/1")
+}
+
+func TestNotificationChannelUpdate_Remote(t *testing.T) {
+	var methods, paths []string
+
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method)
+		paths = append(paths, r.URL.Path)
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(channelListBody))
+		} else {
+			_, _ = w.Write([]byte(channelSingleBody))
+		}
+	})
+
+	body := map[string]interface{}{"events": "secret.rotated"}
+	require.NoError(t, runChannelUpdateRemote(rc, "slack-ops", body))
+	assert.Contains(t, methods, http.MethodGet)
+	assert.Contains(t, methods, http.MethodPut)
+	assert.Contains(t, paths, "/api/v1/notification-channels")
+	assert.Contains(t, paths, "/api/v1/notification-channels/1")
+}
+
+func TestNotificationChannelList_Remote_ServerError(t *testing.T) {
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+	err := runChannelListRemote(rc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}

--- a/internal/cli/notification/channels_test.go
+++ b/internal/cli/notification/channels_test.go
@@ -284,3 +284,121 @@ func TestRunChannelDelete_NoServer(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not connected to a server")
 }
+
+// ── additional coverage: empty list, error paths ──────────────────────────────
+
+// TestNotificationChannelList_Remote_Empty verifies that when the server returns
+// zero channels the function prints a "No notification channels configured."
+// message and returns nil.
+func TestNotificationChannelList_Remote_Empty(t *testing.T) {
+	emptyBody := `{"data":{"channels":[]}}`
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(emptyBody))
+	})
+
+	err := runChannelListRemote(rc)
+	require.NoError(t, err)
+}
+
+// TestNotificationChannelDelete_Remote_DeleteError verifies the rc.Delete error
+// path in runChannelDeleteRemote: list succeeds (name found), but DELETE call fails.
+func TestNotificationChannelDelete_Remote_DeleteError(t *testing.T) {
+	callCount := 0
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Method == http.MethodGet {
+			// First call: return the channel list so resolveChannelID succeeds.
+			_, _ = w.Write([]byte(channelListBody))
+		} else {
+			// Second call (DELETE): return a server error.
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+
+	err := runChannelDeleteRemote(rc, "slack-ops")
+	require.Error(t, err)
+	assert.Equal(t, 2, callCount, "expected exactly GET+DELETE calls")
+}
+
+// TestNotificationChannelUpdate_Remote_PutError verifies the rc.Put error path
+// in runChannelUpdateRemote: list succeeds (name found), but PUT call fails.
+func TestNotificationChannelUpdate_Remote_PutError(t *testing.T) {
+	callCount := 0
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(channelListBody))
+		} else {
+			// PUT returns an error.
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+
+	body := map[string]interface{}{"events": "anomaly.detected"}
+	err := runChannelUpdateRemote(rc, "slack-ops", body)
+	require.Error(t, err)
+	assert.Equal(t, 2, callCount, "expected exactly GET+PUT calls")
+}
+
+// TestResolveChannelID_GetError verifies that when the GET call inside
+// resolveChannelID fails the error is propagated to the caller.
+func TestResolveChannelID_GetError(t *testing.T) {
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	id, err := resolveChannelID(rc, "slack-ops")
+	require.Error(t, err)
+	assert.Zero(t, id)
+	assert.Contains(t, err.Error(), "403")
+}
+
+// TestResolveChannelID_NotFound verifies that when the channel name is absent
+// from the list resolveChannelID returns a "not found" error.
+func TestResolveChannelID_NotFound(t *testing.T) {
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"channels":[]}}`))
+	})
+
+	id, err := resolveChannelID(rc, "nonexistent")
+	require.Error(t, err)
+	assert.Zero(t, id)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestNotificationChannelDelete_Remote_NotFound verifies runChannelDeleteRemote
+// when the channel name is absent from the server list.
+func TestNotificationChannelDelete_Remote_NotFound(t *testing.T) {
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"channels":[]}}`))
+	})
+
+	err := runChannelDeleteRemote(rc, "no-such-channel")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestNotificationChannelUpdate_Remote_NotFound verifies runChannelUpdateRemote
+// when the channel name is absent from the server list.
+func TestNotificationChannelUpdate_Remote_NotFound(t *testing.T) {
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"channels":[]}}`))
+	})
+
+	body := map[string]interface{}{"events": "anomaly.detected"}
+	err := runChannelUpdateRemote(rc, "no-such-channel", body)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestNotificationChannelList_Remote_WithEnabledFalse verifies the list output
+// shows "no" for disabled channels.
+func TestNotificationChannelList_Remote_WithEnabledFalse(t *testing.T) {
+	disabledBody := `{"data":{"channels":[{"id":2,"name":"disabled-hook","type":"webhook","enabled":false,"url":"https://hook.example.com","email":"","events":"","created_by":"admin"}]}}`
+	_, rc := buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(disabledBody))
+	})
+
+	err := runChannelListRemote(rc)
+	require.NoError(t, err)
+}

--- a/internal/core/mock_storage_notification_channels_test.go
+++ b/internal/core/mock_storage_notification_channels_test.go
@@ -1,0 +1,46 @@
+package core
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (m *MockStorage) ListNotificationChannels(ctx context.Context) ([]*models.NotificationChannel, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.NotificationChannel), args.Error(1)
+}
+
+func (m *MockStorage) GetNotificationChannel(ctx context.Context, id uint) (*models.NotificationChannel, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.NotificationChannel), args.Error(1)
+}
+
+func (m *MockStorage) GetNotificationChannelByName(ctx context.Context, name string) (*models.NotificationChannel, error) {
+	args := m.Called(ctx, name)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.NotificationChannel), args.Error(1)
+}
+
+func (m *MockStorage) CreateNotificationChannel(ctx context.Context, ch *models.NotificationChannel) error {
+	args := m.Called(ctx, ch)
+	return args.Error(0)
+}
+
+func (m *MockStorage) UpdateNotificationChannel(ctx context.Context, ch *models.NotificationChannel) error {
+	args := m.Called(ctx, ch)
+	return args.Error(0)
+}
+
+func (m *MockStorage) DeleteNotificationChannel(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}

--- a/internal/core/notification_channels.go
+++ b/internal/core/notification_channels.go
@@ -1,0 +1,111 @@
+// notification_channels.go — runtime CRUD for outbound notification channels.
+// Channels are DB-backed destinations (webhook/slack/teams/email) that can be
+// managed at runtime without editing config files.
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// validChannelTypes is the set of accepted channel type values.
+var validChannelTypes = map[string]struct{}{
+	"webhook": {},
+	"slack":   {},
+	"teams":   {},
+	"email":   {},
+}
+
+// ListNotificationChannels returns all configured notification channels.
+func (c *KeyorixCore) ListNotificationChannels(ctx context.Context) ([]*models.NotificationChannel, error) {
+	return c.storage.ListNotificationChannels(ctx)
+}
+
+// GetNotificationChannel returns the channel with the given id.
+func (c *KeyorixCore) GetNotificationChannel(ctx context.Context, id uint) (*models.NotificationChannel, error) {
+	return c.storage.GetNotificationChannel(ctx, id)
+}
+
+// CreateNotificationChannel validates and persists a new notification channel.
+// Validation:
+//   - Name must be non-empty.
+//   - Type must be one of: webhook, slack, teams, email.
+//   - URL is required for webhook/slack/teams types.
+//   - Email is required for email type.
+func (c *KeyorixCore) CreateNotificationChannel(ctx context.Context, ch *models.NotificationChannel, createdBy string) (*models.NotificationChannel, error) {
+	if err := validateNotificationChannel(ch); err != nil {
+		return nil, err
+	}
+	ch.CreatedBy = createdBy
+	ch.CreatedAt = time.Now().UTC()
+	ch.UpdatedAt = ch.CreatedAt
+	if err := c.storage.CreateNotificationChannel(ctx, ch); err != nil {
+		return nil, err
+	}
+	return ch, nil
+}
+
+// UpdateNotificationChannel applies the given map of field updates to the channel
+// identified by id and returns the updated channel.
+func (c *KeyorixCore) UpdateNotificationChannel(ctx context.Context, id uint, updates map[string]interface{}) (*models.NotificationChannel, error) {
+	ch, err := c.storage.GetNotificationChannel(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if v, ok := updates["name"].(string); ok && v != "" {
+		ch.Name = v
+	}
+	if v, ok := updates["type"].(string); ok && v != "" {
+		ch.Type = v
+	}
+	if v, ok := updates["url"].(string); ok {
+		ch.URL = v
+	}
+	if v, ok := updates["email"].(string); ok {
+		ch.Email = v
+	}
+	if v, ok := updates["events"].(string); ok {
+		ch.Events = v
+	}
+	if v, ok := updates["enabled"].(bool); ok {
+		ch.Enabled = v
+	}
+	if err := validateNotificationChannel(ch); err != nil {
+		return nil, err
+	}
+	ch.UpdatedAt = time.Now().UTC()
+	if err := c.storage.UpdateNotificationChannel(ctx, ch); err != nil {
+		return nil, err
+	}
+	return ch, nil
+}
+
+// DeleteNotificationChannel permanently removes the channel with the given id.
+func (c *KeyorixCore) DeleteNotificationChannel(ctx context.Context, id uint) error {
+	return c.storage.DeleteNotificationChannel(ctx, id)
+}
+
+// validateNotificationChannel enforces invariants for create and update paths.
+func validateNotificationChannel(ch *models.NotificationChannel) error {
+	if strings.TrimSpace(ch.Name) == "" {
+		return fmt.Errorf("notification channel name is required")
+	}
+	if _, ok := validChannelTypes[ch.Type]; !ok {
+		return fmt.Errorf("invalid notification channel type %q: must be one of webhook, slack, teams, email", ch.Type)
+	}
+	switch ch.Type {
+	case "webhook", "slack", "teams":
+		if strings.TrimSpace(ch.URL) == "" {
+			return fmt.Errorf("notification channel URL is required for type %q", ch.Type)
+		}
+	case "email":
+		if strings.TrimSpace(ch.Email) == "" {
+			return fmt.Errorf("notification channel email is required for type \"email\"")
+		}
+	}
+	return nil
+}

--- a/internal/core/notification_channels_test.go
+++ b/internal/core/notification_channels_test.go
@@ -1,0 +1,120 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateNotificationChannel_Validation(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	ctx := context.Background()
+
+	t.Run("invalid type returns error", func(t *testing.T) {
+		ch := &models.NotificationChannel{Name: "bad-type", Type: "sms", URL: "https://example.com"}
+		_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid notification channel type")
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		ch := &models.NotificationChannel{Name: "", Type: "webhook", URL: "https://example.com"}
+		_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name is required")
+	})
+}
+
+func TestCreateNotificationChannel_WebhookRequiresURL(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	ctx := context.Background()
+
+	t.Run("webhook without URL returns error", func(t *testing.T) {
+		ch := &models.NotificationChannel{Name: "my-hook", Type: "webhook", URL: ""}
+		_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "URL is required")
+	})
+
+	t.Run("email type without email returns error", func(t *testing.T) {
+		ch := &models.NotificationChannel{Name: "my-email", Type: "email", Email: ""}
+		_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "email is required")
+	})
+
+	t.Run("slack without URL returns error", func(t *testing.T) {
+		ch := &models.NotificationChannel{Name: "my-slack", Type: "slack", URL: ""}
+		_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "URL is required")
+	})
+}
+
+func TestNotificationChannel_CRUD(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	ctx := context.Background()
+
+	created := &models.NotificationChannel{
+		ID:    1,
+		Name:  "webhook-siem",
+		Type:  "webhook",
+		URL:   "https://siem.example.com/hook",
+		Events: "anomaly.detected,secret.expiring",
+	}
+
+	// Create
+	store.On("CreateNotificationChannel", ctx, mock.MatchedBy(func(ch *models.NotificationChannel) bool {
+		return ch.Name == "webhook-siem" && ch.Type == "webhook"
+	})).Return(nil).Run(func(args mock.Arguments) {
+		ch := args.Get(1).(*models.NotificationChannel)
+		ch.ID = 1
+	})
+
+	result, err := c.CreateNotificationChannel(ctx, &models.NotificationChannel{
+		Name:  "webhook-siem",
+		Type:  "webhook",
+		URL:   "https://siem.example.com/hook",
+		Events: "anomaly.detected,secret.expiring",
+	}, "admin")
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), result.ID)
+	assert.Equal(t, "admin", result.CreatedBy)
+
+	// List
+	store.On("ListNotificationChannels", ctx).Return([]*models.NotificationChannel{created}, nil)
+	channels, err := c.ListNotificationChannels(ctx)
+	require.NoError(t, err)
+	require.Len(t, channels, 1)
+	assert.Equal(t, "webhook-siem", channels[0].Name)
+
+	// Get
+	store.On("GetNotificationChannel", ctx, uint(1)).Return(created, nil)
+	got, err := c.GetNotificationChannel(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "webhook-siem", got.Name)
+
+	// Update
+	store.On("GetNotificationChannel", ctx, uint(1)).Return(created, nil).Maybe()
+	store.On("UpdateNotificationChannel", ctx, mock.AnythingOfType("*models.NotificationChannel")).Return(nil)
+	updated, err := c.UpdateNotificationChannel(ctx, 1, map[string]interface{}{
+		"events":  "secret.rotated",
+		"enabled": false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "secret.rotated", updated.Events)
+	assert.False(t, updated.Enabled)
+
+	// Delete
+	store.On("DeleteNotificationChannel", ctx, uint(1)).Return(nil)
+	require.NoError(t, c.DeleteNotificationChannel(ctx, 1))
+
+	store.AssertExpectations(t)
+}

--- a/internal/core/notification_channels_test.go
+++ b/internal/core/notification_channels_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -63,10 +64,10 @@ func TestNotificationChannel_CRUD(t *testing.T) {
 	ctx := context.Background()
 
 	created := &models.NotificationChannel{
-		ID:    1,
-		Name:  "webhook-siem",
-		Type:  "webhook",
-		URL:   "https://siem.example.com/hook",
+		ID:     1,
+		Name:   "webhook-siem",
+		Type:   "webhook",
+		URL:    "https://siem.example.com/hook",
 		Events: "anomaly.detected,secret.expiring",
 	}
 
@@ -79,9 +80,9 @@ func TestNotificationChannel_CRUD(t *testing.T) {
 	})
 
 	result, err := c.CreateNotificationChannel(ctx, &models.NotificationChannel{
-		Name:  "webhook-siem",
-		Type:  "webhook",
-		URL:   "https://siem.example.com/hook",
+		Name:   "webhook-siem",
+		Type:   "webhook",
+		URL:    "https://siem.example.com/hook",
 		Events: "anomaly.detected,secret.expiring",
 	}, "admin")
 	require.NoError(t, err)
@@ -117,4 +118,132 @@ func TestNotificationChannel_CRUD(t *testing.T) {
 	require.NoError(t, c.DeleteNotificationChannel(ctx, 1))
 
 	store.AssertExpectations(t)
+}
+
+// TestCreateNotificationChannel_StorageError covers the branch where validation
+// passes but the DB write returns an error.
+func TestCreateNotificationChannel_StorageError(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	st.On("CreateNotificationChannel", ctx, mock.AnythingOfType("*models.NotificationChannel")).
+		Return(fmt.Errorf("db: connection refused"))
+
+	ch := &models.NotificationChannel{Name: "hook", Type: "webhook", URL: "https://hook.example.com"}
+	_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+	st.AssertExpectations(t)
+}
+
+// TestUpdateNotificationChannel_GetError covers the branch where the initial
+// fetch of the channel returns an error.
+func TestUpdateNotificationChannel_GetError(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	st.On("GetNotificationChannel", ctx, uint(99)).
+		Return(nil, fmt.Errorf("record not found"))
+
+	_, err := c.UpdateNotificationChannel(ctx, 99, map[string]interface{}{"events": "secret.rotated"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	st.AssertExpectations(t)
+}
+
+// TestUpdateNotificationChannel_UpdateStorageError covers the branch where the
+// DB write for the update itself fails.
+func TestUpdateNotificationChannel_UpdateStorageError(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	existing := &models.NotificationChannel{
+		ID:   2,
+		Name: "hook",
+		Type: "webhook",
+		URL:  "https://hook.example.com",
+	}
+	st.On("GetNotificationChannel", ctx, uint(2)).Return(existing, nil)
+	st.On("UpdateNotificationChannel", ctx, mock.AnythingOfType("*models.NotificationChannel")).
+		Return(fmt.Errorf("db: disk full"))
+
+	_, err := c.UpdateNotificationChannel(ctx, 2, map[string]interface{}{"events": "secret.rotated"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disk full")
+	st.AssertExpectations(t)
+}
+
+// TestValidateNotificationChannel_TeamsRequiresURL explicitly exercises the
+// "teams" case in the URL-required switch.
+func TestValidateNotificationChannel_TeamsRequiresURL(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	ch := &models.NotificationChannel{Name: "teams-ch", Type: "teams", URL: ""}
+	_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "URL is required")
+	assert.Contains(t, err.Error(), "teams")
+}
+
+// TestUpdateNotificationChannel_AllFieldUpdates exercises all field branches
+// in UpdateNotificationChannel (name, type, url, email, events, enabled).
+func TestUpdateNotificationChannel_AllFieldUpdates(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	existing := &models.NotificationChannel{
+		ID:    3,
+		Name:  "old-name",
+		Type:  "webhook",
+		URL:   "https://old.example.com",
+		Email: "",
+	}
+	st.On("GetNotificationChannel", ctx, uint(3)).Return(existing, nil)
+	st.On("UpdateNotificationChannel", ctx, mock.AnythingOfType("*models.NotificationChannel")).Return(nil)
+
+	updated, err := c.UpdateNotificationChannel(ctx, 3, map[string]interface{}{
+		"name":    "new-name",
+		"type":    "webhook",
+		"url":     "https://new.example.com",
+		"email":   "ops@example.com",
+		"events":  "secret.expiring",
+		"enabled": true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "new-name", updated.Name)
+	assert.Equal(t, "https://new.example.com", updated.URL)
+	assert.Equal(t, "ops@example.com", updated.Email)
+	assert.Equal(t, "secret.expiring", updated.Events)
+	assert.True(t, updated.Enabled)
+	st.AssertExpectations(t)
+}
+
+// TestUpdateNotificationChannel_ValidationFails exercises the case where an
+// update causes validation to fail (e.g., clearing the URL of a webhook type).
+func TestUpdateNotificationChannel_ValidationFails(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	existing := &models.NotificationChannel{
+		ID:   4,
+		Name: "hook",
+		Type: "webhook",
+		URL:  "https://hook.example.com",
+	}
+	st.On("GetNotificationChannel", ctx, uint(4)).Return(existing, nil)
+
+	// Clearing the URL of a webhook should fail validation.
+	_, err := c.UpdateNotificationChannel(ctx, 4, map[string]interface{}{
+		"url": "",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "URL is required")
+	st.AssertExpectations(t)
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1222,6 +1222,16 @@ type Storage interface {
 	ListSecretVersionComments(ctx context.Context, versionID uint) ([]models.SecretVersionComment, error)
 	DeleteSecretVersionComment(ctx context.Context, id uint) error
 
+	// Notification channel management — runtime-managed outbound destinations
+	// (webhook/slack/teams/email). The REST API is the remote surface; these
+	// methods only run server-side via LocalStorage.
+	ListNotificationChannels(ctx context.Context) ([]*models.NotificationChannel, error)
+	GetNotificationChannel(ctx context.Context, id uint) (*models.NotificationChannel, error)
+	GetNotificationChannelByName(ctx context.Context, name string) (*models.NotificationChannel, error)
+	CreateNotificationChannel(ctx context.Context, ch *models.NotificationChannel) error
+	UpdateNotificationChannel(ctx context.Context, ch *models.NotificationChannel) error
+	DeleteNotificationChannel(ctx context.Context, id uint) error
+
 }
 
 // SecretFilter defines filtering options for secret queries

--- a/internal/storage/models/all_models.go
+++ b/internal/storage/models/all_models.go
@@ -63,6 +63,7 @@ func AllTestModels() []any {
 		&SchedulerLockLease{},
 		&SecretACL{},
 		&RotationPolicy{},
+		&NotificationChannel{},
 		&AnomalyConfigRecord{},
 		&StatsSnapshot{},
 		&DeploymentStatsSnapshot{},

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -1314,6 +1314,25 @@ type MachineIdentityOIDCBinding struct {
 // used in the migration guard and the GetMachineByOIDCSubject join.
 func (MachineIdentityOIDCBinding) TableName() string { return "machine_identity_oidc_bindings" }
 
+// NotificationChannel is a runtime-managed outbound notification destination.
+// Channel types: "webhook", "slack", "teams", "email".
+type NotificationChannel struct {
+	ID      uint   `gorm:"primarykey" json:"id"`
+	Name    string `gorm:"uniqueIndex;not null" json:"name"`
+	Type    string `gorm:"not null" json:"type"` // webhook|slack|teams|email
+	Enabled bool   `gorm:"default:true" json:"enabled"`
+	// URL is the webhook endpoint (for webhook/slack/teams types)
+	URL string `json:"url,omitempty"`
+	// Email is the recipient address (for email type)
+	Email string `json:"email,omitempty"`
+	// Events is a comma-separated list of event types this channel receives
+	// e.g. "secret.rotated,anomaly.detected,secret.expiring"
+	Events    string    `json:"events"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	CreatedBy string    `json:"created_by"`
+}
+
 // ProjectMembership tracks the onboarding lifecycle of a user into a project
 // (ADR-022), separate from the actual role grant (user_roles). It carries a
 // 5-state machine: invited → identity_verified → provisioned → active, with

--- a/internal/storage/store/local_notification_channels.go
+++ b/internal/storage/store/local_notification_channels.go
@@ -1,0 +1,87 @@
+// local_notification_channels.go — runtime-managed outbound notification channel
+// persistence. Channels can be created, updated, and deleted at runtime without
+// editing config files. The REST API is the remote surface; all methods here run
+// server-side via LocalStorage only (see remote_notification_channels.go).
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (ls *LocalStorage) ListNotificationChannels(ctx context.Context) ([]*models.NotificationChannel, error) {
+	var rows []*models.NotificationChannel
+	if err := ls.db.WithContext(ctx).Order("id ASC").Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
+func (ls *LocalStorage) GetNotificationChannel(ctx context.Context, id uint) (*models.NotificationChannel, error) {
+	var row models.NotificationChannel
+	err := ls.db.WithContext(ctx).First(&row, id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return &row, nil
+}
+
+// GetNotificationChannelByName returns the channel with the given name, or nil, nil
+// when no such channel exists.
+func (ls *LocalStorage) GetNotificationChannelByName(ctx context.Context, name string) (*models.NotificationChannel, error) {
+	var row models.NotificationChannel
+	err := ls.db.WithContext(ctx).Where("name = ?", name).First(&row).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return &row, nil
+}
+
+func (ls *LocalStorage) CreateNotificationChannel(ctx context.Context, ch *models.NotificationChannel) error {
+	if err := ls.db.WithContext(ctx).Create(ch).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
+func (ls *LocalStorage) UpdateNotificationChannel(ctx context.Context, ch *models.NotificationChannel) error {
+	res := ls.db.WithContext(ctx).Model(ch).Updates(map[string]interface{}{
+		"name":    ch.Name,
+		"type":    ch.Type,
+		"enabled": ch.Enabled,
+		"url":     ch.URL,
+		"email":   ch.Email,
+		"events":  ch.Events,
+	})
+	if res.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	return nil
+}
+
+// DeleteNotificationChannel performs a hard delete of the channel with the given id.
+func (ls *LocalStorage) DeleteNotificationChannel(ctx context.Context, id uint) error {
+	res := ls.db.WithContext(ctx).Delete(&models.NotificationChannel{}, id)
+	if res.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	return nil
+}

--- a/internal/storage/store/local_notification_channels_test.go
+++ b/internal/storage/store/local_notification_channels_test.go
@@ -47,6 +47,20 @@ func TestGetNotificationChannelByName_NotFound(t *testing.T) {
 	assert.Nil(t, ch, "GetNotificationChannelByName should return nil, nil for a missing channel")
 }
 
+func TestGetNotificationChannelByName_Found(t *testing.T) {
+	ctx := context.Background()
+	ls := newNotificationChannelTestStore(t)
+
+	orig := &models.NotificationChannel{Name: "find-me", Type: "slack", URL: "https://hooks.slack.com/xyz", Enabled: true}
+	require.NoError(t, ls.CreateNotificationChannel(ctx, orig))
+
+	got, err := ls.GetNotificationChannelByName(ctx, "find-me")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "find-me", got.Name)
+	assert.Equal(t, "slack", got.Type)
+}
+
 func TestUpdateNotificationChannel(t *testing.T) {
 	ctx := context.Background()
 	ls := newNotificationChannelTestStore(t)
@@ -80,4 +94,76 @@ func TestDeleteNotificationChannel(t *testing.T) {
 	channels, err := ls.ListNotificationChannels(ctx)
 	require.NoError(t, err)
 	assert.Empty(t, channels)
+}
+
+// TestGetNotificationChannel_NotFound verifies that the ErrRecordNotFound path
+// returns an error containing "not found" (not the generic retrieval error).
+func TestGetNotificationChannel_NotFound(t *testing.T) {
+	ctx := context.Background()
+	ls := newNotificationChannelTestStore(t)
+
+	_, err := ls.GetNotificationChannel(ctx, 9999)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestUpdateNotificationChannel_NotFound verifies the RowsAffected==0 path when
+// updating a channel that does not exist.
+func TestUpdateNotificationChannel_NotFound(t *testing.T) {
+	ctx := context.Background()
+	ls := newNotificationChannelTestStore(t)
+
+	ghost := &models.NotificationChannel{
+		ID:     9999,
+		Name:   "ghost",
+		Type:   "webhook",
+		URL:    "https://ghost.example.com",
+		Events: "anomaly.detected",
+	}
+	err := ls.UpdateNotificationChannel(ctx, ghost)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestDeleteNotificationChannel_NotFound verifies the RowsAffected==0 path when
+// deleting a channel that does not exist.
+func TestDeleteNotificationChannel_NotFound(t *testing.T) {
+	ctx := context.Background()
+	ls := newNotificationChannelTestStore(t)
+
+	err := ls.DeleteNotificationChannel(ctx, 9999)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestGetNotificationChannelByName_DBError verifies the generic DB error path in
+// GetNotificationChannelByName (non-ErrRecordNotFound).
+func TestGetNotificationChannelByName_DBError(t *testing.T) {
+	ctx := context.Background()
+
+	// Open a DB without the required table to provoke a real DB error.
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	ls := NewLocalStorage(db)
+	// No AutoMigrate — the table doesn't exist, causing a "no such table" error.
+
+	_, err = ls.GetNotificationChannelByName(ctx, "any")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no such table")
+}
+
+// TestGetNotificationChannel_DBError verifies the generic (non-ErrRecordNotFound)
+// error branch in GetNotificationChannel.
+func TestGetNotificationChannel_DBError(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	ls := NewLocalStorage(db)
+	// No AutoMigrate — table missing.
+
+	_, err = ls.GetNotificationChannel(ctx, 1)
+	require.Error(t, err)
+	// Should NOT be "not found" — the generic retrieval error wraps the real DB err.
+	assert.NotContains(t, err.Error(), "not found")
 }

--- a/internal/storage/store/local_notification_channels_test.go
+++ b/internal/storage/store/local_notification_channels_test.go
@@ -1,0 +1,83 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newNotificationChannelTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.NotificationChannel{}))
+	return NewLocalStorage(db)
+}
+
+func TestCreateAndListNotificationChannels(t *testing.T) {
+	ctx := context.Background()
+	ls := newNotificationChannelTestStore(t)
+
+	ch1 := &models.NotificationChannel{Name: "slack-ops", Type: "slack", URL: "https://hooks.slack.com/abc", Enabled: true, Events: "anomaly.detected"}
+	ch2 := &models.NotificationChannel{Name: "webhook-siem", Type: "webhook", URL: "https://siem.example.com/hook", Enabled: true, Events: ""}
+
+	require.NoError(t, ls.CreateNotificationChannel(ctx, ch1))
+	require.NoError(t, ls.CreateNotificationChannel(ctx, ch2))
+	assert.NotZero(t, ch1.ID)
+	assert.NotZero(t, ch2.ID)
+
+	channels, err := ls.ListNotificationChannels(ctx)
+	require.NoError(t, err)
+	require.Len(t, channels, 2)
+	assert.Equal(t, "slack-ops", channels[0].Name)
+	assert.Equal(t, "webhook-siem", channels[1].Name)
+}
+
+func TestGetNotificationChannelByName_NotFound(t *testing.T) {
+	ctx := context.Background()
+	ls := newNotificationChannelTestStore(t)
+
+	ch, err := ls.GetNotificationChannelByName(ctx, "does-not-exist")
+	require.NoError(t, err)
+	assert.Nil(t, ch, "GetNotificationChannelByName should return nil, nil for a missing channel")
+}
+
+func TestUpdateNotificationChannel(t *testing.T) {
+	ctx := context.Background()
+	ls := newNotificationChannelTestStore(t)
+
+	ch := &models.NotificationChannel{Name: "teams-alerts", Type: "teams", URL: "https://outlook.office.com/webhook/abc", Enabled: true}
+	require.NoError(t, ls.CreateNotificationChannel(ctx, ch))
+
+	ch.URL = "https://outlook.office.com/webhook/xyz"
+	ch.Enabled = false
+	ch.Events = "secret.expiring"
+	require.NoError(t, ls.UpdateNotificationChannel(ctx, ch))
+
+	got, err := ls.GetNotificationChannel(ctx, ch.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "https://outlook.office.com/webhook/xyz", got.URL)
+	assert.False(t, got.Enabled)
+	assert.Equal(t, "secret.expiring", got.Events)
+}
+
+func TestDeleteNotificationChannel(t *testing.T) {
+	ctx := context.Background()
+	ls := newNotificationChannelTestStore(t)
+
+	ch := &models.NotificationChannel{Name: "email-ops", Type: "email", Email: "ops@example.com", Enabled: true}
+	require.NoError(t, ls.CreateNotificationChannel(ctx, ch))
+	require.NotZero(t, ch.ID)
+
+	require.NoError(t, ls.DeleteNotificationChannel(ctx, ch.ID))
+
+	// Hard delete: row should be gone.
+	channels, err := ls.ListNotificationChannels(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, channels)
+}

--- a/internal/storage/store/remote_notification_channels.go
+++ b/internal/storage/store/remote_notification_channels.go
@@ -1,0 +1,36 @@
+// remote_notification_channels.go — RemoteStorage stubs for notification channel
+// management. The REST API (/api/v1/notification-channels) is the remote surface;
+// these methods are never invoked directly by a remote-storage caller (the CLI
+// uses the REST endpoints via common.RemoteClient). All six are intentional stubs
+// documented in remote_unsupported_completeness_test.go.
+package store
+
+import (
+	"context"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func (rs *RemoteStorage) ListNotificationChannels(_ context.Context) ([]*models.NotificationChannel, error) {
+	return nil, remoteUnsupported("ListNotificationChannels")
+}
+
+func (rs *RemoteStorage) GetNotificationChannel(_ context.Context, _ uint) (*models.NotificationChannel, error) {
+	return nil, remoteUnsupported("GetNotificationChannel")
+}
+
+func (rs *RemoteStorage) GetNotificationChannelByName(_ context.Context, _ string) (*models.NotificationChannel, error) {
+	return nil, remoteUnsupported("GetNotificationChannelByName")
+}
+
+func (rs *RemoteStorage) CreateNotificationChannel(_ context.Context, _ *models.NotificationChannel) error {
+	return remoteUnsupported("CreateNotificationChannel")
+}
+
+func (rs *RemoteStorage) UpdateNotificationChannel(_ context.Context, _ *models.NotificationChannel) error {
+	return remoteUnsupported("UpdateNotificationChannel")
+}
+
+func (rs *RemoteStorage) DeleteNotificationChannel(_ context.Context, _ uint) error {
+	return remoteUnsupported("DeleteNotificationChannel")
+}

--- a/internal/storage/store/remote_notification_channels_completeness_test.go
+++ b/internal/storage/store/remote_notification_channels_completeness_test.go
@@ -1,0 +1,16 @@
+package store
+
+func init() {
+	// Notification channel management — the REST API (/api/v1/notification-channels)
+	// is the remote surface. The CLI uses common.RemoteClient directly against those
+	// endpoints; the storage layer is only ever reached from the server-side handler
+	// which always runs against LocalStorage.
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		"ListNotificationChannels":     {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
+		"GetNotificationChannel":       {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
+		"GetNotificationChannelByName": {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
+		"CreateNotificationChannel":    {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
+		"UpdateNotificationChannel":    {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
+		"DeleteNotificationChannel":    {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
+	})
+}

--- a/internal/storage/store/remote_notification_channels_test.go
+++ b/internal/storage/store/remote_notification_channels_test.go
@@ -1,0 +1,37 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteNotificationChannelStubs_Unsupported verifies that all six
+// RemoteStorage notification-channel methods return an error (remoteUnsupported)
+// as documented in remote_notification_channels_completeness_test.go.
+func TestRemoteNotificationChannelStubs_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19997"))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	_, err = rs.ListNotificationChannels(ctx)
+	assert.Error(t, err)
+
+	_, err = rs.GetNotificationChannel(ctx, 1)
+	assert.Error(t, err)
+
+	_, err = rs.GetNotificationChannelByName(ctx, "foo")
+	assert.Error(t, err)
+
+	err = rs.CreateNotificationChannel(ctx, nil)
+	assert.Error(t, err)
+
+	err = rs.UpdateNotificationChannel(ctx, nil)
+	assert.Error(t, err)
+
+	err = rs.DeleteNotificationChannel(ctx, 1)
+	assert.Error(t, err)
+}

--- a/server/http/handlers/notification_channels.go
+++ b/server/http/handlers/notification_channels.go
@@ -1,0 +1,175 @@
+// notification_channels.go — CRUD endpoints for runtime-managed outbound
+// notification channels (webhook/slack/teams/email). All routes require the
+// system.write permission (admin only).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// NotificationChannelHandler serves the notification-channel CRUD endpoints.
+type NotificationChannelHandler struct {
+	coreService *core.KeyorixCore
+}
+
+// NewNotificationChannelHandler constructs a NotificationChannelHandler.
+func NewNotificationChannelHandler(coreService *core.KeyorixCore) *NotificationChannelHandler {
+	return &NotificationChannelHandler{coreService: coreService}
+}
+
+// channelToAPI converts a NotificationChannel model to the API wire shape.
+func channelToAPI(ch *models.NotificationChannel) map[string]interface{} {
+	return map[string]interface{}{
+		"id":         ch.ID,
+		"name":       ch.Name,
+		"type":       ch.Type,
+		"enabled":    ch.Enabled,
+		"url":        ch.URL,
+		"email":      ch.Email,
+		"events":     ch.Events,
+		"created_by": ch.CreatedBy,
+		"created_at": ch.CreatedAt,
+		"updated_at": ch.UpdatedAt,
+	}
+}
+
+// List handles GET /api/v1/notification-channels.
+func (h *NotificationChannelHandler) List(w http.ResponseWriter, r *http.Request) {
+	channels, err := h.coreService.ListNotificationChannels(r.Context())
+	if err != nil {
+		log.Printf("Error listing notification channels: %v", err)
+		sendError(w, "InternalError", "Failed to list notification channels", http.StatusInternalServerError, nil)
+		return
+	}
+	out := make([]map[string]interface{}, 0, len(channels))
+	for _, ch := range channels {
+		out = append(out, channelToAPI(ch))
+	}
+	sendSuccess(w, map[string]interface{}{"channels": out}, "")
+}
+
+// Create handles POST /api/v1/notification-channels.
+func (h *NotificationChannelHandler) Create(w http.ResponseWriter, r *http.Request) {
+	u := middleware.GetUserFromContext(r.Context())
+	if u == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Name    string `json:"name"`
+		Type    string `json:"type"`
+		Enabled *bool  `json:"enabled"`
+		URL     string `json:"url"`
+		Email   string `json:"email"`
+		Events  string `json:"events"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	ch := &models.NotificationChannel{
+		Name:   body.Name,
+		Type:   body.Type,
+		URL:    body.URL,
+		Email:  body.Email,
+		Events: body.Events,
+	}
+	if body.Enabled != nil {
+		ch.Enabled = *body.Enabled
+	} else {
+		ch.Enabled = true
+	}
+	created, err := h.coreService.CreateNotificationChannel(r.Context(), ch, u.Username)
+	if err != nil {
+		if isValidationError(err) {
+			sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
+			return
+		}
+		log.Printf("Error creating notification channel: %v", err)
+		sendError(w, "InternalError", clientSafe(err), http.StatusInternalServerError, nil)
+		return
+	}
+	sendCreated(w, channelToAPI(created), "")
+}
+
+// Get handles GET /api/v1/notification-channels/{id}.
+func (h *NotificationChannelHandler) Get(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseUintParam(w, r, "id")
+	if !ok {
+		return
+	}
+	ch, err := h.coreService.GetNotificationChannel(r.Context(), id)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			sendError(w, "NotFound", "Notification channel not found", http.StatusNotFound, nil)
+			return
+		}
+		log.Printf("Error getting notification channel %d: %v", id, err)
+		sendError(w, "InternalError", "Failed to get notification channel", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, channelToAPI(ch), "")
+}
+
+// Update handles PUT /api/v1/notification-channels/{id}.
+func (h *NotificationChannelHandler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseUintParam(w, r, "id")
+	if !ok {
+		return
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	updated, err := h.coreService.UpdateNotificationChannel(r.Context(), id, body)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			sendError(w, "NotFound", "Notification channel not found", http.StatusNotFound, nil)
+			return
+		}
+		if isValidationError(err) {
+			sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
+			return
+		}
+		log.Printf("Error updating notification channel %d: %v", id, err)
+		sendError(w, "InternalError", clientSafe(err), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, channelToAPI(updated), "")
+}
+
+// Delete handles DELETE /api/v1/notification-channels/{id}.
+func (h *NotificationChannelHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseUintParam(w, r, "id")
+	if !ok {
+		return
+	}
+	if err := h.coreService.DeleteNotificationChannel(r.Context(), id); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			sendError(w, "NotFound", "Notification channel not found", http.StatusNotFound, nil)
+			return
+		}
+		log.Printf("Error deleting notification channel %d: %v", id, err)
+		sendError(w, "InternalError", "Failed to delete notification channel", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"id": id, "deleted": true}, "")
+}
+
+// isValidationError reports whether the error comes from the core validation layer
+// (as opposed to a storage/infrastructure error). Validation messages are
+// short, human-readable strings crafted in validateNotificationChannel; they are
+// safe to send back to the client verbatim.
+func isValidationError(err error) bool {
+	msg := err.Error()
+	return strings.HasPrefix(msg, "notification channel") ||
+		strings.HasPrefix(msg, "invalid notification")
+}

--- a/server/http/notification_channels_handler_test.go
+++ b/server/http/notification_channels_handler_test.go
@@ -131,7 +131,7 @@ func TestNotificationChannelList_Empty(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -168,7 +168,7 @@ func TestNotificationChannelCreate_Webhook(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
@@ -204,7 +204,7 @@ func TestNotificationChannelCreate_InvalidType(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
@@ -228,7 +228,7 @@ func TestNotificationChannelCreate_WebhookMissingURL(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
@@ -254,7 +254,7 @@ func TestNotificationChannelDelete(t *testing.T) {
 
 	createResp, err := http.DefaultClient.Do(createReq)
 	require.NoError(t, err)
-	defer createResp.Body.Close()
+	defer func() { _ = createResp.Body.Close() }()
 	require.Equal(t, http.StatusCreated, createResp.StatusCode)
 
 	var createBody map[string]interface{}
@@ -273,7 +273,7 @@ func TestNotificationChannelDelete(t *testing.T) {
 
 	delResp, err := http.DefaultClient.Do(delReq)
 	require.NoError(t, err)
-	defer delResp.Body.Close()
+	defer func() { _ = delResp.Body.Close() }()
 	assert.Equal(t, http.StatusOK, delResp.StatusCode)
 
 	// GET must now return 404.
@@ -283,7 +283,7 @@ func TestNotificationChannelDelete(t *testing.T) {
 
 	getResp, err := http.DefaultClient.Do(getReq)
 	require.NoError(t, err)
-	defer getResp.Body.Close()
+	defer func() { _ = getResp.Body.Close() }()
 	assert.Equal(t, http.StatusNotFound, getResp.StatusCode)
 }
 
@@ -298,7 +298,7 @@ func TestNotificationChannels_Unauthenticated(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }

--- a/server/http/notification_channels_handler_test.go
+++ b/server/http/notification_channels_handler_test.go
@@ -488,32 +488,6 @@ func itoa(n int) string {
 
 // ── broken-DB helpers ─────────────────────────────────────────────────────────
 
-// notificationChannelBrokenSetup is like notificationChannelTestSetup but
-// drops the notification_channels table after migration so every handler call
-// returns a 500 storage error (not a 404 "not found").
-func notificationChannelBrokenSetup(t *testing.T) (*httptest.Server, string) {
-	t.Helper()
-	require.NoError(t, i18n.InitializeForTesting())
-	t.Cleanup(i18n.ResetForTesting)
-
-	c := newNotificationChannelCore(t)
-	token := createTestToken(t, c)
-
-	router, err := NewRouter(&config.Config{}, c)
-	require.NoError(t, err)
-
-	// Drop the notification_channels table so every query returns a DB error.
-	// We need to reach through the core to the underlying DB — the only way
-	// available here is to use a fresh raw-gorm connection to the same named DSN.
-	// Instead, build a fresh LocalStorage whose DB has the table dropped.
-	//
-	// Simpler approach: create a separate in-process DB where the table is absent
-	// and build the core from that broken storage.
-	srv := httptest.NewServer(router)
-	t.Cleanup(srv.Close)
-	return srv, token
-}
-
 // newBrokenNotificationChannelCore returns a *core.KeyorixCore backed by an
 // in-memory SQLite DB that does NOT have the notification_channels table, so
 // all notification-channel storage calls return a real DB error (not "not found").

--- a/server/http/notification_channels_handler_test.go
+++ b/server/http/notification_channels_handler_test.go
@@ -303,6 +303,168 @@ func TestNotificationChannels_Unauthenticated(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
 
+// TestNotificationChannelCreate_BadJSON verifies that a malformed JSON body returns 400.
+func TestNotificationChannelCreate_BadJSON(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels",
+		bytes.NewReader([]byte("not-json")))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestNotificationChannelList_WithChannels verifies that a non-empty list is returned correctly.
+func TestNotificationChannelList_WithChannels(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	createPayload, err := json.Marshal(map[string]interface{}{
+		"name": "list-test", "type": "slack", "url": "https://hooks.slack.com/test",
+	})
+	require.NoError(t, err)
+	createReq, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels",
+		bytes.NewReader(createPayload))
+	require.NoError(t, err)
+	createReq.Header.Set("Authorization", "Bearer "+token)
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := http.DefaultClient.Do(createReq)
+	require.NoError(t, err)
+	_ = createResp.Body.Close()
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	listReq, err := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/notification-channels", nil)
+	require.NoError(t, err)
+	listReq.Header.Set("Authorization", "Bearer "+token)
+	listResp, err := http.DefaultClient.Do(listReq)
+	require.NoError(t, err)
+	defer func() { _ = listResp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, listResp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(listResp.Body).Decode(&body))
+	data := body["data"].(map[string]interface{})
+	channels := data["channels"].([]interface{})
+	assert.Len(t, channels, 1)
+}
+
+// TestNotificationChannelGet_Found verifies that GET /{id} returns the channel.
+func TestNotificationChannelGet_Found(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	createPayload, err := json.Marshal(map[string]interface{}{
+		"name": "get-test", "type": "webhook", "url": "https://hook.example.com",
+	})
+	require.NoError(t, err)
+	createReq, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels",
+		bytes.NewReader(createPayload))
+	require.NoError(t, err)
+	createReq.Header.Set("Authorization", "Bearer "+token)
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := http.DefaultClient.Do(createReq)
+	require.NoError(t, err)
+	var createBody map[string]interface{}
+	require.NoError(t, json.NewDecoder(createResp.Body).Decode(&createBody))
+	_ = createResp.Body.Close()
+	id := int(createBody["data"].(map[string]interface{})["id"].(float64))
+
+	getReq, err := http.NewRequest(http.MethodGet,
+		srv.URL+"/api/v1/notification-channels/"+itoa(id), nil)
+	require.NoError(t, err)
+	getReq.Header.Set("Authorization", "Bearer "+token)
+	getResp, err := http.DefaultClient.Do(getReq)
+	require.NoError(t, err)
+	defer func() { _ = getResp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, getResp.StatusCode)
+}
+
+// TestNotificationChannelUpdate_Success verifies that PUT updates the channel.
+func TestNotificationChannelUpdate_Success(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	createPayload, err := json.Marshal(map[string]interface{}{
+		"name": "upd-test", "type": "webhook", "url": "https://original.example.com",
+	})
+	require.NoError(t, err)
+	createReq, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels",
+		bytes.NewReader(createPayload))
+	require.NoError(t, err)
+	createReq.Header.Set("Authorization", "Bearer "+token)
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := http.DefaultClient.Do(createReq)
+	require.NoError(t, err)
+	var createBody map[string]interface{}
+	require.NoError(t, json.NewDecoder(createResp.Body).Decode(&createBody))
+	_ = createResp.Body.Close()
+	id := int(createBody["data"].(map[string]interface{})["id"].(float64))
+
+	updatePayload, err := json.Marshal(map[string]interface{}{"events": "secret.rotated"})
+	require.NoError(t, err)
+	updateReq, err := http.NewRequest(http.MethodPut,
+		srv.URL+"/api/v1/notification-channels/"+itoa(id),
+		bytes.NewReader(updatePayload))
+	require.NoError(t, err)
+	updateReq.Header.Set("Authorization", "Bearer "+token)
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateResp, err := http.DefaultClient.Do(updateReq)
+	require.NoError(t, err)
+	defer func() { _ = updateResp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, updateResp.StatusCode)
+}
+
+// TestNotificationChannelUpdate_NotFound verifies that PUT on a non-existent channel returns 404.
+func TestNotificationChannelUpdate_NotFound(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	updatePayload, err := json.Marshal(map[string]interface{}{"events": "anomaly.detected"})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPut,
+		srv.URL+"/api/v1/notification-channels/9999",
+		bytes.NewReader(updatePayload))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// TestNotificationChannelUpdate_BadJSON verifies that a malformed PUT body returns 400.
+func TestNotificationChannelUpdate_BadJSON(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	req, err := http.NewRequest(http.MethodPut,
+		srv.URL+"/api/v1/notification-channels/1",
+		bytes.NewReader([]byte("not-json")))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestNotificationChannelDelete_NotFound verifies that deleting a non-existent channel returns 404.
+func TestNotificationChannelDelete_NotFound(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	req, err := http.NewRequest(http.MethodDelete,
+		srv.URL+"/api/v1/notification-channels/9999", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
 // itoa converts an int to its decimal string representation. Used to build URL
 // path segments without importing strconv or fmt in every test.
 func itoa(n int) string {

--- a/server/http/notification_channels_handler_test.go
+++ b/server/http/notification_channels_handler_test.go
@@ -1,0 +1,325 @@
+// notification_channels_handler_test.go — handler-level integration tests for
+// the notification channel CRUD endpoints (feat/notification-channels).
+// All routes live under /api/v1/notification-channels and are gated on
+// system.write (admin only).
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// newNotificationChannelCore replicates newTestCore's full AutoMigrate list and
+// also migrates &models.NotificationChannel{} so the notification-channel
+// handler tests have a database that matches the real production schema.
+func newNotificationChannelCore(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(uniqueMemDSN("&_timeout=30000&_journal_mode=WAL")), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	err = db.AutoMigrate(
+		&models.SecretNode{},
+		&models.SecretVersion{},
+		&models.User{},
+		&models.Role{},
+		&models.UserRole{},
+		&models.Group{},
+		&models.UserGroup{},
+		&models.GroupRole{},
+		&models.ShareRecord{},
+		&models.AuditEvent{},
+		&models.Session{},
+		&models.Project{},
+		&models.Environment{},
+		&models.Permission{},
+		&models.RolePermission{},
+		&models.SystemMetadata{},
+		&models.LoginAttempt{},
+		&models.PasswordHistory{},
+		&models.PersonalAccessToken{},
+		&models.Tag{},
+		&models.SecretTag{},
+		&models.ProjectInvitation{},
+		&models.DynamicSecretConfig{},
+		&models.DynamicSecretLease{},
+		&models.Notification{},
+		&models.SetupToken{},
+		&models.ProjectMembership{},
+		&models.MFASecret{},
+		&models.MFARecoveryCode{},
+		&models.MFAChallenge{},
+		&models.SecretDependency{},
+		&models.MachineIdentity{},
+		&models.MachineIdentityCredential{},
+		&models.MachineIdentityRole{},
+		&models.MachineIdentityOIDCBinding{},
+		&models.WebAuthnCredential{},
+		&models.WebAuthnSession{},
+		&models.LegalHold{},
+		&models.AccessReviewCampaign{},
+		&models.AccessReviewItem{},
+		&models.BreakGlassActivation{},
+		&models.RiskException{},
+		&models.SoDPolicy{},
+		&models.ConnectRefGrant{},
+		&models.AnomalyAlert{},
+		&models.AccessRequest{},
+		&models.AccessRequestApproval{},
+		&models.SSOLoginState{},
+		&models.SchedulerLockLease{},
+		&models.SecretACL{},
+		&models.AnomalyConfigRecord{},
+		&models.NotificationChannel{},
+		&models.StatsSnapshot{},
+		&models.DeploymentStatsSnapshot{},
+	)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_project_memberships_active "+
+		"ON project_memberships (project_id, user_id) WHERE state <> 'revoked'").Error)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_legal_holds_active "+
+		"ON legal_holds (released) WHERE released = false").Error)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_break_glass_active_project_user "+
+		"ON break_glass_activations (project_id, user_id) WHERE state = 'active'").Error)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active "+
+		"ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error)
+	return core.NewKeyorixCore(store.NewLocalStorage(db))
+}
+
+// notificationChannelTestSetup is a convenience helper that initialises i18n,
+// builds a core, mints an admin token, and starts a real httptest.Server. It
+// returns the server and the admin bearer token. Cleanup is registered with t.
+func notificationChannelTestSetup(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	c := newNotificationChannelCore(t)
+	token := createTestToken(t, c)
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	return srv, token
+}
+
+// TestNotificationChannelList_Empty verifies that an admin GET on the list
+// endpoint returns 200 with a "data" field that wraps an empty channels array.
+func TestNotificationChannelList_Empty(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/notification-channels", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Contains(t, body, "data")
+
+	// The handler wraps the list as {"channels": [...]} inside "data".
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "data must be an object")
+	channels, ok := data["channels"].([]interface{})
+	require.True(t, ok, "data.channels must be an array")
+	assert.Empty(t, channels)
+}
+
+// TestNotificationChannelCreate_Webhook verifies that POSTing a valid webhook
+// channel returns 201 with the created record in response data (including an id).
+func TestNotificationChannelCreate_Webhook(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	payload := map[string]interface{}{
+		"name":   "ops-hook",
+		"type":   "webhook",
+		"url":    "https://hook.example.com",
+		"events": "anomaly.detected",
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var respBody map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&respBody))
+
+	data, ok := respBody["data"].(map[string]interface{})
+	require.True(t, ok, "data must be an object")
+	assert.NotNil(t, data["id"], "created channel must have an id")
+	assert.Equal(t, "ops-hook", data["name"])
+	assert.Equal(t, "webhook", data["type"])
+	assert.Equal(t, "https://hook.example.com", data["url"])
+	assert.Equal(t, "anomaly.detected", data["events"])
+}
+
+// TestNotificationChannelCreate_InvalidType verifies that POSTing a channel
+// with an unsupported type returns 400.
+func TestNotificationChannelCreate_InvalidType(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	payload := map[string]interface{}{
+		"name": "fax-channel",
+		"type": "fax",
+		"url":  "https://fax.example.com",
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestNotificationChannelCreate_WebhookMissingURL verifies that creating a
+// webhook channel without a URL returns 400.
+func TestNotificationChannelCreate_WebhookMissingURL(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	payload := map[string]interface{}{
+		"name": "no-url-hook",
+		"type": "webhook",
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestNotificationChannelDelete verifies the delete-then-get-404 flow:
+// create a channel, DELETE it (→ 200), then GET it (→ 404).
+func TestNotificationChannelDelete(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	// Create a channel to delete.
+	createPayload, err := json.Marshal(map[string]interface{}{
+		"name":   "to-delete",
+		"type":   "webhook",
+		"url":    "https://delete.example.com",
+		"events": "secret.rotated",
+	})
+	require.NoError(t, err)
+
+	createReq, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels", bytes.NewReader(createPayload))
+	require.NoError(t, err)
+	createReq.Header.Set("Authorization", "Bearer "+token)
+	createReq.Header.Set("Content-Type", "application/json")
+
+	createResp, err := http.DefaultClient.Do(createReq)
+	require.NoError(t, err)
+	defer createResp.Body.Close()
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	var createBody map[string]interface{}
+	require.NoError(t, json.NewDecoder(createResp.Body).Decode(&createBody))
+	data, ok := createBody["data"].(map[string]interface{})
+	require.True(t, ok)
+	// id comes back as a JSON number (float64 when decoded into interface{}).
+	idFloat, ok := data["id"].(float64)
+	require.True(t, ok, "id must be a number")
+	id := int(idFloat)
+
+	// DELETE the channel.
+	delReq, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/notification-channels/"+itoa(id), nil)
+	require.NoError(t, err)
+	delReq.Header.Set("Authorization", "Bearer "+token)
+
+	delResp, err := http.DefaultClient.Do(delReq)
+	require.NoError(t, err)
+	defer delResp.Body.Close()
+	assert.Equal(t, http.StatusOK, delResp.StatusCode)
+
+	// GET must now return 404.
+	getReq, err := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/notification-channels/"+itoa(id), nil)
+	require.NoError(t, err)
+	getReq.Header.Set("Authorization", "Bearer "+token)
+
+	getResp, err := http.DefaultClient.Do(getReq)
+	require.NoError(t, err)
+	defer getResp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, getResp.StatusCode)
+}
+
+// TestNotificationChannels_Unauthenticated verifies that the list endpoint
+// returns 401 when no Authorization header is present.
+func TestNotificationChannels_Unauthenticated(t *testing.T) {
+	srv, _ := notificationChannelTestSetup(t)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/notification-channels", nil)
+	require.NoError(t, err)
+	// Deliberately omit the Authorization header.
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// itoa converts an int to its decimal string representation. Used to build URL
+// path segments without importing strconv or fmt in every test.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	buf := make([]byte, 0, 10)
+	for n > 0 {
+		buf = append([]byte{byte('0' + n%10)}, buf...)
+		n /= 10
+	}
+	if neg {
+		buf = append([]byte{'-'}, buf...)
+	}
+	return string(buf)
+}

--- a/server/http/notification_channels_handler_test.go
+++ b/server/http/notification_channels_handler_test.go
@@ -485,3 +485,357 @@ func itoa(n int) string {
 	}
 	return string(buf)
 }
+
+// ── broken-DB helpers ─────────────────────────────────────────────────────────
+
+// notificationChannelBrokenSetup is like notificationChannelTestSetup but
+// drops the notification_channels table after migration so every handler call
+// returns a 500 storage error (not a 404 "not found").
+func notificationChannelBrokenSetup(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	c := newNotificationChannelCore(t)
+	token := createTestToken(t, c)
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+
+	// Drop the notification_channels table so every query returns a DB error.
+	// We need to reach through the core to the underlying DB — the only way
+	// available here is to use a fresh raw-gorm connection to the same named DSN.
+	// Instead, build a fresh LocalStorage whose DB has the table dropped.
+	//
+	// Simpler approach: create a separate in-process DB where the table is absent
+	// and build the core from that broken storage.
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	return srv, token
+}
+
+// newBrokenNotificationChannelCore returns a *core.KeyorixCore backed by an
+// in-memory SQLite DB that does NOT have the notification_channels table, so
+// all notification-channel storage calls return a real DB error (not "not found").
+func newBrokenNotificationChannelCore(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	// Full migration first (needed for auth to work), then drop only the NC table.
+	db, err := gorm.Open(sqlite.Open(uniqueMemDSN("&_timeout=30000&_journal_mode=WAL")), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	err = db.AutoMigrate(
+		&models.SecretNode{},
+		&models.SecretVersion{},
+		&models.User{},
+		&models.Role{},
+		&models.UserRole{},
+		&models.Group{},
+		&models.UserGroup{},
+		&models.GroupRole{},
+		&models.ShareRecord{},
+		&models.AuditEvent{},
+		&models.Session{},
+		&models.Project{},
+		&models.Environment{},
+		&models.Permission{},
+		&models.RolePermission{},
+		&models.SystemMetadata{},
+		&models.LoginAttempt{},
+		&models.PasswordHistory{},
+		&models.PersonalAccessToken{},
+		&models.Tag{},
+		&models.SecretTag{},
+		&models.ProjectInvitation{},
+		&models.DynamicSecretConfig{},
+		&models.DynamicSecretLease{},
+		&models.Notification{},
+		&models.SetupToken{},
+		&models.ProjectMembership{},
+		&models.MFASecret{},
+		&models.MFARecoveryCode{},
+		&models.MFAChallenge{},
+		&models.SecretDependency{},
+		&models.MachineIdentity{},
+		&models.MachineIdentityCredential{},
+		&models.MachineIdentityRole{},
+		&models.MachineIdentityOIDCBinding{},
+		&models.WebAuthnCredential{},
+		&models.WebAuthnSession{},
+		&models.LegalHold{},
+		&models.AccessReviewCampaign{},
+		&models.AccessReviewItem{},
+		&models.BreakGlassActivation{},
+		&models.RiskException{},
+		&models.SoDPolicy{},
+		&models.ConnectRefGrant{},
+		&models.AnomalyAlert{},
+		&models.AccessRequest{},
+		&models.AccessRequestApproval{},
+		&models.SSOLoginState{},
+		&models.SchedulerLockLease{},
+		&models.SecretACL{},
+		&models.AnomalyConfigRecord{},
+		// Intentionally omit &models.NotificationChannel{} so the table is absent.
+		&models.StatsSnapshot{},
+		&models.DeploymentStatsSnapshot{},
+	)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_project_memberships_active "+
+		"ON project_memberships (project_id, user_id) WHERE state <> 'revoked'").Error)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_legal_holds_active "+
+		"ON legal_holds (released) WHERE released = false").Error)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_break_glass_active_project_user "+
+		"ON break_glass_activations (project_id, user_id) WHERE state = 'active'").Error)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active "+
+		"ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error)
+	return core.NewKeyorixCore(store.NewLocalStorage(db))
+}
+
+// notificationChannelBrokenDBSetup builds a server backed by a DB that lacks
+// the notification_channels table so every storage call returns a hard error.
+func notificationChannelBrokenDBSetup(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	c := newBrokenNotificationChannelCore(t)
+	token := createTestToken(t, c)
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	return srv, token
+}
+
+// ── storage-error (500) path tests ────────────────────────────────────────────
+
+// TestNotificationChannelList_StorageError verifies that when ListNotificationChannels
+// returns a DB error (non-not-found) the List handler returns 500.
+func TestNotificationChannelList_StorageError(t *testing.T) {
+	srv, token := notificationChannelBrokenDBSetup(t)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/notification-channels", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+// TestNotificationChannelCreate_StorageError verifies that when validation
+// passes but CreateNotificationChannel returns a non-validation DB error the
+// Create handler returns 500.
+func TestNotificationChannelCreate_StorageError(t *testing.T) {
+	srv, token := notificationChannelBrokenDBSetup(t)
+
+	payload, err := json.Marshal(map[string]interface{}{
+		"name": "hook",
+		"type": "webhook",
+		"url":  "https://hook.example.com",
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels",
+		bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+// TestNotificationChannelCreate_EnabledDefaultsTrue verifies that when the
+// request body omits the "enabled" field the channel is created with Enabled=true.
+func TestNotificationChannelCreate_EnabledDefaultsTrue(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	// Explicitly omit the "enabled" key.
+	payload, err := json.Marshal(map[string]interface{}{
+		"name":   "no-enabled-field",
+		"type":   "webhook",
+		"url":    "https://hook.example.com",
+		"events": "anomaly.detected",
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels",
+		bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data := body["data"].(map[string]interface{})
+	assert.Equal(t, true, data["enabled"], "enabled must default to true when omitted from request")
+}
+
+
+// TestNotificationChannelGet_StorageError verifies that a non-not-found DB
+// error on Get returns 500.
+func TestNotificationChannelGet_StorageError(t *testing.T) {
+	srv, token := notificationChannelBrokenDBSetup(t)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/notification-channels/1", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+// TestNotificationChannelUpdate_ValidationError verifies that an update body
+// that triggers core validation (e.g., invalid type) returns 400.
+func TestNotificationChannelUpdate_ValidationError(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	// First create a valid channel.
+	createPayload, err := json.Marshal(map[string]interface{}{
+		"name": "valid-hook",
+		"type": "webhook",
+		"url":  "https://hook.example.com",
+	})
+	require.NoError(t, err)
+	createReq, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels",
+		bytes.NewReader(createPayload))
+	require.NoError(t, err)
+	createReq.Header.Set("Authorization", "Bearer "+token)
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := http.DefaultClient.Do(createReq)
+	require.NoError(t, err)
+	var createBody map[string]interface{}
+	require.NoError(t, json.NewDecoder(createResp.Body).Decode(&createBody))
+	_ = createResp.Body.Close()
+	id := int(createBody["data"].(map[string]interface{})["id"].(float64))
+
+	// Update with an invalid type — triggers core validation error → 400.
+	updatePayload, err := json.Marshal(map[string]interface{}{"type": "fax"})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPut,
+		srv.URL+"/api/v1/notification-channels/"+itoa(id),
+		bytes.NewReader(updatePayload))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestNotificationChannelUpdate_StorageError verifies that a non-not-found DB
+// error on Update returns 500.
+func TestNotificationChannelUpdate_StorageError(t *testing.T) {
+	srv, token := notificationChannelBrokenDBSetup(t)
+
+	payload, err := json.Marshal(map[string]interface{}{"events": "anomaly.detected"})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/v1/notification-channels/1",
+		bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+// TestNotificationChannelDelete_StorageError verifies that a non-not-found DB
+// error on Delete returns 500.
+func TestNotificationChannelDelete_StorageError(t *testing.T) {
+	srv, token := notificationChannelBrokenDBSetup(t)
+
+	req, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/notification-channels/1", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+// TestNotificationChannelGet_NotFound verifies that GET on a non-existent id
+// returns 404.
+func TestNotificationChannelGet_NotFound(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	req, err := http.NewRequest(http.MethodGet,
+		srv.URL+"/api/v1/notification-channels/9999", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// TestNotificationChannelCreate_Email verifies creating an email-type channel.
+func TestNotificationChannelCreate_Email(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	payload, err := json.Marshal(map[string]interface{}{
+		"name":  "email-ops",
+		"type":  "email",
+		"email": "ops@example.com",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels",
+		bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data := body["data"].(map[string]interface{})
+	assert.Equal(t, "email", data["type"])
+	assert.Equal(t, "ops@example.com", data["email"])
+}
+
+// TestNotificationChannelCreate_Teams verifies creating a teams-type channel.
+func TestNotificationChannelCreate_Teams(t *testing.T) {
+	srv, token := notificationChannelTestSetup(t)
+
+	payload, err := json.Marshal(map[string]interface{}{
+		"name": "teams-alerts",
+		"type": "teams",
+		"url":  "https://outlook.office.com/webhook/abc",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notification-channels",
+		bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -138,6 +138,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	rbacHandler := handlers.NewRBACHandler(coreService)
 	usersRolesHandler := handlers.NewUsersRolesHandler(coreService)
 	notificationHandler := handlers.NewNotificationHandler(coreService)
+	notificationChannelHandler := handlers.NewNotificationChannelHandler(coreService)
 	connectHandler := handlers.NewConnectHandler(coreService)
 	adminJobsHandler := handlers.NewAdminJobsHandler(coreService)
 	hygieneTrendsHandler := handlers.NewHygieneTrendsHandler(coreService)
@@ -321,6 +322,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.Get("/notifications", notificationHandler.List)
 		r.Post("/notifications/read-all", notificationHandler.MarkAllRead)
 		r.Post("/notifications/{id}/read", notificationHandler.MarkRead)
+
+		// Notification channel management — admin-only (system.write).
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Get("/notification-channels", notificationChannelHandler.List)
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/notification-channels", notificationChannelHandler.Create)
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Get("/notification-channels/{id}", notificationChannelHandler.Get)
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/notification-channels/{id}", notificationChannelHandler.Update)
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Delete("/notification-channels/{id}", notificationChannelHandler.Delete)
 
 		// Dashboard endpoints
 		// GetStats is the caller's OWN home dashboard (their secret/share counts,


### PR DESCRIPTION
NotificationChannel model + GET/POST/PUT/DELETE /api/v1/notification-channels. CLI: keyorix notification channel list/add/get/update/delete. Runtime webhook/Slack/Teams/email config without YAML edits. 17 tests.