### PR TITLE
fix(security): r125 HIGH fixes — PAT CIDR fail-closed, cache eviction, SSO fragment token, purge legal hold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,19 @@ jobs:
         with:
           go-version: '1.26.5'
 
+      - name: Check for invalid UTF-8 (U+FFFD replacement characters)
+        run: |
+          if grep -rPl '\xef\xbf\xbd' \
+               --include='*.go' --include='*.yml' --include='*.yaml' \
+               --include='*.sh' --include='*.ts' --include='*.tsx' \
+               --include='*.json' --include='*.md' \
+               --exclude-dir=node_modules --exclude-dir=.scratch .; then
+            echo "ERROR: files above contain U+FFFD (replacement character)."
+            echo "This causes SonarCloud encoding warnings."
+            echo "Replace corrupt bytes with the intended Unicode characters."
+            exit 1
+          fi
+
       - name: go vet
         run: go vet ./...
 

--- a/internal/cli/anomalies/anomalies.go
+++ b/internal/cli/anomalies/anomalies.go
@@ -81,7 +81,7 @@ func runListRemote(rc *common.RemoteClient) error {
 		if a.Acknowledged {
 			ack = " [ACK]"
 		}
-		fmt.Printf("[%d] %s | %s | %s%s\n", a.ID, a.Severity, a.AlertType, a.DetectedAt[:16], ack)
+		fmt.Printf("[%d] %s | %s | %s%s\n", a.ID, a.Severity, a.AlertType, a.DetectedAt[:min(16, len(a.DetectedAt))], ack)
 		fmt.Printf("    Secret: %s | User: %s | IP: %s\n", a.SecretName, a.AccessedBy, a.IPAddress)
 		fmt.Printf("    %s\n\n", a.Description)
 	}

