### PR TITLE
fix(security): sanitize raw errors returned to API clients (CWE-209/CWE-532)

### DIFF
--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -411,7 +411,8 @@ func (c *KeyorixCore) RevokeLease(ctx context.Context, leaseID string, userID ui
 	pid := lease.ProjectID
 	if rerr := engine.Revoke(ctx, adminDSN, lease.RoleName); rerr != nil {
 		lease.Status = "revoke_failed"
-		lease.RevokeError = rerr.Error()
+		log.Printf("failed to revoke dynamic secret lease %s: %v", lease.LeaseID, rerr)
+		lease.RevokeError = "backend revoke failed — see server audit log for details"
 		// Deliberately NOT stamping RevokedAt here: the target drop failed, so the
 		// credential is still live. Stamping it would make the audit trail / API
 		// falsely claim the role was dropped at this time, even though it wasn't —

--- a/server/http/handlers/dynamic_secrets.go
+++ b/server/http/handlers/dynamic_secrets.go
@@ -124,7 +124,12 @@ func (h *DynamicSecretHandler) CreateConfig(w http.ResponseWriter, r *http.Reque
 		ActorID:           userCtx.PrincipalID(),
 	})
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)
+		msg := err.Error()
+		if !isSafeDynamicSecretError(msg) {
+			log.Printf("Error creating dynamic-secret config: %v", err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "Error", msg, http.StatusBadRequest, nil)
 		return
 	}
 	// Never echo the admin DSN ciphertext back.
@@ -147,7 +152,7 @@ func (h *DynamicSecretHandler) ListConfigs(w http.ResponseWriter, r *http.Reques
 		sendError(w, "InternalError", "Failed to list configs", http.StatusInternalServerError, nil)
 		return
 	}
-	out := make([]map[string]interface{}, 0, len(cfgs))
+	out := make([]map[string]any, 0, len(cfgs))
 	for _, c := range cfgs {
 		out = append(out, sanitizeConfig(c))
 	}
@@ -201,7 +206,7 @@ func (h *DynamicSecretHandler) ListLeases(w http.ResponseWriter, r *http.Request
 		sendError(w, "InternalError", "Failed to list leases", http.StatusInternalServerError, nil)
 		return
 	}
-	out := make([]map[string]interface{}, 0, len(leases))
+	out := make([]map[string]any, 0, len(leases))
 	for _, l := range leases {
 		out = append(out, sanitizeLease(l))
 	}
@@ -234,7 +239,7 @@ func (h *DynamicSecretHandler) RevokeLease(w http.ResponseWriter, r *http.Reques
 		sendError(w, "Error", msg, http.StatusBadGateway, nil)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{"lease_id": leaseID, "status": "revoked"}, "Lease revoked.")
+	sendSuccess(w, map[string]any{"lease_id": leaseID, "status": "revoked"}, "Lease revoked.")
 }
 
 // RenewLease handles POST /api/v1/dynamic-secrets/leases/{leaseID}/renew
@@ -268,7 +273,7 @@ func (h *DynamicSecretHandler) RenewLease(w http.ResponseWriter, r *http.Request
 		sendError(w, "Error", msg, http.StatusBadGateway, nil)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{"lease_id": leaseID, "expires_at": newExpiry}, "Lease renewed.")
+	sendSuccess(w, map[string]any{"lease_id": leaseID, "expires_at": newExpiry}, "Lease renewed.")
 }
 
 // RevokeAllLeases handles POST /api/v1/dynamic-secrets/configs/{id}/revoke-all —
