### PR TITLE
feat(classification): MFA step-up gate for restricted secrets

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1494,6 +1494,14 @@ type ClassificationConfig struct {
 	// (purely additive: only tightens access, never removes it). Can be combined
 	// with RestrictedRequiresApproval — when both are on, BOTH must be satisfied.
 	RestrictedRequiresPermission bool `yaml:"restricted_requires_permission"`
+	// RestrictedRequiresMFAStepUp, when true, requires the acting user to have
+	// completed a second-factor MFA verification within RestrictedMFAStepUpWindowMinutes
+	// before a "restricted"-classified secret's value may be read. Off by default.
+	// Can be combined with the other gate flags — when multiple are on, all must pass.
+	RestrictedRequiresMFAStepUp bool `yaml:"restricted_requires_mfa_stepup"`
+	// RestrictedMFAStepUpWindowMinutes is how long (in minutes) a completed MFA
+	// verification remains valid for restricted-secret reads. 0 = default (15 min).
+	RestrictedMFAStepUpWindowMinutes int `yaml:"restricted_mfa_stepup_window_minutes"`
 }
 
 // WebAuthnConfig configures the WebAuthn relying party (ADR-036). RPID is the

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -35,6 +35,7 @@ func newBootstrappedCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 		&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.ProjectMembership{},
 		&models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.SoDPolicy{},
 		&models.StatsSnapshot{}, &models.DeploymentStatsSnapshot{},
+		&models.MFAStepupToken{},
 	))
 
 	st := store.NewLocalStorage(db)

