### PR TITLE
fix(storage): normalise ExpiresAt to UTC — fix SQLite timezone mismatch in RBAC grant expiry

### DIFF
--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -530,6 +530,16 @@ type UserRole struct {
 // connect.read plus the operator's allowed_refs (backward compatible); once any grant
 // exists for a connector, a read is permitted only if one of the caller's roles holds
 // a matching grant.
+// BeforeSave normalises ExpiresAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone.
+func (ur *UserRole) BeforeSave(_ *gorm.DB) error {
+	if ur.ExpiresAt != nil {
+		utc := ur.ExpiresAt.UTC()
+		ur.ExpiresAt = &utc
+	}
+	return nil
+}
+
 type ConnectRefGrant struct {
 	ID        uint   `gorm:"primaryKey"`
 	RoleID    uint   `gorm:"not null;index;uniqueIndex:uq_connect_ref_grant,priority:1"`
@@ -574,6 +584,16 @@ type GroupRole struct {
 	EnvironmentID uint `gorm:"primaryKey;not null;default:0"`
 	// ExpiresAt makes a group grant time-bound; see UserRole.ExpiresAt.
 	ExpiresAt *time.Time `gorm:"index"`
+}
+
+// BeforeSave normalises ExpiresAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone.
+func (gr *GroupRole) BeforeSave(_ *gorm.DB) error {
+	if gr.ExpiresAt != nil {
+		utc := gr.ExpiresAt.UTC()
+		gr.ExpiresAt = &utc
+	}
+	return nil
 }
 
 type SecretNode struct {

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -112,6 +112,10 @@ func (ls *LocalStorage) AssignRoleWithExpiry(ctx context.Context, userID, roleID
 }
 
 func (ls *LocalStorage) assignUserRole(ctx context.Context, userID, roleID uint, scope storage.Scope, expiresAt *time.Time) error {
+	if expiresAt != nil {
+		utc := expiresAt.UTC()
+		expiresAt = &utc
+	}
 	var existing models.UserRole
 	err := ls.db.WithContext(ctx).
 		Where(sqlWhereUserRoleEnv,
@@ -191,7 +195,7 @@ func (ls *LocalStorage) GetUserRoles(ctx context.Context, userID uint) ([]*model
 	err := ls.db.WithContext(ctx).Table("roles").
 		Joins("JOIN user_roles ON roles.id = user_roles.role_id").
 		Where(sqlWhereURUserID, userID).
-		Where(sqlWhereURNotExpired, time.Now()).
+		Where(sqlWhereURNotExpired, time.Now().UTC()).
 		Find(&roles).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -223,7 +227,7 @@ func (ls *LocalStorage) GetUserRoleIDsAt(ctx context.Context, userID uint, scope
 		Where(sqlWhereURUserID, userID).
 		Where("user_roles.project_id = 0 OR (user_roles.project_id = ? AND projects.deleted_at IS NULL)", scope.ProjectID).
 		Where("user_roles.environment_id = 0 OR (user_roles.environment_id = ? AND environments.deleted_at IS NULL)", scope.EnvironmentID).
-		Where(sqlWhereURNotExpired, time.Now()).
+		Where(sqlWhereURNotExpired, time.Now().UTC()).
 		Distinct().Pluck("user_roles.role_id", &ids).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -246,7 +250,7 @@ func (ls *LocalStorage) GetUserRoleScopes(ctx context.Context, userID uint) ([]s
 	if err := ls.db.WithContext(ctx).Model(&models.UserRole{}).
 		Select("project_id, environment_id").
 		Where("user_id = ?", userID).
-		Where("expires_at IS NULL OR expires_at > ?", time.Now()).
+		Where("expires_at IS NULL OR expires_at > ?", time.Now().UTC()).
 		Group("project_id, environment_id").
 		Scan(&direct).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -261,7 +265,7 @@ func (ls *LocalStorage) GetUserRoleScopes(ctx context.Context, userID uint) ([]s
 		Joins(sqlJoinUserGroups).
 		Joins(sqlJoinGroups).
 		Where(sqlWhereUGUserID, userID).
-		Where(sqlWhereGRNotExpired, time.Now()).
+		Where(sqlWhereGRNotExpired, time.Now().UTC()).
 		Group("group_roles.project_id, group_roles.environment_id").
 		Scan(&viaGroups).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -285,7 +289,7 @@ func (ls *LocalStorage) GetUserRoleScopes(ctx context.Context, userID uint) ([]s
 func (ls *LocalStorage) ListProjectRoleAssignments(ctx context.Context, projectID uint) ([]storage.RoleAssignment, error) {
 	var out []storage.RoleAssignment
 
-	now := time.Now()
+	now := time.Now().UTC()
 	var userRows []models.UserRole
 	if err := ls.db.WithContext(ctx).
 		Where(sqlWhereProjectID, projectID).
@@ -424,7 +428,7 @@ func (ls *LocalStorage) GetUserRoleIDsExact(ctx context.Context, userID uint, sc
 	err := ls.db.WithContext(ctx).Model(&models.UserRole{}).
 		Where("user_id = ? AND project_id = ? AND environment_id = ?",
 			userID, scope.ProjectID, scope.EnvironmentID).
-		Where(sqlWhereURNotExpired, time.Now()).
+		Where(sqlWhereURNotExpired, time.Now().UTC()).
 		Distinct().Pluck("role_id", &ids).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -440,7 +444,7 @@ func (ls *LocalStorage) IsProjectMember(ctx context.Context, userID, projectID u
 	if projectID == 0 {
 		return false, nil
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	var direct int64
 	if err := ls.db.WithContext(ctx).Model(&models.UserRole{}).
 		Where("user_id = ? AND project_id = ?", userID, projectID).
@@ -477,7 +481,7 @@ func (ls *LocalStorage) ListProjectMembers(ctx context.Context, projectID uint) 
 		Joins("JOIN users u ON u.id = ur.user_id").
 		Joins("JOIN roles r ON r.id = ur.role_id").
 		Where("ur.project_id = ? AND ur.environment_id = 0", projectID).
-		Where("ur.expires_at IS NULL OR ur.expires_at > ?", time.Now()).
+		Where("ur.expires_at IS NULL OR ur.expires_at > ?", time.Now().UTC()).
 		Where("u.deleted_at IS NULL").
 		Order("u.username").
 		Scan(&members).Error
@@ -515,7 +519,7 @@ func (ls *LocalStorage) GetUserGroupRoleIDsAt(ctx context.Context, userID uint, 
 		Where("user_groups.project_id = 0 OR user_groups.project_id = ?", scope.ProjectID).
 		Where("group_roles.project_id = 0 OR (group_roles.project_id = ? AND projects.deleted_at IS NULL)", scope.ProjectID).
 		Where("group_roles.environment_id = 0 OR (group_roles.environment_id = ? AND environments.deleted_at IS NULL)", scope.EnvironmentID).
-		Where(sqlWhereGRNotExpired, time.Now()).
+		Where(sqlWhereGRNotExpired, time.Now().UTC()).
 		Distinct().Pluck("group_roles.role_id", &ids).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -647,6 +651,10 @@ func (ls *LocalStorage) AssignRoleToGroupWithExpiry(ctx context.Context, groupID
 }
 
 func (ls *LocalStorage) assignGroupRole(ctx context.Context, groupID, roleID uint, scope storage.Scope, expiresAt *time.Time) error {
+	if expiresAt != nil {
+		utc := expiresAt.UTC()
+		expiresAt = &utc
+	}
 	var existing models.GroupRole
 	err := ls.db.WithContext(ctx).
 		Where(sqlWhereGroupRoleEnv,
@@ -694,23 +702,24 @@ func (ls *LocalStorage) assignGroupRole(ctx context.Context, groupID, roleID uin
 // can audit each expiry. Runs in a transaction so the rows it reports are exactly
 // the rows it deleted.
 func (ls *LocalStorage) DeleteExpiredRoleGrants(ctx context.Context, before time.Time) ([]storage.RoleAssignment, error) { // NOSONAR -- cognitive complexity 19, suppress go:S3776
+	cutoff := before.UTC()
 	var removed []storage.RoleAssignment
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var userRows []models.UserRole
-		if err := tx.Where(sqlWhereExpired, before).Find(&userRows).Error; err != nil {
+		if err := tx.Where(sqlWhereExpired, cutoff).Find(&userRows).Error; err != nil {
 			return err
 		}
 		var groupRows []models.GroupRole
-		if err := tx.Where(sqlWhereExpired, before).Find(&groupRows).Error; err != nil {
+		if err := tx.Where(sqlWhereExpired, cutoff).Find(&groupRows).Error; err != nil {
 			return err
 		}
 		if len(userRows) > 0 {
-			if err := tx.Where(sqlWhereExpired, before).Delete(&models.UserRole{}).Error; err != nil {
+			if err := tx.Where(sqlWhereExpired, cutoff).Delete(&models.UserRole{}).Error; err != nil {
 				return err
 			}
 		}
 		if len(groupRows) > 0 {
-			if err := tx.Where(sqlWhereExpired, before).Delete(&models.GroupRole{}).Error; err != nil {
+			if err := tx.Where(sqlWhereExpired, cutoff).Delete(&models.GroupRole{}).Error; err != nil {
 				return err
 			}
 		}
@@ -757,7 +766,7 @@ func (ls *LocalStorage) GetUserPermissions(ctx context.Context, userID uint) ([]
 		Joins(sqlJoinRolePerms).
 		Joins("JOIN user_roles ON role_permissions.role_id = user_roles.role_id").
 		Where(sqlWhereURUserID, userID).
-		Where(sqlWhereURNotExpired, time.Now()).
+		Where(sqlWhereURNotExpired, time.Now().UTC()).
 		Group("permissions.id").
 		Find(&permissions).Error
 	if err != nil {
@@ -780,7 +789,7 @@ func (ls *LocalStorage) GetUserGroupPermissions(ctx context.Context, userID uint
 		// A soft-deleted group confers no permissions (matches authz resolution).
 		Joins(sqlJoinGroups).
 		Where(sqlWhereUGUserID, userID).
-		Where(sqlWhereGRNotExpired, time.Now()).
+		Where(sqlWhereGRNotExpired, time.Now().UTC()).
 		Group("permissions.id").
 		Find(&permissions).Error
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Root cause**: GORM formats `time.Time` values using the value's own `Location`. On a UTC+2 machine, a grant arriving via the remote-storage proxy is stored in UTC (JSON preserves timezone), while grants created locally are stored in local CEST time. SQLite's lexicographic string comparison then mismatches the two, causing future UTC grants to be excluded by a local-time `> NOW()` filter and expired local-time grants to appear live to a UTC comparison.

- **Fix (write path)**: Added `BeforeSave` hooks to `UserRole` and `GroupRole` models that normalise `ExpiresAt` to UTC before any write — this covers both `LocalStorage` method calls and direct `db.Create` calls in tests.

- **Fix (read path)**: All `WHERE expires_at > ?` / `expires_at <= ?` comparisons in `local_rbac.go` now pass `time.Now().UTC()` and `DeleteExpiredRoleGrants` normalises its `before` cutoff to UTC so stored UTC values are always compared against UTC comparison values.

## Tests

- `TestRemoteStorageRBACRoleGrants_ReadsAndWrites_RealServer` — was failing (future UTC grant excluded); now passes.
- `TestListProjectMembers_ExcludesExpiredGrants` — regression caught and fixed: expired local-time grants were appearing live after the read-path change alone; resolved by the write-path normalisation.
- `TestDeleteExpiredRoleGrants_S27_RemovesExpiredGrants`, `TestRBAC_DeleteExpiredRoleGrants` — regressions caught and fixed: live grants were being deleted when the cutoff was local time vs UTC-stored values; resolved by `before.UTC()` in `DeleteExpiredRoleGrants`.
- Full `internal/storage/store` suite: all pass.
- `internal/storage/models` suite: all pass (93 tests).