### PR TITLE
fix(core): repair internal/core test suite + CWE-284 stale ACL grants on offboarding

### DIFF
--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -35,7 +35,7 @@ func newBootstrappedCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 		&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.ProjectMembership{},
 		&models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.SoDPolicy{},
 		&models.StatsSnapshot{}, &models.DeploymentStatsSnapshot{},
-		&models.MFAStepupToken{},
+		&models.MFAStepupToken{}, &models.SecretACL{},
 	))
 
 	st := store.NewLocalStorage(db)

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -320,7 +320,7 @@ func TestBreakGlass_ExpiredGrantDeniesAuthorization(t *testing.T) {
 	// elapsing). Role resolution filters out expires_at <= now, so the role drops away.
 	require.NoError(t, h.DB.Model(&models.UserRole{}).
 		Where("user_id = ? AND role_id = ?", 10, 3).
-		Update("expires_at", time.Now().Add(-time.Hour)).Error)
+		Update("expires_at", time.Now().UTC().Add(-time.Hour)).Error)
 
 	// The emergency role no longer resolves...
 	ids, err := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: proj})

--- a/internal/core/bulk_access_requests_test.go
+++ b/internal/core/bulk_access_requests_test.go
@@ -86,9 +86,10 @@ func TestBulkApproveAccessRequests_ApproveError(t *testing.T) {
 	req := pendingReq(5)
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{5}).
 		Return([]*models.AccessRequest{req}, nil)
-	// GetAccessRequest is called inside ApproveAccessRequest.
-	m.On("GetAccessRequest", mock.Anything, uint(5)).
-		Return(nil, errors.New("record not found"))
+	// The per-project Authorize check calls scopedRoleIDs which reads these two
+	// tables; return empty → no permission → "permission denied" in Failed.
+	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 
 	result, err := k.BulkApproveAccessRequests(context.Background(), []uint{5}, 2)
 	require.NoError(t, err)
@@ -105,17 +106,14 @@ func TestBulkApproveAccessRequests_MixedResults(t *testing.T) {
 	req1 := pendingReq(1)
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{1, 99}).
 		Return([]*models.AccessRequest{req1}, nil) // only req1 returned
-
-	// For ID 1: ApproveAccessRequest → GetAccessRequest (returns error to
-	// trigger the "failed" path without having to mock the entire RBAC chain).
-	m.On("GetAccessRequest", mock.Anything, uint(1)).
-		Return(nil, errors.New("something broke"))
+	// Authorize check: empty roles → denied → "permission denied" in Failed.
+	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 
 	result, err := k.BulkApproveAccessRequests(context.Background(), []uint{1, 99}, 2)
 	require.NoError(t, err)
 
-	// ID 1: failed (GetAccessRequest error inside ApproveAccessRequest)
-	// ID 99: failed (not in pre-fetch result)
+	// ID 1: failed (permission denied by Authorize); ID 99: failed (not in pre-fetch).
 	assert.Empty(t, result.Approved)
 	assert.Len(t, result.Failed, 2)
 }
@@ -175,9 +173,9 @@ func TestBulkRejectAccessRequests_RejectError(t *testing.T) {
 	req := pendingReq(7)
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{7}).
 		Return([]*models.AccessRequest{req}, nil)
-	// GetAccessRequest is called inside RejectAccessRequest.
-	m.On("GetAccessRequest", mock.Anything, uint(7)).
-		Return(nil, errors.New("record not found"))
+	// Authorize check: empty roles → denied → "permission denied" in Failed.
+	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 
 	result, err := k.BulkRejectAccessRequests(context.Background(), []uint{7}, 2, "denied")
 	require.NoError(t, err)
@@ -198,6 +196,10 @@ func TestBulkRejectAccessRequests_RejectNonPending(t *testing.T) {
 	}
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{8}).
 		Return([]*models.AccessRequest{already}, nil)
+	// Authorize check: grant admin role so code reaches RejectAccessRequest.
+	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{1}, nil)
+	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	m.On("GetRoleByName", mock.Anything, mock.Anything).Return(&models.Role{ID: 1, Name: "admin"}, nil)
 	m.On("GetAccessRequest", mock.Anything, uint(8)).
 		Return(already, nil)
 
@@ -216,9 +218,9 @@ func TestBulkRejectAccessRequests_MixedResults(t *testing.T) {
 	req3 := pendingReq(3)
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{3, 77}).
 		Return([]*models.AccessRequest{req3}, nil) // only req3 returned
-
-	m.On("GetAccessRequest", mock.Anything, uint(3)).
-		Return(nil, errors.New("storage error"))
+	// Authorize check: empty roles → denied → "permission denied" for ID 3.
+	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 
 	result, err := k.BulkRejectAccessRequests(context.Background(), []uint{3, 77}, 2, "no")
 	require.NoError(t, err)

