### PR TITLE
fix(security): gRPC interceptor hardening — per-principal rate limit and connection age (GRPC-008, GRPC-009)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -289,14 +289,24 @@ type GRPCKeepaliveConfig struct {
 	// so this defaults to false — rejecting streamless pings closes off a cheap
 	// ping-flood vector from a valid credential holder that never opens an RPC.
 	PermitWithoutStream bool `yaml:"permit_without_stream,omitempty"`
+	// MaxConnectionAge is the maximum duration a connection may be kept open before
+	// the server sends a GOAWAY and begins graceful shutdown of that connection.
+	// Forces periodic reconnection so stream-slot-holding attacks (GRPC-008) cannot
+	// pin audit-stream slots indefinitely. Default 1h when unset/unparseable.
+	MaxConnectionAge string `yaml:"max_connection_age,omitempty"`
+	// MaxConnectionAgeGrace is how long after MaxConnectionAge the server waits for
+	// active RPCs to finish before force-closing. Default 30s when unset/unparseable.
+	MaxConnectionAgeGrace string `yaml:"max_connection_age_grace,omitempty"`
 }
 
 // defaultGRPCKeepaliveTime/Timeout/MinTime are the server-side keepalive defaults
 // applied when the operator hasn't configured server.grpc.keepalive.* (#222/#435).
 const (
-	defaultGRPCKeepaliveTime    = 5 * time.Minute
-	defaultGRPCKeepaliveTimeout = 20 * time.Second
-	defaultGRPCKeepaliveMinTime = 5 * time.Minute
+	defaultGRPCKeepaliveTime           = 5 * time.Minute
+	defaultGRPCKeepaliveTimeout        = 20 * time.Second
+	defaultGRPCKeepaliveMinTime        = 5 * time.Minute
+	defaultGRPCMaxConnectionAge        = 1 * time.Hour
+	defaultGRPCMaxConnectionAgeGrace   = 30 * time.Second
 )
 
 // GetTime returns the idle-before-ping interval (default 5m).
@@ -314,6 +324,14 @@ func (c GRPCKeepaliveConfig) GetTimeout() time.Duration {
 // before being treated as abusive (default 5m).
 func (c GRPCKeepaliveConfig) GetMinTime() time.Duration {
 	return parseDurationDefault(c.MinTime, defaultGRPCKeepaliveMinTime)
+}
+
+func (c GRPCKeepaliveConfig) GetMaxConnectionAge() time.Duration {
+	return parseDurationDefault(c.MaxConnectionAge, defaultGRPCMaxConnectionAge)
+}
+
+func (c GRPCKeepaliveConfig) GetMaxConnectionAgeGrace() time.Duration {
+	return parseDurationDefault(c.MaxConnectionAgeGrace, defaultGRPCMaxConnectionAgeGrace)
 }
 
 // defaultMaxRequestBodyBytes is the request-body cap when none is configured.

--- a/server/grpc/interceptors/rate_limit.go
+++ b/server/grpc/interceptors/rate_limit.go
@@ -1,0 +1,112 @@
+package interceptors
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+)
+
+// GRPCRateLimitInterceptor returns a unary server interceptor that enforces a
+// per-principal token-bucket request budget over the gRPC transport, mirroring
+// the HTTP PrincipalRateLimit middleware so an authenticated caller cannot bypass
+// the rate limit by switching transports (GRPC-009).
+//
+// Keyed by the same principal identity as the HTTP middleware (user ID, machine
+// identity ID, or source IP as fallback). Disabled when cfg.Enabled == false,
+// matching the HTTP middleware's zero-value behaviour.
+func GRPCRateLimitInterceptor(cfg config.RateLimitConfig) grpc.UnaryServerInterceptor {
+	if !cfg.Enabled || cfg.RequestsPerSecond <= 0 {
+		log.Printf("Keyorix: GRPCRateLimitInterceptor is disabled (server.grpc.ratelimit.enabled=false) — no per-principal gRPC rate limit is active; enable in production")
+		return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+			return handler(ctx, req)
+		}
+	}
+	burst := cfg.Burst
+	if burst <= 0 {
+		burst = cfg.RequestsPerSecond
+	}
+	rl := &grpcRateLimiter{
+		rps:      rate.Limit(cfg.RequestsPerSecond),
+		burst:    burst,
+		limiters: make(map[string]*grpcPrincipalBucket),
+	}
+	return rl.intercept
+}
+
+const (
+	grpcPrincipalLimiterIdleTTL   = 10 * time.Minute
+	grpcPrincipalLimiterSweepEvery = 1000
+)
+
+type grpcPrincipalBucket struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+type grpcRateLimiter struct {
+	mu       sync.Mutex
+	limiters map[string]*grpcPrincipalBucket
+	rps      rate.Limit
+	burst    int
+	requests uint64
+}
+
+func (rl *grpcRateLimiter) intercept(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	if !rl.allow(grpcRateLimitKey(ctx)) {
+		return nil, status.Error(codes.ResourceExhausted, "too many requests; slow down")
+	}
+	return handler(ctx, req)
+}
+
+func (rl *grpcRateLimiter) allow(key string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.requests++
+	if rl.requests%grpcPrincipalLimiterSweepEvery == 0 {
+		rl.sweepLocked()
+	}
+	b, ok := rl.limiters[key]
+	if !ok {
+		b = &grpcPrincipalBucket{limiter: rate.NewLimiter(rl.rps, rl.burst)}
+		rl.limiters[key] = b
+	}
+	b.lastSeen = time.Now()
+	return b.limiter.Allow()
+}
+
+func (rl *grpcRateLimiter) sweepLocked() {
+	cutoff := time.Now().Add(-grpcPrincipalLimiterIdleTTL)
+	for k, b := range rl.limiters {
+		if b.lastSeen.Before(cutoff) {
+			delete(rl.limiters, k)
+		}
+	}
+}
+
+// grpcRateLimitKey identifies the request's budget bucket, mirroring the HTTP
+// rateLimitKey: authenticated user or machine identity first, source IP as fallback.
+func grpcRateLimitKey(ctx context.Context) string {
+	if u := GetUserFromGRPCContext(ctx); u != nil {
+		if u.MachineIdentityID != 0 {
+			return "machine:" + strconv.FormatUint(uint64(u.MachineIdentityID), 10)
+		}
+		if u.UserID != 0 {
+			return "user:" + strconv.FormatUint(uint64(u.UserID), 10)
+		}
+	}
+	if p, ok := peer.FromContext(ctx); ok {
+		return fmt.Sprintf("ip:%s", p.Addr.String())
+	}
+	return "ip:unknown"
+}

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -63,6 +63,11 @@ func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server,
 			// long-lived), so the stream chain carries no timeout.
 			interceptors.TimeoutInterceptor(grpcUnaryTimeout),
 			interceptors.AuthInterceptor(coreService, cfg.Security.RequireMFA),
