### PR TITLE
fix(security): remote follower audit events silently dropped — wrong route (r122-A)

### DIFF
--- a/internal/storage/store/constants.go
+++ b/internal/storage/store/constants.go
@@ -1,7 +1,13 @@
 package store
 
 const (
-	apiAuditEventsPath = "/api/v1/audit/events"
+	// apiAuditLogsPath is the server's GET /api/v1/audit/logs route (GetAuditLogs).
+	apiAuditLogsPath = "/api/v1/audit/logs"
+	// apiAuditRBACLogsPath is the server's GET /api/v1/audit/rbac-logs route (GetRBACAuditLogs).
+	apiAuditRBACLogsPath = "/api/v1/audit/rbac-logs"
+	// apiAuditIngestPath is the system-write proxy route that persists a
+	// single AuditEvent from a remote-storage follower (#r122-A).
+	apiAuditIngestPath = "/api/v1/system/audit/event"
 	apiSecretsPath = "/api/v1/secrets" // #nosec G101 -- API path constant, not a hardcoded credential
 	apiUsersPath = "/api/v1/users"
 	sqlIncrReadCount = "read_count + 1"

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -21,9 +21,12 @@ import (
 )
 
 
-// LogAuditEvent logs an audit event via remote API.
+// LogAuditEvent proxies to POST /api/v1/system/audit/event, persisting the
+// event in the upstream server's own storage backend. This is the only write
+// path for a remote-storage follower's emitAudit calls; the hub's /audit/logs
+// (GET) and /audit/rbac-logs (GET) routes only serve reads.
 func (rs *RemoteStorage) LogAuditEvent(ctx context.Context, event *models.AuditEvent) error {
-	resp, err := rs.client.Post(ctx, apiAuditEventsPath, event)
+	resp, err := rs.client.Post(ctx, apiAuditIngestPath, event)
 	if err != nil {
 		return fmt.Errorf("failed to log audit event: %w", err)
 	}
@@ -65,10 +68,10 @@ func (rs *RemoteStorage) GetAuditLogs(ctx context.Context, filter *storage.Audit
 	return result.Events, result.Total, nil
 }
 
-// buildAuditFilterPath constructs the /api/v1/audit/events query string.
+// buildAuditFilterPath constructs the GET /api/v1/audit/logs query string.
 func buildAuditFilterPath(filter *storage.AuditFilter) string {
 	if filter == nil {
-		return apiAuditEventsPath
+		return apiAuditLogsPath
 	}
 	params := newQueryBuilder()
 	params.addUint("user_id", filter.UserID)
@@ -84,7 +87,7 @@ func buildAuditFilterPath(filter *storage.AuditFilter) string {
 	params.addString("actor_username", filter.ActorUsername)
 	params.addString("resource_type", filter.ResourceType)
 	params.addPage(filter.Page, filter.PageSize)
-	return apiAuditEventsPath + params.String()
+	return apiAuditLogsPath + params.String()
 }
 
 // GetRBACAuditLogs retrieves RBAC audit logs with optional filtering via remote API.
@@ -107,10 +110,10 @@ func (rs *RemoteStorage) GetRBACAuditLogs(ctx context.Context, filter *storage.R
 	return result.Logs, result.Total, nil
 }
 
-// buildRBACAuditFilterPath constructs the /api/v1/audit/rbac query string.
+// buildRBACAuditFilterPath constructs the GET /api/v1/audit/rbac-logs query string.
 func buildRBACAuditFilterPath(filter *storage.RBACAuditFilter) string {
 	if filter == nil {
-		return "/api/v1/audit/rbac"
+		return apiAuditRBACLogsPath
 	}
 	params := newQueryBuilder()
 	params.addUint("user_id", filter.UserID)
@@ -120,7 +123,7 @@ func buildRBACAuditFilterPath(filter *storage.RBACAuditFilter) string {
 	params.addTime("start_time", filter.StartTime)
 	params.addTime("end_time", filter.EndTime)
 	params.addPage(filter.Page, filter.PageSize)
-	return "/api/v1/audit/rbac" + params.String()
+	return apiAuditRBACLogsPath + params.String()
 }
 
 // ListSecretAccessLogs is not available in remote mode; server handles access logs.

--- a/internal/storage/store/remote_audit_test.go
+++ b/internal/storage/store/remote_audit_test.go
@@ -19,7 +19,7 @@ import (
 func TestRemoteStorage_LogAuditEvent(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v1/audit/events", r.URL.Path)
+		assert.Equal(t, "/api/v1/system/audit/event", r.URL.Path)
 		_, _ = w.Write(apiOK(nil))
 	}))
 	defer srv.Close()
@@ -61,7 +61,7 @@ func TestRemoteStorage_CountImpersonatedActions(t *testing.T) {
 func TestRemoteStorage_GetAuditLogs_NilFilter(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/audit/events", r.URL.Path)
+		assert.Equal(t, "/api/v1/audit/logs", r.URL.Path)
 		_, _ = w.Write(apiOK(map[string]interface{}{
 			"events": []map[string]interface{}{
 				{"EventType": "secret.read", "ActorType": "user"},
@@ -83,7 +83,7 @@ func TestRemoteStorage_GetAuditLogs_NilFilter(t *testing.T) {
 func TestRemoteStorage_GetAuditLogs_WithFilter(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/audit/events", r.URL.Path)
+		assert.Equal(t, "/api/v1/audit/logs", r.URL.Path)
 		_, _ = w.Write(apiOK(map[string]interface{}{
 			"events": []map[string]interface{}{},
 			"total":  int64(0),
@@ -111,7 +111,7 @@ func TestRemoteStorage_GetAuditLogs_WithFilter(t *testing.T) {
 func TestRemoteStorage_GetRBACAuditLogs_NilFilter(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/audit/rbac", r.URL.Path)
+		assert.Equal(t, "/api/v1/audit/rbac-logs", r.URL.Path)
 		_, _ = w.Write(apiOK(map[string]interface{}{
 			"logs": []map[string]interface{}{
 				{
@@ -138,7 +138,7 @@ func TestRemoteStorage_GetRBACAuditLogs_NilFilter(t *testing.T) {
 func TestRemoteStorage_GetRBACAuditLogs_WithFilter(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/audit/rbac", r.URL.Path)
+		assert.Equal(t, "/api/v1/audit/rbac-logs", r.URL.Path)
 		_, _ = w.Write(apiOK(map[string]interface{}{
 			"logs":  []map[string]interface{}{},
 			"total": int64(0),

--- a/server/http/handlers/audit_ingest_proxy.go
+++ b/server/http/handlers/audit_ingest_proxy.go
@@ -1,0 +1,45 @@
+// audit_ingest_proxy.go — server-side endpoint backing RemoteStorage's
+// LogAuditEvent (#r122-A).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049)
+// emits audit events via internal/core.KeyorixCore.emitAudit, which calls
+// storage.LogAuditEvent. On a RemoteStorage backend, LogAuditEvent used to
+// POST to /api/v1/audit/events — a path that has never existed on the hub
+// server (the read route is /api/v1/audit/logs, with no write counterpart).
+// Every emitAudit call on a follower therefore returned a 404, the error was
+// logged and discarded, and the hub's audit trail had a silent, complete gap
+// for all follower-originated events: secret reads, logins, MFA enrolments,
+// RBAC changes, etc.
+//
+// This proxy adds the missing write endpoint at
+// POST /api/v1/system/audit/event (registered in server/http/router.go under
+// the /system group, gated on system.write — the same credential tier every
+// other RemoteStorage proxy already requires). It is a raw passthrough onto
+// storage.Storage.LogAuditEvent, exactly like the access-request,
+// invitation, MFA, and scheduler-lock proxies: no audit POLICY decision is
+// made here; the emitting server's own core.KeyorixCore already made that
+// decision before ever calling storage.LogAuditEvent.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// IngestAuditEventProxy accepts a single models.AuditEvent from a remote-
+// storage follower and persists it in this server's own storage backend.
+// Registered at POST /api/v1/system/audit/event (system.write).
+func (h *AuditHandler) IngestAuditEventProxy(w http.ResponseWriter, r *http.Request) {
+	var event models.AuditEvent
+	if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+		sendError(w, "BadRequest", "invalid audit event body", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.Storage().LogAuditEvent(r.Context(), &event); err != nil {
+		sendError(w, "InternalServerError", "failed to persist audit event", http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, nil, "")
+}

--- a/server/http/handlers/audit_ingest_proxy_test.go
+++ b/server/http/handlers/audit_ingest_proxy_test.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newAuditIngestHandler(t *testing.T) *AuditHandler {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open("file::memory:?mode=memory&cache=shared&_busy_timeout=5000"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(models.AllTestModels()...))
+	return NewAuditHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+}
+
+func postAuditIngest(h http.HandlerFunc, body []byte) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/audit/event", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h(w, req)
+	return w
+}
+
+// TestIngestAuditEventProxy_HappyPath verifies that a valid AuditEvent is
+// persisted and returns 200.
+func TestIngestAuditEventProxy_HappyPath(t *testing.T) {
+	h := newAuditIngestHandler(t)
+	body, _ := json.Marshal(map[string]any{
+		"event_type":  "secret.read",
+		"description": "remote follower event",
+	})
+	w := postAuditIngest(h.IngestAuditEventProxy, body)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["success"])
+}
+
+// TestIngestAuditEventProxy_InvalidJSON verifies that malformed JSON returns 400.
+func TestIngestAuditEventProxy_InvalidJSON(t *testing.T) {
+	h := newAuditIngestHandler(t)
+	w := postAuditIngest(h.IngestAuditEventProxy, []byte("not-json{{{"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/server/http/handlers/audit_ingest_proxy_test.go
+++ b/server/http/handlers/audit_ingest_proxy_test.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -17,10 +19,14 @@ import (
 	"gorm.io/gorm"
 )
 
+var auditIngestTestCounter atomic.Int64
+
 func newAuditIngestHandler(t *testing.T) *AuditHandler {
 	t.Helper()
 	require.NoError(t, i18n.InitializeForTesting())
-	db, err := gorm.Open(sqlite.Open("file::memory:?mode=memory&cache=shared&_busy_timeout=5000"), &gorm.Config{})
+	n := auditIngestTestCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxauditingest_%d?mode=memory&cache=shared&_busy_timeout=5000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(models.AllTestModels()...))
 	return NewAuditHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1795,6 +1795,16 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// exists to prevent.
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/scheduler-lock/acquire", authHandler.AcquireSchedulerLockProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/scheduler-lock/release", authHandler.ReleaseSchedulerLockProxy)
+
+			// Audit-event ingest proxy (#r122-A). Lets a downstream Keyorix server
+			// booted with storage.type: remote persist its emitAudit-emitted events
+			// in THIS server's real storage backend, instead of them silently 404-ing
+			// (RemoteStorage.LogAuditEvent used to POST to /api/v1/audit/events, a
+			// path that has never existed on the hub). See audit_ingest_proxy.go for
+			// the full analysis. system.write: raw storage write, same tier as every
+			// other mutating proxy in this group; no audit POLICY decision is made
+			// here.
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/audit/event", auditHandler.IngestAuditEventProxy)
 		})
 
 		// Offline-license status (ADR-065) — the locally-evaluated commercial entitlement.


### PR DESCRIPTION
## Summary
- **Silent audit trail gap on remote-storage nodes** (`RemoteStorage.LogAuditEvent` 404ed permanently): `LogAuditEvent` posted to `POST /api/v1/audit/events`, which has never existed on the hub server. The error was caught by `emitAudit`'s `"SECURITY: failed to persist audit event"` log line and silently discarded. Every secret read, login, MFA enrolment, RBAC mutation, etc. on a follower node left no trace in the hub's audit trail.
- **GetAuditLogs used the wrong path** (`/audit/events` → should be `/audit/logs`): audit log reads from a follower also 404ed silently.
- **GetRBACAuditLogs used the wrong path** (`/audit/rbac` → should be `/audit/rbac-logs`): same class of bug on the RBAC audit log read path.

## Fix
- Add `POST /api/v1/system/audit/event` — a `system.write`-gated thin passthrough onto `storage.Storage.LogAuditEvent`, matching the pattern of every other RemoteStorage proxy (invitations, access-requests, MFA, scheduler-lock). No audit policy decision is made here; the emitting server's own `core.KeyorixCore` already made that before calling `storage.LogAuditEvent`.
- Replace the single `apiAuditEventsPath` constant with three distinct constants matching the actual server routes: `apiAuditLogsPath`, `apiAuditRBACLogsPath`, `apiAuditIngestPath`.

## Impact
Any Keyorix deployment running a follower node with `storage.type: remote` had a 100% gap in the hub's audit trail for all follower-originated events. This was silent (no user-visible error, only a server log line) and would not have been detectable via `VerifyAuditChain` (no row = no hole to detect).

## Test plan
- [ ] `go test ./internal/storage/store/ -run TestRemoteUnsupportedStubsAreAllowlisted` passes
- [ ] `go build ./internal/storage/store/ ./server/http/handlers/ ./server/` passes
- [ ] In HA mode with a follower: confirm `emitAudit` calls on the follower now reach the hub's storage (previously all 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)