### PR TITLE
fix(security): crypto hardening — bcrypt cost 12, RSA floor, Shamir fatal (r120-E)

### DIFF
--- a/internal/cli/secret/export_encrypt.go
+++ b/internal/cli/secret/export_encrypt.go
@@ -55,6 +55,11 @@ func encryptExport(plainJSON []byte, pubKeyPath string) ([]byte, error) {
 		pub = rsaKey
 	}
 
+	// Enforce a minimum RSA key size to reject weak keys before encrypting.
+	if pub.N.BitLen() < 2048 {
+		return nil, fmt.Errorf("RSA public key must be at least 2048 bits; got %d", pub.N.BitLen())
+	}
+
 	// 2. Generate random 32-byte AES key.
 	aesKey := make([]byte, 32)
 	if _, err := rand.Read(aesKey); err != nil {

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -157,7 +157,7 @@ func (c *KeyorixCore) validateNewPassword(ctx context.Context, user *models.User
 // (hash persisted but the state clear lost, or vice versa) can't happen on backends
 // that support real transactions.
 func (c *KeyorixCore) applyNewPassword(ctx context.Context, user *models.User, newPassword string) error {
-	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), 12)
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcryptCost)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -157,7 +157,7 @@ func (c *KeyorixCore) validateNewPassword(ctx context.Context, user *models.User
 // (hash persisted but the state clear lost, or vice versa) can't happen on backends
 // that support real transactions.
 func (c *KeyorixCore) applyNewPassword(ctx context.Context, user *models.User, newPassword string) error {
-	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), 12)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -38,10 +38,10 @@ type LoginRequest struct {
 	IPAddress string
 }
 
-// dummyBcryptHash is a fixed bcrypt hash (DefaultCost) used to equalize the timing of
+// dummyBcryptHash is a fixed bcrypt hash (cost 12) used to equalize the timing of
 // the user-not-found login path with the wrong-password path, so /auth/login can't be
 // used as a username-existence oracle. Computed once at package load.
-var dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), bcrypt.DefaultCost) // NOSONAR -- not a credential; this is a timing-equalization sentinel to prevent username-existence oracle attacks
+var dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), 12) // NOSONAR -- not a credential; this is a timing-equalization sentinel to prevent username-existence oracle attacks
 
 // RemoteLoginVerifier is implemented by storage backends that cannot themselves
 // supply a real password hash for VerifyPasswordCredentials to compare against

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -38,10 +38,10 @@ type LoginRequest struct {
 	IPAddress string
 }
 
-// dummyBcryptHash is a fixed bcrypt hash (cost 12) used to equalize the timing of
-// the user-not-found login path with the wrong-password path, so /auth/login can't be
-// used as a username-existence oracle. Computed once at package load.
-var dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), 12) // NOSONAR -- not a credential; this is a timing-equalization sentinel to prevent username-existence oracle attacks
+// dummyBcryptHash is a fixed bcrypt hash used to equalize the timing of the
+// user-not-found login path with the wrong-password path, so /auth/login can't
+// be used as a username-existence oracle. Initialized in bcrypt_cost.go init().
+var dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), bcryptCost) // NOSONAR -- not a credential; timing-equalization sentinel
 
 // RemoteLoginVerifier is implemented by storage backends that cannot themselves
 // supply a real password hash for VerifyPasswordCredentials to compare against

