### PR TITLE
feat(rotation): add per-policy rotation state tracking

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1688,6 +1688,19 @@ func (m *MockStorage) DeleteRotationPolicy(_ context.Context, _ uint) error {
 	return nil
 }
 
+func (m *MockStorage) GetRotationPolicyBySecret(ctx context.Context, secretID uint) (*models.RotationPolicy, error) {
+	args := m.Called(ctx, secretID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.RotationPolicy), args.Error(1)
+}
+
+func (m *MockStorage) UpdateRotationState(ctx context.Context, policyID uint, state, errMsg string) error {
+	args := m.Called(ctx, policyID, state, errMsg)
+	return args.Error(0)
+}
+
 // Machine identities (ADR-023).
 func (m *MockStorage) CreateMachineIdentity(ctx context.Context, mi *models.MachineIdentity) (*models.MachineIdentity, error) {
 	args := m.Called(ctx, mi)

--- a/internal/core/rotation_state.go
+++ b/internal/core/rotation_state.go
@@ -1,0 +1,85 @@
+// rotation_state.go — per-policy rotation execution state (idle/pending/rotating/
+// succeeded/failed). The rotation executor stamps these fields so operators can
+// see stalled or failed rotations via GET /api/v1/secrets/{id}/rotation-state.
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Valid rotation state values.
+const (
+	RotationStateIdle      = "idle"
+	RotationStatePending   = "pending"
+	RotationStateRotating  = "rotating"
+	RotationStateSucceeded = "succeeded"
+	RotationStateFailed    = "failed"
+)
+
+// validRotationStates is the exhaustive set of states a RotationPolicy may hold.
+var validRotationStates = map[string]bool{
+	RotationStateIdle:      true,
+	RotationStatePending:   true,
+	RotationStateRotating:  true,
+	RotationStateSucceeded: true,
+	RotationStateFailed:    true,
+}
+
+// RotationStateInfo is the response payload for GET /api/v1/secrets/{id}/rotation-state.
+type RotationStateInfo struct {
+	SecretID          uint       `json:"secret_id"`
+	PolicyID          *uint      `json:"policy_id,omitempty"`
+	State             string     `json:"state"`
+	LastRotationError string     `json:"last_rotation_error,omitempty"`
+	LastStateAt       *time.Time `json:"last_state_at,omitempty"`
+}
+
+// GetRotationState returns the current rotation execution state for the secret's
+// covering rotation policy. If no active policy covers this secret, State is
+// RotationStateIdle and PolicyID is nil (not an error).
+func (c *KeyorixCore) GetRotationState(ctx context.Context, secretID uint) (*RotationStateInfo, error) {
+	policy, err := c.storage.GetRotationPolicyBySecret(ctx, secretID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			// No active policy — idle is the correct answer.
+			return &RotationStateInfo{
+				SecretID: secretID,
+				State:    RotationStateIdle,
+			}, nil
+		}
+		return nil, fmt.Errorf("GetRotationState: %w", err)
+	}
+
+	state := policy.RotationState
+	if state == "" {
+		state = RotationStateIdle
+	}
+
+	info := &RotationStateInfo{
+		SecretID:          secretID,
+		PolicyID:          &policy.ID,
+		State:             state,
+		LastRotationError: policy.LastRotationError,
+		LastStateAt:       policy.LastStateAt,
+	}
+	return info, nil
+}
+
+// SetRotationState stamps the rotation execution state on the given policy.
+// Returns a validation error if state is not one of the five valid values.
+// Called by the rotation executor when a rotation job starts, completes, or fails.
+func (c *KeyorixCore) SetRotationState(ctx context.Context, policyID uint, state, errMsg string) error {
+	if !validRotationStates[state] {
+		return fmt.Errorf("invalid rotation state %q: must be one of idle, pending, rotating, succeeded, failed", state)
+	}
+	if err := c.storage.UpdateRotationState(ctx, policyID, state, errMsg); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return fmt.Errorf("SetRotationState: rotation policy %d not found", policyID)
+		}
+		return fmt.Errorf("SetRotationState: %w", err)
+	}
+	return nil
+}

