### PR TITLE
fix(fuzzing): repair GitHub crash-report notifications on vCD VMs

### DIFF
--- a/docs/DAST.md
+++ b/docs/DAST.md
@@ -1,0 +1,183 @@
+# DAST Rig — Technical Reference
+
+Dynamic Application Security Testing (DAST) runs continuously against a
+dedicated Keyorix instance. Findings are filed automatically as GitHub Issues.
+
+## Infrastructure
+
+| Item | Value |
+|------|-------|
+| Host | Proxmox VE — `192.168.10.20` |
+| Container | LXC 221 — `keyorix-dast` |
+| Container IP | `192.168.10.61` |
+| Base dir | `/opt/keyorix-dast/` |
+| Results | `/opt/keyorix-dast/results/` |
+| Cron log | `/opt/keyorix-dast/results/cron.log` |
+
+## Target stack
+
+A dedicated Keyorix instance runs inside Docker on the LXC container, isolated
+from any production environment. The `docker-compose.yml` defines two services:
+
+| Service | Image | Role |
+|---------|-------|------|
+| `postgres` | `postgres:15-alpine` | Keyorix database |
+| `keyorix` | Built from `server/Dockerfile` | Keyorix server under test |
+
+The Keyorix server is configured by `/opt/keyorix-dast/keyorix-dast.yaml`:
+
+- HTTP on port `8080`, TLS disabled (scanner talks plain HTTP inside the Docker
+  network — no certificate setup needed)
+- gRPC disabled (API surface is HTTP-only for DAST purposes)
+- Swagger/OpenAPI endpoint enabled (`/openapi.yaml`) so ZAP can discover routes
+- Rate limiting disabled (scanner would otherwise hit its own limits)
+- Storage encryption enabled; KEK injected via `KEYORIX_DAST_KEK` env var
+- Soft-delete retention 30 days
+
+Secrets for the stack live in `/opt/keyorix-dast/.env` (never committed):
+
+```
+KEYORIX_DB_PASSWORD     PostgreSQL password  (generate: openssl rand -hex 32)
+KEYORIX_DAST_KEK        32-byte hex KEK — generate once, keep forever; losing
+                        it makes the postgres data volume undecryptable
+KEYORIX_ADMIN_PASSWORD  Bootstrap admin password
+KEYORIX_BOOTSTRAP_TOKEN First-boot bootstrap token
+```
+
+The admin credentials are seeded on first boot via Keyorix's bootstrap flow and
+are idempotent on subsequent restarts.
+
+## Scanner image
+
+A single custom Docker image (`keyorix-scanner:latest`) bundles both scanners:
+
+```
+Base:    ghcr.io/zaproxy/zaproxy:stable   (provides zap-api-scan.py,
+                                            zap-full-scan.py, and the ZAP daemon)
+Added:   Nuclei v3.11.0 binary             (installed into /usr/local/bin/)
+         Nuclei templates                   (pre-fetched at image-build time so
+                                             scans run air-gapped)
+```
+
+Built with `/opt/keyorix-dast/build-scanner.sh`. Rebuild whenever:
+
+- ZAP releases a security fix (pull new base image)
+- Nuclei templates need a forced refresh (`-update-templates`)
+- `NUCLEI_VERSION` in `Dockerfile.scanner` is bumped
+
+The image is **never pulled at scan time** (`--pull never`) to keep scans
+deterministic and avoid network failures mid-scan.
+
+## Scan types and schedule
+
+Three scans run on a fixed cron schedule (`/etc/cron.d/keyorix-dast`,
+`CRON_TZ=Europe/Madrid`):
+
+| Scanner | Script | Schedule | What it tests |
+|---------|--------|----------|---------------|
+| ZAP API scan | `scan-zap.sh` | Mon, Wed, Fri — 04:00 | Every endpoint declared in `/openapi.yaml` (active scan driven by the live spec) |
+| ZAP full scan | `scan-zap-full.sh` | Sunday — 04:00 | Entire app surface — spider-crawls the web UI, static assets, and any routes not in the OpenAPI spec |
+| Nuclei | `scan-nuclei.sh` | Daily — 06:00 | Template-based checks (auth, JWT, token exposure, SQLi, XSS, SSRF, misconfig) against all OpenAPI paths |
+
+All three scripts use a shared **`flock` lock** (`dast.lock`) so scans never
+overlap. A later-scheduled scan waits until the running one finishes before
+acquiring the lock.
+
+## Report files
+
+| Scanner | Format | Filename pattern |
+|---------|--------|-----------------|
+| ZAP API scan | HTML + JSON | `results/zap-<timestamp>.html` / `.json` |
+| ZAP full scan | HTML + JSON | `results/zap-full-<timestamp>.html` / `.json` |
+| Nuclei | SARIF | `results/nuclei-<timestamp>.sarif` |
+
+Nuclei emits a minimal valid fallback SARIF if it finds nothing, so
+`create-issues.sh` always has a parseable file to read.
+
+## GitHub issue creation
+
+`create-issues.sh` runs automatically after every scan. It:
+
+1. Parses the Nuclei SARIF (levels `warning`/`error` → Medium/High) and the ZAP
+   JSON (risk codes ≥ 1, i.e. Low and above).
+2. For each finding, constructs a title of the form `[DAST] <scanner>/<id>: <name>`.
+3. Checks whether an open issue with that exact title already exists in
+   `keyorixhq/keyorix` (using `gh issue list --search`). If one exists, skips.
+4. Creates a new issue with labels `dast` and `security` if no duplicate is found.
+
+The script is **idempotent** — re-running it after a scan that produced
+duplicate findings is safe.
+
+The `GITHUB_TOKEN` is loaded from `/opt/keyorix-dast/.env` or from the `gh`
+CLI's stored credentials (`~/.config/gh/`).
+
+## Closing / suppressing findings
+
+When a fix is merged:
+
+```bash
+gh issue close <number> --comment "Fixed in PR #XXXX: <one-line explanation>."
+```
+
+For findings that will reappear on every scan (e.g. `style-src 'unsafe-inline'`
+required by the SPA's CSS-in-JS runtime), close the issue with an explanation
+and leave a note in this file under **Known accepted exceptions**.
+
+There is currently no per-URL suppression list in the scan scripts; add one to
+`scan-zap.sh` / `scan-zap-full.sh` via ZAP's `-c` config-file option if the
+volume of false positives warrants it.
+
+## Running a scan manually
+
+SSH into the LXC container and run any script directly:
+
+```bash
+# ZAP API scan (OpenAPI-driven)
+bash /opt/keyorix-dast/scan-zap.sh
+
+# ZAP full scan (spider)
+bash /opt/keyorix-dast/scan-zap-full.sh
+
+# Nuclei
+bash /opt/keyorix-dast/scan-nuclei.sh
+
+# File issues from the most recent reports without re-scanning
+bash /opt/keyorix-dast/create-issues.sh
+```
+
+All scripts are idempotent and safe to re-run. They will compete for the
+`flock` lock, so a manual run will queue behind any cron scan in progress.
+
+## Maintaining the rig
+
+**Update the scanner image** (ZAP base or Nuclei version):
+
+```bash
+# Edit NUCLEI_VERSION in Dockerfile.scanner if needed, then:
+bash /opt/keyorix-dast/build-scanner.sh
+```
+
+**Update the Keyorix binary** (after a release):
+
+```bash
+cd /opt/keyorix-dast/src
+git pull origin main
+docker compose build keyorix
+docker compose up -d keyorix
+```
+
+**Rotate secrets** (`.env` values):
+
+```bash
+# Edit /opt/keyorix-dast/.env, then:
+docker compose up -d     # restarts only changed services
+```
+
+Do not rotate `KEYORIX_DAST_KEK` unless you also wipe and re-initialise the
+postgres volume — the KEK is bound to the encrypted data on disk.
+
+## Known accepted exceptions
+
+| Issue | Finding | Reason |
+|-------|---------|--------|
+| #1213 (closed) | `CSP: style-src unsafe-inline` | Required by the SPA's CSS-in-JS / Tailwind runtime. `script-src` does not carry `unsafe-inline`, so inline script injection (the primary XSS vector) remains blocked. |

--- a/scripts/fuzzing/README.md
+++ b/scripts/fuzzing/README.md
@@ -70,29 +70,54 @@ one at a time, not concurrently).
    chown fuzzer:fuzzer /opt/keyorix-fuzz
    ```
 
-3. **Get GitHub push access for the `fuzzer` user.** Two options, in order of
-   preference:
-   - **Deploy key** (preferred — repo-scoped by construction): generate one as
-     the `fuzzer` user (`sudo -u fuzzer ssh-keygen -t ed25519 -f
-     /home/fuzzer/.ssh/id_ed25519 -N ""`), add the public key under the repo's
-     **Settings → Deploy keys → Add deploy key** with **"Allow write access"**
-     checked, and clone via SSH (`git@github.com:...`).
-   - **Fine-grained PAT** (use this if deploy keys are disabled at the org
-     level — `gh repo deploy-key add` fails with "Deploy keys are disabled for
-     this repository" if so): create one at **Settings → Developer settings →
-     Personal access tokens → Fine-grained tokens**, scoped to just this repo,
-     with **Contents: Read and write** permission only. Store it in a single
-     restricted file rather than embedding it in `.git/config` or the
-     plaintext `.git-credentials` file a plain `credential.helper=store` would
-     create:
+3. **Get GitHub access for the `fuzzer` user.** Two things need separate
+   authentication: `git push` (corpus commits) and `gh pr create` (crash
+   reports). Set them up together:
+
+   - **Deploy key + PAT (recommended):** Use a deploy key for `git push` and a
+     fine-grained PAT for `gh`:
+     - Generate a deploy key as the `fuzzer` user:
+       ```
+       sudo -u fuzzer ssh-keygen -t ed25519 -f /home/fuzzer/.ssh/id_ed25519 -N ""
+       ```
+       Add the public key under **Settings → Deploy keys → Add deploy key** with
+       **"Allow write access"** checked. Clone via SSH (`git@github.com:...`).
+     - Create a fine-grained PAT at **Settings → Developer settings → Personal
+       access tokens → Fine-grained tokens**, scoped to this repo, with:
+       - **Contents: Read** (to check branch state)
+       - **Pull requests: Read and write** (to open/comment on crash-report PRs)
+
+       Store it and add it to `config.env` (systemd `EnvironmentFile=` does not
+       expand shell syntax, so paste the token value literally):
+       ```
+       echo "github_pat_..." > /etc/keyorix-fuzz-gh-token
+       chown fuzzer:fuzzer /etc/keyorix-fuzz-gh-token
+       chmod 600 /etc/keyorix-fuzz-gh-token
+       ```
+       Then set `GH_TOKEN=<paste token here>` in `/etc/keyorix-fuzz/config.env`
+       (see step 6).
+
+   - **Single PAT (simpler — use if deploy keys are disabled at the org
+     level):** Create one PAT with both scopes and use it for everything:
+     - **Contents: Read and write** (for `git push`)
+     - **Pull requests: Read and write** (for `gh pr create`/`gh pr list`)
+
+     Store it and wire it up for both `git push` and `gh`:
      ```
