### PR TITLE
feat(audit): add audit log retention purge job

### DIFF
--- a/internal/core/audit_log_retention_test.go
+++ b/internal/core/audit_log_retention_test.go
@@ -28,8 +28,8 @@ func newPurgeTestCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
 	return c, db, fixed
 }
 
-// seedAuditEvent inserts a single AuditEvent with the given event_time.
-func seedAuditEvent(t *testing.T, db *gorm.DB, at time.Time) {
+// seedRetentionAuditEvent inserts a single AuditEvent with the given event_time.
+func seedRetentionAuditEvent(t *testing.T, db *gorm.DB, at time.Time) {
 	t.Helper()
 	require.NoError(t, db.Create(&models.AuditEvent{
 		EventType: "secret.read", EventTime: at,
@@ -44,11 +44,11 @@ func TestPurgeAuditLogs_HappyPath(t *testing.T) {
 
 	// Five events older than 30 days.
 	for i := 0; i < 5; i++ {
-		seedAuditEvent(t, db, fixed.AddDate(0, 0, -(31 + i)))
+		seedRetentionAuditEvent(t, db, fixed.AddDate(0, 0, -(31 + i)))
 	}
 	// Three recent events within the retention window.
 	for i := 0; i < 3; i++ {
-		seedAuditEvent(t, db, fixed.AddDate(0, 0, -(i+1)))
+		seedRetentionAuditEvent(t, db, fixed.AddDate(0, 0, -(i+1)))
 	}
 
 	result, err := c.PurgeAuditLogs(ctx, AuditLogRetentionConfig{RetentionDays: 30})

--- a/internal/core/audit_log_retention_test.go
+++ b/internal/core/audit_log_retention_test.go
@@ -79,7 +79,7 @@ func TestPurgeAuditLogs_RetentionDaysBelowMin(t *testing.T) {
 	for _, days := range []int{-10, -1, 0, 1, 6} {
 		_, err := c.PurgeAuditLogs(context.Background(), AuditLogRetentionConfig{RetentionDays: days})
 		require.Error(t, err, "days=%d should be rejected", days)
-		assert.ErrorIs(t, err, ErrInvalidRetentionDays, "days=%d", days)
+		assert.ErrorIs(t, err, ErrInvalidAuditRetentionDays, "days=%d", days)
 	}
 	store.AssertNotCalled(t, "DeleteAuditLogsBefore")
 }

--- a/internal/core/audit_log_retention_test.go
+++ b/internal/core/audit_log_retention_test.go
@@ -1,0 +1,113 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newPurgeTestCore opens a fresh in-memory SQLite DB, migrates AuditEvent,
+// and returns a KeyorixCore with a fixed clock so retention cutoffs are stable.
+func newPurgeTestCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:?mode=memory&cache=shared&_busy_timeout=5000"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}))
+	fixed := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	c := NewKeyorixCore(store.NewLocalStorage(db))
+	c.now = func() time.Time { return fixed }
+	return c, db, fixed
+}
+
+// seedAuditEvent inserts a single AuditEvent with the given event_time.
+func seedAuditEvent(t *testing.T, db *gorm.DB, at time.Time) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.AuditEvent{
+		EventType: "secret.read", EventTime: at,
+	}).Error)
+}
+
+// TestPurgeAuditLogs_HappyPath seeds 5 old + 3 recent events, purges with
+// retention_days=30, and asserts exactly 5 are deleted with 3 remaining.
+func TestPurgeAuditLogs_HappyPath(t *testing.T) {
+	c, db, fixed := newPurgeTestCore(t)
+	ctx := context.Background()
+
+	// Five events older than 30 days.
+	for i := 0; i < 5; i++ {
+		seedAuditEvent(t, db, fixed.AddDate(0, 0, -(31 + i)))
+	}
+	// Three recent events within the retention window.
+	for i := 0; i < 3; i++ {
+		seedAuditEvent(t, db, fixed.AddDate(0, 0, -(i+1)))
+	}
+
+	result, err := c.PurgeAuditLogs(ctx, AuditLogRetentionConfig{RetentionDays: 30})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(5), result.DeletedCount)
+	// CutoffTime should be 30 days before "now".
+	expectedCutoff := fixed.UTC().AddDate(0, 0, -30)
+	assert.WithinDuration(t, expectedCutoff, result.CutoffTime, time.Second)
+
+	// Verify 3 events remain in the table.
+	var remaining int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "secret.read").Count(&remaining).Error)
+	// 3 user events + 1 audit_purge system event = 4
+	assert.GreaterOrEqual(t, remaining+1, int64(3), "at least 3 user events remain")
+
+	// Count just the user events with event_type="secret.read".
+	var userEvents int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ? AND event_time >= ?", "secret.read", expectedCutoff).Count(&userEvents).Error)
+	assert.Equal(t, int64(3), userEvents, "3 recent events survive the purge")
+}
+
+// TestPurgeAuditLogs_RetentionDaysBelowMin ensures values below 7 are rejected.
+func TestPurgeAuditLogs_RetentionDaysBelowMin(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	for _, days := range []int{-10, -1, 0, 1, 6} {
+		_, err := c.PurgeAuditLogs(context.Background(), AuditLogRetentionConfig{RetentionDays: days})
+		require.Error(t, err, "days=%d should be rejected", days)
+		assert.ErrorIs(t, err, ErrInvalidRetentionDays, "days=%d", days)
+	}
+	store.AssertNotCalled(t, "DeleteAuditLogsBefore")
+}
+
+// TestPurgeAuditLogs_RetentionDaysExactlyMin ensures 7 is accepted.
+func TestPurgeAuditLogs_RetentionDaysExactlyMin(t *testing.T) {
+	c, db, _ := newPurgeTestCore(t)
+	result, err := c.PurgeAuditLogs(context.Background(), AuditLogRetentionConfig{RetentionDays: 7})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	// Nothing to delete on an empty table beyond the system purge event itself.
+	assert.Equal(t, int64(0), result.DeletedCount)
+
+	// Suppress unused variable warning for db.
+	_ = db
+}
+
+// TestPurgeAuditLogs_StorageErrorPropagated ensures a storage failure bubbles up.
+func TestPurgeAuditLogs_StorageErrorPropagated(t *testing.T) {
+	ms := new(MockStorage)
+	storageErr := errors.New("db offline")
+	ms.On("DeleteAuditLogsBefore", mock.Anything, mock.Anything).Return(int64(0), storageErr)
+	// LogAuditEvent is called for the system purge event — but only on success.
+	// On error the function returns early, so LogAuditEvent is never called.
+
+	c := NewKeyorixCore(ms)
+	_, err := c.PurgeAuditLogs(context.Background(), AuditLogRetentionConfig{RetentionDays: 30})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db offline")
+	ms.AssertExpectations(t)
+}

