### PR TITLE
feat: diff between two secret versions

### DIFF
--- a/internal/cli/secret/diff_test.go
+++ b/internal/cli/secret/diff_test.go
@@ -2,15 +2,96 @@
 package secret
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// ── TestRunDiff_InvalidFromVersion ───────────────────────────────────────────
+
+// TestRunDiff_InvalidFromVersion exercises the "from-version must be a positive
+// integer" branch (args[1] is not a valid positive integer).
+func TestRunDiff_InvalidFromVersion(t *testing.T) {
+	err := runDiff(nil, []string{"my-secret", "notanumber", "2"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "from-version must be a positive integer")
+}
+
+// TestRunDiff_ZeroFromVersion exercises the <= 0 branch for from-version.
+func TestRunDiff_ZeroFromVersion(t *testing.T) {
+	err := runDiff(nil, []string{"my-secret", "0", "2"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "from-version must be a positive integer")
+}
+
+// ── TestRunDiff_InvalidToVersion ─────────────────────────────────────────────
+
+// TestRunDiff_InvalidToVersion exercises the "to-version must be a positive
+// integer" branch (args[2] is not a valid positive integer).
+func TestRunDiff_InvalidToVersion(t *testing.T) {
+	err := runDiff(nil, []string{"my-secret", "1", "notanumber"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "to-version must be a positive integer")
+}
+
+// TestRunDiff_ZeroToVersion exercises the <= 0 branch for to-version.
+func TestRunDiff_ZeroToVersion(t *testing.T) {
+	err := runDiff(nil, []string{"my-secret", "1", "0"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "to-version must be a positive integer")
+}
+
+// ── TestRunDiff_EmbeddedMode_NoID ────────────────────────────────────────────
+
+// TestRunDiff_EmbeddedMode_NoID exercises the embedded-mode branch where
+// --id is not set: NewRemoteClient returns ok=false and diffID==0.
+func TestRunDiff_EmbeddedMode_NoID(t *testing.T) {
+	// Ensure no remote client env vars are set.
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	// Ensure diffID is reset to zero (package-level var).
+	prev := diffID
+	diffID = 0
+	defer func() { diffID = prev }()
+
+	err := runDiff(nil, []string{"my-secret", "1", "2"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id is required in embedded mode")
+}
+
+// ── TestRunDiff_RemoteMode ────────────────────────────────────────────────────
+
+// TestRunDiff_RemoteMode exercises the remote-mode branch of runDiff: when
+// KEYORIX_SERVER and KEYORIX_TOKEN are set, runDiff calls runDiffRemote.
+func TestRunDiff_RemoteMode(t *testing.T) {
+	const (
+		sid  = uint(10)
+		from = 1
+		to   = 2
+	)
+	body := `{"data":{` +
+		`"secret_id":10,` +
+		`"secret_name":"my-secret",` +
+		`"from_version":1,` +
+		`"to_version":2,` +
+		`"changes":[],` +
+		`"acl_user_ids":null}}`
+
+	_, done := diffStub(t, sid, from, to, body, http.StatusOK)
+	defer done()
+
+	// With env vars set, runDiff should delegate to runDiffRemote.
+	err := runDiff(nil, []string{"my-secret", "1", "2"})
+	assert.NoError(t, err)
+}
 
 // diffStub starts an httptest server that handles the by-name lookup and the
 // diff endpoint. Returns a configured RemoteClient and a teardown function.
@@ -111,4 +192,173 @@ func TestSecretDiff_Remote_InvalidVersion(t *testing.T) {
 
 	err := runDiffRemote(rc, "my-api-key", from, to)
 	require.Error(t, err, "a 404 from the diff endpoint must surface as an error")
+}
+
+// ── TestSecretDiff_Remote_ByNameFails ────────────────────────────────────────
+
+// TestSecretDiff_Remote_ByNameFails exercises the error branch when the
+// by-name resolution endpoint returns 404 — runDiffRemote should surface the error.
+func TestSecretDiff_Remote_ByNameFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	err := runDiffRemote(rc, "no-such-secret", 1, 2)
+	require.Error(t, err)
+}
+
+// ── TestBuildByNamePath ───────────────────────────────────────────────────────
+
+// TestBuildByNamePath covers all three branches of buildByNamePath:
+// name-only, name+project, and name+project+env.
+func TestBuildByNamePath(t *testing.T) {
+	t.Run("name_only", func(t *testing.T) {
+		p := buildByNamePath("my-key", "", "")
+		assert.Equal(t, "/api/v1/secrets/by-name?name=my-key", p)
+	})
+	t.Run("name_and_project", func(t *testing.T) {
+		p := buildByNamePath("my-key", "prod", "")
+		assert.Equal(t, "/api/v1/secrets/by-name?name=my-key&project=prod", p)
+	})
+	t.Run("name_project_and_env", func(t *testing.T) {
+		p := buildByNamePath("my-key", "prod", "staging")
+		assert.Equal(t, "/api/v1/secrets/by-name?name=my-key&project=prod&environment=staging", p)
+	})
+}
+
+// ── TestRunDiff_EmbeddedMode_Success ─────────────────────────────────────────
+
+// TestRunDiff_EmbeddedMode_Success exercises the embedded-mode success path:
+// --id is set, InitializeStorage succeeds (via a minimal keyorix.yaml), and
+// DiffSecretVersions returns successfully for two existing versions.
+func TestRunDiff_EmbeddedMode_Success(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	cfgStr := "storage:\n  type: local\n  database:\n    path: ./secrets.db\n"
+	if err := os.WriteFile("keyorix.yaml", []byte(cfgStr), 0o600); err != nil {
+		t.Skip("could not write keyorix.yaml:", err)
+	}
+
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		t.Skip("embedded storage unavailable:", err)
+	}
+
+	ctx := context.Background()
+	proj, err := svc.CreateProject(ctx, "diff-embedded-proj", "")
+	if err != nil {
+		t.Skip("CreateProject failed:", err)
+	}
+	envs, err := svc.ListEnvironmentsByProject(ctx, proj.ID)
+	if err != nil || len(envs) == 0 {
+		t.Skip("no envs available:", err)
+	}
+
+	secret, err := svc.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name:          "diff-embedded-secret",
+		Value:         []byte("initial-value"),
+		Type:          "generic",
+		ProjectID:     proj.ID,
+		EnvironmentID: envs[0].ID,
+		CreatedBy:     "cli-test-diff",
+	})
+	if err != nil {
+		t.Skip("CreateSecret failed:", err)
+	}
+
+	// Create a second version by updating the secret.
+	if _, err := svc.UpdateSecret(ctx, &core.UpdateSecretRequest{
+		ID:        secret.ID,
+		Value:     []byte("updated-value"),
+		UpdatedBy: "cli-test-diff",
+	}); err != nil {
+		t.Skip("UpdateSecret failed:", err)
+	}
+
+	prev := diffID
+	diffID = secret.ID
+	defer func() { diffID = prev }()
+
+	// runDiff in embedded mode (no env vars set).
+	err = runDiff(nil, []string{"ignored-in-embedded", "1", "2"})
+	require.NoError(t, err)
+}
+
+// ── TestRunDiff_EmbeddedMode_StorageError ────────────────────────────────────
+
+// TestRunDiff_EmbeddedMode_StorageError exercises the InitializeStorage error
+// branch in runDiff embedded mode: no keyorix.yaml, so config.Load fails.
+func TestRunDiff_EmbeddedMode_StorageError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	// No keyorix.yaml written → InitializeStorage will fail to load config.
+
+	prev := diffID
+	diffID = 99 // non-zero so we pass the diffID==0 guard
+	defer func() { diffID = prev }()
+
+	err := runDiff(nil, []string{"my-secret", "1", "2"})
+	require.Error(t, err)
+}
+
+// ── TestRunDiff_EmbeddedMode_DiffError ───────────────────────────────────────
+
+// TestRunDiff_EmbeddedMode_DiffError exercises the DiffSecretVersions error
+// branch in runDiff embedded mode: storage initializes successfully but the
+// requested version doesn't exist → DiffSecretVersions returns an error.
+func TestRunDiff_EmbeddedMode_DiffError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	cfgStr := "storage:\n  type: local\n  database:\n    path: ./secrets.db\n"
+	if err := os.WriteFile("keyorix.yaml", []byte(cfgStr), 0o600); err != nil {
+		t.Skip("could not write keyorix.yaml:", err)
+	}
+
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		t.Skip("embedded storage unavailable:", err)
+	}
+
+	ctx := context.Background()
+	proj, err := svc.CreateProject(ctx, "diff-err-proj", "")
+	if err != nil {
+		t.Skip("CreateProject failed:", err)
+	}
+	envs, err := svc.ListEnvironmentsByProject(ctx, proj.ID)
+	if err != nil || len(envs) == 0 {
+		t.Skip("no envs available:", err)
+	}
+
+	secret, err := svc.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name:          "diff-err-secret",
+		Value:         []byte("v1-value"),
+		Type:          "generic",
+		ProjectID:     proj.ID,
+		EnvironmentID: envs[0].ID,
+		CreatedBy:     "cli-test-diff-err",
+	})
+	if err != nil {
+		t.Skip("CreateSecret failed:", err)
+	}
+
+	// Set diffID to an existing secret but request version 99 which doesn't exist.
+	prev := diffID
+	diffID = secret.ID
+	defer func() { diffID = prev }()
+
+	// Version 99 doesn't exist → DiffSecretVersions returns an error.
+	err = runDiff(nil, []string{"ignored", "1", "99"})
+	require.Error(t, err)
 }

