### PR TITLE
feat: rotation-overdue report grouped by backend

### DIFF
--- a/internal/cli/compliance/rotation_backend.go
+++ b/internal/cli/compliance/rotation_backend.go
@@ -53,13 +53,13 @@ the whole deployment. Requires audit.read permission.`,
 		}
 
 		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(tw, "BACKEND\tTOTAL\tOVERDUE\tUP-TO-DATE\tNEVER ROTATED")
+		_, _ = fmt.Fprintln(tw, "BACKEND\tTOTAL\tOVERDUE\tUP-TO-DATE\tNEVER ROTATED")
 		for _, b := range report.Backends {
 			backend := b.Backend
 			if backend == "" {
 				backend = "(keyorix-internal)"
 			}
-			fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\n",
+			_, _ = fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\n",
 				backend, b.Total, b.Overdue, b.UpToDate, b.NeverRotated)
 		}
 		_ = tw.Flush()

--- a/internal/cli/compliance/rotation_backend.go
+++ b/internal/cli/compliance/rotation_backend.go
@@ -1,0 +1,72 @@
+// rotation_backend.go — `keyorix compliance rotation-by-backend` command.
+// Prints a table of rotation-overdue secrets grouped by RotationBackend across
+// the whole deployment. Talks to GET /api/v1/compliance/rotation-by-backend.
+package compliance
+
+import (
+	"context"
+	"fmt"
+	"text/tabwriter"
+	"os"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+// backendReport mirrors core.RotationBackendReport for JSON decoding in the CLI.
+type backendReport struct {
+	GeneratedAt  time.Time           `json:"generated_at"`
+	Backends     []backendStat       `json:"backends"`
+	TotalOverdue int                 `json:"total_overdue"`
+}
+
+type backendStat struct {
+	Backend      string `json:"backend"`
+	Total        int    `json:"total"`
+	Overdue      int    `json:"overdue"`
+	UpToDate     int    `json:"up_to_date"`
+	NeverRotated int    `json:"never_rotated"`
+}
+
+var rotationByBackendCmd = &cobra.Command{
+	Use:          "rotation-by-backend",
+	Short:        "Rotation-overdue secrets grouped by backend",
+	Long: `Print a table of rotation-overdue secrets grouped by RotationBackend across
+the whole deployment. Requires audit.read permission.`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, ok := common.NewRemoteClient()
+		if !ok {
+			return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
+		}
+		var report backendReport
+		if err := c.Get(context.Background(), "/api/v1/compliance/rotation-by-backend", &report); err != nil {
+			return err
+		}
+		fmt.Printf("Rotation overdue by backend — %s\n", report.GeneratedAt.Format(time.RFC3339))
+		fmt.Printf("Total overdue: %d\n\n", report.TotalOverdue)
+
+		if len(report.Backends) == 0 {
+			fmt.Println("No rotation policies found.")
+			return nil
+		}
+
+		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "BACKEND\tTOTAL\tOVERDUE\tUP-TO-DATE\tNEVER ROTATED")
+		for _, b := range report.Backends {
+			backend := b.Backend
+			if backend == "" {
+				backend = "(keyorix-internal)"
+			}
+			fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\n",
+				backend, b.Total, b.Overdue, b.UpToDate, b.NeverRotated)
+		}
+		_ = tw.Flush()
+		return nil
+	},
+}
+
+func init() {
+	ComplianceCmd.AddCommand(rotationByBackendCmd)
+}

--- a/internal/cli/compliance/rotation_backend_test.go
+++ b/internal/cli/compliance/rotation_backend_test.go
@@ -1,0 +1,65 @@
+package compliance
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const backendPayloadFull = `{"success":true,"data":{
+	"generated_at":"2026-07-20T12:00:00Z",
+	"total_overdue":3,
+	"backends":[
+		{"backend":"vault","total":10,"overdue":2,"up_to_date":7,"never_rotated":1},
+		{"backend":"","total":5,"overdue":1,"up_to_date":3,"never_rotated":1}
+	]
+}}`
+
+const backendPayloadEmpty = `{"success":true,"data":{
+	"generated_at":"2026-07-20T12:00:00Z",
+	"total_overdue":0,
+	"backends":[]
+}}`
+
+func TestRotationByBackend_NotConnected(t *testing.T) {
+	setupDisconnected(t)
+	err := rotationByBackendCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestRotationByBackend_ServerError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"internal error"}`))
+	})
+	err := rotationByBackendCmd.RunE(nil, nil)
+	require.Error(t, err)
+}
+
+func TestRotationByBackend_WithBackends(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/compliance/rotation-by-backend", r.URL.Path)
+		_, _ = w.Write([]byte(backendPayloadFull))
+	})
+
+	out := captureStdout(t, func() { require.NoError(t, rotationByBackendCmd.RunE(nil, nil)) })
+	assert.Contains(t, out, "Total overdue: 3")
+	assert.Contains(t, out, "vault")
+	assert.Contains(t, out, "(keyorix-internal)")
+	assert.Contains(t, out, "BACKEND")
+	assert.Contains(t, out, "OVERDUE")
+}
+
+func TestRotationByBackend_EmptyBackends(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/compliance/rotation-by-backend", r.URL.Path)
+		_, _ = w.Write([]byte(backendPayloadEmpty))
+	})
+
+	out := captureStdout(t, func() { require.NoError(t, rotationByBackendCmd.RunE(nil, nil)) })
+	assert.Contains(t, out, "No rotation policies found.")
+	assert.Contains(t, out, "Total overdue: 0")
+}

