### PR TITLE
feat(compliance): credential hygiene trends — 30/60/90-day stale PAT + machine credential trending

### DIFF
--- a/internal/cli/compliance/hygiene_trends.go
+++ b/internal/cli/compliance/hygiene_trends.go
@@ -1,0 +1,72 @@
+// hygiene_trends.go — `keyorix compliance credential-trends` subcommand.
+//
+// Talks to GET /api/v1/compliance/credential-trends?days=30|60|90 and prints
+// a per-day table of stale/expired PAT and stale machine-credential counts.
+package compliance
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var credTrendDays int
+
+// trendPoint mirrors core.HygieneTrendPoint for JSON decoding.
+type trendPoint struct {
+	Date          time.Time `json:"date"`
+	StalePATs     int       `json:"stale_pats"`
+	ExpiredPATs   int       `json:"expired_pats"`
+	StaleMachines int       `json:"stale_machines"`
+	TotalPATs     int       `json:"total_pats"`
+	TotalMachines int       `json:"total_machines"`
+}
+
+type trendsReport struct {
+	Days   int          `json:"days"`
+	Points []trendPoint `json:"points"`
+}
+
+var credentialTrendsCmd = &cobra.Command{
+	Use:          "credential-trends",
+	Short:        "Show 30/60/90-day credential hygiene trends (stale/expired PATs, stale machine creds)",
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if credTrendDays != 30 && credTrendDays != 60 && credTrendDays != 90 {
+			credTrendDays = 30
+		}
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var report trendsReport
+		url := fmt.Sprintf("/api/v1/compliance/credential-trends?days=%d", credTrendDays)
+		if err := c.Get(context.Background(), url, &report); err != nil {
+			return err
+		}
+		fmt.Printf("Credential hygiene trends — last %d days\n\n", report.Days)
+		fmt.Printf("%-12s  %10s  %12s  %14s  %10s  %14s\n",
+			"Date", "StalePATs", "ExpiredPATs", "StaleMachines", "TotalPATs", "TotalMachines")
+		fmt.Printf("%-12s  %10s  %12s  %14s  %10s  %14s\n",
+			"------------", "----------", "------------", "--------------", "----------", "--------------")
+		for _, p := range report.Points {
+			fmt.Printf("%-12s  %10d  %12d  %14d  %10d  %14d\n",
+				p.Date.UTC().Format("2006-01-02"),
+				p.StalePATs,
+				p.ExpiredPATs,
+				p.StaleMachines,
+				p.TotalPATs,
+				p.TotalMachines,
+			)
+		}
+		return nil
+	},
+}
+
+func init() {
+	credentialTrendsCmd.Flags().IntVar(&credTrendDays, "days", 30, "Trend window in days (30, 60, or 90)")
+	ComplianceCmd.AddCommand(credentialTrendsCmd)
+}

