### PR TITLE
fix(security): system proxy over-exposure, refresh rate-limit, gRPC cache eviction, RBAC-share gap (r124)

### DIFF
--- a/internal/core/core_s25_test.go
+++ b/internal/core/core_s25_test.go
@@ -776,9 +776,10 @@ func TestEnforceSecretOwnerPermission_NotOwner(t *testing.T) {
 	ms.On("GetSecret", mock.Anything, uint(5)).Return(&models.SecretNode{ID: 5, OwnerID: 99}, nil)
 	// ListSharesBySecret returns no shares
 	ms.On("ListSharesBySecret", mock.Anything, uint(5)).Return([]*models.ShareRecord{}, nil)
-	// Authz checks - no roles
-	ms.On("GetUserRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(1), mock.Anything).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(1), mock.Anything).Return([]uint{}, nil)
 	c := NewKeyorixCore(ms)
 	_, err := c.EnforceSecretOwnerPermission(context.Background(), 5, 1)
 	require.Error(t, err)

--- a/internal/core/core_s26_test.go
+++ b/internal/core/core_s26_test.go
@@ -284,6 +284,9 @@ func TestCheckSecretPermission_Denied(t *testing.T) {
 	ms.On("ListSharesBySecret", mock.Anything, uint(5)).Return([]*models.ShareRecord{}, nil)
 	// CheckGroupPermissions calls GetUserGroups
 	ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(1), mock.Anything).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(1), mock.Anything).Return([]uint{}, nil)
 	c := NewKeyorixCore(ms)
 	_, err := c.CheckSecretPermission(context.Background(), 5, 1, PermissionRead)
 	require.Error(t, err)

--- a/internal/core/core_s28_test.go
+++ b/internal/core/core_s28_test.go
@@ -203,6 +203,9 @@ func TestGetSecretValueByVersionWithPermissionCheck_PermissionDenied(t *testing.
 	ms.On("GetSecret", mock.Anything, uint(5)).Return(secret, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(5)).Return([]*models.ShareRecord{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	c := NewKeyorixCore(ms)
 	_, err := c.GetSecretValueByVersionWithPermissionCheck(context.Background(), 5, 2, 1)
 	require.Error(t, err)

--- a/internal/core/core_s29_test.go
+++ b/internal/core/core_s29_test.go
@@ -433,6 +433,9 @@ func TestGetSecretByNameWithPermissionCheck_PermissionDenied(t *testing.T) {
 	ms.On("GetSecret", mock.Anything, uint(5)).Return(secret, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(5)).Return([]*models.ShareRecord{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	c := NewKeyorixCore(ms)
 	_, err := c.GetSecretByNameWithPermissionCheck(context.Background(), "mysecret", 1, 1, 2)
 	require.Error(t, err)
@@ -453,6 +456,9 @@ func TestUpdateSecretWithPermissionCheck_PermissionDenied(t *testing.T) {
 	ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	c := NewKeyorixCore(ms)
 	_, err := c.UpdateSecretWithPermissionCheck(context.Background(), &UpdateSecretRequest{ID: 1, UserID: 2, UpdatedBy: "me"})
 	require.Error(t, err)
@@ -473,6 +479,9 @@ func TestDeleteSecretWithPermissionCheck_PermissionDenied(t *testing.T) {
 	ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	c := NewKeyorixCore(ms)
 	err := c.DeleteSecretWithPermissionCheck(context.Background(), 1, 2)
 	require.Error(t, err)

--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -190,6 +190,17 @@ func (c *KeyorixCore) TransitionMachineIdentity(ctx context.Context, projectID, 
 	if err != nil {
 		return nil, err
 	}
+	// Suspend or revoke must evict every credential from the auth cache
+	// immediately so the identity stops authenticating on the next HTTP request
+	// rather than after validTokenTTL (30s). The HTTP handler also calls
+	// InvalidateTokenCacheByHash directly (defence-in-depth); this call moves
+	// the eviction into the core so gRPC callers (which have no HTTP middleware
+	// reference) get the same guarantee automatically (#r124).
+	if to == MachineSuspended || to == MachineRevoked {
+		if hashes, herr := c.MachineTokenHashes(ctx, id); herr == nil {
+			c.invalidateTokenCache(hashes...)
+		}
+	}
 	c.logMachineEvent(ctx, "machine_identity."+machineVerb(to), result, actorID)
 	return result, nil
 }

--- a/internal/core/machine_identities_test.go
+++ b/internal/core/machine_identities_test.go
@@ -89,6 +89,8 @@ func TestTransitionMachineIdentity(t *testing.T) {
 			return m.State == MachineSuspended
 		}), MachineActive).Return(true, nil)
 		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+		// Cache eviction: suspend calls MachineTokenHashes which calls ListMachineIdentityCredentials.
+		store.On("ListMachineIdentityCredentials", ctx, uint(10)).Return([]*models.MachineIdentityCredential{}, nil)
 
 		m, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineSuspended, 9)
 		require.NoError(t, err)
@@ -104,6 +106,8 @@ func TestTransitionMachineIdentity(t *testing.T) {
 			return m.State == MachineRevoked && m.RevokedAt != nil
 		}), MachineActive).Return(true, nil)
 		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+		// Cache eviction: revoke calls MachineTokenHashes which calls ListMachineIdentityCredentials.
+		store.On("ListMachineIdentityCredentials", ctx, uint(10)).Return([]*models.MachineIdentityCredential{}, nil)
 
 		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineRevoked, 9)
 		require.NoError(t, err)
@@ -174,5 +178,70 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot transition")
 		store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+	})
+
+	t.Run("suspend evicts auth cache", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := newMachineCore(ms)
+		ctx := context.Background()
+		ms.On("LockMachineIdentityForUpdate", ctx, uint(20)).Return(&models.MachineIdentity{ID: 20, ProjectID: 1, State: MachineActive}, nil)
+		ms.On("TransitionMachineIdentityState", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.State == MachineSuspended
+		}), MachineActive).Return(true, nil)
+		ms.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+		ms.On("ListMachineIdentityCredentials", ctx, uint(20)).Return([]*models.MachineIdentityCredential{
+			{ID: 1, TokenHash: "hash-cred-abc"},
+		}, nil)
+
+		var evicted []string
+		c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+		_, err := c.TransitionMachineIdentity(ctx, 1, 20, MachineSuspended, 9)
+		require.NoError(t, err)
+		assert.Contains(t, evicted, "hash-cred-abc", "suspend must evict the machine token from cache")
+		ms.AssertExpectations(t)
+	})
+
+	t.Run("revoke evicts auth cache", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := newMachineCore(ms)
+		ctx := context.Background()
+		ms.On("LockMachineIdentityForUpdate", ctx, uint(21)).Return(&models.MachineIdentity{ID: 21, ProjectID: 1, State: MachineActive}, nil)
+		ms.On("TransitionMachineIdentityState", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.State == MachineRevoked && m.RevokedAt != nil
+		}), MachineActive).Return(true, nil)
+		ms.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+		ms.On("ListMachineIdentityCredentials", ctx, uint(21)).Return([]*models.MachineIdentityCredential{
+			{ID: 2, TokenHash: "hash-cred-def"},
+		}, nil)
+
+		var evicted []string
+		c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+		_, err := c.TransitionMachineIdentity(ctx, 1, 21, MachineRevoked, 9)
+		require.NoError(t, err)
+		assert.Contains(t, evicted, "hash-cred-def", "revoke must evict the machine token from cache")
+		ms.AssertExpectations(t)
+	})
+
+	t.Run("activate does not evict auth cache", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := newMachineCore(ms)
+		ctx := context.Background()
+		ms.On("LockMachineIdentityForUpdate", ctx, uint(22)).Return(&models.MachineIdentity{ID: 22, ProjectID: 1, State: MachineSuspended}, nil)
+		ms.On("TransitionMachineIdentityState", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.State == MachineActive
+		}), MachineSuspended).Return(true, nil)
+		ms.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+		// ListMachineIdentityCredentials must NOT be called for activate.
+
+		var evicted []string
+		c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+		_, err := c.TransitionMachineIdentity(ctx, 1, 22, MachineActive, 9)
+		require.NoError(t, err)
+		assert.Empty(t, evicted, "re-activating a machine must not evict any tokens")
+		ms.AssertNotCalled(t, "ListMachineIdentityCredentials", mock.Anything, mock.Anything)
+		ms.AssertExpectations(t)
 	})
 }

