### PR TITLE
feat(audit): add secret read aggregation report

### DIFF
--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -16,4 +16,8 @@ var (
 	// ErrInvalidBootstrapToken is returned when the supplied bootstrap token is
 	// missing, empty, or does not match the server's configured token.
 	ErrInvalidBootstrapToken = errors.New("invalid bootstrap token")
+
+	// ErrInvalidInput is returned when a caller supplies a logically inconsistent
+	// or out-of-range parameter (e.g. a time range where Since >= Until).
+	ErrInvalidInput = errors.New("invalid input")
 )

--- a/internal/core/mock_storage_secret_read_aggregation_test.go
+++ b/internal/core/mock_storage_secret_read_aggregation_test.go
@@ -1,0 +1,16 @@
+package core
+
+import (
+	"context"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+func (m *MockStorage) GetSecretReadCounts(ctx context.Context, secretID uint, since, until time.Time, limit int) ([]storage.SecretReadEntry, error) {
+	args := m.Called(ctx, secretID, since, until, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]storage.SecretReadEntry), args.Error(1)
+}

--- a/internal/core/secret_read_aggregation.go
+++ b/internal/core/secret_read_aggregation.go
@@ -1,0 +1,96 @@
+// secret_read_aggregation.go — per-secret top-reader report.
+//
+// GetSecretReadSummary aggregates "secret.read" audit events for one secret
+// into a ranked list of actors (users or machine identities), letting
+// security investigators quickly see who has read a sensitive secret the most
+// often over a configurable time window.
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+const (
+	secretReadSummaryDefaultLimit = 10
+	secretReadSummaryMaxLimit     = 50
+	secretReadSummaryDefaultDays  = 30
+)
+
+// SecretReadSummaryRequest carries the parameters for GetSecretReadSummary.
+type SecretReadSummaryRequest struct {
+	SecretID uint
+	Since    time.Time // zero → 30 days ago
+	Until    time.Time // zero → now
+	Limit    int       // 0 → default 10, capped at 50
+}
+
+// SecretReadEntry re-exports the storage type so callers only need to import core.
+type SecretReadEntry = storage.SecretReadEntry
+
+// SecretReadSummary is the full aggregated report for one secret.
+type SecretReadSummary struct {
+	SecretID   uint              `json:"secret_id"`
+	Since      time.Time         `json:"since"`
+	Until      time.Time         `json:"until"`
+	Entries    []SecretReadEntry `json:"entries"`
+	TotalReads int64             `json:"total_reads"`
+}
+
+// GetSecretReadSummary returns the top readers of a secret in the time window.
+//
+// Defaults applied when zero/unset:
+//   - Since → 30 days ago
+//   - Until → now
+//   - Limit → 10, capped at 50
+//
+// Returns ErrInvalidInput when Since >= Until after defaults are applied.
+func (c *KeyorixCore) GetSecretReadSummary(ctx context.Context, req SecretReadSummaryRequest) (*SecretReadSummary, error) {
+	now := c.now()
+
+	since := req.Since
+	if since.IsZero() {
+		since = now.Add(-secretReadSummaryDefaultDays * 24 * time.Hour)
+	}
+
+	until := req.Until
+	if until.IsZero() {
+		until = now
+	}
+
+	if !since.Before(until) {
+		return nil, fmt.Errorf("since must be before until: %w", ErrInvalidInput)
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = secretReadSummaryDefaultLimit
+	}
+	if limit > secretReadSummaryMaxLimit {
+		limit = secretReadSummaryMaxLimit
+	}
+
+	entries, err := c.storage.GetSecretReadCounts(ctx, req.SecretID, since, until, limit)
+	if err != nil {
+		return nil, fmt.Errorf("GetSecretReadSummary: %w", err)
+	}
+	if entries == nil {
+		entries = []SecretReadEntry{}
+	}
+
+	var total int64
+	for _, e := range entries {
+		total += e.ReadCount
+	}
+
+	return &SecretReadSummary{
+		SecretID:   req.SecretID,
+		Since:      since,
+		Until:      until,
+		Entries:    entries,
+		TotalReads: total,
+	}, nil
+}