--- a/internal/core/bcrypt_cost.go
+++ b/internal/core/bcrypt_cost.go
@@ -1,0 +1,18 @@
+package core
+
+import "golang.org/x/crypto/bcrypt"
+
+// bcryptCost is the work factor for all password hashing. Production default is
+// 12. Tests should call SetBcryptCostForTesting(bcrypt.MinCost) in TestMain to
+// avoid slowing down the test suite.
+var bcryptCost = 12
+
+// SetBcryptCostForTesting sets the bcrypt work factor and regenerates the
+// timing-equalization dummy hash. Call this in TestMain before any test runs;
+// do not call in production code.
+func SetBcryptCostForTesting(cost int) {
+	bcryptCost = cost
+	// Regenerate so the dummy hash matches the test cost; otherwise the
+	// timing-equalization constant is computed at cost 12 even in tests.
+	dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), cost) // NOSONAR
+}

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -96,7 +96,12 @@ func (c *KeyorixCore) ActivateMFA(ctx context.Context, userID uint, code, passwo
 	if err != nil {
 		return nil, fmt.Errorf("no pending MFA enrolment; begin enrolment first")
 	}
-	if !c.validateTOTP(secret, code) {
+	step, ok := c.validateTOTPStep(secret, code)
+	if !ok {
+		c.auditMFAFailed(ctx, userID, "activate")
+		return nil, fmt.Errorf("invalid code")
+	}
+	if fresh, ferr := c.storage.MarkTOTPStepUsed(ctx, userID, step); ferr != nil || !fresh {
 		c.auditMFAFailed(ctx, userID, "activate")
 		return nil, fmt.Errorf("invalid code")
 	}
@@ -376,18 +381,6 @@ func (c *KeyorixCore) loadTOTPSecret(ctx context.Context, userID uint) (string, 
 	return c.decryptAuthSecret(row.SecretEnc, row.SecretMeta, encryption.MFASecretAAD(userID))
 }
 
-func (c *KeyorixCore) validateTOTP(secret, code string) bool {
-	code = strings.TrimSpace(code)
-	if code == "" {
-		return false
-	}
-	// ±1 time-step skew (clock drift); standard 30s SHA-1 6-digit TOTP.
-	valid, _ := totp.ValidateCustom(code, secret, c.now().UTC(), totp.ValidateOpts{
-		Period: 30, Skew: 1, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1,
-	})
-	return valid
-}
-
 // totpPeriod is the TOTP step length in seconds.
 const totpPeriod = 30
 
@@ -437,8 +430,15 @@ func (c *KeyorixCore) requireReauth(ctx context.Context, user *models.User, code
 	}
 	ok := false
 	if user.MFAEnabled {
-		if secret, err := c.loadTOTPSecret(ctx, user.ID); err == nil && c.validateTOTP(secret, codeOrPassword) {
-			ok = true
+		if secret, err := c.loadTOTPSecret(ctx, user.ID); err == nil {
+			// Use the same anti-replay path as VerifyMFACredentials: identify the
+			// matched time-step and atomically mark it used so a stolen code cannot
+			// be replayed within the ±1 step (~90 s) window.
+			if step, matched := c.validateTOTPStep(secret, codeOrPassword); matched {
+				if fresh, ferr := c.storage.MarkTOTPStepUsed(ctx, user.ID, step); ferr == nil && fresh {
+					ok = true
+				}
+			}
 		}
 	}
 	if !ok && codeOrPassword != "" && bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(codeOrPassword)) == nil {

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -102,7 +102,7 @@ func randomPasswordHash() (string, error) {
 	if _, err := rand.Read(b); err != nil {
 		return "", err
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(hex.EncodeToString(b)), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(hex.EncodeToString(b)), 12)
 	if err != nil {
 		return "", err
 	}

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -102,7 +102,7 @@ func randomPasswordHash() (string, error) {
 	if _, err := rand.Read(b); err != nil {
 		return "", err
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(hex.EncodeToString(b)), 12)
+	hash, err := bcrypt.GenerateFromPassword([]byte(hex.EncodeToString(b)), bcryptCost)
 	if err != nil {
 		return "", err
 	}

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -44,7 +44,7 @@ func (c *KeyorixCore) buildUserForCreate(ctx context.Context, req *CreateUserReq
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), 12)
 	if err != nil {
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -44,7 +44,7 @@ func (c *KeyorixCore) buildUserForCreate(ctx context.Context, req *CreateUserReq
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), 12)
+	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcryptCost)
 	if err != nil {
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}

--- a/internal/crypto/crypto_s22_test.go
+++ b/internal/crypto/crypto_s22_test.go
@@ -185,8 +185,9 @@ func TestShamirKeyProvider_S22_EmptyPathsSkipped(t *testing.T) {
 	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
 	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
 
+	commitmentHex := hex.EncodeToString(CommitKEK(kek))
 	// Include empty-string paths that must be silently skipped.
-	got, err := NewShamirKeyProvider([]string{"", f1, "", f2, ""}, nil, "").KEK()
+	got, err := NewShamirKeyProvider([]string{"", f1, "", f2, ""}, nil, commitmentHex).KEK()
 	require.NoError(t, err)
 	assert.Equal(t, kek, got)
 }
@@ -203,8 +204,9 @@ func TestShamirKeyProvider_S22_EmptyEnvVarsSkipped(t *testing.T) {
 	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
 	t.Setenv("KX_S22_SHARE2", base64.StdEncoding.EncodeToString(shares[1]))
 
+	commitmentHex := hex.EncodeToString(CommitKEK(kek))
 	// One empty env-var name that must be skipped; the non-empty one carries the share.
-	got, err := NewShamirKeyProvider([]string{f1}, []string{"", "KX_S22_SHARE2", ""}, "").KEK()
+	got, err := NewShamirKeyProvider([]string{f1}, []string{"", "KX_S22_SHARE2", ""}, commitmentHex).KEK()
 	require.NoError(t, err)
 	assert.Equal(t, kek, got)
 }

--- a/internal/crypto/crypto_s23_test.go
+++ b/internal/crypto/crypto_s23_test.go
@@ -112,7 +112,8 @@ func TestShamirKeyProvider_S23_TwoOfTwoSplit(t *testing.T) {
 	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
 	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
 
-	got, err := NewShamirKeyProvider([]string{f1, f2}, nil, "").KEK()
+	commitmentHex := hex.EncodeToString(CommitKEK(kek))
+	got, err := NewShamirKeyProvider([]string{f1, f2}, nil, commitmentHex).KEK()
 	require.NoError(t, err)
 	assert.Equal(t, kek, got)
 }
@@ -127,7 +128,8 @@ func TestShamirKeyProvider_S23_TwoSharesViaEnvOnly(t *testing.T) {
 	t.Setenv("KX_S23_ENVSHARE1", base64.StdEncoding.EncodeToString(shares[0]))
 	t.Setenv("KX_S23_ENVSHARE2", base64.StdEncoding.EncodeToString(shares[1]))
 
-	got, err := NewShamirKeyProvider(nil, []string{"KX_S23_ENVSHARE1", "KX_S23_ENVSHARE2"}, "").KEK()
+	commitmentHex := hex.EncodeToString(CommitKEK(kek))
+	got, err := NewShamirKeyProvider(nil, []string{"KX_S23_ENVSHARE1", "KX_S23_ENVSHARE2"}, commitmentHex).KEK()
 	require.NoError(t, err)
 	assert.Equal(t, kek, got)
 }

--- a/internal/crypto/shamir_provider.go
+++ b/internal/crypto/shamir_provider.go
@@ -190,7 +190,7 @@ func (p *ShamirKeyProvider) KEK() ([]byte, error) { // NOSONAR -- cognitive comp
 		// Not a hard failure — existing key material split before shamir_commitment
 		// existed has no commitment to check — but this is a real reduction in
 		// verification strength that every startup should surface loudly.
-		log.Printf("shamir key provider: no shamir_commitment configured — reconstruction relies solely on the forgeable magic-byte framing check, NOT a cryptographic integrity check (see issue #429); run `keyorix encryption shamir-split` again (or otherwise compute crypto.CommitKEK over the existing KEK) and set shamir_commitment to close this gap")
+		log.Fatalf("shamir key provider: no shamir_commitment configured — reconstruction relies solely on the forgeable magic-byte framing check, NOT a cryptographic integrity check (see issue #429); run `keyorix encryption shamir-split` again and set shamir_commitment to close this gap")
 	}
 	// combineKEK enforces the embedded threshold and verifies the framing magic, so
 	// a sub-threshold or wrong set of shares fails closed here — including on a fresh

--- a/internal/crypto/shamir_provider_test.go
+++ b/internal/crypto/shamir_provider_test.go
@@ -29,7 +29,8 @@ func TestShamirKeyProvider_CombinesSharesFromFilesAndEnv(t *testing.T) {
 	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
 	t.Setenv("KX_SHARE_3", base64.StdEncoding.EncodeToString(shares[2]))
 
-	got, err := NewShamirKeyProvider([]string{f1, f2}, []string{"KX_SHARE_3"}, "").KEK()
+	commitmentHex := hex.EncodeToString(CommitKEK(kek))
+	got, err := NewShamirKeyProvider([]string{f1, f2}, []string{"KX_SHARE_3"}, commitmentHex).KEK()
 	require.NoError(t, err)
 	assert.Equal(t, kek, got)
 }
@@ -62,7 +63,8 @@ func TestShamirKeyProvider_SubThresholdRejected(t *testing.T) {
 	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
 	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
 
-	_, err = NewShamirKeyProvider([]string{f1, f2}, nil, "").KEK()
+	commitmentHex := hex.EncodeToString(CommitKEK(kek))
+	_, err = NewShamirKeyProvider([]string{f1, f2}, nil, commitmentHex).KEK()
 	require.Error(t, err, "below-threshold shares must fail closed, not reconstruct a wrong KEK")
 }
 
@@ -70,14 +72,18 @@ func TestShamirKeyProvider_UnframedSharesRejected(t *testing.T) {
 	dir := t.TempDir()
 	// Raw Split (not SplitKEK) produces shares without the KEK framing — the provider
 	// must reject them rather than accept an unverified reconstruction.
-	shares, err := Split(testKEK(), 3, 2)
+	kek := testKEK()
+	shares, err := Split(kek, 3, 2)
 	require.NoError(t, err)
 	f1 := filepath.Join(dir, "s1")
 	f2 := filepath.Join(dir, "s2")
 	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
 	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
 
-	_, err = NewShamirKeyProvider([]string{f1, f2}, nil, "").KEK()
+	// A commitment is required now; even with a valid commitment the unframed shares
+	// must be rejected by combineKEK's magic-byte check.
+	commitmentHex := hex.EncodeToString(CommitKEK(kek))
+	_, err = NewShamirKeyProvider([]string{f1, f2}, nil, commitmentHex).KEK()
 	require.Error(t, err, "shares without the KEK framing must be rejected")
 }
 
@@ -125,14 +131,8 @@ func TestShamirKeyProvider_ForgedShareRejectedWithCommitment(t *testing.T) {
 	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(genuine[1])), 0600))
 	require.NoError(t, os.WriteFile(f3, []byte(hex.EncodeToString(forged)), 0600))
 
-	// Without shamir_commitment configured (legacy behavior): the vulnerability —
-	// the forged share is accepted and the attacker's chosen KEK is returned.
-	legacyKEK, err := NewShamirKeyProvider([]string{f1, f2, f3}, nil, "").KEK()
-	require.NoError(t, err, "demonstrates the vulnerability at the provider level")
-	assert.Equal(t, fakeKEK, legacyKEK)
-
-	// With shamir_commitment configured (the fix): the exact same forged share is
-	// now rejected instead of silently returning the attacker-chosen KEK.
+	// With shamir_commitment configured: the forged share is rejected instead of
+	// silently returning the attacker-chosen KEK.
 	_, err = NewShamirKeyProvider([]string{f1, f2, f3}, nil, commitmentHex).KEK()
 	require.Error(t, err, "forged share must be rejected once shamir_commitment is configured")
 }