--- a/internal/core/secret_version_diff_test.go
+++ b/internal/core/secret_version_diff_test.go
@@ -262,3 +262,145 @@ func TestDiffSecretVersions_InvalidVersion(t *testing.T) {
 	_, err := c.DiffSecretVersions(context.Background(), sid, 1, 99)
 	require.Error(t, err, "version 99 does not exist → error expected")
 }
+
+// ── TestDiffSecretVersions_ZeroSecretID ──────────────────────────────────────
+
+// TestDiffSecretVersions_ZeroSecretID confirms that secretID==0 is rejected
+// with a validation error.
+func TestDiffSecretVersions_ZeroSecretID(t *testing.T) {
+	c, _ := newDiffCore(t)
+	_, err := c.DiffSecretVersions(context.Background(), 0, 1, 2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret ID is required")
+}
+
+// ── TestDiffSecretVersions_ZeroVersions ──────────────────────────────────────
+
+// TestDiffSecretVersions_ZeroVersions confirms that non-positive version
+// numbers are rejected with a validation error.
+func TestDiffSecretVersions_ZeroVersions(t *testing.T) {
+	c, _ := newDiffCore(t)
+
+	_, err := c.DiffSecretVersions(context.Background(), 1, 0, 2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version numbers must be positive")
+
+	_, err = c.DiffSecretVersions(context.Background(), 1, 1, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version numbers must be positive")
+}
+
+// ── TestDiffSecretVersions_SameVersion ───────────────────────────────────────
+
+// TestDiffSecretVersions_SameVersion confirms that from==to is rejected.
+func TestDiffSecretVersions_SameVersionCore(t *testing.T) {
+	c, _ := newDiffCore(t)
+	_, err := c.DiffSecretVersions(context.Background(), 1, 3, 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must differ")
+}
+
+// ── TestDiffSecretVersions_SecretNotFound ─────────────────────────────────────
+
+// TestDiffSecretVersions_SecretNotFound confirms that a missing secret node
+// surfaces as an error.
+func TestDiffSecretVersions_SecretNotFound(t *testing.T) {
+	c, _ := newDiffCore(t)
+	_, err := c.DiffSecretVersions(context.Background(), 9999, 1, 2)
+	require.Error(t, err)
+}
+
+// ── TestDiffSecretVersions_FromVersionNotFound ────────────────────────────────
+
+// TestDiffSecretVersions_FromVersionNotFound confirms that a missing FROM
+// version number returns an error (covers the error path after GetSecretVersion
+// for the from-version).
+func TestDiffSecretVersions_FromVersionNotFound(t *testing.T) {
+	c, db := newDiffCore(t)
+	sid := seedDiffFixture(t, db, "", nil)
+	// Only seed version 2; version 1 does not exist.
+	addVersion(t, db, sid, 2, 0)
+
+	_, err := c.DiffSecretVersions(context.Background(), sid, 1, 2)
+	require.Error(t, err, "from version 1 does not exist → error expected")
+}
+
+// ── TestDiffSecretVersions_WithACLEntries ─────────────────────────────────────
+
+// TestDiffSecretVersions_WithACLEntries seeds an ACL entry for the secret and
+// confirms that the ACLUserIDs slice is populated (covers the ACL loop body).
+func TestDiffSecretVersions_WithACLEntries(t *testing.T) {
+	c, db := newDiffCore(t)
+	sid := seedDiffFixture(t, db, "", nil)
+	addVersion(t, db, sid, 1, 0)
+	addVersion(t, db, sid, 2, 0)
+
+	// Seed an ACL entry for user 42.
+	require.NoError(t, db.Create(&models.SecretACL{
+		SecretID:    sid,
+		UserID:      42,
+		Permissions: `["secrets.read"]`,
+		GrantedBy:   1,
+	}).Error)
+
+	diff, err := c.DiffSecretVersions(context.Background(), sid, 1, 2)
+	require.NoError(t, err)
+	assert.Contains(t, diff.ACLUserIDs, uint(42), "ACL entry for user 42 must appear in the result")
+}
+
+// ── TestDiffSecretVersions_NegativeDelta ─────────────────────────────────────
+
+// TestDiffSecretVersions_NegativeDelta exercises the branch where to.ReadCount <
+// from.ReadCount (delta < 0 → sign should be "" not "+").
+func TestDiffSecretVersions_NegativeDelta(t *testing.T) {
+	c, db := newDiffCore(t)
+
+	past := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "production"}).Error)
+	node := &models.SecretNode{
+		ID:            10,
+		Name:          "my-api-key",
+		ProjectID:     1,
+		EnvironmentID: 1,
+		IsSecret:      true,
+		Type:          "password",
+		Status:        "active",
+		CreatedAt:     past,
+		UpdatedAt:     past, // no node update → no classification/expiry change
+	}
+	require.NoError(t, db.Create(node).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: 10, VersionNumber: 1, EncryptedValue: []byte("v1"), ReadCount: 10,
+		CreatedAt: past,
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: 10, VersionNumber: 2, EncryptedValue: []byte("v2"), ReadCount: 3,
+		CreatedAt: past,
+	}).Error)
+
+	diff, err := c.DiffSecretVersions(context.Background(), uint(10), 1, 2)
+	require.NoError(t, err)
+
+	var rc *SecretVersionChange
+	for i := range diff.Changes {
+		if diff.Changes[i].Field == "read_count_delta" {
+			rc = &diff.Changes[i]
+			break
+		}
+	}
+	require.NotNil(t, rc, "expected a read_count_delta change")
+	assert.Equal(t, "10", rc.OldValue)
+	// Negative delta: sign should be "" (no "+"), value should start with "3"
+	assert.True(t, len(rc.NewValue) > 0 && rc.NewValue[0] == '3', "new value starts with to.ReadCount")
+	assert.NotContains(t, rc.NewValue, "+", "negative delta must not have a '+' sign")
+}
+
+// ── TestEmptyOr_EmptyString ───────────────────────────────────────────────────
+
+// TestEmptyOr_EmptyString exercises the emptyOr("") branch that returns "(none)".
+func TestEmptyOr_EmptyString(t *testing.T) {
+	assert.Equal(t, "(none)", emptyOr(""))
+	assert.Equal(t, "(none)", emptyOr("   "))
+	assert.Equal(t, "hello", emptyOr("hello"))
+}

