### PR TITLE
feat(classification): add secrets.read.restricted permission gate for restricted secrets

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1483,6 +1483,12 @@ func (c DualControlConfig) GetRequiredApprovals() int {
 // matching this codebase's established posture for ambiguous authorization).
 type ClassificationConfig struct {
 	RestrictedRequiresApproval bool `yaml:"restricted_requires_approval"`
+	// RestrictedRequiresPermission, when true, requires the acting user to hold
+	// the "secrets.read.restricted" permission at the secret's project scope
+	// before a "restricted"-classified secret's value may be read. Off by default
+	// (purely additive: only tightens access, never removes it). Can be combined
+	// with RestrictedRequiresApproval — when both are on, BOTH must be satisfied.
+	RestrictedRequiresPermission bool `yaml:"restricted_requires_permission"`
 }
 
 // WebAuthnConfig configures the WebAuthn relying party (ADR-036). RPID is the

--- a/internal/core/classification_gate.go
+++ b/internal/core/classification_gate.go
@@ -37,6 +37,13 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
+// PermSecretReadRestricted is the permission a user must hold at the secret's
+// project scope — in addition to the base "secrets.read" RBAC grant — when
+// classification.restricted_requires_permission is enabled. Admin and
+// project_admin roles bypass this check via Authorize's admin-role shortcut;
+// everyone else needs an explicit grant on their role.
+const PermSecretReadRestricted = "secrets.read.restricted"
+
 // SetClassificationRestrictedRequiresApproval mirrors config classification.
 // restricted_requires_approval. false (the default, and the zero value) leaves
 // "restricted" purely informational — identical to today's behaviour. See
@@ -45,42 +52,72 @@ func (c *KeyorixCore) SetClassificationRestrictedRequiresApproval(enabled bool) 
 	c.classificationRestrictedRequiresApproval = enabled
 }
 
+// SetClassificationRestrictedRequiresPermission mirrors config classification.
+// restricted_requires_permission. false (the default) leaves the permission gate
+// inactive — any user who passes the base secrets.read RBAC check can read a
+// "restricted" secret's value. When true, the user must ALSO hold
+// PermSecretReadRestricted at the secret's project scope (or be an admin). Can
+// be combined with SetClassificationRestrictedRequiresApproval.
+func (c *KeyorixCore) SetClassificationRestrictedRequiresPermission(enabled bool) {
+	c.classificationRestrictedRequiresPermission = enabled
+}
+
 // checkRestrictedSecretReadApproval is the fail-closed gate every secret VALUE
 // read path routes through (see versions.go/secret_render.go). It is a no-op
-// (nil, nil) unless BOTH the setting is on AND the secret's own classification is
-// exactly ClassificationRestricted — a lower tier is never gated, regardless of
-// the setting (#128's product decision only concerns the highest tier).
+// unless at least one classification gate setting is active AND the secret's
+// classification is exactly ClassificationRestricted — a lower tier is never
+// gated regardless of configuration (#128's product decision).
+//
+// Two independent guards can be active simultaneously; when both are on, BOTH
+// must be satisfied — defense in depth:
+//
+//  1. restricted_requires_permission: the user must hold PermSecretReadRestricted
+//     at the secret's project scope (or be an admin). Checked first — fast RBAC
+//     lookup, no per-secret DB query.
+//  2. restricted_requires_approval: the user must have an approved, secret-scoped
+//     access request. Checked second.
 //
 // userID identifies the acting human principal, if any. 0 means the read has no
