### PR TITLE
feat(machine): machine identity audit report — JSON + CSV with stale/revoked analysis

### DIFF
--- a/internal/cli/machine/audit.go
+++ b/internal/cli/machine/audit.go
@@ -1,0 +1,100 @@
+// audit.go — `keyorix machine audit` command: machine identity audit report.
+//
+// Prints a deployment-wide audit report of all machine identities, including
+// credential counts, last-used timestamps, stale status, and revocation status.
+// Requires a remote server connection (audit.read permission).
+package machine
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/spf13/cobra"
+)
+
+var auditFormat string
+
+var auditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Print a machine identity audit report (admin)",
+	Long: `Generate a deployment-wide audit report of all machine identities.
+Each row shows the identity's credential count, last-used timestamp,
+whether it is stale (no activity > 30 days), and its revocation status.
+
+Requires global audit.read permission. Run against a connected server.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		report, err := fetchMachineAuditReport(context.Background(), c)
+		if err != nil {
+			return err
+		}
+		switch auditFormat {
+		case "csv":
+			return printMachineAuditCSV(report)
+		default:
+			return printMachineAuditJSON(report)
+		}
+	},
+}
+
+// fetchMachineAuditReport GETs the audit report from the server.
+func fetchMachineAuditReport(ctx context.Context, c *common.RemoteClient) (*core.MachineAuditReport, error) {
+	var report core.MachineAuditReport
+	if err := c.Get(ctx, "/api/v1/machine-identities/audit", &report); err != nil {
+		return nil, fmt.Errorf("failed to fetch machine audit report: %w", err)
+	}
+	return &report, nil
+}
+
+// printMachineAuditJSON prints the report as indented JSON.
+func printMachineAuditJSON(report *core.MachineAuditReport) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}
+
+// printMachineAuditCSV prints the report in CSV format to stdout.
+func printMachineAuditCSV(report *core.MachineAuditReport) error {
+	cw := csv.NewWriter(os.Stdout)
+	defer cw.Flush()
+	if err := cw.Write([]string{
+		"machine_id", "name", "description",
+		"credential_count", "last_used_at",
+		"is_stale", "is_revoked", "created_at",
+	}); err != nil {
+		return err
+	}
+	for _, m := range report.Machines {
+		lastUsed := ""
+		if m.LastUsedAt != nil {
+			lastUsed = m.LastUsedAt.UTC().Format("2006-01-02T15:04:05Z")
+		}
+		if err := cw.Write([]string{
+			fmt.Sprintf("%d", m.MachineID),
+			m.Name,
+			m.Description,
+			fmt.Sprintf("%d", m.CredentialCount),
+			lastUsed,
+			fmt.Sprintf("%v", m.IsStale),
+			fmt.Sprintf("%v", m.IsRevoked),
+			m.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		}); err != nil {
+			return err
+		}
+	}
+	return cw.Error()
+}
+
+func init() {
+	auditCmd.Flags().StringVar(&auditFormat, "format", "json", "Output format: json or csv")
+	MachineCmd.AddCommand(auditCmd)
+}

--- a/internal/cli/machine/audit_test.go
+++ b/internal/cli/machine/audit_test.go
@@ -1,0 +1,167 @@
+package machine
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureAuditStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	fn()
+	require.NoError(t, w.Close())
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+func newAuditRemoteClient(t *testing.T, handler http.HandlerFunc) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+const machineAuditPayload = `{"data":{
+	"generated_at":"2026-06-05T12:00:00Z",
+	"total_count":2,
+	"stale_count":1,
+	"revoked_count":0,
+	"machines":[
+		{"machine_id":1,"name":"ci-runner","description":"main ci","credential_count":3,"last_used_at":"2026-06-05T12:00:00Z","is_stale":false,"is_revoked":false,"created_at":"2026-01-01T00:00:00Z"},
+		{"machine_id":2,"name":"old-bot","description":"legacy","credential_count":0,"is_stale":true,"is_revoked":false,"created_at":"2025-01-01T00:00:00Z"}
+	]
+}}`
+
+func TestFetchMachineAuditReport(t *testing.T) {
+	rc, done := newAuditRemoteClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/machine-identities/audit", r.URL.Path)
+		_, _ = w.Write([]byte(machineAuditPayload))
+	})
+	defer done()
+
+	report, err := fetchMachineAuditReport(context.Background(), rc)
+	require.NoError(t, err)
+	assert.Equal(t, 2, report.TotalCount)
+	assert.Equal(t, 1, report.StaleCount)
+	assert.Len(t, report.Machines, 2)
+	assert.Equal(t, "ci-runner", report.Machines[0].Name)
+	assert.False(t, report.Machines[0].IsStale)
+	assert.True(t, report.Machines[1].IsStale)
+}
+
+func TestFetchMachineAuditReport_ServerError(t *testing.T) {
+	rc, done := newAuditRemoteClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer done()
+
+	_, err := fetchMachineAuditReport(context.Background(), rc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "machine audit report")
+}
+
+func TestPrintMachineAuditJSON(t *testing.T) {
+	ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	report := &core.MachineAuditReport{
+		TotalCount:   1,
+		StaleCount:   0,
+		RevokedCount: 0,
+		Machines: []core.MachineAuditRow{
+			{MachineID: 1, Name: "runner", CredentialCount: 2, IsStale: false, CreatedAt: ts},
+		},
+	}
+
+	out := captureAuditStdout(t, func() {
+		require.NoError(t, printMachineAuditJSON(report))
+	})
+
+	assert.Contains(t, out, `"total_count": 1`)
+	assert.Contains(t, out, `"name": "runner"`)
+	assert.Contains(t, out, `"credential_count": 2`)
+}
+
+func TestPrintMachineAuditCSV_WithLastUsed(t *testing.T) {
+	ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	lastUsed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	report := &core.MachineAuditReport{
+		Machines: []core.MachineAuditRow{
+			{
+				MachineID:       42,
+				Name:            "ci-runner",
+				Description:     "main ci",
+				CredentialCount: 3,
+				LastUsedAt:      &lastUsed,
+				IsStale:         false,
+				IsRevoked:       false,
+				CreatedAt:       ts,
+			},
+		},
+	}
+
+	out := captureAuditStdout(t, func() {
+		require.NoError(t, printMachineAuditCSV(report))
+	})
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, "machine_id,name,description,credential_count,last_used_at,is_stale,is_revoked,created_at", lines[0])
+	assert.Contains(t, lines[1], "42,ci-runner,main ci,3,2026-06-05T12:00:00Z,false,false,")
+}
+
+func TestPrintMachineAuditCSV_NoLastUsed(t *testing.T) {
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	report := &core.MachineAuditReport{
+		Machines: []core.MachineAuditRow{
+			{
+				MachineID:       7,
+				Name:            "old-bot",
+				CredentialCount: 0,
+				LastUsedAt:      nil,
+				IsStale:         true,
+				CreatedAt:       ts,
+			},
+		},
+	}
+
+	out := captureAuditStdout(t, func() {
+		require.NoError(t, printMachineAuditCSV(report))
+	})
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.Len(t, lines, 2)
+	fields := strings.SplitN(lines[1], ",", 8)
+	assert.Equal(t, "7", fields[0])
+	assert.Equal(t, "", fields[4]) // last_used_at empty when nil
+	assert.Equal(t, "true", fields[5])
+}
+
+func TestPrintMachineAuditCSV_Empty(t *testing.T) {
+	report := &core.MachineAuditReport{Machines: []core.MachineAuditRow{}}
+
+	out := captureAuditStdout(t, func() {
+		require.NoError(t, printMachineAuditCSV(report))
+	})
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.Len(t, lines, 1)
+	assert.Contains(t, lines[0], "machine_id")
+}

--- a/internal/core/machine_audit.go
+++ b/internal/core/machine_audit.go
@@ -1,0 +1,101 @@
+// machine_audit.go — deployment-wide machine identity audit report.
+//
+// GetMachineAuditReport produces a structured summary of every machine identity
+// across all projects: credential count, last-used timestamp (most recent across
+// all credentials), stale status (no activity > 30 days), and revocation status.
+package core
+
+import (
+	"context"
+	"time"
+)
+
+// MachineAuditRow is one row in the machine identity audit report.
+type MachineAuditRow struct {
+	MachineID       uint       `json:"machine_id"`
+	Name            string     `json:"name"`
+	Description     string     `json:"description,omitempty"`
+	CredentialCount int        `json:"credential_count"`
+	LastUsedAt      *time.Time `json:"last_used_at,omitempty"`
+	IsStale         bool       `json:"is_stale"`   // no activity > 30 days
+	IsRevoked       bool       `json:"is_revoked"`
+	CreatedAt       time.Time  `json:"created_at"`
+}
+
+// MachineAuditReport is the top-level machine identity audit report payload.
+type MachineAuditReport struct {
+	GeneratedAt  time.Time         `json:"generated_at"`
+	TotalCount   int               `json:"total_count"`
+	StaleCount   int               `json:"stale_count"`
+	RevokedCount int               `json:"revoked_count"`
+	Machines     []MachineAuditRow `json:"machines"`
+}
+
+const machineAuditStaleDays = 30
+
+// GetMachineAuditReport returns an audit report of all machine identities across
+// the deployment. For each identity it counts credentials (all, not only active),
+// derives LastUsedAt from the most recent credential's LastUsedAt, and marks an
+// identity stale when LastUsedAt is nil OR more than 30 days ago.
+func (c *KeyorixCore) GetMachineAuditReport(ctx context.Context) (*MachineAuditReport, error) {
+	now := c.now()
+	staleThreshold := now.Add(-machineAuditStaleDays * 24 * time.Hour)
+
+	identities, err := c.storage.ListAllMachineIdentities(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := make([]MachineAuditRow, 0, len(identities))
+	staleCount := 0
+	revokedCount := 0
+
+	for _, m := range identities {
+		creds, err := c.storage.ListMachineIdentityCredentials(ctx, m.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		// Derive last-used from the most recent credential LastUsedAt.
+		var lastUsedAt *time.Time
+		for _, cred := range creds {
+			if cred.LastUsedAt == nil {
+				continue
+			}
+			if lastUsedAt == nil || cred.LastUsedAt.After(*lastUsedAt) {
+				t := *cred.LastUsedAt
+				lastUsedAt = &t
+			}
+		}
+
+		// An identity is stale when it has never been used OR its last use predates the threshold.
+		isStale := lastUsedAt == nil || lastUsedAt.Before(staleThreshold)
+		isRevoked := m.State == MachineRevoked
+
+		if isStale {
+			staleCount++
+		}
+		if isRevoked {
+			revokedCount++
+		}
+
+		rows = append(rows, MachineAuditRow{
+			MachineID:       m.ID,
+			Name:            m.Name,
+			Description:     m.Description,
+			CredentialCount: len(creds),
+			LastUsedAt:      lastUsedAt,
+			IsStale:         isStale,
+			IsRevoked:       isRevoked,
+			CreatedAt:       m.CreatedAt,
+		})
+	}
+
+	return &MachineAuditReport{
+		GeneratedAt:  now,
+		TotalCount:   len(rows),
+		StaleCount:   staleCount,
+		RevokedCount: revokedCount,
+		Machines:     rows,
+	}, nil
+}

--- a/internal/core/machine_audit_test.go
+++ b/internal/core/machine_audit_test.go
@@ -1,0 +1,196 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var machineAuditFixed = time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+
+func newMachineAuditCore(store *MockStorage) *KeyorixCore {
+	return &KeyorixCore{storage: store, now: func() time.Time { return machineAuditFixed }}
+}
+
+func TestGetMachineAuditReport_Empty(t *testing.T) {
+	store := new(MockStorage)
+	c := newMachineAuditCore(store)
+	ctx := context.Background()
+
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{}, nil)
+
+	report, err := c.GetMachineAuditReport(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, report.TotalCount)
+	assert.Equal(t, 0, report.StaleCount)
+	assert.Equal(t, 0, report.RevokedCount)
+	assert.Empty(t, report.Machines)
+	assert.Equal(t, machineAuditFixed, report.GeneratedAt)
+}
+
+func TestGetMachineAuditReport_StaleWhenNeverUsed(t *testing.T) {
+	store := new(MockStorage)
+	c := newMachineAuditCore(store)
+	ctx := context.Background()
+
+	m := &models.MachineIdentity{ID: 1, Name: "ci-bot", State: MachineActive}
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{m}, nil)
+	// No credential has ever been used — all LastUsedAt are nil.
+	store.On("ListMachineIdentityCredentials", ctx, uint(1)).
+		Return([]*models.MachineIdentityCredential{{ID: 10, LastUsedAt: nil}}, nil)
+
+	report, err := c.GetMachineAuditReport(ctx)
+	require.NoError(t, err)
+	require.Len(t, report.Machines, 1)
+	row := report.Machines[0]
+	assert.True(t, row.IsStale)
+	assert.Nil(t, row.LastUsedAt)
+	assert.Equal(t, 1, report.StaleCount)
+}
+
+func TestGetMachineAuditReport_StaleWhenLastUsedTooLongAgo(t *testing.T) {
+	store := new(MockStorage)
+	c := newMachineAuditCore(store)
+	ctx := context.Background()
+
+	old := machineAuditFixed.Add(-40 * 24 * time.Hour) // 40 days ago > 30-day threshold
+	m := &models.MachineIdentity{ID: 2, Name: "deploy-bot", State: MachineActive}
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{m}, nil)
+	store.On("ListMachineIdentityCredentials", ctx, uint(2)).
+		Return([]*models.MachineIdentityCredential{{ID: 11, LastUsedAt: &old}}, nil)
+
+	report, err := c.GetMachineAuditReport(ctx)
+	require.NoError(t, err)
+	assert.True(t, report.Machines[0].IsStale)
+	assert.Equal(t, 1, report.StaleCount)
+}
+
+func TestGetMachineAuditReport_NotStaleWhenRecentlyUsed(t *testing.T) {
+	store := new(MockStorage)
+	c := newMachineAuditCore(store)
+	ctx := context.Background()
+
+	recent := machineAuditFixed.Add(-5 * 24 * time.Hour) // 5 days ago — within 30-day window
+	m := &models.MachineIdentity{ID: 3, Name: "api-bot", State: MachineActive}
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{m}, nil)
+	store.On("ListMachineIdentityCredentials", ctx, uint(3)).
+		Return([]*models.MachineIdentityCredential{{ID: 12, LastUsedAt: &recent}}, nil)
+
+	report, err := c.GetMachineAuditReport(ctx)
+	require.NoError(t, err)
+	assert.False(t, report.Machines[0].IsStale)
+	assert.Equal(t, 0, report.StaleCount)
+}
+
+func TestGetMachineAuditReport_LastUsedPicksMostRecent(t *testing.T) {
+	store := new(MockStorage)
+	c := newMachineAuditCore(store)
+	ctx := context.Background()
+
+	older := machineAuditFixed.Add(-10 * 24 * time.Hour)
+	newer := machineAuditFixed.Add(-2 * 24 * time.Hour)
+	m := &models.MachineIdentity{ID: 4, Name: "multi-cred", State: MachineActive}
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{m}, nil)
+	store.On("ListMachineIdentityCredentials", ctx, uint(4)).
+		Return([]*models.MachineIdentityCredential{
+			{ID: 13, LastUsedAt: &older},
+			{ID: 14, LastUsedAt: &newer},
+		}, nil)
+
+	report, err := c.GetMachineAuditReport(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, report.Machines[0].LastUsedAt)
+	assert.Equal(t, newer.UTC(), report.Machines[0].LastUsedAt.UTC())
+}
+
+func TestGetMachineAuditReport_RevokedCounted(t *testing.T) {
+	store := new(MockStorage)
+	c := newMachineAuditCore(store)
+	ctx := context.Background()
+
+	recent := machineAuditFixed.Add(-1 * time.Hour)
+	m := &models.MachineIdentity{ID: 5, Name: "old-bot", State: MachineRevoked}
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{m}, nil)
+	store.On("ListMachineIdentityCredentials", ctx, uint(5)).
+		Return([]*models.MachineIdentityCredential{{ID: 15, LastUsedAt: &recent}}, nil)
+
+	report, err := c.GetMachineAuditReport(ctx)
+	require.NoError(t, err)
+	assert.True(t, report.Machines[0].IsRevoked)
+	assert.Equal(t, 1, report.RevokedCount)
+}
+
+func TestGetMachineAuditReport_CredentialCountIncludesAll(t *testing.T) {
+	store := new(MockStorage)
+	c := newMachineAuditCore(store)
+	ctx := context.Background()
+
+	recent := machineAuditFixed.Add(-1 * time.Hour)
+	m := &models.MachineIdentity{ID: 6, Name: "many-keys", State: MachineActive}
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{m}, nil)
+	store.On("ListMachineIdentityCredentials", ctx, uint(6)).
+		Return([]*models.MachineIdentityCredential{
+			{ID: 20, LastUsedAt: &recent},
+			{ID: 21, LastUsedAt: nil},
+			{ID: 22, LastUsedAt: nil},
+		}, nil)
+
+	report, err := c.GetMachineAuditReport(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 3, report.Machines[0].CredentialCount)
+}
+
+func TestGetMachineAuditReport_ListIdentitiesError(t *testing.T) {
+	store := new(MockStorage)
+	c := newMachineAuditCore(store)
+	ctx := context.Background()
+
+	store.On("ListAllMachineIdentities", ctx).Return(nil, errors.New("db error"))
+
+	_, err := c.GetMachineAuditReport(ctx)
+	require.Error(t, err)
+}
+
+func TestGetMachineAuditReport_ListCredentialsError(t *testing.T) {
+	store := new(MockStorage)
+	c := newMachineAuditCore(store)
+	ctx := context.Background()
+
+	m := &models.MachineIdentity{ID: 7, Name: "broken", State: MachineActive}
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{m}, nil)
+	store.On("ListMachineIdentityCredentials", ctx, uint(7)).Return(nil, errors.New("cred error"))
+
+	_, err := c.GetMachineAuditReport(ctx)
+	require.Error(t, err)
+}
+
+func TestGetMachineAuditReport_RowFieldsPopulated(t *testing.T) {
+	store := new(MockStorage)
+	c := newMachineAuditCore(store)
+	ctx := context.Background()
+
+	created := machineAuditFixed.Add(-90 * 24 * time.Hour)
+	m := &models.MachineIdentity{
+		ID:          8,
+		Name:        "svc-account",
+		Description: "production service account",
+		State:       MachineActive,
+		CreatedAt:   created,
+	}
+	store.On("ListAllMachineIdentities", ctx).Return([]*models.MachineIdentity{m}, nil)
+	store.On("ListMachineIdentityCredentials", ctx, uint(8)).
+		Return([]*models.MachineIdentityCredential{}, nil)
+
+	report, err := c.GetMachineAuditReport(ctx)
+	require.NoError(t, err)
+	row := report.Machines[0]
+	assert.Equal(t, uint(8), row.MachineID)
+	assert.Equal(t, "svc-account", row.Name)
+	assert.Equal(t, "production service account", row.Description)
+	assert.Equal(t, created.UTC(), row.CreatedAt.UTC())
+}

--- a/server/http/handlers/machine_audit.go
+++ b/server/http/handlers/machine_audit.go
@@ -1,0 +1,85 @@
+// machine_audit.go — machine identity audit report endpoints.
+//
+// GET /api/v1/machine-identities/audit      → JSON MachineAuditReport
+// GET /api/v1/machine-identities/audit.csv  → CSV of the same data
+//
+// Both require the global audit.read permission (same calibration as
+// /pat-hygiene and /machine-token-hygiene).
+package handlers
+
+import (
+	"encoding/csv"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// MachineAuditHandler serves the machine identity audit report.
+type MachineAuditHandler struct {
+	coreService *core.KeyorixCore
+}
+
+// NewMachineAuditHandler constructs a MachineAuditHandler.
+func NewMachineAuditHandler(coreService *core.KeyorixCore) *MachineAuditHandler {
+	return &MachineAuditHandler{coreService: coreService}
+}
+
+// GetMachineAuditReport handles GET /api/v1/machine-identities/audit.
+// Returns the full audit report as JSON.
+func (h *MachineAuditHandler) GetMachineAuditReport(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	report, err := h.coreService.GetMachineAuditReport(r.Context())
+	if err != nil {
+		sendError(w, "InternalServerError", "Failed to generate machine audit report", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, report, "")
+}
+
+// GetMachineAuditReportCSV handles GET /api/v1/machine-identities/audit.csv.
+// Returns the audit report as a CSV attachment.
+func (h *MachineAuditHandler) GetMachineAuditReportCSV(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+	report, err := h.coreService.GetMachineAuditReport(r.Context())
+	if err != nil {
+		sendError(w, "InternalServerError", "Failed to generate machine audit report", http.StatusInternalServerError, nil)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", `attachment; filename="machine-audit.csv"`)
+
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+	_ = cw.Write([]string{
+		"machine_id", "name", "description",
+		"credential_count", "last_used_at",
+		"is_stale", "is_revoked", "created_at",
+	})
+	for _, m := range report.Machines {
+		lastUsed := ""
+		if m.LastUsedAt != nil {
+			lastUsed = m.LastUsedAt.UTC().Format(time.RFC3339)
+		}
+		_ = cw.Write([]string{
+			strconv.FormatUint(uint64(m.MachineID), 10),
+			csvSafe(m.Name),
+			csvSafe(m.Description),
+			strconv.Itoa(m.CredentialCount),
+			lastUsed,
+			strconv.FormatBool(m.IsStale),
+			strconv.FormatBool(m.IsRevoked),
+			m.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+}

--- a/server/http/handlers/machine_audit_handler_test.go
+++ b/server/http/handlers/machine_audit_handler_test.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMachineAuditReport_Unauthorized(t *testing.T) {
+	h := NewMachineAuditHandler(freshCoreS12(t))
+	w := httptest.NewRecorder()
+	h.GetMachineAuditReport(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMachineAuditReport_EmptyDB(t *testing.T) {
+	h := NewMachineAuditHandler(freshCoreS12(t))
+	w := httptest.NewRecorder()
+	h.GetMachineAuditReport(w, withUserCtx(httptest.NewRequest(http.MethodGet, "/", nil)))
+	require.Equal(t, http.StatusOK, w.Code)
+	d := decodeData(t, w)
+	assert.EqualValues(t, 0, d["total_count"])
+}
+
+func TestMachineAuditReportCSV_Unauthorized(t *testing.T) {
+	h := NewMachineAuditHandler(freshCoreS12(t))
+	w := httptest.NewRecorder()
+	h.GetMachineAuditReportCSV(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMachineAuditReportCSV_EmptyDB(t *testing.T) {
+	h := NewMachineAuditHandler(freshCoreS12(t))
+	w := httptest.NewRecorder()
+	h.GetMachineAuditReportCSV(w, withUserCtx(httptest.NewRequest(http.MethodGet, "/", nil)))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "machine-audit.csv")
+	assert.Contains(t, w.Body.String(), "machine_id")
+}

--- a/server/http/handlers/machine_audit_handler_test.go
+++ b/server/http/handlers/machine_audit_handler_test.go
@@ -3,8 +3,11 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,4 +42,42 @@ func TestMachineAuditReportCSV_EmptyDB(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Header().Get("Content-Disposition"), "machine-audit.csv")
 	assert.Contains(t, w.Body.String(), "machine_id")
+}
+
+func TestMachineAuditReportCSV_WithMachines(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h := NewMachineAuditHandler(cs)
+
+	now := time.Now().UTC()
+	machine := &models.MachineIdentity{Name: "ci-bot", State: "active"}
+	require.NoError(t, db.Create(machine).Error)
+	cred := &models.MachineIdentityCredential{
+		MachineIdentityID: machine.ID,
+		Name:              "tok1",
+		TokenHash:         "aaabbbccc",
+		LastUsedAt:        &now,
+	}
+	require.NoError(t, db.Create(cred).Error)
+
+	w := httptest.NewRecorder()
+	h.GetMachineAuditReportCSV(w, withUserCtx(httptest.NewRequest(http.MethodGet, "/", nil)))
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "ci-bot")
+	lines := strings.Split(strings.TrimSpace(body), "\n")
+	assert.Len(t, lines, 2) // header + one data row
+}
+
+func TestMachineAuditReport_WithMachines(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h := NewMachineAuditHandler(cs)
+
+	machine := &models.MachineIdentity{Name: "svc-account", State: "active"}
+	require.NoError(t, db.Create(machine).Error)
+
+	w := httptest.NewRecorder()
+	h.GetMachineAuditReport(w, withUserCtx(httptest.NewRequest(http.MethodGet, "/", nil)))
+	require.Equal(t, http.StatusOK, w.Code)
+	d := decodeData(t, w)
+	assert.EqualValues(t, 1, d["total_count"])
 }

--- a/server/http/machine_audit_handler_test.go
+++ b/server/http/machine_audit_handler_test.go
@@ -1,0 +1,194 @@
+// machine_audit_handler_test.go — integration tests for the machine identity audit
+// report endpoints:
+//   - GET /api/v1/machine-identities/audit    (JSON)
+//   - GET /api/v1/machine-identities/audit.csv (CSV)
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initMachineAuditTest initializes i18n and returns a cleanup function.
+func initMachineAuditTest(t *testing.T) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+}
+
+// newMachineAuditServer spins up a full HTTP router backed by the given core.
+func newMachineAuditServer(t *testing.T, c *core.KeyorixCore) *httptest.Server {
+	t.Helper()
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "8080"},
+		},
+	}
+	router, err := NewRouter(cfg, c)
+	require.NoError(t, err)
+	return httptest.NewServer(router)
+}
+
+// authGet issues an authenticated GET request and returns the response.
+func authGetMachineAudit(t *testing.T, srv *httptest.Server, token, path string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+path, nil)
+	require.NoError(t, err)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+// Test 1: GET /machine-identities/audit → 200, JSON with expected fields.
+func TestMachineAuditReport_JSON_200(t *testing.T) {
+	initMachineAuditTest(t)
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	srv := newMachineAuditServer(t, c)
+	defer srv.Close()
+
+	resp := authGetMachineAudit(t, srv, token, "/api/v1/machine-identities/audit")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	var body struct {
+		Data struct {
+			TotalCount   int `json:"total_count"`
+			StaleCount   int `json:"stale_count"`
+			RevokedCount int `json:"revoked_count"`
+			Machines     any `json:"machines"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.GreaterOrEqual(t, body.Data.TotalCount, 0)
+	assert.GreaterOrEqual(t, body.Data.StaleCount, 0)
+	assert.GreaterOrEqual(t, body.Data.RevokedCount, 0)
+	assert.NotNil(t, body.Data.Machines)
+}
+
+// Test 2: GET /machine-identities/audit.csv → 200, text/csv.
+func TestMachineAuditReport_CSV_200(t *testing.T) {
+	initMachineAuditTest(t)
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	srv := newMachineAuditServer(t, c)
+	defer srv.Close()
+
+	resp := authGetMachineAudit(t, srv, token, "/api/v1/machine-identities/audit.csv")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/csv")
+	assert.Contains(t, resp.Header.Get("Content-Disposition"), "machine-audit.csv")
+
+	// The body should contain the CSV header row.
+	rawBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	body := strings.TrimSpace(string(rawBody))
+	assert.Contains(t, body, "machine_id")
+	assert.Contains(t, body, "credential_count")
+	assert.Contains(t, body, "is_stale")
+}
+
+// Test 3: Create a machine identity, then GET audit — it appears in the report.
+func TestMachineAuditReport_ContainsCreatedMachine(t *testing.T) {
+	initMachineAuditTest(t)
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	srv := newMachineAuditServer(t, c)
+	defer srv.Close()
+
+	// Create a project first (bootstrap already creates project ID=1).
+	ctx := context.Background()
+	machine, err := c.CreateMachineIdentity(ctx, 1, "audit-test-bot", "ci", "robot for audit test", "", 1)
+	require.NoError(t, err)
+	require.NotNil(t, machine)
+
+	resp := authGetMachineAudit(t, srv, token, "/api/v1/machine-identities/audit")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body struct {
+		Data struct {
+			TotalCount int `json:"total_count"`
+			Machines   []struct {
+				MachineID uint   `json:"machine_id"`
+				Name      string `json:"name"`
+				IsStale   bool   `json:"is_stale"`
+			} `json:"machines"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.GreaterOrEqual(t, body.Data.TotalCount, 1)
+
+	found := false
+	for _, m := range body.Data.Machines {
+		if m.MachineID == machine.ID {
+			assert.Equal(t, "audit-test-bot", m.Name)
+			found = true
+		}
+	}
+	assert.True(t, found, "created machine identity should appear in audit report")
+}
+
+// Test 4: Machine with no credentials is reported as stale (LastUsedAt nil).
+func TestMachineAuditReport_NeverUsedIsStale(t *testing.T) {
+	initMachineAuditTest(t)
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+	srv := newMachineAuditServer(t, c)
+	defer srv.Close()
+
+	ctx := context.Background()
+	machine, err := c.CreateMachineIdentity(ctx, 1, "stale-bot", "ci", "never used", "", 1)
+	require.NoError(t, err)
+
+	resp := authGetMachineAudit(t, srv, token, "/api/v1/machine-identities/audit")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body struct {
+		Data struct {
+			StaleCount int `json:"stale_count"`
+			Machines   []struct {
+				MachineID int  `json:"machine_id"`
+				IsStale   bool `json:"is_stale"`
+			} `json:"machines"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Greater(t, body.Data.StaleCount, 0)
+
+	for _, m := range body.Data.Machines {
+		if uint(m.MachineID) == machine.ID {
+			assert.True(t, m.IsStale, "machine with no credentials should be stale")
+		}
+	}
+}
+
+// Test 5: Unauthenticated request → 401.
+func TestMachineAuditReport_Unauthenticated_401(t *testing.T) {
+	initMachineAuditTest(t)
+	c := newTestCore(t)
+	srv := newMachineAuditServer(t, c)
+	defer srv.Close()
+
+	// JSON endpoint.
+	resp := authGetMachineAudit(t, srv, "", "/api/v1/machine-identities/audit")
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// CSV endpoint.
+	resp2 := authGetMachineAudit(t, srv, "", "/api/v1/machine-identities/audit.csv")
+	assert.Equal(t, http.StatusUnauthorized, resp2.StatusCode)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -128,6 +128,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	}
 
 	catalogHandler := handlers.NewCatalogHandler(coreService)
+	machineAuditHandler := handlers.NewMachineAuditHandler(coreService)
 	dashboardHandler := handlers.NewDashboardHandler(coreService)
 	adminUsageHandler := handlers.NewAdminUsageHandler(coreService)
 	auditHandler := handlers.NewAuditHandler(coreService)
@@ -1710,6 +1711,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// credentials an admin should revoke (non-human token sprawl). Same calibration
 		// as /pat-hygiene: audit.read, not the baseline.
 		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/machine-token-hygiene", catalogHandler.MachineTokenHygiene)
+		// Machine identity audit report — deployment-wide identity inventory with
+		// credential counts, last-used timestamps, stale status, and revocation status.
+		// Same disclosure family as /pat-hygiene and /machine-token-hygiene: audit.read.
+		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/machine-identities/audit", machineAuditHandler.GetMachineAuditReport)
+		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/machine-identities/audit.csv", machineAuditHandler.GetMachineAuditReportCSV)
 		// Secret-hygiene rollup — deployment-wide totals of every project's posture
 		// (orphaned / unused / expiring / stale-MI / rotation-overdue) + per-project
 		// breakdown identified by project name. Same calibration: audit.read.


### PR DESCRIPTION
## Summary

- `GetMachineAuditReport(ctx)` uses existing `ListAllMachineIdentities` + `ListMachineIdentityCredentials` — no new storage methods
- Derives `IsStale` (no credential activity > 30 days), `CredentialCount`, `LastUsedAt` per machine
- `GET /api/v1/machine-identities/audit` — JSON `MachineAuditReport{total_count, stale_count, revoked_count, machines}`
- `GET /api/v1/machine-identities/audit.csv` — CSV download
- CLI: `keyorix machine audit [--format csv]`
- Gated on `audit.read`

## Test plan

- [ ] 5 handler integration tests (JSON 200, CSV 200, created machine appears, never-used is stale, unauthed → 401)
- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)