--- a/internal/encryption/auth_encryption.go
+++ b/internal/encryption/auth_encryption.go
@@ -12,6 +12,10 @@
 // threading each token's owning identity (userID/tokenID) through every encrypt/decrypt
 // call site AND a versioned-AAD migration for existing blobs (mirroring the secret-value
 // AADVersion fallback). Track as a dedicated change.
+//
+// Recommended fix: pass each token's owning identity as AAD via service.EncryptSecretWithAAD —
+// userID for session and password-reset tokens, tokenID for API tokens — matching the
+// MFASecretAAD pattern already used for MFA secrets. This is a tracked deferred gap.
 package encryption
 
 import (

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -350,6 +350,10 @@ func DeserializeEncryptedData(data []byte) (*EncryptedData, error) {
 
 // RotateKey re-encrypts data with a new key version
 func (es *EncryptionService) RotateKey(encryptedData *EncryptedData, newKeyVersion string) (*EncryptedData, error) {
+	// WARNING: RotateKey uses no-AAD decrypt/encrypt and is incompatible with
+	// AAD-bound ciphertexts (e.g. secret versions encrypted with EncryptWithAAD).
+	// To re-key AAD-bound ciphertexts, use sweepSecretVersions in sweep.go instead.
+
 	// Decrypt with current key
 	plaintext, err := es.Decrypt(encryptedData)
 	if err != nil {

--- a/internal/encryption/keyprovider_compat_test.go
+++ b/internal/encryption/keyprovider_compat_test.go
@@ -101,7 +101,8 @@ func TestKeyProvider_ShamirRoundTrip(t *testing.T) {
 		require.NoError(t, os.WriteFile(p, []byte(hex.EncodeToString(shares[i])), 0600))
 		files = append(files, p)
 	}
-	roundTrip(t, dir, func() crypto.KeyProvider { return crypto.NewShamirKeyProvider(files, nil, "") })
+	commitmentHex := hex.EncodeToString(crypto.CommitKEK(kek))
+	roundTrip(t, dir, func() crypto.KeyProvider { return crypto.NewShamirKeyProvider(files, nil, commitmentHex) })
 }
 
 // TestKeyProvider_KMSRoundTrip proves a KMS-envelope KEK wraps/unwraps the DEK

--- a/server/http/handlers/main_test.go
+++ b/server/http/handlers/main_test.go
@@ -1,0 +1,17 @@
+package handlers
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestMain(m *testing.M) {
+	// Lower the bcrypt cost from 12 to MinCost (4) for all tests in this
+	// package. The handler tests exercise CreateUser and ChangePassword
+	// extensively; at cost 12 the suite reliably exceeds the 600s CI timeout.
+	core.SetBcryptCostForTesting(bcrypt.MinCost)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary
- Raise bcrypt work factor from DefaultCost (10) to 12 at all four hash sites, including the timing-equalization sentinel in `internal/core/auth.go`
- Add RSA public key minimum size guard in `internal/cli/secret/export_encrypt.go` (reject keys < 2048 bits)
- Upgrade Shamir commitment absence from `log.Printf` warning to `log.Fatalf` startup error — server now refuses to start without a cryptographic commitment configured
- Add inline warnings to `RotateKey` and `auth_encryption.go` documenting deferred AAD-binding gaps

## Security impact
- **bcrypt 12**: raises brute-force cost ~4× over cost 10; still well within acceptable latency for interactive logins
- **RSA floor**: rejects weak keys at encryption time rather than silently producing weak ciphertexts
- **Shamir fatal**: closes the magic-byte forgery window; operators on existing installs must re-run `keyorix encryption shamir-split` before upgrading

## Test plan
- [ ] `go test ./internal/core/... ./internal/crypto/... ./internal/encryption/...` passes
- [ ] `gosec -severity medium -exclude-generated ./...` reports 0 issues
- [ ] Login round-trip still works (bcrypt at cost 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)