--- a/internal/core/rotation_state_test.go
+++ b/internal/core/rotation_state_test.go
@@ -1,0 +1,175 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetRotationState_PolicyExists verifies that a secret covered by an active
+// rotation policy returns the policy's stamped state fields.
+func TestGetRotationState_PolicyExists(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	policyID := uint(5)
+	at := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	policy := &models.RotationPolicy{
+		ID:                policyID,
+		RotationState:     RotationStateSucceeded,
+		LastRotationError: "",
+		LastStateAt:       &at,
+	}
+	store.On("GetRotationPolicyBySecret", mock.Anything, uint(42)).Return(policy, nil)
+
+	info, err := c.GetRotationState(context.Background(), 42)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, uint(42), info.SecretID)
+	require.NotNil(t, info.PolicyID)
+	assert.Equal(t, policyID, *info.PolicyID)
+	assert.Equal(t, RotationStateSucceeded, info.State)
+	assert.Empty(t, info.LastRotationError)
+	require.NotNil(t, info.LastStateAt)
+	assert.Equal(t, at, *info.LastStateAt)
+
+	store.AssertExpectations(t)
+}
+
+// TestGetRotationState_NoPolicy verifies that when no active policy covers the
+// secret the response has State="idle" and PolicyID=nil (not an error).
+func TestGetRotationState_NoPolicy(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	store.On("GetRotationPolicyBySecret", mock.Anything, uint(7)).
+		Return(nil, errors.New("rotation policy not found"))
+
+	info, err := c.GetRotationState(context.Background(), 7)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, uint(7), info.SecretID)
+	assert.Nil(t, info.PolicyID)
+	assert.Equal(t, RotationStateIdle, info.State)
+
+	store.AssertExpectations(t)
+}
+
+// TestGetRotationState_EmptyStateDefaultsToIdle verifies that a policy row whose
+// RotationState is "" (not yet stamped) is reported as "idle".
+func TestGetRotationState_EmptyStateDefaultsToIdle(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	policyID := uint(3)
+	policy := &models.RotationPolicy{
+		ID:            policyID,
+		RotationState: "", // never stamped yet
+	}
+	store.On("GetRotationPolicyBySecret", mock.Anything, uint(99)).Return(policy, nil)
+
+	info, err := c.GetRotationState(context.Background(), 99)
+	require.NoError(t, err)
+	assert.Equal(t, RotationStateIdle, info.State)
+
+	store.AssertExpectations(t)
+}
+
+// TestGetRotationState_StorageError verifies that a genuine storage failure is
+// propagated as an error (not silenced as "no policy").
+func TestGetRotationState_StorageError(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	store.On("GetRotationPolicyBySecret", mock.Anything, uint(1)).
+		Return(nil, errors.New("connection refused"))
+
+	_, err := c.GetRotationState(context.Background(), 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+
+	store.AssertExpectations(t)
+}
+
+// TestSetRotationState_Valid verifies that a valid state transition calls
+// UpdateRotationState with the correct arguments.
+func TestSetRotationState_Valid(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	store.On("UpdateRotationState", mock.Anything, uint(10), RotationStateFailed, "timeout").Return(nil)
+
+	err := c.SetRotationState(context.Background(), 10, RotationStateFailed, "timeout")
+	require.NoError(t, err)
+
+	store.AssertExpectations(t)
+}
+
+// TestSetRotationState_InvalidState verifies that an unknown state string returns
+// a validation error without calling storage.
+func TestSetRotationState_InvalidState(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	err := c.SetRotationState(context.Background(), 10, "broken", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid rotation state")
+	// storage must NOT have been called
+	store.AssertNotCalled(t, "UpdateRotationState")
+}
+
+// TestSetRotationState_NotFound verifies that "rotation policy not found" from
+// storage surfaces as an error.
+func TestSetRotationState_NotFound(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	store.On("UpdateRotationState", mock.Anything, uint(99), RotationStateIdle, "").
+		Return(errors.New("rotation policy not found"))
+
+	err := c.SetRotationState(context.Background(), 99, RotationStateIdle, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	store.AssertExpectations(t)
+}
+
+// TestSetRotationState_StorageError verifies that a storage failure is propagated.
+func TestSetRotationState_StorageError(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+
+	store.On("UpdateRotationState", mock.Anything, uint(5), RotationStateRotating, "").
+		Return(errors.New("disk full"))
+
+	err := c.SetRotationState(context.Background(), 5, RotationStateRotating, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disk full")
+
+	store.AssertExpectations(t)
+}
+
+// TestSetRotationState_AllValidStates verifies every valid state value is accepted.
+func TestSetRotationState_AllValidStates(t *testing.T) {
+	valid := []string{
+		RotationStateIdle,
+		RotationStatePending,
+		RotationStateRotating,
+		RotationStateSucceeded,
+		RotationStateFailed,
+	}
+	for _, state := range valid {
+		store := new(MockStorage)
+		c := NewKeyorixCore(store)
+		store.On("UpdateRotationState", mock.Anything, uint(1), state, "").Return(nil)
+		err := c.SetRotationState(context.Background(), 1, state, "")
+		require.NoError(t, err, "state %q should be valid", state)
+		store.AssertExpectations(t)
+	}
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1219,9 +1219,16 @@ type Storage interface {
 	// Rotation Policy Management
 	CreateRotationPolicy(ctx context.Context, p *models.RotationPolicy) error
 	GetRotationPolicy(ctx context.Context, id uint) (*models.RotationPolicy, error)
+	// GetRotationPolicyBySecret returns the first active rotation policy that covers
+	// the secret (by matching the secret's project_id and/or environment_id). Returns
+	// ErrNotFound (via the store package) when no policy exists for the secret.
+	GetRotationPolicyBySecret(ctx context.Context, secretID uint) (*models.RotationPolicy, error)
 	ListRotationPolicies(ctx context.Context, projectID *uint, environmentID *uint) ([]*models.RotationPolicy, error)
 	UpdateRotationPolicy(ctx context.Context, p *models.RotationPolicy) error
 	DeleteRotationPolicy(ctx context.Context, id uint) error
+	// UpdateRotationState stamps the execution state on a RotationPolicy row.
+	// state must be one of: idle, pending, rotating, succeeded, failed.
+	UpdateRotationState(ctx context.Context, policyID uint, state, errMsg string) error
 
 	// Health and Maintenance
 	HealthCheck(ctx context.Context) error

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -1224,6 +1224,10 @@ type RotationPolicy struct {
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 	DeletedAt       gorm.DeletedAt `gorm:"index"`
+	// Rotation execution state — stamped by the rotation job.
+	RotationState     string     `gorm:"default:'idle'" json:"rotation_state"` // idle | pending | rotating | succeeded | failed
+	LastRotationError string     `gorm:"default:''" json:"last_rotation_error,omitempty"`
+	LastStateAt       *time.Time `json:"last_state_at,omitempty"`
 }
 
 // AnomalyAlert represents a detected anomaly in secret access patterns.

--- a/internal/storage/store/local_rotation_policies.go
+++ b/internal/storage/store/local_rotation_policies.go
@@ -1,7 +1,8 @@
 // local_rotation_policies.go — RotationPolicy operations for LocalStorage.
 //
-// Covers: CreateRotationPolicy, GetRotationPolicy, ListRotationPolicies,
-// UpdateRotationPolicy, DeleteRotationPolicy.
+// Covers: CreateRotationPolicy, GetRotationPolicy, GetRotationPolicyBySecret,
+// ListRotationPolicies, UpdateRotationPolicy, DeleteRotationPolicy,
+// UpdateRotationState.
 //
 // All operations use direct GORM queries; no network calls.
 // For the remote (HTTP) equivalent see remote_rotation_policies.go.
@@ -11,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"gorm.io/gorm"
@@ -52,4 +54,54 @@ func (ls *LocalStorage) UpdateRotationPolicy(ctx context.Context, p *models.Rota
 
 func (ls *LocalStorage) DeleteRotationPolicy(ctx context.Context, id uint) error {
 	return ls.db.WithContext(ctx).Delete(&models.RotationPolicy{}, id).Error
+}
+
+// GetRotationPolicyBySecret returns the first active rotation policy that covers
+// a secret (matched by the secret's project_id or environment_id). Returns
+// a "rotation policy not found" error (checked via strings.Contains by callers)
+// when no policy exists for the secret.
+func (ls *LocalStorage) GetRotationPolicyBySecret(ctx context.Context, secretID uint) (*models.RotationPolicy, error) {
+	// Resolve the secret's project + environment so we can match policies.
+	var secret models.SecretNode
+	if err := ls.db.WithContext(ctx).First(&secret, secretID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("secret not found")
+		}
+		return nil, fmt.Errorf("GetRotationPolicyBySecret: secret lookup: %w", err)
+	}
+	// Prefer the narrowest scope first (environment-scoped), then fall back to
+	// a project-scoped policy that covers the secret's environment.
+	var policy models.RotationPolicy
+	err := ls.db.WithContext(ctx).
+		Where("(scope = 'environment' AND environment_id = ?) OR (scope = 'project' AND project_id = ?)",
+			secret.EnvironmentID, secret.ProjectID).
+		Where("is_active = ? AND deleted_at IS NULL", true).
+		Order("CASE scope WHEN 'environment' THEN 0 ELSE 1 END").
+		First(&policy).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("rotation policy not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("GetRotationPolicyBySecret: policy lookup: %w", err)
+	}
+	return &policy, nil
+}
+
+// UpdateRotationState stamps the execution state on a RotationPolicy row.
+func (ls *LocalStorage) UpdateRotationState(ctx context.Context, policyID uint, state, errMsg string) error {
+	now := time.Now().UTC()
+	result := ls.db.WithContext(ctx).Model(&models.RotationPolicy{}).
+		Where("id = ?", policyID).
+		Updates(map[string]interface{}{
+			"rotation_state":      state,
+			"last_rotation_error": errMsg,
+			"last_state_at":       now,
+		})
+	if result.Error != nil {
+		return fmt.Errorf("UpdateRotationState: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("rotation policy not found")
+	}
+	return nil
 }

--- a/internal/storage/store/local_rotation_policies_test.go
+++ b/internal/storage/store/local_rotation_policies_test.go
@@ -1,0 +1,256 @@
+// local_rotation_policies_test.go — SQLite integration tests for the two
+// LocalStorage methods introduced by the rotation-state feature:
+// GetRotationPolicyBySecret and UpdateRotationState.
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newRotationPoliciesTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{},
+		&models.Environment{},
+		&models.SecretNode{},
+		&models.RotationPolicy{},
+	))
+	return NewLocalStorage(db)
+}
+
+// seedRotationPolicyFixture creates a project, environment, secret, and an active
+// project-scoped rotation policy. Returns (ls, secretID, policyID).
+func seedRotationPolicyFixture(t *testing.T, ls *LocalStorage) (secretID uint, policyID uint) {
+	t.Helper()
+	ctx := context.Background()
+
+	proj := &models.Project{Name: "rp-test-proj"}
+	require.NoError(t, ls.db.Create(proj).Error)
+
+	env := &models.Environment{Name: "prod", ProjectID: proj.ID}
+	require.NoError(t, ls.db.Create(env).Error)
+
+	secret := &models.SecretNode{
+		Name:          "MY_API_KEY",
+		ProjectID:     proj.ID,
+		EnvironmentID: env.ID,
+		IsSecret:      true,
+	}
+	require.NoError(t, ls.db.Create(secret).Error)
+
+	policy := &models.RotationPolicy{
+		Name:         "30-day",
+		Scope:        "project",
+		ProjectID:    &proj.ID,
+		IntervalDays: 30,
+		IsActive:     true,
+		CreatedBy:    "tester",
+	}
+	require.NoError(t, ls.db.WithContext(ctx).Create(policy).Error)
+
+	return secret.ID, policy.ID
+}
+
+// TestGetRotationPolicyBySecret_HappyPath verifies that a secret with an active
+// project-scoped policy returns that policy.
+func TestGetRotationPolicyBySecret_HappyPath(t *testing.T) {
+	ls := newRotationPoliciesTestStore(t)
+	ctx := context.Background()
+	secretID, policyID := seedRotationPolicyFixture(t, ls)
+
+	got, err := ls.GetRotationPolicyBySecret(ctx, secretID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, policyID, got.ID)
+	assert.Equal(t, "30-day", got.Name)
+}
+
+// TestGetRotationPolicyBySecret_SecretNotFound verifies that a non-existent
+// secret ID returns a "secret not found" error.
+func TestGetRotationPolicyBySecret_SecretNotFound(t *testing.T) {
+	ls := newRotationPoliciesTestStore(t)
+	ctx := context.Background()
+
+	_, err := ls.GetRotationPolicyBySecret(ctx, 99999)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "secret not found"),
+		"expected 'secret not found' in error: %v", err)
+}
+
+// TestGetRotationPolicyBySecret_NoPolicyForSecret verifies that a secret that
+// exists but has no active policy returns a "rotation policy not found" error.
+func TestGetRotationPolicyBySecret_NoPolicyForSecret(t *testing.T) {
+	ls := newRotationPoliciesTestStore(t)
+	ctx := context.Background()
+
+	// Create a secret in its own project with no rotation policy attached.
+	proj := &models.Project{Name: "bare-proj"}
+	require.NoError(t, ls.db.Create(proj).Error)
+	env := &models.Environment{Name: "staging", ProjectID: proj.ID}
+	require.NoError(t, ls.db.Create(env).Error)
+	secret := &models.SecretNode{
+		Name:          "BARE_KEY",
+		ProjectID:     proj.ID,
+		EnvironmentID: env.ID,
+		IsSecret:      true,
+	}
+	require.NoError(t, ls.db.Create(secret).Error)
+
+	_, err := ls.GetRotationPolicyBySecret(ctx, secret.ID)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "rotation policy not found"),
+		"expected 'rotation policy not found' in error: %v", err)
+}
+
+// TestGetRotationPolicyBySecret_EnvironmentScopeWins verifies that when both a
+// project-scoped and an environment-scoped policy exist, the environment-scoped
+// one is preferred (narrowest scope first).
+func TestGetRotationPolicyBySecret_EnvironmentScopeWins(t *testing.T) {
+	ls := newRotationPoliciesTestStore(t)
+	ctx := context.Background()
+
+	proj := &models.Project{Name: "multi-scope-proj"}
+	require.NoError(t, ls.db.Create(proj).Error)
+	env := &models.Environment{Name: "prod", ProjectID: proj.ID}
+	require.NoError(t, ls.db.Create(env).Error)
+	secret := &models.SecretNode{
+		Name:          "TOKEN",
+		ProjectID:     proj.ID,
+		EnvironmentID: env.ID,
+		IsSecret:      true,
+	}
+	require.NoError(t, ls.db.Create(secret).Error)
+
+	// Project-scoped policy (lower priority).
+	projPolicy := &models.RotationPolicy{
+		Name:         "project-wide-60d",
+		Scope:        "project",
+		ProjectID:    &proj.ID,
+		IntervalDays: 60,
+		IsActive:     true,
+		CreatedBy:    "tester",
+	}
+	require.NoError(t, ls.db.Create(projPolicy).Error)
+
+	// Environment-scoped policy (higher priority).
+	envPolicy := &models.RotationPolicy{
+		Name:          "env-30d",
+		Scope:         "environment",
+		ProjectID:     &proj.ID,
+		EnvironmentID: &env.ID,
+		IntervalDays:  30,
+		IsActive:      true,
+		CreatedBy:     "tester",
+	}
+	require.NoError(t, ls.db.Create(envPolicy).Error)
+
+	got, err := ls.GetRotationPolicyBySecret(ctx, secret.ID)
+	require.NoError(t, err)
+	assert.Equal(t, envPolicy.ID, got.ID, "environment-scoped policy should win over project-scoped")
+}
+
+// TestUpdateRotationState_HappyPath verifies that UpdateRotationState stamps the
+// expected state, error message, and last_state_at on the policy row.
+func TestUpdateRotationState_HappyPath(t *testing.T) {
+	ls := newRotationPoliciesTestStore(t)
+	ctx := context.Background()
+	_, policyID := seedRotationPolicyFixture(t, ls)
+
+	err := ls.UpdateRotationState(ctx, policyID, "failed", "connection refused")
+	require.NoError(t, err)
+
+	var got models.RotationPolicy
+	require.NoError(t, ls.db.First(&got, policyID).Error)
+	assert.Equal(t, "failed", got.RotationState)
+	assert.Equal(t, "connection refused", got.LastRotationError)
+	assert.NotNil(t, got.LastStateAt)
+}
+
+// TestUpdateRotationState_NotFound verifies that updating a non-existent policy
+// returns a "rotation policy not found" error.
+func TestUpdateRotationState_NotFound(t *testing.T) {
+	ls := newRotationPoliciesTestStore(t)
+	ctx := context.Background()
+
+	err := ls.UpdateRotationState(ctx, 99999, "succeeded", "")
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "rotation policy not found"),
+		"expected 'rotation policy not found' in error: %v", err)
+}
+
+// TestGetRotationPolicyBySecret_SecretLookupDBError verifies that a real DB
+// failure on the secret lookup propagates as a wrapped error (not "not found").
+func TestGetRotationPolicyBySecret_SecretLookupDBError(t *testing.T) {
+	ls := newRotationPoliciesTestStore(t)
+	ctx := context.Background()
+	_, _ = seedRotationPolicyFixture(t, ls)
+
+	// Drop secret_nodes so the first query returns a table-missing error.
+	require.NoError(t, ls.db.Exec("DROP TABLE secret_nodes").Error)
+
+	_, err := ls.GetRotationPolicyBySecret(ctx, 1)
+	require.Error(t, err)
+	assert.False(t, strings.Contains(err.Error(), "not found"),
+		"expected a DB-error path (not a not-found), got: %v", err)
+}
+
+// TestGetRotationPolicyBySecret_PolicyLookupDBError verifies that a real DB
+// failure on the policy lookup (after a successful secret lookup) propagates
+// as a wrapped error from the policy query path.
+func TestGetRotationPolicyBySecret_PolicyLookupDBError(t *testing.T) {
+	ls := newRotationPoliciesTestStore(t)
+	ctx := context.Background()
+	secretID, _ := seedRotationPolicyFixture(t, ls)
+
+	// Drop rotation_policies so the policy query returns a table-missing error
+	// while the secret lookup still succeeds.
+	require.NoError(t, ls.db.Exec("DROP TABLE rotation_policies").Error)
+
+	_, err := ls.GetRotationPolicyBySecret(ctx, secretID)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "GetRotationPolicyBySecret"),
+		"expected wrapped policy-lookup error, got: %v", err)
+}
+
+// TestUpdateRotationState_DBError verifies that a real DB failure propagates
+// as an error from UpdateRotationState.
+func TestUpdateRotationState_DBError(t *testing.T) {
+	ls := newRotationPoliciesTestStore(t)
+	ctx := context.Background()
+	_, policyID := seedRotationPolicyFixture(t, ls)
+
+	sqlDB, err := ls.db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	err = ls.UpdateRotationState(ctx, policyID, "rotating", "")
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "UpdateRotationState"),
+		"expected error to mention UpdateRotationState, got: %v", err)
+}
+
+// TestUpdateRotationState_ClearsError verifies that a subsequent succeeded state
+// with an empty error message overwrites the previous error string.
+func TestUpdateRotationState_ClearsError(t *testing.T) {
+	ls := newRotationPoliciesTestStore(t)
+	ctx := context.Background()
+	_, policyID := seedRotationPolicyFixture(t, ls)
+
+	require.NoError(t, ls.UpdateRotationState(ctx, policyID, "failed", "timeout"))
+	require.NoError(t, ls.UpdateRotationState(ctx, policyID, "succeeded", ""))
+
+	var got models.RotationPolicy
+	require.NoError(t, ls.db.First(&got, policyID).Error)
+	assert.Equal(t, "succeeded", got.RotationState)
+	assert.Equal(t, "", got.LastRotationError)
+}

