### PR TITLE
fix(security): HTTP hardening — Permissions-Policy, CSP, timeout, rate-limit warning, template validation (r120-G)

### DIFF
--- a/deploy/helm/keyorix/templates/web-config.yaml
+++ b/deploy/helm/keyorix/templates/web-config.yaml
@@ -45,7 +45,7 @@ data:
       add_header X-Content-Type-Options "nosniff" always;
       add_header X-XSS-Protection "1; mode=block" always;
       add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self';" always;
 
       server {
         listen 80;

--- a/internal/core/secret_templates.go
+++ b/internal/core/secret_templates.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -59,6 +60,14 @@ func (c *KeyorixCore) CreateSecretTemplate(ctx context.Context, req *CreateSecre
 	}
 	if err := validateTemplateClassification(req.DefaultClassification); err != nil {
 		return nil, err
+	}
+	if len(req.DescriptionPattern) > maxSecretDescriptionLen {
+		return nil, fmt.Errorf("%s: DescriptionPattern exceeds maximum length of %d", i18n.T("ErrorValidation", nil), maxSecretDescriptionLen)
+	}
+	if req.DefaultTags != "" {
+		if _, err := normalizeTags(strings.Split(req.DefaultTags, ",")); err != nil {
+			return nil, fmt.Errorf("%s: DefaultTags: %w", i18n.T("ErrorValidation", nil), err)
+		}
 	}
 
 	tmpl := &models.SecretTemplate{
@@ -117,6 +126,14 @@ func (c *KeyorixCore) UpdateSecretTemplate(ctx context.Context, id uint, req *Up
 	}
 	if err := validateTemplateClassification(req.DefaultClassification); err != nil {
 		return nil, err
+	}
+	if len(req.DescriptionPattern) > maxSecretDescriptionLen {
+		return nil, fmt.Errorf("%s: DescriptionPattern exceeds maximum length of %d", i18n.T("ErrorValidation", nil), maxSecretDescriptionLen)
+	}
+	if req.DefaultTags != "" {
+		if _, err := normalizeTags(strings.Split(req.DefaultTags, ",")); err != nil {
+			return nil, fmt.Errorf("%s: DefaultTags: %w", i18n.T("ErrorValidation", nil), err)
+		}
 	}
 
 	tmpl.Name = req.Name

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -87,6 +87,9 @@ func (ls *LocalStorage) ListProjectsWithCounts(ctx context.Context, includeDelet
 		UpdatedAt          string
 		LastSecretActivity *string
 	}
+	// Both where values are compile-time string constants — no user input is
+	// interpolated. Do NOT add user-controlled filter terms to this query without
+	// switching to parameterised bindings.
 	where := "WHERE p.deleted_at IS NULL"
 	if includeDeleted {
 		where = ""

--- a/server/main.go
+++ b/server/main.go
@@ -1343,7 +1343,7 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error { // NOSONAR
 		// headers should arrive promptly even for a slow body upload.
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       15 * time.Second,
-		WriteTimeout:      15 * time.Second,
+		WriteTimeout:      60 * time.Second,
 		IdleTimeout:       60 * time.Second,
 	}
 

--- a/server/middleware/rate_limit.go
+++ b/server/middleware/rate_limit.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 	"sync"
@@ -33,6 +34,7 @@ import (
 // docs/CONFIGURATION.md.
 func PrincipalRateLimit(cfg config.RateLimitConfig) func(http.Handler) http.Handler {
 	if !cfg.Enabled || cfg.RequestsPerSecond <= 0 {
+		log.Printf("Keyorix: PrincipalRateLimit is disabled (server.http.ratelimit.enabled=false) — no per-principal API rate limit is active; enable in production")
 		return func(next http.Handler) http.Handler { return next }
 	}
 	burst := cfg.Burst

--- a/server/middleware/security_headers.go
+++ b/server/middleware/security_headers.go
@@ -2,6 +2,7 @@ package middleware
 
 import "net/http"
 
+
 // contentSecurityPolicy mirrors the policy the Helm chart's nginx frontend already sends
 // (deploy/helm/keyorix/templates/web-config.yaml) — the two serving modes (embedded
 // single-binary SPA vs. the separate nginx+API-proxy deployment) should present the same
@@ -9,7 +10,12 @@ import "net/http"
 // injection (a common CSS-in-JS/Tailwind requirement); script-src does not, so an
 // attacker-injected inline <script> — the primary XSS vector — is blocked regardless of
 // where the malicious markup came from.
-const contentSecurityPolicy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;"
+//
+// connect-src uses 'self' only — this already covers same-origin WebSocket connections
+// (ws:/wss: to the same host) in all modern browsers. The bare ws: and wss: scheme
+// values that were here previously allowed WebSocket connections to ANY host, which
+// is a CSP bypass for data exfiltration via WebSocket.
+const contentSecurityPolicy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self';"
 
 // SecurityHeaders sets standard hardening response headers on every response. For a
 // secrets manager these matter beyond the usual:
@@ -39,6 +45,7 @@ func SecurityHeaders(tlsEnabled bool) func(http.Handler) http.Handler {
 			h.Set("X-Frame-Options", "DENY")
 			h.Set("Referrer-Policy", "no-referrer")
 			h.Set("Content-Security-Policy", contentSecurityPolicy)
+			h.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()")
 			if tlsEnabled {
 				h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 			}


### PR DESCRIPTION
## Summary
- **Permissions-Policy**: deny camera, microphone, geolocation, payment, usb, interest-cohort for all responses
- **CSP connect-src**: replace bare `ws: wss:` scheme wildcards with `'self'` — WebSocket connections now restricted to same origin
- **WriteTimeout**: 15s → 60s to match chi router Timeout and prevent truncated large CSV responses
- **PrincipalRateLimit**: log a startup warning when disabled (matches existing login-lockout-disabled warning pattern)
- **Secret templates**: validate `DescriptionPattern` length ≤ maxSecretDescriptionLen and `DefaultTags` through `normalizeTags` at create/update time
- **ListProjectsWithCounts**: annotate raw SQL concatenation to prevent future user-input injection

## Test plan
- [ ] `go test ./server/... ./internal/core/... ./internal/storage/...` passes
- [ ] `gosec -severity medium -exclude-generated ./...` 0 issues
- [ ] Response headers include `Permissions-Policy`
- [ ] CSP `connect-src` no longer contains `ws:` or `wss:` bare schemes

🤖 Generated with [Claude Code](https://claude.com/claude-code)