### PR TITLE
fix(security): DAST #1209 + #1210 — CORP header and bare-path SPA fallback

### DIFF
--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1970,6 +1970,12 @@ func isBackendRoute(p string) bool {
 		if strings.HasPrefix(p, prefix) {
 			return true
 		}
+		// A prefix ending in "/" (e.g. "/api/") also covers the bare path without
+		// the trailing slash (e.g. "/api"), so GET /api or GET /auth returns 404
+		// instead of falling through to the SPA and returning HTML.
+		if strings.HasSuffix(prefix, "/") && p == prefix[:len(prefix)-1] {
+			return true
+		}
 	}
 	return false
 }

--- a/server/http/static_hardening_test.go
+++ b/server/http/static_hardening_test.go
@@ -136,6 +136,12 @@ func TestNotFound_BackendRoutePrefixesReturn404(t *testing.T) {
 		"/status/typo",
 		"/swagger/typo",
 		"/openapi.yaml.bak",
+		// Bare paths without trailing slash — ZAP/100001: these must also 404 rather
+		// than fall through to the SPA and return HTML (DAST #1210).
+		"/api",
+		"/auth",
+		"/scim",
+		"/swagger",
 		// /api/v1/does-not-exist is NOT asserted here: an unmatched path inside the
 		// /api/v1 subrouter never reaches this NotFound handler at all — it's caught
 		// by the subrouter's own auth middleware first (401, see

--- a/server/middleware/security_headers.go
+++ b/server/middleware/security_headers.go
@@ -45,6 +45,7 @@ func SecurityHeaders(tlsEnabled bool) func(http.Handler) http.Handler {
 			h.Set("X-Frame-Options", "DENY")
 			h.Set("Referrer-Policy", "no-referrer")
 			h.Set("Content-Security-Policy", contentSecurityPolicy)
+			h.Set("Cross-Origin-Resource-Policy", "same-origin")
 			h.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()")
 			if tlsEnabled {
 				h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")

--- a/server/middleware/security_headers_test.go
+++ b/server/middleware/security_headers_test.go
@@ -41,3 +41,10 @@ func TestSecurityHeaders_HSTSOnlyWithTLS(t *testing.T) {
 	hdr := serve(t, true)
 	assert.Equal(t, "max-age=31536000; includeSubDomains", hdr.Get("Strict-Transport-Security"))
 }
+
+// DAST #1209 (ZAP/90004): Cross-Origin-Resource-Policy must be set on every response
+// to counter Spectre-style cross-origin side-channel attacks.
+func TestSecurityHeaders_CORPAlwaysSet(t *testing.T) {
+	hdr := serve(t, false)
+	assert.Equal(t, "same-origin", hdr.Get("Cross-Origin-Resource-Policy"))
+}


### PR DESCRIPTION
## Summary

- **#1209 (ZAP/90004, CWE-693)**: `Cross-Origin-Resource-Policy: same-origin` was missing from every response. Added to `SecurityHeaders` middleware alongside the other hardening headers.
- **#1210 (ZAP/100001)**: Bare paths like `/api`, `/auth`, `/scim`, `/swagger` (no trailing slash) were falling through to the SPA fallback and returning `text/html`, flagged as unexpected content type for an API server. Extended `isBackendRoute` to also match each slash-terminated prefix without its trailing slash.

## Root causes

| Issue | Root cause |
|---|---|
| #1209 | `Cross-Origin-Resource-Policy` simply wasn't in the `SecurityHeaders` list |
| #1210 | `backendRoutePrefixes` uses `/api/` (with slash), so `GET /api` (no slash) didn't match → SPA HTML |

## Test plan

- `TestSecurityHeaders_CORPAlwaysSet` — new, verifies `Cross-Origin-Resource-Policy: same-origin` is present
- `TestNotFound_BackendRoutePrefixesReturn404` — extended with `/api`, `/auth`, `/scim`, `/swagger` bare-path cases; all return 404, not the SPA shell

Closes #1209, #1210.