### PR TITLE
feat(rbac): role expiry notifications — warn when UserRole grants near expiry

### DIFF
--- a/internal/cli/system/role_expiry.go
+++ b/internal/cli/system/role_expiry.go
@@ -1,0 +1,42 @@
+// role_expiry.go — CLI command: keyorix system role-expiry-check
+//
+// Triggers the role-expiry notification scan on the connected server
+// (POST /api/v1/admin/jobs/role-expiry-check). Requires system.write.
+package system
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// roleExpiryCheckResult mirrors the {warnings, criticals} response body.
+type roleExpiryCheckResult struct {
+	Warnings  int `json:"warnings"`
+	Criticals int `json:"criticals"`
+}
+
+var roleExpiryCheckCmd = &cobra.Command{
+	Use:   "role-expiry-check",
+	Short: "Trigger a role-expiry notification scan on the connected server",
+	Long: `Send immediate role-expiry notifications for time-bound role grants
+approaching their deadline (POST /api/v1/admin/jobs/role-expiry-check).
+
+Warning notifications are sent for grants expiring within 7 days; critical
+notifications for those expiring within 1 day. Requires system.write.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var result roleExpiryCheckResult
+		if err := c.Post(context.Background(), "/api/v1/admin/jobs/role-expiry-check", nil, &result); err != nil {
+			return err
+		}
+		fmt.Printf("Role-expiry check complete: %d warning(s), %d critical(s)\n", result.Warnings, result.Criticals)
+		return nil
+	},
+}

--- a/internal/cli/system/role_expiry_test.go
+++ b/internal/cli/system/role_expiry_test.go
@@ -1,0 +1,71 @@
+package system
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRoleExpiryRemote(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+}
+
+func setupRoleExpiryDisconnected(t *testing.T) {
+	t.Helper()
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_CONFIG_PATH", filepath.Join(dir, "nonexistent.yaml"))
+}
+
+func TestRoleExpiryCheckCmd_Success(t *testing.T) {
+	setupRoleExpiryRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/admin/jobs/role-expiry-check", r.URL.Path)
+		_, _ = w.Write([]byte(`{"data":{"warnings":3,"criticals":1}}`))
+	})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, roleExpiryCheckCmd.RunE(nil, nil))
+	})
+	assert.Contains(t, out, "3 warning(s)")
+	assert.Contains(t, out, "1 critical(s)")
+}
+
+func TestRoleExpiryCheckCmd_ZeroResults(t *testing.T) {
+	setupRoleExpiryRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"warnings":0,"criticals":0}}`))
+	})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, roleExpiryCheckCmd.RunE(nil, nil))
+	})
+	assert.Contains(t, out, "0 warning(s)")
+	assert.Contains(t, out, "0 critical(s)")
+}
+
+func TestRoleExpiryCheckCmd_ServerError(t *testing.T) {
+	setupRoleExpiryRemote(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := roleExpiryCheckCmd.RunE(nil, nil)
+	require.Error(t, err)
+}
+
+func TestRoleExpiryCheckCmd_NotConnected(t *testing.T) {
+	setupRoleExpiryDisconnected(t)
+
+	err := roleExpiryCheckCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}

--- a/internal/cli/system/system.go
+++ b/internal/cli/system/system.go
@@ -14,4 +14,5 @@ func init() {
 	SystemCmd.AddCommand(auditCmd)
 	SystemCmd.AddCommand(validateCmd)
 	SystemCmd.AddCommand(infoCmd)
+	SystemCmd.AddCommand(roleExpiryCheckCmd)
 }

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -2061,8 +2061,12 @@ func (m *MockStorage) ListAllUserRoleGrants(_ context.Context) ([]*models.UserRo
 	return nil, nil
 }
 
-func (m *MockStorage) ListExpiringUserRoles(_ context.Context, _ time.Time) ([]models.UserRole, error) {
-	return nil, nil
+func (m *MockStorage) ListExpiringUserRoles(ctx context.Context, cutoff time.Time) ([]models.UserRole, error) {
+	args := m.Called(ctx, cutoff)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.UserRole), args.Error(1)
 }
 
 // Per-secret / per-folder ACL stubs (ADR-058).

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -2061,6 +2061,10 @@ func (m *MockStorage) ListAllUserRoleGrants(_ context.Context) ([]*models.UserRo
 	return nil, nil
 }
 
+func (m *MockStorage) ListExpiringUserRoles(_ context.Context, _ time.Time) ([]models.UserRole, error) {
+	return nil, nil
+}
+
 // Per-secret / per-folder ACL stubs (ADR-058).
 func (m *MockStorage) CreateOrUpdateSecretACL(_ context.Context, _ *models.SecretACL) error {
 	return nil

--- a/internal/core/role_expiry_notify.go
+++ b/internal/core/role_expiry_notify.go
@@ -1,0 +1,138 @@
+// role_expiry_notify.go — proactive JIT role-grant expiry notifications.
+//
+// CheckRoleExpiry scans all UserRole rows with a non-nil ExpiresAt and emits
+// in-app Notification rows for those expiring within 7 days (warning) or 1 day
+// (critical). It is idempotent: a user/role pair that already has an unread
+// notification of the appropriate severity in the last 24 h is skipped.
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// NotificationRoleExpiryReminder is the in-app notification type for a
+// time-bound role grant that is approaching its expiry deadline.
+const NotificationRoleExpiryReminder = "role.expiry_reminder"
+
+// roleExpiryWarningWindow is the look-ahead for the "expiring soon" warning.
+const roleExpiryWarningWindow = 7 * 24 * time.Hour
+
+// roleExpiryCriticalWindow is the look-ahead for the "imminent" critical alert.
+const roleExpiryCriticalWindow = 1 * 24 * time.Hour
+
+// RoleExpiryCheckResult summarises what was emitted by CheckRoleExpiry.
+type RoleExpiryCheckResult struct {
+	Warnings  int // notifications created/escalated for the 7-day window
+	Criticals int // notifications created/escalated for the 1-day window
+}
+
+// CheckRoleExpiry scans all UserRole rows with a non-nil ExpiresAt and emits
+// in-app Notification rows for those expiring within 7 days (warning) or 1 day
+// (critical). Already-expired grants are not counted — they have lapsed and the
+// sweep will remove them; this function is forward-looking only.
+//
+// Idempotent: if the user already has an unread notification of the same type
+// for the same role at the same or higher severity, it is skipped (or escalated
+// in place when the new severity is strictly higher, matching the
+// expiry/rotation/license reminder dedup pattern).
+func (k *KeyorixCore) CheckRoleExpiry(ctx context.Context) (*RoleExpiryCheckResult, error) {
+	now := k.now()
+	// Fetch all grants expiring within the wider window (7 days). We pass the
+	// 7-day cutoff so the DB filters out grants beyond that horizon.
+	cutoff := now.Add(roleExpiryWarningWindow)
+	grants, err := k.storage.ListExpiringUserRoles(ctx, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("list expiring user roles: %w", err)
+	}
+
+	result := &RoleExpiryCheckResult{}
+	for _, g := range grants {
+		if g.ExpiresAt == nil {
+			continue
+		}
+		// Skip already-expired grants — forward-looking only.
+		if !g.ExpiresAt.After(now) {
+			continue
+		}
+
+		severity := roleExpirySeverity(g.ExpiresAt, now)
+
+		roleName := k.roleName(ctx, g.RoleID)
+		title, msg := roleExpiryMessage(roleName, g.ExpiresAt)
+
+		existing := k.unreadRoleExpiryReminder(ctx, g.UserID, g.RoleID)
+		if existing != nil {
+			if severity <= existing.Severity {
+				continue // no worse than what's standing — don't pile up
+			}
+			if k.upgradeReminder(ctx, existing, title, msg, severity) {
+				k.bumpRoleExpiryCount(result, severity)
+			}
+			continue
+		}
+		k.notifyWithSeverity(ctx, g.UserID, NotificationRoleExpiryReminder, title, msg, nil, "/profile/roles", severity)
+		k.bumpRoleExpiryCount(result, severity)
+	}
+	return result, nil
+}
+
+// roleExpirySeverity returns Critical when the grant expires within 1 day,
+// Warning when it expires within 7 days.
+func roleExpirySeverity(expiresAt *time.Time, now time.Time) models.NotificationSeverity {
+	if expiresAt.Before(now.Add(roleExpiryCriticalWindow)) {
+		return models.NotificationSeverityCritical
+	}
+	return models.NotificationSeverityWarning
+}
+
+// bumpRoleExpiryCount increments the appropriate counter on result.
+func (k *KeyorixCore) bumpRoleExpiryCount(result *RoleExpiryCheckResult, severity models.NotificationSeverity) {
+	if severity >= models.NotificationSeverityCritical {
+		result.Criticals++
+	} else {
+		result.Warnings++
+	}
+}
+
+// roleName returns the human-readable role name for a role ID, falling back to
+// a "#N" label if the role cannot be fetched.
+func (k *KeyorixCore) roleName(ctx context.Context, roleID uint) string {
+	r, err := k.storage.GetRole(ctx, roleID)
+	if err != nil || r == nil {
+		return fmt.Sprintf("#%d", roleID)
+	}
+	return r.Name
+}
+
+// roleExpiryMessage builds the notification title and message for a role grant
+// approaching expiry.
+func roleExpiryMessage(roleName string, expiresAt *time.Time) (string, string) {
+	date := expiresAt.UTC().Format("2006-01-02 15:04 UTC")
+	return "Role access expiring",
+		fmt.Sprintf("Your %q role grant expires on %s.", roleName, date)
+}
+
+// unreadRoleExpiryReminder returns the user's existing unread role-expiry
+// reminder for a specific role, or nil if none exists.
+func (k *KeyorixCore) unreadRoleExpiryReminder(ctx context.Context, userID, roleID uint) *models.Notification {
+	notes, err := k.storage.ListNotifications(ctx, userID, true, 200)
+	if err != nil {
+		return nil // on read error, prefer notifying over silently skipping
+	}
+	roleName := k.roleName(ctx, roleID)
+	needle := fmt.Sprintf("%q role grant", roleName)
+	for _, n := range notes {
+		if n.Type == NotificationRoleExpiryReminder {
+			// Match by content: the role name is embedded in the message.
+			if strings.Contains(n.Message, needle) {
+				return n
+			}
+		}
+	}
+	return nil
+}

--- a/internal/core/role_expiry_notify_test.go
+++ b/internal/core/role_expiry_notify_test.go
@@ -1,0 +1,187 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var roleExpiryFixed = time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+
+func newRoleExpiryCore(store *MockStorage) *KeyorixCore {
+	return &KeyorixCore{storage: store, now: func() time.Time { return roleExpiryFixed }}
+}
+
+// expiresAt returns a pointer to a time offset from roleExpiryFixed.
+func expiresAt(d time.Duration) *time.Time {
+	t := roleExpiryFixed.Add(d)
+	return &t
+}
+
+func TestCheckRoleExpiry_NoGrants(t *testing.T) {
+	store := new(MockStorage)
+	c := newRoleExpiryCore(store)
+	ctx := context.Background()
+
+	store.On("ListExpiringUserRoles", ctx, mock.AnythingOfType("time.Time")).
+		Return([]models.UserRole{}, nil)
+
+	result, err := c.CheckRoleExpiry(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Warnings)
+	assert.Equal(t, 0, result.Criticals)
+}
+
+func TestCheckRoleExpiry_WarningForFiveDayExpiry(t *testing.T) {
+	store := new(MockStorage)
+	c := newRoleExpiryCore(store)
+	ctx := context.Background()
+
+	// Expires in 5 days → Warning (within 7-day window, outside 1-day window)
+	grant := models.UserRole{UserID: 10, RoleID: 3, ExpiresAt: expiresAt(5 * 24 * time.Hour)}
+	store.On("ListExpiringUserRoles", ctx, mock.AnythingOfType("time.Time")).
+		Return([]models.UserRole{grant}, nil)
+	store.On("GetRole", ctx, uint(3)).Return(&models.Role{ID: 3, Name: "Operator"}, nil)
+	store.On("ListNotifications", ctx, uint(10), true, 200).
+		Return([]*models.Notification{}, nil)
+	store.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).
+		Return(&models.Notification{}, nil)
+
+	result, err := c.CheckRoleExpiry(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Warnings)
+	assert.Equal(t, 0, result.Criticals)
+}
+
+func TestCheckRoleExpiry_CriticalForTwentyHourExpiry(t *testing.T) {
+	store := new(MockStorage)
+	c := newRoleExpiryCore(store)
+	ctx := context.Background()
+
+	// Expires in 20 hours → Critical (within 1-day window)
+	grant := models.UserRole{UserID: 11, RoleID: 4, ExpiresAt: expiresAt(20 * time.Hour)}
+	store.On("ListExpiringUserRoles", ctx, mock.AnythingOfType("time.Time")).
+		Return([]models.UserRole{grant}, nil)
+	store.On("GetRole", ctx, uint(4)).Return(&models.Role{ID: 4, Name: "Admin"}, nil)
+	store.On("ListNotifications", ctx, uint(11), true, 200).
+		Return([]*models.Notification{}, nil)
+	store.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).
+		Return(&models.Notification{}, nil)
+
+	result, err := c.CheckRoleExpiry(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Warnings)
+	assert.Equal(t, 1, result.Criticals)
+}
+
+func TestCheckRoleExpiry_SkipsAlreadyExpiredGrants(t *testing.T) {
+	store := new(MockStorage)
+	c := newRoleExpiryCore(store)
+	ctx := context.Background()
+
+	// ExpiresAt is in the past — already expired, must be skipped.
+	past := roleExpiryFixed.Add(-1 * time.Hour)
+	grant := models.UserRole{UserID: 12, RoleID: 5, ExpiresAt: &past}
+	store.On("ListExpiringUserRoles", ctx, mock.AnythingOfType("time.Time")).
+		Return([]models.UserRole{grant}, nil)
+
+	result, err := c.CheckRoleExpiry(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Warnings)
+	assert.Equal(t, 0, result.Criticals)
+}
+
+func TestCheckRoleExpiry_SkipsDedupSameSeverity(t *testing.T) {
+	// Existing warning notification for same role → skip (no new notification)
+	store := new(MockStorage)
+	c := newRoleExpiryCore(store)
+	ctx := context.Background()
+
+	grant := models.UserRole{UserID: 13, RoleID: 6, ExpiresAt: expiresAt(5 * 24 * time.Hour)}
+	store.On("ListExpiringUserRoles", ctx, mock.AnythingOfType("time.Time")).
+		Return([]models.UserRole{grant}, nil)
+	store.On("GetRole", ctx, uint(6)).Return(&models.Role{ID: 6, Name: "Viewer"}, nil)
+	// Existing unread warning for this role
+	existingMsg := `Your "Viewer" role grant expires on`
+	store.On("ListNotifications", ctx, uint(13), true, 200).
+		Return([]*models.Notification{
+			{
+				Type:     NotificationRoleExpiryReminder,
+				Message:  existingMsg,
+				Severity: models.NotificationSeverityWarning,
+			},
+		}, nil)
+
+	result, err := c.CheckRoleExpiry(ctx)
+	require.NoError(t, err)
+	// Same severity — should be skipped entirely
+	assert.Equal(t, 0, result.Warnings)
+	assert.Equal(t, 0, result.Criticals)
+	store.AssertNotCalled(t, "CreateNotification")
+}
+
+func TestCheckRoleExpiry_UpgradeWarningToCritical(t *testing.T) {
+	// Existing warning for a role now expiring in <1 day → escalate to critical
+	store := new(MockStorage)
+	c := newRoleExpiryCore(store)
+	ctx := context.Background()
+
+	grant := models.UserRole{UserID: 14, RoleID: 7, ExpiresAt: expiresAt(20 * time.Hour)}
+	store.On("ListExpiringUserRoles", ctx, mock.AnythingOfType("time.Time")).
+		Return([]models.UserRole{grant}, nil)
+	store.On("GetRole", ctx, uint(7)).Return(&models.Role{ID: 7, Name: "Manager"}, nil)
+
+	existingMsg := `Your "Manager" role grant expires on`
+	existing := &models.Notification{
+		ID:       99,
+		Type:     NotificationRoleExpiryReminder,
+		Message:  existingMsg,
+		Severity: models.NotificationSeverityWarning,
+	}
+	store.On("ListNotifications", ctx, uint(14), true, 200).
+		Return([]*models.Notification{existing}, nil)
+	store.On("UpdateNotification", ctx, mock.AnythingOfType("*models.Notification")).Return(nil)
+
+	result, err := c.CheckRoleExpiry(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Warnings)
+	assert.Equal(t, 1, result.Criticals)
+	store.AssertCalled(t, "UpdateNotification", ctx, mock.AnythingOfType("*models.Notification"))
+}
+
+func TestCheckRoleExpiry_ListExpiringError(t *testing.T) {
+	store := new(MockStorage)
+	c := newRoleExpiryCore(store)
+	ctx := context.Background()
+
+	store.On("ListExpiringUserRoles", ctx, mock.AnythingOfType("time.Time")).
+		Return(nil, errors.New("db error"))
+
+	_, err := c.CheckRoleExpiry(ctx)
+	require.Error(t, err)
+}
+
+func TestCheckRoleExpiry_RoleNameFallback(t *testing.T) {
+	// When GetRole fails, roleName should fall back to "#<id>".
+	store := new(MockStorage)
+	c := newRoleExpiryCore(store)
+	ctx := context.Background()
+
+	grant := models.UserRole{UserID: 15, RoleID: 999, ExpiresAt: expiresAt(5 * 24 * time.Hour)}
+	store.On("ListExpiringUserRoles", ctx, mock.AnythingOfType("time.Time")).
+		Return([]models.UserRole{grant}, nil)
+	store.On("GetRole", ctx, uint(999)).Return(nil, errors.New("not found"))
+	store.On("ListNotifications", ctx, uint(15), true, 200).Return([]*models.Notification{}, nil)
+	store.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).
+		Return(&models.Notification{}, nil)
+
+	result, err := c.CheckRoleExpiry(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Warnings)
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -824,6 +824,10 @@ type Storage interface {
 	// including scoped (project/environment) and global (project_id=0) grants.
 	// Includes time-bound (JIT) grants; callers filter by ExpiresAt if needed.
 	ListAllUserRoleGrants(ctx context.Context) ([]*models.UserRole, error)
+	// ListExpiringUserRoles returns every UserRole whose ExpiresAt is non-nil and
+	// before the given cutoff (i.e. expiring or already expired). Used by
+	// CheckRoleExpiry to find grants approaching their deadline.
+	ListExpiringUserRoles(ctx context.Context, before time.Time) ([]models.UserRole, error)
 	GetUserRoleIDsAt(ctx context.Context, userID uint, scope Scope) ([]uint, error)
 	GetUserRoleIDsExact(ctx context.Context, userID uint, scope Scope) ([]uint, error)
 	// IsProjectMember reports whether the user holds a LIVE role grant scoped to the

--- a/internal/storage/store/local_role_expiry.go
+++ b/internal/storage/store/local_role_expiry.go
@@ -1,0 +1,20 @@
+// local_role_expiry.go — LocalStorage implementation of ListExpiringUserRoles,
+// used by core.CheckRoleExpiry to find JIT role grants approaching their deadline.
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ListExpiringUserRoles returns every UserRole whose ExpiresAt is non-nil and
+// before the given cutoff. Grants that have already expired (ExpiresAt in the
+// past) are included so the critical-window check can catch them too.
+func (ls *LocalStorage) ListExpiringUserRoles(ctx context.Context, before time.Time) ([]models.UserRole, error) {
+	var grants []models.UserRole
+	return grants, ls.db.WithContext(ctx).
+		Where("expires_at IS NOT NULL AND expires_at < ?", before).
+		Find(&grants).Error
+}

--- a/internal/storage/store/remote_role_expiry.go
+++ b/internal/storage/store/remote_role_expiry.go
@@ -1,0 +1,20 @@
+// remote_role_expiry.go — RemoteStorage stub for ListExpiringUserRoles.
+//
+// Role-expiry scanning is a server-internal background job that always runs
+// against the server's own LocalStorage — there is no self-scoped API route
+// that exposes raw UserRole rows to a remote client, so this path is
+// deliberately unsupported on RemoteStorage.
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ListExpiringUserRoles is not supported in remote storage. The role-expiry
+// check runs server-side against LocalStorage only.
+func (rs *RemoteStorage) ListExpiringUserRoles(_ context.Context, _ time.Time) ([]models.UserRole, error) {
+	return nil, remoteUnsupported("ListExpiringUserRoles")
+}

--- a/internal/storage/store/remote_role_expiry_completeness_test.go
+++ b/internal/storage/store/remote_role_expiry_completeness_test.go
@@ -1,0 +1,8 @@
+package store
+
+func init() {
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		"ListExpiringUserRoles": {statusIntentional,
+			"role-expiry scanning is a server-internal background job running only against LocalStorage; no self-scoped API route exposes raw UserRole rows to a remote client"},
+	})
+}

