### PR TITLE
feat(compliance): week-over-week posture trending

### DIFF
--- a/internal/core/compliance_trend_test.go
+++ b/internal/core/compliance_trend_test.go
@@ -17,6 +17,12 @@ import (
 // minimal tables GetCompliancePosture needs (Project, to avoid a fatal error on
 // ListProjects) and CompliancePostureSnapshot (for the trend machinery).
 // Additional tables left unmigrated degrade the posture sub-rollups gracefully.
+//
+// c.now is fixed to a date far in the future (2099-01-15) so that snapshots saved
+// during tests are dated in 2099 and are never returned by GetPreviousCompliancePostureSnapshot
+// (which queries WHERE snapshot_date < real-today's midnight). Only explicitly seeded
+// rows in the past qualify as "previous", keeping tests deterministic regardless of
+// the actual calendar date they run on.
 func complianceTrendCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -26,7 +32,7 @@ func complianceTrendCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 		&models.CompliancePostureSnapshot{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
-	c.now = func() time.Time { return time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC) }
+	c.now = func() time.Time { return time.Date(2099, 1, 15, 12, 0, 0, 0, time.UTC) }
 	return c, db
 }
 
@@ -115,4 +121,133 @@ func TestGetCompliancePosture_TrendStable(t *testing.T) {
 	assert.Equal(t, 0, *p2.Trend.PassedDelta)
 	require.NotNil(t, p2.Trend.FailedDelta)
 	assert.Equal(t, 0, *p2.Trend.FailedDelta)
+}
+
+// TestComputeComplianceTrend_Regressing verifies the "regressing" branch
+// (passedDelta < 0 || failedDelta > 0) of computeComplianceTrend directly,
+// using a seeded previous snapshot with more passed controls than the current one.
+func TestComputeComplianceTrend_Regressing(t *testing.T) {
+	c, db := complianceTrendCore(t)
+	ctx := context.Background()
+
+	// Seed a previous snapshot with high passed-control counts.
+	prevDate := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.CompliancePostureSnapshot{
+		TotalControls:  20,
+		PassedControls: 18, // previous had many passing
+		FailedControls: 2,
+		SnapshotDate:   prevDate,
+	}).Error)
+
+	// Current snapshot has fewer passed controls (regression).
+	current := &models.CompliancePostureSnapshot{
+		TotalControls:  20,
+		PassedControls: 10, // fewer passing now
+		FailedControls: 8,
+		SnapshotDate:   time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC),
+	}
+
+	trend := c.computeComplianceTrend(ctx, current)
+	require.NotNil(t, trend)
+	assert.Equal(t, "regressing", trend.Direction,
+		"fewer controls passing now than in the prior snapshot → regressing")
+	require.NotNil(t, trend.PassedDelta)
+	assert.Less(t, *trend.PassedDelta, 0,
+		"PassedDelta must be negative when fewer controls are passing now")
+	require.NotNil(t, trend.FailedDelta)
+	assert.Greater(t, *trend.FailedDelta, 0,
+		"FailedDelta must be positive when more controls are failing now")
+	require.NotNil(t, trend.PreviousDate)
+	assert.Equal(t, prevDate, *trend.PreviousDate)
+}
+
+// TestComputeComplianceTrend_RegressingOnFailedDelta covers the sub-case where
+// passedDelta is zero but failedDelta > 0 (more controls failing with the same
+// passed count — still a regression).
+func TestComputeComplianceTrend_RegressingOnFailedDelta(t *testing.T) {
+	c, db := complianceTrendCore(t)
+	ctx := context.Background()
+
+	prevDate := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.CompliancePostureSnapshot{
+		TotalControls:  20,
+		PassedControls: 10,
+		FailedControls: 2, // previously only 2 failing
+		SnapshotDate:   prevDate,
+	}).Error)
+
+	current := &models.CompliancePostureSnapshot{
+		TotalControls:  20,
+		PassedControls: 10, // same passed count
+		FailedControls: 8,  // more failing now
+		SnapshotDate:   time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC),
+	}
+
+	trend := c.computeComplianceTrend(ctx, current)
+	require.NotNil(t, trend)
+	assert.Equal(t, "regressing", trend.Direction,
+		"same passed count but more controls failing → regressing")
+	require.NotNil(t, trend.PassedDelta)
+	assert.Equal(t, 0, *trend.PassedDelta)
+	require.NotNil(t, trend.FailedDelta)
+	assert.Greater(t, *trend.FailedDelta, 0)
+}
+
+// TestComputeComplianceTrend_ErrorPathReturnsNoData verifies that when
+// GetPreviousCompliancePostureSnapshot returns an error, computeComplianceTrend
+// returns a "no_data" trend rather than propagating the error.
+func TestComputeComplianceTrend_ErrorPathReturnsNoData(t *testing.T) {
+	c, db := complianceTrendCore(t)
+	ctx := context.Background()
+
+	// Build a current snapshot to pass into computeComplianceTrend directly.
+	current := &models.CompliancePostureSnapshot{
+		TotalControls:  10,
+		PassedControls: 7,
+		FailedControls: 3,
+		SnapshotDate:   time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC),
+	}
+
+	// Force the DB to return an error by closing the underlying sql.DB.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	// computeComplianceTrend must fall back to "no_data" on a storage error.
+	trend := c.computeComplianceTrend(ctx, current)
+	require.NotNil(t, trend)
+	assert.Equal(t, "no_data", trend.Direction,
+		"a storage error from GetPreviousCompliancePostureSnapshot must yield no_data, not an error response")
+	assert.Nil(t, trend.PreviousDate)
+	assert.Nil(t, trend.PassedDelta)
+	assert.Nil(t, trend.FailedDelta)
+}
+
+// TestBuildCompliancePostureSnapshot_DegradedControlsCounter verifies that when a
+// CompliancePosture has sub-rollup failures (Degraded=true with matching reasons),
+// EvaluateControls produces ControlStatusUnknown entries and buildCompliancePostureSnapshot
+// correctly increments DegradedControls rather than counting those controls as passed
+// or failed.
+func TestBuildCompliancePostureSnapshot_DegradedControlsCounter(t *testing.T) {
+	// Construct a posture with a degraded identity sub-rollup. "identity" is the
+	// DegradedArea prefix checked by the second-factor control in EvaluateControls,
+	// so that control will evaluate to ControlStatusUnknown.
+	p := &CompliancePosture{
+		Degraded:        true,
+		DegradedReasons: []string{"identity: sql: database is closed"},
+	}
+	snapshotDate := time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC)
+
+	snap := buildCompliancePostureSnapshot(p, snapshotDate)
+
+	require.NotNil(t, snap)
+	assert.Equal(t, snapshotDate, snap.SnapshotDate)
+	assert.Greater(t, snap.DegradedControls, 0,
+		"a posture with a degraded sub-rollup must produce at least one DegradedControls entry in the snapshot")
+	assert.Equal(t, len(EvaluateControls(p)), snap.TotalControls,
+		"TotalControls must equal the number of controls EvaluateControls returns")
+
+	// The degraded count must be consistent: total = passed + failed + degraded.
+	assert.Equal(t, snap.TotalControls, snap.PassedControls+snap.FailedControls+snap.DegradedControls,
+		"passed + failed + degraded must sum to total controls")
 }

