### PR TITLE
feat(rbac): permission matrix export

### DIFF
--- a/internal/cli/rbac/export_matrix_test.go
+++ b/internal/cli/rbac/export_matrix_test.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -163,4 +165,209 @@ func TestWriteMatrixRemote_ExpiresAt(t *testing.T) {
 	err := writeMatrixRemote(&buf, rows, "csv")
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "2027-01-15T12:00:00Z")
+}
+
+// ── writeMatrixEmbedded coverage ──────────────────────────────────────────────
+
+// TestWriteMatrixEmbedded_JSON — JSON output path for embedded mode.
+func TestWriteMatrixEmbedded_JSON(t *testing.T) {
+	exp := time.Date(2028, 3, 10, 8, 0, 0, 0, time.UTC)
+	rows := []*core.PermissionMatrixRow{
+		{
+			UserID: 1, Username: "alice", Email: "alice@example.com",
+			RoleID: 10, RoleName: "admin",
+			PermissionName: "secrets.read", Resource: "secrets", Action: "read",
+			Scope: "global", ExpiresAt: &exp,
+		},
+	}
+	var buf bytes.Buffer
+	err := writeMatrixEmbedded(&buf, rows, "json")
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "alice")
+	assert.Contains(t, out, "secrets.read")
+	assert.Contains(t, out, "2028-03-10T08:00:00Z")
+}
+
+// TestWriteMatrixEmbedded_CSV — CSV output path for embedded mode.
+func TestWriteMatrixEmbedded_CSV(t *testing.T) {
+	exp := time.Date(2028, 6, 15, 0, 0, 0, 0, time.UTC)
+	rows := []*core.PermissionMatrixRow{
+		{
+			Username: "bob", Email: "bob@example.com",
+			RoleName: "viewer", PermissionName: "secrets.read",
+			Resource: "secrets", Action: "read",
+			Scope: "project", ProjectName: "proj-alpha", ExpiresAt: &exp,
+		},
+		{
+			Username: "carol", Email: "carol@example.com",
+			RoleName: "admin", PermissionName: "secrets.write",
+			Resource: "secrets", Action: "write",
+			Scope: "global", ExpiresAt: nil,
+		},
+	}
+	var buf bytes.Buffer
+	err := writeMatrixEmbedded(&buf, rows, "csv")
+	require.NoError(t, err)
+	out := buf.String()
+	assert.True(t, strings.HasPrefix(out, "username,"), "expected CSV header line")
+	assert.Contains(t, out, "bob")
+	assert.Contains(t, out, "carol")
+	assert.Contains(t, out, "2028-06-15T00:00:00Z")
+	assert.Contains(t, out, "never") // nil ExpiresAt → "never"
+}
+
+// TestWriteMatrixEmbedded_TableEmpty — empty rows print "No permission grants found."
+func TestWriteMatrixEmbedded_TableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	err := writeMatrixEmbedded(&buf, []*core.PermissionMatrixRow{}, "table")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "No permission grants found.")
+}
+
+// TestWriteMatrixEmbedded_TableNonEmpty — non-empty rows render a tabwriter header + data.
+func TestWriteMatrixEmbedded_TableNonEmpty(t *testing.T) {
+	rows := []*core.PermissionMatrixRow{
+		{
+			Username: "dave", Email: "dave@example.com",
+			RoleName: "poweruser", PermissionName: "secrets.read",
+			Scope: "global", ExpiresAt: nil,
+		},
+	}
+	var buf bytes.Buffer
+	err := writeMatrixEmbedded(&buf, rows, "table")
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "USERNAME")
+	assert.Contains(t, out, "dave")
+	assert.Contains(t, out, "never")
+}
+
+// TestWriteMatrixEmbedded_TableWithExpiry — a time-bound row formats the expiry in table mode.
+func TestWriteMatrixEmbedded_TableWithExpiry(t *testing.T) {
+	exp := time.Date(2029, 1, 1, 0, 0, 0, 0, time.UTC)
+	rows := []*core.PermissionMatrixRow{
+		{
+			Username: "eve", Email: "eve@example.com",
+			RoleName: "jit", PermissionName: "secrets.read",
+			Scope: "project", ProjectName: "proj-x", ExpiresAt: &exp,
+		},
+	}
+	var buf bytes.Buffer
+	err := writeMatrixEmbedded(&buf, rows, "table")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "2029-01-01T00:00:00Z")
+}
+
+// TestExportMatrix_RemoteCSV_WithProject — CSV + project filter combination: the CSV
+// path with a project resolves the project ID first, then requests CSV directly.
+func TestExportMatrix_RemoteCSV_WithProject(t *testing.T) {
+	var capturedQuery string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/rbac/permission-matrix", func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write([]byte(
+			"username,email,role,permission,resource,action,scope,project,environment,expires_at\n" +
+				"alice,alice@example.com,admin,secrets.read,secrets,read,project,proj-a,,never\n",
+		))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":3,"name":"proj-a"}]}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	rc := remoteClientFor(t, srv)
+	ctx := context.Background()
+
+	exportMatrixFormat = "csv"
+	exportMatrixProject = "proj-a"
+	defer func() { exportMatrixProject = "" }()
+
+	var buf bytes.Buffer
+	err := runExportMatrixRemote(ctx, rc, &buf)
+	require.NoError(t, err)
+
+	// Verify both project_id and format=csv were forwarded.
+	assert.Contains(t, capturedQuery, "project_id=3", "project_id must be in the query")
+	assert.Contains(t, capturedQuery, "format=csv", "format=csv must be in the query")
+	assert.Contains(t, buf.String(), "alice")
+}
+
+// TestExportMatrix_RemoteProjectNotFound — resolveProjectIDByName returns an error
+// when the project name does not exist.
+func TestExportMatrix_RemoteProjectNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[]}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	rc := remoteClientFor(t, srv)
+	ctx := context.Background()
+
+	exportMatrixFormat = "json"
+	exportMatrixProject = "does-not-exist"
+	defer func() { exportMatrixProject = "" }()
+
+	var buf bytes.Buffer
+	err := runExportMatrixRemote(ctx, rc, &buf)
+	require.Error(t, err, "missing project must cause an error")
+	assert.Contains(t, err.Error(), "does-not-exist")
+}
+
+// TestExportMatrix_OutputFile — writing to a file path populates the file.
+func TestExportMatrix_OutputFile(t *testing.T) {
+	dir := t.TempDir()
+	outPath := dir + "/matrix.json"
+
+	// Set up a fake matrix server.
+	srv := fakeMatrixServer(t)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	// Save and restore package-level flags.
+	prevFormat := exportMatrixFormat
+	prevProject := exportMatrixProject
+	prevOutput := exportMatrixOutput
+	t.Cleanup(func() {
+		exportMatrixFormat = prevFormat
+		exportMatrixProject = prevProject
+		exportMatrixOutput = prevOutput
+	})
+
+	exportMatrixFormat = "json"
+	exportMatrixProject = ""
+	exportMatrixOutput = outPath
+
+	// Run via the cobra RunE function.
+	err := runExportMatrix(exportMatrixCmd, nil)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "alice")
+}
+
+// TestWriteMatrixRemote_CSVFormat — explicit CSV via writeMatrixRemote validates
+// header + data row with nil ExpiresAt → "never".
+func TestWriteMatrixRemote_CSVFormat(t *testing.T) {
+	rows := []remoteMatrixRow{
+		{
+			Username: "frank", Email: "frank@example.com",
+			RoleName: "viewer", PermissionName: "secrets.read",
+			Resource: "secrets", Action: "read",
+			Scope: "project", ProjectName: "proj-b",
+			EnvironmentName: "", ExpiresAt: nil,
+		},
+	}
+	var buf bytes.Buffer
+	err := writeMatrixRemote(&buf, rows, "csv")
+	require.NoError(t, err)
+	out := buf.String()
+	assert.True(t, strings.HasPrefix(out, "username,"))
+	assert.Contains(t, out, "frank")
+	assert.Contains(t, out, "never")
 }

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -2096,6 +2096,7 @@ func (m *MockStorage) ListExpiringUserRoles(ctx context.Context, cutoff time.Tim
 	return args.Get(0).([]models.UserRole), args.Error(1)
 }
 
