### PR TITLE
fix(security): pin golang builder digest, HEALTHCHECK NONE, bump klauspost/compress (r126)

### DIFF
--- a/cmd/keyorix-k8s-sync/Dockerfile
+++ b/cmd/keyorix-k8s-sync/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 RUN apk add --no-cache git
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -23,4 +23,7 @@ RUN set -- \
 FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 COPY --from=builder /out/keyorix-k8s-sync /usr/local/bin/keyorix-k8s-sync
 USER 65532:65532
+# The sync agent has no HTTP listener; health is managed by the Kubernetes
+# controller lifecycle. HEALTHCHECK NONE makes this explicit.
+HEALTHCHECK NONE
 ENTRYPOINT ["keyorix-k8s-sync"]

--- a/cmd/keyorix-mcp/Dockerfile
+++ b/cmd/keyorix-mcp/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 RUN apk add --no-cache git
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -16,4 +16,7 @@ RUN CGO_ENABLED=0 go build \
 FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 COPY --from=builder /out/keyorix-mcp /usr/local/bin/keyorix-mcp
 USER 65532:65532
+# MCP server communicates over stdio; no HTTP port is exposed so a CMD-based
+# health probe is not applicable. HEALTHCHECK NONE makes this explicit.
+HEALTHCHECK NONE
 ENTRYPOINT ["keyorix-mcp"]

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
+github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage. Build context is the operator/ module directory (a separate Go module
 # from the main repo, so controller-runtime/client-go stay out of the server build).
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 RUN apk add --no-cache git
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 RUN apk add --no-cache git make
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary

Closes Scorecard alerts #566–569, Trivy alerts #564–565, and osv-scanner alert #570 (GO-2026-5841).

- **Scorecard #566–569 (Pinned-Dependencies, Medium):** All four Dockerfiles (`server/`, `operator/`, `cmd/keyorix-mcp/`, `cmd/keyorix-k8s-sync/`) used `golang:1.26.5-alpine` without a digest pin. Pinned to `@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2` (current multi-arch index digest). The runtime base images (`alpine:3.24@sha256:…` and `gcr.io/distroless/static:nonroot@sha256:…`) were already pinned.

- **Trivy #564–565 (No HEALTHCHECK defined, Low):** `cmd/keyorix-mcp` and `cmd/keyorix-k8s-sync` had no `HEALTHCHECK` instruction. Both use `distroless/static` (no shell, no wget), so a CMD-based health probe is not applicable. Added `HEALTHCHECK NONE` to make the intentional opt-out explicit.

- **osv-scanner #570 (GO-2026-5841, Warning):** OOB read vulnerability in `github.com/klauspost/compress/s2`. Bumped the indirect dependency from `v1.18.0` → `v1.19.1` and ran `go mod tidy`.

## Test plan

- [ ] `build-and-test` CI passes (no Go code changed, only go.mod/go.sum version bump)
- [ ] `gosec` and `golangci-lint` pass
- [ ] Scorecard re-scan shows no Pinned-Dependencies alerts for the four Dockerfiles
- [ ] Trivy re-scan shows no HEALTHCHECK alerts for mcp/k8s-sync Dockerfiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)