### PR TITLE
test(fuzz): add continuous-fuzz targets for encryption, SAML, and bundle

### DIFF
--- a/internal/bundle/bundle_fuzz_test.go
+++ b/internal/bundle/bundle_fuzz_test.go
@@ -1,0 +1,41 @@
+package bundle
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/trust"
+)
+
+// FuzzBundleVerify feeds arbitrary byte streams into Verify. The goal is the
+// streaming gzip+tar parse path, the manifest JSON unmarshaller, the signature
+// check, and the per-component digest walk — all must return errors on corrupt
+// input, never panic. A real key pair is registered so the verifier reaches the
+// signature-check layer rather than bailing at registry setup; a tampered
+// signature is expected to fail closed with ErrBadSignature.
+func FuzzBundleVerify(f *testing.F) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		f.Fatal(err)
+	}
+	reg := trust.NewRegistry()
+	if err := reg.Add(trust.PurposeUpdate, "fuzz-key-1", pub); err != nil {
+		f.Fatal(err)
+	}
+
+	f.Add([]byte{})
+	f.Add([]byte("not a gzip bundle"))
+	// Minimal valid gzip stream (empty content) — lets the mutator start from a
+	// structurally recognisable gzip frame rather than random bytes.
+	f.Add([]byte{
+		0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
+		0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Must never panic.
+		_, _ = Verify(bytes.NewReader(data), reg)
+	})
+}

--- a/internal/encryption/encryption_fuzz_test.go
+++ b/internal/encryption/encryption_fuzz_test.go
@@ -1,0 +1,94 @@
+package encryption
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// FuzzDecrypt feeds arbitrary JSON-encoded EncryptedData blobs into Decrypt and
+// DecryptWithAAD. Neither must ever panic — returning an error for any corrupt,
+// truncated, or tampered input is the only acceptable outcome.
+func FuzzDecrypt(f *testing.F) {
+	// Fixed KEK: deterministic across all runs so the corpus is reproducible.
+	kek := make([]byte, 32)
+	for i := range kek {
+		kek[i] = byte(i + 1)
+	}
+	svc, err := NewEncryptionService(kek)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	// Seed 1: a real encrypted blob — gives the mutator a valid JSON shape to work from.
+	enc, err := svc.Encrypt([]byte("hello fuzz"), "v1")
+	if err != nil {
+		f.Fatal(err)
+	}
+	seed, err := json.Marshal(enc)
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(seed)
+
+	// Seed 2: a real AAD-bound blob.
+	encAAD, err := svc.EncryptWithAAD([]byte("hello aad fuzz"), "v1", SecretAAD(1, 2, 3))
+	if err != nil {
+		f.Fatal(err)
+	}
+	seedAAD, err := json.Marshal(encAAD)
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(seedAAD)
+
+	// Seed 3: structurally valid JSON but wrong-length nonce (exercises the nonce-length guard).
+	f.Add([]byte(`{"data":"AAEC","metadata":{"algorithm":"AES-256-GCM","key_version":"v1","encrypted_at":"2026-01-01T00:00:00Z","nonce":"AAAA"}}`))
+	f.Add([]byte("{}"))
+	f.Add([]byte(""))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		ed, err := DeserializeEncryptedData(data)
+		if err != nil {
+			return // invalid JSON — expected
+		}
+		_, _ = svc.Decrypt(ed)
+		_, _ = svc.DecryptWithAAD(ed, SecretAAD(1, 2, 3))
+		_, _ = svc.DecryptWithAAD(ed, nil)
+	})
+}
+
+// FuzzDecryptChunked feeds arbitrary JSON-encoded []*EncryptedData arrays into
+// DecryptChunked. Reorder, splice, truncation, and corrupt-nonce inputs must all
+// return errors, never panics.
+func FuzzDecryptChunked(f *testing.F) {
+	kek := make([]byte, 32)
+	for i := range kek {
+		kek[i] = byte(i + 1)
+	}
+	svc, err := NewEncryptionService(kek)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	// Seed: a real two-chunk encryption.
+	chunks, err := svc.EncryptChunked([]byte("hello chunked fuzz world"), 12, "v1")
+	if err != nil {
+		f.Fatal(err)
+	}
+	seed, err := json.Marshal(chunks)
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(seed)
+	f.Add([]byte("[]"))
+	f.Add([]byte("[{}]"))
+	f.Add([]byte("[{},{}]"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var chunks []*EncryptedData
+		if err := json.Unmarshal(data, &chunks); err != nil {
+			return
+		}
+		_, _ = svc.DecryptChunked(chunks)
+	})
+}

