### PR TITLE
feat(secret): ownership history — audit trail of ownership transfers

### DIFF
--- a/internal/cli/secret/ownership_history.go
+++ b/internal/cli/secret/ownership_history.go
@@ -1,0 +1,70 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var ownershipHistoryID uint
+
+// ownershipRecord mirrors a GET /secrets/{id}/ownership-history entry.
+type ownershipRecord struct {
+	EventID     uint   `json:"event_id"`
+	FromID      uint   `json:"from_id"`
+	ToID        uint   `json:"to_id"`
+	ChangedBy   uint   `json:"changed_by"`
+	ChangedAt   string `json:"changed_at"`
+	Description string `json:"description"`
+}
+
+var ownershipHistoryCmd = &cobra.Command{
+	Use:   "ownership-history",
+	Short: "Show a secret's ownership-transfer chain",
+	Long: `List all ownership transfers for a secret in chronological order. Each record
+shows who the secret was transferred from, who it was transferred to, who performed
+the transfer, and when. Requires secrets.read at the secret's scope.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if ownershipHistoryID == 0 {
+			return fmt.Errorf("--id is required")
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		records, err := fetchOwnershipHistory(context.Background(), c, ownershipHistoryID)
+		if err != nil {
+			return err
+		}
+		if len(records) == 0 {
+			fmt.Println("No ownership transfers recorded.")
+			return nil
+		}
+		fmt.Printf("%-10s %-10s %-10s %-10s %s\n", "EVENT ID", "FROM", "TO", "BY", "TIME")
+		for _, r := range records {
+			fmt.Printf("%-10d %-10d %-10d %-10d %s\n",
+				r.EventID, r.FromID, r.ToID, r.ChangedBy, r.ChangedAt)
+		}
+		return nil
+	},
+}
+
+// fetchOwnershipHistory GETs the ownership-transfer chain (split out for httptest tests).
+func fetchOwnershipHistory(ctx context.Context, c *common.RemoteClient, id uint) ([]ownershipRecord, error) {
+	var body struct {
+		OwnershipHistory []ownershipRecord `json:"ownership_history"`
+	}
+	if err := c.Get(ctx, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/ownership-history", &body); err != nil {
+		return nil, err
+	}
+	return body.OwnershipHistory, nil
+}
+
+func init() {
+	ownershipHistoryCmd.Flags().UintVar(&ownershipHistoryID, "id", 0, "Secret ID (required)")
+	SecretCmd.AddCommand(ownershipHistoryCmd)
+}

--- a/internal/cli/secret/ownership_history_test.go
+++ b/internal/cli/secret/ownership_history_test.go
@@ -1,0 +1,130 @@
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newOwnershipHistoryClient(t *testing.T, handler http.HandlerFunc) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func setupOwnershipDisconnected(t *testing.T) {
+	t.Helper()
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_CONFIG_PATH", filepath.Join(dir, "nonexistent.yaml"))
+}
+
+func TestFetchOwnershipHistory_Success(t *testing.T) {
+	rc, done := newOwnershipHistoryClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/secrets/42/ownership-history", r.URL.Path)
+		_, _ = w.Write([]byte(`{"data":{"ownership_history":[
+			{"event_id":1,"from_id":10,"to_id":20,"changed_by":5,"changed_at":"2026-01-01T00:00:00Z","description":"transferred to ops"},
+			{"event_id":2,"from_id":20,"to_id":30,"changed_by":5,"changed_at":"2026-02-01T00:00:00Z","description":"transferred to security"}
+		]}}`))
+	})
+	defer done()
+
+	records, err := fetchOwnershipHistory(context.Background(), rc, 42)
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	assert.Equal(t, uint(1), records[0].EventID)
+	assert.Equal(t, uint(10), records[0].FromID)
+	assert.Equal(t, uint(20), records[0].ToID)
+	assert.Equal(t, uint(30), records[1].ToID)
+}
+
+func TestFetchOwnershipHistory_Empty(t *testing.T) {
+	rc, done := newOwnershipHistoryClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"ownership_history":[]}}`))
+	})
+	defer done()
+
+	records, err := fetchOwnershipHistory(context.Background(), rc, 5)
+	require.NoError(t, err)
+	assert.Empty(t, records)
+}
+
+func TestFetchOwnershipHistory_ServerError(t *testing.T) {
+	rc, done := newOwnershipHistoryClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+	defer done()
+
+	_, err := fetchOwnershipHistory(context.Background(), rc, 5)
+	require.Error(t, err)
+}
+
+func TestOwnershipHistoryCmd_MissingID(t *testing.T) {
+	orig := ownershipHistoryID
+	defer func() { ownershipHistoryID = orig }()
+	ownershipHistoryID = 0
+
+	err := ownershipHistoryCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id is required")
+}
+
+func TestOwnershipHistoryCmd_NotConnected(t *testing.T) {
+	orig := ownershipHistoryID
+	defer func() { ownershipHistoryID = orig }()
+	ownershipHistoryID = 1
+
+	setupOwnershipDisconnected(t)
+
+	err := ownershipHistoryCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestOwnershipHistoryCmd_PrintsTable(t *testing.T) {
+	orig := ownershipHistoryID
+	defer func() { ownershipHistoryID = orig }()
+	ownershipHistoryID = 42
+
+	_, done := newOwnershipHistoryClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"ownership_history":[
+			{"event_id":1,"from_id":10,"to_id":20,"changed_by":5,"changed_at":"2026-01-01T00:00:00Z","description":"test transfer"}
+		]}}`))
+	})
+	defer done()
+
+	out := captureStdout(t, func() {
+		require.NoError(t, ownershipHistoryCmd.RunE(nil, nil))
+	})
+	assert.Contains(t, out, "EVENT ID")
+	assert.Contains(t, out, "FROM")
+}
+
+func TestOwnershipHistoryCmd_EmptyPrintsMessage(t *testing.T) {
+	orig := ownershipHistoryID
+	defer func() { ownershipHistoryID = orig }()
+	ownershipHistoryID = 99
+
+	_, done := newOwnershipHistoryClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"ownership_history":[]}}`))
+	})
+	defer done()
+
+	out := captureStdout(t, func() {
+		require.NoError(t, ownershipHistoryCmd.RunE(nil, nil))
+	})
+	assert.Contains(t, out, "No ownership transfers")
+}

