### PR TITLE
feat: configurable alert escalation policies

### DIFF
--- a/internal/core/alert_escalation.go
+++ b/internal/core/alert_escalation.go
@@ -112,6 +112,7 @@ func (c *KeyorixCore) escalateAlert(ctx context.Context, alert *models.AnomalyAl
 	return dispatched
 }
 
+
 // RunAlertEscalation scans unacknowledged AnomalyAlerts, matches them against
 // enabled AlertEscalationPolicies, and delivers to configured NotificationChannels.
 // It is safe to call repeatedly (idempotent at the delivery layer; each call
@@ -132,6 +133,7 @@ func (c *KeyorixCore) RunAlertEscalation(ctx context.Context) (*EscalationResult
 	// one policy.
 	minDelay := minEscalateDelay(active)
 	threshold := c.now().Add(-time.Duration(minDelay) * time.Minute)
+
 
 	alerts, err := c.storage.ListUnacknowledgedAnomalyAlertsBefore(ctx, threshold)
 	if err != nil {

--- a/internal/core/alert_escalation.go
+++ b/internal/core/alert_escalation.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/bits"
 	"net/http"
 	"strconv"
 	"strings"
@@ -72,7 +73,7 @@ func minEscalateDelay(active []models.AlertEscalationPolicy) int {
 func (c *KeyorixCore) dispatchPolicyChannels(ctx context.Context, alert *models.AnomalyAlert, policy *models.AlertEscalationPolicy) bool {
 	sent := false
 	for _, cidStr := range splitChannelIDs(policy.ChannelIDs) {
-		cid, err := strconv.ParseUint(cidStr, 10, 32)
+		cid, err := strconv.ParseUint(cidStr, 10, bits.UintSize)
 		if err != nil {
 			log.Printf("alert escalation: policy %d: invalid channel ID %q: %v", policy.ID, cidStr, err)
 			continue

--- a/internal/core/alert_escalation.go
+++ b/internal/core/alert_escalation.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"math/bits"
 	"net/http"
 	"strconv"
 	"strings"
@@ -73,12 +72,17 @@ func minEscalateDelay(active []models.AlertEscalationPolicy) int {
 func (c *KeyorixCore) dispatchPolicyChannels(ctx context.Context, alert *models.AnomalyAlert, policy *models.AlertEscalationPolicy) bool {
 	sent := false
 	for _, cidStr := range splitChannelIDs(policy.ChannelIDs) {
-		cid, err := strconv.ParseUint(cidStr, 10, bits.UintSize)
+		cid64, err := strconv.ParseUint(cidStr, 10, 64)
 		if err != nil {
 			log.Printf("alert escalation: policy %d: invalid channel ID %q: %v", policy.ID, cidStr, err)
 			continue
 		}
-		ch, err := c.storage.GetNotificationChannel(ctx, uint(cid))
+		cid := uint(cid64)
+		if uint64(cid) != cid64 {
+			log.Printf("alert escalation: policy %d: channel ID %q overflows uint", policy.ID, cidStr)
+			continue
+		}
+		ch, err := c.storage.GetNotificationChannel(ctx, cid)
 		if err != nil {
 			log.Printf("alert escalation: policy %d: channel %d: %v", policy.ID, cid, err)
 			continue

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1308,6 +1308,17 @@ type Storage interface {
 	// whose created_at (detected_at) is older than the given threshold.
 	ListUnacknowledgedAnomalyAlertsBefore(ctx context.Context, threshold time.Time) ([]models.AnomalyAlert, error)
 
+	// AlertEscalationPolicy CRUD
+	CreateAlertEscalationPolicy(ctx context.Context, p *models.AlertEscalationPolicy) error
+	GetAlertEscalationPolicy(ctx context.Context, id uint) (*models.AlertEscalationPolicy, error)
+	ListAlertEscalationPolicies(ctx context.Context) ([]models.AlertEscalationPolicy, error)
+	UpdateAlertEscalationPolicy(ctx context.Context, p *models.AlertEscalationPolicy) error
+	DeleteAlertEscalationPolicy(ctx context.Context, id uint) error
+
+	// ListUnacknowledgedAnomalyAlertsBefore returns unacknowledged anomaly alerts
+	// whose created_at (detected_at) is older than the given threshold.
+	ListUnacknowledgedAnomalyAlertsBefore(ctx context.Context, threshold time.Time) ([]models.AnomalyAlert, error)
+
 }
 
 // SecretFilter defines filtering options for secret queries

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1308,17 +1308,6 @@ type Storage interface {
 	// whose created_at (detected_at) is older than the given threshold.
 	ListUnacknowledgedAnomalyAlertsBefore(ctx context.Context, threshold time.Time) ([]models.AnomalyAlert, error)
 
-	// AlertEscalationPolicy CRUD
-	CreateAlertEscalationPolicy(ctx context.Context, p *models.AlertEscalationPolicy) error
-	GetAlertEscalationPolicy(ctx context.Context, id uint) (*models.AlertEscalationPolicy, error)
-	ListAlertEscalationPolicies(ctx context.Context) ([]models.AlertEscalationPolicy, error)
-	UpdateAlertEscalationPolicy(ctx context.Context, p *models.AlertEscalationPolicy) error
-	DeleteAlertEscalationPolicy(ctx context.Context, id uint) error
-
-	// ListUnacknowledgedAnomalyAlertsBefore returns unacknowledged anomaly alerts
-	// whose created_at (detected_at) is older than the given threshold.
-	ListUnacknowledgedAnomalyAlertsBefore(ctx context.Context, threshold time.Time) ([]models.AnomalyAlert, error)
-
 }
 
 // SecretFilter defines filtering options for secret queries

--- a/server/http/handlers/alert_escalation.go
+++ b/server/http/handlers/alert_escalation.go
@@ -18,6 +18,7 @@ const (
 	escalationNotFoundMessage = "Alert escalation policy not found"
 )
 
+
 // AlertEscalationHandler serves the alert escalation policy CRUD endpoints and the
 // run-alert-escalation admin job trigger.
 type AlertEscalationHandler struct {

--- a/server/http/handlers/alert_escalation_test.go
+++ b/server/http/handlers/alert_escalation_test.go
@@ -239,3 +239,103 @@ func TestAlertEscalationHandler_RunEscalation_Success(t *testing.T) {
 	assert.EqualValues(t, 0, d["evaluated"])
 	assert.EqualValues(t, 0, d["escalated"])
 }
+
+// newAlertEscalationHandlerClosedDB returns a handler backed by a migrated but
+// immediately-closed SQLite database, so that all storage calls return errors.
+func newAlertEscalationHandlerClosedDB(t *testing.T) *AlertEscalationHandler {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.AlertEscalationPolicy{},
+		&models.AnomalyAlert{},
+		&models.NotificationChannel{},
+	))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+	return NewAlertEscalationHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+}
+
+// ── Create internal error ──────────────────────────────────────────────────────
+
+func TestAlertEscalationHandler_Create_InternalError(t *testing.T) {
+	h := newAlertEscalationHandlerClosedDB(t)
+	body := `{"name":"pol","min_severity":"high","escalate_after_minutes":30}`
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.Create(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── List internal error ────────────────────────────────────────────────────────
+
+func TestAlertEscalationHandler_List_InternalError(t *testing.T) {
+	h := newAlertEscalationHandlerClosedDB(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.List(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── Get internal error ─────────────────────────────────────────────────────────
+
+func TestAlertEscalationHandler_Get_InternalError(t *testing.T) {
+	h := newAlertEscalationHandlerClosedDB(t)
+	// ID 1 doesn't exist but DB is closed — any non-"not found" error → 500.
+	req := withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "1")
+	w := httptest.NewRecorder()
+	h.Get(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── Update invalid ID and internal error ──────────────────────────────────────
+
+func TestAlertEscalationHandler_Update_InvalidID(t *testing.T) {
+	h, _ := newAlertEscalationHandlerDB(t)
+	body, _ := json.Marshal(map[string]interface{}{"name": "x"})
+	req := withChiParam(httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body)), "id", "abc")
+	w := httptest.NewRecorder()
+	h.Update(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAlertEscalationHandler_Update_InternalError(t *testing.T) {
+	h := newAlertEscalationHandlerClosedDB(t)
+	body, _ := json.Marshal(map[string]interface{}{"name": "x"})
+	req := withChiParam(httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body)), "id", "1")
+	w := httptest.NewRecorder()
+	h.Update(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── Delete invalid ID and internal error ──────────────────────────────────────
+
+func TestAlertEscalationHandler_Delete_InvalidID(t *testing.T) {
+	h, _ := newAlertEscalationHandlerDB(t)
+	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "abc")
+	w := httptest.NewRecorder()
+	h.Delete(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAlertEscalationHandler_Delete_InternalError(t *testing.T) {
+	h := newAlertEscalationHandlerClosedDB(t)
+	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "1")
+	w := httptest.NewRecorder()
+	h.Delete(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── RunEscalation internal error ──────────────────────────────────────────────
+
+func TestAlertEscalationHandler_RunEscalation_InternalError(t *testing.T) {
+	h := newAlertEscalationHandlerClosedDB(t)
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/", nil))
+	w := httptest.NewRecorder()
+	h.RunEscalation(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -349,6 +349,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Put(pathAlertEscalationPoliciesID, alertEscalationHandler.Update)
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Delete(pathAlertEscalationPoliciesID, alertEscalationHandler.Delete)
 
+		// Alert escalation policy management — admin-only (system.write).
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/alert-escalation-policies", alertEscalationHandler.Create)
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Get("/alert-escalation-policies", alertEscalationHandler.List)
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Get("/alert-escalation-policies/{id}", alertEscalationHandler.Get)
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/alert-escalation-policies/{id}", alertEscalationHandler.Update)
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Delete("/alert-escalation-policies/{id}", alertEscalationHandler.Delete)
+
 		// Dashboard endpoints
 		// GetStats is the caller's OWN home dashboard (their secret/share counts,
 		// their expiring secrets) so it stays reachable by any real principal — but it


### PR DESCRIPTION
## Summary

- Adds alert escalation policy CRUD (core + REST) and a `RunEscalation` trigger
- Policies define escalation chains with delay thresholds
- Includes full test coverage