--- a/internal/core/audit_retention.go
+++ b/internal/core/audit_retention.go
@@ -25,12 +25,12 @@ type PurgeAuditLogsResult struct {
 }
 
 // PurgeAuditLogs deletes audit events older than cfg.RetentionDays days.
-// Returns ErrInvalidRetentionDays if RetentionDays < minRetentionDays (7).
+// Returns ErrInvalidAuditRetentionDays if RetentionDays < minRetentionDays (7).
 // A minimum of 7 days is enforced to prevent accidental mass-deletion.
 func (c *KeyorixCore) PurgeAuditLogs(ctx context.Context, cfg AuditLogRetentionConfig) (*PurgeAuditLogsResult, error) {
 	if cfg.RetentionDays < minRetentionDays {
 		return nil, fmt.Errorf("%w: retention_days must be at least %d (got %d)",
-			ErrInvalidRetentionDays, minRetentionDays, cfg.RetentionDays)
+			ErrInvalidAuditRetentionDays, minRetentionDays, cfg.RetentionDays)
 	}
 
 	cutoff := c.now().UTC().AddDate(0, 0, -cfg.RetentionDays)

--- a/internal/core/audit_retention.go
+++ b/internal/core/audit_retention.go
@@ -8,6 +8,45 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 )
 
+// minRetentionDays is the minimum allowed retention window for a purge.
+// Enforced to prevent accidental mass-deletion of recent audit events.
+const minRetentionDays = 7
+
+// AuditLogRetentionConfig controls how old an audit event must be before it
+// can be purged. RetentionDays of 0 means "keep forever" (no purge).
+type AuditLogRetentionConfig struct {
+	RetentionDays int // 0 = no purge
+}
+
+// PurgeAuditLogsResult summarises how many rows were deleted.
+type PurgeAuditLogsResult struct {
+	DeletedCount int64
+	CutoffTime   time.Time
+}
+
+// PurgeAuditLogs deletes audit events older than cfg.RetentionDays days.
+// Returns ErrInvalidRetentionDays if RetentionDays < minRetentionDays (7).
+// A minimum of 7 days is enforced to prevent accidental mass-deletion.
+func (c *KeyorixCore) PurgeAuditLogs(ctx context.Context, cfg AuditLogRetentionConfig) (*PurgeAuditLogsResult, error) {
+	if cfg.RetentionDays < minRetentionDays {
+		return nil, fmt.Errorf("%w: retention_days must be at least %d (got %d)",
+			ErrInvalidRetentionDays, minRetentionDays, cfg.RetentionDays)
+	}
+
+	cutoff := c.now().UTC().AddDate(0, 0, -cfg.RetentionDays)
+	n, err := c.storage.DeleteAuditLogsBefore(ctx, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to purge audit logs: %w", err)
+	}
+
+	sysCtx := WithActorType(ctx, ActorTypeSystem)
+	c.writeAuditEvent(sysCtx, "system.audit_purge", nil, nil,
+		fmt.Sprintf("audit log retention purge: removed %d event(s) older than %d days (cutoff %s)",
+			n, cfg.RetentionDays, cutoff.Format(time.RFC3339)))
+
+	return &PurgeAuditLogsResult{DeletedCount: n, CutoffTime: cutoff}, nil
+}
+
 // nis2RetentionDays is the audit-log retention window NIS2 (and DORA) expect an
 // operator to be able to demonstrate: 12 months.
 const nis2RetentionDays = 365

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -20,4 +20,8 @@ var (
 	// ErrInvalidInput is returned when a caller supplies a logically inconsistent
 	// or out-of-range parameter (e.g. a time range where Since >= Until).
 	ErrInvalidInput = errors.New("invalid input")
+
+	// ErrInvalidRetentionDays is returned by PurgeAuditLogs when the caller
+	// supplies a retention window that is below the minimum 7-day floor.
+	ErrInvalidRetentionDays = errors.New("invalid retention_days")
 )

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -21,7 +21,7 @@ var (
 	// or out-of-range parameter (e.g. a time range where Since >= Until).
 	ErrInvalidInput = errors.New("invalid input")
 
-	// ErrInvalidRetentionDays is returned by PurgeAuditLogs when the caller
+	// ErrInvalidAuditRetentionDays is returned by PurgeAuditLogs when the caller
 	// supplies a retention window that is below the minimum 7-day floor.
-	ErrInvalidRetentionDays = errors.New("invalid retention_days")
+	ErrInvalidAuditRetentionDays = errors.New("invalid retention_days")
 )

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1246,6 +1246,11 @@ func (m *MockStorage) AuditRetentionStats(ctx context.Context) (*storage.AuditRe
 	return args.Get(0).(*storage.AuditRetentionStats), args.Error(1)
 }
 
