### PR TITLE
feat: enforce PAT expiry — list and bulk revoke expired PATs

### DIFF
--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -323,6 +323,7 @@ func (ls *LocalStorage) TouchPersonalAccessToken(ctx context.Context, id uint, u
 
 const sqlWhereExpiredPAT = "user_id = ? AND revoked = ? AND expires_at IS NOT NULL AND expires_at < ?"
 
+
 // ListExpiredPATsByUser returns all non-revoked PATs for userID whose ExpiresAt is in
 // the past (expired but never explicitly revoked). Ordered newest-created first.
 func (ls *LocalStorage) ListExpiredPATsByUser(ctx context.Context, userID uint, now time.Time) ([]*models.PersonalAccessToken, error) {

--- a/internal/storage/store/local_pat_expiry_test.go
+++ b/internal/storage/store/local_pat_expiry_test.go
@@ -123,3 +123,63 @@ func TestLocalStorage_BulkRevokeExpiredPATsByUser_DoesNotRevokeDifferentUser(t *
 	require.NoError(t, db.First(&p, 1).Error)
 	assert.False(t, p.Revoked, "other user's token must remain untouched")
 }
+
+// ── error paths (cancelled context / broken DB) ──────────────────────────────
+
+func TestLocalStorage_ListExpiredPATsByUser_CancelledContext_ReturnsError(t *testing.T) {
+	db := newPatExpiryLocalDB(t)
+	ls := store.NewLocalStorage(db)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ls.ListExpiredPATsByUser(ctx, 5, time.Now())
+	require.Error(t, err)
+}
+
+func TestLocalStorage_BulkRevokeExpiredPATsByUser_CancelledContext_ReturnsError(t *testing.T) {
+	db := newPatExpiryLocalDB(t)
+	ls := store.NewLocalStorage(db)
+
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	past := now.Add(-time.Hour)
+
+	// Seed at least one expired PAT so the Pluck returns rows and the Update path is also
+	// reached. With a cancelled context, the first query (Pluck) should fail immediately.
+	require.NoError(t, db.Create(&models.PersonalAccessToken{ID: 1, UserID: 5, TokenHash: "cx1", Name: "exp", ExpiresAt: &past, Revoked: false}).Error)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ls.BulkRevokeExpiredPATsByUser(ctx, 5, now)
+	require.Error(t, err)
+}
+
+// TestLocalStorage_BulkRevokeExpiredPATsByUser_UpdateFails covers the error branch
+// when the Pluck succeeds (matching rows exist) but the subsequent UPDATE fails.
+// We inject a before-update callback that returns a sentinel error to simulate a
+// transient DB failure mid-operation.
+func TestLocalStorage_BulkRevokeExpiredPATsByUser_UpdateFails_ReturnsError(t *testing.T) {
+	db := newPatExpiryLocalDB(t)
+	ls := store.NewLocalStorage(db)
+	ctx := context.Background()
+
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	past := now.Add(-time.Hour)
+
+	// Seed an expired PAT so the Pluck finds at least one hash.
+	require.NoError(t, db.Create(&models.PersonalAccessToken{ID: 1, UserID: 5, TokenHash: "uf1", Name: "exp", ExpiresAt: &past, Revoked: false}).Error)
+
+	// Register a before-update callback that injects a sentinel error.
+	sentinelErr := fmt.Errorf("injected update failure")
+	require.NoError(t, ls.DB().Callback().Update().Before("gorm:before_update").Register(
+		"test:fail_update_pat_expiry",
+		func(d *gorm.DB) { d.AddError(sentinelErr) },
+	))
+	t.Cleanup(func() {
+		ls.DB().Callback().Update().Remove("test:fail_update_pat_expiry")
+	})
+
+	_, err := ls.BulkRevokeExpiredPATsByUser(ctx, 5, now)
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_pat_expiry_test.go
+++ b/internal/storage/store/local_pat_expiry_test.go
@@ -174,10 +174,10 @@ func TestLocalStorage_BulkRevokeExpiredPATsByUser_UpdateFails_ReturnsError(t *te
 	sentinelErr := fmt.Errorf("injected update failure")
 	require.NoError(t, ls.DB().Callback().Update().Before("gorm:before_update").Register(
 		"test:fail_update_pat_expiry",
-		func(d *gorm.DB) { d.AddError(sentinelErr) },
+		func(d *gorm.DB) { _ = d.AddError(sentinelErr) },
 	))
 	t.Cleanup(func() {
-		ls.DB().Callback().Update().Remove("test:fail_update_pat_expiry")
+		_ = ls.DB().Callback().Update().Remove("test:fail_update_pat_expiry")
 	})
 
 	_, err := ls.BulkRevokeExpiredPATsByUser(ctx, 5, now)

--- a/internal/storage/store/remote_auth_test.go
+++ b/internal/storage/store/remote_auth_test.go
@@ -219,6 +219,12 @@ func TestRemoteStorage_PATStubs_ReturnError(t *testing.T) {
 
 	_, err = rs.RevokeAllPersonalAccessTokensForUser(ctx, 1)
 	assert.Error(t, err)
+
+	_, err = rs.ListExpiredPATsByUser(ctx, 1, time.Now())
+	assert.Error(t, err)
+
+	_, err = rs.BulkRevokeExpiredPATsByUser(ctx, 1, time.Now())
+	assert.Error(t, err)
 }
 
 // --- TouchPersonalAccessToken (no-op) ---


### PR DESCRIPTION
Adds `IsPATExpired`, `ListExpiredOwnPATs`, and `BulkRevokeExpiredOwnPATs` core functions, REST endpoints, and `keyorix pat list-expired` / `keyorix pat cleanup-expired` CLI commands. Expired PATs are rejected at authentication time. Includes full test coverage.