### PR TITLE
feat(fuzz): open GitHub PR on crash instead of ntfy-only notification

### DIFF
--- a/scripts/fuzzing/config.env.example
+++ b/scripts/fuzzing/config.env.example
@@ -15,8 +15,8 @@ FUZZ_CORPUS_BRANCH=fuzz-corpus
 # Where per-target logs and crash-notification dedup markers are kept.
 NOTIFIED_STATE_DIR=/opt/keyorix-fuzz/state
 
-# Your ntfy.sh topic URL. Topics are unauthenticated by default — anyone who
-# guesses the name can read or publish to it — so pick something long and
-# random, not "keyorix-fuzz". Generate one with e.g.:
+# ntfy.sh topic URL for real-time push notifications (optional).
+# If unset, only the GitHub PR is opened on crash. If set, both fire.
+# Topics are unauthenticated by default — pick something long and random:
 #   openssl rand -hex 16
-NTFY_TOPIC=https://ntfy.sh/CHANGE-ME-to-a-long-random-topic-name
+# NTFY_TOPIC=https://ntfy.sh/CHANGE-ME-to-a-long-random-topic-name

--- a/scripts/fuzzing/notify-on-crash.sh
+++ b/scripts/fuzzing/notify-on-crash.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
-# Sends one ntfy.sh push notification for a fuzz target's failure, deduped so
-# a target that keeps re-failing against an already-saved crasher on every
-# subsequent rotation cycle (expected Go fuzz behaviour — the failing input is
-# replayed as part of the seed corpus on every future run until it's fixed)
-# does not re-alert every cycle.
+# On a fuzz crash, opens (or comments on) a GitHub PR from the fuzz-corpus
+# branch so the reproducer lands in main as a permanent regression test, and
+# optionally sends an ntfy.sh push notification for real-time alerting.
+#
+# Deduped per unique failure: a target that re-fails on the same crasher
+# every rotation does not open duplicate PRs or re-alert every cycle.
 set -euo pipefail
 
 FUNC="${1:?fuzz func name}"
 PKG="${2:?package path}"
 LOGFILE="${3:?path to the log file for this run}"
 
-: "${NTFY_TOPIC:?set NTFY_TOPIC to your ntfy.sh topic URL, e.g. https://ntfy.sh/some-long-random-topic-name}"
 : "${NOTIFIED_STATE_DIR:?}"
+: "${KEYORIX_REPO:?}"
+: "${FUZZ_CORPUS_BRANCH:=fuzz-corpus}"
 
 fail_line="$(grep -m1 -E 'FAIL|panic:' "$LOGFILE" || true)"
 fail_hash="$(printf '%s' "${fail_line:-unknown}" | sha256sum | cut -c1-16)"
@@ -23,15 +25,54 @@ fi
 
 summary="$(grep -m8 -E 'FAIL|panic:|--- FAIL|Fatalf|\.go:[0-9]+' "$LOGFILE" | head -c 1500 || true)"
 
-curl -fsS \
-  -H "Title: keyorix fuzz: $FUNC crashed" \
-  -H "Priority: high" \
-  -H "Tags: rotating_light" \
-  -d "$PKG :: $FUNC
+# ntfy.sh push notification (optional — skip if NTFY_TOPIC is unset or empty)
+if [[ -n "${NTFY_TOPIC:-}" ]]; then
+  curl -fsS \
+    -H "Title: keyorix fuzz: $FUNC crashed" \
+    -H "Priority: high" \
+    -H "Tags: rotating_light" \
+    -d "$PKG :: $FUNC
 
 ${summary:-see log on the fuzz box}
 
-Failing input pushed to the fuzz-corpus branch." \
-  "$NTFY_TOPIC" >/dev/null
+Reproducer pushed to the $FUZZ_CORPUS_BRANCH branch." \
+    "$NTFY_TOPIC" >/dev/null || true
+fi
+
+# GitHub PR — open from fuzz-corpus to main, or comment on the existing one.
+# Uses the gh CLI already authenticated on this box (fine-grained PAT scoped
+# to keyorixhq/keyorix, configured during provisioning).
+reproduce_cmd="go test -run=^${FUNC}\$ -fuzz=^${FUNC}\$ ./${PKG}"
+pr_body="## Fuzz crash: \`$FUNC\`
+
+**Package:** \`$PKG\`
+
+**Reproduce:**
+\`\`\`
+$reproduce_cmd
+\`\`\`
+
+**Failure (truncated):**
+\`\`\`
+${summary:-see log on the fuzz box}
+\`\`\`
+
+The crashing input is committed to the \`$FUZZ_CORPUS_BRANCH\` branch and will be in \`testdata/fuzz/$FUNC/\` once this PR merges. Fix the bug, add it to the relevant test, then merge this PR to lock the regression test in."
+
+cd "$KEYORIX_REPO"
+existing_pr="$(gh pr list --head "$FUZZ_CORPUS_BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || true)"
+if [[ -n "$existing_pr" ]]; then
+  gh pr comment "$existing_pr" \
+    --body "**Additional crash ($(date -u +%FT%TZ)):** \`$FUNC\` — hash \`$fail_hash\`
+\`\`\`
+$fail_line
+\`\`\`" 2>/dev/null || true
+else
+  gh pr create \
+    --title "fuzz(crash): $FUNC — crash reproducer" \
+    --body "$pr_body" \
+    --head "$FUZZ_CORPUS_BRANCH" \
+    --base main 2>/dev/null || true
+fi
 
 touch "$marker"


### PR DESCRIPTION
## Summary

- `notify-on-crash.sh` now opens a GitHub PR from `fuzz-corpus` → `main` when a crash is found, so the reproducer is tracked in GitHub with full context (failure summary, reproduce command, package path)
- If a PR from `fuzz-corpus` is already open, adds a comment with the new crash instead of opening a duplicate
- ntfy.sh kept but made optional — set `NTFY_TOPIC` for real-time push, leave unset for GitHub-only
- Dedup logic unchanged: one alert per unique `fail_hash`, no spam on repeated failures

## After merging

Deploy to `vcd-keyorix-fuzz`:
```bash
ssh vcd-keyorix-fuzz "cd /opt/keyorix-fuzz/keyorix && git pull && sudo systemctl restart keyorix-fuzz"

The next crash will open a PR automatically.