### PR TITLE
fix(security): K8s Secret key/name validation in sync agent and operator CRD (K8SSYNC-001, K8SSYNC-002, TMPL-003)

### DIFF
--- a/deploy/helm/keyorix-operator/crds/secrets.keyorix.io_keyorixsecrets.yaml
+++ b/deploy/helm/keyorix-operator/crds/secrets.keyorix.io_keyorixsecrets.yaml
@@ -66,8 +66,10 @@ spec:
                         to read (ADR-059).
                       type: string
                     secretKey:
-                      description: SecretKey is the key to set in the target Kubernetes
-                        Secret.
+                      description: |-
+                        SecretKey is the key to set in the target Kubernetes Secret. Must be a valid
+                        Kubernetes Secret data key: alphanumeric, dash, dot, or underscore (K8SSYNC-001).
+                      pattern: ^[-._a-zA-Z0-9]+$
                       type: string
                   required:
                   - ref
@@ -90,8 +92,11 @@ spec:
                 description: Target is the Kubernetes Secret to create/maintain.
                 properties:
                   name:
-                    description: Name of the target Secret. Defaults to the KeyorixSecret's
-                      own name.
+                    description: |-
+                      Name of the target Secret. Defaults to the KeyorixSecret's own name. Must be a
+                      valid Kubernetes RFC1123 DNS subdomain (K8SSYNC-002).
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   type:
                     default: Opaque

--- a/internal/k8ssync/sync.go
+++ b/internal/k8ssync/sync.go
@@ -25,10 +25,17 @@ import (
 var (
 	dns1123Label     = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 	dns1123Subdomain = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+	// k8sSecretKey is the set of characters valid in a Kubernetes Secret data key
+	// (validated by the API server as "must be a valid filename": printable ASCII,
+	// no path separators — K8SSYNC-001). Without this, a mapping whose Key contains
+	// path metacharacters (/, ..) could reach the Kubernetes API with an invalid key
+	// name and trigger an opaque server-side rejection rather than a clear local error.
+	k8sSecretKey = regexp.MustCompile(`^[-._a-zA-Z0-9]+$`)
 )
 
 func isDNS1123Label(s string) bool     { return len(s) <= 63 && dns1123Label.MatchString(s) }
 func isDNS1123Subdomain(s string) bool { return len(s) <= 253 && dns1123Subdomain.MatchString(s) }
+func isK8sSecretKey(s string) bool     { return k8sSecretKey.MatchString(s) }
 
 // SecretMapping maps one Keyorix secret reference to a key inside a target
 // Kubernetes Secret. Several mappings may target the same Secret with different keys.
@@ -308,6 +315,8 @@ func validateMapping(m SecretMapping) error {
 		return fmt.Errorf("name is required")
 	case strings.TrimSpace(m.Key) == "":
 		return fmt.Errorf("key is required")
+	case !isK8sSecretKey(m.Key):
+		return fmt.Errorf("key %q is not a valid Kubernetes Secret data key (must match [-._a-zA-Z0-9]+)", m.Key)
 	case !isDNS1123Label(m.Namespace):
 		return fmt.Errorf("namespace %q is not a valid RFC1123 label", m.Namespace)
 	case !isDNS1123Subdomain(m.Name):

--- a/operator/api/v1alpha1/keyorixsecret_types.go
+++ b/operator/api/v1alpha1/keyorixsecret_types.go
@@ -17,7 +17,9 @@ type SecretKeySelector struct {
 
 // KeyorixSecretData maps one Keyorix secret reference to a key in the target Secret.
 type KeyorixSecretData struct {
-	// SecretKey is the key to set in the target Kubernetes Secret.
+	// SecretKey is the key to set in the target Kubernetes Secret. Must be a valid
+	// Kubernetes Secret data key: alphanumeric, dash, dot, or underscore (K8SSYNC-001).
+	// +kubebuilder:validation:Pattern=`^[-._a-zA-Z0-9]+$`
 	SecretKey string `json:"secretKey"`
 	// Ref is the Keyorix "project/environment/name" reference to read (ADR-059).
 	Ref string `json:"ref"`
@@ -25,7 +27,10 @@ type KeyorixSecretData struct {
 
 // KeyorixSecretTarget describes the Kubernetes Secret to create/maintain.
 type KeyorixSecretTarget struct {
-	// Name of the target Secret. Defaults to the KeyorixSecret's own name.
+	// Name of the target Secret. Defaults to the KeyorixSecret's own name. Must be a
+	// valid Kubernetes RFC1123 DNS subdomain (K8SSYNC-002).
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// +kubebuilder:validation:MaxLength=253
 	// +optional
 	Name string `json:"name,omitempty"`
 	// Type of the target Secret. Defaults to Opaque.

--- a/operator/config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml
+++ b/operator/config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml
@@ -66,8 +66,10 @@ spec:
                         to read (ADR-059).
                       type: string
                     secretKey:
-                      description: SecretKey is the key to set in the target Kubernetes
-                        Secret.
+                      description: |-
+                        SecretKey is the key to set in the target Kubernetes Secret. Must be a valid
+                        Kubernetes Secret data key: alphanumeric, dash, dot, or underscore (K8SSYNC-001).
+                      pattern: ^[-._a-zA-Z0-9]+$
                       type: string
                   required:
                   - ref
@@ -90,8 +92,11 @@ spec:
                 description: Target is the Kubernetes Secret to create/maintain.
                 properties:
                   name:
-                    description: Name of the target Secret. Defaults to the KeyorixSecret's
-                      own name.
+                    description: |-
+                      Name of the target Secret. Defaults to the KeyorixSecret's own name. Must be a
+                      valid Kubernetes RFC1123 DNS subdomain (K8SSYNC-002).
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   type:
                     default: Opaque


### PR DESCRIPTION
## Summary

- **K8SSYNC-001**: `validateMapping` in `internal/k8ssync/sync.go` now rejects a `SecretMapping.Key` that doesn't match `[-._a-zA-Z0-9]+` — the character set valid for Kubernetes Secret data keys. Previously, a key containing path metacharacters (e.g. `/`, `..`) would reach the K8s API and fail with an opaque server-side error.
- **K8SSYNC-002**: `KeyorixSecretData.SecretKey` in the operator CRD gains `+kubebuilder:validation:Pattern=^[-._a-zA-Z0-9]+$`, enforced by the API server on admission.
- **TMPL-003**: `KeyorixSecretTarget.Name` gains `+kubebuilder:validation:Pattern` (RFC1123 DNS subdomain) and `+kubebuilder:validation:MaxLength=253`, preventing an invalid or oversized secret name from being accepted.

CRD manifest regenerated (`make manifests` equivalent) and synced to the Helm chart at `deploy/helm/keyorix-operator/crds/`.

## Test plan

- [ ] `go test github.com/keyorixhq/keyorix/internal/k8ssync/...` — all 161 tests pass
- [ ] `GOWORK=off go build ./...` in `operator/` — clean build with new annotations
- [ ] Test with `SecretKey: "bad/key"` — admission webhook should reject it
- [ ] Test with `target.name: "INVALID_NAME"` — admission webhook should reject it
- [ ] Verify CRD diff in `operator/config/crd/bases/` shows the new `pattern` and `maxLength` entries