### PR TITLE
fix(security): SSRF + PII leakage in alert escalation webhook dispatcher

### DIFF
--- a/internal/core/alert_escalation.go
+++ b/internal/core/alert_escalation.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -159,7 +160,7 @@ func (c *KeyorixCore) RunAlertEscalation(ctx context.Context) (*EscalationResult
 // splitChannelIDs splits a comma-separated channel-ID string into trimmed, non-empty tokens.
 func splitChannelIDs(ids string) []string {
 	var out []string
-	for _, s := range strings.Split(ids, ",") {
+	for s := range strings.SplitSeq(ids, ",") {
 		s = strings.TrimSpace(s)
 		if s != "" {
 			out = append(out, s)
@@ -175,15 +176,16 @@ func splitChannelIDs(ids string) []string {
 func (c *KeyorixCore) dispatchToChannel(ctx context.Context, ch *models.NotificationChannel, alert *models.AnomalyAlert, policy *models.AlertEscalationPolicy) error {
 	switch ch.Type {
 	case "webhook", "slack":
-		return c.postJSONToURL(ctx, ch.URL, map[string]interface{}{
+		// accessed_by and ip_address are intentionally omitted: PII must not be
+		// forwarded to an external webhook receiver. The server-side audit log
+		// already captures this data for incident investigation.
+		return c.postJSONToURL(ctx, ch.URL, map[string]any{
 			"event":       "anomaly.escalated",
 			"alert_id":    alert.ID,
 			"severity":    alert.Severity,
 			"alert_type":  alert.AlertType,
 			"description": alert.Description,
 			"secret_name": alert.SecretName,
-			"accessed_by": alert.AccessedBy,
-			"ip_address":  alert.IPAddress,
 			"detected_at": alert.DetectedAt.Format(time.RFC3339),
 			"policy_name": policy.Name,
 			"channel":     ch.Name,
@@ -195,8 +197,8 @@ func (c *KeyorixCore) dispatchToChannel(ctx context.Context, ch *models.Notifica
 	}
 }
 
-// postJSONToURL marshals payload to JSON and sends a best-effort HTTP POST to url.
-func (c *KeyorixCore) postJSONToURL(_ context.Context, url string, payload interface{}) error {
+// postJSONToURL marshals payload to JSON and sends a best-effort HTTP POST to rawURL.
+func (c *KeyorixCore) postJSONToURL(_ context.Context, rawURL string, payload any) error {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
@@ -205,13 +207,20 @@ func (c *KeyorixCore) postJSONToURL(_ context.Context, url string, payload inter
 	if client == nil {
 		client = &http.Client{Timeout: 10 * time.Second}
 	}
-	resp, err := client.Post(url, "application/json", bytes.NewReader(body)) // #nosec G107 -- URL is operator-configured
+	// Compute a redacted form of the URL for use in error messages so that
+	// embedded credentials (e.g. https://token:secret@hooks.example.com) are
+	// never written to logs (CWE-312).
+	redactedURL := rawURL
+	if u, perr := url.Parse(rawURL); perr == nil {
+		redactedURL = u.Redacted()
+	}
+	resp, err := client.Post(rawURL, "application/json", bytes.NewReader(body)) // #nosec G107 -- URL is operator-configured; SSRF-guarded at write time
 	if err != nil {
-		return fmt.Errorf("POST %s: %w", url, err)
+		return fmt.Errorf("POST %s: %w", redactedURL, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("POST %s: unexpected status %d", url, resp.StatusCode)
+		return fmt.Errorf("POST %s: unexpected status %d", redactedURL, resp.StatusCode)
 	}
 	return nil
 }
@@ -243,7 +252,7 @@ func (c *KeyorixCore) ListAlertEscalationPolicies(ctx context.Context) ([]models
 }
 
 // UpdateAlertEscalationPolicy applies field updates to the policy identified by id.
-func (c *KeyorixCore) UpdateAlertEscalationPolicy(ctx context.Context, id uint, updates map[string]interface{}) (*models.AlertEscalationPolicy, error) {
+func (c *KeyorixCore) UpdateAlertEscalationPolicy(ctx context.Context, id uint, updates map[string]any) (*models.AlertEscalationPolicy, error) {
 	p, err := c.storage.GetAlertEscalationPolicy(ctx, id)
 	if err != nil {
 		return nil, err

--- a/internal/core/alert_escalation_test.go
+++ b/internal/core/alert_escalation_test.go
@@ -49,14 +49,19 @@ func makeAlert(id uint, sev string, ageMinutes int) models.AnomalyAlert {
 // fakeWebhookTransport is a sandbox-safe http.RoundTripper that intercepts
 // outbound webhook POSTs without binding a TCP port.
 type fakeWebhookTransport struct {
-	statusCode int          // returned status; 0 → 200
-	err        error        // if non-nil, returned instead of a response
-	called     chan struct{} // signalled on each call when non-nil
+	statusCode int              // returned status; 0 → 200
+	err        error            // if non-nil, returned instead of a response
+	called     chan struct{}     // signalled on each call when non-nil
+	capture    func(body []byte) // called with the raw request body when non-nil
 }
 
-func (t *fakeWebhookTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+func (t *fakeWebhookTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.err != nil {
 		return nil, t.err
+	}
+	if t.capture != nil && req.Body != nil {
+		b, _ := io.ReadAll(req.Body)
+		t.capture(b)
 	}
 	if t.called != nil {
 		select {

--- a/internal/core/notification_channels.go
+++ b/internal/core/notification_channels.go
@@ -6,6 +6,8 @@ package core
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 	"time"
 
@@ -37,7 +39,7 @@ func (c *KeyorixCore) GetNotificationChannel(ctx context.Context, id uint) (*mod
 //   - URL is required for webhook/slack/teams types.
 //   - Email is required for email type.
 func (c *KeyorixCore) CreateNotificationChannel(ctx context.Context, ch *models.NotificationChannel, createdBy string) (*models.NotificationChannel, error) {
-	if err := validateNotificationChannel(ch); err != nil {
+	if err := c.validateNotificationChannel(ch); err != nil {
 		return nil, err
 	}
 	ch.CreatedBy = createdBy
@@ -51,7 +53,7 @@ func (c *KeyorixCore) CreateNotificationChannel(ctx context.Context, ch *models.
 
 // UpdateNotificationChannel applies the given map of field updates to the channel
 // identified by id and returns the updated channel.
-func (c *KeyorixCore) UpdateNotificationChannel(ctx context.Context, id uint, updates map[string]interface{}) (*models.NotificationChannel, error) {
+func (c *KeyorixCore) UpdateNotificationChannel(ctx context.Context, id uint, updates map[string]any) (*models.NotificationChannel, error) {
 	ch, err := c.storage.GetNotificationChannel(ctx, id)
 	if err != nil {
 		return nil, err
@@ -74,7 +76,7 @@ func (c *KeyorixCore) UpdateNotificationChannel(ctx context.Context, id uint, up
 	if v, ok := updates["enabled"].(bool); ok {
 		ch.Enabled = v
 	}
-	if err := validateNotificationChannel(ch); err != nil {
+	if err := c.validateNotificationChannel(ch); err != nil {
 		return nil, err
 	}
 	ch.UpdatedAt = time.Now().UTC()
@@ -90,17 +92,24 @@ func (c *KeyorixCore) DeleteNotificationChannel(ctx context.Context, id uint) er
 }
 
 // validateNotificationChannel enforces invariants for create and update paths.
-func validateNotificationChannel(ch *models.NotificationChannel) error {
+func (c *KeyorixCore) validateNotificationChannel(ch *models.NotificationChannel) error {
 	if strings.TrimSpace(ch.Name) == "" {
 		return fmt.Errorf("notification channel name is required")
 	}
 	if _, ok := validChannelTypes[ch.Type]; !ok {
 		return fmt.Errorf("invalid notification channel type %q: must be one of webhook, slack, teams, email", ch.Type)
 	}
+	urlValidator := c.webhookURLValidator
+	if urlValidator == nil {
+		urlValidator = validateWebhookURL
+	}
 	switch ch.Type {
 	case "webhook", "slack", "teams":
 		if strings.TrimSpace(ch.URL) == "" {
 			return fmt.Errorf("notification channel URL is required for type %q", ch.Type)
+		}
+		if err := urlValidator(ch.URL); err != nil {
+			return err
 		}
 	case "email":
 		if strings.TrimSpace(ch.Email) == "" {
@@ -108,4 +117,40 @@ func validateNotificationChannel(ch *models.NotificationChannel) error {
 		}
 	}
 	return nil
+}
+
+// validateWebhookURL enforces SSRF-prevention rules on outbound webhook/slack/teams URLs.
+// It requires an https scheme and rejects destinations that resolve to RFC 1918,
+// loopback, link-local, or IMDS (169.254.0.0/16) addresses.
+func validateWebhookURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("notification channel: invalid URL %q: %w", raw, err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("notification channel: URL must use https (got %q)", u.Scheme)
+	}
+	host := u.Hostname()
+	if ip := net.ParseIP(host); ip != nil {
+		if isChannelDisallowedIP(ip) {
+			return fmt.Errorf("notification channel: URL targets a private/link-local address; refusing internal destination")
+		}
+		return nil
+	}
+	addrs, err := net.DefaultResolver.LookupIPAddr(context.Background(), host)
+	if err != nil {
+		return fmt.Errorf("notification channel: could not resolve URL hostname to verify it is not private/internal: %w", err)
+	}
+	for _, a := range addrs {
+		if isChannelDisallowedIP(a.IP) {
+			return fmt.Errorf("notification channel: URL resolves to a private/link-local address (%s); refusing internal destination", a.IP)
+		}
+	}
+	return nil
+}
+
+// isChannelDisallowedIP reports whether ip is a private, link-local, or loopback
+// address — all of which are forbidden as outbound webhook destinations (SSRF guard).
+func isChannelDisallowedIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
 }

--- a/internal/core/notification_channels_test.go
+++ b/internal/core/notification_channels_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -58,9 +59,14 @@ func TestCreateNotificationChannel_WebhookRequiresURL(t *testing.T) {
 	})
 }
 
+// noopWebhookURLValidator bypasses the real DNS-based SSRF check in tests that
+// focus on storage / field logic rather than URL security validation.
+func noopWebhookURLValidator(_ string) error { return nil }
+
 func TestNotificationChannel_CRUD(t *testing.T) {
 	store := new(MockStorage)
 	c := NewKeyorixCore(store)
+	c.webhookURLValidator = noopWebhookURLValidator
 	ctx := context.Background()
 
 	created := &models.NotificationChannel{
@@ -125,6 +131,7 @@ func TestNotificationChannel_CRUD(t *testing.T) {
 func TestCreateNotificationChannel_StorageError(t *testing.T) {
 	st := new(MockStorage)
 	c := NewKeyorixCore(st)
+	c.webhookURLValidator = noopWebhookURLValidator
 	ctx := context.Background()
 
 	st.On("CreateNotificationChannel", ctx, mock.AnythingOfType("*models.NotificationChannel")).
@@ -158,6 +165,7 @@ func TestUpdateNotificationChannel_GetError(t *testing.T) {
 func TestUpdateNotificationChannel_UpdateStorageError(t *testing.T) {
 	st := new(MockStorage)
 	c := NewKeyorixCore(st)
+	c.webhookURLValidator = noopWebhookURLValidator
 	ctx := context.Background()
 
 	existing := &models.NotificationChannel{
@@ -195,6 +203,7 @@ func TestValidateNotificationChannel_TeamsRequiresURL(t *testing.T) {
 func TestUpdateNotificationChannel_AllFieldUpdates(t *testing.T) {
 	st := new(MockStorage)
 	c := NewKeyorixCore(st)
+	c.webhookURLValidator = noopWebhookURLValidator
 	ctx := context.Background()
 
 	existing := &models.NotificationChannel{
@@ -246,4 +255,68 @@ func TestUpdateNotificationChannel_ValidationFails(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "URL is required")
 	st.AssertExpectations(t)
+}
+
+// ---- validateWebhookURL (SSRF guard) ----
+
+func TestValidateWebhookURL_RequiresHTTPS(t *testing.T) {
+	err := validateWebhookURL("http://hooks.example.com/webhook")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+}
+
+func TestValidateWebhookURL_RejectsPrivateIPs(t *testing.T) {
+	disallowed := []string{
+		"https://127.0.0.1/hook",
+		"https://192.168.1.100/hook",
+		"https://10.0.0.1/hook",
+		"https://172.16.0.1/hook",
+		"https://169.254.169.254/latest/meta-data",
+		"https://[::1]/hook",
+	}
+	for _, u := range disallowed {
+		err := validateWebhookURL(u)
+		require.Error(t, err, "expected error for %s", u)
+		assert.Contains(t, err.Error(), "private/link-local", "wrong error for %s", u)
+	}
+}
+
+func TestValidateWebhookURL_AcceptsPublicIP(t *testing.T) {
+	// 93.184.216.34 is the well-known IANA example.com address — public, non-private.
+	err := validateWebhookURL("https://93.184.216.34/hook")
+	require.NoError(t, err)
+}
+
+func TestValidateWebhookURL_InvalidURL(t *testing.T) {
+	err := validateWebhookURL("://bad-url")
+	require.Error(t, err)
+}
+
+// ---- PII: accessed_by / ip_address must not appear in webhook payload ----
+
+func TestDispatchToChannel_WebhookPayload_NoPII(t *testing.T) {
+	var capturedBody []byte
+	tr := &fakeWebhookTransport{
+		capture: func(b []byte) { capturedBody = b },
+	}
+
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	c.httpClient = &http.Client{Transport: tr}
+
+	ch := &models.NotificationChannel{ID: 1, Name: "wh", Type: "webhook", URL: "https://fake.test/hook", Enabled: true}
+	alert := &models.AnomalyAlert{
+		ID: 5, Severity: "high", AlertType: "off_hours",
+		Description: "late access", SecretName: "db-password",
+		AccessedBy: "alice", IPAddress: "10.0.0.1",
+	}
+	policy := &models.AlertEscalationPolicy{ID: 1, Name: "p1"}
+
+	err := c.dispatchToChannel(context.Background(), ch, alert, policy)
+	require.NoError(t, err)
+
+	body := string(capturedBody)
+	assert.NotContains(t, body, "alice", "accessed_by must not be in webhook payload")
+	assert.NotContains(t, body, "10.0.0.1", "ip_address must not be in webhook payload")
+	assert.Contains(t, body, "db-password")
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -41,6 +41,10 @@ type KeyorixCore struct {
 	// nil = a fresh &http.Client{Timeout: 10s} per call. Overridable in tests to
 	// inject a custom transport so no TCP port binding is needed.
 	httpClient *http.Client
+	// webhookURLValidator enforces SSRF rules on notification channel URLs (scheme
+	// + private-IP rejection). nil = use the real validateWebhookURL (which does a
+	// live DNS lookup); overridable in tests to avoid network calls.
+	webhookURLValidator func(string) error
 	// secretValueEncryptor encrypts secret VALUES at rest (ADR-004 envelope
 	// AES-256-GCM, AAD-bound per #94). nil = encryption disabled (plaintext at
 	// rest, dev/test only — the loud startup banner covers it). Wired from the
@@ -466,6 +470,14 @@ func NewKeyorixCore(storage storage.Storage) *KeyorixCore {
 		passwordPolicy: DefaultPasswordPolicy(),
 		auditStream:    newAuditBroker(),
 	}
+}
+
+// SetWebhookURLValidator replaces the SSRF guard applied to notification channel
+// URLs on create and update. The default (nil) uses validateWebhookURL which
+// enforces https-only and rejects private/loopback destinations via a live DNS
+// lookup. Tests call this with a no-op to avoid real network calls.
+func (c *KeyorixCore) SetWebhookURLValidator(fn func(string) error) {
+	c.webhookURLValidator = fn
 }
 
 // SetAuthEncryptor wires the encryption service used to protect reversibly-

--- a/server/http/handlers/notification_channels_handler_test.go
+++ b/server/http/handlers/notification_channels_handler_test.go
@@ -33,6 +33,7 @@ func newNotifChannelHandler(t *testing.T) (*NotificationChannelHandler, *gorm.DB
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.NotificationChannel{}))
 	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	cs.SetWebhookURLValidator(func(_ string) error { return nil })
 	return NewNotificationChannelHandler(cs), db
 }
 

--- a/server/http/notification_channels_handler_test.go
+++ b/server/http/notification_channels_handler_test.go
@@ -110,6 +110,7 @@ func notificationChannelTestSetup(t *testing.T) (*httptest.Server, string) {
 	t.Cleanup(i18n.ResetForTesting)
 
 	c := newNotificationChannelCore(t)
+	c.SetWebhookURLValidator(func(_ string) error { return nil })
 	token := createTestToken(t, c)
 
 	router, err := NewRouter(&config.Config{}, c)
@@ -564,7 +565,9 @@ func newBrokenNotificationChannelCore(t *testing.T) *core.KeyorixCore {
 		"ON break_glass_activations (project_id, user_id) WHERE state = 'active'").Error)
 	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active "+
 		"ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error)
-	return core.NewKeyorixCore(store.NewLocalStorage(db))
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	cs.SetWebhookURLValidator(func(_ string) error { return nil })
+	return cs
 }
 
 // notificationChannelBrokenDBSetup builds a server backed by a DB that lacks


### PR DESCRIPTION
## Summary

- **SSRF prevention (CWE-918):** Webhook/Slack/Teams URLs are now validated at write time — https-only scheme, IP literal check, and DNS-resolved private/link-local/IMDS (RFC 1918, loopback, 169.254.x.x) rejection via `validateWebhookURL` wired into `validateNotificationChannel`
- **PII leakage fix (CWE-200):** `accessed_by` and `ip_address` fields removed from outbound webhook JSON payload in `dispatchToChannel`
- **Credential exposure in logs (CWE-312):** `url.URL.Redacted()` used in `postJSONToURL` error messages so embedded credentials (e.g. `https://token:secret@host`) are not leaked to logs
- `webhookURLValidator` injectable field on `KeyorixCore` (with `SetWebhookURLValidator`) keeps tests hermetic — no live DNS, no TCP port binding

## Test plan

- [ ] `go test ./internal/core/... ./server/http/...` passes (excluding pre-existing `TestScopedRBACEnforcement` flake)
- [ ] `TestValidateWebhookURL_RequiresHTTPS` — rejects `http://` URLs
- [ ] `TestValidateWebhookURL_RejectsPrivateIPs` — rejects 127.x, 10.x, 192.168.x, 172.16.x, 169.254.x, `::1`
- [ ] `TestValidateWebhookURL_AcceptsPublicIP` — allows public IANA example address
- [ ] `TestDispatchToChannel_WebhookPayload_NoPII` — confirms `accessed_by`/`ip_address` absent from webhook body