--- a/internal/notary/notary_fuzz_test.go
+++ b/internal/notary/notary_fuzz_test.go
@@ -1,0 +1,35 @@
+package notary
+
+import (
+	"crypto/x509"
+	"testing"
+)
+
+// FuzzVerifyReceipt feeds arbitrary bytes as an RFC 3161 TimeStampToken into
+// VerifyReceipt. The fuzz target is the two external ASN.1/DER parsers inside:
+// digitorus/timestamp.Parse (RFC 3161 token structure) and digitorus/pkcs7.Parse
+// (PKCS#7 envelope). Both must return errors on malformed input, never panic.
+//
+// An empty but non-nil CertPool is used so the fuzzer bypasses the nil-roots
+// guard and reaches the parse layers. Chain verification will always fail (no
+// trusted root is configured), which is fine — the goal is parser robustness, not
+// valid receipt verification.
+func FuzzVerifyReceipt(f *testing.F) {
+	roots := x509.NewCertPool() // non-nil → reaches timestamp.Parse; empty → chain always fails
+	message := []byte("fuzz anchor message")
+
+	f.Add([]byte{})
+	f.Add([]byte("not DER at all"))
+	// Minimal DER SEQUENCE (empty) — a structurally recognisable starting point
+	// for the mutator to build valid-ish DER from.
+	f.Add([]byte{0x30, 0x00})
+	// SEQUENCE with one content byte.
+	f.Add([]byte{0x30, 0x01, 0x00})
+	// Claimed length longer than actual content — classic DER truncation.
+	f.Add([]byte{0x30, 0x10, 0x00})
+
+	f.Fuzz(func(t *testing.T, token []byte) {
+		// Must never panic.
+		_, _ = VerifyReceipt(roots, message, token)
+	})
+}

--- a/internal/saml/saml_fuzz_test.go
+++ b/internal/saml/saml_fuzz_test.go
@@ -1,0 +1,39 @@
+package saml
+
+import (
+	"testing"
+)
+
+// minimalIDPMetadata is a structurally valid SAML IdP metadata document with no signing
+// certificate — a useful fuzzer seed because it exercises the full parse path without
+// requiring real crypto material in the seed corpus.
+var minimalIDPMetadata = []byte(`<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://idp.example/entity">
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example/sso"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>`)
+
+// FuzzSAMLMetadata feeds arbitrary bytes as IdP metadata XML into NewProvider.
+// The target is the XML parsing + entity-descriptor unmarshalling path inside
+// parseIDPMetadata — historically the most fuzz-productive surface in SAML stacks
+// (XXE, entity-expansion, malformed attribute names). NewProvider must never panic;
+// returning an error for any malformed input is the only acceptable outcome.
+func FuzzSAMLMetadata(f *testing.F) {
+	f.Add(minimalIDPMetadata)
+	f.Add([]byte(""))
+	f.Add([]byte("<foo/>"))
+	f.Add([]byte("not xml at all"))
+	f.Add([]byte(`<?xml version="1.0"?><EntityDescriptor/>`))
+	f.Add([]byte(`<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID=""><IDPSSODescriptor/></EntityDescriptor>`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		cfg := Config{
+			Name:           "fuzz",
+			IDPMetadataXML: data,
+			SPEntityID:     "https://keyorix.internal/saml/fuzz/metadata",
+			ACSURL:         "https://keyorix.internal/auth/saml/fuzz/acs",
+		}
+		// Must never panic.
+		_, _ = NewProvider(cfg)
+	})
+}

