### PR TITLE
feat: bulk approve/reject access requests

### DIFF
--- a/internal/cli/request/bulk.go
+++ b/internal/cli/request/bulk.go
@@ -12,6 +12,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// bulkInitService is the function used by bulk run-commands to obtain a core
+// service. It is a package-level variable so tests can replace it with one
+// that returns a pre-seeded or intentionally-broken service without forking the
+// production code path.
+var bulkInitService = common.InitializeCoreService
+
 // ── bulk-approve ──────────────────────────────────────────────────────────────
 
 var (
@@ -41,7 +47,7 @@ func runBulkApprove(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("--ids: %w", err)
 	}
-	service, err := common.InitializeCoreService()
+	service, err := bulkInitService()
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
@@ -99,7 +105,7 @@ func runBulkReject(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("--ids: %w", err)
 	}
-	service, err := common.InitializeCoreService()
+	service, err := bulkInitService()
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
@@ -171,7 +177,7 @@ func init() {
 }
 
 func runTmplList(cmd *cobra.Command, args []string) error {
-	service, err := common.InitializeCoreService()
+	service, err := bulkInitService()
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
@@ -192,7 +198,7 @@ func runTmplList(cmd *cobra.Command, args []string) error {
 }
 
 func runTmplAdd(cmd *cobra.Command, args []string) error {
-	service, err := common.InitializeCoreService()
+	service, err := bulkInitService()
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
@@ -216,7 +222,7 @@ func runTmplDelete(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("invalid template ID %q: %w", args[0], err)
 	}
-	service, err := common.InitializeCoreService()
+	service, err := bulkInitService()
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}

--- a/internal/cli/request/bulk_test.go
+++ b/internal/cli/request/bulk_test.go
@@ -4,11 +4,82 @@
 package request
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
+
+// errInitService is the sentinel error returned by the failing service factory.
+var errInitService = errors.New("simulated service init failure")
+
+// withFailingInitService temporarily replaces bulkInitService with one that
+// always returns errInitService, then restores the original on cleanup.
+func withFailingInitService(t *testing.T) {
+	t.Helper()
+	orig := bulkInitService
+	bulkInitService = func() (*core.KeyorixCore, error) { return nil, errInitService }
+	t.Cleanup(func() { bulkInitService = orig })
+}
+
+// bulkBrokenCounter avoids DSN collisions across parallel tests.
+var bulkBrokenCounter int
+
+// withBrokenDBService replaces bulkInitService with one that returns a
+// KeyorixCore backed by a closed SQLite connection (all storage calls fail).
+func withBrokenDBService(t *testing.T) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	bulkBrokenCounter++
+	dsn := fmt.Sprintf("file:bulk_broken_%d?mode=memory&cache=shared", bulkBrokenCounter)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.AccessRequest{},
+		&models.RejectionReasonTemplate{},
+	))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+	svc := core.NewKeyorixCore(store.NewLocalStorage(db))
+	orig := bulkInitService
+	bulkInitService = func() (*core.KeyorixCore, error) { return svc, nil }
+	t.Cleanup(func() { bulkInitService = orig })
+}
+
+// withUserSeededPartialService returns a KeyorixCore backed by a SQLite DB
+// that has ONLY the users table migrated (not access_requests / templates),
+// with an admin user seeded. GetUserByEmail succeeds; bulk-access / template
+// storage calls fail because those tables don't exist.
+func withUserSeededPartialService(t *testing.T, email string) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	bulkBrokenCounter++
+	dsn := fmt.Sprintf("file:bulk_partial_%d?mode=memory&cache=shared", bulkBrokenCounter)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	// Migrate ONLY the users table so GetUserByEmail works.
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+	require.NoError(t, db.Create(&models.User{
+		Username: "admin", Email: email, IsActive: true,
+	}).Error)
+	svc := core.NewKeyorixCore(store.NewLocalStorage(db))
+	orig := bulkInitService
+	bulkInitService = func() (*core.KeyorixCore, error) { return svc, nil }
+	t.Cleanup(func() {
+		bulkInitService = orig
+		sqlDB, _ := db.DB()
+		_ = sqlDB.Close()
+	})
+}
 
 // ── Command structure ─────────────────────────────────────────────────────────
 
