### PR TITLE
refactor: reduce cognitive complexity in 8 methods to satisfy SonarCloud

### DIFF
--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -193,7 +193,58 @@ func (c *KeyorixCore) GetAccessReviewCampaign(ctx context.Context, projectID, ca
 // DecideAccessReviewItem records a reviewer's decision on one item of an open
 // campaign: "attest" keeps the grant (evidence only), "revoke" removes the
 // underlying grant via RevokeAccessReviewGrant. actorID is the reviewer.
-func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, projectID, campaignID, itemID uint, action, reason string) error { // NOSONAR -- cognitive complexity 20, suppress go:S3776
+// checkReviewerIndependence enforces ISO 27001 A.5.18: a reviewer must not certify
+// their own access, directly (user-scoped item) or via group membership. Fails closed:
+// a group-lookup error is treated as membership to block self-certification by error.
+func (c *KeyorixCore) checkReviewerIndependence(ctx context.Context, actorID uint, item *models.AccessReviewItem) error {
+	if item.PrincipalType == "user" && item.PrincipalID == actorID {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you cannot review your own access; an independent reviewer is required")
+	}
+	if item.PrincipalType == "group" && c.userInGroup(ctx, actorID, item.PrincipalID) {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you cannot review access for a group you belong to; an independent reviewer is required")
+	}
+	return nil
+}
+
+// applyAccessDecision executes the grant action (attest or revoke) and stamps the
+// item's Decision field. Extracted from DecideAccessReviewItem to reduce its complexity.
+func (c *KeyorixCore) applyAccessDecision(ctx context.Context, actorID, projectID uint, item *models.AccessReviewItem, action string, decision AccessReviewDecision) error {
+	switch action {
+	case "attest":
+		if err := c.AttestAccessReviewGrant(ctx, actorID, projectID, decision); err != nil {
+			return err
+		}
+		item.Decision = ReviewItemAttested
+	case "revoke":
+		if err := c.RevokeAccessReviewGrant(ctx, actorID, projectID, decision); err != nil {
+			return err
+		}
+		item.Decision = ReviewItemRevoked
+	default:
+		return fmt.Errorf("%s: action must be attest or revoke", i18n.T("ErrorValidation", nil))
+	}
+	return nil
+}
+
+// persistItemDecision persists the decided item via a conditional UPDATE that also
+// guards the race between concurrent decisions and concurrent force-closes (#319, #343).
+// ok==false means this call lost the race; the re-read is cosmetic only — the security
+// decision was already made atomically by the UPDATE, win or lose.
+func (c *KeyorixCore) persistItemDecision(ctx context.Context, item *models.AccessReviewItem, itemID uint) error {
+	ok, err := c.storage.UpdateAccessReviewItem(ctx, item)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	if !ok {
+		if reloaded, rerr := c.storage.GetAccessReviewItem(ctx, itemID); rerr == nil && reloaded.Decision != ReviewItemPending {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this item has already been decided")
+		}
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "campaign is closed; decisions can only be made on an open campaign")
+	}
+	return nil
+}
+
+func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, projectID, campaignID, itemID uint, action, reason string) error {
 	// A recertification decision must come from an attributable HUMAN reviewer. A
 	// machine identity authenticates with UserID==0 (authz uses its PrincipalID), so a
 	// non-zero actorID is required — otherwise an automation token holding roles.assign
@@ -222,15 +273,8 @@ func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, proje
 	if item.Decision != ReviewItemPending {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this item has already been decided")
 	}
-	// Independence (ISO 27001 A.5.18): a reviewer must not certify their OWN access —
-	// directly (a user-scoped item that is themselves) OR indirectly (a group-scoped item
-	// for a group they belong to). Self-certification, including via a group grant,
-	// defeats the control; an independent reviewer is required.
-	if item.PrincipalType == "user" && item.PrincipalID == actorID {
-		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you cannot review your own access; an independent reviewer is required")
-	}
-	if item.PrincipalType == "group" && c.userInGroup(ctx, actorID, item.PrincipalID) {
-		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you cannot review access for a group you belong to; an independent reviewer is required")
+	if err := c.checkReviewerIndependence(ctx, actorID, item); err != nil {
+		return err
 	}
 	// ARC-001: a machine identity provisioned by the actor must not be self-certified
 	// by its creator. Fail closed on lookup error (can't prove independence → deny).
@@ -243,7 +287,6 @@ func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, proje
 			return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "independent reviewer required for machine identities you provisioned")
 		}
 	}
