### PR TITLE
fix(ci): scope workflow token permissions to job level (Scorecard #556, #572)

### DIFF
--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -10,13 +10,12 @@ jobs:
   sbom:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 
-      - name: Generate SBOM and upload dependency snapshot
+      - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.20.0
         with:
           path: .
           artifact-name: sbom.spdx.json
-          dependency-snapshot: true

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -8,14 +8,15 @@ on:
   schedule:
     - cron: '19 17 * * 5'
 
-permissions:
-  contents: read
-  security-events: write
-  actions: read
+permissions: {}
 
 jobs:
   scan:
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@8bd1ce1c4be9d98053ffd9e6e14585276a36762c" # v1.9.1
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     with:
       scan-args: |-
         --recursive


### PR DESCRIPTION
## Summary

- **osv-scanner.yml**: moves `contents/security-events/actions` permissions from workflow-level to the job's `uses:` block. Scorecard Token-Permissions flags any `write` at workflow scope; job-level is the correct granularity for reusable-workflow callers.
- **anchore-syft.yml**: drops `dependency-snapshot: true` and reduces `contents: write` → `contents: read`. The dependency snapshot GitHub API requires `contents: write` with no more-specific alternative; removing the feature eliminates the write permission entirely. Go dependency graph is covered by Dependabot via `go.sum`/`go.mod`.

Closes Scorecard alerts #556 and #572.

## Test plan

- [ ] CI passes on this PR
- [ ] Scorecard Token-Permissions alerts #556 and #572 auto-close after merge