+func (m *MockStorage) DeleteAuditLogsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	args := m.Called(ctx, cutoff)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 func (m *MockStorage) VerifyAuditChain(ctx context.Context) (*storage.AuditChainVerification, error) {
 	args := m.Called(ctx)
 	if args.Get(0) == nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1009,6 +1009,9 @@ type Storage interface {
 	// (NIS2 mandates 12 months of retention). Oldest/Newest are nil on an empty
 	// table.
 	AuditRetentionStats(ctx context.Context) (*AuditRetentionStats, error)
+	// DeleteAuditLogsBefore hard-deletes AuditEvent rows with created_at < cutoff.
+	// Returns the number of rows deleted.
+	DeleteAuditLogsBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	// VerifyAuditChain re-walks the tamper-evidence hash chain (ADR-029) over
 	// audit_events and reports whether it is intact. The first divergence —
 	// modified field, deleted/inserted row, or broken linkage — is reported

--- a/internal/storage/store/audit_retention_test.go
+++ b/internal/storage/store/audit_retention_test.go
@@ -53,3 +53,66 @@ func TestAuditRetentionStats_OldestNewestAndCount(t *testing.T) {
 	assert.WithinDuration(t, oldest, *stats.Oldest, time.Second)
 	assert.WithinDuration(t, newest, *stats.Newest, time.Second)
 }
+
+// TestDeleteAuditLogsBefore_DeletesOldRows verifies the hard-delete removes
+// events strictly before the cutoff and leaves newer ones intact.
+func TestDeleteAuditLogsBefore_DeletesOldRows(t *testing.T) {
+	ls := newAuditRetentionTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	cutoff := now.AddDate(0, 0, -30)
+
+	// Three events older than the cutoff.
+	for i := 0; i < 3; i++ {
+		require.NoError(t, ls.db.WithContext(ctx).Create(&models.AuditEvent{
+			EventType: "secret.read", EventTime: now.AddDate(0, 0, -(31 + i)),
+		}).Error)
+	}
+	// Two events newer than the cutoff.
+	for i := 0; i < 2; i++ {
+		require.NoError(t, ls.db.WithContext(ctx).Create(&models.AuditEvent{
+			EventType: "secret.read", EventTime: now.AddDate(0, 0, -(i + 1)),
+		}).Error)
+	}
+
+	n, err := ls.DeleteAuditLogsBefore(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), n, "three old events deleted")
+
+	stats, err := ls.AuditRetentionStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), stats.TotalEvents, "two recent events remain")
+}
+
+// TestDeleteAuditLogsBefore_EmptyTable returns 0 rows deleted on an empty table.
+func TestDeleteAuditLogsBefore_EmptyTable(t *testing.T) {
+	ls := newAuditRetentionTestStore(t)
+	ctx := context.Background()
+
+	n, err := ls.DeleteAuditLogsBefore(ctx, time.Now().UTC())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}
+
+// TestDeleteAuditLogsBefore_NoneBeforeCutoff returns 0 when all events are newer.
+func TestDeleteAuditLogsBefore_NoneBeforeCutoff(t *testing.T) {
+	ls := newAuditRetentionTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	// All events are 1 day old; cutoff is 30 days ago.
+	for i := 0; i < 3; i++ {
+		require.NoError(t, ls.db.WithContext(ctx).Create(&models.AuditEvent{
+			EventType: "secret.read", EventTime: now.AddDate(0, 0, -1),
+		}).Error)
+	}
+
+	n, err := ls.DeleteAuditLogsBefore(ctx, now.AddDate(0, 0, -30))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "no events old enough to delete")
+
+	stats, err := ls.AuditRetentionStats(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), stats.TotalEvents, "all 3 events remain")
+}

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -289,6 +289,15 @@ func (ls *LocalStorage) CountUnusedSecretsByProject(ctx context.Context, project
 	return counts, nil
 }
 
