### PR TITLE
fix(storage): wire AnomalyConfigRecord migration + SonarCloud refactor

### DIFF
--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1351,6 +1351,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 		&models.IdentityProvider{},
 		&models.ExternalIdentity{},
 		&models.AnomalyAlert{},
+		&models.AnomalyConfigRecord{},
 		&models.StatsSnapshot{},
 		&models.DeploymentStatsSnapshot{},
 	} {


### PR DESCRIPTION
## Summary

Two follow-up fixes on top of the r122-r137 security bundle (#1193):

- **Storage migration**: `anomaly_config_records` table was added to `AllTestModels()` (test-only schema helper) but never wired into `factory.go`'s production `migrateDatabase` bulk AutoMigrate list. Fresh PostgreSQL installs started without the table — the anomaly subsystem logged an error on every config reload and fell back to file-based defaults. Added `&models.AnomalyConfigRecord{}` next to `&models.AnomalyAlert{}` in the bulk loop.

- **SonarCloud**: Reduce cognitive complexity in 8 additional methods to satisfy the quality gate (continuation of dd6574e5 from the security bundle).

## Test plan

- [ ] `go test ./internal/storage/...` green
- [ ] Fresh PostgreSQL install: confirm `anomaly_config_records` created on first boot and `Anomaly: persisted runtime config applied` in logs
- [ ] CI build-and-test + lint pass