-     echo "<the token>" > /etc/keyorix-fuzz-github-token
+     echo "github_pat_..." > /etc/keyorix-fuzz-github-token
      chown fuzzer:fuzzer /etc/keyorix-fuzz-github-token
      chmod 600 /etc/keyorix-fuzz-github-token
      sudo -u fuzzer git config --global credential.'https://github.com'.helper \
        '!f() { echo username=x-access-token; echo password=$(cat /etc/keyorix-fuzz-github-token); }; f'
      ```
-     Clone via HTTPS (`https://github.com/...`) with this option, not SSH.
+     Then set `GH_TOKEN=<paste token here>` in `/etc/keyorix-fuzz/config.env`
+     (see step 6). Clone via HTTPS (`https://github.com/...`).
+
+   > **Why two separate auth paths?** `git push` uses the git credential helper;
+   > `gh pr create` uses the `gh` CLI which reads `GH_TOKEN` (or `GITHUB_TOKEN`)
+   > from the environment — not from git's credential store. Without `GH_TOKEN`
+   > in `config.env`, the systemd service cannot authenticate `gh` and crash
+   > reports are silently lost.
 
 4. **Clone the repo twice** as the `fuzzer` user — once for fuzzing (stays on
    `main`), once as a worktree for the corpus branch. Use whichever URL scheme