--- a/internal/cli/compliance/hygiene_trends_test.go
+++ b/internal/cli/compliance/hygiene_trends_test.go
@@ -1,0 +1,81 @@
+package compliance
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialTrendsCmd_Success(t *testing.T) {
+	t.Cleanup(func() { credTrendDays = 30 })
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/compliance/credential-trends", r.URL.Path)
+		assert.Equal(t, "30", r.URL.Query().Get("days"))
+		_, _ = w.Write([]byte(`{"data":{
+			"days":30,
+			"points":[
+				{"date":"2026-06-01T00:00:00Z","stale_pats":2,"expired_pats":1,"stale_machines":0,"total_pats":10,"total_machines":3},
+				{"date":"2026-06-02T00:00:00Z","stale_pats":3,"expired_pats":1,"stale_machines":1,"total_pats":10,"total_machines":3}
+			]
+		}}`))
+	})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, credentialTrendsCmd.RunE(nil, nil))
+	})
+	assert.Contains(t, out, "last 30 days")
+	assert.Contains(t, out, "Date")
+	assert.Contains(t, out, "StalePATs")
+	assert.Contains(t, out, "2026-06-01")
+}
+
+func TestCredentialTrendsCmd_60Days(t *testing.T) {
+	t.Cleanup(func() { credTrendDays = 30 })
+	credTrendDays = 60
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "60", r.URL.Query().Get("days"))
+		_, _ = w.Write([]byte(`{"data":{"days":60,"points":[]}}`))
+	})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, credentialTrendsCmd.RunE(nil, nil))
+	})
+	assert.Contains(t, out, "last 60 days")
+}
+
+func TestCredentialTrendsCmd_InvalidDaysDefaultsTo30(t *testing.T) {
+	t.Cleanup(func() { credTrendDays = 30 })
+	credTrendDays = 45 // invalid — should fall back to 30
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "30", r.URL.Query().Get("days"))
+		_, _ = w.Write([]byte(`{"data":{"days":30,"points":[]}}`))
+	})
+
+	require.NoError(t, credentialTrendsCmd.RunE(nil, nil))
+	assert.Equal(t, 30, credTrendDays)
+}
+
+func TestCredentialTrendsCmd_NotConnected(t *testing.T) {
+	t.Cleanup(func() { credTrendDays = 30 })
+	setupDisconnected(t)
+
+	err := credentialTrendsCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestCredentialTrendsCmd_ServerError(t *testing.T) {
+	t.Cleanup(func() { credTrendDays = 30 })
+
+	setupRemote(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := credentialTrendsCmd.RunE(nil, nil)
+	require.Error(t, err)
+}

--- a/internal/core/hygiene_trends.go
+++ b/internal/core/hygiene_trends.go
@@ -1,0 +1,164 @@
+// hygiene_trends.go — 30/60/90-day credential-hygiene trend data.
+//
+// Exposes per-day counts of stale PATs (active but unused > 30 days), expired
+// PATs (not yet revoked), and stale machine credentials (no credential used in
+// 30 days). Today's point is always computed live from the current table state;
+// historical points come from HygieneTrendSnapshot rows persisted by
+// RecordHygieneTrendPoint (a daily scheduler job or the on-demand admin endpoint).
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// stalePATWindow is the inactivity window after which a non-expired PAT is
+// considered stale (mirrors the defaultPATStaleAfter definition in pat_hygiene.go).
+const stalePATWindow = 30 * 24 * time.Hour
+
+// staleMachineWindow is the inactivity window after which an active machine
+// identity is considered stale (no credential used in 30 days).
+const staleMachineWindow = 30 * 24 * time.Hour
+
+// HygieneTrendPoint holds hygiene counts for one calendar day.
+type HygieneTrendPoint struct {
+	Date          time.Time `json:"date"`
+	StalePATs     int       `json:"stale_pats"`     // active PATs unused > 30 days
+	ExpiredPATs   int       `json:"expired_pats"`   // PATs where ExpiresAt < now, not revoked
+	StaleMachines int       `json:"stale_machines"` // active machine identities with no recent credential use
+	TotalPATs     int       `json:"total_pats"`
+	TotalMachines int       `json:"total_machines"`
+}
+
+// HygieneTrendsReport is the response for GET /compliance/credential-trends.
+type HygieneTrendsReport struct {
+	Days   int                 `json:"days"`
+	Points []HygieneTrendPoint `json:"points"`
+}
+
+// GetHygieneTrends returns per-day credential hygiene counts for the last
+// `days` days (valid values: 30, 60, 90; anything else defaults to 30).
+//
+// Today's point is always derived from the current table state; historical
+// points come from persisted HygieneTrendSnapshot rows (written by
+// RecordHygieneTrendPoint). Days with no snapshot (i.e. before the first
+// RecordHygieneTrendPoint call) are omitted from Points.
+func (k *KeyorixCore) GetHygieneTrends(ctx context.Context, days int) (*HygieneTrendsReport, error) {
+	if days != 30 && days != 60 && days != 90 {
+		days = 30
+	}
+
+	// Always compute today's live point.
+	today, err := k.computeHygieneTrendPoint(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("compute today's hygiene trend: %w", err)
+	}
+
+	// Fetch historical snapshots for the window.
+	snaps, err := k.storage.ListHygieneTrendSnapshots(ctx, days)
+	if err != nil {
+		return nil, fmt.Errorf("list hygiene trend snapshots: %w", err)
+	}
+
+	todayDate := truncateToDay(today.Date)
+
+	// Build the points list: today first, then historical rows (excluding any
+	// row whose date matches today — the live computation supersedes it).
+	points := []HygieneTrendPoint{*today}
+	for _, s := range snaps {
+		if truncateToDay(s.SnapshotDate).Equal(todayDate) {
+			continue
+		}
+		points = append(points, HygieneTrendPoint{
+			Date:          s.SnapshotDate,
+			StalePATs:     s.StalePATs,
+			ExpiredPATs:   s.ExpiredPATs,
+			StaleMachines: s.StaleMachines,
+			TotalPATs:     s.TotalPATs,
+			TotalMachines: s.TotalMachines,
+		})
+	}
+
+	return &HygieneTrendsReport{Days: days, Points: points}, nil
+}
+
+// RecordHygieneTrendPoint computes today's credential-hygiene counts and
+// persists them as a HygieneTrendSnapshot for future trend queries. Returns
+// the point that was saved.
+func (k *KeyorixCore) RecordHygieneTrendPoint(ctx context.Context) (*HygieneTrendPoint, error) {
+	point, err := k.computeHygieneTrendPoint(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("compute hygiene trend point: %w", err)
+	}
+
+	snap := &models.HygieneTrendSnapshot{
+		StalePATs:     point.StalePATs,
+		ExpiredPATs:   point.ExpiredPATs,
+		StaleMachines: point.StaleMachines,
+		TotalPATs:     point.TotalPATs,
+		TotalMachines: point.TotalMachines,
+		SnapshotDate:  truncateToDay(point.Date),
+	}
+	if err := k.storage.SaveHygieneTrendSnapshot(ctx, snap); err != nil {
+		return nil, fmt.Errorf("save hygiene trend snapshot: %w", err)
+	}
+	return point, nil
+}
+
+// computeHygieneTrendPoint derives the current hygiene counts from the live
+// table state. Called for today's point by both GetHygieneTrends and
+// RecordHygieneTrendPoint.
+func (k *KeyorixCore) computeHygieneTrendPoint(ctx context.Context) (*HygieneTrendPoint, error) {
+	now := k.now()
+	staleCutoff := now.Add(-stalePATWindow)
+	machineStaleCutoff := now.Add(-staleMachineWindow)
+
+	stalePATs, err := k.storage.CountStalePATs(ctx, staleCutoff)
+	if err != nil {
+		return nil, fmt.Errorf("count stale PATs: %w", err)
+	}
+
+	expiredPATs, err := k.storage.CountExpiredPATs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("count expired PATs: %w", err)
+	}
+
+	staleMachines, err := k.storage.CountStaleMachineCredentials(ctx, machineStaleCutoff)
+	if err != nil {
+		return nil, fmt.Errorf("count stale machine credentials: %w", err)
+	}
+
+	// Total PATs (non-revoked) and total active machine identities for context.
+	allPATs, err := k.storage.ListActivePersonalAccessTokens(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list active PATs: %w", err)
+	}
+	allMachines, err := k.storage.ListAllMachineIdentities(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list all machine identities: %w", err)
+	}
+	totalMachines := 0
+	for _, m := range allMachines {
+		if m.State == "active" {
+			totalMachines++
+		}
+	}
+
+	return &HygieneTrendPoint{
+		Date:          now,
+		StalePATs:     stalePATs,
+		ExpiredPATs:   expiredPATs,
+		StaleMachines: staleMachines,
+		TotalPATs:     len(allPATs),
+		TotalMachines: totalMachines,
+	}, nil
+}
+
+// truncateToDay returns t truncated to UTC midnight.
+func truncateToDay(t time.Time) time.Time {
+	t = t.UTC()
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}

--- a/internal/core/hygiene_trends_test.go
+++ b/internal/core/hygiene_trends_test.go
@@ -1,0 +1,220 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedNow is the frozen clock used by all hygiene trend tests.
+var hygieneFixedNow = time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+
+func newHygieneCore(store *MockStorage) *KeyorixCore {
+	return &KeyorixCore{storage: store, now: func() time.Time { return hygieneFixedNow }}
+}
+
+// setupComputeCalls sets up the five storage calls made by computeHygieneTrendPoint.
+func setupComputeCalls(store *MockStorage, ctx context.Context, stalePATs, expiredPATs, staleMachines int, pats []*models.PersonalAccessToken, machines []*models.MachineIdentity) {
+	store.On("CountStalePATs", ctx, mock.AnythingOfType("time.Time")).Return(stalePATs, nil)
+	store.On("CountExpiredPATs", ctx).Return(expiredPATs, nil)
+	store.On("CountStaleMachineCredentials", ctx, mock.AnythingOfType("time.Time")).Return(staleMachines, nil)
+	store.On("ListActivePersonalAccessTokens", ctx).Return(pats, nil)
+	store.On("ListAllMachineIdentities", ctx).Return(machines, nil)
+}
+
+// --- GetHygieneTrends ---
+
+func TestGetHygieneTrends_ValidDaysAccepted(t *testing.T) {
+	for _, days := range []int{30, 60, 90} {
+		store := new(MockStorage)
+		c := newHygieneCore(store)
+		ctx := context.Background()
+
+		setupComputeCalls(store, ctx, 1, 2, 3,
+			[]*models.PersonalAccessToken{{}, {}},
+			[]*models.MachineIdentity{{State: "active"}, {State: "revoked"}},
+		)
+		store.On("ListHygieneTrendSnapshots", ctx, days).Return([]*models.HygieneTrendSnapshot{}, nil)
+
+		report, err := c.GetHygieneTrends(ctx, days)
+		require.NoError(t, err)
+		assert.Equal(t, days, report.Days)
+	}
+}
+
+func TestGetHygieneTrends_InvalidDaysDefaultsTo30(t *testing.T) {
+	store := new(MockStorage)
+	c := newHygieneCore(store)
+	ctx := context.Background()
+
+	setupComputeCalls(store, ctx, 0, 0, 0,
+		[]*models.PersonalAccessToken{},
+		[]*models.MachineIdentity{},
+	)
+	store.On("ListHygieneTrendSnapshots", ctx, 30).Return([]*models.HygieneTrendSnapshot{}, nil)
+
+	report, err := c.GetHygieneTrends(ctx, 15) // invalid
+	require.NoError(t, err)
+	assert.Equal(t, 30, report.Days)
+	store.AssertCalled(t, "ListHygieneTrendSnapshots", ctx, 30)
+}
+
+func TestGetHygieneTrends_TodayPointPopulatedFromLiveState(t *testing.T) {
+	store := new(MockStorage)
+	c := newHygieneCore(store)
+	ctx := context.Background()
+
+	setupComputeCalls(store, ctx, 5, 3, 2,
+		[]*models.PersonalAccessToken{{}, {}, {}},                                          // 3 PATs
+		[]*models.MachineIdentity{{State: "active"}, {State: "active"}, {State: "revoked"}}, // 2 active
+	)
+	store.On("ListHygieneTrendSnapshots", ctx, 30).Return([]*models.HygieneTrendSnapshot{}, nil)
+
+	report, err := c.GetHygieneTrends(ctx, 30)
+	require.NoError(t, err)
+	require.Len(t, report.Points, 1)
+	today := report.Points[0]
+	assert.Equal(t, 5, today.StalePATs)
+	assert.Equal(t, 3, today.ExpiredPATs)
+	assert.Equal(t, 2, today.StaleMachines)
+	assert.Equal(t, 3, today.TotalPATs)
+	assert.Equal(t, 2, today.TotalMachines)
+}
+
+func TestGetHygieneTrends_HistoricalPointsAppended(t *testing.T) {
+	store := new(MockStorage)
+	c := newHygieneCore(store)
+	ctx := context.Background()
+
+	yesterday := hygieneFixedNow.UTC().AddDate(0, 0, -1).Truncate(24 * time.Hour)
+	dayBefore := hygieneFixedNow.UTC().AddDate(0, 0, -2).Truncate(24 * time.Hour)
+
+	setupComputeCalls(store, ctx, 0, 0, 0,
+		[]*models.PersonalAccessToken{},
+		[]*models.MachineIdentity{},
+	)
+	store.On("ListHygieneTrendSnapshots", ctx, 30).Return([]*models.HygieneTrendSnapshot{
+		{SnapshotDate: yesterday, StalePATs: 10, ExpiredPATs: 4, StaleMachines: 1, TotalPATs: 20, TotalMachines: 5},
+		{SnapshotDate: dayBefore, StalePATs: 8, ExpiredPATs: 2, StaleMachines: 0, TotalPATs: 18, TotalMachines: 5},
+	}, nil)
+
+	report, err := c.GetHygieneTrends(ctx, 30)
+	require.NoError(t, err)
+	require.Len(t, report.Points, 3) // today + 2 historical
+	assert.Equal(t, 10, report.Points[1].StalePATs)
+	assert.Equal(t, 8, report.Points[2].StalePATs)
+}
+
+func TestGetHygieneTrends_TodaySnapshotExcluded(t *testing.T) {
+	// A stored snapshot whose SnapshotDate equals today must be dropped — the
+	// live computation already provides today's point.
+	store := new(MockStorage)
+	c := newHygieneCore(store)
+	ctx := context.Background()
+
+	todayMidnight := truncateToDay(hygieneFixedNow)
+	yesterday := todayMidnight.AddDate(0, 0, -1)
+
+	setupComputeCalls(store, ctx, 0, 0, 0,
+		[]*models.PersonalAccessToken{},
+		[]*models.MachineIdentity{},
+	)
+	store.On("ListHygieneTrendSnapshots", ctx, 30).Return([]*models.HygieneTrendSnapshot{
+		{SnapshotDate: todayMidnight, StalePATs: 99}, // stale snapshot for today — must be skipped
+		{SnapshotDate: yesterday, StalePATs: 7},
+	}, nil)
+
+	report, err := c.GetHygieneTrends(ctx, 30)
+	require.NoError(t, err)
+	require.Len(t, report.Points, 2) // today (live) + yesterday only
+	assert.Equal(t, 0, report.Points[0].StalePATs) // live value, not 99
+	assert.Equal(t, 7, report.Points[1].StalePATs)
+}
+
+func TestGetHygieneTrends_CountStalePATsError(t *testing.T) {
+	store := new(MockStorage)
+	c := newHygieneCore(store)
+	ctx := context.Background()
+
+	store.On("CountStalePATs", ctx, mock.AnythingOfType("time.Time")).
+		Return(0, errors.New("db error"))
+
+	_, err := c.GetHygieneTrends(ctx, 30)
+	require.Error(t, err)
+}
+
+func TestGetHygieneTrends_ListSnapshotsError(t *testing.T) {
+	store := new(MockStorage)
+	c := newHygieneCore(store)
+	ctx := context.Background()
+
+	setupComputeCalls(store, ctx, 0, 0, 0,
+		[]*models.PersonalAccessToken{},
+		[]*models.MachineIdentity{},
+	)
+	store.On("ListHygieneTrendSnapshots", ctx, 30).Return(nil, errors.New("db error"))
+
+	_, err := c.GetHygieneTrends(ctx, 30)
+	require.Error(t, err)
+}
+
+// --- RecordHygieneTrendPoint ---
+
+func TestRecordHygieneTrendPoint_PersistsSnapshot(t *testing.T) {
+	store := new(MockStorage)
+	c := newHygieneCore(store)
+	ctx := context.Background()
+
+	setupComputeCalls(store, ctx, 4, 1, 2,
+		[]*models.PersonalAccessToken{{}, {}, {}, {}},
+		[]*models.MachineIdentity{{State: "active"}, {State: "active"}, {State: "suspended"}},
+	)
+	store.On("SaveHygieneTrendSnapshot", ctx, mock.AnythingOfType("*models.HygieneTrendSnapshot")).Return(nil)
+
+	point, err := c.RecordHygieneTrendPoint(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 4, point.StalePATs)
+	assert.Equal(t, 1, point.ExpiredPATs)
+	assert.Equal(t, 2, point.StaleMachines)
+	assert.Equal(t, 4, point.TotalPATs)
+	assert.Equal(t, 2, point.TotalMachines)
+
+	store.AssertCalled(t, "SaveHygieneTrendSnapshot", ctx,
+		mock.MatchedBy(func(s *models.HygieneTrendSnapshot) bool {
+			return s.StalePATs == 4 &&
+				s.ExpiredPATs == 1 &&
+				s.StaleMachines == 2 &&
+				s.TotalPATs == 4 &&
+				s.TotalMachines == 2 &&
+				s.SnapshotDate.Equal(truncateToDay(hygieneFixedNow))
+		}),
+	)
+}
+
+func TestRecordHygieneTrendPoint_PropagatesSaveError(t *testing.T) {
+	store := new(MockStorage)
+	c := newHygieneCore(store)
+	ctx := context.Background()
+
+	setupComputeCalls(store, ctx, 0, 0, 0,
+		[]*models.PersonalAccessToken{},
+		[]*models.MachineIdentity{},
+	)
+	store.On("SaveHygieneTrendSnapshot", ctx, mock.AnythingOfType("*models.HygieneTrendSnapshot")).
+		Return(errors.New("write failed"))
+
+	_, err := c.RecordHygieneTrendPoint(ctx)
+	require.Error(t, err)
+}
+
+func TestTruncateToDay_ReturnsUTCMidnight(t *testing.T) {
+	ts := time.Date(2026, 3, 15, 17, 45, 59, 999, time.UTC)
+	got := truncateToDay(ts)
+	assert.Equal(t, time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC), got)
+}