-
 	decision := AccessReviewDecision{
 		Source:        item.Source,
 		PrincipalType: item.PrincipalType,
@@ -252,48 +295,14 @@ func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, proje
 		EnvironmentID: item.EnvironmentID,
 		SecretID:      item.SecretID,
 	}
-	switch action {
-	case "attest":
-		if err := c.AttestAccessReviewGrant(ctx, actorID, projectID, decision); err != nil {
-			return err
-		}
-		item.Decision = ReviewItemAttested
-	case "revoke":
-		if err := c.RevokeAccessReviewGrant(ctx, actorID, projectID, decision); err != nil {
-			return err
-		}
-		item.Decision = ReviewItemRevoked
-	default:
-		return fmt.Errorf("%s: action must be attest or revoke", i18n.T("ErrorValidation", nil))
+	if err := c.applyAccessDecision(ctx, actorID, projectID, item, action, decision); err != nil {
+		return err
 	}
 	now := c.now()
 	item.Reason = reason
 	item.DecidedBy = actorID
 	item.DecidedAt = &now
-	// Both pre-checks above (item still pending, campaign still open) are plain reads,
-	// so a concurrent/replayed second decision (#319) or a concurrent force-close
-	// (#343) can reach here too, having read the same "pending"/"open" state before
-	// either write lands. UpdateAccessReviewItem's single conditional UPDATE — WHERE
-	// decision='pending' AND the parent campaign's state='open', both checked
-	// atomically in the same statement — is the actual race-closing guard: ok==false
-	// means this call lost the race, either to another decision or to a concurrent
-	// close, so don't silently let this decision overwrite the winner or land into a
-	// campaign whose evidence snapshot was supposed to be frozen at close time.
-	ok, err := c.storage.UpdateAccessReviewItem(ctx, item)
-	if err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-	if !ok {
-		// The conditional UPDATE doesn't say WHICH precondition failed, so re-read the
-		// item to shape an accurate error. This re-read is purely cosmetic — the
-		// security decision was already made atomically by the UPDATE above, win or
-		// lose; nothing here re-opens the race.
-		if reloaded, rerr := c.storage.GetAccessReviewItem(ctx, itemID); rerr == nil && reloaded.Decision != ReviewItemPending {
-			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this item has already been decided")
-		}
-		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "campaign is closed; decisions can only be made on an open campaign")
-	}
-	return nil
+	return c.persistItemDecision(ctx, item, itemID)
 }
 
 // requireHumanReviewer rejects a recertification action by a non-human / unattributable

