### PR TITLE
feat(notifications): add retry policy configuration for channels

### DIFF
--- a/internal/core/mock_storage_notification_channels_test.go
+++ b/internal/core/mock_storage_notification_channels_test.go
@@ -44,3 +44,8 @@ func (m *MockStorage) DeleteNotificationChannel(ctx context.Context, id uint) er
 	args := m.Called(ctx, id)
 	return args.Error(0)
 }
+
+func (m *MockStorage) UpdateNotificationRetryPolicy(ctx context.Context, channelID uint, maxRetries, backoffMs int) error {
+	args := m.Called(ctx, channelID, maxRetries, backoffMs)
+	return args.Error(0)
+}

--- a/internal/core/notification_retry.go
+++ b/internal/core/notification_retry.go
@@ -1,0 +1,56 @@
+// notification_retry.go — retry policy configuration for notification channels.
+// Allows operators to control how many times delivery is retried and the base
+// backoff interval for each channel independently.
+package core
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	// EventNotificationRetryPolicyUpdated is the audit event type emitted when
+	// the retry policy of a notification channel is changed.
+	EventNotificationRetryPolicyUpdated = "notification_channel.retry_policy_updated"
+
+	maxRetriesMax    = 10
+	retryBackoffMsMin = 100
+	retryBackoffMsMax = 60000
+)
+
+// NotificationRetryConfig is the retry policy for a notification channel.
+type NotificationRetryConfig struct {
+	MaxRetries     int `json:"max_retries"`      // 0–10
+	RetryBackoffMs int `json:"retry_backoff_ms"` // 100–60000 ms
+}
+
+// SetNotificationRetryPolicy updates the retry config for a notification channel.
+// Validates: MaxRetries in [0,10], RetryBackoffMs in [100,60000].
+// Returns a descriptive error if validation fails.
+func (c *KeyorixCore) SetNotificationRetryPolicy(ctx context.Context, actorID, channelID uint, cfg NotificationRetryConfig) error {
+	if cfg.MaxRetries < 0 || cfg.MaxRetries > maxRetriesMax {
+		return fmt.Errorf("invalid notification channel retry policy: max_retries must be between 0 and %d, got %d", maxRetriesMax, cfg.MaxRetries)
+	}
+	if cfg.RetryBackoffMs < retryBackoffMsMin || cfg.RetryBackoffMs > retryBackoffMsMax {
+		return fmt.Errorf("invalid notification channel retry policy: retry_backoff_ms must be between %d and %d, got %d", retryBackoffMsMin, retryBackoffMsMax, cfg.RetryBackoffMs)
+	}
+	if err := c.storage.UpdateNotificationRetryPolicy(ctx, channelID, cfg.MaxRetries, cfg.RetryBackoffMs); err != nil {
+		return err
+	}
+	c.writeAuditEvent(ctx, EventNotificationRetryPolicyUpdated, actorPtr(actorID), nil,
+		fmt.Sprintf("notification channel %d retry policy updated: max_retries=%d retry_backoff_ms=%d by actor %d",
+			channelID, cfg.MaxRetries, cfg.RetryBackoffMs, actorID))
+	return nil
+}
+
+// GetNotificationRetryPolicy returns the current retry config for a channel.
+func (c *KeyorixCore) GetNotificationRetryPolicy(ctx context.Context, channelID uint) (*NotificationRetryConfig, error) {
+	ch, err := c.storage.GetNotificationChannel(ctx, channelID)
+	if err != nil {
+		return nil, err
+	}
+	return &NotificationRetryConfig{
+		MaxRetries:     ch.MaxRetries,
+		RetryBackoffMs: ch.RetryBackoffMs,
+	}, nil
+}

