### PR TITLE
fix(security): r139 GRPC-003/004/005 — sanitise gRPC error messages

### DIFF
--- a/server/grpc/services/break_glass_service.go
+++ b/server/grpc/services/break_glass_service.go
@@ -108,13 +108,13 @@ func breakGlassError(err error) error {
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "not found"):
-		return status.Error(codes.NotFound, msg)
+		return status.Error(codes.NotFound, "break-glass activation not found") // GRPC-005: was msg — leaked storage error details
 	case strings.Contains(msg, "justification") || strings.Contains(msg, "required") || strings.Contains(msg, "invalid"):
-		return status.Error(codes.InvalidArgument, msg)
+		return status.Error(codes.InvalidArgument, "invalid request") // GRPC-005: was msg — leaked minimum justification length
 	case strings.Contains(msg, "permission") || strings.Contains(msg, "denied"):
 		return status.Error(codes.PermissionDenied, "access denied")
 	case strings.Contains(msg, "already revoked") || strings.Contains(msg, "not active") || strings.Contains(msg, "expired"):
-		return status.Error(codes.FailedPrecondition, msg)
+		return status.Error(codes.FailedPrecondition, "activation is not in a valid state for this operation") // GRPC-005: was msg
 	default:
 		return status.Error(codes.Internal, "break-glass operation failed")
 	}

--- a/server/grpc/services/machine_identity_service.go
+++ b/server/grpc/services/machine_identity_service.go
@@ -35,11 +35,11 @@ func mapMachineError(err error) error {
 	case strings.Contains(msg, "not found"):
 		return status.Error(codes.NotFound, "machine identity or token not found")
 	case strings.Contains(msg, "cannot transition"):
-		return status.Error(codes.FailedPrecondition, msg)
+		return status.Error(codes.FailedPrecondition, "invalid state transition") // GRPC-004: was msg — leaked internal state names
 	case strings.Contains(msg, "must be active"):
-		return status.Error(codes.FailedPrecondition, msg)
+		return status.Error(codes.FailedPrecondition, "machine identity is not active") // GRPC-004: was msg — leaked current state
 	case strings.Contains(msg, "invalid") || strings.Contains(msg, "classification must be") || strings.Contains(msg, "required"):
-		return status.Error(codes.InvalidArgument, msg)
+		return status.Error(codes.InvalidArgument, "invalid request") // GRPC-004: was msg — leaked classification enum values
 	case strings.Contains(msg, "permission") || strings.Contains(msg, "denied"):
 		return status.Error(codes.PermissionDenied, "access denied")
 	default:

--- a/server/grpc/services/user_service.go
+++ b/server/grpc/services/user_service.go
@@ -295,9 +295,9 @@ func mapUserError(err error) error {
 	case strings.Contains(msg, "already exists"), strings.Contains(msg, "duplicate"):
 		return status.Error(codes.AlreadyExists, "a user with that username or email already exists")
 	case strings.Contains(msg, "administrator can grant"):
-		return status.Error(codes.PermissionDenied, err.Error())
+		return status.Error(codes.PermissionDenied, "insufficient privileges to assign this role") // GRPC-003: was err.Error() — leaked internal role name
 	case strings.Contains(msg, "validation"), strings.Contains(msg, "required"), strings.Contains(msg, "invalid"), strings.Contains(msg, "must be"):
-		return status.Error(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, "invalid request parameters") // GRPC-003: was err.Error() — leaked password policy thresholds
 	default:
 		return status.Error(codes.Internal, "user operation failed")
 	}


### PR DESCRIPTION
## Summary

Fixes 3 findings from the r139 audit where gRPC error mappers passed raw core error strings verbatim to the client, leaking internal implementation details.

| ID | Severity | File | What leaked |
|----|----------|------|-------------|
| GRPC-003 | HIGH | `user_service.go:297-300` | Internal role names (`"super_admin"`) via `%q`; exact password policy thresholds |
| GRPC-004 | MEDIUM | `machine_identity_service.go:38-43` | Internal state machine names; full classification enum values |
| GRPC-005 | MEDIUM | `break_glass_service.go:110-113` | Minimum justification length; storage-wrapped error details; activation state names |

## Changes

**GRPC-003** (`mapUserError`):
- `"administrator can grant"` branch: `err.Error()` → `"insufficient privileges to assign this role"` (was leaking `"only an administrator can grant the administrative role \"super_admin\""`)
- validation/required/invalid/must-be branch: `err.Error()` → `"invalid request parameters"` (was leaking `"password must be at least N characters, contain an uppercase letter…"`)

**GRPC-004** (`mapMachineError`):
- `"cannot transition"` branch: `msg` → `"invalid state transition"`
- `"must be active"` branch: `msg` → `"machine identity is not active"`
- validation branch: `msg` → `"invalid request"`

**GRPC-005** (`breakGlassError`):
- `"not found"` branch: `msg` → `"break-glass activation not found"`
- justification/required/invalid branch: `msg` → `"invalid request"`
- already-revoked/not-active/expired branch: `msg` → `"activation is not in a valid state for this operation"`

All other branches in each mapper already used safe fixed strings; only the leaking branches are changed.

## Test plan

- [ ] `go build ./server/grpc/...` passes
- [ ] Existing gRPC service tests pass
- [ ] Manual: call `CreateUser` with an invalid role via gRPC — verify response body no longer contains role names
- [ ] Manual: call `TransitionMachineIdentity` with an invalid transition — verify response body no longer contains state names
- [ ] CI: lint + build-and-test