@@ -121,10 +146,11 @@ one at a time, not concurrently).
 
 6. **Write the config file.** Systemd's `EnvironmentFile=` does NOT source
    `/etc/profile.d/`, so `PATH` needs `/usr/local/go/bin` added explicitly or
-   the service will fail with "go: command not found":
+   the service will fail with "go: command not found". Also set `GH_TOKEN` here
+   (the `gh` CLI reads it; without it crash-report PRs fail silently):
    ```
    cp scripts/fuzzing/config.env.example /etc/keyorix-fuzz/config.env
-   $EDITOR /etc/keyorix-fuzz/config.env   # fill in NTFY_TOPIC at minimum
+   $EDITOR /etc/keyorix-fuzz/config.env   # set GH_TOKEN and optionally NTFY_TOPIC
    echo 'PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
      >> /etc/keyorix-fuzz/config.env
    chmod 600 /etc/keyorix-fuzz/config.env
@@ -175,6 +201,17 @@ one at a time, not concurrently).
   `go test -run=<FuzzName>/<hash> ./<package>` once you've pulled that branch.
 - **No heartbeat today** → the service or the box is down; check
   `systemctl status keyorix-fuzz.service` / whether the LXC itself is up.
+- **`gh` notification failed** → check `journalctl -u keyorix-fuzz.service -n 50`
+  for "GitHub notification failed" lines, then read the corresponding
+  `gh-error-<func>-<hash>.log` in `$NOTIFIED_STATE_DIR` for the actual error
+  (auth failure, missing PAT scope, branch not pushed yet, etc.). Fix `GH_TOKEN`
+  in `/etc/keyorix-fuzz/config.env`, then clear the stale dedup markers so the
+  next rotation retries:
+  ```
+  ls /opt/keyorix-fuzz/state/notified-*   # see which crashes were never reported
+  rm /opt/keyorix-fuzz/state/notified-<FuzzName>-<hash>
+  systemctl restart keyorix-fuzz.service
+  ```
 - **Widening coverage** → add a line to `targets.conf`; no script changes
   needed. The service picks it up on its next full rotation cycle restart
   (`systemctl restart keyorix-fuzz.service` to pick it up immediately).

--- a/scripts/fuzzing/config.env.example
+++ b/scripts/fuzzing/config.env.example
@@ -15,6 +15,22 @@ FUZZ_CORPUS_BRANCH=fuzz-corpus
 # Where per-target logs and crash-notification dedup markers are kept.
 NOTIFIED_STATE_DIR=/opt/keyorix-fuzz/state
 
+# Fine-grained PAT for the gh CLI to open/comment on crash-report PRs.
+# This is SEPARATE from the deploy-key or credential-helper token used for
+# git push — git push needs "Contents: Read and write"; gh pr create/list
+# additionally needs "Pull requests: Read and write".
+# You can use a single PAT with both scopes, or two separate tokens.
+#
+# Generate at: https://github.com/settings/tokens?type=beta
+# Required permissions: Contents (Read), Pull requests (Read and write).
+# Store the token in a 600-mode file, then paste the value here:
+#   echo "github_pat_..." > /etc/keyorix-fuzz-gh-token
+#   chown fuzzer:fuzzer /etc/keyorix-fuzz-gh-token
+#   chmod 600 /etc/keyorix-fuzz-gh-token
+# Then read it into this variable (systemd EnvironmentFile does NOT expand $(),
+# so paste the token value literally below):
+GH_TOKEN=CHANGE-ME
+
 # ntfy.sh topic URL for real-time push notifications (optional).
 # If unset, only the GitHub PR is opened on crash. If set, both fire.
 # Topics are unauthenticated by default — pick something long and random:

--- a/scripts/fuzzing/notify-on-crash.sh
+++ b/scripts/fuzzing/notify-on-crash.sh
@@ -40,8 +40,8 @@ Reproducer pushed to the $FUZZ_CORPUS_BRANCH branch." \
 fi
 
 # GitHub PR — open from fuzz-corpus to main, or comment on the existing one.
-# Uses the gh CLI already authenticated on this box (fine-grained PAT scoped
-# to keyorixhq/keyorix, configured during provisioning).
+# Authenticated via GH_TOKEN in /etc/keyorix-fuzz/config.env (see README.md
+# step 3). Required PAT scopes: Contents (Read), Pull requests (Read+Write).
 reproduce_cmd="go test -run=^${FUNC}\$ -fuzz=^${FUNC}\$ ./${PKG}"
 pr_body="## Fuzz crash: \`$FUNC\`
 
@@ -59,20 +59,37 @@ ${summary:-see log on the fuzz box}
 
 The crashing input is committed to the \`$FUZZ_CORPUS_BRANCH\` branch and will be in \`testdata/fuzz/$FUNC/\` once this PR merges. Fix the bug, add it to the relevant test, then merge this PR to lock the regression test in."
 
+# Log gh errors to a persistent file so auth/permission failures are visible.
+# Do NOT use 2>/dev/null — silent failures caused markers to be written for
+# crashes that were never actually reported, permanently suppressing them.
+gh_err="$NOTIFIED_STATE_DIR/gh-error-$FUNC-$fail_hash.log"
+
 cd "$KEYORIX_REPO"
-existing_pr="$(gh pr list --head "$FUZZ_CORPUS_BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || true)"
+pr_notified=false
+existing_pr="$(gh pr list --head "$FUZZ_CORPUS_BRANCH" --state open --json number --jq '.[0].number' 2>>"$gh_err" || true)"
 if [[ -n "$existing_pr" ]]; then
-  gh pr comment "$existing_pr" \
+  if gh pr comment "$existing_pr" \
     --body "**Additional crash ($(date -u +%FT%TZ)):** \`$FUNC\` — hash \`$fail_hash\`
 \`\`\`
 $fail_line
-\`\`\`" 2>/dev/null || true
+\`\`\`" 2>>"$gh_err"; then
+    pr_notified=true
+  fi
 else
-  gh pr create \
+  if gh pr create \
     --title "fuzz(crash): $FUNC — crash reproducer" \
     --body "$pr_body" \
     --head "$FUZZ_CORPUS_BRANCH" \
-    --base main 2>/dev/null || true
+    --base main 2>>"$gh_err"; then
+    pr_notified=true
+  fi
 fi
 
-touch "$marker"
+# Only mark as notified when gh actually succeeded. If not, emit a visible
+# error so the systemd journal (journalctl -u keyorix-fuzz.service) shows it,
+# and leave the marker unwritten so the next rotation retries.
+if $pr_notified; then
+  touch "$marker"
+else
+  echo "notify-on-crash: GitHub notification failed for $FUNC (hash $fail_hash) — see $gh_err" >&2
+fi


### PR DESCRIPTION
## Summary

- **Root cause 1 (worst):** `touch "$marker"` in `notify-on-crash.sh` ran unconditionally after `gh pr create`/`gh pr comment`, even when they failed silently. Any crash the VM tried (and failed) to report got permanently de-duped — the marker was written, so the next rotation never retried. Crashes were found but permanently lost.

- **Root cause 2:** All `gh` stderr was discarded with `2>/dev/null || true`. Auth failures, missing PAT permissions, and branch-not-found errors were completely invisible in the systemd journal. No one could tell reporting was broken.

- **Root cause 3:** The README step 3 only documented `Contents: Read and write` for the fine-grained PAT — enough for `git push` (via `sync-corpus.sh`) but not for `gh pr create`/`gh pr list`, which require `Pull requests: Read and write`. More importantly, there was no step documenting how to authenticate the `gh` CLI at all. The git credential helper and `gh` CLI use separate auth paths: `gh` reads `GH_TOKEN` from the environment, not from git's credential store. The systemd `EnvironmentFile=` never had a `GH_TOKEN` entry, so the `gh` CLI had no credentials on any of the vCD VMs.

## Changes

**`notify-on-crash.sh`**
- Replace `2>/dev/null || true` with `2>>"$gh_err"` (persistent log file per crash in `$NOTIFIED_STATE_DIR`)
- Only `touch "$marker"` when `gh` actually succeeds (`pr_notified=true`)
- Emit a visible `>&2` message on failure so `journalctl -u keyorix-fuzz.service` shows it

**`config.env.example`**
- Add `GH_TOKEN=CHANGE-ME` with documentation of the required PAT scopes and why this is separate from the git credential token

**`README.md`**
- Rewrite step 3 to cover both auth paths (deploy key + PAT-for-gh, or single PAT with both scopes)
- Document required PAT scopes: Contents (Read), Pull requests (Read and write)
- Explain why `GH_TOKEN` in `config.env` is needed and how it differs from the git credential helper
- Add a "gh notification failed" entry to the Day-to-day section with instructions for clearing stale markers

## Recovery for existing VMs

VMs that have already accumulated stale dedup markers (crashes attempted but never reported):

```bash
# Check which crashes were silently swallowed
ls /opt/keyorix-fuzz/state/notified-*

# Fix GH_TOKEN in the config, then clear stale markers
rm /opt/keyorix-fuzz/state/notified-<FuzzName>-<hash>

# Restart the service; next rotation will retry notification
systemctl restart keyorix-fuzz.service
```

## Test plan

- [ ] Deploy updated scripts to a vCD fuzzing VM
- [ ] Verify `GH_TOKEN` is set in `/etc/keyorix-fuzz/config.env` with a PAT that has both `Contents: Read` and `Pull requests: Read and write`
- [ ] Clear any stale `notified-*` markers, restart the service
- [ ] Confirm `journalctl -u keyorix-fuzz.service` shows crash notifications succeeding (no "GitHub notification failed" lines)
- [ ] Confirm PRs are opened on crash (or `gh-error-*.log` files in `$NOTIFIED_STATE_DIR` are empty)