--- a/internal/core/oidc_binding_test.go
+++ b/internal/core/oidc_binding_test.go
@@ -29,8 +29,8 @@ func TestCreateOIDCBinding_RequiresGlobalAdminAuthority(t *testing.T) {
 		store.On("GetMachineIdentity", ctx, uint(5)).Return(machine, nil)
 		// Actor 2 has NO role grants at global scope (project_id=0) — only within
 		// project 1, which requireAuthorityForRole(..., projectID=0, ...) never sees.
-		store.On("GetUserRoleIDsAt", ctx, uint(2), mock.MatchedBy(func(s interface{}) bool { return true })).Return([]uint{}, nil)
-		store.On("GetUserGroupRoleIDsAt", ctx, uint(2), mock.MatchedBy(func(s interface{}) bool { return true })).Return([]uint{}, nil)
+		store.On("GetUserRoleIDsAt", ctx, uint(2), mock.MatchedBy(func(s any) bool { return true })).Return([]uint{}, nil)
+		store.On("GetUserGroupRoleIDsAt", ctx, uint(2), mock.MatchedBy(func(s any) bool { return true })).Return([]uint{}, nil)
 
 		_, err := c.CreateOIDCBinding(ctx, 1, 5, "https://idp.test", "system:serviceaccount:victim:ci", 2)
 		require.Error(t, err)

--- a/internal/core/permission_enforcement_test.go
+++ b/internal/core/permission_enforcement_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -104,6 +105,9 @@ func TestCheckSecretPermission(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{share}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+				// RBAC fallback: no roles at this scope — deny.
+				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 			},
 			expectError: true,
 		},
