### PR TITLE
fix(security): enforce machine token authz on secret list + revoke ACLs on delete

### DIFF
--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -499,6 +499,12 @@ func (ls *LocalStorage) DeleteSecret(ctx context.Context, id uint) error {
 			Delete(&models.ShareRecord{}).Error; err != nil {
 			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 		}
+		// CWE-284: revoke SecretACL grants in the same transaction so that
+		// ACL-based access cannot silently reactivate on restore (same class of
+		// bug fixed for ShareRecord in #370).
+		if err := tx.Where("secret_id = ?", id).Delete(&models.SecretACL{}).Error; err != nil {
+			return fmt.Errorf("failed to revoke secret ACLs: %w", err)
+		}
 		return nil
 	})
 }
@@ -888,7 +894,7 @@ func (ls *LocalStorage) GetSecretAncestors(ctx context.Context, nodeID uint) ([]
 	var ancestors []uint
 	visited := make(map[uint]struct{})
 	currentID := nodeID
-	for depth := 0; depth < maxAncestorDepth; depth++ {
+	for range maxAncestorDepth {
 		var node models.SecretNode
 		err := ls.db.WithContext(ctx).
 			Select("id", "parent_id").

--- a/internal/storage/store/local_sharing_test.go
+++ b/internal/storage/store/local_sharing_test.go
@@ -27,6 +27,7 @@ func sharingConcurrentDB(t *testing.T) *gorm.DB {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.User{}, &models.Group{}, &models.UserGroup{}, &models.SecretNode{}, &models.ShareRecord{},
+		&models.SecretACL{},
 	))
 	require.NoError(t, db.Exec(
 		"CREATE UNIQUE INDEX IF NOT EXISTS uniq_share_records_active ON share_records (secret_id, recipient_id, is_group) WHERE deleted_at IS NULL",
@@ -53,7 +54,7 @@ func TestCreateShareRecord_ConcurrentGrantsNoDuplicateRow(t *testing.T) {
 	errs := make([]error, n)
 	var start sync.WaitGroup
 	start.Add(1)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
@@ -428,4 +429,40 @@ func TestCheckSharePermission_DirectVsGroupConflict_StrongestWins(t *testing.T) 
 		require.NoError(t, err)
 		assert.Equal(t, "write", perm, "a stronger direct grant must win over a weaker group grant")
 	})
+}
+
+// CWE-284 / sibling of #370: DeleteSecret must also delete SecretACL rows in the
+// same transaction so that ACL-based access cannot silently reactivate when the
+// secret is later restored from the recycle bin (the same class of bug fixed for
+// ShareRecord in #370).
+func TestDeleteSecret_RevokesSecretACLs(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretACL{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "grantee", Email: "g@x.io"}).Error)
+	proj, err := ls.CreateProject(ctx, &models.Project{Name: "acl-app"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: proj.ID})
+	require.NoError(t, err)
+	sec, err := ls.CreateSecret(ctx, &models.SecretNode{
+		ProjectID: proj.ID, EnvironmentID: env.ID, Name: "acl-secret", IsSecret: true, Type: "text",
+		Status: "active", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	// Grant user 2 an ACL on the secret.
+	acl := &models.SecretACL{SecretID: sec.ID, UserID: 2, Permissions: `["secrets.read"]`, GrantedBy: 1}
+	require.NoError(t, db.Create(acl).Error)
+	aclID := acl.ID
+
+	// Delete the secret — both the soft-delete and the ACL row must be transacted together.
+	require.NoError(t, ls.DeleteSecret(ctx, sec.ID))
+
+	// The ACL row must be gone (hard-deleted by the Where+Delete call).
+	var count int64
+	require.NoError(t, db.Model(&models.SecretACL{}).Where("id = ?", aclID).Count(&count).Error)
+	assert.Equal(t, int64(0), count, "SecretACL row must be deleted alongside the secret")
 }

--- a/internal/storage/store/restore_test.go
+++ b/internal/storage/store/restore_test.go
@@ -17,8 +17,8 @@ func newRestoreTestStore(t *testing.T) *LocalStorage {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	// #370: DeleteSecret revokes ShareRecord rows in the same transaction as the
-	// secret's own soft-delete.
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.ShareRecord{}, &models.DynamicSecretConfig{}))
+	// secret's own soft-delete; SecretACL rows are revoked in the same transaction too (CWE-284).
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.ShareRecord{}, &models.SecretACL{}, &models.DynamicSecretConfig{}))
 	return NewLocalStorage(db)
 }
 

