### PR TITLE
feat(secrets): bulk delete

### DIFF
--- a/internal/cli/secret/bulk_delete.go
+++ b/internal/cli/secret/bulk_delete.go
@@ -1,0 +1,251 @@
+// bulk_delete.go — CLI command for deleting multiple secrets in a single call.
+// Follows the bulk-rename pattern; destructive so --confirm is required.
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/spf13/cobra"
+)
+
+var (
+	bulkDeleteProject uint
+	bulkDeleteIDs     []uint
+	bulkDeleteNames   []string
+	bulkDeleteConfirm bool
+)
+
+// bulkDeleteResult mirrors the BulkDeleteResult from core / the HTTP response envelope.
+type bulkDeleteResult struct {
+	Deleted []uint             `json:"deleted"`
+	Failed  []bulkDeleteError  `json:"failed"`
+	Total   int                `json:"total"`
+}
+
+type bulkDeleteError struct {
+	SecretID uint   `json:"secret_id"`
+	Name     string `json:"name"`
+	Error    string `json:"error"`
+}
+
+var bulkDeleteCmd = &cobra.Command{
+	Use:   "bulk-delete",
+	Short: "Delete multiple secrets in one operation",
+	Long: `Delete one or more secrets in a project in a single call.
+
+Pass secret IDs directly with --ids, or resolve by name with --names (requires
+--project for name resolution). --confirm is mandatory for the deletion to
+proceed; without it the command prints what would be deleted and exits.
+
+  keyorix secret bulk-delete --ids 1,2,3 --confirm
+  keyorix secret bulk-delete --names s1,s2,s3 --project 7 --confirm`,
+	SilenceUsage: true,
+	RunE:         runBulkDelete,
+}
+
+func init() {
+	bulkDeleteCmd.Flags().UintVar(&bulkDeleteProject, "project", 0, "Project ID (required for --names and for cross-project guard)")
+	bulkDeleteCmd.Flags().UintSliceVar(&bulkDeleteIDs, "ids", nil, "Comma-separated secret IDs to delete")
+	bulkDeleteCmd.Flags().StringSliceVar(&bulkDeleteNames, "names", nil, "Comma-separated secret names to delete (requires --project)")
+	bulkDeleteCmd.Flags().BoolVar(&bulkDeleteConfirm, "confirm", false, "Required to actually delete (omit to preview)")
+	SecretCmd.AddCommand(bulkDeleteCmd)
+}
+
+func runBulkDelete(_ *cobra.Command, _ []string) error {
+	if len(bulkDeleteIDs) == 0 && len(bulkDeleteNames) == 0 {
+		return fmt.Errorf("at least one of --ids or --names is required")
+	}
+
+	rc, ok := common.NewRemoteClient()
+	if !ok {
+		return runBulkDeleteEmbedded(context.Background())
+	}
+	return runBulkDeleteRemote(context.Background(), rc)
+}
+
+// ── Remote mode ───────────────────────────────────────────────────────────────
+
+func runBulkDeleteRemote(ctx context.Context, rc *common.RemoteClient) error {
+	if bulkDeleteProject == 0 && len(bulkDeleteNames) > 0 {
+		return fmt.Errorf("--project is required when using --names")
+	}
+
+	ids := make([]uint, 0, len(bulkDeleteIDs)+len(bulkDeleteNames))
+	ids = append(ids, bulkDeleteIDs...)
+
+	// Resolve names → IDs via the project's secret list.
+	if len(bulkDeleteNames) > 0 {
+		resolved, err := resolveNamesToIDs(ctx, rc, bulkDeleteProject, bulkDeleteNames)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, resolved...)
+	}
+
+	if !bulkDeleteConfirm {
+		fmt.Printf("Would delete %d secret(s): %s\n", len(ids), joinUints(ids))
+		fmt.Println("Pass --confirm to actually delete.")
+		return nil
+	}
+
+	result, err := postBulkDelete(ctx, rc, bulkDeleteProject, ids)
+	if err != nil {
+		return err
+	}
+	printBulkDeleteResult(result)
+	return nil
+}
+
+// postBulkDelete POSTs the bulk-delete request and returns the result.
+// Extracted for httptest-level unit tests.
+func postBulkDelete(ctx context.Context, rc *common.RemoteClient, projectID uint, ids []uint) (bulkDeleteResult, error) {
+	path := "/api/v1/projects/" + strconv.Itoa(int(projectID)) + "/secrets/bulk-delete"
+	body := map[string]interface{}{"secret_ids": ids}
+	var result bulkDeleteResult
+	if err := rc.Post(ctx, path, body, &result); err != nil {
+		return bulkDeleteResult{}, err
+	}
+	return result, nil
+}
+
+// resolveNamesToIDs fetches the project's secret list and resolves each name to
+// its ID. Unknown names produce an error.
+func resolveNamesToIDs(ctx context.Context, rc *common.RemoteClient, projectID uint, names []string) ([]uint, error) {
+	path := fmt.Sprintf("/api/v1/secrets?project_id=%d&page_size=500", projectID)
+	var resp models.SecretListResponse
+	if err := rc.Get(ctx, path, &resp); err != nil {
+		return nil, fmt.Errorf("failed to list secrets for name resolution: %w", err)
+	}
+
+	nameToID := make(map[string]uint, len(resp.Secrets))
+	for _, s := range resp.Secrets {
+		if s.SecretNode != nil {
+			nameToID[s.SecretNode.Name] = s.SecretNode.ID
+		}
+	}
+
+	ids := make([]uint, 0, len(names))
+	var missing []string
+	for _, name := range names {
+		id, ok := nameToID[name]
+		if !ok {
+			missing = append(missing, name)
+			continue
+		}
+		ids = append(ids, id)
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("secret(s) not found in project %d: %s", projectID, strings.Join(missing, ", "))
+	}
+	return ids, nil
+}
+
+// ── Embedded mode ─────────────────────────────────────────────────────────────
+
+func runBulkDeleteEmbedded(ctx context.Context) error {
+	if bulkDeleteProject == 0 {
+		return fmt.Errorf("--project is required in embedded mode")
+	}
+
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return err
+	}
+
+	ids := make([]uint, 0, len(bulkDeleteIDs)+len(bulkDeleteNames))
+	ids = append(ids, bulkDeleteIDs...)
+
+	if len(bulkDeleteNames) > 0 {
+		resolved, err := resolveNamesToIDsEmbedded(ctx, svc, bulkDeleteProject, bulkDeleteNames)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, resolved...)
+	}
+
+	if !bulkDeleteConfirm {
+		fmt.Printf("Would delete %d secret(s): %s\n", len(ids), joinUints(ids))
+		fmt.Println("Pass --confirm to actually delete.")
+		return nil
+	}
+
+	req := core.BulkDeleteRequest{SecretIDs: ids}
+	result, err := svc.BulkDeleteSecrets(ctx, req, bulkDeleteProject, "cli", 0, "", "")
+	if err != nil {
+		return fmt.Errorf("bulk delete failed: %w", err)
+	}
+
+	// Map core result to display type.
+	dr := bulkDeleteResult{
+		Deleted: result.Deleted,
+		Total:   result.Total,
+	}
+	for _, f := range result.Failed {
+		dr.Failed = append(dr.Failed, bulkDeleteError{
+			SecretID: f.SecretID,
+			Name:     f.Name,
+			Error:    f.Error,
+		})
+	}
+	printBulkDeleteResult(dr)
+	return nil
+}
+
+func resolveNamesToIDsEmbedded(ctx context.Context, svc *core.KeyorixCore, projectID uint, names []string) ([]uint, error) {
+	filter := &coreStorage.SecretFilter{ProjectID: &projectID, PageSize: 500}
+	secrets, _, err := svc.ListSecrets(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secrets for name resolution: %w", err)
+	}
+
+	nameToID := make(map[string]uint, len(secrets))
+	for _, s := range secrets {
+		nameToID[s.Name] = s.ID
+	}
+
+	ids := make([]uint, 0, len(names))
+	var missing []string
+	for _, name := range names {
+		id, ok := nameToID[name]
+		if !ok {
+			missing = append(missing, name)
+			continue
+		}
+		ids = append(ids, id)
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("secret(s) not found in project %d: %s", projectID, strings.Join(missing, ", "))
+	}
+	return ids, nil
+}
+
+// ── Output ────────────────────────────────────────────────────────────────────
+
+func printBulkDeleteResult(r bulkDeleteResult) {
+	fmt.Printf("Deleted %d secrets.\n", len(r.Deleted))
+	if len(r.Failed) > 0 {
+		fmt.Println("\nFailed:")
+		for _, f := range r.Failed {
+			label := f.Name
+			if label == "" {
+				label = fmt.Sprintf("id=%d", f.SecretID)
+			}
+			fmt.Printf("  %s: %s\n", label, f.Error)
+		}
+	}
+}
+
+func joinUints(ids []uint) string {
+	parts := make([]string, len(ids))
+	for i, id := range ids {
+		parts[i] = strconv.Itoa(int(id))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/cli/secret/bulk_delete_test.go
+++ b/internal/cli/secret/bulk_delete_test.go
@@ -1,0 +1,166 @@
+package secret
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bulkDeleteStub sets up an httptest server that mimics the bulk-delete endpoint.
+// captureBody, if non-nil, receives the decoded request body.
+func bulkDeleteStub(t *testing.T, projectID int, handler http.HandlerFunc) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Also serve the secrets list endpoint used for name resolution.
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/secrets" {
+			// Return two named secrets for the --names resolution test.
+			_, _ = w.Write([]byte(`{"data":{"secrets":[` +
+				`{"id":10,"name":"alpha","project_id":7,"environment_id":1,"is_secret":true},` +
+				`{"id":11,"name":"beta","project_id":7,"environment_id":1,"is_secret":true}` +
+				`],"total":2}}`))
+			return
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	_ = projectID
+	return rc, srv.Close
+}
+
+func successHandler(deleted []uint) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"deleted": deleted,
+					"failed":  []interface{}{},
+					"total":   len(deleted),
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		} else {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+func TestBulkDelete_Remote_Success(t *testing.T) {
+	var capturedBody map[string]interface{}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &capturedBody)
+		successHandler([]uint{1, 2, 3})(w, r)
+	}
+	rc, done := bulkDeleteStub(t, 7, handler)
+	defer done()
+
+	result, err := postBulkDelete(context.Background(), rc, 7, []uint{1, 2, 3})
+	require.NoError(t, err)
+	assert.Len(t, result.Deleted, 3)
+	assert.Empty(t, result.Failed)
+	assert.Equal(t, 3, result.Total)
+}
+
+func TestBulkDelete_Remote_PartialFailure(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{
+				"deleted": []uint{1},
+				"failed": []interface{}{
+					map[string]interface{}{
+						"secret_id": 99,
+						"name":      "ghost",
+						"error":     "secret not found",
+					},
+				},
+				"total": 2,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+	rc, done := bulkDeleteStub(t, 7, handler)
+	defer done()
+
+	result, err := postBulkDelete(context.Background(), rc, 7, []uint{1, 99})
+	require.NoError(t, err)
+	assert.Len(t, result.Deleted, 1)
+	require.Len(t, result.Failed, 1)
+	assert.Equal(t, "secret not found", result.Failed[0].Error)
+}
+
+func TestBulkDelete_Remote_RequiresConfirm(t *testing.T) {
+	called := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		successHandler([]uint{1})(w, r)
+	}
+	_, done := bulkDeleteStub(t, 7, handler)
+	defer done()
+
+	// Simulate the --no-confirm path: call runBulkDeleteRemote via the exported
+	// postBulkDelete but gate on bulkDeleteConfirm being false.
+	// The command itself doesn't reach postBulkDelete when confirm is false.
+	// We verify this by checking the flag guard inline.
+	origConfirm := bulkDeleteConfirm
+	bulkDeleteConfirm = false
+	defer func() { bulkDeleteConfirm = origConfirm }()
+
+	// Without --confirm the command should print and return nil without calling the API.
+	// We reset IDs/names to match a dry-run scenario.
+	origIDs := bulkDeleteIDs
+	origNames := bulkDeleteNames
+	origProject := bulkDeleteProject
+	bulkDeleteIDs = []uint{1}
+	bulkDeleteNames = nil
+	bulkDeleteProject = 7
+	defer func() {
+		bulkDeleteIDs = origIDs
+		bulkDeleteNames = origNames
+		bulkDeleteProject = origProject
+	}()
+
+	err := runBulkDeleteRemote(context.Background(), nil)
+	// nil rc is fine because we never reach postBulkDelete without confirm.
+	// The function returns nil after printing the preview.
+	assert.NoError(t, err)
+	assert.False(t, called, "API must not be called without --confirm")
+}
+
+func TestBulkDelete_Remote_NamesResolved(t *testing.T) {
+	// The stub serves GET /api/v1/secrets returning alpha(10) and beta(11).
+	// postBulkDelete should be called with IDs [10,11] after name resolution.
+	var capturedIDs []interface{}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &body)
+		if ids, ok := body["secret_ids"].([]interface{}); ok {
+			capturedIDs = ids
+		}
+		successHandler([]uint{10, 11})(w, r)
+	}
+	rc, done := bulkDeleteStub(t, 7, handler)
+	defer done()
+
+	ids, err := resolveNamesToIDs(context.Background(), rc, 7, []string{"alpha", "beta"})
+	require.NoError(t, err)
+	require.Len(t, ids, 2)
+	assert.Contains(t, ids, uint(10))
+	assert.Contains(t, ids, uint(11))
+
+	// Now post with the resolved IDs.
+	result, err := postBulkDelete(context.Background(), rc, 7, ids)
+	require.NoError(t, err)
+	assert.Len(t, result.Deleted, 2)
+	_ = capturedIDs // verified by result assertions
+}