--- a/internal/storage/store/remote_rotation_policies.go
+++ b/internal/storage/store/remote_rotation_policies.go
@@ -101,3 +101,18 @@ func (rs *RemoteStorage) DeleteRotationPolicy(ctx context.Context, id uint) erro
 	}
 	return nil
 }
+
+// GetRotationPolicyBySecret is a server-side-only operation: the rotation state
+// endpoint (GET /api/v1/secrets/{id}/rotation-state) is served by the HTTP handler
+// which always runs against LocalStorage. A remote-storage caller reaches the state
+// via the REST endpoint, not this raw storage method.
+func (rs *RemoteStorage) GetRotationPolicyBySecret(_ context.Context, _ uint) (*models.RotationPolicy, error) {
+	return nil, remoteUnsupported("GetRotationPolicyBySecret")
+}
+
+// UpdateRotationState is a server-side-only operation: the rotation executor runs
+// exclusively in the server process (LocalStorage). No REST route exposes this
+// mutation to remote callers.
+func (rs *RemoteStorage) UpdateRotationState(_ context.Context, _ uint, _, _ string) error {
+	return remoteUnsupported("UpdateRotationState")
+}

--- a/internal/storage/store/remote_rotation_state_completeness_test.go
+++ b/internal/storage/store/remote_rotation_state_completeness_test.go
@@ -1,0 +1,13 @@
+package store
+
+func init() {
+	// Rotation state methods are server-side only: the rotation executor
+	// (GetRotationPolicyBySecret / UpdateRotationState) runs exclusively in the
+	// server process against LocalStorage. The rotation state is exposed to remote
+	// callers via GET /api/v1/secrets/{id}/rotation-state (the HTTP handler), not
+	// through the raw storage interface.
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		"GetRotationPolicyBySecret": {statusIntentional, "rotation state lookup runs server-side only; remote callers use GET /api/v1/secrets/{id}/rotation-state"},
+		"UpdateRotationState":       {statusIntentional, "rotation executor runs server-side only; no REST route exposes raw state mutation to remote callers"},
+	})
+}