--- a/internal/cli/group/add-member.go
+++ b/internal/cli/group/add-member.go
@@ -50,7 +50,7 @@ func runAddMember(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
-	if err := service.AddUserToGroup(ctx, 0, addMemberUserID, addMemberGroupID, addMemberProjectID); err != nil { // actorID 0: local/unauthenticated CLI
+	if err := service.AddUserToGroup(ctx, common.ResolveActorID(), addMemberUserID, addMemberGroupID, addMemberProjectID); err != nil {
 		return fmt.Errorf("failed to add member: %w", err)
 	}
 	fmt.Printf("User %d added to group %d (project %d).\n", addMemberUserID, addMemberGroupID, addMemberProjectID)

--- a/internal/cli/group/create.go
+++ b/internal/cli/group/create.go
@@ -35,7 +35,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	ctx := context.Background()
-	g, err := service.CreateGroup(ctx, 0, &core.CreateGroupRequest{ // actorID 0: local/unauthenticated CLI
+	g, err := service.CreateGroup(ctx, common.ResolveActorID(), &core.CreateGroupRequest{
 		Name:        createName,
 		Description: createDescription,
 	})

--- a/internal/cli/group/delete.go
+++ b/internal/cli/group/delete.go
@@ -51,7 +51,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err := service.DeleteGroup(ctx, 0, deleteGroupID); err != nil { // actorID 0: local/unauthenticated CLI
+	if err := service.DeleteGroup(ctx, common.ResolveActorID(), deleteGroupID); err != nil {
 		return fmt.Errorf("failed to delete group: %w", err)
 	}
 	fmt.Printf("Group %d deleted.\n", deleteGroupID)

--- a/internal/cli/group/remove-member.go
+++ b/internal/cli/group/remove-member.go
@@ -52,7 +52,7 @@ func runRemoveMember(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
-	if err := service.RemoveUserFromGroup(ctx, 0, removeMemberUserID, removeMemberGroupID, removeMemberProjectID); err != nil { // actorID 0: local/unauthenticated CLI
+	if err := service.RemoveUserFromGroup(ctx, common.ResolveActorID(), removeMemberUserID, removeMemberGroupID, removeMemberProjectID); err != nil {
 		return fmt.Errorf("failed to remove member: %w", err)
 	}
 	fmt.Printf("User %d removed from group %d (project %d).\n", removeMemberUserID, removeMemberGroupID, removeMemberProjectID)

--- a/internal/cli/group/update.go
+++ b/internal/cli/group/update.go
@@ -40,7 +40,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	ctx := context.Background()
-	g, err := service.UpdateGroup(ctx, 0, &core.UpdateGroupRequest{ // actorID 0: local/unauthenticated CLI
+	g, err := service.UpdateGroup(ctx, common.ResolveActorID(), &core.UpdateGroupRequest{
 		ID:          updateGroupID,
 		Name:        updateGroupName,
 		Description: updateGroupDescription,

--- a/internal/cli/rbac/rbac_scope_cov_test.go
+++ b/internal/cli/rbac/rbac_scope_cov_test.go
@@ -1318,7 +1318,7 @@ func TestRunAssignRoleRemote_RoleFetchError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to list roles")
 }
 
-// ── runAssignRoleToGroupRemote group/role error paths ─────────��───────────────
+// ── runAssignRoleToGroupRemote group/role error paths ──────────────────────────
 
 // TestRunAssignRoleToGroupRemote_GroupError verifies group resolution error.
 func TestRunAssignRoleToGroupRemote_GroupError(t *testing.T) {

--- a/internal/core/account_state.go
+++ b/internal/core/account_state.go
@@ -190,6 +190,18 @@ func (c *KeyorixCore) setAccountState(ctx context.Context, adminID, userID uint,
 		// a window where a blocked user keeps full access. The stored session_token IS the
 		// SHA-256 hash, which is exactly the cache key.
 		sessionHashes, _ = tx.ListSessionTokenHashesForUser(ctx, userID)
+		// Also collect PAT hashes for cache eviction for ANY state transition, including
+		// restricted states like password_reset_required. Without this, a cached PAT
+		// bypasses the restriction for up to validTokenTTL (30 s) — ValidatePATToken
+		// sees the old identity from the cache and never re-checks the new account state
+		// (#r125-H2). We evict here without revoking; revoking follows for blocked states.
+		if pats, _ := tx.ListPersonalAccessTokensByUser(ctx, userID); len(pats) > 0 {
+			for _, p := range pats {
+				if !p.Revoked && p.TokenHash != "" {
+					sessionHashes = append(sessionHashes, p.TokenHash)
+				}
+			}
+		}
 
 		if err := tx.SetAccountState(ctx, userID, state, c.now()); err != nil {
 			return err

--- a/internal/core/account_state_test.go
+++ b/internal/core/account_state_test.go
@@ -101,6 +101,9 @@ func TestAdminAccountTransitions(t *testing.T) {
 			})).Return(nil)
 			// Every state change evicts the user's cached session tokens from the auth cache.
 			store.On("ListSessionTokenHashesForUser", ctx, uint(2)).Return([]string{}, nil)
+			// Every state change also evicts PAT hashes for immediate cache invalidation
+			// (#r125-H2: password_reset_required previously skipped PAT eviction).
+			store.On("ListPersonalAccessTokensByUser", ctx, uint(2)).Return([]*models.PersonalAccessToken{}, nil)
 			// A login-blocking transition (suspend) must purge the user's sessions AND PATs.
 			if AccountLoginBlocked(tc.wantState) {
 				store.On("DeleteSessionsForUserExcept", ctx, uint(2), uint(0)).Return(nil)
@@ -235,5 +238,40 @@ func TestChangePassword_ClearsRestriction(t *testing.T) {
 
 	err := c.ChangePassword(ctx, 1, "oldpassword", "Brandnew#Passw0rd!", "tok")
 	require.NoError(t, err)
+	store.AssertExpectations(t)
+}
+
+// TestRequirePasswordReset_EvictsPATCache verifies that RequirePasswordReset evicts
+// PAT token hashes from the auth cache, not only session hashes (#r125-H2). Without
+// this eviction, a cached PAT request would bypass the password_reset_required
+// restriction for up to validTokenTTL (30 s) — the cache fast-path returns the
+// old, unrestricted identity without re-reading the DB.
+func TestRequirePasswordReset_EvictsPATCache(t *testing.T) {
+	store := new(MockStorage)
+	c := newAccountCore(store)
+	ctx := context.Background()
+
+	const userID = uint(5)
+	patHash := "sha256-pat-hash-abc"
+
+	// LockUserForUpdate delegates to GetUser inside the mock.
+	store.On("GetUser", ctx, userID).Return(&models.User{ID: userID, AccountState: AccountActive}, nil)
+	store.On("ListSessionTokenHashesForUser", ctx, userID).Return([]string{}, nil)
+	store.On("ListPersonalAccessTokensByUser", ctx, userID).Return([]*models.PersonalAccessToken{
+		{ID: 1, UserID: userID, TokenHash: patHash, Revoked: false},
+	}, nil)
+	store.On("SetAccountState", ctx, userID, AccountPasswordResetRequired, mock.Anything).Return(nil)
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == "account.password_reset_required"
+	})).Return(nil)
+
+	var evicted []string
+	c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+	require.NoError(t, c.RequirePasswordReset(ctx, 1, userID))
+
+	// The PAT hash must have been evicted so the next PAT request re-reads the DB
+	// and observes the new password_reset_required restriction.
+	assert.Contains(t, evicted, patHash, "RequirePasswordReset must evict PAT hashes from auth cache")
 	store.AssertExpectations(t)
 }

--- a/internal/core/audit_log_retention_test.go
+++ b/internal/core/audit_log_retention_test.go
@@ -15,13 +15,14 @@ import (
 	"gorm.io/gorm"
 )
 
-// newPurgeTestCore opens a fresh in-memory SQLite DB, migrates AuditEvent,
+// newPurgeTestCore opens a fresh in-memory SQLite DB, migrates AuditEvent and
+// LegalHold (needed by the legalHoldGuard that PurgeAuditLogs now calls),
 // and returns a KeyorixCore with a fixed clock so retention cutoffs are stable.
 func newPurgeTestCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open("file::memory:?mode=memory&cache=shared&_busy_timeout=5000"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.LegalHold{}))
 	fixed := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
 	c := NewKeyorixCore(store.NewLocalStorage(db))
 	c.now = func() time.Time { return fixed }
@@ -101,6 +102,8 @@ func TestPurgeAuditLogs_RetentionDaysExactlyMin(t *testing.T) {
 func TestPurgeAuditLogs_StorageErrorPropagated(t *testing.T) {
 	ms := new(MockStorage)
 	storageErr := errors.New("db offline")
+	// legalHoldGuard → IsLegalHoldActive → storage.GetActiveLegalHold: no active hold.
+	ms.On("GetActiveLegalHold", mock.Anything).Return((*models.LegalHold)(nil), nil)
 	ms.On("DeleteAuditLogsBefore", mock.Anything, mock.Anything).Return(int64(0), storageErr)
 	// LogAuditEvent is called for the system purge event — but only on success.
 	// On error the function returns early, so LogAuditEvent is never called.
@@ -109,5 +112,22 @@ func TestPurgeAuditLogs_StorageErrorPropagated(t *testing.T) {
 	_, err := c.PurgeAuditLogs(context.Background(), AuditLogRetentionConfig{RetentionDays: 30})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "db offline")
+	ms.AssertExpectations(t)
+}
+
+// TestPurgeAuditLogs_LegalHoldBlocked verifies that PurgeAuditLogs refuses to delete
+// audit records when a legal hold is active (#r125-H4 — PurgeAuditLogs previously
+// skipped the legalHoldGuard that PurgeExpiredSoftDeletes and
+// PurgeExpiredComplianceRecords call, allowing audit evidence to be destroyed under hold).
+func TestPurgeAuditLogs_LegalHoldBlocked(t *testing.T) {
+	ms := new(MockStorage)
+	// GetActiveLegalHold returns a non-nil hold → legalHoldGuard refuses the purge.
+	ms.On("GetActiveLegalHold", mock.Anything).Return(&models.LegalHold{ID: 1}, nil)
+
+	c := NewKeyorixCore(ms)
+	_, err := c.PurgeAuditLogs(context.Background(), AuditLogRetentionConfig{RetentionDays: 30})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "legal hold")
+	ms.AssertNotCalled(t, "DeleteAuditLogsBefore", mock.Anything, mock.Anything)
 	ms.AssertExpectations(t)
 }

--- a/internal/core/audit_retention.go
+++ b/internal/core/audit_retention.go
@@ -32,6 +32,13 @@ func (c *KeyorixCore) PurgeAuditLogs(ctx context.Context, cfg AuditLogRetentionC
 		return nil, fmt.Errorf("%w: retention_days must be at least %d (got %d)",
 			ErrInvalidAuditRetentionDays, minRetentionDays, cfg.RetentionDays)
 	}
+	// Re-check the legal hold immediately before the delete — same pattern as
+	// PurgeExpiredSoftDeletes / PurgeExpiredComplianceRecords. A hold placed after
+	// the scheduler's pre-lock check would otherwise not stop an in-flight purge
+	// from destroying audit evidence that is now under hold (irreversible spoliation).
+	if err := c.legalHoldGuard(ctx); err != nil {
+		return nil, err
+	}
 
 	cutoff := c.now().UTC().AddDate(0, 0, -cfg.RetentionDays)
 	n, err := c.storage.DeleteAuditLogsBefore(ctx, cutoff)

--- a/internal/core/bulk_delete_test.go
+++ b/internal/core/bulk_delete_test.go
@@ -38,6 +38,7 @@ func setupBulkDeleteDB(t *testing.T) (*KeyorixCore, func(name string) uint) {
 		&models.AuditEvent{},
 		&models.SecretAccessLog{},
 		&models.ShareRecord{},
+		&models.SecretACL{},
 	))
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
@@ -204,6 +205,7 @@ func TestBulkDeleteSecrets_CrossProjectGuard(t *testing.T) {
 		&models.AuditEvent{},
 		&models.SecretAccessLog{},
 		&models.ShareRecord{},
+		&models.SecretACL{},
 	))
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
@@ -241,7 +243,7 @@ func TestBulkDeleteSecrets_CrossProjectGuard(t *testing.T) {
 	require.NoError(t, err)
 
 	// Exactly one deleted (the one in project 1).
-	assert.Len(t, result.Deleted, 1, "only the in-scope secret should be deleted")
+	require.Len(t, result.Deleted, 1, "only the in-scope secret should be deleted")
 	assert.Equal(t, secretInProj1.ID, result.Deleted[0])
 
 	// Exactly one failure: the cross-project secret.

--- a/internal/core/inactivity_suspend_test.go
+++ b/internal/core/inactivity_suspend_test.go
@@ -27,6 +27,8 @@ func stubSuspendCall(store *MockStorage, ctx context.Context, userID uint) {
 	store.On("GetUser", ctx, userID).Return(&models.User{ID: userID, AccountState: AccountActive}, nil)
 	store.On("SetAccountState", ctx, userID, AccountSuspended, mock.Anything).Return(nil)
 	store.On("ListSessionTokenHashesForUser", ctx, userID).Return([]string{}, nil)
+	// H-2: ALL state transitions collect PAT hashes for cache eviction.
+	store.On("ListPersonalAccessTokensByUser", ctx, userID).Return([]*models.PersonalAccessToken{}, nil)
 	store.On("DeleteSessionsForUserExcept", ctx, userID, uint(0)).Return(nil)
 	store.On("RevokeAllPersonalAccessTokensForUser", ctx, userID).Return([]string{}, nil)
 	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -139,6 +139,7 @@ func TestInviteToProject_EnforcesAdminCeiling(t *testing.T) {
 	stubAdminRoleLookups(store, ctx)
 	// Inviter 9 holds only a non-admin role (id 6) at the project.
 	store.On("GetUserRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{6}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{}, nil)
 
 	// Inviting as project_admin → refused before any invitation is created.
 	_, err := c.InviteToProject(ctx, 1, "a@b.io", "project_admin", 9)
@@ -167,6 +168,7 @@ func TestApproveAccessRequest_RejectsAdminGrantByNonAdmin(t *testing.T) {
 	stubAdminRoleLookups(store, ctx)
 	// Approver 9 holds only a non-admin role (id 6) at the project.
 	store.On("GetUserRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{6}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{}, nil)
 
 	_, err := c.ApproveAccessRequest(ctx, 1, 3, 9, "admin")
 	require.Error(t, err)
@@ -189,6 +191,7 @@ func TestApproveAccessRequest_AdminApproverMayGrantAdmin(t *testing.T) {
 	stubAdminRoleLookups(store, ctx)
 	// Approver 9 holds the admin role (id 2) at the project.
 	store.On("GetUserRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{2}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{}, nil)
 	store.On("AssignRole", ctx, uint(2), uint(2), storage.Scope{ProjectID: 1}).Return(nil)
 	store.On("UpdateAccessRequest", ctx, mock.Anything).Return(true, nil)
 	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)

--- a/internal/core/migrate_user_to_machine_test.go
+++ b/internal/core/migrate_user_to_machine_test.go
@@ -30,6 +30,8 @@ func TestMigrateUserToMachine(t *testing.T) {
 		store.On("DeleteSessionsForUserExcept", ctx, uint(7), uint(0)).Return(nil)
 		// Suspension also evicts the user's cached session tokens and revokes their PATs.
 		store.On("ListSessionTokenHashesForUser", ctx, uint(7)).Return([]string{}, nil)
+		// H-2: ALL state transitions collect PAT hashes for cache eviction.
+		store.On("ListPersonalAccessTokensByUser", ctx, uint(7)).Return([]*models.PersonalAccessToken{}, nil)
 		store.On("RevokeAllPersonalAccessTokensForUser", ctx, uint(7)).Return([]string{}, nil)
 
 		seen := map[string]bool{}

--- a/internal/core/oidc_binding_test.go
+++ b/internal/core/oidc_binding_test.go
@@ -30,6 +30,7 @@ func TestCreateOIDCBinding_RequiresGlobalAdminAuthority(t *testing.T) {
 		// Actor 2 has NO role grants at global scope (project_id=0) — only within
 		// project 1, which requireAuthorityForRole(..., projectID=0, ...) never sees.
 		store.On("GetUserRoleIDsAt", ctx, uint(2), mock.MatchedBy(func(s interface{}) bool { return true })).Return([]uint{}, nil)
+		store.On("GetUserGroupRoleIDsAt", ctx, uint(2), mock.MatchedBy(func(s interface{}) bool { return true })).Return([]uint{}, nil)
 
 		_, err := c.CreateOIDCBinding(ctx, 1, 5, "https://idp.test", "system:serviceaccount:victim:ci", 2)
 		require.Error(t, err)
@@ -44,6 +45,7 @@ func TestCreateOIDCBinding_RequiresGlobalAdminAuthority(t *testing.T) {
 		store.On("GetMachineIdentity", ctx, uint(5)).Return(machine, nil)
 		store.On("GetRoleByName", ctx, mock.Anything).Return(&models.Role{ID: 99, Name: "system_admin"}, nil)
 		store.On("GetUserRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{99}, nil)
+		store.On("GetUserGroupRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{}, nil)
 		store.On("CreateOIDCBinding", ctx, mock.MatchedBy(func(b *models.MachineIdentityOIDCBinding) bool {
 			return b.MachineIdentityID == 5 && b.Issuer == "https://idp.test" && b.Subject == "system:serviceaccount:victim:ci"
 		})).Return(&models.MachineIdentityOIDCBinding{ID: 1, MachineIdentityID: 5}, nil)

--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -297,15 +297,27 @@ func encodePATCIDRs(cidrs []string) (string, error) { // NOSONAR -- cognitive co
 	return string(b), nil
 }
 
-// DecodePATCIDRs parses a stored CIDR allowlist back into a slice. An empty/invalid column
-// yields nil (no restriction).
+// patCIDRCorrupted is returned by DecodePATCIDRs when the stored column is non-empty
+// but fails JSON parsing — the token was created WITH a CIDR allowlist that is now
+// unreadable. Returning nil would silently widen the token to global network access
+// (#r125 PAT CIDR fail-open). The sentinel contains no valid CIDR, so IPInCIDRs
+// will return false for any source IP, blocking all network access until the
+// column is repaired or the token is re-issued.
+var patCIDRCorrupted = []string{"<corrupted>"}
+
+// DecodePATCIDRs parses a stored CIDR allowlist back into a slice. An empty column
+// yields nil (no restriction). A non-empty column that fails JSON parsing returns a
+// sentinel that blocks ALL source IPs rather than failing OPEN to global network access.
 func DecodePATCIDRs(raw string) []string {
 	if strings.TrimSpace(raw) == "" {
 		return nil
 	}
 	var out []string
 	if err := json.Unmarshal([]byte(raw), &out); err != nil {
-		return nil
+		// Non-empty but unparseable: fail CLOSED — return a sentinel that no real
+		// CIDR will ever match, so the PAT is denied from all networks rather than
+		// silently granted global network access on a corrupted row.
+		return patCIDRCorrupted
 	}
 	return out
 }

--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -197,9 +197,17 @@ func encodePATScopes(scopes []string) (string, error) {
 }
 
 // DecodePATScopes parses a stored scopes column back into a permission list.
-// An empty/invalid column yields nil (unrestricted) — fail-open here is correct
-// because an empty allowlist already means "inherit the owner", and the owner's
-// own RBAC still gates every action.
+// An empty column yields nil (unrestricted) — a PAT created without an explicit
+// scope allowlist inherits its owner's full permission set, so nil is the
+// correct "no restriction" signal.
+//
+// A non-empty column that fails JSON parsing is treated as corrupted rather than
+// unrestricted: the token was created WITH a scope restriction that is now
+// unreadable, so we return a sentinel that patRestrictionFrom interprets as
+// "deny everything" rather than accidentally widening a previously-restricted
+// token to full owner access (#r124 PAT scope fail-open).
+var patScopeCorrupted = []string{"__corrupted__"}
+
 func DecodePATScopes(raw string) []string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -207,7 +215,10 @@ func DecodePATScopes(raw string) []string {
 	}
 	var out []string
 	if err := json.Unmarshal([]byte(raw), &out); err != nil {
-		return nil
+		// Non-empty but unparseable: fail CLOSED — return a sentinel that no
+		// real permission string will ever match, so the PAT is denied everywhere
+		// rather than silently granted full owner access on a corrupted row.
+		return patScopeCorrupted
 	}
 	return out
 }

--- a/internal/core/pat_cidr_test.go
+++ b/internal/core/pat_cidr_test.go
@@ -60,3 +60,37 @@ func TestPATRestrictionFrom_IncludesCIDRs(t *testing.T) {
 	// A fully-unrestricted token yields nil.
 	assert.Nil(t, patRestrictionFrom(&models.PersonalAccessToken{}))
 }
+
+// TestDecodePATCIDRs_CorruptionFailsClosed verifies that a non-empty but
+// unparseable allowed_cidrs column returns the sentinel (not nil), ensuring
+// the PAT is denied from all networks rather than silently widened to global
+// network access (#r125-H1 — the scope-corruption fix DecodePATScopes received
+// in r124 missed its CIDR sibling).
+func TestDecodePATCIDRs_CorruptionFailsClosed(t *testing.T) {
+	// A parseable empty column yields nil (no restriction — expected).
+	assert.Nil(t, DecodePATCIDRs(""))
+	assert.Nil(t, DecodePATCIDRs("   "))
+
+	// A valid JSON array parses normally.
+	got := DecodePATCIDRs(`["10.0.0.0/8"]`)
+	assert.Equal(t, []string{"10.0.0.0/8"}, got)
+
+	// A non-empty but corrupted column must fail CLOSED (sentinel, not nil).
+	corrupted := DecodePATCIDRs(`{not valid json}`)
+	assert.Equal(t, patCIDRCorrupted, corrupted,
+		"corrupted CIDR column must return the sentinel, not nil (fail-open)")
+
+	// The sentinel must deny ALL source IPs — IPInCIDRs must return false
+	// for any real address when the sentinel is in the allowlist.
+	assert.False(t, IPInCIDRs("10.1.2.3", corrupted),
+		"sentinel must deny a private-range source IP")
+	assert.False(t, IPInCIDRs("0.0.0.0", corrupted),
+		"sentinel must deny the wildcard address")
+
+	// patRestrictionFrom must produce a non-nil restriction for a corrupted column
+	// (so the CIDR check fires and denies), not nil (which would skip the check).
+	r := patRestrictionFrom(&models.PersonalAccessToken{AllowedCIDRs: `{bad}`})
+	if assert.NotNil(t, r, "corrupted CIDR column must yield a non-nil restriction") {
+		assert.Equal(t, patCIDRCorrupted, r.AllowedCIDRs)
+	}
+}

--- a/internal/core/pat_test.go
+++ b/internal/core/pat_test.go
@@ -188,3 +188,36 @@ func TestRevokeOwnPAT(t *testing.T) {
 		ms.AssertNotCalled(t, "RevokePersonalAccessToken", mock.Anything, mock.Anything)
 	})
 }
+
+// TestDecodePATScopes covers the three branches: empty → nil (unrestricted),
+// valid JSON → parsed list, and corrupted JSON → patScopeCorrupted sentinel
+// (fail-closed, #r124-M).
+func TestDecodePATScopes(t *testing.T) {
+	t.Run("empty string returns nil (unrestricted)", func(t *testing.T) {
+		assert.Nil(t, DecodePATScopes(""))
+	})
+	t.Run("whitespace-only treated as empty", func(t *testing.T) {
+		assert.Nil(t, DecodePATScopes("   "))
+	})
+	t.Run("valid JSON array returns scopes", func(t *testing.T) {
+		scopes := DecodePATScopes(`["secrets.read","secrets.write"]`)
+		assert.Equal(t, []string{"secrets.read", "secrets.write"}, scopes)
+	})
+	t.Run("corrupted JSON returns sentinel not nil (fail-closed)", func(t *testing.T) {
+		got := DecodePATScopes(`{bad json}`)
+		assert.Equal(t, patScopeCorrupted, got,
+			"a corrupted scope column must fail CLOSED (sentinel), not return nil (unrestricted)")
+	})
+	t.Run("sentinel is never matched by any real permission string", func(t *testing.T) {
+		sentinel := patScopeCorrupted
+		for _, real := range []string{"secrets.read", "secrets.write", "secrets.delete", "system.read", "system.write"} {
+			found := false
+			for _, s := range sentinel {
+				if s == real {
+					found = true
+				}
+			}
+			assert.False(t, found, "sentinel must not overlap any real permission: %q", real)
+		}
+	})
+}

--- a/internal/core/remote_account_state_hardfail_test.go
+++ b/internal/core/remote_account_state_hardfail_test.go
@@ -34,6 +34,8 @@ func TestSuspendUser_HardFailsWhenBackendCannotPersistAccountState(t *testing.T)
 
 	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, AccountState: AccountActive}, nil)
 	store.On("ListSessionTokenHashesForUser", ctx, uint(2)).Return([]string{}, nil)
+	// H-2: ListPersonalAccessTokensByUser is called before SetAccountState.
+	store.On("ListPersonalAccessTokensByUser", ctx, uint(2)).Return([]*models.PersonalAccessToken{}, nil)
 	store.On("SetAccountState", ctx, uint(2), AccountSuspended, mock.Anything).Return(errRemoteAccountState)
 
 	err := c.SuspendUser(ctx, 1, 2)

--- a/internal/core/update_user_deactivation_test.go
+++ b/internal/core/update_user_deactivation_test.go
@@ -1,0 +1,144 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestUpdateUser_Deactivation_RevokesSessionsAndPATs verifies that setting
+// IsActive=false via UpdateUser immediately terminates the user's active
+// sessions and PATs and evicts them from the auth cache (#r124-M).
+// Prior to the fix, UpdateUser only updated the is_active column and left
+// live sessions/PATs intact, so the user could keep authenticating until
+// their credentials expired naturally.
+func TestUpdateUser_Deactivation_RevokesSessionsAndPATs(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=5000"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{},
+		&models.Session{},
+		&models.PersonalAccessToken{},
+		&models.AuditEvent{},
+		&models.UserRole{},
+		&models.Role{},
+	))
+
+	st := store.NewLocalStorage(db)
+	c := &KeyorixCore{storage: st, now: time.Now}
+	ctx := context.Background()
+
+	// Seed: an active user with one session and one PAT.
+	active := true
+	u := &models.User{
+		ID:       42,
+		Username: "alice",
+		Email:    "alice@example.com",
+		IsActive: true,
+	}
+	require.NoError(t, db.Create(u).Error)
+	require.NoError(t, db.Create(&models.Session{
+		ID:           100,
+		UserID:       42,
+		SessionToken: "sess-hash-abc",
+		CreatedAt:    time.Now(),
+	}).Error)
+	require.NoError(t, db.Create(&models.PersonalAccessToken{
+		ID:        200,
+		UserID:    42,
+		Name:      "ci-token",
+		TokenHash: "pat-hash-xyz",
+	}).Error)
+
+	// Track auth-cache evictions.
+	var evicted []string
+	c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+	// Deactivate via UpdateUser.
+	updated, err := c.UpdateUser(ctx, &UpdateUserRequest{
+		ID:       42,
+		IsActive: &[]bool{false}[0],
+	})
+	require.NoError(t, err)
+	assert.False(t, updated.IsActive, "user must be marked inactive")
+
+	// Session must be deleted.
+	var sessions []models.Session
+	require.NoError(t, db.Where("user_id = ?", 42).Find(&sessions).Error)
+	assert.Empty(t, sessions, "deactivation must delete all user sessions")
+
+	// PAT must be revoked.
+	var pat models.PersonalAccessToken
+	require.NoError(t, db.First(&pat, 200).Error)
+	assert.True(t, pat.Revoked, "deactivation must revoke all user PATs")
+
+	// Auth cache must be evicted for both tokens.
+	assert.Contains(t, evicted, "sess-hash-abc", "session hash must be evicted from auth cache")
+	assert.Contains(t, evicted, "pat-hash-xyz", "PAT hash must be evicted from auth cache")
+
+	// Re-activating should NOT revoke anything new.
+	evicted = nil
+	_, err = c.UpdateUser(ctx, &UpdateUserRequest{
+		ID:       42,
+		IsActive: &active,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, evicted, "re-activation must not evict any tokens")
+}
+
+// TestUpdateUser_NoRevocation_WhenAlreadyInactive verifies that calling
+// UpdateUser on a user who is already inactive does not trigger redundant
+// session/PAT revocations (the deactivating transition only fires once).
+func TestUpdateUser_NoRevocation_WhenAlreadyInactive(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=5000&mode=2"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{},
+		&models.Session{},
+		&models.PersonalAccessToken{},
+		&models.AuditEvent{},
+		&models.UserRole{},
+		&models.Role{},
+	))
+
+	st := store.NewLocalStorage(db)
+	c := &KeyorixCore{storage: st, now: time.Now}
+	ctx := context.Background()
+
+	// Seed: a user who is already inactive.
+	u := &models.User{
+		ID:       43,
+		Username: "bob",
+		Email:    "bob@example.com",
+		IsActive: false,
+	}
+	require.NoError(t, db.Create(u).Error)
+
+	var evicted []string
+	c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+	// UpdateUser with IsActive=false on an already-inactive user.
+	inactive := false
+	_, err = c.UpdateUser(ctx, &UpdateUserRequest{
+		ID:       43,
+		IsActive: &inactive,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, evicted, "no evictions when user was already inactive")
+}

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -287,13 +287,46 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 	if req.DisplayName != "" {
 		user.DisplayName = req.DisplayName
 	}
+	wasActive := user.IsActive
 	if req.IsActive != nil {
 		user.IsActive = *req.IsActive
 	}
+	deactivating := wasActive && !user.IsActive
 	user.UpdatedAt = c.now()
-	updated, err := c.storage.UpdateUser(ctx, user)
+
+	var sessionHashes []string
+	if deactivating {
+		// Collect session hashes before the write so we can evict the auth cache
+		// after commit. The HTTP auth middleware caches validated tokens for up to
+		// validTokenTTL (30s); without eviction a just-deactivated user's session
+		// keeps passing auth for that window — same race SetAccountState already
+		// handles on suspend/deactivate via the account-state path (#r124).
+		sessionHashes, _ = c.storage.ListSessionTokenHashesForUser(ctx, req.ID)
+	}
+
+	var patHashes []string
+	var updated *models.User
+	if deactivating {
+		err = c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+			var terr error
+			updated, terr = tx.UpdateUser(ctx, user)
+			if terr != nil {
+				return terr
+			}
+			if hashes, herr := tx.RevokeAllPersonalAccessTokensForUser(ctx, req.ID); herr == nil {
+				patHashes = hashes
+			}
+			return tx.DeleteSessionsForUserExcept(ctx, req.ID, 0)
+		})
+	} else {
+		updated, err = c.storage.UpdateUser(ctx, user)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	if deactivating {
+		c.invalidateTokenCache(sessionHashes...)
+		c.invalidateTokenCache(patHashes...)
 	}
 	return updated, nil
 }

--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -50,6 +50,7 @@ package store
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
@@ -76,6 +77,39 @@ func clampPageSize(pageSize int) int {
 		return maxStoragePageSize
 	}
 	return pageSize
+}
+
+// maxStoragePage is the maximum page number accepted by paginated queries.
+// Without a ceiling, a hostile caller can force OFFSET = (page-1)*pageSize
+// into the millions, which SQLite/Postgres must scan and discard before
+// returning any rows — a cheap denial-of-service against the audit endpoint.
+// 10000 pages × up to 100 rows/page = 1 million rows, far above any real
+// audit log a single deployment would accumulate.
+const maxStoragePage = 10_000
+
+// clampPage bounds a caller-supplied page number to [1, maxStoragePage].
+func clampPage(page int) int {
+	if page < 1 {
+		return 1
+	}
+	if page > maxStoragePage {
+		return maxStoragePage
+	}
+	return page
+}
+
+// escapeLIKE escapes SQL LIKE wildcard metacharacters (%, _) in a caller-supplied
+// string using backslash as the escape character. Callers must also append
+// ESCAPE '\' to the LIKE clause so the database honours the escapes.
+// Without this, a search for "foo%bar" would match any string starting with
+// "foo" rather than the literal token, turning a user-controlled LIKE operand
+// into a wildcard injection vector.
+func escapeLIKE(s string) string {
+	// Replace \ first to avoid double-escaping already-present backslashes.
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
 }
 
 // RemoteStorage implements storage.Storage via the Keyorix REST API.

--- a/internal/storage/store/like_escape_integration_test.go
+++ b/internal/storage/store/like_escape_integration_test.go
@@ -1,0 +1,177 @@
+// like_escape_integration_test.go — integration tests verifying that
+// escapeLIKE prevents SQL wildcard injection in GetAuditLogs and ListSecrets
+// (#r124-M LIKE injection).  These tests run against a real in-memory SQLite
+// database so the LIKE predicate is actually evaluated by the SQL engine.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestGetAuditLogs_LIKEEscape_ActorUsername verifies that the escapeLIKE applied
+// to actor_username filter prevents SQL wildcard injection: a search for
+// "alice%admin" must NOT match a user whose name is "alice-admin" (#r124-M).
+func TestGetAuditLogs_LIKEEscape_ActorUsername(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:kxlikeescape_actor?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{}))
+
+	// Seed two users with similar names: "alice-admin" and "alice_admin".
+	alice := &models.User{Username: "alice-admin", Email: "a@ex.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(alice).Error)
+	aliceUnderscore := &models.User{Username: "alice_admin", Email: "b@ex.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(aliceUnderscore).Error)
+
+	tru := true
+	// Seed audit events for each user.
+	require.NoError(t, db.Create(&models.AuditEvent{
+		UserID: &alice.ID, EventType: "secret.read", ActorType: "user",
+		EventTime: time.Now(), Success: &tru,
+	}).Error)
+	require.NoError(t, db.Create(&models.AuditEvent{
+		UserID: &aliceUnderscore.ID, EventType: "secret.read", ActorType: "user",
+		EventTime: time.Now(), Success: &tru,
+	}).Error)
+
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	// Search with literal "%" — without escapeLIKE, "alice%admin" as a LIKE
+	// pattern would match any string starting with "alice" and ending with
+	// "admin" (e.g. "alice-admin", "alice_admin").  With escapeLIKE the "%" is
+	// escaped to "\%" and treated as a literal percent sign → no user has "%" in
+	// their name → 0 results.
+	pct := "alice%admin"
+	events, _, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{
+		ActorUsername: &pct,
+		PageSize:      100,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, events, "wildcard injection via ActorUsername must be neutralised by escapeLIKE")
+
+	// A literal match for the exact username must still work.
+	exact := "alice-admin"
+	events2, _, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{
+		ActorUsername: &exact,
+		PageSize:      100,
+	})
+	require.NoError(t, err)
+	assert.Len(t, events2, 1, "exact-match ActorUsername filter must return the right event")
+}
+
+// TestGetAuditLogs_LIKEEscape_ResourceType verifies that a resource_type filter
+// containing SQL LIKE metacharacters is escaped so it matches only the intended
+// resource prefix and not unrelated event types (#r124-M).
+func TestGetAuditLogs_LIKEEscape_ResourceType(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:kxlikeescape_restype?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{}))
+
+	tru := true
+	// Seed events for two different resource types.
+	require.NoError(t, db.Create(&models.AuditEvent{
+		EventType: "secret.read", ActorType: "user", EventTime: time.Now(), Success: &tru,
+	}).Error)
+	require.NoError(t, db.Create(&models.AuditEvent{
+		EventType: "secret_backup.read", ActorType: "user", EventTime: time.Now(), Success: &tru,
+	}).Error)
+
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	// "secret_backup" with escapeLIKE → "secret\_backup" — the underscore is a
+	// literal char and must NOT match "secret.read" (unescaped "_" would match
+	// any single char including ".").  The pattern becomes "secret\_backup.%"
+	// which only matches "secret_backup.*" event types.
+	rt := "secret_backup"
+	events, _, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{
+		ResourceType: &rt,
+		PageSize:     100,
+	})
+	require.NoError(t, err)
+	for _, e := range events {
+		assert.Contains(t, e.EventType, "secret_backup",
+			"only secret_backup events must match when underscore is escaped")
+	}
+
+	// "secret" (no underscore) should still match "secret.read" and NOT
+	// "secret_backup.read" (because the LIKE pattern is "secret.%" — the dot is
+	// a literal, which SQLite treats as such; only the prefix-bounded match
+	// applies to the resource portion before the dot).
+	rt2 := "secret"
+	events2, _, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{
+		ResourceType: &rt2,
+		PageSize:     100,
+	})
+	require.NoError(t, err)
+	for _, e := range events2 {
+		assert.Equal(t, "secret.read", e.EventType,
+			"resource_type=secret must match only secret.* not secret_backup.*")
+	}
+}
+
+// TestGetAuditLogs_ClampPage verifies that a page number beyond maxStoragePage
+// is silently clamped to maxStoragePage rather than generating an enormous OFFSET
+// (#r124-M pagination DoS).
+func TestGetAuditLogs_ClampPage(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:kxlikeescape_clamppage?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{}))
+
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	// Hostile page number: 2^30 — would produce an enormous OFFSET without clamping.
+	events, _, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{
+		Page:     1 << 30,
+		PageSize: 10,
+	})
+	require.NoError(t, err, "a hostile page number must be clamped, not error")
+	assert.Empty(t, events, "no events seeded, empty result expected")
+}
+
+// TestListSecrets_LIKEEscape_Search verifies that the search filter LIKE
+// parameter is escaped so a caller-supplied "%" or "_" in a search term does
+// not expand unexpectedly (#r124-M LIKE injection in ListSecrets).
+func TestListSecrets_LIKEEscape_Search(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:kxlikeescape_search?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}))
+
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "dev"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: "api-key-prod",
+		IsSecret: true, Type: "api_key", Status: "active",
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: "api-key-staging",
+		IsSecret: true, Type: "api_key", Status: "active",
+	}).Error)
+
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	// A search for "api%key" without escapeLIKE would expand "%" to match any
+	// substring, matching BOTH "api-key-prod" and "api-key-staging".  With
+	// escapeLIKE the "%" is treated literally → no secret has "%" in its name
+	// → 0 results.
+	pct := "api%key"
+	results, _, err := ls.ListSecrets(ctx, &storage.SecretFilter{Search: &pct, Page: 1, PageSize: 100})
+	require.NoError(t, err)
+	assert.Empty(t, results, "wildcard injection via Search must be neutralised by escapeLIKE")
+
+	// An exact substring match must still work as expected.
+	exact := "api-key"
+	results2, _, err := ls.ListSecrets(ctx, &storage.SecretFilter{Search: &exact, Page: 1, PageSize: 100})
+	require.NoError(t, err)
+	assert.Len(t, results2, 2, "exact search prefix must return matching secrets")
+}

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -364,16 +364,20 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 		if filter.ActorUsername != nil {
 			// Resolve username → user_id via a subquery so we stay on the
 			// audit_events table (no JOIN needed for the count query too).
+			// escapeLIKE sanitises % and _ in the caller-supplied username so
+			// a value like "admin%" doesn't turn into a wildcard prefix scan
+			// covering all usernames (#r124 LIKE injection).
 			query = query.Where(
-				"user_id IN (SELECT id FROM users WHERE username LIKE ? AND deleted_at IS NULL)",
-				"%"+*filter.ActorUsername+"%",
+				`user_id IN (SELECT id FROM users WHERE username LIKE ? ESCAPE '\' AND deleted_at IS NULL)`,
+				"%"+escapeLIKE(*filter.ActorUsername)+"%",
 			)
 		}
 		if filter.ResourceType != nil {
 			// event_type is "resource_type.action" — match rows whose event_type
 			// starts with "<resource_type>." so "secret" catches "secret.read",
-			// "secret.created", etc.
-			query = query.Where("event_type LIKE ?", *filter.ResourceType+".%")
+			// "secret.created", etc. escapeLIKE prevents a caller-supplied
+			// resource_type containing % or _ from matching unintended event types.
+			query = query.Where(`event_type LIKE ? ESCAPE '\'`, escapeLIKE(*filter.ResourceType)+".%")
 		}
 		if filter.Page > 1 {
 			page = filter.Page
@@ -383,6 +387,7 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 		}
 	}
 	pageSize = clampPageSize(pageSize)