--- a/internal/core/classification_gate.go
+++ b/internal/core/classification_gate.go
@@ -33,6 +33,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -43,6 +44,9 @@ import (
 // project_admin roles bypass this check via Authorize's admin-role shortcut;
 // everyone else needs an explicit grant on their role.
 const PermSecretReadRestricted = "secrets.read.restricted"
+
+// defaultMFAStepUpWindow is the fallback step-up window when the config value is 0.
+const defaultMFAStepUpWindow = 15 * time.Minute
 
 // SetClassificationRestrictedRequiresApproval mirrors config classification.
 // restricted_requires_approval. false (the default, and the zero value) leaves
@@ -62,20 +66,44 @@ func (c *KeyorixCore) SetClassificationRestrictedRequiresPermission(enabled bool
 	c.classificationRestrictedRequiresPermission = enabled
 }
 
+// SetClassificationRestrictedRequiresMFAStepUp mirrors config classification.
+// restricted_requires_mfa_stepup and restricted_mfa_stepup_window_minutes.
+// When enabled, reading a "restricted" secret requires a recent MFA verification
+// (within windowMinutes minutes; 0 = 15 min default). Can be combined with the
+// other gate flags.
+func (c *KeyorixCore) SetClassificationRestrictedRequiresMFAStepUp(enabled bool, windowMinutes int) {
+	c.classificationRestrictedRequiresMFAStepUp = enabled
+	if windowMinutes > 0 {
+		c.classificationRestrictedMFAStepUpWindow = time.Duration(windowMinutes) * time.Minute
+	} else {
+		c.classificationRestrictedMFAStepUpWindow = defaultMFAStepUpWindow
+	}
+}
+
+// mfaStepUpWindow returns the effective step-up window, defaulting when 0.
+func (c *KeyorixCore) mfaStepUpWindow() time.Duration {
+	if c.classificationRestrictedMFAStepUpWindow > 0 {
+		return c.classificationRestrictedMFAStepUpWindow
+	}
+	return defaultMFAStepUpWindow
+}
+
 // checkRestrictedSecretReadApproval is the fail-closed gate every secret VALUE
 // read path routes through (see versions.go/secret_render.go). It is a no-op
 // unless at least one classification gate setting is active AND the secret's
 // classification is exactly ClassificationRestricted — a lower tier is never
 // gated regardless of configuration (#128's product decision).
 //
-// Two independent guards can be active simultaneously; when both are on, BOTH
-// must be satisfied — defense in depth:
+// Three independent guards can be active simultaneously; when multiple are on,
+// ALL must be satisfied — defense in depth:
 //
 //  1. restricted_requires_permission: the user must hold PermSecretReadRestricted
 //     at the secret's project scope (or be an admin). Checked first — fast RBAC
 //     lookup, no per-secret DB query.
 //  2. restricted_requires_approval: the user must have an approved, secret-scoped
 //     access request. Checked second.
+//  3. restricted_requires_mfa_stepup: the user must have completed MFA within the
+//     configured step-up window (default 15 min), recorded by VerifyMFALogin.
 //
 // userID identifies the acting human principal, if any. 0 means the read has no
 // identifiable user behind it — a machine/service-account credential, the
@@ -85,7 +113,7 @@ func (c *KeyorixCore) SetClassificationRestrictedRequiresPermission(enabled bool
 // flow on behalf of a user. Any failure to positively confirm a gate condition —
 // including a storage error — denies the read; this never fails open.
 func (c *KeyorixCore) checkRestrictedSecretReadApproval(ctx context.Context, secret *models.SecretNode, userID uint) error {
-	if !c.classificationRestrictedRequiresApproval && !c.classificationRestrictedRequiresPermission {
+	if !c.classificationRestrictedRequiresApproval && !c.classificationRestrictedRequiresPermission && !c.classificationRestrictedRequiresMFAStepUp {
 		return nil
 	}
 	if secret == nil || secret.Classification != ClassificationRestricted {
@@ -115,6 +143,17 @@ func (c *KeyorixCore) checkRestrictedSecretReadApproval(ctx context.Context, sec
 		}
 		if !ok {
 			return fmt.Errorf("secret %q is restricted: an approved access request for this specific secret is required before its value can be read", secret.Name)
+		}
+	}
+
+	// Gate 3: recent MFA step-up (completed within the configured window).
+	if c.classificationRestrictedRequiresMFAStepUp {
+		ok, err := c.storage.HasActiveMFAStepup(ctx, userID)
+		if err != nil {
+			return fmt.Errorf("secret %q is restricted: could not verify MFA step-up: %w", secret.Name, err)
+		}
+		if !ok {
+			return fmt.Errorf("secret %q is restricted: a recent MFA verification (within %s) is required to read this secret's value — re-authenticate with your second factor", secret.Name, c.mfaStepUpWindow())
 		}
 	}
 

--- a/internal/core/classification_gate_test.go
+++ b/internal/core/classification_gate_test.go
@@ -446,3 +446,17 @@ func TestClassificationMFAStepUp_Combined_BothRequired(t *testing.T) {
 	require.Error(t, err, "approval gate must still deny even with a valid MFA step-up token")
 	assert.Contains(t, err.Error(), "access request")
 }
+
+// Requirement: when windowMinutes > 0 the custom duration is applied and surfaced in
+// the denial message, exercising the positive-windowMinutes branch of
+// SetClassificationRestrictedRequiresMFAStepUp.
+func TestClassificationMFAStepUp_On_CustomWindow_Denied(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, ownerID, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresMFAStepUp(true, 5) // positive windowMinutes
+
+	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "5m0s", "denial must mention the custom 5-minute window")
+}

--- a/internal/core/classification_gate_test.go
+++ b/internal/core/classification_gate_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -338,5 +339,110 @@ func TestClassificationPermissionGate_Combined_BothRequired(t *testing.T) {
 	// grantedUser has the secrets.read.restricted permission but no approved request.
 	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, grantedUserID)
 	require.Error(t, err, "both gates active: permission alone is insufficient without approval")
+	assert.Contains(t, err.Error(), "access request")
+}
+
+// ── restricted_requires_mfa_stepup tests ─────────────────────────────────────
+
+// Requirement: off by default — no change even for a user without a step-up token.
+func TestClassificationMFAStepUp_OffByDefault_OwnerCanRead(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, ownerID, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+
+	val, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
+	require.NoError(t, err, "MFA step-up gate off: owner must read unrestricted")
+	assert.Equal(t, "s3cr3t-value", string(val))
+}
+
+// Requirement: when on, a user without an active step-up token is denied.
+func TestClassificationMFAStepUp_On_NoToken_Denied(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, ownerID, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
+
+	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restricted")
+	assert.Contains(t, err.Error(), "MFA")
+}
+
+// Requirement: machine/no-user read is always denied when the gate is active.
+func TestClassificationMFAStepUp_On_NoUser_Denied(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, _, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
+
+	_, err := c.GetSecretValue(ctx, secretID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restricted")
+}
+
+// Requirement: a user with an active (non-expired) step-up token can read.
+func TestClassificationMFAStepUp_On_ActiveToken_Allowed(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, ownerID, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
+
+	// Directly seed the step-up token (as VerifyMFALogin would).
+	expiresAt := c.now().Add(15 * time.Minute)
+	require.NoError(t, st.UpsertMFAStepupToken(ctx, ownerID, expiresAt))
+
+	val, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
+	require.NoError(t, err, "active MFA step-up token must allow the read")
+	assert.Equal(t, "s3cr3t-value", string(val))
+}
+
+// Requirement: an expired step-up token is treated as absent — denied.
+func TestClassificationMFAStepUp_On_ExpiredToken_Denied(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, ownerID, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
+
+	// Seed an already-expired token.
+	expiredAt := c.now().Add(-1 * time.Minute)
+	require.NoError(t, st.UpsertMFAStepupToken(ctx, ownerID, expiredAt))
+
+	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
+	require.Error(t, err, "expired step-up token must not grant access")
+	assert.Contains(t, err.Error(), "MFA")
+}
+
+// Requirement: lower-tier secrets are never gated by the MFA step-up check.
+func TestClassificationMFAStepUp_On_LowerTierUnaffected(t *testing.T) {
+	for _, level := range []string{ClassificationPublic, ClassificationInternal, ClassificationConfidential, ""} {
+		level := level
+		t.Run("classification="+level, func(t *testing.T) {
+			c, st := newBootstrappedCore(t)
+			secretID, ownerID, _, _ := seedClassificationGateFixture(t, st, level)
+			ctx := context.Background()
+			c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
+
+			val, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
+			require.NoError(t, err, "MFA step-up gate must not affect non-restricted secrets")
+			assert.Equal(t, "s3cr3t-value", string(val))
+		})
+	}
+}
+
+// Requirement: combined with approval gate — both must pass. A user with a valid
+// step-up token but no approved access request is still denied.
+func TestClassificationMFAStepUp_Combined_BothRequired(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, ownerID, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresApproval(true)
+	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
+
+	// Give the owner an active step-up token.
+	require.NoError(t, st.UpsertMFAStepupToken(ctx, ownerID, c.now().Add(15*time.Minute)))
+
+	// No approved access request yet → denied.
+	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
+	require.Error(t, err, "approval gate must still deny even with a valid MFA step-up token")
 	assert.Contains(t, err.Error(), "access request")
 }

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -346,6 +346,12 @@ func (c *KeyorixCore) VerifyMFALogin(ctx context.Context, challenge, code, userA
 	if err != nil {
 		return nil, nil, err
 	}
+	// Record the MFA step-up window when the classification gate requires it.
+	// Best-effort: a write failure does not block the login, but the user won't
+	// be able to read restricted secrets until they re-verify successfully.
+	if c.classificationRestrictedRequiresMFAStepUp {
+		_ = c.storage.UpsertMFAStepupToken(ctx, user.ID, c.now().Add(c.mfaStepUpWindow()))
+	}
 	uid := user.ID
 	if usedRecovery {
 		c.writeAuditEventFull(ctx, "mfa.recovery_used", &uid, nil, nil, ip, fmt.Sprintf("user %s used a recovery code", user.Username))

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -27,7 +27,8 @@ func newMFATestCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.MFASecret{},
-		&models.MFARecoveryCode{}, &models.MFAChallenge{}, &models.Session{}, &models.AuditEvent{}))
+		&models.MFARecoveryCode{}, &models.MFAChallenge{}, &models.Session{}, &models.AuditEvent{},
+		&models.MFAStepupToken{}))
 	hash, _ := bcrypt.GenerateFromPassword([]byte(mfaTestPassword), bcrypt.DefaultCost)
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@b.com",
 		PasswordHash: string(hash), AccountState: "active"}).Error)
