### PR TITLE
fix(security): PAT-SCOPE-002, WAUN-001, TMPL-002, K8SSYNC-007 + TOTP anti-replay proxy + operator Helm clusterScoped

### DIFF
--- a/deploy/helm/keyorix-operator/templates/rbac.yaml
+++ b/deploy/helm/keyorix-operator/templates/rbac.yaml
@@ -48,7 +48,23 @@ rules:
     resources: ["keyorixsecrets/finalizers"]
     verbs: ["update"]
 ---
-{{- if .Values.watchNamespaces }}
+{{- if .Values.rbac.clusterScoped }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kxop.fullname" . }}
+  labels:
+    {{- include "kxop.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kxop.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kxop.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+{{- else if .Values.watchNamespaces }}
 {{- $root := . }}
 {{- range .Values.watchNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -70,9 +86,10 @@ subjects:
 {{- end }}
 {{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ include "kxop.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kxop.labels" . | nindent 4 }}
 roleRef:

--- a/deploy/helm/keyorix-operator/templates/rbac.yaml
+++ b/deploy/helm/keyorix-operator/templates/rbac.yaml
@@ -48,23 +48,7 @@ rules:
     resources: ["keyorixsecrets/finalizers"]
     verbs: ["update"]
 ---
-{{- if .Values.rbac.clusterScoped }}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "kxop.fullname" . }}
-  labels:
-    {{- include "kxop.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "kxop.fullname" . }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "kxop.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
----
-{{- else if .Values.watchNamespaces }}
+{{- if .Values.watchNamespaces }}
 {{- $root := . }}
 {{- range .Values.watchNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -84,6 +68,22 @@ subjects:
     namespace: {{ $root.Release.Namespace }}
 ---
 {{- end }}
+{{- else if .Values.rbac.clusterScoped }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kxop.fullname" . }}
+  labels:
+    {{- include "kxop.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kxop.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kxop.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
 {{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/helm/keyorix-operator/values.yaml
+++ b/deploy/helm/keyorix-operator/values.yaml
@@ -31,6 +31,13 @@ healthPort: 8081
 #   watchNamespaces: [team-a, team-b]
 watchNamespaces: []
 
+rbac:
+  # clusterScoped: when false (the default), the operator is bound via a RoleBinding
+  # scoped to watchNamespaces (if set) or the release namespace — least privilege.
+  # Set to true only when the operator must watch CRs across ALL namespaces and a
+  # ClusterRoleBinding is genuinely required.
+  clusterScoped: false
+
 serviceAccount:
   create: true
   # name overrides the generated ServiceAccount name.

--- a/deploy/helm/keyorix-operator/values.yaml
+++ b/deploy/helm/keyorix-operator/values.yaml
@@ -32,11 +32,11 @@ healthPort: 8081
 watchNamespaces: []
 
 rbac:
-  # clusterScoped: when false (the default), the operator is bound via a RoleBinding
-  # scoped to watchNamespaces (if set) or the release namespace — least privilege.
-  # Set to true only when the operator must watch CRs across ALL namespaces and a
-  # ClusterRoleBinding is genuinely required.
-  clusterScoped: false
+  # clusterScoped: ignored when watchNamespaces is set (that path always uses per-namespace
+  # RoleBindings). When watchNamespaces is empty, true (the default) preserves the original
+  # cluster-wide ClusterRoleBinding; set to false to instead use a RoleBinding scoped to the
+  # release namespace only — least-privilege for single-namespace deployments.
+  clusterScoped: true
 
 serviceAccount:
   create: true

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -35,7 +35,7 @@ func newBootstrappedCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 		&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.ProjectMembership{},
 		&models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.SoDPolicy{},
 		&models.StatsSnapshot{}, &models.DeploymentStatsSnapshot{},
-		&models.MFAStepupToken{},
+		&models.MFAStepupToken{}, &models.SecretACL{},
 	))
 
 	st := store.NewLocalStorage(db)

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -228,7 +228,19 @@ func (c *KeyorixCore) principalHasScopedPermission(ctx context.Context, userID u
 // falls back to project-scope RBAC (Authorize at the secret's own project/environment
 // scope). Fails closed: any resolution error returns (false, err).
 func (c *KeyorixCore) AuthorizeSecret(ctx context.Context, userID, secretID uint, perm string) (bool, error) {
-	// Check per-secret ACL first (additive grant).
+	// Resolve the secret first so we know its scope for the PAT check below.
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	if err != nil {
+		return false, err
+	}
+	scope := Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
+	// PAT-SCOPE-002: a per-secret ACL grant must not let a project-scoped PAT read
+	// secrets outside the token's own project/environment — check the restriction
+	// against the secret's actual scope before honouring an ACL grant.
+	if !patRestrictionFromContext(ctx).Allows(perm, scope) {
+		return false, nil
+	}
+	// Check per-secret ACL (additive grant).
 	hasACL, err := c.HasSecretACL(ctx, userID, secretID, perm)
 	if err != nil {
 		return false, err
@@ -237,11 +249,7 @@ func (c *KeyorixCore) AuthorizeSecret(ctx context.Context, userID, secretID uint
 		return true, nil
 	}
 	// Fall back to project-scope RBAC.
-	secret, err := c.storage.GetSecret(ctx, secretID)
-	if err != nil {
-		return false, err
-	}
-	return c.Authorize(ctx, userID, perm, Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID})
+	return c.Authorize(ctx, userID, perm, scope)
 }
 
 // IsGlobalAdmin reports whether userID holds an admin role assigned globally

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -320,7 +320,7 @@ func TestBreakGlass_ExpiredGrantDeniesAuthorization(t *testing.T) {
 	// elapsing). Role resolution filters out expires_at <= now, so the role drops away.
 	require.NoError(t, h.DB.Model(&models.UserRole{}).
 		Where("user_id = ? AND role_id = ?", 10, 3).
-		Update("expires_at", time.Now().Add(-time.Hour)).Error)
+		Update("expires_at", time.Now().UTC().Add(-time.Hour)).Error)
 
 	// The emergency role no longer resolves...
 	ids, err := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: proj})

--- a/internal/core/bulk_access_requests_test.go
+++ b/internal/core/bulk_access_requests_test.go
@@ -86,9 +86,10 @@ func TestBulkApproveAccessRequests_ApproveError(t *testing.T) {
 	req := pendingReq(5)
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{5}).
 		Return([]*models.AccessRequest{req}, nil)
-	// GetAccessRequest is called inside ApproveAccessRequest.
-	m.On("GetAccessRequest", mock.Anything, uint(5)).
-		Return(nil, errors.New("record not found"))
+	// The per-project Authorize check (added in #1185) calls scopedRoleIDs which
+	// reads these two tables; return empty → no permission → "permission denied" in Failed.
+	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 
 	result, err := k.BulkApproveAccessRequests(context.Background(), []uint{5}, 2)
 	require.NoError(t, err)
@@ -105,17 +106,14 @@ func TestBulkApproveAccessRequests_MixedResults(t *testing.T) {
 	req1 := pendingReq(1)
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{1, 99}).
 		Return([]*models.AccessRequest{req1}, nil) // only req1 returned
-
-	// For ID 1: ApproveAccessRequest → GetAccessRequest (returns error to
-	// trigger the "failed" path without having to mock the entire RBAC chain).
-	m.On("GetAccessRequest", mock.Anything, uint(1)).
-		Return(nil, errors.New("something broke"))
+	// Authorize check added in #1185: return empty roles → denied → "permission denied" in Failed.
+	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 
 	result, err := k.BulkApproveAccessRequests(context.Background(), []uint{1, 99}, 2)
 	require.NoError(t, err)
 
-	// ID 1: failed (GetAccessRequest error inside ApproveAccessRequest)
-	// ID 99: failed (not in pre-fetch result)
+	// ID 1: failed (permission denied by Authorize); ID 99: failed (not in pre-fetch).
 	assert.Empty(t, result.Approved)
 	assert.Len(t, result.Failed, 2)
 }
@@ -175,9 +173,9 @@ func TestBulkRejectAccessRequests_RejectError(t *testing.T) {
 	req := pendingReq(7)
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{7}).
 		Return([]*models.AccessRequest{req}, nil)
-	// GetAccessRequest is called inside RejectAccessRequest.
-	m.On("GetAccessRequest", mock.Anything, uint(7)).
-		Return(nil, errors.New("record not found"))
+	// Authorize check added in #1185: empty roles → denied → "permission denied" in Failed.
+	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 
 	result, err := k.BulkRejectAccessRequests(context.Background(), []uint{7}, 2, "denied")
 	require.NoError(t, err)
@@ -198,6 +196,10 @@ func TestBulkRejectAccessRequests_RejectNonPending(t *testing.T) {
 	}
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{8}).
 		Return([]*models.AccessRequest{already}, nil)
+	// Authorize check added in #1185: grant admin role so code reaches RejectAccessRequest.
+	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{1}, nil)
+	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	m.On("GetRoleByName", mock.Anything, mock.Anything).Return(&models.Role{ID: 1, Name: "admin"}, nil)
 	m.On("GetAccessRequest", mock.Anything, uint(8)).
 		Return(already, nil)
 
@@ -216,9 +218,9 @@ func TestBulkRejectAccessRequests_MixedResults(t *testing.T) {
 	req3 := pendingReq(3)
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{3, 77}).
 		Return([]*models.AccessRequest{req3}, nil) // only req3 returned
-
-	m.On("GetAccessRequest", mock.Anything, uint(3)).
-		Return(nil, errors.New("storage error"))
+	// Authorize check added in #1185: empty roles → denied → "permission denied" for ID 3.
+	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 
 	result, err := k.BulkRejectAccessRequests(context.Background(), []uint{3, 77}, 2, "no")
 	require.NoError(t, err)

--- a/internal/core/bulk_access_requests_test.go
+++ b/internal/core/bulk_access_requests_test.go
@@ -86,8 +86,8 @@ func TestBulkApproveAccessRequests_ApproveError(t *testing.T) {
 	req := pendingReq(5)
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{5}).
 		Return([]*models.AccessRequest{req}, nil)
-	// The per-project Authorize check (added in #1185) calls scopedRoleIDs which
-	// reads these two tables; return empty → no permission → "permission denied" in Failed.
+	// The per-project Authorize check calls scopedRoleIDs which reads these two
+	// tables; return empty → no permission → "permission denied" in Failed.
 	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 
@@ -106,7 +106,7 @@ func TestBulkApproveAccessRequests_MixedResults(t *testing.T) {
 	req1 := pendingReq(1)
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{1, 99}).
 		Return([]*models.AccessRequest{req1}, nil) // only req1 returned
-	// Authorize check added in #1185: return empty roles → denied → "permission denied" in Failed.
+	// Authorize check: empty roles → denied → "permission denied" in Failed.
 	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 
@@ -173,7 +173,7 @@ func TestBulkRejectAccessRequests_RejectError(t *testing.T) {
 	req := pendingReq(7)
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{7}).
 		Return([]*models.AccessRequest{req}, nil)
-	// Authorize check added in #1185: empty roles → denied → "permission denied" in Failed.
+	// Authorize check: empty roles → denied → "permission denied" in Failed.
 	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 
@@ -196,7 +196,7 @@ func TestBulkRejectAccessRequests_RejectNonPending(t *testing.T) {
 	}
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{8}).
 		Return([]*models.AccessRequest{already}, nil)
-	// Authorize check added in #1185: grant admin role so code reaches RejectAccessRequest.
+	// Authorize check: grant admin role so code reaches RejectAccessRequest.
 	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{1}, nil)
 	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	m.On("GetRoleByName", mock.Anything, mock.Anything).Return(&models.Role{ID: 1, Name: "admin"}, nil)
@@ -218,7 +218,7 @@ func TestBulkRejectAccessRequests_MixedResults(t *testing.T) {
 	req3 := pendingReq(3)
 	m.On("ListAccessRequestsByIDs", mock.Anything, []uint{3, 77}).
 		Return([]*models.AccessRequest{req3}, nil) // only req3 returned
-	// Authorize check added in #1185: empty roles → denied → "permission denied" for ID 3.
+	// Authorize check: empty roles → denied → "permission denied" for ID 3.
 	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 

--- a/internal/core/certificate_test.go
+++ b/internal/core/certificate_test.go
@@ -101,17 +101,21 @@ func newCertCore(t *testing.T, now time.Time) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{},
+		&models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
+	))
+	// CheckSecretPermission gates the owner path on IsProjectMember (RBAC-001): user 9
+	// (the standard cert-test actor) must be a member of project 1 so the read succeeds.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 9, RoleID: 1, ProjectID: 1}).Error)
 	return &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}, db
 }
 
 // mkCertSecret stores a secret (no encryption → value lives in the version row), owned
-// by user 9 — the actor ID every InspectCertificate call in this file uses — so the
-// EnforceSecretReadPermission check InspectCertificate now performs is satisfied via
-// ownership without needing the shares/groups tables migrated.
+// by user 9 in project 1 — the actor ID every InspectCertificate call in this file uses.
 func mkCertSecret(t *testing.T, db *gorm.DB, id uint, name, status string, value []byte) {
 	t.Helper()
-	require.NoError(t, db.Create(&models.SecretNode{ID: id, Name: name, IsSecret: true, Status: status, Type: "certificate", OwnerID: 9}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: id, Name: name, IsSecret: true, Status: status, Type: "certificate", OwnerID: 9, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: id, VersionNumber: 1, EncryptedValue: value}).Error)
 }
 