@@ -136,6 +140,9 @@ func TestCheckSecretPermission(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(4)).Return([]*models.Group{}, nil)
+				// RBAC fallback: no roles at this scope — deny.
+				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 			},
 			expectError: true,
 		},
@@ -252,6 +259,9 @@ func TestEnforceSecretWritePermission(t *testing.T) {
 		},
 	}, nil)
 	mockStorage.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+	// RBAC fallback: no roles — deny.
+	mockStorage.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+	mockStorage.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 
 	core := NewKeyorixCore(mockStorage)
 
@@ -329,6 +339,9 @@ func TestCanUserModifySecret(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{share}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+				// RBAC fallback: no roles — deny.
+				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 			},
 			expected: false,
 		},
@@ -406,6 +419,9 @@ func TestCanUserShareSecret(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{share}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+				// RBAC fallback: no roles — deny.
+				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 			},
 			expected: false,
 		},
@@ -493,6 +509,9 @@ func TestGetEffectivePermission(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+				// RBAC fallback: no roles — deny.
+				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 			},
 			expectedPermission: PermissionNone,
 		},
@@ -632,6 +651,9 @@ func TestGetSecretWithPermissionCheck(t *testing.T) {
 		mockStorage.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 		mockStorage.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 		mockStorage.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+		// RBAC fallback: no roles — deny.
+		mockStorage.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+		mockStorage.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 
 		core := NewKeyorixCore(mockStorage)
 
@@ -642,4 +664,53 @@ func TestGetSecretWithPermissionCheck(t *testing.T) {
 
 		mockStorage.AssertExpectations(t)
 	})
