### PR TITLE
feat(compliance): permission baseline attestation — JSON + CSV export of all user→role→permission edges

### DIFF
--- a/internal/cli/compliance/baseline.go
+++ b/internal/cli/compliance/baseline.go
@@ -1,0 +1,69 @@
+// baseline.go — `keyorix compliance permission-baseline`: download the
+// deployment's full user→role→permission edge list as CSV (default) or JSON.
+// Remote-only: calls GET /api/v1/compliance/permission-baseline[.csv].
+package compliance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	baselineFormat string
+	baselineOutput string
+)
+
+var baselineCmd = &cobra.Command{
+	Use:   "permission-baseline",
+	Short: "Export the permission baseline (every user's effective permissions) as CSV or JSON",
+	Long: `Download the full permission baseline — every user's effective permissions,
+expanded through direct role grants and group membership — for auditor hand-off.
+Outputs CSV by default; use --format json for the JSON form.
+Writes to stdout by default, or to --output FILE.
+Requires audit.read.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+
+		switch baselineFormat {
+		case "json":
+			var raw json.RawMessage
+			if err := c.Get(context.Background(), "/api/v1/compliance/permission-baseline", &raw); err != nil {
+				return err
+			}
+			var pretty bytes.Buffer
+			if err := json.Indent(&pretty, raw, "", "  "); err != nil {
+				pretty.Write(raw)
+			}
+			pretty.WriteByte('\n')
+			if baselineOutput != "" {
+				if err := os.WriteFile(baselineOutput, pretty.Bytes(), 0o600); err != nil {
+					return fmt.Errorf("failed to write %s: %w", baselineOutput, err)
+				}
+				fmt.Printf("Permission baseline JSON written to %s.\n", baselineOutput)
+				return nil
+			}
+			_, _ = os.Stdout.Write(pretty.Bytes())
+			return nil
+		case "csv", "":
+			return emitCSV(c, "/api/v1/compliance/permission-baseline.csv", baselineOutput, "Permission baseline CSV")
+		default:
+			return fmt.Errorf("unknown format %q — use csv or json", baselineFormat)
+		}
+	},
+}
+
+func init() {
+	baselineCmd.Flags().StringVar(&baselineFormat, "format", "csv", "Output format: csv or json")
+	baselineCmd.Flags().StringVar(&baselineOutput, "output", "", "Write the output to a file instead of stdout")
+	ComplianceCmd.AddCommand(baselineCmd)
+}

--- a/internal/cli/compliance/baseline_test.go
+++ b/internal/cli/compliance/baseline_test.go
@@ -1,0 +1,115 @@
+package compliance
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBaselineCmd_CSVToStdout(t *testing.T) {
+	t.Cleanup(func() { baselineFormat = "csv"; baselineOutput = "" })
+	baselineFormat = "csv"
+	baselineOutput = ""
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/compliance/permission-baseline.csv", r.URL.Path)
+		_, _ = w.Write([]byte("user_id,username,role,permission,scope\n1,alice,Admin,secrets.read,global\n"))
+	})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, baselineCmd.RunE(nil, nil))
+	})
+	assert.Contains(t, out, "user_id,username,role,permission,scope")
+	assert.Contains(t, out, "alice")
+}
+
+func TestBaselineCmd_CSVToFile(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "baseline.csv")
+
+	t.Cleanup(func() { baselineFormat = "csv"; baselineOutput = "" })
+	baselineFormat = "csv"
+	baselineOutput = outFile
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/compliance/permission-baseline.csv", r.URL.Path)
+		_, _ = w.Write([]byte("user_id,username,role,permission,scope\n2,bob,Viewer,secrets.read,project:1\n"))
+	})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, baselineCmd.RunE(nil, nil))
+	})
+	assert.Contains(t, out, "baseline.csv")
+
+	data, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "bob")
+}
+
+func TestBaselineCmd_JSONToStdout(t *testing.T) {
+	t.Cleanup(func() { baselineFormat = "csv"; baselineOutput = "" })
+	baselineFormat = "json"
+	baselineOutput = ""
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/compliance/permission-baseline", r.URL.Path)
+		_, _ = w.Write([]byte(`{"data":{"rows":[{"user_id":1,"username":"alice","permission":"secrets.read","scope":"global"}]}}`))
+	})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, baselineCmd.RunE(nil, nil))
+	})
+	assert.Contains(t, out, "alice")
+	assert.Contains(t, out, "secrets.read")
+}
+
+func TestBaselineCmd_JSONToFile(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "baseline.json")
+
+	t.Cleanup(func() { baselineFormat = "csv"; baselineOutput = "" })
+	baselineFormat = "json"
+	baselineOutput = outFile
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"rows":[{"user_id":2,"username":"bob"}]}}`))
+	})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, baselineCmd.RunE(nil, nil))
+	})
+	assert.Contains(t, out, "baseline.json")
+
+	data, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "bob")
+}
+
+func TestBaselineCmd_UnknownFormat(t *testing.T) {
+	t.Cleanup(func() { baselineFormat = "csv"; baselineOutput = "" })
+	baselineFormat = "xml"
+	baselineOutput = ""
+
+	setupRemote(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := baselineCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "xml")
+}
+
+func TestBaselineCmd_NotConnected(t *testing.T) {
+	setupDisconnected(t)
+	t.Cleanup(func() { baselineFormat = "csv"; baselineOutput = "" })
+	baselineFormat = "csv"
+	baselineOutput = ""
+
+	err := baselineCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1596,11 +1596,16 @@ func (m *MockStorage) GetPermission(_ context.Context, id uint) (*models.Permiss
 }
 
 func (m *MockStorage) GetRolePermissions(ctx context.Context, roleID uint) ([]*models.Permission, error) {
-	args := m.Called(ctx, roleID)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
+	for _, c := range m.ExpectedCalls {
+		if c.Method == "GetRolePermissions" {
+			args := m.Called(ctx, roleID)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).([]*models.Permission), args.Error(1)
+		}
 	}
-	return args.Get(0).([]*models.Permission), args.Error(1)
+	return nil, nil
 }
 
 func (m *MockStorage) RemovePermissionFromRole(_ context.Context, _, _ uint) error {
@@ -1625,11 +1630,16 @@ func (m *MockStorage) DeleteConnectRefGrant(_ context.Context, _ uint) error {
 // Group-Role assignments
 
 func (m *MockStorage) GetGroupRoles(ctx context.Context, groupID uint) ([]*models.Role, error) {
-	args := m.Called(ctx, groupID)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
+	for _, c := range m.ExpectedCalls {
+		if c.Method == "GetGroupRoles" {
+			args := m.Called(ctx, groupID)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).([]*models.Role), args.Error(1)
+		}
 	}
-	return args.Get(0).([]*models.Role), args.Error(1)
+	return nil, nil
 }
 
 func (m *MockStorage) GetGroupRoleGrants(_ context.Context, _ uint) ([]*storage.GroupRoleGrant, error) {
@@ -2066,11 +2076,16 @@ func (m *MockStorage) ConsumeWebAuthnSession(_ context.Context, _ string, _ time
 }
 
 func (m *MockStorage) ListAllUserRoleGrants(ctx context.Context) ([]*models.UserRole, error) {
-	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
+	for _, c := range m.ExpectedCalls {
+		if c.Method == "ListAllUserRoleGrants" {
+			args := m.Called(ctx)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).([]*models.UserRole), args.Error(1)
+		}
 	}
-	return args.Get(0).([]*models.UserRole), args.Error(1)
+	return nil, nil
 }
 
 // Per-secret / per-folder ACL stubs (ADR-058).

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1595,8 +1595,12 @@ func (m *MockStorage) GetPermission(_ context.Context, id uint) (*models.Permiss
 	return &models.Permission{ID: id}, nil
 }
 
-func (m *MockStorage) GetRolePermissions(_ context.Context, _ uint) ([]*models.Permission, error) {
-	return nil, nil
+func (m *MockStorage) GetRolePermissions(ctx context.Context, roleID uint) ([]*models.Permission, error) {
+	args := m.Called(ctx, roleID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.Permission), args.Error(1)
 }
 
 func (m *MockStorage) RemovePermissionFromRole(_ context.Context, _, _ uint) error {
@@ -1620,8 +1624,12 @@ func (m *MockStorage) DeleteConnectRefGrant(_ context.Context, _ uint) error {
 
 // Group-Role assignments
 
-func (m *MockStorage) GetGroupRoles(_ context.Context, _ uint) ([]*models.Role, error) {
-	return nil, nil
+func (m *MockStorage) GetGroupRoles(ctx context.Context, groupID uint) ([]*models.Role, error) {
+	args := m.Called(ctx, groupID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.Role), args.Error(1)
 }
 
 func (m *MockStorage) GetGroupRoleGrants(_ context.Context, _ uint) ([]*storage.GroupRoleGrant, error) {
@@ -2057,8 +2065,12 @@ func (m *MockStorage) ConsumeWebAuthnSession(_ context.Context, _ string, _ time
 	return nil, nil
 }
 
-func (m *MockStorage) ListAllUserRoleGrants(_ context.Context) ([]*models.UserRole, error) {
-	return nil, nil
+func (m *MockStorage) ListAllUserRoleGrants(ctx context.Context) ([]*models.UserRole, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.UserRole), args.Error(1)
 }
 
 // Per-secret / per-folder ACL stubs (ADR-058).

--- a/internal/core/permission_baseline.go
+++ b/internal/core/permission_baseline.go
@@ -1,0 +1,174 @@
+// permission_baseline.go — GetPermissionBaseline: export every user's effective
+// permissions (through roles + group membership) as a flat edge list.
+// Used for auditor hand-off (CSV / JSON) via the compliance endpoints.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// PermissionBaselineRow is one user→role→permission edge in the deployment,
+// annotated with the scope at which the role was granted.
+type PermissionBaselineRow struct {
+	UserID     uint   `json:"user_id"`
+	Username   string `json:"username"`
+	Email      string `json:"email"`
+	RoleName   string `json:"role_name"`
+	Scope      string `json:"scope"` // "global" or "project:<id>"
+	Permission string `json:"permission"`
+}
+
+// PermissionBaseline is the full permission edge list for the deployment.
+type PermissionBaseline struct {
+	GeneratedAt time.Time               `json:"generated_at"`
+	Rows        []PermissionBaselineRow `json:"rows"`
+}
+
+// GetPermissionBaseline returns every user→role→permission edge in the system,
+// expanding through both direct UserRole grants and GroupRole grants (via
+// UserGroup→Group→GroupRole). Each distinct (user, role, scope, permission)
+// tuple becomes one PermissionBaselineRow. Expired grants are included (snapshot
+// of all grants, including time-bound ones) so the auditor sees the full history;
+// callers that need only live grants should filter by expiry themselves.
+func (k *KeyorixCore) GetPermissionBaseline(ctx context.Context) (*PermissionBaseline, error) {
+	// 1. Load all users (no filter — we want every principal).
+	users, _, err := k.storage.ListUsers(ctx, &storage.UserFilter{PageSize: 100000})
+	if err != nil {
+		return nil, fmt.Errorf("permission baseline: list users: %w", err)
+	}
+
+	// 2. Load all role grants in one shot (user_roles table).
+	allGrants, err := k.storage.ListAllUserRoleGrants(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("permission baseline: list user role grants: %w", err)
+	}
+
+	// Build quick lookup maps.
+	userByID := make(map[uint]*userBaseline, len(users))
+	for _, u := range users {
+		userByID[u.ID] = &userBaseline{username: u.Username, email: u.Email}
+	}
+
+	// rolePermCache: roleID → []permissionName (populated on first access).
+	rolePermCache := make(map[uint][]string)
+	rolePermLookup := func(roleID uint) ([]string, error) {
+		if perms, ok := rolePermCache[roleID]; ok {
+			return perms, nil
+		}
+		perms, err := k.storage.GetRolePermissions(ctx, roleID)
+		if err != nil {
+			return nil, err
+		}
+		names := make([]string, 0, len(perms))
+		for _, p := range perms {
+			names = append(names, p.Name)
+		}
+		rolePermCache[roleID] = names
+		return names, nil
+	}
+
+	// roleNameCache: roleID → roleName.
+	roleNameCache := make(map[uint]string)
+	roleNameLookup := func(roleID uint) (string, error) {
+		if name, ok := roleNameCache[roleID]; ok {
+			return name, nil
+		}
+		role, err := k.storage.GetRole(ctx, roleID)
+		if err != nil {
+			return "", err
+		}
+		roleNameCache[roleID] = role.Name
+		return role.Name, nil
+	}
+
+	var rows []PermissionBaselineRow
+
+	// 3. Direct user→role grants.
+	for _, grant := range allGrants {
+		u, ok := userByID[grant.UserID]
+		if !ok {
+			continue // skip if the user row is gone (soft-deleted outside the window)
+		}
+		roleName, err := roleNameLookup(grant.RoleID)
+		if err != nil {
+			return nil, fmt.Errorf("permission baseline: get role %d: %w", grant.RoleID, err)
+		}
+		perms, err := rolePermLookup(grant.RoleID)
+		if err != nil {
+			return nil, fmt.Errorf("permission baseline: get permissions for role %d: %w", grant.RoleID, err)
+		}
+		scope := scopeLabel(grant.ProjectID)
+		for _, perm := range perms {
+			rows = append(rows, PermissionBaselineRow{
+				UserID:     grant.UserID,
+				Username:   u.username,
+				Email:      u.email,
+				RoleName:   roleName,
+				Scope:      scope,
+				Permission: perm,
+			})
+		}
+	}
+
+	// 4. Group-inherited grants: for each user, enumerate groups → group roles →
+	//    permissions. We iterate over users and call GetUserGroups so the expansion
+	//    is readable and doesn't require a new bulk storage method.
+	for _, u := range users {
+		groups, err := k.storage.GetUserGroups(ctx, u.ID)
+		if err != nil {
+			return nil, fmt.Errorf("permission baseline: get groups for user %d: %w", u.ID, err)
+		}
+		for _, g := range groups {
+			groupRoles, err := k.storage.GetGroupRoles(ctx, g.ID)
+			if err != nil {
+				return nil, fmt.Errorf("permission baseline: get roles for group %d: %w", g.ID, err)
+			}
+			for _, role := range groupRoles {
+				perms, err := rolePermLookup(role.ID)
+				if err != nil {
+					return nil, fmt.Errorf("permission baseline: get permissions for role %d (group %d): %w", role.ID, g.ID, err)
+				}
+				// Group roles don't carry a per-grant scope in GetGroupRoles; for the
+				// baseline we report the group's role as global scope (project_id=0
+				// semantics). Callers needing exact per-scope rows can use
+				// ListGroupRoleAssignments separately.
+				for _, perm := range perms {
+					rows = append(rows, PermissionBaselineRow{
+						UserID:     u.ID,
+						Username:   u.Username,
+						Email:      u.Email,
+						RoleName:   role.Name,
+						Scope:      "global",
+						Permission: perm,
+					})
+				}
+			}
+		}
+	}
+
+	if rows == nil {
+		rows = []PermissionBaselineRow{}
+	}
+	return &PermissionBaseline{
+		GeneratedAt: time.Now().UTC(),
+		Rows:        rows,
+	}, nil
+}
+
+// scopeLabel turns a project_id sentinel into the string form stored in the CSV/JSON.
+func scopeLabel(projectID uint) string {
+	if projectID == 0 {
+		return "global"
+	}
+	return fmt.Sprintf("project:%d", projectID)
+}
+
+// userBaseline is a compact struct for the fields we carry per-user in the builder.
+type userBaseline struct {
+	username string
+	email    string
+}

--- a/internal/core/permission_baseline_test.go
+++ b/internal/core/permission_baseline_test.go
@@ -1,0 +1,190 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	stg "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newBaselineCore(store *MockStorage) *KeyorixCore {
+	return &KeyorixCore{storage: store}
+}
+
+// userFilterPageSize matches any UserFilter with the given PageSize (other fields may be zero).
+func userFilterPageSize(n int) interface{} {
+	return mock.MatchedBy(func(f *stg.UserFilter) bool {
+		return f != nil && f.PageSize == n
+	})
+}
+
+func TestGetPermissionBaseline_Empty(t *testing.T) {
+	store := new(MockStorage)
+	c := newBaselineCore(store)
+	ctx := context.Background()
+
+	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
+		Return([]*models.User{}, int64(0), nil)
+	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{}, nil)
+
+	baseline, err := c.GetPermissionBaseline(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, baseline.Rows)
+}
+
+func TestGetPermissionBaseline_DirectGrant_GlobalScope(t *testing.T) {
+	store := new(MockStorage)
+	c := newBaselineCore(store)
+	ctx := context.Background()
+
+	user := &models.User{ID: 10, Username: "alice", Email: "alice@example.com"}
+	grant := &models.UserRole{UserID: 10, RoleID: 5, ProjectID: 0}
+
+	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
+		Return([]*models.User{user}, int64(1), nil)
+	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{grant}, nil)
+	store.On("GetRole", mock.Anything, uint(5)).Return(&models.Role{ID: 5, Name: "Admin"}, nil)
+	store.On("GetRolePermissions", mock.Anything, uint(5)).
+		Return([]*models.Permission{{Name: "secrets.read"}, {Name: "secrets.write"}}, nil)
+	store.On("GetUserGroups", mock.Anything, uint(10)).Return([]*models.Group{}, nil)
+
+	baseline, err := c.GetPermissionBaseline(ctx)
+	require.NoError(t, err)
+	assert.Len(t, baseline.Rows, 2)
+
+	row := baseline.Rows[0]
+	assert.Equal(t, uint(10), row.UserID)
+	assert.Equal(t, "alice", row.Username)
+	assert.Equal(t, "alice@example.com", row.Email)
+	assert.Equal(t, "Admin", row.RoleName)
+	assert.Equal(t, "global", row.Scope)
+}
+
+func TestGetPermissionBaseline_DirectGrant_ProjectScope(t *testing.T) {
+	store := new(MockStorage)
+	c := newBaselineCore(store)
+	ctx := context.Background()
+
+	user := &models.User{ID: 11, Username: "bob", Email: "bob@example.com"}
+	grant := &models.UserRole{UserID: 11, RoleID: 7, ProjectID: 3}
+
+	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
+		Return([]*models.User{user}, int64(1), nil)
+	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{grant}, nil)
+	store.On("GetRole", mock.Anything, uint(7)).Return(&models.Role{ID: 7, Name: "Viewer"}, nil)
+	store.On("GetRolePermissions", mock.Anything, uint(7)).
+		Return([]*models.Permission{{Name: "secrets.read"}}, nil)
+	store.On("GetUserGroups", mock.Anything, uint(11)).Return([]*models.Group{}, nil)
+
+	baseline, err := c.GetPermissionBaseline(ctx)
+	require.NoError(t, err)
+	require.Len(t, baseline.Rows, 1)
+	assert.Equal(t, "project:3", baseline.Rows[0].Scope)
+}
+
+func TestGetPermissionBaseline_GroupInheritedGrant(t *testing.T) {
+	store := new(MockStorage)
+	c := newBaselineCore(store)
+	ctx := context.Background()
+
+	user := &models.User{ID: 12, Username: "carol", Email: "carol@example.com"}
+	group := &models.Group{ID: 20}
+	role := &models.Role{ID: 9, Name: "Operator"}
+
+	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
+		Return([]*models.User{user}, int64(1), nil)
+	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{}, nil)
+	store.On("GetUserGroups", mock.Anything, uint(12)).Return([]*models.Group{group}, nil)
+	store.On("GetGroupRoles", mock.Anything, uint(20)).Return([]*models.Role{role}, nil)
+	store.On("GetRolePermissions", mock.Anything, uint(9)).
+		Return([]*models.Permission{{Name: "audit.read"}}, nil)
+
+	baseline, err := c.GetPermissionBaseline(ctx)
+	require.NoError(t, err)
+	require.Len(t, baseline.Rows, 1)
+	row := baseline.Rows[0]
+	assert.Equal(t, "carol", row.Username)
+	assert.Equal(t, "Operator", row.RoleName)
+	assert.Equal(t, "global", row.Scope)
+	assert.Equal(t, "audit.read", row.Permission)
+}
+
+func TestGetPermissionBaseline_RolePermissionsCached(t *testing.T) {
+	// Two grants with the same roleID should only call GetRolePermissions once.
+	store := new(MockStorage)
+	c := newBaselineCore(store)
+	ctx := context.Background()
+
+	u1 := &models.User{ID: 13, Username: "dave", Email: "dave@example.com"}
+	u2 := &models.User{ID: 14, Username: "eve", Email: "eve@example.com"}
+	grant1 := &models.UserRole{UserID: 13, RoleID: 5, ProjectID: 0}
+	grant2 := &models.UserRole{UserID: 14, RoleID: 5, ProjectID: 0}
+
+	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
+		Return([]*models.User{u1, u2}, int64(2), nil)
+	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{grant1, grant2}, nil)
+	store.On("GetRole", mock.Anything, uint(5)).Return(&models.Role{ID: 5, Name: "Admin"}, nil)
+	store.On("GetRolePermissions", mock.Anything, uint(5)).
+		Return([]*models.Permission{{Name: "secrets.read"}}, nil)
+	store.On("GetUserGroups", mock.Anything, uint(13)).Return([]*models.Group{}, nil)
+	store.On("GetUserGroups", mock.Anything, uint(14)).Return([]*models.Group{}, nil)
+
+	baseline, err := c.GetPermissionBaseline(ctx)
+	require.NoError(t, err)
+	assert.Len(t, baseline.Rows, 2)
+	// GetRolePermissions should have been called exactly once for the cached role.
+	store.AssertNumberOfCalls(t, "GetRolePermissions", 1)
+}
+
+func TestGetPermissionBaseline_SkipsGrantsForMissingUsers(t *testing.T) {
+	store := new(MockStorage)
+	c := newBaselineCore(store)
+	ctx := context.Background()
+
+	// Grant references userID 99 which is not in the users list (soft-deleted).
+	grant := &models.UserRole{UserID: 99, RoleID: 5, ProjectID: 0}
+
+	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
+		Return([]*models.User{}, int64(0), nil)
+	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{grant}, nil)
+
+	baseline, err := c.GetPermissionBaseline(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, baseline.Rows)
+}
+
+func TestGetPermissionBaseline_ListUsersError(t *testing.T) {
+	store := new(MockStorage)
+	c := newBaselineCore(store)
+	ctx := context.Background()
+
+	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
+		Return(nil, int64(0), errors.New("db error"))
+
+	_, err := c.GetPermissionBaseline(ctx)
+	require.Error(t, err)
+}
+
+func TestGetPermissionBaseline_ListGrantsError(t *testing.T) {
+	store := new(MockStorage)
+	c := newBaselineCore(store)
+	ctx := context.Background()
+
+	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
+		Return([]*models.User{}, int64(0), nil)
+	store.On("ListAllUserRoleGrants", mock.Anything).Return(nil, errors.New("grants error"))
+
+	_, err := c.GetPermissionBaseline(ctx)
+	require.Error(t, err)
+}
+
+func TestScopeLabel(t *testing.T) {
+	assert.Equal(t, "global", scopeLabel(0))
+	assert.Equal(t, "project:7", scopeLabel(7))
+	assert.Equal(t, "project:100", scopeLabel(100))
+}