@@ -289,7 +294,7 @@ func (h *DynamicSecretHandler) RevokeAllLeases(w http.ResponseWriter, r *http.Re
 		sendError(w, "Error", msg, http.StatusBadGateway, nil)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{
+	sendSuccess(w, map[string]any{
 		"config_id": cfg.ID, "revoked": revoked, "failed": failed,
 	}, fmt.Sprintf("Revoked %d active lease(s); %d failed.", revoked, failed))
 }
@@ -311,7 +316,12 @@ func (h *DynamicSecretHandler) ClassifyConfig(w http.ResponseWriter, r *http.Req
 	}
 	updated, err := h.coreService.ClassifyDynamicSecretConfig(r.Context(), userCtx.UserID, cfg.ID, body.Classification)
 	if err != nil {
-		sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)
+		msg := err.Error()
+		if !isSafeDynamicSecretError(msg) {
+			log.Printf("Error classifying dynamic-secret config %d: %v", cfg.ID, err)
+			msg = clientSafe(err)
+		}
+		sendError(w, "Error", msg, http.StatusBadRequest, nil)
 		return
 	}
 	sendSuccess(w, sanitizeConfig(updated), "Classification updated.")
@@ -366,8 +376,8 @@ func (h *DynamicSecretHandler) loadAuthorizedConfig(w http.ResponseWriter, r *ht
 
 // sanitizeConfig returns the safe public view of a config — never the encrypted
 // admin DSN bytes.
-func sanitizeConfig(c *models.DynamicSecretConfig) map[string]interface{} {
-	return map[string]interface{}{
+func sanitizeConfig(c *models.DynamicSecretConfig) map[string]any {
+	return map[string]any{
 		"id":                  c.ID,
 		"name":                c.Name,
 		"project_id":          c.ProjectID,
@@ -386,8 +396,8 @@ func sanitizeConfig(c *models.DynamicSecretConfig) map[string]interface{} {
 
 // sanitizeLease returns the safe public view of a lease — never the encrypted
 // credential bytes.
-func sanitizeLease(l *models.DynamicSecretLease) map[string]interface{} {
-	return map[string]interface{}{
+func sanitizeLease(l *models.DynamicSecretLease) map[string]any {
+	return map[string]any{
 		"lease_id":      l.LeaseID,
 		"config_id":     l.ConfigID,
 		"role_name":     l.RoleName,

--- a/server/http/handlers/pat_handler.go
+++ b/server/http/handlers/pat_handler.go
@@ -9,12 +9,15 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
@@ -133,7 +136,7 @@ func (h *PATHandler) PATHygiene(w http.ResponseWriter, r *http.Request) {
 			Stale:       e.Stale,
 		})
 	}
-	sendSuccess(w, map[string]interface{}{"tokens": out, "total": len(out)}, "")
+	sendSuccess(w, map[string]any{"tokens": out, "total": len(out)}, "")
 }
 
 type createPATRequestBody struct {
@@ -176,14 +179,19 @@ func (h *PATHandler) CreatePAT(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.coreService.CreateOwnPAT(r.Context(), userCtx.UserID, body.Name, expiresAt, body.Scopes, body.ProjectScope, body.EnvironmentScope, body.AllowedCIDRs)
 	if err != nil {
-		sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
+		if strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)) {
+			sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
+		} else {
+			log.Printf("CreateOwnPAT storage error for user %d: %v", userCtx.UserID, err)
+			sendError(w, "InternalError", clientSafe(err), http.StatusInternalServerError, nil)
+		}
 		return
 	}
 
 	resp := toPATResponse(result.Token)
 	w.WriteHeader(http.StatusCreated)
 	// The plaintext token is included once here and never again.
-	sendSuccess(w, map[string]interface{}{
+	sendSuccess(w, map[string]any{
 		"token": result.PlainToken,
 		"pat":   resp,
 	}, "Token created — copy it now, it will not be shown again")

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -126,7 +126,7 @@ func (h *RBACHandler) ListRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sendSuccess(w, map[string]interface{}{"roles": roles, "total": len(roles)}, "")
+	sendSuccess(w, map[string]any{"roles": roles, "total": len(roles)}, "")
 }
 
 // CreateRole handles POST /api/v1/roles
@@ -191,7 +191,7 @@ func (h *RBACHandler) CreateRole(w http.ResponseWriter, r *http.Request) {
 
 	h.coreService.LogRoleCreated(r.Context(), userCtx.UserID, role.ID, role.Name)
 	w.WriteHeader(http.StatusCreated)
-	sendSuccess(w, map[string]interface{}{"role": role, "permissions": assignedPerms}, "Role created successfully")
+	sendSuccess(w, map[string]any{"role": role, "permissions": assignedPerms}, "Role created successfully")
 }
 
 // resolveAndAuthorizePermissions resolves each named permission and checks the actor
@@ -241,7 +241,7 @@ func (h *RBACHandler) GetRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sendSuccess(w, map[string]interface{}{"role": role, "permissions": perms}, "")
+	sendSuccess(w, map[string]any{"role": role, "permissions": perms}, "")
 }
 
 // GetRoleByName handles GET /api/v1/roles/by-name?name=X — looks up a role by
@@ -334,7 +334,8 @@ func (h *RBACHandler) UpdateRole(w http.ResponseWriter, r *http.Request) { // NO
 			if strings.Contains(aerr.Error(), "cannot bundle") {
 				sendError(w, "Forbidden", aerr.Error(), http.StatusForbidden, nil)
 			} else {
-				sendError(w, "InternalError", aerr.Error(), http.StatusInternalServerError, nil)
+				log.Printf("failed to resolve permissions for role update: %v", aerr)
+				sendError(w, "InternalError", clientSafe(aerr), http.StatusInternalServerError, nil)
 			}
 			return
 		}
@@ -356,7 +357,7 @@ func (h *RBACHandler) UpdateRole(w http.ResponseWriter, r *http.Request) { // NO
 	}
 
 	perms, _ := h.coreService.Storage().GetRolePermissions(r.Context(), id)
-	sendSuccess(w, map[string]interface{}{"role": role, "permissions": perms}, "Role updated successfully")
+	sendSuccess(w, map[string]any{"role": role, "permissions": perms}, "Role updated successfully")
 }
 
 func (h *RBACHandler) authorizeAndCollectPermissions(ctx context.Context, userCtx *middleware.UserContext, permNames []string) ([]*models.Permission, error) {
@@ -484,7 +485,7 @@ func (h *RBACHandler) AssignRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	sendSuccess(w, map[string]interface{}{"user_id": req.UserID, "role_id": req.RoleID, "expires_at": req.ExpiresAt}, "Role assigned successfully")
+	sendSuccess(w, map[string]any{"user_id": req.UserID, "role_id": req.RoleID, "expires_at": req.ExpiresAt}, "Role assigned successfully")
 }
 
 // RemoveRole handles DELETE /api/v1/user-roles
@@ -570,7 +571,7 @@ func (h *RBACHandler) ListPermissions(w http.ResponseWriter, r *http.Request) {
 		perms = filtered
 	}
 
-	sendSuccess(w, map[string]interface{}{"permissions": perms, "total": len(perms)}, "")
+	sendSuccess(w, map[string]any{"permissions": perms, "total": len(perms)}, "")
 }
 
 // GetPermission handles GET /api/v1/permissions/{id} — added for #526 as the
@@ -631,7 +632,7 @@ func (h *RBACHandler) GetRolePermissions(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	sendSuccess(w, map[string]interface{}{"role_id": role.ID, "role_name": role.Name, "permissions": perms}, "")
+	sendSuccess(w, map[string]any{"role_id": role.ID, "role_name": role.Name, "permissions": perms}, "")
 }
 
 // AssignPermissionToRole handles POST /api/v1/roles/{id}/permissions
@@ -673,7 +674,7 @@ func (h *RBACHandler) AssignPermissionToRole(w http.ResponseWriter, r *http.Requ
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	sendSuccess(w, map[string]interface{}{"role_id": roleID, "permission_id": body.PermissionID}, "Permission assigned successfully")
+	sendSuccess(w, map[string]any{"role_id": roleID, "permission_id": body.PermissionID}, "Permission assigned successfully")
 }
 
 // RemovePermissionFromRole handles DELETE /api/v1/roles/{id}/permissions/{permissionId}
@@ -730,7 +731,7 @@ func (h *RBACHandler) GetGroupRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sendSuccess(w, map[string]interface{}{"group_id": groupID, "roles": roles}, "")
+	sendSuccess(w, map[string]any{"group_id": groupID, "roles": roles}, "")
 }
 
 // AssignRoleToGroup handles POST /api/v1/groups/{id}/roles
@@ -784,7 +785,7 @@ func (h *RBACHandler) AssignRoleToGroup(w http.ResponseWriter, r *http.Request) 
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	sendSuccess(w, map[string]interface{}{"group_id": groupID, "role_id": body.RoleID, "expires_at": body.ExpiresAt}, "Role assigned to group successfully")
+	sendSuccess(w, map[string]any{"group_id": groupID, "role_id": body.RoleID, "expires_at": body.ExpiresAt}, "Role assigned to group successfully")
 }
 
 // RemoveRoleFromGroup handles DELETE /api/v1/groups/{id}/roles/{roleId}
@@ -830,7 +831,7 @@ func ListRoles(w http.ResponseWriter, r *http.Request) {
 	if _, ok := mustGetUser(w, r); !ok {
 		return
 	}
-	sendSuccess(w, map[string]interface{}{"roles": []interface{}{}, "total": 0}, "")
+	sendSuccess(w, map[string]any{"roles": []any{}, "total": 0}, "")
 }
 
 func CreateRole(w http.ResponseWriter, r *http.Request) {
@@ -847,7 +848,7 @@ func CreateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
-	sendSuccess(w, map[string]interface{}{"name": req.Name}, "Role created successfully")
+	sendSuccess(w, map[string]any{"name": req.Name}, "Role created successfully")
 }
 
 // GetRole returns a mock 200 for IDs in the predefined stub set, 404 otherwise.
@@ -863,7 +864,7 @@ func GetRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if id >= 1 && id <= 10 {
-		sendSuccess(w, map[string]interface{}{"id": id, "name": "mock-role", "permissions": []interface{}{}}, "")
+		sendSuccess(w, map[string]any{"id": id, "name": "mock-role", "permissions": []any{}}, "")
 		return
 	}
 	sendError(w, "NotFound", errRoleNotFound, http.StatusNotFound, nil)
@@ -886,7 +887,7 @@ func UpdateRole(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "ValidationError", errInvalidRequestData, http.StatusBadRequest, err)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{}, "Role updated successfully")
+	sendSuccess(w, map[string]any{}, "Role updated successfully")
 }
 
 func DeleteRole(w http.ResponseWriter, r *http.Request) {
@@ -914,7 +915,7 @@ func AssignRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
-	sendSuccess(w, map[string]interface{}{"user_id": req.UserID, "role_id": req.RoleID}, "Role assigned successfully")
+	sendSuccess(w, map[string]any{"user_id": req.UserID, "role_id": req.RoleID}, "Role assigned successfully")
 }
 
 func RemoveRole(w http.ResponseWriter, r *http.Request) {
@@ -941,7 +942,7 @@ func GetUserRoles(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InvalidParameter", "Invalid user ID", http.StatusBadRequest, nil)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{"roles": []interface{}{}, "total": 0}, "")
+	sendSuccess(w, map[string]any{"roles": []any{}, "total": 0}, "")
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1027,5 +1028,5 @@ func (h *RBACHandler) GetPermissionMatrix(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	sendSuccess(w, map[string]interface{}{"rows": rows, "total": len(rows)}, "")
+	sendSuccess(w, map[string]any{"rows": rows, "total": len(rows)}, "")
 }

--- a/server/http/handlers/secret_schedule.go
+++ b/server/http/handlers/secret_schedule.go
@@ -12,6 +12,7 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -28,7 +29,8 @@ func (h *SecretHandler) GetSecretSchedule(w http.ResponseWriter, r *http.Request
 	}
 	sched, err := h.coreService.GetSecretSchedule(r.Context(), uint(secretID))
 	if err != nil {
-		h.sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("GetSecretSchedule error for secret %d: %v", uint(secretID), err)
+		h.sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	if sched == nil {
@@ -78,7 +80,8 @@ func (h *SecretHandler) DeleteSecretSchedule(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if err := h.coreService.DeleteSecretSchedule(r.Context(), uint(secretID)); err != nil {
-		h.sendError(w, "Error", err.Error(), http.StatusInternalServerError, nil)
+		log.Printf("DeleteSecretSchedule error for secret %d: %v", uint(secretID), err)
+		h.sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	h.sendSuccess(w, map[string]bool{"deleted": true}, "schedule removed")

--- a/server/http/handlers/secrets_error_sanitization_test.go
+++ b/server/http/handlers/secrets_error_sanitization_test.go
@@ -107,7 +107,7 @@ func captureLog(t *testing.T) func() string {
 func assertSanitizedInternalError(t *testing.T, w *httptest.ResponseRecorder, rawErr error, logs func() string) {
 	t.Helper()
 	require.Equal(t, http.StatusInternalServerError, w.Code, w.Body.String())
-	var resp map[string]interface{}
+	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	msg, _ := resp["message"].(string)
 	assert.NotEmpty(t, msg)

--- a/server/http/handlers/secrets_versions.go
+++ b/server/http/handlers/secrets_versions.go
@@ -57,7 +57,7 @@ func (h *SecretHandler) GetSecretVersions(w http.ResponseWriter, r *http.Request
 		}) // #nosec G118
 	}
 
-	h.sendSuccess(w, map[string]interface{}{"versions": versions}, "")
+	h.sendSuccess(w, map[string]any{"versions": versions}, "")
 }
 
 // RotateSecret handles POST /api/v1/secrets/{id}/rotate
@@ -106,7 +106,8 @@ func (h *SecretHandler) RotateSecret(w http.ResponseWriter, r *http.Request) {
 			// distinctly (502) so the caller never mistakes this for a clean success,
 			// even though a partial attempt may have stored a new value; see the audit
 			// trail (secret.rotate_failed / secret.rotate_incomplete) for the outcome.
-			h.sendError(w, "BackendRotationFailed", err.Error(), http.StatusBadGateway, nil)
+			log.Printf("rotation backend error for secret %d: %v", uint(id), err)
+			h.sendError(w, "BackendRotationFailed", "Rotation backend call failed; see server logs for details", http.StatusBadGateway, nil)
 		case strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)):
 			h.sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
 		default:

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -119,7 +119,7 @@ func (h *UserHandler) createUserWithOTP(w http.ResponseWriter, r *http.Request, 
 		sendError(w, "InternalError", "Failed to create user", http.StatusInternalServerError, nil)
 		return
 	}
-	sendCreated(w, map[string]interface{}{
+	sendCreated(w, map[string]any{
 		"user":              userToAPIResponse(created),
 		"one_time_password": otp,
 	}, i18n.T("SuccessUserCreated", nil))
@@ -144,7 +144,7 @@ func (h *UserHandler) createUserWithSetupLink(w http.ResponseWriter, r *http.Req
 		sendError(w, "InternalError", "Failed to create user", http.StatusInternalServerError, nil)
 		return
 	}
-	sendCreated(w, map[string]interface{}{
+	sendCreated(w, map[string]any{
 		"user":       userToAPIResponse(created),
 		"setup_link": prov,
 	}, i18n.T("SuccessUserCreated", nil))
@@ -228,7 +228,7 @@ func (h *UserHandler) GetUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := userToAPIResponse(u)
-	h.attachProjectCounts(r.Context(), []map[string]interface{}{resp}, []uint{u.ID})
+	h.attachProjectCounts(r.Context(), []map[string]any{resp}, []uint{u.ID})
 	sendSuccess(w, resp, "")
 }
 
@@ -265,7 +265,7 @@ func (h *UserHandler) GetUserByEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := userToAPIResponse(u)
-	h.attachProjectCounts(r.Context(), []map[string]interface{}{resp}, []uint{u.ID})
+	h.attachProjectCounts(r.Context(), []map[string]any{resp}, []uint{u.ID})
 	sendSuccess(w, resp, "")
 }
 
@@ -295,7 +295,7 @@ func (h *UserHandler) GetUserByUsername(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	resp := userToAPIResponse(u)
-	h.attachProjectCounts(r.Context(), []map[string]interface{}{resp}, []uint{u.ID})
+	h.attachProjectCounts(r.Context(), []map[string]any{resp}, []uint{u.ID})
 	sendSuccess(w, resp, "")
 }
 
@@ -324,7 +324,7 @@ func (h *UserHandler) GetUserByExternalID(w http.ResponseWriter, r *http.Request
 		return
 	}
 	resp := userToAPIResponse(u)
-	h.attachProjectCounts(r.Context(), []map[string]interface{}{resp}, []uint{u.ID})
+	h.attachProjectCounts(r.Context(), []map[string]any{resp}, []uint{u.ID})
 	sendSuccess(w, resp, "")
 }
 
@@ -409,7 +409,7 @@ func (h *UserHandler) VerifyCredentials(w http.ResponseWriter, r *http.Request) 
 		sendError(w, "Unauthorized", "Invalid credentials", http.StatusUnauthorized, nil)
 		return
 	}
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"id":               u.ID,
 		"username":         u.Username,
 		"email":            u.Email,
@@ -422,7 +422,7 @@ func (h *UserHandler) VerifyCredentials(w http.ResponseWriter, r *http.Request) 
 	// no session to report in that case; the spoke applies its own MFA gate from
 	// mfa_enabled/webauthn_enabled above.
 	if session != nil {
-		resp["session"] = map[string]interface{}{
+		resp["session"] = map[string]any{
 			"id":                  session.ID,
 			"token":               session.SessionToken,
 			"family_id":           session.FamilyID,
@@ -470,7 +470,7 @@ func (h *UserHandler) IssueMFAChallenge(w http.ResponseWriter, r *http.Request) 
 		sendError(w, "Internal", "failed to start MFA challenge", http.StatusInternalServerError, nil)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{"challenge": challenge}, "")
+	sendSuccess(w, map[string]any{"challenge": challenge}, "")
 }
 
 // VerifyMFACredentials handles POST /api/v1/users/verify-mfa (#509) — the
@@ -519,7 +519,7 @@ func (h *UserHandler) VerifyMFACredentials(w http.ResponseWriter, r *http.Reques
 		sendError(w, "Unauthorized", "Invalid code", http.StatusUnauthorized, nil)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{
+	sendSuccess(w, map[string]any{
 		"id":            u.ID,
 		"username":      u.Username,
 		"used_recovery": usedRecovery,
@@ -794,8 +794,10 @@ func (h *UserHandler) accountStateAction(w http.ResponseWriter, r *http.Request,
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), errNotFound) {
 			status = http.StatusNotFound
+		} else {
+			log.Printf("account state transition error for user %d: %v", uint(id), err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", clientSafe(err), status, nil)
 		return
 	}
 	sendSuccess(w, nil, okMessage)
@@ -840,11 +842,13 @@ func (h *UserHandler) RevokeSessions(w http.ResponseWriter, r *http.Request) {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), errNotFound) {
 			status = http.StatusNotFound
+		} else {
+			log.Printf("revoke sessions error for user %d: %v", uint(id), err)
 		}
-		sendError(w, "Error", err.Error(), status, nil)
+		sendError(w, "Error", clientSafe(err), status, nil)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{"revoked": n}, "Sessions revoked")
+	sendSuccess(w, map[string]any{"revoked": n}, "Sessions revoked")
 }
 
 // ResendSetupLink handles POST /api/v1/users/{id}/resend-setup-link (ADR-028). It

--- a/server/middleware/logger.go
+++ b/server/middleware/logger.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
@@ -20,11 +21,27 @@ import (
 // POST /auth/password-reset).
 var sensitiveURIPattern = regexp.MustCompile(`(?i)^(/(?:api/v1/)?auth/(?:setup|invite|password-reset)/)[^/?]+`)
 
+// sensitiveQueryPattern matches paths whose query-string parameters carry secret
+// identifiers — /secrets/value and /secrets/by-name accept a ?ref= or ?name=
+// query param that is the secret reference or name. Logging these verbatim would
+// write secret names/references to the access log (container logs, log-aggregation
+// SaaS, on-call terminal), leaking the secret catalogue to log readers.
+var sensitiveQueryPattern = regexp.MustCompile(`(?i)/secrets/(?:value|by-name)\b`)
+
 // redactSensitiveURI replaces the credential segment of a known-sensitive path
-// with a fixed placeholder, leaving the rest of the path/query untouched. It
-// returns the input unchanged when no sensitive pattern matches.
+// with a fixed placeholder, and strips the entire query string for paths that
+// carry secret identifiers in query parameters. It returns the input unchanged
+// when no sensitive pattern matches.
 func redactSensitiveURI(uri string) string {
-	return sensitiveURIPattern.ReplaceAllString(uri, "${1}[REDACTED]")
+	// First redact path-segment credentials (setup/invite/password-reset tokens).
+	uri = sensitiveURIPattern.ReplaceAllString(uri, "${1}[REDACTED]")
+	// Then redact query strings for endpoints that accept secret ref/name params.
+	if idx := strings.IndexByte(uri, '?'); idx != -1 {
+		if sensitiveQueryPattern.MatchString(uri[:idx]) {
+			uri = uri[:idx] + "?[redacted]"
+		}
+	}
+	return uri
 }
 
 // Logger returns a middleware that logs HTTP requests. It behaves like chi's


### PR DESCRIPTION
## Summary

- Replace `err.Error()` with `clientSafe()` + `log.Printf` on all identified raw-error-to-client paths (CWE-209): rotation backend 502, account state transitions, RevokeSessions, UpdateRole permission resolution, dynamic-secret CreateConfig/ClassifyConfig, CreatePAT storage failures, GetSecretSchedule/DeleteSecretSchedule
- Sanitize the persisted `RevokeError` field in `internal/core/dynamic_secrets.go` so raw backend/driver error text is never stored in the DB or returned via the leases API
- Extend logger middleware `redactSensitiveURI` to strip query strings on `/secrets/value` and `/secrets/by-name` endpoints, preventing secret `ref`/`name` identifiers from appearing in access logs (CWE-532)

## Test plan

- [ ] `go build ./...` passes (verified clean)
- [ ] Trigger a rotation backend error and confirm the 502 body contains the safe message, not raw driver text; raw error appears in server logs
- [ ] Trigger an account suspend/reactivate/revoke-sessions failure and confirm the 500/404 body is generic; raw error in server logs
- [ ] Trigger a dynamic-secret config creation error and confirm safe message returned; raw error in server logs
- [ ] Trigger a dynamic-secret lease revoke failure and confirm `revoke_error` field in DB/API is the fixed sanitized string
- [ ] Create a PAT with a bad storage state and confirm `InternalError` with safe message is returned (not raw storage error)
- [ ] Call `GET /api/v1/secrets/value?ref=my-secret` and confirm access log shows `?[redacted]`, not the actual ref value
- [ ] Call `GET /api/v1/secrets/by-name?name=my-secret` and confirm access log shows `?[redacted]`
- [ ] Auth setup/invite/password-reset token redaction still works (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)