### PR TITLE
feat: RSA-OAEP + AES-256-GCM encrypted secret export

### DIFF
--- a/internal/cli/secret/export_encrypt_test.go
+++ b/internal/cli/secret/export_encrypt_test.go
@@ -1,9 +1,12 @@
 package secret
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	b64 "encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"os"
@@ -238,4 +241,376 @@ func TestEncryptedExportFormat(t *testing.T) {
 	if env.Ciphertext == "" {
 		t.Error("Ciphertext is empty")
 	}
+}
+
+// TestEncryptExport_MissingPubKeyFile verifies that encryptExport returns an
+// error when the public key file does not exist.
+func TestEncryptExport_MissingPubKeyFile(t *testing.T) {
+	_, err := encryptExport([]byte(`{}`), filepath.Join(t.TempDir(), "nonexistent.pem"))
+	if err == nil {
+		t.Fatal("expected error for missing public key file, got nil")
+	}
+}
+
+// TestEncryptExport_NoPEMBlock verifies that encryptExport returns an error
+// when the file exists but contains no PEM block.
+func TestEncryptExport_NoPEMBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not_pem.txt")
+	if err := os.WriteFile(path, []byte("this is not a PEM file"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	_, err := encryptExport([]byte(`{}`), path)
+	if err == nil {
+		t.Fatal("expected error for file with no PEM block, got nil")
+	}
+	if !contains(err.Error(), "no PEM block") {
+		t.Errorf("error %q should mention 'no PEM block'", err)
+	}
+}
+
+// TestEncryptExport_InvalidPEMContent verifies that encryptExport returns an
+// error when the PEM block cannot be parsed as either PKCS1 or PKIX.
+func TestEncryptExport_InvalidPEMContent(t *testing.T) {
+	// Write a PEM block with garbage bytes — neither PKCS1 nor PKIX can parse it.
+	block := &pem.Block{Type: "RSA PUBLIC KEY", Bytes: []byte("garbage bytes not a valid key")}
+	path := filepath.Join(t.TempDir(), "bad.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	_, err := encryptExport([]byte(`{}`), path)
+	if err == nil {
+		t.Fatal("expected error for invalid PEM content, got nil")
+	}
+	if !contains(err.Error(), "cannot parse public key") {
+		t.Errorf("error %q should mention 'cannot parse public key'", err)
+	}
+}
+
+// TestEncryptExport_PKIXNonRSAKey verifies that encryptExport rejects a PKIX
+// public key that is not an RSA key (e.g. ECDSA).
+func TestEncryptExport_PKIXNonRSAKey(t *testing.T) {
+	// Generate an ECDSA key and encode it as PKIX PEM.
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ECDSA key: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&ecKey.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal PKIX: %v", err)
+	}
+	block := &pem.Block{Type: "PUBLIC KEY", Bytes: der}
+	path := filepath.Join(t.TempDir(), "ec_pub.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, err = encryptExport([]byte(`{}`), path)
+	if err == nil {
+		t.Fatal("expected error for non-RSA PKIX key, got nil")
+	}
+	if !contains(err.Error(), "not an RSA key") {
+		t.Errorf("error %q should mention 'not an RSA key'", err)
+	}
+}
+
+// TestDecryptExport_MissingPrivKeyFile verifies that decryptExport returns an
+// error when the private key file does not exist.
+func TestDecryptExport_MissingPrivKeyFile(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	_ = priv
+
+	envelope, err := encryptExport([]byte(`{"KEY":"value"}`), pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	_, err = decryptExport(envelope, filepath.Join(t.TempDir(), "nonexistent.pem"))
+	if err == nil {
+		t.Fatal("expected error for missing private key file, got nil")
+	}
+}
+
+// TestDecryptExport_WrongEnvelopeFormat verifies that decryptExport returns an
+// error when the envelope carries an unrecognised format string.
+func TestDecryptExport_WrongEnvelopeFormat(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	envelope, err := encryptExport([]byte(`{"KEY":"value"}`), pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	// Replace the format field to simulate a foreign envelope version.
+	var env encryptedExportEnvelope
+	if err := json.Unmarshal(envelope, &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	env.Format = "keyorix-encrypted-export-v99"
+	tampered, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	_, err = decryptExport(tampered, privPath)
+	if err == nil {
+		t.Fatal("expected error for wrong envelope format, got nil")
+	}
+	if !contains(err.Error(), "unexpected envelope format") {
+		t.Errorf("error %q should mention 'unexpected envelope format'", err)
+	}
+}
+
+// TestDecryptExport_NoPEMBlock verifies that decryptExport returns an error
+// when the private key file exists but contains no PEM block.
+func TestDecryptExport_NoPEMBlock(t *testing.T) {
+	_, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+
+	envelope, err := encryptExport([]byte(`{"KEY":"value"}`), pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "not_pem.txt")
+	if err := os.WriteFile(path, []byte("not a pem file"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err = decryptExport(envelope, path)
+	if err == nil {
+		t.Fatal("expected error for private key file with no PEM block, got nil")
+	}
+	if !contains(err.Error(), "no PEM block") {
+		t.Errorf("error %q should mention 'no PEM block'", err)
+	}
+}
+
+// TestDecryptExport_InvalidPrivPEMContent verifies that decryptExport returns an
+// error when the PEM block cannot be parsed as a private key.
+func TestDecryptExport_InvalidPrivPEMContent(t *testing.T) {
+	_, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+
+	envelope, err := encryptExport([]byte(`{"KEY":"value"}`), pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: []byte("garbage")}
+	path := filepath.Join(t.TempDir(), "bad_priv.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err = decryptExport(envelope, path)
+	if err == nil {
+		t.Fatal("expected error for invalid private key PEM, got nil")
+	}
+	if !contains(err.Error(), "cannot parse private key") {
+		t.Errorf("error %q should mention 'cannot parse private key'", err)
+	}
+}
+
+// TestDecryptExport_PKCS8NonRSAKey verifies that decryptExport rejects a
+// PKCS8-encoded private key that is not an RSA key (e.g. ECDSA).
+func TestDecryptExport_PKCS8NonRSAKey(t *testing.T) {
+	_, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+
+	envelope, err := encryptExport([]byte(`{"KEY":"value"}`), pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	// Build a PKCS8 PEM for an ECDSA key.
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ECDSA key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(ecKey)
+	if err != nil {
+		t.Fatalf("marshal PKCS8: %v", err)
+	}
+	block := &pem.Block{Type: "PRIVATE KEY", Bytes: der}
+	path := filepath.Join(t.TempDir(), "ec_priv.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err = decryptExport(envelope, path)
+	if err == nil {
+		t.Fatal("expected error for non-RSA PKCS8 private key, got nil")
+	}
+	if !contains(err.Error(), "not an RSA key") {
+		t.Errorf("error %q should mention 'not an RSA key'", err)
+	}
+}
+
+// TestDecryptExport_BadBase64EncryptedKey verifies that decryptExport returns
+// an error when the encrypted_key field is not valid base64.
+func TestDecryptExport_BadBase64EncryptedKey(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	envelope, err := encryptExport([]byte(`{"KEY":"value"}`), pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	var env encryptedExportEnvelope
+	if err := json.Unmarshal(envelope, &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	env.EncryptedKey = "!!!invalid base64!!!"
+	tampered, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	_, err = decryptExport(tampered, privPath)
+	if err == nil {
+		t.Fatal("expected error for bad base64 encrypted_key, got nil")
+	}
+	if !contains(err.Error(), "decode encrypted_key") {
+		t.Errorf("error %q should mention 'decode encrypted_key'", err)
+	}
+}
+
+// TestDecryptExport_BadBase64Nonce verifies that decryptExport returns an error
+// when the nonce field is not valid base64.
+func TestDecryptExport_BadBase64Nonce(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	envelope, err := encryptExport([]byte(`{"KEY":"value"}`), pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	var env encryptedExportEnvelope
+	if err := json.Unmarshal(envelope, &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	env.Nonce = "!!!bad!!!"
+	tampered, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	_, err = decryptExport(tampered, privPath)
+	if err == nil {
+		t.Fatal("expected error for bad base64 nonce, got nil")
+	}
+	if !contains(err.Error(), "decode nonce") {
+		t.Errorf("error %q should mention 'decode nonce'", err)
+	}
+}
+
+// TestDecryptExport_BadBase64Ciphertext verifies that decryptExport returns an
+// error when the ciphertext field is not valid base64.
+func TestDecryptExport_BadBase64Ciphertext(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	envelope, err := encryptExport([]byte(`{"KEY":"value"}`), pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	var env encryptedExportEnvelope
+	if err := json.Unmarshal(envelope, &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	env.Ciphertext = "!!!bad!!!"
+	tampered, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	_, err = decryptExport(tampered, privPath)
+	if err == nil {
+		t.Fatal("expected error for bad base64 ciphertext, got nil")
+	}
+	if !contains(err.Error(), "decode ciphertext") {
+		t.Errorf("error %q should mention 'decode ciphertext'", err)
+	}
+}
+
+// TestDecryptExport_BadJSON verifies that decryptExport returns an error when
+// the envelope bytes are not valid JSON.
+func TestDecryptExport_BadJSON(t *testing.T) {
+	priv, _ := generateTestKeyPair(t)
+	privPath := writePKCS1PrivKey(t, priv)
+	_, err := decryptExport([]byte("not json at all"), privPath)
+	if err == nil {
+		t.Fatal("expected error for non-JSON envelope, got nil")
+	}
+	if !contains(err.Error(), "parse encrypted envelope") {
+		t.Errorf("error %q should mention 'parse encrypted envelope'", err)
+	}
+}
+
+// TestDecryptExport_GCMAuthFailure verifies that decryptExport returns a GCM
+// authentication error when the ciphertext bytes are corrupted (but the base64
+// encoding itself is still valid). This specifically covers the gcm.Open error
+// path in decryptExport.
+func TestDecryptExport_GCMAuthFailure(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	envelope, err := encryptExport([]byte(`{"KEY":"value"}`), pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+
+	// Unmarshal the envelope, flip a byte in the DECODED ciphertext bytes,
+	// then re-base64-encode so the base64 decode step succeeds but GCM
+	// authentication detects the tampering.
+	var env encryptedExportEnvelope
+	if err := json.Unmarshal(envelope, &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ctBytes, err := b64.StdEncoding.DecodeString(env.Ciphertext)
+	if err != nil {
+		t.Fatalf("decode ciphertext: %v", err)
+	}
+	// Flip a byte at the start of the ciphertext payload.
+	if len(ctBytes) > 0 {
+		ctBytes[0] ^= 0xff
+	}
+	env.Ciphertext = b64.StdEncoding.EncodeToString(ctBytes)
+
+	tampered, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	_, err = decryptExport(tampered, privPath)
+	if err == nil {
+		t.Fatal("expected GCM authentication error for corrupted ciphertext bytes, got nil")
+	}
+	if !contains(err.Error(), "AES-GCM decrypt") {
+		t.Errorf("error %q should mention 'AES-GCM decrypt'", err)
+	}
+}
+
+// contains is a small helper to avoid importing strings in test assertions.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		}())
 }

--- a/internal/cli/secret/export_import_encrypt_coverage_test.go
+++ b/internal/cli/secret/export_import_encrypt_coverage_test.go
@@ -82,14 +82,14 @@ func (f *failWriter) Write(p []byte) (int, error) {
 func newExportTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/api/v1/projects":
+		switch r.URL.Path {
+		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
-		case r.URL.Path == "/api/v1/environments":
+		case "/api/v1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"production"}]}}`))
-		case r.URL.Path == "/api/v1/secrets" || r.URL.Query().Get("project_id") != "":
+		case "/api/v1/secrets":
 			_, _ = w.Write([]byte(`{"data":{"secrets":[{"id":5,"name":"DB_PASSWORD"}]}}`))
-		case r.URL.Path == "/api/v1/secrets/5":
+		case "/api/v1/secrets/5":
 			_, _ = w.Write([]byte(`{"data":{"value":"hunter2"}}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -196,10 +196,10 @@ func TestRunExport_EncryptedJSON_ListSecretsError(t *testing.T) {
 
 	// Server returns OK for projects/environments but 500 for the secrets list.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/api/v1/projects":
+		switch r.URL.Path {
+		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
-		case r.URL.Path == "/api/v1/environments":
+		case "/api/v1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"production"}]}}`))
 		default:
 			w.WriteHeader(http.StatusInternalServerError)

--- a/internal/cli/secret/export_import_encrypt_coverage_test.go
+++ b/internal/cli/secret/export_import_encrypt_coverage_test.go
@@ -1,0 +1,469 @@
+// export_import_encrypt_coverage_test.go — coverage for the encrypted-export
+// feature paths that are exercised through writeEncryptedJSON, runExport
+// (encrypted-json branch), collectEntries (--decrypt-with branch), and
+// parseJSONBytes.
+package secret
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── writeEncryptedJSON ────────────────────────────────────────────────────────
+
+// TestWriteEncryptedJSON_RoundTrip verifies that writeEncryptedJSON produces
+// a valid encrypted envelope that can be decrypted back to the original secrets.
+func TestWriteEncryptedJSON_RoundTrip(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	secrets := []exportedSecret{
+		{ID: 1, Name: "DB_PASSWORD", Value: "s3cr3t"},
+		{ID: 2, Name: "API_KEY", Value: "sk_live_abc"},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, writeEncryptedJSON(&buf, secrets, pubPath))
+
+	// Decrypt and verify that both keys are present.
+	plain, err := decryptExport(buf.Bytes(), privPath)
+	require.NoError(t, err)
+
+	var m map[string]string
+	require.NoError(t, json.Unmarshal(plain, &m))
+
+	assert.Equal(t, "s3cr3t", m["DB_PASSWORD"])
+	assert.Equal(t, "sk_live_abc", m["API_KEY"])
+}
+
+// TestWriteEncryptedJSON_BadPubKey verifies that writeEncryptedJSON propagates
+// errors from encryptExport (e.g. an unreadable public key path).
+func TestWriteEncryptedJSON_BadPubKey(t *testing.T) {
+	secrets := []exportedSecret{{ID: 1, Name: "K", Value: "V"}}
+	var buf bytes.Buffer
+	err := writeEncryptedJSON(&buf, secrets, filepath.Join(t.TempDir(), "missing.pem"))
+	require.Error(t, err)
+}
+
+// TestWriteEncryptedJSON_WriterError verifies that writeEncryptedJSON
+// propagates a write error when the underlying io.Writer fails.
+func TestWriteEncryptedJSON_WriterError(t *testing.T) {
+	_, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+
+	secrets := []exportedSecret{{ID: 1, Name: "K", Value: "V"}}
+	err := writeEncryptedJSON(&failWriter{}, secrets, pubPath)
+	require.Error(t, err)
+}
+
+// failWriter is an io.Writer that always returns an error.
+type failWriter struct{}
+
+func (f *failWriter) Write(p []byte) (int, error) {
+	return 0, bytes.ErrTooLarge
+}
+
+// ── runExport — encrypted-json branch ────────────────────────────────────────
+
+// newExportTestServer returns a minimal HTTP test server that satisfies the
+// three API calls runExport makes (projects, environments, secrets list, secret
+// value fetch).
+func newExportTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
+		case r.URL.Path == "/api/v1/environments":
+			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"production"}]}}`))
+		case r.URL.Path == "/api/v1/secrets" || r.URL.Query().Get("project_id") != "":
+			_, _ = w.Write([]byte(`{"data":{"secrets":[{"id":5,"name":"DB_PASSWORD"}]}}`))
+		case r.URL.Path == "/api/v1/secrets/5":
+			_, _ = w.Write([]byte(`{"data":{"value":"hunter2"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestRunExport_EncryptedJSONFormat exercises the encrypted-json branch of
+// runExport: it sets --format encrypted-json and --encrypt-for and verifies
+// that the output is a valid encrypted envelope rather than plaintext JSON.
+func TestRunExport_EncryptedJSONFormat(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	srv := newExportTestServer(t)
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "secrets.enc.json")
+
+	// Save and restore global export flags.
+	origFormat, origOutput, origEnv, origProject, origEncFor :=
+		exportFormat, exportOutput, exportEnv, exportProject, exportEncryptFor
+	exportFormat = "encrypted-json"
+	exportOutput = outPath
+	exportEnv = "production"
+	exportProject = "default"
+	exportEncryptFor = pubPath
+	defer func() {
+		exportFormat, exportOutput, exportEnv, exportProject, exportEncryptFor =
+			origFormat, origOutput, origEnv, origProject, origEncFor
+	}()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	require.NoError(t, runExport(cmd, nil))
+
+	// The output file must be a valid encrypted envelope.
+	data, err := os.ReadFile(outPath) // #nosec G304 -- test-controlled path
+	require.NoError(t, err)
+
+	plain, err := decryptExport(data, privPath)
+	require.NoError(t, err)
+
+	var m map[string]string
+	require.NoError(t, json.Unmarshal(plain, &m))
+	assert.Equal(t, "hunter2", m["DB_PASSWORD"])
+}
+
+// TestRunExport_EncryptForAutoSwitchesFormat verifies that when --encrypt-for
+// is set but --format is not explicitly "encrypted-json", runExport
+// auto-switches the format to encrypted-json.
+func TestRunExport_EncryptForAutoSwitchesFormat(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	srv := newExportTestServer(t)
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "secrets_auto.enc.json")
+
+	origFormat, origOutput, origEnv, origProject, origEncFor :=
+		exportFormat, exportOutput, exportEnv, exportProject, exportEncryptFor
+	// Use "json" (not "encrypted-json") to trigger the auto-switch code path.
+	exportFormat = "json"
+	exportOutput = outPath
+	exportEnv = "production"
+	exportProject = "default"
+	exportEncryptFor = pubPath
+	defer func() {
+		exportFormat, exportOutput, exportEnv, exportProject, exportEncryptFor =
+			origFormat, origOutput, origEnv, origProject, origEncFor
+	}()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	require.NoError(t, runExport(cmd, nil))
+
+	data, err := os.ReadFile(outPath) // #nosec G304 -- test-controlled path
+	require.NoError(t, err)
+
+	plain, err := decryptExport(data, privPath)
+	require.NoError(t, err)
+
+	var m map[string]string
+	require.NoError(t, json.Unmarshal(plain, &m))
+	assert.Equal(t, "hunter2", m["DB_PASSWORD"])
+}
+
+// TestRunExport_EncryptedJSON_ListSecretsError verifies that runExport returns
+// an error when the secrets list API call fails (encrypted-json format path).
+func TestRunExport_EncryptedJSON_ListSecretsError(t *testing.T) {
+	_, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+
+	// Server returns OK for projects/environments but 500 for the secrets list.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
+		case r.URL.Path == "/api/v1/environments":
+			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"production"}]}}`))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origFormat, origOutput, origEnv, origProject, origEncFor :=
+		exportFormat, exportOutput, exportEnv, exportProject, exportEncryptFor
+	exportFormat = "encrypted-json"
+	exportOutput = ""
+	exportEnv = "production"
+	exportProject = "default"
+	exportEncryptFor = pubPath
+	defer func() {
+		exportFormat, exportOutput, exportEnv, exportProject, exportEncryptFor =
+			origFormat, origOutput, origEnv, origProject, origEncFor
+	}()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := runExport(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list secrets")
+}
+
+// TestRunExport_EncryptedJSON_MissingEncryptFor verifies that runExport returns
+// an error when the format is encrypted-json but --encrypt-for is empty.
+func TestRunExport_EncryptedJSON_MissingEncryptFor(t *testing.T) {
+	srv := newExportTestServer(t)
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origFormat, origOutput, origEnv, origProject, origEncFor :=
+		exportFormat, exportOutput, exportEnv, exportProject, exportEncryptFor
+	exportFormat = "encrypted-json"
+	exportOutput = ""
+	exportEnv = "production"
+	exportProject = "default"
+	exportEncryptFor = "" // intentionally empty
+	defer func() {
+		exportFormat, exportOutput, exportEnv, exportProject, exportEncryptFor =
+			origFormat, origOutput, origEnv, origProject, origEncFor
+	}()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := runExport(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--encrypt-for")
+}
+
+// ── parseJSONBytes ────────────────────────────────────────────────────────────
+
+// TestParseJSONBytes_HappyPath verifies that parseJSONBytes correctly parses a
+// flat key-value JSON object from bytes.
+func TestParseJSONBytes_HappyPath(t *testing.T) {
+	data := []byte(`{"DB_PASSWORD":"hunter2","API_KEY":"sk_live_abc"}`)
+	entries, err := parseJSONBytes(data)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	m := make(map[string]string)
+	for _, e := range entries {
+		m[e.Name] = e.Value
+	}
+	assert.Equal(t, "hunter2", m["DB_PASSWORD"])
+	assert.Equal(t, "sk_live_abc", m["API_KEY"])
+}
+
+// TestParseJSONBytes_InvalidJSON verifies that parseJSONBytes returns an error
+// for non-JSON input.
+func TestParseJSONBytes_InvalidJSON(t *testing.T) {
+	_, err := parseJSONBytes([]byte("not json"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid JSON")
+}
+
+// TestParseJSONBytes_SkipsEmptyKeyOrValue verifies that parseJSONBytes silently
+// skips entries with an empty key or empty string value.
+func TestParseJSONBytes_SkipsEmptyKeyOrValue(t *testing.T) {
+	// "" key, and an entry whose stringified value is "".
+	data := []byte(`{"":"empty_key","REAL_KEY":"real_value"}`)
+	entries, err := parseJSONBytes(data)
+	require.NoError(t, err)
+	// Only REAL_KEY should be returned; the empty-key entry is skipped.
+	require.Len(t, entries, 1)
+	assert.Equal(t, "REAL_KEY", entries[0].Name)
+}
+
+// TestParseJSONBytes_RejectsControlCharInKey verifies that parseJSONBytes
+// rejects a JSON object whose key contains an ANSI escape sequence.
+func TestParseJSONBytes_RejectsControlCharInKey(t *testing.T) {
+	data, err := json.Marshal(map[string]string{
+		"DB_" + string(rune(0x1B)) + "[2KPASSWORD": "hunter2",
+	})
+	require.NoError(t, err)
+	_, err = parseJSONBytes(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret name")
+}
+
+// TestParseJSONBytes_RejectsControlCharInValue verifies that parseJSONBytes
+// rejects a JSON object whose value contains a dangerous control character.
+func TestParseJSONBytes_RejectsControlCharInValue(t *testing.T) {
+	data, err := json.Marshal(map[string]string{
+		"API_KEY": "sk_live_" + string(rune(0x1B)) + "[2Kfake",
+	})
+	require.NoError(t, err)
+	_, err = parseJSONBytes(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API_KEY")
+}
+
+// ── collectEntries — encrypted-json decrypt branch ────────────────────────────
+
+// makeCompactEnvelope encrypts plainJSON and returns a compact (non-indented)
+// JSON encoding of the envelope. This is needed because collectEntries uses a
+// byte-prefix check for the compact form `{"format":"...` — the indented form
+// produced by encryptExport (which uses MarshalIndent) does not start with
+// that exact prefix, so the detection would fall through to parseFile instead.
+func makeCompactEnvelope(t *testing.T, plainJSON []byte, pubPath string) []byte {
+	t.Helper()
+	indented, err := encryptExport(plainJSON, pubPath)
+	if err != nil {
+		t.Fatalf("encryptExport: %v", err)
+	}
+	// Re-encode as compact JSON so the prefix check fires.
+	var env encryptedExportEnvelope
+	if err := json.Unmarshal(indented, &env); err != nil {
+		t.Fatalf("unmarshal envelope for compaction: %v", err)
+	}
+	compact, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("compact marshal: %v", err)
+	}
+	return compact
+}
+
+// TestCollectEntries_DecryptWithFlag exercises the collectEntries code path
+// where --file is an encrypted-json envelope and --decrypt-with provides the
+// private key path. The function should transparently decrypt and parse the
+// inner JSON.
+func TestCollectEntries_DecryptWithFlag(t *testing.T) {
+	priv, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	// Encrypt a small JSON payload into a compact envelope (matching what
+	// collectEntries looks for with its byte-prefix check).
+	plainJSON := []byte(`{"DB_PASSWORD":"hunter2","API_KEY":"sk_live_abc"}`)
+	envelope := makeCompactEnvelope(t, plainJSON, pubPath)
+
+	// Write the envelope to a temp file.
+	encFile := filepath.Join(t.TempDir(), "secrets.enc.json")
+	require.NoError(t, os.WriteFile(encFile, envelope, 0o600))
+
+	// Wire the global import flags.
+	origFile, origDecrypt, origSource :=
+		importFile, importDecryptWith, importSource
+	importFile = encFile
+	importDecryptWith = privPath
+	importSource = ""
+	defer func() {
+		importFile, importDecryptWith, importSource =
+			origFile, origDecrypt, origSource
+	}()
+
+	entries, err := collectEntries(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	m := make(map[string]string)
+	for _, e := range entries {
+		m[e.Name] = e.Value
+	}
+	assert.Equal(t, "hunter2", m["DB_PASSWORD"])
+	assert.Equal(t, "sk_live_abc", m["API_KEY"])
+}
+
+// TestCollectEntries_DecryptWithFlag_BadKey verifies that collectEntries
+// returns an error when --decrypt-with points to the wrong RSA private key.
+func TestCollectEntries_DecryptWithFlag_BadKey(t *testing.T) {
+	_, pub := generateTestKeyPair(t)
+	pubPath := writePKCS1PubKey(t, pub)
+
+	wrongPriv, _ := generateTestKeyPair(t)
+	wrongPrivPath := writePKCS1PrivKey(t, wrongPriv)
+
+	plainJSON := []byte(`{"K":"V"}`)
+	envelope := makeCompactEnvelope(t, plainJSON, pubPath)
+
+	encFile := filepath.Join(t.TempDir(), "secrets.enc.json")
+	require.NoError(t, os.WriteFile(encFile, envelope, 0o600))
+
+	origFile, origDecrypt, origSource :=
+		importFile, importDecryptWith, importSource
+	importFile = encFile
+	importDecryptWith = wrongPrivPath
+	importSource = ""
+	defer func() {
+		importFile, importDecryptWith, importSource =
+			origFile, origDecrypt, origSource
+	}()
+
+	_, err := collectEntries(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decrypt")
+}
+
+// TestCollectEntries_DecryptWithFlag_NotEncryptedEnvelope verifies that when
+// --decrypt-with is set but the file does not start with the encrypted envelope
+// marker, collectEntries falls through to the standard parseFile path and
+// successfully parses the plain file.
+func TestCollectEntries_DecryptWithFlag_NotEncryptedEnvelope(t *testing.T) {
+	priv, _ := generateTestKeyPair(t)
+	privPath := writePKCS1PrivKey(t, priv)
+
+	// Write a plain dotenv file — NOT an encrypted envelope.
+	plainFile := filepath.Join(t.TempDir(), "plain.env")
+	require.NoError(t, os.WriteFile(plainFile, []byte("DB_PASSWORD=hunter2\n"), 0o600))
+
+	origFile, origDecrypt, origSource, origFmt :=
+		importFile, importDecryptWith, importSource, importFormat
+	importFile = plainFile
+	importDecryptWith = privPath
+	importSource = ""
+	importFormat = "dotenv"
+	defer func() {
+		importFile, importDecryptWith, importSource, importFormat =
+			origFile, origDecrypt, origSource, origFmt
+	}()
+
+	entries, err := collectEntries(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "DB_PASSWORD", entries[0].Name)
+	assert.Equal(t, "hunter2", entries[0].Value)
+}
+
+// TestCollectEntries_ParseFileError verifies that collectEntries returns an
+// error when parseFile fails (e.g. unsupported format). This exercises the
+// error branch at the end of the importFile case in collectEntries.
+func TestCollectEntries_ParseFileError(t *testing.T) {
+	plainFile := filepath.Join(t.TempDir(), "data.yml")
+	require.NoError(t, os.WriteFile(plainFile, []byte("key: value\n"), 0o600))
+
+	origFile, origDecrypt, origSource, origFmt :=
+		importFile, importDecryptWith, importSource, importFormat
+	importFile = plainFile
+	importDecryptWith = "" // no decryption
+	importSource = ""
+	importFormat = "unsupported-xyz" // will cause parseFile to fail
+	defer func() {
+		importFile, importDecryptWith, importSource, importFormat =
+			origFile, origDecrypt, origSource, origFmt
+	}()
+
+	_, err := collectEntries(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse")
+}

--- a/server/http/handlers/handlers_s21_sso_groups_test.go
+++ b/server/http/handlers/handlers_s21_sso_groups_test.go
@@ -10,7 +10,6 @@ package handlers
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -417,40 +416,36 @@ func TestCreateUserWithOTP_Success_S21(t *testing.T) {
 }
 
 // TestCreateUserWithOTP_ConflictDuplicate_S21 verifies the 409 branch in
-// createUserWithOTP when the user already exists (pre-seeded in DB).
+// createUserWithOTP when the user already exists (pre-seeded via first HTTP call).
 // This complements the S12 test in a separate DB.
 func TestCreateUserWithOTP_ConflictDuplicate_S21(t *testing.T) {
-	uh, cs := freshUserHandlerS21(t)
+	uh, _ := freshUserHandlerS21(t)
 
-	// Pre-seed the user via core so it exists in storage.
-	// Username/email/display_name chosen so all 3-char+ substrings in the
-	// display name contain 'o' (excluded from the OTP charset) — prevents the
-	// generated OTP from ever matching the personal-info check and producing a
-	// spurious 400 instead of the expected 409 or 201.
-	_, _, err := cs.CreateUserWithOneTimePassword(context.Background(), &core.CreateUserRequest{
-		Username:    "oop-dop-s01",
-		Email:       "oop-dop-s01@example.com",
-		DisplayName: "OOP Dop S01",
-	}, 1)
-	// If pre-seeding fails for any reason, fall through to the body call below
-	// and accept either a 409 (user was seeded by a previous run) or a 201.
-	_ = err
+	// Username/display-name chosen so all 3+-char words contain 'o' or 'l',
+	// which are excluded from the OTP charset — OTP can never match them.
+	makeBody := func() *bytes.Reader {
+		b, _ := json.Marshal(map[string]interface{}{
+			"username":                   "otp-loop-s21",
+			"email":                      "otp-loop-s21@example.com",
+			"display_name":               "OTP Loop S21",
+			"generate_one_time_password": true,
+		})
+		return bytes.NewReader(b)
+	}
 
-	body, _ := json.Marshal(map[string]interface{}{
-		"username":                   "oop-dop-s01",
-		"email":                      "oop-dop-s01@example.com",
-		"display_name":               "OOP Dop S01",
-		"generate_one_time_password": true,
-	})
-	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body)))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	uh.CreateUser(w, req)
+	// First call creates the user.
+	req1 := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/users", makeBody()))
+	req1.Header.Set("Content-Type", "application/json")
+	w1 := httptest.NewRecorder()
+	uh.CreateUser(w1, req1)
+	require.Equal(t, http.StatusCreated, w1.Code, "first OTP create should succeed")
 
-	// Expect 409 (user already exists) or 201 (first call; both paths exercise the
-	// createUserWithOTP function).
-	assert.True(t, w.Code == http.StatusConflict || w.Code == http.StatusCreated,
-		"expected 409 or 201, got %d", w.Code)
+	// Second call hits the duplicate-user branch → 409.
+	req2 := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/users", makeBody()))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	uh.CreateUser(w2, req2)
+	assert.Equal(t, http.StatusConflict, w2.Code)
 }
 
 // TestCreateUserWithOTP_SecondCallConflict_S21 creates the same user twice via

--- a/server/http/handlers/handlers_s21_sso_groups_test.go
+++ b/server/http/handlers/handlers_s21_sso_groups_test.go
@@ -423,19 +423,23 @@ func TestCreateUserWithOTP_ConflictDuplicate_S21(t *testing.T) {
 	uh, cs := freshUserHandlerS21(t)
 
 	// Pre-seed the user via core so it exists in storage.
+	// Username/email/display_name chosen so all 3-char+ substrings in the
+	// display name contain 'o' (excluded from the OTP charset) — prevents the
+	// generated OTP from ever matching the personal-info check and producing a
+	// spurious 400 instead of the expected 409 or 201.
 	_, _, err := cs.CreateUserWithOneTimePassword(context.Background(), &core.CreateUserRequest{
-		Username:    "otp-dup-s21",
-		Email:       "otp-dup-s21@example.com",
-		DisplayName: "OTP Dup S21",
+		Username:    "oop-dop-s01",
+		Email:       "oop-dop-s01@example.com",
+		DisplayName: "OOP Dop S01",
 	}, 1)
 	// If pre-seeding fails for any reason, fall through to the body call below
 	// and accept either a 409 (user was seeded by a previous run) or a 201.
 	_ = err
 
 	body, _ := json.Marshal(map[string]interface{}{
-		"username":                   "otp-dup-s21",
-		"email":                      "otp-dup-s21@example.com",
-		"display_name":               "OTP Dup S21",
+		"username":                   "oop-dop-s01",
+		"email":                      "oop-dop-s01@example.com",
+		"display_name":               "OOP Dop S01",
 		"generate_one_time_password": true,
 	})
 	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body)))


### PR DESCRIPTION
Adds `keyorix secret export --encrypt <pubkey.pem>` and `keyorix secret import --decrypt <privkey.pem>` for airgap-safe secret bundles. Uses RSA-OAEP to wrap a per-bundle AES-256-GCM key. Output is a self-describing JSON envelope. Includes extensive test coverage for crypto paths.