--- a/internal/storage/store/remote_rotation_state_test.go
+++ b/internal/storage/store/remote_rotation_state_test.go
@@ -1,0 +1,46 @@
+// remote_rotation_state_test.go — exercises the two RemoteStorage stubs
+// introduced by the rotation-state feature: GetRotationPolicyBySecret and
+// UpdateRotationState. Both are intentionally server-side only (see
+// remote_rotation_state_completeness_test.go) so each returns
+// ErrRemoteUnsupported immediately — no HTTP server is needed.
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"errors"
+
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newRotationStateRemote(t *testing.T) *store.RemoteStorage {
+	t.Helper()
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:1"))
+	require.NoError(t, err)
+	return rs
+}
+
+// TestRemoteGetRotationPolicyBySecret_ReturnsUnsupported verifies that calling
+// GetRotationPolicyBySecret on a RemoteStorage returns ErrRemoteUnsupported.
+func TestRemoteGetRotationPolicyBySecret_ReturnsUnsupported(t *testing.T) {
+	rs := newRotationStateRemote(t)
+	_, err := rs.GetRotationPolicyBySecret(context.Background(), 1)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "GetRotationPolicyBySecret")
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected errors.Is(err, ErrRemoteUnsupported)")
+}
+
+// TestRemoteUpdateRotationState_ReturnsUnsupported verifies that calling
+// UpdateRotationState on a RemoteStorage returns ErrRemoteUnsupported.
+func TestRemoteUpdateRotationState_ReturnsUnsupported(t *testing.T) {
+	rs := newRotationStateRemote(t)
+	err := rs.UpdateRotationState(context.Background(), 1, "succeeded", "")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "UpdateRotationState")
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected errors.Is(err, ErrRemoteUnsupported)")
+}

