### PR TITLE
fix(security): MongoDB role blocklist + SoD pre-existing violation scan (r136)

### DIFF
--- a/internal/cli/encryption/auth_encrypt_validate_s23_test.go
+++ b/internal/cli/encryption/auth_encrypt_validate_s23_test.go
@@ -42,7 +42,7 @@ func TestValidateSessions_S23_VerboseNoUnmigrated(t *testing.T) {
 
 	// Insert a single fully-encrypted session (session_token must be unique, so
 	// we insert only one with an empty string cleared via NULL-equivalent pointer).
-	enc, meta, err := ae.EncryptSessionToken("s23-sess-tok-only")
+	enc, meta, err := ae.EncryptSessionToken("s23-sess-tok-only", uint(10))
 	require.NoError(t, err)
 	// Use Exec directly to set session_token to NULL (satisfies the unique constraint).
 	require.NoError(t, db.Exec(
@@ -62,7 +62,7 @@ func TestValidateAPITokens_S23_VerboseNoUnmigrated(t *testing.T) {
 
 	// Insert a single fully-encrypted API token with token set to NULL
 	// to satisfy the unique constraint on the token column.
-	enc, meta, err := ae.EncryptAPIToken("s23-api-tok-only")
+	enc, meta, err := ae.EncryptAPIToken("s23-api-tok-only", uint(0))
 	require.NoError(t, err)
 	require.NoError(t, db.Exec(
 		`INSERT INTO api_tokens (client_id, token, encrypted_token, token_metadata, revoked) VALUES (?, NULL, ?, ?, false)`,
@@ -82,7 +82,7 @@ func TestValidatePasswordResetTokens_S23_VerboseNoUnmigrated(t *testing.T) {
 
 	// Insert a single fully-encrypted reset token with token set to NULL
 	// to satisfy the unique constraint on the token column.
-	enc, meta, err := ae.EncryptPasswordResetToken("s23-reset-tok-only")
+	enc, meta, err := ae.EncryptPasswordResetToken("s23-reset-tok-only", uint(30))
 	require.NoError(t, err)
 	require.NoError(t, db.Exec(
 		`INSERT INTO password_resets (user_id, token, encrypted_token, token_metadata) VALUES (?, NULL, ?, ?)`,

--- a/internal/cli/encryption/auth_encryption_migrate.go
+++ b/internal/cli/encryption/auth_encryption_migrate.go
@@ -99,7 +99,7 @@ func migrateSessions(db *gorm.DB, authEnc *encryption.AuthEncryption, dryRun boo
 		return nil
 	}
 	for _, session := range sessions {
-		enc, meta, err := authEnc.EncryptSessionToken(session.SessionToken)
+		enc, meta, err := authEnc.EncryptSessionToken(session.SessionToken, session.UserID)
 		if err != nil {
 			return fmt.Errorf("failed to encrypt session token for session %d: %w", session.ID, err)
 		}
@@ -126,7 +126,11 @@ func migrateAPITokens(db *gorm.DB, authEnc *encryption.AuthEncryption, dryRun bo
 		return nil
 	}
 	for _, token := range tokens {
-		enc, meta, err := authEnc.EncryptAPIToken(token.Token)
+		var migrateTokenUserID uint
+		if token.UserID != nil {
+			migrateTokenUserID = *token.UserID
+		}
+		enc, meta, err := authEnc.EncryptAPIToken(token.Token, migrateTokenUserID)
 		if err != nil {
 			return fmt.Errorf("failed to encrypt API token %d: %w", token.ID, err)
 		}
@@ -153,7 +157,7 @@ func migratePasswordResetTokens(db *gorm.DB, authEnc *encryption.AuthEncryption,
 		return nil
 	}
 	for _, reset := range resets {
-		enc, meta, err := authEnc.EncryptPasswordResetToken(reset.Token)
+		enc, meta, err := authEnc.EncryptPasswordResetToken(reset.Token, reset.UserID)
 		if err != nil {
 			return fmt.Errorf("failed to encrypt password reset token %d: %w", reset.ID, err)
 		}

--- a/internal/cli/encryption/auth_encryption_validate.go
+++ b/internal/cli/encryption/auth_encryption_validate.go
@@ -117,7 +117,7 @@ func validateSessions(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose b
 		fmt.Printf("🎫 Validating %d encrypted sessions...\n", len(sessions))
 	}
 	for _, session := range sessions {
-		if _, err := authEnc.DecryptSessionToken(session.EncryptedSessionToken, []byte(session.SessionTokenMetadata)); err != nil {
+		if _, err := authEnc.DecryptSessionToken(session.EncryptedSessionToken, []byte(session.SessionTokenMetadata), session.UserID); err != nil {
 			return 0, fmt.Errorf("failed to decrypt session token for session %d: %w", session.ID, err)
 		}
 		if verbose {
@@ -144,7 +144,11 @@ func validateAPITokens(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose 
 		fmt.Printf("🎟️  Validating %d encrypted API tokens...\n", len(tokens))
 	}
 	for _, token := range tokens {
-		if _, err := authEnc.DecryptAPIToken(token.EncryptedToken, []byte(token.TokenMetadata)); err != nil {
+		var validateTokenUserID uint
+		if token.UserID != nil {
+			validateTokenUserID = *token.UserID
+		}
+		if _, err := authEnc.DecryptAPIToken(token.EncryptedToken, []byte(token.TokenMetadata), validateTokenUserID); err != nil {
 			return 0, fmt.Errorf("failed to decrypt API token %d: %w", token.ID, err)
 		}
 		if verbose {
@@ -171,7 +175,7 @@ func validatePasswordResetTokens(db *gorm.DB, authEnc *encryption.AuthEncryption
 		fmt.Printf("🔄 Validating %d encrypted password reset tokens...\n", len(resets))
 	}
 	for _, reset := range resets {
-		if _, err := authEnc.DecryptPasswordResetToken(reset.EncryptedToken, []byte(reset.TokenMetadata)); err != nil {
+		if _, err := authEnc.DecryptPasswordResetToken(reset.EncryptedToken, []byte(reset.TokenMetadata), reset.UserID); err != nil {
 			return 0, fmt.Errorf("failed to decrypt password reset token %d: %w", reset.ID, err)
 		}
 		if verbose {

--- a/internal/cli/encryption/encryption_s24_test.go
+++ b/internal/cli/encryption/encryption_s24_test.go
@@ -221,7 +221,7 @@ func TestValidateSessions_S24_VerboseWithUnmigrated(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
 
 	// Insert one properly encrypted session.
-	encTok, encMeta, err := ae.EncryptSessionToken("s24-session-token")
+	encTok, encMeta, err := ae.EncryptSessionToken("s24-session-token", uint(50))
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&models.Session{
 		UserID:                50,
@@ -247,7 +247,7 @@ func TestValidateSessions_S24_VerboseWithUnmigrated(t *testing.T) {
 func TestValidateAPITokens_S24_VerboseWithUnmigrated(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
 
-	encTok, encMeta, err := ae.EncryptAPIToken("s24-api-token")
+	encTok, encMeta, err := ae.EncryptAPIToken("s24-api-token", uint(0))
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&models.APIToken{
 		ClientID:       10,
@@ -272,7 +272,7 @@ func TestValidateAPITokens_S24_VerboseWithUnmigrated(t *testing.T) {
 func TestValidatePasswordResetTokens_S24_VerboseWithUnmigrated(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
 
-	encTok, encMeta, err := ae.EncryptPasswordResetToken("s24-reset-token")
+	encTok, encMeta, err := ae.EncryptPasswordResetToken("s24-reset-token", uint(60))
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&models.PasswordReset{
 		UserID:         60,
@@ -380,7 +380,7 @@ func TestShowAuthEncryptionStats_S24_AllFourTablesEncrypted(t *testing.T) {
 		ClientSecretMetadata:  models.JSON(encSecMeta),
 	}).Error)
 
-	encSess, encSessMeta, err := ae.EncryptSessionToken("s24-stats-session")
+	encSess, encSessMeta, err := ae.EncryptSessionToken("s24-stats-session", uint(70))
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&models.Session{
 		UserID:                70,
@@ -388,7 +388,7 @@ func TestShowAuthEncryptionStats_S24_AllFourTablesEncrypted(t *testing.T) {
 		SessionTokenMetadata:  encSessMeta,
 	}).Error)
 
-	encTok, encTokMeta, err := ae.EncryptAPIToken("s24-stats-token")
+	encTok, encTokMeta, err := ae.EncryptAPIToken("s24-stats-token", uint(0))
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&models.APIToken{
 		ClientID:       20,
@@ -396,7 +396,7 @@ func TestShowAuthEncryptionStats_S24_AllFourTablesEncrypted(t *testing.T) {
 		TokenMetadata:  encTokMeta,
 	}).Error)
 
-	encRst, encRstMeta, err := ae.EncryptPasswordResetToken("s24-stats-reset")
+	encRst, encRstMeta, err := ae.EncryptPasswordResetToken("s24-stats-reset", uint(70))
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&models.PasswordReset{
 		UserID:         70,

--- a/internal/cli/encryption/encryption_s3_test.go
+++ b/internal/cli/encryption/encryption_s3_test.go
@@ -102,7 +102,7 @@ func TestValidateSessions_UnmigratedRow(t *testing.T) {
 func TestValidateSessions_EncryptedRow_Verbose(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
 
-	enc, meta, err := ae.EncryptSessionToken("valid-session-token")
+	enc, meta, err := ae.EncryptSessionToken("valid-session-token", uint(1))
 	require.NoError(t, err)
 	s := &models.Session{UserID: 1, EncryptedSessionToken: enc, SessionTokenMetadata: meta}
 	require.NoError(t, db.Create(s).Error)
@@ -142,7 +142,7 @@ func TestValidateAPITokens_UnmigratedRow(t *testing.T) {
 func TestValidateAPITokens_EncryptedRow_Verbose(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
 
-	enc, meta, err := ae.EncryptAPIToken("api-token-value")
+	enc, meta, err := ae.EncryptAPIToken("api-token-value", uint(0))
 	require.NoError(t, err)
 	tok := &models.APIToken{ClientID: 1, EncryptedToken: enc, TokenMetadata: meta}
 	require.NoError(t, db.Create(tok).Error)
@@ -182,7 +182,7 @@ func TestValidatePasswordResetTokens_UnmigratedRow(t *testing.T) {
 func TestValidatePasswordResetTokens_EncryptedRow_Verbose(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
 
-	enc, meta, err := ae.EncryptPasswordResetToken("reset-token-value")
+	enc, meta, err := ae.EncryptPasswordResetToken("reset-token-value", uint(1))
 	require.NoError(t, err)
 	reset := &models.PasswordReset{UserID: 1, EncryptedToken: enc, TokenMetadata: meta}
 	require.NoError(t, db.Create(reset).Error)

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -45,7 +45,8 @@ type AccessGovernancePosture struct {
 
 // RotationPosture summarises secret-rotation hygiene (ISO A.5.15 / NIS2).
 type RotationPosture struct {
-	CoveredSecrets int `json:"covered_secrets"`
+	TotalSecrets   int `json:"total_secrets"`   // all static secrets in scope
+	CoveredSecrets int `json:"covered_secrets"` // those with a rotation schedule
 	Overdue        int `json:"overdue"`
 	DueSoon        int `json:"due_soon"`
 }
@@ -300,6 +301,9 @@ type complianceSnapshot struct {
 	rotationStatuses []*RotationStatusEntry
 	rotationErr      error
 
+	totalSecrets    int
+	totalSecretsErr error
+
 	sodReport *SoDViolationsReport
 	sodErr    error
 
@@ -342,6 +346,11 @@ func (c *KeyorixCore) buildComplianceSnapshot(ctx context.Context) (*complianceS
 
 	snap.auditChain, snap.auditChainErr = c.VerifyAuditChain(ctx)
 	snap.rotationStatuses, snap.rotationErr = c.GetRotationStatus(ctx, nil, nil)
+	if _, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{Page: 1, PageSize: 1}); err == nil {
+		snap.totalSecrets = int(total)
+	} else {
+		snap.totalSecretsErr = err
+	}
 	snap.sodReport, snap.sodErr = c.DetectSoDViolations(ctx)
 	if views, err := c.listRiskExceptionRows(ctx, true); err == nil {
 		for _, v := range views {
@@ -595,6 +604,11 @@ func applyRotationPosture(p *CompliancePosture, snap *complianceSnapshot) {
 		p.degrade("rotation", err)
 		return
 	}
+	if snap.totalSecretsErr != nil {
+		p.degrade("rotation:total_secrets", snap.totalSecretsErr)
+	} else {
+		p.Rotation.TotalSecrets = snap.totalSecrets
+	}
 	p.Rotation.CoveredSecrets = len(statuses)
 	for _, s := range statuses {
 		switch s.Status {
@@ -749,10 +763,14 @@ func (c *KeyorixCore) accessGovernancePostureFromSnapshot(ctx context.Context, p
 	p.AccessGovernance.Projects = len(snap.projects)
 	p.AccessRequests.RequiredApprovals = c.requiredApprovals()
 	recertCutoff := c.now().AddDate(0, 0, -c.recertCadence())
+	// CP-005: hoist the role-permissions cache across all per-project iterations so
+	// GetRolePermissions is called at most once per role, not once per project per role.
+	sharedPermsByRole := map[uint][]*models.Permission{}
+	sharedDegradedRoles := map[uint]bool{}
 	for _, proj := range snap.projects {
 		pid := proj.ID
 		accumulateCampaignPosture(p, pid, recertCutoff, snap)
-		p.AccessGovernance.DormantRoleGrants += c.countDormantRoleGrants(ctx, pid, p)
+		p.AccessGovernance.DormantRoleGrants += c.countDormantRoleGrants(ctx, pid, p, sharedPermsByRole, sharedDegradedRoles)
 		accumulateBreakGlassPosture(p, pid, snap)
 		accumulateAccessRequestPosture(p, pid, snap)
 	}
@@ -772,6 +790,11 @@ func accumulateCampaignPosture(p *CompliancePosture, pid uint, recertCutoff time
 		p.AccessGovernance.ProjectsWithOpenCampaign++
 		p.AccessGovernance.OpenCampaigns++
 		p.AccessGovernance.PendingItems += open.Progress.Pending
+		// CP-002: a campaign that has been open past the recertification cadence cutoff
+		// is itself overdue — count it regardless of whether it's still in progress.
+		if open.Campaign.CreatedAt.Before(recertCutoff) {
+			p.AccessGovernance.ProjectsOverdue++
+		}
 		return
 	}
 	overdue := lastClosed == nil
@@ -885,7 +908,7 @@ func accumulateAccessRequestPosture(p *CompliancePosture, pid uint, snap *compli
 // grants are credited (neither shown falsely dormant) — the same "no worse than
 // before" behaviour as pre-#487 for this narrower, structurally irreducible case.
 // See roleIsAdminTier's doc for the exact tier boundary.
-func (c *KeyorixCore) countDormantRoleGrants(ctx context.Context, projectID uint, cp *CompliancePosture) int { // NOSONAR -- cognitive complexity 25, suppress go:S3776
+func (c *KeyorixCore) countDormantRoleGrants(ctx context.Context, projectID uint, cp *CompliancePosture, permsByRole map[uint][]*models.Permission, degradedRoles map[uint]bool) int { // NOSONAR -- cognitive complexity 25, suppress go:S3776
 	assignments, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
 	if err != nil {
 		cp.degrade(fmt.Sprintf("dormant_role_grants:assignments:project=%d", projectID), err)
@@ -913,8 +936,6 @@ func (c *KeyorixCore) countDormantRoleGrants(ctx context.Context, projectID uint
 	}
 	cutoff := c.now().Add(-dormantThreshold)
 
-	permsByRole := map[uint][]*models.Permission{}
-	degradedRoles := map[uint]bool{}
 	rolePerms := func(roleID uint) []*models.Permission {
 		if v, ok := permsByRole[roleID]; ok {
 			return v

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -198,24 +198,48 @@ func refMatches(pattern, ref string) bool {
 // identities resolve from machine_identity_roles; users resolve their direct roles
 // PLUS group-derived roles (scopedRoleIDs). Resolving only direct roles would deny a
 // user whose granted role comes via a group even though connect.read itself honors it.
-// Connect is a global surface, so roles are resolved at global scope.
+//
+// CONN-005: roles are resolved at global scope AND at every project scope the actor
+// holds a grant in, so a user with only project-scoped role grants can match a
+// ConnectRefGrant that references one of those roles. Connect ref grants reference a
+// role by ID — if a user has that role at any scope, they should be permitted.
 func (c *KeyorixCore) actorRoleIDs(ctx context.Context, actorType string, principalID uint) (map[uint]bool, error) {
-	var ids []uint
-	var err error
+	set := map[uint]bool{}
 	if actorType == ActorTypeMachine {
-		ids, err = c.storage.GetMachineRoleIDsAt(ctx, principalID, Scope{})
+		ids, err := c.storage.GetMachineRoleIDsAt(ctx, principalID, Scope{})
 		if err != nil {
 			return nil, fmt.Errorf("connect ref-grant: load machine roles: %w", err)
 		}
-	} else {
-		ids, err = c.scopedRoleIDs(ctx, principalID, Scope{})
-		if err != nil {
-			return nil, fmt.Errorf("connect ref-grant: load actor roles: %w", err)
+		for _, id := range ids {
+			set[id] = true
 		}
+		return set, nil
 	}
-	set := make(map[uint]bool, len(ids))
+	// Global scope first.
+	ids, err := c.scopedRoleIDs(ctx, principalID, Scope{})
+	if err != nil {
+		return nil, fmt.Errorf("connect ref-grant: load actor roles: %w", err)
+	}
 	for _, id := range ids {
 		set[id] = true
+	}
+	// Also include roles assigned at any project scope — a project-scoped role
+	// assignment for a role that appears in a ConnectRefGrant should be honoured.
+	scopes, err := c.storage.GetUserRoleScopes(ctx, principalID)
+	if err != nil {
+		return nil, fmt.Errorf("connect ref-grant: enumerate role scopes: %w", err)
+	}
+	for _, sc := range scopes {
+		if sc.ProjectID == 0 {
+			continue // already covered by global query above
+		}
+		projectIDs, err := c.scopedRoleIDs(ctx, principalID, sc)
+		if err != nil {
+			return nil, fmt.Errorf("connect ref-grant: load actor roles at scope %v: %w", sc, err)
+		}
+		for _, id := range projectIDs {
+			set[id] = true
+		}
 	}
 	return set, nil
 }

--- a/internal/core/control_framework.go
+++ b/internal/core/control_framework.go
@@ -150,8 +150,11 @@ func EvaluateControls(p *CompliancePosture) []ControlState {
 		},
 		{
 			ID: "secret-rotation", Name: "Secret-rotation hygiene", Area: "Cryptography",
-			Status:     controlStatus(p.DegradedArea("rotation", "evidence:rotation_overdue"), p.Rotation.Overdue > 0),
-			Detail:     fmt.Sprintf("%d overdue, %d due soon of %d covered", p.Rotation.Overdue, p.Rotation.DueSoon, p.Rotation.CoveredSecrets),
+			// CP-007: also fail when fewer secrets are covered than exist in the deployment
+			// (vacuous-truth pass when CoveredSecrets == 0 and Overdue == 0 but TotalSecrets > 0).
+			Status: controlStatus(p.DegradedArea("rotation", "evidence:rotation_overdue"),
+				p.Rotation.Overdue > 0 || (p.Rotation.TotalSecrets > 0 && p.Rotation.CoveredSecrets < p.Rotation.TotalSecrets)),
+			Detail:     fmt.Sprintf("%d overdue, %d due soon; %d of %d secrets covered", p.Rotation.Overdue, p.Rotation.DueSoon, p.Rotation.CoveredSecrets, p.Rotation.TotalSecrets),
 			Frameworks: FrameworkRefs{ISO27001: []string{ctrlA515, "A.8.24"}, SOC2: []string{"CC6.1"}, NIS2: []string{"Art.21(2)(h)"}, ENS: []string{"op.exp.11"}},
 		},
 		{

--- a/internal/core/core_s25_test.go
+++ b/internal/core/core_s25_test.go
@@ -776,9 +776,10 @@ func TestEnforceSecretOwnerPermission_NotOwner(t *testing.T) {
 	ms.On("GetSecret", mock.Anything, uint(5)).Return(&models.SecretNode{ID: 5, OwnerID: 99}, nil)
 	// ListSharesBySecret returns no shares
 	ms.On("ListSharesBySecret", mock.Anything, uint(5)).Return([]*models.ShareRecord{}, nil)
-	// Authz checks - no roles
-	ms.On("GetUserRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(1), mock.Anything).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(1), mock.Anything).Return([]uint{}, nil)
 	c := NewKeyorixCore(ms)
 	_, err := c.EnforceSecretOwnerPermission(context.Background(), 5, 1)
 	require.Error(t, err)

--- a/internal/core/core_s26_test.go
+++ b/internal/core/core_s26_test.go
@@ -284,6 +284,9 @@ func TestCheckSecretPermission_Denied(t *testing.T) {
 	ms.On("ListSharesBySecret", mock.Anything, uint(5)).Return([]*models.ShareRecord{}, nil)
 	// CheckGroupPermissions calls GetUserGroups
 	ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(1), mock.Anything).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(1), mock.Anything).Return([]uint{}, nil)
 	c := NewKeyorixCore(ms)
 	_, err := c.CheckSecretPermission(context.Background(), 5, 1, PermissionRead)
 	require.Error(t, err)

--- a/internal/core/core_s28_test.go
+++ b/internal/core/core_s28_test.go
@@ -203,6 +203,9 @@ func TestGetSecretValueByVersionWithPermissionCheck_PermissionDenied(t *testing.
 	ms.On("GetSecret", mock.Anything, uint(5)).Return(secret, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(5)).Return([]*models.ShareRecord{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	c := NewKeyorixCore(ms)
 	_, err := c.GetSecretValueByVersionWithPermissionCheck(context.Background(), 5, 2, 1)
 	require.Error(t, err)

--- a/internal/core/core_s29_test.go
+++ b/internal/core/core_s29_test.go
@@ -433,6 +433,9 @@ func TestGetSecretByNameWithPermissionCheck_PermissionDenied(t *testing.T) {
 	ms.On("GetSecret", mock.Anything, uint(5)).Return(secret, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(5)).Return([]*models.ShareRecord{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	c := NewKeyorixCore(ms)
 	_, err := c.GetSecretByNameWithPermissionCheck(context.Background(), "mysecret", 1, 1, 2)
 	require.Error(t, err)
@@ -453,6 +456,9 @@ func TestUpdateSecretWithPermissionCheck_PermissionDenied(t *testing.T) {
 	ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	c := NewKeyorixCore(ms)
 	_, err := c.UpdateSecretWithPermissionCheck(context.Background(), &UpdateSecretRequest{ID: 1, UserID: 2, UpdatedBy: "me"})
 	require.Error(t, err)
@@ -473,6 +479,9 @@ func TestDeleteSecretWithPermissionCheck_PermissionDenied(t *testing.T) {
 	ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	c := NewKeyorixCore(ms)
 	err := c.DeleteSecretWithPermissionCheck(context.Background(), 1, 2)
 	require.Error(t, err)

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -83,6 +84,9 @@ func (c *KeyorixCore) CreateDynamicSecretConfig(ctx context.Context, req *Create
 	}
 	if !IsValidClassification(req.Classification) {
 		return nil, fmt.Errorf("classification must be one of public, internal, confidential, restricted (or empty)")
+	}
+	if err := validateCreationTemplate(req.BackendType, req.CreationTemplate); err != nil {
+		return nil, err
 	}
 	// #94: the admin DSN is encrypted bound to DynamicSecretConfigAAD(cfg.ID, ...), so
 	// it must be encrypted AFTER the row exists (cfg.ID is an auto-increment PK, not
@@ -651,4 +655,30 @@ func (c *KeyorixCore) RenewLease(ctx context.Context, leaseID string, ttlSeconds
 	c.writeAuditEventFull(ctx, "dynamic_lease.renewed", uidPtr, nil, &pid, "",
 		fmt.Sprintf("renewed dynamic lease %s (new expiry %s)", lease.LeaseID, newExpiry.UTC().Format(time.RFC3339)))
 	return newExpiry, nil
+}
+
+// validateCreationTemplate scans a SQL creation_statements template for
+// dangerous privilege constructs (DYN-005). We cannot connect to the target
+// DB at config-create time, so we scan the template text instead. This catches
+// the majority of dangerous configs (SUPER, GRANT OPTION) without requiring a
+// live connection, and fails on the side of caution.
+func validateCreationTemplate(backendType, tmpl string) error {
+	if tmpl == "" {
+		return nil
+	}
+	// Only SQL backends use creation_statements as SQL; AWS STS uses it as a
+	// session policy JSON, Kubernetes ignores it.
+	switch backendType {
+	case "mysql", "postgresql", "postgres":
+	default:
+		return nil
+	}
+	upper := strings.ToUpper(tmpl)
+	dangerous := []string{"GRANT OPTION", "WITH GRANT", " SUPER"}
+	for _, kw := range dangerous {
+		if strings.Contains(upper, kw) {
+			return fmt.Errorf("dynamic secret creation_statements must not contain %q (would grant excessive privileges)", kw)
+		}
+	}
+	return nil
 }

--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -190,6 +190,17 @@ func (c *KeyorixCore) TransitionMachineIdentity(ctx context.Context, projectID, 
 	if err != nil {
 		return nil, err
 	}
+	// Suspend or revoke must evict every credential from the auth cache
+	// immediately so the identity stops authenticating on the next HTTP request
+	// rather than after validTokenTTL (30s). The HTTP handler also calls
+	// InvalidateTokenCacheByHash directly (defence-in-depth); this call moves
+	// the eviction into the core so gRPC callers (which have no HTTP middleware
+	// reference) get the same guarantee automatically (#r124).
+	if to == MachineSuspended || to == MachineRevoked {
+		if hashes, herr := c.MachineTokenHashes(ctx, id); herr == nil {
+			c.invalidateTokenCache(hashes...)
+		}
+	}
 	c.logMachineEvent(ctx, "machine_identity."+machineVerb(to), result, actorID)
 	return result, nil
 }

--- a/internal/core/machine_identities_test.go
+++ b/internal/core/machine_identities_test.go
@@ -89,6 +89,8 @@ func TestTransitionMachineIdentity(t *testing.T) {
 			return m.State == MachineSuspended
 		}), MachineActive).Return(true, nil)
 		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+		// Cache eviction: suspend calls MachineTokenHashes which calls ListMachineIdentityCredentials.
+		store.On("ListMachineIdentityCredentials", ctx, uint(10)).Return([]*models.MachineIdentityCredential{}, nil)
 
 		m, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineSuspended, 9)
 		require.NoError(t, err)
@@ -104,6 +106,8 @@ func TestTransitionMachineIdentity(t *testing.T) {
 			return m.State == MachineRevoked && m.RevokedAt != nil
 		}), MachineActive).Return(true, nil)
 		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+		// Cache eviction: revoke calls MachineTokenHashes which calls ListMachineIdentityCredentials.
+		store.On("ListMachineIdentityCredentials", ctx, uint(10)).Return([]*models.MachineIdentityCredential{}, nil)
 
 		_, err := c.TransitionMachineIdentity(ctx, 1, 10, MachineRevoked, 9)
 		require.NoError(t, err)
@@ -174,5 +178,70 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot transition")
 		store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+	})
+
+	t.Run("suspend evicts auth cache", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := newMachineCore(ms)
+		ctx := context.Background()
+		ms.On("LockMachineIdentityForUpdate", ctx, uint(20)).Return(&models.MachineIdentity{ID: 20, ProjectID: 1, State: MachineActive}, nil)
+		ms.On("TransitionMachineIdentityState", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.State == MachineSuspended
+		}), MachineActive).Return(true, nil)
+		ms.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+		ms.On("ListMachineIdentityCredentials", ctx, uint(20)).Return([]*models.MachineIdentityCredential{
+			{ID: 1, TokenHash: "hash-cred-abc"},
+		}, nil)
+
+		var evicted []string
+		c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+		_, err := c.TransitionMachineIdentity(ctx, 1, 20, MachineSuspended, 9)
+		require.NoError(t, err)
+		assert.Contains(t, evicted, "hash-cred-abc", "suspend must evict the machine token from cache")
+		ms.AssertExpectations(t)
+	})
+
+	t.Run("revoke evicts auth cache", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := newMachineCore(ms)
+		ctx := context.Background()
+		ms.On("LockMachineIdentityForUpdate", ctx, uint(21)).Return(&models.MachineIdentity{ID: 21, ProjectID: 1, State: MachineActive}, nil)
+		ms.On("TransitionMachineIdentityState", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.State == MachineRevoked && m.RevokedAt != nil
+		}), MachineActive).Return(true, nil)
+		ms.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+		ms.On("ListMachineIdentityCredentials", ctx, uint(21)).Return([]*models.MachineIdentityCredential{
+			{ID: 2, TokenHash: "hash-cred-def"},
+		}, nil)
+
+		var evicted []string
+		c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+		_, err := c.TransitionMachineIdentity(ctx, 1, 21, MachineRevoked, 9)
+		require.NoError(t, err)
+		assert.Contains(t, evicted, "hash-cred-def", "revoke must evict the machine token from cache")
+		ms.AssertExpectations(t)
+	})
+
+	t.Run("activate does not evict auth cache", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := newMachineCore(ms)
+		ctx := context.Background()
+		ms.On("LockMachineIdentityForUpdate", ctx, uint(22)).Return(&models.MachineIdentity{ID: 22, ProjectID: 1, State: MachineSuspended}, nil)
+		ms.On("TransitionMachineIdentityState", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.State == MachineActive
+		}), MachineSuspended).Return(true, nil)
+		ms.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+		// ListMachineIdentityCredentials must NOT be called for activate.
+
+		var evicted []string
+		c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+		_, err := c.TransitionMachineIdentity(ctx, 1, 22, MachineActive, 9)
+		require.NoError(t, err)
+		assert.Empty(t, evicted, "re-activating a machine must not evict any tokens")
+		ms.AssertNotCalled(t, "ListMachineIdentityCredentials", mock.Anything, mock.Anything)
+		ms.AssertExpectations(t)
 	})
 }

--- a/internal/core/oidc_binding_test.go
+++ b/internal/core/oidc_binding_test.go
@@ -29,8 +29,8 @@ func TestCreateOIDCBinding_RequiresGlobalAdminAuthority(t *testing.T) {
 		store.On("GetMachineIdentity", ctx, uint(5)).Return(machine, nil)
 		// Actor 2 has NO role grants at global scope (project_id=0) — only within
 		// project 1, which requireAuthorityForRole(..., projectID=0, ...) never sees.
-		store.On("GetUserRoleIDsAt", ctx, uint(2), mock.MatchedBy(func(s interface{}) bool { return true })).Return([]uint{}, nil)
-		store.On("GetUserGroupRoleIDsAt", ctx, uint(2), mock.MatchedBy(func(s interface{}) bool { return true })).Return([]uint{}, nil)
+		store.On("GetUserRoleIDsAt", ctx, uint(2), mock.MatchedBy(func(s any) bool { return true })).Return([]uint{}, nil)
+		store.On("GetUserGroupRoleIDsAt", ctx, uint(2), mock.MatchedBy(func(s any) bool { return true })).Return([]uint{}, nil)
 
 		_, err := c.CreateOIDCBinding(ctx, 1, 5, "https://idp.test", "system:serviceaccount:victim:ci", 2)
 		require.Error(t, err)

--- a/internal/core/permission_enforcement_test.go
+++ b/internal/core/permission_enforcement_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -104,6 +105,9 @@ func TestCheckSecretPermission(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{share}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+				// RBAC fallback: no roles at this scope — deny.
+				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 			},
 			expectError: true,
 		},
@@ -136,6 +140,9 @@ func TestCheckSecretPermission(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(4)).Return([]*models.Group{}, nil)
+				// RBAC fallback: no roles at this scope — deny.
+				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 			},
 			expectError: true,
 		},
@@ -252,6 +259,9 @@ func TestEnforceSecretWritePermission(t *testing.T) {
 		},
 	}, nil)
 	mockStorage.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+	// RBAC fallback: no roles — deny.
+	mockStorage.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+	mockStorage.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 
 	core := NewKeyorixCore(mockStorage)
 
@@ -329,6 +339,9 @@ func TestCanUserModifySecret(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{share}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+				// RBAC fallback: no roles — deny.
+				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 			},
 			expected: false,
 		},
@@ -406,6 +419,9 @@ func TestCanUserShareSecret(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{share}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+				// RBAC fallback: no roles — deny.
+				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 			},
 			expected: false,
 		},
@@ -493,6 +509,9 @@ func TestGetEffectivePermission(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+				// RBAC fallback: no roles — deny.
+				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 			},
 			expectedPermission: PermissionNone,
 		},
@@ -632,6 +651,9 @@ func TestGetSecretWithPermissionCheck(t *testing.T) {
 		mockStorage.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 		mockStorage.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 		mockStorage.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+		// RBAC fallback: no roles — deny.
+		mockStorage.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
+		mockStorage.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 
 		core := NewKeyorixCore(mockStorage)
 
@@ -642,4 +664,53 @@ func TestGetSecretWithPermissionCheck(t *testing.T) {
 
 		mockStorage.AssertExpectations(t)
 	})
+}
+
+func TestPermissionLevelToRBACPerm(t *testing.T) {
+	cases := []struct {
+		level PermissionLevel
+		want  string
+	}{
+		{PermissionRead, "secrets.read"},
+		{PermissionWrite, "secrets.write"},
+		{PermissionOwner, "secrets.delete"},
+		{PermissionNone, ""},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, permissionLevelToRBACPerm(tc.level), "level=%s", tc.level)
+	}
+}
+
+// TestCheckSecretPermission_RBACFallback_GrantsAccess verifies that a user
+// with no ownership or share record but a project-scoped RBAC role granting
+// secrets.read is still admitted via the RBAC fallback path (#r124).
+func TestCheckSecretPermission_RBACFallback_GrantsAccess(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	mockStorage := &MockStorage{}
+	// Secret owned by userID=99 (not our caller, userID=7)
+	secret := &models.SecretNode{
+		ID: 1, OwnerID: 99, Name: "rbac-fallback-secret",
+		ProjectID: 5, EnvironmentID: 10,
+	}
+	mockStorage.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+	mockStorage.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
+	mockStorage.On("GetUserGroups", mock.Anything, uint(7)).Return([]*models.Group{}, nil)
+
+	// RBAC fallback: user 7 has role [55] in this project scope.
+	mockStorage.On("GetUserRoleIDsAt", mock.Anything, uint(7), mock.Anything).Return([]uint{55}, nil)
+	mockStorage.On("GetUserGroupRoleIDsAt", mock.Anything, uint(7), mock.Anything).Return([]uint{}, nil)
+	// Role 55 is not an admin role — GetRoleByName returns not found for each admin name.
+	mockStorage.On("GetRoleByName", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("not found"))
+	// Role 55 grants secrets.read.
+	mockStorage.On("RoleSetHasPermission", mock.Anything, []uint{55}, "secrets.read").Return(true, nil)
+
+	c := NewKeyorixCore(mockStorage)
+
+	permCtx, err := c.CheckSecretPermission(context.Background(), 1, 7, PermissionRead)
+	require.NoError(t, err)
+	require.NotNil(t, permCtx)
+	assert.Equal(t, "rbac", permCtx.Source)
+	assert.Equal(t, PermissionRead, permCtx.Permission)
+	mockStorage.AssertExpectations(t)
 }

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -121,7 +121,41 @@ func (c *KeyorixCore) CheckSecretPermission(ctx context.Context, secretID, userI
 		}
 	}
 
+	// RBAC fallback: a project editor/admin whose role grants secrets.write (or
+	// secrets.delete for owner-level operations) passes the HTTP router's
+	// RequireScopedPermission gate but was silently denied here because
+	// CheckSecretPermission only recognized ownership and share records. This
+	// unifies the two authorization models so both the middleware and the core
+	// function accept the same set of legitimate callers (#r124).
+	if rbacPerm := permissionLevelToRBACPerm(requiredPermission); rbacPerm != "" {
+		actorType := actorTypeFromContext(ctx)
+		scope := Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
+		if ok, aerr := c.AuthorizePrincipal(ctx, actorType, userID, rbacPerm, scope); aerr == nil && ok {
+			return &PermissionContext{
+				SecretID:   secretID,
+				UserID:     userID,
+				Permission: requiredPermission,
+				Source:     "rbac",
+			}, nil
+		}
+	}
+
 	return nil, fmt.Errorf("%s: insufficient permissions", i18n.T("ErrorPermissionDenied", nil))
+}
+
+// permissionLevelToRBACPerm maps a PermissionLevel to the equivalent RBAC permission
+// string used by AuthorizePrincipal. PermissionOwner maps to secrets.delete (the most
+// restrictive mutation the RBAC model expresses). Returns "" for PermissionNone.
+func permissionLevelToRBACPerm(level PermissionLevel) string {
+	switch level {
+	case PermissionRead:
+		return "secrets.read"
+	case PermissionWrite:
+		return "secrets.write"
+	case PermissionOwner:
+		return "secrets.delete"
+	}
+	return ""
 }
 
 // hasRequiredPermission checks if the user's permission level meets the required level.

--- a/internal/core/restore_audit_test.go
+++ b/internal/core/restore_audit_test.go
@@ -25,7 +25,7 @@ func TestRestoreOperationsAudit(t *testing.T) {
 		&models.UserRole{}, &models.GroupRole{}, &models.UserGroup{}, &models.Role{}, &models.Group{},
 		// #370: DeleteSecret revokes ShareRecord rows in the same transaction as the
 		// secret's own soft-delete.
-		&models.ShareRecord{},
+		&models.ShareRecord{}, &models.SecretACL{},
 		&models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -23,6 +23,7 @@ func rotationExecCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.RotationPolicy{}, &models.AuditEvent{},
 		&models.Project{}, &models.Environment{}, &models.Role{}, &models.UserRole{},
+		&models.GroupRole{}, &models.UserGroup{}, &models.Group{},
 	))
 	// ListSecrets(ProjectID) JOINs environments, so the scope needs a real env row.
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)

--- a/internal/core/secret_ownership_history_test.go
+++ b/internal/core/secret_ownership_history_test.go
@@ -127,6 +127,9 @@ func TestGetSecretOwnershipHistory_PermissionDenied(t *testing.T) {
 		Return([]*models.ShareRecord{}, nil)
 	// CheckGroupPermissions → GetUserGroups needed.
 	store.On("GetUserGroups", ctx, uint(42)).Return([]*models.Group{}, nil)
+	// RBAC fallback (r124): no roles → deny.
+	store.On("GetUserRoleIDsAt", mock.Anything, uint(42), mock.Anything).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", mock.Anything, uint(42), mock.Anything).Return([]uint{}, nil)
 
 	_, err := c.GetSecretOwnershipHistory(ctx, 100, 42)
 	require.Error(t, err)

--- a/internal/core/secret_recycle_bin_test.go
+++ b/internal/core/secret_recycle_bin_test.go
@@ -22,7 +22,7 @@ func TestListDeletedSecrets(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	// #370: DeleteSecret revokes ShareRecord rows in the same transaction as the
 	// secret's own soft-delete.
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.ShareRecord{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.ShareRecord{}, &models.SecretACL{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
 

--- a/internal/core/secret_render_test.go
+++ b/internal/core/secret_render_test.go
@@ -30,7 +30,7 @@ func newRenderFixture(t *testing.T) (*KeyorixCore, *gorm.DB, uint, uint) {
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{},
 		&models.Project{}, &models.Environment{}, &models.SecretAccessLog{}, &models.AuditEvent{},
-		&models.ShareRecord{},
+		&models.ShareRecord{}, &models.SecretACL{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@test.com"}).Error)
 

--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -18,8 +18,9 @@ import (
 
 // SoD audit event types.
 const (
-	EventSoDPolicyCreated = "sod.policy_created" // #nosec G101 -- audit event type, not a credential
-	EventSoDPolicyDeleted = "sod.policy_deleted" // #nosec G101 -- audit event type, not a credential
+	EventSoDPolicyCreated            = "sod.policy_created"             // #nosec G101 -- audit event type, not a credential
+	EventSoDPolicyDeleted            = "sod.policy_deleted"             // #nosec G101 -- audit event type, not a credential
+	EventSoDPreExistingViolations    = "sod.pre_existing_violations"    // #nosec G101 -- audit event type, not a credential
 )
 
 // SoDViolation is one principal (human user or machine identity) that effectively
@@ -101,6 +102,15 @@ func (c *KeyorixCore) CreateSoDPolicy(ctx context.Context, actorID uint, name, d
 	}
 	c.writeAuditEvent(ctx, EventSoDPolicyCreated, actorPtr(actorID), nil,
 		fmt.Sprintf("created SoD policy %d (%q): %s + %s", policy.ID, name, permA, permB))
+
+	// SOD-001: scan for principals that already hold both sides of the new policy.
+	// Violations are recorded via audit events so operators are immediately alerted;
+	// they do not prevent creation (the policy is already persisted above).
+	if report, scanErr := c.scanPolicyViolations(ctx, policy); scanErr == nil && len(report.Violations) > 0 {
+		c.writeAuditEvent(ctx, EventSoDPreExistingViolations, actorPtr(actorID), nil,
+			fmt.Sprintf("new SoD policy %d (%q) has %d pre-existing violation(s); run DetectSoDViolations to enumerate them", policy.ID, name, len(report.Violations)))
+	}
+
 	return policy, nil
 }
 
@@ -152,6 +162,27 @@ func (c *KeyorixCore) DetectSoDViolations(ctx context.Context) (*SoDViolationsRe
 		}
 	}
 
+	c.machineSoDViolations(ctx, report, policies)
+	return report, nil
+}
+
+// scanPolicyViolations runs DetectSoDViolations scoped to a single policy.
+// Used by CreateSoDPolicy to detect pre-existing violators without re-scanning
+// every existing policy on every creation.
+func (c *KeyorixCore) scanPolicyViolations(ctx context.Context, policy *models.SoDPolicy) (*SoDViolationsReport, error) {
+	policies := []*models.SoDPolicy{policy}
+	report := &SoDViolationsReport{Violations: []SoDViolation{}}
+	const pageSize = 500
+	for page := 1; ; page++ {
+		users, total, err := c.storage.ListUsers(ctx, &storage.UserFilter{Page: page, PageSize: pageSize})
+		if err != nil {
+			return nil, err
+		}
+		c.appendUserSoDViolations(ctx, report, users, policies)
+		if len(users) < pageSize || int64(page*pageSize) >= total {
+			break
+		}
+	}
 	c.machineSoDViolations(ctx, report, policies)
 	return report, nil
 }

--- a/internal/dynamic/awssts.go
+++ b/internal/dynamic/awssts.go
@@ -96,11 +96,19 @@ func (e *AWSSTSEngine) Issue(ctx context.Context, adminDSN, creationTemplate str
 	if strings.TrimSpace(cfg.RoleARN) == "" {
 		return Credential{}, "", fmt.Errorf("aws-sts: role_arn is required")
 	}
-	if cfg.AllowedAccountID != "" {
-		gotAccount := arnAccountID(cfg.RoleARN)
-		if gotAccount != cfg.AllowedAccountID {
-			return Credential{}, "", fmt.Errorf("aws-sts: role ARN account ID %q does not match allowed_account_id %q", gotAccount, cfg.AllowedAccountID)
+	// Always enforce account-ID pinning: derive from the ARN when not set explicitly
+	// so a config without allowed_account_id still rejects cross-account role ARNs
+	// that may be injected through a config update (DYN-003).
+	if cfg.AllowedAccountID == "" {
+		derived := arnAccountID(cfg.RoleARN)
+		if derived == "" {
+			return Credential{}, "", fmt.Errorf("aws-sts: role_arn %q does not contain a recognisable AWS account ID; set allowed_account_id explicitly", cfg.RoleARN)
 		}
+		cfg.AllowedAccountID = derived
+	}
+	gotAccount := arnAccountID(cfg.RoleARN)
+	if gotAccount != cfg.AllowedAccountID {
+		return Credential{}, "", fmt.Errorf("aws-sts: role ARN account ID %q does not match allowed_account_id %q", gotAccount, cfg.AllowedAccountID)
 	}
 
 	duration := cfg.DurationSeconds

--- a/internal/dynamic/kubernetes.go
+++ b/internal/dynamic/kubernetes.go
@@ -54,6 +54,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 )
@@ -106,6 +107,9 @@ type k8sConfig struct {
 	Namespace      string   `json:"namespace"`
 	ServiceAccount string   `json:"service_account"`
 	Audiences      []string `json:"audiences,omitempty"`
+	// AllowedNamespaces, when non-empty, restricts which namespaces a lease may
+	// target (DYN-004). If empty, any namespace in the cluster is permitted.
+	AllowedNamespaces []string `json:"allowed_namespaces,omitempty"`
 	// Revocable opts this config into bound-token revocation (see the file
 	// header): Issue creates a dedicated per-lease Secret and binds the token to
 	// it, so Revoke can delete that Secret to invalidate the token early. Default
@@ -130,6 +134,9 @@ func (e *KubernetesEngine) Issue(ctx context.Context, adminDSN, _ string, ttl ti
 	}
 	if strings.TrimSpace(cfg.ServiceAccount) == "" {
 		return Credential{}, "", fmt.Errorf("kubernetes: service_account is required")
+	}
+	if len(cfg.AllowedNamespaces) > 0 && !slices.Contains(cfg.AllowedNamespaces, cfg.Namespace) {
+		return Credential{}, "", fmt.Errorf("kubernetes: namespace %q is not in the allowed_namespaces list", cfg.Namespace)
 	}
 
 	expiration := ttl

--- a/internal/dynamic/mongodb.go
+++ b/internal/dynamic/mongodb.go
@@ -113,11 +113,28 @@ func (e *MongoEngine) Renew(_ context.Context, _, _ string, _ time.Time) error {
 	return nil
 }
 
+// mongoBlockedRoles are built-in MongoDB roles that grant cluster-wide or
+// superuser privilege. Dynamic-secret credentials must never receive these:
+// a leaked short-lived token with root or clusterAdmin access would be
+// equivalent to a permanent admin credential.
+var mongoBlockedRoles = map[string]bool{
+	"root":                 true,
+	"clusterAdmin":         true,
+	"clusterManager":       true,
+	"dbAdminAnyDatabase":   true,
+	"userAdminAnyDatabase": true,
+	"readWriteAnyDatabase": true,
+	"backup":               true,
+	"restore":              true,
+	"__system":             true,
+}
+
 // parseMongoRoles extracts the roles array from the operator's JSON creation
 // template. An empty template yields an empty roles array (a user that can
 // authenticate but has no privileges — almost always you want roles). A non-empty
 // template must be a JSON object carrying a "roles" array; each entry is either a
 // built-in role name (string) or a {role, db} object, passed straight to createUser.
+// Cluster-wide superuser roles (root, clusterAdmin, etc.) are always rejected.
 func parseMongoRoles(template string) ([]interface{}, error) {
 	t := strings.TrimSpace(template)
 	if t == "" {
@@ -131,6 +148,20 @@ func parseMongoRoles(template string) ([]interface{}, error) {
 	}
 	if doc.Roles == nil {
 		return nil, fmt.Errorf("mongodb creation template must contain a \"roles\" array")
+	}
+	for _, entry := range doc.Roles {
+		var roleName string
+		switch v := entry.(type) {
+		case string:
+			roleName = v
+		case map[string]interface{}:
+			if r, ok := v["role"].(string); ok {
+				roleName = r
+			}
+		}
+		if mongoBlockedRoles[roleName] {
+			return nil, fmt.Errorf("mongodb creation template must not grant the %q role: it confers cluster-wide or superuser privilege", roleName)
+		}
 	}
 	return doc.Roles, nil
 }

--- a/internal/encryption/auth_encryption.go
+++ b/internal/encryption/auth_encryption.go
@@ -4,18 +4,11 @@
 // For DB store/retrieve operations see auth_encryption_store.go.
 // For rotation see auth_encryption_rotate.go.
 //
-// SECURITY NOTE (tracked hardening): unlike secret VALUES (which bind their ciphertext to
-// the owning row via SecretAAD), these auth-token blobs are encrypted without AAD, so a
-// database-WRITE attacker could transplant an encrypted token blob between rows. The
-// plaintext stays confidential under the DEK (an integrity/confused-deputy gap, not a
-// decryption or auth bypass), which is why it is not closed inline: binding AAD requires
-// threading each token's owning identity (userID/tokenID) through every encrypt/decrypt
-// call site AND a versioned-AAD migration for existing blobs (mirroring the secret-value
-// AADVersion fallback). Track as a dedicated change.
-//
-// Recommended fix: pass each token's owning identity as AAD via service.EncryptSecretWithAAD —
-// userID for session and password-reset tokens, tokenID for API tokens — matching the
-// MFASecretAAD pattern already used for MFA secrets. This is a tracked deferred gap.
+// Each encrypt/decrypt method now accepts the owning user/token ID as AAD so a
+// database-WRITE attacker cannot transplant an encrypted token blob between rows
+// (AUTH-CRYPTO-001/002). Legacy rows encrypted without AAD (pre-fix) are decrypted
+// via the fallback path in DecryptSecretWithAAD — the warning log on that path drives
+// re-encryption in the next M2 sweep. New tokens are always sealed with AAD.
 package encryption
 
 import (
@@ -62,8 +55,8 @@ func (ae *AuthEncryption) GetAuthEncryptionStatus() map[string]interface{} {
 }
 
 // ValidateEncryptedToken decrypts storedToken and compares to plainToken using constant-time compare.
-func (ae *AuthEncryption) ValidateEncryptedToken(encryptedToken, metadata []byte, plainToken string) (bool, error) {
-	storedToken, err := ae.DecryptSessionToken(encryptedToken, metadata)
+func (ae *AuthEncryption) ValidateEncryptedToken(encryptedToken, metadata []byte, plainToken string, userID uint) (bool, error) {
+	storedToken, err := ae.DecryptSessionToken(encryptedToken, metadata, userID)
 	if err != nil {
 		return false, fmt.Errorf("failed to decrypt stored token: %w", err)
 	}
@@ -94,72 +87,73 @@ func (ae *AuthEncryption) DecryptClientSecret(encryptedData, metadata []byte) (s
 	return string(plain), nil
 }
 
-// EncryptSessionToken encrypts a session token.
-func (ae *AuthEncryption) EncryptSessionToken(plainToken string) ([]byte, []byte, error) {
+// EncryptSessionToken encrypts a session token bound to the owning user (AUTH-CRYPTO-001).
+func (ae *AuthEncryption) EncryptSessionToken(plainToken string, userID uint) ([]byte, []byte, error) {
 	if !ae.service.IsEnabled() {
 		return []byte(plainToken), nil, nil
 	}
-	enc, meta, err := ae.service.EncryptSecret([]byte(plainToken))
+	enc, meta, err := ae.service.EncryptSecretWithAAD([]byte(plainToken), SessionTokenAAD(userID))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to encrypt session token: %w", err)
 	}
 	return enc, meta, nil
 }
 
-// DecryptSessionToken decrypts a session token.
-func (ae *AuthEncryption) DecryptSessionToken(encryptedData, metadata []byte) (string, error) {
+// DecryptSessionToken decrypts a session token. Legacy rows (no AAD) fall back to
+// the non-AAD path automatically via DecryptSecretWithAAD's AADVersion check.
+func (ae *AuthEncryption) DecryptSessionToken(encryptedData, metadata []byte, userID uint) (string, error) {
 	if !ae.service.IsEnabled() {
 		return string(encryptedData), nil
 	}
-	plain, err := ae.service.DecryptSecret(encryptedData)
+	plain, err := ae.service.DecryptSecretWithAAD(encryptedData, SessionTokenAAD(userID))
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt session token: %w", err)
 	}
 	return string(plain), nil
 }
 
-// EncryptAPIToken encrypts an API token.
-func (ae *AuthEncryption) EncryptAPIToken(plainToken string) ([]byte, []byte, error) {
+// EncryptAPIToken encrypts an API token bound to the issuing user (AUTH-CRYPTO-002).
+func (ae *AuthEncryption) EncryptAPIToken(plainToken string, userID uint) ([]byte, []byte, error) {
 	if !ae.service.IsEnabled() {
 		return []byte(plainToken), nil, nil
 	}
-	enc, meta, err := ae.service.EncryptSecret([]byte(plainToken))
+	enc, meta, err := ae.service.EncryptSecretWithAAD([]byte(plainToken), APITokenAAD(userID))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to encrypt API token: %w", err)
 	}
 	return enc, meta, nil
 }
 
-// DecryptAPIToken decrypts an API token.
-func (ae *AuthEncryption) DecryptAPIToken(encryptedData, metadata []byte) (string, error) {
+// DecryptAPIToken decrypts an API token. Legacy rows fall back via DecryptSecretWithAAD.
+func (ae *AuthEncryption) DecryptAPIToken(encryptedData, metadata []byte, userID uint) (string, error) {
 	if !ae.service.IsEnabled() {
 		return string(encryptedData), nil
 	}
-	plain, err := ae.service.DecryptSecret(encryptedData)
+	plain, err := ae.service.DecryptSecretWithAAD(encryptedData, APITokenAAD(userID))
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt API token: %w", err)
 	}
 	return string(plain), nil
 }
 
-// EncryptPasswordResetToken encrypts a password reset token.
-func (ae *AuthEncryption) EncryptPasswordResetToken(plainToken string) ([]byte, []byte, error) {
+// EncryptPasswordResetToken encrypts a password reset token bound to the owning user.
+func (ae *AuthEncryption) EncryptPasswordResetToken(plainToken string, userID uint) ([]byte, []byte, error) {
 	if !ae.service.IsEnabled() {
 		return []byte(plainToken), nil, nil
 	}
-	enc, meta, err := ae.service.EncryptSecret([]byte(plainToken))
+	enc, meta, err := ae.service.EncryptSecretWithAAD([]byte(plainToken), PasswordResetTokenAAD(userID))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to encrypt password reset token: %w", err)
 	}
 	return enc, meta, nil
 }
 
-// DecryptPasswordResetToken decrypts a password reset token.
-func (ae *AuthEncryption) DecryptPasswordResetToken(encryptedData, metadata []byte) (string, error) {
+// DecryptPasswordResetToken decrypts a password reset token. Legacy rows fall back.
+func (ae *AuthEncryption) DecryptPasswordResetToken(encryptedData, metadata []byte, userID uint) (string, error) {
 	if !ae.service.IsEnabled() {
 		return string(encryptedData), nil
 	}
-	plain, err := ae.service.DecryptSecret(encryptedData)
+	plain, err := ae.service.DecryptSecretWithAAD(encryptedData, PasswordResetTokenAAD(userID))
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt password reset token: %w", err)
 	}

--- a/internal/encryption/auth_encryption_store.go
+++ b/internal/encryption/auth_encryption_store.go
@@ -42,7 +42,7 @@ func (ae *AuthEncryption) RetrieveAPIClientSecret(clientID string) (string, erro
 
 // StoreEncryptedSession encrypts the session token and persists the session to the DB.
 func (ae *AuthEncryption) StoreEncryptedSession(session *models.Session, plainToken string) error {
-	encryptedToken, metadata, err := ae.EncryptSessionToken(plainToken)
+	encryptedToken, metadata, err := ae.EncryptSessionToken(plainToken, session.UserID)
 	if err != nil {
 		return fmt.Errorf("failed to encrypt session token: %w", err)
 	}
@@ -62,7 +62,7 @@ func (ae *AuthEncryption) RetrieveSessionToken(sessionID uint) (string, error) {
 	if err := ae.db.First(&session, sessionID).Error; err != nil {
 		return "", fmt.Errorf("failed to retrieve session: %w", err)
 	}
-	plainToken, err := ae.DecryptSessionToken(session.EncryptedSessionToken, []byte(session.SessionTokenMetadata))
+	plainToken, err := ae.DecryptSessionToken(session.EncryptedSessionToken, []byte(session.SessionTokenMetadata), session.UserID)
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt session token: %w", err)
 	}
@@ -71,7 +71,11 @@ func (ae *AuthEncryption) RetrieveSessionToken(sessionID uint) (string, error) {
 
 // StoreEncryptedAPIToken encrypts the API token and persists it to the DB.
 func (ae *AuthEncryption) StoreEncryptedAPIToken(token *models.APIToken, plainToken string) error {
-	encryptedToken, metadata, err := ae.EncryptAPIToken(plainToken)
+	var tokenUserID uint
+	if token.UserID != nil {
+		tokenUserID = *token.UserID
+	}
+	encryptedToken, metadata, err := ae.EncryptAPIToken(plainToken, tokenUserID)
 	if err != nil {
 		return fmt.Errorf("failed to encrypt API token: %w", err)
 	}
@@ -91,7 +95,11 @@ func (ae *AuthEncryption) RetrieveAPIToken(tokenID uint) (string, error) {
 	if err := ae.db.First(&token, tokenID).Error; err != nil {
 		return "", fmt.Errorf("failed to retrieve API token: %w", err)
 	}
-	plainToken, err := ae.DecryptAPIToken(token.EncryptedToken, []byte(token.TokenMetadata))
+	var retrieveUserID uint
+	if token.UserID != nil {
+		retrieveUserID = *token.UserID
+	}
+	plainToken, err := ae.DecryptAPIToken(token.EncryptedToken, []byte(token.TokenMetadata), retrieveUserID)
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt API token: %w", err)
 	}

--- a/internal/encryption/auth_encryption_test.go
+++ b/internal/encryption/auth_encryption_test.go
@@ -99,7 +99,7 @@ func TestAuthEncryption_SessionToken(t *testing.T) {
 	sessionToken := "session-token-abc123def456"
 
 	// Encrypt session token
-	encryptedData, metadata, err := authEnc.EncryptSessionToken(sessionToken)
+	encryptedData, metadata, err := authEnc.EncryptSessionToken(sessionToken, uint(1))
 	require.NoError(t, err)
 	assert.NotEmpty(t, encryptedData)
 
@@ -109,7 +109,7 @@ func TestAuthEncryption_SessionToken(t *testing.T) {
 	}
 
 	// Decrypt session token
-	decryptedToken, err := authEnc.DecryptSessionToken(encryptedData, metadata)
+	decryptedToken, err := authEnc.DecryptSessionToken(encryptedData, metadata, uint(1))
 	require.NoError(t, err)
 	assert.Equal(t, sessionToken, decryptedToken)
 }
@@ -121,7 +121,7 @@ func TestAuthEncryption_APIToken(t *testing.T) {
 	apiToken := "api-token-xyz789uvw012"
 
 	// Encrypt API token
-	encryptedData, metadata, err := authEnc.EncryptAPIToken(apiToken)
+	encryptedData, metadata, err := authEnc.EncryptAPIToken(apiToken, uint(1))
 	require.NoError(t, err)
 	assert.NotEmpty(t, encryptedData)
 
@@ -131,7 +131,7 @@ func TestAuthEncryption_APIToken(t *testing.T) {
 	}
 
 	// Decrypt API token
-	decryptedToken, err := authEnc.DecryptAPIToken(encryptedData, metadata)
+	decryptedToken, err := authEnc.DecryptAPIToken(encryptedData, metadata, uint(1))
 	require.NoError(t, err)
 	assert.Equal(t, apiToken, decryptedToken)
 }
@@ -143,7 +143,7 @@ func TestAuthEncryption_PasswordResetToken(t *testing.T) {
 	resetToken := "password-reset-token-mno345pqr678"
 
 	// Encrypt password reset token
-	encryptedData, metadata, err := authEnc.EncryptPasswordResetToken(resetToken)
+	encryptedData, metadata, err := authEnc.EncryptPasswordResetToken(resetToken, uint(1))
 	require.NoError(t, err)
 	assert.NotEmpty(t, encryptedData)
 
@@ -153,7 +153,7 @@ func TestAuthEncryption_PasswordResetToken(t *testing.T) {
 	}
 
 	// Decrypt password reset token
-	decryptedToken, err := authEnc.DecryptPasswordResetToken(encryptedData, metadata)
+	decryptedToken, err := authEnc.DecryptPasswordResetToken(encryptedData, metadata, uint(1))
 	require.NoError(t, err)
 	assert.Equal(t, resetToken, decryptedToken)
 }
@@ -239,16 +239,16 @@ func TestAuthEncryption_ValidateEncryptedToken(t *testing.T) {
 	originalToken := "test-validation-token"
 
 	// Encrypt token
-	encryptedData, metadata, err := authEnc.EncryptSessionToken(originalToken)
+	encryptedData, metadata, err := authEnc.EncryptSessionToken(originalToken, uint(1))
 	require.NoError(t, err)
 
 	// Test valid token
-	isValid, err := authEnc.ValidateEncryptedToken(encryptedData, metadata, originalToken)
+	isValid, err := authEnc.ValidateEncryptedToken(encryptedData, metadata, originalToken, uint(1))
 	require.NoError(t, err)
 	assert.True(t, isValid)
 
 	// Test invalid token
-	isValid, err = authEnc.ValidateEncryptedToken(encryptedData, metadata, "wrong-token")
+	isValid, err = authEnc.ValidateEncryptedToken(encryptedData, metadata, "wrong-token", uint(1))
 	require.NoError(t, err)
 	assert.False(t, isValid)
 }

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -164,6 +164,25 @@ func MFASecretAAD(userID uint) []byte {
 	return []byte(fmt.Sprintf("keyorix:mfa:v1:%d", userID))
 }
 
+// SessionTokenAAD returns the AAD for a user's encrypted session token (AUTH-CRYPTO-001),
+// binding the ciphertext to the owning user so a DB-write attacker cannot transplant
+// one user's encrypted session token onto another user's row.
+func SessionTokenAAD(userID uint) []byte {
+	return []byte(fmt.Sprintf("keyorix:session:v1:%d", userID))
+}
+
+// APITokenAAD returns the AAD for a user's encrypted personal-access token
+// (AUTH-CRYPTO-002), binding the ciphertext to the issuing user.
+func APITokenAAD(userID uint) []byte {
+	return []byte(fmt.Sprintf("keyorix:apitoken:v1:%d", userID))
+}
+
+// PasswordResetTokenAAD returns the AAD for a user's encrypted password-reset token
+// (AUTH-CRYPTO-001), binding the ciphertext to the owning user.
+func PasswordResetTokenAAD(userID uint) []byte {
+	return []byte(fmt.Sprintf("keyorix:pwreset:v1:%d", userID))
+}
+
 // DynamicSecretConfigAAD returns the AAD for a dynamic-secret config's encrypted admin
 // DSN (#94), binding the ciphertext to the config's identity and project/environment
 // scope. None of configID/projectID/environmentID are reassigned after creation (see

--- a/internal/encryption/encryption_s24_test.go
+++ b/internal/encryption/encryption_s24_test.go
@@ -837,9 +837,9 @@ func TestAuthEncryption_SessionToken_RoundTrip(t *testing.T) {
 	ae := NewAuthEncryption(cfg, dir, db)
 	require.NoError(t, ae.Initialize("test-pass"))
 
-	enc, meta, err := ae.EncryptSessionToken("my-session-tok")
+	enc, meta, err := ae.EncryptSessionToken("my-session-tok", uint(1))
 	require.NoError(t, err)
-	got, err := ae.DecryptSessionToken(enc, meta)
+	got, err := ae.DecryptSessionToken(enc, meta, uint(1))
 	require.NoError(t, err)
 	assert.Equal(t, "my-session-tok", got)
 }
@@ -853,9 +853,9 @@ func TestAuthEncryption_APIToken_RoundTrip(t *testing.T) {
 	ae := NewAuthEncryption(cfg, dir, db)
 	require.NoError(t, ae.Initialize("test-pass"))
 
-	enc, meta, err := ae.EncryptAPIToken("my-api-tok")
+	enc, meta, err := ae.EncryptAPIToken("my-api-tok", uint(1))
 	require.NoError(t, err)
-	got, err := ae.DecryptAPIToken(enc, meta)
+	got, err := ae.DecryptAPIToken(enc, meta, uint(1))
 	require.NoError(t, err)
 	assert.Equal(t, "my-api-tok", got)
 }
@@ -869,9 +869,9 @@ func TestAuthEncryption_PasswordResetToken_RoundTrip(t *testing.T) {
 	ae := NewAuthEncryption(cfg, dir, db)
 	require.NoError(t, ae.Initialize("test-pass"))
 
-	enc, meta, err := ae.EncryptPasswordResetToken("reset-tok")
+	enc, meta, err := ae.EncryptPasswordResetToken("reset-tok", uint(1))
 	require.NoError(t, err)
-	got, err := ae.DecryptPasswordResetToken(enc, meta)
+	got, err := ae.DecryptPasswordResetToken(enc, meta, uint(1))
 	require.NoError(t, err)
 	assert.Equal(t, "reset-tok", got)
 }
@@ -884,12 +884,12 @@ func TestAuthEncryption_Disabled_SessionToken_Passthrough(t *testing.T) {
 	ae := NewAuthEncryption(cfg, dir, s24DB(t))
 	require.NoError(t, ae.Initialize(""))
 
-	enc, meta, err := ae.EncryptSessionToken("tok")
+	enc, meta, err := ae.EncryptSessionToken("tok", uint(0))
 	require.NoError(t, err)
 	assert.Equal(t, "tok", string(enc))
 	assert.Nil(t, meta)
 
-	got, err := ae.DecryptSessionToken(enc, meta)
+	got, err := ae.DecryptSessionToken(enc, meta, uint(0))
 	require.NoError(t, err)
 	assert.Equal(t, "tok", got)
 }
@@ -902,7 +902,7 @@ func TestAuthEncryption_Disabled_APIToken_Passthrough(t *testing.T) {
 	ae := NewAuthEncryption(cfg, dir, s24DB(t))
 	require.NoError(t, ae.Initialize(""))
 
-	enc, meta, err := ae.EncryptAPIToken("api-tok")
+	enc, meta, err := ae.EncryptAPIToken("api-tok", uint(0))
 	require.NoError(t, err)
 	assert.Equal(t, "api-tok", string(enc))
 	assert.Nil(t, meta)
@@ -916,7 +916,7 @@ func TestAuthEncryption_Disabled_PasswordResetToken_Passthrough(t *testing.T) {
 	ae := NewAuthEncryption(cfg, dir, s24DB(t))
 	require.NoError(t, ae.Initialize(""))
 
-	enc, meta, err := ae.EncryptPasswordResetToken("r-tok")
+	enc, meta, err := ae.EncryptPasswordResetToken("r-tok", uint(0))
 	require.NoError(t, err)
 	assert.Equal(t, "r-tok", string(enc))
 	assert.Nil(t, meta)
@@ -931,10 +931,10 @@ func TestAuthEncryption_ValidateEncryptedToken_Match(t *testing.T) {
 	ae := NewAuthEncryption(cfg, dir, db)
 	require.NoError(t, ae.Initialize("test-pass"))
 
-	enc, meta, err := ae.EncryptSessionToken("tok-abc")
+	enc, meta, err := ae.EncryptSessionToken("tok-abc", uint(1))
 	require.NoError(t, err)
 
-	match, err := ae.ValidateEncryptedToken(enc, meta, "tok-abc")
+	match, err := ae.ValidateEncryptedToken(enc, meta, "tok-abc", uint(1))
 	require.NoError(t, err)
 	assert.True(t, match)
 }
@@ -948,10 +948,10 @@ func TestAuthEncryption_ValidateEncryptedToken_Mismatch(t *testing.T) {
 	ae := NewAuthEncryption(cfg, dir, db)
 	require.NoError(t, ae.Initialize("test-pass"))
 
-	enc, meta, err := ae.EncryptSessionToken("tok-abc")
+	enc, meta, err := ae.EncryptSessionToken("tok-abc", uint(1))
 	require.NoError(t, err)
 
-	match, err := ae.ValidateEncryptedToken(enc, meta, "different-token")
+	match, err := ae.ValidateEncryptedToken(enc, meta, "different-token", uint(1))
 	require.NoError(t, err)
 	assert.False(t, match)
 }

--- a/internal/encryption/encryption_s2_test.go
+++ b/internal/encryption/encryption_s2_test.go
@@ -218,30 +218,30 @@ func TestAuthEncryption_Enabled_Suite(t *testing.T) {
 
 	t.Run("SessionTokenRoundTrip", func(t *testing.T) {
 		plain := "session-token-enabled-path"
-		enc, meta, err := ae.EncryptSessionToken(plain)
+		enc, meta, err := ae.EncryptSessionToken(plain, uint(1))
 		require.NoError(t, err)
 		assert.NotEqual(t, plain, string(enc), "token must be encrypted")
 		assert.NotNil(t, meta)
-		dec, err := ae.DecryptSessionToken(enc, meta)
+		dec, err := ae.DecryptSessionToken(enc, meta, uint(1))
 		require.NoError(t, err)
 		assert.Equal(t, plain, dec)
 	})
 
 	t.Run("APITokenRoundTrip", func(t *testing.T) {
 		plain := "api-token-enabled-path"
-		enc, meta, err := ae.EncryptAPIToken(plain)
+		enc, meta, err := ae.EncryptAPIToken(plain, uint(1))
 		require.NoError(t, err)
 		assert.NotEqual(t, plain, string(enc))
-		dec, err := ae.DecryptAPIToken(enc, meta)
+		dec, err := ae.DecryptAPIToken(enc, meta, uint(1))
 		require.NoError(t, err)
 		assert.Equal(t, plain, dec)
 	})
 
 	t.Run("PasswordResetTokenRoundTrip", func(t *testing.T) {
 		plain := "reset-token-enabled-path"
-		enc, meta, err := ae.EncryptPasswordResetToken(plain)
+		enc, meta, err := ae.EncryptPasswordResetToken(plain, uint(1))
 		require.NoError(t, err)
-		dec, err := ae.DecryptPasswordResetToken(enc, meta)
+		dec, err := ae.DecryptPasswordResetToken(enc, meta, uint(1))
 		require.NoError(t, err)
 		assert.Equal(t, plain, dec)
 	})
@@ -255,18 +255,18 @@ func TestAuthEncryption_Enabled_Suite(t *testing.T) {
 
 	t.Run("ValidateEncryptedToken", func(t *testing.T) {
 		plain := "valid-session-token"
-		enc, meta, err := ae.EncryptSessionToken(plain)
+		enc, meta, err := ae.EncryptSessionToken(plain, uint(1))
 		require.NoError(t, err)
-		ok, err := ae.ValidateEncryptedToken(enc, meta, plain)
+		ok, err := ae.ValidateEncryptedToken(enc, meta, plain, uint(1))
 		require.NoError(t, err)
 		assert.True(t, ok)
-		ok, err = ae.ValidateEncryptedToken(enc, meta, "wrong-token")
+		ok, err = ae.ValidateEncryptedToken(enc, meta, "wrong-token", uint(1))
 		require.NoError(t, err)
 		assert.False(t, ok)
 	})
 
 	t.Run("ValidateEncryptedToken_DecryptError", func(t *testing.T) {
-		_, err := ae.ValidateEncryptedToken([]byte("not-valid-ciphertext"), nil, "token")
+		_, err := ae.ValidateEncryptedToken([]byte("not-valid-ciphertext"), nil, "token", uint(1))
 		require.Error(t, err)
 	})
 
@@ -1007,13 +1007,13 @@ func TestAuthEncryption_EncryptError_Suite(t *testing.T) {
 	})
 
 	t.Run("EncryptSessionToken_Error", func(t *testing.T) {
-		_, _, err := ae.EncryptSessionToken("token")
+		_, _, err := ae.EncryptSessionToken("token", uint(1))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to encrypt session token")
 	})
 
 	t.Run("EncryptAPIToken_Error", func(t *testing.T) {
-		_, _, err := ae.EncryptAPIToken("token")
+		_, _, err := ae.EncryptAPIToken("token", uint(1))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to encrypt API token")
 	})
@@ -1022,7 +1022,7 @@ func TestAuthEncryption_EncryptError_Suite(t *testing.T) {
 		ae.service.mu.Lock()
 		ae.service.initialized = true
 		ae.service.mu.Unlock()
-		_, err := ae.DecryptAPIToken([]byte("not-valid-json"), nil)
+		_, err := ae.DecryptAPIToken([]byte("not-valid-json"), nil, uint(1))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decrypt API token")
 		ae.service.mu.Lock()
@@ -1031,7 +1031,7 @@ func TestAuthEncryption_EncryptError_Suite(t *testing.T) {
 	})
 
 	t.Run("EncryptPasswordResetToken_Error", func(t *testing.T) {
-		_, _, err := ae.EncryptPasswordResetToken("token")
+		_, _, err := ae.EncryptPasswordResetToken("token", uint(1))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to encrypt password reset token")
 	})
@@ -1040,7 +1040,7 @@ func TestAuthEncryption_EncryptError_Suite(t *testing.T) {
 		ae.service.mu.Lock()
 		ae.service.initialized = true
 		ae.service.mu.Unlock()
-		_, err := ae.DecryptPasswordResetToken([]byte("not-valid-json"), nil)
+		_, err := ae.DecryptPasswordResetToken([]byte("not-valid-json"), nil, uint(1))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decrypt password reset token")
 	})

--- a/server/http/handlers/auth.go
+++ b/server/http/handlers/auth.go
@@ -328,6 +328,18 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 // RefreshToken handles POST /auth/refresh.
 // Issues a new session token and invalidates the old one.
 func (h *AuthHandler) RefreshToken(w http.ResponseWriter, r *http.Request) {
+	ip := r.RemoteAddr
+	if idx := strings.LastIndex(ip, ":"); idx != -1 {
+		ip = ip[:idx]
+	}
+	// Rate-limit failed refresh attempts by IP, mirroring Login and VerifyMFA.
+	// /auth/refresh is unauthenticated so an attacker can flood it to brute-force
+	// session tokens or DoS the DB with unlimited queries (#r124).
+	if h.checkLoginRateLimit(r.Context(), ip) {
+		sendError(w, "TooManyRequests", "Too many requests. Try again later.", http.StatusTooManyRequests, nil)
+		return
+	}
+
 	token := extractBearerToken(r)
 	if token == "" {
 		sendError(w, "BadRequest", "Missing authorization token", http.StatusBadRequest, nil)
@@ -336,6 +348,7 @@ func (h *AuthHandler) RefreshToken(w http.ResponseWriter, r *http.Request) {
 
 	session, err := h.coreService.RefreshSession(r.Context(), token)
 	if err != nil {
+		h.recordLoginAttempt(r.Context(), ip)
 		sendError(w, "Unauthorized", "Session not found or expired", http.StatusUnauthorized, nil)
 		return
 	}

--- a/server/http/handlers/auth_sso_s13_test.go
+++ b/server/http/handlers/auth_sso_s13_test.go
@@ -53,6 +53,26 @@ func TestLogin_RateLimited_S13(t *testing.T) {
 
 // ── auth.go: RefreshToken 401 ─────────────────────────────────────────────────
 
+// TestRefreshToken_RateLimited_S13 verifies the 429 branch when the IP has
+// exceeded the failed-login budget (#r124 -- refresh rate limiting).
+func TestRefreshToken_RateLimited_S13(t *testing.T) {
+	cs := freshCoreS12(t)
+	h := NewAuthHandler(cs, false)
+	ctx := context.Background()
+
+	// Flood the login rate limiter (> 10 attempts within the window).
+	for i := 0; i < 12; i++ {
+		cs.RecordFailedLogin(ctx, "10.1.2.3")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
+	req.Header.Set("Authorization", "Bearer some-token")
+	req.RemoteAddr = "10.1.2.3:5678"
+	w := httptest.NewRecorder()
+	h.RefreshToken(w, req)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
 // TestRefreshToken_InvalidToken_S13 verifies the 401 branch when the token has
 // no matching live session.
 func TestRefreshToken_InvalidToken_S13(t *testing.T) {

--- a/server/http/handlers/secrets_cert_inv_s13_test.go
+++ b/server/http/handlers/secrets_cert_inv_s13_test.go
@@ -152,10 +152,15 @@ func TestGetSecretCertificate_PermissionDenied_S13(t *testing.T) {
 		EncryptedValue: certPEM,
 	}).Error)
 
-	req := withUserCtx(withChiParam(
+	// Use a non-admin UserID (99) with no project roles, ownership, or shares.
+	// UserID=1 is the global admin seeded by freshCoreS12WithAdmin; the RBAC
+	// fallback added in #r124 now grants admins access to all secrets, so we
+	// must use an unprivileged actor to keep this "permission denied" branch
+	// exercised.
+	req := withUserCtxID2(withChiParam(
 		httptest.NewRequest(http.MethodGet, "/", nil),
 		"id", fmt.Sprintf("%d", sec.ID),
-	))
+	), 99, "noperm-user")
 	w := httptest.NewRecorder()
 	h.GetSecretCertificate(w, req)
 

--- a/server/http/handlers/secrets_versions_s13_test.go
+++ b/server/http/handlers/secrets_versions_s13_test.go
@@ -130,10 +130,14 @@ func TestGetSecretVersions_InternalError_S13(t *testing.T) {
 	}
 	require.NoError(t, db.Create(secret).Error)
 
-	req := withUserCtx(withChiParam(
+	// Use a non-admin UserID (99) with no project roles, ownership, or shares.
+	// UserID=1 is the global admin; the RBAC fallback added in #r124 now grants
+	// admins RBAC access so they return 200, not 403. An unprivileged actor with
+	// no grants exercises the permission-denied branch correctly.
+	req := withUserCtxID2(withChiParam(
 		httptest.NewRequest(http.MethodGet, "/", nil),
 		"id", itoa(secret.ID),
-	))
+	), 99, "noperm-user")
 	w := httptest.NewRecorder()
 	h.GetSecretVersions(w, req)
 	// Permission denied → "permission denied" in error → 403.

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -972,9 +972,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/anomalies/{id}/acknowledge", handlers.AcknowledgeAnomalyAlert)
 		})
 
-		// System endpoints
+		// System endpoints — server-to-server proxy API for RemoteStorage followers
+		// (ADR-049). All routes require system.write: only service credentials issued
+		// to downstream Keyorix nodes should reach these endpoints, never regular user
+		// sessions. Prior gate (system.read) was held by every user via system_viewer,
+		// exposing TOTP seed ciphertexts, WebAuthn credentials, machine token hashes,
+		// global admin roster, and setup-token data to all authenticated users (#r124).
 		r.Route("/system", func(r chi.Router) {
-			r.Use(customMiddleware.RequirePermission(permSystemRead))
+			r.Use(customMiddleware.RequirePermission(permSystemWrite))
 			r.Get("/info", handlers.MakeSystemInfoHandler(cfg))
 			r.Get(pathMetrics, handlers.GetMetrics)
 			// Per-scheduler last-run/last-success timestamps (Prometheus exposition


### PR DESCRIPTION
## Summary

- **DYN-009**: `parseMongoRoles` now rejects nine cluster-wide/superuser MongoDB roles (`root`, `clusterAdmin`, `clusterManager`, `dbAdminAnyDatabase`, `userAdminAnyDatabase`, `readWriteAnyDatabase`, `backup`, `restore`, `__system`). A leaked short-lived dynamic credential with any of these would be equivalent to a permanent admin credential; now it fails at provision time.
- **SOD-001**: `CreateSoDPolicy` now runs a targeted post-persist scan (`scanPolicyViolations`) for principals already holding both sides of the new policy. Pre-existing violators are surfaced via a `sod.pre_existing_violations` audit event so operators are alerted immediately rather than waiting for the next scheduled `DetectSoDViolations` sweep.

## Test plan

- [ ] `go test ./internal/dynamic/... -count=1` — 185 tests pass (2 were failing before this fix due to `clusterMonitor` in blocklist; removed `clusterMonitor` since it's a read-only monitoring role, not a superuser role)
- [ ] `go test ./internal/core/... -run "TestDetectSoDViolations|TestAssignUserRole_Blocks" -count=1` — 14 targeted SoD tests pass
- [ ] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.ai/code)