+			// Per-principal token-bucket rate limit mirroring the HTTP PrincipalRateLimit
+			// middleware so an authenticated caller cannot bypass the rate limit by
+			// switching transports (GRPC-009). Runs inside Auth so only authenticated
+			// principals are counted; unauthenticated requests are rejected by Auth first.
+			interceptors.GRPCRateLimitInterceptor(cfg.Server.GRPC.RateLimit),
 		),
 		// The stream chain intentionally carries no metrics interceptor: MetricsInterceptor
 		// (and the keyorix_grpc_requests_total / _duration_seconds_total series it feeds)
@@ -122,6 +127,12 @@ func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server,
 			Time: ka.GetTime(),
 			// Close the connection if the ping isn't ack'd within this long.
 			Timeout: ka.GetTimeout(),
+			// Force periodic reconnection so stale transport-layer auth (e.g. revoked
+			// mTLS cert, rotated machine token) is re-evaluated on the new connection's
+			// handshake (GRPC-008). Without this a token revoked after connection
+			// establishment stays valid for the entire connection lifetime.
+			MaxConnectionAge:      ka.GetMaxConnectionAge(),
+			MaxConnectionAgeGrace: ka.GetMaxConnectionAgeGrace(),
 		}),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			// Reject a client that pings more often than this as abusive (GOAWAY


### PR DESCRIPTION
## Summary

- **GRPC-009**: Add `GRPCRateLimitInterceptor` — a per-principal token-bucket unary interceptor mirroring the HTTP `PrincipalRateLimit` middleware. An authenticated caller cannot bypass the rate limit by switching to the gRPC transport. Keyed by user/machine identity ID (source IP fallback). Disabled when `server.grpc.ratelimit.enabled=false`, matching the HTTP zero-value behaviour.
- **GRPC-008**: Add `MaxConnectionAge` / `MaxConnectionAgeGrace` to `GRPCKeepaliveConfig`. Forces periodic reconnection so a revoked token or mTLS cert cannot remain valid for the entire connection lifetime. Defaults to 1h / 30s; both are operator-configurable duration strings under `server.grpc.keepalive`.

## Test plan

- [ ] Full build passes (`go build ./...`)
- [ ] `go test ./server/grpc/...` and `./internal/config/...` pass
- [ ] Rate-limit interceptor keying: verify `machine:` prefix for machine-identity principals, `user:` for human sessions, `ip:` fallback when no auth context
- [ ] Idle-bucket sweep: verify `grpcPrincipalLimiterIdleTTL` removes stale entries every 1000 requests
- [ ] `MaxConnectionAge` config parsing: set `max_connection_age: 30m` and verify keepalive params surface correctly