@@ -543,4 +544,32 @@ func TestMFA_TOTPSecretTransplantBetweenUsersFailsToDecrypt(t *testing.T) {
 
 	_, err = c.loadTOTPSecret(ctx, 2)
 	require.Error(t, err, "a TOTP secret transplanted from another user's row must fail to decrypt, not silently succeed")
+}
+
+// VerifyMFALogin must record a MFA step-up token when the classification gate
+// requires it. The write is best-effort (error discarded), so VerifyMFALogin
+// must still succeed even if UpsertMFAStepupToken were to fail. This test
+// exercises the recording branch (mfa.go:352-353) that is otherwise skipped
+// when classificationRestrictedRequiresMFAStepUp is false.
+func TestVerifyMFALogin_RecordsMFAStepupWhenGateEnabled(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
+
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	actCode, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	_, err = c.ActivateMFA(ctx, 1, actCode, mfaTestPassword)
+	require.NoError(t, err)
+
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	code, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+
+	sess, user, err := c.VerifyMFALogin(ctx, ch, code, "ua", "1.2.3.4")
+	require.NoError(t, err, "VerifyMFALogin must succeed even with the MFA step-up gate enabled (UpsertMFAStepupToken is best-effort)")
+	require.NotNil(t, sess)
+	assert.Equal(t, "alice", user.Username)
 }