+// DeleteAuditLogsBefore hard-deletes all AuditEvent rows whose event_time is
+// before cutoff. It returns the number of rows deleted.
+func (ls *LocalStorage) DeleteAuditLogsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	result := ls.db.WithContext(ctx).
+		Where("event_time < ?", cutoff).
+		Delete(&models.AuditEvent{})
+	return result.RowsAffected, result.Error
+}
+
 // AuditRetentionStats returns the total audit event count plus the oldest and
 // newest event_time in a single aggregate query. Keyorix applies no retention
 // cap, so MIN(event_time) is the true start of the trail — the basis for the

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -163,6 +163,11 @@ func (rs *RemoteStorage) AuditRetentionStats(_ context.Context) (*storage.AuditR
 	return nil, fmt.Errorf("AuditRetentionStats not available in remote mode")
 }
 
+// DeleteAuditLogsBefore is not available in remote mode; audit purge runs server-side.
+func (rs *RemoteStorage) DeleteAuditLogsBefore(_ context.Context, _ time.Time) (int64, error) {
+	return 0, fmt.Errorf("DeleteAuditLogsBefore not available in remote mode")
+}
+
 // VerifyAuditChain is not available in remote mode; chain verification runs server-side.
 func (rs *RemoteStorage) VerifyAuditChain(_ context.Context) (*storage.AuditChainVerification, error) {
 	return nil, fmt.Errorf("VerifyAuditChain not available in remote mode")

--- a/internal/storage/store/remote_audit_test.go
+++ b/internal/storage/store/remote_audit_test.go
@@ -383,3 +383,15 @@ func TestRemoteStorage_GetDistinctActiveUserIDs_Unsupported(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not available in remote mode")
 }
+
+// --- DeleteAuditLogsBefore (unsupported in remote mode) ---
+
+func TestRemoteStorage_DeleteAuditLogsBefore_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	n, err := rs.DeleteAuditLogsBefore(context.Background(), time.Now())
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), n)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}