--- a/internal/core/certificate_test.go
+++ b/internal/core/certificate_test.go
@@ -101,17 +101,21 @@ func newCertCore(t *testing.T, now time.Time) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{},
+		&models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
+	))
+	// CheckSecretPermission gates the owner path on IsProjectMember (RBAC-001): user 9
+	// (the standard cert-test actor) must be a member of project 1 so the read succeeds.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 9, RoleID: 1, ProjectID: 1}).Error)
 	return &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}, db
 }
 
 // mkCertSecret stores a secret (no encryption → value lives in the version row), owned
-// by user 9 — the actor ID every InspectCertificate call in this file uses — so the
-// EnforceSecretReadPermission check InspectCertificate now performs is satisfied via
-// ownership without needing the shares/groups tables migrated.
+// by user 9 in project 1 — the actor ID every InspectCertificate call in this file uses.
 func mkCertSecret(t *testing.T, db *gorm.DB, id uint, name, status string, value []byte) {
 	t.Helper()
-	require.NoError(t, db.Create(&models.SecretNode{ID: id, Name: name, IsSecret: true, Status: status, Type: "certificate", OwnerID: 9}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: id, Name: name, IsSecret: true, Status: status, Type: "certificate", OwnerID: 9, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: id, VersionNumber: 1, EncryptedValue: value}).Error)
 }
 