--- a/internal/cli/secret/bulk_delete_test.go
+++ b/internal/cli/secret/bulk_delete_test.go
@@ -3,14 +3,23 @@ package secret
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 // bulkDeleteStub sets up an httptest server that mimics the bulk-delete endpoint.
@@ -163,4 +172,221 @@ func TestBulkDelete_Remote_NamesResolved(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, result.Deleted, 2)
 	_ = capturedIDs // verified by result assertions
+}
+
+// ── runBulkDelete entry-point ─────────────────────────────────────────────────
+
+func TestRunBulkDelete_NoIDsOrNames(t *testing.T) {
+	origIDs := bulkDeleteIDs
+	origNames := bulkDeleteNames
+	t.Cleanup(func() { bulkDeleteIDs = origIDs; bulkDeleteNames = origNames })
+	bulkDeleteIDs = nil
+	bulkDeleteNames = nil
+
+	err := runBulkDelete(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one of --ids or --names is required")
+}
+
+// ── runBulkDeleteRemote ───────────────────────────────────────────────────────
+
+func TestRunBulkDeleteRemote_NamesWithoutProject(t *testing.T) {
+	origProject := bulkDeleteProject
+	origNames := bulkDeleteNames
+	t.Cleanup(func() { bulkDeleteProject = origProject; bulkDeleteNames = origNames })
+	bulkDeleteProject = 0
+	bulkDeleteNames = []string{"foo"}
+
+	// rc is never reached due to early return.
+	err := runBulkDeleteRemote(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project is required when using --names")
+}
+
+func TestRunBulkDeleteRemote_WithIDsConfirmed(t *testing.T) {
+	origProject := bulkDeleteProject
+	origIDs := bulkDeleteIDs
+	origNames := bulkDeleteNames
+	origConfirm := bulkDeleteConfirm
+	t.Cleanup(func() {
+		bulkDeleteProject = origProject
+		bulkDeleteIDs = origIDs
+		bulkDeleteNames = origNames
+		bulkDeleteConfirm = origConfirm
+	})
+	bulkDeleteProject = 7
+	bulkDeleteIDs = []uint{1, 2}
+	bulkDeleteNames = nil
+	bulkDeleteConfirm = true
+
+	rc, done := bulkDeleteStub(t, 7, successHandler([]uint{1, 2}))
+	defer done()
+
+	err := runBulkDeleteRemote(context.Background(), rc)
+	require.NoError(t, err)
+}
+
+func TestRunBulkDeleteRemote_NamesWithProjectConfirmed(t *testing.T) {
+	origProject := bulkDeleteProject
+	origIDs := bulkDeleteIDs
+	origNames := bulkDeleteNames
+	origConfirm := bulkDeleteConfirm
+	t.Cleanup(func() {
+		bulkDeleteProject = origProject
+		bulkDeleteIDs = origIDs
+		bulkDeleteNames = origNames
+		bulkDeleteConfirm = origConfirm
+	})
+	bulkDeleteProject = 7
+	bulkDeleteIDs = nil
+	bulkDeleteNames = []string{"alpha"}
+	bulkDeleteConfirm = true
+
+	rc, done := bulkDeleteStub(t, 7, successHandler([]uint{10}))
+	defer done()
+
+	err := runBulkDeleteRemote(context.Background(), rc)
+	require.NoError(t, err)
+}
+
+func TestResolveNamesToIDs_NameNotFound(t *testing.T) {
+	rc, done := bulkDeleteStub(t, 7, func(w http.ResponseWriter, r *http.Request) {})
+	defer done()
+
+	// The stub serves alpha(10) and beta(11); "gamma" is not present.
+	_, err := resolveNamesToIDs(context.Background(), rc, 7, []string{"gamma"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gamma")
+}
+
+// ── printBulkDeleteResult ─────────────────────────────────────────────────────
+
+func TestPrintBulkDeleteResult_NoFailures(t *testing.T) {
+	r := bulkDeleteResult{
+		Deleted: []uint{1, 2, 3},
+		Total:   3,
+	}
+	// Verify no panic; output goes to stdout.
+	printBulkDeleteResult(r)
+}
+
+func TestPrintBulkDeleteResult_WithFailures(t *testing.T) {
+	r := bulkDeleteResult{
+		Deleted: []uint{1},
+		Failed: []bulkDeleteError{
+			{SecretID: 99, Name: "ghost", Error: "not found"},  // named failure
+			{SecretID: 100, Error: "access denied"},             // unnamed failure (id=N label)
+		},
+		Total: 3,
+	}
+	printBulkDeleteResult(r)
+}
+
+// ── joinUints ─────────────────────────────────────────────────────────────────
+
+func TestJoinUints(t *testing.T) {
+	assert.Equal(t, "", joinUints(nil))
+	assert.Equal(t, "1", joinUints([]uint{1}))
+	assert.Equal(t, "1, 2, 3", joinUints([]uint{1, 2, 3}))
+}
+
+// ── runBulkDeleteEmbedded ─────────────────────────────────────────────────────
+
+func TestRunBulkDeleteEmbedded_NoProject(t *testing.T) {
+	origProject := bulkDeleteProject
+	t.Cleanup(func() { bulkDeleteProject = origProject })
+	bulkDeleteProject = 0
+
+	err := runBulkDeleteEmbedded(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project is required in embedded mode")
+}
+
+func TestRunBulkDeleteEmbedded_PreviewMode(t *testing.T) {
+	origProject := bulkDeleteProject
+	origIDs := bulkDeleteIDs
+	origNames := bulkDeleteNames
+	origConfirm := bulkDeleteConfirm
+	t.Cleanup(func() {
+		bulkDeleteProject = origProject
+		bulkDeleteIDs = origIDs
+		bulkDeleteNames = origNames
+		bulkDeleteConfirm = origConfirm
+		_ = os.Remove("secrets.db")
+	})
+	bulkDeleteProject = 1
+	bulkDeleteIDs = []uint{42}
+	bulkDeleteNames = nil
+	bulkDeleteConfirm = false
+
+	// InitializeCoreService creates ./secrets.db and initialises i18n with English.
+	err := runBulkDeleteEmbedded(context.Background())
+	require.NoError(t, err)
+}
+
+func TestRunBulkDeleteEmbedded_DeleteNotFound(t *testing.T) {
+	origProject := bulkDeleteProject
+	origIDs := bulkDeleteIDs
+	origNames := bulkDeleteNames
+	origConfirm := bulkDeleteConfirm
+	t.Cleanup(func() {
+		bulkDeleteProject = origProject
+		bulkDeleteIDs = origIDs
+		bulkDeleteNames = origNames
+		bulkDeleteConfirm = origConfirm
+		_ = os.Remove("secrets.db")
+	})
+	bulkDeleteProject = 1
+	bulkDeleteIDs = []uint{9999}
+	bulkDeleteNames = nil
+	bulkDeleteConfirm = true
+
+	// BulkDeleteSecrets returns (result, nil) with 9999 in Failed (record not found).
+	err := runBulkDeleteEmbedded(context.Background())
+	require.NoError(t, err)
+}
+
+// ── resolveNamesToIDsEmbedded ─────────────────────────────────────────────────
+
+var bulkEmbeddedDBCounter atomic.Int64
+
+func newBulkEmbeddedCore(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+	n := bulkEmbeddedDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxbulkembed_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(models.AllTestModels()...))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "test"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "prod"}).Error)
+	return core.NewKeyorixCore(store.NewLocalStorage(db))
+}
+
+func TestResolveNamesToIDsEmbedded_NotFound(t *testing.T) {
+	svc := newBulkEmbeddedCore(t)
+
+	_, err := resolveNamesToIDsEmbedded(context.Background(), svc, 1, []string{"nonexistent"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestResolveNamesToIDsEmbedded_Found(t *testing.T) {
+	svc := newBulkEmbeddedCore(t)
+
+	// Create a secret so name resolution succeeds.
+	s, err := svc.CreateSecret(context.Background(), &core.CreateSecretRequest{
+		Name: "my-secret", Value: []byte("val"), ProjectID: 1, EnvironmentID: 1,
+		Type: "generic", CreatedBy: "test", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	ids, err := resolveNamesToIDsEmbedded(context.Background(), svc, 1, []string{"my-secret"})
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	assert.Equal(t, s.ID, ids[0])
 }

--- a/internal/core/bulk_delete.go
+++ b/internal/core/bulk_delete.go
@@ -1,0 +1,105 @@
+// bulk_delete.go — bulk deletion of secrets in a single call. Each deletion
+// calls the same logic as single-secret delete (audit log, dependency events,
+// ACL cleanup, etc.) rather than bypassing with a raw DB delete. Partial
+// success is allowed — individual failures are collected in Failed.
+// Project-scoped (route-gated secrets.delete). Parallels bulk-rename / extend-expiring.
+package core
+
+import (
+	"context"
+	"fmt"
+)
+
+// BulkDeleteRequest carries the set of secret node IDs to delete.
+type BulkDeleteRequest struct {
+	SecretIDs []uint `json:"secret_ids"`
+}
+
+// BulkOpError captures why a single secret in a bulk operation could not be processed.
+type BulkOpError struct {
+	SecretID uint   `json:"secret_id"`
+	Name     string `json:"name,omitempty"`
+	Error    string `json:"error"`
+}
+
+// BulkDeleteResult reports outcome counts and per-secret failures.
+type BulkDeleteResult struct {
+	Deleted []uint        `json:"deleted"`
+	Failed  []BulkOpError `json:"failed"`
+	Total   int           `json:"total"`
+}
+
+// BulkDeleteSecrets deletes multiple secrets by ID within a project.
+// Partial success is allowed — individual failures are collected in Failed.
+// Each deletion calls DeleteSecret (the same path as single-secret delete)
+// so audit logging, dependency-invalidation events, and any other cleanup
+// are all applied consistently.
+//
+// projectID gates a cross-project guard: a secret belonging to a different
+// project is rejected even if the caller holds a token with broad permissions.
+// deletedBy is the authenticated username used in the audit trail.
+func (c *KeyorixCore) BulkDeleteSecrets(ctx context.Context, req BulkDeleteRequest, projectID uint, deletedBy string, actorID uint, ip, ua string) (*BulkDeleteResult, error) {
+	if len(req.SecretIDs) == 0 {
+		return nil, fmt.Errorf("at least one secret ID is required")
+	}
+
+	result := &BulkDeleteResult{
+		Deleted: make([]uint, 0, len(req.SecretIDs)),
+		Failed:  make([]BulkOpError, 0),
+		Total:   len(req.SecretIDs),
+	}
+
+	for _, id := range req.SecretIDs {
+		if id == 0 {
+			result.Failed = append(result.Failed, BulkOpError{
+				SecretID: 0,
+				Error:    "secret ID must be non-zero",
+			})
+			continue
+		}
+
+		// Pre-fetch the secret so we have its name and project for the audit
+		// trail even after the row is soft-deleted, and for the cross-project guard.
+		secret, err := c.storage.GetSecret(ctx, id)
+		if err != nil || secret == nil {
+			result.Failed = append(result.Failed, BulkOpError{
+				SecretID: id,
+				Error:    "secret not found",
+			})
+			continue
+		}
+
+		// Cross-project guard: bulk delete is project-scoped; a caller must not
+		// reach secrets belonging to another project.
+		if projectID != 0 && secret.ProjectID != projectID {
+			result.Failed = append(result.Failed, BulkOpError{
+				SecretID: id,
+				Name:     secret.Name,
+				Error:    "secret does not belong to this project",
+			})
+			continue
+		}
+
+		secretName := secret.Name
+		secretProjectID := secret.ProjectID
+
+		if err := c.DeleteSecret(ctx, id); err != nil {
+			result.Failed = append(result.Failed, BulkOpError{
+				SecretID: id,
+				Name:     secretName,
+				Error:    err.Error(),
+			})
+			continue
+		}
+
+		// Audit: same event shape as the single-delete handler's post-delete log.
+		auditCtx := DetachedAuditContext(ctx)
+		go func(sID, projID, aID uint, name, actor, remoteIP, userAgent string) {
+			c.LogSecretDeletedWithProject(auditCtx, aID, sID, projID, actor, name, remoteIP, userAgent)
+		}(id, secretProjectID, actorID, secretName, deletedBy, ip, ua)
+
+		result.Deleted = append(result.Deleted, id)
+	}
+
+	return result, nil
+}

--- a/internal/core/bulk_delete_test.go
+++ b/internal/core/bulk_delete_test.go
@@ -159,3 +159,23 @@ func TestBulkDeleteSecrets_VerifyCleanup(t *testing.T) {
 	assert.False(t, liveIDs[id2], "id2 should not appear in ListSecrets after delete")
 	assert.True(t, liveIDs[id3], "id3 should still appear in ListSecrets")
 }
+
+func TestBulkDeleteSecrets_ZeroID(t *testing.T) {
+	c, _ := setupBulkDeleteDB(t)
+	ctx := context.Background()
+
+	// SecretID=0 is explicitly rejected before any storage call.
+	req := BulkDeleteRequest{SecretIDs: []uint{0, 1}}
+	result, err := c.BulkDeleteSecrets(ctx, req, 0, "tester", 1, "", "")
+	require.NoError(t, err)
+
+	// ID 0 must appear in Failed with "invalid secret ID"; ID 1 is not found.
+	zeroFailed := false
+	for _, f := range result.Failed {
+		if f.SecretID == 0 {
+			zeroFailed = true
+			assert.Contains(t, f.Error, "invalid")
+		}
+	}
+	assert.True(t, zeroFailed, "ID 0 must be in the failed list")
+}

--- a/internal/core/bulk_delete_test.go
+++ b/internal/core/bulk_delete_test.go
@@ -1,0 +1,161 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// setupBulkDeleteDB opens an in-memory SQLite DB, migrates the necessary models,
+// and returns a core instance plus a factory for creating test secrets.
+func setupBulkDeleteDB(t *testing.T) (*KeyorixCore, func(name string) uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+
+	// Use a unique in-memory DSN per test to avoid shared state across tests.
+	dsn := "file:bulkdelete_" + t.Name() + "?mode=memory&cache=shared&_busy_timeout=5000"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{},
+		&models.SecretVersion{},
+		&models.Project{},
+		&models.Environment{},
+		&models.AuditEvent{},
+		&models.SecretAccessLog{},
+		&models.ShareRecord{},
+	))
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "proj-bulk-delete"})
+	require.NoError(t, err)
+	env, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "test", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	projectID := p.ID
+	envID := env.ID
+
+	mk := func(name string) uint {
+		s, e := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name:          name,
+			ProjectID:     projectID,
+			EnvironmentID: envID,
+			Type:          "password",
+			OwnerID:       1,
+			IsSecret:      true,
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		})
+		require.NoError(t, e)
+		return s.ID
+	}
+
+	return c, mk
+}
+
+func TestBulkDeleteSecrets_Success(t *testing.T) {
+	c, mk := setupBulkDeleteDB(t)
+	ctx := context.Background()
+
+	id1 := mk("secret-a")
+	id2 := mk("secret-b")
+	id3 := mk("secret-c")
+
+	req := BulkDeleteRequest{SecretIDs: []uint{id1, id2, id3}}
+	result, err := c.BulkDeleteSecrets(ctx, req, 0, "tester", 1, "", "")
+	require.NoError(t, err)
+	assert.Len(t, result.Deleted, 3)
+	assert.Empty(t, result.Failed)
+	assert.Equal(t, 3, result.Total)
+}
+
+func TestBulkDeleteSecrets_PartialFailure(t *testing.T) {
+	c, mk := setupBulkDeleteDB(t)
+	ctx := context.Background()
+
+	id1 := mk("partial-a")
+	id2 := mk("partial-b")
+	missingID := uint(99999)
+
+	req := BulkDeleteRequest{SecretIDs: []uint{id1, missingID, id2}}
+	result, err := c.BulkDeleteSecrets(ctx, req, 0, "tester", 1, "", "")
+	require.NoError(t, err)
+
+	// Two should succeed, one should fail.
+	assert.Len(t, result.Deleted, 2)
+	require.Len(t, result.Failed, 1)
+	assert.Equal(t, missingID, result.Failed[0].SecretID)
+	assert.Contains(t, result.Failed[0].Error, "not found")
+	assert.Equal(t, 3, result.Total)
+}
+
+func TestBulkDeleteSecrets_EmptyRequest(t *testing.T) {
+	c, _ := setupBulkDeleteDB(t)
+	ctx := context.Background()
+
+	req := BulkDeleteRequest{SecretIDs: nil}
+	_, err := c.BulkDeleteSecrets(ctx, req, 0, "tester", 1, "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+func TestBulkDeleteSecrets_AlreadyDeleted(t *testing.T) {
+	c, mk := setupBulkDeleteDB(t)
+	ctx := context.Background()
+
+	id := mk("to-delete-twice")
+
+	// First deletion should succeed.
+	req := BulkDeleteRequest{SecretIDs: []uint{id}}
+	result, err := c.BulkDeleteSecrets(ctx, req, 0, "tester", 1, "", "")
+	require.NoError(t, err)
+	assert.Len(t, result.Deleted, 1)
+	assert.Empty(t, result.Failed)
+
+	// Second attempt on the same (now-deleted) ID must not panic; it should fail gracefully.
+	result2, err := c.BulkDeleteSecrets(ctx, req, 0, "tester", 1, "", "")
+	require.NoError(t, err)
+	assert.Empty(t, result2.Deleted)
+	require.Len(t, result2.Failed, 1)
+	assert.Equal(t, id, result2.Failed[0].SecretID)
+}
+
+func TestBulkDeleteSecrets_VerifyCleanup(t *testing.T) {
+	c, mk := setupBulkDeleteDB(t)
+	ctx := context.Background()
+
+	id1 := mk("cleanup-a")
+	id2 := mk("cleanup-b")
+	id3 := mk("cleanup-c-keep") // this one stays
+
+	req := BulkDeleteRequest{SecretIDs: []uint{id1, id2}}
+	result, err := c.BulkDeleteSecrets(ctx, req, 0, "tester", 1, "", "")
+	require.NoError(t, err)
+	assert.Len(t, result.Deleted, 2)
+
+	// After bulk delete, deleted secrets must no longer appear in ListSecrets.
+	secrets, _, err := c.ListSecrets(ctx, &coreStorage.SecretFilter{PageSize: 100})
+	require.NoError(t, err)
+
+	liveIDs := make(map[uint]bool)
+	for _, s := range secrets {
+		liveIDs[s.ID] = true
+	}
+	assert.False(t, liveIDs[id1], "id1 should not appear in ListSecrets after delete")
+	assert.False(t, liveIDs[id2], "id2 should not appear in ListSecrets after delete")
+	assert.True(t, liveIDs[id3], "id3 should still appear in ListSecrets")
+}

--- a/internal/core/bulk_delete_test.go
+++ b/internal/core/bulk_delete_test.go
@@ -2,14 +2,16 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
-	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -169,13 +171,124 @@ func TestBulkDeleteSecrets_ZeroID(t *testing.T) {
 	result, err := c.BulkDeleteSecrets(ctx, req, 0, "tester", 1, "", "")
 	require.NoError(t, err)
 
-	// ID 0 must appear in Failed with "invalid secret ID"; ID 1 is not found.
+	// ID 0 must appear in Failed; ID 1 is not found.
 	zeroFailed := false
 	for _, f := range result.Failed {
 		if f.SecretID == 0 {
 			zeroFailed = true
-			assert.Contains(t, f.Error, "invalid")
+			assert.Contains(t, f.Error, "non-zero")
 		}
 	}
 	assert.True(t, zeroFailed, "ID 0 must be in the failed list")
+}
+
+// TestBulkDeleteSecrets_CrossProjectGuard covers the cross-project guard branch
+// (bulk_delete.go lines 74-80): a secret that belongs to project B must be
+// rejected when the caller passes projectID=A, even if the caller holds a token
+// with broad permissions.
+func TestBulkDeleteSecrets_CrossProjectGuard(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	ctx := context.Background()
+
+	dsn := "file:bulkdelete_crossproject_" + t.Name() + "?mode=memory&cache=shared&_busy_timeout=5000"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{},
+		&models.SecretVersion{},
+		&models.Project{},
+		&models.Environment{},
+		&models.AuditEvent{},
+		&models.SecretAccessLog{},
+		&models.ShareRecord{},
+	))
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+
+	// Create two distinct projects.
+	proj1, err := c.storage.CreateProject(ctx, &models.Project{Name: "project-one"})
+	require.NoError(t, err)
+	proj2, err := c.storage.CreateProject(ctx, &models.Project{Name: "project-two"})
+	require.NoError(t, err)
+
+	env1, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "env1", ProjectID: proj1.ID})
+	require.NoError(t, err)
+	env2, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "env2", ProjectID: proj2.ID})
+	require.NoError(t, err)
+
+	// Create a secret in project 1 and a secret in project 2.
+	secretInProj1, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "secret-p1", ProjectID: proj1.ID, EnvironmentID: env1.ID,
+		Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	secretInProj2, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "secret-p2", ProjectID: proj2.ID, EnvironmentID: env2.ID,
+		Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Attempt to bulk-delete both secrets while scoped to project 1.
+	// secret-p1 should succeed; secret-p2 must be rejected by the guard.
+	req := BulkDeleteRequest{SecretIDs: []uint{secretInProj1.ID, secretInProj2.ID}}
+	result, err := c.BulkDeleteSecrets(ctx, req, proj1.ID, "tester", 1, "127.0.0.1", "test-agent")
+	require.NoError(t, err)
+
+	// Exactly one deleted (the one in project 1).
+	assert.Len(t, result.Deleted, 1, "only the in-scope secret should be deleted")
+	assert.Equal(t, secretInProj1.ID, result.Deleted[0])
+
+	// Exactly one failure: the cross-project secret.
+	require.Len(t, result.Failed, 1, "the out-of-scope secret must appear in Failed")
+	assert.Equal(t, secretInProj2.ID, result.Failed[0].SecretID)
+	assert.Equal(t, "secret-p2", result.Failed[0].Name)
+	assert.Contains(t, result.Failed[0].Error, "does not belong to this project")
+	assert.Equal(t, 2, result.Total)
+}
+
+// TestBulkDeleteSecrets_DeleteSecretRuntimeError covers the branch where
+// BulkDeleteSecrets successfully pre-fetches a secret but the underlying
+// DeleteSecret call returns a runtime error (bulk_delete.go lines 86-92).
+// This is exercised via MockStorage so the storage.DeleteSecret can be made
+// to return an error while storage.GetSecret succeeds.
+func TestBulkDeleteSecrets_DeleteSecretRuntimeError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	ctx := context.Background()
+
+	const secretID = uint(42)
+	secret := &models.SecretNode{
+		ID:        secretID,
+		Name:      "my-secret",
+		ProjectID: 1,
+	}
+	storageErr := fmt.Errorf("disk I/O error")
+
+	ms := new(MockStorage)
+	// First GetSecret call: BulkDeleteSecrets pre-fetch.
+	ms.On("GetSecret", mock.Anything, secretID).Return(secret, nil).Once()
+	// Second GetSecret call: inside DeleteSecret itself.
+	ms.On("GetSecret", mock.Anything, secretID).Return(secret, nil).Once()
+	// DeleteSecret returns a runtime error.
+	ms.On("DeleteSecret", mock.Anything, secretID).Return(storageErr)
+
+	c := NewKeyorixCore(ms)
+
+	req := BulkDeleteRequest{SecretIDs: []uint{secretID}}
+	result, err := c.BulkDeleteSecrets(ctx, req, 0, "tester", 1, "", "")
+	require.NoError(t, err, "BulkDeleteSecrets itself must not error on individual failures")
+
+	assert.Empty(t, result.Deleted, "nothing should be in Deleted when DeleteSecret errors")
+	require.Len(t, result.Failed, 1, "the failed deletion must appear in Failed")
+	assert.Equal(t, secretID, result.Failed[0].SecretID)
+	assert.Equal(t, "my-secret", result.Failed[0].Name)
+	assert.NotEmpty(t, result.Failed[0].Error)
+	assert.Equal(t, 1, result.Total)
+
+	ms.AssertExpectations(t)
 }

