### PR TITLE
fix(security): DAST #1211-#1215 — CSP hardening and cross-origin isolation headers

### DIFF
--- a/deploy/helm/keyorix/templates/web-config.yaml
+++ b/deploy/helm/keyorix/templates/web-config.yaml
@@ -41,11 +41,14 @@ data:
         {{- end }}
       }
 
-      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header X-Frame-Options "DENY" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header X-XSS-Protection "1; mode=block" always;
-      add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self';" always;
+      add_header Referrer-Policy "no-referrer" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; form-action 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none';" always;
+      add_header Cross-Origin-Resource-Policy "same-origin" always;
+      add_header Cross-Origin-Embedder-Policy "require-corp" always;
+      add_header Cross-Origin-Opener-Policy "same-origin" always;
 
       server {
         listen 80;

--- a/server/middleware/security_headers.go
+++ b/server/middleware/security_headers.go
@@ -15,7 +15,11 @@ import "net/http"
 // (ws:/wss: to the same host) in all modern browsers. The bare ws: and wss: scheme
 // values that were here previously allowed WebSocket connections to ANY host, which
 // is a CSP bypass for data exfiltration via WebSocket.
-const contentSecurityPolicy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self';"
+//
+// form-action, base-uri, frame-ancestors do NOT inherit from default-src; they must be
+// explicit. object-src 'none' blocks Flash/Java plugins. img-src omits the https: scheme
+// wildcard (#1212) — all images are same-origin or inline data URIs.
+const contentSecurityPolicy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; form-action 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none';"
 
 // SecurityHeaders sets standard hardening response headers on every response. For a
 // secrets manager these matter beyond the usual:
@@ -30,6 +34,12 @@ const contentSecurityPolicy = "default-src 'self'; script-src 'self'; style-src 
 //     nginx frontend did), so the strongest practical mitigation against an XSS reading
 //     the SSO/SAML session-token URL fragment or localStorage was entirely absent in
 //     that mode. Now sent unconditionally, matching the nginx config's policy.
+//   - Cross-Origin-Resource-Policy: same-origin — opt-in Spectre mitigation; prevents
+//     cross-origin reads of responses via speculative execution side channels.
+//   - Cross-Origin-Embedder-Policy: require-corp — all subresources must carry CORP or
+//     CORS; together with COOP this enables cross-origin isolation in the browser.
+//   - Cross-Origin-Opener-Policy: same-origin — isolates the browsing context group so
+//     cross-origin documents cannot share the same context (closes window.opener leaks).
 //
 // HSTS is sent only when this process terminates TLS (tlsEnabled); deployments that
 // terminate TLS at a proxy add HSTS there, and sending it over plain HTTP is wrong.
@@ -46,6 +56,8 @@ func SecurityHeaders(tlsEnabled bool) func(http.Handler) http.Handler {
 			h.Set("Referrer-Policy", "no-referrer")
 			h.Set("Content-Security-Policy", contentSecurityPolicy)
 			h.Set("Cross-Origin-Resource-Policy", "same-origin")
+			h.Set("Cross-Origin-Embedder-Policy", "require-corp")
+			h.Set("Cross-Origin-Opener-Policy", "same-origin")
 			h.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()")
 			if tlsEnabled {
 				h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")

--- a/server/middleware/security_headers_test.go
+++ b/server/middleware/security_headers_test.go
@@ -35,6 +35,14 @@ func TestSecurityHeaders_CSPAlwaysSet(t *testing.T) {
 	assert.Contains(t, csp, "default-src 'self'")
 	assert.Contains(t, csp, "script-src 'self'", "no unsafe-inline/unsafe-eval on scripts — the primary XSS vector")
 	assert.NotContains(t, csp, "script-src 'self' 'unsafe-inline'")
+	// DAST #1211: directives that don't fall back to default-src must be explicit.
+	assert.Contains(t, csp, "form-action 'self'")
+	assert.Contains(t, csp, "base-uri 'self'")
+	assert.Contains(t, csp, "frame-ancestors 'none'")
+	assert.Contains(t, csp, "object-src 'none'")
+	// DAST #1212: no https: scheme wildcard in img-src.
+	assert.NotContains(t, csp, "img-src 'self' data: https:")
+	assert.Contains(t, csp, "img-src 'self' data:")
 }
 
 func TestSecurityHeaders_HSTSOnlyWithTLS(t *testing.T) {
@@ -47,4 +55,12 @@ func TestSecurityHeaders_HSTSOnlyWithTLS(t *testing.T) {
 func TestSecurityHeaders_CORPAlwaysSet(t *testing.T) {
 	hdr := serve(t, false)
 	assert.Equal(t, "same-origin", hdr.Get("Cross-Origin-Resource-Policy"))
+}
+
+// DAST #1209 / #1214 / #1215: all three Cross-Origin-* headers must be present.
+func TestSecurityHeaders_CrossOriginHeadersAlwaysSet(t *testing.T) {
+	hdr := serve(t, false)
+	assert.Equal(t, "same-origin", hdr.Get("Cross-Origin-Resource-Policy"))
+	assert.Equal(t, "require-corp", hdr.Get("Cross-Origin-Embedder-Policy"))
+	assert.Equal(t, "same-origin", hdr.Get("Cross-Origin-Opener-Policy"))
 }


### PR DESCRIPTION
## Summary

Fixes four of five DAST issues filed by the ZAP full scan. All changes are in the `SecurityHeaders` middleware and the matching Helm nginx config.

| Issue | Fix |
|---|---|
| #1211 — CSP no-fallback directives | Added `form-action 'self'`, `base-uri 'self'`, `frame-ancestors 'none'`, `object-src 'none'` |
| #1212 — CSP wildcard (`https:` in img-src) | Removed `https:` scheme; images are same-origin or `data:` only |
| #1214 — COEP missing | Added `Cross-Origin-Embedder-Policy: require-corp` |
| #1215 — COOP missing | Added `Cross-Origin-Opener-Policy: same-origin` |

Also adds `Cross-Origin-Resource-Policy: same-origin` (mirror of PR #1216) so this PR is self-contained.

**Not fixed here — #1213 (`style-src unsafe-inline`)**: `'unsafe-inline'` is required by the SPA's Tailwind/CSS-in-JS runtime style injection. Removing it needs a SPA refactor (nonce-based styles). Tracked in #1213.

**Helm chart alignment**: `X-Frame-Options` changed from `SAMEORIGIN` → `DENY` and `Referrer-Policy` from `strict-origin-when-cross-origin` → `no-referrer` to match the Go server.

## Test plan

- `TestSecurityHeaders_CSPAlwaysSet` — extended: asserts `form-action`, `base-uri`, `frame-ancestors`, `object-src`, absence of `https:` wildcard in img-src
- `TestSecurityHeaders_CrossOriginHeadersAlwaysSet` — new: asserts all three Cross-Origin-* headers

Closes #1211, #1212, #1214, #1215.