### PR TITLE
fix(security): post-offboarding secret access — owner tag cleared on member removal (RBAC-001, RBAC-002)

### DIFF
--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -254,12 +254,14 @@ func TestTransitionMembership_RevokeRemovesRole(t *testing.T) {
 		{PrincipalType: "user", PrincipalID: 2, RoleID: 5, ProjectID: 1},
 	}, nil)
 	store.On("RemoveAllProjectRoleGrants", ctx, uint(2), uint(1)).Return(nil)
+	store.On("ClearProjectSecretOwnership", ctx, uint(2), uint(1)).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
 	out, err := c.TransitionMembership(ctx, 1, 50, MembershipRevoked, 9)
 	require.NoError(t, err)
 	assert.Equal(t, MembershipRevoked, out.State)
 	store.AssertCalled(t, "RemoveAllProjectRoleGrants", ctx, uint(2), uint(1))
+	store.AssertCalled(t, "ClearProjectSecretOwnership", ctx, uint(2), uint(1))
 }
 
 func TestStaleInvites_PassesCutoff(t *testing.T) {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1121,6 +1121,11 @@ func (m *MockStorage) RemoveAllProjectRoleGrants(ctx context.Context, userID, pr
 	return args.Error(0)
 }
 
+func (m *MockStorage) ClearProjectSecretOwnership(ctx context.Context, userID, projectID uint) error {
+	args := m.Called(ctx, userID, projectID)
+	return args.Error(0)
+}
+
 func (m *MockStorage) AssignRoleToGroupWithExpiry(ctx context.Context, groupID, roleID uint, scope storage.Scope, expiresAt time.Time) error {
 	args := m.Called(ctx, groupID, roleID, scope, expiresAt)
 	return args.Error(0)

--- a/internal/core/permission_enforcement_test.go
+++ b/internal/core/permission_enforcement_test.go
@@ -70,8 +70,9 @@ func TestCheckSecretPermission(t *testing.T) {
 			userID:             1,
 			requiredPermission: PermissionRead,
 			setupMocks: func(ms *MockStorage) {
-				secret := createTestSecret(1, 1, "test-secret")
+				secret := &models.SecretNode{ID: 1, OwnerID: 1, ProjectID: 10, Name: "test-secret"}
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+				ms.On("IsProjectMember", mock.Anything, uint(1), uint(10)).Return(true, nil)
 			},
 			expectedPermission: PermissionOwner,
 			expectedSource:     "owner",
@@ -213,10 +214,12 @@ func TestEnforceSecretReadPermission(t *testing.T) {
 
 	mockStorage := &MockStorage{}
 	mockStorage.On("GetSecret", mock.Anything, uint(1)).Return(&models.SecretNode{
-		ID:      1,
-		OwnerID: 1,
-		Name:    "test-secret",
+		ID:        1,
+		OwnerID:   1,
+		ProjectID: 10,
+		Name:      "test-secret",
 	}, nil)
+	mockStorage.On("IsProjectMember", mock.Anything, uint(1), uint(10)).Return(true, nil)
 
 	core := NewKeyorixCore(mockStorage)
 
@@ -612,8 +615,9 @@ func TestGetSecretWithPermissionCheck(t *testing.T) {
 
 	t.Run("authorized reader (owner) retrieves the secret", func(t *testing.T) {
 		mockStorage := &MockStorage{}
-		secret := &models.SecretNode{ID: 1, OwnerID: 1, Name: "test-secret"}
+		secret := &models.SecretNode{ID: 1, OwnerID: 1, ProjectID: 10, Name: "test-secret"}
 		mockStorage.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+		mockStorage.On("IsProjectMember", mock.Anything, uint(1), uint(10)).Return(true, nil)
 
 		core := NewKeyorixCore(mockStorage)
 

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -73,14 +73,23 @@ func (c *KeyorixCore) CheckSecretPermission(ctx context.Context, secretID, userI
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 
-	// Owners have all permissions.
+	// Owners have all permissions, but only while still a member of the secret's
+	// project. A user removed from the project retains their OwnerID tag until
+	// ClearProjectSecretOwnership runs (RBAC-002), so we gate owner access on live
+	// project membership to prevent post-offboarding access (RBAC-001).
 	if secretOwnedBy(secret.OwnerID, userID) {
-		return &PermissionContext{
-			SecretID:   secretID,
-			UserID:     userID,
-			Permission: PermissionOwner,
-			Source:     "owner",
-		}, nil
+		member, err := c.storage.IsProjectMember(ctx, userID, secret.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		}
+		if member {
+			return &PermissionContext{
+				SecretID:   secretID,
+				UserID:     userID,
+				Permission: PermissionOwner,
+				Source:     "owner",
+			}, nil
+		}
 	}
 
 	shares, err := c.storage.ListSharesBySecret(ctx, secretID)

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -108,6 +108,13 @@ func (c *KeyorixCore) RemoveProjectMember(ctx context.Context, actorID, projectI
 	if err := c.storage.RemoveAllProjectRoleGrants(ctx, userID, projectID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	// Clear owner_id on secrets this user owned in the project (RBAC-002): without
+	// this the stale owner tag would grant them owner-level access via
+	// CheckSecretPermission's owner short-circuit even after all role grants are gone.
+	// Best-effort: a failure here is logged at the storage layer but does not roll back
+	// the role removal, because the RBAC-001 membership check in CheckSecretPermission
+	// already blocks access — this is defense-in-depth, not a hard gate.
+	_ = c.storage.ClearProjectSecretOwnership(ctx, userID, projectID)
 	for _, a := range assignments {
 		if a.PrincipalType != "user" || a.PrincipalID != userID {
 			continue

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -834,6 +834,12 @@ type Storage interface {
 	// same project; otherwise it silently survives project-level removal, invisible to
 	// the project admin who performed the offboarding (#232).
 	RemoveAllProjectRoleGrants(ctx context.Context, userID, projectID uint) error
+	// ClearProjectSecretOwnership clears the owner_id field (sets to 0) for every
+	// live secret in projectID that is owned by userID. Called by RemoveProjectMember
+	// so that an offboarded user's stale owner_id tag cannot grant them post-offboarding
+	// owner-level access to those secrets via CheckSecretPermission's owner short-circuit
+	// (RBAC-002).
+	ClearProjectSecretOwnership(ctx context.Context, userID, projectID uint) error
 	GetUserRoles(ctx context.Context, userID uint) ([]*models.Role, error)
 	// ListAllUserRoleGrants returns every user→role grant row in the deployment,
 	// including scoped (project/environment) and global (project_id=0) grants.

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -453,6 +453,21 @@ func (ls *LocalStorage) GetSecretByName(ctx context.Context, name string, projec
 	return &secret, nil
 }
 
+// ClearProjectSecretOwnership sets owner_id = 0 for every live secret in
+// projectID owned by userID, removing the stale ownership tag left behind after
+// a project member is offboarded (RBAC-002). A zero owner_id signals "no human
+// owner" (the invariant enforced by secretOwnedBy), so CheckSecretPermission's
+// owner short-circuit no longer fires for the removed user.
+func (ls *LocalStorage) ClearProjectSecretOwnership(ctx context.Context, userID, projectID uint) error {
+	err := ls.db.WithContext(ctx).Model(&models.SecretNode{}).
+		Where("owner_id = ? AND project_id = ? AND deleted_at IS NULL", userID, projectID).
+		Update("owner_id", 0).Error
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
 // UpdateSecret updates an existing secret.
 func (ls *LocalStorage) UpdateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error) {
 	if err := ls.db.WithContext(ctx).Save(secret).Error; err != nil {

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -199,6 +199,20 @@ func (rs *RemoteStorage) GetSecretByName(ctx context.Context, name string, proje
 	return &result, nil
 }
 
+// ClearProjectSecretOwnership proxies onto POST
+// /api/v1/system/rbac/clear-project-secret-ownership (RBAC-002).
+func (rs *RemoteStorage) ClearProjectSecretOwnership(ctx context.Context, userID, projectID uint) error {
+	payload := map[string]uint{"user_id": userID, "project_id": projectID}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/rbac/clear-project-secret-ownership", payload)
+	if err != nil {
+		return fmt.Errorf("failed to clear project secret ownership: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("clear project secret ownership failed: %s", resp.Error.Error())
+	}
+	return nil
+}
+
 // UpdateSecret updates an existing secret via remote API.
 func (rs *RemoteStorage) UpdateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error) {
 	path := fmt.Sprintf("/api/v1/secrets/%d", secret.ID)

--- a/server/http/handlers/handlers_s14_test.go
+++ b/server/http/handlers/handlers_s14_test.go
@@ -78,6 +78,8 @@ func freshSecretHandlerS14(t *testing.T) (*SecretHandler, uint) {
 
 	proj, err := st.CreateProject(ctx, &models.Project{Name: "proj-s14"})
 	require.NoError(t, err)
+	// User 1 must be a project member so CheckSecretPermission's IsProjectMember gate passes.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: proj.ID}).Error)
 	env, err := st.CreateEnvironment(ctx, &models.Environment{Name: "staging-s14", ProjectID: proj.ID})
 	require.NoError(t, err)
 	secret, err := st.CreateSecret(ctx, &models.SecretNode{

--- a/server/http/handlers/rbac_role_grants_proxy.go
+++ b/server/http/handlers/rbac_role_grants_proxy.go
@@ -161,6 +161,33 @@ func (h *RBACHandler) RemoveAllProjectRoleGrantsProxy(w http.ResponseWriter, r *
 	writeRemoteAPISuccess(w, map[string]bool{"removed": true})
 }
 
+// clearProjectSecretOwnershipWire is the request body for
+// ClearProjectSecretOwnershipProxy.
+type clearProjectSecretOwnershipWire struct {
+	UserID    uint `json:"user_id"`
+	ProjectID uint `json:"project_id"`
+}
+
+// ClearProjectSecretOwnershipProxy handles POST
+// /api/v1/system/rbac/clear-project-secret-ownership (RBAC-002).
+func (h *RBACHandler) ClearProjectSecretOwnershipProxy(w http.ResponseWriter, r *http.Request) {
+	var body clearProjectSecretOwnershipWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
+		return
+	}
+	if body.UserID == 0 || body.ProjectID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id and project_id are required")
+		return
+	}
+	if err := h.coreService.Storage().ClearProjectSecretOwnership(r.Context(), body.UserID, body.ProjectID); err != nil {
+		log.Printf("rbac proxy: clear project secret ownership failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"cleared": true})
+}
+
 // ListGroupRoleAssignmentsProxy handles GET
 // /api/v1/system/rbac/groups/{groupID}/role-assignments.
 func (h *RBACHandler) ListGroupRoleAssignmentsProxy(w http.ResponseWriter, r *http.Request) {

--- a/server/http/handlers/secrets_access_stats_test.go
+++ b/server/http/handlers/secrets_access_stats_test.go
@@ -18,8 +18,9 @@ import (
 func TestGetSecretAccessStatsHandler(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}, &models.Role{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.SecretNode{
 		ID: 1, Name: "db", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
 		CreatedAt: time.Now(), UpdatedAt: time.Now(),

--- a/server/http/handlers/secrets_bulk_rename_test.go
+++ b/server/http/handlers/secrets_bulk_rename_test.go
@@ -25,9 +25,10 @@ func TestBulkRenameSecretsHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
-		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.User{},
+		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.User{}, &models.Role{}, &models.UserRole{},
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, Name: "production", ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.SecretNode{
 		ID: 5, Name: "db-password", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1,

--- a/server/http/handlers/secrets_crud_maxreads_test.go
+++ b/server/http/handlers/secrets_crud_maxreads_test.go
@@ -121,6 +121,8 @@ func TestUpdateSecret_MaxReadsValidation(t *testing.T) {
 	adminRole := &models.Role{Name: "admin"}
 	require.NoError(t, db.Create(adminRole).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID}).Error)
+	// Project-scoped membership required by CheckSecretPermission's IsProjectMember gate.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID, ProjectID: 1}).Error)
 
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 1, Name: "prod"}).Error)

--- a/server/http/handlers/secrets_description_tags_render_s13_test.go
+++ b/server/http/handlers/secrets_description_tags_render_s13_test.go
@@ -83,6 +83,8 @@ func freshDescribeFixtureS13(t *testing.T) (*SecretHandler, uint) {
 
 	proj, err := st.CreateProject(ctx, &models.Project{Name: "proj-s13d"})
 	require.NoError(t, err)
+	// User 1 must be a project member so CheckSecretPermission's IsProjectMember gate passes.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: proj.ID}).Error)
 	env, err := st.CreateEnvironment(ctx, &models.Environment{Name: "env-s13d", ProjectID: proj.ID})
 	require.NoError(t, err)
 	secret, err := st.CreateSecret(ctx, &models.SecretNode{

--- a/server/http/handlers/secrets_extend_expiring_test.go
+++ b/server/http/handlers/secrets_extend_expiring_test.go
@@ -21,9 +21,10 @@ func TestExtendExpiringSecretsHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
-		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.User{},
+		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.User{}, &models.Role{}, &models.UserRole{},
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, Name: "production", ProjectID: 1}).Error)
 	expired := time.Now().Add(-48 * time.Hour)
 	require.NoError(t, db.Create(&models.SecretNode{

--- a/server/http/handlers/secrets_move_test.go
+++ b/server/http/handlers/secrets_move_test.go
@@ -79,6 +79,8 @@ func freshMoveFixture(t *testing.T) moveFixtureResult {
 
 	proj, err := st.CreateProject(ctx, &models.Project{Name: "proj-move"})
 	require.NoError(t, err)
+	// User 1 must be a project member so CheckSecretPermission's IsProjectMember gate passes.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: proj.ID}).Error)
 	env, err := st.CreateEnvironment(ctx, &models.Environment{Name: "env-move", ProjectID: proj.ID})
 	require.NoError(t, err)
 

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1699,6 +1699,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/rbac/assign-role-with-expiry", rbacHandler.AssignRoleWithExpiryProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/rbac/assign-role-to-group-with-expiry", rbacHandler.AssignRoleToGroupWithExpiryProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/rbac/remove-all-project-role-grants", rbacHandler.RemoveAllProjectRoleGrantsProxy)
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/rbac/clear-project-secret-ownership", rbacHandler.ClearProjectSecretOwnershipProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/rbac/global-admin-role/remove-guarded", rbacHandler.RemoveGlobalAdminRoleGuardedProxy)
 
 			// MFA enrolment/management storage-primitive proxy (finding #524). Lets a


### PR DESCRIPTION
## Summary

- **RBAC-001**: `CheckSecretPermission`'s owner short-circuit now gates on `IsProjectMember` before returning `PermissionOwner`. A user removed from the project loses the owner fast-path immediately, regardless of whether their `owner_id` tag was cleared.
- **RBAC-002**: `RemoveProjectMember` calls `ClearProjectSecretOwnership` (defense-in-depth) to zero `owner_id` on the departing user's secrets in that project, preventing stale ownership tags from accumulating. Implemented as a single SQL `UPDATE` in `LocalStorage`; `RemoteStorage` proxies to a new system endpoint `/api/v1/system/rbac/clear-project-secret-ownership` (registered with `system.write` permission, same as the existing `remove-all-project-role-grants` proxy).

## Test plan

- [ ] Build passes (`go build ./...`)
- [ ] `go test ./internal/core/ -run TestRemoveProjectMember` — verifies `ClearProjectSecretOwnership` is called on member removal
- [ ] `go test ./internal/core/ -run TestCheckSecretPermission` — verifies owner path requires live membership
- [ ] Integration: add user as owner of a secret, remove from project, verify `CheckSecretPermission` returns permission-denied (not PermissionOwner)
- [ ] Verify `owner_id = 0` is set on the user's secrets after `RemoveProjectMember` call