@@ -195,4 +266,108 @@ func TestRunTmplDelete_ServiceInitError(t *testing.T) {
 	// Will fail at DeleteRejectionReasonTemplate step with a DB error.
 	err := runTmplDelete(nil, []string{"1"})
 	require.Error(t, err)
+}
+
+// ── InitializeCoreService failure paths (via bulkInitService override) ────────
+
+func TestRunBulkApprove_InitServiceError(t *testing.T) {
+	origIDs, origBy := bulkApproveIDs, bulkApproveBy
+	defer func() { bulkApproveIDs = origIDs; bulkApproveBy = origBy }()
+	bulkApproveIDs = "1"
+	bulkApproveBy = "a@example.com"
+	withFailingInitService(t)
+	err := runBulkApprove(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunBulkReject_InitServiceError(t *testing.T) {
+	origIDs, origBy, origReason := bulkRejectIDs, bulkRejectBy, bulkRejectReason
+	defer func() { bulkRejectIDs = origIDs; bulkRejectBy = origBy; bulkRejectReason = origReason }()
+	bulkRejectIDs = "1"
+	bulkRejectBy = "a@example.com"
+	bulkRejectReason = "reason"
+	withFailingInitService(t)
+	err := runBulkReject(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunTmplList_InitServiceError(t *testing.T) {
+	withFailingInitService(t)
+	err := runTmplList(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunTmplAdd_InitServiceError(t *testing.T) {
+	origName, origReason, origBy := tmplName, tmplReason, tmplBy
+	defer func() { tmplName = origName; tmplReason = origReason; tmplBy = origBy }()
+	tmplName = "x"
+	tmplReason = "y"
+	tmplBy = "a@example.com"
+	withFailingInitService(t)
+	err := runTmplAdd(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunTmplDelete_InitServiceError(t *testing.T) {
+	withFailingInitService(t)
+	err := runTmplDelete(nil, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+// ── BulkApprove / BulkReject / template storage errors (broken DB) ────────────
+
+func TestRunBulkApprove_BulkApproveError(t *testing.T) {
+	origIDs, origBy := bulkApproveIDs, bulkApproveBy
+	defer func() { bulkApproveIDs = origIDs; bulkApproveBy = origBy }()
+	bulkApproveIDs = "1"
+	bulkApproveBy = "partial@example.com"
+	// Service has only the users table — GetUserByEmail succeeds but
+	// ListAccessRequestsByIDs fails (no access_requests table), triggering
+	// the BulkApproveAccessRequests error branch (lines 62-64).
+	withUserSeededPartialService(t, "partial@example.com")
+	err := runBulkApprove(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bulk approve failed")
+}
+
+func TestRunBulkReject_BulkRejectError(t *testing.T) {
+	origIDs, origBy, origReason := bulkRejectIDs, bulkRejectBy, bulkRejectReason
+	defer func() { bulkRejectIDs = origIDs; bulkRejectBy = origBy; bulkRejectReason = origReason }()
+	bulkRejectIDs = "1"
+	bulkRejectBy = "partial@example.com"
+	bulkRejectReason = "expired"
+	// Service has only the users table — GetUserByEmail succeeds but
+	// ListAccessRequestsByIDs fails (no access_requests table), triggering
+	// the BulkRejectAccessRequests error branch (lines 120-122).
+	withUserSeededPartialService(t, "partial@example.com")
+	err := runBulkReject(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bulk reject failed")
+}
+
+func TestRunTmplList_ListError(t *testing.T) {
+	withBrokenDBService(t)
+	err := runTmplList(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list templates")
+}
+
+func TestRunTmplAdd_CreateError(t *testing.T) {
+	origName, origReason, origBy := tmplName, tmplReason, tmplBy
+	defer func() { tmplName = origName; tmplReason = origReason; tmplBy = origBy }()
+	tmplName = "x"
+	tmplReason = "y"
+	tmplBy = "partial@example.com"
+	// Service has only the users table — GetUserByEmail succeeds (user is seeded)
+	// but CreateRejectionReasonTemplate fails (no rejection_reason_templates table),
+	// triggering the error branch at lines 207-209.
+	withUserSeededPartialService(t, "partial@example.com")
+	err := runTmplAdd(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create template")
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1308,17 +1308,6 @@ type Storage interface {
 	// whose created_at (detected_at) is older than the given threshold.
 	ListUnacknowledgedAnomalyAlertsBefore(ctx context.Context, threshold time.Time) ([]models.AnomalyAlert, error)
 
-	// Rejection reason templates — pre-defined reasons for rejecting access
-	// requests. The REST API is the remote surface; these methods only run
-	// server-side via LocalStorage.
-	CreateRejectionReasonTemplate(ctx context.Context, t *models.RejectionReasonTemplate) error
-	ListRejectionReasonTemplates(ctx context.Context) ([]models.RejectionReasonTemplate, error)
-	DeleteRejectionReasonTemplate(ctx context.Context, id uint) error
-
-	// ListAccessRequestsByIDs returns the access requests matching the given IDs.
-	// Used by the bulk-approve/reject operations to pre-fetch all requests in one
-	// query and provide per-item errors without N individual GetAccessRequest calls.
-	ListAccessRequestsByIDs(ctx context.Context, ids []uint) ([]*models.AccessRequest, error)
 
 }
 

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1308,6 +1308,18 @@ type Storage interface {
 	// whose created_at (detected_at) is older than the given threshold.
 	ListUnacknowledgedAnomalyAlertsBefore(ctx context.Context, threshold time.Time) ([]models.AnomalyAlert, error)
 
+	// Rejection reason templates — pre-defined reasons for rejecting access
+	// requests. The REST API is the remote surface; these methods only run
+	// server-side via LocalStorage.
+	CreateRejectionReasonTemplate(ctx context.Context, t *models.RejectionReasonTemplate) error
+	ListRejectionReasonTemplates(ctx context.Context) ([]models.RejectionReasonTemplate, error)
+	DeleteRejectionReasonTemplate(ctx context.Context, id uint) error
+
+	// ListAccessRequestsByIDs returns the access requests matching the given IDs.
+	// Used by the bulk-approve/reject operations to pre-fetch all requests in one
+	// query and provide per-item errors without N individual GetAccessRequest calls.
+	ListAccessRequestsByIDs(ctx context.Context, ids []uint) ([]*models.AccessRequest, error)
+
 }
 
 // SecretFilter defines filtering options for secret queries

--- a/server/http/handlers/bulk_access_requests_test.go
+++ b/server/http/handlers/bulk_access_requests_test.go
@@ -37,6 +37,26 @@ func newBulkAccessTestHandler(t *testing.T) *CatalogHandler {
 	return NewCatalogHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
 }
 
+// newBulkAccessBrokenHandler returns a CatalogHandler backed by a closed
+// SQLite connection so that every storage call returns a DB error, allowing
+// coverage of the 500 error-path branches in each handler function.
+func newBulkAccessBrokenHandler(t *testing.T) *CatalogHandler {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	bulkHandlerCounter++
+	dsn := fmt.Sprintf("file:bah_broken%d?mode=memory&cache=shared", bulkHandlerCounter)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.AccessRequest{},
+		&models.RejectionReasonTemplate{},
+	))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+	return NewCatalogHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+}
+
 // ── BulkApproveAccessRequests ─────────────────────────────────────────────────
 
 func TestBulkApprove_NilUser(t *testing.T) {
@@ -196,4 +216,59 @@ func TestDeleteRejectionTemplate_Success(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.DeleteRejectionReasonTemplate(w, req)
 	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+// ── 500 error-path coverage (broken DB) ──────────────────────────────────────
+
+func TestBulkApprove_DBError_Returns500(t *testing.T) {
+	h := newBulkAccessBrokenHandler(t)
+	// DB is closed: ListAccessRequestsByIDs returns a generic error (not "required")
+	// which routes to the 500 branch in BulkApproveAccessRequests.
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/",
+		bytes.NewBufferString(`{"request_ids":[1]}`)))
+	w := httptest.NewRecorder()
+	h.BulkApproveAccessRequests(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestBulkReject_DBError_Returns500(t *testing.T) {
+	h := newBulkAccessBrokenHandler(t)
+	// DB is closed: ListAccessRequestsByIDs returns a generic error (not "required")
+	// which routes to the 500 branch in BulkRejectAccessRequests.
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/",
+		bytes.NewBufferString(`{"request_ids":[1],"reason":"expired"}`)))
+	w := httptest.NewRecorder()
+	h.BulkRejectAccessRequests(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestCreateRejectionTemplate_DBError_Returns500(t *testing.T) {
+	h := newBulkAccessBrokenHandler(t)
+	// DB is closed: CreateRejectionReasonTemplate returns a generic error (not
+	// "required") which routes to the 500 else-branch.
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/",
+		bytes.NewBufferString(`{"name":"x","reason":"y"}`)))
+	w := httptest.NewRecorder()
+	h.CreateRejectionReasonTemplate(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestListRejectionTemplates_DBError_Returns500(t *testing.T) {
+	h := newBulkAccessBrokenHandler(t)
+	// DB is closed: ListRejectionReasonTemplates returns an error that triggers
+	// the 500 branch.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.ListRejectionReasonTemplates(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestDeleteRejectionTemplate_DBError_Returns500(t *testing.T) {
+	h := newBulkAccessBrokenHandler(t)
+	// DB is closed: DeleteRejectionReasonTemplate returns a generic error (not
+	// "not found") which routes to the 500 else-branch.
+	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "1")
+	w := httptest.NewRecorder()
+	h.DeleteRejectionReasonTemplate(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }


### PR DESCRIPTION
Adds `BulkApproveAccessRequests` and `BulkRejectAccessRequests` core functions, rejection reason templates CRUD, and corresponding REST endpoints and CLI commands. Includes full test coverage.