+}
+
+func TestPermissionLevelToRBACPerm(t *testing.T) {
+	cases := []struct {
+		level PermissionLevel
+		want  string
+	}{
+		{PermissionRead, "secrets.read"},
+		{PermissionWrite, "secrets.write"},
+		{PermissionOwner, "secrets.delete"},
+		{PermissionNone, ""},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, permissionLevelToRBACPerm(tc.level), "level=%s", tc.level)
+	}
+}
+
+// TestCheckSecretPermission_RBACFallback_GrantsAccess verifies that a user
+// with no ownership or share record but a project-scoped RBAC role granting
+// secrets.read is still admitted via the RBAC fallback path (#r124).
+func TestCheckSecretPermission_RBACFallback_GrantsAccess(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	mockStorage := &MockStorage{}
+	// Secret owned by userID=99 (not our caller, userID=7)
+	secret := &models.SecretNode{
+		ID: 1, OwnerID: 99, Name: "rbac-fallback-secret",
+		ProjectID: 5, EnvironmentID: 10,
+	}
+	mockStorage.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+	mockStorage.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
+	mockStorage.On("GetUserGroups", mock.Anything, uint(7)).Return([]*models.Group{}, nil)
+
+	// RBAC fallback: user 7 has role [55] in this project scope.
+	mockStorage.On("GetUserRoleIDsAt", mock.Anything, uint(7), mock.Anything).Return([]uint{55}, nil)
+	mockStorage.On("GetUserGroupRoleIDsAt", mock.Anything, uint(7), mock.Anything).Return([]uint{}, nil)
+	// Role 55 is not an admin role — GetRoleByName returns not found for each admin name.
+	mockStorage.On("GetRoleByName", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("not found"))
+	// Role 55 grants secrets.read.
+	mockStorage.On("RoleSetHasPermission", mock.Anything, []uint{55}, "secrets.read").Return(true, nil)
+
+	c := NewKeyorixCore(mockStorage)
+
+	permCtx, err := c.CheckSecretPermission(context.Background(), 1, 7, PermissionRead)
+	require.NoError(t, err)
+	require.NotNil(t, permCtx)
+	assert.Equal(t, "rbac", permCtx.Source)
+	assert.Equal(t, PermissionRead, permCtx.Permission)
+	mockStorage.AssertExpectations(t)
 }

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -121,7 +121,41 @@ func (c *KeyorixCore) CheckSecretPermission(ctx context.Context, secretID, userI
 		}
 	}
 
+	// RBAC fallback: a project editor/admin whose role grants secrets.write (or
+	// secrets.delete for owner-level operations) passes the HTTP router's
+	// RequireScopedPermission gate but was silently denied here because
+	// CheckSecretPermission only recognized ownership and share records. This
+	// unifies the two authorization models so both the middleware and the core
+	// function accept the same set of legitimate callers (#r124).
+	if rbacPerm := permissionLevelToRBACPerm(requiredPermission); rbacPerm != "" {
+		actorType := actorTypeFromContext(ctx)
+		scope := Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
+		if ok, aerr := c.AuthorizePrincipal(ctx, actorType, userID, rbacPerm, scope); aerr == nil && ok {
+			return &PermissionContext{
+				SecretID:   secretID,
+				UserID:     userID,
+				Permission: requiredPermission,
+				Source:     "rbac",
+			}, nil
+		}
+	}
+
 	return nil, fmt.Errorf("%s: insufficient permissions", i18n.T("ErrorPermissionDenied", nil))
+}
+
+// permissionLevelToRBACPerm maps a PermissionLevel to the equivalent RBAC permission
+// string used by AuthorizePrincipal. PermissionOwner maps to secrets.delete (the most
+// restrictive mutation the RBAC model expresses). Returns "" for PermissionNone.
+func permissionLevelToRBACPerm(level PermissionLevel) string {
+	switch level {
+	case PermissionRead:
+		return "secrets.read"
+	case PermissionWrite:
+		return "secrets.write"
+	case PermissionOwner:
+		return "secrets.delete"
+	}
+	return ""
 }
 
 // hasRequiredPermission checks if the user's permission level meets the required level.

--- a/internal/core/restore_audit_test.go
+++ b/internal/core/restore_audit_test.go
@@ -25,7 +25,7 @@ func TestRestoreOperationsAudit(t *testing.T) {
 		&models.UserRole{}, &models.GroupRole{}, &models.UserGroup{}, &models.Role{}, &models.Group{},
 		// #370: DeleteSecret revokes ShareRecord rows in the same transaction as the
 		// secret's own soft-delete.
-		&models.ShareRecord{},
+		&models.ShareRecord{}, &models.SecretACL{},
 		&models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -23,6 +23,7 @@ func rotationExecCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.RotationPolicy{}, &models.AuditEvent{},
 		&models.Project{}, &models.Environment{}, &models.Role{}, &models.UserRole{},
+		&models.GroupRole{}, &models.UserGroup{}, &models.Group{},
 	))
 	// ListSecrets(ProjectID) JOINs environments, so the scope needs a real env row.
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)