--- a/internal/core/rotation_backend_report.go
+++ b/internal/core/rotation_backend_report.go
@@ -1,0 +1,93 @@
+// rotation_backend_report.go — deployment-wide rotation-overdue aggregation grouped
+// by RotationBackend so operators can see "200 secrets overdue on Postgres, 50 on
+// Vault" to triage remediation. Uses the same rotation-status evaluation path as the
+// compliance-posture and hygiene-rollup callers — no new storage queries.
+package core
+
+import (
+	"context"
+	"sort"
+	"time"
+)
+
+// BackendRotationStat holds per-backend rotation counts for the overdue-by-backend
+// report.
+type BackendRotationStat struct {
+	// Backend is the RotationBackend label — e.g. "aws_sm", "vault", "generic",
+	// or "" (empty string) for secrets whose rotation is regenerated in Keyorix only.
+	Backend      string `json:"backend"`
+	Total        int    `json:"total"`         // total secrets with a rotation policy on this backend
+	Overdue      int    `json:"overdue"`        // past their scheduled rotation date
+	UpToDate     int    `json:"up_to_date"`     // rotated within their schedule (ok + due_soon)
+	NeverRotated int    `json:"never_rotated"`  // policy set but LastRotatedAt is nil
+}
+
+// RotationBackendReport is the response body for GET /api/v1/compliance/rotation-by-backend.
+type RotationBackendReport struct {
+	GeneratedAt  time.Time             `json:"generated_at"`
+	Backends     []BackendRotationStat `json:"backends"`
+	TotalOverdue int                   `json:"total_overdue"`
+}
+
+// GetRotationBackendReport aggregates rotation-policy status (overdue / up-to-date /
+// never-rotated) grouped by RotationBackend across the whole deployment.
+//
+// It reuses GetRotationStatus with no project filter so the result spans every
+// active policy; callers should gate this endpoint on audit.read.
+func (k *KeyorixCore) GetRotationBackendReport(ctx context.Context) (*RotationBackendReport, error) {
+	entries, err := k.GetRotationStatus(ctx, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Accumulate per-backend stats in a map; preserve insertion order for stable
+	// output by tracking first-seen order separately.
+	type mutableStat struct {
+		BackendRotationStat
+	}
+	byBackend := make(map[string]*mutableStat)
+	var order []string
+
+	for _, e := range entries {
+		key := e.RotationBackend
+		stat, ok := byBackend[key]
+		if !ok {
+			stat = &mutableStat{BackendRotationStat{Backend: key}}
+			byBackend[key] = stat
+			order = append(order, key)
+		}
+		stat.Total++
+		if e.LastRotatedAt == nil {
+			stat.NeverRotated++
+		}
+		if e.Status == RotationStatusOverdue {
+			stat.Overdue++
+		} else {
+			stat.UpToDate++
+		}
+	}
+
+	// Build result slice sorted by Overdue descending, then by Backend name for
+	// determinism within ties.
+	stats := make([]BackendRotationStat, 0, len(order))
+	for _, key := range order {
+		stats = append(stats, byBackend[key].BackendRotationStat)
+	}
+	sort.Slice(stats, func(i, j int) bool {
+		if stats[i].Overdue != stats[j].Overdue {
+			return stats[i].Overdue > stats[j].Overdue
+		}
+		return stats[i].Backend < stats[j].Backend
+	})
+
+	totalOverdue := 0
+	for _, s := range stats {
+		totalOverdue += s.Overdue
+	}
+
+	return &RotationBackendReport{
+		GeneratedAt:  k.now(),
+		Backends:     stats,
+		TotalOverdue: totalOverdue,
+	}, nil
+}

--- a/internal/core/rotation_backend_report_test.go
+++ b/internal/core/rotation_backend_report_test.go
@@ -1,0 +1,304 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// fixed clock for all sub-tests.
+var rbFixed = time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+
+func rbDaysAgo(d int) *time.Time {
+	t := rbFixed.Add(-time.Duration(d) * 24 * time.Hour)
+	return &t
+}
+
+// newRBCore returns a core with the mock store and a frozen clock.
+func newRBCore(store *MockStorage) *KeyorixCore {
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return rbFixed }
+	return c
+}
+
+// policyForBackend is a helper that creates a minimal, active project-scoped policy
+// (project 1, no environment scope) with the given ID, interval and — importantly —
+// no EnvironmentID so scopedPolicySecrets uses a nil envID (lists all secrets in the
+// project).
+func policyForBackend(id uint, intervalDays int) *models.RotationPolicy {
+	pid := uint(1)
+	return &models.RotationPolicy{
+		ID:           id,
+		Name:         "test-policy",
+		Scope:        "project",
+		ProjectID:    &pid,
+		IntervalDays: intervalDays,
+		IsActive:     true,
+	}
+}
+
+// TestGetRotationBackendReport_NoPolicies — no rotation policies → empty backends
+// slice and TotalOverdue == 0.
+func TestGetRotationBackendReport_NoPolicies(t *testing.T) {
+	store := new(MockStorage)
+	store.On("ListRotationPolicies", mock.Anything, (*uint)(nil), (*uint)(nil)).
+		Return([]*models.RotationPolicy{}, nil)
+
+	c := newRBCore(store)
+	report, err := c.GetRotationBackendReport(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, report.Backends)
+	assert.Equal(t, 0, report.TotalOverdue)
+	assert.False(t, report.GeneratedAt.IsZero())
+	store.AssertExpectations(t)
+}
+
+// TestGetRotationBackendReport_SinglePolicyUpToDate — one secret, rotated recently
+// → up_to_date=1, overdue=0.
+func TestGetRotationBackendReport_SinglePolicyUpToDate(t *testing.T) {
+	store := new(MockStorage)
+	policy := policyForBackend(1, 90)
+
+	secrets := []*models.SecretNode{
+		{ID: 1, Name: "fresh-key", RotationBackend: "vault", LastRotatedAt: rbDaysAgo(10)},
+	}
+	store.On("ListRotationPolicies", mock.Anything, (*uint)(nil), (*uint)(nil)).
+		Return([]*models.RotationPolicy{policy}, nil)
+	store.On("ListSecrets", mock.Anything, mock.AnythingOfType("*storage.SecretFilter")).
+		Return(secrets, int64(1), nil)
+
+	c := newRBCore(store)
+	report, err := c.GetRotationBackendReport(context.Background())
+	require.NoError(t, err)
+	require.Len(t, report.Backends, 1)
+	b := report.Backends[0]
+	assert.Equal(t, "vault", b.Backend)
+	assert.Equal(t, 1, b.Total)
+	assert.Equal(t, 0, b.Overdue)
+	assert.Equal(t, 1, b.UpToDate)
+	assert.Equal(t, 0, b.NeverRotated)
+	assert.Equal(t, 0, report.TotalOverdue)
+	store.AssertExpectations(t)
+}
+
+// TestGetRotationBackendReport_SinglePolicyOverdue — one secret past its interval
+// → overdue=1.
+func TestGetRotationBackendReport_SinglePolicyOverdue(t *testing.T) {
+	store := new(MockStorage)
+	policy := policyForBackend(1, 30)
+
+	secrets := []*models.SecretNode{
+		{ID: 2, Name: "stale-key", RotationBackend: "aws_sm", LastRotatedAt: rbDaysAgo(120)},
+	}
+	store.On("ListRotationPolicies", mock.Anything, (*uint)(nil), (*uint)(nil)).
+		Return([]*models.RotationPolicy{policy}, nil)
+	store.On("ListSecrets", mock.Anything, mock.AnythingOfType("*storage.SecretFilter")).
+		Return(secrets, int64(1), nil)
+
+	c := newRBCore(store)
+	report, err := c.GetRotationBackendReport(context.Background())
+	require.NoError(t, err)
+	require.Len(t, report.Backends, 1)
+	b := report.Backends[0]
+	assert.Equal(t, "aws_sm", b.Backend)
+	assert.Equal(t, 1, b.Overdue)
+	assert.Equal(t, 0, b.UpToDate)
+	assert.Equal(t, 1, report.TotalOverdue)
+}
+
+// TestGetRotationBackendReport_NeverRotated — policy set but LastRotatedAt is nil
+// (secret was never rotated). Falls back to CreatedAt → likely overdue. Also counts
+// in never_rotated.
+func TestGetRotationBackendReport_NeverRotated(t *testing.T) {
+	store := new(MockStorage)
+	policy := policyForBackend(1, 30)
+
+	secrets := []*models.SecretNode{
+		// CreatedAt is 200 days ago → overdue under 30-day policy; LastRotatedAt nil.
+		{ID: 3, Name: "never-rotated", RotationBackend: "generic", CreatedAt: *rbDaysAgo(200)},
+	}
+	store.On("ListRotationPolicies", mock.Anything, (*uint)(nil), (*uint)(nil)).
+		Return([]*models.RotationPolicy{policy}, nil)
+	store.On("ListSecrets", mock.Anything, mock.AnythingOfType("*storage.SecretFilter")).
+		Return(secrets, int64(1), nil)
+
+	c := newRBCore(store)
+	report, err := c.GetRotationBackendReport(context.Background())
+	require.NoError(t, err)
+	require.Len(t, report.Backends, 1)
+	b := report.Backends[0]
+	assert.Equal(t, "generic", b.Backend)
+	assert.Equal(t, 1, b.NeverRotated, "never_rotated counter must fire when LastRotatedAt is nil")
+	assert.Equal(t, 1, b.Overdue, "overdue counter: falls back to CreatedAt (200 days > 30)")
+	assert.Equal(t, 0, b.UpToDate)
+}
+
+// TestGetRotationBackendReport_MultipleBackends — secrets across aws_sm, vault,
+// and (empty = keyorix-internal). Report must group correctly.
+func TestGetRotationBackendReport_MultipleBackends(t *testing.T) {
+	store := new(MockStorage)
+	policy := policyForBackend(1, 30)
+
+	secrets := []*models.SecretNode{
+		{ID: 1, RotationBackend: "aws_sm", LastRotatedAt: rbDaysAgo(100)},  // overdue
+		{ID: 2, RotationBackend: "aws_sm", LastRotatedAt: rbDaysAgo(5)},    // up-to-date
+		{ID: 3, RotationBackend: "vault", LastRotatedAt: rbDaysAgo(200)},   // overdue
+		{ID: 4, RotationBackend: "vault", LastRotatedAt: rbDaysAgo(200)},   // overdue
+		{ID: 5, RotationBackend: "", LastRotatedAt: rbDaysAgo(10)},         // up-to-date, no backend
+	}
+	store.On("ListRotationPolicies", mock.Anything, (*uint)(nil), (*uint)(nil)).
+		Return([]*models.RotationPolicy{policy}, nil)
+	store.On("ListSecrets", mock.Anything, mock.AnythingOfType("*storage.SecretFilter")).
+		Return(secrets, int64(5), nil)
+
+	c := newRBCore(store)
+	report, err := c.GetRotationBackendReport(context.Background())
+	require.NoError(t, err)
+	require.Len(t, report.Backends, 3, "three distinct backends")
+
+	byBackend := make(map[string]BackendRotationStat)
+	for _, b := range report.Backends {
+		byBackend[b.Backend] = b
+	}
+
+	aws := byBackend["aws_sm"]
+	assert.Equal(t, 2, aws.Total)
+	assert.Equal(t, 1, aws.Overdue)
+	assert.Equal(t, 1, aws.UpToDate)
+
+	vault := byBackend["vault"]
+	assert.Equal(t, 2, vault.Total)
+	assert.Equal(t, 2, vault.Overdue)
+	assert.Equal(t, 0, vault.UpToDate)
+
+	internal := byBackend[""]
+	assert.Equal(t, 1, internal.Total)
+	assert.Equal(t, 0, internal.Overdue)
+	assert.Equal(t, 1, internal.UpToDate)
+
+	assert.Equal(t, 3, report.TotalOverdue)
+}
+
+// TestGetRotationBackendReport_SortedByOverdueDescending — the backend with the
+// most overdue secrets must appear first; ties broken by backend name.
+func TestGetRotationBackendReport_SortedByOverdueDescending(t *testing.T) {
+	store := new(MockStorage)
+	policy := policyForBackend(1, 30)
+
+	// vault: 3 overdue, aws_sm: 1 overdue, generic: 0 overdue
+	secrets := []*models.SecretNode{
+		{ID: 1, RotationBackend: "aws_sm", LastRotatedAt: rbDaysAgo(200)}, // overdue
+		{ID: 2, RotationBackend: "vault", LastRotatedAt: rbDaysAgo(200)},  // overdue
+		{ID: 3, RotationBackend: "vault", LastRotatedAt: rbDaysAgo(200)},  // overdue
+		{ID: 4, RotationBackend: "vault", LastRotatedAt: rbDaysAgo(200)},  // overdue
+		{ID: 5, RotationBackend: "generic", LastRotatedAt: rbDaysAgo(5)},  // up-to-date
+	}
+	store.On("ListRotationPolicies", mock.Anything, (*uint)(nil), (*uint)(nil)).
+		Return([]*models.RotationPolicy{policy}, nil)
+	store.On("ListSecrets", mock.Anything, mock.AnythingOfType("*storage.SecretFilter")).
+		Return(secrets, int64(5), nil)
+
+	c := newRBCore(store)
+	report, err := c.GetRotationBackendReport(context.Background())
+	require.NoError(t, err)
+	require.Len(t, report.Backends, 3)
+	assert.Equal(t, "vault", report.Backends[0].Backend, "vault has most overdue")
+	assert.Equal(t, "aws_sm", report.Backends[1].Backend, "aws_sm second")
+	assert.Equal(t, "generic", report.Backends[2].Backend, "generic last (0 overdue)")
+}
+
+// TestGetRotationBackendReport_TieBreakByName — two backends with the same overdue
+// count must be ordered alphabetically.
+func TestGetRotationBackendReport_TieBreakByName(t *testing.T) {
+	store := new(MockStorage)
+	policy := policyForBackend(1, 30)
+
+	secrets := []*models.SecretNode{
+		{ID: 1, RotationBackend: "zebra", LastRotatedAt: rbDaysAgo(200)}, // overdue
+		{ID: 2, RotationBackend: "alpha", LastRotatedAt: rbDaysAgo(200)}, // overdue
+	}
+	store.On("ListRotationPolicies", mock.Anything, (*uint)(nil), (*uint)(nil)).
+		Return([]*models.RotationPolicy{policy}, nil)
+	store.On("ListSecrets", mock.Anything, mock.AnythingOfType("*storage.SecretFilter")).
+		Return(secrets, int64(2), nil)
+
+	c := newRBCore(store)
+	report, err := c.GetRotationBackendReport(context.Background())
+	require.NoError(t, err)
+	require.Len(t, report.Backends, 2)
+	assert.Equal(t, "alpha", report.Backends[0].Backend, "alpha comes before zebra on tie")
+}
+
+// TestGetRotationBackendReport_TotalOverdueSumsAllBackends — TotalOverdue must equal
+// the sum of all per-backend Overdue counts.
+func TestGetRotationBackendReport_TotalOverdueSumsAllBackends(t *testing.T) {
+	store := new(MockStorage)
+	policy := policyForBackend(1, 30)
+
+	secrets := []*models.SecretNode{
+		{ID: 1, RotationBackend: "a", LastRotatedAt: rbDaysAgo(200)}, // overdue
+		{ID: 2, RotationBackend: "a", LastRotatedAt: rbDaysAgo(200)}, // overdue
+		{ID: 3, RotationBackend: "b", LastRotatedAt: rbDaysAgo(200)}, // overdue
+		{ID: 4, RotationBackend: "b", LastRotatedAt: rbDaysAgo(5)},   // up-to-date
+	}
+	store.On("ListRotationPolicies", mock.Anything, (*uint)(nil), (*uint)(nil)).
+		Return([]*models.RotationPolicy{policy}, nil)
+	store.On("ListSecrets", mock.Anything, mock.AnythingOfType("*storage.SecretFilter")).
+		Return(secrets, int64(4), nil)
+
+	c := newRBCore(store)
+	report, err := c.GetRotationBackendReport(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 3, report.TotalOverdue)
+}
+
+// TestGetRotationBackendReport_StorageError — a storage error from GetRotationStatus
+// must propagate to the caller.
+func TestGetRotationBackendReport_StorageError(t *testing.T) {
+	store := new(MockStorage)
+	store.On("ListRotationPolicies", mock.Anything, (*uint)(nil), (*uint)(nil)).
+		Return(nil, errors.New("db is down"))
+
+	c := newRBCore(store)
+	_, err := c.GetRotationBackendReport(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db is down")
+}
+
+// TestGetRotationBackendReport_GeneratedAtSet — GeneratedAt is set to the core's
+// current time.
+func TestGetRotationBackendReport_GeneratedAtSet(t *testing.T) {
+	store := new(MockStorage)
+	store.On("ListRotationPolicies", mock.Anything, (*uint)(nil), (*uint)(nil)).
+		Return([]*models.RotationPolicy{}, nil)
+
+	c := newRBCore(store)
+	report, err := c.GetRotationBackendReport(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, rbFixed, report.GeneratedAt)
+}
+
+// TestGetRotationBackendReport_ListSecretsError — if listing secrets for a policy
+// fails, GetRotationStatus returns an error that GetRotationBackendReport propagates.
+func TestGetRotationBackendReport_ListSecretsError(t *testing.T) {
+	store := new(MockStorage)
+	policy := policyForBackend(1, 30)
+	store.On("ListRotationPolicies", mock.Anything, (*uint)(nil), (*uint)(nil)).
+		Return([]*models.RotationPolicy{policy}, nil)
+	store.On("ListSecrets", mock.Anything, mock.AnythingOfType("*storage.SecretFilter")).
+		Return(nil, int64(0), errors.New("secrets table missing"))
+
+	c := newRBCore(store)
+	_, err := c.GetRotationBackendReport(context.Background())
+	require.Error(t, err, "storage error from ListSecrets must propagate")
+}
+
+// Ensure the storage package import is used (SecretFilter comes from there).
+var _ = storage.SecretFilter{}

--- a/server/http/handlers/rotation_backend_report.go
+++ b/server/http/handlers/rotation_backend_report.go
@@ -1,0 +1,32 @@
+// rotation_backend_report.go — HTTP handler for the deployment-wide rotation-overdue
+// report grouped by RotationBackend.
+//
+// Route: GET /api/v1/compliance/rotation-by-backend
+// Permission: audit.read (global) — same disclosure family as /compliance/evidence.
+package handlers
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// RotationByBackend handles GET /api/v1/compliance/rotation-by-backend.
+// Returns a RotationBackendReport: per-backend counts of overdue / up-to-date /
+// never-rotated secrets across the whole deployment, sorted by overdue count
+// descending so the worst offenders appear first.
+func (h *SecretHandler) RotationByBackend(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUserFromContext(r.Context()) == nil {
+		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+		return
+	}
+
+	report, err := h.coreService.GetRotationBackendReport(r.Context())
+	if err != nil {
+		log.Printf("rotation-by-backend: %v", err)
+		h.sendError(w, "InternalError", "Failed to build rotation-by-backend report", http.StatusInternalServerError, nil)
+		return
+	}
+	h.sendSuccess(w, report, "")
+}

--- a/server/http/handlers/rotation_backend_report_handler_test.go
+++ b/server/http/handlers/rotation_backend_report_handler_test.go
@@ -1,0 +1,95 @@
+// rotation_backend_report_handler_test.go — unit tests for RotationByBackend handler.
+// Tests the 401 (no user ctx), 500 (core error), and 200 (success) branches.
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var rbhDBCounter atomic.Int64
+
+// freshCoreRBH opens a uniquely-named in-memory SQLite DB and returns a ready-to-use
+// KeyorixCore for rotation_backend_report_handler tests.
+func freshCoreRBH(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := rbhDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhandlers_rbh_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	err = db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{},
+		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SecretNode{},
+		&models.AuditEvent{}, &models.RotationPolicy{}, &models.SystemMetadata{},
+		&models.Session{}, &models.SecretVersion{},
+	)
+	require.NoError(t, err)
+	return core.NewKeyorixCore(store.NewLocalStorage(db))
+}
+
+// freshCoreRBHClosed returns a core backed by a closed DB to trigger storage errors.
+func freshCoreRBHClosed(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := rbhDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhandlers_rbh_closed_%d?mode=memory&cache=shared", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	err = db.AutoMigrate(&models.RotationPolicy{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.Close()
+	return core.NewKeyorixCore(store.NewLocalStorage(db))
+}
+
+// TestRotationByBackend_NoUserCtx — nil user context produces a 401.
+func TestRotationByBackend_NoUserCtx(t *testing.T) {
+	cs := freshCoreRBH(t)
+	h := &SecretHandler{coreService: cs}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/compliance/rotation-by-backend", nil)
+	w := httptest.NewRecorder()
+	h.RotationByBackend(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestRotationByBackend_Success — authenticated request against an empty DB produces 200.
+func TestRotationByBackend_Success(t *testing.T) {
+	cs := freshCoreRBH(t)
+	h := &SecretHandler{coreService: cs}
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/compliance/rotation-by-backend", nil))
+	w := httptest.NewRecorder()
+	h.RotationByBackend(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestRotationByBackend_StorageError — a closed DB causes GetRotationBackendReport
+// to error; the handler must respond with 500.
+func TestRotationByBackend_StorageError(t *testing.T) {
+	cs := freshCoreRBHClosed(t)
+	h := &SecretHandler{coreService: cs}
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/compliance/rotation-by-backend", nil))
+	w := httptest.NewRecorder()
+	h.RotationByBackend(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/server/http/handlers/rotation_backend_report_handler_test.go
+++ b/server/http/handlers/rotation_backend_report_handler_test.go
@@ -53,7 +53,7 @@ func freshCoreRBHClosed(t *testing.T) *core.KeyorixCore {
 	require.NoError(t, err)
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
-	sqlDB.Close()
+	_ = sqlDB.Close()
 	return core.NewKeyorixCore(store.NewLocalStorage(db))
 }
 

--- a/server/http/rotation_backend_report_handler_test.go
+++ b/server/http/rotation_backend_report_handler_test.go
@@ -1,0 +1,173 @@
+// rotation_backend_report_handler_test.go — integration tests for
+// GET /api/v1/compliance/rotation-by-backend.
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newRotationBackendTestEnv bootstraps a core, token, and server for
+// rotation-by-backend tests.
+func newRotationBackendTestEnv(t *testing.T) (c *core.KeyorixCore, token string, srv *httptest.Server) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	c = newTestCore(t)
+	token = createTestToken(t, c)
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv = httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	return
+}
+
+// doRotationByBackend sends a GET to /api/v1/compliance/rotation-by-backend and
+// returns the HTTP status code + the decoded JSON body.
+func doRotationByBackend(t *testing.T, srv *httptest.Server, token string) (int, map[string]interface{}) {
+	t.Helper()
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/compliance/rotation-by-backend", nil)
+	require.NoError(t, err)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	var body map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	return resp.StatusCode, body
+}
+
+// TestRotationByBackend_Unauthenticated — no token → 401.
+func TestRotationByBackend_Unauthenticated(t *testing.T) {
+	_, _, srv := newRotationBackendTestEnv(t)
+	code, _ := doRotationByBackend(t, srv, "")
+	assert.Equal(t, http.StatusUnauthorized, code)
+}
+
+// TestRotationByBackend_AuthenticatedEmpty — no rotation policies → 200 with an
+// empty backends array and total_overdue == 0.
+func TestRotationByBackend_AuthenticatedEmpty(t *testing.T) {
+	_, token, srv := newRotationBackendTestEnv(t)
+	code, body := doRotationByBackend(t, srv, token)
+	assert.Equal(t, http.StatusOK, code)
+
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object: %v", body)
+
+	// backends must be present (empty slice or null is fine here).
+	_, hasBackends := data["backends"]
+	assert.True(t, hasBackends, "response must contain backends field: %v", data)
+
+	totalOverdue, ok := data["total_overdue"].(float64)
+	require.True(t, ok, "total_overdue must be numeric: %v", data)
+	assert.Equal(t, float64(0), totalOverdue)
+
+	_, hasGeneratedAt := data["generated_at"]
+	assert.True(t, hasGeneratedAt, "response must contain generated_at: %v", data)
+}
+
+// TestRotationByBackend_WithPolicy — seed a rotation policy and secret; the
+// secret appears in the report's backends array.
+func TestRotationByBackend_WithPolicy(t *testing.T) {
+	c, token, srv := newRotationBackendTestEnv(t)
+	ctx := context.Background()
+
+	// Discover bootstrapped project / environment.
+	projects, err := c.ListProjects(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, projects)
+	projectID := projects[0].ID
+
+	envs, err := c.ListEnvironmentsByProject(ctx, projectID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+	envID := envs[0].ID
+
+	// Create a secret (RotationBackend defaults to "" — regenerate in Keyorix only).
+	_, err = c.CreateSecret(ctx, &core.CreateSecretRequest{
+		ProjectID:     projectID,
+		EnvironmentID: envID,
+		Name:          "test-backend-secret",
+		Value:         []byte("supersecret"),
+		Type:          "password",
+		CreatedBy:     "testadmin",
+	})
+	require.NoError(t, err)
+
+	// Create an active rotation policy covering the project (30-day interval).
+	// The secret's creation date is "now", so with a 30-day interval the secret
+	// is not yet overdue — but it is covered by the policy and will appear.
+	pid := projectID
+	_, err = c.CreateRotationPolicy(ctx, 0, &core.CreateRotationPolicyRequest{
+		Name:            "test-policy",
+		Scope:           "project",
+		ProjectID:       &pid,
+		IntervalDays:    30,
+		AlertDaysBefore: 5,
+		NotifyOnBreach:  false,
+		CreatedBy:       "testadmin",
+	})
+	require.NoError(t, err)
+
+	code, body := doRotationByBackend(t, srv, token)
+	require.Equal(t, http.StatusOK, code)
+
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "expected data object: %v", body)
+
+	backends, ok := data["backends"].([]interface{})
+	require.True(t, ok, "backends must be an array: %v", data)
+	require.NotEmpty(t, backends, "at least one backend must appear when a policy is set")
+
+	// The secret has no RotationBackend (empty string = keyorix-internal). Confirm
+	// at least one backend entry exists with total >= 1.
+	found := false
+	for _, raw := range backends {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		total, _ := entry["total"].(float64)
+		if total >= 1 {
+			found = true
+		}
+	}
+	assert.True(t, found, "at least one backend entry with total >= 1 must appear")
+}
+
+// TestRotationByBackend_ResponseEnvelopeShape — validate the exact response shape:
+// success=true, data.generated_at, data.backends (array), data.total_overdue.
+func TestRotationByBackend_ResponseEnvelopeShape(t *testing.T) {
+	_, token, srv := newRotationBackendTestEnv(t)
+	code, body := doRotationByBackend(t, srv, token)
+	assert.Equal(t, http.StatusOK, code)
+
+	success, _ := body["success"].(bool)
+	assert.True(t, success, "success must be true: %v", body)
+
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "data must be an object: %v", body)
+	assert.Contains(t, data, "generated_at", "data must contain generated_at")
+	assert.Contains(t, data, "backends", "data must contain backends")
+	assert.Contains(t, data, "total_overdue", "data must contain total_overdue")
+}
+
+// Ensure models package is used (RotationPolicy).
+var _ = models.RotationPolicy{}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1761,6 +1761,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/compliance/credential-trends", hygieneTrendsHandler.GetCredentialTrends)
 
 		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/compliance/posture", dashboardHandler.GetCompliancePosture)
+		// Rotation-overdue report grouped by backend: per-backend counts of overdue /
+		// up-to-date / never-rotated secrets deployment-wide. Discloses backend labels
+		// and secret counts across the whole deployment, so audit.read (not the
+		// baseline) applies â same disclosure family as /compliance/evidence.
+		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/compliance/rotation-by-backend", secretHandler.RotationByBackend)
 		// Compliance control matrix — controls mapped to ISO/SOC2/NIS2/DORA + status.
 		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/compliance/controls", dashboardHandler.GetComplianceControls)
 		// Control matrix as CSV — the same matrix for an auditor's spreadsheet; same gate


### PR DESCRIPTION
Adds `GetRotationBackendReport` that groups overdue rotation secrets by their backend (vault, k8s, aws, etc.) with per-backend overdue counts and oldest-overdue ages. Exposes `GET /api/v1/compliance/rotation-by-backend` and `keyorix compliance rotation-backend` CLI. Includes full test coverage.