### PR TITLE
fix(security): auth hardening — CSRF log, rate limit, ChangePassword, TOTP replay, error leakage (r120-F)

### DIFF
--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -96,7 +96,12 @@ func (c *KeyorixCore) ActivateMFA(ctx context.Context, userID uint, code, passwo
 	if err != nil {
 		return nil, fmt.Errorf("no pending MFA enrolment; begin enrolment first")
 	}
-	if !c.validateTOTP(secret, code) {
+	step, ok := c.validateTOTPStep(secret, code)
+	if !ok {
+		c.auditMFAFailed(ctx, userID, "activate")
+		return nil, fmt.Errorf("invalid code")
+	}
+	if fresh, ferr := c.storage.MarkTOTPStepUsed(ctx, userID, step); ferr != nil || !fresh {
 		c.auditMFAFailed(ctx, userID, "activate")
 		return nil, fmt.Errorf("invalid code")
 	}

--- a/server/http/handlers/access_review_campaign_export_csv.go
+++ b/server/http/handlers/access_review_campaign_export_csv.go
@@ -6,6 +6,7 @@ package handlers
 
 import (
 	"encoding/csv"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -36,7 +37,8 @@ func (h *CatalogHandler) ExportAccessReviewCampaignCSV(w http.ResponseWriter, r 
 
 	detail, err := h.coreService.GetAccessReviewCampaign(r.Context(), uint(projectID), uint(campaignID))
 	if err != nil {
-		sendError(w, "Error", err.Error(), campaignStatusForError(err.Error()), nil)
+		log.Printf("ExportAccessReviewCampaignCSV: error: %v", err)
+		sendError(w, "Error", clientSafe(err), campaignStatusForError(err.Error()), nil)
 		return
 	}
 

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -54,6 +55,8 @@ func (h *AuthHandler) setSessionCookies(w http.ResponseWriter, session *models.S
 	middleware.SetSessionCookie(w, session.SessionToken, session.ExpiresAt, h.tlsEnabled)
 	if csrfToken, err := middleware.GenerateCSRFToken(); err == nil {
 		middleware.SetCSRFCookie(w, csrfToken, h.tlsEnabled)
+	} else {
+		log.Printf("setSessionCookies: CSRF token generation failed: %v; session issued without CSRF cookie", err)
 	}
 }
 
@@ -242,6 +245,10 @@ func (h *AuthHandler) ConsumeSetup(w http.ResponseWriter, r *http.Request) {
 	ip := r.RemoteAddr
 	if idx := strings.LastIndex(ip, ":"); idx != -1 {
 		ip = ip[:idx]
+	}
+	if h.checkLoginRateLimit(r.Context(), ip) {
+		sendError(w, "TooManyRequests", "Too many requests. Try again later.", http.StatusTooManyRequests, nil)
+		return
 	}
 	result, err := h.coreService.CompleteSetup(r.Context(), body.Token, body.Password, r.Header.Get(hdrUserAgent), ip)
 	// The new password was accepted, but the account has MFA (TOTP) or a passkey
@@ -493,7 +500,8 @@ func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 			sendError(w, "Unauthorized", "Current password is incorrect", http.StatusUnauthorized, nil)
 			return
 		}
-		sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
+		log.Printf("ChangePassword: user %d error: %v", userCtx.UserID, err)
+		sendError(w, "BadRequest", clientSafe(err), http.StatusBadRequest, nil)
 		return
 	}
 	// Evict the cached identity so a restriction cleared by this change (ADR-025)

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -79,7 +79,7 @@ func (h *CatalogHandler) GetProject(w http.ResponseWriter, r *http.Request) {
 	project, err := h.coreService.GetProject(r.Context(), id)
 	if err != nil {
 		if strings.Contains(err.Error(), errNotFound) {
-			sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)
+			sendError(w, "NotFound", "Project not found", http.StatusNotFound, nil)
 			return
 		}
 		log.Printf("Error getting project %d: %v", id, err)
@@ -148,7 +148,7 @@ func (h *CatalogHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Error creating project: %v", err)
 		switch {
 		case strings.Contains(err.Error(), "already exists"):
-			sendError(w, "ConflictError", err.Error(), http.StatusConflict, nil)
+			sendError(w, "ConflictError", "A project with that name already exists", http.StatusConflict, nil)
 		case strings.Contains(err.Error(), i18n.T("ErrorValidation", nil)):
 			sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
 		default:


### PR DESCRIPTION
## Summary
- `setSessionCookies`: log CSRF token generation failure (was silent)
- `ConsumeSetup`: apply `checkLoginRateLimit` (same as `Login` and `PasswordReset`), defending against bcrypt-load DoS via concurrent unauthenticated requests
- `ChangePassword`: use `clientSafe(err)` for storage/unexpected errors (was `err.Error()`)
- `ActivateMFA`: apply `validateTOTPStep`/`MarkTOTPStepUsed` anti-replay (same fix as `requireReauth` in #1157); enrollment code can no longer be reused in the same 90-second window
- `catalog.go` `GetProject`/`CreateProject`: replace `err.Error()` with static safe messages for NotFound and Conflict
- `access_review_campaign_export_csv.go`: use `clientSafe` for error body (was `err.Error()`)

## Test plan
- [ ] `go test ./server/http/handlers/... ./internal/core/...` passes
- [ ] `gosec -severity medium -exclude-generated ./...` 0 issues
- [ ] Login and ConsumeSetup are rate-limited at the IP level
- [ ] ActivateMFA rejects code reuse within the 30-second window

🤖 Generated with [Claude Code](https://claude.com/claude-code)