--- a/internal/core/secret_ownership_history_test.go
+++ b/internal/core/secret_ownership_history_test.go
@@ -127,6 +127,9 @@ func TestGetSecretOwnershipHistory_PermissionDenied(t *testing.T) {
 		Return([]*models.ShareRecord{}, nil)
 	// CheckGroupPermissions → GetUserGroups needed.
 	store.On("GetUserGroups", ctx, uint(42)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	store.On("GetUserRoleIDsAt", mock.Anything, uint(42), mock.Anything).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", mock.Anything, uint(42), mock.Anything).Return([]uint{}, nil)
 
 	_, err := c.GetSecretOwnershipHistory(ctx, 100, 42)
 	require.Error(t, err)

--- a/internal/core/secret_recycle_bin_test.go
+++ b/internal/core/secret_recycle_bin_test.go
@@ -22,7 +22,7 @@ func TestListDeletedSecrets(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	// #370: DeleteSecret revokes ShareRecord rows in the same transaction as the
 	// secret's own soft-delete.
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.ShareRecord{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.ShareRecord{}, &models.SecretACL{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
 

--- a/internal/core/secret_render_test.go
+++ b/internal/core/secret_render_test.go
@@ -30,7 +30,7 @@ func newRenderFixture(t *testing.T) (*KeyorixCore, *gorm.DB, uint, uint) {
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{},
 		&models.Project{}, &models.Environment{}, &models.SecretAccessLog{}, &models.AuditEvent{},
-		&models.ShareRecord{},
+		&models.ShareRecord{}, &models.SecretACL{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@test.com"}).Error)
 

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -328,6 +328,18 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 // RefreshToken handles POST /auth/refresh.
 // Issues a new session token and invalidates the old one.
 func (h *AuthHandler) RefreshToken(w http.ResponseWriter, r *http.Request) {
+	ip := r.RemoteAddr
+	if idx := strings.LastIndex(ip, ":"); idx != -1 {
+		ip = ip[:idx]
+	}
+	// Rate-limit failed refresh attempts by IP, mirroring Login and VerifyMFA.
+	// /auth/refresh is unauthenticated so an attacker can flood it to brute-force
+	// session tokens or DoS the DB with unlimited queries (#r124).
+	if h.checkLoginRateLimit(r.Context(), ip) {
+		sendError(w, "TooManyRequests", "Too many requests. Try again later.", http.StatusTooManyRequests, nil)
+		return
+	}
+
 	token := extractBearerToken(r)
 	if token == "" {
 		sendError(w, "BadRequest", "Missing authorization token", http.StatusBadRequest, nil)
@@ -336,6 +348,7 @@ func (h *AuthHandler) RefreshToken(w http.ResponseWriter, r *http.Request) {
 
 	session, err := h.coreService.RefreshSession(r.Context(), token)
 	if err != nil {
+		h.recordLoginAttempt(r.Context(), ip)
 		sendError(w, "Unauthorized", "Session not found or expired", http.StatusUnauthorized, nil)
 		return
 	}

--- a/server/http/handlers/auth_sso_s13_test.go
+++ b/server/http/handlers/auth_sso_s13_test.go
@@ -53,6 +53,26 @@ func TestLogin_RateLimited_S13(t *testing.T) {
 
 // ── auth.go: RefreshToken 401 ─────────────────────────────────────────────────
 
+// TestRefreshToken_RateLimited_S13 verifies the 429 branch when the IP has
+// exceeded the failed-login budget (#r124 -- refresh rate limiting).
+func TestRefreshToken_RateLimited_S13(t *testing.T) {
+	cs := freshCoreS12(t)
+	h := NewAuthHandler(cs, false)
+	ctx := context.Background()
+
+	// Flood the login rate limiter (> 10 attempts within the window).
+	for i := 0; i < 12; i++ {
+		cs.RecordFailedLogin(ctx, "10.1.2.3")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
+	req.Header.Set("Authorization", "Bearer some-token")
+	req.RemoteAddr = "10.1.2.3:5678"
+	w := httptest.NewRecorder()
+	h.RefreshToken(w, req)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
 // TestRefreshToken_InvalidToken_S13 verifies the 401 branch when the token has
 // no matching live session.
 func TestRefreshToken_InvalidToken_S13(t *testing.T) {

--- a/server/http/handlers/secrets_cert_inv_s13_test.go
+++ b/server/http/handlers/secrets_cert_inv_s13_test.go
@@ -152,10 +152,15 @@ func TestGetSecretCertificate_PermissionDenied_S13(t *testing.T) {
 		EncryptedValue: certPEM,
 	}).Error)
 
-	req := withUserCtx(withChiParam(
+	// Use a non-admin UserID (99) with no project roles, ownership, or shares.
+	// UserID=1 is the global admin seeded by freshCoreS12WithAdmin; the RBAC
+	// fallback added in #r124 now grants admins access to all secrets, so we
+	// must use an unprivileged actor to keep this "permission denied" branch
+	// exercised.
+	req := withUserCtxID2(withChiParam(
 		httptest.NewRequest(http.MethodGet, "/", nil),
 		"id", fmt.Sprintf("%d", sec.ID),
-	))
+	), 99, "noperm-user")
 	w := httptest.NewRecorder()
 	h.GetSecretCertificate(w, req)
 

--- a/server/http/handlers/secrets_versions_s13_test.go
+++ b/server/http/handlers/secrets_versions_s13_test.go
@@ -130,10 +130,14 @@ func TestGetSecretVersions_InternalError_S13(t *testing.T) {
 	}
 	require.NoError(t, db.Create(secret).Error)
 
-	req := withUserCtx(withChiParam(
+	// Use a non-admin UserID (99) with no project roles, ownership, or shares.
+	// UserID=1 is the global admin; the RBAC fallback added in #r124 now grants
+	// admins RBAC access so they return 200, not 403. An unprivileged actor with
+	// no grants exercises the permission-denied branch correctly.
+	req := withUserCtxID2(withChiParam(
 		httptest.NewRequest(http.MethodGet, "/", nil),
 		"id", itoa(secret.ID),
-	))
+	), 99, "noperm-user")
 	w := httptest.NewRecorder()
 	h.GetSecretVersions(w, req)
 	// Permission denied → "permission denied" in error → 403.

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -972,9 +972,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/anomalies/{id}/acknowledge", handlers.AcknowledgeAnomalyAlert)
 		})
 
-		// System endpoints
+		// System endpoints — server-to-server proxy API for RemoteStorage followers
+		// (ADR-049). All routes require system.write: only service credentials issued
+		// to downstream Keyorix nodes should reach these endpoints, never regular user
+		// sessions. Prior gate (system.read) was held by every user via system_viewer,
+		// exposing TOTP seed ciphertexts, WebAuthn credentials, machine token hashes,
+		// global admin roster, and setup-token data to all authenticated users (#r124).
 		r.Route("/system", func(r chi.Router) {
-			r.Use(customMiddleware.RequirePermission(permSystemRead))
+			r.Use(customMiddleware.RequirePermission(permSystemWrite))
 			r.Get("/info", handlers.MakeSystemInfoHandler(cfg))
 			r.Get(pathMetrics, handlers.GetMetrics)
 			// Per-scheduler last-run/last-success timestamps (Prometheus exposition


### PR DESCRIPTION
## Summary

- **System proxy over-exposure** — `/system` route group was gated on `system.read`, which every user holds via `system_viewer`. Raised to `system.write` (service credentials only); removes authenticated-user access to TOTP seed ciphertexts, WebAuthn credentials, machine token hashes, global admin roster, and setup-token data.
- **Refresh rate limit gap** — `POST /auth/refresh` was unauthenticated with no rate limit, unlike Login/VerifyMFA. Adds `checkLoginRateLimit` + `recordLoginAttempt` to mirror the existing pattern.
- **gRPC cache eviction gap** — Machine suspend/revoke via gRPC did not evict the auth-token cache; HTTP handler did. Eviction moved into `TransitionMachineIdentity` core so both transports get the guarantee automatically. HTTP handler kept as defence-in-depth.
- **RBAC–share model split** — `CheckSecretPermission` only checked ownership and share records; project RBAC grants (`secrets.write` via editor role) were ignored. RBAC added as a third authorization path via `AuthorizePrincipal`, closing the silent-deny gap for project editors.

## Test plan

- [ ] `GET /api/v1/system/mfa/...` with a regular user session returns 403
- [ ] `POST /api/v1/auth/refresh` with 6 rapid invalid tokens returns 429 on the 6th
- [ ] Revoking a machine identity via gRPC invalidates its token within one request cycle (not after 30 s TTL)
- [ ] A project editor with `secrets.write` RBAC can read/update a secret they do not own and have no share record for

🤖 Generated with [Claude Code](https://claude.com/claude-code)