--- a/internal/core/mock_storage_hygiene_trends_test.go
+++ b/internal/core/mock_storage_hygiene_trends_test.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"context"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// SaveHygieneTrendSnapshot implements storage.Storage for MockStorage.
+func (m *MockStorage) SaveHygieneTrendSnapshot(ctx context.Context, snap *models.HygieneTrendSnapshot) error {
+	args := m.Called(ctx, snap)
+	return args.Error(0)
+}
+
+// ListHygieneTrendSnapshots implements storage.Storage for MockStorage.
+func (m *MockStorage) ListHygieneTrendSnapshots(ctx context.Context, days int) ([]*models.HygieneTrendSnapshot, error) {
+	args := m.Called(ctx, days)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.HygieneTrendSnapshot), args.Error(1)
+}
+
+// CountStalePATs implements storage.Storage for MockStorage.
+func (m *MockStorage) CountStalePATs(ctx context.Context, threshold time.Time) (int, error) {
+	args := m.Called(ctx, threshold)
+	return args.Int(0), args.Error(1)
+}
+
+// CountExpiredPATs implements storage.Storage for MockStorage.
+func (m *MockStorage) CountExpiredPATs(ctx context.Context) (int, error) {
+	args := m.Called(ctx)
+	return args.Int(0), args.Error(1)
+}
+
+// CountStaleMachineCredentials implements storage.Storage for MockStorage.
+func (m *MockStorage) CountStaleMachineCredentials(ctx context.Context, threshold time.Time) (int, error) {
+	args := m.Called(ctx, threshold)
+	return args.Int(0), args.Error(1)
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -906,6 +906,28 @@ type Storage interface {
 	// Returns nil, nil when no prior snapshot exists.
 	GetPreviousCompliancePostureSnapshot(ctx context.Context) (*models.CompliancePostureSnapshot, error)
 
+	// Credential Hygiene Trend Snapshots — daily counts of stale/expired PATs and
+	// stale machine credentials for per-day trend queries.
+	//
+	// SaveHygieneTrendSnapshot upserts a snapshot for the given UTC calendar day
+	// (first write creates; same-day re-run overwrites in place). Used by
+	// RecordHygieneTrendPoint and the daily hygiene scheduler.
+	SaveHygieneTrendSnapshot(ctx context.Context, snap *models.HygieneTrendSnapshot) error
+	// ListHygieneTrendSnapshots returns up to `days` snapshots ordered by
+	// snapshot_date DESC (newest first). Used by GetHygieneTrends.
+	ListHygieneTrendSnapshots(ctx context.Context, days int) ([]*models.HygieneTrendSnapshot, error)
+	// CountStalePATs returns the count of non-revoked PersonalAccessTokens where
+	// ExpiresAt IS NULL OR ExpiresAt > now (active), AND
+	// (LastUsedAt IS NULL OR LastUsedAt < threshold) — stale but not expired.
+	CountStalePATs(ctx context.Context, threshold time.Time) (int, error)
+	// CountExpiredPATs returns the count of non-revoked PersonalAccessTokens where
+	// ExpiresAt IS NOT NULL AND ExpiresAt < now (expired but never revoked).
+	CountExpiredPATs(ctx context.Context) (int, error)
+	// CountStaleMachineCredentials returns the count of distinct machine identities
+	// (active state) where all their credentials are either never used or were
+	// last used before threshold (i.e. the machine identity is "stale").
+	CountStaleMachineCredentials(ctx context.Context, threshold time.Time) (int, error)
+
 	// Audit Logging
 	LogAuditEvent(ctx context.Context, event *models.AuditEvent) error
 	CreateSecretAccessLog(ctx context.Context, log *models.SecretAccessLog) error

--- a/internal/storage/models/all_models.go
+++ b/internal/storage/models/all_models.go
@@ -67,5 +67,6 @@ func AllTestModels() []any {
 		&DeploymentStatsSnapshot{},
 		&CompliancePostureSnapshot{},
 		&SecretAccessSchedule{},
+		&HygieneTrendSnapshot{},
 	}
 }

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -1061,6 +1061,20 @@ type DeploymentStatsSnapshot struct {
 	CreatedAt      time.Time
 }
 
+// HygieneTrendSnapshot captures one day's credential-hygiene counts for
+// per-day trend queries (stale PATs, expired PATs, stale machine credentials).
+// One row per UTC calendar day (SnapshotDate is truncated to midnight).
+type HygieneTrendSnapshot struct {
+	ID            uint      `gorm:"primarykey"`
+	StalePATs     int       `json:"stale_pats"`     // non-revoked, active PATs unused > 30 days
+	ExpiredPATs   int       `json:"expired_pats"`   // non-revoked PATs where ExpiresAt < now
+	StaleMachines int       `json:"stale_machines"` // machine identities with no credential used in 30 days
+	TotalPATs     int       `json:"total_pats"`
+	TotalMachines int       `json:"total_machines"`
+	SnapshotDate  time.Time `gorm:"uniqueIndex" json:"snapshot_date"` // UTC midnight
+	CreatedAt     time.Time `json:"created_at"`
+}
+
 // CompliancePostureSnapshot captures daily deployment compliance posture counts
 // for week-over-week trend computation.
 type CompliancePostureSnapshot struct {

--- a/internal/storage/store/local_hygiene_counts.go
+++ b/internal/storage/store/local_hygiene_counts.go
@@ -1,0 +1,86 @@
+// local_hygiene_counts.go — credential-hygiene trend count queries for LocalStorage.
+//
+// Covers: SaveHygieneTrendSnapshot, ListHygieneTrendSnapshots,
+// CountStalePATs, CountExpiredPATs, CountStaleMachineCredentials.
+//
+// For the remote (stub) equivalent see remote_hygiene_counts.go.
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// SaveHygieneTrendSnapshot upserts a daily hygiene trend snapshot. If a row
+// already exists for the given SnapshotDate it is updated in-place; otherwise
+// a new row is created.
+func (ls *LocalStorage) SaveHygieneTrendSnapshot(ctx context.Context, snap *models.HygieneTrendSnapshot) error {
+	return ls.db.WithContext(ctx).
+		Where(models.HygieneTrendSnapshot{SnapshotDate: snap.SnapshotDate}).
+		Assign(*snap).
+		FirstOrCreate(snap).Error
+}
+
+// ListHygieneTrendSnapshots returns up to `days` snapshots ordered by
+// snapshot_date DESC (newest first).
+func (ls *LocalStorage) ListHygieneTrendSnapshots(ctx context.Context, days int) ([]*models.HygieneTrendSnapshot, error) {
+	if days <= 0 {
+		days = 30
+	}
+	var snaps []*models.HygieneTrendSnapshot
+	err := ls.db.WithContext(ctx).
+		Order("snapshot_date DESC").
+		Limit(days).
+		Find(&snaps).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	return snaps, err
+}
+
+// CountStalePATs returns the count of non-revoked, active (not expired) PATs
+// that have not been used since threshold (or never used).
+func (ls *LocalStorage) CountStalePATs(ctx context.Context, threshold time.Time) (int, error) {
+	var count int64
+	err := ls.db.WithContext(ctx).Model(&models.PersonalAccessToken{}).
+		Where("revoked = ? AND (expires_at IS NULL OR expires_at > ?) AND (last_used_at IS NULL OR last_used_at < ?)",
+			false, time.Now(), threshold).
+		Count(&count).Error
+	return int(count), err
+}
+
+// CountExpiredPATs returns the count of non-revoked PATs whose ExpiresAt is
+// in the past (expired but never explicitly revoked — token sprawl).
+func (ls *LocalStorage) CountExpiredPATs(ctx context.Context) (int, error) {
+	var count int64
+	err := ls.db.WithContext(ctx).Model(&models.PersonalAccessToken{}).
+		Where("revoked = ? AND expires_at IS NOT NULL AND expires_at < ?", false, time.Now()).
+		Count(&count).Error
+	return int(count), err
+}
+
+// CountStaleMachineCredentials returns the count of active machine identities
+// that have no credential used since threshold (or no credential at all).
+// An active machine identity is "stale" when its most-recent credential
+// LastUsedAt is NULL or before threshold.
+func (ls *LocalStorage) CountStaleMachineCredentials(ctx context.Context, threshold time.Time) (int, error) {
+	// Subquery: machine identity IDs that have at least one credential used
+	// since threshold (i.e. NOT stale).
+	// We count active machine identities NOT in that set.
+	var count int64
+	err := ls.db.WithContext(ctx).
+		Table("machine_identities mi").
+		Where("mi.state = ?", "active").
+		Where("mi.id NOT IN (?)",
+			ls.db.WithContext(ctx).
+				Table("machine_identity_credentials mic").
+				Select("mic.machine_identity_id").
+				Where("mic.revoked = ? AND mic.last_used_at IS NOT NULL AND mic.last_used_at >= ?", false, threshold),
+		).
+		Count(&count).Error
+	return int(count), err
+}

--- a/internal/storage/store/local_hygiene_counts_test.go
+++ b/internal/storage/store/local_hygiene_counts_test.go
@@ -1,0 +1,247 @@
+// local_hygiene_counts_test.go — unit tests for local_hygiene_counts.go.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newHygieneCountsStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	return newStoreS3(t, "hygiene_counts_"+t.Name(),
+		&models.HygieneTrendSnapshot{},
+		&models.PersonalAccessToken{},
+		&models.MachineIdentity{}, &models.MachineIdentityCredential{},
+	)
+}
+
+// ─── SaveHygieneTrendSnapshot / ListHygieneTrendSnapshots ───────────────────
+
+func TestSaveHygieneTrendSnapshot_CreatesRow(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+	today := time.Date(2026, 6, 5, 0, 0, 0, 0, time.UTC)
+
+	snap := &models.HygieneTrendSnapshot{
+		StalePATs: 3, ExpiredPATs: 1, StaleMachines: 2,
+		TotalPATs: 10, TotalMachines: 5, SnapshotDate: today,
+	}
+	require.NoError(t, ls.SaveHygieneTrendSnapshot(ctx, snap))
+	assert.NotZero(t, snap.ID)
+
+	snaps, err := ls.ListHygieneTrendSnapshots(ctx, 30)
+	require.NoError(t, err)
+	require.Len(t, snaps, 1)
+	assert.Equal(t, 3, snaps[0].StalePATs)
+}
+
+func TestSaveHygieneTrendSnapshot_Upserts(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+	day := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	first := &models.HygieneTrendSnapshot{StalePATs: 5, SnapshotDate: day}
+	require.NoError(t, ls.SaveHygieneTrendSnapshot(ctx, first))
+
+	second := &models.HygieneTrendSnapshot{StalePATs: 9, SnapshotDate: day}
+	require.NoError(t, ls.SaveHygieneTrendSnapshot(ctx, second))
+
+	snaps, err := ls.ListHygieneTrendSnapshots(ctx, 30)
+	require.NoError(t, err)
+	require.Len(t, snaps, 1, "upsert must not create a second row for the same day")
+	assert.Equal(t, 9, snaps[0].StalePATs)
+}
+
+func TestListHygieneTrendSnapshots_Empty(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+
+	snaps, err := ls.ListHygieneTrendSnapshots(ctx, 30)
+	require.NoError(t, err)
+	assert.Empty(t, snaps)
+}
+
+func TestListHygieneTrendSnapshots_NonPositiveDaysDefaultsTo30(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+
+	// Insert 5 snapshots.
+	for i := range 5 {
+		d := time.Date(2026, 6, 5-i, 0, 0, 0, 0, time.UTC)
+		require.NoError(t, ls.SaveHygieneTrendSnapshot(ctx, &models.HygieneTrendSnapshot{SnapshotDate: d}))
+	}
+
+	// days=0 must behave like days=30 (return all 5).
+	snaps, err := ls.ListHygieneTrendSnapshots(ctx, 0)
+	require.NoError(t, err)
+	assert.Len(t, snaps, 5)
+
+	// days=-1 similarly.
+	snaps, err = ls.ListHygieneTrendSnapshots(ctx, -1)
+	require.NoError(t, err)
+	assert.Len(t, snaps, 5)
+}
+
+// ─── CountStalePATs ─────────────────────────────────────────────────────────
+
+func TestCountStalePATs_EmptyDB(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	n, err := ls.CountStalePATs(context.Background(), time.Now().Add(-30*24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestCountStalePATs_CountsNeverUsed(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+
+	// Active (non-revoked, non-expired) PAT that was never used → stale.
+	pat := &models.PersonalAccessToken{
+		UserID: 1, Name: "unused", TokenHash: "h1", LastUsedAt: nil, Revoked: false,
+	}
+	require.NoError(t, ls.db.WithContext(ctx).Create(pat).Error)
+
+	n, err := ls.CountStalePATs(ctx, time.Now().Add(-30*24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+}
+
+func TestCountStalePATs_SkipsRevoked(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+
+	revoked := &models.PersonalAccessToken{
+		UserID: 1, Name: "revoked", TokenHash: "h2", Revoked: true,
+	}
+	require.NoError(t, ls.db.WithContext(ctx).Create(revoked).Error)
+
+	n, err := ls.CountStalePATs(ctx, time.Now().Add(-30*24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "revoked PATs must not be counted as stale")
+}
+
+func TestCountStalePATs_SkipsRecentlyUsed(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+
+	recent := time.Now().Add(-5 * 24 * time.Hour)
+	pat := &models.PersonalAccessToken{
+		UserID: 1, Name: "recent", TokenHash: "h3", LastUsedAt: &recent, Revoked: false,
+	}
+	require.NoError(t, ls.db.WithContext(ctx).Create(pat).Error)
+
+	n, err := ls.CountStalePATs(ctx, time.Now().Add(-30*24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "recently-used PATs must not be counted as stale")
+}
+
+// ─── CountExpiredPATs ───────────────────────────────────────────────────────
+
+func TestCountExpiredPATs_EmptyDB(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	n, err := ls.CountExpiredPATs(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestCountExpiredPATs_CountsExpired(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+
+	past := time.Now().Add(-24 * time.Hour)
+	pat := &models.PersonalAccessToken{
+		UserID: 1, Name: "expired", TokenHash: "h4", ExpiresAt: &past, Revoked: false,
+	}
+	require.NoError(t, ls.db.WithContext(ctx).Create(pat).Error)
+
+	n, err := ls.CountExpiredPATs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+}
+
+func TestCountExpiredPATs_SkipsRevoked(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+
+	past := time.Now().Add(-24 * time.Hour)
+	pat := &models.PersonalAccessToken{
+		UserID: 1, Name: "exp-revoked", TokenHash: "h5", ExpiresAt: &past, Revoked: true,
+	}
+	require.NoError(t, ls.db.WithContext(ctx).Create(pat).Error)
+
+	n, err := ls.CountExpiredPATs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "revoked PATs must not be counted as expired")
+}
+
+func TestCountExpiredPATs_SkipsFuture(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+
+	future := time.Now().Add(24 * time.Hour)
+	pat := &models.PersonalAccessToken{
+		UserID: 1, Name: "future", TokenHash: "h6", ExpiresAt: &future, Revoked: false,
+	}
+	require.NoError(t, ls.db.WithContext(ctx).Create(pat).Error)
+
+	n, err := ls.CountExpiredPATs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "non-expired PATs must not be counted")
+}
+
+// ─── CountStaleMachineCredentials ───────────────────────────────────────────
+
+func TestCountStaleMachineCredentials_EmptyDB(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	n, err := ls.CountStaleMachineCredentials(context.Background(), time.Now().Add(-30*24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestCountStaleMachineCredentials_ActiveWithNoCredentials(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+
+	m := &models.MachineIdentity{Name: "no-creds", State: "active"}
+	require.NoError(t, ls.db.WithContext(ctx).Create(m).Error)
+
+	n, err := ls.CountStaleMachineCredentials(ctx, time.Now().Add(-30*24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "machine with no credentials should be counted as stale")
+}
+
+func TestCountStaleMachineCredentials_SkipsRevoked(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+
+	m := &models.MachineIdentity{Name: "revoked-machine", State: "revoked"}
+	require.NoError(t, ls.db.WithContext(ctx).Create(m).Error)
+
+	n, err := ls.CountStaleMachineCredentials(ctx, time.Now().Add(-30*24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "non-active machines must not be counted")
+}
+
+func TestCountStaleMachineCredentials_NotStaleWhenRecentlyUsed(t *testing.T) {
+	ls := newHygieneCountsStore(t)
+	ctx := context.Background()
+
+	m := &models.MachineIdentity{Name: "recent-machine", State: "active"}
+	require.NoError(t, ls.db.WithContext(ctx).Create(m).Error)
+
+	recent := time.Now().Add(-2 * 24 * time.Hour)
+	cred := &models.MachineIdentityCredential{
+		MachineIdentityID: m.ID, TokenHash: "mh1",
+		LastUsedAt: &recent, Revoked: false,
+	}
+	require.NoError(t, ls.db.WithContext(ctx).Create(cred).Error)
+
+	n, err := ls.CountStaleMachineCredentials(ctx, time.Now().Add(-30*24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "machine with recently-used credential must not be stale")
+}

--- a/internal/storage/store/remote_hygiene_counts.go
+++ b/internal/storage/store/remote_hygiene_counts.go
@@ -1,0 +1,42 @@
+// remote_hygiene_counts.go — credential-hygiene trend count stubs for RemoteStorage.
+//
+// Hygiene trend snapshots are written and read server-side only (the
+// RecordHygieneTrendPoint job and GetHygieneTrends run on the server); no REST
+// proxy routes exist for these raw storage calls. The count methods likewise run
+// server-side as part of RecordHygieneTrendPoint. All are intentional stubs
+// (statusIntentional in remote_hygiene_counts_completeness_test.go).
+//
+// For the local (GORM) equivalent see local_hygiene_counts.go.
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// SaveHygieneTrendSnapshot is not supported in remote mode.
+func (rs *RemoteStorage) SaveHygieneTrendSnapshot(_ context.Context, _ *models.HygieneTrendSnapshot) error {
+	return remoteUnsupported("SaveHygieneTrendSnapshot")
+}
+
+// ListHygieneTrendSnapshots is not supported in remote mode.
+func (rs *RemoteStorage) ListHygieneTrendSnapshots(_ context.Context, _ int) ([]*models.HygieneTrendSnapshot, error) {
+	return nil, remoteUnsupported("ListHygieneTrendSnapshots")
+}
+
+// CountStalePATs is not supported in remote mode.
+func (rs *RemoteStorage) CountStalePATs(_ context.Context, _ time.Time) (int, error) {
+	return 0, remoteUnsupported("CountStalePATs")
+}
+
+// CountExpiredPATs is not supported in remote mode.
+func (rs *RemoteStorage) CountExpiredPATs(_ context.Context) (int, error) {
+	return 0, remoteUnsupported("CountExpiredPATs")
+}
+
+// CountStaleMachineCredentials is not supported in remote mode.
+func (rs *RemoteStorage) CountStaleMachineCredentials(_ context.Context, _ time.Time) (int, error) {
+	return 0, remoteUnsupported("CountStaleMachineCredentials")
+}

--- a/internal/storage/store/remote_hygiene_counts_completeness_test.go
+++ b/internal/storage/store/remote_hygiene_counts_completeness_test.go
@@ -1,0 +1,17 @@
+package store
+
+func init() {
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		// Credential hygiene trend snapshots — all server-side only.
+		"SaveHygieneTrendSnapshot": {statusIntentional,
+			"hygiene trend snapshots are written server-side by RecordHygieneTrendPoint; no remote caller ever invokes this directly"},
+		"ListHygieneTrendSnapshots": {statusIntentional,
+			"hygiene trend snapshot reads are server-side only; GetHygieneTrends is a server-only handler"},
+		"CountStalePATs": {statusIntentional,
+			"stale-PAT count is computed server-side as part of RecordHygieneTrendPoint; no remote caller ever invokes this directly"},
+		"CountExpiredPATs": {statusIntentional,
+			"expired-PAT count is computed server-side as part of RecordHygieneTrendPoint; no remote caller ever invokes this directly"},
+		"CountStaleMachineCredentials": {statusIntentional,
+			"stale-machine-credential count is computed server-side as part of RecordHygieneTrendPoint; no remote caller ever invokes this directly"},
+	})
+}

--- a/internal/storage/store/remote_unsupported_test.go
+++ b/internal/storage/store/remote_unsupported_test.go
@@ -122,3 +122,41 @@ func TestRemoteStorage_RemovePermissionFromRole(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, rs.RemovePermissionFromRole(context.Background(), 2, 8))
 }
+
+// TestRemoteStorage_HygieneCountsUnsupported verifies that all five
+// credential-hygiene trend functions return ErrRemoteUnsupported on RemoteStorage
+// (they run server-side only — see remote_hygiene_counts.go).
+func TestRemoteStorage_HygieneCountsUnsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("https://unused.example"))
+	require.NoError(t, err)
+	ctx := context.Background()
+	threshold := time.Now()
+
+	calls := map[string]func() error{
+		"SaveHygieneTrendSnapshot": func() error {
+			return rs.SaveHygieneTrendSnapshot(ctx, &models.HygieneTrendSnapshot{})
+		},
+		"ListHygieneTrendSnapshots": func() error {
+			_, e := rs.ListHygieneTrendSnapshots(ctx, 30)
+			return e
+		},
+		"CountStalePATs": func() error {
+			_, e := rs.CountStalePATs(ctx, threshold)
+			return e
+		},
+		"CountExpiredPATs": func() error {
+			_, e := rs.CountExpiredPATs(ctx)
+			return e
+		},
+		"CountStaleMachineCredentials": func() error {
+			_, e := rs.CountStaleMachineCredentials(ctx, threshold)
+			return e
+		},
+	}
+	for name, call := range calls {
+		err := call()
+		require.Error(t, err, "%s should error", name)
+		assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+			"%s should wrap ErrRemoteUnsupported, got %v", name, err)
+	}
+}

--- a/server/http/handlers/hygiene_trends.go
+++ b/server/http/handlers/hygiene_trends.go
@@ -1,0 +1,71 @@
+// hygiene_trends.go — HTTP handlers for credential-hygiene trend data.
+//
+// GET  /api/v1/compliance/credential-trends?days=30|60|90
+//   Returns a HygieneTrendsReport (per-day stale/expired PAT + stale machine counts).
+//   Gated on audit.read in the router.
+//
+// POST /api/v1/system/admin/jobs/record-hygiene-snapshot
+//   Triggers RecordHygieneTrendPoint: computes today's counts and persists a
+//   HygieneTrendSnapshot row. Gated on system.write in the router.
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// HygieneTrendsHandler handles the credential-hygiene trend endpoints.
+type HygieneTrendsHandler struct {
+	coreService *core.KeyorixCore
+}
+
+// NewHygieneTrendsHandler creates a new HygieneTrendsHandler.
+func NewHygieneTrendsHandler(coreService *core.KeyorixCore) *HygieneTrendsHandler {
+	return &HygieneTrendsHandler{coreService: coreService}
+}
+
+// GetCredentialTrends handles GET /api/v1/compliance/credential-trends?days=30|60|90.
+// Returns a HygieneTrendsReport with per-day stale/expired PAT and stale machine counts.
+func (h *HygieneTrendsHandler) GetCredentialTrends(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+
+	days := 30
+	if v := r.URL.Query().Get("days"); v != "" {
+		if d, err := strconv.Atoi(v); err == nil {
+			days = d
+		}
+		// invalid / non-integer values silently default to 30 (clamped in core)
+	}
+
+	report, err := h.coreService.GetHygieneTrends(r.Context(), days)
+	if err != nil {
+		log.Printf("Error computing credential hygiene trends: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, report, "")
+}
+
+// RecordHygieneSnapshot handles POST /api/v1/system/admin/jobs/record-hygiene-snapshot.
+// Computes today's hygiene counts and persists them as a HygieneTrendSnapshot row.
+func (h *HygieneTrendsHandler) RecordHygieneSnapshot(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+
+	point, err := h.coreService.RecordHygieneTrendPoint(r.Context())
+	if err != nil {
+		log.Printf("Error recording hygiene trend snapshot: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, point, "")
+}

--- a/server/http/handlers/hygiene_trends_handler_test.go
+++ b/server/http/handlers/hygiene_trends_handler_test.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newHygieneTrendsTestHandler(t *testing.T) *HygieneTrendsHandler {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.PersonalAccessToken{},
+		&models.MachineIdentity{}, &models.MachineIdentityCredential{},
+		&models.HygieneTrendSnapshot{},
+	))
+	return NewHygieneTrendsHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+}
+
+func TestGetCredentialTrends_Unauthorized(t *testing.T) {
+	h := newHygieneTrendsTestHandler(t)
+	w := httptest.NewRecorder()
+	h.GetCredentialTrends(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestGetCredentialTrends_EmptyDB(t *testing.T) {
+	h := newHygieneTrendsTestHandler(t)
+	w := httptest.NewRecorder()
+	h.GetCredentialTrends(w, withUserCtx(httptest.NewRequest(http.MethodGet, "/?days=30", nil)))
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestGetCredentialTrends_InvalidDaysDefaultsTo30(t *testing.T) {
+	h := newHygieneTrendsTestHandler(t)
+	w := httptest.NewRecorder()
+	h.GetCredentialTrends(w, withUserCtx(httptest.NewRequest(http.MethodGet, "/?days=banana", nil)))
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRecordHygieneSnapshot_Unauthorized(t *testing.T) {
+	h := newHygieneTrendsTestHandler(t)
+	w := httptest.NewRecorder()
+	h.RecordHygieneSnapshot(w, httptest.NewRequest(http.MethodPost, "/", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestRecordHygieneSnapshot_EmptyDB(t *testing.T) {
+	h := newHygieneTrendsTestHandler(t)
+	w := httptest.NewRecorder()
+	h.RecordHygieneSnapshot(w, withUserCtx(httptest.NewRequest(http.MethodPost, "/", nil)))
+	require.Equal(t, http.StatusOK, w.Code)
+}

--- a/server/http/hygiene_trends_handler_test.go
+++ b/server/http/hygiene_trends_handler_test.go
@@ -1,0 +1,161 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cfg shared by all hygiene-trends handler tests.
+var hygieneTrendsCfg = &config.Config{
+	Server: config.ServerConfig{
+		HTTP: config.ServerInstanceConfig{
+			Enabled: true,
+			Port:    "8080",
+		},
+	},
+}
+
+// TestGetCredentialTrends_DefaultDays verifies that GET /compliance/credential-trends
+// with no query parameter returns 200 and a JSON response with days=30.
+func TestGetCredentialTrends_DefaultDays(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+
+	router, err := NewRouter(hygieneTrendsCfg, c)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/compliance/credential-trends", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body struct {
+		Data struct {
+			Days   int   `json:"days"`
+			Points []any `json:"points"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, 30, body.Data.Days)
+	assert.NotNil(t, body.Data.Points)
+}
+
+// TestGetCredentialTrends_Days90 verifies that ?days=90 is honoured and the
+// response carries days=90.
+func TestGetCredentialTrends_Days90(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+
+	router, err := NewRouter(hygieneTrendsCfg, c)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/compliance/credential-trends?days=90", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body struct {
+		Data struct {
+			Days int `json:"days"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, 90, body.Data.Days)
+}
+
+// TestGetCredentialTrends_InvalidDaysDefaultsTo30 verifies that an invalid
+// ?days=invalid parameter silently defaults to 30.
+func TestGetCredentialTrends_InvalidDaysDefaultsTo30(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+
+	router, err := NewRouter(hygieneTrendsCfg, c)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/compliance/credential-trends?days=invalid", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body struct {
+		Data struct {
+			Days int `json:"days"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	// core clamps anything != 30/60/90 to 30
+	assert.Equal(t, 30, body.Data.Days)
+}
+
+// TestRecordHygieneSnapshot_ReturnsPoint verifies that
+// POST /admin/jobs/record-hygiene-snapshot returns 200 and a trend point payload.
+func TestRecordHygieneSnapshot_ReturnsPoint(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+
+	router, err := NewRouter(hygieneTrendsCfg, c)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/jobs/record-hygiene-snapshot", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body struct {
+		Data struct {
+			Date          string `json:"date"`
+			StalePATs     int    `json:"stale_pats"`
+			ExpiredPATs   int    `json:"expired_pats"`
+			StaleMachines int    `json:"stale_machines"`
+			TotalPATs     int    `json:"total_pats"`
+			TotalMachines int    `json:"total_machines"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.NotEmpty(t, body.Data.Date, "trend point should carry a date")
+}
+
+// TestGetCredentialTrends_Unauthenticated verifies that an unauthenticated
+// request returns 401.
+func TestGetCredentialTrends_Unauthenticated(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	router, err := NewRouter(hygieneTrendsCfg, c)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/compliance/credential-trends", nil)
+	// No Authorization header.
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -139,6 +139,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	notificationHandler := handlers.NewNotificationHandler(coreService)
 	connectHandler := handlers.NewConnectHandler(coreService)
 	adminJobsHandler := handlers.NewAdminJobsHandler(coreService)
+	hygieneTrendsHandler := handlers.NewHygieneTrendsHandler(coreService)
 	folderHandler := handlers.NewFolderHandler(coreService)
 
 	// Auth endpoints (no authentication middleware). Several of these mint or hand back a
@@ -1719,6 +1720,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// the same disclosure family as /compliance/evidence (SoD-violation counts,
 		// legal-hold reason, risk-register counts): gated on audit.read, not the
 		// universal system_viewer baseline.
+		// Credential hygiene trends — 30/60/90-day per-day counts of stale/expired PATs
+		// and stale machine credentials. Same disclosure family as /compliance/evidence;
+		// gated on audit.read.
+		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/compliance/credential-trends", hygieneTrendsHandler.GetCredentialTrends)
+
 		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)
 		// Compliance control matrix — controls mapped to ISO/SOC2/NIS2/DORA + status.
 		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/compliance/controls", dashboardHandler.GetComplianceControls)
@@ -1777,6 +1783,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Post("/rotation-reminders", adminJobsHandler.RunRotationReminders)
 			r.Post("/expiry-reminders", adminJobsHandler.RunExpiryReminders)
 			r.Post("/compliance-digest", adminJobsHandler.RunComplianceDigest)
+			// Persist today's credential-hygiene counts for trend queries.
+			r.Post("/record-hygiene-snapshot", hygieneTrendsHandler.RecordHygieneSnapshot)
 		})
 
 		// Runtime anomaly detection configuration — read/write the DB-persisted


### PR DESCRIPTION
## Summary

- New `HygieneTrendSnapshot` model for daily persistence
- `GetHygieneTrends(ctx, days)` — live point + historical snapshots; `RecordHygieneTrendPoint(ctx)` — persist today's counts
- New storage methods: `CountStalePATs`, `CountExpiredPATs`, `CountStaleMachineCredentials` + save/list snapshot
- `GET /api/v1/compliance/credential-trends?days=30|60|90` — JSON trend series
- `POST /api/v1/admin/jobs/record-hygiene-snapshot` — trigger snapshot
- CLI: `keyorix compliance credential-trends [--days 30|60|90]`

## Test plan

- [ ] 5 handler integration tests (default days=30, explicit days=90, invalid → default, snapshot POST, unauthed → 401)
- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)