### PR TITLE
fix(sonar): resolve 6 SonarCloud code-smell issues

### DIFF
--- a/internal/cli/machine/token.go
+++ b/internal/cli/machine/token.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/spf13/cobra"
 )
 
@@ -91,7 +92,11 @@ func runTokenIssue(cmd *cobra.Command, args []string) error {
 		t := time.Now().AddDate(0, 0, tokenIssueExpiryDays)
 		expiresAt = &t
 	}
-	result, err := svc.IssueMachineToken(ctx, projectID, m.ID, tokenIssueName, expiresAt, tokenIssueClass, 0, nil)
+	result, err := svc.IssueMachineToken(ctx, projectID, m.ID, 0, core.IssueMachineTokenParams{
+		Name:           tokenIssueName,
+		ExpiresAt:      expiresAt,
+		Classification: tokenIssueClass,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to issue machine token: %w", err)
 	}

--- a/internal/core/classification_gate.go
+++ b/internal/core/classification_gate.go
@@ -125,38 +125,57 @@ func (c *KeyorixCore) checkRestrictedSecretReadApproval(ctx context.Context, sec
 
 	// Gate 1: narrower RBAC permission (fast path — no per-secret DB query).
 	if c.classificationRestrictedRequiresPermission {
-		scope := Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
-		ok, err := c.Authorize(ctx, userID, PermSecretReadRestricted, scope)
-		if err != nil {
-			return fmt.Errorf("secret %q is restricted: could not verify the %q permission: %w", secret.Name, PermSecretReadRestricted, err)
-		}
-		if !ok {
-			return fmt.Errorf("secret %q is restricted: the %q permission is required at the project scope to read this secret's value", secret.Name, PermSecretReadRestricted)
+		if err := c.checkRestrictedPermissionGate(ctx, secret, userID); err != nil {
+			return err
 		}
 	}
-
 	// Gate 2: approved secret-scoped access request.
 	if c.classificationRestrictedRequiresApproval {
-		ok, err := c.hasApprovedSecretAccessRequest(ctx, secret.ProjectID, secret.ID, userID)
-		if err != nil {
-			return fmt.Errorf("secret %q is restricted: could not verify an approved access request: %w", secret.Name, err)
-		}
-		if !ok {
-			return fmt.Errorf("secret %q is restricted: an approved access request for this specific secret is required before its value can be read", secret.Name)
+		if err := c.checkRestrictedApprovalGate(ctx, secret, userID); err != nil {
+			return err
 		}
 	}
-
 	// Gate 3: recent MFA step-up (completed within the configured window).
 	if c.classificationRestrictedRequiresMFAStepUp {
-		ok, err := c.storage.HasActiveMFAStepup(ctx, userID)
-		if err != nil {
-			return fmt.Errorf("secret %q is restricted: could not verify MFA step-up: %w", secret.Name, err)
-		}
-		if !ok {
-			return fmt.Errorf("secret %q is restricted: a recent MFA verification (within %s) is required to read this secret's value — re-authenticate with your second factor", secret.Name, c.mfaStepUpWindow())
+		if err := c.checkRestrictedMFAGate(ctx, secret, userID); err != nil {
+			return err
 		}
 	}
 
+	return nil
+}
+
+func (c *KeyorixCore) checkRestrictedPermissionGate(ctx context.Context, secret *models.SecretNode, userID uint) error {
+	scope := Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
+	ok, err := c.Authorize(ctx, userID, PermSecretReadRestricted, scope)
+	if err != nil {
+		return fmt.Errorf("secret %q is restricted: could not verify the %q permission: %w", secret.Name, PermSecretReadRestricted, err)
+	}
+	if !ok {
+		return fmt.Errorf("secret %q is restricted: the %q permission is required at the project scope to read this secret's value", secret.Name, PermSecretReadRestricted)
+	}
+	return nil
+}
+
+func (c *KeyorixCore) checkRestrictedApprovalGate(ctx context.Context, secret *models.SecretNode, userID uint) error {
+	ok, err := c.hasApprovedSecretAccessRequest(ctx, secret.ProjectID, secret.ID, userID)
+	if err != nil {
+		return fmt.Errorf("secret %q is restricted: could not verify an approved access request: %w", secret.Name, err)
+	}
+	if !ok {
+		return fmt.Errorf("secret %q is restricted: an approved access request for this specific secret is required before its value can be read", secret.Name)
+	}
+	return nil
+}
+
+func (c *KeyorixCore) checkRestrictedMFAGate(ctx context.Context, secret *models.SecretNode, userID uint) error {
+	ok, err := c.storage.HasActiveMFAStepup(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("secret %q is restricted: could not verify MFA step-up: %w", secret.Name, err)
+	}
+	if !ok {
+		return fmt.Errorf("secret %q is restricted: a recent MFA verification (within %s) is required to read this secret's value — re-authenticate with your second factor", secret.Name, c.mfaStepUpWindow())
+	}
 	return nil
 }
 

--- a/internal/core/machine_ip_allowlist_test.go
+++ b/internal/core/machine_ip_allowlist_test.go
@@ -27,7 +27,7 @@ func TestIssueMachineToken_StoresCIDRs(t *testing.T) {
 	c.now = func() time.Time { return fixed }
 
 	cidrs := []string{"10.0.0.0/8", "192.0.2.0/24"}
-	_, err := c.IssueMachineToken(context.Background(), 2, 1, "ci", nil, "", 9, cidrs)
+	_, err := c.IssueMachineToken(context.Background(), 2, 1, 9, IssueMachineTokenParams{Name: "ci", AllowedCIDRs: cidrs})
 	require.NoError(t, err)
 
 	var stored *models.MachineIdentityCredential
@@ -56,7 +56,7 @@ func TestIssueMachineToken_NilCIDRsOmitted(t *testing.T) {
 	c := NewKeyorixCore(store)
 	c.now = func() time.Time { return fixed }
 
-	_, err := c.IssueMachineToken(context.Background(), 2, 1, "ci", nil, "", 9, nil)
+	_, err := c.IssueMachineToken(context.Background(), 2, 1, 9, IssueMachineTokenParams{Name: "ci"})
 	require.NoError(t, err)
 
 	var stored *models.MachineIdentityCredential

--- a/internal/core/machine_token.go
+++ b/internal/core/machine_token.go
@@ -45,11 +45,19 @@ func (c *KeyorixCore) machineInProject(ctx context.Context, projectID, machineID
 	return m, nil
 }
 
+// IssueMachineTokenParams groups the token-specific fields for IssueMachineToken.
+type IssueMachineTokenParams struct {
+	Name           string
+	ExpiresAt      *time.Time
+	Classification string
+	AllowedCIDRs   []string
+}
+
 // IssueMachineToken mints an opaque bearer token for an active machine identity.
 // The raw token is returned once for out-of-band delivery; only its SHA-256 hash
-// is stored. allowedCIDRs, when non-nil and non-empty, restricts the token to
-// requests whose source IP falls within one of the listed CIDR blocks.
-func (c *KeyorixCore) IssueMachineToken(ctx context.Context, projectID, machineID uint, name string, expiresAt *time.Time, classification string, actorID uint, allowedCIDRs []string) (*IssueMachineTokenResult, error) {
+// is stored. params.AllowedCIDRs, when non-nil and non-empty, restricts the token
+// to requests whose source IP falls within one of the listed CIDR blocks.
+func (c *KeyorixCore) IssueMachineToken(ctx context.Context, projectID, machineID, actorID uint, params IssueMachineTokenParams) (*IssueMachineTokenResult, error) {
 	m, err := c.machineInProject(ctx, projectID, machineID)
 	if err != nil {
 		return nil, err
@@ -57,6 +65,7 @@ func (c *KeyorixCore) IssueMachineToken(ctx context.Context, projectID, machineI
 	if m.State != MachineActive {
 		return nil, fmt.Errorf("cannot issue a token for a %s machine identity (must be active)", m.State)
 	}
+	classification := params.Classification
 	if !IsValidClassification(classification) {
 		return nil, fmt.Errorf("classification must be one of public, internal, confidential, restricted (or empty)")
 	}
@@ -72,17 +81,17 @@ func (c *KeyorixCore) IssueMachineToken(ctx context.Context, projectID, machineI
 	raw := machineTokenPrefix + base64.RawURLEncoding.EncodeToString(b)
 
 	var cidrJSON string
-	if len(allowedCIDRs) > 0 {
-		b, _ := json.Marshal(allowedCIDRs)
+	if len(params.AllowedCIDRs) > 0 {
+		b, _ := json.Marshal(params.AllowedCIDRs)
 		cidrJSON = string(b)
 	}
 	cred := &models.MachineIdentityCredential{
 		MachineIdentityID: machineID,
-		Name:              strings.TrimSpace(name),
+		Name:              strings.TrimSpace(params.Name),
 		TokenHash:         sha256Hex(raw),
 		TokenPrefix:       raw[:len(machineTokenPrefix)+6], // "kx_machine_ab12cd"
 		AllowedCIDRs:      cidrJSON,
-		ExpiresAt:         expiresAt,
+		ExpiresAt:         params.ExpiresAt,
 		Classification:    classification,
 		CreatedAt:         c.now(),
 	}

--- a/internal/core/machine_token_test.go
+++ b/internal/core/machine_token_test.go
@@ -19,13 +19,13 @@ func TestIssueMachineToken_ActiveOnly(t *testing.T) {
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineSuspended}, nil).Once()
 	c := NewKeyorixCore(store)
 	c.now = func() time.Time { return fixed }
-	_, err := c.IssueMachineToken(context.Background(), 2, 1, "ci", nil, "", 7, nil)
+	_, err := c.IssueMachineToken(context.Background(), 2, 1, 7, IssueMachineTokenParams{Name: "ci"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "must be active")
 
 	// Wrong project → not found (cross-project IDOR guard).
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
-	_, err = c.IssueMachineToken(context.Background(), 999, 1, "ci", nil, "", 7, nil)
+	_, err = c.IssueMachineToken(context.Background(), 999, 1, 7, IssueMachineTokenParams{Name: "ci"})
 	require.ErrorContains(t, err, "not found")
 
 	// Active machine → token minted with the kx_machine_ prefix, hash stored.
@@ -34,7 +34,7 @@ func TestIssueMachineToken_ActiveOnly(t *testing.T) {
 		Return(&models.MachineIdentityCredential{ID: 5}, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	res, err := c.IssueMachineToken(context.Background(), 2, 1, "ci", nil, "", 7, nil)
+	res, err := c.IssueMachineToken(context.Background(), 2, 1, 7, IssueMachineTokenParams{Name: "ci"})
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(res.PlainToken, "kx_machine_"))
 

--- a/internal/core/permission_baseline.go
+++ b/internal/core/permission_baseline.go
@@ -32,17 +32,16 @@ type PermissionBaseline struct {
 // permBaselineBuilder holds the shared caches used during a GetPermissionBaseline call.
 type permBaselineBuilder struct {
 	k             *KeyorixCore
-	ctx           context.Context
 	rolePermCache map[uint][]string
 	roleNameCache map[uint]string
 }
 
 // rolePermNames returns the permission names for roleID, caching the result.
-func (b *permBaselineBuilder) rolePermNames(roleID uint) ([]string, error) {
+func (b *permBaselineBuilder) rolePermNames(ctx context.Context, roleID uint) ([]string, error) {
 	if names, ok := b.rolePermCache[roleID]; ok {
 		return names, nil
 	}
-	perms, err := b.k.storage.GetRolePermissions(b.ctx, roleID)
+	perms, err := b.k.storage.GetRolePermissions(ctx, roleID)
 	if err != nil {
 		return nil, err
 	}
@@ -55,11 +54,11 @@ func (b *permBaselineBuilder) rolePermNames(roleID uint) ([]string, error) {
 }
 
 // roleName returns the name of roleID, caching the result.
-func (b *permBaselineBuilder) roleName(roleID uint) (string, error) {
+func (b *permBaselineBuilder) roleName(ctx context.Context, roleID uint) (string, error) {
 	if name, ok := b.roleNameCache[roleID]; ok {
 		return name, nil
 	}
-	role, err := b.k.storage.GetRole(b.ctx, roleID)
+	role, err := b.k.storage.GetRole(ctx, roleID)
 	if err != nil {
 		return "", err
 	}
@@ -68,18 +67,18 @@ func (b *permBaselineBuilder) roleName(roleID uint) (string, error) {
 }
 
 // directGrantRows appends rows for direct user→role grants.
-func (b *permBaselineBuilder) directGrantRows(allGrants []*models.UserRole, userByID map[uint]*userBaseline) ([]PermissionBaselineRow, error) {
+func (b *permBaselineBuilder) directGrantRows(ctx context.Context, allGrants []*models.UserRole, userByID map[uint]*userBaseline) ([]PermissionBaselineRow, error) {
 	var rows []PermissionBaselineRow
 	for _, grant := range allGrants {
 		u, ok := userByID[grant.UserID]
 		if !ok {
 			continue // skip if the user row is gone (soft-deleted outside the window)
 		}
-		name, err := b.roleName(grant.RoleID)
+		name, err := b.roleName(ctx, grant.RoleID)
 		if err != nil {
 			return nil, fmt.Errorf("permission baseline: get role %d: %w", grant.RoleID, err)
 		}
-		perms, err := b.rolePermNames(grant.RoleID)
+		perms, err := b.rolePermNames(ctx, grant.RoleID)
 		if err != nil {
 			return nil, fmt.Errorf("permission baseline: get permissions for role %d: %w", grant.RoleID, err)
 		}
@@ -99,19 +98,19 @@ func (b *permBaselineBuilder) directGrantRows(allGrants []*models.UserRole, user
 }
 
 // groupGrantRowsForUser appends rows for group-inherited grants for one user.
-func (b *permBaselineBuilder) groupGrantRowsForUser(u *models.User) ([]PermissionBaselineRow, error) {
+func (b *permBaselineBuilder) groupGrantRowsForUser(ctx context.Context, u *models.User) ([]PermissionBaselineRow, error) {
 	var rows []PermissionBaselineRow
-	groups, err := b.k.storage.GetUserGroups(b.ctx, u.ID)
+	groups, err := b.k.storage.GetUserGroups(ctx, u.ID)
 	if err != nil {
 		return nil, fmt.Errorf("permission baseline: get groups for user %d: %w", u.ID, err)
 	}
 	for _, g := range groups {
-		groupRoles, err := b.k.storage.GetGroupRoles(b.ctx, g.ID)
+		groupRoles, err := b.k.storage.GetGroupRoles(ctx, g.ID)
 		if err != nil {
 			return nil, fmt.Errorf("permission baseline: get roles for group %d: %w", g.ID, err)
 		}
 		for _, role := range groupRoles {
-			perms, err := b.rolePermNames(role.ID)
+			perms, err := b.rolePermNames(ctx, role.ID)
 			if err != nil {
 				return nil, fmt.Errorf("permission baseline: get permissions for role %d (group %d): %w", role.ID, g.ID, err)
 			}
@@ -161,20 +160,19 @@ func (k *KeyorixCore) GetPermissionBaseline(ctx context.Context) (*PermissionBas
 
 	b := &permBaselineBuilder{
 		k:             k,
-		ctx:           ctx,
 		rolePermCache: make(map[uint][]string),
 		roleNameCache: make(map[uint]string),
 	}
 
 	// 3. Direct user→role grants.
-	rows, err := b.directGrantRows(allGrants, userByID)
+	rows, err := b.directGrantRows(ctx, allGrants, userByID)
 	if err != nil {
 		return nil, err
 	}
 
 	// 4. Group-inherited grants.
 	for _, u := range users {
-		groupRows, err := b.groupGrantRowsForUser(u)
+		groupRows, err := b.groupGrantRowsForUser(ctx, u)
 		if err != nil {
 			return nil, err
 		}

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -241,7 +241,7 @@ func TestAuthInterceptor_MachineTokenAuthenticatesAndUsesMachineRBAC(t *testing.
 
 	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot", "service", "", "", 1)
 	require.NoError(t, err)
-	tok, err := h.CoreService.IssueMachineToken(context.Background(), 2, m.ID, "tok", nil, "", 1, nil)
+	tok, err := h.CoreService.IssueMachineToken(context.Background(), 2, m.ID, 1, core.IssueMachineTokenParams{Name: "tok"})
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(tok.PlainToken, "kx_machine_"))
 	// Grant the machine viewer (secrets.read) in project 2 only.
@@ -400,7 +400,7 @@ func TestAuthInterceptor_MachineRequestStampsMachineActorInAudit(t *testing.T) {
 
 	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot", "service", "", "", 1)
 	require.NoError(t, err)
-	tok, err := h.CoreService.IssueMachineToken(context.Background(), 2, m.ID, "tok", nil, "", 1, nil)
+	tok, err := h.CoreService.IssueMachineToken(context.Background(), 2, m.ID, 1, core.IssueMachineTokenParams{Name: "tok"})
 	require.NoError(t, err)
 
 	var captured context.Context

--- a/server/grpc/interceptors/interceptors_s22_test.go
+++ b/server/grpc/interceptors/interceptors_s22_test.go
@@ -502,7 +502,7 @@ func TestStreamAuthInterceptor_S22_MachineTokenAuthenticates(t *testing.T) {
 
 	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "stream-bot", "service", "", "", 1)
 	require.NoError(t, err)
-	tok, err := h.CoreService.IssueMachineToken(context.Background(), 2, m.ID, "tok", nil, "", 1, nil)
+	tok, err := h.CoreService.IssueMachineToken(context.Background(), 2, m.ID, 1, core.IssueMachineTokenParams{Name: "tok"})
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(tok.PlainToken, "kx_machine_"))
 

--- a/server/grpc/services/machine_identity_service.go
+++ b/server/grpc/services/machine_identity_service.go
@@ -156,7 +156,11 @@ func (s *MachineIdentityGRPCService) IssueMachineToken(ctx context.Context, req 
 		t := time.Now().AddDate(0, 0, int(req.GetExpiresInDays()))
 		expiresAt = &t
 	}
-	res, err := s.core.IssueMachineToken(ctx, uint(req.GetProjectId()), uint(req.GetMachineId()), req.GetName(), expiresAt, req.GetClassification(), user.UserID, nil)
+	res, err := s.core.IssueMachineToken(ctx, uint(req.GetProjectId()), uint(req.GetMachineId()), user.UserID, core.IssueMachineTokenParams{
+		Name:           req.GetName(),
+		ExpiresAt:      expiresAt,
+		Classification: req.GetClassification(),
+	})
 	if err != nil {
 		return nil, mapMachineError(err)
 	}

--- a/server/http/deployment_disclosure_family_test.go
+++ b/server/http/deployment_disclosure_family_test.go
@@ -127,7 +127,7 @@ func seedFamilyFixtures(t *testing.T, c *core.KeyorixCore) familyFixtures {
 	// flagged entry.
 	mi, err := c.CreateMachineIdentity(ctx, project.ID, "family-ci-runner", "ci", "", "", admin.ID)
 	require.NoError(t, err)
-	_, err = c.IssueMachineToken(ctx, project.ID, mi.ID, "family-ci-token", &pastExpiry, "", admin.ID, nil)
+	_, err = c.IssueMachineToken(ctx, project.ID, mi.ID, admin.ID, core.IssueMachineTokenParams{Name: "family-ci-token", ExpiresAt: &pastExpiry})
 	require.NoError(t, err)
 
 	// An SoD policy that the system_auditor role itself violates (system_auditor holds

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -232,7 +232,12 @@ func (h *CatalogHandler) IssueMachineToken(w http.ResponseWriter, r *http.Reques
 		t := time.Now().AddDate(0, 0, body.ExpiresInDays)
 		expiresAt = &t
 	}
-	result, err := h.coreService.IssueMachineToken(r.Context(), projectID, uint(machineID), body.Name, expiresAt, body.Classification, actor.UserID, body.AllowedCIDRs)
+	result, err := h.coreService.IssueMachineToken(r.Context(), projectID, uint(machineID), actor.UserID, core.IssueMachineTokenParams{
+		Name:           body.Name,
+		ExpiresAt:      expiresAt,
+		Classification: body.Classification,
+		AllowedCIDRs:   body.AllowedCIDRs,
+	})
 	if err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()

--- a/server/http/handlers/notification_channels.go
+++ b/server/http/handlers/notification_channels.go
@@ -76,7 +76,7 @@ func (h *NotificationChannelHandler) Create(w http.ResponseWriter, r *http.Reque
 		Events  string `json:"events"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		sendError(w, "BadRequest", errInvalidRequestBody, http.StatusBadRequest, nil)
 		return
 	}
 	ch := &models.NotificationChannel{
@@ -131,7 +131,7 @@ func (h *NotificationChannelHandler) Update(w http.ResponseWriter, r *http.Reque
 	}
 	var body map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		sendError(w, "BadRequest", errInvalidRequestBody, http.StatusBadRequest, nil)
 		return
 	}
 	updated, err := h.coreService.UpdateNotificationChannel(r.Context(), id, body)
@@ -187,7 +187,7 @@ func (h *NotificationChannelHandler) SetRetryPolicy(w http.ResponseWriter, r *ht
 		RetryBackoffMs int `json:"retry_backoff_ms"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		sendError(w, "BadRequest", "Invalid request body", http.StatusBadRequest, nil)
+		sendError(w, "BadRequest", errInvalidRequestBody, http.StatusBadRequest, nil)
 		return
 	}
 	cfg := core.NotificationRetryConfig{

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -33,6 +33,7 @@ const (
 	pathIDSchedule = "/{id}/schedule"
 	pathInvitations              = "/invitations"
 	pathNotificationChannelsID    = "/notification-channels/{id}"
+	pathAlertEscalationPolicies   = "/alert-escalation-policies"
 	pathAlertEscalationPoliciesID = "/alert-escalation-policies/{id}"
 	pathLegalHold = "/legal-hold"
 	pathMetrics = "/metrics"
@@ -343,18 +344,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/notification-channels/{id}/retry-policy", notificationChannelHandler.GetRetryPolicy)
 
 		// Alert escalation policy management — admin-only (system.write).
-		r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/alert-escalation-policies", alertEscalationHandler.Create)
-		r.With(customMiddleware.RequirePermission(permSystemWrite)).Get("/alert-escalation-policies", alertEscalationHandler.List)
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Post(pathAlertEscalationPolicies, alertEscalationHandler.Create)
+		r.With(customMiddleware.RequirePermission(permSystemWrite)).Get(pathAlertEscalationPolicies, alertEscalationHandler.List)
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Get(pathAlertEscalationPoliciesID, alertEscalationHandler.Get)
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Put(pathAlertEscalationPoliciesID, alertEscalationHandler.Update)
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Delete(pathAlertEscalationPoliciesID, alertEscalationHandler.Delete)
-
-		// Alert escalation policy management — admin-only (system.write).
-		r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/alert-escalation-policies", alertEscalationHandler.Create)
-		r.With(customMiddleware.RequirePermission(permSystemWrite)).Get("/alert-escalation-policies", alertEscalationHandler.List)
-		r.With(customMiddleware.RequirePermission(permSystemWrite)).Get("/alert-escalation-policies/{id}", alertEscalationHandler.Get)
-		r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/alert-escalation-policies/{id}", alertEscalationHandler.Update)
-		r.With(customMiddleware.RequirePermission(permSystemWrite)).Delete("/alert-escalation-policies/{id}", alertEscalationHandler.Delete)
 
 		// Dashboard endpoints
 		// GetStats is the caller's OWN home dashboard (their secret/share counts,


### PR DESCRIPTION
## Summary

- **classification_gate.go**: extract `checkRestrictedPermissionGate`, `checkRestrictedApprovalGate`, `checkRestrictedMFAGate` helpers to bring `checkRestrictedSecretReadApproval` Cognitive Complexity from 20 → 15 (max allowed: 15)
- **machine_token.go**: introduce `IssueMachineTokenParams` struct, reduce `IssueMachineToken` from 8 parameters to 5; update all callers across core, gRPC service, HTTP handler, CLI, and tests
- **permission_baseline.go**: remove `context.Context` struct field from `permBaselineBuilder`, thread `ctx` through method signatures instead
- **router.go**: add `pathAlertEscalationPolicies` constant, eliminate duplicate route registration block (alert-escalation routes were registered twice)
- **notification_channels.go**: replace 3 inline `"Invalid request body"` string literals with the existing `errInvalidRequestBody` package constant

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/core/... ./server/...` passes
- [ ] SonarCloud gate clears on the PR scan

🤖 Generated with [Claude Code](https://claude.ai/claude-code)