--- a/internal/core/mock_storage_classification_mfa_stepup_test.go
+++ b/internal/core/mock_storage_classification_mfa_stepup_test.go
@@ -1,0 +1,14 @@
+package core
+
+import (
+	"context"
+	"time"
+)
+
+func (m *MockStorage) UpsertMFAStepupToken(_ context.Context, _ uint, _ time.Time) error {
+	return nil
+}
+
+func (m *MockStorage) HasActiveMFAStepup(_ context.Context, _ uint) (bool, error) {
+	return false, nil
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -205,6 +205,14 @@ type KeyorixCore struct {
 	// the user must ALSO hold the "secrets.read.restricted" permission (or an admin
 	// bypass role). Set at startup via SetClassificationRestrictedRequiresPermission.
 	classificationRestrictedRequiresPermission bool
+	// classificationRestrictedRequiresMFAStepUp mirrors config classification.
+	// restricted_requires_mfa_stepup; when true, reading a "restricted" secret
+	// also requires the user to have completed MFA within the step-up window. Set
+	// at startup via SetClassificationRestrictedRequiresMFAStepUp.
+	classificationRestrictedRequiresMFAStepUp bool
+	// classificationRestrictedMFAStepUpWindow is how long a completed MFA
+	// verification remains valid for the step-up gate. 0 = default (15 min).
+	classificationRestrictedMFAStepUpWindow time.Duration
 	// retentionPolicy holds the configured per-record-type data-retention windows
 	// (ISO A.5.33) so the compliance posture can report them; zero value = no
 	// retention configured. Set from config at startup via SetRetentionPolicy.

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1130,6 +1130,18 @@ type Storage interface {
 	// challenge is consumed later, atomically, at login-finish).
 	GetActiveMFAChallenge(ctx context.Context, tokenHash string, now time.Time) (*models.MFAChallenge, error)
 
+	// UpsertMFAStepupToken records (or refreshes) the MFA step-up window for
+	// userID. expiresAt is set by the caller (core) from the configured window. One
+	// row per user; the previous row is replaced on re-verification so re-login
+	// extends the window cleanly. Intentional no-op stub on RemoteStorage — the
+	// step-up token is always created and checked server-side.
+	UpsertMFAStepupToken(ctx context.Context, userID uint, expiresAt time.Time) error
+	// HasActiveMFAStepup reports whether userID has a non-expired MFA step-up
+	// record, confirming a recent second-factor verification. Intentional stub on
+	// RemoteStorage (always false, ErrUnsupportedByBackend) — the classification
+	// gate and MFA step-up token both live on the same server node.
+	HasActiveMFAStepup(ctx context.Context, userID uint) (bool, error)
+
 	// WebAuthn / passkeys (ADR-036).
 	CreateWebAuthnCredential(ctx context.Context, c *models.WebAuthnCredential) error
 	ListWebAuthnCredentials(ctx context.Context, userID uint) ([]*models.WebAuthnCredential, error)

--- a/internal/storage/models/all_models.go
+++ b/internal/storage/models/all_models.go
@@ -42,6 +42,7 @@ func AllTestModels() []any {
 		&MFASecret{},
 		&MFARecoveryCode{},
 		&MFAChallenge{},
+		&MFAStepupToken{},
 		&SecretDependency{},
 		&MachineIdentity{},
 		&MachineIdentityCredential{},

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -392,6 +392,17 @@ type MFARecoveryCode struct {
 	UsedAt   *time.Time
 }
 
+// MFAStepupToken records that a user recently completed a successful MFA
+// second-factor check, allowing the classification gate to confirm step-up for
+// restricted secret reads without re-prompting on every call. One active row per
+// user; UpsertMFAStepupToken replaces it on each re-verification.
+type MFAStepupToken struct {
+	ID        uint      `gorm:"primaryKey"`
+	UserID    uint      `gorm:"uniqueIndex"`
+	ExpiresAt time.Time `gorm:"index"`
+	CreatedAt time.Time
+}
+
 // MFAChallenge is a short-lived, single-use pre-auth token issued when an
 // MFA-enabled user passes the password step; the verify step consumes it. The
 // raw token is never stored — only its SHA-256 hash.

--- a/internal/storage/store/local_mfa_stepup.go
+++ b/internal/storage/store/local_mfa_stepup.go
@@ -1,0 +1,42 @@
+// local_mfa_stepup.go — MFA step-up token persistence for LocalStorage.
+// One row per user (uniqueIndex on user_id); UpsertMFAStepupToken replaces it
+// on each re-verification using ON CONFLICT, mirroring local_mfa.go's
+// UpsertMFASecret pattern exactly.
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const sqlWhereUserIDAndNotExpired = "user_id = ? AND expires_at > ?"
+
+// UpsertMFAStepupToken inserts or replaces the step-up record for userID,
+// setting its expiry to expiresAt. A second MFA verification within the window
+// extends the window cleanly (ON CONFLICT updates expires_at in place).
+func (ls *LocalStorage) UpsertMFAStepupToken(ctx context.Context, userID uint, expiresAt time.Time) error {
+	tok := &models.MFAStepupToken{UserID: userID, ExpiresAt: expiresAt}
+	return ls.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}},
+		DoUpdates: clause.Assignments(map[string]interface{}{"expires_at": expiresAt}),
+	}).Create(tok).Error
+}
+
+// HasActiveMFAStepup reports whether userID has a non-expired step-up record —
+// i.e., that they completed MFA verification within the configured window.
+// Returns (false, nil) when no record exists or the record has expired.
+func (ls *LocalStorage) HasActiveMFAStepup(ctx context.Context, userID uint) (bool, error) {
+	var tok models.MFAStepupToken
+	err := ls.db.WithContext(ctx).
+		Where(sqlWhereUserIDAndNotExpired, userID, time.Now()).
+		First(&tok).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, nil
+	}
+	return err == nil, err
+}