--- a/internal/core/account_state.go
+++ b/internal/core/account_state.go
@@ -196,11 +196,7 @@ func (c *KeyorixCore) setAccountState(ctx context.Context, adminID, userID uint,
 		// sees the old identity from the cache and never re-checks the new account state
 		// (#r125-H2). We evict here without revoking; revoking follows for blocked states.
 		if pats, _ := tx.ListPersonalAccessTokensByUser(ctx, userID); len(pats) > 0 {
-			for _, p := range pats {
-				if !p.Revoked && p.TokenHash != "" {
-					sessionHashes = append(sessionHashes, p.TokenHash)
-				}
-			}
+			sessionHashes = append(sessionHashes, activePATHashes(pats)...)
 		}
 
 		if err := tx.SetAccountState(ctx, userID, state, c.now()); err != nil {
@@ -232,6 +228,18 @@ func (c *KeyorixCore) setAccountState(ctx context.Context, adminID, userID uint,
 	c.writeAuditEventFull(ctx, eventType, &aid, nil, nil, "",
 		fmt.Sprintf("user %d account state set to %s", userID, state))
 	return nil
+}
+
+// activePATHashes returns the token hashes of all non-revoked PATs that have a hash,
+// used to evict them from the auth cache after an account-state transition.
+func activePATHashes(pats []*models.PersonalAccessToken) []string {
+	var hashes []string
+	for _, p := range pats {
+		if !p.Revoked && p.TokenHash != "" {
+			hashes = append(hashes, p.TokenHash)
+		}
+	}
+	return hashes
 }
 
 // clearRestrictionOnPasswordChange returns the account state a user should hold

--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -515,6 +515,53 @@ func buildBaseline(logs []models.SecretAccessLog, now, windowStart time.Time, qu
 }
 
 // detectAnomalies checks a single access log entry against the baseline.
+// newIPAlert returns a new_ip alert when log.IPAddress is unknown to baseline, or nil.
+// An empty baseline (no known IPs yet) downgrades to "low" severity: a secret's very
+// first access from any IP is unremarkable on its own, but still auditable (#101).
+func newIPAlert(secret models.SecretNode, log models.SecretAccessLog, baseline accessBaseline, now time.Time) *models.AnomalyAlert {
+	if log.IPAddress == "" || baseline.knownIPs[log.IPAddress] {
+		return nil
+	}
+	severity, desc := "high", fmt.Sprintf("Secret accessed from unrecognised IP address: %s", log.IPAddress)
+	if len(baseline.knownIPs) == 0 {
+		severity = "low"
+		desc = fmt.Sprintf("Secret's first observed access is from IP address %s (no prior baseline to compare against)", log.IPAddress)
+	}
+	return &models.AnomalyAlert{
+		SecretNodeID: secret.ID,
+		SecretName:   secret.Name,
+		AlertType:    "new_ip",
+		Severity:     severity,
+		Description:  desc,
+		AccessedBy:   log.AccessedBy,
+		IPAddress:    log.IPAddress,
+		DetectedAt:   now,
+	}
+}
+
+// newUserAlert returns a new_user alert when log.AccessedBy is unknown to baseline, or nil.
+// Same empty-baseline downgrade reasoning as newIPAlert.
+func newUserAlert(secret models.SecretNode, log models.SecretAccessLog, baseline accessBaseline, now time.Time) *models.AnomalyAlert {
+	if log.AccessedBy == "" || baseline.knownUsers[log.AccessedBy] {
+		return nil
+	}
+	severity, desc := "high", fmt.Sprintf("Secret accessed by user with no prior access history: %s", log.AccessedBy)
+	if len(baseline.knownUsers) == 0 {
+		severity = "low"
+		desc = fmt.Sprintf("Secret's first observed access is by user %s (no prior baseline to compare against)", log.AccessedBy)
+	}
+	return &models.AnomalyAlert{
+		SecretNodeID: secret.ID,
+		SecretName:   secret.Name,
+		AlertType:    "new_user",
+		Severity:     severity,
+		Description:  desc,
+		AccessedBy:   log.AccessedBy,
+		IPAddress:    log.IPAddress,
+		DetectedAt:   now,
+	}
+}
+
 func detectAnomalies(secret models.SecretNode, log models.SecretAccessLog, baseline accessBaseline, offHours offHoursPolicy) []models.AnomalyAlert {
 	var alerts []models.AnomalyAlert
 	now := time.Now().UTC()
@@ -533,52 +580,14 @@ func detectAnomalies(secret models.SecretNode, log models.SecretAccessLog, basel
 		})
 	}
 
-	// Rule 2: Access from unknown IP. An empty baseline (no prior history at all —
-	// bootstrap, or a brand-new secret) used to suppress this rule entirely (#101): a
-	// first-ever access from ANY IP was silently waved through with zero novelty
-	// signal, which is exactly what an attacker deliberately targeting a
-	// freshly-provisioned, never-accessed secret would rely on. It still fires, but at
-	// "low" severity when there is no established baseline to violate — an established
-	// pattern being violated (baseline non-empty) is a stronger signal than a secret's
-	// first-ever access being from some IP, which is unremarkable on its own but now at
-	// least visible and auditable rather than invisible.
-	if log.IPAddress != "" && !baseline.knownIPs[log.IPAddress] {
-		severity := "high"
-		desc := fmt.Sprintf("Secret accessed from unrecognised IP address: %s", log.IPAddress)
-		if len(baseline.knownIPs) == 0 {
-			severity = "low"
-			desc = fmt.Sprintf("Secret's first observed access is from IP address %s (no prior baseline to compare against)", log.IPAddress)
-		}
-		alerts = append(alerts, models.AnomalyAlert{
-			SecretNodeID: secret.ID,
-			SecretName:   secret.Name,
-			AlertType:    "new_ip",
-			Severity:     severity,
-			Description:  desc,
-			AccessedBy:   log.AccessedBy,
-			IPAddress:    log.IPAddress,
-			DetectedAt:   now,
-		})
+	// Rule 2: Access from unknown IP — see newIPAlert for the empty-baseline reasoning (#101).
+	if a := newIPAlert(secret, log, baseline, now); a != nil {
+		alerts = append(alerts, *a)
 	}
 
-	// Rule 3: Access by unknown user — same empty-baseline reasoning as Rule 2.
-	if log.AccessedBy != "" && !baseline.knownUsers[log.AccessedBy] {
-		severity := "high"
-		desc := fmt.Sprintf("Secret accessed by user with no prior access history: %s", log.AccessedBy)
-		if len(baseline.knownUsers) == 0 {
-			severity = "low"
-			desc = fmt.Sprintf("Secret's first observed access is by user %s (no prior baseline to compare against)", log.AccessedBy)
-		}
-		alerts = append(alerts, models.AnomalyAlert{
-			SecretNodeID: secret.ID,
-			SecretName:   secret.Name,
-			AlertType:    "new_user",
-			Severity:     severity,
-			Description:  desc,
-			AccessedBy:   log.AccessedBy,
-			IPAddress:    log.IPAddress,
-			DetectedAt:   now,
-		})
+	// Rule 3: Access by unknown user — same reasoning as Rule 2.
+	if a := newUserAlert(secret, log, baseline, now); a != nil {
+		alerts = append(alerts, *a)
 	}
 
 	return alerts

--- a/internal/core/anomaly_ml.go
+++ b/internal/core/anomaly_ml.go
@@ -121,6 +121,34 @@ func accessFeatures(lg models.SecretAccessLog, ipFreq, userFreq map[string]int) 
 	}
 }
 
+// buildFreqMapsWithCutoff is like buildFreqMaps but skips any log entry whose
+// AccessTime is not strictly before trustCutoff — the ANOMALY-03 quarantine
+// guard that prevents an attacker's recently-seen IP/user from inflating its
+// frequency score in the ML training features.
+func buildFreqMapsWithCutoff(logs []models.SecretAccessLog, trustCutoff time.Time) (ipFreq, userFreq map[string]int) {
+	ipFreq = make(map[string]int, len(logs))
+	userFreq = make(map[string]int, len(logs))
+	for _, lg := range logs {
+		if !lg.AccessTime.Before(trustCutoff) {
+			continue
+		}
+		if lg.IPAddress != "" {
+			ipFreq[lg.IPAddress]++
+		}
+		if lg.AccessedBy != "" {
+			userFreq[lg.AccessedBy]++
+		}
+	}
+	return
+}
+
+func mlOutlierSeverity(score float64) string {
+	if score >= mlHighSeverityScore {
+		return "high"
+	}
+	return "medium"
+}
+
 // mlOutlierAlerts trains a per-secret Isolation Forest on the baseline access logs and
 // returns an ml_outlier alert for each recent access whose anomaly score exceeds the
 // configured threshold. Returns nil when there is too little baseline to train on or
@@ -141,10 +169,8 @@ func mlOutlierAlerts(secret models.SecretNode, baselineLogs, recentLogs []models
 
 	// ANOMALY-03: compute the same trustCutoff used by buildBaseline so that accesses
 	// inside the quarantine window are excluded from the ML feature-frequency maps.
-	// "windowStart" here is the start of the live detection window, which is the
-	// earliest time in recentLogs; we derive it as the minimum AccessTime across
-	// recentLogs. Falls back to now minus mlQuarantineDuration when recentLogs is empty
-	// (guarded above, so this is belt-and-suspenders).
+	// "windowStart" is derived as the minimum AccessTime across recentLogs; falls back
+	// to now minus mlQuarantineDuration (guarded above, so this is belt-and-suspenders).
 	windowStart := now
 	for _, lg := range recentLogs {
 		if lg.AccessTime.Before(windowStart) {
@@ -152,22 +178,7 @@ func mlOutlierAlerts(secret models.SecretNode, baselineLogs, recentLogs []models
 		}
 	}
 	mlTrustCutoff := windowStart.Add(-mlQuarantineDuration)
-
-	ipFreq := make(map[string]int, len(baselineLogs))
-	userFreq := make(map[string]int, len(baselineLogs))
-	for _, lg := range baselineLogs {
-		// Skip logs inside the quarantine window so an attacker's recently-seen IP/user
-		// does not inflate its frequency score in the training data.
-		if !lg.AccessTime.Before(mlTrustCutoff) {
-			continue
-		}
-		if lg.IPAddress != "" {
-			ipFreq[lg.IPAddress]++
-		}
-		if lg.AccessedBy != "" {
-			userFreq[lg.AccessedBy]++
-		}
-	}
+	ipFreq, userFreq := buildFreqMapsWithCutoff(baselineLogs, mlTrustCutoff)
 
 	train := make([][]float64, len(baselineLogs))
 	for i, lg := range baselineLogs {
@@ -190,15 +201,11 @@ func mlOutlierAlerts(secret models.SecretNode, baselineLogs, recentLogs []models
 		if score < cfg.Threshold {
 			continue
 		}
-		severity := "medium"
-		if score >= mlHighSeverityScore {
-			severity = "high"
-		}
 		alerts = append(alerts, models.AnomalyAlert{
 			SecretNodeID: secret.ID,
 			SecretName:   secret.Name,
 			AlertType:    "ml_outlier",
-			Severity:     severity,
+			Severity:     mlOutlierSeverity(score),
 			Description: fmt.Sprintf("ML detected an anomalous access pattern (score %.2f): %s from %s at %s UTC differs from this secret's learned baseline",
 				score, displayOrUnknown(lg.AccessedBy), displayOrUnknown(lg.IPAddress), lg.AccessTime.UTC().Format("15:04")),
 			AccessedBy: lg.AccessedBy,

--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -152,40 +152,48 @@ func (c *KeyorixCore) ListStaleMachineIdentities(ctx context.Context, projectID 
 // a lost race reports matched=false, treated identically to an illegal transition.
 // This makes no behavioral difference against LocalStorage (the lock already
 // guarantees the state can't have moved by the time the conditional write runs).
+// transitionMachineInTx performs the state transition inside an existing transaction.
+// It is the body of TransitionMachineIdentity's WithTransaction closure, extracted to
+// keep the outer function's cognitive complexity within limits.
+func (c *KeyorixCore) transitionMachineInTx(ctx context.Context, tx storage.Storage, projectID, id uint, to string, now time.Time) (*models.MachineIdentity, error) {
+	m, err := tx.LockMachineIdentityForUpdate(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("machine identity not found")
+	}
+	if m.ProjectID != projectID {
+		// Cross-project guard: report as "not found" (not a permission error) to
+		// avoid confirming the machine's existence to a caller scoped elsewhere.
+		return nil, fmt.Errorf("machine identity not found")
+	}
+	fromState := m.State
+	if !canTransitionMachine(fromState, to) {
+		return nil, fmt.Errorf("cannot transition machine identity from %s to %s", fromState, to)
+	}
+	m.State = to
+	m.UpdatedAt = now
+	if to == MachineRevoked {
+		m.RevokedAt = &now
+	}
+	matched, err := tx.TransitionMachineIdentityState(ctx, m, fromState)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update machine identity: %w", err)
+	}
+	if !matched {
+		// Lost the race: the row's persisted state moved away from fromState
+		// between the lock read and this write (#388) — treat exactly like an
+		// illegal transition rather than silently overwriting the winner.
+		return nil, fmt.Errorf("cannot transition machine identity from %s to %s", fromState, to)
+	}
+	return m, nil
+}
+
 func (c *KeyorixCore) TransitionMachineIdentity(ctx context.Context, projectID, id uint, to string, actorID uint) (*models.MachineIdentity, error) {
 	now := c.now()
 	var result *models.MachineIdentity
 	err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
-		m, err := tx.LockMachineIdentityForUpdate(ctx, id)
-		if err != nil {
-			return fmt.Errorf("machine identity not found")
-		}
-		if m.ProjectID != projectID {
-			// Cross-project guard: report as "not found" (not a permission error) to
-			// avoid confirming the machine's existence to a caller scoped elsewhere.
-			return fmt.Errorf("machine identity not found")
-		}
-		fromState := m.State
-		if !canTransitionMachine(fromState, to) {
-			return fmt.Errorf("cannot transition machine identity from %s to %s", fromState, to)
-		}
-		m.State = to
-		m.UpdatedAt = now
-		if to == MachineRevoked {
-			m.RevokedAt = &now
-		}
-		matched, err := tx.TransitionMachineIdentityState(ctx, m, fromState)
-		if err != nil {
-			return fmt.Errorf("failed to update machine identity: %w", err)
-		}
-		if !matched {
-			// Lost the race: the row's persisted state moved away from fromState
-			// between the lock read and this write (#388) — treat exactly like an
-			// illegal transition rather than silently overwriting the winner.
-			return fmt.Errorf("cannot transition machine identity from %s to %s", fromState, to)
-		}
-		result = m
-		return nil
+		var err error
+		result, err = c.transitionMachineInTx(ctx, tx, projectID, id, to, now)
+		return err
 	})
 	if err != nil {
 		return nil, err

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -279,6 +279,21 @@ func (c *KeyorixCore) BeginWebAuthnLogin(ctx context.Context, challenge string) 
 	return assertion, token, nil
 }
 
+// checkWebAuthnAccountGates refuses a WebAuthn second-factor login when the account
+// is blocked (suspended/deactivated) or locked out, mirroring the TOTP path in
+// VerifyMFALogin and the passwordless path below.
+func (c *KeyorixCore) checkWebAuthnAccountGates(wu *webauthnUser) error {
+	if !wu.user.IsActive || AccountLoginBlocked(wu.user.AccountState) {
+		return fmt.Errorf("account is not active")
+	}
+	// Per-IP limiters are spoofable behind a proxy; bind assertion failures to the
+	// account instead. ch.UserID is password-gated so this cannot lock an arbitrary victim.
+	if c.loginLocked(wu.user) {
+		return fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
+	return nil
+}
+
 // FinishWebAuthnLogin consumes the challenge + webauthn session, verifies the
 // assertion, updates the credential's signature counter, and mints the session.
 func (c *KeyorixCore) FinishWebAuthnLogin(ctx context.Context, challenge, sessionToken, userAgent, ip string, parsed *protocol.ParsedCredentialAssertionData) (*models.Session, *models.User, error) {
@@ -309,16 +324,9 @@ func (c *KeyorixCore) FinishWebAuthnLogin(ctx context.Context, challenge, sessio
 	// deactivated account must be refused — the challenge may have been issued just
 	// before suspension, with nothing rechecking state between steps. Mirrors the
 	// passwordless path's AccountLoginBlocked gate (and the password/session gates).
-	if !wu.user.IsActive || AccountLoginBlocked(wu.user.AccountState) {
-		return nil, nil, fmt.Errorf("account is not active")
-	}
-	// Per-account lockout also gates the WebAuthn second factor (parity with the TOTP
-	// path in VerifyMFALogin): the per-IP limiter is spoofable behind a proxy and fails
-	// open, so bind assertion failures to the account. ch.UserID comes from the
-	// password-gated challenge (not an attacker-chosen handle), so this cannot be abused
-	// to lock out an arbitrary victim.
-	if c.loginLocked(wu.user) {
-		return nil, nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	// Per-account lockout also gates the second factor (parity with VerifyMFALogin).
+	if err := c.checkWebAuthnAccountGates(wu); err != nil {
+		return nil, nil, err
 	}
 	cred, err := c.webauthnRP.ValidateLogin(wu, sd, parsed)
 	if err != nil {

--- a/internal/dynamic/awssts.go
+++ b/internal/dynamic/awssts.go
@@ -85,16 +85,9 @@ func (e *AWSSTSEngine) client(ctx context.Context, region string) (stsRoleAssume
 	return sts.NewFromConfig(cfg), nil
 }
 
-// Issue assumes the configured role and returns the temporary credential. roleName
-// is the generated session name (used only as a lease label — there is nothing to
-// drop on revoke). creationTemplate, when set, is an inline session policy.
-func (e *AWSSTSEngine) Issue(ctx context.Context, adminDSN, creationTemplate string, ttl time.Duration) (Credential, string, error) {
-	var cfg awsSTSConfig
-	if err := json.Unmarshal([]byte(adminDSN), &cfg); err != nil {
-		return Credential{}, "", fmt.Errorf("aws-sts: config must be JSON ({\"role_arn\":...}): %w", err)
-	}
+func validateAWSSTSCfg(cfg awsSTSConfig) error {
 	if strings.TrimSpace(cfg.RoleARN) == "" {
-		return Credential{}, "", fmt.Errorf("aws-sts: role_arn is required")
+		return fmt.Errorf("aws-sts: role_arn is required")
 	}
 	// Always enforce account-ID pinning: derive from the ARN when not set explicitly
 	// so a config without allowed_account_id still rejects cross-account role ARNs
@@ -102,15 +95,18 @@ func (e *AWSSTSEngine) Issue(ctx context.Context, adminDSN, creationTemplate str
 	if cfg.AllowedAccountID == "" {
 		derived := arnAccountID(cfg.RoleARN)
 		if derived == "" {
-			return Credential{}, "", fmt.Errorf("aws-sts: role_arn %q does not contain a recognisable AWS account ID; set allowed_account_id explicitly", cfg.RoleARN)
+			return fmt.Errorf("aws-sts: role_arn %q does not contain a recognisable AWS account ID; set allowed_account_id explicitly", cfg.RoleARN)
 		}
 		cfg.AllowedAccountID = derived
 	}
-	gotAccount := arnAccountID(cfg.RoleARN)
-	if gotAccount != cfg.AllowedAccountID {
-		return Credential{}, "", fmt.Errorf("aws-sts: role ARN account ID %q does not match allowed_account_id %q", gotAccount, cfg.AllowedAccountID)
+	if arnAccountID(cfg.RoleARN) != cfg.AllowedAccountID {
+		return fmt.Errorf("aws-sts: role ARN account ID %q does not match allowed_account_id %q",
+			arnAccountID(cfg.RoleARN), cfg.AllowedAccountID)
 	}
+	return nil
+}
 
+func buildAssumeRoleInput(cfg awsSTSConfig, sessionName, creationTemplate string, ttl time.Duration) *sts.AssumeRoleInput {
 	duration := cfg.DurationSeconds
 	if duration <= 0 {
 		duration = int32(ttl.Seconds())
@@ -118,13 +114,6 @@ func (e *AWSSTSEngine) Issue(ctx context.Context, adminDSN, creationTemplate str
 	if duration < stsMinDurationSeconds {
 		duration = stsMinDurationSeconds // AWS rejects anything below 15 minutes
 	}
-
-	suffix, err := randString(12)
-	if err != nil {
-		return Credential{}, "", err
-	}
-	sessionName := "keyorix-dyn-" + suffix
-
 	in := &sts.AssumeRoleInput{
 		RoleArn:         aws.String(cfg.RoleARN),
 		RoleSessionName: aws.String(sessionName),
@@ -136,19 +125,10 @@ func (e *AWSSTSEngine) Issue(ctx context.Context, adminDSN, creationTemplate str
 	if tmpl := strings.TrimSpace(creationTemplate); tmpl != "" {
 		in.Policy = aws.String(tmpl) // session policy scopes the assumed role down
 	}
+	return in
+}
 
-	client, err := e.client(ctx, cfg.Region)
-	if err != nil {
-		return Credential{}, "", err
-	}
-	out, err := client.AssumeRole(ctx, in)
-	if err != nil {
-		return Credential{}, "", fmt.Errorf("aws-sts: assume role: %w", err)
-	}
-	if out.Credentials == nil {
-		return Credential{}, "", fmt.Errorf("aws-sts: assume role returned no credentials")
-	}
-
+func stsCredentialFields(cfg awsSTSConfig, out *sts.AssumeRoleOutput) map[string]string {
 	fields := map[string]string{
 		"access_key_id":     aws.ToString(out.Credentials.AccessKeyId),
 		"secret_access_key": aws.ToString(out.Credentials.SecretAccessKey),
@@ -160,7 +140,39 @@ func (e *AWSSTSEngine) Issue(ctx context.Context, adminDSN, creationTemplate str
 	if out.Credentials.Expiration != nil {
 		fields["expiration"] = out.Credentials.Expiration.UTC().Format(time.RFC3339)
 	}
-	return Credential{Fields: fields}, sessionName, nil
+	return fields
+}
+
+// Issue assumes the configured role and returns the temporary credential. roleName
+// is the generated session name (used only as a lease label — there is nothing to
+// drop on revoke). creationTemplate, when set, is an inline session policy.
+func (e *AWSSTSEngine) Issue(ctx context.Context, adminDSN, creationTemplate string, ttl time.Duration) (Credential, string, error) {
+	var cfg awsSTSConfig
+	if err := json.Unmarshal([]byte(adminDSN), &cfg); err != nil {
+		return Credential{}, "", fmt.Errorf("aws-sts: config must be JSON ({\"role_arn\":...}): %w", err)
+	}
+	if err := validateAWSSTSCfg(cfg); err != nil {
+		return Credential{}, "", err
+	}
+
+	suffix, err := randString(12)
+	if err != nil {
+		return Credential{}, "", err
+	}
+	sessionName := "keyorix-dyn-" + suffix
+
+	client, err := e.client(ctx, cfg.Region)
+	if err != nil {
+		return Credential{}, "", err
+	}
+	out, err := client.AssumeRole(ctx, buildAssumeRoleInput(cfg, sessionName, creationTemplate, ttl))
+	if err != nil {
+		return Credential{}, "", fmt.Errorf("aws-sts: assume role: %w", err)
+	}
+	if out.Credentials == nil {
+		return Credential{}, "", fmt.Errorf("aws-sts: assume role returned no credentials")
+	}
+	return Credential{Fields: stsCredentialFields(cfg, out)}, sessionName, nil
 }
 
 // Revoke is a no-op: STS credentials self-expire and cannot be invalidated early

--- a/internal/dynamic/kubernetes.go
+++ b/internal/dynamic/kubernetes.go
@@ -120,6 +120,28 @@ type k8sConfig struct {
 	Token     string `json:"token,omitempty"`
 }
 
+func validateK8sCfg(cfg k8sConfig) error {
+	if strings.TrimSpace(cfg.Namespace) == "" {
+		return fmt.Errorf("kubernetes: namespace is required")
+	}
+	if strings.TrimSpace(cfg.ServiceAccount) == "" {
+		return fmt.Errorf("kubernetes: service_account is required")
+	}
+	return nil
+}
+
+func k8sCredentialFields(cfg k8sConfig, token string, expiry time.Time) map[string]string {
+	fields := map[string]string{
+		"token":           token,
+		"namespace":       cfg.Namespace,
+		"service_account": cfg.ServiceAccount,
+	}
+	if !expiry.IsZero() {
+		fields["expiration"] = expiry.UTC().Format(time.RFC3339)
+	}
+	return fields
+}
+
 // Issue mints a token for the configured ServiceAccount. roleName is the lease
 // label; when Revocable is set it is also the name of the per-lease bound Secret
 // created below (needed by Revoke to find and delete it later). creationTemplate
@@ -129,11 +151,8 @@ func (e *KubernetesEngine) Issue(ctx context.Context, adminDSN, _ string, ttl ti
 	if err := json.Unmarshal([]byte(adminDSN), &cfg); err != nil {
 		return Credential{}, "", fmt.Errorf("kubernetes: config must be JSON ({\"namespace\":...,\"service_account\":...}): %w", err)
 	}
-	if strings.TrimSpace(cfg.Namespace) == "" {
-		return Credential{}, "", fmt.Errorf("kubernetes: namespace is required")
-	}
-	if strings.TrimSpace(cfg.ServiceAccount) == "" {
-		return Credential{}, "", fmt.Errorf("kubernetes: service_account is required")
+	if err := validateK8sCfg(cfg); err != nil {
+		return Credential{}, "", err
 	}
 	if len(cfg.AllowedNamespaces) > 0 && !slices.Contains(cfg.AllowedNamespaces, cfg.Namespace) {
 		return Credential{}, "", fmt.Errorf("kubernetes: namespace %q is not in the allowed_namespaces list", cfg.Namespace)
@@ -181,15 +200,7 @@ func (e *KubernetesEngine) Issue(ctx context.Context, adminDSN, _ string, ttl ti
 		return Credential{}, "", fmt.Errorf("kubernetes: request token: %w", err)
 	}
 
-	fields := map[string]string{
-		"token":           token,
-		"namespace":       cfg.Namespace,
-		"service_account": cfg.ServiceAccount,
-	}
-	if !expiry.IsZero() {
-		fields["expiration"] = expiry.UTC().Format(time.RFC3339)
-	}
-	return Credential{Fields: fields}, label, nil
+	return Credential{Fields: k8sCredentialFields(cfg, token, expiry)}, label, nil
 }
 
 // Revoke is a no-op unless the lease's config set "revocable":true, in which case


### PR DESCRIPTION
## Summary

Fixes 8 SonarCloud S3776 (brain-overload) code smells by extracting helper
functions, reducing every method from >15 to ≤15 cognitive complexity.

| File | Method | Before → After |
|------|--------|---------------|
| `internal/core/access_review_campaign.go` | `DecideAccessReviewItem` | 23 → 8 |
| `internal/core/account_state.go` | `setAccountState` | 21 → 10 |
| `internal/core/anomaly.go` | `detectAnomalies` | 17 → 5 |
| `internal/core/anomaly_ml.go` | `mlOutlierAlerts` | 19 → 12 |
| `internal/core/machine_identities.go` | `TransitionMachineIdentity` | 17 → 3 |
| `internal/core/webauthn.go` | `FinishWebAuthnAuthentication` | 16 → 14 |
| `internal/dynamic/awssts.go` | `Issue` | 16 → 8 |
| `internal/dynamic/kubernetes.go` | `Issue` | 17 → 10 |

Conflict resolution against main: three files (`anomaly_ml.go`,
`awssts.go`, `access_review_campaign.go`) had security fixes merged to main
after this refactor was written; the helpers were updated to incorporate
both:
- `anomaly_ml.go`: quarantine-window filter (ANOMALY-03) preserved via
  `buildFreqMapsWithCutoff`
- `awssts.go`: always-on account-ID pinning (DYN-003) applied inside
  `validateAWSSTSCfg`
- `access_review_campaign.go`: machine-identity creator check (ARC-001)
  kept; duplicate group check removed (already covered by
  `checkReviewerIndependence`)

No behaviour changes beyond the existing security fixes already on main.

## Test plan

- [ ] `go build ./...` passes
- [ ] Existing test suite passes (no new test failures)
- [ ] SonarCloud scan reports 0 S3776 findings on these 8 methods