--- a/internal/core/classification_gate_test.go
+++ b/internal/core/classification_gate_test.go
@@ -30,6 +30,11 @@ func seedClassificationGateFixture(t *testing.T, st *store.LocalStorage, classif
 	adminRole, err := st.GetRoleByName(ctx, "admin")
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRole(ctx, approver.ID, adminRole.ID, storage.Scope{}))
+	// IsProjectMember (RBAC-001): requester must be a project member or the owner
+	// gate short-circuits before returning PermissionOwner.
+	viewerRole, err := st.GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, requester.ID, viewerRole.ID, storage.Scope{ProjectID: proj.ID}))
 
 	secret, err := st.CreateSecret(ctx, &models.SecretNode{
 		Name: "db-password", ProjectID: proj.ID, EnvironmentID: 1, Type: "password",

--- a/internal/core/classify_dynamic_test.go
+++ b/internal/core/classify_dynamic_test.go
@@ -10,12 +10,14 @@ import (
 
 func makeDynConfig(t *testing.T, c *KeyorixCore, name, classification string) uint {
 	t.Helper()
+	// Use db.example.com (unresolvable) instead of localhost so the SSRF guard passes
+	// without needing allowPrivateNetworkTargets — validateAdminDSNHost allows unresolvable hosts.
 	cfg, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
 		Name:           name,
 		ProjectID:      1,
 		EnvironmentID:  1,
 		BackendType:    "postgres",
-		AdminDSN:       "postgres://admin:pw@localhost/db",
+		AdminDSN:       "postgres://admin:pw@db.example.com/db",
 		Classification: classification,
 		CreatedBy:      "admin",
 		ActorID:        testAdminActorID,

--- a/internal/core/core_s26_test.go
+++ b/internal/core/core_s26_test.go
@@ -222,6 +222,7 @@ func TestGetSecretVersionsWithPermissionCheck_Success(t *testing.T) {
 	ms := new(MockStorage)
 	secret := &models.SecretNode{ID: 10, OwnerID: 1}
 	ms.On("GetSecret", mock.Anything, uint(10)).Return(secret, nil)
+	ms.On("IsProjectMember", mock.Anything, uint(1), uint(0)).Return(true, nil)
 	versions := []*models.SecretVersion{{ID: 1, SecretNodeID: 10, VersionNumber: 1}}
 	ms.On("GetSecretVersions", mock.Anything, uint(10)).Return(versions, nil)
 	c := NewKeyorixCore(ms)
@@ -234,6 +235,7 @@ func TestGetSecretVersionWithPermissionCheck_Success(t *testing.T) {
 	ms := new(MockStorage)
 	secret := &models.SecretNode{ID: 10, OwnerID: 1}
 	ms.On("GetSecret", mock.Anything, uint(10)).Return(secret, nil)
+	ms.On("IsProjectMember", mock.Anything, uint(1), uint(0)).Return(true, nil)
 	versions := []*models.SecretVersion{{ID: 1, SecretNodeID: 10, VersionNumber: 2}}
 	ms.On("GetSecretVersions", mock.Anything, uint(10)).Return(versions, nil)
 	c := NewKeyorixCore(ms)
@@ -246,6 +248,7 @@ func TestGetLatestSecretVersionWithPermissionCheck_Success(t *testing.T) {
 	ms := new(MockStorage)
 	secret := &models.SecretNode{ID: 10, OwnerID: 1}
 	ms.On("GetSecret", mock.Anything, uint(10)).Return(secret, nil)
+	ms.On("IsProjectMember", mock.Anything, uint(1), uint(0)).Return(true, nil)
 	// GetLatestSecretVersion calls storage.GetSecretVersions (not GetLatestSecretVersion).
 	latest := []*models.SecretVersion{{ID: 3, SecretNodeID: 10, VersionNumber: 1}}
 	ms.On("GetSecretVersions", mock.Anything, uint(10)).Return(latest, nil)

--- a/internal/core/env_clone_test.go
+++ b/internal/core/env_clone_test.go
@@ -35,7 +35,12 @@ func newCloneTestCore(t *testing.T) *KeyorixCore {
 		&models.Environment{},
 		&models.AuditEvent{},
 		&models.SecretAccessLog{},
+		&models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
 	))
+	// CopySecret calls GetSecretValueWithPermissionCheck which gates the owner path on
+	// IsProjectMember (RBAC-001). The first project created in each test gets ID=1;
+	// seed actor 1 as a project member so the copy read passes.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 	return &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 }
 

--- a/internal/core/login_lockout_remote_test.go
+++ b/internal/core/login_lockout_remote_test.go
@@ -174,9 +174,9 @@ func (f *fakeUpstreamLoginLockout) server(t *testing.T) *httptest.Server {
 		_, _ = fmt.Fprint(w, `{"success":true,"data":{"updated":true}}`)
 	})
 
-	// POST /api/v1/audit/events — backs LogAuditEvent, so UnlockUser's audit write
+	// POST /api/v1/system/audit/event — backs LogAuditEvent, so UnlockUser's audit write
 	// (EventAccountUnlocked) genuinely round-trips too, not just the counter reset.
-	mux.HandleFunc("/api/v1/audit/events", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/system/audit/event", func(w http.ResponseWriter, r *http.Request) {
 		var event models.AuditEvent
 		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
 			w.WriteHeader(http.StatusBadRequest)

--- a/internal/core/machine_ip_allowlist_test.go
+++ b/internal/core/machine_ip_allowlist_test.go
@@ -19,6 +19,8 @@ func TestIssueMachineToken_StoresCIDRs(t *testing.T) {
 
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).
 		Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
+	// requireMachinePrivilegeCeiling (added in #1187) checks the machine's roles.
+	store.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
 	store.On("CreateMachineIdentityCredential", mock.Anything, mock.AnythingOfType("*models.MachineIdentityCredential")).
 		Return(&models.MachineIdentityCredential{ID: 7}, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
@@ -49,6 +51,8 @@ func TestIssueMachineToken_NilCIDRsOmitted(t *testing.T) {
 
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).
 		Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
+	// requireMachinePrivilegeCeiling (added in #1187) checks the machine's roles.
+	store.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
 	store.On("CreateMachineIdentityCredential", mock.Anything, mock.AnythingOfType("*models.MachineIdentityCredential")).
 		Return(&models.MachineIdentityCredential{ID: 8}, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
@@ -111,9 +115,14 @@ func TestMachineRestrictionFrom(t *testing.T) {
 		assert.Equal(t, []string{"10.0.0.0/8"}, r.AllowedCIDRs)
 	})
 
-	t.Run("invalid JSON returns nil", func(t *testing.T) {
+	t.Run("invalid JSON returns corrupted sentinel (fail-closed)", func(t *testing.T) {
+		// PAT-001 (#1185): corrupt JSON returns a blocking sentinel, not nil.
+		// Returning nil was fail-open: a token with broken CIDR data would gain
+		// unrestricted network access instead of being blocked entirely.
 		cred := &models.MachineIdentityCredential{AllowedCIDRs: `not json`}
-		assert.Nil(t, machineRestrictionFrom(cred))
+		r := machineRestrictionFrom(cred)
+		require.NotNil(t, r)
+		assert.Equal(t, []string{"<corrupted>"}, r.AllowedCIDRs)
 	})
 
 	t.Run("JSON empty array returns nil", func(t *testing.T) {

--- a/internal/core/machine_ip_allowlist_test.go
+++ b/internal/core/machine_ip_allowlist_test.go
@@ -19,7 +19,7 @@ func TestIssueMachineToken_StoresCIDRs(t *testing.T) {
 
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).
 		Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
-	// requireMachinePrivilegeCeiling (added in #1187) checks the machine's roles.
+	// requireMachinePrivilegeCeiling checks the machine's roles before issuing.
 	store.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
 	store.On("CreateMachineIdentityCredential", mock.Anything, mock.AnythingOfType("*models.MachineIdentityCredential")).
 		Return(&models.MachineIdentityCredential{ID: 7}, nil)
@@ -51,7 +51,6 @@ func TestIssueMachineToken_NilCIDRsOmitted(t *testing.T) {
 
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).
 		Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
-	// requireMachinePrivilegeCeiling (added in #1187) checks the machine's roles.
 	store.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
 	store.On("CreateMachineIdentityCredential", mock.Anything, mock.AnythingOfType("*models.MachineIdentityCredential")).
 		Return(&models.MachineIdentityCredential{ID: 8}, nil)
@@ -116,9 +115,6 @@ func TestMachineRestrictionFrom(t *testing.T) {
 	})
 
 	t.Run("invalid JSON returns corrupted sentinel (fail-closed)", func(t *testing.T) {
-		// PAT-001 (#1185): corrupt JSON returns a blocking sentinel, not nil.
-		// Returning nil was fail-open: a token with broken CIDR data would gain
-		// unrestricted network access instead of being blocked entirely.
 		cred := &models.MachineIdentityCredential{AllowedCIDRs: `not json`}
 		r := machineRestrictionFrom(cred)
 		require.NotNil(t, r)

--- a/internal/core/machine_token_test.go
+++ b/internal/core/machine_token_test.go
@@ -30,7 +30,6 @@ func TestIssueMachineToken_ActiveOnly(t *testing.T) {
 
 	// Active machine → token minted with the kx_machine_ prefix, hash stored.
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
-	// requireMachinePrivilegeCeiling (added in #1187) checks the machine's roles.
 	store.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
 	store.On("CreateMachineIdentityCredential", mock.Anything, mock.AnythingOfType("*models.MachineIdentityCredential")).
 		Return(&models.MachineIdentityCredential{ID: 5}, nil)

--- a/internal/core/machine_token_test.go
+++ b/internal/core/machine_token_test.go
@@ -30,6 +30,8 @@ func TestIssueMachineToken_ActiveOnly(t *testing.T) {
 
 	// Active machine → token minted with the kx_machine_ prefix, hash stored.
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
+	// requireMachinePrivilegeCeiling (added in #1187) checks the machine's roles.
+	store.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
 	store.On("CreateMachineIdentityCredential", mock.Anything, mock.AnythingOfType("*models.MachineIdentityCredential")).
 		Return(&models.MachineIdentityCredential{ID: 5}, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -2182,6 +2182,10 @@ func (m *MockStorage) DeleteSecretACL(_ context.Context, _ uint) error {
 	return nil
 }
 
+func (m *MockStorage) DeleteSecretACLsByUserAndProject(_ context.Context, _, _ uint) error {
+	return nil
+}
+
 func (m *MockStorage) GetSecretAncestors(ctx context.Context, nodeID uint) ([]uint, error) {
 	args := m.Called(ctx, nodeID)
 	if args.Get(0) == nil {

--- a/internal/core/permission_enforcement_test.go
+++ b/internal/core/permission_enforcement_test.go
@@ -319,6 +319,7 @@ func TestCanUserModifySecret(t *testing.T) {
 			setupMocks: func(ms *MockStorage) {
 				secret := createTestSecret(1, 1, "test-secret")
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+				ms.On("IsProjectMember", mock.Anything, uint(1), uint(0)).Return(true, nil)
 			},
 			expected: true,
 		},
@@ -410,6 +411,8 @@ func TestCanUserShareSecret(t *testing.T) {
 			setupMocks: func(ms *MockStorage) {
 				secret := createTestSecret(1, 1, "test-secret")
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+				// CheckSecretPermission gates the owner path on IsProjectMember (RBAC-001).
+				ms.On("IsProjectMember", mock.Anything, uint(1), uint(0)).Return(true, nil)
 			},
 			expected: true,
 		},
@@ -490,6 +493,7 @@ func TestGetEffectivePermission(t *testing.T) {
 			setupMocks: func(ms *MockStorage) {
 				secret := createTestSecret(1, 1, "test-secret")
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+				ms.On("IsProjectMember", mock.Anything, uint(1), uint(0)).Return(true, nil)
 			},
 			expectedPermission: PermissionOwner,
 		},

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -115,6 +115,11 @@ func (c *KeyorixCore) RemoveProjectMember(ctx context.Context, actorID, projectI
 	// the role removal, because the RBAC-001 membership check in CheckSecretPermission
 	// already blocks access — this is defense-in-depth, not a hard gate.
 	_ = c.storage.ClearProjectSecretOwnership(ctx, userID, projectID)
+	// Revoke per-secret ACL grants in this project (CWE-284): without this a removed
+	// member retains access to any secret they held a SecretACL grant for, because
+	// AuthorizeSecret checks ACL grants before project-scope RBAC and short-circuits
+	// on the first match — the role removal above provides no protection against stale ACLs.
+	_ = c.storage.DeleteSecretACLsByUserAndProject(ctx, userID, projectID)
 	for _, a := range assignments {
 		if a.PrincipalType != "user" || a.PrincipalID != userID {
 			continue

--- a/internal/core/project_members_test.go
+++ b/internal/core/project_members_test.go
@@ -251,6 +251,54 @@ func TestRemoveProjectMember_AllowsNonLastAdmin(t *testing.T) {
 	assert.Contains(t, err.Error(), "last administrator")
 }
 
+// CWE-284: removing a project member must revoke any per-secret ACL grants the
+// user holds on secrets in that project. Without this, a removed member retains
+// access because AuthorizeSecret checks ACL grants before project-scope RBAC
+// and short-circuits on the first match.
+func TestRemoveProjectMember_RevokesSecretACLGrants(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(5)
+	const env = uint(5)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	// Seed the project and environment so the secret can be created.
+	require.NoError(t, st.DB().Create(&models.Project{ID: proj, Name: "acl-project"}).Error)
+	require.NoError(t, st.DB().Create(&models.Environment{ID: env, ProjectID: proj, Name: "env"}).Error)
+
+	// Create a secret in the project.
+	sec := &models.SecretNode{ProjectID: proj, EnvironmentID: env, Name: "db-password", IsSecret: true, Status: "active"}
+	require.NoError(t, st.DB().Create(sec).Error)
+
+	// Create a user and add them to the project.
+	u, err := st.CreateUser(ctx, &models.User{Username: "ivy", Email: "ivy@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
+
+	// Grant the user a per-secret ACL on the secret.
+	require.NoError(t, c.GrantSecretACL(ctx, actor, sec.ID, u.ID, []string{"secrets.read"}))
+
+	// Sanity: the ACL is live before removal.
+	acls, err := c.ListSecretACLs(ctx, sec.ID)
+	require.NoError(t, err)
+	require.Len(t, acls, 1, "ACL grant must exist before member removal")
+
+	// Remove the user from the project.
+	require.NoError(t, c.RemoveProjectMember(ctx, actor, proj, u.ID))
+
+	// ACL grant must be gone after offboarding.
+	acls, err = c.ListSecretACLs(ctx, sec.ID)
+	require.NoError(t, err)
+	assert.Empty(t, acls, "SecretACL grant must be revoked when the user is removed from the project")
+
+	// AuthorizeSecret must also deny: HasSecretACL returns false, and the
+	// project-scope RBAC fallback denies a user with no remaining role.
+	allowed, err := c.AuthorizeSecret(ctx, u.ID, sec.ID, "secrets.read")
+	require.NoError(t, err)
+	assert.False(t, allowed, "removed member must not retain access via stale ACL grant")
+}
+
 // #236 (negative case): a non-admin member (no roles.assign) can always be freely
 // removed — the guard only fires for the LAST roles.assign holder.
 func TestRemoveProjectMember_NonAdminAlwaysRemovable(t *testing.T) {

--- a/internal/core/saml_flow_test.go
+++ b/internal/core/saml_flow_test.go
@@ -205,7 +205,7 @@ func TestCompleteSAML_PasswordExpiredGateError(t *testing.T) {
 	stub := &stubSAML{info: &samlpkg.AssertionInfo{Subject: "corp|99", Email: "exp@x.io", Name: "Expired"}}
 	c, store := samlTestCore(stub)
 	c.passwordPolicy = PasswordPolicy{MaxAgeDays: 1}
-	expiredUser := &models.User{ID: 99, AccountState: "active", IsActive: true, CreatedAt: time.Now().Add(-48 * time.Hour)}
+	expiredUser := &models.User{ID: 99, IsActive: true, AccountState: "active", CreatedAt: time.Now().Add(-48 * time.Hour)}
 
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-exp").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
@@ -233,10 +233,10 @@ func TestCompleteSAML_TrustAssertedEmailOptInLinksExistingAccount(t *testing.T) 
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-7").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
 	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|123").Return((*models.User)(nil), userNotFound())
-	store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, ExternalID: "", IsActive: true}, nil)
+	store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, IsActive: true, ExternalID: ""}, nil)
 	store.On("UpdateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
 		return u.ID == 9 && u.ExternalID == "sso:corp:corp|123"
-	})).Return(&models.User{ID: 9, ExternalID: "sso:corp:corp|123", IsActive: true}, nil)
+	})).Return(&models.User{ID: 9, IsActive: true, ExternalID: "sso:corp:corp|123"}, nil)
 	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 9, SessionToken: "tok"}, nil)
 	store.On("UpdateLastLogin", mock.Anything, uint(9), mock.Anything).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)

--- a/internal/core/saml_flow_test.go
+++ b/internal/core/saml_flow_test.go
@@ -88,7 +88,7 @@ func TestCompleteSAML_ExistingUser(t *testing.T) {
 	c, store := samlTestCore(stub)
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-1").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ReturnTo: "/home", ExpiresAt: time.Now().Add(time.Minute)}, nil)
-	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|123").Return(&models.User{ID: 7}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|123").Return(&models.User{ID: 7, IsActive: true}, nil)
 	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 7, SessionToken: "tok"}, nil)
 	store.On("UpdateLastLogin", mock.Anything, uint(7), mock.Anything).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
@@ -205,7 +205,7 @@ func TestCompleteSAML_PasswordExpiredGateError(t *testing.T) {
 	stub := &stubSAML{info: &samlpkg.AssertionInfo{Subject: "corp|99", Email: "exp@x.io", Name: "Expired"}}
 	c, store := samlTestCore(stub)
 	c.passwordPolicy = PasswordPolicy{MaxAgeDays: 1}
-	expiredUser := &models.User{ID: 99, AccountState: "active", CreatedAt: time.Now().Add(-48 * time.Hour)}
+	expiredUser := &models.User{ID: 99, AccountState: "active", IsActive: true, CreatedAt: time.Now().Add(-48 * time.Hour)}
 
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-exp").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
@@ -233,10 +233,10 @@ func TestCompleteSAML_TrustAssertedEmailOptInLinksExistingAccount(t *testing.T) 
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-7").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
 	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|123").Return((*models.User)(nil), userNotFound())
-	store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, ExternalID: ""}, nil)
+	store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, ExternalID: "", IsActive: true}, nil)
 	store.On("UpdateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
 		return u.ID == 9 && u.ExternalID == "sso:corp:corp|123"
-	})).Return(&models.User{ID: 9, ExternalID: "sso:corp:corp|123"}, nil)
+	})).Return(&models.User{ID: 9, ExternalID: "sso:corp:corp|123", IsActive: true}, nil)
 	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 9, SessionToken: "tok"}, nil)
 	store.On("UpdateLastLogin", mock.Anything, uint(9), mock.Anything).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)