--- a/internal/storage/store/local_mfa_stepup_test.go
+++ b/internal/storage/store/local_mfa_stepup_test.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newStepupStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.MFAStepupToken{}))
+	return NewLocalStorage(db)
+}
+
+func TestUpsertMFAStepupToken_InsertsNewRow(t *testing.T) {
+	s := newStepupStore(t)
+	ctx := context.Background()
+	exp := time.Now().Add(5 * time.Minute)
+
+	require.NoError(t, s.UpsertMFAStepupToken(ctx, 1, exp))
+
+	var tok models.MFAStepupToken
+	require.NoError(t, s.db.First(&tok).Error)
+	assert.Equal(t, uint(1), tok.UserID)
+	assert.WithinDuration(t, exp, tok.ExpiresAt, time.Second)
+}
+
+func TestUpsertMFAStepupToken_UpdatesExistingRow(t *testing.T) {
+	s := newStepupStore(t)
+	ctx := context.Background()
+	first := time.Now().Add(2 * time.Minute)
+	second := time.Now().Add(10 * time.Minute)
+
+	require.NoError(t, s.UpsertMFAStepupToken(ctx, 2, first))
+	require.NoError(t, s.UpsertMFAStepupToken(ctx, 2, second))
+
+	var count int64
+	s.db.Model(&models.MFAStepupToken{}).Count(&count)
+	assert.Equal(t, int64(1), count, "upsert must not create a second row")
+
+	var tok models.MFAStepupToken
+	require.NoError(t, s.db.First(&tok).Error)
+	assert.WithinDuration(t, second, tok.ExpiresAt, time.Second)
+}
+
+func TestHasActiveMFAStepup_TrueWhenNotExpired(t *testing.T) {
+	s := newStepupStore(t)
+	ctx := context.Background()
+	exp := time.Now().Add(5 * time.Minute)
+
+	require.NoError(t, s.UpsertMFAStepupToken(ctx, 3, exp))
+
+	ok, err := s.HasActiveMFAStepup(ctx, 3)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestHasActiveMFAStepup_FalseWhenExpired(t *testing.T) {
+	s := newStepupStore(t)
+	ctx := context.Background()
+	exp := time.Now().Add(-1 * time.Minute)
+
+	require.NoError(t, s.UpsertMFAStepupToken(ctx, 4, exp))
+
+	ok, err := s.HasActiveMFAStepup(ctx, 4)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestHasActiveMFAStepup_FalseWhenNoRecord(t *testing.T) {
+	s := newStepupStore(t)
+	ctx := context.Background()
+
+	ok, err := s.HasActiveMFAStepup(ctx, 99)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/internal/storage/store/remote_coverage_mfa_rbac_secrets_test.go
+++ b/internal/storage/store/remote_coverage_mfa_rbac_secrets_test.go
@@ -9,6 +9,7 @@ package store_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -971,4 +972,27 @@ func TestRemoteCov_IncrementSecretReadCount_APIError(t *testing.T) {
 	err = rs.IncrementSecretReadCount(context.Background(), 999)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "increment read count failed")
+}
+
+// --------------------------------------------------------------------------
+// remote_mfa.go — MFA step-up stubs (intentionally unsupported in remote mode)
+// --------------------------------------------------------------------------
+
+func TestRemoteCov_UpsertMFAStepupToken_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:1"))
+	require.NoError(t, err)
+
+	err = rs.UpsertMFAStepupToken(context.Background(), 1, time.Now().Add(time.Hour))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, corestorage.ErrUnsupportedByBackend))
+}
+
+func TestRemoteCov_HasActiveMFAStepup_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:1"))
+	require.NoError(t, err)
+
+	ok, err := rs.HasActiveMFAStepup(context.Background(), 1)
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.True(t, errors.Is(err, corestorage.ErrUnsupportedByBackend))
 }