--- a/server/http/handlers/admin_jobs.go
+++ b/server/http/handlers/admin_jobs.go
@@ -95,3 +95,21 @@ func (h *AdminJobsHandler) RunComplianceDigest(w http.ResponseWriter, r *http.Re
 	}
 	sendSuccess(w, map[string]interface{}{"sent": sent}, "")
 }
+
+// RunRoleExpiryCheck handles POST /api/v1/system/admin/jobs/role-expiry-check —
+// scans all time-bound role grants and emits in-app notifications for those
+// expiring within 7 days (warning) or 1 day (critical). Returns {warnings, criticals}.
+// Requires system.write (enforced by the router).
+func (h *AdminJobsHandler) RunRoleExpiryCheck(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+	result, err := h.coreService.CheckRoleExpiry(r.Context())
+	if err != nil {
+		log.Printf("Error running role-expiry-check job: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"warnings": result.Warnings, "criticals": result.Criticals}, "")
+}

--- a/server/http/handlers/admin_jobs_test.go
+++ b/server/http/handlers/admin_jobs_test.go
@@ -59,6 +59,14 @@ func TestAdminJobsHandlers_HappyPath(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Code)
 		assert.EqualValues(t, 0, decodeData(t, w)["sent"])
 	})
+
+	t.Run("role-expiry-check returns zero counters on empty state", func(t *testing.T) {
+		w := postJob(h.RunRoleExpiryCheck, "/api/v1/admin/jobs/role-expiry-check", true)
+		require.Equal(t, http.StatusOK, w.Code)
+		d := decodeData(t, w)
+		assert.EqualValues(t, 0, d["warnings"])
+		assert.EqualValues(t, 0, d["criticals"])
+	})
 }
 
 func TestAdminJobsHandlers_RequireUserContext(t *testing.T) {
@@ -68,6 +76,7 @@ func TestAdminJobsHandlers_RequireUserContext(t *testing.T) {
 		"rotation-reminders": h.RunRotationReminders,
 		"expiry-reminders":   h.RunExpiryReminders,
 		"compliance-digest":  h.RunComplianceDigest,
+		"role-expiry-check":  h.RunRoleExpiryCheck,
 	}
 	for name, fn := range cases {
 		t.Run(name+" is unauthorized without a user context", func(t *testing.T) {

--- a/server/http/role_expiry_handler_test.go
+++ b/server/http/role_expiry_handler_test.go
@@ -1,0 +1,179 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// roleExpiryTestEnv bundles the pieces needed by each role-expiry sub-test.
+type roleExpiryTestEnv struct {
+	server *httptest.Server
+	token  string
+	c      *core.KeyorixCore
+	db     *gorm.DB
+}
+
+// newRoleExpiryEnv creates a minimal server with a bootstrapped admin.
+func newRoleExpiryEnv(t *testing.T) *roleExpiryTestEnv {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	db, err := gorm.Open(sqlite.Open(uniqueMemDSN("")), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(models.AllTestModels()...))
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	token := createTestToken(t, c)
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+
+	return &roleExpiryTestEnv{server: server, token: token, c: c, db: db}
+}
+
+// postRoleExpiryCheck POSTs to the role-expiry-check endpoint and returns
+// the status code plus the parsed data map.
+func postRoleExpiryCheck(t *testing.T, env *roleExpiryTestEnv, authHeader string) (int, map[string]interface{}) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, env.server.URL+"/api/v1/admin/jobs/role-expiry-check", nil)
+	require.NoError(t, err)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var envelope struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	if resp.StatusCode == http.StatusOK {
+		require.NoError(t, json.Unmarshal(body, &envelope))
+	}
+	return resp.StatusCode, envelope.Data
+}
+
+// seedExpiringRole inserts a UserRole row for the bootstrapped admin user that
+// expires at the given time. It uses the "viewer" role (also seeded by
+// BootstrapSystem) so the composite PK (user, role, project=0, env=0) does not
+// collide with the admin's existing permanent "admin" role grant.
+func seedExpiringRole(t *testing.T, env *roleExpiryTestEnv, expiresAt time.Time) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Look up the admin user seeded by createTestToken.
+	user, err := env.c.GetUserByUsername(ctx, "testadmin")
+	require.NoError(t, err)
+	require.NotNil(t, user)
+
+	// Use "viewer" — always seeded by BootstrapSystem and not yet held by testadmin.
+	var role models.Role
+	require.NoError(t, env.db.Where("name = ?", "viewer").First(&role).Error)
+
+	// Write an expiring UserRole directly (bypasses SoD gates which aren't relevant here).
+	require.NoError(t, env.db.Save(&models.UserRole{
+		UserID:    user.ID,
+		RoleID:    role.ID,
+		ProjectID: 0,
+		ExpiresAt: &expiresAt,
+	}).Error)
+}
+
+// TestRoleExpiryCheck_NoExpiringRoles verifies that when no role grants are
+// near expiry the endpoint returns 200 with {warnings:0, criticals:0}.
+func TestRoleExpiryCheck_NoExpiringRoles(t *testing.T) {
+	env := newRoleExpiryEnv(t)
+	code, data := postRoleExpiryCheck(t, env, "Bearer "+env.token)
+	assert.Equal(t, http.StatusOK, code)
+	assert.EqualValues(t, 0, data["warnings"])
+	assert.EqualValues(t, 0, data["criticals"])
+}
+
+// TestRoleExpiryCheck_RoleExpiringIn3Days verifies that a grant expiring in
+// 3 days triggers a warning notification ({warnings:1, criticals:0}).
+func TestRoleExpiryCheck_RoleExpiringIn3Days(t *testing.T) {
+	env := newRoleExpiryEnv(t)
+	expiresAt := time.Now().Add(3 * 24 * time.Hour)
+	seedExpiringRole(t, env, expiresAt)
+
+	code, data := postRoleExpiryCheck(t, env, "Bearer "+env.token)
+	assert.Equal(t, http.StatusOK, code)
+	assert.EqualValues(t, 1, data["warnings"], "expected 1 warning for a grant expiring in 3 days")
+	assert.EqualValues(t, 0, data["criticals"])
+}
+
+// TestRoleExpiryCheck_RoleExpiringIn12Hours verifies that a grant expiring
+// within 24 hours triggers a critical notification ({warnings:0, criticals:1}).
+func TestRoleExpiryCheck_RoleExpiringIn12Hours(t *testing.T) {
+	env := newRoleExpiryEnv(t)
+	expiresAt := time.Now().Add(12 * time.Hour)
+	seedExpiringRole(t, env, expiresAt)
+
+	code, data := postRoleExpiryCheck(t, env, "Bearer "+env.token)
+	assert.Equal(t, http.StatusOK, code)
+	assert.EqualValues(t, 0, data["warnings"])
+	assert.EqualValues(t, 1, data["criticals"], "expected 1 critical for a grant expiring in 12 hours")
+}
+
+// TestRoleExpiryCheck_AlreadyExpiredRoleNotCounted verifies that a grant that
+// has already expired is not counted (it is past the deadline, not approaching it).
+func TestRoleExpiryCheck_AlreadyExpiredRoleNotCounted(t *testing.T) {
+	env := newRoleExpiryEnv(t)
+	// Expired 1 hour ago.
+	expiresAt := time.Now().Add(-1 * time.Hour)
+	seedExpiringRole(t, env, expiresAt)
+
+	code, data := postRoleExpiryCheck(t, env, "Bearer "+env.token)
+	assert.Equal(t, http.StatusOK, code)
+	assert.EqualValues(t, 0, data["warnings"], "already-expired grant must not be counted")
+	assert.EqualValues(t, 0, data["criticals"], "already-expired grant must not be counted")
+}
+
+// TestRoleExpiryCheck_Unauthenticated verifies that a request without a valid
+// Bearer token is rejected with 401.
+func TestRoleExpiryCheck_Unauthenticated(t *testing.T) {
+	env := newRoleExpiryEnv(t)
+	code, _ := postRoleExpiryCheck(t, env, "") // no Authorization header
+	assert.Equal(t, http.StatusUnauthorized, code)
+}
+
+// TestRoleExpiryCheck_Idempotent verifies that calling the endpoint twice for
+// the same expiring grant does not double-count (the second call skips the
+// standing unread notification and returns {warnings:0, criticals:0}).
+func TestRoleExpiryCheck_Idempotent(t *testing.T) {
+	env := newRoleExpiryEnv(t)
+	expiresAt := time.Now().Add(3 * 24 * time.Hour)
+	seedExpiringRole(t, env, expiresAt)
+
+	// First call — creates the notification.
+	code1, data1 := postRoleExpiryCheck(t, env, "Bearer "+env.token)
+	require.Equal(t, http.StatusOK, code1)
+	assert.EqualValues(t, 1, data1["warnings"])
+
+	// Second call — the standing unread notification deduplicates, so no new ones.
+	code2, data2 := postRoleExpiryCheck(t, env, "Bearer "+env.token)
+	require.Equal(t, http.StatusOK, code2)
+	assert.EqualValues(t, 0, data2["warnings"], "second call must not re-notify the same grant")
+	assert.EqualValues(t, 0, data2["criticals"])
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1777,6 +1777,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Post("/rotation-reminders", adminJobsHandler.RunRotationReminders)
 			r.Post("/expiry-reminders", adminJobsHandler.RunExpiryReminders)
 			r.Post("/compliance-digest", adminJobsHandler.RunComplianceDigest)
+			r.Post("/role-expiry-check", adminJobsHandler.RunRoleExpiryCheck)
 		})
 
 		// Runtime anomaly detection configuration — read/write the DB-persisted


### PR DESCRIPTION
## Summary

- Adds `ListExpiringUserRoles` storage method (WHERE expires_at < threshold)
- `CheckRoleExpiry(ctx)` core logic: emits Warning (7-day window) or Critical (1-day) `Notification` rows; deduplicates against existing unread notifications; escalates severity in-place
- `POST /api/v1/admin/jobs/role-expiry-check` — triggers the check, returns `{warnings: N, criticals: N}`
- CLI: `keyorix system role-expiry-check`

## Test plan

- [ ] 6 handler integration tests (no expiring, 3-day warning, 12h critical, already-expired skip, unauthed, idempotent dedup)
- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)