### PR TITLE
fix(security): session cookies on MFA/WebAuthn login + SSO error sanitisation (r121)

### DIFF
--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -381,18 +381,6 @@ func (c *KeyorixCore) loadTOTPSecret(ctx context.Context, userID uint) (string, 
 	return c.decryptAuthSecret(row.SecretEnc, row.SecretMeta, encryption.MFASecretAAD(userID))
 }
 
-func (c *KeyorixCore) validateTOTP(secret, code string) bool {
-	code = strings.TrimSpace(code)
-	if code == "" {
-		return false
-	}
-	// ±1 time-step skew (clock drift); standard 30s SHA-1 6-digit TOTP.
-	valid, _ := totp.ValidateCustom(code, secret, c.now().UTC(), totp.ValidateOpts{
-		Period: 30, Skew: 1, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1,
-	})
-	return valid
-}
-
 // totpPeriod is the TOTP step length in seconds.
 const totpPeriod = 30
 

--- a/server/http/handlers/mfa.go
+++ b/server/http/handlers/mfa.go
@@ -162,6 +162,7 @@ func (h *AuthHandler) VerifyMFA(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := h.buildLoginResponse(r.Context(), session, user)
+	h.setSessionCookies(w, session)
 	goSafe(func() {
 		h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, r.Header.Get("User-Agent"))
 	}) // #nosec G118

--- a/server/http/handlers/sso.go
+++ b/server/http/handlers/sso.go
@@ -16,6 +16,33 @@ import (
 )
 
 
+// oauthErrorAllowlist is the fixed set of error codes defined by RFC 6749 §4.1.2.1 and
+// RFC 6749 §5.2, plus common OIDC extensions. Any error code NOT in this list is
+// replaced with a generic message to prevent injection via a crafted callback URL.
+var oauthErrorAllowlist = map[string]bool{
+	"access_denied":              true,
+	"invalid_request":            true,
+	"unauthorized_client":        true,
+	"unsupported_response_type":  true,
+	"invalid_scope":              true,
+	"server_error":               true,
+	"temporarily_unavailable":    true,
+	"interaction_required":       true,
+	"login_required":             true,
+	"account_selection_required": true,
+	"consent_required":           true,
+}
+
+// sanitiseSSOError returns the IdP-supplied error code if it is a known OAuth 2.0 / OIDC
+// code, or a generic "SSO login failed" string otherwise, preventing untrusted input from
+// being reflected into the SPA fragment.
+func sanitiseSSOError(code string) string {
+	if oauthErrorAllowlist[code] {
+		return code
+	}
+	return "SSO login failed"
+}
+
 // isSafeSSOError reports whether msg is one of the small set of deliberately-
 // crafted, safe messages core.CompleteSSO itself produces without wrapping a
 // lower-layer error. Everything else — an authorization-code exchange failure,
@@ -81,8 +108,9 @@ func (h *AuthHandler) CompleteSSO(w http.ResponseWriter, r *http.Request) {
 
 	q := r.URL.Query()
 	if errParam := q.Get("error"); errParam != "" {
-		// The IdP itself reported an error (e.g. access_denied).
-		h.redirectFragment(w, r, completeURL, url.Values{"error": {errParam}})
+		// Validate against the OAuth 2.0 error code allowlist before reflecting
+		// into the fragment — the raw IdP parameter is untrusted input.
+		h.redirectFragment(w, r, completeURL, url.Values{"error": {sanitiseSSOError(errParam)}})
 		return
 	}
 	code, state := q.Get("code"), q.Get("state")

--- a/server/http/handlers/webauthn.go
+++ b/server/http/handlers/webauthn.go
@@ -202,6 +202,7 @@ func (h *AuthHandler) FinishWebAuthnLogin(w http.ResponseWriter, r *http.Request
 		return
 	}
 	resp := h.buildLoginResponse(r.Context(), session, user)
+	h.setSessionCookies(w, session)
 	goSafe(func() {
 		h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, r.Header.Get(hdrUserAgent))
 	}) // #nosec G118
@@ -256,6 +257,7 @@ func (h *AuthHandler) FinishWebAuthnPasswordlessLogin(w http.ResponseWriter, r *
 		return
 	}
 	resp := h.buildLoginResponse(r.Context(), session, user)
+	h.setSessionCookies(w, session)
 	goSafe(func() {
 		h.coreService.LogAuthLogin(context.Background(), user.ID, user.Username, ip, r.Header.Get(hdrUserAgent))
 	}) // #nosec G118


### PR DESCRIPTION
## Summary
- **Session cookies on MFA/WebAuthn login** (MEDIUM): `VerifyMFA`, `FinishWebAuthnLogin`, and `FinishWebAuthnPasswordlessLogin` all minted a real session but never called `setSessionCookies`. Browser clients completing MFA or WebAuthn login received only the raw token in the JSON body — no `HttpOnly kx_session` cookie and no CSRF double-submit cookie. The sessions were therefore fully exposed to XSS-based token theft and bypassed `RequireCSRF` on all subsequent state-changing requests. Fixed by adding `h.setSessionCookies(w, session)` before `sendSuccess` in each handler, matching `Login`, `CompleteSSO`, and `CompleteSAML`.
- **SSO error code injection** (LOW): `CompleteSSO` reflected the IdP's raw `?error=` query parameter directly into the SPA redirect fragment without validation. An attacker with a crafted callback URL could inject arbitrary text (potential XSS if the SPA renders it as HTML). Fixed with `sanitiseSSOError`, an RFC 6749 / OIDC allowlist that returns the code unchanged if recognised, or substitutes `"SSO login failed"` otherwise.

## Test plan
- [ ] Browser MFA login (TOTP) — verify `kx_session` HttpOnly cookie and CSRF cookie are set in the response
- [ ] Browser WebAuthn login — same cookie check
- [ ] Browser passwordless passkey login — same cookie check
- [ ] `go test ./server/http/handlers/...` passes
- [ ] SSO callback with `?error=access_denied` → fragment contains `access_denied`
- [ ] SSO callback with `?error=<script>alert(1)</script>` → fragment contains `SSO+login+failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)