--- a/internal/storage/store/remote_mfa.go
+++ b/internal/storage/store/remote_mfa.go
@@ -482,3 +482,16 @@ func (rs *RemoteStorage) VerifyMFALoginCredentials(ctx context.Context, challeng
 	}
 	return wire.toModel(), wire.UsedRecovery, nil
 }
+
+// UpsertMFAStepupToken and HasActiveMFAStepup are intentional stubs: the step-up
+// token is created by VerifyMFALogin and checked by the classification gate on the
+// same server node that holds the LocalStorage. RemoteStorage (a spoke CLI node) is
+// never the node making these calls — the HTTP request for a restricted secret value
+// goes straight to the upstream server, which checks its own local table.
+func (rs *RemoteStorage) UpsertMFAStepupToken(_ context.Context, _ uint, _ time.Time) error {
+	return remoteUnsupported("UpsertMFAStepupToken")
+}
+
+func (rs *RemoteStorage) HasActiveMFAStepup(_ context.Context, _ uint) (bool, error) {
+	return false, remoteUnsupported("HasActiveMFAStepup")
+}

--- a/internal/storage/store/remote_mfa_stepup_completeness_test.go
+++ b/internal/storage/store/remote_mfa_stepup_completeness_test.go
@@ -1,0 +1,15 @@
+package store
+
+func init() {
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		"UpsertMFAStepupToken": {statusIntentional,
+			"step-up token recording is triggered by VerifyMFALogin; under storage.type: remote the MFA " +
+				"verification is proxied to the server via RemoteMFAVerifier before the token write — the " +
+				"write always runs server-side, never from a remote-storage caller"},
+		"HasActiveMFAStepup": {statusIntentional,
+			"step-up check runs inside checkRestrictedSecretReadApproval, which is called during secret " +
+				"value reads; under storage.type: remote, value reads are proxied to the server via the " +
+				"HTTP /api/v1/secrets/:id/value route — the gate always executes server-side, never from " +
+				"a remote-storage caller"},
+	})
+}