+
 // Per-secret / per-folder ACL stubs (ADR-058).
 func (m *MockStorage) CreateOrUpdateSecretACL(_ context.Context, _ *models.SecretACL) error {
 	return nil

--- a/internal/core/permission_matrix_test.go
+++ b/internal/core/permission_matrix_test.go
@@ -2,9 +2,12 @@ package core
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
@@ -12,6 +15,29 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+// matrixStorageOverride wraps MockStorage and lets individual tests override
+// ListAllUserRoleGrants and GetRolePermissions without touching the shared mock.
+type matrixStorageOverride struct {
+	corestorage.Storage
+	listGrantsErr  error
+	listGrantsRows []*models.UserRole
+	getRolePermsErr error
+}
+
+func (o *matrixStorageOverride) ListAllUserRoleGrants(_ context.Context) ([]*models.UserRole, error) {
+	if o.listGrantsErr != nil {
+		return nil, o.listGrantsErr
+	}
+	return o.listGrantsRows, nil
+}
+
+func (o *matrixStorageOverride) GetRolePermissions(ctx context.Context, roleID uint) ([]*models.Permission, error) {
+	if o.getRolePermsErr != nil {
+		return nil, o.getRolePermsErr
+	}
+	return o.Storage.GetRolePermissions(ctx, roleID)
+}
 
 func newMatrixCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
@@ -190,44 +216,220 @@ func TestGetPermissionMatrix_MultiplePermissions(t *testing.T) {
 	}
 }
 
