### PR TITLE
feat(secrets): add dependency cascade impact preview

### DIFF
--- a/internal/core/secret_impact_preview.go
+++ b/internal/core/secret_impact_preview.go
@@ -1,0 +1,69 @@
+// secret_impact_preview.go — cascade-delete impact preview for a secret (ADR-052
+// companion). Answers "if I soft-delete this secret, how many secrets would also
+// be cascade-deleted?" — a flat count/summary rather than the full dependency
+// graph that GetSecretImpact returns. Re-uses the same storage calls and BFS
+// helpers as the existing dependency analysis.
+package core
+
+import "context"
+
+// ImpactPreviewResult is the response payload for
+// GET /api/v1/secrets/{id}/impact-preview.
+type ImpactPreviewResult struct {
+	SecretID             uint   `json:"secret_id"`
+	DirectDependents     int    `json:"direct_dependents"`   // secrets that directly depend on this one (depth=1)
+	TransitiveDependents int    `json:"transitive_dependents"` // full transitive-closure count (excludes root)
+	AffectedSecretIDs    []uint `json:"affected_secret_ids"` // IDs of all transitively affected secrets
+	MaxDepth             int    `json:"max_depth"`           // deepest dependency chain length found
+}
+
+// GetSecretImpactPreview computes the cascade-delete impact of removing secretID.
+//
+// It reuses the same SecretDependency storage infrastructure as GetSecretImpact /
+// ListSecretDependencies: one ListSecretDependenciesForProject call loads the
+// project's full edge list, edgesWithinEnvironment restricts it to the secret's
+// own environment (defence-in-depth), and transitiveDependents does a BFS to find
+// every dependent in the "dependents" direction (i.e. secrets that depend on
+// secretID and would therefore lose their upstream if secretID were deleted).
+//
+// The result is a flat count/summary, not the annotated node graph that
+// GetSecretImpact returns.
+func (c *KeyorixCore) GetSecretImpactPreview(ctx context.Context, secretID uint) (*ImpactPreviewResult, error) {
+	secret, err := c.requireSecret(ctx, secretID)
+	if err != nil {
+		return nil, err
+	}
+
+	edges, err := c.storage.ListSecretDependenciesForProject(ctx, secret.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+
+	info := c.resolveSecretInfo(ctx, edges)
+	// Defence-in-depth: restrict to the focal secret's environment only, matching
+	// the same guard in ListSecretDependencies and GetSecretImpact.
+	edges = edgesWithinEnvironment(edges, info, secret.EnvironmentID)
+
+	// transitiveDependents walks the "dependents" direction (secrets that depend ON
+	// secretID), which is the correct direction for cascade-delete impact: if secretID
+	// is removed, every secret that depended on it is affected.
+	affected := transitiveDependents(edges, secretID)
+
+	result := &ImpactPreviewResult{
+		SecretID:          secretID,
+		AffectedSecretIDs: make([]uint, 0, len(affected)),
+	}
+
+	for _, a := range affected {
+		result.AffectedSecretIDs = append(result.AffectedSecretIDs, a.id)
+		result.TransitiveDependents++
+		if a.depth == 1 {
+			result.DirectDependents++
+		}
+		if a.depth > result.MaxDepth {
+			result.MaxDepth = a.depth
+		}
+	}
+
+	return result, nil
+}

--- a/internal/core/secret_impact_preview_test.go
+++ b/internal/core/secret_impact_preview_test.go
@@ -1,0 +1,164 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newImpactPreviewCore builds a minimal in-memory core for impact-preview tests.
+// Each call gets a fresh in-memory DB via ":memory:" — no DSN collision because
+// each gorm.Open(":memory:") allocates its own SQLite database.
+func newImpactPreviewCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{},
+		&models.SecretDependency{},
+		&models.AuditEvent{},
+		&models.Project{},
+		&models.Environment{},
+		&models.ShareRecord{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p-impact"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env-impact"}).Error)
+	now := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	return c, db
+}
+
+// mkIPSecret inserts a live secret in project 1, environment 1.
+func mkIPSecret(t *testing.T, db *gorm.DB, name string) uint {
+	t.Helper()
+	s := &models.SecretNode{ProjectID: 1, EnvironmentID: 1, Name: name, IsSecret: true, Status: "active"}
+	require.NoError(t, db.Create(s).Error)
+	return s.ID
+}
+
+
+// TestGetSecretImpactPreview_NoDependents: a secret with no downstream dependents
+// returns all-zero counts and an empty (non-nil) slice.
+func TestGetSecretImpactPreview_NoDependents(t *testing.T) {
+	c, db := newImpactPreviewCore(t)
+	aID := mkIPSecret(t, db, "standalone")
+
+	got, err := c.GetSecretImpactPreview(context.Background(), aID)
+	require.NoError(t, err)
+	assert.Equal(t, aID, got.SecretID)
+	assert.Equal(t, 0, got.DirectDependents)
+	assert.Equal(t, 0, got.TransitiveDependents)
+	assert.Empty(t, got.AffectedSecretIDs)
+	assert.Equal(t, 0, got.MaxDepth)
+}
+
+// TestGetSecretImpactPreview_TwoDirectDependents: two secrets directly depend on
+// the focal secret; no transitive chain beyond depth 1.
+func TestGetSecretImpactPreview_TwoDirectDependents(t *testing.T) {
+	c, db := newImpactPreviewCore(t)
+	rootID := mkIPSecret(t, db, "root")
+	depA := mkIPSecret(t, db, "dep-a")
+	depB := mkIPSecret(t, db, "dep-b")
+	addImpactEdge(t, db, depA, rootID)
+	addImpactEdge(t, db, depB, rootID)
+
+	got, err := c.GetSecretImpactPreview(context.Background(), rootID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, got.DirectDependents)
+	assert.Equal(t, 2, got.TransitiveDependents)
+	assert.Equal(t, 1, got.MaxDepth)
+	assert.ElementsMatch(t, []uint{depA, depB}, got.AffectedSecretIDs)
+}
+
+// TestGetSecretImpactPreview_TransitiveChain: A is depended on by B; B is
+// depended on by C. Removing A affects B (depth 1) and C (depth 2).
+func TestGetSecretImpactPreview_TransitiveChain(t *testing.T) {
+	c, db := newImpactPreviewCore(t)
+	aID := mkIPSecret(t, db, "chain-a")
+	bID := mkIPSecret(t, db, "chain-b")
+	cID := mkIPSecret(t, db, "chain-c")
+	// B depends on A; C depends on B.
+	addImpactEdge(t, db, bID, aID)
+	addImpactEdge(t, db, cID, bID)
+
+	got, err := c.GetSecretImpactPreview(context.Background(), aID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.DirectDependents, "only B directly depends on A")
+	assert.Equal(t, 2, got.TransitiveDependents, "B and C are both affected")
+	assert.Equal(t, 2, got.MaxDepth)
+	assert.ElementsMatch(t, []uint{bID, cID}, got.AffectedSecretIDs)
+}
+
+// TestGetSecretImpactPreview_CycleDetection: a hand-crafted cycle (rejected by
+// core at add-time, but defensive) must not cause an infinite loop.
+func TestGetSecretImpactPreview_CycleDetection(t *testing.T) {
+	c, db := newImpactPreviewCore(t)
+	aID := mkIPSecret(t, db, "cycle-a")
+	bID := mkIPSecret(t, db, "cycle-b")
+	// A depends on B AND B depends on A — manually inserted cycle.
+	addImpactEdge(t, db, aID, bID)
+	addImpactEdge(t, db, bID, aID)
+
+	// Must not hang or panic; returns safely.
+	got, err := c.GetSecretImpactPreview(context.Background(), aID)
+	require.NoError(t, err)
+	// B is a direct dependent of A (depth 1); A is already in the visited set so
+	// the back-edge is cut — transitive total is 1.
+	assert.Equal(t, 1, got.DirectDependents)
+	assert.Equal(t, 1, got.TransitiveDependents)
+	assert.Equal(t, 1, got.MaxDepth)
+	assert.Contains(t, got.AffectedSecretIDs, bID)
+}
+
+// TestGetSecretImpactPreview_SecretNotFound: a non-existent secretID propagates
+// the storage error.
+func TestGetSecretImpactPreview_SecretNotFound(t *testing.T) {
+	c, db := newImpactPreviewCore(t)
+	_ = db
+	_, err := c.GetSecretImpactPreview(context.Background(), 999999)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestGetSecretImpactPreview_StorageError: when ListSecretDependenciesForProject
+// fails the error is surfaced to the caller. Uses MockStorage (already defined in
+// mock_storage_test.go in the same package) to inject the error.
+func TestGetSecretImpactPreview_StorageError(t *testing.T) {
+	storageErr := errors.New("db unavailable")
+	ms := new(MockStorage)
+	liveSecret := &models.SecretNode{
+		ID: 1, ProjectID: 1, EnvironmentID: 1, Name: "test-secret", IsSecret: true,
+	}
+	ms.On("GetSecret", mock.Anything, uint(1)).Return(liveSecret, nil)
+	ms.On("ListSecretDependenciesForProject", mock.Anything, uint(1)).Return(nil, storageErr)
+
+	now := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: ms, now: func() time.Time { return now }}
+
+	_, err := c.GetSecretImpactPreview(context.Background(), 1)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storageErr)
+
+	ms.AssertExpectations(t)
+}
+
+// addImpactEdge inserts an edge directly into the DB: dependentID depends on dependsOnID.
+// Separate from addIPEdge to avoid collision with other test helpers in the package
+// (this file uses the shared "1" project/env, so the function name is prefixed).
+func addImpactEdge(t *testing.T, db *gorm.DB, dependentID, dependsOnID uint) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.SecretDependency{
+		ProjectID:         1,
+		DependentSecretID: dependentID,
+		DependsOnSecretID: dependsOnID,
+	}).Error)
+}