--- a/internal/core/secret_access_history_test.go
+++ b/internal/core/secret_access_history_test.go
@@ -20,9 +20,10 @@ func TestListSecretAccessHistory(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/secret_access_list_test.go
+++ b/internal/core/secret_access_list_test.go
@@ -36,6 +36,9 @@ func TestListSecretAccessors(t *testing.T) {
 	} {
 		require.NoError(t, db.Create(&u).Error)
 	}
+	// IsProjectMember gates CheckSecretPermission (RBAC-001) and ShareSecret recipient check.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "platform"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 3, GroupID: 10}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 4, GroupID: 10}).Error)
@@ -97,6 +100,8 @@ func TestListSecretAccessors_StrongestGrantWins(t *testing.T) {
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "alice", Email: "a@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "g"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 10}).Error)
 	// IsProjectMember check (added in #1185): alice (user 2) must be a project member.
@@ -146,10 +151,11 @@ func TestListSecretAccessors_DegradedOnGroupMembersError(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
-		&models.Group{}, &models.UserGroup{},
+		&models.Group{}, &models.UserGroup{}, &models.UserRole{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", Email: "b@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "platform"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 10}).Error)
 

--- a/internal/core/secret_access_list_test.go
+++ b/internal/core/secret_access_list_test.go
@@ -24,7 +24,7 @@ func TestListSecretAccessors(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
-		&models.Group{}, &models.UserGroup{},
+		&models.Group{}, &models.UserGroup{}, &models.UserRole{},
 	))
 	// Users: 1 owner, 2 direct recipient, 3 & 4 group members, 5 expired-share recipient.
 	for _, u := range []models.User{
@@ -39,6 +39,8 @@ func TestListSecretAccessors(t *testing.T) {
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "platform"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 3, GroupID: 10}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 4, GroupID: 10}).Error)
+	// IsProjectMember check (added in #1185): alice (user 2) must be a project member.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 
 	now := time.Now()
 	st := store.NewLocalStorage(db)