-// identifiable user behind it — a machine/service-account credential (the HTTP
-// handlers' isMachine branch calls the base GetSecretValue with no userID at
-// all), the embedded-mode CLI (which has no user/session concept either), or any
-// other caller that cannot present one. Such a read is ALWAYS denied when the
-// gate is active: there is no "wait for approval" for automation, and — just as
-// importantly — no quiet exemption for it either. A machine identity that
-// legitimately needs a restricted secret goes through the exact same
-// RequestSecretAccess/ApproveSecretAccessRequest flow as a human would, on
-// behalf of a user who then reads it, rather than being carved out as a bypass.
-//
-// Any failure to positively confirm approval — including a storage error while
-// checking — denies the read; this never fails open.
+// identifiable user behind it — a machine/service-account credential, the
+// embedded-mode CLI, or any other caller without a user context. Such a read is
+// ALWAYS denied when any gate is active: no silent bypass for automation. A
+// machine identity that needs a restricted secret goes through the same human
+// flow on behalf of a user. Any failure to positively confirm a gate condition —
+// including a storage error — denies the read; this never fails open.
 func (c *KeyorixCore) checkRestrictedSecretReadApproval(ctx context.Context, secret *models.SecretNode, userID uint) error {
-	if !c.classificationRestrictedRequiresApproval {
+	if !c.classificationRestrictedRequiresApproval && !c.classificationRestrictedRequiresPermission {
 		return nil
 	}
 	if secret == nil || secret.Classification != ClassificationRestricted {
 		return nil
 	}
 	if userID == 0 {
-		return fmt.Errorf("secret %q is restricted: reading its value requires an approved access request, and this read has no identifiable user to check one against", secret.Name)
+		return fmt.Errorf("secret %q is restricted: this read has no identifiable user — automated/machine reads of restricted secrets are always denied when any classification gate is active", secret.Name)
 	}
-	ok, err := c.hasApprovedSecretAccessRequest(ctx, secret.ProjectID, secret.ID, userID)
-	if err != nil {
-		return fmt.Errorf("secret %q is restricted: could not verify an approved access request: %w", secret.Name, err)
+
+	// Gate 1: narrower RBAC permission (fast path — no per-secret DB query).
+	if c.classificationRestrictedRequiresPermission {
+		scope := Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
+		ok, err := c.Authorize(ctx, userID, PermSecretReadRestricted, scope)
+		if err != nil {
+			return fmt.Errorf("secret %q is restricted: could not verify the %q permission: %w", secret.Name, PermSecretReadRestricted, err)
+		}
+		if !ok {
+			return fmt.Errorf("secret %q is restricted: the %q permission is required at the project scope to read this secret's value", secret.Name, PermSecretReadRestricted)
+		}
 	}
-	if !ok {
-		return fmt.Errorf("secret %q is restricted: an approved access request for this specific secret is required before its value can be read", secret.Name)
+
+	// Gate 2: approved secret-scoped access request.
+	if c.classificationRestrictedRequiresApproval {
+		ok, err := c.hasApprovedSecretAccessRequest(ctx, secret.ProjectID, secret.ID, userID)
+		if err != nil {
+			return fmt.Errorf("secret %q is restricted: could not verify an approved access request: %w", secret.Name, err)
+		}
+		if !ok {
+			return fmt.Errorf("secret %q is restricted: an approved access request for this specific secret is required before its value can be read", secret.Name)
+		}
 	}
+
 	return nil
 }
 

--- a/internal/core/classification_gate_test.go
+++ b/internal/core/classification_gate_test.go
@@ -184,3 +184,159 @@ func TestApproveSecretAccessRequest_Guards(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only a pending")
 }
+
+// ── restricted_requires_permission tests ─────────────────────────────────────
+
+// seedRestrictedPermissionFixture extends the base fixture with a second user who
+// owns a restricted secret and holds an explicit secrets.read.restricted grant at
+// the project scope — used to verify that the explicit-grant path allows reads.
+func seedRestrictedPermissionFixture(t *testing.T, st *store.LocalStorage) (secretID, ownerID, grantedUserID, projectID uint) {
+	t.Helper()
+	ctx := context.Background()
+
+	secretID, ownerID, _, projectID = seedClassificationGateFixture(t, st, ClassificationRestricted)
+
+	// Create a role with secrets.read.restricted and assign it to grantedUser at
+	// the project scope. The user also needs to pass ValidateSecretAccess, so we
+	// share the secret with them at read level.
+	perm, err := st.CreatePermission(ctx, &models.Permission{Name: PermSecretReadRestricted})
+	require.NoError(t, err)
+
+	role, err := st.CreateRole(ctx, &models.Role{Name: "restricted-reader"})
+	require.NoError(t, err)
+
+	require.NoError(t, st.AssignPermissionToRole(ctx, role.ID, perm.ID))
+
+	grantedUser, err := st.CreateUser(ctx, &models.User{Username: "granted-user", Email: "granted@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	require.NoError(t, st.AssignRole(ctx, grantedUser.ID, role.ID, storage.Scope{ProjectID: projectID}))
+
+	// Share the secret with grantedUser so ValidateSecretAccess passes.
+	secret, err := st.GetSecret(ctx, secretID)
+	require.NoError(t, err)
+	_, err = st.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID:    secretID,
+		OwnerID:     secret.OwnerID,
+		RecipientID: grantedUser.ID,
+		Permission:  "read",
+		IsGroup:     false,
+	})
+	require.NoError(t, err)
+
+	return secretID, ownerID, grantedUser.ID, projectID
+}
+
+// Requirement: off by default — owner (no secrets.read.restricted grant) can still read.
+func TestClassificationPermissionGate_OffByDefault_OwnerCanRead(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, ownerID, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+
+	// gate is off (zero value); owner has no secrets.read.restricted grant
+	val, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
+	require.NoError(t, err, "permission gate off: owner must read unrestricted")
+	assert.Equal(t, "s3cr3t-value", string(val))
+}
+
+// Requirement: when on, a user without secrets.read.restricted is denied.
+func TestClassificationPermissionGate_On_NoPermission_Denied(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, ownerID, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresPermission(true)
+
+	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restricted")
+	assert.Contains(t, err.Error(), PermSecretReadRestricted)
+}
+
+// Requirement: machine/no-user read is always denied when the gate is active.
+func TestClassificationPermissionGate_On_NoUser_Denied(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, _, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresPermission(true)
+
+	_, err := c.GetSecretValue(ctx, secretID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restricted")
+}
+
+// Requirement: admin role bypass — an admin who owns the secret passes both
+// ValidateSecretAccess (as owner) and the RBAC check (admin bypass in Authorize).
+func TestClassificationPermissionGate_On_AdminAllowed(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	// Seed a project and an admin who OWNS the restricted secret.
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "admin-restricted-gate-test"})
+	require.NoError(t, err)
+
+	admin, err := st.CreateUser(ctx, &models.User{Username: "admin-owner", Email: "admin-owner@example.com", IsActive: true})
+	require.NoError(t, err)
+	adminRole, err := st.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, admin.ID, adminRole.ID, storage.Scope{}))
+
+	secret, err := st.CreateSecret(ctx, &models.SecretNode{
+		Name: "top-secret", ProjectID: proj.ID, EnvironmentID: 1, Type: "password",
+		IsSecret: true, OwnerID: admin.ID, Status: "active", Classification: ClassificationRestricted,
+	})
+	require.NoError(t, err)
+	_, err = st.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: secret.ID, VersionNumber: 1, EncryptedValue: []byte("top-secret-value"),
+	})
+	require.NoError(t, err)
+
+	c.SetClassificationRestrictedRequiresPermission(true)
+
+	val, err := c.GetSecretValueWithPermissionCheck(ctx, secret.ID, admin.ID)
+	require.NoError(t, err, "admin bypass must let an admin owner read a restricted secret")
+	assert.Equal(t, "top-secret-value", string(val))
+}
+
+// Requirement: explicit secrets.read.restricted grant allows the read.
+func TestClassificationPermissionGate_On_ExplicitGrantAllowed(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, _, grantedUserID, _ := seedRestrictedPermissionFixture(t, st)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresPermission(true)
+
+	val, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, grantedUserID)
+	require.NoError(t, err, "explicit secrets.read.restricted grant must allow the read")
+	assert.Equal(t, "s3cr3t-value", string(val))
+}
+
+// Requirement: lower-tier secrets are never gated by the permission check.
+func TestClassificationPermissionGate_On_LowerTierUnaffected(t *testing.T) {
+	for _, level := range []string{ClassificationPublic, ClassificationInternal, ClassificationConfidential, ""} {
+		level := level
+		t.Run("classification="+level, func(t *testing.T) {
+			c, st := newBootstrappedCore(t)
+			secretID, ownerID, _, _ := seedClassificationGateFixture(t, st, level)
+			ctx := context.Background()
+			c.SetClassificationRestrictedRequiresPermission(true)
+
+			val, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
+			require.NoError(t, err, "permission gate must not affect non-restricted secrets")
+			assert.Equal(t, "s3cr3t-value", string(val))
+		})
+	}
+}
+
+// Requirement: when both gates are on, BOTH must be satisfied. A user who holds
+// the permission but lacks an approved access request is still denied.
+func TestClassificationPermissionGate_Combined_BothRequired(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, _, grantedUserID, _ := seedRestrictedPermissionFixture(t, st)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresPermission(true)
+	c.SetClassificationRestrictedRequiresApproval(true)
+
+	// grantedUser has the secrets.read.restricted permission but no approved request.
+	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, grantedUserID)
+	require.Error(t, err, "both gates active: permission alone is insufficient without approval")
+	assert.Contains(t, err.Error(), "access request")
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -199,6 +199,12 @@ type KeyorixCore struct {
 	// approved, secret-scoped access request (see classification_gate.go). Set from
 	// config at startup via SetClassificationRestrictedRequiresApproval.
 	classificationRestrictedRequiresApproval bool
+	// classificationRestrictedRequiresPermission mirrors config classification.
+	// restricted_requires_permission; false (the default) leaves "restricted" readable
+	// by anyone whose RBAC roles grant secrets.read at the project scope. When true,
+	// the user must ALSO hold the "secrets.read.restricted" permission (or an admin
+	// bypass role). Set at startup via SetClassificationRestrictedRequiresPermission.
+	classificationRestrictedRequiresPermission bool
 	// retentionPolicy holds the configured per-record-type data-retention windows
 	// (ISO A.5.33) so the compliance posture can report them; zero value = no
 	// retention configured. Set from config at startup via SetRetentionPolicy.

--- a/server/main.go
+++ b/server/main.go
@@ -709,6 +709,10 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	if cfg.Classification.RestrictedRequiresApproval {
 		log.Printf("Classification enforcement enabled: reading a \"restricted\" secret's value now requires an approved, secret-scoped access request")
 	}
+	coreService.SetClassificationRestrictedRequiresPermission(cfg.Classification.RestrictedRequiresPermission)
+	if cfg.Classification.RestrictedRequiresPermission {
+		log.Printf("Classification enforcement enabled: reading a \"restricted\" secret's value now requires the %q permission at the project scope", core.PermSecretReadRestricted)
+	}
 
 	// Wire the configured data-retention windows (A.5.33) so the compliance posture
 	// reports them; the scheduler below drives the actual purge. Audited (#160) so a


### PR DESCRIPTION
## Summary

- Adds `classification.restricted_requires_permission` config flag (default `false`)
- When enabled, reading a `restricted`-classified secret's value requires the acting user to hold the `secrets.read.restricted` permission at the project scope
- Admin/`project_admin` roles bypass via the existing `Authorize` admin-role shortcut; everyone else needs an explicit grant on their role
- Stacks additively with `restricted_requires_approval` when both are on (both must be satisfied)
- Machine/no-user reads are denied whenever either gate is active (fail-closed)

This resolves the "narrower RBAC for 'restricted' remain undecided/unimplemented" note in `classification.go`.

## Test plan

- [ ] `TestClassificationPermissionGate_OffByDefault_OwnerCanRead` — no change when flag is off
- [ ] `TestClassificationPermissionGate_On_NoPermission_Denied` — owner without grant is denied
- [ ] `TestClassificationPermissionGate_On_NoUser_Denied` — machine read denied
- [ ] `TestClassificationPermissionGate_On_AdminAllowed` — admin bypass works
- [ ] `TestClassificationPermissionGate_On_ExplicitGrantAllowed` — explicit `secrets.read.restricted` grant allows read
- [ ] `TestClassificationPermissionGate_On_LowerTierUnaffected` — public/internal/confidential unaffected
- [ ] `TestClassificationPermissionGate_Combined_BothRequired` — with both gates on, permission alone isn't enough without an approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)