--- a/server/http/handlers/secret_dependencies.go
+++ b/server/http/handlers/secret_dependencies.go
@@ -6,6 +6,7 @@
 //	POST   /{id}/dependencies            — declare that {id} depends on another secret
 //	DELETE /{id}/dependencies/{depId}    — remove one dependency edge
 //	GET    /{id}/impact                  — blast radius (transitive dependents)
+//	GET    /{id}/impact-preview          — flat count/summary of cascade-delete impact
 //
 // Plus, under /api/v1/projects (project-scoped):
 //
@@ -134,6 +135,28 @@ func (h *SecretHandler) GetSecretImpact(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	h.sendSuccess(w, impact, "")
+}
+
+// GetSecretImpactPreview handles GET /api/v1/secrets/{id}/impact-preview.
+// It returns a flat count/summary of how many secrets would be cascade-affected
+// if the given secret were soft-deleted: direct dependent count, total transitive
+// count, all affected IDs, and the maximum dependency chain depth reached.
+func (h *SecretHandler) GetSecretImpactPreview(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
+		return
+	}
+	preview, err := h.coreService.GetSecretImpactPreview(r.Context(), uint(id))
+	if err != nil {
+		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
+		return
+	}
+	h.sendSuccess(w, preview, "")
 }
 
 // GetProjectRotationOrder handles GET /api/v1/projects/{id}/rotation-order