--- a/server/http/compliance_trend_handler_test.go
+++ b/server/http/compliance_trend_handler_test.go
@@ -1,0 +1,246 @@
+// compliance_trend_handler_test.go — handler-level integration tests for the
+// compliance posture trend field (GET /api/v1/compliance/posture → data.trend).
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// complianceTrendSetup bundles the core and its underlying LocalStorage so tests
+// that need to seed snapshot rows with custom timestamps can do so via the storage
+// interface without going around the production code.
+type complianceTrendSetup struct {
+	core    *core.KeyorixCore
+	storage *store.LocalStorage
+}
+
+// newComplianceTrendCore creates a minimal *core.KeyorixCore backed by an isolated
+// in-memory SQLite DB that includes CompliancePostureSnapshot in its AutoMigrate list,
+// alongside all the standard models required by the real router.
+func newComplianceTrendCore(t *testing.T) complianceTrendSetup {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(uniqueMemDSN("&_timeout=30000&_journal_mode=WAL")), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	err = db.AutoMigrate(
+		&models.SecretNode{},
+		&models.SecretVersion{},
+		&models.User{},
+		&models.Role{},
+		&models.UserRole{},
+		&models.Group{},
+		&models.UserGroup{},
+		&models.GroupRole{},
+		&models.ShareRecord{},
+		&models.AuditEvent{},
+		&models.Session{},
+		&models.Project{},
+		&models.Environment{},
+		&models.Permission{},
+		&models.RolePermission{},
+		&models.SystemMetadata{},
+		&models.LoginAttempt{},
+		&models.PasswordHistory{},
+		&models.PersonalAccessToken{},
+		&models.Tag{},
+		&models.SecretTag{},
+		&models.ProjectInvitation{},
+		&models.DynamicSecretConfig{},
+		&models.DynamicSecretLease{},
+		&models.Notification{},
+		&models.SetupToken{},
+		&models.ProjectMembership{},
+		&models.MFASecret{},
+		&models.MFARecoveryCode{},
+		&models.MFAChallenge{},
+		&models.SecretDependency{},
+		&models.MachineIdentity{},
+		&models.MachineIdentityCredential{},
+		&models.MachineIdentityRole{},
+		&models.MachineIdentityOIDCBinding{},
+		&models.WebAuthnCredential{},
+		&models.WebAuthnSession{},
+		&models.LegalHold{},
+		&models.AccessReviewCampaign{},
+		&models.AccessReviewItem{},
+		&models.BreakGlassActivation{},
+		&models.RiskException{},
+		&models.SoDPolicy{},
+		&models.ConnectRefGrant{},
+		&models.AnomalyAlert{},
+		&models.AccessRequest{},
+		&models.AccessRequestApproval{},
+		&models.SSOLoginState{},
+		&models.SchedulerLockLease{},
+		&models.SecretACL{},
+		&models.AnomalyConfigRecord{},
+		&models.StatsSnapshot{},
+		&models.DeploymentStatsSnapshot{},
+		// compliance posture trending — CompliancePostureSnapshot is written by
+		// GetCompliancePosture on every call and read for trend computation.
+		&models.CompliancePostureSnapshot{},
+	)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_project_memberships_active "+
+		"ON project_memberships (project_id, user_id) WHERE state <> 'revoked'").Error)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_legal_holds_active "+
+		"ON legal_holds (released) WHERE released = false").Error)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_break_glass_active_project_user "+
+		"ON break_glass_activations (project_id, user_id) WHERE state = 'active'").Error)
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active "+
+		"ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error)
+	ls := store.NewLocalStorage(db)
+	return complianceTrendSetup{core: core.NewKeyorixCore(ls), storage: ls}
+}
+
+// TestGetCompliancePosture_HasTrendField verifies that an authenticated admin
+// receives a 200 response with a data.trend object containing a direction field.
+func TestGetCompliancePosture_HasTrendField(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	setup := newComplianceTrendCore(t)
+	token := createTestToken(t, setup.core)
+	router, err := NewRouter(&config.Config{}, setup.core)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/compliance/posture", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "response body must have a data object")
+	assert.Contains(t, data, "trend")
+	trend, ok := data["trend"].(map[string]interface{})
+	require.True(t, ok, "data.trend must be an object")
+	assert.Contains(t, trend, "direction")
+}
+
+// TestGetCompliancePosture_TrendNoData_FirstCall verifies that the very first call
+// returns direction == "no_data" because no previous snapshot exists yet.
+func TestGetCompliancePosture_TrendNoData_FirstCall(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	setup := newComplianceTrendCore(t)
+	token := createTestToken(t, setup.core)
+	router, err := NewRouter(&config.Config{}, setup.core)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/compliance/posture", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "response body must have a data object")
+	trend, ok := data["trend"].(map[string]interface{})
+	require.True(t, ok, "data.trend must be an object")
+	assert.Equal(t, "no_data", trend["direction"], "first call must report no_data — no previous snapshot exists")
+}
+
+// TestGetCompliancePosture_Unauthenticated verifies that a request without a Bearer
+// token is rejected with 401 Unauthorized.
+func TestGetCompliancePosture_Unauthenticated(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	setup := newComplianceTrendCore(t)
+	router, err := NewRouter(&config.Config{}, setup.core)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/compliance/posture")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestGetCompliancePosture_TrendDirection_AfterTwoCalls verifies that after a
+// prior-day snapshot is seeded, a call to the endpoint returns a trend direction
+// that is not "no_data".
+//
+// GetPreviousCompliancePostureSnapshot intentionally queries for snapshots with
+// snapshot_date strictly before today's UTC midnight (to avoid same-day
+// self-comparison). Two HTTP calls on the same calendar day both write to the
+// same "today" slot and neither sees the other as "previous". To test that the
+// trend logic activates correctly we seed one snapshot dated yesterday directly
+// through the storage layer, then confirm the endpoint returns a real direction.
+func TestGetCompliancePosture_TrendDirection_AfterTwoCalls(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	setup := newComplianceTrendCore(t)
+	token := createTestToken(t, setup.core)
+	router, err := NewRouter(&config.Config{}, setup.core)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	// Seed a snapshot dated yesterday so GetPreviousCompliancePostureSnapshot
+	// finds it. We use yesterday's UTC midnight directly.
+	ctx := context.Background()
+	now := time.Now().UTC()
+	yesterday := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+	prevSnap := &models.CompliancePostureSnapshot{
+		TotalControls:  10,
+		PassedControls: 8,
+		FailedControls: 2,
+		SnapshotDate:   yesterday,
+	}
+	require.NoError(t, setup.storage.SaveCompliancePostureSnapshot(ctx, prevSnap))
+
+	// Call the endpoint — a previous snapshot now exists, so direction must not be "no_data".
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/compliance/posture", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "response body must have a data object")
+	trend, ok := data["trend"].(map[string]interface{})
+	require.True(t, ok, "data.trend must be an object")
+	direction, _ := trend["direction"].(string)
+	assert.NotEqual(t, "no_data", direction, "a previous snapshot exists — direction must be a real value, not no_data")
+}

--- a/server/http/compliance_trend_handler_test.go
+++ b/server/http/compliance_trend_handler_test.go
@@ -128,7 +128,7 @@ func TestGetCompliancePosture_HasTrendField(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -160,7 +160,7 @@ func TestGetCompliancePosture_TrendNoData_FirstCall(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -187,7 +187,7 @@ func TestGetCompliancePosture_Unauthenticated(t *testing.T) {
 
 	resp, err := http.Get(srv.URL + "/api/v1/compliance/posture")
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
@@ -232,7 +232,7 @@ func TestGetCompliancePosture_TrendDirection_AfterTwoCalls(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	var body map[string]interface{}


### PR DESCRIPTION
## Summary

- Adds `CompliancePostureSnapshot` model — daily snapshot of total/passed/failed/degraded control counts
- `GET /api/v1/compliance/posture` now includes a `trend` field: `{direction, passed_delta, failed_delta, previous_date}`
- Direction: `improving` / `regressing` / `stable` / `no_data` (first call)
- Remote storage stubs — snapshots are server-side only

## Test plan

- [ ] 12 core + store tests (no_data/improving/stable, upsert, same-day exclusion)
- [ ] 4 handler integration tests (trend field present, no_data on first call, unauthenticated, after seeded prior snapshot)
- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)