--- a/server/http/handlers/permission_baseline.go
+++ b/server/http/handlers/permission_baseline.go
@@ -1,0 +1,68 @@
+// permission_baseline.go — HTTP handlers for the permission baseline attestation
+// endpoints. Two routes:
+//
+//	GET /api/v1/compliance/permission-baseline       → JSON PermissionBaseline
+//	GET /api/v1/compliance/permission-baseline.csv   → CSV attachment
+//
+// Both require the audit.read permission (same gate as the other compliance
+// endpoints in this family). The handler lives on DashboardHandler so it has no
+// new struct to register in the router.
+package handlers
+
+import (
+	"encoding/csv"
+	"net/http"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// GetPermissionBaseline handles GET /api/v1/compliance/permission-baseline.
+// Returns the full user→role→permission edge list as JSON.
+func (h *DashboardHandler) GetPermissionBaseline(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	baseline, err := h.coreService.GetPermissionBaseline(r.Context())
+	if err != nil {
+		sendError(w, "InternalError", "Failed to generate permission baseline", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, baseline, "")
+}
+
+// GetPermissionBaselineCSV handles GET /api/v1/compliance/permission-baseline.csv.
+// Returns the same data as a CSV attachment suitable for auditor hand-off.
+func (h *DashboardHandler) GetPermissionBaselineCSV(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	baseline, err := h.coreService.GetPermissionBaseline(r.Context())
+	if err != nil {
+		sendError(w, "InternalError", "Failed to generate permission baseline", http.StatusInternalServerError, nil)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", `attachment; filename="permission-baseline.csv"`)
+
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+
+	_ = cw.Write([]string{"user_id", "username", "email", "role_name", "scope", "permission"})
+	for _, row := range baseline.Rows {
+		_ = cw.Write([]string{
+			strconv.FormatUint(uint64(row.UserID), 10),
+			csvSafe(row.Username),
+			csvSafe(row.Email),
+			csvSafe(row.RoleName),
+			csvSafe(row.Scope),
+			csvSafe(row.Permission),
+		})
+	}
+}

--- a/server/http/handlers/permission_baseline_handler_test.go
+++ b/server/http/handlers/permission_baseline_handler_test.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPermissionBaseline_Unauthorized(t *testing.T) {
+	h := NewDashboardHandler(freshCoreS12(t))
+	w := httptest.NewRecorder()
+	h.GetPermissionBaseline(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestGetPermissionBaseline_EmptyDB(t *testing.T) {
+	h := NewDashboardHandler(freshCoreS12(t))
+	w := httptest.NewRecorder()
+	h.GetPermissionBaseline(w, withUserCtx(httptest.NewRequest(http.MethodGet, "/", nil)))
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestGetPermissionBaselineCSV_Unauthorized(t *testing.T) {
+	h := NewDashboardHandler(freshCoreS12(t))
+	w := httptest.NewRecorder()
+	h.GetPermissionBaselineCSV(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestGetPermissionBaselineCSV_EmptyDB(t *testing.T) {
+	h := NewDashboardHandler(freshCoreS12(t))
+	w := httptest.NewRecorder()
+	h.GetPermissionBaselineCSV(w, withUserCtx(httptest.NewRequest(http.MethodGet, "/", nil)))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/csv")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "permission-baseline.csv")
+	assert.True(t, strings.Contains(w.Body.String(), "user_id"))
+}

--- a/server/http/permission_baseline_handler_test.go
+++ b/server/http/permission_baseline_handler_test.go
@@ -1,0 +1,188 @@
+package http
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newPermBaselineRouter is a convenience helper that boots a fresh core + router
+// for each permission-baseline test.
+func newPermBaselineRouter(t *testing.T) (router http.Handler, token string) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	cfg := &config.Config{}
+	c := newTestCore(t)
+	token = createTestToken(t, c)
+
+	r, err := NewRouter(cfg, c)
+	require.NoError(t, err)
+	return r, token
+}
+
+// TestPermissionBaseline_JSON verifies GET /compliance/permission-baseline returns
+// 200 with a JSON body that contains the admin user's rows.
+func TestPermissionBaseline_JSON(t *testing.T) {
+	router, token := newPermBaselineRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/compliance/permission-baseline", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["success"])
+
+	data, ok := resp["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object in response")
+
+	rows, ok := data["rows"].([]interface{})
+	require.True(t, ok, "expected rows array in data")
+	assert.NotEmpty(t, rows, "admin user should have at least one permission row")
+
+	// Confirm at least one row belongs to "testadmin".
+	found := false
+	for _, r := range rows {
+		row := r.(map[string]interface{})
+		if row["username"] == "testadmin" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "testadmin should appear in the baseline rows")
+}
+
+// TestPermissionBaseline_CSV verifies GET /compliance/permission-baseline.csv returns
+// 200 with Content-Type text/csv and a valid CSV body.
+func TestPermissionBaseline_CSV(t *testing.T) {
+	router, token := newPermBaselineRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/compliance/permission-baseline.csv", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, strings.HasPrefix(w.Header().Get("Content-Type"), "text/csv"),
+		"expected text/csv Content-Type, got %s", w.Header().Get("Content-Type"))
+
+	// Parse CSV and assert it is well-formed.
+	records, err := csv.NewReader(w.Body).ReadAll()
+	require.NoError(t, err, "CSV body must be parseable")
+	assert.NotEmpty(t, records, "CSV must have at least a header row")
+}
+
+// TestPermissionBaseline_CSV_Headers verifies the CSV header row has exactly the
+// required columns in the correct order.
+func TestPermissionBaseline_CSV_Headers(t *testing.T) {
+	router, token := newPermBaselineRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/compliance/permission-baseline.csv", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	records, err := csv.NewReader(w.Body).ReadAll()
+	require.NoError(t, err)
+	require.NotEmpty(t, records, "expected at least a header row")
+
+	wantHeaders := []string{"user_id", "username", "email", "role_name", "scope", "permission"}
+	assert.Equal(t, wantHeaders, records[0], "CSV header must match the spec exactly")
+}
+
+// TestPermissionBaseline_SecondUser verifies that after assigning a role to a second
+// user, both users appear in the baseline.
+func TestPermissionBaseline_SecondUser(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	cfg := &config.Config{}
+	c := newTestCore(t)
+	adminToken := createTestToken(t, c)
+
+	// Create a second user and give them a role.
+	ctx := context.Background()
+	second, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "seconduser",
+		Email:    "second@example.com",
+		Password: "Xk7#Qp2$Rn5@Wv9!",
+	})
+	require.NoError(t, err, "create second user")
+	_ = second // suppress unused variable
+
+	// Assign the "viewer" or "system_admin" role to the second user.
+	// BootstrapSystem seeds roles including "system_admin"; use AssignRoleToUser.
+	_ = c.AssignRoleToUser(ctx, "second@example.com", "system_admin")
+
+	r, err := NewRouter(cfg, c)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/compliance/permission-baseline", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].(map[string]interface{})
+	rows := data["rows"].([]interface{})
+
+	foundAdmin := false
+	foundSecond := false
+	for _, row := range rows {
+		r := row.(map[string]interface{})
+		switch r["username"] {
+		case "testadmin":
+			foundAdmin = true
+		case "seconduser":
+			foundSecond = true
+		}
+	}
+	assert.True(t, foundAdmin, "testadmin should be in baseline")
+	assert.True(t, foundSecond, "seconduser should be in baseline after role assignment")
+}
+
+// TestPermissionBaseline_Unauthenticated verifies that an unauthenticated request
+// receives 401 for both the JSON and CSV endpoints.
+func TestPermissionBaseline_Unauthenticated(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	cfg := &config.Config{}
+	c := newTestCore(t)
+	r, err := NewRouter(cfg, c)
+	require.NoError(t, err)
+
+	for _, path := range []string{
+		"/api/v1/compliance/permission-baseline",
+		"/api/v1/compliance/permission-baseline.csv",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			// No Authorization header.
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusUnauthorized, w.Code, "unauthenticated request must be rejected")
+		})
+	}
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1747,6 +1747,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/compliance/evidence", dashboardHandler.GetComplianceEvidence)
 		// Verify a previously-exported evidence pack against its detached signature.
 		r.With(customMiddleware.RequirePermission(permAuditRead)).Post("/compliance/evidence/verify", dashboardHandler.VerifyComplianceEvidence)
+		// Permission baseline attestation — every user's effective permissions (through
+		// roles + group membership) as JSON or CSV for auditor hand-off. Gated on
+		// audit.read: it discloses the full role/permission topology deployment-wide,
+		// same disclosure family as /compliance/evidence.
+		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/compliance/permission-baseline", dashboardHandler.GetPermissionBaseline)
+		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/compliance/permission-baseline.csv", dashboardHandler.GetPermissionBaselineCSV)
 		// Risk register (ISO A.5.8): list discloses free-text Reference/Justification
 		// (which may itself name a secret) deployment-wide, so reads need audit.read;
 		// create/revoke stay system.write.


### PR DESCRIPTION
## Summary

- `GetPermissionBaseline(ctx)` expands every user's direct + group-inherited role grants into `PermissionBaselineRow{user_id, username, email, role_name, scope, permission}`
- `GET /api/v1/compliance/permission-baseline` — JSON
- `GET /api/v1/compliance/permission-baseline.csv` — CSV download (headers: user_id,username,email,role_name,scope,permission)
- CLI: `keyorix compliance permission-baseline [--format csv|json]`
- Both routes gated on `audit.read`

## Test plan

- [ ] 7 handler integration tests (JSON 200, CSV 200, correct headers, two-user baseline, unauthed JSON 401, unauthed CSV 401)
- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)