-// TestGetPermissionMatrix_EnvScoped covers getEnvName and grantScope("environment").
-func TestGetPermissionMatrix_EnvScoped(t *testing.T) {
+// TestGetPermissionMatrix_EnvironmentScoped — a grant with both project_id and
+// environment_id set yields Scope="environment" and records both names.
+func TestGetPermissionMatrix_EnvironmentScoped(t *testing.T) {
 	c, db := newMatrixCore(t)
 	ctx := context.Background()
 
-	require.NoError(t, db.Create(&models.Project{ID: 7, Name: "proj-g"}).Error)
-	require.NoError(t, db.Create(&models.Environment{ID: 3, Name: "staging", ProjectID: 7}).Error)
-	seedMatrixUser(t, db, 20, "eve", "eve@example.com")
-	seedMatrixRole(t, db, 50, "dev")
+	require.NoError(t, db.Create(&models.Project{ID: 7, Name: "proj-gamma"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 3, ProjectID: 7, Name: "staging"}).Error)
+	seedMatrixUser(t, db, 20, "frank", "frank@example.com")
+	seedMatrixRole(t, db, 50, "env-reader")
 	seedMatrixPerm(t, db, 500, "secrets.read", "secrets", "read")
 	seedMatrixRolePerm(t, db, 50, 500)
-	// environment-scoped grant
-	require.NoError(t, db.Create(&models.UserRole{UserID: 20, RoleID: 50, ProjectID: 7, EnvironmentID: 3}).Error)
+	// environment-scoped grant: both project_id and environment_id are non-zero
+	require.NoError(t, db.Create(&models.UserRole{
+		UserID: 20, RoleID: 50, ProjectID: 7, EnvironmentID: 3,
+	}).Error)
 
 	rows, err := c.GetPermissionMatrix(ctx, 0)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
+
 	r := rows[0]
-	assert.Equal(t, "environment", r.Scope)
+	assert.Equal(t, "frank", r.Username)
+	assert.Equal(t, "environment", r.Scope, "scope should be 'environment' when both project_id and environment_id are set")
+	assert.Equal(t, uint(7), r.ProjectID)
+	assert.Equal(t, "proj-gamma", r.ProjectName)
+	assert.Equal(t, uint(3), r.EnvironmentID)
 	assert.Equal(t, "staging", r.EnvironmentName)
-	assert.Equal(t, "proj-g", r.ProjectName)
 }
 
-// TestGetPermissionMatrix_MissingProject covers getProjectName error path (soft-deleted project).
-func TestGetPermissionMatrix_MissingProject(t *testing.T) {
+// TestGetPermissionMatrix_SoftDeletedProjectFallback — a grant that references a
+// project that no longer exists (soft-deleted or missing) falls back to the
+// "project-<id>" synthetic name rather than failing.
+func TestGetPermissionMatrix_SoftDeletedProjectFallback(t *testing.T) {
 	c, db := newMatrixCore(t)
 	ctx := context.Background()
 
-	seedMatrixUser(t, db, 30, "frank", "frank@example.com")
-	seedMatrixRole(t, db, 60, "ops")
+	// seed user + role + permission, but deliberately omit the project row
+	seedMatrixUser(t, db, 30, "grace", "grace@example.com")
+	seedMatrixRole(t, db, 60, "viewer")
 	seedMatrixPerm(t, db, 600, "secrets.read", "secrets", "read")
 	seedMatrixRolePerm(t, db, 60, 600)
-	// grant references project 999 which does not exist in the DB (soft-deleted)
-	require.NoError(t, db.Create(&models.UserRole{UserID: 30, RoleID: 60, ProjectID: 999, EnvironmentID: 0}).Error)
+	// grant references project_id=99 which does not exist
+	require.NoError(t, db.Create(&models.UserRole{UserID: 30, RoleID: 60, ProjectID: 99, EnvironmentID: 0}).Error)
 
 	rows, err := c.GetPermissionMatrix(ctx, 0)
 	require.NoError(t, err)
-	require.Len(t, rows, 1)
-	// getProjectName falls back to "project-999" placeholder
-	assert.Contains(t, rows[0].ProjectName, "999")
+	require.Len(t, rows, 1, "missing project must not drop the row")
+
+	r := rows[0]
+	assert.Equal(t, "project", r.Scope)
+	assert.Equal(t, fmt.Sprintf("project-%d", 99), r.ProjectName,
+		"project name must fall back to 'project-<id>' for missing projects")
+}
+
+// TestGetPermissionMatrix_MissingEnvironmentFallback — a grant with a valid project
+// but a missing environment falls back to the "env-<id>" synthetic name.
+func TestGetPermissionMatrix_MissingEnvironmentFallback(t *testing.T) {
+	c, db := newMatrixCore(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Project{ID: 8, Name: "proj-delta"}).Error)
+	// no environment row for env_id=77 — intentionally absent
+	seedMatrixUser(t, db, 31, "heidi", "heidi@example.com")
+	seedMatrixRole(t, db, 61, "env-writer")
+	seedMatrixPerm(t, db, 601, "secrets.write", "secrets", "write")
+	seedMatrixRolePerm(t, db, 61, 601)
+	require.NoError(t, db.Create(&models.UserRole{
+		UserID: 31, RoleID: 61, ProjectID: 8, EnvironmentID: 77,
+	}).Error)
+
+	rows, err := c.GetPermissionMatrix(ctx, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "missing environment must not drop the row")
+
+	r := rows[0]
+	assert.Equal(t, "environment", r.Scope)
+	assert.Equal(t, "proj-delta", r.ProjectName)
+	assert.Equal(t, fmt.Sprintf("env-%d", 77), r.EnvironmentName,
+		"environment name must fall back to 'env-<id>' for missing environments")
+}
+
+// TestGetPermissionMatrix_UnknownUserSkipped — a grant whose user_id has no matching
+// user row is silently skipped (stale JIT grant scenario).
+func TestGetPermissionMatrix_UnknownUserSkipped(t *testing.T) {
+	c, db := newMatrixCore(t)
+	ctx := context.Background()
+
+	seedMatrixUser(t, db, 40, "ivan", "ivan@example.com")
+	seedMatrixRole(t, db, 70, "admin")
+	seedMatrixPerm(t, db, 700, "secrets.read", "secrets", "read")
+	seedMatrixRolePerm(t, db, 70, 700)
+
+	// valid grant
+	require.NoError(t, db.Create(&models.UserRole{UserID: 40, RoleID: 70, ProjectID: 0}).Error)
+	// grant for non-existent user_id=999 (SQLite does not enforce FK by default)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 999, RoleID: 70, ProjectID: 0}).Error)
+
+	rows, err := c.GetPermissionMatrix(ctx, 0)
+	require.NoError(t, err)
+	// Only the valid grant should produce a row; the stale one is skipped.
+	require.Len(t, rows, 1, "stale grant with unknown user must be skipped")
+	assert.Equal(t, uint(40), rows[0].UserID)
+}
+
+// TestGetPermissionMatrix_MissingRoleSkipped — a grant whose role_id has no matching
+// role row causes the entire grant to be skipped (defensive: stale/orphaned grant).
+func TestGetPermissionMatrix_MissingRoleSkipped(t *testing.T) {
+	c, db := newMatrixCore(t)
+	ctx := context.Background()
+
+	seedMatrixUser(t, db, 41, "judy", "judy@example.com")
+	seedMatrixRole(t, db, 80, "real-role")
+	seedMatrixPerm(t, db, 800, "secrets.read", "secrets", "read")
+	seedMatrixRolePerm(t, db, 80, 800)
+
+	// valid grant
+	require.NoError(t, db.Create(&models.UserRole{UserID: 41, RoleID: 80, ProjectID: 0}).Error)
+	// grant referencing a role that doesn't exist in the roles table
+	require.NoError(t, db.Create(&models.UserRole{UserID: 41, RoleID: 9999, ProjectID: 0}).Error)
+
+	rows, err := c.GetPermissionMatrix(ctx, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "grant with missing role must be skipped")
+	assert.Equal(t, uint(80), rows[0].RoleID)
+}
+
+// TestGetPermissionMatrix_EmptyDB — an empty deployment returns an empty slice.
+func TestGetPermissionMatrix_EmptyDB(t *testing.T) {
+	c, _ := newMatrixCore(t)
+	rows, err := c.GetPermissionMatrix(context.Background(), 0)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+// TestGetPermissionMatrix_ListGrantsError — storage failure in ListAllUserRoleGrants
+// propagates as an error.
+func TestGetPermissionMatrix_ListGrantsError(t *testing.T) {
+	base := &MockStorage{}
+	override := &matrixStorageOverride{
+		Storage:       base,
+		listGrantsErr: errors.New("db connection lost"),
+	}
+	c := NewKeyorixCore(override)
+	_, err := c.GetPermissionMatrix(context.Background(), 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list grants")
+}
+
+// TestGetPermissionMatrix_GetRolePermsError — a storage failure in GetRolePermissions
+// causes that grant to be silently skipped (continue path at line 152-154).
+func TestGetPermissionMatrix_GetRolePermsError(t *testing.T) {
+	// Build a LocalStorage-backed core that has a valid user + role, then wrap it
+	// with the override that injects an error from GetRolePermissions.
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.User{},
+	))
+	local := store.NewLocalStorage(db)
+	require.NoError(t, db.Create(&models.User{ID: 50, Username: "kate", Email: "kate@example.com"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 90, Name: "the-role"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 50, RoleID: 90, ProjectID: 0}).Error)
+
+	override := &matrixStorageOverride{
+		Storage:         local,
+		getRolePermsErr: errors.New("permissions table gone"),
+	}
+	c := NewKeyorixCore(override)
+
+	// The grant is silently skipped: no error returned, but no rows produced.
+	rows, err := c.GetPermissionMatrix(context.Background(), 0)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "grant with GetRolePermissions failure must be skipped silently")
+}
+
+// TestGetPermissionMatrix_RoleWithNoPermissions — a role that has zero permissions
+// contributes no rows (empty perms slice, inner loop never executes).
+func TestGetPermissionMatrix_RoleWithNoPermissions(t *testing.T) {
+	c, db := newMatrixCore(t)
+	ctx := context.Background()
+
+	seedMatrixUser(t, db, 42, "lena", "lena@example.com")
+	seedMatrixRole(t, db, 85, "empty-role") // no permissions assigned
+	require.NoError(t, db.Create(&models.UserRole{UserID: 42, RoleID: 85, ProjectID: 0}).Error)
+
+	rows, err := c.GetPermissionMatrix(ctx, 0)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "a role with zero permissions must produce no matrix rows")
+}
+
+// TestGetPermissionMatrix_ProjectNameCache — the same project_id resolved twice
+// uses the cache; only one DB lookup occurs (indirectly verified by result
+// correctness across multiple grants for the same project).
+func TestGetPermissionMatrix_ProjectNameCache(t *testing.T) {
+	c, db := newMatrixCore(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Project{ID: 10, Name: "cached-proj"}).Error)
+	seedMatrixUser(t, db, 43, "mike", "mike@example.com")
+	seedMatrixUser(t, db, 44, "nina", "nina@example.com")
+	seedMatrixRole(t, db, 86, "viewer")
+	seedMatrixPerm(t, db, 860, "secrets.read", "secrets", "read")
+	seedMatrixRolePerm(t, db, 86, 860)
+	// two grants for the same project — project name should be resolved once and cached
+	require.NoError(t, db.Create(&models.UserRole{UserID: 43, RoleID: 86, ProjectID: 10}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 44, RoleID: 86, ProjectID: 10}).Error)
+
+	rows, err := c.GetPermissionMatrix(ctx, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	for _, r := range rows {
+		assert.Equal(t, "cached-proj", r.ProjectName)
+	}
 }

