### PR TITLE
feat: RBAC scope flags, per-secret ACLs, scoped-list UX, rotation policies + test coverage

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -58,6 +58,14 @@ jobs:
           fail=0
           for sha in $(git rev-list --no-merges "$base..$head"); do
             author_email="$(git log -1 --format=%ae "$sha")"
+            # Skip commits authored by bots (e.g. dependabot, renovate) — they
+            # have no mechanism to add a Signed-off-by trailer themselves.
+            case "$author_email" in
+              *'[bot]@users.noreply.github.com')
+                echo "Skipping bot-authored commit $sha ($author_email)."
+                continue
+                ;;
+            esac
             msg="$(git log -1 --format=%B "$sha")"
             found=0
             while IFS= read -r line; do

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -10,6 +10,31 @@ _(nothing claimed)_
 
 ## Done
 
+- **Scoped list UX** — ACL-only users (no project role) now see their
+  per-secret / per-folder ACL-granted secrets on both scoped
+  (`?project_id=X`) and unfiltered `GET /secrets` requests. Previously
+  the scoped path returned 403 and the unfiltered path returned an empty
+  list; both now call `ListSecretsWithSharingInfo` which already enforces
+  access through owned + ACL-granted filtering. PR #1151.
+- **RBAC Phase 3 — per-folder / per-secret ACLs** — `internal/core/secret_acl.go`:
+  `SecretACL` model + `GrantSecretACL` / `RevokeSecretACL` / `ListSecretACLs` /
+  `HasSecretACL`; folder-grant inheritance walks the ancestor chain
+  (`GetSecretAncestors`). Storage: `ListSecretACLsByUser` inverse query. Listing
+  integration in `getACLGrantedSecretsWithSharingInfo` with BFS folder expansion.
+  HTTP handlers in `secret_acl_handler.go`. ADR-066.
+- **RBAC Phase 3 — project-scoped Group membership** — `UserGroup.ProjectID`
+  scopes memberships to a project (`0` = global). `RemoveUserFromGroup` and
+  `applyGroupMembershipChanges` carry the scope; authz inheritance already
+  resolves correctly.
+- **CLI scope flags** — `--project` / `--environment` on `keyorix rbac assign-role`
+  and `remove-role`; `--environment` requires `--project`. Group role commands
+  carry the same flags.
+- **Rotation policy execution** — background sweep (`rotation_reminders.go`)
+  calls `EvaluateRotationPolicies` on a schedule wired in `server/main.go:1016`;
+  `RunAutoRotation` executes wave-ordered auto-rotate jobs.
+- **gRPC services** — all 13 services in `server/grpc/services/` are fully
+  implemented; `UnimplementedXxxServer` embedding is the Go forward-compat
+  pattern, not a stub.
 - **RBAC PK rebuild migration** — `migrateDatabase` now detects when
   `user_roles`/`group_roles` carry the old `(user_id, role_id)` or
   `(user_id, role_id, project_id)` primary key (from GORM-created pre-Phase-2
@@ -32,26 +57,12 @@ _(nothing claimed)_
 ## Backlog
 
 ### RBAC follow-ups (from Phase 2)
-- **CLI scope flags** — add `--project` / `--environment` to the `keyorix rbac`
-  assign/remove commands. The HTTP API and remote storage client already carry
-  scope in the payload; only the CLI surface is missing.
 - **OpenAPI sync** — document the new optional `project_id` / `environment_id`
   fields on `POST /user-roles`, `PUT /users/{id}/roles`, and
   `POST /groups/{id}/roles`.
-- **Scoped list UX** — an unscoped `GET /secrets` by a non-global reader returns
-  403; consider instead returning the union of secrets across the scopes they can
-  read (requires a readable-scopes query + result filtering, with a log line when
-  results are truncated).
-
-### RBAC Phase 3 (proposed)
-- Per-folder / per-secret ACLs (Vault-path-style depth).
-- Scope `Group` membership itself to a project.
 
 ### Other
-- **Rotation policy execution** — `EvaluateRotationPolicies` is reachable only via
-  a GET endpoint; nothing runs it on a schedule, and the `Notification` model is
-  never written. Wire a background sweep that flags overdue secrets and emits
-  notifications.
-- **gRPC services** — `server/grpc/services/*` are `codes.Unimplemented` stubs;
-  implement against the core service if/when gRPC is on the roadmap.
 - **ADR-020** — project detail page (frontend, `keyorix-web`), still Proposed.
+- **FinOps / billing** — no `internal/billing/` or equivalent; no
+  chargeback / usage-by-team reporting. Required for enterprise multi-team
+  deployments.

--- a/internal/cli/rbac/rbac_scope_cov_test.go
+++ b/internal/cli/rbac/rbac_scope_cov_test.go
@@ -1,0 +1,1640 @@
+// rbac_scope_cov_test.go — coverage tests for RBAC CLI scope flags and
+// embedded-mode code paths that were not exercised by the existing test suite.
+//
+// Targets:
+//   - resolveScope: all branches (project only, project+env, errors)
+//   - runAssignRole embedded: success with and without scope
+//   - runRemoveRole embedded: success with and without scope
+//   - runAssignRoleToGroup embedded: success path
+//   - runRemoveRoleFromGroup embedded: success path
+//   - runListGroupRoles embedded: with-roles and empty branches
+//   - resolveRoleIDEmbedded: success and error
+//   - printGroupRoleTable: ExpiresAt branch
+//   - printRemoteGroupRoleTable: ExpiresAt branch
+//   - resolveProjectIDByName remote: GET error and not-found
+//   - resolveEnvironmentIDByName remote: GET error and not-found
+//   - runRemoveRoleRemote: project + env paths
+//   - runAssignRoleRemote: project + env paths
+
+package rbac
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── resolveScope ──────────────────────────────────────────────────────────────
+
+// TestResolveScope_ProjectOnly verifies project-only scope resolution.
+func TestResolveScope_ProjectOnly(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "scope-proj-only"})
+	require.NoError(t, err)
+
+	scope, err := resolveScope(ctx, st, "scope-proj-only", "")
+	require.NoError(t, err)
+	assert.Equal(t, proj.ID, scope.ProjectID)
+	assert.Equal(t, uint(0), scope.EnvironmentID)
+}
+
+// TestResolveScope_ProjectNotFound ensures LookupProjectIDByName failure is surfaced.
+func TestResolveScope_ProjectNotFound(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	_, err := resolveScope(ctx, st, "no-such-project", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve project")
+}
+
+// TestResolveScope_ProjectAndEnv verifies project+environment scope resolution.
+func TestResolveScope_ProjectAndEnv(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "scope-proj-env"})
+	require.NoError(t, err)
+	env, err := st.CreateEnvironment(ctx, &models.Environment{Name: "staging", ProjectID: proj.ID})
+	require.NoError(t, err)
+
+	scope, err := resolveScope(ctx, st, "scope-proj-env", "STAGING") // case-insensitive
+	require.NoError(t, err)
+	assert.Equal(t, proj.ID, scope.ProjectID)
+	assert.Equal(t, env.ID, scope.EnvironmentID)
+}
+
+// TestResolveScope_EnvNotFound verifies not-found error for missing environment.
+func TestResolveScope_EnvNotFound(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "scope-proj-noenv"})
+	require.NoError(t, err)
+	// Create a different env so the list is non-empty.
+	_, err = st.CreateEnvironment(ctx, &models.Environment{Name: "other-env", ProjectID: proj.ID})
+	require.NoError(t, err)
+
+	_, err = resolveScope(ctx, st, "scope-proj-noenv", "missing-env")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `environment "missing-env" not found`)
+}
+
+// TestResolveScope_Empty verifies the fast-return for an empty project flag.
+func TestResolveScope_Empty(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	scope, err := resolveScope(context.Background(), st, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, corestorage.Scope{}, scope)
+}
+
+// ── runAssignRole embedded ────────────────────────────────────────────────────
+
+// TestRunAssignRole_Embedded_GlobalScope verifies the embedded happy path for a
+// global (no project) role assignment.
+func TestRunAssignRole_Embedded_GlobalScope(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	_, err := st.CreateUser(ctx, &models.User{Username: "assign-global", Email: "assign-global@example.com"})
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, &models.Role{Name: "assign-global-role", Description: "test"})
+	require.NoError(t, err)
+
+	orig, origR, origP, origE := userEmail, roleName, assignProjectFlag, assignEnvFlag
+	defer func() { userEmail = orig; roleName = origR; assignProjectFlag = origP; assignEnvFlag = origE }()
+	userEmail = "assign-global@example.com"
+	roleName = "assign-global-role"
+	assignProjectFlag = ""
+	assignEnvFlag = ""
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, runAssignRole(nil, nil))
+}
+
+// TestRunAssignRole_Embedded_WithProject verifies scope propagation when --project
+// is set in embedded mode.
+func TestRunAssignRole_Embedded_WithProject(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	_, err := st.CreateUser(ctx, &models.User{Username: "assign-proj", Email: "assign-proj@example.com"})
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, &models.Role{Name: "assign-proj-role", Description: "test"})
+	require.NoError(t, err)
+	_, err = st.CreateProject(ctx, &models.Project{Name: "assign-proj-project"})
+	require.NoError(t, err)
+
+	orig, origR, origP, origE := userEmail, roleName, assignProjectFlag, assignEnvFlag
+	defer func() { userEmail = orig; roleName = origR; assignProjectFlag = origP; assignEnvFlag = origE }()
+	userEmail = "assign-proj@example.com"
+	roleName = "assign-proj-role"
+	assignProjectFlag = "assign-proj-project"
+	assignEnvFlag = ""
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, runAssignRole(nil, nil))
+}
+
+// TestRunAssignRole_Embedded_ScopeError verifies resolveScope error propagation.
+func TestRunAssignRole_Embedded_ScopeError(t *testing.T) {
+	initEmbeddedDB(t)
+
+	orig, origR, origP, origE := userEmail, roleName, assignProjectFlag, assignEnvFlag
+	defer func() { userEmail = orig; roleName = origR; assignProjectFlag = origP; assignEnvFlag = origE }()
+	userEmail = "nobody@example.com"
+	roleName = "anyrole"
+	assignProjectFlag = "no-such-project"
+	assignEnvFlag = ""
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := runAssignRole(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve project")
+}
+
+// ── runRemoveRole embedded ────────────────────────────────────────────────────
+
+// TestRunRemoveRole_Embedded_GlobalScope verifies the embedded happy path for
+// removing a global role assignment.
+func TestRunRemoveRole_Embedded_GlobalScope(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	user, err := st.CreateUser(ctx, &models.User{Username: "remove-global", Email: "remove-global@example.com"})
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, &models.Role{Name: "remove-global-role", Description: "test"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, user.ID, role.ID, corestorage.Scope{}))
+
+	origU, origR, origP, origE := removeUserEmail, removeRoleName, removeProjectFlag, removeEnvFlag
+	defer func() {
+		removeUserEmail = origU; removeRoleName = origR
+		removeProjectFlag = origP; removeEnvFlag = origE
+	}()
+	removeUserEmail = "remove-global@example.com"
+	removeRoleName = "remove-global-role"
+	removeProjectFlag = ""
+	removeEnvFlag = ""
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, runRemoveRole(nil, nil))
+}
+
+// TestRunRemoveRole_Embedded_WithProjectAndEnv verifies project+env scope for
+// the remove command.
+func TestRunRemoveRole_Embedded_WithProjectAndEnv(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	user, err := st.CreateUser(ctx, &models.User{Username: "remove-scoped", Email: "remove-scoped@example.com"})
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, &models.Role{Name: "remove-scoped-role", Description: "test"})
+	require.NoError(t, err)
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "remove-scoped-proj"})
+	require.NoError(t, err)
+	env, err := st.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: proj.ID})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, user.ID, role.ID, corestorage.Scope{ProjectID: proj.ID, EnvironmentID: env.ID}))
+
+	origU, origR, origP, origE := removeUserEmail, removeRoleName, removeProjectFlag, removeEnvFlag
+	defer func() {
+		removeUserEmail = origU; removeRoleName = origR
+		removeProjectFlag = origP; removeEnvFlag = origE
+	}()
+	removeUserEmail = "remove-scoped@example.com"
+	removeRoleName = "remove-scoped-role"
+	removeProjectFlag = "remove-scoped-proj"
+	removeEnvFlag = "prod"
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, runRemoveRole(nil, nil))
+}
+
+// TestRunRemoveRole_Embedded_ScopeError verifies resolveScope error propagation.
+func TestRunRemoveRole_Embedded_ScopeError(t *testing.T) {
+	initEmbeddedDB(t)
+
+	origU, origR, origP, origE := removeUserEmail, removeRoleName, removeProjectFlag, removeEnvFlag
+	defer func() {
+		removeUserEmail = origU; removeRoleName = origR
+		removeProjectFlag = origP; removeEnvFlag = origE
+	}()
+	removeUserEmail = "nobody@example.com"
+	removeRoleName = "anyrole"
+	removeProjectFlag = "nonexistent-project"
+	removeEnvFlag = ""
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := runRemoveRole(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve project")
+}
+
+// ── runAssignRoleToGroup embedded ─────────────────────────────────────────────
+
+// TestRunAssignRoleToGroup_Embedded_GlobalScope exercises the embedded happy path.
+func TestRunAssignRoleToGroup_Embedded_GlobalScope(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	_, err := st.CreateGroup(ctx, &models.Group{Name: "embed-group-assign", Description: ""})
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, &models.Role{Name: "embed-group-role-assign", Description: "test"})
+	require.NoError(t, err)
+
+	origG, origR, origP, origE, origT := groupRoleGroupFlag, groupRoleName, groupRoleProjectFlag, groupRoleEnvFlag, groupRoleTTL
+	defer func() {
+		groupRoleGroupFlag = origG; groupRoleName = origR
+		groupRoleProjectFlag = origP; groupRoleEnvFlag = origE; groupRoleTTL = origT
+	}()
+	groupRoleGroupFlag = "embed-group-assign"
+	groupRoleName = "embed-group-role-assign"
+	groupRoleProjectFlag = ""
+	groupRoleEnvFlag = ""
+	groupRoleTTL = 0
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, runAssignRoleToGroup(nil, nil))
+}
+
+// TestRunAssignRoleToGroup_Embedded_WithProject exercises project-scoped assign.
+func TestRunAssignRoleToGroup_Embedded_WithProject(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	_, err := st.CreateGroup(ctx, &models.Group{Name: "embed-group-proj", Description: ""})
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, &models.Role{Name: "embed-group-role-proj", Description: "test"})
+	require.NoError(t, err)
+	_, err = st.CreateProject(ctx, &models.Project{Name: "embed-group-project"})
+	require.NoError(t, err)
+
+	origG, origR, origP, origE, origT := groupRoleGroupFlag, groupRoleName, groupRoleProjectFlag, groupRoleEnvFlag, groupRoleTTL
+	defer func() {
+		groupRoleGroupFlag = origG; groupRoleName = origR
+		groupRoleProjectFlag = origP; groupRoleEnvFlag = origE; groupRoleTTL = origT
+	}()
+	groupRoleGroupFlag = "embed-group-proj"
+	groupRoleName = "embed-group-role-proj"
+	groupRoleProjectFlag = "embed-group-project"
+	groupRoleEnvFlag = ""
+	groupRoleTTL = 0
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, runAssignRoleToGroup(nil, nil))
+}
+
+// TestRunAssignRoleToGroup_Embedded_RoleNotFound verifies error when role name is invalid.
+func TestRunAssignRoleToGroup_Embedded_RoleNotFound(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	_, err := st.CreateGroup(ctx, &models.Group{Name: "embed-group-noRole", Description: ""})
+	require.NoError(t, err)
+
+	origG, origR, origP, origE, origT := groupRoleGroupFlag, groupRoleName, groupRoleProjectFlag, groupRoleEnvFlag, groupRoleTTL
+	defer func() {
+		groupRoleGroupFlag = origG; groupRoleName = origR
+		groupRoleProjectFlag = origP; groupRoleEnvFlag = origE; groupRoleTTL = origT
+	}()
+	groupRoleGroupFlag = "embed-group-noRole"
+	groupRoleName = "nonexistent-role"
+	groupRoleProjectFlag = ""
+	groupRoleEnvFlag = ""
+	groupRoleTTL = 0
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err = runAssignRoleToGroup(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve role")
+}
+
+// ── runRemoveRoleFromGroup embedded ──────────────────────────────────────────
+
+// TestRunRemoveRoleFromGroup_Embedded_Success exercises the embedded happy path.
+func TestRunRemoveRoleFromGroup_Embedded_Success(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	grp, err := st.CreateGroup(ctx, &models.Group{Name: "embed-grp-remove", Description: ""})
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, &models.Role{Name: "embed-grp-role-remove", Description: "test"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, grp.ID, role.ID, corestorage.Scope{}))
+
+	origG, origR, origP, origE := removeGroupRoleGroupFlag, removeGroupRoleName, removeGroupRoleProjectFlag, removeGroupRoleEnvFlag
+	defer func() {
+		removeGroupRoleGroupFlag = origG; removeGroupRoleName = origR
+		removeGroupRoleProjectFlag = origP; removeGroupRoleEnvFlag = origE
+	}()
+	removeGroupRoleGroupFlag = "embed-grp-remove"
+	removeGroupRoleName = "embed-grp-role-remove"
+	removeGroupRoleProjectFlag = ""
+	removeGroupRoleEnvFlag = ""
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, runRemoveRoleFromGroup(nil, nil))
+}
+
+// ── runListGroupRoles embedded ────────────────────────────────────────────────
+
+// TestRunListGroupRoles_Embedded_WithRoles exercises the table-print branch.
+func TestRunListGroupRoles_Embedded_WithRoles(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	grp, err := st.CreateGroup(ctx, &models.Group{Name: "embed-grp-list", Description: ""})
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, &models.Role{Name: "embed-grp-list-role", Description: "test"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, grp.ID, role.ID, corestorage.Scope{}))
+
+	origG := listGroupRoleGroupFlag
+	defer func() { listGroupRoleGroupFlag = origG }()
+	listGroupRoleGroupFlag = "embed-grp-list"
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, runListGroupRoles(nil, nil))
+}
+
+// TestRunListGroupRoles_Embedded_Empty exercises the "No roles assigned" branch.
+func TestRunListGroupRoles_Embedded_Empty(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	_, err := st.CreateGroup(ctx, &models.Group{Name: "embed-grp-empty", Description: ""})
+	require.NoError(t, err)
+
+	origG := listGroupRoleGroupFlag
+	defer func() { listGroupRoleGroupFlag = origG }()
+	listGroupRoleGroupFlag = "embed-grp-empty"
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, runListGroupRoles(nil, nil))
+}
+
+// ── resolveRoleIDEmbedded ─────────────────────────────────────────────────────
+
+// TestResolveRoleIDEmbedded_Success verifies a known role is resolved.
+func TestResolveRoleIDEmbedded_Success(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	role, err := st.CreateRole(ctx, &models.Role{Name: "embed-resolve-role", Description: "test"})
+	require.NoError(t, err)
+
+	id, err := resolveRoleIDEmbedded(ctx, st, "embed-resolve-role")
+	require.NoError(t, err)
+	assert.Equal(t, role.ID, id)
+}
+
+// TestResolveRoleIDEmbedded_Error verifies error when the role doesn't exist.
+func TestResolveRoleIDEmbedded_Error(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+
+	_, err := resolveRoleIDEmbedded(context.Background(), st, "no-such-role")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve role")
+}
+
+// ── printGroupRoleTable ExpiresAt branch ──────────────────────────────────────
+
+// TestPrintGroupRoleTable_WithExpiry ensures the non-"never" branch of ExpiresAt
+// prints a formatted timestamp.
+func TestPrintGroupRoleTable_WithExpiry(t *testing.T) {
+	orig := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	exp := time.Date(2030, 1, 15, 12, 0, 0, 0, time.UTC)
+	grants := []*corestorage.GroupRoleGrant{
+		{ID: 1, Name: "editor", Description: "Edit access", ExpiresAt: &exp},
+	}
+	printGroupRoleTable(grants)
+
+	_ = w.Close()
+	os.Stdout = orig
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	out := buf.String()
+	assert.Contains(t, out, "editor")
+	assert.Contains(t, out, "2030-01-15")
+}
+
+// TestPrintRemoteGroupRoleTable_WithExpiry ensures the non-"never" branch for
+// the remote variant also prints a formatted timestamp.
+func TestPrintRemoteGroupRoleTable_WithExpiry(t *testing.T) {
+	orig := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	exp := time.Date(2030, 6, 1, 9, 30, 0, 0, time.UTC)
+	roles := []remoteGroupRole{
+		{ID: 1, Name: "reader", Description: "Read-only", ExpiresAt: &exp},
+	}
+	printRemoteGroupRoleTable(roles)
+
+	_ = w.Close()
+	os.Stdout = orig
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	out := buf.String()
+	assert.Contains(t, out, "reader")
+	assert.Contains(t, out, "2030-06-01")
+}
+
+// ── resolveProjectIDByName remote error paths ─────────────────────────────────
+
+// TestResolveProjectIDByName_GETError verifies rc.Get error propagation.
+func TestResolveProjectIDByName_GETError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	_, err := resolveProjectIDByName(context.Background(), rc, "any")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list projects")
+}
+
+// TestResolveProjectIDByName_NotFound verifies not-found error when project is absent.
+func TestResolveProjectIDByName_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"other-proj"}]}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	_, err := resolveProjectIDByName(context.Background(), rc, "missing-project")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"missing-project" not found`)
+}
+
+// ── resolveEnvironmentIDByName remote error paths ─────────────────────────────
+
+// TestResolveEnvironmentIDByName_GETError verifies rc.Get error propagation.
+func TestResolveEnvironmentIDByName_GETError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"down"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	_, err := resolveEnvironmentIDByName(context.Background(), rc, "any")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list environments")
+}
+
+// TestResolveEnvironmentIDByName_NotFound verifies not-found error.
+func TestResolveEnvironmentIDByName_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"staging"}]}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	_, err := resolveEnvironmentIDByName(context.Background(), rc, "production")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"production" not found`)
+}
+
+// ── runRemoveRoleRemote project+env path ──────────────────────────────────────
+
+// TestRunRemoveRoleRemote_WithProjectAndEnv verifies project+env query params.
+func TestRunRemoveRoleRemote_WithProjectAndEnv(t *testing.T) {
+	var requestURI string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":1,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":3,"name":"myproject"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":7,"name":"production"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/user-roles", func(w http.ResponseWriter, r *http.Request) {
+		requestURI = r.URL.RequestURI()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runRemoveRoleRemote(context.Background(), rc, "alice@test.com", "admin", "myproject", "production")
+	require.NoError(t, err)
+	_ = requestURI // just verify no error; URL encoding varies by DeleteWithBody
+}
+
+// TestRunRemoveRoleRemote_ProjectError verifies project-resolution error in remote remove.
+func TestRunRemoveRoleRemote_ProjectError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":1,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runRemoveRoleRemote(context.Background(), rc, "alice@test.com", "admin", "any-project", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list projects")
+}
+
+// ── runAssignRoleRemote project+env path ──────────────────────────────────────
+
+// TestRunAssignRoleRemote_EnvError verifies error propagation when environment
+// resolution fails during remote assign-role with --project + --environment.
+func TestRunAssignRoleRemote_EnvError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":1,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":3,"name":"myproject"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runAssignRoleRemote(context.Background(), rc, "alice@test.com", "admin", 0, "myproject", "production")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list environments")
+}
+
+// TestRunAssignRoleRemote_ProjectError verifies error from project resolution.
+func TestRunAssignRoleRemote_ProjectError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":1,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runAssignRoleRemote(context.Background(), rc, "alice@test.com", "admin", 0, "bad-project", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list projects")
+}
+
+// ── embedded InitializeStorage error path (no config file) ───────────────────
+
+// noConfigDir creates a fresh temp dir with NO keyorix.yaml and changes into it.
+// This causes InitializeStorage() → config.Load("") → SafeReadFile to fail.
+func noConfigDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+}
+
+// TestRunAssignRoleToGroup_InitStorageError verifies the InitializeStorage error
+// return in runAssignRoleToGroup (TTL=0, no env without project, no remote).
+func TestRunAssignRoleToGroup_InitStorageError(t *testing.T) {
+	noConfigDir(t)
+	origG, origR, origT := groupRoleGroupFlag, groupRoleName, groupRoleTTL
+	defer func() { groupRoleGroupFlag = origG; groupRoleName = origR; groupRoleTTL = origT }()
+	groupRoleGroupFlag = "any-group"
+	groupRoleName = "any-role"
+	groupRoleTTL = 0
+
+	err := runAssignRoleToGroup(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+// TestRunAssignRoleToGroup_GroupNotFound verifies the resolveGroupID error return.
+func TestRunAssignRoleToGroup_GroupNotFound(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	// Seed a role so resolveRoleIDEmbedded would succeed if we got that far.
+	_, err := st.CreateRole(ctx, &models.Role{Name: "g-grp-nf-role", Description: "test"})
+	require.NoError(t, err)
+
+	origG, origR, origP, origE, origT := groupRoleGroupFlag, groupRoleName, groupRoleProjectFlag, groupRoleEnvFlag, groupRoleTTL
+	defer func() {
+		groupRoleGroupFlag = origG; groupRoleName = origR
+		groupRoleProjectFlag = origP; groupRoleEnvFlag = origE; groupRoleTTL = origT
+	}()
+	groupRoleGroupFlag = "no-such-group-xyz"
+	groupRoleName = "g-grp-nf-role"
+	groupRoleProjectFlag = ""
+	groupRoleEnvFlag = ""
+	groupRoleTTL = 0
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err = runAssignRoleToGroup(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestRunAssignRoleToGroup_ScopeError verifies the resolveScope error return when
+// the --project flag resolves to a non-existent project.
+func TestRunAssignRoleToGroup_ScopeError(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	_, err := st.CreateGroup(ctx, &models.Group{Name: "grp-scope-err", Description: ""})
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, &models.Role{Name: "grp-scope-err-role", Description: "test"})
+	require.NoError(t, err)
+
+	origG, origR, origP, origE, origT := groupRoleGroupFlag, groupRoleName, groupRoleProjectFlag, groupRoleEnvFlag, groupRoleTTL
+	defer func() {
+		groupRoleGroupFlag = origG; groupRoleName = origR
+		groupRoleProjectFlag = origP; groupRoleEnvFlag = origE; groupRoleTTL = origT
+	}()
+	groupRoleGroupFlag = "grp-scope-err"
+	groupRoleName = "grp-scope-err-role"
+	groupRoleProjectFlag = "no-such-project-xyz"
+	groupRoleEnvFlag = ""
+	groupRoleTTL = 0
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err = runAssignRoleToGroup(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve project")
+}
+
+// ── runRemoveRoleFromGroup embedded error paths ────────────────────────────────
+
+// TestRunRemoveRoleFromGroup_InitStorageError verifies the InitializeStorage error.
+func TestRunRemoveRoleFromGroup_InitStorageError(t *testing.T) {
+	noConfigDir(t)
+	origG, origR := removeGroupRoleGroupFlag, removeGroupRoleName
+	defer func() { removeGroupRoleGroupFlag = origG; removeGroupRoleName = origR }()
+	removeGroupRoleGroupFlag = "any-group"
+	removeGroupRoleName = "any-role"
+
+	err := runRemoveRoleFromGroup(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+// TestRunRemoveRoleFromGroup_GroupNotFound verifies the resolveGroupID error return.
+func TestRunRemoveRoleFromGroup_GroupNotFound(t *testing.T) {
+	initEmbeddedDB(t)
+
+	origG, origR, origP, origE := removeGroupRoleGroupFlag, removeGroupRoleName, removeGroupRoleProjectFlag, removeGroupRoleEnvFlag
+	defer func() {
+		removeGroupRoleGroupFlag = origG; removeGroupRoleName = origR
+		removeGroupRoleProjectFlag = origP; removeGroupRoleEnvFlag = origE
+	}()
+	removeGroupRoleGroupFlag = "no-such-group-abc"
+	removeGroupRoleName = "any-role"
+	removeGroupRoleProjectFlag = ""
+	removeGroupRoleEnvFlag = ""
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := runRemoveRoleFromGroup(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestRunRemoveRoleFromGroup_RoleNotFound verifies the resolveRoleIDEmbedded error.
+func TestRunRemoveRoleFromGroup_RoleNotFound(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	_, err := st.CreateGroup(ctx, &models.Group{Name: "rrfg-role-nf", Description: ""})
+	require.NoError(t, err)
+
+	origG, origR, origP, origE := removeGroupRoleGroupFlag, removeGroupRoleName, removeGroupRoleProjectFlag, removeGroupRoleEnvFlag
+	defer func() {
+		removeGroupRoleGroupFlag = origG; removeGroupRoleName = origR
+		removeGroupRoleProjectFlag = origP; removeGroupRoleEnvFlag = origE
+	}()
+	removeGroupRoleGroupFlag = "rrfg-role-nf"
+	removeGroupRoleName = "nonexistent-role-xyz"
+	removeGroupRoleProjectFlag = ""
+	removeGroupRoleEnvFlag = ""
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err = runRemoveRoleFromGroup(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve role")
+}
+
+// TestRunRemoveRoleFromGroup_ScopeError verifies the resolveScope error return.
+func TestRunRemoveRoleFromGroup_ScopeError(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	_, err := st.CreateGroup(ctx, &models.Group{Name: "rrfg-scope-err", Description: ""})
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, &models.Role{Name: "rrfg-scope-role", Description: "test"})
+	require.NoError(t, err)
+
+	origG, origR, origP, origE := removeGroupRoleGroupFlag, removeGroupRoleName, removeGroupRoleProjectFlag, removeGroupRoleEnvFlag
+	defer func() {
+		removeGroupRoleGroupFlag = origG; removeGroupRoleName = origR
+		removeGroupRoleProjectFlag = origP; removeGroupRoleEnvFlag = origE
+	}()
+	removeGroupRoleGroupFlag = "rrfg-scope-err"
+	removeGroupRoleName = "rrfg-scope-role"
+	removeGroupRoleProjectFlag = "bad-project-xyz"
+	removeGroupRoleEnvFlag = ""
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err = runRemoveRoleFromGroup(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve project")
+}
+
+// ── runListGroupRoles embedded error paths ─────────────────────────────────────
+
+// TestRunListGroupRoles_InitStorageError verifies the InitializeStorage error.
+func TestRunListGroupRoles_InitStorageError(t *testing.T) {
+	noConfigDir(t)
+	origG := listGroupRoleGroupFlag
+	defer func() { listGroupRoleGroupFlag = origG }()
+	listGroupRoleGroupFlag = "any-group"
+
+	err := runListGroupRoles(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+// TestRunListGroupRoles_GroupNotFound verifies the resolveGroupID error.
+func TestRunListGroupRoles_GroupNotFound(t *testing.T) {
+	initEmbeddedDB(t)
+
+	origG := listGroupRoleGroupFlag
+	defer func() { listGroupRoleGroupFlag = origG }()
+	listGroupRoleGroupFlag = "no-such-group-list"
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := runListGroupRoles(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// ── runAssignRole / runRemoveRole embedded error paths ────────────────────────
+
+// TestRunAssignRole_AssignError verifies the AssignUserRoleScoped error return.
+func TestRunAssignRole_AssignError(t *testing.T) {
+	initEmbeddedDB(t)
+	// No user/role seeded — AssignUserRoleScoped will fail because the user doesn't exist.
+	orig, origR, origP, origE := userEmail, roleName, assignProjectFlag, assignEnvFlag
+	defer func() { userEmail = orig; roleName = origR; assignProjectFlag = origP; assignEnvFlag = origE }()
+	userEmail = "nonexistent-user@example.com"
+	roleName = "nonexistent-role"
+	assignProjectFlag = ""
+	assignEnvFlag = ""
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := runAssignRole(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to assign role")
+}
+
+// TestRunRemoveRole_RemoveError verifies the RemoveUserRoleScoped error return.
+func TestRunRemoveRole_RemoveError(t *testing.T) {
+	initEmbeddedDB(t)
+	// No role assignment exists — RemoveUserRoleScoped will fail.
+	origU, origR, origP, origE := removeUserEmail, removeRoleName, removeProjectFlag, removeEnvFlag
+	defer func() {
+		removeUserEmail = origU; removeRoleName = origR
+		removeProjectFlag = origP; removeEnvFlag = origE
+	}()
+	removeUserEmail = "nobody-remove@example.com"
+	removeRoleName = "nonexistent-remove-role"
+	removeProjectFlag = ""
+	removeEnvFlag = ""
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := runRemoveRole(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to remove role")
+}
+
+// ── remote error paths for group commands ─────────────────────────────────────
+
+// TestResolveGroupIDRemote_NotFound verifies not-found error from group lookup.
+func TestResolveGroupIDRemote_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":1,"name":"other-group","description":""}],"total":1}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	_, _, err := resolveGroupIDRemote(context.Background(), rc, "no-such-group")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestRunAssignRoleToGroupRemote_EnvError verifies env resolution error.
+func TestRunAssignRoleToGroupRemote_EnvError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":2,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"production"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runAssignRoleToGroupRemote(context.Background(), rc, "ops-team", "admin", 0, "production", "bad-env")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list environments")
+}
+
+// TestRunRemoveRoleFromGroupRemote_GroupError verifies group resolution error.
+func TestRunRemoveRoleFromGroupRemote_GroupError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runRemoveRoleFromGroupRemote(context.Background(), rc, "ops-team", "admin", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list groups")
+}
+
+// TestRunRemoveRoleFromGroupRemote_RoleError verifies role resolution error.
+func TestRunRemoveRoleFromGroupRemote_RoleError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runRemoveRoleFromGroupRemote(context.Background(), rc, "ops-team", "admin", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list roles")
+}
+
+// TestRunRemoveRoleFromGroupRemote_ProjectError verifies project resolution error.
+func TestRunRemoveRoleFromGroupRemote_ProjectError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":2,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runRemoveRoleFromGroupRemote(context.Background(), rc, "ops-team", "admin", "bad-project", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list projects")
+}
+
+// TestRunRemoveRoleFromGroupRemote_EnvError verifies env resolution error.
+func TestRunRemoveRoleFromGroupRemote_EnvError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":2,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"production"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runRemoveRoleFromGroupRemote(context.Background(), rc, "ops-team", "admin", "production", "bad-env")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list environments")
+}
+
+// TestRunListGroupRolesRemote_GroupError verifies group resolution error.
+func TestRunListGroupRolesRemote_GroupError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runListGroupRolesRemote(context.Background(), rc, "bad-group")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list groups")
+}
+
+// ── remaining remote error paths ──────────────────────────────────────────────
+
+// TestResolveRoleIDByName_FetchError verifies fetchRoles error propagation.
+func TestResolveRoleIDByName_FetchError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	_, err := resolveRoleIDByName(context.Background(), rc, "any-role")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list roles")
+}
+
+// TestRunRemoveRoleRemote_EnvError verifies env resolution error in remove.
+func TestRunRemoveRoleRemote_EnvError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":1,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":3,"name":"myproject"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runRemoveRoleRemote(context.Background(), rc, "alice@test.com", "admin", "myproject", "bad-env")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list environments")
+}
+
+// TestRunListUserRolesRemote_FetchError verifies fetchUserRoles error propagation.
+func TestRunListUserRolesRemote_FetchError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/users/5/roles", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runListUserRolesRemote(context.Background(), rc, "alice@test.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get user roles")
+}
+
+// TestRunListPermissionsRemote_PermsError verifies userEffectivePermissions error.
+func TestRunListPermissionsRemote_PermsError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/users/5/roles", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runListPermissionsRemote(context.Background(), rc, "alice@test.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get user roles")
+}
+
+// TestRunCheckPermissionRemote_PermsError verifies userEffectivePermissions error.
+func TestRunCheckPermissionRemote_PermsError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/users/5/roles", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runCheckPermissionRemote(context.Background(), rc, "alice@test.com", "secrets.read")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get user roles")
+}
+
+// ── missing top-level function dispatch paths ─────────────────────────────────
+
+// groupRemoteServer builds a minimal httptest server sufficient for the group
+// commands to succeed: group lookup, role lookup, and the mutating endpoint.
+func groupRemoteServer(t *testing.T, assignPath, assignResp string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":2,"name":"member","description":"Member"}]}}`))
+	})
+	if assignPath != "" {
+		mux.HandleFunc(assignPath, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost || r.Method == http.MethodDelete || r.Method == http.MethodGet {
+				if r.Method == http.MethodPost {
+					w.WriteHeader(http.StatusCreated)
+				} else if r.Method == http.MethodDelete {
+					w.WriteHeader(http.StatusNoContent)
+				}
+				_, _ = w.Write([]byte(assignResp))
+			}
+		})
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestRunAssignRoleToGroup_NegativeTTL verifies the --ttl < 0 guard.
+func TestRunAssignRoleToGroup_NegativeTTL(t *testing.T) {
+	origT := groupRoleTTL
+	defer func() { groupRoleTTL = origT }()
+	groupRoleTTL = -1 * time.Second
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := runAssignRoleToGroup(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--ttl must be positive")
+}
+
+// TestRunAssignRoleToGroup_RemoteDispatch exercises the remote-client dispatch line
+// inside runAssignRoleToGroup (line 75: return runAssignRoleToGroupRemote(...)).
+func TestRunAssignRoleToGroup_RemoteDispatch(t *testing.T) {
+	srv := groupRemoteServer(t, "/api/v1/groups/7/roles",
+		`{"data":{"group_id":7,"role_id":2}}`)
+	origG, origR, origP, origE, origT := groupRoleGroupFlag, groupRoleName, groupRoleProjectFlag, groupRoleEnvFlag, groupRoleTTL
+	defer func() {
+		groupRoleGroupFlag = origG; groupRoleName = origR
+		groupRoleProjectFlag = origP; groupRoleEnvFlag = origE; groupRoleTTL = origT
+	}()
+	groupRoleGroupFlag = "ops-team"
+	groupRoleName = "member"
+	groupRoleProjectFlag = ""
+	groupRoleEnvFlag = ""
+	groupRoleTTL = 0
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	err := runAssignRoleToGroup(nil, nil)
+	require.NoError(t, err)
+}
+
+// TestRunRemoveRoleFromGroup_RemoteDispatch exercises the remote-client dispatch line
+// inside runRemoveRoleFromGroup.
+func TestRunRemoveRoleFromGroup_RemoteDispatch(t *testing.T) {
+	srv := groupRemoteServer(t, "/api/v1/groups/7/roles/2", "")
+	origG, origR, origP, origE := removeGroupRoleGroupFlag, removeGroupRoleName, removeGroupRoleProjectFlag, removeGroupRoleEnvFlag
+	defer func() {
+		removeGroupRoleGroupFlag = origG; removeGroupRoleName = origR
+		removeGroupRoleProjectFlag = origP; removeGroupRoleEnvFlag = origE
+	}()
+	removeGroupRoleGroupFlag = "ops-team"
+	removeGroupRoleName = "member"
+	removeGroupRoleProjectFlag = ""
+	removeGroupRoleEnvFlag = ""
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	err := runRemoveRoleFromGroup(nil, nil)
+	require.NoError(t, err)
+}
+
+// TestRunListGroupRoles_RemoteDispatch exercises the remote-client dispatch line
+// inside runListGroupRoles.
+func TestRunListGroupRoles_RemoteDispatch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/groups/7/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"group_id":7,"roles":[]}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	origG := listGroupRoleGroupFlag
+	defer func() { listGroupRoleGroupFlag = origG }()
+	listGroupRoleGroupFlag = "ops-team"
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	err := runListGroupRoles(nil, nil)
+	require.NoError(t, err)
+}
+
+// ── assign-role / remove-role top-level error paths ───────────────────────────
+
+// TestRunAssignRole_EnvWithoutProject verifies the guard in embedded mode when
+// --environment is set without --project.
+func TestRunAssignRole_EnvWithoutProject(t *testing.T) {
+	origP, origE := assignProjectFlag, assignEnvFlag
+	defer func() { assignProjectFlag = origP; assignEnvFlag = origE }()
+	assignProjectFlag = ""
+	assignEnvFlag = "production"
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := runAssignRole(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--environment requires --project")
+}
+
+// TestRunAssignRole_InitStorageError verifies the InitializeStorage error path.
+func TestRunAssignRole_InitStorageError(t *testing.T) {
+	noConfigDir(t)
+	orig, origR, origP, origE, origT := userEmail, roleName, assignProjectFlag, assignEnvFlag, roleTTL
+	defer func() {
+		userEmail = orig; roleName = origR; assignProjectFlag = origP
+		assignEnvFlag = origE; roleTTL = origT
+	}()
+	userEmail = "any@example.com"
+	roleName = "any"
+	assignProjectFlag = ""
+	assignEnvFlag = ""
+	roleTTL = 0
+
+	err := runAssignRole(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+// TestRunRemoveRole_EnvWithoutProject verifies the guard when --environment is
+// set without --project in embedded mode.
+func TestRunRemoveRole_EnvWithoutProject(t *testing.T) {
+	origP, origE := removeProjectFlag, removeEnvFlag
+	defer func() { removeProjectFlag = origP; removeEnvFlag = origE }()
+	removeProjectFlag = ""
+	removeEnvFlag = "production"
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := runRemoveRole(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--environment requires --project")
+}
+
+// TestRunRemoveRole_InitStorageError verifies the InitializeStorage error path.
+func TestRunRemoveRole_InitStorageError(t *testing.T) {
+	noConfigDir(t)
+	origU, origR, origP, origE := removeUserEmail, removeRoleName, removeProjectFlag, removeEnvFlag
+	defer func() {
+		removeUserEmail = origU; removeRoleName = origR
+		removeProjectFlag = origP; removeEnvFlag = origE
+	}()
+	removeUserEmail = "any@example.com"
+	removeRoleName = "any"
+	removeProjectFlag = ""
+	removeEnvFlag = ""
+
+	err := runRemoveRole(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+// ── runAssignRoleRemote user/role fetch error paths ───────────────────────────
+
+// TestRunAssignRoleRemote_UserFetchError verifies user resolution error in remote assign.
+func TestRunAssignRoleRemote_UserFetchError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runAssignRoleRemote(context.Background(), rc, "alice@test.com", "admin", 0, "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list users")
+}
+
+// TestRunAssignRoleRemote_RoleFetchError verifies role resolution error in remote assign.
+func TestRunAssignRoleRemote_RoleFetchError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"users":[{"id":5,"email":"alice@test.com"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runAssignRoleRemote(context.Background(), rc, "alice@test.com", "admin", 0, "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list roles")
+}
+
+// ── runAssignRoleToGroupRemote group/role error paths ─────────��───────────────
+
+// TestRunAssignRoleToGroupRemote_GroupError verifies group resolution error.
+func TestRunAssignRoleToGroupRemote_GroupError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runAssignRoleToGroupRemote(context.Background(), rc, "ops-team", "admin", 0, "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list groups")
+}
+
+// TestRunAssignRoleToGroupRemote_RoleError verifies role resolution error.
+func TestRunAssignRoleToGroupRemote_RoleError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runAssignRoleToGroupRemote(context.Background(), rc, "ops-team", "admin", 0, "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list roles")
+}
+
+// TestRunAssignRoleToGroupRemote_TTLSuffix exercises the time-bound print branch.
+func TestRunAssignRoleToGroupRemote_TTLSuffix(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":2,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/groups/7/roles", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"group_id":7,"role_id":2}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	// TTL > 0 exercises the "time-bound" print branch (line 280-281).
+	err := runAssignRoleToGroupRemote(context.Background(), rc, "ops-team", "admin", 2*time.Hour, "", "")
+	require.NoError(t, err)
+}
+
+// TestRunRemoveRoleFromGroupRemote_WithEnv exercises the env query-param path.
+func TestRunRemoveRoleFromGroupRemote_WithEnv(t *testing.T) {
+	var requestURI string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":2,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"production"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":9,"name":"prod"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/groups/7/roles/2", func(w http.ResponseWriter, r *http.Request) {
+		requestURI = r.URL.RequestURI()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runRemoveRoleFromGroupRemote(context.Background(), rc, "ops-team", "admin", "production", "prod")
+	require.NoError(t, err)
+	assert.Contains(t, requestURI, "environment_id=9")
+}
+
+// TestRunListGroupRolesRemote_GetRolesError verifies GetGroupRoles error.
+func TestRunListGroupRolesRemote_GetRolesError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/groups/7/roles", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runListGroupRolesRemote(context.Background(), rc, "ops-team")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get group roles")
+}
+
+// ── runAssignRoleToGroupRemote remaining branches ─────────────────────────────
+
+// TestRunAssignRoleToGroupRemote_ProjectError verifies project resolution error.
+func TestRunAssignRoleToGroupRemote_ProjectError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":2,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runAssignRoleToGroupRemote(context.Background(), rc, "ops-team", "admin", 0, "bad-project", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list projects")
+}
+
+// TestRunAssignRoleToGroupRemote_WithProjectAndEnv verifies project+env success path.
+func TestRunAssignRoleToGroupRemote_WithProjectAndEnv(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":2,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"production"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":9,"name":"prod"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/groups/7/roles", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"data":{"group_id":7,"role_id":2}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runAssignRoleToGroupRemote(context.Background(), rc, "ops-team", "admin", 0, "production", "prod")
+	require.NoError(t, err)
+}
+
+// TestRunAssignRoleToGroupRemote_PostError verifies the POST failure path.
+func TestRunAssignRoleToGroupRemote_PostError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":2,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/groups/7/roles", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runAssignRoleToGroupRemote(context.Background(), rc, "ops-team", "admin", 0, "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to assign role")
+}
+
+// ── runRemoveRoleFromGroupRemote Delete error ─────────────────────────────────
+
+// TestRunRemoveRoleFromGroupRemote_DeleteError verifies rc.Delete error propagation.
+func TestRunRemoveRoleFromGroupRemote_DeleteError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":2,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/groups/7/roles/2", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runRemoveRoleFromGroupRemote(context.Background(), rc, "ops-team", "admin", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to remove role")
+}
+
+// TestRunRemoveRoleFromGroupRemote_WithEnvSuccess exercises the env body param path.
+func TestRunRemoveRoleFromGroupRemote_WithEnvSuccess(t *testing.T) {
+	var requestURI string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"groups":[{"id":7,"name":"ops-team","description":""}],"total":1}}`))
+	})
+	mux.HandleFunc("/api/v1/roles", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"roles":[{"id":2,"name":"admin","description":""}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"prod"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":9,"name":"staging"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/groups/7/roles/2", func(w http.ResponseWriter, r *http.Request) {
+		requestURI = r.URL.RequestURI()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	err := runRemoveRoleFromGroupRemote(context.Background(), rc, "ops-team", "admin", "prod", "staging")
+	require.NoError(t, err)
+	assert.Contains(t, requestURI, "environment_id=9")
+}
+
+// ── runCheckPermission embedded path ─────────────────────────────────────────
+
+// TestRunCheckPermission_Embedded_HasPermission exercises the "has permission" branch.
+func TestRunCheckPermission_Embedded_HasPermission(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	user, err := st.CreateUser(ctx, &models.User{Username: "chkperm-yes", Email: "chkperm-yes@example.com"})
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, &models.Role{Name: "chkperm-role", Description: "test"})
+	require.NoError(t, err)
+	perm, err := st.CreatePermission(ctx, &models.Permission{
+		Name: "chkperm.read", Resource: "chkperm", Action: "read", Description: "test",
+	})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, user.ID, role.ID, corestorage.Scope{}))
+	require.NoError(t, st.AssignPermissionToRole(ctx, role.ID, perm.ID))
+
+	origU, origP := checkUserEmail, checkPermissionName
+	defer func() { checkUserEmail = origU; checkPermissionName = origP }()
+	checkUserEmail = "chkperm-yes@example.com"
+	checkPermissionName = "chkperm.read"
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, runCheckPermission(nil, nil))
+}
+
+// TestRunCheckPermission_Embedded_NoPermission exercises the "no permission" branch.
+func TestRunCheckPermission_Embedded_NoPermission(t *testing.T) {
+	_, st := initEmbeddedDB(t)
+	ctx := context.Background()
+
+	_, err := st.CreateUser(ctx, &models.User{Username: "chkperm-no", Email: "chkperm-no@example.com"})
+	require.NoError(t, err)
+
+	origU, origP := checkUserEmail, checkPermissionName
+	defer func() { checkUserEmail = origU; checkPermissionName = origP }()
+	checkUserEmail = "chkperm-no@example.com"
+	checkPermissionName = "secrets.read"
+
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, runCheckPermission(nil, nil))
+}
+
+// TestRunCheckPermission_InitStorageError verifies the InitializeStorage error path.
+func TestRunCheckPermission_InitStorageError(t *testing.T) {
+	noConfigDir(t)
+	origU, origP := checkUserEmail, checkPermissionName
+	defer func() { checkUserEmail = origU; checkPermissionName = origP }()
+	checkUserEmail = "any@example.com"
+	checkPermissionName = "secrets.read"
+
+	err := runCheckPermission(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+// ── embedded InitStorage error for list-roles, list-user-roles, list-permissions ──
+
+// TestRunListRoles_InitStorageError verifies InitializeStorage error in runListRoles.
+func TestRunListRoles_InitStorageError(t *testing.T) {
+	noConfigDir(t)
+	err := runListRoles(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+// TestRunListUserRoles_InitStorageError verifies InitializeStorage error in runListUserRoles.
+func TestRunListUserRoles_InitStorageError(t *testing.T) {
+	noConfigDir(t)
+	origU := listUserEmail
+	defer func() { listUserEmail = origU }()
+	listUserEmail = "any@example.com"
+
+	err := runListUserRoles(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+// TestRunListPermissions_InitStorageError verifies InitializeStorage error.
+func TestRunListPermissions_InitStorageError(t *testing.T) {
+	noConfigDir(t)
+	origU := listPermissionsUserEmail
+	defer func() { listPermissionsUserEmail = origU }()
+	listPermissionsUserEmail = "any@example.com"
+
+	err := runListPermissions(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+

--- a/internal/core/authz_readable_scopes_test.go
+++ b/internal/core/authz_readable_scopes_test.go
@@ -1,0 +1,116 @@
+// authz_readable_scopes_test.go — unit tests for GetReadableScopes.
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// userRoleScopesStub overrides GetUserRoleScopes to return a fixed slice.
+type userRoleScopesStub struct {
+	corestorage.Storage
+	scopes []corestorage.Scope
+	err    error
+}
+
+func (s *userRoleScopesStub) GetUserRoleScopes(_ context.Context, _ uint) ([]corestorage.Scope, error) {
+	return s.scopes, s.err
+}
+
+// TestGetReadableScopes_StorageError verifies that a GetUserRoleScopes error is
+// propagated unchanged.
+func TestGetReadableScopes_StorageError(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newACLCore(t)
+	wantErr := errors.New("scopes db failure")
+	c2 := newACLCoreWithStorage(c, &userRoleScopesStub{Storage: c.storage, err: wantErr})
+	_, err := c2.GetReadableScopes(ctx, 1, "secrets.read")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// TestGetReadableScopes_GlobalScopeSkipped verifies that scopes with ProjectID==0
+// (global) are silently skipped; the result is empty even though a scope was
+// returned by storage.
+func TestGetReadableScopes_GlobalScopeSkipped(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newACLCore(t)
+	stub := &userRoleScopesStub{
+		Storage: c.storage,
+		scopes:  []corestorage.Scope{{ProjectID: 0, EnvironmentID: 0}},
+	}
+	c2 := newACLCoreWithStorage(c, stub)
+	scopes, err := c2.GetReadableScopes(ctx, 1, "secrets.read")
+	require.NoError(t, err)
+	assert.Empty(t, scopes)
+}
+
+// TestGetReadableScopes_AuthorizeError verifies that a scope where Authorize
+// returns an error is silently skipped (fail-closed).  The stub provides a
+// non-zero-project scope; the real storage (DB) is then closed so that the
+// Authorize call fails with a DB error, triggering the aerr != nil continue.
+func TestGetReadableScopes_AuthorizeError(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	stub := &userRoleScopesStub{
+		Storage: c.storage,
+		scopes:  []corestorage.Scope{{ProjectID: 1, EnvironmentID: 0}},
+	}
+	c2 := newACLCoreWithStorage(c, stub)
+
+	// Close the DB so that Authorize's storage calls (GetUserRoles, etc.) fail.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	scopes, err := c2.GetReadableScopes(ctx, 1, "secrets.read")
+	require.NoError(t, err) // GetReadableScopes itself doesn't propagate Authorize errors
+	assert.Empty(t, scopes)
+}
+
+// TestGetReadableScopes_AuthorizeFalse verifies that a scope where Authorize
+// returns (false, nil) is not included in the result.
+func TestGetReadableScopes_AuthorizeFalse(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newACLCore(t)
+	// User 99 has no role grants in the DB → Authorize returns (false, nil).
+	stub := &userRoleScopesStub{
+		Storage: c.storage,
+		scopes:  []corestorage.Scope{{ProjectID: 1, EnvironmentID: 0}},
+	}
+	c2 := newACLCoreWithStorage(c, stub)
+	scopes, err := c2.GetReadableScopes(ctx, 99, "secrets.read")
+	require.NoError(t, err)
+	assert.Empty(t, scopes)
+}
+
+// TestGetReadableScopes_AuthorizeTrue verifies that a scope where the user has
+// the required permission is included in the result.
+func TestGetReadableScopes_AuthorizeTrue(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+
+	// Seed a project-scoped secrets.read role for user 88.
+	role := &models.Role{Name: "readable_scope_role"}
+	require.NoError(t, db.Create(role).Error)
+	perm := &models.Permission{Name: "secrets.read", Resource: "secrets", Action: "read"}
+	require.NoError(t, db.Create(perm).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: role.ID, PermissionID: perm.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 88, RoleID: role.ID, ProjectID: 1}).Error)
+
+	stub := &userRoleScopesStub{
+		Storage: c.storage,
+		scopes:  []corestorage.Scope{{ProjectID: 1, EnvironmentID: 0}},
+	}
+	c2 := newACLCoreWithStorage(c, stub)
+	scopes, err := c2.GetReadableScopes(ctx, 88, "secrets.read")
+	require.NoError(t, err)
+	require.Len(t, scopes, 1)
+	assert.Equal(t, uint(1), scopes[0].ProjectID)
+}

--- a/internal/core/rotation_policies_cov_test.go
+++ b/internal/core/rotation_policies_cov_test.go
@@ -1,0 +1,233 @@
+// rotation_policies_cov_test.go — coverage top-up for rotation_policies.go error paths.
+//
+// Covers:
+//   - CreateRotationPolicy: scope=project with nil ProjectID; validateDescription error; storage error
+//   - GetRotationPolicy: storage not-found error
+//   - UpdateRotationPolicy: alert >= interval; validateDescription error; Get not-found; Update storage error
+//   - DeleteRotationPolicy: Get not-found; Delete storage error
+//   - EvaluateRotationPolicies: ListRotationPolicies error; inactive policy skip
+package core
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// --- storage stubs for rotation policy error paths ---
+
+type createRotPolicyErrStorage struct {
+	corestorage.Storage
+	err error
+}
+
+func (s *createRotPolicyErrStorage) CreateRotationPolicy(_ context.Context, _ *models.RotationPolicy) error {
+	return s.err
+}
+
+type updateRotPolicyErrStorage struct {
+	corestorage.Storage
+	err error
+}
+
+func (s *updateRotPolicyErrStorage) UpdateRotationPolicy(_ context.Context, _ *models.RotationPolicy) error {
+	return s.err
+}
+
+type deleteRotPolicyErrStorage struct {
+	corestorage.Storage
+	err error
+}
+
+func (s *deleteRotPolicyErrStorage) DeleteRotationPolicy(_ context.Context, _ uint) error {
+	return s.err
+}
+
+type listRotPoliciesErrStorage struct {
+	corestorage.Storage
+	err error
+}
+
+func (s *listRotPoliciesErrStorage) ListRotationPolicies(_ context.Context, _, _ *uint) ([]*models.RotationPolicy, error) {
+	return nil, s.err
+}
+
+// newRotPolicyCore returns a KeyorixCore backed by an in-memory SQLite with
+// the RotationPolicy + AuditEvent tables migrated.
+func newRotPolicyCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.RotationPolicy{}, &models.AuditEvent{}))
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	return c, db
+}
+
+// --- CreateRotationPolicy ---
+
+func TestCreateRotationPolicy_ProjectScopeNilID(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newRotPolicyCore(t)
+	_, err := c.CreateRotationPolicy(ctx, 1, &CreateRotationPolicyRequest{
+		Name: "p", Scope: "project", ProjectID: nil,
+		IntervalDays: 90, AlertDaysBefore: 7,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project_id is required")
+}
+
+func TestCreateRotationPolicy_ValidateDescriptionError(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newRotPolicyCore(t)
+	pid := uint(1)
+	_, err := c.CreateRotationPolicy(ctx, 1, &CreateRotationPolicyRequest{
+		Name:         "p",
+		Scope:        "project",
+		ProjectID:    &pid,
+		IntervalDays: 90, AlertDaysBefore: 7,
+		Description: strings.Repeat("x", maxSecretDescriptionLen+1),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "description exceeds")
+}
+
+func TestCreateRotationPolicy_StorageError(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newRotPolicyCore(t)
+	wantErr := errors.New("db write failed")
+	c2 := &KeyorixCore{storage: &createRotPolicyErrStorage{Storage: c.storage, err: wantErr}, now: c.now}
+	pid := uint(1)
+	_, err := c2.CreateRotationPolicy(ctx, 1, &CreateRotationPolicyRequest{
+		Name: "p", Scope: "project", ProjectID: &pid,
+		IntervalDays: 90, AlertDaysBefore: 7,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// --- GetRotationPolicy ---
+
+func TestGetRotationPolicy_NotFound(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newRotPolicyCore(t)
+	_, err := c.GetRotationPolicy(ctx, 99999)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get rotation policy")
+}
+
+// --- UpdateRotationPolicy ---
+
+func TestUpdateRotationPolicy_AlertGTInterval(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newRotPolicyCore(t)
+	_, err := c.UpdateRotationPolicy(ctx, 1, &UpdateRotationPolicyRequest{
+		ID: 1, Name: "p", IntervalDays: 10, AlertDaysBefore: 10, IsActive: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "alert_days_before must be less than interval_days")
+}
+
+func TestUpdateRotationPolicy_ValidateDescriptionError(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newRotPolicyCore(t)
+	_, err := c.UpdateRotationPolicy(ctx, 1, &UpdateRotationPolicyRequest{
+		ID: 1, Name: "p", IntervalDays: 90, AlertDaysBefore: 7, IsActive: true,
+		Description: strings.Repeat("z", maxSecretDescriptionLen+1),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "description exceeds")
+}
+
+func TestUpdateRotationPolicy_GetNotFound(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newRotPolicyCore(t)
+	_, err := c.UpdateRotationPolicy(ctx, 1, &UpdateRotationPolicyRequest{
+		ID: 99999, Name: "p", IntervalDays: 90, AlertDaysBefore: 7, IsActive: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get rotation policy")
+}
+
+func TestUpdateRotationPolicy_StorageError(t *testing.T) {
+	ctx := context.Background()
+	c, db := newRotPolicyCore(t)
+	pid := uint(1)
+	p, err := c.CreateRotationPolicy(ctx, 1, &CreateRotationPolicyRequest{
+		Name: "to-update", Scope: "project", ProjectID: &pid,
+		IntervalDays: 90, AlertDaysBefore: 7,
+	})
+	require.NoError(t, err)
+	wantErr := errors.New("update failed")
+	c2 := &KeyorixCore{storage: &updateRotPolicyErrStorage{Storage: store.NewLocalStorage(db), err: wantErr}, now: c.now}
+	_, err = c2.UpdateRotationPolicy(ctx, 1, &UpdateRotationPolicyRequest{
+		ID: p.ID, Name: "updated", IntervalDays: 60, AlertDaysBefore: 5, IsActive: true,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// --- DeleteRotationPolicy ---
+
+func TestDeleteRotationPolicy_GetNotFound(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newRotPolicyCore(t)
+	err := c.DeleteRotationPolicy(ctx, 1, 99999)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get rotation policy")
+}
+
+func TestDeleteRotationPolicy_StorageError(t *testing.T) {
+	ctx := context.Background()
+	c, db := newRotPolicyCore(t)
+	pid := uint(1)
+	p, err := c.CreateRotationPolicy(ctx, 1, &CreateRotationPolicyRequest{
+		Name: "to-delete", Scope: "project", ProjectID: &pid,
+		IntervalDays: 90, AlertDaysBefore: 7,
+	})
+	require.NoError(t, err)
+	wantErr := errors.New("delete failed")
+	c2 := &KeyorixCore{storage: &deleteRotPolicyErrStorage{Storage: store.NewLocalStorage(db), err: wantErr}, now: c.now}
+	err = c2.DeleteRotationPolicy(ctx, 1, p.ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// --- EvaluateRotationPolicies ---
+
+func TestEvaluateRotationPolicies_ListError(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newRotPolicyCore(t)
+	wantErr := errors.New("list failed")
+	c2 := &KeyorixCore{storage: &listRotPoliciesErrStorage{Storage: c.storage, err: wantErr}, now: c.now}
+	_, err := c2.EvaluateRotationPolicies(ctx, nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestEvaluateRotationPolicies_InactivePolicySkipped(t *testing.T) {
+	ctx := context.Background()
+	c, db := newRotPolicyCore(t)
+	// Create an inactive policy — EvaluateRotationPolicies must skip it.
+	pid := uint(1)
+	p, err := c.CreateRotationPolicy(ctx, 1, &CreateRotationPolicyRequest{
+		Name: "inactive-policy", Scope: "project", ProjectID: &pid,
+		IntervalDays: 90, AlertDaysBefore: 7,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Model(p).Update("is_active", false).Error)
+
+	evals, err := c.EvaluateRotationPolicies(ctx, nil, nil)
+	require.NoError(t, err)
+	assert.Empty(t, evals, "inactive policy should be skipped and produce no evaluations")
+}

--- a/internal/core/secret_acl_cov_test.go
+++ b/internal/core/secret_acl_cov_test.go
@@ -1,0 +1,269 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- storage stubs for error-path coverage ---
+
+type ancestorErrStorage struct {
+	corestorage.Storage
+	err error
+}
+
+func (s *ancestorErrStorage) GetSecretAncestors(ctx context.Context, nodeID uint) ([]uint, error) {
+	return nil, s.err
+}
+
+type getACLErrStorage struct {
+	corestorage.Storage
+	err error
+}
+
+func (s *getACLErrStorage) GetSecretACL(ctx context.Context, secretID, userID uint) (*models.SecretACL, error) {
+	return nil, s.err
+}
+
+type createACLErrStorage struct {
+	corestorage.Storage
+	err error
+}
+
+func (s *createACLErrStorage) CreateOrUpdateSecretACL(ctx context.Context, acl *models.SecretACL) error {
+	return s.err
+}
+
+type listACLErrStorage struct {
+	corestorage.Storage
+	err error
+}
+
+func (s *listACLErrStorage) ListSecretACLs(ctx context.Context, secretID uint) ([]*models.SecretACL, error) {
+	return nil, s.err
+}
+
+type deleteACLErrStorage struct {
+	corestorage.Storage
+	acls []*models.SecretACL
+	err  error
+}
+
+func (s *deleteACLErrStorage) ListSecretACLs(ctx context.Context, secretID uint) ([]*models.SecretACL, error) {
+	return s.acls, nil
+}
+
+func (s *deleteACLErrStorage) DeleteSecretACL(ctx context.Context, id uint) error {
+	return s.err
+}
+
+// ancestorLoopErrStorage returns the direct secretID with a not-found error
+// (so the direct ACL check passes through) then returns real ancestors so the
+// loop can be entered, and finally returns a non-not-found error from GetSecretACL
+// for any ancestorID, triggering the loop-error path (line 180–182).
+type ancestorLoopErrStorage struct {
+	corestorage.Storage
+	directID  uint
+	loopErr   error
+}
+
+func (s *ancestorLoopErrStorage) GetSecretAncestors(_ context.Context, _ uint) ([]uint, error) {
+	return []uint{9999}, nil
+}
+
+func (s *ancestorLoopErrStorage) GetSecretACL(_ context.Context, secretID, _ uint) (*models.SecretACL, error) {
+	if secretID == s.directID {
+		return nil, errors.New("record not found")
+	}
+	return nil, s.loopErr
+}
+
+// newACLCoreWithStorage builds a KeyorixCore using the given storage backend,
+// inheriting the clock from base.
+func newACLCoreWithStorage(base *KeyorixCore, st corestorage.Storage) *KeyorixCore {
+	return &KeyorixCore{storage: st, now: base.now}
+}
+
+// --- EncodeSecretACLPerms ---
+
+func TestEncodeSecretACLPerms_Empty(t *testing.T) {
+	_, err := EncodeSecretACLPerms([]string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one permission is required")
+}
+
+func TestEncodeSecretACLPerms_Nil(t *testing.T) {
+	_, err := EncodeSecretACLPerms(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one permission is required")
+}
+
+// --- DecodeSecretACLPerms ---
+
+func TestDecodeSecretACLPerms_EmptyString(t *testing.T) {
+	assert.Nil(t, DecodeSecretACLPerms(""))
+}
+
+func TestDecodeSecretACLPerms_BadJSON(t *testing.T) {
+	assert.Nil(t, DecodeSecretACLPerms("not-valid-json"))
+}
+
+// --- GrantSecretACL validation errors ---
+
+func TestGrantSecretACL_ZeroActorID(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "g-actor-zero")
+	err := c.GrantSecretACL(ctx, 0, sid, 1, []string{"secrets.read"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "actor ID is required")
+}
+
+func TestGrantSecretACL_ZeroSecretID(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newACLCore(t)
+	err := c.GrantSecretACL(ctx, 1, 0, 1, []string{"secrets.read"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret ID is required")
+}
+
+func TestGrantSecretACL_ZeroUserID(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "g-user-zero")
+	err := c.GrantSecretACL(ctx, 1, sid, 0, []string{"secrets.read"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user ID is required")
+}
+
+func TestGrantSecretACL_EmptyPermsSlice(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "g-empty-perms")
+	err := c.GrantSecretACL(ctx, 1, sid, 1, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one permission is required")
+}
+
+func TestGrantSecretACL_MissingSecret(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newACLCore(t)
+	// secretID 99999 does not exist → requireSecret returns error.
+	err := c.GrantSecretACL(ctx, 1, 99999, 1, []string{"secrets.read"})
+	require.Error(t, err)
+}
+
+func TestGrantSecretACL_CreateOrUpdateError(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "g-create-err")
+	wantErr := errors.New("write failed")
+	c2 := newACLCoreWithStorage(c, &createACLErrStorage{Storage: c.storage, err: wantErr})
+	err := c2.GrantSecretACL(ctx, 1, sid, 1, []string{"secrets.read"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// --- RevokeSecretACL ---
+
+func TestRevokeSecretACL_ZeroACLID(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "rv-zero-id")
+	err := c.RevokeSecretACL(ctx, 1, sid, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ACL ID is required")
+}
+
+func TestRevokeSecretACL_ListError(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "rv-list-err")
+	wantErr := errors.New("list failed")
+	c2 := newACLCoreWithStorage(c, &listACLErrStorage{Storage: c.storage, err: wantErr})
+	err := c2.RevokeSecretACL(ctx, 1, sid, 99)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestRevokeSecretACL_DeleteError(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "rv-delete-err")
+	wantErr := errors.New("delete failed")
+	fakeACL := &models.SecretACL{ID: 77, SecretID: sid, UserID: 5}
+	stub := &deleteACLErrStorage{Storage: c.storage, acls: []*models.SecretACL{fakeACL}, err: wantErr}
+	c2 := newACLCoreWithStorage(c, stub)
+	err := c2.RevokeSecretACL(ctx, 1, sid, 77)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// --- HasSecretACL ancestor paths ---
+
+func TestHasSecretACL_AncestorUnsupported(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "ha-unsupported")
+	// No ACL on sid → direct check returns false.
+	// GetSecretAncestors returns ErrUnsupportedByBackend → must return (false, nil).
+	c2 := newACLCoreWithStorage(c, &ancestorErrStorage{Storage: c.storage, err: corestorage.ErrUnsupportedByBackend})
+	got, err := c2.HasSecretACL(ctx, 99, sid, "secrets.read")
+	require.NoError(t, err)
+	assert.False(t, got)
+}
+
+func TestHasSecretACL_AncestorStorageError(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "ha-anc-err")
+	wantErr := errors.New("ancestors unavailable")
+	c2 := newACLCoreWithStorage(c, &ancestorErrStorage{Storage: c.storage, err: wantErr})
+	_, err := c2.HasSecretACL(ctx, 99, sid, "secrets.read")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestHasSecretACL_AncestorLoopACLError(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "ha-loop-err")
+	wantErr := errors.New("acl lookup failed in ancestor loop")
+	stub := &ancestorLoopErrStorage{Storage: c.storage, directID: sid, loopErr: wantErr}
+	c2 := newACLCoreWithStorage(c, stub)
+	_, err := c2.HasSecretACL(ctx, 99, sid, "secrets.read")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// --- aclGrantsPermission non-not-found error ---
+
+func TestAclGrantsPermission_NonNotFoundErr(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "ggp-non-notfound")
+	wantErr := errors.New("unexpected db failure")
+	c2 := newACLCoreWithStorage(c, &getACLErrStorage{Storage: c.storage, err: wantErr})
+	got, err := c2.aclGrantsPermission(ctx, sid, 99, "secrets.read")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.False(t, got)
+}
+
+// --- isNotFound ---
+
+func TestIsNotFound_Nil(t *testing.T) {
+	assert.False(t, isNotFound(nil))
+}
+
+func TestIsNotFound_Messages(t *testing.T) {
+	assert.True(t, isNotFound(errors.New("record not found")))
+	assert.True(t, isNotFound(errors.New("entry not found")))
+	assert.False(t, isNotFound(errors.New("some other error")))
+}

--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -634,6 +634,30 @@ paths:
         '403': {$ref: '#/components/responses/Error'}
         '404': {$ref: '#/components/responses/Error'}
 
+  /api/v1/projects/{id}/access-review/campaigns/{campaignId}/export.csv:
+    get:
+      tags: [Projects]
+      summary: Download campaign items as CSV (auditor evidence export)
+      description: >-
+        Returns every item of the campaign with its recertification decision as
+        a CSV attachment. Intended as the signed-off recertification record for
+        ISO 27001 A.5.18 archiving. No secret values are included. Gated by
+        roles.read at project scope.
+      operationId: exportAccessReviewCampaignCSV
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer, format: uint32}}
+        - {name: campaignId, in: path, required: true, schema: {type: integer, format: uint32}}
+      responses:
+        '200':
+          description: CSV file download (`text/csv`). Columns — id, item_type, subject, role/permission, decision, decided_by, decided_at, created_at.
+          content:
+            text/csv:
+              schema: {type: string, format: binary}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+        '404': {$ref: '#/components/responses/Error'}
+
   /api/v1/projects/{id}/access-review/campaigns/{campaignId}/items/{itemId}/decide:
     post:
       tags: [Projects]
@@ -1742,6 +1766,36 @@ paths:
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}
         '404': {$ref: '#/components/responses/Error'}
+
+  /api/v1/secrets/{id}/access-log/export:
+    get:
+      tags: [Secrets]
+      summary: Download secret access log as a file
+      description: >-
+        Returns the secret's full access history (secret.read audit events) as
+        a downloadable file. Supports JSON (default) and CSV formats via the
+        `format` query parameter. Gated by secrets.read at the secret's project
+        scope.
+      operationId: exportSecretAccessLog
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: integer}}
+        - name: format
+          in: query
+          schema: {type: string, enum: [json, csv], default: json}
+          description: "Output format. `json` returns a JSON array; `csv` returns a spreadsheet-friendly attachment."
+      responses:
+        '200':
+          description: File download. Content-Type is `application/json` or `text/csv` depending on `format`.
+          content:
+            application/json:
+              schema: {type: string, format: binary}
+            text/csv:
+              schema: {type: string, format: binary}
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '404': {$ref: '#/components/responses/Error'}
+
   /api/v1/shares:
     get:
       tags: [Shares]
@@ -2346,6 +2400,7 @@ paths:
                 role_id: {type: integer}
                 project_id: {type: integer, description: "Scope (0 = global)."}
                 environment_id: {type: integer, description: "Scope (0 = global)."}
+                expires_at: {type: string, format: date-time, nullable: true, description: "RFC3339; omit or null for a non-expiring grant. JIT access — the assignment is automatically revoked when the timestamp is reached."}
       responses:
         '201':
           description: "Envelope `data` is `{group_id, role_id}`."
@@ -2539,6 +2594,7 @@ paths:
                 role_id: {type: integer}
                 project_id: {type: integer, description: "Scope (0 = global)."}
                 environment_id: {type: integer, description: "Scope (0 = global)."}
+                expires_at: {type: string, format: date-time, nullable: true, description: "RFC3339; omit or null for a non-expiring grant. JIT access — the assignment is automatically revoked when the timestamp is reached."}
       responses:
         '201':
           description: "Envelope `data` is `{user_id, role_id}`."
@@ -2626,6 +2682,66 @@ paths:
         '400': {$ref: '#/components/responses/Error'}
         '401': {$ref: '#/components/responses/Error'}
         '403': {$ref: '#/components/responses/Error'}
+
+  /api/v1/audit/export.csv:
+    get:
+      tags: [Audit]
+      summary: Download audit events as CSV (compliance hand-off)
+      description: >-
+        Returns a bounded, human/auditor-friendly CSV attachment with a header
+        row. Distinct from the JSON /audit/export SIEM feed — this is a
+        single one-shot download capped at 10 000 rows. Gated by audit.read.
+      operationId: exportAuditLogsCSV
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: project_id, in: query, schema: {type: integer}, description: Filter by project ID.}
+        - {name: user_id, in: query, schema: {type: integer}, description: Filter by acting user ID.}
+        - {name: since, in: query, schema: {type: string, format: date-time}, description: RFC3339 lower bound on event time (inclusive).}
+        - {name: until, in: query, schema: {type: string, format: date-time}, description: RFC3339 upper bound on event time (inclusive).}
+        - {name: limit, in: query, schema: {type: integer, default: 1000, maximum: 10000}, description: Maximum rows to include.}
+      responses:
+        '200':
+          description: CSV file download (`text/csv`). Columns — id, event_type, actor, actor_type, description, ip_address, project_id, secret_id, success, timestamp.
+          content:
+            text/csv:
+              schema: {type: string, format: binary}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+
+  /api/v1/audit/search:
+    get:
+      tags: [Audit]
+      summary: Rich-filter audit search
+      description: >-
+        Exposes finer-grained search filters than GET /audit/logs: partial
+        actor username match, exact IP address, resource type/ID, success
+        flag, RFC3339 time range, and limit/offset pagination. Gated by
+        audit.read.
+      operationId: searchAuditLogs
+      security: [{bearerAuth: []}]
+      parameters:
+        - {name: actor, in: query, schema: {type: string}, description: Partial username match on the acting principal.}
+        - {name: user_id, in: query, schema: {type: integer}, description: Exact numeric user ID.}
+        - {name: project_id, in: query, schema: {type: integer}, description: Exact project ID.}
+        - {name: action, in: query, schema: {type: string}, description: "Exact event_type (e.g. secret.read)."}
+        - {name: resource_type, in: query, schema: {type: string}, description: "Resource kind prefix (e.g. secret)."}
+        - {name: resource_id, in: query, schema: {type: integer}, description: Exact secret_node_id.}
+        - {name: ip, in: query, schema: {type: string}, description: Exact originating IP address.}
+        - {name: success, in: query, schema: {type: string, enum: [true, false]}, description: Filter by operation success/failure.}
+        - {name: since, in: query, schema: {type: string, format: date-time}, description: RFC3339 start of time range (inclusive).}
+        - {name: until, in: query, schema: {type: string, format: date-time}, description: RFC3339 end of time range (inclusive).}
+        - {name: limit, in: query, schema: {type: integer, default: 100, maximum: 1000}, description: Maximum results.}
+        - {name: offset, in: query, schema: {type: integer, default: 0, minimum: 0}, description: Pagination offset.}
+      responses:
+        '200':
+          description: >-
+            Envelope {data, message}. data has events[] (each: id, event_type, actor,
+            actor_type, description, timestamp, ip_address, project_id, secret_id,
+            success) and total.
+        '400': {$ref: '#/components/responses/Error'}
+        '401': {$ref: '#/components/responses/Error'}
+        '403': {$ref: '#/components/responses/Error'}
+
   /api/v1/audit/rbac-logs:
     get:
       tags: [Audit]

--- a/server/http/handlers/secrets_list.go
+++ b/server/http/handlers/secrets_list.go
@@ -25,13 +25,18 @@ import (
 // a blanket 403.
 //
 // Decision tree:
-//  1. If a specific project_id or environment_id filter is in the query the
-//     caller must hold secrets.read at that scope; deny 403 otherwise.
+//  1. If a specific project_id or environment_id filter is in the query, call
+//     ListSecretsWithSharingInfo directly — it returns owned + ACL-granted
+//     secrets within the requested scope. Users with no project role but
+//     per-secret ACL grants see exactly their granted secrets; users with
+//     neither see an empty list. No 403 is returned for scoped queries.
 //  2. If no scope filter is given, check for a global (Scope{}) grant first.
 //     Global readers proceed normally (original behaviour).
 //  3. If neither check passes, enumerate every scope where the user holds
 //     secrets.read, fetch secrets for each, union them (deduplicated by ID),
-//     and return the merged page. A user with NO scope returns an empty list.
+//     and return the merged page. A user with NO role scopes calls
+//     ListSecretsWithSharingInfo without a scope filter so that their owned
+//     and ACL-granted secrets are still surfaced.
 //  4. Machine principals skip steps 2–3 and always use ListSecretsInScope
 //     (machines have no user ownership model and are already gated by their
 //     own role assignments).
@@ -162,15 +167,13 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) { //
 	scopeRequested := requestedScope.ProjectID != 0 || requestedScope.EnvironmentID != 0
 
 	if scopeRequested {
-		// Caller narrowed to a specific scope — enforce secrets.read there.
-		allowed, aerr := h.coreService.AuthorizePrincipal(
-			r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), permSecretsRead, requestedScope,
-		)
-		if aerr != nil || !allowed {
-			h.sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
-			return
-		}
-		// Authorized for the requested scope; proceed with normal listing.
+		// Scoped listing: return whatever the caller can access within the
+		// requested project/environment — owned secrets + ACL-granted secrets.
+		// No RBAC gate here: ListSecretsWithSharingInfo already enforces access
+		// through ownership (OwnerID) and per-secret ACL grants, so ACL-only
+		// users (no project role) see their granted secrets and users with no
+		// access see an empty list.  A hard 403 on this path would block ACL-only
+		// principals who hold a valid per-secret grant in the requested scope.
 		response, err = h.coreService.ListSecretsWithSharingInfo(r.Context(), userCtx.UserID, filter)
 		if err != nil {
 			log.Printf("Error listing secrets: %v", err)
@@ -208,14 +211,17 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) { //
 	}
 
 	if len(scopes) == 0 {
-		// No accessible scopes — return an empty list rather than 403.
-		h.sendSuccess(w, &models.SecretListResponse{
-			Secrets:    []*models.SecretWithSharingInfo{},
-			Total:      0,
-			Page:       filter.Page,
-			PageSize:   filter.PageSize,
-			TotalPages: 1,
-		}, "")
+		// No project-role scopes, but the user may still hold per-secret ACL
+		// grants or own secrets directly.  Call ListSecretsWithSharingInfo with
+		// no scope filter so owned + ACL-granted secrets are surfaced.
+		response, err = h.coreService.ListSecretsWithSharingInfo(r.Context(), userCtx.UserID, filter)
+		if err != nil {
+			log.Printf("Error listing secrets for ACL-only user %d: %v", userCtx.UserID, err)
+			h.sendError(w, "InternalError", errFailedToListSecrets, http.StatusInternalServerError, nil)
+			return
+		}
+		h.resolveSecretNames(r.Context(), response.Secrets)
+		h.sendSuccess(w, response, "")
 		return
 	}
 

--- a/server/http/handlers/secrets_list_cov_test.go
+++ b/server/http/handlers/secrets_list_cov_test.go
@@ -1,0 +1,210 @@
+// secrets_list_cov_test.go — coverage top-up for secrets_list.go error and
+// edge-case paths not reached by secrets_list_scoped_test.go or secrets_list_s38_test.go.
+//
+// Covers:
+//   - Machine identity ListSecretsInScope error → 500 (line 147–151)
+//   - Scoped request ListSecretsWithSharingInfo error → 500 (line 178–182)
+//   - GetReadableScopes error → 500 (line 207–211)
+//   - Env-scoped role (EnvironmentID != 0) in the union loop (line 236–239)
+//   - Page beyond total results → start > totalInt clamp (line 260–262)
+//   - Zero secrets in union → totalPages == 0 → set to 1 (line 267–269)
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var covListDBCounter atomic.Int64
+
+func freshCovListFixture(t *testing.T) (*SecretHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := covListDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhandlers_cov_list_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.User{},
+		&models.Role{},
+		&models.UserRole{},
+		&models.Permission{},
+		&models.RolePermission{},
+		&models.Group{},
+		&models.UserGroup{},
+		&models.GroupRole{},
+		&models.Project{},
+		&models.Environment{},
+		&models.SecretNode{},
+		&models.SecretACL{},
+		&models.AuditEvent{},
+		&models.SecretVersion{},
+		&models.SecretAccessLog{},
+		&models.ShareRecord{},
+	))
+
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	return h, db
+}
+
+func withMachineCtx(r *http.Request) *http.Request {
+	machineID := uint(42)
+	uc := &middleware.UserContext{
+		UserID:            0,
+		ActorType:         core.ActorTypeMachine,
+		MachineIdentityID: &machineID,
+	}
+	return r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), uc))
+}
+
+func withCovUserCtx(r *http.Request, userID uint) *http.Request {
+	uc := &middleware.UserContext{
+		UserID:    userID,
+		Username:  fmt.Sprintf("cov-user-%d", userID),
+		ActorType: core.ActorTypeUser,
+	}
+	return r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), uc))
+}
+
+// TestListSecrets_MachineIdentity_ListError closes the DB so ListSecretsInScope
+// fails and the machine-principal path returns 500 (line 147–151).
+func TestListSecrets_MachineIdentity_ListError(t *testing.T) {
+	h, db := freshCovListFixture(t)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	req := withMachineCtx(httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil))
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestListSecrets_ScopedRequest_ListError closes the DB so ListSecretsWithSharingInfo
+// fails on the scoped path and the handler returns 500 (line 178–182).
+func TestListSecrets_ScopedRequest_ListError(t *testing.T) {
+	h, db := freshCovListFixture(t)
+
+	// Seed a project so the project_id query param resolves (not strictly needed;
+	// the scope check path is entered regardless of project existence).
+	require.NoError(t, db.Create(&models.Project{ID: 10, Name: "scoped-err-proj"}).Error)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	req := withCovUserCtx(
+		httptest.NewRequest(http.MethodGet, "/api/v1/secrets?project_id=10", nil), 20)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestListSecrets_GetReadableScopesError closes the DB so GetReadableScopes
+// fails for a non-global user (AuthorizePrincipal also fails, making globalOK
+// false and falling through to GetReadableScopes), returning 500 (line 207–211).
+func TestListSecrets_GetReadableScopesError(t *testing.T) {
+	h, db := freshCovListFixture(t)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	// No scope filter; non-machine user with no global role (both conditions
+	// fall through to GetReadableScopes which fails with the closed DB).
+	req := withCovUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil), 30)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestListSecrets_EnvScopedRole_Union verifies that a user whose secrets.read
+// grant is scoped to a specific environment (EnvironmentID != 0) triggers the
+// env-scoped branch of the union loop (line 236–239) and returns their secrets.
+func TestListSecrets_EnvScopedRole_Union(t *testing.T) {
+	h, db := freshCovListFixture(t)
+
+	proj := &models.Project{Name: "proj-env-scoped"}
+	require.NoError(t, db.Create(proj).Error)
+	env := &models.Environment{Name: "env-env-scoped", ProjectID: proj.ID}
+	require.NoError(t, db.Create(env).Error)
+	secret := &models.SecretNode{
+		Name: "env-scoped-secret", ProjectID: proj.ID, EnvironmentID: env.ID,
+		OwnerID: 50, Type: "static", IsSecret: true,
+	}
+	require.NoError(t, db.Create(secret).Error)
+
+	// User 50: secrets.read scoped to (proj, env) — EnvironmentID != 0.
+	require.NoError(t, db.Create(&models.User{ID: 50, Username: "env-scoped-user", AccountState: "active"}).Error)
+	role := &models.Role{Name: "env_viewer"}
+	require.NoError(t, db.Create(role).Error)
+	perm := &models.Permission{Name: "secrets.read", Resource: "secrets", Action: "read"}
+	require.NoError(t, db.Create(perm).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: role.ID, PermissionID: perm.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{
+		UserID: 50, RoleID: role.ID, ProjectID: proj.ID, EnvironmentID: env.ID,
+	}).Error)
+
+	req := withCovUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil), 50)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := decodeListResponse(t, w.Body.Bytes())
+	assert.GreaterOrEqual(t, resp.Total, int64(1), "env-scoped user should see at least their scoped secret")
+}
+
+// TestListSecrets_PageBeyondTotal_Clamp verifies that requesting a page beyond
+// the available results clamps start to totalInt (line 260–262) and sets
+// totalPages to 1 when the union is empty (line 267–269).
+func TestListSecrets_PageBeyondTotal_Clamp(t *testing.T) {
+	h, db := freshCovListFixture(t)
+
+	proj := &models.Project{Name: "proj-page-clamp"}
+	require.NoError(t, db.Create(proj).Error)
+
+	// User 60: project-scoped role but the project has no secrets → union is empty.
+	require.NoError(t, db.Create(&models.User{ID: 60, Username: "page-clamp-user", AccountState: "active"}).Error)
+	role := &models.Role{Name: "viewer_page_clamp"}
+	require.NoError(t, db.Create(role).Error)
+	perm := &models.Permission{Name: "secrets.read", Resource: "secrets", Action: "read"}
+	if err := db.Where("name = ?", "secrets.read").First(perm).Error; err != nil {
+		require.NoError(t, db.Create(perm).Error)
+	}
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: role.ID, PermissionID: perm.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{
+		UserID: 60, RoleID: role.ID, ProjectID: proj.ID, EnvironmentID: 0,
+	}).Error)
+
+	// page=2, page_size=1 → start = (2-1)*1 = 1. With 0 secrets, start > totalInt=0 → clamped.
+	req := withCovUserCtx(
+		httptest.NewRequest(http.MethodGet, "/api/v1/secrets?page=2&page_size=1", nil), 60)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := decodeListResponse(t, w.Body.Bytes())
+	assert.Equal(t, int64(0), resp.Total)
+	assert.Equal(t, 1, resp.TotalPages, "totalPages should be at least 1 even with 0 results")
+}

--- a/server/http/handlers/secrets_list_s38_test.go
+++ b/server/http/handlers/secrets_list_s38_test.go
@@ -147,9 +147,11 @@ func TestListSecrets_FilterParams_S38(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-// TestListSecrets_ScopeFilter_403_S38 verifies that a scope filter with an unauthorized
-// user returns 403 (exercises the project_id/environment_id parse + scope-auth check).
-func TestListSecrets_ScopeFilter_403_S38(t *testing.T) {
+// TestListSecrets_ScopeFilter_NoAccess_S38 verifies that a scope filter with a
+// user who has no role or ACL grants in the requested project returns 200+empty
+// (not 403).  The scoped-list endpoint never returns 403 — it returns the
+// intersection of the requested scope and the caller's accessible secrets.
+func TestListSecrets_ScopeFilter_NoAccess_S38(t *testing.T) {
 	t.Parallel()
 	h, _ := freshListFixtureS38(t)
 	req := withUserCtxS38(
@@ -157,7 +159,7 @@ func TestListSecrets_ScopeFilter_403_S38(t *testing.T) {
 			"/api/v1/secrets?project_id=1&environment_id=1", nil), 1)
 	w := httptest.NewRecorder()
 	h.ListSecrets(w, req)
-	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 // TestListSecrets_ExpiresBeforeParam_S38 exercises the expires_before RFC3339 filter.

--- a/server/http/handlers/secrets_list_scoped_test.go
+++ b/server/http/handlers/secrets_list_scoped_test.go
@@ -226,16 +226,17 @@ func TestListSecrets_NoSecretsReadPerm_ReturnsEmpty(t *testing.T) {
 	assert.Equal(t, int64(0), resp.Total, "expected empty list for user with no permissions")
 }
 
-// TestListSecrets_ScopedUser_ForbiddenSpecificScope verifies that a
-// project-scoped user gets 403 when they explicitly request a project
-// they are NOT authorized for.
-func TestListSecrets_ScopedUser_ForbiddenSpecificScope(t *testing.T) {
+// TestListSecrets_ScopedUser_NoAccessProject_ReturnsEmpty verifies that a
+// project-scoped user gets an empty list (not 403) when they explicitly
+// request a project they have no role or ACL grants in.  The scoped-list
+// endpoint never returns 403 — it returns what the caller can access.
+func TestListSecrets_ScopedUser_NoAccessProject_ReturnsEmpty(t *testing.T) {
 	h, db := freshScopedListFixture(t)
 
 	// Seed two projects; user 5 has read on proj1 only.
 	proj1 := &models.Project{Name: "proj-allowed"}
 	require.NoError(t, db.Create(proj1).Error)
-	proj2 := &models.Project{Name: "proj-forbidden"}
+	proj2 := &models.Project{Name: "proj-no-access"}
 	require.NoError(t, db.Create(proj2).Error)
 
 	require.NoError(t, db.Create(&models.User{ID: 5, Username: "partial-user", AccountState: "active"}).Error)
@@ -244,13 +245,93 @@ func TestListSecrets_ScopedUser_ForbiddenSpecificScope(t *testing.T) {
 		UserID: 5, RoleID: roleID, ProjectID: proj1.ID, EnvironmentID: 0,
 	}).Error)
 
-	// Request secrets from the forbidden project.
+	// Request secrets from the project where the user has no access.
 	url := fmt.Sprintf("/api/v1/secrets?project_id=%d", proj2.ID)
 	req := withUserCtxID2(httptest.NewRequest(http.MethodGet, url, nil), 5, "partial-user")
 	w := httptest.NewRecorder()
 	h.ListSecrets(w, req)
 
-	assert.Equal(t, http.StatusForbidden, w.Code, "expected 403 for unauthorized scope")
+	require.Equal(t, http.StatusOK, w.Code, "scoped listing should return 200+empty, not 403")
+	resp := decodeListResponse(t, w.Body.Bytes())
+	assert.Equal(t, int64(0), resp.Total, "expected empty list for project with no access")
+}
+
+// TestListSecrets_ACLOnly_ScopedRequest verifies that a user with no project
+// role but a per-secret ACL grant in a project gets their granted secrets
+// when filtering by that project_id (not a 403 or empty list).
+func TestListSecrets_ACLOnly_ScopedRequest(t *testing.T) {
+	h, db := freshScopedListFixture(t)
+
+	proj := &models.Project{Name: "proj-acl-scoped"}
+	require.NoError(t, db.Create(proj).Error)
+	env := &models.Environment{Name: "env-acl-scoped", ProjectID: proj.ID}
+	require.NoError(t, db.Create(env).Error)
+
+	// Two secrets in the project; user 8 gets an ACL grant only on secret1.
+	secret1 := &models.SecretNode{
+		Name: "acl-secret-1", ProjectID: proj.ID, EnvironmentID: env.ID,
+		OwnerID: 99, Type: "static", IsSecret: true,
+	}
+	require.NoError(t, db.Create(secret1).Error)
+	secret2 := &models.SecretNode{
+		Name: "acl-secret-2", ProjectID: proj.ID, EnvironmentID: env.ID,
+		OwnerID: 99, Type: "static", IsSecret: true,
+	}
+	require.NoError(t, db.Create(secret2).Error)
+
+	require.NoError(t, db.Create(&models.User{ID: 8, Username: "acl-only-user", AccountState: "active"}).Error)
+	// No UserRole — ACL grant only.
+	require.NoError(t, db.Create(&models.SecretACL{
+		SecretID:    secret1.ID,
+		UserID:      8,
+		Permissions: `["secrets.read"]`,
+		GrantedBy:   99,
+	}).Error)
+
+	url := fmt.Sprintf("/api/v1/secrets?project_id=%d", proj.ID)
+	req := withUserCtxID2(httptest.NewRequest(http.MethodGet, url, nil), 8, "acl-only-user")
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "ACL-only user should get 200, not 403")
+	resp := decodeListResponse(t, w.Body.Bytes())
+	require.Equal(t, int64(1), resp.Total, "expected exactly the ACL-granted secret")
+	assert.Equal(t, "acl-secret-1", resp.Secrets[0].Name)
+}
+
+// TestListSecrets_ACLOnly_UnfilteredRequest verifies that a user with no
+// project role but per-secret ACL grants gets those secrets on an unfiltered
+// GET /secrets (not an empty list).
+func TestListSecrets_ACLOnly_UnfilteredRequest(t *testing.T) {
+	h, db := freshScopedListFixture(t)
+
+	proj := &models.Project{Name: "proj-acl-unfiltered"}
+	require.NoError(t, db.Create(proj).Error)
+	env := &models.Environment{Name: "env-acl-unfiltered", ProjectID: proj.ID}
+	require.NoError(t, db.Create(env).Error)
+
+	secret := &models.SecretNode{
+		Name: "acl-unfiltered-secret", ProjectID: proj.ID, EnvironmentID: env.ID,
+		OwnerID: 99, Type: "static", IsSecret: true,
+	}
+	require.NoError(t, db.Create(secret).Error)
+
+	require.NoError(t, db.Create(&models.User{ID: 9, Username: "acl-only-user-2", AccountState: "active"}).Error)
+	require.NoError(t, db.Create(&models.SecretACL{
+		SecretID:    secret.ID,
+		UserID:      9,
+		Permissions: `["secrets.read"]`,
+		GrantedBy:   99,
+	}).Error)
+
+	req := withUserCtxID2(httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil), 9, "acl-only-user-2")
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := decodeListResponse(t, w.Body.Bytes())
+	require.Equal(t, int64(1), resp.Total, "expected the ACL-granted secret to appear on unfiltered list")
+	assert.Equal(t, "acl-unfiltered-secret", resp.Secrets[0].Name)
 }
 
 // TestListSecrets_GlobalReader_StillWorks verifies that a user with a global


### PR DESCRIPTION
## Summary

- **Scoped list UX** — `GET /secrets` now returns ACL-granted secrets for users with no project role; scoped requests (`?project_id=X`) no longer 403
- **Test coverage pass** — 5 new test files covering all four M3 feature areas:
  - `internal/cli/rbac/rbac_scope_cov_test.go` — `--project`/`--environment` flag wiring + server round-trips → 98.6%
  - `internal/core/secret_acl_cov_test.go` — all reachable error paths in `GrantSecretACL`/`RevokeSecretACL`/`ListSecretACLs`/`HasSecretACL`
  - `internal/core/rotation_policies_cov_test.go` — CRUD error paths + `EvaluateRotationPolicies` → 100%
  - `internal/core/authz_readable_scopes_test.go` — `GetReadableScopes` all branches → 100%
  - `server/http/handlers/secrets_list_cov_test.go` — handler error paths + pagination edge cases → 96.4%
- **OpenAPI sync** — 6 previously undocumented routes/fields added to `docs/openapi.yaml`
- **BACKLOG.md** — mark shipped M3 items done, add FinObs/billing

## Test plan

- [ ] `go test ./internal/cli/rbac/... ./internal/core/... ./server/http/handlers/...` green
- [ ] golangci-lint clean
- [ ] CI build-and-test, lint, gitleaks all pass