### PR TITLE
feat: secret health scoring and project health summary

### DIFF
--- a/internal/cli/project/health.go
+++ b/internal/cli/project/health.go
@@ -20,6 +20,15 @@ var (
 	healthFormat string
 )
 
+// coreServiceInit is the factory used by runHealthEmbedded to obtain a core
+// service instance. It is a package-level variable so tests can swap it out to
+// inject a mock that triggers specific error paths.
+var coreServiceInit = common.InitializeCoreService
+
+// jsonMarshalFn is the JSON marshal function used by printHealthJSON. It is a
+// package-level variable so tests can swap it out to trigger the error branch.
+var jsonMarshalFn = json.Marshal
+
 var healthCmd = &cobra.Command{
 	Use:   "health <name>",
 	Short: "Show the secret health summary for a project",
@@ -123,7 +132,7 @@ func runHealthRemote(ctx context.Context, rc *common.RemoteClient, name string) 
 // ── Embedded mode ──────────────────────────────────────────────────────────
 
 func runHealthEmbedded(ctx context.Context, name string) error {
-	svc, err := common.InitializeCoreService()
+	svc, err := coreServiceInit()
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
@@ -182,7 +191,7 @@ func printHealth(projectName string, s *healthSummary) error {
 }
 
 func printHealthJSON(s *healthSummary) error {
-	b, err := json.Marshal(s)
+	b, err := jsonMarshalFn(s)
 	if err != nil {
 		return fmt.Errorf("failed to marshal health summary: %w", err)
 	}

--- a/internal/cli/project/health_test.go
+++ b/internal/cli/project/health_test.go
@@ -1,17 +1,25 @@
 package project
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
 
 // setupHealthRemote creates a mock HTTP server backed by handler, sets the
 // KEYORIX_* env vars so common.NewRemoteClient returns true, and returns the
@@ -112,4 +120,383 @@ func TestProjectHealth_Remote_JSONFormat(t *testing.T) {
 	assert.Contains(t, out, `"low_risk_count":28`)
 	assert.Contains(t, out, `"prod-db-password"`)
 	assert.Contains(t, out, `"score":91`)
+}
+
+// ── Additional remote error paths ──────────────────────────────────────────
+
+func TestProjectHealth_Remote_ListProjectsError(t *testing.T) {
+	_, done := setupHealthRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		// All requests fail with 500.
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"StorageError","message":"db down","code":500}`))
+	})
+	defer done()
+
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	err := runHealthRemote(t.Context(), rc, "web")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list projects")
+}
+
+func TestProjectHealth_Remote_ProjectNotFound(t *testing.T) {
+	rc, done := setupHealthRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		// /api/v1/projects returns an empty list.
+		_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[]}}`))
+	})
+	defer done()
+
+	err := runHealthRemote(t.Context(), rc, "nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestProjectHealth_Remote_HealthEndpointError(t *testing.T) {
+	rc, done := setupHealthRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		default:
+			// Health endpoint returns 500.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"success":false,"error":"InternalError","message":"failed","code":500}`))
+		}
+	})
+	defer done()
+
+	err := runHealthRemote(t.Context(), rc, "web")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get project health")
+}
+
+func TestProjectHealth_Remote_LimitParam(t *testing.T) {
+	var capturedPath string
+	rc, done := setupHealthRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		default:
+			capturedPath = r.URL.RequestURI()
+			_, _ = w.Write([]byte(`{"success":true,"data":{"project_id":1,"total_secrets":0,"high_risk_count":0,"medium_risk_count":0,"low_risk_count":0,"secrets":[]}}`))
+		}
+	})
+	defer done()
+
+	// Set a non-default limit to trigger the ?limit= query string branch.
+	healthLimit = 5
+	require.NoError(t, runHealthRemote(t.Context(), rc, "web"))
+	assert.Contains(t, capturedPath, "limit=5")
+}
+
+func TestProjectHealth_Remote_UnsupportedFormat(t *testing.T) {
+	rc, done := setupHealthRemote(t, projectsAndHealthHandler)
+	defer done()
+
+	healthFormat = "xml" // unsupported
+	err := runHealthRemote(t.Context(), rc, "web")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+}
+
+func TestProjectHealth_Remote_TableNoSecrets(t *testing.T) {
+	rc, done := setupHealthRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"empty"}]}}`))
+		default:
+			_, _ = w.Write([]byte(`{"success":true,"data":{"project_id":1,"total_secrets":0,"high_risk_count":0,"medium_risk_count":0,"low_risk_count":0,"secrets":[]}}`))
+		}
+	})
+	defer done()
+
+	healthFormat = "table"
+	out := captureHealthStdout(t, func() {
+		require.NoError(t, runHealthRemote(t.Context(), rc, "empty"))
+	})
+	assert.Contains(t, out, "No secrets found")
+}
+
+func TestProjectHealth_TopFactorDetail_NoFactors(t *testing.T) {
+	// topFactorDetail must return "" for an empty factor slice (not panic).
+	result := topFactorDetail(nil)
+	assert.Equal(t, "", result)
+}
+
+func TestProjectHealth_TopFactorDetail_MultipleFactors(t *testing.T) {
+	factors := []healthRiskFactor{
+		{Key: "rotation", Score: 50, Detail: "medium detail"},
+		{Key: "expiry", Score: 100, Detail: "highest detail"},
+		{Key: "usage", Score: 30, Detail: "low detail"},
+	}
+	result := topFactorDetail(factors)
+	assert.Equal(t, "highest detail", result)
+}
+
+// ── Embedded mode ──────────────────────────────────────────────────────────
+
+// setupHealthEmbedded configures an isolated on-disk SQLite database for the
+// health command in embedded mode (no KEYORIX_SERVER/TOKEN set).
+func setupHealthEmbedded(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "test.db")}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_PROJECT", "")
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() {
+		healthLimit = 20
+		healthFormat = "table"
+	})
+}
+
+func TestProjectHealth_Embedded_NotFound(t *testing.T) {
+	setupHealthEmbedded(t)
+
+	err := runHealthEmbedded(context.Background(), "no-such-project")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestProjectHealth_Embedded_EmptyProject_Table(t *testing.T) {
+	setupHealthEmbedded(t)
+
+	// Create a project via the create command so it exists in the embedded DB.
+	createName = "alpha"
+	createDescription = ""
+	createEnvs = "dev"
+	require.NoError(t, runCreate(nil, nil))
+	t.Cleanup(func() { createName, createDescription, createEnvs = "", "", "" })
+
+	healthFormat = "table"
+	out := captureHealthStdout(t, func() {
+		require.NoError(t, runHealthEmbedded(context.Background(), "alpha"))
+	})
+	assert.Contains(t, out, "alpha")
+	assert.Contains(t, out, "0 secrets")
+}
+
+func TestProjectHealth_Embedded_EmptyProject_JSON(t *testing.T) {
+	setupHealthEmbedded(t)
+
+	createName = "beta"
+	createDescription = ""
+	createEnvs = "prod"
+	require.NoError(t, runCreate(nil, nil))
+	t.Cleanup(func() { createName, createDescription, createEnvs = "", "", "" })
+
+	healthFormat = "json"
+	out := captureHealthStdout(t, func() {
+		require.NoError(t, runHealthEmbedded(context.Background(), "beta"))
+	})
+	assert.Contains(t, out, `"total_secrets"`)
+	assert.Contains(t, out, `"project_id"`)
+}
+
+func TestProjectHealth_Embedded_WithSecrets(t *testing.T) {
+	setupHealthEmbedded(t)
+	ctx := context.Background()
+
+	// Create project + environment via CLI.
+	createName = "gamma"
+	createDescription = ""
+	createEnvs = "prod"
+	require.NoError(t, runCreate(nil, nil))
+	t.Cleanup(func() { createName, createDescription, createEnvs = "", "", "" })
+
+	// Seed a secret via the core service so TopRiskSecrets is non-empty
+	// and exercises the factor-conversion loop inside runHealthEmbedded.
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	projects, err := svc.ListProjects(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, projects)
+	var gammaID uint
+	for _, p := range projects {
+		if p.Name == "gamma" {
+			gammaID = p.ID
+		}
+	}
+	require.NotZero(t, gammaID, "project gamma must have been created")
+
+	envs, err := svc.ListEnvironmentsByProject(ctx, gammaID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs, "project gamma must have at least one environment")
+
+	_, err = svc.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name:          "gamma-secret",
+		Value:         []byte("s3cr3t"),
+		ProjectID:     gammaID,
+		EnvironmentID: envs[0].ID,
+		Type:          "password",
+		CreatedBy:     "test",
+	})
+	require.NoError(t, err)
+
+	healthFormat = "table"
+	out := captureHealthStdout(t, func() {
+		require.NoError(t, runHealthEmbedded(ctx, "gamma"))
+	})
+	assert.Contains(t, out, "gamma")
+	assert.Contains(t, out, "1 secrets")
+}
+
+// TestProjectHealth_RunE_Remote verifies that healthCmd.RunE dispatches to the
+// remote path when KEYORIX_SERVER + KEYORIX_TOKEN are set.
+func TestProjectHealth_RunE_Remote(t *testing.T) {
+	setupHealthRemote(t, projectsAndHealthHandler)
+
+	healthFormat = "table"
+	out := captureHealthStdout(t, func() {
+		require.NoError(t, healthCmd.RunE(healthCmd, []string{"web"}))
+	})
+	assert.Contains(t, out, "web")
+}
+
+// TestProjectHealth_RunE_Embedded verifies that healthCmd.RunE dispatches to the
+// embedded path when no server env vars are set.
+func TestProjectHealth_RunE_Embedded(t *testing.T) {
+	setupHealthEmbedded(t)
+
+	// project doesn't exist → error expected (embedded path)
+	err := healthCmd.RunE(healthCmd, []string{"no-such-project"})
+	require.Error(t, err)
+}
+
+// TestProjectHealth_Embedded_ServiceInitError forces InitializeCoreService to
+// fail by pointing the DB path at a directory (SQLite cannot open a directory).
+func TestProjectHealth_Embedded_ServiceInitError(t *testing.T) {
+	dir := t.TempDir()
+	// Point the DB path at a sub-directory — SQLite will fail to open it.
+	dbDirPath := filepath.Join(dir, "isadirectory")
+	require.NoError(t, os.MkdirAll(dbDirPath, 0o700))
+
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: dbDirPath}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_SERVER", "")
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() { healthLimit = 20; healthFormat = "table" })
+
+	err := runHealthEmbedded(context.Background(), "any-project")
+	require.Error(t, err, "expected error when storage cannot be opened")
+}
+
+
+func TestProjectHealth_Embedded_LongSecretName(t *testing.T) {
+	setupHealthEmbedded(t)
+	ctx := context.Background()
+
+	createName = "delta"
+	createDescription = ""
+	createEnvs = "dev"
+	require.NoError(t, runCreate(nil, nil))
+	t.Cleanup(func() { createName, createDescription, createEnvs = "", "", "" })
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	projects, err := svc.ListProjects(ctx)
+	require.NoError(t, err)
+	var deltaID uint
+	for _, p := range projects {
+		if p.Name == "delta" {
+			deltaID = p.ID
+		}
+	}
+	require.NotZero(t, deltaID)
+
+	envs, err := svc.ListEnvironmentsByProject(ctx, deltaID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+
+	// A 35-character name will be truncated to "..." in the table output.
+	longName := "this-is-a-very-long-secret-name-xyz"
+	_, err = svc.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name:          longName,
+		Value:         []byte("v"),
+		ProjectID:     deltaID,
+		EnvironmentID: envs[0].ID,
+		Type:          "password",
+		CreatedBy:     "test",
+	})
+	require.NoError(t, err)
+
+	healthFormat = "table"
+	out := captureHealthStdout(t, func() {
+		require.NoError(t, runHealthEmbedded(ctx, "delta"))
+	})
+	// The name exceeds 30 chars so it should be truncated with "...".
+	assert.Contains(t, out, "...")
+}
+
+// ── Mock storage helpers for error-path coverage ───────────────────────────
+
+// healthErrorStorage embeds a nil coreStorage.Storage and implements only the
+// two methods called by the runHealthEmbedded path: ListProjects (succeeds,
+// returning a project named "err-proj") and ListSecrets (fails).
+type healthErrorStorage struct {
+	coreStorage.Storage
+	projectName string
+	projectID   uint
+	listErr     error
+}
+
+func (s *healthErrorStorage) ListProjects(_ context.Context) ([]*models.Project, error) {
+	return []*models.Project{{ID: s.projectID, Name: s.projectName}}, nil
+}
+
+func (s *healthErrorStorage) ListSecrets(_ context.Context, _ *coreStorage.SecretFilter) ([]*models.SecretNode, int64, error) {
+	return nil, 0, s.listErr
+}
+
+// TestPrintHealthJSON_MarshalError exercises lines 191-193 in printHealthJSON
+// by swapping jsonMarshalFn to a failing implementation.
+func TestPrintHealthJSON_MarshalError(t *testing.T) {
+	savedMarshal := jsonMarshalFn
+	t.Cleanup(func() { jsonMarshalFn = savedMarshal })
+
+	injErr := errors.New("marshal failed")
+	jsonMarshalFn = func(_ any) ([]byte, error) { return nil, injErr }
+
+	err := printHealthJSON(&healthSummary{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to marshal health summary")
+}
+
+// TestRunHealthEmbedded_HealthSummaryError exercises lines 137-139 in
+// runHealthEmbedded: LookupProjectIDByName succeeds (finds the project) but
+// GetProjectHealthSummary fails because ListSecrets returns an error. The
+// function must propagate it as "failed to compute project health: …".
+func TestRunHealthEmbedded_HealthSummaryError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() {
+		healthLimit = 20
+		healthFormat = "table"
+		coreServiceInit = common.InitializeCoreService
+	})
+
+	injErr := errors.New("storage unavailable")
+	coreServiceInit = func() (*core.KeyorixCore, error) {
+		return core.NewKeyorixCore(&healthErrorStorage{
+			projectName: "err-proj",
+			projectID:   42,
+			listErr:     injErr,
+		}), nil
+	}
+
+	err := runHealthEmbedded(context.Background(), "err-proj")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to compute project health")
 }

--- a/internal/cli/secret/score.go
+++ b/internal/cli/secret/score.go
@@ -21,6 +21,11 @@ var (
 	scoreEnv     uint
 )
 
+// coreServiceInit is the factory used by runScoreEmbedded to obtain a core
+// service instance. It is a package-level variable so tests can swap it out to
+// inject a mock that triggers specific error paths.
+var coreServiceInit = common.InitializeCoreService
+
 var scoreCmd = &cobra.Command{
 	Use:   "score <name>",
 	Short: "Show the risk score for a secret",
@@ -135,7 +140,7 @@ func resolveSecretIDByName(ctx context.Context, rc *common.RemoteClient, name st
 // ── Embedded mode ──────────────────────────────────────────────────────────
 
 func runScoreEmbedded(ctx context.Context, name string) error {
-	svc, err := common.InitializeCoreService()
+	svc, err := coreServiceInit()
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}

--- a/internal/cli/secret/score_test.go
+++ b/internal/cli/secret/score_test.go
@@ -2,13 +2,21 @@ package secret
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -152,4 +160,369 @@ func TestSecretScore_Remote_NotFound(t *testing.T) {
 	err := runScoreRemote(t.Context(), rc, "ghost-secret")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
+}
+
+// ── Additional remote error / branch coverage ──────────────────────────────
+
+// TestSecretScore_Remote_ListError verifies that when the secrets list endpoint
+// returns a non-2xx status, runScoreRemote returns a "failed to list secrets" error.
+func TestSecretScore_Remote_ListError(t *testing.T) {
+	rc, done := scoreSetup(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"DBError","message":"db down","code":500}`))
+	})
+	defer done()
+
+	err := runScoreRemote(t.Context(), rc, "any-secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list secrets")
+}
+
+// TestSecretScore_Remote_RiskEndpointError verifies that when the risk endpoint
+// returns a non-2xx status, runScoreRemote returns a "failed to get risk score" error.
+func TestSecretScore_Remote_RiskEndpointError(t *testing.T) {
+	rc, done := scoreSetup(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/secrets":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[{"ID":5,"Name":"my-secret"}],"total":1,"page":1,"page_size":500,"total_pages":1}}`))
+		default:
+			// Risk endpoint returns error.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"success":false,"error":"InternalError","message":"score failed","code":500}`))
+		}
+	})
+	defer done()
+
+	err := runScoreRemote(t.Context(), rc, "my-secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get risk score")
+}
+
+// TestSecretScore_Remote_WithProjectFilter exercises the project-name resolution
+// branch of resolveSecretIDByName (scoreProject != "").
+func TestSecretScore_Remote_WithProjectFilter(t *testing.T) {
+	rc, done := scoreSetup(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":3,"name":"myproject"}]}}`))
+		case "/api/v1/secrets":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[{"ID":9,"Name":"proj-secret"}],"total":1,"page":1,"page_size":500,"total_pages":1}}`))
+		default:
+			// risk endpoint
+			_, _ = w.Write([]byte(`{"success":true,"data":{"secret_id":9,"secret_name":"proj-secret","score":20,"band":"low","factors":[],"degraded":false}}`))
+		}
+	})
+	defer done()
+
+	scoreProject = "myproject"
+	var runErr error
+	stdout, _ := captureScoreOutput(t, func() {
+		runErr = runScoreRemote(t.Context(), rc, "proj-secret")
+	})
+	require.NoError(t, runErr)
+	assert.Contains(t, stdout, "proj-secret")
+}
+
+// TestSecretScore_Remote_WithProjectFilter_ProjectNotFound exercises the error
+// path when the specified project does not exist in the remote list.
+func TestSecretScore_Remote_WithProjectFilter_ProjectNotFound(t *testing.T) {
+	rc, done := scoreSetup(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer done()
+
+	scoreProject = "ghost-project"
+	err := runScoreRemote(t.Context(), rc, "any-secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestSecretScore_Remote_WithEnvFilter exercises the env-ID filter branch of
+// resolveSecretIDByName (scoreEnv != 0).
+func TestSecretScore_Remote_WithEnvFilter(t *testing.T) {
+	rc, done := scoreSetup(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/secrets":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[{"ID":11,"Name":"env-secret"}],"total":1,"page":1,"page_size":500,"total_pages":1}}`))
+		default:
+			_, _ = w.Write([]byte(`{"success":true,"data":{"secret_id":11,"secret_name":"env-secret","score":5,"band":"low","factors":[],"degraded":false}}`))
+		}
+	})
+	defer done()
+
+	scoreEnv = 2
+	var runErr error
+	stdout, _ := captureScoreOutput(t, func() {
+		runErr = runScoreRemote(t.Context(), rc, "env-secret")
+	})
+	require.NoError(t, runErr)
+	assert.Contains(t, stdout, "env-secret")
+}
+
+// TestSecretScore_Remote_DegradedScore exercises the printRiskScore degraded
+// branch (score marked as degraded → warning on stderr).
+func TestSecretScore_Remote_DegradedScore(t *testing.T) {
+	rc, done := scoreSetup(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/secrets":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[{"ID":7,"Name":"degraded-secret"}],"total":1,"page":1,"page_size":500,"total_pages":1}}`))
+		default:
+			// degraded=true in the risk result
+			_, _ = w.Write([]byte(`{"success":true,"data":{"secret_id":7,"secret_name":"degraded-secret","score":50,"band":"medium","factors":[],"degraded":true}}`))
+		}
+	})
+	defer done()
+
+	var runErr error
+	stdout, _ := captureScoreOutput(t, func() {
+		runErr = runScoreRemote(t.Context(), rc, "degraded-secret")
+	})
+	require.NoError(t, runErr)
+	assert.Contains(t, stdout, "exposure data incomplete")
+}
+
+// TestSecretScore_RunE_Remote exercises scoreCmd.RunE in remote mode (covers the
+// cobra dispatch path for runScore).
+func TestSecretScore_RunE_Remote(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(highRiskHandler))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	t.Setenv("KEYORIX_PROJECT", "")
+	t.Cleanup(func() { scoreProject = ""; scoreEnv = 0 })
+
+	_, _ = captureScoreOutput(t, func() {
+		require.NoError(t, scoreCmd.RunE(scoreCmd, []string{"prod-db"}))
+	})
+}
+
+// TestSecretScore_RunE_Embedded exercises scoreCmd.RunE in embedded mode
+// (covers the other branch of the cobra dispatch function runScore).
+func TestSecretScore_RunE_Embedded(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "test.db")}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_PROJECT", "")
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() { scoreProject = ""; scoreEnv = 0 })
+
+	// Embedded mode, secret not found → error.
+	err := scoreCmd.RunE(scoreCmd, []string{"no-such-secret"})
+	require.Error(t, err)
+}
+
+// ── Embedded mode ──────────────────────────────────────────────────────────
+
+// setupScoreEmbedded configures an isolated SQLite database for embedded score tests.
+func setupScoreEmbedded(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "test.db")}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_PROJECT", "")
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() { scoreProject = ""; scoreEnv = 0 })
+}
+
+// TestSecretScore_Embedded_NotFound verifies that runScoreEmbedded returns a
+// "not found" error when the named secret doesn't exist.
+func TestSecretScore_Embedded_NotFound(t *testing.T) {
+	setupScoreEmbedded(t)
+	err := runScoreEmbedded(context.Background(), "no-such-secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestSecretScore_Embedded_WithEnvFilter exercises the scoreEnv != 0 branch in
+// runScoreEmbedded.
+func TestSecretScore_Embedded_WithEnvFilter(t *testing.T) {
+	setupScoreEmbedded(t)
+	// Set scoreEnv to a non-zero value — the secret won't be found in that env.
+	scoreEnv = 99
+	err := runScoreEmbedded(context.Background(), "any-secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestSecretScore_Embedded_Found verifies the happy path of runScoreEmbedded
+// when a matching secret exists. It exercises the secret-found loop body,
+// ComputeSecretRiskScore, factor conversion, and printRiskScore.
+func TestSecretScore_Embedded_Found(t *testing.T) {
+	setupScoreEmbedded(t)
+	ctx := context.Background()
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+
+	p, err := svc.CreateProject(ctx, "score-proj", "")
+	require.NoError(t, err)
+
+	env, err := svc.CreateEnvironment(ctx, p.ID, "dev")
+	require.NoError(t, err)
+
+	_, err = svc.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name:          "embedded-score-secret",
+		Value:         []byte("secretvalue"),
+		ProjectID:     p.ID,
+		EnvironmentID: env.ID,
+		Type:          "password",
+		CreatedBy:     "test",
+	})
+	require.NoError(t, err)
+
+	stdout, _ := captureScoreOutput(t, func() {
+		runErr := runScoreEmbedded(ctx, "embedded-score-secret")
+		require.NoError(t, runErr)
+	})
+	assert.Contains(t, stdout, "embedded-score-secret")
+	assert.Contains(t, stdout, "/100")
+}
+
+// TestSecretScore_Embedded_WithProject exercises the projectName != "" branch in
+// runScoreEmbedded by setting scoreProject to a non-empty value.
+func TestSecretScore_Embedded_WithProject(t *testing.T) {
+	setupScoreEmbedded(t)
+	// Set scoreProject to a non-existent project → LookupProjectIDByName returns "not found"
+	scoreProject = "no-such-project"
+	err := runScoreEmbedded(context.Background(), "any-secret")
+	require.Error(t, err)
+}
+
+// TestSecretScore_Embedded_WithProject_Found exercises the filter.ProjectID
+// assignment path (line 153) in runScoreEmbedded. It sets scoreProject to a
+// project that actually exists so LookupProjectIDByName succeeds and
+// filter.ProjectID is assigned — but the named secret is not in that project,
+// so runScoreEmbedded returns "not found".
+func TestSecretScore_Embedded_WithProject_Found(t *testing.T) {
+	setupScoreEmbedded(t)
+	ctx := context.Background()
+
+	// Create the project so the lookup succeeds.
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	_, err = svc.CreateProject(ctx, "existing-project", "")
+	require.NoError(t, err)
+
+	// Set scoreProject to the project that now exists.
+	scoreProject = "existing-project"
+	// The secret does not exist in that project → "not found" error, but
+	// line 153 (filter.ProjectID = &projectID) will have been executed.
+	err = runScoreEmbedded(ctx, "no-such-secret-in-project")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestSecretScore_Embedded_ServiceInitError verifies the InitializeCoreService
+// error path by pointing the DB at a directory.
+func TestSecretScore_Embedded_ServiceInitError(t *testing.T) {
+	dir := t.TempDir()
+	dbDirPath := filepath.Join(dir, "isadirectory")
+	require.NoError(t, os.MkdirAll(dbDirPath, 0o700))
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: dbDirPath}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_SERVER", "")
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() { scoreProject = ""; scoreEnv = 0 })
+
+	err := runScoreEmbedded(context.Background(), "any-secret")
+	require.Error(t, err, "expected error when DB cannot be opened")
+}
+
+// ── Mock storage helpers for error-path coverage ───────────────────────────
+
+// listSecretsErrStorage embeds a nil coreStorage.Storage and overrides only
+// ListSecrets so that the embedded nil never gets called.
+type listSecretsErrStorage struct {
+	coreStorage.Storage
+	err error
+}
+
+func (s *listSecretsErrStorage) ListSecrets(_ context.Context, _ *coreStorage.SecretFilter) ([]*models.SecretNode, int64, error) {
+	return nil, 0, s.err
+}
+
+// getSecretErrStorage embeds a nil coreStorage.Storage, implements ListSecrets
+// to return one fake secret, and overrides GetSecret to return an error. This
+// causes ComputeSecretRiskScore to fail after the secret ID has been resolved.
+type getSecretErrStorage struct {
+	coreStorage.Storage
+	secretName string
+	err        error
+}
+
+func (s *getSecretErrStorage) ListSecrets(_ context.Context, _ *coreStorage.SecretFilter) ([]*models.SecretNode, int64, error) {
+	return []*models.SecretNode{{ID: 77, Name: s.secretName}}, 1, nil
+}
+
+func (s *getSecretErrStorage) GetSecret(_ context.Context, _ uint) (*models.SecretNode, error) {
+	return nil, s.err
+}
+
+// TestSecretScore_Embedded_ListSecretsError exercises lines 160-162 in
+// runScoreEmbedded: when svc.ListSecrets returns an error the function must
+// wrap it as "failed to list secrets: …".
+func TestSecretScore_Embedded_ListSecretsError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() {
+		scoreProject = ""
+		scoreEnv = 0
+		coreServiceInit = common.InitializeCoreService
+	})
+
+	injErr := errors.New("storage exploded")
+	coreServiceInit = func() (*core.KeyorixCore, error) {
+		return core.NewKeyorixCore(&listSecretsErrStorage{err: injErr}), nil
+	}
+
+	err := runScoreEmbedded(context.Background(), "any-secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list secrets")
+}
+
+// TestSecretScore_Embedded_ComputeScoreError exercises lines 176-178 in
+// runScoreEmbedded: when svc.ComputeSecretRiskScore returns an error (because
+// GetSecret fails after ListSecrets found the ID) the function must wrap it as
+// "failed to compute risk score: …".
+func TestSecretScore_Embedded_ComputeScoreError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() {
+		scoreProject = ""
+		scoreEnv = 0
+		coreServiceInit = common.InitializeCoreService
+	})
+
+	injErr := errors.New("storage exploded")
+	const secretName = "target-secret"
+	coreServiceInit = func() (*core.KeyorixCore, error) {
+		return core.NewKeyorixCore(&getSecretErrStorage{secretName: secretName, err: injErr}), nil
+	}
+
+	err := runScoreEmbedded(context.Background(), secretName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to compute risk score")
 }