--- a/internal/core/secret_ownership_history.go
+++ b/internal/core/secret_ownership_history.go
@@ -65,8 +65,8 @@ func (c *KeyorixCore) GetSecretOwnershipHistory(ctx context.Context, secretID, a
 		}
 		// Parse "from user X to user Y" from the description.
 		if m := ownershipDescRe.FindStringSubmatch(e.Description); len(m) == 3 {
-			fromID, err1 := strconv.ParseUint(m[1], 10, 64)
-			toID, err2 := strconv.ParseUint(m[2], 10, 64)
+			fromID, err1 := strconv.ParseUint(m[1], 10, 32)
+			toID, err2 := strconv.ParseUint(m[2], 10, 32)
 			if err1 == nil && err2 == nil {
 				rec.FromID = uint(fromID)
 				rec.ToID = uint(toID)

--- a/internal/core/secret_ownership_history.go
+++ b/internal/core/secret_ownership_history.go
@@ -1,0 +1,78 @@
+// secret_ownership_history.go — per-secret ownership-transfer chain, derived from
+// existing audit_events rows (event_type = "secret.owner_transferred"). No new DB
+// table: the data already lives in the audit log written by transferOwnership.
+package core
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+// OwnershipRecord is one link in a secret's ownership-transfer chain.
+type OwnershipRecord struct {
+	EventID   uint      `json:"event_id"`
+	FromID    uint      `json:"from_id"`    // previous owner user ID
+	ToID      uint      `json:"to_id"`      // new owner user ID
+	ChangedBy uint      `json:"changed_by"` // actor who performed the transfer (UserID on the audit row)
+	ChangedAt time.Time `json:"changed_at"`
+	// Description is the full human-readable audit description, preserved as-is for
+	// consumers that want more context than the parsed IDs alone.
+	Description string `json:"description"`
+}
+
+// ownershipDescRe parses the description written by transferOwnership:
+//
+//	transferred ownership of secret "NAME" from user OLD_ID to user NEW_ID
+var ownershipDescRe = regexp.MustCompile(`from user (\d+) to user (\d+)`)
+
+// GetSecretOwnershipHistory returns the chain of ownership transfers for secretID
+// in chronological order (oldest first), derived from AuditEvent rows where
+// EventType == EventSecretOwnerTransferred. The actor must be able to read the
+// secret. An empty slice (not an error) is returned when no transfers have
+// occurred yet.
+func (c *KeyorixCore) GetSecretOwnershipHistory(ctx context.Context, secretID, actorID uint) ([]OwnershipRecord, error) {
+	if _, err := c.EnforceSecretReadPermission(ctx, secretID, actorID); err != nil {
+		return nil, err
+	}
+
+	action := EventSecretOwnerTransferred
+	// Ascending = true so results are ordered oldest-first (chronological chain).
+	events, _, err := c.storage.GetAuditLogs(ctx, &storage.AuditFilter{
+		SecretID:  &secretID,
+		Action:    &action,
+		Ascending: true,
+		PageSize:  500,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+
+	records := make([]OwnershipRecord, 0, len(events))
+	for _, e := range events {
+		rec := OwnershipRecord{
+			EventID:     e.ID,
+			ChangedAt:   e.EventTime,
+			Description: e.Description,
+		}
+		if e.UserID != nil {
+			rec.ChangedBy = *e.UserID
+		}
+		// Parse "from user X to user Y" from the description.
+		if m := ownershipDescRe.FindStringSubmatch(e.Description); len(m) == 3 {
+			fromID, err1 := strconv.ParseUint(m[1], 10, 64)
+			toID, err2 := strconv.ParseUint(m[2], 10, 64)
+			if err1 == nil && err2 == nil {
+				rec.FromID = uint(fromID)
+				rec.ToID = uint(toID)
+			}
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}

--- a/internal/core/secret_ownership_history_test.go
+++ b/internal/core/secret_ownership_history_test.go
@@ -1,0 +1,167 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	stg "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newOwnershipCore(store *MockStorage) *KeyorixCore {
+	fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	return &KeyorixCore{storage: store, now: func() time.Time { return fixed }}
+}
+
+// setupOwnerPermission makes secretID owned by actorID so EnforceSecretReadPermission passes.
+func setupOwnerPermission(store *MockStorage, ctx context.Context, secretID, actorID uint) {
+	store.On("GetSecret", ctx, secretID).
+		Return(&models.SecretNode{ID: secretID, OwnerID: actorID}, nil)
+}
+
+func TestGetSecretOwnershipHistory_Empty(t *testing.T) {
+	store := new(MockStorage)
+	c := newOwnershipCore(store)
+	ctx := context.Background()
+
+	setupOwnerPermission(store, ctx, 100, 42)
+	store.On("GetAuditLogs", ctx, mock.AnythingOfType("*storage.AuditFilter")).
+		Return([]*models.AuditEvent{}, int64(0), nil)
+
+	records, err := c.GetSecretOwnershipHistory(ctx, 100, 42)
+	require.NoError(t, err)
+	assert.Empty(t, records)
+}
+
+func TestGetSecretOwnershipHistory_ParsesOwnershipDescription(t *testing.T) {
+	store := new(MockStorage)
+	c := newOwnershipCore(store)
+	ctx := context.Background()
+
+	actor := uint(42)
+	ts := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+
+	setupOwnerPermission(store, ctx, 100, actor)
+	store.On("GetAuditLogs", ctx, mock.AnythingOfType("*storage.AuditFilter")).
+		Return([]*models.AuditEvent{
+			{
+				ID:          7,
+				EventTime:   ts,
+				UserID:      &actor,
+				Description: `transferred ownership of secret "alpha" from user 5 to user 10`,
+			},
+		}, int64(1), nil)
+
+	records, err := c.GetSecretOwnershipHistory(ctx, 100, actor)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	rec := records[0]
+	assert.Equal(t, uint(7), rec.EventID)
+	assert.Equal(t, ts, rec.ChangedAt)
+	assert.Equal(t, actor, rec.ChangedBy)
+	assert.Equal(t, uint(5), rec.FromID)
+	assert.Equal(t, uint(10), rec.ToID)
+}
+
+func TestGetSecretOwnershipHistory_InvalidDescriptionKeepsZeroIDs(t *testing.T) {
+	store := new(MockStorage)
+	c := newOwnershipCore(store)
+	ctx := context.Background()
+
+	actor := uint(42)
+	setupOwnerPermission(store, ctx, 100, actor)
+	store.On("GetAuditLogs", ctx, mock.AnythingOfType("*storage.AuditFilter")).
+		Return([]*models.AuditEvent{
+			{
+				ID:          8,
+				EventTime:   time.Now(),
+				Description: "some legacy event without from/to pattern",
+			},
+		}, int64(1), nil)
+
+	records, err := c.GetSecretOwnershipHistory(ctx, 100, actor)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, uint(0), records[0].FromID)
+	assert.Equal(t, uint(0), records[0].ToID)
+}
+
+func TestGetSecretOwnershipHistory_MultipleRecordsPreserveOrder(t *testing.T) {
+	store := new(MockStorage)
+	c := newOwnershipCore(store)
+	ctx := context.Background()
+
+	actor := uint(42)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	setupOwnerPermission(store, ctx, 100, actor)
+	store.On("GetAuditLogs", ctx, mock.AnythingOfType("*storage.AuditFilter")).
+		Return([]*models.AuditEvent{
+			{ID: 1, EventTime: t1, Description: `transferred ownership of secret "x" from user 1 to user 2`},
+			{ID: 2, EventTime: t2, Description: `transferred ownership of secret "x" from user 2 to user 3`},
+		}, int64(2), nil)
+
+	records, err := c.GetSecretOwnershipHistory(ctx, 100, actor)
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	assert.Equal(t, uint(1), records[0].EventID)
+	assert.Equal(t, uint(2), records[1].EventID)
+}
+
+func TestGetSecretOwnershipHistory_PermissionDenied(t *testing.T) {
+	store := new(MockStorage)
+	c := newOwnershipCore(store)
+	ctx := context.Background()
+
+	// GetSecret returns secret owned by user 99, not actorID 42.
+	store.On("GetSecret", ctx, uint(100)).
+		Return(&models.SecretNode{ID: 100, OwnerID: 99}, nil)
+	// CheckSecretPermission also checks shares when not the owner.
+	store.On("ListSharesBySecret", ctx, uint(100)).
+		Return([]*models.ShareRecord{}, nil)
+	// CheckGroupPermissions → GetUserGroups needed.
+	store.On("GetUserGroups", ctx, uint(42)).Return([]*models.Group{}, nil)
+
+	_, err := c.GetSecretOwnershipHistory(ctx, 100, 42)
+	require.Error(t, err)
+}
+
+func TestGetSecretOwnershipHistory_AuditLogsError(t *testing.T) {
+	store := new(MockStorage)
+	c := newOwnershipCore(store)
+	ctx := context.Background()
+
+	setupOwnerPermission(store, ctx, 100, 42)
+	store.On("GetAuditLogs", ctx, mock.AnythingOfType("*storage.AuditFilter")).
+		Return(nil, int64(0), errors.New("db error"))
+
+	_, err := c.GetSecretOwnershipHistory(ctx, 100, 42)
+	require.Error(t, err)
+}
+
+// Ensure the filter produced by GetSecretOwnershipHistory uses the correct action type.
+func TestGetSecretOwnershipHistory_FilterUsesOwnerTransferredAction(t *testing.T) {
+	store := new(MockStorage)
+	c := newOwnershipCore(store)
+	ctx := context.Background()
+
+	setupOwnerPermission(store, ctx, 100, 42)
+
+	capturedAction := ""
+	store.On("GetAuditLogs", ctx, mock.MatchedBy(func(f *stg.AuditFilter) bool {
+		if f != nil && f.Action != nil {
+			capturedAction = *f.Action
+		}
+		return true
+	})).Return([]*models.AuditEvent{}, int64(0), nil)
+
+	_, err := c.GetSecretOwnershipHistory(ctx, 100, 42)
+	require.NoError(t, err)
+	assert.Equal(t, EventSecretOwnerTransferred, capturedAction)
+}

--- a/server/http/handlers/secret_ownership_history.go
+++ b/server/http/handlers/secret_ownership_history.go
@@ -1,0 +1,48 @@
+// secret_ownership_history.go — OwnershipHistory handler: the chain of ownership
+// transfers for a single secret, derived from the audit log.
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// OwnershipHistory handles GET /api/v1/secrets/{id}/ownership-history — the ordered
+// list of ownership transfers for a secret (oldest first). Requires secrets.read at
+// the secret's scope; core re-checks read access. Returns an empty array when no
+// transfers have occurred.
+func (h *SecretHandler) OwnershipHistory(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "BadRequest", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	records, err := h.coreService.GetSecretOwnershipHistory(r.Context(), uint(id), userCtx.UserID)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "not found"):
+			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
+		case strings.Contains(err.Error(), "permission") || strings.Contains(err.Error(), "not authorized"):
+			h.sendError(w, "Forbidden", "Not authorized to view this secret's ownership history", http.StatusForbidden, nil)
+		default:
+			h.sendError(w, "InternalError", "Failed to retrieve ownership history", http.StatusInternalServerError, nil)
+		}
+		return
+	}
+
+	if records == nil {
+		records = []core.OwnershipRecord{}
+	}
+	h.sendSuccess(w, map[string]interface{}{"ownership_history": records, "total": len(records)}, "")
+}

--- a/server/http/handlers/secret_ownership_history_test.go
+++ b/server/http/handlers/secret_ownership_history_test.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOwnershipHistory_Unauthorized(t *testing.T) {
+	h, err := NewSecretHandler(freshCoreS12(t))
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	h.OwnershipHistory(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestOwnershipHistory_InvalidID(t *testing.T) {
+	h, err := NewSecretHandler(freshCoreS12(t))
+	require.NoError(t, err)
+	r := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "notanid"))
+	w := httptest.NewRecorder()
+	h.OwnershipHistory(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestOwnershipHistory_NotFound(t *testing.T) {
+	h, err := NewSecretHandler(freshCoreS12(t))
+	require.NoError(t, err)
+	r := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "99999"))
+	w := httptest.NewRecorder()
+	h.OwnershipHistory(w, r)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/server/http/handlers/secret_ownership_history_test.go
+++ b/server/http/handlers/secret_ownership_history_test.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,4 +35,22 @@ func TestOwnershipHistory_NotFound(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.OwnershipHistory(w, r)
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestOwnershipHistory_EmptyHistory(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+
+	secret := &models.SecretNode{
+		Name:    "test-secret",
+		OwnerID: 1, // matches withUserCtx's UserID
+		IsSecret: true,
+	}
+	require.NoError(t, db.Create(secret).Error)
+
+	r := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", fmt.Sprintf("%d", secret.ID)))
+	w := httptest.NewRecorder()
+	h.OwnershipHistory(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
 }

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -530,6 +530,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// Per-secret read statistics — lifetime total + recent-window summary.
 			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/stats", secretHandler.GetSecretAccessStats)
 			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/audit", secretHandler.AuditTrail)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/ownership-history", secretHandler.OwnershipHistory)
 			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/tags", secretHandler.GetTags)
 			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Put("/{id}/tags", secretHandler.SetTags)
 

--- a/server/http/secret_ownership_history_handler_test.go
+++ b/server/http/secret_ownership_history_handler_test.go
@@ -1,0 +1,253 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedSecretForOwnershipTest creates a secret via the HTTP API and returns its ID.
+func seedSecretForOwnershipTest(t *testing.T, client *http.Client, baseURL, token, name string) uint {
+	t.Helper()
+	body, err := json.Marshal(map[string]interface{}{
+		"name": name, "value": "v", "project_id": 1, "environment_id": 1, "type": "password",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequest("POST", baseURL+"/api/v1/secrets", bytes.NewBuffer(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	var out map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	data := out["data"].(map[string]interface{})
+	return uint(data["ID"].(float64))
+}
+
+// ownershipHistoryResponse is the decoded response shape for the
+// GET /api/v1/secrets/{id}/ownership-history endpoint.
+type ownershipHistoryResponse struct {
+	Success          bool `json:"success"`
+	Data             struct {
+		OwnershipHistory []map[string]interface{} `json:"ownership_history"`
+		Total            float64                  `json:"total"`
+	} `json:"data"`
+}
+
+// doOwnershipHistoryRequest issues a GET ownership-history request and decodes the body.
+func doOwnershipHistoryRequest(t *testing.T, client *http.Client, baseURL, token string, secretID uint) (*http.Response, ownershipHistoryResponse) {
+	t.Helper()
+	url := fmt.Sprintf("%s/api/v1/secrets/%d/ownership-history", baseURL, secretID)
+	req, err := http.NewRequest("GET", url, nil)
+	require.NoError(t, err)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	var body ownershipHistoryResponse
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	_ = resp.Body.Close()
+	return resp, body
+}
+
+// grantViewerRoleAtProject assigns the "viewer" role to userID at project 1 so
+// they satisfy secrets.read for transfer eligibility.
+func grantViewerRoleAtProject(t *testing.T, c *core.KeyorixCore, userID uint) {
+	t.Helper()
+	ctx := context.Background()
+	role, err := c.Storage().GetRoleByName(ctx, "viewer")
+	require.NoError(t, err)
+	require.NoError(t, c.Storage().AssignRole(ctx, userID, role.ID, core.Scope{ProjectID: 1}))
+}
+
+// TestOwnershipHistory_NoTransfers verifies GET /secrets/{id}/ownership-history
+// returns 200 with an empty list when the secret has never changed owners.
+func TestOwnershipHistory_NoTransfers(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	secretID := seedSecretForOwnershipTest(t, client, srv.URL, token, "no-transfer-secret")
+
+	resp, body := doOwnershipHistoryRequest(t, client, srv.URL, token, secretID)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, body.Success)
+	assert.Equal(t, float64(0), body.Data.Total)
+	assert.Empty(t, body.Data.OwnershipHistory)
+}
+
+// TestOwnershipHistory_OneTransfer verifies GET /secrets/{id}/ownership-history
+// returns 200 with exactly one record after a single ownership transfer.
+func TestOwnershipHistory_OneTransfer(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	ctx := context.Background()
+	secretID := seedSecretForOwnershipTest(t, client, srv.URL, token, "one-transfer-secret")
+
+	// Create a second user and give them project-scoped secrets.read so they are a
+	// valid transfer target.
+	user2, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "transferee", Email: "transferee@example.com", Password: "Transfer99!PassValid",
+	})
+	require.NoError(t, err)
+	grantViewerRoleAtProject(t, c, user2.ID)
+
+	// Resolve admin user ID.
+	admin, err := c.Storage().GetUserByUsername(ctx, "testadmin")
+	require.NoError(t, err)
+
+	// Perform a real ownership transfer via the core (seeds the audit event).
+	_, err = c.TransferSecretOwnership(ctx, secretID, user2.ID, admin.ID)
+	require.NoError(t, err)
+
+	// Log in as user2 (the new owner) to view the history: CheckSecretPermission
+	// only allows the current owner or share recipients, so we must use the new
+	// owner's session to pass the core-layer permission re-check.
+	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "transferee", Password: "Transfer99!PassValid"})
+	require.NoError(t, err)
+	user2Token := sess.SessionToken
+
+	resp, body := doOwnershipHistoryRequest(t, client, srv.URL, user2Token, secretID)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, body.Success)
+	assert.Equal(t, float64(1), body.Data.Total)
+	require.Len(t, body.Data.OwnershipHistory, 1)
+
+	rec := body.Data.OwnershipHistory[0]
+	assert.Equal(t, float64(admin.ID), rec["from_id"])
+	assert.Equal(t, float64(user2.ID), rec["to_id"])
+	assert.Equal(t, float64(admin.ID), rec["changed_by"])
+}
+
+// TestOwnershipHistory_MultipleTransfers verifies that multiple transfers are all
+// returned in chronological order (oldest first).
+func TestOwnershipHistory_MultipleTransfers(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	ctx := context.Background()
+	secretID := seedSecretForOwnershipTest(t, client, srv.URL, token, "multi-transfer-secret")
+
+	// Create two additional users, both with project-scoped read access.
+	user2, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "user2mt", Email: "user2mt@example.com", Password: "Multi99!PassValid1",
+	})
+	require.NoError(t, err)
+	grantViewerRoleAtProject(t, c, user2.ID)
+
+	user3, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "user3mt", Email: "user3mt@example.com", Password: "Multi99!PassValid2",
+	})
+	require.NoError(t, err)
+	grantViewerRoleAtProject(t, c, user3.ID)
+
+	admin, err := c.Storage().GetUserByUsername(ctx, "testadmin")
+	require.NoError(t, err)
+
+	// Transfer 1: admin → user2
+	_, err = c.TransferSecretOwnership(ctx, secretID, user2.ID, admin.ID)
+	require.NoError(t, err)
+
+	// Transfer 2: user2 → user3
+	_, err = c.TransferSecretOwnership(ctx, secretID, user3.ID, user2.ID)
+	require.NoError(t, err)
+
+	// Log in as user3 (the final owner) to view the history.
+	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "user3mt", Password: "Multi99!PassValid2"})
+	require.NoError(t, err)
+	user3Token := sess.SessionToken
+
+	resp, body := doOwnershipHistoryRequest(t, client, srv.URL, user3Token, secretID)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, body.Success)
+	assert.Equal(t, float64(2), body.Data.Total)
+	require.Len(t, body.Data.OwnershipHistory, 2)
+
+	// First record: admin → user2
+	rec0 := body.Data.OwnershipHistory[0]
+	assert.Equal(t, float64(admin.ID), rec0["from_id"])
+	assert.Equal(t, float64(user2.ID), rec0["to_id"])
+
+	// Second record: user2 → user3
+	rec1 := body.Data.OwnershipHistory[1]
+	assert.Equal(t, float64(user2.ID), rec1["from_id"])
+	assert.Equal(t, float64(user3.ID), rec1["to_id"])
+}
+
+// TestOwnershipHistory_NonExistentSecret verifies that requesting ownership
+// history for a secret that does not exist returns 404.
+func TestOwnershipHistory_NonExistentSecret(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	resp, _ := doOwnershipHistoryRequest(t, client, srv.URL, token, 99999)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// TestOwnershipHistory_Unauthenticated verifies that an unauthenticated request
+// to the ownership-history endpoint returns 401.
+func TestOwnershipHistory_Unauthenticated(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	// Seed a real secret so the ID is valid.
+	secretID := seedSecretForOwnershipTest(t, client, srv.URL, token, "unauth-ownership-secret")
+
+	// Make the request WITHOUT an Authorization header.
+	resp, _ := doOwnershipHistoryRequest(t, client, srv.URL, "" /*no token*/, secretID)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}


### PR DESCRIPTION
## Summary

- `GetSecretOwnershipHistory(ctx, secretID)` queries existing `AuditEvent` rows (event_type `secret.owner_transferred`), no new table
- `GET /api/v1/secrets/{id}/ownership-history` — returns chronological list of `OwnershipRecord{from, to, changed_by, changed_at}`
- CLI: `keyorix secret ownership-history --id N`

## Test plan

- [ ] 5 handler integration tests (no transfers → empty, one transfer, multiple chronological, non-existent → 404, unauthed → 401)
- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)