--- a/server/http/handlers/rotation_policies_handler.go
+++ b/server/http/handlers/rotation_policies_handler.go
@@ -383,3 +383,31 @@ func (h *RotationPolicyHandler) Status(w http.ResponseWriter, r *http.Request) {
 
 	h.sendSuccess(w, entries, "")
 }
+
+// GetRotationState handles GET /api/v1/secrets/{id}/rotation-state.
+// Returns the per-policy execution state (idle/pending/rotating/succeeded/failed)
+// for the secret's covering rotation policy. Secrets with no active policy return
+// state="idle" with a 200 (not a 404) — absence of a policy is a normal case.
+func (h *RotationPolicyHandler) GetRotationState(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+
+	idStr := chi.URLParam(r, "id")
+	secretID, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
+		return
+	}
+
+	info, err := h.coreService.GetRotationState(r.Context(), uint(secretID))
+	if err != nil {
+		log.Printf("Error getting rotation state for secret %d: %v", secretID, err)
+		h.sendError(w, "InternalError", "Failed to get rotation state", http.StatusInternalServerError, nil)
+		return
+	}
+
+	h.sendSuccess(w, info, "")
+}

--- a/server/http/handlers/rotation_state_handler_test.go
+++ b/server/http/handlers/rotation_state_handler_test.go
@@ -164,6 +164,29 @@ func TestGetRotationState_401_NoUser(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
+// TestGetRotationState_500_DBError verifies that when the underlying DB is
+// unavailable (closed) the handler returns HTTP 500 rather than panicking or
+// returning a misleading 404/200.
+func TestGetRotationState_500_DBError(t *testing.T) {
+	handler, db := setupRotationStateTest(t)
+	secretID, _ := seedRotationStateFixtures(t, db)
+
+	// Close the underlying *sql.DB so the next query fails with a real error
+	// (not a "not found" — which would map to idle/200).
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/api/v1/secrets/%d/rotation-state", secretID), nil)
+	req = withUserCtx(withChiParam(req, "id", fmt.Sprintf("%d", secretID)))
+
+	w := httptest.NewRecorder()
+	handler.GetRotationState(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
 // TestGetRotationState_StateAfterStamp verifies that after SetRotationState is called
 // the GET endpoint reflects the updated state.
 func TestGetRotationState_StateAfterStamp(t *testing.T) {

--- a/server/http/handlers/rotation_state_handler_test.go
+++ b/server/http/handlers/rotation_state_handler_test.go
@@ -1,0 +1,189 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupRotationStateTest(t *testing.T) (*RotationPolicyHandler, *gorm.DB) {
+	t.Helper()
+
+	cfg := &config.Config{
+		Locale: config.LocaleConfig{
+			Language:         "en",
+			FallbackLanguage: "en",
+		},
+	}
+	require.NoError(t, i18n.Initialize(cfg))
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{},
+		&models.Environment{},
+		&models.SecretNode{},
+		&models.RotationPolicy{},
+		&models.Role{},
+		&models.Permission{},
+		&models.RolePermission{},
+		&models.UserRole{},
+		&models.Group{},
+		&models.UserGroup{},
+		&models.GroupRole{},
+	))
+
+	// Make the test user (ID 1) a global admin so scoped permission checks pass.
+	adminRole := &models.Role{Name: "admin", Description: "Administrator"}
+	require.NoError(t, db.Create(adminRole).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID}).Error)
+
+	localStorage := store.NewLocalStorage(db)
+	coreService := core.NewKeyorixCore(localStorage)
+	handler := NewRotationPolicyHandler(coreService)
+	return handler, db
+}
+
+// seedRotationStateFixtures creates a project, environment, secret, and an active
+// rotation policy scoped to that project. Returns the secret ID and policy ID.
+func seedRotationStateFixtures(t *testing.T, db *gorm.DB) (secretID uint, policyID uint) {
+	t.Helper()
+	proj := &models.Project{Name: "rot-state-proj"}
+	require.NoError(t, db.Create(proj).Error)
+
+	env := &models.Environment{Name: "prod", ProjectID: proj.ID}
+	require.NoError(t, db.Create(env).Error)
+
+	secret := &models.SecretNode{
+		Name:          "MY_SECRET",
+		ProjectID:     proj.ID,
+		EnvironmentID: env.ID,
+		IsSecret:      true,
+	}
+	require.NoError(t, db.Create(secret).Error)
+
+	policy := &models.RotationPolicy{
+		Name:         "30-day policy",
+		Scope:        "project",
+		ProjectID:    &proj.ID,
+		IntervalDays: 30,
+		IsActive:     true,
+		CreatedBy:    "testuser",
+	}
+	require.NoError(t, db.Create(policy).Error)
+	return secret.ID, policy.ID
+}
+
+// TestGetRotationState_200_WithPolicy verifies that a secret with an active policy
+// returns HTTP 200 with the policy state fields.
+func TestGetRotationState_200_WithPolicy(t *testing.T) {
+	handler, db := setupRotationStateTest(t)
+	secretID, _ := seedRotationStateFixtures(t, db)
+
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/api/v1/secrets/%d/rotation-state", secretID), nil)
+	req = withUserCtx(withChiParam(req, "id", fmt.Sprintf("%d", secretID)))
+
+	w := httptest.NewRecorder()
+	handler.GetRotationState(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"state"`)
+	assert.Contains(t, body, `"secret_id"`)
+}
+
+// TestGetRotationState_200_NoPolicy verifies that a secret with no active policy
+// returns HTTP 200 with state="idle" (no 404).
+func TestGetRotationState_200_NoPolicy(t *testing.T) {
+	handler, db := setupRotationStateTest(t)
+
+	// Create a secret in a project that has no rotation policy.
+	proj := &models.Project{Name: "no-policy-proj"}
+	require.NoError(t, db.Create(proj).Error)
+	env := &models.Environment{Name: "staging", ProjectID: proj.ID}
+	require.NoError(t, db.Create(env).Error)
+	secret := &models.SecretNode{
+		Name:          "BARE_SECRET",
+		ProjectID:     proj.ID,
+		EnvironmentID: env.ID,
+		IsSecret:      true,
+	}
+	require.NoError(t, db.Create(secret).Error)
+
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/api/v1/secrets/%d/rotation-state", secret.ID), nil)
+	req = withUserCtx(withChiParam(req, "id", fmt.Sprintf("%d", secret.ID)))
+
+	w := httptest.NewRecorder()
+	handler.GetRotationState(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"idle"`)
+}
+
+// TestGetRotationState_400_BadID verifies that a non-numeric secret ID returns 400.
+func TestGetRotationState_400_BadID(t *testing.T) {
+	handler, _ := setupRotationStateTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets/abc/rotation-state", nil)
+	req = withUserCtx(withChiParam(req, "id", "abc"))
+
+	w := httptest.NewRecorder()
+	handler.GetRotationState(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestGetRotationState_401_NoUser verifies that a missing user context returns 401.
+func TestGetRotationState_401_NoUser(t *testing.T) {
+	handler, _ := setupRotationStateTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/secrets/1/rotation-state", nil)
+	// No withUserCtx — user context is absent.
+	req = withChiParam(req, "id", "1")
+
+	w := httptest.NewRecorder()
+	handler.GetRotationState(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestGetRotationState_StateAfterStamp verifies that after SetRotationState is called
+// the GET endpoint reflects the updated state.
+func TestGetRotationState_StateAfterStamp(t *testing.T) {
+	handler, db := setupRotationStateTest(t)
+	secretID, policyID := seedRotationStateFixtures(t, db)
+
+	// Stamp the policy via the store directly (simulating the rotation executor).
+	localStorage := store.NewLocalStorage(db)
+	err := localStorage.UpdateRotationState(context.Background(), policyID, core.RotationStateFailed, "backend timeout")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/api/v1/secrets/%d/rotation-state", secretID), nil)
+	req = withUserCtx(withChiParam(req, "id", fmt.Sprintf("%d", secretID)))
+
+	w := httptest.NewRecorder()
+	handler.GetRotationState(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.True(t, strings.Contains(body, `"failed"`) || strings.Contains(body, `"backend timeout"`),
+		"expected failed state or error message in response: %s", body)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -593,6 +593,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// Blast-radius report: richer impact view with OwnerID, ProjectID, and risk level.
 			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/blast-radius", secretHandler.GetBlastRadius)
 
+			// Rotation state — per-policy execution state (idle/pending/rotating/succeeded/failed).
+			// Gated on secrets.read because it exposes metadata (when rotation last ran, any error)
+			// without disclosing the secret value.
+			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/rotation-state", rotationPolicyHandler.GetRotationState)
+
 			// Per-secret ACLs (RBAC Phase 3): fine-grained user grants independent of project RBAC.
 			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Get("/{id}/acl", secretHandler.ListSecretACLs)
 			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Post("/{id}/acl", secretHandler.GrantSecretACL)


### PR DESCRIPTION
## Summary

- Adds `RotationState`, `LastRotationError`, `LastStateAt` fields to `RotationPolicy` model (GORM AutoMigrate handles columns)
- Adds `GetRotationState` and `SetRotationState` core methods; `GetRotationState` returns `state: "idle"` when no policy exists (not an error)
- Adds `GetRotationPolicyBySecret` and `UpdateRotationState` to storage interface with local implementations and remote stubs
- Exposes `GET /api/v1/secrets/{id}/rotation-state` gated on `secrets.read`

## Test plan

- [ ] Secret with no rotation policy returns `state: "idle"` with 200
- [ ] After rotation job stamps failed state, endpoint shows `state: "failed"` + `last_rotation_error`
- [ ] `SetRotationState` with unknown state string returns ErrInvalidInput
- [ ] 401 without auth, 400 with invalid secret ID

🤖 Generated with [Claude Code](https://claude.ai/code)