--- a/internal/storage/store/secret_soft_delete_test.go
+++ b/internal/storage/store/secret_soft_delete_test.go
@@ -19,7 +19,7 @@ func newSoftDeleteTestStore(t *testing.T) *LocalStorage {
 	require.NoError(t, err)
 	// #370: DeleteSecret revokes ShareRecord rows in the same transaction as the
 	// secret's own soft-delete.
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.SecretNode{}, &models.SecretVersion{}, &models.Environment{}, &models.SecretDependency{}, &models.ShareRecord{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.SecretNode{}, &models.SecretVersion{}, &models.Environment{}, &models.SecretDependency{}, &models.ShareRecord{}, &models.SecretACL{}))
 	return NewLocalStorage(db)
 }
 
@@ -46,10 +46,11 @@ func TestSecretSoftDeleteLifecycle(t *testing.T) {
 	assert.True(t, got.DeletedAt.Valid, "row retained with deleted_at set")
 
 	// ListSecrets excludes by default, includes with IncludeDeleted.
-	live, _, err := ls.ListSecrets(ctx, &storage.SecretFilter{ProjectID: ptr(projectID), Page: 1, PageSize: 50})
+	pid := uint(projectID)
+	live, _, err := ls.ListSecrets(ctx, &storage.SecretFilter{ProjectID: &pid, Page: 1, PageSize: 50})
 	require.NoError(t, err)
 	assert.Len(t, live, 0, "soft-deleted secret excluded from default listing")
-	all, _, err := ls.ListSecrets(ctx, &storage.SecretFilter{ProjectID: ptr(projectID), Page: 1, PageSize: 50, IncludeDeleted: true})
+	all, _, err := ls.ListSecrets(ctx, &storage.SecretFilter{ProjectID: &pid, Page: 1, PageSize: 50, IncludeDeleted: true})
 	require.NoError(t, err)
 	assert.Len(t, all, 1, "IncludeDeleted surfaces it for the restore UI")
 
@@ -107,4 +108,3 @@ func TestPurgeDeletedSecretsBefore_CascadesDependencyEdges(t *testing.T) {
 	assert.Equal(t, int64(0), edges, "the edge incident to the purged secret is removed (no orphan)")
 }
 
-func ptr[T any](v T) *T { return &v }

--- a/internal/storage/store/store_max_test.go
+++ b/internal/storage/store/store_max_test.go
@@ -370,7 +370,7 @@ func newSecretsStore(t *testing.T) *LocalStorage {
 	ls := newMaxStore(t, "sec_"+t.Name(),
 		&models.Project{}, &models.Environment{}, &models.SecretNode{},
 		&models.SecretVersion{}, &models.Tag{}, &models.SecretTag{},
-		&models.ShareRecord{}, &models.DynamicSecretConfig{},
+		&models.ShareRecord{}, &models.SecretACL{}, &models.DynamicSecretConfig{},
 		&models.UserRole{}, &models.GroupRole{},
 	)
 	// Partial unique indexes for name uniqueness (replicate migrateDatabase).
@@ -999,7 +999,7 @@ func newPurgeStore(t *testing.T) *LocalStorage {
 	t.Helper()
 	return newMaxStore(t, "purge_"+t.Name(),
 		&models.User{}, &models.UserRole{}, &models.UserGroup{},
-		&models.ShareRecord{}, &models.PersonalAccessToken{}, &models.Session{},
+		&models.ShareRecord{}, &models.SecretACL{}, &models.PersonalAccessToken{}, &models.Session{},
 		&models.Project{}, &models.Environment{},
 		&models.SecretNode{}, &models.SecretVersion{}, &models.SecretDependency{},
 		&models.GroupRole{}, &models.Group{},

--- a/internal/storage/store/store_s29_test.go
+++ b/internal/storage/store/store_s29_test.go
@@ -79,7 +79,7 @@ import (
 // ---------------------------------------------------------------------------
 
 // newS29Store opens a unique in-memory SQLite DB with requested models migrated.
-func newS29Store(t *testing.T, mods ...interface{}) *LocalStorage {
+func newS29Store(t *testing.T, mods ...any) *LocalStorage {
 	t.Helper()
 	dsn := "file:" + t.Name() + "_s29?mode=memory&cache=shared"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
@@ -91,9 +91,9 @@ func newS29Store(t *testing.T, mods ...interface{}) *LocalStorage {
 }
 
 // sharingModels lists the models needed for sharing-related tests.
-var sharingModels = []interface{}{
+var sharingModels = []any{
 	&models.User{}, &models.Group{}, &models.UserGroup{},
-	&models.SecretNode{}, &models.ShareRecord{},
+	&models.SecretNode{}, &models.ShareRecord{}, &models.SecretACL{},
 	&models.Project{}, &models.Environment{},
 }
 
@@ -517,7 +517,7 @@ func TestCheckSharePermission_S29_OwnerGetsWrite(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDeleteSecret_S29_NotFound(t *testing.T) {
-	ls := newS29Store(t, &models.SecretNode{}, &models.ShareRecord{})
+	ls := newS29Store(t, &models.SecretNode{}, &models.ShareRecord{}, &models.SecretACL{})
 	err := ls.DeleteSecret(context.Background(), 9999)
 	require.Error(t, err)
 }
@@ -841,7 +841,7 @@ func TestSetSecretTags_S29_HappyPath(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestListSecrets_S29_DeletedOnly(t *testing.T) {
-	ls := newS29Store(t, &models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.ShareRecord{})
+	ls := newS29Store(t, &models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.ShareRecord{}, &models.SecretACL{})
 	ctx := context.Background()
 
 	p, err := ls.CreateProject(ctx, &models.Project{Name: "P"})
@@ -865,7 +865,7 @@ func TestListSecrets_S29_DeletedOnly(t *testing.T) {
 }
 
 func TestListSecrets_S29_IncludeDeleted(t *testing.T) {
-	ls := newS29Store(t, &models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.ShareRecord{})
+	ls := newS29Store(t, &models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.ShareRecord{}, &models.SecretACL{})
 	ctx := context.Background()
 
 	p, err := ls.CreateProject(ctx, &models.Project{Name: "P2"})

--- a/server/http/handlers/folders_handler_test.go
+++ b/server/http/handlers/folders_handler_test.go
@@ -53,7 +53,7 @@ func freshFolderFixture(t *testing.T) (*FolderHandler, *core.KeyorixCore, *gorm.
 		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.Project{}, &models.Environment{}, &models.SecretNode{},
 		&models.AuditEvent{}, &models.SecretVersion{}, &models.SecretAccessLog{},
-		&models.ShareRecord{},
+		&models.ShareRecord{}, &models.SecretACL{},
 	))
 
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice-folder", AccountState: "active"}).Error)
@@ -83,7 +83,7 @@ func withFolderAdminCtx(r *http.Request) *http.Request {
 func TestCreateFolder_HappyPath(t *testing.T) {
 	h, _, _ := freshFolderFixture(t)
 
-	body, _ := json.Marshal(map[string]interface{}{
+	body, _ := json.Marshal(map[string]any{
 		"name":           "configs",
 		"project_id":     1,
 		"environment_id": 10,
@@ -102,7 +102,7 @@ func TestCreateFolder_HappyPath(t *testing.T) {
 func TestCreateFolder_MissingName(t *testing.T) {
 	h, _, _ := freshFolderFixture(t)
 
-	body, _ := json.Marshal(map[string]interface{}{
+	body, _ := json.Marshal(map[string]any{
 		"project_id":     1,
 		"environment_id": 10,
 	})
@@ -118,7 +118,7 @@ func TestCreateFolder_MissingName(t *testing.T) {
 func TestCreateFolder_MissingProjectID(t *testing.T) {
 	h, _, _ := freshFolderFixture(t)
 
-	body, _ := json.Marshal(map[string]interface{}{
+	body, _ := json.Marshal(map[string]any{
 		"name":           "configs",
 		"environment_id": 10,
 	})
@@ -134,7 +134,7 @@ func TestCreateFolder_MissingProjectID(t *testing.T) {
 func TestCreateFolder_NoUserContext_401(t *testing.T) {
 	h, _, _ := freshFolderFixture(t)
 
-	body, _ := json.Marshal(map[string]interface{}{
+	body, _ := json.Marshal(map[string]any{
 		"name": "configs", "project_id": 1, "environment_id": 10,
 	})
 	// No user context injected.

--- a/server/http/handlers/secrets_error_sanitization_test.go
+++ b/server/http/handlers/secrets_error_sanitization_test.go
@@ -49,7 +49,8 @@ func secretErrSanitizationFixture(t *testing.T) (*SecretHandler, *core.KeyorixCo
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{},
 		&models.Permission{}, &models.RolePermission{}, &models.Group{}, &models.GroupRole{},
 		&models.UserGroup{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{},
-		&models.SecretNode{}, &models.SecretVersion{}, &models.SecretAccessLog{}, &models.ShareRecord{}))
+		&models.SecretNode{}, &models.SecretVersion{}, &models.SecretAccessLog{}, &models.ShareRecord{},
+		&models.SecretACL{}))
 
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", AccountState: "active"}).Error)
 	adminRole := &models.Role{Name: "admin"}

--- a/server/http/handlers/secrets_list.go
+++ b/server/http/handlers/secrets_list.go
@@ -105,7 +105,7 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) { //
 	// Tag filter: repeatable ?tag=a&tag=b or a single comma-separated ?tag=a,b.
 	// A secret must carry every requested tag (AND).
 	for _, raw := range r.URL.Query()["tag"] {
-		for _, part := range strings.Split(raw, ",") {
+		for part := range strings.SplitSeq(raw, ",") {
 			if t := strings.TrimSpace(part); t != "" {
 				filter.Tags = append(filter.Tags, t)
 			}
@@ -140,9 +140,28 @@ func (h *SecretHandler) ListSecrets(w http.ResponseWriter, r *http.Request) { //
 
 	// Machine principals (ADR-030) have no user identity for the owned/shared
 	// model; they list by their authorized scope without the scoped-union logic.
+	// Security gate (CWE-862): a machine token must supply an explicit project_id
+	// and must be authorized for secrets.read within that project. Without this
+	// gate, any machine token (regardless of its assigned project scope) could
+	// enumerate secrets from arbitrary projects or across all projects.
 	var response *models.SecretListResponse
 	var err error
 	if userCtx.MachineIdentityID != nil {
+		if filter.ProjectID == nil {
+			h.sendError(w, "BadRequest", "machine tokens must specify project_id", http.StatusBadRequest, nil)
+			return
+		}
+		scope := core.Scope{ProjectID: *filter.ProjectID}
+		if filter.EnvironmentID != nil {
+			scope.EnvironmentID = *filter.EnvironmentID
+		}
+		allowed, aerr := h.coreService.AuthorizePrincipal(
+			r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), permSecretsRead, scope,
+		)
+		if aerr != nil || !allowed {
+			h.sendError(w, "Forbidden", "Insufficient permissions", http.StatusForbidden, nil)
+			return
+		}
 		response, err = h.coreService.ListSecretsInScope(r.Context(), filter)
 		if err != nil {
 			log.Printf("Error listing secrets: %v", err)

--- a/server/http/handlers/secrets_list_cov_test.go
+++ b/server/http/handlers/secrets_list_cov_test.go
@@ -2,12 +2,12 @@
 // edge-case paths not reached by secrets_list_scoped_test.go or secrets_list_s38_test.go.
 //
 // Covers:
-//   - Machine identity ListSecretsInScope error → 500 (line 147–151)
-//   - Scoped request ListSecretsWithSharingInfo error → 500 (line 178–182)
-//   - GetReadableScopes error → 500 (line 207–211)
-//   - Env-scoped role (EnvironmentID != 0) in the union loop (line 236–239)
-//   - Page beyond total results → start > totalInt clamp (line 260–262)
-//   - Zero secrets in union → totalPages == 0 → set to 1 (line 267–269)
+//   - Machine identity missing project_id → 400 (CWE-862 param gate)
+//   - Scoped request ListSecretsWithSharingInfo error → 500
+//   - GetReadableScopes error → 500
+//   - Env-scoped role (EnvironmentID != 0) in the union loop
+//   - Page beyond total results → start > totalInt clamp
+//   - Zero secrets in union → totalPages == 0 → set to 1
 package handlers
 
 import (
@@ -86,9 +86,11 @@ func withCovUserCtx(r *http.Request, userID uint) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), uc))
 }
 
-// TestListSecrets_MachineIdentity_ListError closes the DB so ListSecretsInScope
-// fails and the machine-principal path returns 500 (line 147–151).
-func TestListSecrets_MachineIdentity_ListError(t *testing.T) {
+// TestListSecrets_MachineIdentity_NoProjectID verifies that a machine principal
+// without an explicit ?project_id= query parameter receives 400 (CWE-862 gate).
+// The DB does not need to be reachable for this check — it is a param-validation
+// guard that runs before any storage call.
+func TestListSecrets_MachineIdentity_NoProjectID(t *testing.T) {
 	h, db := freshCovListFixture(t)
 
 	sqlDB, err := db.DB()
@@ -98,7 +100,7 @@ func TestListSecrets_MachineIdentity_ListError(t *testing.T) {
 	req := withMachineCtx(httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil))
 	w := httptest.NewRecorder()
 	h.ListSecrets(w, req)
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 // TestListSecrets_ScopedRequest_ListError closes the DB so ListSecretsWithSharingInfo

--- a/server/http/handlers/secrets_list_machine_authz_test.go
+++ b/server/http/handlers/secrets_list_machine_authz_test.go
@@ -1,0 +1,181 @@
+// secrets_list_machine_authz_test.go — machine-principal authorization tests for ListSecrets.
+//
+// Covers CWE-862: machine tokens must supply an explicit project_id and must hold
+// secrets.read in that project's scope before the handler calls ListSecretsInScope.
+//
+// Test matrix:
+//   - Machine token with no project_id → 400 (missing required param)
+//   - Machine token with project_id for a project it has NO role in → 403
+//   - Machine token scoped to project 1 accessing project 2 → 403
+//   - Machine token scoped to project 1 accessing project 1 → 200 (authorised)
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var machineAuthzDBCounter atomic.Int64
+
+// freshMachineAuthzFixture opens an isolated named in-memory SQLite DB with all
+// models required by the ListSecrets handler and the RBAC / machine-role layer.
+func freshMachineAuthzFixture(t *testing.T) (*SecretHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := machineAuthzDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhandlers_machine_authz_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, db.AutoMigrate(
+		&models.User{},
+		&models.Role{},
+		&models.UserRole{},
+		&models.Permission{},
+		&models.RolePermission{},
+		&models.Group{},
+		&models.UserGroup{},
+		&models.GroupRole{},
+		&models.Project{},
+		&models.Environment{},
+		&models.SecretNode{},
+		&models.SecretACL{},
+		&models.AuditEvent{},
+		&models.SecretVersion{},
+		&models.SecretAccessLog{},
+		&models.ShareRecord{},
+		&models.MachineIdentity{},
+		&models.MachineIdentityRole{},
+	))
+
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	return h, db
+}
+
+// withMachineCtxID builds a request UserContext for the given machine identity ID.
+func withMachineCtxID(r *http.Request, machineID uint) *http.Request {
+	uc := &middleware.UserContext{
+		UserID:            0,
+		ActorType:         core.ActorTypeMachine,
+		MachineIdentityID: &machineID,
+	}
+	return r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), uc))
+}
+
+// seedMachineReadRole creates a Role with secrets.read and grants it to machineID at
+// projectID scope via MachineIdentityRole. Returns the role ID.
+func seedMachineReadRole(t *testing.T, db *gorm.DB, roleName string, machineID, projectID uint) uint {
+	t.Helper()
+
+	role := &models.Role{Name: roleName}
+	require.NoError(t, db.Create(role).Error)
+
+	perm := &models.Permission{}
+	if err := db.Where("name = ?", permSecretsRead).First(perm).Error; err != nil {
+		perm = &models.Permission{Name: permSecretsRead, Resource: "secrets", Action: "read"}
+		require.NoError(t, db.Create(perm).Error)
+	}
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: role.ID, PermissionID: perm.ID}).Error)
+
+	require.NoError(t, db.Create(&models.MachineIdentityRole{
+		MachineIdentityID: machineID,
+		RoleID:            role.ID,
+		ProjectID:         projectID,
+		EnvironmentID:     0,
+	}).Error)
+	return role.ID
+}
+
+// TestListSecrets_MachineToken_NoProjectID verifies that a machine principal
+// calling GET /api/v1/secrets without ?project_id= receives 400.
+func TestListSecrets_MachineToken_NoProjectID(t *testing.T) {
+	h, db := freshMachineAuthzFixture(t)
+
+	// Seed a machine identity so it is a valid principal.
+	const machineID = uint(10)
+	require.NoError(t, db.Create(&models.MachineIdentity{
+		ID: machineID, ProjectID: 1, Name: "ci-runner", State: "active",
+	}).Error)
+
+	req := withMachineCtxID(httptest.NewRequest(http.MethodGet, "/api/v1/secrets", nil), machineID)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "machine token without project_id must get 400")
+}
+
+// TestListSecrets_MachineToken_WrongProject verifies that a machine principal
+// scoped to project 1 cannot list secrets from project 2 (→ 403).
+func TestListSecrets_MachineToken_WrongProject(t *testing.T) {
+	h, db := freshMachineAuthzFixture(t)
+
+	// Seed two projects.
+	proj1 := &models.Project{Name: "proj-machine-1"}
+	require.NoError(t, db.Create(proj1).Error)
+	proj2 := &models.Project{Name: "proj-machine-2"}
+	require.NoError(t, db.Create(proj2).Error)
+
+	// Machine 20 has secrets.read only in project 1.
+	const machineID = uint(20)
+	require.NoError(t, db.Create(&models.MachineIdentity{
+		ID: machineID, ProjectID: proj1.ID, Name: "ci-runner-20", State: "active",
+	}).Error)
+	seedMachineReadRole(t, db, "machine_reader_p1", machineID, proj1.ID)
+
+	// Request secrets from project 2 — the machine has no role there.
+	url := fmt.Sprintf("/api/v1/secrets?project_id=%d", proj2.ID)
+	req := withMachineCtxID(httptest.NewRequest(http.MethodGet, url, nil), machineID)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "machine token accessing wrong project must get 403")
+}
+
+// TestListSecrets_MachineToken_AuthorizedProject verifies that a machine principal
+// with secrets.read in project 1 can list secrets from project 1 (→ 200).
+func TestListSecrets_MachineToken_AuthorizedProject(t *testing.T) {
+	h, db := freshMachineAuthzFixture(t)
+
+	proj := &models.Project{Name: "proj-machine-auth"}
+	require.NoError(t, db.Create(proj).Error)
+	env := &models.Environment{Name: "env-machine-auth", ProjectID: proj.ID}
+	require.NoError(t, db.Create(env).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		Name: "machine-visible-secret", ProjectID: proj.ID, EnvironmentID: env.ID,
+		OwnerID: 0, Type: "static", IsSecret: true,
+	}).Error)
+
+	const machineID = uint(30)
+	require.NoError(t, db.Create(&models.MachineIdentity{
+		ID: machineID, ProjectID: proj.ID, Name: "ci-runner-30", State: "active",
+	}).Error)
+	seedMachineReadRole(t, db, "machine_reader_auth", machineID, proj.ID)
+
+	url := fmt.Sprintf("/api/v1/secrets?project_id=%d", proj.ID)
+	req := withMachineCtxID(httptest.NewRequest(http.MethodGet, url, nil), machineID)
+	w := httptest.NewRecorder()
+	h.ListSecrets(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "authorized machine token should get 200")
+	resp := decodeListResponse(t, w.Body.Bytes())
+	assert.GreaterOrEqual(t, resp.Total, int64(1), "authorized machine token should see its project's secrets")
+}

--- a/server/http/handlers/secrets_list_s38_test.go
+++ b/server/http/handlers/secrets_list_s38_test.go
@@ -174,8 +174,10 @@ func TestListSecrets_ExpiresBeforeParam_S38(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-// TestListSecrets_MachineIdentityPath_S38 exercises the machine-identity dispatch branch
-// (ListSecretsInScope rather than ListSecretsWithSharingInfo).
+// TestListSecrets_MachineIdentityPath_S38 exercises the machine-identity dispatch branch.
+// A machine token without project_id must now receive 400 (CWE-862 gate).
+// The authorized path (with project_id + a matching role) is covered by the
+// secrets_list_machine_authz_test.go suite.
 func TestListSecrets_MachineIdentityPath_S38(t *testing.T) {
 	t.Parallel()
 	h, _ := freshListFixtureS38(t)
@@ -190,8 +192,8 @@ func TestListSecrets_MachineIdentityPath_S38(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), middleware.GetUserContextKey(), uc))
 	w := httptest.NewRecorder()
 	h.ListSecrets(w, req)
-	// Machine identity path uses ListSecretsInScope — must return 200.
-	assert.Equal(t, http.StatusOK, w.Code)
+	// Machine tokens without an explicit project_id are rejected with 400.
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 // TestListSecrets_TagCommaList_S38 exercises the comma-separated tag syntax.


### PR DESCRIPTION
## Summary

- **CWE-862 (Missing Authorization):** Machine tokens calling `GET /api/v1/secrets` now require an explicit `?project_id=` parameter and pass an `AuthorizePrincipal` check against their assigned role scope before `ListSecretsInScope` is called. Previously, any machine token could enumerate secrets from arbitrary projects or across all projects with no authorization gate.

- **CWE-284 (Improper Access Control):** `DeleteSecret` now deletes all `SecretACL` rows for the secret in the same DB transaction as the soft-delete and `ShareRecord` revocation. ACL grants could silently reactivate on restore — the same class of bug fixed for shares in #370.

## Test plan

- [ ] `TestListSecrets_MachineToken_NoProjectID` → 400 when `project_id` param absent
- [ ] `TestListSecrets_MachineToken_WrongProject` → 403 when machine has role in project 1 but requests project 2
- [ ] `TestListSecrets_MachineToken_AuthorizedProject` → 200 when machine has `secrets.read` in the requested project
- [ ] `TestDeleteSecret_RevokesSecretACLs` → ACL row gone after `DeleteSecret`
- [ ] Updated existing tests (`TestListSecrets_MachineIdentity_NoProjectID`, `TestListSecrets_MachineIdentityPath_S38`) aligned with new 400 response
- [ ] All test fixtures that call `DeleteSecret` updated to include `SecretACL` in their AutoMigrate list so the transaction does not fail on a missing table
- [ ] `go build ./...` clean
- [ ] `go test ./server/http/handlers/...` passes
- [ ] `go test ./internal/storage/store/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)