### PR TITLE
feat: secret templates for standardised secret creation

### DIFF
--- a/internal/cli/secret/templates.go
+++ b/internal/cli/secret/templates.go
@@ -32,6 +32,10 @@ var (
 	tmplDescription    string
 	tmplDescPattern    string
 	tmplRotationDays   int
+
+	// jsonMarshalIndentFn is the json.MarshalIndent implementation used by
+	// runTemplateGet; swapped in tests to exercise the error path.
+	jsonMarshalIndentFn = json.MarshalIndent
 )
 
 // templateCmd is the root "template" sub-command under "secret".
@@ -95,7 +99,7 @@ func runTemplateGet(ctx context.Context, c *common.RemoteClient, name string) er
 	}
 	for _, t := range result.Templates {
 		if t.Name == name {
-			out, err := json.MarshalIndent(t, "", "  ")
+			out, err := jsonMarshalIndentFn(t, "", "  ")
 			if err != nil {
 				return fmt.Errorf("marshal template: %w", err)
 			}

--- a/internal/cli/secret/templates_test.go
+++ b/internal/cli/secret/templates_test.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -194,4 +195,80 @@ func TestRunTemplateDelete_DeleteError(t *testing.T) {
 	err := runTemplateDelete(context.Background(), rc, "api-key")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "delete template")
+}
+
+// ── RunE closure coverage ──────────────────────────────────────────────────────
+//
+// Each cobra command's RunE closure is only executed when cobra dispatches the
+// command.  We invoke cmd.RunE directly so the coverage tool registers those
+// lines without spinning up the full CLI binary.
+
+// TestTemplateListCmd_NoServer exercises the !ok branch in templateListCmd.RunE.
+func TestTemplateListCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := templateListCmd.RunE(templateListCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+// TestTemplateGetCmd_NoServer exercises the !ok branch in templateGetCmd.RunE.
+func TestTemplateGetCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := templateGetCmd.RunE(templateGetCmd, []string{"some-name"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+// TestTemplateCreateCmd_NoName exercises the empty-name guard in templateCreateCmd.RunE.
+func TestTemplateCreateCmd_NoName(t *testing.T) {
+	orig := tmplName
+	defer func() { tmplName = orig }()
+	tmplName = ""
+	err := templateCreateCmd.RunE(templateCreateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--name is required")
+}
+
+// TestTemplateCreateCmd_NoServer exercises the !ok branch in templateCreateCmd.RunE.
+func TestTemplateCreateCmd_NoServer(t *testing.T) {
+	orig := tmplName
+	defer func() { tmplName = orig }()
+	tmplName = "some-tpl"
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := templateCreateCmd.RunE(templateCreateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+// TestTemplateDeleteCmd_NoServer exercises the !ok branch in templateDeleteCmd.RunE.
+func TestTemplateDeleteCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := templateDeleteCmd.RunE(templateDeleteCmd, []string{"some-name"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+// TestRunTemplateGet_MarshalError exercises the json.MarshalIndent error path in
+// runTemplateGet. Because models.SecretTemplate contains only serialisable
+// types, this path is dead code in production; we reach it by injecting a
+// failing marshaler via the package-level jsonMarshalIndentFn variable.
+func TestRunTemplateGet_MarshalError(t *testing.T) {
+	orig := jsonMarshalIndentFn
+	jsonMarshalIndentFn = func(_ interface{}, _, _ string) ([]byte, error) {
+		return nil, errors.New("forced marshal failure")
+	}
+	defer func() { jsonMarshalIndentFn = orig }()
+
+	rc, done := tmplStub(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(tmplListJSON))
+	})
+	defer done()
+
+	err := runTemplateGet(context.Background(), rc, "db-secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal template")
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1308,6 +1308,15 @@ type Storage interface {
 	// whose created_at (detected_at) is older than the given threshold.
 	ListUnacknowledgedAnomalyAlertsBefore(ctx context.Context, threshold time.Time) ([]models.AnomalyAlert, error)
 
+	// Secret Template Management — reusable metadata presets for secret creation.
+	// Templates pre-fill classification, tags, and description hints at create time.
+	CreateSecretTemplate(ctx context.Context, t *models.SecretTemplate) error
+	GetSecretTemplate(ctx context.Context, id uint) (*models.SecretTemplate, error)
+	GetSecretTemplateByName(ctx context.Context, name string) (*models.SecretTemplate, error)
+	ListSecretTemplates(ctx context.Context) ([]*models.SecretTemplate, error)
+	UpdateSecretTemplate(ctx context.Context, t *models.SecretTemplate) error
+	DeleteSecretTemplate(ctx context.Context, id uint) error
+
 }
 
 // SecretFilter defines filtering options for secret queries

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1308,15 +1308,6 @@ type Storage interface {
 	// whose created_at (detected_at) is older than the given threshold.
 	ListUnacknowledgedAnomalyAlertsBefore(ctx context.Context, threshold time.Time) ([]models.AnomalyAlert, error)
 
-	// Secret Template Management — reusable metadata presets for secret creation.
-	// Templates pre-fill classification, tags, and description hints at create time.
-	CreateSecretTemplate(ctx context.Context, t *models.SecretTemplate) error
-	GetSecretTemplate(ctx context.Context, id uint) (*models.SecretTemplate, error)
-	GetSecretTemplateByName(ctx context.Context, name string) (*models.SecretTemplate, error)
-	ListSecretTemplates(ctx context.Context) ([]*models.SecretTemplate, error)
-	UpdateSecretTemplate(ctx context.Context, t *models.SecretTemplate) error
-	DeleteSecretTemplate(ctx context.Context, id uint) error
-
 }
 
 // SecretFilter defines filtering options for secret queries

--- a/server/http/handlers/secret_templates_unit_test.go
+++ b/server/http/handlers/secret_templates_unit_test.go
@@ -1,17 +1,104 @@
 // secret_templates_unit_test.go — unit tests for SecretTemplateHandler that
-// exercise branches unreachable through the HTTP router (e.g. nil-user context).
+// exercise branches unreachable through the HTTP router (e.g. nil-user context,
+// injected storage errors).
 package handlers
 
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
+
+// ---------- failing store wrapper ----------
+
+// failingSecretTemplateStore embeds LocalStorage and overrides SecretTemplate
+// methods so individual paths can be made to return an injected error,
+// reaching the HTTP handler's 500 branches.
+type failingSecretTemplateStore struct {
+	*store.LocalStorage
+	failCreate bool
+	failList   bool
+	failGet    bool
+	failUpdate bool
+	failDelete bool
+}
+
+func (s *failingSecretTemplateStore) CreateSecretTemplate(_ context.Context, _ *models.SecretTemplate) error {
+	if s.failCreate {
+		return errors.New("injected create error")
+	}
+	return s.LocalStorage.CreateSecretTemplate(context.Background(), &models.SecretTemplate{})
+}
+
+func (s *failingSecretTemplateStore) ListSecretTemplates(_ context.Context) ([]*models.SecretTemplate, error) {
+	if s.failList {
+		return nil, errors.New("injected list error")
+	}
+	return s.LocalStorage.ListSecretTemplates(context.Background())
+}
+
+func (s *failingSecretTemplateStore) GetSecretTemplate(_ context.Context, id uint) (*models.SecretTemplate, error) {
+	if s.failGet {
+		// Return an error that is NOT "not found" — triggers the 500 branch.
+		return nil, errors.New("injected db error")
+	}
+	return s.LocalStorage.GetSecretTemplate(context.Background(), id)
+}
+
+func (s *failingSecretTemplateStore) UpdateSecretTemplate(_ context.Context, t *models.SecretTemplate) error {
+	if s.failUpdate {
+		return errors.New("injected update error")
+	}
+	return s.LocalStorage.UpdateSecretTemplate(context.Background(), t)
+}
+
+func (s *failingSecretTemplateStore) DeleteSecretTemplate(_ context.Context, id uint) error {
+	if s.failDelete {
+		return errors.New("injected delete error")
+	}
+	return s.LocalStorage.DeleteSecretTemplate(context.Background(), id)
+}
+
+// newFailingSTHandler opens a migrated SQLite DB, seeds it with one template
+// (ID=1), and wraps it with failingSecretTemplateStore for error injection.
+var stUnitCounter int
+
+func newFailingSTHandler(t *testing.T, flags failingSecretTemplateStore) *SecretTemplateHandler {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	stUnitCounter++
+	dsn := "file:stunit" + string(rune('0'+stUnitCounter)) + "?mode=memory&cache=private"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretTemplate{}))
+	t.Cleanup(func() { sqlDB, _ := db.DB(); _ = sqlDB.Close() })
+
+	// Seed a template so GET/UPDATE/DELETE have a valid ID to work with before
+	// the injected error fires at the storage layer.
+	require.NoError(t, db.Create(&models.SecretTemplate{Name: "seed"}).Error)
+
+	fs := &failingSecretTemplateStore{
+		LocalStorage: store.NewLocalStorage(db),
+		failCreate:   flags.failCreate,
+		failList:     flags.failList,
+		failGet:      flags.failGet,
+		failUpdate:   flags.failUpdate,
+		failDelete:   flags.failDelete,
+	}
+	return NewSecretTemplateHandler(core.NewKeyorixCore(fs))
+}
 
 // TestSecretTemplateCreate_NilUser exercises the nil-user-context guard in
 // Create. In production this path is unreachable (RequirePermission middleware
@@ -33,4 +120,74 @@ func TestSecretTemplateCreate_NilUser(t *testing.T) {
 	h.Create(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// ---------- storage-error (500) paths ----------
+
+// TestSecretTemplateCreate_StorageError exercises the default branch in
+// Create's error switch — triggered when the storage returns an unexpected
+// error (not "name is required" / "invalid classification").
+func TestSecretTemplateCreate_StorageError(t *testing.T) {
+	h := newFailingSTHandler(t, failingSecretTemplateStore{failCreate: true})
+	body := bytes.NewBufferString(`{"name":"valid-name"}`)
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/", body))
+	w := httptest.NewRecorder()
+	h.Create(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestSecretTemplateList_StorageError exercises the error path in List when
+// the storage layer returns an error.
+func TestSecretTemplateList_StorageError(t *testing.T) {
+	h := newFailingSTHandler(t, failingSecretTemplateStore{failList: true})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.List(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestSecretTemplateGet_StorageError exercises the internal-error branch in
+// Get — the storage returns an error that is NOT a "not found" message, so the
+// handler must return 500 rather than 404.
+func TestSecretTemplateGet_StorageError(t *testing.T) {
+	h := newFailingSTHandler(t, failingSecretTemplateStore{failGet: true})
+	req := withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "1")
+	w := httptest.NewRecorder()
+	h.Get(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestSecretTemplateUpdate_StorageError exercises the default branch in
+// Update's error switch — triggered when UpdateSecretTemplate returns an
+// unexpected error (not "not found" / "name is required" / "invalid classification").
+func TestSecretTemplateUpdate_StorageError(t *testing.T) {
+	h := newFailingSTHandler(t, failingSecretTemplateStore{failUpdate: true})
+	body := bytes.NewBufferString(`{"name":"new-name"}`)
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodPut, "/", body)), "id", "1")
+	w := httptest.NewRecorder()
+	h.Update(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestSecretTemplateDelete_StorageError exercises the internal-error branch in
+// Delete — DeleteSecretTemplate returns an error that is NOT "not found", so
+// the handler must return 500 rather than 404.
+func TestSecretTemplateDelete_StorageError(t *testing.T) {
+	h := newFailingSTHandler(t, failingSecretTemplateStore{failDelete: true})
+	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "1")
+	w := httptest.NewRecorder()
+	h.Delete(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestSecretTemplateApply_StorageError exercises the internal-error branch in
+// Apply — GetSecretTemplate returns an error that is NOT "not found", so the
+// handler must return 500 rather than 404.
+func TestSecretTemplateApply_StorageError(t *testing.T) {
+	h := newFailingSTHandler(t, failingSecretTemplateStore{failGet: true})
+	body := bytes.NewBufferString(`{"classification":"internal"}`)
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", body), "id", "1")
+	w := httptest.NewRecorder()
+	h.Apply(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }


### PR DESCRIPTION
Adds secret template CRUD (name, description, key/value schema, rotation config). Templates can be applied to pre-populate new secrets. Exposes full REST API and `keyorix secret template` CLI subcommands. Includes full test coverage.