### PR TITLE
fix(security): SSRF + PII leakage in alert escalation webhook dispatcher

### DIFF
--- a/internal/core/alert_escalation.go
+++ b/internal/core/alert_escalation.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -159,7 +160,7 @@ func (c *KeyorixCore) RunAlertEscalation(ctx context.Context) (*EscalationResult
 // splitChannelIDs splits a comma-separated channel-ID string into trimmed, non-empty tokens.
 func splitChannelIDs(ids string) []string {
 	var out []string
-	for _, s := range strings.Split(ids, ",") {
+	for s := range strings.SplitSeq(ids, ",") {
 		s = strings.TrimSpace(s)
 		if s != "" {
 			out = append(out, s)
@@ -175,15 +176,16 @@ func splitChannelIDs(ids string) []string {
 func (c *KeyorixCore) dispatchToChannel(ctx context.Context, ch *models.NotificationChannel, alert *models.AnomalyAlert, policy *models.AlertEscalationPolicy) error {
 	switch ch.Type {
 	case "webhook", "slack":
-		return c.postJSONToURL(ctx, ch.URL, map[string]interface{}{
+		// accessed_by and ip_address are intentionally omitted: PII must not be
+		// forwarded to an external webhook receiver. The server-side audit log
+		// already captures this data for incident investigation.
+		return c.postJSONToURL(ctx, ch.URL, map[string]any{
 			"event":       "anomaly.escalated",
 			"alert_id":    alert.ID,
 			"severity":    alert.Severity,
 			"alert_type":  alert.AlertType,
 			"description": alert.Description,
 			"secret_name": alert.SecretName,
-			"accessed_by": alert.AccessedBy,
-			"ip_address":  alert.IPAddress,
 			"detected_at": alert.DetectedAt.Format(time.RFC3339),
 			"policy_name": policy.Name,
 			"channel":     ch.Name,
@@ -195,8 +197,8 @@ func (c *KeyorixCore) dispatchToChannel(ctx context.Context, ch *models.Notifica
 	}
 }
 
-// postJSONToURL marshals payload to JSON and sends a best-effort HTTP POST to url.
-func (c *KeyorixCore) postJSONToURL(_ context.Context, url string, payload interface{}) error {
+// postJSONToURL marshals payload to JSON and sends a best-effort HTTP POST to rawURL.
+func (c *KeyorixCore) postJSONToURL(_ context.Context, rawURL string, payload any) error {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
@@ -205,13 +207,20 @@ func (c *KeyorixCore) postJSONToURL(_ context.Context, url string, payload inter
 	if client == nil {
 		client = &http.Client{Timeout: 10 * time.Second}
 	}
-	resp, err := client.Post(url, "application/json", bytes.NewReader(body)) // #nosec G107 -- URL is operator-configured
+	// Compute a redacted form of the URL for use in error messages so that
+	// embedded credentials (e.g. https://token:secret@hooks.example.com) are
+	// never written to logs (CWE-312).
+	redactedURL := rawURL
+	if u, perr := url.Parse(rawURL); perr == nil {
+		redactedURL = u.Redacted()
+	}
+	resp, err := client.Post(rawURL, "application/json", bytes.NewReader(body)) // #nosec G107 -- URL is operator-configured; SSRF-guarded at write time
 	if err != nil {
-		return fmt.Errorf("POST %s: %w", url, err)
+		return fmt.Errorf("POST %s: %w", redactedURL, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("POST %s: unexpected status %d", url, resp.StatusCode)
+		return fmt.Errorf("POST %s: unexpected status %d", redactedURL, resp.StatusCode)
 	}
 	return nil
 }
@@ -243,7 +252,7 @@ func (c *KeyorixCore) ListAlertEscalationPolicies(ctx context.Context) ([]models
 }
 
 // UpdateAlertEscalationPolicy applies field updates to the policy identified by id.
-func (c *KeyorixCore) UpdateAlertEscalationPolicy(ctx context.Context, id uint, updates map[string]interface{}) (*models.AlertEscalationPolicy, error) {
+func (c *KeyorixCore) UpdateAlertEscalationPolicy(ctx context.Context, id uint, updates map[string]any) (*models.AlertEscalationPolicy, error) {
 	p, err := c.storage.GetAlertEscalationPolicy(ctx, id)
 	if err != nil {
 		return nil, err

--- a/internal/core/notification_channels.go
+++ b/internal/core/notification_channels.go
@@ -6,6 +6,8 @@ package core
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 	"time"
 
@@ -51,7 +53,7 @@ func (c *KeyorixCore) CreateNotificationChannel(ctx context.Context, ch *models.
 
 // UpdateNotificationChannel applies the given map of field updates to the channel
 // identified by id and returns the updated channel.
-func (c *KeyorixCore) UpdateNotificationChannel(ctx context.Context, id uint, updates map[string]interface{}) (*models.NotificationChannel, error) {
+func (c *KeyorixCore) UpdateNotificationChannel(ctx context.Context, id uint, updates map[string]any) (*models.NotificationChannel, error) {
 	ch, err := c.storage.GetNotificationChannel(ctx, id)
 	if err != nil {
 		return nil, err
@@ -102,10 +104,49 @@ func validateNotificationChannel(ch *models.NotificationChannel) error {
 		if strings.TrimSpace(ch.URL) == "" {
 			return fmt.Errorf("notification channel URL is required for type %q", ch.Type)
 		}
+		if err := validateWebhookURL(ch.URL); err != nil {
+			return err
+		}
 	case "email":
 		if strings.TrimSpace(ch.Email) == "" {
 			return fmt.Errorf("notification channel email is required for type \"email\"")
 		}
 	}
 	return nil
+}
+
+// validateWebhookURL enforces SSRF-prevention rules on outbound webhook/slack/teams URLs.
+// It requires an https scheme and rejects destinations that resolve to RFC 1918,
+// loopback, link-local, or IMDS (169.254.0.0/16) addresses.
+func validateWebhookURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("notification channel: invalid URL %q: %w", raw, err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("notification channel: URL must use https (got %q)", u.Scheme)
+	}
+	host := u.Hostname()
+	if ip := net.ParseIP(host); ip != nil {
+		if isChannelDisallowedIP(ip) {
+			return fmt.Errorf("notification channel: URL targets a private/link-local address; refusing internal destination")
+		}
+		return nil
+	}
+	addrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), host)
+	if err != nil {
+		return fmt.Errorf("notification channel: could not resolve URL hostname to verify it is not private/internal: %w", err)
+	}
+	for _, a := range addrs {
+		if isChannelDisallowedIP(a.IP) {
+			return fmt.Errorf("notification channel: URL resolves to a private/link-local address (%s); refusing internal destination", a.IP)
+		}
+	}
+	return nil
+}
+
+// isChannelDisallowedIP reports whether ip is a private, link-local, or loopback
+// address — all of which are forbidden as outbound webhook destinations (SSRF guard).
+func isChannelDisallowedIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
 }


### PR DESCRIPTION
## Summary

- **SSRF (HIGH, CWE-918):** `validateNotificationChannel` now calls `validateWebhookURL` for all webhook/slack/teams channel types, enforcing `https`-only scheme and rejecting RFC 1918, loopback, link-local, and IMDS (169.254.x.x) destinations — both on create and update paths.
- **PII leakage (HIGH, CWE-200):** `dispatchToChannel` no longer includes `accessed_by` or `ip_address` in the webhook JSON payload. These fields remain in server-side audit logs for incident investigation.
- **Credential exposure in logs (MEDIUM, CWE-312):** `postJSONToURL` now parses the target URL and calls `url.URL.Redacted()` before using it in error strings, so embedded credentials (e.g. `https://token:secret@hooks.example.com`) are never written to logs.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] Create a webhook channel with `http://` URL — expect validation error
- [ ] Create a webhook channel with `https://169.254.169.254/foo` — expect validation error
- [ ] Create a webhook channel with `https://192.168.1.1/foo` — expect validation error
- [ ] Create a webhook channel with a valid public `https://` URL — expect success
- [ ] Trigger an alert escalation and confirm the outbound webhook payload contains no `accessed_by` or `ip_address` fields
- [ ] Confirm a POST failure log message does not expose any credentials embedded in the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)