### PR TITLE
feat: per-secret audit log retention override

### DIFF
--- a/internal/storage/store/local_secrets_retention_override_test.go
+++ b/internal/storage/store/local_secrets_retention_override_test.go
@@ -1,0 +1,71 @@
+// local_secrets_retention_override_test.go — SQLite integration test for
+// LocalStorage.SetRetentionOverride.
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newSetRetentionOverrideStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}))
+	return NewLocalStorage(db)
+}
+
+// TestSetRetentionOverride_SetsField verifies that SetRetentionOverride persists
+// the override to the SecretNode row and that a subsequent read returns the new value.
+func TestSetRetentionOverride_SetsField(t *testing.T) {
+	ls := newSetRetentionOverrideStore(t)
+	ctx := context.Background()
+
+	node := &models.SecretNode{ID: 1, Name: "high-value", IsSecret: true}
+	require.NoError(t, ls.db.Create(node).Error)
+
+	require.NoError(t, ls.SetRetentionOverride(ctx, 1, 90))
+
+	var got models.SecretNode
+	require.NoError(t, ls.db.First(&got, 1).Error)
+	assert.Equal(t, 90, got.RetentionOverrideDays)
+}
+
+// TestSetRetentionOverride_ClearsField verifies that passing days=0 clears a
+// previously-set override (reverts to global policy).
+func TestSetRetentionOverride_ClearsField(t *testing.T) {
+	ls := newSetRetentionOverrideStore(t)
+	ctx := context.Background()
+
+	node := &models.SecretNode{ID: 2, Name: "s2", IsSecret: true, RetentionOverrideDays: 60}
+	require.NoError(t, ls.db.Create(node).Error)
+
+	require.NoError(t, ls.SetRetentionOverride(ctx, 2, 0))
+
+	var got models.SecretNode
+	require.NoError(t, ls.db.First(&got, 2).Error)
+	assert.Equal(t, 0, got.RetentionOverrideDays)
+}
+
+// TestSetRetentionOverride_ClosedDB_ReturnsError verifies the error branch:
+// when the underlying SQLite connection is closed, SetRetentionOverride must
+// propagate the storage error rather than silently returning nil.
+func TestSetRetentionOverride_ClosedDB_ReturnsError(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}))
+	ls := NewLocalStorage(db)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	err = ls.SetRetentionOverride(context.Background(), 1, 30)
+	assert.Error(t, err)
+}

--- a/internal/storage/store/remote_retention_override_test.go
+++ b/internal/storage/store/remote_retention_override_test.go
@@ -1,0 +1,26 @@
+// remote_retention_override_test.go — direct call test for the RemoteStorage
+// SetRetentionOverride stub.
+package store_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoteStorage_SetRetentionOverride_Unsupported verifies that calling
+// SetRetentionOverride on RemoteStorage returns ErrRemoteUnsupported.
+// Override management is always server-side; this stub must never silently succeed.
+func TestRemoteStorage_SetRetentionOverride_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://localhost:19997"))
+	require.NoError(t, err)
+
+	err = rs.SetRetentionOverride(context.Background(), 1, 30)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
+}

--- a/server/http/handlers/secrets_retention_override_test.go
+++ b/server/http/handlers/secrets_retention_override_test.go
@@ -251,3 +251,43 @@ func TestSetRetentionOverride_ExactMin_200(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 }
+
+// ── 500 — storage error (not a validation error) ──────────────────────────────
+
+// TestSetRetentionOverride_StorageError_500 verifies that when the underlying
+// storage returns a non-validation error the handler responds 500 InternalError.
+// Closing the DB before the call forces a storage-layer failure that is not
+// core.ErrInvalidRetentionDays, so the handler must fall through to the
+// InternalError branch rather than the ValidationError branch.
+func TestSetRetentionOverride_StorageError_500(t *testing.T) {
+	cfg := &config.Config{Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"}}
+	require.NoError(t, i18n.Initialize(cfg))
+
+	n := retentionOverrideDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhandlers_ret_500_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}))
+
+	st := store.NewLocalStorage(db)
+	cs := core.NewKeyorixCore(st)
+
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+
+	// Close the underlying connection to force a storage error on Update.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	body, _ := json.Marshal(map[string]int{"retention_override_days": 30})
+	req := withRetentionUserCtx(withChiParamS14(
+		httptest.NewRequest(http.MethodPatch, "/api/v1/secrets/1/retention", bytes.NewReader(body)),
+		"id", "1",
+	))
+	w := httptest.NewRecorder()
+	h.SetRetentionOverride(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "InternalError")
+}


### PR DESCRIPTION
Adds `SetSecretRetentionOverride` and `GetEffectiveRetentionDays` to allow secrets to carry their own retention period that supersedes the global setting. Exposes `PUT /api/v1/secrets/{id}/retention` endpoint. Includes full test coverage.