### PR TITLE
fix(security): TOTP replay in requireReauth, password expiry on remote MFA, WebAuthn step-up

### DIFF
--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -437,8 +437,15 @@ func (c *KeyorixCore) requireReauth(ctx context.Context, user *models.User, code
 	}
 	ok := false
 	if user.MFAEnabled {
-		if secret, err := c.loadTOTPSecret(ctx, user.ID); err == nil && c.validateTOTP(secret, codeOrPassword) {
-			ok = true
+		if secret, err := c.loadTOTPSecret(ctx, user.ID); err == nil {
+			// Use the same anti-replay path as VerifyMFACredentials: identify the
+			// matched time-step and atomically mark it used so a stolen code cannot
+			// be replayed within the ±1 step (~90 s) window.
+			if step, matched := c.validateTOTPStep(secret, codeOrPassword); matched {
+				if fresh, ferr := c.storage.MarkTOTPStepUsed(ctx, user.ID, step); ferr == nil && fresh {
+					ok = true
+				}
+			}
 		}
 	}
 	if !ok && codeOrPassword != "" && bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(codeOrPassword)) == nil {

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -546,6 +546,33 @@ func TestMFA_TOTPSecretTransplantBetweenUsersFailsToDecrypt(t *testing.T) {
 	require.Error(t, err, "a TOTP secret transplanted from another user's row must fail to decrypt, not silently succeed")
 }
 
+// requireReauth must consume a TOTP code as single-use: a code accepted once for
+// DisableMFA / RegenerateMFARecoveryCodes / FinishWebAuthnRegistration /
+// DeleteWebAuthnCredential must be rejected on a second call within the same
+// ±1 time-step window (~90 s). Before the fix, requireReauth used validateTOTP
+// (no replay tracking) instead of validateTOTPStep+MarkTOTPStepUsed; this test
+// confirms the correct anti-replay path now applies.
+func TestRequireReauth_TOTPCodeNotReplayable(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	secret, _ := activateMFAForTest(t, c, fixed)
+
+	code, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+
+	user, err := c.storage.GetUser(ctx, 1)
+	require.NoError(t, err)
+
+	// First use must succeed.
+	require.NoError(t, c.requireReauth(ctx, user, code, "test_phase"),
+		"first requireReauth with a valid TOTP code must succeed")
+
+	// Second use of the SAME code within the same step window must be rejected.
+	err = c.requireReauth(ctx, user, code, "test_phase")
+	require.Error(t, err, "replaying the same TOTP code must be rejected by requireReauth")
+	assert.Contains(t, err.Error(), "invalid", "replay must surface as an invalid-code error, not a lock error")
+}
+
 // VerifyMFALogin must record a MFA step-up token when the classification gate
 // requires it. The write is best-effort (error discarded), so VerifyMFALogin
 // must still succeed even if UpsertMFAStepupToken were to fail. This test

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -348,6 +348,14 @@ func (c *KeyorixCore) FinishWebAuthnLogin(ctx context.Context, challenge, sessio
 	if err != nil {
 		return nil, nil, err
 	}
+	// Record the MFA step-up window when the classification gate requires it,
+	// matching the existing TOTP path in VerifyMFALogin. WebAuthn (possession +
+	// user-verification) is at least as strong as TOTP, so it must satisfy the
+	// same restricted_requires_mfa_stepup gate. Best-effort: a write failure
+	// does not block the login.
+	if c.classificationRestrictedRequiresMFAStepUp {
+		_ = c.storage.UpsertMFAStepupToken(ctx, ch.UserID, c.now().Add(c.mfaStepUpWindow()))
+	}
 	uid := ch.UserID
 	c.writeAuditEventFull(ctx, "webauthn.login_verified", &uid, nil, nil, ip,
 		fmt.Sprintf("user %s passed WebAuthn", wu.user.Username))
@@ -431,6 +439,12 @@ func (c *KeyorixCore) FinishWebAuthnPasswordlessLogin(ctx context.Context, sessi
 	session, err := c.mintSession(ctx, resolved.ID, userAgent, ip)
 	if err != nil {
 		return nil, nil, err
+	}
+	// Record the MFA step-up window when the classification gate requires it,
+	// matching both VerifyMFALogin and FinishWebAuthnLogin. A passkey satisfies
+	// user-verification and is at minimum as strong as TOTP. Best-effort.
+	if c.classificationRestrictedRequiresMFAStepUp {
+		_ = c.storage.UpsertMFAStepupToken(ctx, resolved.ID, c.now().Add(c.mfaStepUpWindow()))
 	}
 	uid := resolved.ID
 	c.writeAuditEventFull(ctx, "webauthn.passwordless_login", &uid, nil, nil, ip,

--- a/internal/storage/store/remote_mfa.go
+++ b/internal/storage/store/remote_mfa.go
@@ -435,20 +435,31 @@ type verifyMFAWireRequest struct {
 	Code      string `json:"code"`
 }
 
-// verifyMFAWireResponse is deliberately narrow — it carries exactly what
-// core.VerifyMFALogin needs after a successful verdict (enough identity to
-// mint/describe the session, plus whether a recovery code was used for the
-// matching audit event) and nothing else: no TOTP secret, no recovery-code
-// hashes, no lockout-accounting counters (meaningless here — the upstream
-// already applied/cleared them before ever returning success).
+// verifyMFAWireResponse carries what core.VerifyMFALogin needs after a
+// successful verdict: enough identity to mint/describe the session, whether a
+// recovery code was used (for the audit event), and the two password-age fields
+// that enforcePasswordExpiryGate (ADR-025) reads. PasswordChangedAt and
+// CreatedAt are intentionally included: without them toModel() returns a sparse
+// User where both fields are zero/nil, causing PasswordExpired() to always
+// return false and silently bypassing the password-expiry hard gate on
+// storage.type: remote spoke deployments. No TOTP secret, no recovery-code
+// hashes, no lockout counters — those are meaningless here: the upstream already
+// applied/cleared them before ever returning success.
 type verifyMFAWireResponse struct {
-	ID           uint   `json:"id"`
-	Username     string `json:"username"`
-	UsedRecovery bool   `json:"used_recovery"`
+	ID                uint       `json:"id"`
+	Username          string     `json:"username"`
+	UsedRecovery      bool       `json:"used_recovery"`
+	PasswordChangedAt *time.Time `json:"password_changed_at"`
+	CreatedAt         time.Time  `json:"created_at"`
 }
 
 func (w verifyMFAWireResponse) toModel() *models.User {
-	return &models.User{ID: w.ID, Username: w.Username}
+	return &models.User{
+		ID:                w.ID,
+		Username:          w.Username,
+		PasswordChangedAt: w.PasswordChangedAt,
+		CreatedAt:         w.CreatedAt,
+	}
 }
 
 // VerifyMFALoginCredentials implements core.RemoteMFAVerifier: it proxies the

--- a/internal/storage/store/remote_mfa_wire_test.go
+++ b/internal/storage/store/remote_mfa_wire_test.go
@@ -1,0 +1,63 @@
+// remote_mfa_wire_test.go — unit tests for verifyMFAWireResponse.toModel(),
+// specifically that the password-age fields (PasswordChangedAt, CreatedAt)
+// survive the wire→model conversion so enforcePasswordExpiryGate (ADR-025)
+// evaluates correctly on storage.type: remote spoke deployments.
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifyMFAWireResponse_ToModel_PreservesPasswordAgeFields confirms that
+// toModel() populates PasswordChangedAt and CreatedAt from the wire response.
+// Before the fix these fields were absent from verifyMFAWireResponse, so
+// toModel() always returned a sparse User{ID, Username} — causing
+// core.PasswordExpired() to return false regardless of the actual password age,
+// silently bypassing enforcePasswordExpiryGate on remote spoke deployments.
+func TestVerifyMFAWireResponse_ToModel_PreservesPasswordAgeFields(t *testing.T) {
+	changedAt := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	wire := verifyMFAWireResponse{
+		ID:                42,
+		Username:          "alice",
+		UsedRecovery:      false,
+		PasswordChangedAt: &changedAt,
+		CreatedAt:         createdAt,
+	}
+	u := wire.toModel()
+	require.NotNil(t, u)
+	assert.Equal(t, uint(42), u.ID)
+	assert.Equal(t, "alice", u.Username)
+	require.NotNil(t, u.PasswordChangedAt,
+		"PasswordChangedAt must be propagated from the wire response so "+
+			"enforcePasswordExpiryGate can evaluate the password age on remote storage")
+	assert.Equal(t, changedAt, *u.PasswordChangedAt)
+	assert.Equal(t, createdAt, u.CreatedAt,
+		"CreatedAt must be propagated so the fallback expiry path (nil PasswordChangedAt) works correctly")
+}
+
+// TestVerifyMFAWireResponse_ToModel_NilPasswordChangedAt confirms that a nil
+// PasswordChangedAt (legacy user, never explicitly set) is preserved as nil
+// rather than replaced with a zero value — core.PasswordExpired's fallback
+// path uses user.CreatedAt in that case, so both fields must round-trip cleanly.
+func TestVerifyMFAWireResponse_ToModel_NilPasswordChangedAt(t *testing.T) {
+	createdAt := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	wire := verifyMFAWireResponse{
+		ID:                7,
+		Username:          "bob",
+		UsedRecovery:      true,
+		PasswordChangedAt: nil,
+		CreatedAt:         createdAt,
+	}
+	u := wire.toModel()
+	require.NotNil(t, u)
+	assert.Nil(t, u.PasswordChangedAt,
+		"nil PasswordChangedAt must remain nil so the CreatedAt fallback in PasswordExpired is reached")
+	assert.Equal(t, createdAt, u.CreatedAt)
+}

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -520,9 +520,11 @@ func (h *UserHandler) VerifyMFACredentials(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	sendSuccess(w, map[string]interface{}{
-		"id":            u.ID,
-		"username":      u.Username,
-		"used_recovery": usedRecovery,
+		"id":                  u.ID,
+		"username":            u.Username,
+		"used_recovery":       usedRecovery,
+		"password_changed_at": u.PasswordChangedAt,
+		"created_at":          u.CreatedAt,
 	}, "")
 }
 


### PR DESCRIPTION
## Summary

- **Finding 1 (HIGH/CWE-294):** `requireReauth` used `validateTOTP` (no replay tracking) instead of `validateTOTPStep + MarkTOTPStepUsed`, leaving a ~90 s window where a stolen TOTP code could be replayed to authorize `DisableMFA`, `RegenerateMFARecoveryCodes`, `FinishWebAuthnRegistration`, and `DeleteWebAuthnCredential`. Fixed to use the same anti-replay path `VerifyMFACredentials` already applies.

- **Finding 2 (HIGH/CWE-287):** `verifyMFAWireResponse.toModel()` returned a sparse `User{ID, Username}` with zero `PasswordChangedAt`/`CreatedAt`, causing `enforcePasswordExpiryGate` to always evaluate `PasswordExpired()` as false on `storage.type: remote` spoke deployments. `PasswordChangedAt` and `CreatedAt` are now included in both the upstream wire response (`VerifyMFACredentials` handler) and the downstream struct, so the password-expiry hard gate applies correctly.

- **Finding 3 (MEDIUM/CWE-287):** `FinishWebAuthnLogin` and `FinishWebAuthnPasswordlessLogin` did not call `UpsertMFAStepupToken`, permanently locking out WebAuthn-authenticated users from `restricted_requires_mfa_stepup`-classified secrets despite WebAuthn being at least as strong a factor as TOTP. Both functions now record the step-up token when the gate is enabled, matching `VerifyMFALogin`.

## Test plan

- [ ] `TestRequireReauth_TOTPCodeNotReplayable` — verifies a TOTP code accepted once by `requireReauth` is rejected on a second call within the same step window
- [ ] `TestVerifyMFAWireResponse_ToModel_PreservesPasswordAgeFields` — verifies `PasswordChangedAt` and `CreatedAt` survive the wire→model conversion
- [ ] `TestVerifyMFAWireResponse_ToModel_NilPasswordChangedAt` — verifies nil `PasswordChangedAt` round-trips as nil (fallback expiry path)
- [ ] Existing `TestVerifyMFALogin_RecordsMFAStepupWhenGateEnabled` continues to pass
- [ ] `go build ./internal/core/ ./internal/storage/store/ ./server/http/handlers/` passes cleanly
- [ ] Full `go test ./internal/core/...` and `./internal/storage/store/` pass (only pre-existing sandbox TCP-bind failures excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)