### PR TITLE
fix(security): MCP hardening — response size cap, ref format validation, truncation warning

### DIFF
--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -194,7 +194,144 @@ func TestListSecrets_HTTPError(t *testing.T) {
 	defer srv.Close()
 
 	c := mustClient(t, srv.URL, "tok")
-	_, err := c.ListSecrets(context.Background(), "")
+	_, _, err := c.ListSecrets(context.Background(), "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HTTP 500")
+}
+
+// -- MCP-002: response body size cap -----------------------------------------
+
+// TestGetJSON_LargeBodyCapped verifies that getJSON refuses to decode a response
+// body exceeding 10 MiB, preventing memory exhaustion from a hostile or broken
+// server sending an enormous payload.
+func TestGetJSON_LargeBodyCapped(t *testing.T) {
+	// Build a response that exceeds the 10 MiB cap: valid JSON envelope followed
+	// by 11 MiB of whitespace inside the "data" object — the decoder will hit the
+	// limit before finishing the read and return a decode error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Write a valid prefix, then fill well past 10 MiB so LimitReader truncates.
+		_, _ = w.Write([]byte(`{"data":{"value":"`))
+		pad := make([]byte, 11<<20) // 11 MiB of 'A'
+		for i := range pad {
+			pad[i] = 'A'
+		}
+		_, _ = w.Write(pad)
+		_, _ = w.Write([]byte(`"}}`))
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, srv.URL, "tok")
+	_, err := c.GetSecret(context.Background(), "app/prod/db")
+	// Either a decode error (truncated JSON) or an oversized value — either way, must fail.
+	require.Error(t, err)
+}
+
+// -- MCP-003: ref format validation ------------------------------------------
+
+// TestToolGetSecret_RefTooLong verifies that a ref exceeding 512 characters is
+// rejected before reaching the network.
+func TestToolGetSecret_RefTooLong(t *testing.T) {
+	long := "a/b/" + strings.Repeat("x", 510) // > 512 total
+	resps := run(t, NewServer(&fakeReader{value: "v"}, ""),
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"keyorix_get_secret","arguments":{"ref":"`+long+`"}}}`)
+	require.Len(t, resps, 1)
+	res := resultMap(t, resps[0])
+	assert.Equal(t, true, res["isError"])
+	assert.Contains(t, res["content"].([]any)[0].(map[string]any)["text"], "project/environment/name")
+}
+
+// TestToolGetSecret_RefWrongSegments verifies that a ref without exactly three
+// slash-separated segments is rejected.
+func TestToolGetSecret_RefWrongSegments(t *testing.T) {
+	cases := []string{
+		"no-slashes",
+		"only/two",
+		"too/many/slashes/here",
+	}
+	for _, ref := range cases {
+		resps := run(t, NewServer(&fakeReader{value: "v"}, ""),
+			`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"keyorix_get_secret","arguments":{"ref":"`+ref+`"}}}`)
+		require.Len(t, resps, 1)
+		res := resultMap(t, resps[0])
+		assert.Equal(t, true, res["isError"], "ref %q should be rejected", ref)
+	}
+}
+
+// TestToolGetSecret_RefEmptySegment verifies that a ref with an empty segment
+// (e.g. "/env/name" or "proj//name") is rejected.
+func TestToolGetSecret_RefEmptySegment(t *testing.T) {
+	cases := []string{"/env/name", "proj//name", "proj/env/"}
+	for _, ref := range cases {
+		resps := run(t, NewServer(&fakeReader{value: "v"}, ""),
+			`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"keyorix_get_secret","arguments":{"ref":"`+ref+`"}}}`)
+		require.Len(t, resps, 1)
+		res := resultMap(t, resps[0])
+		assert.Equal(t, true, res["isError"], "ref %q should be rejected", ref)
+	}
+}
+
+// -- MCP-005: pagination truncation warning ----------------------------------
+
+// TestListSecrets_Truncated verifies that when the upstream returns a full page
+// (≥100 secrets), toolListSecrets appends a truncation notice to the result so
+// the agent knows to re-query with an environment filter.
+func TestListSecrets_Truncated(t *testing.T) {
+	// Build exactly 100 secrets so the fakeReader signals truncated=true.
+	infos := make([]SecretInfo, 100)
+	for i := range infos {
+		infos[i] = SecretInfo{Ref: "app/prod/db"}
+	}
+	fr := &fakeReader{list: infos, listTruncated: true}
+	resps := run(t, NewServer(fr, ""),
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"keyorix_list_secrets","arguments":{}}}`)
+	require.Len(t, resps, 1)
+	res := resultMap(t, resps[0])
+	assert.NotEqual(t, true, res["isError"])
+	text := res["content"].([]any)[0].(map[string]any)["text"].(string)
+	assert.Contains(t, text, "results may be incomplete")
+	assert.Contains(t, text, "environment filter")
+}
+
+// TestListSecrets_NotTruncated verifies that when the upstream returns fewer
+// than 100 secrets, no truncation notice appears.
+func TestListSecrets_NotTruncated(t *testing.T) {
+	fr := &fakeReader{list: []SecretInfo{{Ref: "app/prod/db"}}, listTruncated: false}
+	resps := run(t, NewServer(fr, ""),
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"keyorix_list_secrets","arguments":{}}}`)
+	require.Len(t, resps, 1)
+	res := resultMap(t, resps[0])
+	assert.NotEqual(t, true, res["isError"])
+	text := res["content"].([]any)[0].(map[string]any)["text"].(string)
+	assert.NotContains(t, text, "incomplete")
+}
+
+// TestKeyorixClient_ListSecretsTruncated verifies that the KeyorixClient sets
+// the truncated flag when the server returns exactly 100 secrets.
+func TestKeyorixClient_ListSecretsTruncated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Build a response with exactly 100 secrets.
+		type sec struct {
+			Name            string `json:"Name"`
+			Type            string `json:"Type"`
+			ProjectName     string `json:"project_name"`
+			EnvironmentName string `json:"environment_name"`
+		}
+		type resp struct {
+			Secrets []sec `json:"secrets"`
+		}
+		secrets := make([]sec, 100)
+		for i := range secrets {
+			secrets[i] = sec{Name: "s", ProjectName: "p", EnvironmentName: "e", Type: "password"}
+		}
+		b, _ := json.Marshal(map[string]any{"data": resp{Secrets: secrets}})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(b)
+	}))
+	defer srv.Close()
+
+	c := mustClient(t, srv.URL, "tok")
+	_, truncated, err := c.ListSecrets(context.Background(), "")
+	require.NoError(t, err)
+	assert.True(t, truncated, "100 secrets returned → truncated must be true")
 }

--- a/internal/mcp/keyorix.go
+++ b/internal/mcp/keyorix.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -89,7 +90,9 @@ func (c *KeyorixClient) GetSecret(ctx context.Context, ref string) (string, erro
 
 // ListSecrets returns the references the token can see, optionally filtered to one
 // environment. Metadata only — no values are read. Capped at one page (100).
-func (c *KeyorixClient) ListSecrets(ctx context.Context, environment string) ([]SecretInfo, error) {
+// The second return value is true when the server returned a full page (≥100 entries),
+// indicating that results may be incomplete (MCP-005).
+func (c *KeyorixClient) ListSecrets(ctx context.Context, environment string) ([]SecretInfo, bool, error) {
 	var body struct {
 		Secrets []struct {
 			Name            string `json:"Name"`
@@ -99,8 +102,9 @@ func (c *KeyorixClient) ListSecrets(ctx context.Context, environment string) ([]
 		} `json:"secrets"`
 	}
 	if err := c.getJSON(ctx, "/api/v1/secrets?page_size=100", &body); err != nil {
-		return nil, err
+		return nil, false, err
 	}
+	truncated := len(body.Secrets) >= 100
 	out := make([]SecretInfo, 0, len(body.Secrets))
 	for _, s := range body.Secrets {
 		if environment != "" && !strings.EqualFold(s.EnvironmentName, environment) {
@@ -114,7 +118,7 @@ func (c *KeyorixClient) ListSecrets(ctx context.Context, environment string) ([]
 			Type: s.Type,
 		})
 	}
-	return out, nil
+	return out, truncated, nil
 }
 
 // getJSON performs an authenticated GET and decodes the {"data": …} envelope into out.
@@ -146,7 +150,7 @@ func (c *KeyorixClient) getJSON(ctx context.Context, path string, out interface{
 	var env struct {
 		Data json.RawMessage `json:"data"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 10<<20)).Decode(&env); err != nil {
 		return fmt.Errorf("decode response: %w", err)
 	}
 	if env.Data == nil {

--- a/internal/mcp/keyorix_test.go
+++ b/internal/mcp/keyorix_test.go
@@ -69,15 +69,16 @@ func TestKeyorixClient_ListSecretsBuildsRefsAndFilters(t *testing.T) {
 
 	// No filter: the two complete entries map to refs; the entry missing an environment
 	// is dropped (can't form an unambiguous ref).
-	all, err := mustClient(t, srv.URL, "tok").ListSecrets(context.Background(), "")
+	all, truncated, err := mustClient(t, srv.URL, "tok").ListSecrets(context.Background(), "")
 	require.NoError(t, err)
+	assert.False(t, truncated) // only 3 items returned — well below 100
 	require.Len(t, all, 2)
 	assert.Equal(t, "app/production/db", all[0].Ref)
 	assert.Equal(t, "password", all[0].Type)
 	assert.Equal(t, "app/staging/api", all[1].Ref)
 
 	// Environment filter (case-insensitive) narrows to one.
-	prod, err := mustClient(t, srv.URL, "tok").ListSecrets(context.Background(), "Production")
+	prod, _, err := mustClient(t, srv.URL, "tok").ListSecrets(context.Background(), "Production")
 	require.NoError(t, err)
 	require.Len(t, prod, 1)
 	assert.Equal(t, "app/production/db", prod[0].Ref)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -20,7 +20,7 @@ const jsonrpcVersion = "2.0"
 // unit-tested without HTTP. Satisfied by *KeyorixClient.
 type SecretReader interface {
 	GetSecret(ctx context.Context, ref string) (string, error)
-	ListSecrets(ctx context.Context, environment string) ([]SecretInfo, error)
+	ListSecrets(ctx context.Context, environment string) ([]SecretInfo, bool, error)
 }
 
 // Server speaks MCP over a JSON-RPC 2.0 stream (stdio). It exposes read-only Keyorix

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -14,10 +14,11 @@ import (
 )
 
 type fakeReader struct {
-	value   string
-	getErr  error
-	list    []SecretInfo
-	listErr error
+	value         string
+	getErr        error
+	list          []SecretInfo
+	listTruncated bool
+	listErr       error
 
 	gotRef string
 	gotEnv string
@@ -31,12 +32,12 @@ func (f *fakeReader) GetSecret(_ context.Context, ref string) (string, error) {
 	return f.value, nil
 }
 
-func (f *fakeReader) ListSecrets(_ context.Context, env string) ([]SecretInfo, error) {
+func (f *fakeReader) ListSecrets(_ context.Context, env string) ([]SecretInfo, bool, error) {
 	f.gotEnv = env
 	if f.listErr != nil {
-		return nil, f.listErr
+		return nil, false, f.listErr
 	}
-	return f.list, nil
+	return f.list, f.listTruncated, nil
 }
 
 // run feeds the given JSON-RPC messages through Serve and returns the decoded responses.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -88,6 +88,16 @@ func (s *Server) toolGetSecret(ctx context.Context, args json.RawMessage) map[st
 	if ref == "" {
 		return errorResult("ref is required (project/environment/name)")
 	}
+	// MCP-003: validate ref format before touching the network. A ref must be
+	// exactly "project/environment/name" (3 non-empty segments, ≤512 chars).
+	// Returning a clear format error here is safe — the agent needs it to fix
+	// the call, and no secret existence information is revealed.
+	if len(ref) > 512 || strings.Count(ref, "/") != 2 {
+		return errorResult("ref must be project/environment/name (e.g. app/production/db-password)")
+	}
+	if parts := strings.SplitN(ref, "/", 3); parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return errorResult("ref must be project/environment/name (e.g. app/production/db-password)")
+	}
 	if !refAllowed(s.allowedRefs, ref) {
 		log.Printf("keyorix_get_secret: ref %q rejected by the configured allowlist", ref)
 		return errorResult(genericReadError)
@@ -116,7 +126,7 @@ func (s *Server) toolListSecrets(ctx context.Context, args json.RawMessage) map[
 		Environment string `json:"environment"`
 	}
 	_ = json.Unmarshal(args, &a)
-	infos, err := s.reader.ListSecrets(ctx, a.Environment)
+	infos, truncated, err := s.reader.ListSecrets(ctx, a.Environment)
 	if err != nil {
 		log.Printf("keyorix_list_secrets: failed: %v", err)
 		return errorResult(genericListError)
@@ -137,7 +147,13 @@ func (s *Server) toolListSecrets(ctx context.Context, args json.RawMessage) map[
 	if shown == 0 {
 		return textResult("(no secrets visible to this token)")
 	}
-	return textResult(strings.TrimRight(b.String(), "\n"))
+	// MCP-005: warn when the server returned a full page (≥100 entries) and there
+	// may be more. The agent should re-query with an environment filter to narrow.
+	result := strings.TrimRight(b.String(), "\n")
+	if truncated {
+		result += "\n\n(results may be incomplete — more than 100 secrets exist; use an environment filter to narrow the list)"
+	}
+	return textResult(result)
 }
 
 // refAllowed reports whether ref matches at least one of patterns (path.Match-style


### PR DESCRIPTION
## Summary

- **MCP-002** (`internal/mcp/keyorix.go`): Wrap `getJSON` response body in `io.LimitReader(10 MiB)` before JSON decoding — prevents memory exhaustion when a malicious or misbehaving Keyorix server returns an unbounded payload.
- **MCP-003** (`internal/mcp/tools.go`): Validate `keyorix_get_secret` ref before touching the network — must be exactly three non-empty slash-separated segments (`project/environment/name`) and ≤512 chars; returns a clear format error to the LLM without leaking any secret existence information.
- **MCP-005** (`internal/mcp/keyorix.go`, `tools.go`, `server.go`): `ListSecrets` now returns a `truncated bool` signalling when the upstream returned a full page (≥100 entries); `toolListSecrets` appends a truncation notice prompting the agent to re-query with an environment filter.

## Test plan

- `TestGetJSON_LargeBodyCapped` — 11 MiB response body is rejected by `LimitReader`
- `TestToolGetSecret_RefTooLong` — ref > 512 chars is rejected before the network
- `TestToolGetSecret_RefWrongSegments` — refs with ≠2 slashes are rejected
- `TestToolGetSecret_RefEmptySegment` — refs with empty segments are rejected
- `TestListSecrets_Truncated` — truncation notice appears when `truncated=true`
- `TestListSecrets_NotTruncated` — no notice for a small result set
- `TestKeyorixClient_ListSecretsTruncated` — `KeyorixClient.ListSecrets` sets the flag at exactly 100 entries