### PR TITLE
fix(security): backend hardening — K8s path segments, GCP enforcement, AWS ARN allowlist, Vault TTL (r120-I)

### DIFF
--- a/internal/connect/vault.go
+++ b/internal/connect/vault.go
@@ -86,6 +86,36 @@ func sanitizeVaultRef(ref string) (string, error) {
 	return strings.Join(clean, "/"), nil
 }
 
+// CheckTokenTTL performs a token self-lookup and returns the remaining TTL in
+// seconds. Returns (0, false, nil) for root tokens (TTL = 0). Returns an error if the
+// lookup fails or the token is invalid.
+func (c *VaultConnector) CheckTokenTTL(ctx context.Context) (ttlSeconds int, renewable bool, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.address+"/v1/auth/token/lookup-self", nil)
+	if err != nil {
+		return 0, false, err
+	}
+	req.Header.Set("X-Vault-Token", c.token)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return 0, false, fmt.Errorf("vault: token TTL lookup failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, vaultMaxResponseBytes))
+	if resp.StatusCode != http.StatusOK {
+		return 0, false, fmt.Errorf("vault: token lookup returned %d", resp.StatusCode)
+	}
+	var result struct {
+		Data struct {
+			TTL       int  `json:"ttl"`
+			Renewable bool `json:"renewable"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return 0, false, fmt.Errorf("vault: token lookup parse error: %w", err)
+	}
+	return result.Data.TTL, result.Data.Renewable, nil
+}
+
 func (c *VaultConnector) GetSecret(ctx context.Context, ref string) (string, error) {
 	if ref == "" {
 		return "", fmt.Errorf("vault: secret reference (path) is required, e.g. secret/data/myapp")

--- a/internal/dynamic/awssts.go
+++ b/internal/dynamic/awssts.go
@@ -63,10 +63,11 @@ func (e *AWSSTSEngine) SupportsNativeExpiry() bool { return true } // AWS enforc
 func (e *AWSSTSEngine) IsEphemeralBackend() bool   { return true }
 
 type awsSTSConfig struct {
-	RoleARN         string `json:"role_arn"`
-	Region          string `json:"region,omitempty"`
-	ExternalID      string `json:"external_id,omitempty"`
-	DurationSeconds int32  `json:"duration_seconds,omitempty"`
+	RoleARN          string `json:"role_arn"`
+	Region           string `json:"region,omitempty"`
+	ExternalID       string `json:"external_id,omitempty"`
+	DurationSeconds  int32  `json:"duration_seconds,omitempty"`
+	AllowedAccountID string `json:"allowed_account_id,omitempty"` // when set, RoleARN must belong to this AWS account ID
 }
 
 func (e *AWSSTSEngine) client(ctx context.Context, region string) (stsRoleAssumer, error) {
@@ -94,6 +95,12 @@ func (e *AWSSTSEngine) Issue(ctx context.Context, adminDSN, creationTemplate str
 	}
 	if strings.TrimSpace(cfg.RoleARN) == "" {
 		return Credential{}, "", fmt.Errorf("aws-sts: role_arn is required")
+	}
+	if cfg.AllowedAccountID != "" {
+		gotAccount := arnAccountID(cfg.RoleARN)
+		if gotAccount != cfg.AllowedAccountID {
+			return Credential{}, "", fmt.Errorf("aws-sts: role ARN account ID %q does not match allowed_account_id %q", gotAccount, cfg.AllowedAccountID)
+		}
 	}
 
 	duration := cfg.DurationSeconds
@@ -160,4 +167,15 @@ func (e *AWSSTSEngine) RevokeInvalidatesCredential(_ string) bool { return false
 // guards on IsEphemeralBackend before reaching here; this is a defensive backstop.
 func (e *AWSSTSEngine) Renew(_ context.Context, _, _ string, _ time.Time) error {
 	return fmt.Errorf("aws-sts: credentials are not renewable; issue a new lease instead")
+}
+
+// arnAccountID extracts the AWS account ID from a role ARN.
+// ARN format: arn:partition:iam::account-id:role/name
+// Returns empty string if the ARN is not in the expected format.
+func arnAccountID(arn string) string {
+	parts := strings.SplitN(arn, ":", 6)
+	if len(parts) < 5 {
+		return ""
+	}
+	return parts[4]
 }

--- a/internal/dynamic/kubernetes.go
+++ b/internal/dynamic/kubernetes.go
@@ -52,6 +52,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -447,10 +448,13 @@ func (m *realK8sMinter) deleteBoundSecret(ctx context.Context, namespace, name s
 
 // pathSegment guards a namespace/service-account name placed into the request path: K8s
 // names are DNS labels (lowercase alphanumerics and '-'), so anything else is rejected
-// rather than escaped, closing off path traversal in the constructed URL.
+// rather than escaped, closing off path traversal in the constructed URL. The '.'
+// character is rejected explicitly to block dot-segment sequences (`.`, `..`) even
+// when combined with url.PathEscape, then url.PathEscape is applied to the accepted
+// value to neutralise any unexpected metacharacters that survive the allowlist.
 func pathSegment(s string) string {
-	if s == "" || strings.ContainsAny(s, "/?#%") {
+	if s == "" || s == "." || s == ".." || strings.ContainsAny(s, "/?#%.") {
 		return "INVALID"
 	}
-	return s
+	return url.PathEscape(s)
 }

--- a/server/main.go
+++ b/server/main.go
@@ -516,8 +516,10 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			case "aws-secrets-manager":
 				connectors = append(connectors, connect.NewAWSSecretsManagerConnector(cn.Name, cn.Region, cn.AllowedRefs))
 			case "gcp-secret-manager":
-				if cn.ProjectID == "" {
-					log.Printf("Keyorix Connect: gcp-secret-manager connector %q has no project_id configured — reads can reach ANY GCP project the ambient identity can access, relying solely on allowed_refs to scope reach; set project_id to pin the connector to one project (#431)", cn.Name)
+				if cn.ProjectID == "" && len(cn.AllowedRefs) == 0 {
+					log.Fatalf("Keyorix Connect: gcp-secret-manager connector %q has neither project_id nor allowed_refs — this grants unrestricted cross-project read access to the ambient identity; set project_id or allowed_refs before starting", cn.Name)
+				} else if cn.ProjectID == "" {
+					log.Printf("Keyorix Connect: gcp-secret-manager connector %q has no project_id configured — reads can reach any GCP project the ambient identity can access; allowed_refs is the only scope restriction; set project_id to pin the connector to one project (#431)", cn.Name)
 				}
 				connectors = append(connectors, connect.NewGCPSecretManagerConnector(cn.Name, cn.ProjectID, cn.AllowedRefs))
 			case "azure-key-vault":
@@ -531,7 +533,15 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 				if token == "" {
 					log.Printf("Keyorix Connect: vault connector %q has no token (%s unset) — reads will fail", cn.Name, tokenEnv)
 				}
-				connectors = append(connectors, connect.NewVaultConnector(cn.Name, cn.Address, token, cn.AllowedRefs))
+				vc := connect.NewVaultConnector(cn.Name, cn.Address, token, cn.AllowedRefs)
+				if ttl, renewable, terr := vc.CheckTokenTTL(context.Background()); terr != nil {
+					log.Printf("Keyorix Connect: vault connector %q: token TTL check failed: %v", cn.Name, terr)
+				} else if ttl > 0 && ttl < 86400 && !renewable {
+					log.Printf("Keyorix Connect: vault connector %q: token has %d seconds remaining and is NOT renewable — replace before expiry", cn.Name, ttl)
+				} else if ttl > 0 && ttl < 86400 {
+					log.Printf("Keyorix Connect: vault connector %q: token expires in %d seconds; ensure renewal is configured", cn.Name, ttl)
+				}
+				connectors = append(connectors, vc)
 			default:
 				log.Printf("Keyorix Connect: skipping connector %q with unknown type %q", cn.Name, cn.Type)
 			}


### PR DESCRIPTION
## Summary
- **Kubernetes `pathSegment`**: reject `.` and `..` segments + `url.PathEscape` the result, closing URL path traversal via dot-segment sequences in namespace/service-account names
- **GCP Secret Manager**: `log.Fatalf` when both `project_id` and `allowed_refs` are unset (previously only logged a warning), since that combination allows unrestricted cross-project reads
- **AWS STS**: optional `allowed_account_id` field in admin DSN JSON; when set, validates the `RoleARN`'s account ID before calling AssumeRole, guarding against ARN misconfiguration
- **Vault**: `CheckTokenTTL` method on `VaultConnector`; startup log warnings when token expires within 24h or is non-renewable

## Test plan
- [ ] `go test ./internal/dynamic/... ./internal/connect/...` passes
- [ ] `gosec -severity medium -exclude-generated ./...` 0 issues
- [ ] `pathSegment("../kube-system")` returns `"INVALID"`
- [ ] GCP connector with empty `project_id` AND empty `allowed_refs` fails startup
- [ ] AWS STS with `allowed_account_id` set rejects mismatched role ARN account ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)