--- a/server/main.go
+++ b/server/main.go
@@ -714,6 +714,14 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	if cfg.Classification.RestrictedRequiresPermission {
 		log.Printf("Classification enforcement enabled: reading a \"restricted\" secret's value now requires the %q permission at the project scope", core.PermSecretReadRestricted)
 	}
+	coreService.SetClassificationRestrictedRequiresMFAStepUp(cfg.Classification.RestrictedRequiresMFAStepUp, cfg.Classification.RestrictedMFAStepUpWindowMinutes)
+	if cfg.Classification.RestrictedRequiresMFAStepUp {
+		window := cfg.Classification.RestrictedMFAStepUpWindowMinutes
+		if window == 0 {
+			window = 15
+		}
+		log.Printf("Classification enforcement enabled: reading a \"restricted\" secret's value now requires a recent MFA verification (window: %d min)", window)
+	}
 
 	// Wire the configured data-retention windows (A.5.33) so the compliance posture
 	// reports them; the scheduler below drives the actual purge. Audited (#160) so a


### PR DESCRIPTION
## Summary

- Adds `classification.restricted_requires_mfa_stepup` config gate: when enabled, reading a `restricted`-classified secret requires the user to have completed MFA within the configured window (default 15 min)
- New `mfa_stepup_tokens` DB table (one row per user, upserted on every successful `VerifyMFALogin` while the gate is active)
- `HasActiveMFAStepup` / `UpsertMFAStepupToken` storage methods on `LocalStorage`; `RemoteStorage` stubs return `remoteUnsupported` (step-up is always server-side)
- Configurable window via `restricted_mfa_stepup_window_minutes` (0 = 15 min default)
- Stacks additively with `restricted_requires_approval` and `restricted_requires_permission` — all active gates must pass

## Test plan

- [x] `TestClassificationMFAStepUp_OffByDefault_OwnerCanRead` — gate off: no change
- [x] `TestClassificationMFAStepUp_On_NoToken_Denied` — no step-up token → denied
- [x] `TestClassificationMFAStepUp_On_NoUser_Denied` — machine/no-user read → denied
- [x] `TestClassificationMFAStepUp_On_ActiveToken_Allowed` — non-expired token → allowed
- [x] `TestClassificationMFAStepUp_On_ExpiredToken_Denied` — expired token → denied
- [x] `TestClassificationMFAStepUp_On_LowerTierUnaffected` — non-restricted tiers unaffected
- [x] `TestClassificationMFAStepUp_Combined_BothRequired` — both approval + MFA gates must pass simultaneously
- [x] Full `./internal/core/` suite: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)