--- a/internal/core/classification_gate_test.go
+++ b/internal/core/classification_gate_test.go
@@ -30,6 +30,11 @@ func seedClassificationGateFixture(t *testing.T, st *store.LocalStorage, classif
 	adminRole, err := st.GetRoleByName(ctx, "admin")
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRole(ctx, approver.ID, adminRole.ID, storage.Scope{}))
+	// IsProjectMember (RBAC-001): requester must be a project member or the owner
+	// gate short-circuits before returning PermissionOwner.
+	viewerRole, err := st.GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, requester.ID, viewerRole.ID, storage.Scope{ProjectID: proj.ID}))
 
 	secret, err := st.CreateSecret(ctx, &models.SecretNode{
 		Name: "db-password", ProjectID: proj.ID, EnvironmentID: 1, Type: "password",

--- a/internal/core/classify_dynamic_test.go
+++ b/internal/core/classify_dynamic_test.go
@@ -10,12 +10,14 @@ import (
 
 func makeDynConfig(t *testing.T, c *KeyorixCore, name, classification string) uint {
 	t.Helper()
+	// Use db.example.com (unresolvable) instead of localhost so the SSRF guard passes
+	// without needing allowPrivateNetworkTargets — validateAdminDSNHost allows unresolvable hosts.
 	cfg, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
 		Name:           name,
 		ProjectID:      1,
 		EnvironmentID:  1,
 		BackendType:    "postgres",
-		AdminDSN:       "postgres://admin:pw@localhost/db",
+		AdminDSN:       "postgres://admin:pw@db.example.com/db",
 		Classification: classification,
 		CreatedBy:      "admin",
 		ActorID:        testAdminActorID,

--- a/internal/core/core_s26_test.go
+++ b/internal/core/core_s26_test.go
@@ -222,6 +222,7 @@ func TestGetSecretVersionsWithPermissionCheck_Success(t *testing.T) {
 	ms := new(MockStorage)
 	secret := &models.SecretNode{ID: 10, OwnerID: 1}
 	ms.On("GetSecret", mock.Anything, uint(10)).Return(secret, nil)
+	ms.On("IsProjectMember", mock.Anything, uint(1), uint(0)).Return(true, nil)
 	versions := []*models.SecretVersion{{ID: 1, SecretNodeID: 10, VersionNumber: 1}}
 	ms.On("GetSecretVersions", mock.Anything, uint(10)).Return(versions, nil)
 	c := NewKeyorixCore(ms)
@@ -234,6 +235,7 @@ func TestGetSecretVersionWithPermissionCheck_Success(t *testing.T) {
 	ms := new(MockStorage)
 	secret := &models.SecretNode{ID: 10, OwnerID: 1}
 	ms.On("GetSecret", mock.Anything, uint(10)).Return(secret, nil)
+	ms.On("IsProjectMember", mock.Anything, uint(1), uint(0)).Return(true, nil)
 	versions := []*models.SecretVersion{{ID: 1, SecretNodeID: 10, VersionNumber: 2}}
 	ms.On("GetSecretVersions", mock.Anything, uint(10)).Return(versions, nil)
 	c := NewKeyorixCore(ms)
@@ -246,6 +248,7 @@ func TestGetLatestSecretVersionWithPermissionCheck_Success(t *testing.T) {
 	ms := new(MockStorage)
 	secret := &models.SecretNode{ID: 10, OwnerID: 1}
 	ms.On("GetSecret", mock.Anything, uint(10)).Return(secret, nil)
+	ms.On("IsProjectMember", mock.Anything, uint(1), uint(0)).Return(true, nil)
 	// GetLatestSecretVersion calls storage.GetSecretVersions (not GetLatestSecretVersion).
 	latest := []*models.SecretVersion{{ID: 3, SecretNodeID: 10, VersionNumber: 1}}
 	ms.On("GetSecretVersions", mock.Anything, uint(10)).Return(latest, nil)

--- a/internal/core/env_clone_test.go
+++ b/internal/core/env_clone_test.go
@@ -35,7 +35,12 @@ func newCloneTestCore(t *testing.T) *KeyorixCore {
 		&models.Environment{},
 		&models.AuditEvent{},
 		&models.SecretAccessLog{},
+		&models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
 	))
+	// CopySecret calls GetSecretValueWithPermissionCheck which gates the owner path on
+	// IsProjectMember (RBAC-001). The first project created in each test gets ID=1;
+	// seed actor 1 as a project member so the copy read passes.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 	return &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 }
 

--- a/internal/core/login_lockout_remote_test.go
+++ b/internal/core/login_lockout_remote_test.go
@@ -174,9 +174,9 @@ func (f *fakeUpstreamLoginLockout) server(t *testing.T) *httptest.Server {
 		_, _ = fmt.Fprint(w, `{"success":true,"data":{"updated":true}}`)
 	})
 
-	// POST /api/v1/audit/events — backs LogAuditEvent, so UnlockUser's audit write
+	// POST /api/v1/system/audit/event — backs LogAuditEvent, so UnlockUser's audit write
 	// (EventAccountUnlocked) genuinely round-trips too, not just the counter reset.
-	mux.HandleFunc("/api/v1/audit/events", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/system/audit/event", func(w http.ResponseWriter, r *http.Request) {
 		var event models.AuditEvent
 		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
 			w.WriteHeader(http.StatusBadRequest)

--- a/internal/core/machine_ip_allowlist_test.go
+++ b/internal/core/machine_ip_allowlist_test.go
@@ -19,6 +19,8 @@ func TestIssueMachineToken_StoresCIDRs(t *testing.T) {
 
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).
 		Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
+	// requireMachinePrivilegeCeiling checks the machine's roles before issuing.
+	store.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
 	store.On("CreateMachineIdentityCredential", mock.Anything, mock.AnythingOfType("*models.MachineIdentityCredential")).
 		Return(&models.MachineIdentityCredential{ID: 7}, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
@@ -49,6 +51,7 @@ func TestIssueMachineToken_NilCIDRsOmitted(t *testing.T) {
 
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).
 		Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
+	store.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
 	store.On("CreateMachineIdentityCredential", mock.Anything, mock.AnythingOfType("*models.MachineIdentityCredential")).
 		Return(&models.MachineIdentityCredential{ID: 8}, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
@@ -111,9 +114,11 @@ func TestMachineRestrictionFrom(t *testing.T) {
 		assert.Equal(t, []string{"10.0.0.0/8"}, r.AllowedCIDRs)
 	})
 
-	t.Run("invalid JSON returns nil", func(t *testing.T) {
+	t.Run("invalid JSON returns corrupted sentinel (fail-closed)", func(t *testing.T) {
 		cred := &models.MachineIdentityCredential{AllowedCIDRs: `not json`}
-		assert.Nil(t, machineRestrictionFrom(cred))
+		r := machineRestrictionFrom(cred)
+		require.NotNil(t, r)
+		assert.Equal(t, []string{"<corrupted>"}, r.AllowedCIDRs)
 	})
 
 	t.Run("JSON empty array returns nil", func(t *testing.T) {

--- a/internal/core/machine_token_test.go
+++ b/internal/core/machine_token_test.go
@@ -30,6 +30,7 @@ func TestIssueMachineToken_ActiveOnly(t *testing.T) {
 
 	// Active machine → token minted with the kx_machine_ prefix, hash stored.
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
+	store.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
 	store.On("CreateMachineIdentityCredential", mock.Anything, mock.AnythingOfType("*models.MachineIdentityCredential")).
 		Return(&models.MachineIdentityCredential{ID: 5}, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -2182,6 +2182,10 @@ func (m *MockStorage) DeleteSecretACL(_ context.Context, _ uint) error {
 	return nil
 }
 
+func (m *MockStorage) DeleteSecretACLsByUserAndProject(_ context.Context, _, _ uint) error {
+	return nil
+}
+
 func (m *MockStorage) GetSecretAncestors(ctx context.Context, nodeID uint) ([]uint, error) {
 	args := m.Called(ctx, nodeID)
 	if args.Get(0) == nil {

--- a/internal/core/permission_enforcement_test.go
+++ b/internal/core/permission_enforcement_test.go
@@ -319,6 +319,7 @@ func TestCanUserModifySecret(t *testing.T) {
 			setupMocks: func(ms *MockStorage) {
 				secret := createTestSecret(1, 1, "test-secret")
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+				ms.On("IsProjectMember", mock.Anything, uint(1), uint(0)).Return(true, nil)
 			},
 			expected: true,
 		},
@@ -410,6 +411,8 @@ func TestCanUserShareSecret(t *testing.T) {
 			setupMocks: func(ms *MockStorage) {
 				secret := createTestSecret(1, 1, "test-secret")
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+				// CheckSecretPermission gates the owner path on IsProjectMember (RBAC-001).
+				ms.On("IsProjectMember", mock.Anything, uint(1), uint(0)).Return(true, nil)
 			},
 			expected: true,
 		},
@@ -490,6 +493,7 @@ func TestGetEffectivePermission(t *testing.T) {
 			setupMocks: func(ms *MockStorage) {
 				secret := createTestSecret(1, 1, "test-secret")
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+				ms.On("IsProjectMember", mock.Anything, uint(1), uint(0)).Return(true, nil)
 			},
 			expectedPermission: PermissionOwner,
 		},

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -115,6 +115,11 @@ func (c *KeyorixCore) RemoveProjectMember(ctx context.Context, actorID, projectI
 	// the role removal, because the RBAC-001 membership check in CheckSecretPermission
 	// already blocks access — this is defense-in-depth, not a hard gate.
 	_ = c.storage.ClearProjectSecretOwnership(ctx, userID, projectID)
+	// Revoke per-secret ACL grants in this project (CWE-284): without this a removed
+	// member retains access to any secret they held a SecretACL grant for, because
+	// AuthorizeSecret checks ACL grants before project-scope RBAC and short-circuits
+	// on the first match — the role removal above provides no protection against stale ACLs.
+	_ = c.storage.DeleteSecretACLsByUserAndProject(ctx, userID, projectID)
 	for _, a := range assignments {
 		if a.PrincipalType != "user" || a.PrincipalID != userID {
 			continue

--- a/internal/core/project_members_test.go
+++ b/internal/core/project_members_test.go
@@ -251,6 +251,54 @@ func TestRemoveProjectMember_AllowsNonLastAdmin(t *testing.T) {
 	assert.Contains(t, err.Error(), "last administrator")
 }
 
+// CWE-284: removing a project member must revoke any per-secret ACL grants the
+// user holds on secrets in that project. Without this, a removed member retains
+// access because AuthorizeSecret checks ACL grants before project-scope RBAC
+// and short-circuits on the first match.
+func TestRemoveProjectMember_RevokesSecretACLGrants(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(5)
+	const env = uint(5)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	// Seed the project and environment so the secret can be created.
+	require.NoError(t, st.DB().Create(&models.Project{ID: proj, Name: "acl-project"}).Error)
+	require.NoError(t, st.DB().Create(&models.Environment{ID: env, ProjectID: proj, Name: "env"}).Error)
+
+	// Create a secret in the project.
+	sec := &models.SecretNode{ProjectID: proj, EnvironmentID: env, Name: "db-password", IsSecret: true, Status: "active"}
+	require.NoError(t, st.DB().Create(sec).Error)
+
+	// Create a user and add them to the project.
+	u, err := st.CreateUser(ctx, &models.User{Username: "ivy", Email: "ivy@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
+
+	// Grant the user a per-secret ACL on the secret.
+	require.NoError(t, c.GrantSecretACL(ctx, actor, sec.ID, u.ID, []string{"secrets.read"}))
+
+	// Sanity: the ACL is live before removal.
+	acls, err := c.ListSecretACLs(ctx, sec.ID)
+	require.NoError(t, err)
+	require.Len(t, acls, 1, "ACL grant must exist before member removal")
+
+	// Remove the user from the project.
+	require.NoError(t, c.RemoveProjectMember(ctx, actor, proj, u.ID))
+
+	// ACL grant must be gone after offboarding.
+	acls, err = c.ListSecretACLs(ctx, sec.ID)
+	require.NoError(t, err)
+	assert.Empty(t, acls, "SecretACL grant must be revoked when the user is removed from the project")
+
+	// AuthorizeSecret must also deny: HasSecretACL returns false, and the
+	// project-scope RBAC fallback denies a user with no remaining role.
+	allowed, err := c.AuthorizeSecret(ctx, u.ID, sec.ID, "secrets.read")
+	require.NoError(t, err)
+	assert.False(t, allowed, "removed member must not retain access via stale ACL grant")
+}
+
 // #236 (negative case): a non-admin member (no roles.assign) can always be freely
 // removed — the guard only fires for the LAST roles.assign holder.
 func TestRemoveProjectMember_NonAdminAlwaysRemovable(t *testing.T) {

--- a/internal/core/saml_flow_test.go
+++ b/internal/core/saml_flow_test.go
@@ -88,7 +88,7 @@ func TestCompleteSAML_ExistingUser(t *testing.T) {
 	c, store := samlTestCore(stub)
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-1").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ReturnTo: "/home", ExpiresAt: time.Now().Add(time.Minute)}, nil)
-	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|123").Return(&models.User{ID: 7}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|123").Return(&models.User{ID: 7, IsActive: true}, nil)
 	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 7, SessionToken: "tok"}, nil)
 	store.On("UpdateLastLogin", mock.Anything, uint(7), mock.Anything).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
@@ -205,7 +205,7 @@ func TestCompleteSAML_PasswordExpiredGateError(t *testing.T) {
 	stub := &stubSAML{info: &samlpkg.AssertionInfo{Subject: "corp|99", Email: "exp@x.io", Name: "Expired"}}
 	c, store := samlTestCore(stub)
 	c.passwordPolicy = PasswordPolicy{MaxAgeDays: 1}
-	expiredUser := &models.User{ID: 99, AccountState: "active", CreatedAt: time.Now().Add(-48 * time.Hour)}
+	expiredUser := &models.User{ID: 99, IsActive: true, AccountState: "active", CreatedAt: time.Now().Add(-48 * time.Hour)}
 
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-exp").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
@@ -233,10 +233,10 @@ func TestCompleteSAML_TrustAssertedEmailOptInLinksExistingAccount(t *testing.T) 
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-7").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
 	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|123").Return((*models.User)(nil), userNotFound())
-	store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, ExternalID: ""}, nil)
+	store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, IsActive: true, ExternalID: ""}, nil)
 	store.On("UpdateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
 		return u.ID == 9 && u.ExternalID == "sso:corp:corp|123"
-	})).Return(&models.User{ID: 9, ExternalID: "sso:corp:corp|123"}, nil)
+	})).Return(&models.User{ID: 9, IsActive: true, ExternalID: "sso:corp:corp|123"}, nil)
 	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 9, SessionToken: "tok"}, nil)
 	store.On("UpdateLastLogin", mock.Anything, uint(9), mock.Anything).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)

--- a/internal/core/secret_access_history_test.go
+++ b/internal/core/secret_access_history_test.go
@@ -20,9 +20,10 @@ func TestListSecretAccessHistory(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/secret_access_list_test.go
+++ b/internal/core/secret_access_list_test.go
@@ -24,7 +24,7 @@ func TestListSecretAccessors(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
-		&models.Group{}, &models.UserGroup{},
+		&models.Group{}, &models.UserGroup{}, &models.UserRole{},
 	))
 	// Users: 1 owner, 2 direct recipient, 3 & 4 group members, 5 expired-share recipient.
 	for _, u := range []models.User{
@@ -36,6 +36,9 @@ func TestListSecretAccessors(t *testing.T) {
 	} {
 		require.NoError(t, db.Create(&u).Error)
 	}
+	// IsProjectMember gates CheckSecretPermission (RBAC-001) and ShareSecret recipient check.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "platform"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 3, GroupID: 10}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 4, GroupID: 10}).Error)
@@ -91,10 +94,12 @@ func TestListSecretAccessors_StrongestGrantWins(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
-		&models.Group{}, &models.UserGroup{},
+		&models.Group{}, &models.UserGroup{}, &models.UserRole{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "alice", Email: "a@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "g"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 10}).Error)
 
@@ -142,10 +147,11 @@ func TestListSecretAccessors_DegradedOnGroupMembersError(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
-		&models.Group{}, &models.UserGroup{},
+		&models.Group{}, &models.UserGroup{}, &models.UserRole{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", Email: "b@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "platform"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 10}).Error)
 

--- a/internal/core/secret_access_stats_test.go
+++ b/internal/core/secret_access_stats_test.go
@@ -20,9 +20,10 @@ func TestGetSecretAccessStats(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/secret_audit_trail_test.go
+++ b/internal/core/secret_audit_trail_test.go
@@ -20,9 +20,10 @@ func TestListSecretAuditEvents(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/secret_bulk_rename_test.go
+++ b/internal/core/secret_bulk_rename_test.go
@@ -22,7 +22,7 @@ func TestBulkRenameSecrets(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
-		&models.AuditEvent{}, &models.SecretAccessLog{},
+		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.UserRole{},
 	))
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
@@ -35,6 +35,9 @@ func TestBulkRenameSecrets(t *testing.T) {
 	require.NoError(t, err)
 	env, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
 	require.NoError(t, err)
+	// CheckSecretPermission gates the owner path on IsProjectMember (RBAC-001); seed
+	// user 1 so the owning actor passes the project-membership guard.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p.ID}).Error)
 
 	mk := func(name string, projectID uint, isSecret bool) uint {
 		s, e := c.storage.CreateSecret(ctx, &models.SecretNode{

--- a/internal/core/secret_copy_environment_test.go
+++ b/internal/core/secret_copy_environment_test.go
@@ -20,7 +20,7 @@ func TestCopyEnvironmentSecrets(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
 	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
@@ -28,6 +28,7 @@ func TestCopyEnvironmentSecrets(t *testing.T) {
 	prod, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
 	p2, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
 	otherEnv, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p.ID}).Error)
 
 	mk := func(envID uint, name string) {
 		_, err := c.CreateSecret(ctx, &CreateSecretRequest{

--- a/internal/core/secret_copy_test.go
+++ b/internal/core/secret_copy_test.go
@@ -20,7 +20,7 @@ func TestCopySecret(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
@@ -30,6 +30,8 @@ func TestCopySecret(t *testing.T) {
 	prod, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p1.ID})
 	p2, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
 	otherEnv, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+	// IsProjectMember gates CheckSecretPermission (RBAC-001); owner must be a member of p1.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p1.ID}).Error)
 
 	src, err := c.CreateSecret(ctx, &CreateSecretRequest{
 		Name: "db-url", Value: []byte("postgres://secret"), ProjectID: p1.ID, EnvironmentID: staging.ID,

--- a/internal/core/secret_description_test.go
+++ b/internal/core/secret_description_test.go
@@ -21,9 +21,10 @@ func TestSetSecretDescription(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/secret_extend_expiring_test.go
+++ b/internal/core/secret_extend_expiring_test.go
@@ -22,7 +22,7 @@ func TestExtendExpiringSecrets(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
-		&models.AuditEvent{}, &models.SecretAccessLog{},
+		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
@@ -30,6 +30,7 @@ func TestExtendExpiringSecrets(t *testing.T) {
 
 	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
 	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p.ID}).Error)
 	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
 	require.NoError(t, err)
 

--- a/internal/core/secret_listing_pagination_test.go
+++ b/internal/core/secret_listing_pagination_test.go
@@ -36,7 +36,7 @@ func TestListSecretsInScope_PaginationSurvivesPostFetchTagFilter(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
@@ -45,6 +45,7 @@ func TestListSecretsInScope_PaginationSurvivesPostFetchTagFilter(t *testing.T) {
 	require.NoError(t, err)
 	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
 	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p.ID}).Error)
 
 	mk := func(name string, keep bool) {
 		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{

--- a/internal/core/secret_move_test.go
+++ b/internal/core/secret_move_test.go
@@ -38,10 +38,13 @@ func newMoveFixture(t *testing.T) (c *KeyorixCore, secretID, folderID uint, db *
 		&models.User{},
 		&models.Group{},
 		&models.UserGroup{},
+		&models.UserRole{},
 	))
 
 	// Seed a user so share-lookup JOIN does not hit a missing table.
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@test.com"}).Error)
+	// IsProjectMember gates CheckSecretPermission (RBAC-001); owner must be a member of project 1.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	c = &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/secret_ownership_history_test.go
+++ b/internal/core/secret_ownership_history_test.go
@@ -22,6 +22,8 @@ func newOwnershipCore(store *MockStorage) *KeyorixCore {
 func setupOwnerPermission(store *MockStorage, ctx context.Context, secretID, actorID uint) {
 	store.On("GetSecret", ctx, secretID).
 		Return(&models.SecretNode{ID: secretID, OwnerID: actorID}, nil)
+	// CheckSecretPermission gates the owner fast-path on IsProjectMember (RBAC-001).
+	store.On("IsProjectMember", mock.Anything, actorID, uint(0)).Return(true, nil)
 }
 
 func TestGetSecretOwnershipHistory_Empty(t *testing.T) {

--- a/internal/core/secret_render_test.go
+++ b/internal/core/secret_render_test.go
@@ -30,7 +30,7 @@ func newRenderFixture(t *testing.T) (*KeyorixCore, *gorm.DB, uint, uint) {
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{},
 		&models.Project{}, &models.Environment{}, &models.SecretAccessLog{}, &models.AuditEvent{},
-		&models.ShareRecord{}, &models.SecretACL{},
+		&models.ShareRecord{}, &models.SecretACL{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@test.com"}).Error)
 
@@ -41,6 +41,8 @@ func newRenderFixture(t *testing.T) (*KeyorixCore, *gorm.DB, uint, uint) {
 	proj, err := st.CreateProject(ctx, &models.Project{Name: "payments"})
 	require.NoError(t, err)
 	env, err := st.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: proj.ID})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: proj.ID}).Error)
 	require.NoError(t, err)
 	secret, err := st.CreateSecret(ctx, &models.SecretNode{
 		Name: "db-password", ProjectID: proj.ID, EnvironmentID: env.ID, Type: "password",

--- a/internal/core/secret_search_metadata_test.go
+++ b/internal/core/secret_search_metadata_test.go
@@ -20,11 +20,12 @@ func TestSecretSearch_NameDescriptionTags(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}, &models.AuditEvent{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
 	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
 	e, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p.ID}).Error)
 
 	mk := func(name, desc string, tags ...string) {
 		s, err := c.CreateSecret(ctx, &CreateSecretRequest{

--- a/internal/core/secret_tag_filter_test.go
+++ b/internal/core/secret_tag_filter_test.go
@@ -20,7 +20,7 @@ func TestListSecretsInScope_TagFilter(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
@@ -29,6 +29,7 @@ func TestListSecretsInScope_TagFilter(t *testing.T) {
 	require.NoError(t, err)
 	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
 	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p.ID}).Error)
 
 	mk := func(name string, tags ...string) uint {
 		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{

--- a/internal/core/secret_tags_test.go
+++ b/internal/core/secret_tags_test.go
@@ -21,9 +21,10 @@ func TestSecretTags(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Tag{}, &models.SecretTag{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Tag{}, &models.SecretTag{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/shares_expiry_test.go
+++ b/internal/core/shares_expiry_test.go
@@ -34,10 +34,15 @@ func newSharesExpiryFixture(t *testing.T) (*KeyorixCore, uint, time.Time, *gorm.
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{},
 		&models.AuditEvent{}, &models.User{}, &models.Group{}, &models.UserGroup{},
+		&models.UserRole{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@test.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "recip2", Email: "recip2@test.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 3, Username: "recip3", Email: "recip3@test.com"}).Error)
+	// ShareSecret checks IsProjectMember before creating the share record; seed
+	// project membership for both recipients so that check passes.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 1, ProjectID: 1}).Error)
 
 	now := time.Now()
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}

--- a/internal/core/sharing_integration_simple_test.go
+++ b/internal/core/sharing_integration_simple_test.go
@@ -54,6 +54,12 @@ func TestSharingIntegrationSimple(t *testing.T) {
 	for i := 10; i <= 20; i++ {
 		require.NoError(t, db.Create(&models.User{ID: uint(i), Username: fmt.Sprintf("user%d", i), Email: fmt.Sprintf("user%d@test.com", i)}).Error)
 	}
+	// ShareSecret verifies recipient is a project member (RBAC-001); seed all test users in project 1.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
+	for i := 10; i <= 20; i++ {
+		require.NoError(t, db.Create(&models.UserRole{UserID: uint(i), RoleID: 1, ProjectID: 1}).Error)
+	}
 	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "test-group"}).Error)
 
 	// Initialize storage

--- a/internal/core/sharing_test.go
+++ b/internal/core/sharing_test.go
@@ -57,6 +57,8 @@ func TestKeyorixCore_ShareSecret(t *testing.T) {
 
 	// Mock expectations
 	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+	// ShareSecret verifies the recipient is a member of the secret's project.
+	mockStorage.On("IsProjectMember", ctx, uint(2), uint(0)).Return(true, nil)
 	mockStorage.On("CreateShareRecord", ctx, mock.AnythingOfType("*models.ShareRecord")).Return(shareRecord, nil)
 	mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
 	// A direct share notifies the recipient (best-effort).
@@ -229,6 +231,7 @@ func TestKeyorixCore_ShareSecret_RejectsSelfShare(t *testing.T) {
 	otherSecret := &models.SecretNode{ID: 3, Name: "s2", OwnerID: 1}
 	otherShareRecord := &models.ShareRecord{ID: 4, SecretID: 3, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}
 	mockStorage.On("GetSecret", ctx, uint(3)).Return(otherSecret, nil)
+	mockStorage.On("IsProjectMember", ctx, uint(2), uint(0)).Return(true, nil)
 	mockStorage.On("CreateShareRecord", ctx, mock.MatchedBy(func(s *models.ShareRecord) bool {
 		return s.SecretID == 3 && !s.IsGroup
 	})).Return(otherShareRecord, nil)

--- a/internal/core/sod_degraded_test.go
+++ b/internal/core/sod_degraded_test.go
@@ -34,7 +34,9 @@ func TestDetectSoDViolations_DegradedOnUserPermissionsError(t *testing.T) {
 
 	// Neither user holds an admin permission-bypass role.
 	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
+	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil)
 	store.On("GetUserRoles", ctx, uint(11)).Return([]*models.Role{}, nil)
+	store.On("GetUserGroups", ctx, uint(11)).Return([]*models.Group{}, nil)
 
 	// alice: a real, detectable violation.
 	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
@@ -86,6 +88,7 @@ func TestDetectSoDViolations_DegradedOnMachineRolesError(t *testing.T) {
 		{ID: 10, Username: "alice", IsActive: true},
 	}, int64(1), nil)
 	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
+	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil)
 	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
 		{Name: "secrets.write"}, {Name: "users.read"},
 	}, nil)
@@ -154,6 +157,7 @@ func TestDetectSoDViolations_NotDegradedOnCleanScan(t *testing.T) {
 		{ID: 10, Username: "alice", IsActive: true},
 	}, int64(1), nil)
 	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
+	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil)
 	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
 		{Name: "secrets.read"},
 	}, nil)

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -634,7 +634,7 @@ func TestCompleteSSO_PasswordExpiredGateError(t *testing.T) {
 	c.passwordPolicy = PasswordPolicy{MaxAgeDays: 1}
 
 	const testNonce = "nonce-expiry-err"
-	expiredUser := &models.User{ID: 55, AccountState: "active", CreatedAt: time.Now().Add(-48 * time.Hour)}
+	expiredUser := &models.User{ID: 55, IsActive: true, AccountState: "active", CreatedAt: time.Now().Add(-48 * time.Hour)}
 
 	idToken := signToken(t, key, "kid-1", jwt.MapClaims{
 		"iss":            "https://idp.test",

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -343,6 +343,10 @@ type Storage interface {
 	ListSecretACLsByUser(ctx context.Context, userID uint) ([]*models.SecretACL, error)
 	GetSecretACL(ctx context.Context, secretID, userID uint) (*models.SecretACL, error)
 	DeleteSecretACL(ctx context.Context, id uint) error
+	// DeleteSecretACLsByUserAndProject removes all ACL grants for userID on secrets
+	// that belong to projectID. Called during project member removal so that a
+	// revoked member's per-secret ACL grants do not survive offboarding (CWE-284).
+	DeleteSecretACLsByUserAndProject(ctx context.Context, userID, projectID uint) error
 	// GetSecretAncestors returns the ancestor SecretNode IDs for nodeID,
 	// ordered from immediate parent to root (breadth-first up the ParentID
 	// chain). Used by HasSecretACL to walk the folder ACL inheritance path.

--- a/internal/storage/store/local_secret_acl.go
+++ b/internal/storage/store/local_secret_acl.go
@@ -64,3 +64,16 @@ func (ls *LocalStorage) DeleteSecretACL(ctx context.Context, id uint) error {
 	}
 	return nil
 }
+
+// DeleteSecretACLsByUserAndProject removes all ACL grants for userID on secrets
+// that belong to projectID. Used by RemoveProjectMember to prevent stale
+// per-secret ACL grants from persisting after a user is offboarded (CWE-284).
+func (ls *LocalStorage) DeleteSecretACLsByUserAndProject(ctx context.Context, userID, projectID uint) error {
+	result := ls.db.WithContext(ctx).
+		Where("user_id = ? AND secret_id IN (SELECT id FROM secret_nodes WHERE project_id = ?)", userID, projectID).
+		Delete(&models.SecretACL{})
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	return nil
+}

--- a/internal/storage/store/remote_secret_acl.go
+++ b/internal/storage/store/remote_secret_acl.go
@@ -33,6 +33,10 @@ func (rs *RemoteStorage) DeleteSecretACL(_ context.Context, _ uint) error {
 	return remoteUnsupported("DeleteSecretACL")
 }
 
+func (rs *RemoteStorage) DeleteSecretACLsByUserAndProject(_ context.Context, _, _ uint) error {
+	return remoteUnsupported("DeleteSecretACLsByUserAndProject")
+}
+
 // GetSecretAncestors is the folder-ACL inheritance walk helper. Folder-ACL
 // enforcement is server-side only; the inheritance walk in HasSecretACL skips
 // this path when ErrUnsupportedByBackend is returned.

--- a/internal/storage/store/remote_unsupported_registry_test.go
+++ b/internal/storage/store/remote_unsupported_registry_test.go
@@ -49,8 +49,9 @@ func init() {
 		"ListSecretACLs":           {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
 		"ListSecretACLsByUser":     {statusIntentional, "RBAC Phase 3 — listing ACL-granted secrets for a user runs server-side in ListSecretsWithSharingInfo; the core function calls LocalStorage on the server, not RemoteStorage"},
 		"GetSecretACL":             {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
-		"DeleteSecretACL":          {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
-		"GetSecretAncestors":       {statusIntentional, "RBAC Phase 3 — folder-ACL inheritance walk runs server-side; HasSecretACL uses ErrUnsupportedByBackend to skip the ancestor walk on remote callers"},
+		"DeleteSecretACL":                      {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
+		"DeleteSecretACLsByUserAndProject":     {statusIntentional, "RBAC Phase 3 — project member removal runs server-side; RemoveProjectMember is never called from a remote-storage CLI context"},
+		"GetSecretAncestors":                   {statusIntentional, "RBAC Phase 3 — folder-ACL inheritance walk runs server-side; HasSecretACL uses ErrUnsupportedByBackend to skip the ancestor walk on remote callers"},
 
 		"GetProjectUsageStats": {statusIntentional, "usage report queries run server-side; a future PR may add a /api/v1/system/usage proxy route"},
 


### PR DESCRIPTION
## Summary

**Test suite fixes** (41 files) — cascade of failures caused by four merged security changes:

- **RBAC-001** (`#1205`): `CheckSecretPermission` now gates the owner fast-path on `IsProjectMember`. MockStorage tests needed `IsProjectMember` mock expectations; LocalStorage tests needed `user_roles` in `AutoMigrate` and seed rows so the membership check doesn't error or return false.
- **SSRF guard** (`#1208`): `CreateDynamicSecretConfig` rejects private-IP DSNs. Tests using private-IP fixtures updated.
- **Machine privilege ceiling**: `IssueMachineToken` calls `GetMachineRoles`. MockStorage tests needed `GetMachineRoles` expectations.
- **SAML/SSO `IsActive` gate**: `CompleteSAML`/`CompleteSSO` now gate on `!user.IsActive`. Mock users needed `IsActive: true`.
- **Break-glass expiry** (`TestBreakGlass_ExpiredGrantDeniesAuthorization`): The test's raw `Update("expires_at", time.Now().Add(-time.Hour))` bypasses the `BeforeSave` UTC-normalisation hook from `#1218`. On machines not in UTC the stored local-time string compared false against the WHERE clause's `time.Now().UTC()`. Fixed by using `.UTC()` on the update value.

**CWE-284 security fix** — stale per-secret ACL grants surviving project member removal:
- `DeleteSecretACLsByUserAndProject` added to the `Storage` interface, implemented in `LocalStorage`, and called from `RemoveProjectMember`.
- Without this, a revoked member retains access to any secret where they held a `SecretACL` grant, because `AuthorizeSecret` checks ACL grants before project-scope RBAC and short-circuits on the first match — the role removal above provides no protection.

## Test plan

- [ ] `go test ./internal/core/` passes (was 30+ failures before this PR)
- [ ] `go test ./internal/storage/...` passes
- [ ] Manual: remove a project member who has per-secret ACL grants; confirm they can no longer access those secrets