--- a/server/http/bulk_delete_handler_test.go
+++ b/server/http/bulk_delete_handler_test.go
@@ -195,3 +195,51 @@ func TestBulkDeleteSecrets_EmptyRequest(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
+
+func TestBulkDeleteSecrets_BadJSON(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	req, err := http.NewRequest("POST", srv.URL+"/api/v1/projects/1/secrets/bulk-delete", strings.NewReader("not-json"))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestBulkDeleteSecrets_InvalidProjectID(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	// Use an ID that overflows uint32 to trigger the ParseUint error path.
+	req, err := http.NewRequest("POST", srv.URL+"/api/v1/projects/9999999999999999999/secrets/bulk-delete",
+		strings.NewReader(`{"secret_ids":[1]}`))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/server/http/bulk_delete_handler_test.go
+++ b/server/http/bulk_delete_handler_test.go
@@ -1,0 +1,197 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createBulkDelTestSecret POSTs to /api/v1/secrets and returns the created secret's ID.
+func createBulkDelTestSecret(t *testing.T, client *http.Client, baseURL, token, name string) uint {
+	t.Helper()
+	body := fmt.Sprintf(`{"name":%q,"value":"test-value","project_id":1,"environment_id":1,"type":"password"}`, name)
+	req, err := http.NewRequest("POST", baseURL+"/api/v1/secrets", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "createBulkDelTestSecret: unexpected status")
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	data := out["data"].(map[string]interface{})
+	return uint(data["ID"].(float64))
+}
+
+func TestBulkDeleteSecrets_Success(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	id1 := createBulkDelTestSecret(t, client, srv.URL, token, "bulk-del-1")
+	id2 := createBulkDelTestSecret(t, client, srv.URL, token, "bulk-del-2")
+
+	body := fmt.Sprintf(`{"secret_ids":[%d,%d]}`, id1, id2)
+	req, err := http.NewRequest("POST", srv.URL+"/api/v1/projects/1/secrets/bulk-delete", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	data := out["data"].(map[string]interface{})
+
+	deleted := data["deleted"].([]interface{})
+	assert.Len(t, deleted, 2)
+
+	failed, ok := data["failed"].([]interface{})
+	if ok {
+		assert.Empty(t, failed)
+	}
+}
+
+func TestBulkDeleteSecrets_VerifyDeleted(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	id1 := createBulkDelTestSecret(t, client, srv.URL, token, "verify-del-1")
+	id2 := createBulkDelTestSecret(t, client, srv.URL, token, "verify-del-2")
+
+	// Bulk-delete both secrets.
+	body := fmt.Sprintf(`{"secret_ids":[%d,%d]}`, id1, id2)
+	req, err := http.NewRequest("POST", srv.URL+"/api/v1/projects/1/secrets/bulk-delete", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// GET each secret — both must now return 404.
+	for _, id := range []uint{id1, id2} {
+		getReq, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/secrets/%d", srv.URL, id), nil)
+		require.NoError(t, err)
+		getReq.Header.Set("Authorization", "Bearer "+token)
+		getResp, err := client.Do(getReq)
+		require.NoError(t, err)
+		getResp.Body.Close()
+		assert.Equal(t, http.StatusNotFound, getResp.StatusCode, "expected 404 for secret %d after bulk delete", id)
+	}
+}
+
+func TestBulkDeleteSecrets_NonExistentID(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	body := `{"secret_ids":[999999]}`
+	req, err := http.NewRequest("POST", srv.URL+"/api/v1/projects/1/secrets/bulk-delete", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	data := out["data"].(map[string]interface{})
+
+	failed := data["failed"].([]interface{})
+	require.NotEmpty(t, failed, "expected 999999 to appear in failed list")
+
+	found := false
+	for _, f := range failed {
+		entry := f.(map[string]interface{})
+		if uint(entry["secret_id"].(float64)) == 999999 {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "secret ID 999999 must appear in the failed list")
+}
+
+func TestBulkDeleteSecrets_Unauthenticated(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	body := `{"secret_ids":[1]}`
+	req, err := http.NewRequest("POST", srv.URL+"/api/v1/projects/1/secrets/bulk-delete", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestBulkDeleteSecrets_EmptyRequest(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	body := `{"secret_ids":[]}`
+	req, err := http.NewRequest("POST", srv.URL+"/api/v1/projects/1/secrets/bulk-delete", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/server/http/bulk_delete_handler_test.go
+++ b/server/http/bulk_delete_handler_test.go
@@ -24,7 +24,7 @@ func createBulkDelTestSecret(t *testing.T, client *http.Client, baseURL, token, 
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusCreated, resp.StatusCode, "createBulkDelTestSecret: unexpected status")
 	var out map[string]interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
@@ -54,7 +54,7 @@ func TestBulkDeleteSecrets_Success(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 

--- a/server/http/bulk_delete_handler_test.go
+++ b/server/http/bulk_delete_handler_test.go
@@ -94,7 +94,7 @@ func TestBulkDeleteSecrets_VerifyDeleted(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// GET each secret — both must now return 404.
@@ -104,7 +104,7 @@ func TestBulkDeleteSecrets_VerifyDeleted(t *testing.T) {
 		getReq.Header.Set("Authorization", "Bearer "+token)
 		getResp, err := client.Do(getReq)
 		require.NoError(t, err)
-		getResp.Body.Close()
+		_ = getResp.Body.Close()
 		assert.Equal(t, http.StatusNotFound, getResp.StatusCode, "expected 404 for secret %d after bulk delete", id)
 	}
 }
@@ -128,7 +128,7 @@ func TestBulkDeleteSecrets_NonExistentID(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -167,7 +167,7 @@ func TestBulkDeleteSecrets_Unauthenticated(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
@@ -191,7 +191,7 @@ func TestBulkDeleteSecrets_EmptyRequest(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }

--- a/server/http/handlers/secrets_bulk_delete.go
+++ b/server/http/handlers/secrets_bulk_delete.go
@@ -1,0 +1,53 @@
+// secrets_bulk_delete.go — BulkDeleteSecrets handler: delete multiple secrets in
+// one call. Scoped secrets.delete (project) is enforced by the router.
+// Each deletion calls the same DeleteSecret logic as the single-delete path
+// (audit log, dependency events, etc.) so no cleanup is bypassed.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// BulkDeleteSecrets handles POST /api/v1/projects/{id}/secrets/bulk-delete with
+// {"secret_ids":[1,2,3]}. Each ID is deleted via the normal single-secret delete
+// path; partial success is allowed — failures are collected in the response rather
+// than aborting the entire batch.
+func (h *SecretHandler) BulkDeleteSecrets(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	projectID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	var req core.BulkDeleteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+
+	ip, ua := r.RemoteAddr, r.Header.Get("User-Agent")
+	result, err := h.coreService.BulkDeleteSecrets(r.Context(), req, uint(projectID), userCtx.Username, userCtx.UserID, ip, ua)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "required") {
+			status = http.StatusBadRequest
+		}
+		h.sendError(w, "Error", err.Error(), status, nil)
+		return
+	}
+
+	h.sendSuccess(w, result, "")
+}

--- a/server/http/handlers/secrets_bulk_delete_test.go
+++ b/server/http/handlers/secrets_bulk_delete_test.go
@@ -1,0 +1,156 @@
+// secrets_bulk_delete_test.go — unit tests for the BulkDeleteSecrets handler.
+// These tests run at the handlers package level (no full router) so they cover
+// every branch in the handler directly without integration overhead.
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// setupBulkDeleteHandler returns a SecretHandler backed by an in-memory SQLite
+// DB that already contains project 1, environment 1, and optionally one secret
+// (ID 10, name "alpha", project 1).
+func setupBulkDeleteHandler(t *testing.T) (*SecretHandler, uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{},
+		&models.SecretVersion{},
+		&models.Project{},
+		&models.Environment{},
+		&models.AuditEvent{},
+		&models.SecretAccessLog{},
+		&models.ShareRecord{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, Name: "env", ProjectID: 1}).Error)
+
+	secretID := uint(10)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: secretID, Name: "alpha", ProjectID: 1, EnvironmentID: 1,
+		Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h, err := NewSecretHandler(c)
+	require.NoError(t, err)
+	return h, secretID
+}
+
+// bulkDeleteRequest constructs an httptest.Request for BulkDeleteSecrets, wiring
+// the chi route parameter {id} to projectIDStr and setting a valid user context.
+func bulkDeleteRequest(method, projectIDStr, body string) *http.Request {
+	req := httptest.NewRequest(method, "/api/v1/projects/"+projectIDStr+"/secrets/bulk-delete", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(withUserCtx(req), "id", projectIDStr)
+	return req
+}
+
+func TestBulkDeleteSecretsHandler_Success(t *testing.T) {
+	h, secretID := setupBulkDeleteHandler(t)
+
+	body := `{"secret_ids":[10]}`
+	req := bulkDeleteRequest(http.MethodPost, "1", body)
+	w := httptest.NewRecorder()
+	h.BulkDeleteSecrets(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := w.Body.String()
+	assert.Contains(t, resp, `"deleted"`)
+	_ = secretID
+}
+
+func TestBulkDeleteSecretsHandler_Unauthorized(t *testing.T) {
+	h, _ := setupBulkDeleteHandler(t)
+
+	// No user context — withUserCtx is NOT applied.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/secrets/bulk-delete",
+		strings.NewReader(`{"secret_ids":[10]}`))
+	req = withChiParam(req, "id", "1")
+	w := httptest.NewRecorder()
+	h.BulkDeleteSecrets(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestBulkDeleteSecretsHandler_InvalidProjectID(t *testing.T) {
+	h, _ := setupBulkDeleteHandler(t)
+
+	// Project ID that overflows uint32 triggers the ParseUint error path.
+	req := bulkDeleteRequest(http.MethodPost, "99999999999999999999", `{"secret_ids":[1]}`)
+	w := httptest.NewRecorder()
+	h.BulkDeleteSecrets(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestBulkDeleteSecretsHandler_BadJSON(t *testing.T) {
+	h, _ := setupBulkDeleteHandler(t)
+
+	req := bulkDeleteRequest(http.MethodPost, "1", "not-valid-json")
+	w := httptest.NewRecorder()
+	h.BulkDeleteSecrets(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestBulkDeleteSecretsHandler_RequiredError tests the "required" → 400 branch:
+// when BulkDeleteSecrets returns an error containing "required" (empty IDs list),
+// the handler must respond with 400 rather than 500.
+func TestBulkDeleteSecretsHandler_RequiredError(t *testing.T) {
+	h, _ := setupBulkDeleteHandler(t)
+
+	// An empty secret_ids slice triggers "at least one secret ID is required".
+	req := bulkDeleteRequest(http.MethodPost, "1", `{"secret_ids":[]}`)
+	w := httptest.NewRecorder()
+	h.BulkDeleteSecrets(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "required")
+}
+
+func TestBulkDeleteSecretsHandler_PartialSuccess(t *testing.T) {
+	h, secretID := setupBulkDeleteHandler(t)
+
+	// Include one valid ID and one that does not exist.
+	body := `{"secret_ids":[10,99999]}`
+	req := bulkDeleteRequest(http.MethodPost, "1", body)
+	w := httptest.NewRecorder()
+	h.BulkDeleteSecrets(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := w.Body.String()
+	assert.Contains(t, resp, `"deleted"`)
+	assert.Contains(t, resp, `"failed"`)
+	_ = secretID
+}
+
+func TestBulkDeleteSecretsHandler_NonExistentOnly(t *testing.T) {
+	h, _ := setupBulkDeleteHandler(t)
+
+	req := bulkDeleteRequest(http.MethodPost, "1", `{"secret_ids":[888888]}`)
+	w := httptest.NewRecorder()
+	h.BulkDeleteSecrets(w, req)
+
+	// A missing secret is a partial-success (200 with failed list), not a 4xx.
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"failed"`)
+}

--- a/server/http/handlers/secrets_bulk_rename_test.go
+++ b/server/http/handlers/secrets_bulk_rename_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,9 @@ import (
 )
 
 func TestBulkRenameSecretsHandler(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -465,6 +465,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, projectScope)).Post("/projects/{id}/secrets/bulk-rename", secretHandler.BulkRenameSecrets)
 		// Bulk rotation — trigger rotation for multiple secrets at once (incident response).
 		r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, projectScope)).Post("/projects/{id}/secrets/bulk-rotate", secretHandler.BulkRotateSecrets)
+		// Bulk delete — remove multiple secrets in one call; same cleanup as single delete.
+		r.With(customMiddleware.RequireScopedPermission(permSecretsDelete, projectScope)).Post("/projects/{id}/secrets/bulk-delete", secretHandler.BulkDeleteSecrets)
 		// Bulk copy also requires secrets.read on the SOURCE environment (resolved from
 		// the envId path param, not attacker-supplied input) — mirroring the single-secret
 		// copy route below, which gates secrets.read on the source in addition to


### PR DESCRIPTION
POST /projects/{id}/secrets/bulk-delete — calls existing DeleteSecret per secret (audit log preserved). CLI: keyorix secret bulk-delete --names s1,s2 --project <p> --confirm. Cross-project guard + partial success. 9 tests.