--- a/server/http/handlers/rbac_permission_matrix_test.go
+++ b/server/http/handlers/rbac_permission_matrix_test.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newMatrixHandlerCore returns an RBACHandler backed by a fully-seeded
+// in-memory DB so GetPermissionMatrix returns real data rows.
+func newMatrixHandlerCore(t *testing.T) (*RBACHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.User{},
+	))
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	return NewRBACHandler(c), db
+}
+
+// seedMatrixHandlerData seeds a minimal (user, role, permission, grant) set.
+func seedMatrixHandlerData(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "alice@example.com"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 0, EnvironmentID: 0}).Error)
+}
+
+// TestGetPermissionMatrixHandler_JSONWithData — JSON response contains seeded row.
+func TestGetPermissionMatrixHandler_JSONWithData(t *testing.T) {
+	h, db := newMatrixHandlerCore(t)
+	seedMatrixHandlerData(t, db)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/system/rbac/permission-matrix", nil))
+	w := httptest.NewRecorder()
+	h.GetPermissionMatrix(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok)
+	rows, ok := data["rows"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, rows, 1, "one seeded grant should produce exactly one row")
+
+	row := rows[0].(map[string]interface{})
+	assert.Equal(t, "alice", row["username"])
+	assert.Equal(t, "admin", row["role_name"])
+	assert.Equal(t, "global", row["scope"])
+}
+
+// TestGetPermissionMatrixHandler_CSVWithData — CSV response includes a data row.
+func TestGetPermissionMatrixHandler_CSVWithData(t *testing.T) {
+	h, db := newMatrixHandlerCore(t)
+	seedMatrixHandlerData(t, db)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/system/rbac/permission-matrix?format=csv", nil))
+	w := httptest.NewRecorder()
+	h.GetPermissionMatrix(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/csv")
+	assert.Equal(t, `attachment; filename="permission-matrix.csv"`, w.Header().Get("Content-Disposition"))
+
+	records, err := csv.NewReader(w.Body).ReadAll()
+	require.NoError(t, err)
+	// header + 1 data row
+	require.Len(t, records, 2, "CSV must have header + 1 data row")
+	assert.Contains(t, records[0], "username")
+	assert.Contains(t, records[1], "alice")
+	assert.Contains(t, records[1], "secrets.read")
+}
+
+// TestGetPermissionMatrixHandler_CSVEmpty — CSV response with no grants: only header.
+func TestGetPermissionMatrixHandler_CSVEmpty(t *testing.T) {
+	h, _ := newMatrixHandlerCore(t)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/system/rbac/permission-matrix?format=csv", nil))
+	w := httptest.NewRecorder()
+	h.GetPermissionMatrix(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	records, err := csv.NewReader(w.Body).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 1, "empty DB: CSV should have header row only")
+	assert.Contains(t, records[0], "username")
+}
+
+// TestGetPermissionMatrixHandler_ProjectFilter — project_id query param is accepted
+// and returns 200 (empty for an empty DB).
+func TestGetPermissionMatrixHandler_ProjectFilter(t *testing.T) {
+	h, _ := newMatrixHandlerCore(t)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/system/rbac/permission-matrix?project_id=42", nil))
+	w := httptest.NewRecorder()
+	h.GetPermissionMatrix(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestGetPermissionMatrixHandler_StorageError — a storage failure produces HTTP 500.
+func TestGetPermissionMatrixHandler_StorageError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	// Build a core whose ListAllUserRoleGrants will fail by closing the DB.
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.User{},
+	))
+	// Close the underlying SQL connection so all queries fail.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.Close()
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h := NewRBACHandler(c)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/system/rbac/permission-matrix", nil))
+	w := httptest.NewRecorder()
+	h.GetPermissionMatrix(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/server/http/handlers/rbac_permission_matrix_test.go
+++ b/server/http/handlers/rbac_permission_matrix_test.go
@@ -131,7 +131,7 @@ func TestGetPermissionMatrixHandler_StorageError(t *testing.T) {
 	// Close the underlying SQL connection so all queries fail.
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
-	sqlDB.Close()
+	_ = sqlDB.Close()
 
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	h := NewRBACHandler(c)

--- a/server/http/permission_matrix_handler_test.go
+++ b/server/http/permission_matrix_handler_test.go
@@ -1,0 +1,131 @@
+package http
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPermissionMatrix_JSON(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(cfg, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/system/rbac/permission-matrix", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "response body must contain a 'data' object")
+	assert.Contains(t, data, "rows")
+	assert.Contains(t, data, "total")
+}
+
+func TestGetPermissionMatrix_CSV(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(cfg, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/system/rbac/permission-matrix?format=csv", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, strings.HasPrefix(resp.Header.Get("Content-Type"), "text/csv"),
+		"Content-Type must be text/csv, got %s", resp.Header.Get("Content-Type"))
+
+	records, err := csv.NewReader(resp.Body).ReadAll()
+	require.NoError(t, err)
+	require.NotEmpty(t, records, "CSV response must contain at least the header row")
+
+	header := records[0]
+	assert.Contains(t, header, "username")
+	assert.Contains(t, header, "email")
+	assert.Contains(t, header, "role")
+	assert.Contains(t, header, "permission")
+}
+
+func TestGetPermissionMatrix_Unauthenticated(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	c := newTestCore(t)
+	router, err := NewRouter(cfg, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/system/rbac/permission-matrix", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestGetPermissionMatrix_ProjectFilter(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(cfg, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/system/rbac/permission-matrix?project_id=1", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "response body must contain a 'data' object")
+	assert.Contains(t, data, "rows")
+	assert.Contains(t, data, "total")
+}

--- a/server/http/permission_matrix_handler_test.go
+++ b/server/http/permission_matrix_handler_test.go
@@ -32,7 +32,7 @@ func TestGetPermissionMatrix_JSON(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -62,7 +62,7 @@ func TestGetPermissionMatrix_CSV(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.True(t, strings.HasPrefix(resp.Header.Get("Content-Type"), "text/csv"),
@@ -95,7 +95,7 @@ func TestGetPermissionMatrix_Unauthenticated(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
@@ -118,7 +118,7 @@ func TestGetPermissionMatrix_ProjectFilter(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/system/rbac/permission-matrix[?project_id=N&format=csv]` — full deployment-wide (user × role × permission × scope) audit matrix, CSV or JSON
- Adds `keyorix rbac export-matrix [--format table|csv|json] [--project <name>] [--output <file>]` CLI
- New `ListAllUserRoleGrants` storage method (local: full-table scan; remote: `remoteUnsupported`)
- Core `GetPermissionMatrix` cross-joins grants × permissions × user details × project names

## Test plan

- [ ] 8 core + CLI tests (global grant, project-scoped, filter, multi-permission, CSV/JSON/table remote, empty, JIT expiry)
- [ ] 4 handler integration tests through full router stack (JSON, CSV, unauthenticated, project filter)
- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)