### PR TITLE
fix(security): SSRF guard for dynamic-secret admin DSNs (GRPC-006)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1555,6 +1555,14 @@ type DynamicSecretsConfig struct {
 	// max_ttl_seconds unbounded and mint a credential valid for, say, 100 years). Go
 	// duration string (e.g. "720h"); defaults to 90 days when unset or unparseable.
 	MaxLeaseTTL string `yaml:"max_lease_ttl"`
+	// AllowPrivateNetworkTargets, when true, disables the SSRF guard on admin_dsn so
+	// dynamic-secret backends at RFC-1918, loopback, or link-local addresses can be
+	// registered. False by default: Keyorix otherwise rejects DSNs whose resolved host
+	// is a private address, preventing an internal operator from using the service as
+	// an SSRF proxy against other internal hosts (including cloud IMDS at
+	// 169.254.169.254). Set this only when the dynamic-secret backend legitimately
+	// lives on a private network segment that Keyorix must reach.
+	AllowPrivateNetworkTargets bool `yaml:"allow_private_network_targets"`
 }
 
 // GetSweepInterval returns the auto-revoke sweep cadence, parsing SweepInterval

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
+	"net/url"
 	"strings"
 	"time"
 
@@ -26,6 +28,118 @@ const defaultDynamicTTL = 1 * time.Hour
 // own default so behaviour is identical whether or not the server wired
 // SetDynamicMaxLeaseTTL, e.g. in tests that construct KeyorixCore directly).
 const defaultMaxLeaseTTL = 90 * 24 * time.Hour