--- a/server/http/handlers/audit_retention_handler.go
+++ b/server/http/handlers/audit_retention_handler.go
@@ -1,0 +1,58 @@
+// audit_retention_handler.go — on-demand audit log retention purge job.
+//
+// POST /api/v1/system/admin/jobs/purge-audit-logs deletes audit events older
+// than the requested retention window. Gated by system.write (enforced by the
+// admin jobs subrouter in router.go).
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// purgeAuditLogsRequest is the JSON body accepted by PurgeAuditLogsJob.
+type purgeAuditLogsRequest struct {
+	RetentionDays int `json:"retention_days"`
+}
+
+// PurgeAuditLogsJob handles
+//
+//	POST /api/v1/system/admin/jobs/purge-audit-logs
+//
+// Body:     {"retention_days": N}   (N must be >= 7)
+// Response: {"data": {"deleted_count": N, "cutoff_time": "..."}}
+func (h *AdminJobsHandler) PurgeAuditLogsJob(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+
+	var req purgeAuditLogsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		sendError(w, "Bad Request", "invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+
+	result, err := h.coreService.PurgeAuditLogs(r.Context(), core.AuditLogRetentionConfig{
+		RetentionDays: req.RetentionDays,
+	})
+	if err != nil {
+		if errors.Is(err, core.ErrInvalidRetentionDays) {
+			sendError(w, "Bad Request", clientSafe(err), http.StatusBadRequest, nil)
+			return
+		}
+		log.Printf("Error running purge-audit-logs job: %v", err)
+		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
+		return
+	}
+
+	sendSuccess(w, map[string]interface{}{
+		"deleted_count": result.DeletedCount,
+		"cutoff_time":   result.CutoffTime,
+	}, "")
+}

--- a/server/http/handlers/audit_retention_handler.go
+++ b/server/http/handlers/audit_retention_handler.go
@@ -42,7 +42,7 @@ func (h *AdminJobsHandler) PurgeAuditLogsJob(w http.ResponseWriter, r *http.Requ
 		RetentionDays: req.RetentionDays,
 	})
 	if err != nil {
-		if errors.Is(err, core.ErrInvalidRetentionDays) {
+		if errors.Is(err, core.ErrInvalidAuditRetentionDays) {
 			sendError(w, "Bad Request", clientSafe(err), http.StatusBadRequest, nil)
 			return
 		}

--- a/server/http/handlers/audit_retention_handler_test.go
+++ b/server/http/handlers/audit_retention_handler_test.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newAuditRetentionHandler builds an AdminJobsHandler backed by a fresh
+// in-memory SQLite DB with the AuditEvent schema migrated.
+func newAuditRetentionHandler(t *testing.T) *AdminJobsHandler {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open("file::memory:?mode=memory&cache=shared&_busy_timeout=5000"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(models.AllTestModels()...))
+	return NewAdminJobsHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+}
+
+// postPurgeAuditLogs sends a POST request directly to PurgeAuditLogsJob.
+func postPurgeAuditLogs(h http.HandlerFunc, body interface{}, auth bool) *httptest.ResponseRecorder {
+	var buf bytes.Buffer
+	if body != nil {
+		_ = json.NewEncoder(&buf).Encode(body)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/admin/jobs/purge-audit-logs", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	if auth {
+		req = withUserCtx(req)
+	}
+	w := httptest.NewRecorder()
+	h(w, req)
+	return w
+}
+
+// TestPurgeAuditLogsHandler_HappyPath verifies 200 + deleted_count in the response.
+func TestPurgeAuditLogsHandler_HappyPath(t *testing.T) {
+	h := newAuditRetentionHandler(t)
+	w := postPurgeAuditLogs(h.PurgeAuditLogsJob,
+		map[string]interface{}{"retention_days": 30}, true)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	data := decodeData(t, w)
+	assert.Equal(t, float64(0), data["deleted_count"], "empty DB → zero deleted")
+	assert.NotNil(t, data["cutoff_time"], "cutoff_time is present")
+}
+
+// TestPurgeAuditLogsHandler_BelowMinimum verifies 400 when retention_days < 7.
+func TestPurgeAuditLogsHandler_BelowMinimum(t *testing.T) {
+	h := newAuditRetentionHandler(t)
+
+	for _, days := range []int{0, 1, 6} {
+		w := postPurgeAuditLogs(h.PurgeAuditLogsJob,
+			map[string]interface{}{"retention_days": days}, true)
+		assert.Equal(t, http.StatusBadRequest, w.Code, "days=%d should return 400", days)
+	}
+}
+
+// TestPurgeAuditLogsHandler_RequiresAuth verifies 401 when no user context.
+func TestPurgeAuditLogsHandler_RequiresAuth(t *testing.T) {
+	h := newAuditRetentionHandler(t)
+	w := postPurgeAuditLogs(h.PurgeAuditLogsJob,
+		map[string]interface{}{"retention_days": 30}, false)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestPurgeAuditLogsHandler_InvalidJSON verifies 400 on malformed JSON.
+func TestPurgeAuditLogsHandler_InvalidJSON(t *testing.T) {
+	h := newAuditRetentionHandler(t)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/system/admin/jobs/purge-audit-logs",
+		bytes.NewReader([]byte("{bad")))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.PurgeAuditLogsJob(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestPurgeAuditLogsHandler_StorageError verifies 500 when the DB is closed.
+func TestPurgeAuditLogsHandler_StorageError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open("file::memory:?mode=memory&cache=shared&_busy_timeout=5000"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(models.AllTestModels()...))
+
+	h := NewAdminJobsHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	w := postPurgeAuditLogs(h.PurgeAuditLogsJob,
+		map[string]interface{}{"retention_days": 30}, true)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1898,6 +1898,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Post("/run-alert-escalation", alertEscalationHandler.RunEscalation)
 			r.Post("/token-expiry-check", adminJobsHandler.RunTokenExpiryCheck)
 			r.Post("/suspend-inactive-users", adminJobsHandler.SuspendInactiveUsers)
+			r.Post("/purge-audit-logs", adminJobsHandler.PurgeAuditLogsJob)
 		})
 
 		// Runtime anomaly detection configuration — read/write the DB-persisted


### PR DESCRIPTION
## Summary

- Adds `PurgeAuditLogs` core method with a 7-day minimum retention floor and `ErrInvalidRetentionDays` sentinel
- Adds `DeleteAuditLogsBefore` to the storage interface with local implementation (hard-delete by cutoff) and remote stub
- Exposes `POST /api/v1/system/admin/jobs/purge-audit-logs` gated on `system.write` permission; emits `system.audit_purge` audit event on success

## Test plan

- [ ] `POST /purge-audit-logs` with `retention_days < 7` returns 400
- [ ] Valid request deletes only events older than the cutoff and returns `deleted_count` + `cutoff_time`
- [ ] 401 without auth token
- [ ] Core, store, and handler all at 100% coverage

🤖 Generated with [Claude Code](https://claude.ai/code)