### PR TITLE
fix(security): access review proxy integrity — fabricated campaigns, pre-decided items, self-certification (r128)

### DIFF
--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -130,6 +130,17 @@ func (c *KeyorixCore) OpenAccessReviewCampaign(ctx context.Context, actorID, pro
 	return &CampaignWithProgress{Campaign: campaign, Progress: CampaignProgress{Total: len(items), Pending: len(items)}}, nil
 }
 
+// AuditCampaignCreated emits the campaign_opened audit event on behalf of a
+// proxy caller (e.g. CreateAccessReviewCampaignProxy) that already ran the
+// OpenAccessReviewCampaign business logic on the downstream server and only
+// persisted the raw campaign row here. The proxy calls this after a successful
+// CreateAccessReviewCampaign storage write to keep the upstream audit trail
+// consistent with the human-facing OpenAccessReviewCampaign path.
+func (c *KeyorixCore) AuditCampaignCreated(ctx context.Context, actorID, projectID, campaignID uint, name string, itemCount int) {
+	c.auditProjectScoped(ctx, EventCampaignOpened, actorID, projectID,
+		fmt.Sprintf("opened access-review campaign %d (%q) with %d item(s) [via proxy]", campaignID, name, itemCount))
+}
+
 // ListAccessReviewCampaigns returns the project's campaigns, newest first, each
 // with its decision tally.
 func (c *KeyorixCore) ListAccessReviewCampaigns(ctx context.Context, projectID uint) ([]*CampaignWithProgress, error) {
@@ -220,6 +231,17 @@ func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, proje
 	}
 	if item.PrincipalType == "group" && c.userInGroup(ctx, actorID, item.PrincipalID) {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you cannot review access for a group you belong to; an independent reviewer is required")
+	}
+	// ARC-001: a machine identity provisioned by the actor must not be self-certified
+	// by its creator. Fail closed on lookup error (can't prove independence → deny).
+	if item.PrincipalType == "machine" {
+		machine, err := c.storage.GetMachineIdentity(ctx, item.PrincipalID)
+		if err != nil {
+			return fmt.Errorf("loading machine identity: %w", err)
+		}
+		if machine.CreatedBy == actorID {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "independent reviewer required for machine identities you provisioned")
+		}
 	}
 
 	decision := AccessReviewDecision{
@@ -319,6 +341,23 @@ func (c *KeyorixCore) CloseAccessReviewCampaign(ctx context.Context, actorID, pr
 	progress := tallyProgress(items)
 	if progress.Pending > 0 && !force {
 		return nil, fmt.Errorf("%s: %d item(s) still pending — decide them or close with force", i18n.T("ErrorValidation", nil), progress.Pending)
+	}
+	// ARC-002: even a forced close must not let the actor suppress their own
+	// undecided access item — that would allow the closer to silently freeze a
+	// campaign before an independent reviewer could decide on their grant.
+	// Mirror the DecideAccessReviewItem independence check: fail closed on lookup.
+	if force && progress.Pending > 0 {
+		for _, it := range items {
+			if it.Decision != ReviewItemPending {
+				continue
+			}
+			if it.PrincipalType == "user" && it.PrincipalID == actorID {
+				return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you cannot force-close a campaign while your own access item is still pending; an independent reviewer must decide it first")
+			}
+			if it.PrincipalType == "group" && c.userInGroup(ctx, actorID, it.PrincipalID) {
+				return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you cannot force-close a campaign while an access item for a group you belong to is still pending; an independent reviewer must decide it first")
+			}
+		}
 	}
 	now := c.now()
 	campaign.State = CampaignStateClosed

--- a/server/http/handlers/access_review_campaigns_proxy.go
+++ b/server/http/handlers/access_review_campaigns_proxy.go
@@ -64,6 +64,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -213,6 +214,10 @@ func parseRequiredProjectIDQuery(w http.ResponseWriter, r *http.Request) (projec
 // project's live access-review report and generates the campaign's items; the
 // calling server's own core.OpenAccessReviewCampaign already did that and
 // calls CreateAccessReviewItemsProxy separately to persist them.
+//
+// ARC-003: lifecycle fields (state/closed_by/closed_at/forced_incomplete) are
+// unconditionally normalised to the freshly-opened state before persisting.
+// A caller cannot inject a pre-closed or force-completed campaign via this route.
 func (h *CatalogHandler) CreateAccessReviewCampaignProxy(w http.ResponseWriter, r *http.Request) {
 	var body accessReviewCampaignProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -223,12 +228,22 @@ func (h *CatalogHandler) CreateAccessReviewCampaignProxy(w http.ResponseWriter, 
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id and name are required")
 		return
 	}
+	// ARC-003: strip any caller-supplied lifecycle state — a new campaign is
+	// always open with no closer and no forced-incomplete flag.
+	body.State = core.CampaignStateOpen
+	body.ClosedBy = 0
+	body.ClosedAt = nil
+	body.ForcedIncomplete = false
 	created, err := h.coreService.Storage().CreateAccessReviewCampaign(r.Context(), body.toModel())
 	if err != nil {
 		log.Printf("access-review-campaigns proxy: create campaign failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
 	}
+	// Emit the same audit event that OpenAccessReviewCampaign emits so the upstream
+	// audit trail records the campaign creation even when items are persisted separately.
+	actorID := actorID(r)
+	h.coreService.AuditCampaignCreated(r.Context(), actorID, created.ProjectID, created.ID, created.Name, 0)
 	writeRemoteAPISuccess(w, newAccessReviewCampaignProxyWire(created))
 }
 
@@ -364,9 +379,14 @@ func (h *CatalogHandler) CreateAccessReviewItemsProxy(w http.ResponseWriter, r *
 		return
 	}
 	items := make([]*models.AccessReviewItem, 0, len(body.Items))
-	for _, w := range body.Items {
-		w.CampaignID = uint(campaignID)
-		items = append(items, w.toModel())
+	for _, item := range body.Items {
+		item.CampaignID = uint(campaignID)
+		// ARC-004: strip any pre-supplied decision state — every newly created
+		// item must start pending regardless of what the caller sent.
+		item.Decision = core.ReviewItemPending
+		item.DecidedBy = 0
+		item.DecidedAt = nil
+		items = append(items, item.toModel())
 	}
 	if err := h.coreService.Storage().CreateAccessReviewItems(r.Context(), items); err != nil {
 		log.Printf("access-review-campaigns proxy: create items failed: %v", err)
@@ -465,6 +485,16 @@ func (h *CatalogHandler) UpdateAccessReviewItemProxy(w http.ResponseWriter, r *h
 		return
 	}
 	body.ID = uint(id)
+	// ARC-005: a reviewer must be identified (decided_by != 0) and must not
+	// self-certify their own user-scoped access item.
+	if body.DecidedBy == 0 {
+		writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", "decided_by must identify an attributable reviewer; zero is not allowed")
+		return
+	}
+	if body.PrincipalType == "user" && body.DecidedBy == body.PrincipalID {
+		writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", "self-certification is not allowed; an independent reviewer is required")
+		return
+	}
 	updated, err := h.coreService.Storage().UpdateAccessReviewItem(r.Context(), body.toModel())
 	if err != nil {
 		log.Printf("access-review-campaigns proxy: update item failed: %v", err)

--- a/server/http/handlers/access_review_campaigns_proxy_r128_test.go
+++ b/server/http/handlers/access_review_campaigns_proxy_r128_test.go
@@ -1,0 +1,299 @@
+// access_review_campaigns_proxy_r128_test.go — regression tests for the r128
+// security fixes in access_review_campaigns_proxy.go:
+//
+//   ARC-003: CreateAccessReviewCampaignProxy must ignore caller-supplied lifecycle
+//            state and always create an open campaign.
+//   ARC-004: CreateAccessReviewItemsProxy must strip decision fields from each
+//            incoming item, forcing every new item to "pending".
+//   ARC-005: UpdateAccessReviewItemProxy must reject self-certification
+//            (decided_by == principal_id for user-type items) and must reject a
+//            zero decided_by.
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── ARC-003: CreateAccessReviewCampaignProxy lifecycle-state stripping ────────
+
+// TestCreateAccessReviewCampaignProxy_IgnoresClosedState_R128 pins ARC-003:
+// a body carrying state="closed" must be persisted as state="open".
+func TestCreateAccessReviewCampaignProxy_IgnoresClosedState_R128(t *testing.T) {
+	h := freshCatalogHandlerS13(t)
+	now := time.Now()
+	body, _ := json.Marshal(map[string]interface{}{
+		"project_id":        42,
+		"name":              "ARC-003 closed-state injection attempt",
+		"state":             "closed",
+		"closed_by":         99,
+		"closed_at":         now,
+		"forced_incomplete": true,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/access-review-campaigns", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateAccessReviewCampaignProxy(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp remoteAPIResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Success)
+
+	// The returned campaign must carry the normalised lifecycle fields.
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok, "response data should be an object")
+	assert.Equal(t, "open", data["state"], "state must be forced to open")
+	// closed_by is omitempty — absent in response when zero is correct.
+	if v, present := data["closed_by"]; present {
+		assert.EqualValues(t, 0, v, "closed_by must be zero when present")
+	}
+	assert.Nil(t, data["closed_at"], "closed_at must be nil")
+	assert.False(t, data["forced_incomplete"].(bool), "forced_incomplete must be false")
+}
+
+// TestCreateAccessReviewCampaignProxy_IgnoresForcedIncomplete_R128 pins ARC-003
+// for forced_incomplete only: even without state="closed", forced_incomplete must
+// be stripped.
+func TestCreateAccessReviewCampaignProxy_IgnoresForcedIncomplete_R128(t *testing.T) {
+	h := freshCatalogHandlerS13(t)
+	body, _ := json.Marshal(map[string]interface{}{
+		"project_id":        43,
+		"name":              "ARC-003 forced-incomplete injection",
+		"forced_incomplete": true,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/access-review-campaigns", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateAccessReviewCampaignProxy(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp remoteAPIResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Success)
+
+	data := resp.Data.(map[string]interface{})
+	assert.Equal(t, "open", data["state"])
+	assert.False(t, data["forced_incomplete"].(bool))
+}
+
+// ── ARC-004: CreateAccessReviewItemsProxy decision-field stripping ────────────
+
+// TestCreateAccessReviewItemsProxy_StripsDecisionFields_R128 pins ARC-004:
+// items submitted with decision/decided_by/decided_at pre-set must be stored as
+// "pending" with no decided_by or decided_at.
+func TestCreateAccessReviewItemsProxy_StripsDecisionFields_R128(t *testing.T) {
+	cs, db := freshCoreS26WithAdmin(t)
+	h := NewCatalogHandler(cs)
+
+	proj := &models.Project{Name: "arc004-proj"}
+	require.NoError(t, db.Create(proj).Error)
+	campaign := &models.AccessReviewCampaign{
+		ProjectID: proj.ID,
+		Name:      "ARC-004 test",
+		State:     "open",
+		CreatedBy: 1,
+	}
+	require.NoError(t, db.Create(campaign).Error)
+
+	decidedAt := time.Now()
+	body, _ := json.Marshal(map[string]interface{}{
+		"items": []map[string]interface{}{
+			{
+				"principal_type": "user",
+				"principal_id":   5,
+				"principal_name": "alice",
+				"access_level":   "read",
+				"environment_id": 1,
+				// Pre-supplied decision fields — must be stripped.
+				"decision":   "attested",
+				"decided_by": 9,
+				"decided_at": decidedAt,
+			},
+		},
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPost,
+			fmt.Sprintf("/api/v1/system/access-review-campaigns/%d/items", campaign.ID),
+			bytes.NewReader(body)),
+		"id", fmt.Sprintf("%d", campaign.ID),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateAccessReviewItemsProxy(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp remoteAPIResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Success)
+
+	// Verify the persisted item has decision="pending" and zero decided_by.
+	var items []models.AccessReviewItem
+	require.NoError(t, db.Where("campaign_id = ?", campaign.ID).Find(&items).Error)
+	require.Len(t, items, 1)
+	assert.Equal(t, "pending", items[0].Decision, "decision must be forced to pending")
+	assert.EqualValues(t, 0, items[0].DecidedBy, "decided_by must be zeroed")
+	assert.Nil(t, items[0].DecidedAt, "decided_at must be nil")
+}
+
+// ── ARC-005: UpdateAccessReviewItemProxy self-certification rejection ─────────
+
+// TestUpdateAccessReviewItemProxy_RejectsSelfCertification_R128 pins ARC-005:
+// a request where decided_by == principal_id (user type) must return 403.
+func TestUpdateAccessReviewItemProxy_RejectsSelfCertification_R128(t *testing.T) {
+	h := freshCatalogHandlerS13(t)
+	body, _ := json.Marshal(map[string]interface{}{
+		"principal_type": "user",
+		"principal_id":   7,
+		"decision":       "attest",
+		// decided_by equals principal_id → self-certification.
+		"decided_by": 7,
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/system/access-review-campaigns/items/1",
+			bytes.NewReader(body)),
+		"itemID", "1",
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.UpdateAccessReviewItemProxy(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	var resp remoteAPIResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Success)
+	assert.Equal(t, "FORBIDDEN", resp.Error.Code)
+}
+
+// TestUpdateAccessReviewItemProxy_AllowsNonSelfCertification_R128 pins ARC-005:
+// a request where decided_by != principal_id is accepted (403 not raised).
+func TestUpdateAccessReviewItemProxy_AllowsNonSelfCertification_R128(t *testing.T) {
+	cs, db := freshCoreS26WithAdmin(t)
+	h := NewCatalogHandler(cs)
+
+	proj := &models.Project{Name: "arc005-allow-proj"}
+	require.NoError(t, db.Create(proj).Error)
+	campaign := &models.AccessReviewCampaign{
+		ProjectID: proj.ID,
+		Name:      "ARC-005 allow test",
+		State:     "open",
+		CreatedBy: 1,
+	}
+	require.NoError(t, db.Create(campaign).Error)
+	item := &models.AccessReviewItem{
+		CampaignID:    campaign.ID,
+		PrincipalType: "user",
+		PrincipalID:   3,
+		Decision:      "pending",
+	}
+	require.NoError(t, db.Create(item).Error)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"id":             item.ID,
+		"campaign_id":    campaign.ID,
+		"principal_type": "user",
+		"principal_id":   3,
+		"decision":       "attest",
+		// decided_by (4) differs from principal_id (3) — independence check passes.
+		"decided_by": 4,
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut,
+			fmt.Sprintf("/api/v1/system/access-review-campaigns/items/%d", item.ID),
+			bytes.NewReader(body)),
+		"itemID", fmt.Sprintf("%d", item.ID),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.UpdateAccessReviewItemProxy(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp remoteAPIResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Success)
+}
+
+// TestUpdateAccessReviewItemProxy_RejectsZeroDecidedBy_R128 pins ARC-005:
+// a request with decided_by == 0 must return 403.
+func TestUpdateAccessReviewItemProxy_RejectsZeroDecidedBy_R128(t *testing.T) {
+	h := freshCatalogHandlerS13(t)
+	body, _ := json.Marshal(map[string]interface{}{
+		"principal_type": "user",
+		"principal_id":   5,
+		"decision":       "attest",
+		// decided_by absent (zero) → rejected.
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/system/access-review-campaigns/items/1",
+			bytes.NewReader(body)),
+		"itemID", "1",
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.UpdateAccessReviewItemProxy(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	var resp remoteAPIResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Success)
+	assert.Equal(t, "FORBIDDEN", resp.Error.Code)
+}
+
+// TestUpdateAccessReviewItemProxy_SelfCertNonUserType_R128 pins ARC-005:
+// the self-certification check is type-scoped to "user" — a non-user item
+// (e.g. "group") with principal_id == decided_by must NOT be blocked here
+// (that check lives in core.DecideAccessReviewItem on the decision path).
+func TestUpdateAccessReviewItemProxy_SelfCertNonUserType_R128(t *testing.T) {
+	cs, db := freshCoreS26WithAdmin(t)
+	h := NewCatalogHandler(cs)
+
+	proj := &models.Project{Name: "arc005-group-proj"}
+	require.NoError(t, db.Create(proj).Error)
+	campaign := &models.AccessReviewCampaign{
+		ProjectID: proj.ID,
+		Name:      "ARC-005 group type test",
+		State:     "open",
+		CreatedBy: 1,
+	}
+	require.NoError(t, db.Create(campaign).Error)
+	item := &models.AccessReviewItem{
+		CampaignID:    campaign.ID,
+		PrincipalType: "group",
+		PrincipalID:   7,
+		Decision:      "pending",
+	}
+	require.NoError(t, db.Create(item).Error)
+
+	// decided_by == principal_id but principal_type is "group", not "user" —
+	// ARC-005 proxy check doesn't block this (the deeper group-membership check
+	// runs inside core.DecideAccessReviewItem on the human-facing path).
+	body, _ := json.Marshal(map[string]interface{}{
+		"id":             item.ID,
+		"campaign_id":    campaign.ID,
+		"principal_type": "group",
+		"principal_id":   7,
+		"decision":       "attest",
+		"decided_by":     7,
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut,
+			fmt.Sprintf("/api/v1/system/access-review-campaigns/items/%d", item.ID),
+			bytes.NewReader(body)),
+		"itemID", fmt.Sprintf("%d", item.ID),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.UpdateAccessReviewItemProxy(w, req)
+
+	// Should reach storage (200 or 500), NOT 403.
+	assert.NotEqual(t, http.StatusForbidden, w.Code)
+}

--- a/server/http/handlers/handlers_s26_test.go
+++ b/server/http/handlers/handlers_s26_test.go
@@ -1022,7 +1022,8 @@ func TestUpdateAccessReviewItemProxy_HappyPath_S26(t *testing.T) {
 		"principal_id":   1,
 		"principal_type": "user",
 		"decision":       "attest",
-		"decided_by":     1,
+		// decided_by must differ from principal_id (ARC-005: no self-certification).
+		"decided_by": 2,
 	})
 	req := withChiParam_S25(
 		httptest.NewRequest(http.MethodPut,

--- a/server/http/handlers/handlers_s31_test.go
+++ b/server/http/handlers/handlers_s31_test.go
@@ -142,7 +142,9 @@ func TestGetAccessReviewItemProxy_DBError_S31(t *testing.T) {
 func TestUpdateAccessReviewItemProxy_DBError_S31(t *testing.T) {
 	t.Parallel()
 	h := NewCatalogHandler(freshCoreBrokenS31(t))
-	body := bytes.NewBufferString(`{"user_id":1,"role":"viewer","decision":"approved","reviewed_by":2}`)
+	// decided_by (2) != principal_id (1) so ARC-005 passes; broken storage then
+	// returns 500.
+	body := bytes.NewBufferString(`{"principal_id":1,"principal_type":"user","decision":"attest","decided_by":2}`)
 	r := withChiParamS7(httptest.NewRequest(http.MethodPut, "/api/v1/system/access-review-campaigns/items/1", body), "itemID", "1")
 	w := httptest.NewRecorder()
 	h.UpdateAccessReviewItemProxy(w, r)


### PR DESCRIPTION
## Summary

Five access-review security gaps fixed across the proxy layer and core business logic:

- **ARC-003 (HIGH)** — `CreateAccessReviewCampaignProxy`: caller-supplied lifecycle fields (`state`, `closed_by`, `closed_at`, `forced_incomplete`) are now unconditionally stripped before the storage write, preventing injection of a pre-closed or force-completed campaign via the proxy. Audit event emission added to match the human-facing `OpenAccessReviewCampaign` path.
- **ARC-004 (HIGH)** — `CreateAccessReviewItemsProxy`: decision fields (`decision`, `decided_by`, `decided_at`) are stripped from every incoming item, forcing all newly-created items to `"pending"` regardless of what the downstream caller sent.
- **ARC-005 (HIGH)** — `UpdateAccessReviewItemProxy`: zero `decided_by` is rejected (HTTP 403); self-certification (`decided_by == principal_id` for `principal_type == "user"`) is rejected (HTTP 403) before the request reaches storage.
- **ARC-001 (LOW)** — `DecideAccessReviewItem` (core): machine-identity branch added to the ISO 27001 A.5.18 independence check — a reviewer cannot certify a machine identity they provisioned. Fails closed on lookup error.
- **ARC-002 (MEDIUM)** — `CloseAccessReviewCampaign` (core, `force=true`): force-close is now blocked when any pending item has the closing actor as its direct user-principal or as a member of a pending group-principal, mirroring the `DecideAccessReviewItem` independence gate.

## Test plan

- 7 new regression tests in `access_review_campaigns_proxy_r128_test.go` pin ARC-003, ARC-004, and ARC-005 behaviour
- Existing `TestUpdateAccessReviewItemProxy_HappyPath_S26` and `TestUpdateAccessReviewItemProxy_DBError_S31` updated to satisfy the new ARC-005 constraints
- All core `TestDecide*` / `TestClose*` / `TestOpen*` / `TestCampaign*` tests continue to pass
- `golangci-lint` and `gosec` report zero issues on changed packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)