--- a/scripts/fuzzing/targets.conf
+++ b/scripts/fuzzing/targets.conf
@@ -38,3 +38,9 @@ internal/saml|FuzzSAMLMetadata|1h
 # check → per-component sha256 walk. Must fail closed on any corrupt/truncated
 # input. 2h: the gzip+tar+JSON surface warrants more time than a pure parser.
 internal/bundle|FuzzBundleVerify|2h
+# RFC 3161 TimeStampToken: exercises digitorus/timestamp.Parse (RFC 3161 ASN.1)
+# and digitorus/pkcs7.Parse (PKCS#7 envelope) inside VerifyReceipt. Both are
+# external ASN.1/DER parsers — historically productive fuzz targets. 1h is
+# enough; the interesting cases (truncated length, unknown tag, zero-length
+# content) surface quickly.
+internal/notary|FuzzVerifyReceipt|1h

--- a/scripts/fuzzing/targets.conf
+++ b/scripts/fuzzing/targets.conf
@@ -23,3 +23,18 @@ internal/rotation|FuzzMySQLQuoteString|2h
 # (internal/secrettemplate/render.go's parse) — much smaller/simpler than the
 # targets above, so 1h is plenty.
 internal/secrettemplate|FuzzParse|1h
+# AES-256-GCM decryption path: feeds arbitrary JSON-encoded EncryptedData blobs
+# into Decrypt/DecryptWithAAD. Target: wrong-length nonce guard, GCM Open panic
+# surface, AAD-mismatch path. 2h each; chunked variant separately exercises the
+# reorder/splice/duplicate-index guards in DecryptChunked.
+internal/encryption|FuzzDecrypt|2h
+internal/encryption|FuzzDecryptChunked|1h
+# SAML IdP metadata XML parsing (crewjam/saml + mattermost/xml-roundtrip-validator).
+# XML parsers are historically the most fuzz-productive surface in SAML stacks.
+# 1h: the parser is fast and the interesting cases (XXE, entity-expansion,
+# malformed attribute names) surface quickly.
+internal/saml|FuzzSAMLMetadata|1h
+# Air-gapped bundle: streaming gzip+tar parse → manifest JSON → ed25519 signature
+# check → per-component sha256 walk. Must fail closed on any corrupt/truncated
+# input. 2h: the gzip+tar+JSON surface warrants more time than a pure parser.
+internal/bundle|FuzzBundleVerify|2h


### PR DESCRIPTION
## Summary

- **`FuzzDecrypt` / `FuzzDecryptChunked`** (`internal/encryption`): feeds arbitrary JSON-encoded `EncryptedData` blobs into `Decrypt`, `DecryptWithAAD`, and `DecryptChunked`. Targets the wrong-length nonce guard, GCM Open panic surface, AAD-mismatch path, and chunk reorder/splice/duplicate-index guards. Previously zero fuzz coverage on the core encryption layer.
- **`FuzzSAMLMetadata`** (`internal/saml`): feeds arbitrary bytes as IdP metadata XML into `NewProvider`. Targets the `crewjam/saml` + `mattermost/xml-roundtrip-validator` parse path — historically the most fuzz-productive surface in SAML stacks.
- **`FuzzBundleVerify`** (`internal/bundle`): feeds arbitrary byte streams into `Verify`. Covers the full streaming gzip+tar → manifest JSON → ed25519 signature check → per-component sha256 walk path.
- **`scripts/fuzzing/targets.conf`**: 4 new entries (FuzzDecrypt 2h, FuzzDecryptChunked 1h, FuzzSAMLMetadata 1h, FuzzBundleVerify 2h). Cycle grows from ~14h to ~20h. Auto-discovered by run-rotation.sh on next git pull — no script changes needed.

## Test plan

- [ ] `go test -run ^$ ./internal/encryption/ ./internal/saml/ ./internal/bundle/` — compiles clean
- [ ] `go test -fuzz=FuzzDecrypt -fuzztime=10s ./internal/encryption/` — runs without panic
- [ ] `go test -fuzz=FuzzSAMLMetadata -fuzztime=10s ./internal/saml/` — runs without panic
- [ ] `go test -fuzz=FuzzBundleVerify -fuzztime=10s ./internal/bundle/` — runs without panic
- [ ] After merge to main: vcd-fuzz picks up new targets at next cycle boundary (no restart needed)