--- a/internal/core/project_health_test.go
+++ b/internal/core/project_health_test.go
@@ -2,14 +2,17 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -197,4 +200,83 @@ func TestGetProjectHealthSummary_WrongProject(t *testing.T) {
 	assert.Equal(t, p2.ID, summary.ProjectID)
 	assert.Equal(t, 0, summary.TotalSecrets)
 	assert.Empty(t, summary.TopRiskSecrets)
+}
+
+// TestGetProjectHealthSummary_LimitClamping ensures that limit values that are
+// out of range (<=0 or >100) are silently clamped to the default of 20.
+func TestGetProjectHealthSummary_LimitClamping(t *testing.T) {
+	db := newHealthTestDB(t)
+	ctx := context.Background()
+	now := time.Now()
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "clamp-project"})
+	require.NoError(t, err)
+	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	// Create 25 secrets so we can verify the clamp to defaultHealthLimit (20).
+	for i := 0; i < 25; i++ {
+		makeHealthSecret(t, c, fmt.Sprintf("clamp-s%d", i), p.ID, e.ID, 1)
+	}
+
+	// limit=0 → clamped to 20.
+	summary, err := c.GetProjectHealthSummary(ctx, p.ID, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 25, summary.TotalSecrets)
+	assert.LessOrEqual(t, len(summary.TopRiskSecrets), 20, "limit=0 should clamp to defaultHealthLimit=20")
+
+	// limit=-1 → clamped to 20.
+	summary, err = c.GetProjectHealthSummary(ctx, p.ID, -1)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(summary.TopRiskSecrets), 20, "limit=-1 should clamp to defaultHealthLimit=20")
+
+	// limit=200 → clamped to 20.
+	summary, err = c.GetProjectHealthSummary(ctx, p.ID, 200)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(summary.TopRiskSecrets), 20, "limit=200 should clamp to defaultHealthLimit=20")
+}
+
+// TestGetProjectHealthSummary_ListSecretsError verifies that a storage failure
+// on ListSecrets propagates as an error rather than producing a partial result.
+func TestGetProjectHealthSummary_ListSecretsError(t *testing.T) {
+	db := newHealthTestDB(t)
+	ctx := context.Background()
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+
+	// Close the underlying connection pool to force every query to fail.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	_, err = c.GetProjectHealthSummary(ctx, 1, 20)
+	require.Error(t, err, "expected an error when the database is closed")
+}
+
+// TestGetProjectHealthSummary_BatchScoreError verifies that a failure inside
+// ComputeSecretRiskScoresBatch is propagated as an error by GetProjectHealthSummary.
+//
+// The test wires a MockStorage whose ListSecrets returns one secret (so the IDs
+// slice is non-empty and the batch scorer is called) while GetSecretsByIDs —
+// the first call inside ComputeSecretRiskScoresBatch — returns a synthetic error.
+func TestGetProjectHealthSummary_BatchScoreError(t *testing.T) {
+	const proj = uint(7)
+	ctx := context.Background()
+
+	ms := &MockStorage{}
+	ms.On("ListSecrets", ctx, mock.MatchedBy(func(f *storage.SecretFilter) bool {
+		return f.ProjectID != nil && *f.ProjectID == proj
+	})).Return([]*models.SecretNode{
+		{ID: 42, ProjectID: proj, Name: "a-secret", IsSecret: true},
+	}, int64(1), nil)
+	// GetSecretsByIDs is the first storage call inside ComputeSecretRiskScoresBatch.
+	ms.On("GetSecretsByIDs", ctx, []uint{42}).Return(nil, errors.New("storage error"))
+
+	c := &KeyorixCore{storage: ms, now: time.Now}
+	_, err := c.GetProjectHealthSummary(ctx, proj, 20)
+	require.Error(t, err, "expected error when ComputeSecretRiskScoresBatch fails")
+	assert.Contains(t, err.Error(), "compute risk scores")
+
+	ms.AssertExpectations(t)
 }