--- a/server/http/handlers/secret_impact_preview_handler_test.go
+++ b/server/http/handlers/secret_impact_preview_handler_test.go
@@ -1,0 +1,94 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newImpactPreviewHandlerCore sets up a minimal in-memory core with one secret
+// and one dependent (so the happy-path response is non-trivial).
+func newImpactPreviewHandlerCore(t *testing.T) (*core.KeyorixCore, uint) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{},
+		&models.SecretNode{}, &models.SecretDependency{},
+		&models.AuditEvent{}, &models.ShareRecord{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env1"}).Error)
+
+	root := &models.SecretNode{ProjectID: 1, EnvironmentID: 1, Name: "root-secret", IsSecret: true, Status: "active"}
+	require.NoError(t, db.Create(root).Error)
+	dep := &models.SecretNode{ProjectID: 1, EnvironmentID: 1, Name: "dep-secret", IsSecret: true, Status: "active"}
+	require.NoError(t, db.Create(dep).Error)
+	// dep depends on root — so root's impact preview shows 1 direct dependent.
+	require.NoError(t, db.Create(&models.SecretDependency{
+		ProjectID:         1,
+		DependentSecretID: dep.ID,
+		DependsOnSecretID: root.ID,
+	}).Error)
+
+	return core.NewKeyorixCore(store.NewLocalStorage(db)), root.ID
+}
+
+// TestGetSecretImpactPreview_Unauthenticated: requests without a user context
+// receive 401.
+func TestGetSecretImpactPreview_Unauthenticated(t *testing.T) {
+	h := newSecretHandlerS4(t)
+	req := withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "1")
+	w := httptest.NewRecorder()
+	h.GetSecretImpactPreview(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestGetSecretImpactPreview_BadID: a non-numeric path param returns 400.
+func TestGetSecretImpactPreview_BadID(t *testing.T) {
+	h := newSecretHandlerS4(t)
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "not-a-number"))
+	w := httptest.NewRecorder()
+	h.GetSecretImpactPreview(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestGetSecretImpactPreview_NotFound: a non-existent secret ID returns 404.
+func TestGetSecretImpactPreview_NotFound(t *testing.T) {
+	h := newSecretHandlerS4(t)
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "99999"))
+	w := httptest.NewRecorder()
+	h.GetSecretImpactPreview(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestGetSecretImpactPreview_HappyPath: a real secret with one direct dependent
+// returns 200 and the expected JSON fields.
+func TestGetSecretImpactPreview_HappyPath(t *testing.T) {
+	c, secretID := newImpactPreviewHandlerCore(t)
+	h, err := NewSecretHandler(c)
+	require.NoError(t, err)
+
+	req := withUserCtx(withChiParam(
+		httptest.NewRequest(http.MethodGet, "/", nil), "id",
+		fmt.Sprintf("%d", secretID),
+	))
+	w := httptest.NewRecorder()
+	h.GetSecretImpactPreview(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"direct_dependents":1`)
+	assert.Contains(t, body, `"transitive_dependents":1`)
+	assert.Contains(t, body, `"max_depth":1`)
+	assert.Contains(t, body, `"affected_secret_ids"`)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -598,6 +598,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/blast-radius", secretHandler.GetBlastRadius)
 			// Secret read aggregation report: top readers of a secret over a time window.
 			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Get("/{id}/read-summary", secretHandler.GetSecretReadSummary)
+			// Impact preview: flat cascade-delete count/summary before committing a delete.
+			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/impact-preview", secretHandler.GetSecretImpactPreview)
 
 			// Per-secret ACLs (RBAC Phase 3): fine-grained user grants independent of project RBAC.
 			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Get("/{id}/acl", secretHandler.ListSecretACLs)


### PR DESCRIPTION
## Summary

- Adds `GetSecretImpactPreview` core method: BFS over `SecretDependency` graph (max depth 10, cycle-safe) returning direct/transitive dependent counts and affected secret IDs
- Reuses existing `ListSecretDependencies`/`transitiveDependents` infrastructure — no new storage interface methods
- Exposes `GET /api/v1/secrets/{id}/impact-preview` gated on `secrets.read`, adjacent to the existing `/{id}/blast-radius` route

## Test plan

- [ ] Secret with no dependents returns all zeros and empty `affected_secret_ids`
- [ ] Two direct dependents: `direct_dependents=2`, `transitive_dependents=2`, `max_depth=1`
- [ ] Transitive chain A→B→C: `direct_dependents=1`, `transitive_dependents=2`, `max_depth=2`
- [ ] Cycle A→B→A terminates correctly
- [ ] 401 without auth, 400 with invalid ID

🤖 Generated with [Claude Code](https://claude.ai/code)