### PR TITLE
feat(secrets): add per-secret retention policy override

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -717,6 +717,10 @@ func (m *MockStorage) SetSecretCertNotAfter(ctx context.Context, secretID uint, 
 	return m.Called(ctx, secretID, notAfter).Error(0)
 }
 
+func (m *MockStorage) SetRetentionOverride(ctx context.Context, secretID uint, days int) error {
+	return m.Called(ctx, secretID, days).Error(0)
+}
+
 func (m *MockStorage) IncrementSecretReadCount(ctx context.Context, versionID uint) error {
 	args := m.Called(ctx, versionID)
 	return args.Error(0)

--- a/internal/core/secret_retention_override.go
+++ b/internal/core/secret_retention_override.go
@@ -1,0 +1,60 @@
+// secret_retention_override.go — per-secret retention policy override.
+//
+// Allows operators to set a per-secret retention window that takes precedence
+// over the global data-retention policy (ADR-032). High-value secrets can
+// therefore be retained longer than the global default without changing the
+// deployment-wide window for every secret.
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ErrInvalidRetentionDays is returned when a caller supplies a non-zero
+// retention override value that is below the minimum allowed floor (7 days).
+var ErrInvalidRetentionDays = errors.New("retention_override_days must be 0 (clear) or >= 7")
+
+const minRetentionOverrideDays = 7
+
+// SetSecretRetentionOverride sets or clears the per-secret retention override.
+//
+//   - days = 0 clears the override (reverts to the global policy).
+//   - days >= 7 sets the override.
+//   - Any other non-zero value returns ErrInvalidRetentionDays.
+//
+// The caller (transport layer) is responsible for ensuring the actor holds
+// secrets.manage at the secret's scope before invoking this method.
+func (c *KeyorixCore) SetSecretRetentionOverride(ctx context.Context, actorID, secretID uint, days int) error {
+	if days != 0 && days < minRetentionOverrideDays {
+		return fmt.Errorf("%w (got %d)", ErrInvalidRetentionDays, days)
+	}
+	if err := c.storage.SetRetentionOverride(ctx, secretID, days); err != nil {
+		return err
+	}
+	uid := actorID
+	sid := secretID
+	var desc string
+	if days == 0 {
+		desc = fmt.Sprintf("cleared per-secret retention override on secret %d (reverts to global policy)", secretID)
+	} else {
+		desc = fmt.Sprintf("set per-secret retention override on secret %d to %d days", secretID, days)
+	}
+	c.writeAuditEvent(ctx, "secret.retention_override_set", &uid, &sid, desc)
+	return nil
+}
+
+// GetEffectiveRetentionDays returns the effective retention window for a
+// secret. If the secret has a non-zero RetentionOverrideDays the override wins;
+// otherwise globalDays (the deployment-wide policy value) is returned. This is
+// a pure, dependency-free helper for purge-sweep callers so they do not need to
+// re-read the config for every secret they evaluate.
+func GetEffectiveRetentionDays(secret *models.SecretNode, globalDays int) int {
+	if secret.RetentionOverrideDays > 0 {
+		return secret.RetentionOverrideDays
+	}
+	return globalDays
+}

--- a/internal/core/secret_retention_override_test.go
+++ b/internal/core/secret_retention_override_test.go
@@ -1,0 +1,124 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// ── SetSecretRetentionOverride ────────────────────────────────────────────────
+
+// TestSetSecretRetentionOverride_HappyPath verifies that a valid override (>= 7
+// days) is forwarded to storage and that an audit event is emitted.
+func TestSetSecretRetentionOverride_HappyPath(t *testing.T) {
+	m := &MockStorage{}
+	c := NewKeyorixCore(m)
+
+	m.On("SetRetentionOverride", mock.Anything, uint(42), 30).Return(nil)
+	// Audit event sink — emitAudit calls LogAuditEvent on storage.
+	m.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	err := c.SetSecretRetentionOverride(context.Background(), 1, 42, 30)
+	require.NoError(t, err)
+	m.AssertCalled(t, "SetRetentionOverride", mock.Anything, uint(42), 30)
+}
+
+// TestSetSecretRetentionOverride_ClearOverride verifies that days=0 is allowed
+// (clears the override) and is forwarded to storage.
+func TestSetSecretRetentionOverride_ClearOverride(t *testing.T) {
+	m := &MockStorage{}
+	c := NewKeyorixCore(m)
+
+	m.On("SetRetentionOverride", mock.Anything, uint(7), 0).Return(nil)
+	m.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	err := c.SetSecretRetentionOverride(context.Background(), 1, 7, 0)
+	require.NoError(t, err)
+	m.AssertCalled(t, "SetRetentionOverride", mock.Anything, uint(7), 0)
+}
+
+// TestSetSecretRetentionOverride_BelowMinimum verifies that days=6 (below the
+// 7-day floor) is rejected with ErrInvalidRetentionDays without touching storage.
+func TestSetSecretRetentionOverride_BelowMinimum(t *testing.T) {
+	m := &MockStorage{}
+	c := NewKeyorixCore(m)
+
+	err := c.SetSecretRetentionOverride(context.Background(), 1, 99, 6)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidRetentionDays), "expected ErrInvalidRetentionDays, got: %v", err)
+	m.AssertNotCalled(t, "SetRetentionOverride", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestSetSecretRetentionOverride_Negative verifies that a negative days value
+// is rejected with ErrInvalidRetentionDays.
+func TestSetSecretRetentionOverride_Negative(t *testing.T) {
+	m := &MockStorage{}
+	c := NewKeyorixCore(m)
+
+	err := c.SetSecretRetentionOverride(context.Background(), 1, 5, -1)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidRetentionDays), "expected ErrInvalidRetentionDays, got: %v", err)
+	m.AssertNotCalled(t, "SetRetentionOverride", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestSetSecretRetentionOverride_StorageError verifies that a storage error is
+// propagated to the caller (and no audit event is emitted on failure).
+func TestSetSecretRetentionOverride_StorageError(t *testing.T) {
+	m := &MockStorage{}
+	c := NewKeyorixCore(m)
+
+	storageErr := errors.New("db unavailable")
+	m.On("SetRetentionOverride", mock.Anything, uint(10), 90).Return(storageErr)
+
+	err := c.SetSecretRetentionOverride(context.Background(), 1, 10, 90)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storageErr)
+	// No audit event should be emitted when storage fails.
+	m.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+}
+
+// TestSetSecretRetentionOverride_ExactMinimum verifies that exactly 7 days is
+// accepted (boundary condition).
+func TestSetSecretRetentionOverride_ExactMinimum(t *testing.T) {
+	m := &MockStorage{}
+	c := NewKeyorixCore(m)
+
+	m.On("SetRetentionOverride", mock.Anything, uint(1), 7).Return(nil)
+	m.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	err := c.SetSecretRetentionOverride(context.Background(), 1, 1, 7)
+	require.NoError(t, err)
+	m.AssertCalled(t, "SetRetentionOverride", mock.Anything, uint(1), 7)
+}
+
+// ── GetEffectiveRetentionDays ─────────────────────────────────────────────────
+
+// TestGetEffectiveRetentionDays_OverrideSet verifies that a non-zero
+// RetentionOverrideDays on the secret takes precedence over the global value.
+func TestGetEffectiveRetentionDays_OverrideSet(t *testing.T) {
+	secret := &models.SecretNode{RetentionOverrideDays: 365}
+	result := GetEffectiveRetentionDays(secret, 90)
+	assert.Equal(t, 365, result)
+}
+
+// TestGetEffectiveRetentionDays_OverrideZero verifies that when
+// RetentionOverrideDays is 0 the global policy value is returned.
+func TestGetEffectiveRetentionDays_OverrideZero(t *testing.T) {
+	secret := &models.SecretNode{RetentionOverrideDays: 0}
+	result := GetEffectiveRetentionDays(secret, 90)
+	assert.Equal(t, 90, result)
+}
+
+// TestGetEffectiveRetentionDays_OverrideEqualsGlobal verifies that a secret
+// whose override equals the global policy correctly returns the override value
+// (same effective result, but driven by the override branch).
+func TestGetEffectiveRetentionDays_OverrideEqualsGlobal(t *testing.T) {
+	secret := &models.SecretNode{RetentionOverrideDays: 90}
+	result := GetEffectiveRetentionDays(secret, 90)
+	assert.Equal(t, 90, result)
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -600,6 +600,9 @@ type Storage interface {
 	// SetSecretCertNotAfter caches a certificate-typed secret's parsed leaf expiry
 	// (ADR-056), a targeted column update with no other side effects.
 	SetSecretCertNotAfter(ctx context.Context, secretID uint, notAfter *time.Time) error
+	// SetRetentionOverride sets the RetentionOverrideDays on a SecretNode row.
+	// days = 0 clears the override (reverts to the global policy).
+	SetRetentionOverride(ctx context.Context, secretID uint, days int) error
 	IncrementSecretReadCount(ctx context.Context, versionID uint) error
 	// TryIncrementSecretReadCount atomically increments a version's read count only
 	// while it is still below maxReads, in a single conditional UPDATE. Returns true

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -627,6 +627,9 @@ type SecretNode struct {
 	// auto-scopes `deleted_at IS NULL` on model-based queries — raw/Table/Joins
 	// queries on secret_nodes must filter it explicitly.
 	DeletedAt gorm.DeletedAt `gorm:"index"`
+	// RetentionOverrideDays overrides the global retention window for this secret.
+	// 0 means "use global setting". Must be >= 7 if non-zero.
+	RetentionOverrideDays int `gorm:"default:0" json:"retention_override_days,omitempty"`
 	// ValueStored is a transient, in-process-only signal (#499): never persisted
 	// (`gorm:"-"`) and never serialized (`json:"-"`). storage.Storage.CreateSecret
 	// sets it true on the node it returns ONLY when the backend already durably

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -468,6 +468,17 @@ func (ls *LocalStorage) SetSecretCertNotAfter(ctx context.Context, secretID uint
 	return nil
 }
 
+// SetRetentionOverride sets the per-secret retention override. days = 0 clears
+// the override (reverts to the global policy). The caller is responsible for
+// validating the minimum floor before invoking this method.
+func (ls *LocalStorage) SetRetentionOverride(ctx context.Context, secretID uint, days int) error {
+	if err := ls.db.WithContext(ctx).Model(&models.SecretNode{}).
+		Where(sqlWhereID, secretID).Update("retention_override_days", days).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
 // DeleteSecret deletes a secret by ID. #370: ShareRecord rows are a fully
 // independent lifecycle from SecretNode's — left untouched, a share grant would
 // silently reactivate (via CheckSharePermission) the instant the secret is later

--- a/internal/storage/store/remote_retention_override.go
+++ b/internal/storage/store/remote_retention_override.go
@@ -1,0 +1,17 @@
+// remote_retention_override.go — RemoteStorage stub for SetRetentionOverride.
+//
+// Per-secret retention override management is always server-side: the
+// PATCH /api/v1/secrets/{id}/retention endpoint mutates the SecretNode row
+// directly on the server. A remote client (storage.type: remote) never calls
+// SetRetentionOverride on its own storage backend — it issues the HTTP request
+// instead, and the server-side handler invokes LocalStorage. This stub is
+// therefore intentionally permanent.
+package store
+
+import "context"
+
+// SetRetentionOverride is not supported in remote storage. Override management
+// is always performed server-side via PATCH /api/v1/secrets/{id}/retention.
+func (rs *RemoteStorage) SetRetentionOverride(_ context.Context, _ uint, _ int) error {
+	return remoteUnsupported("SetRetentionOverride")
+}

--- a/internal/storage/store/remote_retention_override_completeness_test.go
+++ b/internal/storage/store/remote_retention_override_completeness_test.go
@@ -1,0 +1,8 @@
+package store
+
+func init() {
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		"SetRetentionOverride": {statusIntentional,
+			"per-secret retention override is always set server-side via PATCH /api/v1/secrets/{id}/retention; a remote-storage client never calls this method directly"},
+	})
+}

--- a/server/http/handlers/secrets_retention_override.go
+++ b/server/http/handlers/secrets_retention_override.go
@@ -1,0 +1,58 @@
+// secrets_retention_override.go — SetRetentionOverride handler.
+//
+// PATCH /api/v1/secrets/{id}/retention
+// Body:    {"retention_override_days": N}  (0 = clear override)
+// Success: 200 {"data": {"secret_id": N, "retention_override_days": N}}
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// SetRetentionOverride handles PATCH /api/v1/secrets/{id}/retention.
+// Gated by secrets.manage at the secret scope (wired in router.go).
+func (h *SecretHandler) SetRetentionOverride(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	rawID := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(rawID, 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid secret ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	var reqBody struct {
+		RetentionOverrideDays int `json:"retention_override_days"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
+		return
+	}
+
+	if err := h.coreService.SetSecretRetentionOverride(
+		r.Context(), userCtx.UserID, uint(id), reqBody.RetentionOverrideDays,
+	); err != nil {
+		if errors.Is(err, core.ErrInvalidRetentionDays) {
+			h.sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
+			return
+		}
+		h.sendError(w, "InternalError", "Failed to set retention override", http.StatusInternalServerError, nil)
+		return
+	}
+
+	h.sendSuccess(w, map[string]interface{}{
+		"secret_id":             uint(id),
+		"retention_override_days": reqBody.RetentionOverrideDays,
+	}, "Retention override updated")
+}

--- a/server/http/handlers/secrets_retention_override_test.go
+++ b/server/http/handlers/secrets_retention_override_test.go
@@ -1,0 +1,253 @@
+// secrets_retention_override_test.go — handler coverage for SetRetentionOverride.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	customMiddleware "github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var retentionOverrideDBCounter atomic.Int64
+
+// freshRetentionHandlerFixture opens a unique in-memory SQLite DB, migrates
+// models, seeds one user + project + env + secret, and returns the handler and
+// the secret's ID.
+func freshRetentionHandlerFixture(t *testing.T) (*SecretHandler, uint) {
+	t.Helper()
+
+	cfg := &config.Config{Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"}}
+	require.NoError(t, i18n.Initialize(cfg))
+
+	n := retentionOverrideDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhandlers_ret_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{},
+		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{},
+		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.ShareRecord{},
+		&models.Tag{}, &models.SecretTag{},
+		&models.ProjectMembership{}, &models.SoDPolicy{},
+		&models.AnomalyAlert{}, &models.RotationPolicy{}, &models.Notification{},
+		&models.BreakGlassActivation{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{},
+		&models.LoginAttempt{},
+		&models.AccessRequest{}, &models.AccessRequestApproval{},
+		&models.WebAuthnCredential{}, &models.WebAuthnSession{},
+		&models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
+		&models.ConnectRefGrant{}, &models.Session{}, &models.SetupToken{},
+		&models.MFAChallenge{}, &models.SSOLoginState{},
+		&models.MachineIdentity{}, &models.MachineIdentityCredential{},
+		&models.MachineIdentityRole{}, &models.MachineIdentityOIDCBinding{},
+		&models.SecretDependency{}, &models.RiskException{},
+		&models.MFASecret{}, &models.MFARecoveryCode{},
+		&models.IdentityProvider{}, &models.ExternalIdentity{},
+		&models.LegalHold{},
+		&models.PersonalAccessToken{},
+		&models.ProjectInvitation{}, &models.SchedulerLockLease{},
+		&models.SystemMetadata{},
+		&models.PasswordHistory{},
+	))
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "retowner", Email: "retowner@test.com"}).Error)
+
+	st := store.NewLocalStorage(db)
+	cs := core.NewKeyorixCore(st)
+	ctx := context.Background()
+
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "proj-ret"})
+	require.NoError(t, err)
+	env, err := st.CreateEnvironment(ctx, &models.Environment{Name: "env-ret", ProjectID: proj.ID})
+	require.NoError(t, err)
+	secret, err := st.CreateSecret(ctx, &models.SecretNode{
+		Name:          "high-value-secret",
+		ProjectID:     proj.ID,
+		EnvironmentID: env.ID,
+		Type:          "static",
+		OwnerID:       1,
+		IsSecret:      true,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	})
+	require.NoError(t, err)
+
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	return h, secret.ID
+}
+
+// withRetentionUserCtx injects UserID=1 into the request context.
+func withRetentionUserCtx(r *http.Request) *http.Request {
+	uctx := &customMiddleware.UserContext{UserID: 1, Username: "retowner", Email: "retowner@test.com"}
+	return r.WithContext(context.WithValue(r.Context(), customMiddleware.GetUserContextKey(), uctx))
+}
+
+// ── 401 — missing user context ────────────────────────────────────────────────
+
+// TestSetRetentionOverride_NoUserCtx_401 verifies that a request without an
+// authenticated user context returns 401.
+func TestSetRetentionOverride_NoUserCtx_401(t *testing.T) {
+	h, id := freshRetentionHandlerFixture(t)
+
+	body, _ := json.Marshal(map[string]int{"retention_override_days": 30})
+	req := withChiParamS14(
+		httptest.NewRequest(http.MethodPatch, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/retention", bytes.NewReader(body)),
+		"id", strconv.Itoa(int(id)),
+	)
+	w := httptest.NewRecorder()
+	h.SetRetentionOverride(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// ── 400 — bad secret ID ───────────────────────────────────────────────────────
+
+// TestSetRetentionOverride_BadID_400 sends a non-numeric id path parameter → 400.
+func TestSetRetentionOverride_BadID_400(t *testing.T) {
+	h, _ := freshRetentionHandlerFixture(t)
+
+	body, _ := json.Marshal(map[string]int{"retention_override_days": 30})
+	req := withRetentionUserCtx(withChiParamS14(
+		httptest.NewRequest(http.MethodPatch, "/api/v1/secrets/bad/retention", bytes.NewReader(body)),
+		"id", "not-a-number",
+	))
+	w := httptest.NewRecorder()
+	h.SetRetentionOverride(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── 400 — invalid JSON ────────────────────────────────────────────────────────
+
+// TestSetRetentionOverride_InvalidJSON_400 sends a malformed body → 400.
+func TestSetRetentionOverride_InvalidJSON_400(t *testing.T) {
+	h, id := freshRetentionHandlerFixture(t)
+
+	req := withRetentionUserCtx(withChiParamS14(
+		httptest.NewRequest(http.MethodPatch, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/retention",
+			bytes.NewBufferString("{not-valid-json")),
+		"id", strconv.Itoa(int(id)),
+	))
+	w := httptest.NewRecorder()
+	h.SetRetentionOverride(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── 400 — below minimum (days=6) ─────────────────────────────────────────────
+
+// TestSetRetentionOverride_BelowMin_400 sends retention_override_days=6 (below
+// the 7-day floor) → core returns ErrInvalidRetentionDays → 400.
+func TestSetRetentionOverride_BelowMin_400(t *testing.T) {
+	h, id := freshRetentionHandlerFixture(t)
+
+	body, _ := json.Marshal(map[string]int{"retention_override_days": 6})
+	req := withRetentionUserCtx(withChiParamS14(
+		httptest.NewRequest(http.MethodPatch, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/retention", bytes.NewReader(body)),
+		"id", strconv.Itoa(int(id)),
+	))
+	w := httptest.NewRecorder()
+	h.SetRetentionOverride(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "ValidationError")
+}
+
+// ── 400 — negative days ───────────────────────────────────────────────────────
+
+// TestSetRetentionOverride_Negative_400 sends retention_override_days=-1 → 400.
+func TestSetRetentionOverride_Negative_400(t *testing.T) {
+	h, id := freshRetentionHandlerFixture(t)
+
+	body, _ := json.Marshal(map[string]int{"retention_override_days": -1})
+	req := withRetentionUserCtx(withChiParamS14(
+		httptest.NewRequest(http.MethodPatch, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/retention", bytes.NewReader(body)),
+		"id", strconv.Itoa(int(id)),
+	))
+	w := httptest.NewRecorder()
+	h.SetRetentionOverride(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── 200 — valid override ──────────────────────────────────────────────────────
+
+// TestSetRetentionOverride_Valid_200 sets a valid 30-day override → 200.
+func TestSetRetentionOverride_Valid_200(t *testing.T) {
+	h, id := freshRetentionHandlerFixture(t)
+
+	body, _ := json.Marshal(map[string]int{"retention_override_days": 30})
+	req := withRetentionUserCtx(withChiParamS14(
+		httptest.NewRequest(http.MethodPatch, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/retention", bytes.NewReader(body)),
+		"id", strconv.Itoa(int(id)),
+	))
+	w := httptest.NewRecorder()
+	h.SetRetentionOverride(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["success"])
+	data := resp["data"].(map[string]interface{})
+	assert.Equal(t, float64(30), data["retention_override_days"])
+}
+
+// ── 200 — clear override (days=0) ────────────────────────────────────────────
+
+// TestSetRetentionOverride_ClearOverride_200 sends days=0 to clear an override → 200.
+func TestSetRetentionOverride_ClearOverride_200(t *testing.T) {
+	h, id := freshRetentionHandlerFixture(t)
+
+	body, _ := json.Marshal(map[string]int{"retention_override_days": 0})
+	req := withRetentionUserCtx(withChiParamS14(
+		httptest.NewRequest(http.MethodPatch, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/retention", bytes.NewReader(body)),
+		"id", strconv.Itoa(int(id)),
+	))
+	w := httptest.NewRecorder()
+	h.SetRetentionOverride(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["success"])
+	data := resp["data"].(map[string]interface{})
+	assert.Equal(t, float64(0), data["retention_override_days"])
+}
+
+// ── 200 — exact minimum (days=7) ─────────────────────────────────────────────
+
+// TestSetRetentionOverride_ExactMin_200 sets exactly 7 days (the minimum) → 200.
+func TestSetRetentionOverride_ExactMin_200(t *testing.T) {
+	h, id := freshRetentionHandlerFixture(t)
+
+	body, _ := json.Marshal(map[string]int{"retention_override_days": 7})
+	req := withRetentionUserCtx(withChiParamS14(
+		httptest.NewRequest(http.MethodPatch, "/api/v1/secrets/"+strconv.Itoa(int(id))+"/retention", bytes.NewReader(body)),
+		"id", strconv.Itoa(int(id)),
+	))
+	w := httptest.NewRecorder()
+	h.SetRetentionOverride(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -603,6 +603,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Put(pathIDSchedule, secretHandler.SetSecretSchedule)
 			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Delete(pathIDSchedule, secretHandler.DeleteSecretSchedule)
 
+			// Per-secret retention policy override: allows operators to give a
+			// specific secret a longer (or shorter) retention window than the global
+			// data-retention policy (ADR-032). Gated by secrets.manage because it
+			// changes how long the secret persists after deletion — a privileged
+			// policy decision, not a routine write.
+			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Patch("/{id}/retention", secretHandler.SetRetentionOverride)
+
 			// Certificate inspection (ADR-054) — public X.509 metadata, no value/key.
 			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/certificate", secretHandler.GetSecretCertificate)
 


### PR DESCRIPTION
## Summary

- Adds `RetentionOverrideDays int` to `SecretNode` (GORM default 0 = use global); minimum 7 days if non-zero
- Adds `SetSecretRetentionOverride` core method and `GetEffectiveRetentionDays` pure helper for purge sweep callers
- Adds `SetRetentionOverride` to storage interface with local implementation and remote stub
- Exposes `PATCH /api/v1/secrets/{id}/retention` gated on `secrets.manage`; passing `retention_override_days: 0` clears the override

## Test plan

- [ ] `PATCH` with `retention_override_days: 30` persists and returns 200
- [ ] `retention_override_days: 0` clears override (reverts to global)
- [ ] `retention_override_days: 6` returns 400 (below 7-day floor)
- [ ] `retention_override_days: -1` returns 400
- [ ] `GetEffectiveRetentionDays` returns override when set, global otherwise

🤖 Generated with [Claude Code](https://claude.ai/code)