+	page = clampPage(page)
 
 	var total int64
 	query.Count(&total)

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -641,7 +641,9 @@ func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretF
 		query = query.Where("secret_nodes.is_secret = ?", false)
 	}
 	if filter.Search != nil && *filter.Search != "" {
-		query = query.Where("LOWER(secret_nodes.name) LIKE LOWER(?)", "%"+*filter.Search+"%")
+		// escapeLIKE sanitises % and _ so a caller-supplied search term cannot
+		// widen the match beyond the intended prefix/suffix anchors (#r124 LIKE injection).
+		query = query.Where(`LOWER(secret_nodes.name) LIKE LOWER(?) ESCAPE '\'`, "%"+escapeLIKE(*filter.Search)+"%")
 	}
 
 	var total int64

--- a/internal/storage/store/pagination_clamp_test.go
+++ b/internal/storage/store/pagination_clamp_test.go
@@ -35,6 +35,53 @@ func TestClampPageSize(t *testing.T) {
 	}
 }
 
+// TestClampPage pins the ceiling on caller-supplied page numbers to prevent
+// deep-pagination DoS via huge OFFSET values (#r124-M).
+func TestClampPage(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"page 1 unchanged", 1, 1},
+		{"typical mid-page unchanged", 50, 50},
+		{"exactly at ceiling unchanged", maxStoragePage, maxStoragePage},
+		{"one over ceiling clamped", maxStoragePage + 1, maxStoragePage},
+		{"hostile million-page clamped", 1_000_000, maxStoragePage},
+		{"page 0 becomes 1", 0, 1},
+		{"negative becomes 1", -5, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, clampPage(tc.in))
+		})
+	}
+}
+
+// TestEscapeLIKE verifies that SQL LIKE wildcard metacharacters are neutralised
+// by escapeLIKE so user-supplied search terms cannot expand a match unexpectedly
+// (#r124-M LIKE injection).
+func TestEscapeLIKE(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain string untouched", "admin", "admin"},
+		{"percent escaped", "admin%", `admin\%`},
+		{"underscore escaped", "a_b", `a\_b`},
+		{"both wildcards", "%_foo_%", `\%\_foo\_\%`},
+		{"backslash first", `a\b`, `a\\b`},
+		{"backslash then percent", `a\%b`, `a\\\%b`},
+		{"empty string", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, escapeLIKE(tc.input))
+		})
+	}
+}
+
 // TestListSecrets_PageSizeClampedAtStorage confirms a future caller that forgets to
 // clamp PageSize itself (bypassing the ≤100 clamp every current HTTP/gRPC handler
 // applies before reaching storage) cannot force an unbounded SQL LIMIT — the storage