+
+// privateNetworkCIDRs is the set of IP ranges rejected by the admin-DSN SSRF guard.
+// Covers RFC-1918, loopback, link-local (including cloud IMDS at 169.254.169.254),
+// shared carrier-grade NAT (RFC 6598), and IPv6 private/link-local ranges.
+var privateNetworkCIDRs = func() []*net.IPNet {
+	var nets []*net.IPNet
+	for _, cidr := range []string{
+		"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", // RFC-1918
+		"127.0.0.0/8",    // loopback
+		"169.254.0.0/16", // link-local / cloud IMDS
+		"100.64.0.0/10",  // shared address space (RFC 6598)
+		"::1/128",        // IPv6 loopback
+		"fc00::/7",       // IPv6 unique local
+		"fe80::/10",      // IPv6 link-local
+	} {
+		_, n, _ := net.ParseCIDR(cidr)
+		if n != nil {
+			nets = append(nets, n)
+		}
+	}
+	return nets
+}()
+
+func isPrivateIP(ip net.IP) bool {
+	for _, cidr := range privateNetworkCIDRs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseDSNHost extracts the host (without port) from an admin DSN in any of the
+// supported formats:
+//   - URL-form: postgres://user:pass@host:port/db, mysql://…, mongodb://…, redis://…
+//   - PostgreSQL key-value: host=xxx port=yyy user=zzz dbname=www
+//   - MySQL tcp-wrapper: user:pass@tcp(host:port)/db or user:pass@(host:port)/db
+//
+// Returns "" when the format is unrecognised or the host cannot be extracted.
+func parseDSNHost(dsn string) string {
+	// URL-form DSNs (any scheme that carries ://host).
+	if strings.Contains(dsn, "://") {
+		if u, err := url.Parse(dsn); err == nil && u.Host != "" {
+			h, _, _ := net.SplitHostPort(u.Host)
+			if h == "" {
+				return u.Host
+			}
+			return h
+		}
+	}
+	// MySQL tcp-wrapper: user:pass@tcp(host:port)/db
+	if i := strings.Index(dsn, "@tcp("); i >= 0 {
+		rest := dsn[i+5:]
+		if j := strings.IndexByte(rest, ')'); j >= 0 {
+			h, _, _ := net.SplitHostPort(rest[:j])
+			if h == "" {
+				return rest[:j]
+			}
+			return h
+		}
+	}
+	// MySQL alternative wrapper: user:pass@(host:port)/db
+	if i := strings.Index(dsn, "@("); i >= 0 {
+		rest := dsn[i+2:]
+		if j := strings.IndexByte(rest, ')'); j >= 0 {
+			h, _, _ := net.SplitHostPort(rest[:j])
+			if h == "" {
+				return rest[:j]
+			}
+			return h
+		}
+	}
+	// PostgreSQL key-value: scan for host=<value>
+	for _, part := range strings.Fields(dsn) {
+		if strings.HasPrefix(part, "host=") {
+			return strings.TrimPrefix(part, "host=")
+		}
+	}
+	return ""
+}
+
+// validateAdminDSNHost rejects an admin DSN whose host is a private or link-local
+// address. Literal IPs are checked directly; hostnames are resolved and each
+// returned address is checked. If the hostname cannot be resolved (e.g. the target
+// is in a network segment not reachable from Keyorix at config-register time), the
+// check is skipped — the connection will fail at issue time. This prevents an internal
+// operator from using Keyorix as an SSRF proxy against other services on the same
+// private network (including the cloud IMDS endpoint).
+func validateAdminDSNHost(adminDSN string) error {
+	host := parseDSNHost(adminDSN)
+	if host == "" {
+		return nil // unrecognised format — can't extract host
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if isPrivateIP(ip) {
+			return fmt.Errorf("admin_dsn host %q is a private or link-local address; "+
+				"set dynamic_secrets.allow_private_network_targets: true to allow private-network backends", host)
+		}
+		return nil
+	}
+	addrs, err := net.LookupHost(host)
+	if err != nil {
+		return nil // unresolvable at register time — actual connection fails at issue time
+	}
+	for _, addr := range addrs {
+		if ip := net.ParseIP(addr); ip != nil && isPrivateIP(ip) {
+			return fmt.Errorf("admin_dsn host %q resolves to private or link-local address %s; "+
+				"set dynamic_secrets.allow_private_network_targets: true to allow private-network backends", host, addr)
+		}
+	}
+	return nil
+}
 
 // CreateDynamicSecretConfigRequest registers a dynamic-secrets target.
 type CreateDynamicSecretConfigRequest struct {
@@ -87,6 +201,15 @@ func (c *KeyorixCore) CreateDynamicSecretConfig(ctx context.Context, req *Create
 	}
 	if err := validateCreationTemplate(req.BackendType, req.CreationTemplate); err != nil {
 		return nil, err
+	}
+	// SSRF guard: reject an admin_dsn whose host is a private or link-local address
+	// unless the operator has explicitly opted in (allow_private_network_targets).
+	// Prevents an internal operator from using Keyorix as a proxy to scan/reach
+	// other services at its network position, including cloud IMDS.
+	if !c.dynamicAllowPrivateTargets {
+		if err := validateAdminDSNHost(req.AdminDSN); err != nil {
+			return nil, err
+		}
 	}
 	// #94: the admin DSN is encrypted bound to DynamicSecretConfigAAD(cfg.ID, ...), so
 	// it must be encrypted AFTER the row exists (cfg.ID is an auto-increment PK, not

--- a/internal/core/dynamic_secrets_ssrf_test.go
+++ b/internal/core/dynamic_secrets_ssrf_test.go
@@ -1,0 +1,155 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -- parseDSNHost -------------------------------------------------------------
+
+func TestParseDSNHost_URLForms(t *testing.T) {
+	cases := []struct {
+		dsn  string
+		want string
+	}{
+		{"postgres://admin:pass@db.example.com:5432/app", "db.example.com"},
+		{"mysql://user:pass@mysql.internal:3306/db", "mysql.internal"},
+		{"mongodb://user:pass@mongo.internal:27017/db", "mongo.internal"},
+		{"redis://user:pass@redis.internal:6379/0", "redis.internal"},
+		// IPv4 literal
+		{"postgres://admin:pass@10.0.0.5:5432/app", "10.0.0.5"},
+		// IPv6 literal (bracketed)
+		{"postgres://admin:pass@[::1]:5432/app", "::1"},
+	}
+	for _, tc := range cases {
+		got := parseDSNHost(tc.dsn)
+		assert.Equal(t, tc.want, got, "DSN: %s", tc.dsn)
+	}
+}
+
+func TestParseDSNHost_PostgresKeyValue(t *testing.T) {
+	dsn := "host=db.internal port=5432 user=admin dbname=app sslmode=require"
+	assert.Equal(t, "db.internal", parseDSNHost(dsn))
+
+	dsnIP := "host=10.0.0.5 port=5432 user=admin dbname=app"
+	assert.Equal(t, "10.0.0.5", parseDSNHost(dsnIP))
+}
+
+func TestParseDSNHost_MySQLTCPWrapper(t *testing.T) {
+	dsn := "admin:pass@tcp(db.internal:3306)/app"
+	assert.Equal(t, "db.internal", parseDSNHost(dsn))
+
+	dsnAlt := "admin:pass@(db.internal:3306)/app"
+	assert.Equal(t, "db.internal", parseDSNHost(dsnAlt))
+
+	dsnIP := "admin:pass@tcp(192.168.1.10:3306)/app"
+	assert.Equal(t, "192.168.1.10", parseDSNHost(dsnIP))
+}
+
+func TestParseDSNHost_UnrecognisedReturnsEmpty(t *testing.T) {
+	assert.Equal(t, "", parseDSNHost(""))
+	assert.Equal(t, "", parseDSNHost("not-a-dsn"))
+}
+
+// -- validateAdminDSNHost -----------------------------------------------------
+
+func TestValidateAdminDSNHost_PrivateLiteralIPRejected(t *testing.T) {
+	cases := []struct {
+		desc string
+		dsn  string
+	}{
+		{"RFC-1918 10/8", "postgres://admin:pass@10.0.0.5:5432/app"},
+		{"RFC-1918 172.16/12", "postgres://admin:pass@172.16.0.1:5432/app"},
+		{"RFC-1918 192.168/16", "postgres://admin:pass@192.168.1.1:5432/app"},
+		{"loopback 127.0.0.1", "postgres://admin:pass@127.0.0.1:5432/app"},
+		{"link-local 169.254.x.x", "postgres://admin:pass@169.254.169.254:5432/app"},
+		{"shared CGN 100.64.x.x", "postgres://admin:pass@100.64.0.1:5432/app"},
+		{"key-value private", "host=10.1.2.3 port=5432 user=admin dbname=app"},
+		{"mysql tcp private", "admin:pass@tcp(192.168.0.5:3306)/app"},
+	}
+	for _, tc := range cases {
+		err := validateAdminDSNHost(tc.dsn)
+		assert.Error(t, err, "should reject private IP (%s): %s", tc.desc, tc.dsn)
+		if err != nil {
+			assert.Contains(t, err.Error(), "private or link-local")
+		}
+	}
+}
+
+func TestValidateAdminDSNHost_PublicIPAllowed(t *testing.T) {
+	dsn := "postgres://admin:pass@203.0.113.5:5432/app" // TEST-NET, globally routable
+	require.NoError(t, validateAdminDSNHost(dsn))
+}
+
+func TestValidateAdminDSNHost_UnresolvableHostAllowed(t *testing.T) {
+	// A hostname that can't be DNS-resolved at register time — fail-open so that
+	// private-segment targets (reachable from Keyorix but not from DNS resolvers
+	// it happens to use at startup) aren't locked out without AllowPrivateNetworkTargets.
+	dsn := "postgres://admin:pass@this-hostname-does-not-exist.example.invalid:5432/app"
+	require.NoError(t, validateAdminDSNHost(dsn))
+}
+
+func TestValidateAdminDSNHost_UnrecognisedDSNAllowed(t *testing.T) {
+	// Unrecognised DSN format → host extraction fails → skip check (can't validate).
+	require.NoError(t, validateAdminDSNHost("not-a-dsn"))
+}
+
+// -- CreateDynamicSecretConfig SSRF guard integration -------------------------
+
+func TestDynamicSecrets_CreateConfig_SSRFGuardRejectsPrivateIP(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+
+	// Private IP in the DSN must be rejected by the SSRF guard (default: guard ON).
+	_, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name:          "ssrf-test",
+		ProjectID:     1,
+		EnvironmentID: 2,
+		BackendType:   "postgres",
+		AdminDSN:      "postgres://admin:pass@10.0.0.5:5432/app",
+		CreatedBy:     "alice",
+		ActorID:       testAdminActorID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "private or link-local")
+}
+
+func TestDynamicSecrets_CreateConfig_SSRFGuardBypassed(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	// Opt in to allow private targets — the private IP must now be accepted.
+	c.SetDynamicAllowPrivateTargets(true)
+
+	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name:          "ssrf-bypass",
+		ProjectID:     1,
+		EnvironmentID: 2,
+		BackendType:   "postgres",
+		AdminDSN:      "postgres://admin:pass@10.0.0.5:5432/app",
+		CreatedBy:     "alice",
+		ActorID:       testAdminActorID,
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, cfg.ID)
+}
+
+func TestDynamicSecrets_CreateConfig_SSRFGuardLinkLocal(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+
+	// 169.254.169.254 is the cloud IMDS endpoint — should be blocked.
+	_, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name:          "imds-attempt",
+		ProjectID:     1,
+		EnvironmentID: 2,
+		BackendType:   "postgres",
+		AdminDSN:      "postgres://admin:pass@169.254.169.254:5432/steal-imds",
+		CreatedBy:     "alice",
+		ActorID:       testAdminActorID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "private or link-local")
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -74,6 +74,11 @@ type KeyorixCore struct {
 	// config's own MaxTTLSeconds, which has no ceiling of its own. Zero = the
 	// package default (90 days) applies. Set via SetDynamicMaxLeaseTTL.
 	dynamicMaxLeaseTTL time.Duration
+	// dynamicAllowPrivateTargets mirrors config
+	// dynamic_secrets.allow_private_network_targets. When false (the default), the
+	// SSRF guard in CreateDynamicSecretConfig rejects admin DSNs whose host resolves
+	// to a private or link-local address. Set via SetDynamicAllowPrivateTargets.
+	dynamicAllowPrivateTargets bool
 	// webauthnRP is the WebAuthn relying party (ADR-036); nil = WebAuthn disabled.
 	// Set from config at startup via SetWebAuthn.
 	webauthnRP     *webauthn.WebAuthn
@@ -546,6 +551,14 @@ func (c *KeyorixCore) SetDynamicEngineFactory(f func(string) (dynamic.Credential
 // to mint a credential from a backend whose TTL only the sweeper would enforce.
 func (c *KeyorixCore) SetDynamicSweepEnabled(enabled bool) {
 	c.dynamicSweepEnabled = enabled
+}
+
+// SetDynamicAllowPrivateTargets controls whether the admin-DSN SSRF guard is
+// bypassed. When false (the default), CreateDynamicSecretConfig rejects DSNs
+// whose host resolves to a private or link-local address. Set to true only when
+// the dynamic-secret backend legitimately lives on a private segment.
+func (c *KeyorixCore) SetDynamicAllowPrivateTargets(allow bool) {
+	c.dynamicAllowPrivateTargets = allow
 }
 
 // SetDynamicMaxLeaseTTL sets the install-wide dynamic-secret lease TTL ceiling

--- a/server/grpc/services/dynamic_secret_service_test.go
+++ b/server/grpc/services/dynamic_secret_service_test.go
@@ -55,6 +55,7 @@ func newDynamicTestRig(t *testing.T) *DynamicSecretGRPCService {
 
 	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
 	coreService.SetAuthEncryptor(enc)
+	coreService.SetDynamicAllowPrivateTargets(true) // tests use localhost DSNs; real SSRF guard tested in dynamic_secrets_ssrf_test.go
 	fake := &dynamic.FakeEngine{NativeExpiry: true}
 	coreService.SetDynamicEngineFactory(func(string) (dynamic.CredentialEngine, error) { return fake, nil })
 	return NewDynamicSecretService(coreService)

--- a/server/http/handlers/handlers_s11_test.go
+++ b/server/http/handlers/handlers_s11_test.go
@@ -75,7 +75,9 @@ func freshCoreS11(t *testing.T) *core.KeyorixCore {
 		&models.SecretVersion{},
 	)
 	require.NoError(t, err)
-	return core.NewKeyorixCore(store.NewLocalStorage(db))
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	cs.SetDynamicAllowPrivateTargets(true) // tests use localhost DSNs; SSRF guard tested in dynamic_secrets_ssrf_test.go
+	return cs
 }
 
 // bootstrapS11 bootstraps a fresh core and returns the admin's session token.

--- a/server/http/handlers/handlers_s23_test.go
+++ b/server/http/handlers/handlers_s23_test.go
@@ -234,6 +234,7 @@ func TestGetUserGroupsProxy_EmptyList_S23(t *testing.T) {
 // user with a seeded project+environment creates a config successfully.
 func TestDynamic_CreateConfig_HappyPath_S23(t *testing.T) {
 	cs, db := freshCoreS12WithAdmin(t)
+	cs.SetDynamicAllowPrivateTargets(true) // test uses localhost DSN; SSRF guard tested in dynamic_secrets_ssrf_test.go
 	h := NewDynamicSecretHandler(cs)
 
 	proj := &models.Project{Name: "s23-create-cfg-proj"}

--- a/server/http/handlers/handlers_s8_test.go
+++ b/server/http/handlers/handlers_s8_test.go
@@ -69,7 +69,9 @@ func freshCoreS8(t *testing.T) *core.KeyorixCore {
 		&models.PasswordHistory{},
 	)
 	require.NoError(t, err)
-	return core.NewKeyorixCore(store.NewLocalStorage(db))
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	cs.SetDynamicAllowPrivateTargets(true) // tests use localhost DSNs; SSRF guard tested in dynamic_secrets_ssrf_test.go
+	return cs
 }
 
 // bootstrapS8 boots a fresh core and returns a session token for the admin.

--- a/server/main.go
+++ b/server/main.go
@@ -696,6 +696,9 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	// refuses to mint from backends whose lease TTL only the sweeper enforces
 	// (MySQL/MongoDB) when it is disabled — otherwise the credential never expires.
 	coreService.SetDynamicSweepEnabled(cfg.DynamicSecrets.SweepEnabled)
+	// SSRF guard for admin DSNs: disabled (private targets allowed) only when the
+	// operator explicitly opts in via dynamic_secrets.allow_private_network_targets.
+	coreService.SetDynamicAllowPrivateTargets(cfg.DynamicSecrets.AllowPrivateNetworkTargets)
 	// Install-wide hard ceiling on any dynamic-secret lease's TTL (#97); enforced on
 	// top of each config's own optional (default-unbounded) MaxTTLSeconds.
 	coreService.SetDynamicMaxLeaseTTL(cfg.DynamicSecrets.GetMaxLeaseTTL())


### PR DESCRIPTION
## Summary

- **GRPC-006**: `CreateDynamicSecretConfig` now rejects `admin_dsn` values whose host resolves to a private or link-local address (RFC-1918, loopback, 169.254.0.0/16 cloud IMDS, RFC-6598 shared CGN, IPv6 private/link-local).
- Prevents a project admin from using Keyorix as an SSRF proxy against other services on its private network segment — including the AWS/GCP/Azure instance metadata endpoint at `169.254.169.254`.
- Operators who genuinely need a private-segment backend can opt in: `dynamic_secrets.allow_private_network_targets: true` (wired via `SetDynamicAllowPrivateTargets`).
- DSN host extraction handles: URL-form (`postgres://`, `mysql://`, `mongodb://`, `redis://`), PostgreSQL key-value (`host=…`), MySQL tcp-wrapper (`@tcp(host:port)/db`). Unresolvable hostnames are fail-open (private-segment targets not reachable from the Keyorix DNS resolver at startup would otherwise be permanently blocked).

## Test plan

- `TestParseDSNHost_URLForms` — URL-form DSN host extraction across all URL schemes
- `TestParseDSNHost_PostgresKeyValue` — key-value `host=` extraction
- `TestParseDSNHost_MySQLTCPWrapper` — `@tcp(host:port)` and `@(host:port)` extraction
- `TestParseDSNHost_UnrecognisedReturnsEmpty` — unrecognised DSN returns empty host
- `TestValidateAdminDSNHost_PrivateLiteralIPRejected` — 8 private/link-local literal IPs all rejected
- `TestValidateAdminDSNHost_PublicIPAllowed` — globally routable IP passes
- `TestValidateAdminDSNHost_UnresolvableHostAllowed` — unresolvable hostname passes (fail-open)
- `TestValidateAdminDSNHost_UnrecognisedDSNAllowed` — unrecognised DSN passes (can't validate)
- `TestDynamicSecrets_CreateConfig_SSRFGuardRejectsPrivateIP` — end-to-end: private IP rejected at `CreateDynamicSecretConfig`
- `TestDynamicSecrets_CreateConfig_SSRFGuardBypassed` — bypass via `SetDynamicAllowPrivateTargets(true)`
- `TestDynamicSecrets_CreateConfig_SSRFGuardLinkLocal` — IMDS endpoint `169.254.169.254` blocked