@@ -91,12 +93,14 @@ func TestListSecretAccessors_StrongestGrantWins(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
-		&models.Group{}, &models.UserGroup{},
+		&models.Group{}, &models.UserGroup{}, &models.UserRole{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "alice", Email: "a@t.com"}).Error)
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "g"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 10}).Error)
+	// IsProjectMember check (added in #1185): alice (user 2) must be a project member.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 
 	now := time.Now()
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}

--- a/internal/core/secret_access_stats_test.go
+++ b/internal/core/secret_access_stats_test.go
@@ -20,9 +20,10 @@ func TestGetSecretAccessStats(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/secret_audit_trail_test.go
+++ b/internal/core/secret_audit_trail_test.go
@@ -20,9 +20,10 @@ func TestListSecretAuditEvents(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/secret_bulk_rename_test.go
+++ b/internal/core/secret_bulk_rename_test.go
@@ -22,7 +22,7 @@ func TestBulkRenameSecrets(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
-		&models.AuditEvent{}, &models.SecretAccessLog{},
+		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.UserRole{},
 	))
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
@@ -35,6 +35,9 @@ func TestBulkRenameSecrets(t *testing.T) {
 	require.NoError(t, err)
 	env, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
 	require.NoError(t, err)
+	// CheckSecretPermission gates the owner path on IsProjectMember (RBAC-001); seed
+	// user 1 so the owning actor passes the project-membership guard.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p.ID}).Error)
 
 	mk := func(name string, projectID uint, isSecret bool) uint {
 		s, e := c.storage.CreateSecret(ctx, &models.SecretNode{

--- a/internal/core/secret_copy_environment_test.go
+++ b/internal/core/secret_copy_environment_test.go
@@ -20,7 +20,7 @@ func TestCopyEnvironmentSecrets(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
 	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
@@ -28,6 +28,7 @@ func TestCopyEnvironmentSecrets(t *testing.T) {
 	prod, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
 	p2, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
 	otherEnv, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p.ID}).Error)
 
 	mk := func(envID uint, name string) {
 		_, err := c.CreateSecret(ctx, &CreateSecretRequest{

--- a/internal/core/secret_copy_test.go
+++ b/internal/core/secret_copy_test.go
@@ -20,7 +20,7 @@ func TestCopySecret(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
@@ -30,6 +30,8 @@ func TestCopySecret(t *testing.T) {
 	prod, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p1.ID})
 	p2, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p2"})
 	otherEnv, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
+	// IsProjectMember gates CheckSecretPermission (RBAC-001); owner must be a member of p1.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p1.ID}).Error)
 
 	src, err := c.CreateSecret(ctx, &CreateSecretRequest{
 		Name: "db-url", Value: []byte("postgres://secret"), ProjectID: p1.ID, EnvironmentID: staging.ID,

--- a/internal/core/secret_description_test.go
+++ b/internal/core/secret_description_test.go
@@ -21,9 +21,10 @@ func TestSetSecretDescription(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/secret_extend_expiring_test.go
+++ b/internal/core/secret_extend_expiring_test.go
@@ -22,7 +22,7 @@ func TestExtendExpiringSecrets(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{},
-		&models.AuditEvent{}, &models.SecretAccessLog{},
+		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
@@ -30,6 +30,7 @@ func TestExtendExpiringSecrets(t *testing.T) {
 
 	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
 	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p.ID}).Error)
 	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
 	require.NoError(t, err)
 

--- a/internal/core/secret_listing_pagination_test.go
+++ b/internal/core/secret_listing_pagination_test.go
@@ -36,7 +36,7 @@ func TestListSecretsInScope_PaginationSurvivesPostFetchTagFilter(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
@@ -45,6 +45,7 @@ func TestListSecretsInScope_PaginationSurvivesPostFetchTagFilter(t *testing.T) {
 	require.NoError(t, err)
 	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
 	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p.ID}).Error)
 
 	mk := func(name string, keep bool) {
 		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{

--- a/internal/core/secret_move_test.go
+++ b/internal/core/secret_move_test.go
@@ -38,10 +38,13 @@ func newMoveFixture(t *testing.T) (c *KeyorixCore, secretID, folderID uint, db *
 		&models.User{},
 		&models.Group{},
 		&models.UserGroup{},
+		&models.UserRole{},
 	))
 
 	// Seed a user so share-lookup JOIN does not hit a missing table.
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@test.com"}).Error)
+	// IsProjectMember gates CheckSecretPermission (RBAC-001); owner must be a member of project 1.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	c = &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/secret_ownership_history_test.go
+++ b/internal/core/secret_ownership_history_test.go
@@ -22,6 +22,8 @@ func newOwnershipCore(store *MockStorage) *KeyorixCore {
 func setupOwnerPermission(store *MockStorage, ctx context.Context, secretID, actorID uint) {
 	store.On("GetSecret", ctx, secretID).
 		Return(&models.SecretNode{ID: secretID, OwnerID: actorID}, nil)
+	// CheckSecretPermission gates the owner fast-path on IsProjectMember (RBAC-001).
+	store.On("IsProjectMember", mock.Anything, actorID, uint(0)).Return(true, nil)
 }
 
 func TestGetSecretOwnershipHistory_Empty(t *testing.T) {

--- a/internal/core/secret_render.go
+++ b/internal/core/secret_render.go
@@ -45,7 +45,9 @@ func (c *KeyorixCore) RenderSecretTemplate(ctx context.Context, template string,
 		}
 		envID, ok := envByName[envName]
 		if !ok {
-			return "", fmt.Errorf("environment %q not found in this project", envName)
+			// TMPL-002: use the same sentinel as "secret not found" to avoid leaking
+			// the environment name in the HTTP response via sendRenderTemplateError.
+			return "", ErrSecretRefNotFound
 		}
 		secret, err := c.storage.GetSecretByName(ctx, secretName, projectID, envID)
 		if err != nil || secret == nil {

--- a/internal/core/secret_render_test.go
+++ b/internal/core/secret_render_test.go
@@ -65,9 +65,11 @@ func TestRenderSecretTemplate(t *testing.T) {
 	})
 
 	t.Run("unknown environment fails", func(t *testing.T) {
+		// TMPL-002: unknown environment uses ErrSecretRefNotFound so the HTTP handler
+		// doesn't reflect the environment name to the caller.
 		_, err := c.RenderSecretTemplate(ctx, "${secret:staging/db-password}", projectID, 1, "owner", "10.0.0.1", "ua")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "environment")
+		assert.Contains(t, err.Error(), "not found")
 	})
 
 	t.Run("unknown secret fails", func(t *testing.T) {

--- a/internal/core/secret_render_test.go
+++ b/internal/core/secret_render_test.go
@@ -30,7 +30,7 @@ func newRenderFixture(t *testing.T) (*KeyorixCore, *gorm.DB, uint, uint) {
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{},
 		&models.Project{}, &models.Environment{}, &models.SecretAccessLog{}, &models.AuditEvent{},
-		&models.ShareRecord{}, &models.SecretACL{},
+		&models.ShareRecord{}, &models.SecretACL{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@test.com"}).Error)
 
@@ -41,6 +41,8 @@ func newRenderFixture(t *testing.T) (*KeyorixCore, *gorm.DB, uint, uint) {
 	proj, err := st.CreateProject(ctx, &models.Project{Name: "payments"})
 	require.NoError(t, err)
 	env, err := st.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: proj.ID})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: proj.ID}).Error)
 	require.NoError(t, err)
 	secret, err := st.CreateSecret(ctx, &models.SecretNode{
 		Name: "db-password", ProjectID: proj.ID, EnvironmentID: env.ID, Type: "password",

--- a/internal/core/secret_search_metadata_test.go
+++ b/internal/core/secret_search_metadata_test.go
@@ -20,11 +20,12 @@ func TestSecretSearch_NameDescriptionTags(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}, &models.AuditEvent{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
 	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
 	e, _ := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p.ID}).Error)
 
 	mk := func(name, desc string, tags ...string) {
 		s, err := c.CreateSecret(ctx, &CreateSecretRequest{

--- a/internal/core/secret_tag_filter_test.go
+++ b/internal/core/secret_tag_filter_test.go
@@ -20,7 +20,7 @@ func TestListSecretsInScope_TagFilter(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.Tag{}, &models.SecretTag{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
@@ -29,6 +29,7 @@ func TestListSecretsInScope_TagFilter(t *testing.T) {
 	require.NoError(t, err)
 	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
 	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p.ID}).Error)
 
 	mk := func(name string, tags ...string) uint {
 		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{

--- a/internal/core/secret_tags_test.go
+++ b/internal/core/secret_tags_test.go
@@ -21,9 +21,10 @@ func TestSecretTags(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Tag{}, &models.SecretTag{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.AuditEvent{}, &models.Tag{}, &models.SecretTag{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "mallory", Email: "m@t.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()

--- a/internal/core/shares_expiry_test.go
+++ b/internal/core/shares_expiry_test.go
@@ -34,10 +34,14 @@ func newSharesExpiryFixture(t *testing.T) (*KeyorixCore, uint, time.Time, *gorm.
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{},
 		&models.AuditEvent{}, &models.User{}, &models.Group{}, &models.UserGroup{},
+		&models.UserRole{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@test.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "recip2", Email: "recip2@test.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 3, Username: "recip3", Email: "recip3@test.com"}).Error)
+	// IsProjectMember check (added in #1185): recipients need a project role to receive shares.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 1, ProjectID: 1}).Error)
 
 	now := time.Now()
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}

--- a/internal/core/shares_expiry_test.go
+++ b/internal/core/shares_expiry_test.go
@@ -39,7 +39,8 @@ func newSharesExpiryFixture(t *testing.T) (*KeyorixCore, uint, time.Time, *gorm.
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@test.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "recip2", Email: "recip2@test.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 3, Username: "recip3", Email: "recip3@test.com"}).Error)
-	// IsProjectMember check (added in #1185): recipients need a project role to receive shares.
+	// ShareSecret checks IsProjectMember before creating the share record; seed
+	// project membership for both recipients so that check passes.
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 1, ProjectID: 1}).Error)
 

--- a/internal/core/sharing_integration_simple_test.go
+++ b/internal/core/sharing_integration_simple_test.go
@@ -55,6 +55,12 @@ func TestSharingIntegrationSimple(t *testing.T) {
 		require.NoError(t, db.Create(&models.User{ID: uint(i), Username: fmt.Sprintf("user%d", i), Email: fmt.Sprintf("user%d@test.com", i)}).Error)
 	}
 	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "test-group"}).Error)
+	// IsProjectMember check (added in #1185): user shares require the recipient to be a
+	// project member. Grant a role in project 1 for user 2 and users 10-14 (concurrent test).
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
+	for i := 10; i <= 14; i++ {
+		require.NoError(t, db.Create(&models.UserRole{UserID: uint(i), RoleID: 1, ProjectID: 1}).Error)
+	}
 
 	// Initialize storage
 	storage := store.NewLocalStorage(db)

--- a/internal/core/sharing_integration_simple_test.go
+++ b/internal/core/sharing_integration_simple_test.go
@@ -54,13 +54,13 @@ func TestSharingIntegrationSimple(t *testing.T) {
 	for i := 10; i <= 20; i++ {
 		require.NoError(t, db.Create(&models.User{ID: uint(i), Username: fmt.Sprintf("user%d", i), Email: fmt.Sprintf("user%d@test.com", i)}).Error)
 	}
-	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "test-group"}).Error)
-	// IsProjectMember check (added in #1185): user shares require the recipient to be a
-	// project member. Grant a role in project 1 for user 2 and users 10-14 (concurrent test).
+	// ShareSecret verifies recipient is a project member (RBAC-001); seed all test users in project 1.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
-	for i := 10; i <= 14; i++ {
+	for i := 10; i <= 20; i++ {
 		require.NoError(t, db.Create(&models.UserRole{UserID: uint(i), RoleID: 1, ProjectID: 1}).Error)
 	}
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "test-group"}).Error)
 
 	// Initialize storage
 	storage := store.NewLocalStorage(db)
@@ -323,7 +323,7 @@ func TestSharingIntegrationSimple(t *testing.T) {
 		const numConcurrentShares = 5
 		results := make(chan error, numConcurrentShares)
 
-		for i := 0; i < numConcurrentShares; i++ {
+		for i := range numConcurrentShares {
 			go func(recipientID uint) {
 				shareReq := &ShareSecretRequest{
 					SecretID:    createdSecret.ID,
@@ -339,7 +339,7 @@ func TestSharingIntegrationSimple(t *testing.T) {
 
 		// Collect results
 		successCount := 0
-		for i := 0; i < numConcurrentShares; i++ {
+		for range numConcurrentShares {
 			select {
 			case err := <-results:
 				if err == nil {

--- a/internal/core/sharing_test.go
+++ b/internal/core/sharing_test.go
@@ -57,7 +57,7 @@ func TestKeyorixCore_ShareSecret(t *testing.T) {
 
 	// Mock expectations
 	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
-	// IsProjectMember check added in #1185 for user shares.
+	// ShareSecret verifies the recipient is a member of the secret's project.
 	mockStorage.On("IsProjectMember", ctx, uint(2), uint(0)).Return(true, nil)
 	mockStorage.On("CreateShareRecord", ctx, mock.AnythingOfType("*models.ShareRecord")).Return(shareRecord, nil)
 	mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
@@ -231,7 +231,6 @@ func TestKeyorixCore_ShareSecret_RejectsSelfShare(t *testing.T) {
 	otherSecret := &models.SecretNode{ID: 3, Name: "s2", OwnerID: 1}
 	otherShareRecord := &models.ShareRecord{ID: 4, SecretID: 3, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}
 	mockStorage.On("GetSecret", ctx, uint(3)).Return(otherSecret, nil)
-	// IsProjectMember check added in #1185.
 	mockStorage.On("IsProjectMember", ctx, uint(2), uint(0)).Return(true, nil)
 	mockStorage.On("CreateShareRecord", ctx, mock.MatchedBy(func(s *models.ShareRecord) bool {
 		return s.SecretID == 3 && !s.IsGroup

--- a/internal/core/sharing_test.go
+++ b/internal/core/sharing_test.go
@@ -57,6 +57,8 @@ func TestKeyorixCore_ShareSecret(t *testing.T) {
 
 	// Mock expectations
 	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+	// IsProjectMember check added in #1185 for user shares.
+	mockStorage.On("IsProjectMember", ctx, uint(2), uint(0)).Return(true, nil)
 	mockStorage.On("CreateShareRecord", ctx, mock.AnythingOfType("*models.ShareRecord")).Return(shareRecord, nil)
 	mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
 	// A direct share notifies the recipient (best-effort).
@@ -229,6 +231,8 @@ func TestKeyorixCore_ShareSecret_RejectsSelfShare(t *testing.T) {
 	otherSecret := &models.SecretNode{ID: 3, Name: "s2", OwnerID: 1}
 	otherShareRecord := &models.ShareRecord{ID: 4, SecretID: 3, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}
 	mockStorage.On("GetSecret", ctx, uint(3)).Return(otherSecret, nil)
+	// IsProjectMember check added in #1185.
+	mockStorage.On("IsProjectMember", ctx, uint(2), uint(0)).Return(true, nil)
 	mockStorage.On("CreateShareRecord", ctx, mock.MatchedBy(func(s *models.ShareRecord) bool {
 		return s.SecretID == 3 && !s.IsGroup
 	})).Return(otherShareRecord, nil)

--- a/internal/core/sod_degraded_test.go
+++ b/internal/core/sod_degraded_test.go
@@ -34,8 +34,8 @@ func TestDetectSoDViolations_DegradedOnUserPermissionsError(t *testing.T) {
 
 	// Neither user holds an admin permission-bypass role (direct or via group — #1185 added group check).
 	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
-	store.On("GetUserRoles", ctx, uint(11)).Return([]*models.Role{}, nil)
 	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil)
+	store.On("GetUserRoles", ctx, uint(11)).Return([]*models.Role{}, nil)
 	store.On("GetUserGroups", ctx, uint(11)).Return([]*models.Group{}, nil)
 
 	// alice: a real, detectable violation.
@@ -88,7 +88,7 @@ func TestDetectSoDViolations_DegradedOnMachineRolesError(t *testing.T) {
 		{ID: 10, Username: "alice", IsActive: true},
 	}, int64(1), nil)
 	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
-	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil) // #1185 added group admin check
+	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil)
 	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
 		{Name: "secrets.write"}, {Name: "users.read"},
 	}, nil)
@@ -157,7 +157,7 @@ func TestDetectSoDViolations_NotDegradedOnCleanScan(t *testing.T) {
 		{ID: 10, Username: "alice", IsActive: true},
 	}, int64(1), nil)
 	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
-	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil) // #1185 added group admin check
+	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil)
 	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
 		{Name: "secrets.read"},
 	}, nil)

--- a/internal/core/sod_degraded_test.go
+++ b/internal/core/sod_degraded_test.go
@@ -32,9 +32,11 @@ func TestDetectSoDViolations_DegradedOnUserPermissionsError(t *testing.T) {
 		{ID: 11, Username: "bob", IsActive: true},
 	}, int64(2), nil)
 
-	// Neither user holds an admin permission-bypass role.
+	// Neither user holds an admin permission-bypass role (direct or via group — #1185 added group check).
 	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
 	store.On("GetUserRoles", ctx, uint(11)).Return([]*models.Role{}, nil)
+	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil)
+	store.On("GetUserGroups", ctx, uint(11)).Return([]*models.Group{}, nil)
 
 	// alice: a real, detectable violation.
 	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
@@ -86,6 +88,7 @@ func TestDetectSoDViolations_DegradedOnMachineRolesError(t *testing.T) {
 		{ID: 10, Username: "alice", IsActive: true},
 	}, int64(1), nil)
 	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
+	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil) // #1185 added group admin check
 	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
 		{Name: "secrets.write"}, {Name: "users.read"},
 	}, nil)
@@ -154,6 +157,7 @@ func TestDetectSoDViolations_NotDegradedOnCleanScan(t *testing.T) {
 		{ID: 10, Username: "alice", IsActive: true},
 	}, int64(1), nil)
 	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
+	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil) // #1185 added group admin check
 	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
 		{Name: "secrets.read"},
 	}, nil)

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -634,7 +634,7 @@ func TestCompleteSSO_PasswordExpiredGateError(t *testing.T) {
 	c.passwordPolicy = PasswordPolicy{MaxAgeDays: 1}
 
 	const testNonce = "nonce-expiry-err"
-	expiredUser := &models.User{ID: 55, AccountState: "active", IsActive: true, CreatedAt: time.Now().Add(-48 * time.Hour)}
+	expiredUser := &models.User{ID: 55, IsActive: true, AccountState: "active", CreatedAt: time.Now().Add(-48 * time.Hour)}
 
 	idToken := signToken(t, key, "kid-1", jwt.MapClaims{
 		"iss":            "https://idp.test",

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -634,7 +634,7 @@ func TestCompleteSSO_PasswordExpiredGateError(t *testing.T) {
 	c.passwordPolicy = PasswordPolicy{MaxAgeDays: 1}
 
 	const testNonce = "nonce-expiry-err"
-	expiredUser := &models.User{ID: 55, AccountState: "active", CreatedAt: time.Now().Add(-48 * time.Hour)}
+	expiredUser := &models.User{ID: 55, AccountState: "active", IsActive: true, CreatedAt: time.Now().Add(-48 * time.Hour)}
 
 	idToken := signToken(t, key, "kid-1", jwt.MapClaims{
 		"iss":            "https://idp.test",

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -343,6 +343,10 @@ type Storage interface {
 	ListSecretACLsByUser(ctx context.Context, userID uint) ([]*models.SecretACL, error)
 	GetSecretACL(ctx context.Context, secretID, userID uint) (*models.SecretACL, error)
 	DeleteSecretACL(ctx context.Context, id uint) error
+	// DeleteSecretACLsByUserAndProject removes all ACL grants for userID on secrets
+	// that belong to projectID. Called during project member removal so that a
+	// revoked member's per-secret ACL grants do not survive offboarding (CWE-284).
+	DeleteSecretACLsByUserAndProject(ctx context.Context, userID, projectID uint) error
 	// GetSecretAncestors returns the ancestor SecretNode IDs for nodeID,
 	// ordered from immediate parent to root (breadth-first up the ParentID
 	// chain). Used by HasSecretACL to walk the folder ACL inheritance path.

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -272,7 +272,12 @@ func (c *KeyorixCore) BeginWebAuthnLogin(ctx context.Context, challenge string) 
 	if len(wu.creds) == 0 {
 		return nil, "", fmt.Errorf("no passkeys registered")
 	}
-	assertion, sd, err := c.webauthnRP.BeginLogin(wu)
+	// WAUN-001: require user-verification (PIN or biometric) for the MFA assertion,
+	// not just key presence — prevents a stolen/found hardware key from satisfying the
+	// second factor without the user's knowledge.
+	assertion, sd, err := c.webauthnRP.BeginLogin(wu,
+		webauthn.WithUserVerification(protocol.VerificationRequired),
+	)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to begin login: %w", err)
 	}

--- a/internal/k8ssync/config.go
+++ b/internal/k8ssync/config.go
@@ -2,7 +2,6 @@ package k8ssync
 
 import (
 	"fmt"
-	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -83,9 +82,9 @@ func requireHTTPSURL(raw string) error {
 		if host == "localhost" {
 			return nil
 		}
-		if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
-			return nil
-		}
+		// K8SSYNC-007: only the hostname "localhost" is allowed over http, not any
+		// loopback IP — an attacker who controls DNS can map a loopback IP to a
+		// hostname of their choosing, so accepting raw IPs widens the bypass surface.
 		return fmt.Errorf("keyorix_url %q must use https (http is allowed only for localhost); sending the bearer token over plaintext would expose it", raw)
 	default:
 		return fmt.Errorf("keyorix_url %q must use https", raw)

--- a/internal/k8ssync/config_test.go
+++ b/internal/k8ssync/config_test.go
@@ -107,8 +107,8 @@ mappings:
 		"https allowed":            {"https://keyorix.internal", false},
 		"http non-loopback denied": {"http://keyorix.internal", true},
 		"http localhost allowed":   {"http://localhost:8080", false},
-		"http 127.0.0.1 allowed":   {"http://127.0.0.1:8080", false},
-		"http ::1 allowed":         {"http://[::1]:8080", false},
+		"http 127.0.0.1 rejected":  {"http://127.0.0.1:8080", true},
+		"http ::1 rejected":        {"http://[::1]:8080", true},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/k8ssync/k8ssync_s21_test.go
+++ b/internal/k8ssync/k8ssync_s21_test.go
@@ -55,7 +55,7 @@ func TestGetInterval_S21(t *testing.T) {
 }
 
 // TestRequireHTTPSURL_S21 covers requireHTTPSURL directly for all branches:
-// https (allowed), http+localhost (allowed), http+loopback IP (allowed),
+// https (allowed), http+localhost (allowed), http+loopback IP (rejected — K8SSYNC-007),
 // http+non-loopback (rejected), invalid URL (rejected), non-http/https (rejected).
 func TestRequireHTTPSURL_S21(t *testing.T) {
 	cases := []struct {
@@ -66,8 +66,8 @@ func TestRequireHTTPSURL_S21(t *testing.T) {
 		{"https allowed", "https://keyorix.example.com", false},
 		{"https with port allowed", "https://keyorix.example.com:8443", false},
 		{"http localhost allowed", "http://localhost:8080", false},
-		{"http 127.0.0.1 allowed", "http://127.0.0.1:8080", false},
-		{"http ::1 allowed", "http://[::1]:8080", false},
+		{"http 127.0.0.1 rejected", "http://127.0.0.1:8080", true},
+		{"http ::1 rejected", "http://[::1]:8080", true},
 		{"http non-loopback rejected", "http://10.0.0.1:8080", true},
 		{"http public host rejected", "http://keyorix.example.com", true},
 		{"ftp scheme rejected", "ftp://keyorix.example.com", true},

--- a/internal/secrettemplate/render.go
+++ b/internal/secrettemplate/render.go
@@ -23,6 +23,12 @@ const marker = "${secret:"
 // rendering use cases.
 const MaxDistinctReferences = 100
 
+// MaxOutputBytes caps the total size of a single rendered output. 1 MiB is
+// generous for .env / config files; an attacker injecting many large secret
+// values cannot use Render as an amplifier to produce a response that exhausts
+// downstream memory.
+const MaxOutputBytes = 1 << 20 // 1 MiB
+
 // Resolver maps a secret reference (the text between "${secret:" and "}") to its
 // value. It returns an error when the reference is unknown or inaccessible.
 type Resolver func(ref string) (string, error)
@@ -143,9 +149,12 @@ func Render(tmpl string, resolve Resolver) (string, error) {
 	for _, seg := range segments {
 		if seg.ref == "" {
 			b.WriteString(seg.literal)
-			continue
+		} else {
+			b.WriteString(resolved[seg.ref])
 		}
-		b.WriteString(resolved[seg.ref])
+		if b.Len() > MaxOutputBytes {
+			return "", fmt.Errorf("rendered output exceeds the %d-byte limit", MaxOutputBytes)
+		}
 	}
 	return b.String(), nil
 }

--- a/internal/storage/store/local_secret_acl.go
+++ b/internal/storage/store/local_secret_acl.go
@@ -64,3 +64,16 @@ func (ls *LocalStorage) DeleteSecretACL(ctx context.Context, id uint) error {
 	}
 	return nil
 }
+
+// DeleteSecretACLsByUserAndProject removes all ACL grants for userID on secrets
+// that belong to projectID. Used by RemoveProjectMember to prevent stale
+// per-secret ACL grants from persisting after a user is offboarded (CWE-284).
+func (ls *LocalStorage) DeleteSecretACLsByUserAndProject(ctx context.Context, userID, projectID uint) error {
+	result := ls.db.WithContext(ctx).
+		Where("user_id = ? AND secret_id IN (SELECT id FROM secret_nodes WHERE project_id = ?)", userID, projectID).
+		Delete(&models.SecretACL{})
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	return nil
+}

--- a/internal/storage/store/remote_mfa.go
+++ b/internal/storage/store/remote_mfa.go
@@ -192,8 +192,33 @@ func (rs *RemoteStorage) ActivateMFASecret(ctx context.Context, userID uint) err
 	return nil
 }
 
-func (rs *RemoteStorage) MarkTOTPStepUsed(_ context.Context, _ uint, _ int64) (bool, error) {
-	return false, remoteUnsupported("MarkTOTPStepUsed")
+// markTOTPStepUsedWire mirrors MarkTOTPStepUsedProxy's request body.
+type markTOTPStepUsedWire struct {
+	UserID uint  `json:"user_id"`
+	Step   int64 `json:"step"`
+}
+
+// markTOTPStepUsedResponse mirrors MarkTOTPStepUsedProxy's data envelope.
+type markTOTPStepUsedResponse struct {
+	Fresh bool `json:"fresh"`
+}
+
+// MarkTOTPStepUsed atomically advances the per-user last-used TOTP step via
+// POST /api/v1/system/mfa/totp-step-used, so requireReauth and
+// VerifyMFACredentials anti-replay work correctly under storage.type: remote.
+func (rs *RemoteStorage) MarkTOTPStepUsed(ctx context.Context, userID uint, step int64) (bool, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/mfa/totp-step-used", markTOTPStepUsedWire{UserID: userID, Step: step})
+	if err != nil {
+		return false, fmt.Errorf("failed to mark TOTP step used: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("mark TOTP step used failed: %s", resp.Error.Error())
+	}
+	var result markTOTPStepUsedResponse
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse mark TOTP step used response: %w", err)
+	}
+	return result.Fresh, nil
 }
 
 // DeleteMFAForUser clears a user's secret and all recovery codes via DELETE

--- a/internal/storage/store/remote_secret_acl.go
+++ b/internal/storage/store/remote_secret_acl.go
@@ -33,6 +33,10 @@ func (rs *RemoteStorage) DeleteSecretACL(_ context.Context, _ uint) error {
 	return remoteUnsupported("DeleteSecretACL")
 }
 
+func (rs *RemoteStorage) DeleteSecretACLsByUserAndProject(_ context.Context, _, _ uint) error {
+	return remoteUnsupported("DeleteSecretACLsByUserAndProject")
+}
+
 // GetSecretAncestors is the folder-ACL inheritance walk helper. Folder-ACL
 // enforcement is server-side only; the inheritance walk in HasSecretACL skips
 // this path when ErrUnsupportedByBackend is returned.

--- a/internal/storage/store/remote_unsupported_registry_test.go
+++ b/internal/storage/store/remote_unsupported_registry_test.go
@@ -38,8 +38,6 @@ func init() {
 
 		"CreateMFAChallenge": {statusIntentional,
 			"round 119 audit: core.CreateMFAChallenge checks the RemoteMFAVerifier interface before ever calling storage.CreateMFAChallenge — under storage.type: remote this raw stub is never reached regardless of which second factor (TOTP or WebAuthn) follows; confirmed by TestLogin_RemoteStorage_ProxiesMFACredentialCheck"},
-		"MarkTOTPStepUsed": {statusIntentional,
-			"round 119 audit: sole caller is VerifyMFACredentials, only invoked from VerifyMFALogin's branch that's bypassed entirely when RemoteMFAVerifier is present"},
 		"ConsumeMFARecoveryCode": {statusIntentional,
 			"round 119 audit: sole caller is VerifyMFACredentials, same bypassed-branch reasoning as MarkTOTPStepUsed — recovery codes are only ever consumed at login, never during enrollment/management"},
 

--- a/internal/storage/store/remote_unsupported_registry_test.go
+++ b/internal/storage/store/remote_unsupported_registry_test.go
@@ -49,8 +49,9 @@ func init() {
 		"ListSecretACLs":           {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
 		"ListSecretACLsByUser":     {statusIntentional, "RBAC Phase 3 — listing ACL-granted secrets for a user runs server-side in ListSecretsWithSharingInfo; the core function calls LocalStorage on the server, not RemoteStorage"},
 		"GetSecretACL":             {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
-		"DeleteSecretACL":          {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
-		"GetSecretAncestors":       {statusIntentional, "RBAC Phase 3 — folder-ACL inheritance walk runs server-side; HasSecretACL uses ErrUnsupportedByBackend to skip the ancestor walk on remote callers"},
+		"DeleteSecretACL":                      {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
+		"DeleteSecretACLsByUserAndProject":     {statusIntentional, "RBAC Phase 3 — project member removal runs server-side; RemoveProjectMember is never called from a remote-storage CLI context"},
+		"GetSecretAncestors":                   {statusIntentional, "RBAC Phase 3 — folder-ACL inheritance walk runs server-side; HasSecretACL uses ErrUnsupportedByBackend to skip the ancestor walk on remote callers"},
 
 		"GetProjectUsageStats": {statusIntentional, "usage report queries run server-side; a future PR may add a /api/v1/system/usage proxy route"},
 

--- a/server/http/authz_share_parity_test.go
+++ b/server/http/authz_share_parity_test.go
@@ -73,10 +73,14 @@ func TestAuthzParity_HTTPvsGRPC_ShareCreate(t *testing.T) {
 	writerToken := login("writer", "Qr7#Kp2$Lm5@Vn9!")
 
 	// Recipients just need to exist. Distinct ones for the allow case so the HTTP and
-	// gRPC shares don't collide as duplicates.
+	// gRPC shares don't collide as duplicates. Each must be a project member (#1185
+	// added an IsProjectMember gate in ShareSecret).
 	require.NoError(t, db.Create(&models.User{ID: 500, Username: "rcpt-http", Email: "rh@example.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 501, Username: "rcpt-grpc", Email: "rg@example.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 502, Username: "rcpt-deny", Email: "rd@example.com"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 500, RoleID: editorRole.ID, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 501, RoleID: editorRole.ID, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 502, RoleID: editorRole.ID, ProjectID: 1}).Error)
 
 	// The secret, owned by owner in project 1.
 	sec, err := c.CreateSecret(ctx, &core.CreateSecretRequest{
@@ -198,6 +202,8 @@ func TestAuthzParity_HTTPvsGRPC_ShareList(t *testing.T) {
 
 	recipient, err := c.CreateUser(ctx, &core.CreateUserRequest{Username: "recipient2", Email: "recipient2@example.com", Password: "Qr7#Kp2$Lm5@Vn9!"})
 	require.NoError(t, err)
+	// IsProjectMember gate (#1185): recipient must be a project member to receive a share.
+	require.NoError(t, db.Create(&models.UserRole{UserID: recipient.ID, RoleID: editorRole.ID, ProjectID: 1}).Error)
 
 	// The secret, owned by owner in project 1, shared once with recipient so the list
 	// isn't trivially empty.

--- a/server/http/handlers/handlers_s13_auth_extra_test.go
+++ b/server/http/handlers/handlers_s13_auth_extra_test.go
@@ -439,7 +439,7 @@ func TestIsSafeSSOError_AdditionalStrings_S13(t *testing.T) {
 		{"the token response carried no id_token", true},
 		{"the assertion carried no subject or email", true},
 		{"no Keyorix account matches this SSO identity", true},
-		{"account suspended", true},
+		{"account suspended", false},
 		{"the IdP returned no email; cannot auto-provision an account", true},
 		{"some totally unrelated internal error details", false},
 		{"", false},

--- a/server/http/handlers/handlers_s21_sso_groups_test.go
+++ b/server/http/handlers/handlers_s21_sso_groups_test.go
@@ -241,7 +241,6 @@ func TestIsSafeSSOError_SafeMessages_S21(t *testing.T) {
 		"the token response carried no id_token",
 		"the assertion carried no subject or email",
 		"no Keyorix account matches this SSO identity",
-		"account suspended",
 		"the IdP returned no email; cannot auto-provision an account",
 	}
 	for _, msg := range safeMessages {

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -4573,7 +4573,7 @@ func newSecretHandlerS4(t *testing.T) *SecretHandler {
 func TestIsSafeSSOError_Known(t *testing.T) {
 	assert.True(t, isSafeSSOError("unknown SSO provider"))
 	assert.True(t, isSafeSSOError("invalid or expired login state"))
-	assert.True(t, isSafeSSOError("account suspended"))
+	assert.False(t, isSafeSSOError("account suspended"))
 	assert.True(t, isSafeSSOError("no Keyorix account matches this SSO identity"))
 }
 
@@ -10212,7 +10212,7 @@ func TestIsSafeSSOError_KnownMessages(t *testing.T) {
 	assert.True(t, isSafeSSOError("the token response carried no id_token"))
 	assert.True(t, isSafeSSOError("the assertion carried no subject or email"))
 	assert.True(t, isSafeSSOError("no Keyorix account matches this SSO identity"))
-	assert.True(t, isSafeSSOError("account suspended"))
+	assert.False(t, isSafeSSOError("account suspended"))
 	assert.True(t, isSafeSSOError("the IdP returned no email; cannot auto-provision an account"))
 	assert.False(t, isSafeSSOError("some internal error"))
 	assert.False(t, isSafeSSOError(""))

--- a/server/http/handlers/handlers_s6_test.go
+++ b/server/http/handlers/handlers_s6_test.go
@@ -349,7 +349,7 @@ func TestAuthHandler_CompleteSSO_UnknownProvider_S6(t *testing.T) {
 func TestIsSafeSSOError_S6(t *testing.T) {
 	assert.True(t, isSafeSSOError("unknown SSO provider"))
 	assert.True(t, isSafeSSOError("invalid or expired login state"))
-	assert.True(t, isSafeSSOError("account suspended"))
+	assert.False(t, isSafeSSOError("account suspended"))
 	assert.False(t, isSafeSSOError("some random internal error"))
 	assert.False(t, isSafeSSOError(""))
 }

--- a/server/http/handlers/handlers_s7_test.go
+++ b/server/http/handlers/handlers_s7_test.go
@@ -1138,7 +1138,6 @@ func TestIsSafeSSOError_S7(t *testing.T) {
 		"the token response carried no id_token",
 		"the assertion carried no subject or email",
 		"no Keyorix account matches this SSO identity",
-		"account suspended",
 		"the IdP returned no email; cannot auto-provision an account",
 	}
 	for _, msg := range safeMsgs {

--- a/server/http/handlers/mfa_management_proxy.go
+++ b/server/http/handlers/mfa_management_proxy.go
@@ -263,6 +263,35 @@ func (h *AuthHandler) CountUnusedMFARecoveryCodesProxy(w http.ResponseWriter, r 
 	writeRemoteAPISuccess(w, map[string]int{"count": n})
 }
 
+// markTOTPStepUsedWire is the request body for MarkTOTPStepUsedProxy.
+type markTOTPStepUsedWire struct {
+	UserID uint  `json:"user_id"`
+	Step   int64 `json:"step"`
+}
+
+// MarkTOTPStepUsedProxy handles POST /api/v1/system/mfa/totp-step-used.
+// Atomically advances the per-user last-used TOTP step so the downstream
+// core's requireReauth/VerifyMFACredentials anti-replay guard works correctly
+// under storage.type: remote (finding in PR that follows #524).
+func (h *AuthHandler) MarkTOTPStepUsedProxy(w http.ResponseWriter, r *http.Request) {
+	var body markTOTPStepUsedWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.UserID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id is required")
+		return
+	}
+	fresh, err := h.coreService.Storage().MarkTOTPStepUsed(r.Context(), body.UserID, body.Step)
+	if err != nil {
+		log.Printf("mfa proxy: mark TOTP step used failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"fresh": fresh})
+}
+
 // DeleteMFARecoveryCodesProxy handles DELETE
 // /api/v1/system/mfa/recovery-codes/{userId}.
 func (h *AuthHandler) DeleteMFARecoveryCodesProxy(w http.ResponseWriter, r *http.Request) {

--- a/server/http/handlers/sso.go
+++ b/server/http/handlers/sso.go
@@ -61,7 +61,6 @@ func isSafeSSOError(msg string) bool {
 		"the token response carried no id_token",
 		"the assertion carried no subject or email",
 		"no Keyorix account matches this SSO identity",
-		"account suspended",
 		"the IdP returned no email; cannot auto-provision an account",
 	} {
 		if strings.Contains(msg, safe) {

--- a/server/http/remote_storage_mfa_login_test.go
+++ b/server/http/remote_storage_mfa_login_test.go
@@ -125,7 +125,10 @@ func TestLogin_RemoteStorage_ProxiesMFACredentialCheck(t *testing.T) {
 	// one was consumed above.
 	challenge2, err := downstreamCore.CreateMFAChallenge(ctx, loginUser.ID)
 	require.NoError(t, err)
-	correctCode, err := totp.GenerateCode(totpSecret, time.Now())
+	// Generate the code for the NEXT 30-second TOTP window so it does not collide
+	// with actCode's window, which ActivateMFA marked as used (anti-replay).
+	nextWindow := time.Unix((time.Now().Unix()/30+1)*30+1, 0)
+	correctCode, err := totp.GenerateCode(totpSecret, nextWindow)
 	require.NoError(t, err)
 	_, _, err = downstreamCore.VerifyMFALogin(ctx, challenge2, correctCode, "test-agent", "203.0.113.1")
 	require.Error(t, err, "session persistence is a separate, unimplemented gap (#508) — "+

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1735,6 +1735,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/mfa/recovery-codes/count", authHandler.CountUnusedMFARecoveryCodesProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/mfa/recovery-codes", authHandler.CreateMFARecoveryCodesProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Delete("/mfa/recovery-codes/{userId}", authHandler.DeleteMFARecoveryCodesProxy)
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/mfa/totp-step-used", authHandler.MarkTOTPStepUsedProxy)
 
 			// Project/environment catalog CRUD storage-primitive proxy (finding #528).
 			// Lets a downstream Keyorix server booted with storage.type: remote


### PR DESCRIPTION
## Summary

**PAT-SCOPE-002** (`authz.go`): per-secret ACL grants bypassed the PAT scope restriction. `AuthorizeSecret` resolved the ACL before checking the token's scope, letting a project-scoped PAT access a secret in a different project via a legacy ACL row. Fixed: resolve the secret's scope first, apply `patRestrictionFromContext` before honouring any ACL.

**WAUN-001** (`webauthn.go`): `BeginWebAuthnLogin` passed no verification preference, so a hardware key could satisfy the WebAuthn MFA assertion without user-verification (PIN/biometric). A stolen key silently passes the second factor. Fixed: `WithUserVerification(protocol.VerificationRequired)`.

**TMPL-002** (`secret_render.go`): a missing environment in a secret template returned the env name in the error, leaking it through the HTTP response. Fixed: return `ErrSecretRefNotFound` (same sentinel as "secret not found").

**K8SSYNC-007** (`k8ssync/config.go`): only the hostname `localhost` is allowed for HTTP in the k8s-sync agent; raw loopback IPs widened the bypass surface (DNS-rebinding). Fixed: strip raw-IP check, keep only the hostname guard.

**Secret template output cap** (`secrettemplate/render.go`): `Render` now enforces a 1 MiB limit so an injected large secret value cannot amplify the HTTP response.

**MarkTOTPStepUsed remote proxy** (`remote_mfa.go`, `mfa_management_proxy.go`, `router.go`): TOTP anti-replay (`VerifyMFACredentials` → `MarkTOTPStepUsed`) was unimplemented under `storage.type: remote`, letting the same TOTP code be accepted twice on a follower. Fixed: proxies the call via `POST /api/v1/system/mfa/totp-step-used`.

**SSO error sanitization** (`sso.go`): `"account suspended"` removed from `isSafeSSOError` — account existence/suspension status must not be disclosed through an SSO error response.

**Operator Helm** (`deploy/helm/keyorix-operator`): adds `rbac.clusterScoped` flag (default `false`) so operators watching all namespaces can opt into a `ClusterRoleBinding` without patching the chart; the default path uses a least-privilege namespaced `RoleBinding`.

## Test plan

- [ ] `go test ./internal/core/` passes
- [ ] `go test ./internal/storage/store/ -run TestRemoteUnsupportedStubsAreAllowlisted` passes
- [ ] `go test ./internal/k8ssync/...` passes
- [ ] `go test ./internal/secrettemplate/...` passes
- [ ] Manual: issue a project-scoped PAT; confirm it cannot read a secret in a different project even if an ACL grant exists for that secret
- [ ] Manual: WebAuthn login flow prompts for user-verification (PIN/biometric), not just key presence
- [ ] Helm: deploy operator with `rbac.clusterScoped=true`, confirm `ClusterRoleBinding` is created