--- a/internal/core/secret_read_aggregation_test.go
+++ b/internal/core/secret_read_aggregation_test.go
@@ -1,0 +1,174 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// ── helper ────────────────────────────────────────────────────────────────────
+
+func newAggCore(t *testing.T) (*KeyorixCore, *MockStorage) {
+	t.Helper()
+	ms := &MockStorage{}
+	return NewKeyorixCore(ms), ms
+}
+
+// ── happy path ────────────────────────────────────────────────────────────────
+
+func TestGetSecretReadSummary_HappyPath(t *testing.T) {
+	c, ms := newAggCore(t)
+	now := time.Now().UTC()
+	since := now.Add(-24 * time.Hour)
+	until := now
+
+	entries := []storage.SecretReadEntry{
+		{ActorID: "1", ActorUsername: "alice", ReadCount: 10, LastReadAt: now.Add(-1 * time.Hour)},
+		{ActorID: "2", ActorUsername: "bob", ReadCount: 5, LastReadAt: now.Add(-2 * time.Hour)},
+		{ActorID: "3", ActorUsername: "carol", ReadCount: 3, LastReadAt: now.Add(-3 * time.Hour)},
+	}
+	ms.On("GetSecretReadCounts", mock.Anything, uint(42), mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time"), 10).
+		Return(entries, nil)
+
+	summary, err := c.GetSecretReadSummary(context.Background(), SecretReadSummaryRequest{
+		SecretID: 42,
+		Since:    since,
+		Until:    until,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(42), summary.SecretID)
+	assert.Equal(t, int64(18), summary.TotalReads) // 10+5+3
+	assert.Len(t, summary.Entries, 3)
+	assert.Equal(t, "alice", summary.Entries[0].ActorUsername)
+	ms.AssertExpectations(t)
+}
+
+// ── defaults ──────────────────────────────────────────────────────────────────
+
+func TestGetSecretReadSummary_SinceDefaultIs30Days(t *testing.T) {
+	c, ms := newAggCore(t)
+
+	ms.On("GetSecretReadCounts", mock.Anything, uint(1), mock.MatchedBy(func(since time.Time) bool {
+		// since should be approximately 30 days ago
+		expected := c.now().Add(-30 * 24 * time.Hour)
+		diff := since.Sub(expected)
+		if diff < 0 {
+			diff = -diff
+		}
+		return diff < 2*time.Second
+	}), mock.AnythingOfType("time.Time"), 10).
+		Return([]storage.SecretReadEntry{}, nil)
+
+	summary, err := c.GetSecretReadSummary(context.Background(), SecretReadSummaryRequest{
+		SecretID: 1,
+		// Since and Until are zero → defaults
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), summary.TotalReads)
+	ms.AssertExpectations(t)
+}
+
+func TestGetSecretReadSummary_UntilDefaultIsNow(t *testing.T) {
+	c, ms := newAggCore(t)
+
+	ms.On("GetSecretReadCounts", mock.Anything, uint(1), mock.AnythingOfType("time.Time"), mock.MatchedBy(func(until time.Time) bool {
+		diff := c.now().Sub(until)
+		if diff < 0 {
+			diff = -diff
+		}
+		return diff < 2*time.Second
+	}), 10).
+		Return([]storage.SecretReadEntry{}, nil)
+
+	_, err := c.GetSecretReadSummary(context.Background(), SecretReadSummaryRequest{SecretID: 1})
+	require.NoError(t, err)
+	ms.AssertExpectations(t)
+}
+
+func TestGetSecretReadSummary_LimitZeroDefaultsTo10(t *testing.T) {
+	c, ms := newAggCore(t)
+
+	ms.On("GetSecretReadCounts", mock.Anything, uint(1), mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time"), 10).
+		Return([]storage.SecretReadEntry{}, nil)
+
+	_, err := c.GetSecretReadSummary(context.Background(), SecretReadSummaryRequest{SecretID: 1})
+	require.NoError(t, err)
+	ms.AssertExpectations(t)
+}
+
+func TestGetSecretReadSummary_LimitCappedAt50(t *testing.T) {
+	c, ms := newAggCore(t)
+
+	ms.On("GetSecretReadCounts", mock.Anything, uint(1), mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time"), 50).
+		Return([]storage.SecretReadEntry{}, nil)
+
+	_, err := c.GetSecretReadSummary(context.Background(), SecretReadSummaryRequest{
+		SecretID: 1,
+		Limit:    60, // over max → capped at 50
+	})
+	require.NoError(t, err)
+	ms.AssertExpectations(t)
+}
+
+// ── validation ────────────────────────────────────────────────────────────────
+
+func TestGetSecretReadSummary_SinceEqualUntilReturnsError(t *testing.T) {
+	c, _ := newAggCore(t)
+
+	ts := time.Now()
+	_, err := c.GetSecretReadSummary(context.Background(), SecretReadSummaryRequest{
+		SecretID: 1,
+		Since:    ts,
+		Until:    ts, // equal → invalid
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidInput))
+}
+
+func TestGetSecretReadSummary_SinceAfterUntilReturnsError(t *testing.T) {
+	c, _ := newAggCore(t)
+
+	ts := time.Now()
+	_, err := c.GetSecretReadSummary(context.Background(), SecretReadSummaryRequest{
+		SecretID: 1,
+		Since:    ts.Add(time.Hour),
+		Until:    ts,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidInput))
+}
+
+// ── storage error propagation ─────────────────────────────────────────────────
+
+func TestGetSecretReadSummary_StorageErrorPropagated(t *testing.T) {
+	c, ms := newAggCore(t)
+
+	storageErr := errors.New("db is on fire")
+	ms.On("GetSecretReadCounts", mock.Anything, uint(1), mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time"), 10).
+		Return(nil, storageErr)
+
+	_, err := c.GetSecretReadSummary(context.Background(), SecretReadSummaryRequest{SecretID: 1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db is on fire")
+}
+
+// ── nil entries from storage → empty slice ────────────────────────────────────
+
+func TestGetSecretReadSummary_NilEntriesBecomesEmpty(t *testing.T) {
+	c, ms := newAggCore(t)
+
+	ms.On("GetSecretReadCounts", mock.Anything, uint(1), mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time"), 10).
+		Return([]storage.SecretReadEntry(nil), nil)
+
+	summary, err := c.GetSecretReadSummary(context.Background(), SecretReadSummaryRequest{SecretID: 1})
+	require.NoError(t, err)
+	assert.NotNil(t, summary.Entries)
+	assert.Len(t, summary.Entries, 0)
+	assert.Equal(t, int64(0), summary.TotalReads)
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -976,6 +976,10 @@ type Storage interface {
 	// hygiene rollup (#393) instead of calling UnusedSecrets once per project. A
 	// project absent from the result has zero unused secrets.
 	CountUnusedSecretsByProject(ctx context.Context, projectIDs []uint, notReadSince time.Time) (map[uint]int, error)
+	// GetSecretReadCounts aggregates "secret.read" audit events for the given
+	// secret in the time window [since, until), returning the top-N actors sorted
+	// by read count desc. Used by the secret read aggregation report.
+	GetSecretReadCounts(ctx context.Context, secretID uint, since, until time.Time, limit int) ([]SecretReadEntry, error)
 	// GetAnomalyConfig retrieves the single anomaly config row, or returns sensible
 	// defaults if no row has been saved yet.
 	GetAnomalyConfig(ctx context.Context) (*models.AnomalyConfigRecord, error)
@@ -1572,6 +1576,19 @@ type UnusedSecretStat struct {
 	SecretName    string     `json:"secret_name"`
 	EnvironmentID uint       `json:"environment_id"`
 	LastRead      *time.Time `json:"last_read"`
+}
+
+// SecretReadEntry is one row in the secret read aggregation report, representing
+// the total reads by a single actor (user or machine identity) within a window.
+type SecretReadEntry struct {
+	// ActorID is the actor identifier: a user's numeric ID rendered as a string,
+	// or a machine identity name (from actor_type="machine_identity" rows).
+	ActorID string `json:"actor_id"`
+	// ActorUsername is the resolved display name for the actor, empty when the
+	// user row is absent (e.g. deleted users or machine identities).
+	ActorUsername string `json:"actor_username,omitempty"`
+	ReadCount     int64  `json:"read_count"`
+	LastReadAt    time.Time `json:"last_read_at"`
 }
 
 // ProjectMember is a user who holds a role at a project's scope (ADR-021).

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -401,6 +401,48 @@ func (ls *LocalStorage) GetRBACAuditLogs(_ context.Context, _ *storage.RBACAudit
 	return nil, 0, nil
 }
 
+// GetSecretReadCounts aggregates "secret.read" audit events for the given secret
+// in [since, until), returning the top-N actors sorted by read count descending.
+// Actor identity is taken from user_id; a LEFT JOIN on users resolves usernames.
+// Machine-identity reads (actor_type="machine_identity") have no user row — their
+// username column is empty in the result, consistent with the description column.
+func (ls *LocalStorage) GetSecretReadCounts(ctx context.Context, secretID uint, since, until time.Time, limit int) ([]storage.SecretReadEntry, error) {
+	type row struct {
+		ActorID       string
+		ActorUsername string
+		ReadCount     int64
+		LastReadAt    scanTime
+	}
+	var rows []row
+	err := ls.db.WithContext(ctx).
+		Table("audit_events ae").
+		Select("CAST(ae.user_id AS TEXT) AS actor_id, COALESCE(u.username, '') AS actor_username, COUNT(*) AS read_count, MAX(ae.event_time) AS last_read_at").
+		Joins("LEFT JOIN users u ON u.id = ae.user_id AND u.deleted_at IS NULL").
+		Where("ae.secret_node_id = ? AND ae.event_type = ? AND ae.event_time >= ? AND ae.event_time < ?", secretID, "secret.read", since, until).
+		Group("ae.user_id").
+		Order("read_count DESC").
+		Limit(limit).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("GetSecretReadCounts: %w", err)
+	}
+
+	out := make([]storage.SecretReadEntry, 0, len(rows))
+	for _, r := range rows {
+		var lastReadAt time.Time
+		if r.LastReadAt.t != nil {
+			lastReadAt = *r.LastReadAt.t
+		}
+		out = append(out, storage.SecretReadEntry{
+			ActorID:       r.ActorID,
+			ActorUsername: r.ActorUsername,
+			ReadCount:     r.ReadCount,
+			LastReadAt:    lastReadAt,
+		})
+	}
+	return out, nil
+}
+
 // CountImpersonatedActions counts impersonated audit events for actingAs by
 // impersonator since `since`, excluding the impersonation.start/.end markers.
 func (ls *LocalStorage) CountImpersonatedActions(ctx context.Context, actingAs, impersonator uint, since time.Time) (int64, error) {

--- a/internal/storage/store/local_audit_read_agg_test.go
+++ b/internal/storage/store/local_audit_read_agg_test.go
@@ -1,0 +1,181 @@
+// local_audit_read_agg_test.go — unit tests for GetSecretReadCounts (LocalStorage).
+package store
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var readAggTestCounter atomic.Int64
+
+// newReadAggStore opens a uniquely-named in-memory SQLite DB with the tables
+// needed by GetSecretReadCounts (audit_events + users for the JOIN).
+func newReadAggStore(t *testing.T) (*LocalStorage, *gorm.DB) {
+	t.Helper()
+	n := readAggTestCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxreadagg_%d?mode=memory&cache=shared", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{},
+		&models.AuditEvent{},
+	))
+	return NewLocalStorage(db), db
+}
+
+func seedReadEvent(t *testing.T, db *gorm.DB, secretID, userID uint, at time.Time) {
+	t.Helper()
+	tru := true
+	uid := userID
+	sid := secretID
+	evt := &models.AuditEvent{
+		EventType:    "secret.read",
+		UserID:       &uid,
+		SecretNodeID: &sid,
+		EventTime:    at,
+		Success:      &tru,
+	}
+	require.NoError(t, db.Create(evt).Error)
+}
+
+// ── happy path ────────────────────────────────────────────────────────────────
+
+func TestGetSecretReadCounts_HappyPath(t *testing.T) {
+	ls, db := newReadAggStore(t)
+	now := time.Now().UTC()
+	since := now.Add(-24 * time.Hour)
+	until := now.Add(time.Hour)
+
+	// User 1: 3 reads, user 2: 1 read.
+	seedReadEvent(t, db, 10, 1, now.Add(-1*time.Hour))
+	seedReadEvent(t, db, 10, 1, now.Add(-2*time.Hour))
+	seedReadEvent(t, db, 10, 1, now.Add(-3*time.Hour))
+	seedReadEvent(t, db, 10, 2, now.Add(-4*time.Hour))
+
+	entries, err := ls.GetSecretReadCounts(context.Background(), 10, since, until, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	// User 1 should be first (highest count).
+	assert.Equal(t, int64(3), entries[0].ReadCount)
+	assert.Equal(t, int64(1), entries[1].ReadCount)
+}
+
+// ── events outside the window are excluded ────────────────────────────────────
+
+func TestGetSecretReadCounts_OutsideWindowExcluded(t *testing.T) {
+	ls, db := newReadAggStore(t)
+	now := time.Now().UTC()
+	since := now.Add(-1 * time.Hour)
+	until := now
+
+	// Two events — one inside, one before the window.
+	seedReadEvent(t, db, 10, 1, now.Add(-30*time.Minute)) // inside
+	seedReadEvent(t, db, 10, 1, now.Add(-2*time.Hour))    // before since → excluded
+
+	entries, err := ls.GetSecretReadCounts(context.Background(), 10, since, until, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(1), entries[0].ReadCount)
+}
+
+// ── non-read events are excluded ─────────────────────────────────────────────
+
+func TestGetSecretReadCounts_NonReadEventsExcluded(t *testing.T) {
+	ls, db := newReadAggStore(t)
+	now := time.Now().UTC()
+	since := now.Add(-24 * time.Hour)
+	until := now.Add(time.Hour)
+
+	uid := uint(1)
+	sid := uint(10)
+	tru := true
+	// Insert a "secret.created" event — should be ignored.
+	require.NoError(t, db.Create(&models.AuditEvent{
+		EventType: "secret.created", UserID: &uid, SecretNodeID: &sid,
+		EventTime: now.Add(-1 * time.Hour), Success: &tru,
+	}).Error)
+	// Insert a proper "secret.read" event.
+	seedReadEvent(t, db, 10, 1, now.Add(-2*time.Hour))
+
+	entries, err := ls.GetSecretReadCounts(context.Background(), 10, since, until, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(1), entries[0].ReadCount)
+}
+
+// ── different secret IDs don't bleed through ─────────────────────────────────
+
+func TestGetSecretReadCounts_DifferentSecretExcluded(t *testing.T) {
+	ls, db := newReadAggStore(t)
+	now := time.Now().UTC()
+	since := now.Add(-24 * time.Hour)
+	until := now.Add(time.Hour)
+
+	// Reads on secret 10 and secret 99.
+	seedReadEvent(t, db, 10, 1, now.Add(-1*time.Hour))
+	seedReadEvent(t, db, 99, 1, now.Add(-1*time.Hour)) // different secret
+
+	entries, err := ls.GetSecretReadCounts(context.Background(), 10, since, until, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(1), entries[0].ReadCount)
+}
+
+// ── no events → empty result ──────────────────────────────────────────────────
+
+func TestGetSecretReadCounts_NoEvents(t *testing.T) {
+	ls, _ := newReadAggStore(t)
+	now := time.Now().UTC()
+
+	entries, err := ls.GetSecretReadCounts(context.Background(), 10, now.Add(-24*time.Hour), now, 10)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+// ── limit is respected ────────────────────────────────────────────────────────
+
+func TestGetSecretReadCounts_LimitRespected(t *testing.T) {
+	ls, db := newReadAggStore(t)
+	now := time.Now().UTC()
+	since := now.Add(-24 * time.Hour)
+	until := now.Add(time.Hour)
+
+	// 5 different users, each reading secret 10 once.
+	for i := uint(1); i <= 5; i++ {
+		seedReadEvent(t, db, 10, i, now.Add(-time.Duration(i)*time.Hour))
+	}
+
+	entries, err := ls.GetSecretReadCounts(context.Background(), 10, since, until, 3)
+	require.NoError(t, err)
+	assert.Len(t, entries, 3)
+}
+
+// ── username resolved from users table ───────────────────────────────────────
+
+func TestGetSecretReadCounts_UsernameResolved(t *testing.T) {
+	ls, db := newReadAggStore(t)
+	now := time.Now().UTC()
+
+	// Insert a real user.
+	user := &models.User{Username: "alice"}
+	require.NoError(t, db.Create(user).Error)
+
+	since := now.Add(-24 * time.Hour)
+	until := now.Add(time.Hour)
+	seedReadEvent(t, db, 10, user.ID, now.Add(-1*time.Hour))
+
+	entries, err := ls.GetSecretReadCounts(context.Background(), 10, since, until, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "alice", entries[0].ActorUsername)
+}

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -168,6 +168,12 @@ func (rs *RemoteStorage) VerifyAuditChain(_ context.Context) (*storage.AuditChai
 	return nil, fmt.Errorf("VerifyAuditChain not available in remote mode")
 }
 
+// GetSecretReadCounts is server-side only; read aggregation runs against the
+// local audit table and is never proxied over a remote HTTP call.
+func (rs *RemoteStorage) GetSecretReadCounts(_ context.Context, _ uint, _, _ time.Time, _ int) ([]storage.SecretReadEntry, error) {
+	return nil, remoteUnsupported("GetSecretReadCounts")
+}
+
 // CreateAuditCheckpoint is not available in remote mode; checkpointing is server-side.
 func (rs *RemoteStorage) CreateAuditCheckpoint(_ context.Context, _ *models.AuditCheckpoint) error {
 	return fmt.Errorf("CreateAuditCheckpoint not available in remote mode")

--- a/internal/storage/store/remote_secret_read_aggregation_completeness_test.go
+++ b/internal/storage/store/remote_secret_read_aggregation_completeness_test.go
@@ -1,0 +1,11 @@
+package store
+
+func init() {
+	// Secret read aggregation — the GET /api/v1/secrets/{id}/read-summary endpoint
+	// is served by a handler running against LocalStorage on the server side.
+	// A remote (CLI) caller hits the HTTP endpoint directly, not the raw storage
+	// method, so GetSecretReadCounts is never reached from a RemoteStorage caller.
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		"GetSecretReadCounts": {statusIntentional, "secret read aggregation runs server-side via GET /api/v1/secrets/{id}/read-summary; raw storage call never reached from a remote-storage caller"},
+	})
+}

--- a/server/http/handlers/secret_read_aggregation_handler.go
+++ b/server/http/handlers/secret_read_aggregation_handler.go
@@ -1,0 +1,68 @@
+// secret_read_aggregation_handler.go — GET /api/v1/secrets/{id}/read-summary handler.
+//
+// Returns the top readers of a secret (by audit event count) over a configurable
+// time window. Requires secrets.manage permission at the secret scope.
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// GetSecretReadSummary handles GET /api/v1/secrets/{id}/read-summary
+//
+// Query parameters (all optional):
+//
+//	since  — RFC3339 start of the window (default: 30 days ago)
+//	until  — RFC3339 end of the window (default: now)
+//	limit  — max actors to return (default: 10, max: 50)
+func (h *SecretHandler) GetSecretReadSummary(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
+		return
+	}
+
+	req := core.SecretReadSummaryRequest{
+		SecretID: uint(id),
+	}
+
+	if v := r.URL.Query().Get("since"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			req.Since = t
+		}
+	}
+	if v := r.URL.Query().Get("until"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			req.Until = t
+		}
+	}
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if l, err := strconv.Atoi(v); err == nil && l > 0 {
+			req.Limit = l
+		}
+	}
+
+	summary, err := h.coreService.GetSecretReadSummary(r.Context(), req)
+	if err != nil {
+		if errors.Is(err, core.ErrInvalidInput) {
+			h.sendError(w, "InvalidParameter", err.Error(), http.StatusBadRequest, nil)
+			return
+		}
+		h.sendError(w, "InternalServerError", "failed to retrieve read summary", http.StatusInternalServerError, nil)
+		return
+	}
+
+	h.sendSuccess(w, summary, "")
+}

--- a/server/http/handlers/secret_read_aggregation_handler_test.go
+++ b/server/http/handlers/secret_read_aggregation_handler_test.go
@@ -1,0 +1,189 @@
+// secret_read_aggregation_handler_test.go — tests for GET /api/v1/secrets/{id}/read-summary.
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var secretReadAggDBCounter atomic.Int64
+
+// newSecretReadAggCore opens a fresh in-memory SQLite DB with all tables needed
+// by the read-aggregation handler and returns the core + raw DB for seeding.
+func newSecretReadAggCore(t *testing.T) (*core.KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := secretReadAggDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhdlr_readagg_%d?mode=memory&cache=shared", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{},
+		&models.AuditEvent{},
+		&models.Role{},
+		&models.UserRole{},
+		&models.Permission{},
+		&models.RolePermission{},
+		&models.Group{},
+		&models.UserGroup{},
+		&models.GroupRole{},
+		&models.Project{},
+		&models.Environment{},
+		&models.SecretNode{},
+	))
+	return core.NewKeyorixCore(store.NewLocalStorage(db)), db
+}
+
+// seedReadAuditEvent inserts a "secret.read" audit event for a given secret and user.
+func seedReadAuditEvent(t *testing.T, db *gorm.DB, secretID, userID uint, at time.Time) {
+	t.Helper()
+	evt := &models.AuditEvent{
+		EventType:    "secret.read",
+		UserID:       &userID,
+		SecretNodeID: &secretID,
+		EventTime:    at,
+	}
+	success := true
+	evt.Success = &success
+	require.NoError(t, db.Create(evt).Error)
+}
+
+// ── 401 Unauthorized ──────────────────────────────────────────────────────────
+
+func TestGetSecretReadSummary_Unauthorized(t *testing.T) {
+	h := newSecretHandlerS4(t)
+	req := withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "1")
+	w := httptest.NewRecorder()
+	h.GetSecretReadSummary(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// ── 400 invalid ID ────────────────────────────────────────────────────────────
+
+func TestGetSecretReadSummary_BadID(t *testing.T) {
+	h := newSecretHandlerS4(t)
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "not-a-number"))
+	w := httptest.NewRecorder()
+	h.GetSecretReadSummary(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── 400 since >= until ────────────────────────────────────────────────────────
+
+func TestGetSecretReadSummary_InvalidTimeRange(t *testing.T) {
+	c, _ := newSecretReadAggCore(t)
+	h, err := NewSecretHandler(c)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	url := fmt.Sprintf("/?since=%s&until=%s",
+		now.Format(time.RFC3339),
+		now.Add(-time.Hour).Format(time.RFC3339),
+	)
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, url, nil), "id", "1"))
+	w := httptest.NewRecorder()
+	h.GetSecretReadSummary(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── 200 happy path — no reads ─────────────────────────────────────────────────
+
+func TestGetSecretReadSummary_NoReads(t *testing.T) {
+	c, _ := newSecretReadAggCore(t)
+	h, err := NewSecretHandler(c)
+	require.NoError(t, err)
+
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "1"))
+	w := httptest.NewRecorder()
+	h.GetSecretReadSummary(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "total_reads")
+	assert.Contains(t, w.Body.String(), "entries")
+}
+
+// ── 200 happy path — seeded reads ────────────────────────────────────────────
+
+func TestGetSecretReadSummary_HappyPath(t *testing.T) {
+	c, db := newSecretReadAggCore(t)
+	h, err := NewSecretHandler(c)
+	require.NoError(t, err)
+
+	secretID := uint(7)
+	userID := uint(1)
+	now := time.Now().UTC()
+
+	// Seed 3 reads for user 1 in the last hour.
+	for i := 0; i < 3; i++ {
+		seedReadAuditEvent(t, db, secretID, userID, now.Add(-time.Duration(i+1)*time.Minute))
+	}
+
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", fmt.Sprintf("%d", secretID)))
+	w := httptest.NewRecorder()
+	h.GetSecretReadSummary(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "total_reads")
+	// The 3 reads should be reflected.
+	assert.Contains(t, body, `"secret_id":7`)
+}
+
+// ── limit=60 is silently capped at 50 by core ────────────────────────────────
+
+func TestGetSecretReadSummary_LimitCappedAt50(t *testing.T) {
+	c, _ := newSecretReadAggCore(t)
+	h, err := NewSecretHandler(c)
+	require.NoError(t, err)
+
+	// limit=60 in URL; core caps it at 50 transparently — still 200.
+	req := withUserCtx(withChiParam(
+		httptest.NewRequest(http.MethodGet, "/?limit=60", nil), "id", "1"))
+	w := httptest.NewRecorder()
+	h.GetSecretReadSummary(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// ── 500 storage error ─────────────────────────────────────────────────────────
+
+// failingReadAggStore wraps LocalStorage and fails GetSecretReadCounts.
+type failingReadAggStore struct {
+	*store.LocalStorage
+}
+
+func (s *failingReadAggStore) GetSecretReadCounts(_ context.Context, _ uint, _, _ time.Time, _ int) ([]storage.SecretReadEntry, error) {
+	return nil, errors.New("simulated read-agg outage")
+}
+
+func TestGetSecretReadSummary_StorageError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	n := secretReadAggDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhdlr_readagg_fail_%d?mode=memory&cache=shared", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}))
+
+	c := core.NewKeyorixCore(&failingReadAggStore{store.NewLocalStorage(db)})
+	h, err := NewSecretHandler(c)
+	require.NoError(t, err)
+
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "1"))
+	w := httptest.NewRecorder()
+	h.GetSecretReadSummary(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -580,6 +580,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/impact", secretHandler.GetSecretImpact)
 			// Blast-radius report: richer impact view with OwnerID, ProjectID, and risk level.
 			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/blast-radius", secretHandler.GetBlastRadius)
+			// Secret read aggregation report: top readers of a secret over a time window.
+			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Get("/{id}/read-summary", secretHandler.GetSecretReadSummary)
 
 			// Per-secret ACLs (RBAC Phase 3): fine-grained user grants independent of project RBAC.
 			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Get("/{id}/acl", secretHandler.ListSecretACLs)


### PR DESCRIPTION
## Summary

- Adds `GetSecretReadSummary` core method aggregating `secret.read` audit events into per-actor read counts with configurable time window and limit (default 10, cap 50)
- Adds `GetSecretReadCounts` to the storage interface with a GORM aggregate query (GROUP BY actor, ORDER BY count DESC); remote stub registered as intentional
- Exposes `GET /api/v1/secrets/{id}/read-summary?since=&until=&limit=` gated on `secrets.manage`

## Test plan

- [ ] Returns top readers sorted by count desc with correct `total_reads` sum
- [ ] `since >= until` returns 400
- [ ] Limit=0 defaults to 10; limit=60 is capped at 50
- [ ] 401 without auth, 400 with invalid secret ID

🤖 Generated with [Claude Code](https://claude.ai/code)