### PR TITLE
fix(security): LIKE injection, pagination DoS, deactivation revocation, PAT scope fail-open, logout CSRF, group CLI actor, anomaly panic (r124-M)

### DIFF
--- a/internal/cli/anomalies/anomalies.go
+++ b/internal/cli/anomalies/anomalies.go
@@ -81,7 +81,7 @@ func runListRemote(rc *common.RemoteClient) error {
 		if a.Acknowledged {
 			ack = " [ACK]"
 		}
-		fmt.Printf("[%d] %s | %s | %s%s\n", a.ID, a.Severity, a.AlertType, a.DetectedAt[:16], ack)
+		fmt.Printf("[%d] %s | %s | %s%s\n", a.ID, a.Severity, a.AlertType, a.DetectedAt[:min(16, len(a.DetectedAt))], ack)
 		fmt.Printf("    Secret: %s | User: %s | IP: %s\n", a.SecretName, a.AccessedBy, a.IPAddress)
 		fmt.Printf("    %s\n\n", a.Description)
 	}

--- a/internal/cli/group/add-member.go
+++ b/internal/cli/group/add-member.go
@@ -50,7 +50,7 @@ func runAddMember(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
-	if err := service.AddUserToGroup(ctx, 0, addMemberUserID, addMemberGroupID, addMemberProjectID); err != nil { // actorID 0: local/unauthenticated CLI
+	if err := service.AddUserToGroup(ctx, common.ResolveActorID(), addMemberUserID, addMemberGroupID, addMemberProjectID); err != nil {
 		return fmt.Errorf("failed to add member: %w", err)
 	}
 	fmt.Printf("User %d added to group %d (project %d).\n", addMemberUserID, addMemberGroupID, addMemberProjectID)

--- a/internal/cli/group/create.go
+++ b/internal/cli/group/create.go
@@ -35,7 +35,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	ctx := context.Background()
-	g, err := service.CreateGroup(ctx, 0, &core.CreateGroupRequest{ // actorID 0: local/unauthenticated CLI
+	g, err := service.CreateGroup(ctx, common.ResolveActorID(), &core.CreateGroupRequest{
 		Name:        createName,
 		Description: createDescription,
 	})

--- a/internal/cli/group/delete.go
+++ b/internal/cli/group/delete.go
@@ -51,7 +51,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err := service.DeleteGroup(ctx, 0, deleteGroupID); err != nil { // actorID 0: local/unauthenticated CLI
+	if err := service.DeleteGroup(ctx, common.ResolveActorID(), deleteGroupID); err != nil {
 		return fmt.Errorf("failed to delete group: %w", err)
 	}
 	fmt.Printf("Group %d deleted.\n", deleteGroupID)

--- a/internal/cli/group/remove-member.go
+++ b/internal/cli/group/remove-member.go
@@ -52,7 +52,7 @@ func runRemoveMember(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
-	if err := service.RemoveUserFromGroup(ctx, 0, removeMemberUserID, removeMemberGroupID, removeMemberProjectID); err != nil { // actorID 0: local/unauthenticated CLI
+	if err := service.RemoveUserFromGroup(ctx, common.ResolveActorID(), removeMemberUserID, removeMemberGroupID, removeMemberProjectID); err != nil {
 		return fmt.Errorf("failed to remove member: %w", err)
 	}
 	fmt.Printf("User %d removed from group %d (project %d).\n", removeMemberUserID, removeMemberGroupID, removeMemberProjectID)

--- a/internal/cli/group/update.go
+++ b/internal/cli/group/update.go
@@ -40,7 +40,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	ctx := context.Background()
-	g, err := service.UpdateGroup(ctx, 0, &core.UpdateGroupRequest{ // actorID 0: local/unauthenticated CLI
+	g, err := service.UpdateGroup(ctx, common.ResolveActorID(), &core.UpdateGroupRequest{
 		ID:          updateGroupID,
 		Name:        updateGroupName,
 		Description: updateGroupDescription,

--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -197,9 +197,17 @@ func encodePATScopes(scopes []string) (string, error) {
 }
 
 // DecodePATScopes parses a stored scopes column back into a permission list.
-// An empty/invalid column yields nil (unrestricted) — fail-open here is correct
-// because an empty allowlist already means "inherit the owner", and the owner's
-// own RBAC still gates every action.
+// An empty column yields nil (unrestricted) — a PAT created without an explicit
+// scope allowlist inherits its owner's full permission set, so nil is the
+// correct "no restriction" signal.
+//
+// A non-empty column that fails JSON parsing is treated as corrupted rather than
+// unrestricted: the token was created WITH a scope restriction that is now
+// unreadable, so we return a sentinel that patRestrictionFrom interprets as
+// "deny everything" rather than accidentally widening a previously-restricted
+// token to full owner access (#r124 PAT scope fail-open).
+var patScopeCorrupted = []string{"__corrupted__"}
+
 func DecodePATScopes(raw string) []string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -207,7 +215,10 @@ func DecodePATScopes(raw string) []string {
 	}
 	var out []string
 	if err := json.Unmarshal([]byte(raw), &out); err != nil {
-		return nil
+		// Non-empty but unparseable: fail CLOSED — return a sentinel that no
+		// real permission string will ever match, so the PAT is denied everywhere
+		// rather than silently granted full owner access on a corrupted row.
+		return patScopeCorrupted
 	}
 	return out
 }

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -287,13 +287,46 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 	if req.DisplayName != "" {
 		user.DisplayName = req.DisplayName
 	}
+	wasActive := user.IsActive
 	if req.IsActive != nil {
 		user.IsActive = *req.IsActive
 	}
+	deactivating := wasActive && !user.IsActive
 	user.UpdatedAt = c.now()
-	updated, err := c.storage.UpdateUser(ctx, user)
+
+	var sessionHashes []string
+	if deactivating {
+		// Collect session hashes before the write so we can evict the auth cache
+		// after commit. The HTTP auth middleware caches validated tokens for up to
+		// validTokenTTL (30s); without eviction a just-deactivated user's session
+		// keeps passing auth for that window — same race SetAccountState already
+		// handles on suspend/deactivate via the account-state path (#r124).
+		sessionHashes, _ = c.storage.ListSessionTokenHashesForUser(ctx, req.ID)
+	}
+
+	var patHashes []string
+	var updated *models.User
+	if deactivating {
+		err = c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+			var terr error
+			updated, terr = tx.UpdateUser(ctx, user)
+			if terr != nil {
+				return terr
+			}
+			if hashes, herr := tx.RevokeAllPersonalAccessTokensForUser(ctx, req.ID); herr == nil {
+				patHashes = hashes
+			}
+			return tx.DeleteSessionsForUserExcept(ctx, req.ID, 0)
+		})
+	} else {
+		updated, err = c.storage.UpdateUser(ctx, user)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	if deactivating {
+		c.invalidateTokenCache(sessionHashes...)
+		c.invalidateTokenCache(patHashes...)
 	}
 	return updated, nil
 }

--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -50,6 +50,7 @@ package store
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
@@ -76,6 +77,39 @@ func clampPageSize(pageSize int) int {
 		return maxStoragePageSize
 	}
 	return pageSize
+}
+
+// maxStoragePage is the maximum page number accepted by paginated queries.
+// Without a ceiling, a hostile caller can force OFFSET = (page-1)*pageSize
+// into the millions, which SQLite/Postgres must scan and discard before
+// returning any rows — a cheap denial-of-service against the audit endpoint.
+// 10000 pages × up to 100 rows/page = 1 million rows, far above any real
+// audit log a single deployment would accumulate.
+const maxStoragePage = 10_000
+
+// clampPage bounds a caller-supplied page number to [1, maxStoragePage].
+func clampPage(page int) int {
+	if page < 1 {
+		return 1
+	}
+	if page > maxStoragePage {
+		return maxStoragePage
+	}
+	return page
+}
+
+// escapeLIKE escapes SQL LIKE wildcard metacharacters (%, _) in a caller-supplied
+// string using backslash as the escape character. Callers must also append
+// ESCAPE '\' to the LIKE clause so the database honours the escapes.
+// Without this, a search for "foo%bar" would match any string starting with
+// "foo" rather than the literal token, turning a user-controlled LIKE operand
+// into a wildcard injection vector.
+func escapeLIKE(s string) string {
+	// Replace \ first to avoid double-escaping already-present backslashes.
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
 }
 
 // RemoteStorage implements storage.Storage via the Keyorix REST API.

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -364,16 +364,20 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 		if filter.ActorUsername != nil {
 			// Resolve username → user_id via a subquery so we stay on the
 			// audit_events table (no JOIN needed for the count query too).
+			// escapeLIKE sanitises % and _ in the caller-supplied username so
+			// a value like "admin%" doesn't turn into a wildcard prefix scan
+			// covering all usernames (#r124 LIKE injection).
 			query = query.Where(
-				"user_id IN (SELECT id FROM users WHERE username LIKE ? AND deleted_at IS NULL)",
-				"%"+*filter.ActorUsername+"%",
+				`user_id IN (SELECT id FROM users WHERE username LIKE ? ESCAPE '\' AND deleted_at IS NULL)`,
+				"%"+escapeLIKE(*filter.ActorUsername)+"%",
 			)
 		}
 		if filter.ResourceType != nil {
 			// event_type is "resource_type.action" — match rows whose event_type
 			// starts with "<resource_type>." so "secret" catches "secret.read",
-			// "secret.created", etc.
-			query = query.Where("event_type LIKE ?", *filter.ResourceType+".%")
+			// "secret.created", etc. escapeLIKE prevents a caller-supplied
+			// resource_type containing % or _ from matching unintended event types.
+			query = query.Where(`event_type LIKE ? ESCAPE '\'`, escapeLIKE(*filter.ResourceType)+".%")
 		}
 		if filter.Page > 1 {
 			page = filter.Page
@@ -383,6 +387,7 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 		}
 	}
 	pageSize = clampPageSize(pageSize)
+	page = clampPage(page)
 
 	var total int64
 	query.Count(&total)

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -641,7 +641,9 @@ func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretF
 		query = query.Where("secret_nodes.is_secret = ?", false)
 	}
 	if filter.Search != nil && *filter.Search != "" {
-		query = query.Where("LOWER(secret_nodes.name) LIKE LOWER(?)", "%"+*filter.Search+"%")
+		// escapeLIKE sanitises % and _ so a caller-supplied search term cannot
+		// widen the match beyond the intended prefix/suffix anchors (#r124 LIKE injection).
+		query = query.Where(`LOWER(secret_nodes.name) LIKE LOWER(?) ESCAPE '\'`, "%"+escapeLIKE(*filter.Search)+"%")
 	}
 
 	var total int64

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -160,7 +160,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	// no-store default (above) rather than a group-local one.
 	r.Group(func(r chi.Router) {
 		r.Post("/auth/login", authHandler.Login)
-		r.Post("/auth/logout", authHandler.Logout)
+		// RequireCSRF is applied individually: logout lives in the unauthenticated
+		// group because it accepts both session-cookie and Bearer callers, but a
+		// cookie-carrying browser is still susceptible to logout-CSRF without this
+		// check. Bearer-only callers (no session cookie) pass through unchanged per
+		// RequireCSRF's own logic (#r124).
+		r.With(customMiddleware.RequireCSRF).Post("/auth/logout", authHandler.Logout)
 		r.Post("/auth/refresh", authHandler.RefreshToken)
 		r.Post("/auth/password-reset", authHandler.PasswordReset)
 		// MFA second-step: unauthenticated — the bearer is the single-use challenge


### PR DESCRIPTION
## Summary

Seven MEDIUM findings from round 124:

- **LIKE wildcard injection** — `actor_username`/`resource_type` in `GetAuditLogs` and `search` in `ListSecrets` were interpolated raw into `LIKE` patterns. Added `escapeLIKE()` helper (escapes `\`, `%`, `_`) + `ESCAPE '\'` clause to all three sites.
- **Deep-pagination DoS** — `GetAuditLogs` accepted unbounded `page`, allowing `page=1000000` to force a 20M-row `OFFSET` scan. Added `clampPage()` capping at 10 000.
- **UpdateUser deactivation doesn't revoke sessions/PATs** — `IsActive=false` left live sessions/PATs active until natural expiry. Now runs in a transaction that revokes all sessions+PATs and evicts them from the auth cache post-commit.
- **PAT scope fail-open on JSON corruption** — `DecodePATScopes` returned `nil` (unrestricted) on parse error, widening a scoped token to full owner access. Non-empty rows that fail JSON parsing now return a sentinel that matches no permission (fail CLOSED).
- **`POST /auth/logout` bypasses CSRF** — logout was in the unauthenticated group, exposing cookie sessions to logout-CSRF. Applied `RequireCSRF` inline via `r.With()`; Bearer-only callers pass through unchanged.
- **Group CLI commands passed `actorID=0`** — `create`/`update`/`delete`/`add-member`/`remove-member` all hard-coded `0`, producing anonymous audit events. Replaced with `common.ResolveActorID()` (reads `KEYORIX_CLI_ACTOR`), matching `machine/binding.go`.
- **Anomaly list panics on short `DetectedAt`** — `DetectedAt[:16]` panics on a field shorter than 16 bytes. Guarded with `min(16, len(a.DetectedAt))`.

## Test plan

- [ ] Audit log search with `actor_username=admin%` returns only exact prefix matches, not all users
- [ ] `GET /api/v1/audit?page=9999999` returns results for the clamped page, not a timeout
- [ ] Admin setting `is_active=false` via `PUT /api/v1/admin/users/:id` revokes the target's sessions within one request cycle
- [ ] A PAT with a corrupted `scopes` column is denied on all endpoints rather than granted full access
- [ ] `POST /auth/logout` from a browser (cookie auth) without `X-CSRF-Token` returns 403
- [ ] `keyorix group create --name test` with `KEYORIX_CLI_ACTOR=1` shows actor ID 1 in audit log
- [ ] `keyorix anomaly list` with a backend returning a short `DetectedAt` doesn't panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)