--- a/server/http/handlers/handlers_s36_test.go
+++ b/server/http/handlers/handlers_s36_test.go
@@ -1,0 +1,299 @@
+// handlers_s36_test.go — unit coverage sweep for secret_version_diff.go.
+//
+// Covers all branches of (*SecretHandler).DiffSecretVersions:
+//   - No user context → 401
+//   - Non-numeric "id" param → 400
+//   - Non-numeric "from" param → 400
+//   - Non-numeric "to" param → 400
+//   - from <= 0 → 400
+//   - to <= 0 → 400
+//   - Core error containing "not found" → 404
+//   - Core validation error ("must differ") → 400
+//   - Core generic error → 500
+//   - Happy path (success) → 200
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// ── DB helpers ────────────────────────────────────────────────────────────────
+
+var s36DBCounter atomic.Int64
+
+// freshCoreS36WithAdmin opens a uniquely-named in-memory SQLite DB, migrates
+// all needed models, seeds user 1 as system_admin, and returns the core + DB.
+func freshCoreS36WithAdmin(t *testing.T) (*core.KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := s36DBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhandlers_s36a_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{},
+		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SecretNode{},
+		&models.AuditEvent{}, &models.AnomalyAlert{},
+		&models.RotationPolicy{}, &models.Notification{},
+		&models.ProjectMembership{}, &models.SoDPolicy{},
+		&models.BreakGlassActivation{}, &models.AccessReviewCampaign{}, &models.AccessReviewItem{},
+		&models.LoginAttempt{},
+		&models.AccessRequest{}, &models.AccessRequestApproval{},
+		&models.WebAuthnCredential{}, &models.WebAuthnSession{},
+		&models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
+		&models.ConnectRefGrant{}, &models.Session{}, &models.SetupToken{},
+		&models.MFAChallenge{}, &models.SSOLoginState{},
+		&models.MachineIdentity{}, &models.MachineIdentityCredential{},
+		&models.MachineIdentityRole{}, &models.MachineIdentityOIDCBinding{},
+		&models.SecretDependency{}, &models.RiskException{},
+		&models.MFASecret{}, &models.MFARecoveryCode{},
+		&models.IdentityProvider{}, &models.ExternalIdentity{},
+		&models.LegalHold{}, &models.ShareRecord{},
+		&models.PersonalAccessToken{},
+		&models.ProjectInvitation{}, &models.SchedulerLockLease{},
+		&models.SecretAccessLog{},
+		&models.SystemMetadata{},
+		&models.PasswordHistory{},
+		&models.SecretVersion{},
+		&models.SecretACL{},
+	))
+
+	adminRole := &models.Role{Name: "system_admin", Description: "Administrator"}
+	require.NoError(t, db.Create(adminRole).Error)
+	testUser := &models.User{Username: "testuser_s36", Email: "testuser_s36@example.com", AccountState: "active"}
+	require.NoError(t, db.Create(testUser).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: testUser.ID, RoleID: adminRole.ID}).Error)
+	return core.NewKeyorixCore(store.NewLocalStorage(db)), db
+}
+
+// withChiParam3_S36 sets three chi URL params at once.
+func withChiParam3_S36(r *http.Request, k1, v1, k2, v2, k3, v3 string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(k1, v1)
+	rctx.URLParams.Add(k2, v2)
+	rctx.URLParams.Add(k3, v3)
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+// seedVersionDiffFixtureS36 creates a project, environment, secret node with
+// two versions, and returns the secret's node ID.
+func seedVersionDiffFixtureS36(t *testing.T, db *gorm.DB) uint {
+	t.Helper()
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj-s36"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env-s36"}).Error)
+	now := time.Now()
+	node := &models.SecretNode{
+		ID:            100,
+		Name:          "s36-secret",
+		ProjectID:     1,
+		EnvironmentID: 1,
+		IsSecret:      true,
+		Type:          "password",
+		Status:        "active",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	require.NoError(t, db.Create(node).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: 100, VersionNumber: 1, EncryptedValue: []byte("cv1"), ReadCount: 5,
+		CreatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: 100, VersionNumber: 2, EncryptedValue: []byte("cv2"), ReadCount: 10,
+		CreatedAt: now,
+	}).Error)
+	return node.ID
+}
+
+// newDiffHandlerS36 returns a (*SecretHandler, *gorm.DB) pre-seeded with an
+// admin user and two secret versions ready for diffing.
+func newDiffHandlerS36(t *testing.T) (*SecretHandler, *gorm.DB, uint) {
+	t.Helper()
+	cs, db := freshCoreS36WithAdmin(t)
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	sid := seedVersionDiffFixtureS36(t, db)
+	return h, db, sid
+}
+
+// ── DiffSecretVersions: no user context → 401 ────────────────────────────────
+
+func TestDiffSecretVersions_NoUserCtx_S36(t *testing.T) {
+	h, _, sid := newDiffHandlerS36(t)
+	r := withChiParam3_S36(
+		httptest.NewRequest(http.MethodGet, "/api/v1/secrets/100/versions/1/diff/2", nil),
+		"id", fmt.Sprintf("%d", sid), "from", "1", "to", "2",
+	)
+	// deliberately NO user context injected
+	w := httptest.NewRecorder()
+	h.DiffSecretVersions(w, r)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// ── DiffSecretVersions: bad "id" param → 400 ─────────────────────────────────
+
+func TestDiffSecretVersions_BadID_S36(t *testing.T) {
+	h, _, _ := newDiffHandlerS36(t)
+	r := withUserCtx(withChiParam3_S36(
+		httptest.NewRequest(http.MethodGet, "/api/v1/secrets/notanumber/versions/1/diff/2", nil),
+		"id", "notanumber", "from", "1", "to", "2",
+	))
+	w := httptest.NewRecorder()
+	h.DiffSecretVersions(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "InvalidParameter")
+}
+
+// ── DiffSecretVersions: bad "from" param → 400 ───────────────────────────────
+
+func TestDiffSecretVersions_BadFrom_S36(t *testing.T) {
+	h, _, sid := newDiffHandlerS36(t)
+	r := withUserCtx(withChiParam3_S36(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/secrets/%d/versions/bad/diff/2", sid), nil),
+		"id", fmt.Sprintf("%d", sid), "from", "bad", "to", "2",
+	))
+	w := httptest.NewRecorder()
+	h.DiffSecretVersions(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "InvalidParameter")
+}
+
+// ── DiffSecretVersions: from <= 0 → 400 ──────────────────────────────────────
+
+func TestDiffSecretVersions_FromZero_S36(t *testing.T) {
+	h, _, sid := newDiffHandlerS36(t)
+	r := withUserCtx(withChiParam3_S36(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/secrets/%d/versions/0/diff/2", sid), nil),
+		"id", fmt.Sprintf("%d", sid), "from", "0", "to", "2",
+	))
+	w := httptest.NewRecorder()
+	h.DiffSecretVersions(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── DiffSecretVersions: bad "to" param → 400 ─────────────────────────────────
+
+func TestDiffSecretVersions_BadTo_S36(t *testing.T) {
+	h, _, sid := newDiffHandlerS36(t)
+	r := withUserCtx(withChiParam3_S36(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/secrets/%d/versions/1/diff/bad", sid), nil),
+		"id", fmt.Sprintf("%d", sid), "from", "1", "to", "bad",
+	))
+	w := httptest.NewRecorder()
+	h.DiffSecretVersions(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "InvalidParameter")
+}
+
+// ── DiffSecretVersions: to <= 0 → 400 ────────────────────────────────────────
+
+func TestDiffSecretVersions_ToZero_S36(t *testing.T) {
+	h, _, sid := newDiffHandlerS36(t)
+	r := withUserCtx(withChiParam3_S36(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/secrets/%d/versions/1/diff/0", sid), nil),
+		"id", fmt.Sprintf("%d", sid), "from", "1", "to", "0",
+	))
+	w := httptest.NewRecorder()
+	h.DiffSecretVersions(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── DiffSecretVersions: not found → 404 ──────────────────────────────────────
+
+// TestDiffSecretVersions_NotFound_S36 exercises the "not found" error branch by
+// requesting a version number that does not exist in the DB.
+func TestDiffSecretVersions_NotFound_S36(t *testing.T) {
+	h, _, sid := newDiffHandlerS36(t)
+	r := withUserCtx(withChiParam3_S36(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/secrets/%d/versions/1/diff/99", sid), nil),
+		"id", fmt.Sprintf("%d", sid), "from", "1", "to", "99",
+	))
+	w := httptest.NewRecorder()
+	h.DiffSecretVersions(w, r)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ── DiffSecretVersions: validation error ("must differ") → 400 ───────────────
+
+// TestDiffSecretVersions_SameVersions_S36 exercises the validation error branch
+// by requesting from==to (core returns "must differ" → 400).
+func TestDiffSecretVersions_SameVersions_S36(t *testing.T) {
+	h, _, sid := newDiffHandlerS36(t)
+	r := withUserCtx(withChiParam3_S36(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/secrets/%d/versions/1/diff/1", sid), nil),
+		"id", fmt.Sprintf("%d", sid), "from", "1", "to", "1",
+	))
+	w := httptest.NewRecorder()
+	h.DiffSecretVersions(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── DiffSecretVersions: generic internal error → 500 ─────────────────────────
+
+// TestDiffSecretVersions_InternalError_S36 exercises the default 500 branch by
+// temporarily switching the i18n locale to French so error messages (e.g.
+// "Secret non trouvé") do not contain "not found", bypassing the 404 branch and
+// falling through to the 500 default.
+func TestDiffSecretVersions_InternalError_S36(t *testing.T) {
+	// Switch i18n locale to French for this test so "Secret non trouvé" is used.
+	// ResetForTesting + InitializeForTesting restores English at the end.
+	loc := i18n.GetLocalizer()
+	loc.SetLanguage("fr")
+	defer loc.SetLanguage("en")
+
+	cs, db := freshCoreS36WithAdmin(t)
+	// Close the DB so GetSecret returns a storage error.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+
+	r := withUserCtx(withChiParam3_S36(
+		httptest.NewRequest(http.MethodGet, "/api/v1/secrets/1/versions/1/diff/2", nil),
+		"id", "1", "from", "1", "to", "2",
+	))
+	w := httptest.NewRecorder()
+	h.DiffSecretVersions(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── DiffSecretVersions: happy path → 200 ─────────────────────────────────────
+
+// TestDiffSecretVersions_HappyPath_S36 exercises the success branch: valid
+// secret with two existing versions → 200 with expected fields.
+func TestDiffSecretVersions_HappyPath_S36(t *testing.T) {
+	h, _, sid := newDiffHandlerS36(t)
+	r := withUserCtx(withChiParam3_S36(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/secrets/%d/versions/1/diff/2", sid), nil),
+		"id", fmt.Sprintf("%d", sid), "from", "1", "to", "2",
+	))
+	w := httptest.NewRecorder()
+	h.DiffSecretVersions(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "secret_id")
+	assert.Contains(t, body, "changes")
+}


### PR DESCRIPTION
Adds `DiffSecretVersions` core function that computes a structured diff (added/removed/changed fields) between any two versions of a secret. Exposes `GET /api/v1/secrets/{id}/versions/{from}/diff/{to}` and `keyorix secret diff` CLI command. Includes full test coverage.