--- a/server/http/handlers/project_health_handler_test.go
+++ b/server/http/handlers/project_health_handler_test.go
@@ -1,0 +1,164 @@
+// project_health_handler_test.go — unit tests for GetProjectHealth handler.
+//
+// Tests all branches in server/http/handlers/project_health.go:
+//   - 401 when user context is absent
+//   - 400 when the project ID is not a valid integer
+//   - 400 when ?limit is present but not a positive integer
+//   - 500 when the core service returns an error
+//   - 200 on success (empty project)
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newProjectHealthHandler(t *testing.T) (*SecretHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{},
+		&models.Project{},
+		&models.Environment{},
+		&models.SecretNode{},
+		&models.SecretVersion{},
+		&models.SecretAccessLog{},
+		&models.MachineIdentity{},
+		&models.AuditEvent{},
+		&models.RotationPolicy{},
+		&models.ShareRecord{},
+		&models.UserGroup{},
+	))
+	h, err := NewSecretHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+	return h, db
+}
+
+func TestGetProjectHealth_Unauthorized(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+
+	req := withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/projects/1/health", nil), "id", "1")
+	w := httptest.NewRecorder()
+	h.GetProjectHealth(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestGetProjectHealth_InvalidProjectID(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+
+	req := withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/projects/abc/health", nil), "id", "abc")
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.GetProjectHealth(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "InvalidParameter")
+}
+
+func TestGetProjectHealth_InvalidLimit_NonInteger(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+
+	req := withChiParam(
+		httptest.NewRequest(http.MethodGet, "/api/v1/projects/1/health?limit=abc", nil),
+		"id", "1",
+	)
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.GetProjectHealth(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "InvalidParameter")
+}
+
+func TestGetProjectHealth_InvalidLimit_Zero(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+
+	req := withChiParam(
+		httptest.NewRequest(http.MethodGet, "/api/v1/projects/1/health?limit=0", nil),
+		"id", "1",
+	)
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.GetProjectHealth(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "InvalidParameter")
+}
+
+func TestGetProjectHealth_InvalidLimit_Negative(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+
+	req := withChiParam(
+		httptest.NewRequest(http.MethodGet, "/api/v1/projects/1/health?limit=-5", nil),
+		"id", "1",
+	)
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.GetProjectHealth(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetProjectHealth_CoreError_InternalServerError(t *testing.T) {
+	h, db := newProjectHealthHandler(t)
+
+	// Close the underlying DB connection to force a core-layer error.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	req := withChiParam(
+		httptest.NewRequest(http.MethodGet, "/api/v1/projects/1/health", nil),
+		"id", "1",
+	)
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.GetProjectHealth(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "InternalError")
+}
+
+func TestGetProjectHealth_Success_EmptyProject(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+
+	req := withChiParam(
+		httptest.NewRequest(http.MethodGet, "/api/v1/projects/99/health", nil),
+		"id", "99",
+	)
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.GetProjectHealth(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "total_secrets")
+}
+
+func TestGetProjectHealth_Success_WithLimit(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+
+	req := withChiParam(
+		httptest.NewRequest(http.MethodGet, "/api/v1/projects/99/health?limit=5", nil),
+		"id", "99",
+	)
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.GetProjectHealth(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/server/http/project_health_handler_test.go
+++ b/server/http/project_health_handler_test.go
@@ -36,7 +36,7 @@ func createSecret(t *testing.T, srv *httptest.Server, token, name string) uint {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	require.Equal(t, http.StatusCreated, resp.StatusCode, "createSecret: expected 201")
 
 	var response map[string]interface{}
@@ -68,7 +68,7 @@ func TestGetProjectHealth_EmptyProject(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -104,7 +104,7 @@ func TestGetProjectHealth_WithSecrets(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -143,7 +143,7 @@ func TestGetProjectHealth_LimitParam(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -172,7 +172,7 @@ func TestGetProjectHealth_Unauthenticated(t *testing.T) {
 
 	resp, err := http.DefaultClient.Get(srv.URL + "/api/v1/projects/1/health")
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
@@ -199,7 +199,7 @@ func TestGetProjectHealth_NotFound(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	// The handler returns 200 with an empty summary for non-existent projects
 	// rather than 404, because it delegates to GetProjectHealthSummary which

--- a/server/http/project_health_handler_test.go
+++ b/server/http/project_health_handler_test.go
@@ -1,0 +1,215 @@
+// project_health_handler_test.go — handler-level integration tests for
+// GET /api/v1/projects/{id}/health.
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createSecret is a test helper that POSTs a secret to project 1 / environment 1 and
+// returns the newly-created secret's ID.
+func createSecret(t *testing.T, srv *httptest.Server, token, name string) uint {
+	t.Helper()
+	body, err := json.Marshal(map[string]interface{}{
+		"name":           name,
+		"value":          "test-value",
+		"project_id":     1,
+		"environment_id": 1,
+		"type":           "password",
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", srv.URL+"/api/v1/secrets", bytes.NewBuffer(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "createSecret: expected 201")
+
+	var response map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&response))
+	data, ok := response["data"].(map[string]interface{})
+	require.True(t, ok, "createSecret: missing data field")
+	id, ok := data["ID"].(float64)
+	require.True(t, ok, "createSecret: missing ID field")
+	return uint(id)
+}
+
+// TestGetProjectHealth_EmptyProject checks that an authenticated admin gets 200
+// with zero secrets when the project has no secrets.
+func TestGetProjectHealth_EmptyProject(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/projects/1/health", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "response body missing 'data' object")
+
+	assert.EqualValues(t, 0, data["total_secrets"])
+	assert.EqualValues(t, 0, data["high_risk_count"])
+}
+
+// TestGetProjectHealth_WithSecrets checks that after creating 2 secrets the
+// health endpoint reports total_secrets == 2 and returns a 'secrets' array.
+func TestGetProjectHealth_WithSecrets(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	createSecret(t, srv, token, "health-secret-a")
+	createSecret(t, srv, token, "health-secret-b")
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/projects/1/health", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "response body missing 'data' object")
+
+	assert.EqualValues(t, 2, data["total_secrets"])
+	secrets, ok := data["secrets"].([]interface{})
+	require.True(t, ok, "'secrets' field must be an array")
+	assert.Len(t, secrets, 2)
+}
+
+// TestGetProjectHealth_LimitParam checks that ?limit=2 caps the returned
+// secrets slice to at most 2 entries even when more exist.
+func TestGetProjectHealth_LimitParam(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	for i := 0; i < 5; i++ {
+		createSecret(t, srv, token, fmt.Sprintf("limit-secret-%d", i))
+	}
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/projects/1/health?limit=2", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "response body missing 'data' object")
+
+	assert.EqualValues(t, 5, data["total_secrets"])
+	secrets, ok := data["secrets"].([]interface{})
+	require.True(t, ok, "'secrets' field must be an array")
+	assert.LessOrEqual(t, len(secrets), 2)
+}
+
+// TestGetProjectHealth_Unauthenticated checks that a request with no token
+// receives 401.
+func TestGetProjectHealth_Unauthenticated(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	resp, err := http.DefaultClient.Get(srv.URL + "/api/v1/projects/1/health")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestGetProjectHealth_NotFound checks the behaviour for a project ID that does
+// not exist. GetProjectHealthSummary never queries the projects table; it simply
+// lists secrets filtered by project_id and returns an empty summary, so the
+// handler returns 200 with total_secrets == 0 rather than 404.
+func TestGetProjectHealth_NotFound(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	c := newTestCore(t)
+	token := createTestToken(t, c)
+
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/projects/999999/health", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// The handler returns 200 with an empty summary for non-existent projects
+	// rather than 404, because it delegates to GetProjectHealthSummary which
+	// lists secrets filtered by project_id and returns an empty summary when
+	// none exist.
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	data, ok := body["data"].(map[string]interface{})
+	require.True(t, ok, "response body missing 'data' object")
+	assert.EqualValues(t, 0, data["total_secrets"])
+}


### PR DESCRIPTION
Adds `ComputeSecretScore` (0-100 score based on rotation age, ACL coverage, read quota, and activity) and `GetProjectHealthSummary` aggregating scores across a project. Exposes `GET /api/v1/projects/{id}/health` and `keyorix secret score` / `keyorix project health` CLI commands. Includes full test coverage.