### PR TITLE
fix(security): access control — admin authority groups, ACL membership, expired share guard (r120-H)

### DIFF
--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -85,6 +85,9 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 	if !affiliated {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "break-glass is available only to members of the project")
 	}
+	// Note: IsProjectMember has no minimum-tenure requirement — a user added
+	// to the project seconds ago can immediately self-activate break-glass.
+	// A configurable join-date cooldown would close this gap.
 	// Refuse a new activation while the user already holds an active, unexpired one on
 	// this project — otherwise the time-bound grant becomes indefinitely renewable.
 	bgNow := c.now()

--- a/internal/core/classification_gate.go
+++ b/internal/core/classification_gate.go
@@ -186,6 +186,10 @@ func (c *KeyorixCore) checkRestrictedMFAGate(ctx context.Context, secret *models
 // approved with no grant TTL — mirrored here for consistency rather than
 // inventing a second expiry model.
 //
+// Future: a grant_expires_at nullable field on AccessRequest would allow
+// time-bounded approvals (e.g. "approved for 4 hours"). Until then,
+// revoke the AccessRequest row directly to end access.
+//
 // Listing by project and filtering in memory reuses the existing
 // ListAccessRequests storage method as-is (no storage interface change): access
 // requests per project are not high-cardinality, and this mirrors the same

--- a/internal/core/impersonation.go
+++ b/internal/core/impersonation.go
@@ -75,6 +75,12 @@ func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID 
 	if err := c.requireEqualOrGreaterAdminAuthority(ctx, adminID, targetID, "impersonate"); err != nil {
 		return nil, nil, err
 	}
+	// The ceiling check above runs once at impersonation start. If the target
+	// user's roles are elevated above the impersonator's DURING an active
+	// impersonation session (up to 1h TTL), the impersonator retains the
+	// already-issued session — the check is not re-evaluated per-request.
+	// The auth cache TTL (30s) bounds the propagation delay for role changes,
+	// but the ceiling is not continuously enforced.
 	token, err := generateSecureToken()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate session token: %w", err)

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -76,7 +76,7 @@ func (c *KeyorixCore) requireAuthorityForRole(ctx context.Context, actorID, proj
 // rotation backend to a secret (#90): the backend often carries org-wide admin
 // credentials, so the same escalation-by-proxy ceiling applies.
 func (c *KeyorixCore) requireAdminAuthorityAt(ctx context.Context, actorID, projectID uint) error {
-	ids, err := c.storage.GetUserRoleIDsAt(ctx, actorID, storage.Scope{ProjectID: projectID})
+	ids, err := c.scopedRoleIDs(ctx, actorID, storage.Scope{ProjectID: projectID})
 	if err != nil {
 		return fmt.Errorf("failed to resolve actor authority: %w", err)
 	}

--- a/internal/core/secret_access_log_export.go
+++ b/internal/core/secret_access_log_export.go
@@ -38,6 +38,12 @@ type AccessLogExportRow struct {
 // for secretID and serialises them to the requested format (csv or json).
 // Returns the encoded bytes and the MIME content-type.
 // An unrecognised format or a non-existent secret returns an error.
+//
+// Authorization contract: callers must verify that the requesting user holds
+// secrets.read permission for this secret before calling this function.
+// The HTTP handler enforces this via RequireScopedPermission; other transports
+// (gRPC, CLI) must enforce it independently. This function does NOT check
+// per-user read permission itself.
 func (k *KeyorixCore) ExportSecretAccessLog(ctx context.Context, secretID uint, format string) ([]byte, string, error) {
 	format = strings.ToLower(strings.TrimSpace(format))
 	if format != ExportFormatCSV && format != ExportFormatJSON {

--- a/internal/core/secret_acl.go
+++ b/internal/core/secret_acl.go
@@ -91,6 +91,14 @@ func (c *KeyorixCore) GrantSecretACL(ctx context.Context, actorID, secretID, use
 		return err
 	}
 
+	// Check that the grant target is a project member — granting access to a
+	// non-member is confusing and potentially unintended.
+	if isMember, merr := c.storage.IsProjectMember(ctx, userID, secret.ProjectID); merr != nil {
+		return fmt.Errorf("failed to verify project membership: %w", merr)
+	} else if !isMember {
+		return fmt.Errorf("%s: user %d is not a member of this secret's project", i18n.T("ErrorValidation", nil), userID)
+	}
+
 	permsJSON, err := EncodeSecretACLPerms(perms)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)

--- a/internal/core/sharing.go
+++ b/internal/core/sharing.go
@@ -114,6 +114,10 @@ func (c *KeyorixCore) UpdateSharePermission(ctx context.Context, req *UpdateShar
 		return nil, fmt.Errorf("%s", i18n.T("ErrorPermissionDenied", nil))
 	}
 
+	if shareRecord.ExpiresAt != nil && shareRecord.ExpiresAt.Before(c.now()) {
+		return nil, fmt.Errorf("cannot update an expired share record; revoke and re-share instead")
+	}
+
 	// Resolve the share's expiry: clear it (permanent), set/extend/shorten it, or
 	// preserve the current value when the request specifies neither. A new expiry must
 	// be in the future, just like at creation.

--- a/server/grpc/services/secret_acl_service_test.go
+++ b/server/grpc/services/secret_acl_service_test.go
@@ -35,9 +35,10 @@ type aclTestRig struct {
 }
 
 const (
-	aclAdminRoleID = 10
-	aclAdminUserID = 1
-	aclGuestUserID = 2
+	aclAdminRoleID  = 10
+	aclMemberRoleID = 11 // no permissions — makes a user a project member without any manage access
+	aclAdminUserID  = 1
+	aclGuestUserID  = 2
 )
 
 func newACLTestRig(t *testing.T) *aclTestRig {
@@ -61,7 +62,8 @@ func newACLTestRig(t *testing.T) *aclTestRig {
 		&models.SecretVersion{}, &models.User{}, &models.Role{}, &models.ShareRecord{},
 		&models.Permission{}, &models.RolePermission{}, &models.UserRole{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.DynamicSecretConfig{}, &models.SecretACL{},
+		&models.DynamicSecretConfig{}, &models.SecretACL{}, &models.SecretAccessLog{},
+		&models.AuditEvent{},
 	))
 
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "default"}).Error)
@@ -83,8 +85,16 @@ func newACLTestRig(t *testing.T) *aclTestRig {
 	for _, p := range perms {
 		require.NoError(t, db.Create(&models.RolePermission{RoleID: aclAdminRoleID, PermissionID: p.ID}).Error)
 	}
-	// Assign the role globally (project 0, env 0) to the admin user.
+	// Seed a no-permission "member" role for the guest user: gives project membership
+	// without any manage grants, so PermissionDenied tests still pass.
+	require.NoError(t, db.Create(&models.Role{ID: aclMemberRoleID, Name: "acl-member"}).Error)
+	// Assign the admin role globally (project 0, env 0) to the admin user.
 	require.NoError(t, db.Create(&models.UserRole{UserID: aclAdminUserID, RoleID: aclAdminRoleID}).Error)
+	// Also assign at project 1 so IsProjectMember returns true.
+	// GrantSecretACL verifies the grant target is a project member (IsProjectMember checks project_id).
+	require.NoError(t, db.Create(&models.UserRole{UserID: aclAdminUserID, RoleID: aclAdminRoleID, ProjectID: 1}).Error)
+	// Guest gets the no-permission member role at project 1: a project member but cannot manage ACLs.
+	require.NoError(t, db.Create(&models.UserRole{UserID: aclGuestUserID, RoleID: aclMemberRoleID, ProjectID: 1}).Error)
 
 	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
 	svc := NewSecretService(coreService)

--- a/server/http/handlers/secret_acl_handler_test.go
+++ b/server/http/handlers/secret_acl_handler_test.go
@@ -39,7 +39,7 @@ func freshCoreACL(t *testing.T) (*core.KeyorixCore, *gorm.DB) {
 		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.Project{}, &models.Environment{}, &models.SecretNode{},
 		&models.AuditEvent{}, &models.AnomalyAlert{},
-		&models.ShareRecord{}, &models.SecretACL{},
+		&models.ShareRecord{}, &models.SecretACL{}, &models.SecretAccessLog{},
 	))
 	// Seed project + environment so secrets can resolve scope.
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
@@ -47,8 +47,21 @@ func freshCoreACL(t *testing.T) (*core.KeyorixCore, *gorm.DB) {
 	// Make user 1 a global admin so they can call all handlers.
 	adminRole := &models.Role{Name: "system_admin", Description: "Administrator"}
 	require.NoError(t, db.Create(adminRole).Error)
+	// memberRole is a minimal role used to make grant-target users project members.
+	memberRole := &models.Role{Name: "member", Description: "Project member"}
+	require.NoError(t, db.Create(memberRole).Error)
 	require.NoError(t, db.Create(&models.User{Username: "testuser_acl", Email: "testuser_acl@example.com", AccountState: "active"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID}).Error)
+	// Seed grant-target users used across ACL happy-path tests and give them project membership.
+	// GrantSecretACL verifies the target is a project member (IsProjectMember checks project_id).
+	for _, uid := range []uint{77, 88, 99, 123} {
+		require.NoError(t, db.Create(&models.User{
+			ID:       uid,
+			Username: fmt.Sprintf("testgrant_%d", uid),
+			Email:    fmt.Sprintf("grant%d@example.com", uid),
+		}).Error)
+		require.NoError(t, db.Create(&models.UserRole{UserID: uid, RoleID: memberRole.ID, ProjectID: 1}).Error)
+	}
 	return core.NewKeyorixCore(store.NewLocalStorage(db)), db
 }
 


### PR DESCRIPTION
## Summary
- **`requireAdminAuthorityAt`**: switched from `GetUserRoleIDsAt` (direct roles only) to `scopedRoleIDs` (direct + group-inherited), fixing inconsistency with `Authorize`/`AuthorizePrincipal` — group-admins can now grant admin roles as expected
- **`GrantSecretACL`**: added `IsProjectMember` pre-flight; blocks granting access to users outside the secret's project
- **`UpdateSharePermission`**: reject updates to expired share records (was silently re-activatable by clearing the expiry)
- **`ExportSecretAccessLog`**: explicit authz-contract doc comment (HTTP path already correct; this protects future transports)
- Comments on `classification_gate.go`, `break_glass.go`, `impersonation.go` documenting bounded authorization gaps

## Test plan
- [ ] `go test ./internal/core/...` passes
- [ ] `gosec -severity medium -exclude-generated ./...` 0 issues
- [ ] A group-admin can successfully use `requireAdminAuthorityAt` paths
- [ ] `GrantSecretACL` with non-member userID returns validation error
- [ ] `UpdateSharePermission` on expired share returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)