--- a/internal/core/notification_retry_test.go
+++ b/internal/core/notification_retry_test.go
@@ -1,0 +1,185 @@
+// notification_retry_test.go — unit tests for SetNotificationRetryPolicy and
+// GetNotificationRetryPolicy. Uses MockStorage to isolate storage interactions.
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// ── SetNotificationRetryPolicy ────────────────────────────────────────────────
+
+// TestSetNotificationRetryPolicy_HappyPath verifies a valid config is persisted
+// and an audit event is emitted.
+func TestSetNotificationRetryPolicy_HappyPath(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	st.On("UpdateNotificationRetryPolicy", ctx, uint(1), 5, 2000).Return(nil)
+	st.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	err := c.SetNotificationRetryPolicy(ctx, 42, 1, NotificationRetryConfig{MaxRetries: 5, RetryBackoffMs: 2000})
+	require.NoError(t, err)
+	st.AssertCalled(t, "UpdateNotificationRetryPolicy", ctx, uint(1), 5, 2000)
+}
+
+// TestSetNotificationRetryPolicy_MaxRetriesZero verifies MaxRetries=0 (no retry) is valid.
+func TestSetNotificationRetryPolicy_MaxRetriesZero(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	st.On("UpdateNotificationRetryPolicy", ctx, uint(1), 0, 500).Return(nil)
+	st.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	err := c.SetNotificationRetryPolicy(ctx, 1, 1, NotificationRetryConfig{MaxRetries: 0, RetryBackoffMs: 500})
+	require.NoError(t, err)
+}
+
+// TestSetNotificationRetryPolicy_MaxRetriesTen verifies MaxRetries=10 (ceiling) is valid.
+func TestSetNotificationRetryPolicy_MaxRetriesTen(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	st.On("UpdateNotificationRetryPolicy", ctx, uint(1), 10, 1000).Return(nil)
+	st.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	err := c.SetNotificationRetryPolicy(ctx, 1, 1, NotificationRetryConfig{MaxRetries: 10, RetryBackoffMs: 1000})
+	require.NoError(t, err)
+}
+
+// TestSetNotificationRetryPolicy_MaxRetriesEleven verifies MaxRetries=11 is rejected.
+func TestSetNotificationRetryPolicy_MaxRetriesEleven(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	err := c.SetNotificationRetryPolicy(ctx, 1, 1, NotificationRetryConfig{MaxRetries: 11, RetryBackoffMs: 1000})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max_retries")
+	st.AssertNotCalled(t, "UpdateNotificationRetryPolicy")
+}
+
+// TestSetNotificationRetryPolicy_MaxRetriesNegative verifies MaxRetries=-1 is rejected.
+func TestSetNotificationRetryPolicy_MaxRetriesNegative(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	err := c.SetNotificationRetryPolicy(ctx, 1, 1, NotificationRetryConfig{MaxRetries: -1, RetryBackoffMs: 1000})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max_retries")
+	st.AssertNotCalled(t, "UpdateNotificationRetryPolicy")
+}
+
+// TestSetNotificationRetryPolicy_BackoffMsMin verifies RetryBackoffMs=100 (floor) is valid.
+func TestSetNotificationRetryPolicy_BackoffMsMin(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	st.On("UpdateNotificationRetryPolicy", ctx, uint(1), 3, 100).Return(nil)
+	st.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	err := c.SetNotificationRetryPolicy(ctx, 1, 1, NotificationRetryConfig{MaxRetries: 3, RetryBackoffMs: 100})
+	require.NoError(t, err)
+}
+
+// TestSetNotificationRetryPolicy_BackoffMsMax verifies RetryBackoffMs=60000 (ceiling) is valid.
+func TestSetNotificationRetryPolicy_BackoffMsMax(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	st.On("UpdateNotificationRetryPolicy", ctx, uint(1), 3, 60000).Return(nil)
+	st.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	err := c.SetNotificationRetryPolicy(ctx, 1, 1, NotificationRetryConfig{MaxRetries: 3, RetryBackoffMs: 60000})
+	require.NoError(t, err)
+}
+
+// TestSetNotificationRetryPolicy_BackoffMsBelowMin verifies RetryBackoffMs=99 is rejected.
+func TestSetNotificationRetryPolicy_BackoffMsBelowMin(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	err := c.SetNotificationRetryPolicy(ctx, 1, 1, NotificationRetryConfig{MaxRetries: 3, RetryBackoffMs: 99})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "retry_backoff_ms")
+	st.AssertNotCalled(t, "UpdateNotificationRetryPolicy")
+}
+
+// TestSetNotificationRetryPolicy_BackoffMsAboveMax verifies RetryBackoffMs=60001 is rejected.
+func TestSetNotificationRetryPolicy_BackoffMsAboveMax(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	err := c.SetNotificationRetryPolicy(ctx, 1, 1, NotificationRetryConfig{MaxRetries: 3, RetryBackoffMs: 60001})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "retry_backoff_ms")
+	st.AssertNotCalled(t, "UpdateNotificationRetryPolicy")
+}
+
+// TestSetNotificationRetryPolicy_StorageError verifies storage errors are propagated.
+func TestSetNotificationRetryPolicy_StorageError(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	st.On("UpdateNotificationRetryPolicy", ctx, uint(7), 3, 1000).
+		Return(fmt.Errorf("db: disk full"))
+
+	err := c.SetNotificationRetryPolicy(ctx, 1, 7, NotificationRetryConfig{MaxRetries: 3, RetryBackoffMs: 1000})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disk full")
+}
+
+// ── GetNotificationRetryPolicy ────────────────────────────────────────────────
+
+// TestGetNotificationRetryPolicy_HappyPath verifies the policy is read from the channel.
+func TestGetNotificationRetryPolicy_HappyPath(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	ch := &models.NotificationChannel{
+		ID:             3,
+		Name:           "slack-ops",
+		Type:           "slack",
+		URL:            "https://hooks.slack.com/services/xxx",
+		MaxRetries:     5,
+		RetryBackoffMs: 2000,
+	}
+	st.On("GetNotificationChannel", ctx, uint(3)).Return(ch, nil)
+
+	policy, err := c.GetNotificationRetryPolicy(ctx, 3)
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+	assert.Equal(t, 5, policy.MaxRetries)
+	assert.Equal(t, 2000, policy.RetryBackoffMs)
+}
+
+// TestGetNotificationRetryPolicy_StorageError verifies storage errors are propagated.
+func TestGetNotificationRetryPolicy_StorageError(t *testing.T) {
+	st := new(MockStorage)
+	c := NewKeyorixCore(st)
+	ctx := context.Background()
+
+	st.On("GetNotificationChannel", ctx, uint(99)).
+		Return(nil, fmt.Errorf("record not found"))
+
+	policy, err := c.GetNotificationRetryPolicy(ctx, 99)
+	require.Error(t, err)
+	assert.Nil(t, policy)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1260,6 +1260,8 @@ type Storage interface {
 	CreateNotificationChannel(ctx context.Context, ch *models.NotificationChannel) error
 	UpdateNotificationChannel(ctx context.Context, ch *models.NotificationChannel) error
 	DeleteNotificationChannel(ctx context.Context, id uint) error
+	// UpdateNotificationRetryPolicy updates the retry fields on a NotificationChannel row.
+	UpdateNotificationRetryPolicy(ctx context.Context, channelID uint, maxRetries, backoffMs int) error
 
 	// Rejection reason templates — pre-defined reasons for rejecting access
 	// requests. The REST API is the remote surface; these methods only run

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -1380,7 +1380,10 @@ type NotificationChannel struct {
 	Email string `json:"email,omitempty"`
 	// Events is a comma-separated list of event types this channel receives
 	// e.g. "secret.rotated,anomaly.detected,secret.expiring"
-	Events    string    `json:"events"`
+	Events string `json:"events"`
+	// Retry policy for failed deliveries.
+	MaxRetries     int `gorm:"default:3" json:"max_retries"`      // 0 = no retry, max 10
+	RetryBackoffMs int `gorm:"default:1000" json:"retry_backoff_ms"` // base backoff in ms, min 100, max 60000
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 	CreatedBy string    `json:"created_by"`

--- a/internal/storage/store/local_notification_channels.go
+++ b/internal/storage/store/local_notification_channels.go
@@ -74,6 +74,24 @@ func (ls *LocalStorage) UpdateNotificationChannel(ctx context.Context, ch *model
 	return nil
 }
 
+// UpdateNotificationRetryPolicy updates only the retry policy fields on the
+// channel row identified by channelID.
+func (ls *LocalStorage) UpdateNotificationRetryPolicy(ctx context.Context, channelID uint, maxRetries, backoffMs int) error {
+	res := ls.db.WithContext(ctx).Model(&models.NotificationChannel{}).
+		Where("id = ?", channelID).
+		Updates(map[string]interface{}{
+			"max_retries":      maxRetries,
+			"retry_backoff_ms": backoffMs,
+		})
+	if res.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	return nil
+}
+
 // DeleteNotificationChannel performs a hard delete of the channel with the given id.
 func (ls *LocalStorage) DeleteNotificationChannel(ctx context.Context, id uint) error {
 	res := ls.db.WithContext(ctx).Delete(&models.NotificationChannel{}, id)

--- a/internal/storage/store/local_notification_channels_test.go
+++ b/internal/storage/store/local_notification_channels_test.go
@@ -167,3 +167,43 @@ func TestGetNotificationChannel_DBError(t *testing.T) {
 	// Should NOT be "not found" — the generic retrieval error wraps the real DB err.
 	assert.NotContains(t, err.Error(), "not found")
 }
+
+// TestUpdateNotificationRetryPolicy_HappyPath verifies that the retry fields
+// are updated correctly.
+func TestUpdateNotificationRetryPolicy_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	ls := newNotificationChannelTestStore(t)
+
+	ch := &models.NotificationChannel{Name: "retry-ch", Type: "webhook", URL: "https://example.com/hook", Enabled: true}
+	require.NoError(t, ls.CreateNotificationChannel(ctx, ch))
+
+	require.NoError(t, ls.UpdateNotificationRetryPolicy(ctx, ch.ID, 7, 3000))
+
+	got, err := ls.GetNotificationChannel(ctx, ch.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 7, got.MaxRetries)
+	assert.Equal(t, 3000, got.RetryBackoffMs)
+}
+
+// TestUpdateNotificationRetryPolicy_NotFound verifies the RowsAffected==0 path.
+func TestUpdateNotificationRetryPolicy_NotFound(t *testing.T) {
+	ctx := context.Background()
+	ls := newNotificationChannelTestStore(t)
+
+	err := ls.UpdateNotificationRetryPolicy(ctx, 9999, 3, 1000)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestUpdateNotificationRetryPolicy_DBError verifies the generic DB error path.
+func TestUpdateNotificationRetryPolicy_DBError(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	ls := NewLocalStorage(db)
+	// No AutoMigrate — table missing.
+
+	err = ls.UpdateNotificationRetryPolicy(ctx, 1, 3, 1000)
+	require.Error(t, err)
+}

--- a/internal/storage/store/remote_notification_channels.go
+++ b/internal/storage/store/remote_notification_channels.go
@@ -34,3 +34,7 @@ func (rs *RemoteStorage) UpdateNotificationChannel(_ context.Context, _ *models.
 func (rs *RemoteStorage) DeleteNotificationChannel(_ context.Context, _ uint) error {
 	return remoteUnsupported("DeleteNotificationChannel")
 }
+
+func (rs *RemoteStorage) UpdateNotificationRetryPolicy(_ context.Context, _ uint, _, _ int) error {
+	return remoteUnsupported("UpdateNotificationRetryPolicy")
+}

--- a/internal/storage/store/remote_notification_channels_completeness_test.go
+++ b/internal/storage/store/remote_notification_channels_completeness_test.go
@@ -10,7 +10,8 @@ func init() {
 		"GetNotificationChannel":       {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
 		"GetNotificationChannelByName": {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
 		"CreateNotificationChannel":    {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
-		"UpdateNotificationChannel":    {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
-		"DeleteNotificationChannel":    {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
+		"UpdateNotificationChannel":       {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
+		"DeleteNotificationChannel":       {statusIntentional, "notification channel CRUD is managed via /api/v1/notification-channels; raw storage call never reached from a remote-storage caller"},
+		"UpdateNotificationRetryPolicy":   {statusIntentional, "retry policy update is managed via /api/v1/notification-channels/{id}/retry-policy; raw storage call never reached from a remote-storage caller"},
 	})
 }

--- a/internal/storage/store/remote_notification_channels_test.go
+++ b/internal/storage/store/remote_notification_channels_test.go
@@ -34,4 +34,7 @@ func TestRemoteNotificationChannelStubs_Unsupported(t *testing.T) {
 
 	err = rs.DeleteNotificationChannel(ctx, 1)
 	assert.Error(t, err)
+
+	err = rs.UpdateNotificationRetryPolicy(ctx, 1, 3, 1000)
+	assert.Error(t, err)
 }

--- a/server/http/handlers/notification_channels.go
+++ b/server/http/handlers/notification_channels.go
@@ -164,6 +164,81 @@ func (h *NotificationChannelHandler) Delete(w http.ResponseWriter, r *http.Reque
 	sendSuccess(w, map[string]interface{}{"id": id, "deleted": true}, "")
 }
 
+// SetRetryPolicy handles PUT /api/v1/notification-channels/{id}/retry-policy.
+// Body: {"max_retries": 5, "retry_backoff_ms": 2000}
+// Response 200: {"data": {"channel_id": N, "max_retries": 5, "retry_backoff_ms": 2000}}
+func (h *NotificationChannelHandler) SetRetryPolicy(w http.ResponseWriter, r *http.Request) {
+	u := middleware.GetUserFromContext(r.Context())
+	if u == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+	id, ok := parseUintParam(w, r, "id")
+	if !ok {
+		return
+	}
+	var body struct {
+		MaxRetries     int `json:"max_retries"`
+		RetryBackoffMs int `json:"retry_backoff_ms"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		return
+	}
+	cfg := core.NotificationRetryConfig{
+		MaxRetries:     body.MaxRetries,
+		RetryBackoffMs: body.RetryBackoffMs,
+	}
+	if err := h.coreService.SetNotificationRetryPolicy(r.Context(), u.UserID, id, cfg); err != nil {
+		if isRetryPolicyValidationError(err) {
+			sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
+			return
+		}
+		if strings.Contains(err.Error(), errNotFound) {
+			sendError(w, "NotFound", errNotificationChannelNotFound, http.StatusNotFound, nil)
+			return
+		}
+		log.Printf("Error setting retry policy for notification channel %d: %v", id, err)
+		sendError(w, "InternalError", "Failed to set retry policy", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"channel_id":       id,
+		"max_retries":      body.MaxRetries,
+		"retry_backoff_ms": body.RetryBackoffMs,
+	}, "")
+}
+
+// GetRetryPolicy handles GET /api/v1/notification-channels/{id}/retry-policy.
+// Response 200: {"data": {"channel_id": N, "max_retries": 3, "retry_backoff_ms": 1000}}
+func (h *NotificationChannelHandler) GetRetryPolicy(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseUintParam(w, r, "id")
+	if !ok {
+		return
+	}
+	policy, err := h.coreService.GetNotificationRetryPolicy(r.Context(), id)
+	if err != nil {
+		if strings.Contains(err.Error(), errNotFound) {
+			sendError(w, "NotFound", errNotificationChannelNotFound, http.StatusNotFound, nil)
+			return
+		}
+		log.Printf("Error getting retry policy for notification channel %d: %v", id, err)
+		sendError(w, "InternalError", "Failed to get retry policy", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"channel_id":       id,
+		"max_retries":      policy.MaxRetries,
+		"retry_backoff_ms": policy.RetryBackoffMs,
+	}, "")
+}
+
+// isRetryPolicyValidationError reports whether the error is a validation error
+// from SetNotificationRetryPolicy (safe to return verbatim to the client).
+func isRetryPolicyValidationError(err error) bool {
+	return strings.HasPrefix(err.Error(), "invalid notification channel retry policy")
+}
+
 // isValidationError reports whether the error comes from the core validation layer
 // (as opposed to a storage/infrastructure error). Validation messages are
 // short, human-readable strings crafted in validateNotificationChannel; they are

--- a/server/http/handlers/notification_channels.go
+++ b/server/http/handlers/notification_channels.go
@@ -14,7 +14,10 @@ import (
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
-const errNotificationChannelNotFound = "Notification channel not found"
+const (
+	channelNotFound        = "not found"
+	channelNotFoundMessage = "Notification channel not found"
+)
 
 // NotificationChannelHandler serves the notification-channel CRUD endpoints.
 type NotificationChannelHandler struct {
@@ -109,8 +112,8 @@ func (h *NotificationChannelHandler) Get(w http.ResponseWriter, r *http.Request)
 	}
 	ch, err := h.coreService.GetNotificationChannel(r.Context(), id)
 	if err != nil {
-		if strings.Contains(err.Error(), errNotFound) {
-			sendError(w, "NotFound", errNotificationChannelNotFound, http.StatusNotFound, nil)
+		if strings.Contains(err.Error(), channelNotFound) {
+			sendError(w, "NotFound", channelNotFoundMessage, http.StatusNotFound, nil)
 			return
 		}
 		log.Printf("Error getting notification channel %d: %v", id, err)
@@ -133,8 +136,8 @@ func (h *NotificationChannelHandler) Update(w http.ResponseWriter, r *http.Reque
 	}
 	updated, err := h.coreService.UpdateNotificationChannel(r.Context(), id, body)
 	if err != nil {
-		if strings.Contains(err.Error(), errNotFound) {
-			sendError(w, "NotFound", errNotificationChannelNotFound, http.StatusNotFound, nil)
+		if strings.Contains(err.Error(), channelNotFound) {
+			sendError(w, "NotFound", channelNotFoundMessage, http.StatusNotFound, nil)
 			return
 		}
 		if isValidationError(err) {
@@ -155,8 +158,8 @@ func (h *NotificationChannelHandler) Delete(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := h.coreService.DeleteNotificationChannel(r.Context(), id); err != nil {
-		if strings.Contains(err.Error(), errNotFound) {
-			sendError(w, "NotFound", errNotificationChannelNotFound, http.StatusNotFound, nil)
+		if strings.Contains(err.Error(), channelNotFound) {
+			sendError(w, "NotFound", channelNotFoundMessage, http.StatusNotFound, nil)
 			return
 		}
 		log.Printf("Error deleting notification channel %d: %v", id, err)
@@ -196,8 +199,8 @@ func (h *NotificationChannelHandler) SetRetryPolicy(w http.ResponseWriter, r *ht
 			sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
 			return
 		}
-		if strings.Contains(err.Error(), errNotFound) {
-			sendError(w, "NotFound", errNotificationChannelNotFound, http.StatusNotFound, nil)
+		if strings.Contains(err.Error(), channelNotFound) {
+			sendError(w, "NotFound", channelNotFoundMessage, http.StatusNotFound, nil)
 			return
 		}
 		log.Printf("Error setting retry policy for notification channel %d: %v", id, err)
@@ -220,8 +223,8 @@ func (h *NotificationChannelHandler) GetRetryPolicy(w http.ResponseWriter, r *ht
 	}
 	policy, err := h.coreService.GetNotificationRetryPolicy(r.Context(), id)
 	if err != nil {
-		if strings.Contains(err.Error(), errNotFound) {
-			sendError(w, "NotFound", errNotificationChannelNotFound, http.StatusNotFound, nil)
+		if strings.Contains(err.Error(), channelNotFound) {
+			sendError(w, "NotFound", channelNotFoundMessage, http.StatusNotFound, nil)
 			return
 		}
 		log.Printf("Error getting retry policy for notification channel %d: %v", id, err)

--- a/server/http/handlers/notification_channels.go
+++ b/server/http/handlers/notification_channels.go
@@ -14,6 +14,8 @@ import (
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
+const errNotificationChannelNotFound = "Notification channel not found"
+
 // NotificationChannelHandler serves the notification-channel CRUD endpoints.
 type NotificationChannelHandler struct {
 	coreService *core.KeyorixCore
@@ -107,8 +109,8 @@ func (h *NotificationChannelHandler) Get(w http.ResponseWriter, r *http.Request)
 	}
 	ch, err := h.coreService.GetNotificationChannel(r.Context(), id)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			sendError(w, "NotFound", "Notification channel not found", http.StatusNotFound, nil)
+		if strings.Contains(err.Error(), errNotFound) {
+			sendError(w, "NotFound", errNotificationChannelNotFound, http.StatusNotFound, nil)
 			return
 		}
 		log.Printf("Error getting notification channel %d: %v", id, err)
@@ -131,8 +133,8 @@ func (h *NotificationChannelHandler) Update(w http.ResponseWriter, r *http.Reque
 	}
 	updated, err := h.coreService.UpdateNotificationChannel(r.Context(), id, body)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			sendError(w, "NotFound", "Notification channel not found", http.StatusNotFound, nil)
+		if strings.Contains(err.Error(), errNotFound) {
+			sendError(w, "NotFound", errNotificationChannelNotFound, http.StatusNotFound, nil)
 			return
 		}
 		if isValidationError(err) {
@@ -153,8 +155,8 @@ func (h *NotificationChannelHandler) Delete(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := h.coreService.DeleteNotificationChannel(r.Context(), id); err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			sendError(w, "NotFound", "Notification channel not found", http.StatusNotFound, nil)
+		if strings.Contains(err.Error(), errNotFound) {
+			sendError(w, "NotFound", errNotificationChannelNotFound, http.StatusNotFound, nil)
 			return
 		}
 		log.Printf("Error deleting notification channel %d: %v", id, err)

--- a/server/http/handlers/notification_retry_policy_handler_test.go
+++ b/server/http/handlers/notification_retry_policy_handler_test.go
@@ -261,3 +261,76 @@ func TestGetRetryPolicy_BadID(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
+
+// TestSetRetryPolicy_InternalError — storage error that is neither a validation
+// error nor a not-found error returns 500.
+func TestSetRetryPolicy_InternalError(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, i18n.InitializeForTesting())
+
+	n := retryPolicyDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kx_retry_set_ie_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{},
+		&models.AuditEvent{},
+		&models.NotificationChannel{},
+	))
+	chanID := seedChannel(t, db)
+
+	// Close the underlying connection to provoke a real DB error (not not-found).
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h := NewNotificationChannelHandler(cs)
+
+	body, _ := json.Marshal(map[string]any{"max_retries": 3, "retry_backoff_ms": 1000})
+	req := withUserCtx(withChiParam(
+		httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body)),
+		"id", fmt.Sprintf("%d", chanID),
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.SetRetryPolicy(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestGetRetryPolicy_InternalError — storage error that is not a not-found
+// error returns 500.
+func TestGetRetryPolicy_InternalError(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, i18n.InitializeForTesting())
+
+	n := retryPolicyDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kx_retry_get_ie_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{},
+		&models.AuditEvent{},
+		&models.NotificationChannel{},
+	))
+	chanID := seedChannel(t, db)
+
+	// Close the underlying connection so GetNotificationChannel returns a real
+	// DB error (not ErrRecordNotFound) instead of 404.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h := NewNotificationChannelHandler(cs)
+
+	req := withChiParam(
+		httptest.NewRequest(http.MethodGet, "/", nil),
+		"id", fmt.Sprintf("%d", chanID),
+	)
+	w := httptest.NewRecorder()
+	h.GetRetryPolicy(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/server/http/handlers/notification_retry_policy_handler_test.go
+++ b/server/http/handlers/notification_retry_policy_handler_test.go
@@ -1,0 +1,263 @@
+// notification_retry_policy_handler_test.go — HTTP handler tests for
+// PUT/GET /api/v1/notification-channels/{id}/retry-policy.
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var retryPolicyDBCounter atomic.Int64
+
+// freshCoreRetryPolicy opens a unique in-memory SQLite DB that includes
+// models.NotificationChannel (plus the dependencies AuditEvent needs) and
+// returns a ready-to-use KeyorixCore.
+func freshCoreRetryPolicy(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := retryPolicyDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kx_retry_policy_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{},
+		&models.AuditEvent{},
+		&models.NotificationChannel{},
+	))
+	return core.NewKeyorixCore(store.NewLocalStorage(db))
+}
+
+// seedChannel creates a NotificationChannel row directly in the DB and returns its ID.
+func seedChannel(t *testing.T, db *gorm.DB) uint {
+	t.Helper()
+	ch := &models.NotificationChannel{
+		Name:           "test-webhook",
+		Type:           "webhook",
+		URL:            "https://example.com/hook",
+		Enabled:        true,
+		MaxRetries:     3,
+		RetryBackoffMs: 1000,
+	}
+	require.NoError(t, db.Create(ch).Error)
+	return ch.ID
+}
+
+// freshCoreRetryPolicyWithChannel opens the DB, migrates, and seeds one channel.
+// Returns the core and the channel ID.
+func freshCoreRetryPolicyWithChannel(t *testing.T) (*core.KeyorixCore, *gorm.DB, uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := retryPolicyDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kx_retry_policy_ch_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{},
+		&models.AuditEvent{},
+		&models.NotificationChannel{},
+	))
+	id := seedChannel(t, db)
+	return core.NewKeyorixCore(store.NewLocalStorage(db)), db, id
+}
+
+// ── SetRetryPolicy ────────────────────────────────────────────────────────────
+
+// TestSetRetryPolicy_HappyPath — valid body → 200 with policy fields.
+func TestSetRetryPolicy_HappyPath(t *testing.T) {
+	t.Parallel()
+	cs, _, chanID := freshCoreRetryPolicyWithChannel(t)
+	h := NewNotificationChannelHandler(cs)
+
+	body, _ := json.Marshal(map[string]any{"max_retries": 5, "retry_backoff_ms": 2000})
+	req := withUserCtx(withChiParam(
+		httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body)),
+		"id", fmt.Sprintf("%d", chanID),
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.SetRetryPolicy(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	data := resp["data"].(map[string]any)
+	assert.Equal(t, float64(5), data["max_retries"])
+	assert.Equal(t, float64(2000), data["retry_backoff_ms"])
+}
+
+// TestSetRetryPolicy_ValidationError_MaxRetries — max_retries=11 → 400.
+func TestSetRetryPolicy_ValidationError_MaxRetries(t *testing.T) {
+	t.Parallel()
+	cs, _, chanID := freshCoreRetryPolicyWithChannel(t)
+	h := NewNotificationChannelHandler(cs)
+
+	body, _ := json.Marshal(map[string]any{"max_retries": 11, "retry_backoff_ms": 1000})
+	req := withUserCtx(withChiParam(
+		httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body)),
+		"id", fmt.Sprintf("%d", chanID),
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.SetRetryPolicy(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestSetRetryPolicy_ValidationError_BackoffMs — retry_backoff_ms=50 → 400.
+func TestSetRetryPolicy_ValidationError_BackoffMs(t *testing.T) {
+	t.Parallel()
+	cs, _, chanID := freshCoreRetryPolicyWithChannel(t)
+	h := NewNotificationChannelHandler(cs)
+
+	body, _ := json.Marshal(map[string]any{"max_retries": 3, "retry_backoff_ms": 50})
+	req := withUserCtx(withChiParam(
+		httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body)),
+		"id", fmt.Sprintf("%d", chanID),
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.SetRetryPolicy(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestSetRetryPolicy_NoAuth — missing user context → 401.
+func TestSetRetryPolicy_NoAuth(t *testing.T) {
+	t.Parallel()
+	cs := freshCoreRetryPolicy(t)
+	h := NewNotificationChannelHandler(cs)
+
+	body, _ := json.Marshal(map[string]any{"max_retries": 3, "retry_backoff_ms": 1000})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body)),
+		"id", "1",
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.SetRetryPolicy(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestSetRetryPolicy_BadID — non-numeric id → 400.
+func TestSetRetryPolicy_BadID(t *testing.T) {
+	t.Parallel()
+	cs := freshCoreRetryPolicy(t)
+	h := NewNotificationChannelHandler(cs)
+
+	body, _ := json.Marshal(map[string]any{"max_retries": 3, "retry_backoff_ms": 1000})
+	req := withUserCtx(withChiParam(
+		httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body)),
+		"id", "abc",
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.SetRetryPolicy(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestSetRetryPolicy_InvalidBody — malformed JSON → 400.
+func TestSetRetryPolicy_InvalidBody(t *testing.T) {
+	t.Parallel()
+	cs := freshCoreRetryPolicy(t)
+	h := NewNotificationChannelHandler(cs)
+
+	req := withUserCtx(withChiParam(
+		httptest.NewRequest(http.MethodPut, "/", bytes.NewReader([]byte("not-json"))),
+		"id", "1",
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.SetRetryPolicy(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestSetRetryPolicy_NotFound — channel ID does not exist → 404.
+func TestSetRetryPolicy_NotFound(t *testing.T) {
+	t.Parallel()
+	cs := freshCoreRetryPolicy(t)
+	h := NewNotificationChannelHandler(cs)
+
+	body, _ := json.Marshal(map[string]any{"max_retries": 3, "retry_backoff_ms": 1000})
+	req := withUserCtx(withChiParam(
+		httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body)),
+		"id", "9999",
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.SetRetryPolicy(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ── GetRetryPolicy ────────────────────────────────────────────────────────────
+
+// TestGetRetryPolicy_HappyPath — existing channel → 200 with current policy.
+func TestGetRetryPolicy_HappyPath(t *testing.T) {
+	t.Parallel()
+	cs, _, chanID := freshCoreRetryPolicyWithChannel(t)
+	h := NewNotificationChannelHandler(cs)
+
+	req := withChiParam(
+		httptest.NewRequest(http.MethodGet, "/", nil),
+		"id", fmt.Sprintf("%d", chanID),
+	)
+	w := httptest.NewRecorder()
+	h.GetRetryPolicy(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	data := resp["data"].(map[string]any)
+	assert.Equal(t, float64(3), data["max_retries"])
+	assert.Equal(t, float64(1000), data["retry_backoff_ms"])
+	assert.Equal(t, float64(chanID), data["channel_id"])
+}
+
+// TestGetRetryPolicy_NotFound — unknown channel ID → 404.
+func TestGetRetryPolicy_NotFound(t *testing.T) {
+	t.Parallel()
+	cs := freshCoreRetryPolicy(t)
+	h := NewNotificationChannelHandler(cs)
+
+	req := withChiParam(
+		httptest.NewRequest(http.MethodGet, "/", nil),
+		"id", "9999",
+	)
+	w := httptest.NewRecorder()
+	h.GetRetryPolicy(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestGetRetryPolicy_BadID — non-numeric id → 400.
+func TestGetRetryPolicy_BadID(t *testing.T) {
+	t.Parallel()
+	cs := freshCoreRetryPolicy(t)
+	h := NewNotificationChannelHandler(cs)
+
+	req := withChiParam(
+		httptest.NewRequest(http.MethodGet, "/", nil),
+		"id", "bad",
+	)
+	w := httptest.NewRecorder()
+	h.GetRetryPolicy(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -336,6 +336,8 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Get("/notification-channels/{id}", notificationChannelHandler.Get)
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/notification-channels/{id}", notificationChannelHandler.Update)
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Delete("/notification-channels/{id}", notificationChannelHandler.Delete)
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/notification-channels/{id}/retry-policy", notificationChannelHandler.SetRetryPolicy)
+		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/notification-channels/{id}/retry-policy", notificationChannelHandler.GetRetryPolicy)
 
 		// Alert escalation policy management — admin-only (system.write).
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/alert-escalation-policies", alertEscalationHandler.Create)


### PR DESCRIPTION
## Summary

- Adds `MaxRetries int` (default 3, range 0–10) and `RetryBackoffMs int` (default 1000ms, range 100–60000ms) to `NotificationChannel` model
- Adds `SetNotificationRetryPolicy` and `GetNotificationRetryPolicy` core methods with full boundary validation
- Adds `UpdateNotificationRetryPolicy` to storage interface with local implementation and remote stub
- Exposes `PUT /api/v1/notification-channels/{id}/retry-policy` (system.write) and `GET /api/v1/notification-channels/{id}/retry-policy` (system.read)

## Test plan

- [ ] `PUT` with `max_retries: 5`, `retry_backoff_ms: 2000` returns 200 with persisted values
- [ ] `max_retries: 11` returns 400; `max_retries: 0` is valid (no retry)
- [ ] `retry_backoff_ms: 99` returns 400; `retry_backoff_ms: 100` is valid
- [ ] `GET` returns current policy including defaults
- [ ] 401 without auth, 404 for unknown channel ID
- [ ] 500 on storage error (closed DB) for both PUT and GET

🤖 Generated with [Claude Code](https://claude.ai/code)