### PR TITLE
fix(docker): bump builder image to golang:1.26.5-alpine

### DIFF
--- a/cmd/keyorix-k8s-sync/Dockerfile
+++ b/cmd/keyorix-k8s-sync/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
+FROM golang:1.26.5-alpine AS builder
 RUN apk add --no-cache git
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/cmd/keyorix-mcp/Dockerfile
+++ b/cmd/keyorix-mcp/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
+FROM golang:1.26.5-alpine AS builder
 RUN apk add --no-cache git
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage. Build context is the operator/ module directory (a separate Go module
 # from the main repo, so controller-runtime/client-go stay out of the server build).
-FROM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
+FROM golang:1.26.5-alpine AS builder
 RUN apk add --no-cache git
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
+FROM golang:1.26.5-alpine AS builder
 RUN apk add --no-cache git make
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary

- The pinned digest `golang:1.26-alpine@sha256:3ad57304…` resolved to Go 1.26.4, but `go.mod` and `go.work` both require `go 1.26.5`.
- With `GOTOOLCHAIN=local` in the Docker builder, `go mod download` exits 1: `go: go.mod requires go >= 1.26.5 (running go 1.26.4)`.
- All CI workflows and `go.mod`/`go.work` were already on 1.26.5; only the four Dockerfiles were missed.

## Files changed

`server/Dockerfile`, `operator/Dockerfile`, `cmd/keyorix-mcp/Dockerfile`, `cmd/keyorix-k8s-sync/Dockerfile` — `FROM golang:1.26.5-alpine` (digest pin to follow once the image is stable).

## Test plan

- [ ] `docker-publish` pipeline passes for `v0.88.0` after this merges and the tag is moved/re-cut