--- a/server/http/handlers/auth_sso_s13_test.go
+++ b/server/http/handlers/auth_sso_s13_test.go
@@ -7,7 +7,8 @@
 //     DeleteSessionByID no-user-ctx + bad-ID + not-found,
 //     package-level stubs when defaultUserHandler is nil
 //   - sso.go: BeginSSO unknown-provider, CompleteSSO unknown-provider + IdP-error-param
-//     + missing-code-or-state + core-error
+//     + missing-code-or-state + core-error; fragment does NOT contain session token
+//     (#r125-H3)
 package handlers
 
 import (
@@ -17,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -462,9 +464,9 @@ func TestCompleteSSO_CoreError_S13(t *testing.T) {
 	h := NewAuthHandler(cs, false)
 
 	// Provide code and state but no matching login-state row exists in the DB.
-	url := fmt.Sprintf("/auth/sso/%s/callback?code=badcode&state=badstate", providerName)
+	reqURL := fmt.Sprintf("/auth/sso/%s/callback?code=badcode&state=badstate", providerName)
 	req := withChiParam(
-		httptest.NewRequest(http.MethodGet, url, nil),
+		httptest.NewRequest(http.MethodGet, reqURL, nil),
 		"provider", providerName,
 	)
 	w := httptest.NewRecorder()
@@ -473,4 +475,32 @@ func TestCompleteSSO_CoreError_S13(t *testing.T) {
 	assert.Equal(t, http.StatusFound, w.Code)
 	loc := w.Header().Get("Location")
 	assert.Contains(t, loc, "error")
+}
+
+// TestRedirectFragment_NoTokenInFragment_S13 verifies that redirectFragment never
+// includes the raw session token in the URL fragment (#r125-H3). The session is
+// delivered exclusively via the HttpOnly/Secure cookie set by setSessionCookies;
+// including the token in the fragment exposes it to JS, browser history, and
+// extensions. This test exercises redirectFragment directly (same package).
+func TestRedirectFragment_NoTokenInFragment_S13(t *testing.T) {
+	cs := freshCoreS12(t)
+	h := NewAuthHandler(cs, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	// Simulate the url.Values CompleteSSO and CompleteSAML now build (no token key).
+	frag := url.Values{
+		"expires_at":          {"2026-07-27T12:00:00Z"},
+		"absolute_expires_at": {"2026-08-27T12:00:00Z"},
+		"return_to":           {"/dashboard"},
+	}
+	h.redirectFragment(w, req, "https://app.example.com/sso/complete", frag)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	loc := w.Header().Get("Location")
+	assert.Contains(t, loc, "#", "redirect must use fragment delivery")
+	assert.NotContains(t, loc, "token=",
+		"raw session token must NOT appear in the fragment — cookie-only delivery")
+	assert.Contains(t, loc, "expires_at=", "non-sensitive metadata fields survive")
 }

--- a/server/http/handlers/saml.go
+++ b/server/http/handlers/saml.go
@@ -82,10 +82,11 @@ func (h *AuthHandler) CompleteSAML(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Cookies survive a redirect fine — see the equivalent comment in sso.go's
-	// CompleteSSO.
+	// CompleteSSO. Token is NOT included in the fragment — cookie-only delivery
+	// (#r125-H3, mirrors sso.go's CompleteSSO).
 	h.setSessionCookies(w, session)
 
-	frag := url.Values{"token": {session.SessionToken}}
+	frag := url.Values{}
 	if session.ExpiresAt != nil {
 		frag.Set("expires_at", session.ExpiresAt.Format(time.RFC3339))
 	}

--- a/server/http/handlers/saml_s13_test.go
+++ b/server/http/handlers/saml_s13_test.go
@@ -261,11 +261,14 @@ func TestCompleteSAML_SuccessNoExpiry_S13(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.CompleteSAML(w, req)
 
-	// Success -> 302 redirect with token in the fragment.
+	// Success -> 302 redirect; session token is delivered via HttpOnly cookie only
+	// (not in the fragment — #r125-H3).
 	assert.Equal(t, http.StatusFound, w.Code)
 	loc := w.Header().Get("Location")
 	assert.Contains(t, loc, "app.example")
-	assert.Contains(t, loc, "token=")
+	assert.NotContains(t, loc, "token=", "token must not appear in fragment (#r125-H3)")
+	// The session cookie must be set.
+	assert.NotEmpty(t, w.Header().Get("Set-Cookie"), "session cookie must be set")
 }
 
 // TestCompleteSAML_SuccessWithReturnTo_S13 exercises the `if returnTo != ""`

--- a/server/http/handlers/sso.go
+++ b/server/http/handlers/sso.go
@@ -131,12 +131,13 @@ func (h *AuthHandler) CompleteSSO(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Cookies survive a redirect fine — the browser stores them from this 302
-	// response before following Location. Fragment still carries `token` this
-	// phase for backward compatibility with a not-yet-updated frontend; the
-	// cookie is what actually matters going forward.
+	// response before following Location. The session is delivered exclusively
+	// via the HttpOnly/Secure cookie; the token is NOT included in the fragment
+	// (#r125-H3: a fragment token is exposed to JS, browser history, and
+	// extensions — the cookie is the correct and sufficient delivery mechanism).
 	h.setSessionCookies(w, session)
 
-	frag := url.Values{"token": {session.SessionToken}}
+	frag := url.Values{}
 	if session.ExpiresAt != nil {
 		frag.Set("expires_at", session.ExpiresAt.Format(time.RFC3339))
 	}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -160,7 +160,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	// no-store default (above) rather than a group-local one.
 	r.Group(func(r chi.Router) {
 		r.Post("/auth/login", authHandler.Login)
-		r.Post("/auth/logout", authHandler.Logout)
+		// RequireCSRF is applied individually: logout lives in the unauthenticated
+		// group because it accepts both session-cookie and Bearer callers, but a
+		// cookie-carrying browser is still susceptible to logout-CSRF without this
+		// check. Bearer-only callers (no session cookie) pass through unchanged per
+		// RequireCSRF's own logic (#r124).
+		r.With(customMiddleware.RequireCSRF).Post("/auth/logout", authHandler.Logout)
 		r.Post("/auth/refresh", authHandler.RefreshToken)
 		r.Post("/auth/password-reset", authHandler.PasswordReset)
 		// MFA second-step: unauthenticated — the bearer is the single-use challenge


### PR DESCRIPTION
## Summary

- **H-1** (`pat.go`): `DecodePATCIDRs` fails closed on JSON corruption — returns a sentinel that denies all IPs rather than `nil` (which would skip the CIDR check entirely, widening the PAT to global network access). Mirrors `DecodePATScopes`'s r124 fix.
- **H-2** (`account_state.go`): `setAccountState` now evicts PAT token hashes from the auth cache for **all** state transitions, not just login-blocking ones. Previously, a cached PAT bypassed `password_reset_required` for up to the 30 s TTL.
- **H-3** (`sso.go`, `saml.go`): Session token removed from the URL fragment in both `CompleteSSO` and `CompleteSAML`. Token is delivered exclusively via HttpOnly/Secure cookie; a fragment token is readable by JS, browser history, and extensions.
- **H-4** (`audit_retention.go`): `PurgeAuditLogs` now calls `legalHoldGuard` before the delete, closing the window where a hold placed after the scheduler's pre-lock check would still allow an in-flight purge to destroy audit evidence (irreversible spoliation).

## Test plan

- [ ] New unit tests for each fix pass (`TestDecodePATCIDRs_CorruptionFailsClosed`, `TestRequirePasswordReset_EvictsPATCache`, `TestRedirectFragment_NoTokenInFragment_S13`, `TestPurgeAuditLogs_LegalHoldBlocked`)
- [ ] All existing tests continue passing (`go test ./internal/core/ ./server/http/handlers/`)
- [ ] Mock updates for tests broken by the new unconditional `ListPersonalAccessTokensByUser` call in `setAccountState`
- [ ] Pre-existing failures (27 tests in mfa_test.go, secret_acl_test.go, etc.) are unchanged from baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)