### PR TITLE
feat(billing): FinOps billing report — per-project usage breakdown with date-range queries

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -10,6 +10,20 @@ _(nothing claimed)_
 
 ## Done
 
+- **FinOps / billing report** — `GET /api/v1/admin/billing/report?from=&to=` and
+  `keyorix billing report --from --to` CLI command. Date-range per-project
+  breakdown: secret counts, reads, writes, rotations, unique human users, machine
+  reads. Gated behind `FeatureBilling = "billing"` license feature.
+  `internal/core/billing.go`, `internal/storage/store/local_billing.go`,
+  `server/http/handlers/admin_billing.go`, `internal/cli/billing/`.
+  PR [#1227].
+- **Dashboard stat-card trends** — `DeploymentStatsSnapshot` extended with 4 new
+  metrics (audit logins, secret reads, failed auth attempts, inactive users);
+  `DashboardStats` gains 8 prev+trend fields for all 6 deployment metrics.
+  `saveDeploymentSnapshot` wires full trend computation. PR [#1226].
+- **Secret `--type` update via CLI** — `UpdateSecretRequest.Type` wired through
+  core → HTTP handler → CLI `keyorix secret update --type`; audit diff records
+  before/after. PR [#1225].
 - **Password expiry hard gate** — `enforcePasswordExpiryGate` wired into `Login`
   and `VerifyMFALogin`: when `max_age_days` is exceeded for an active user, the
   account state is transitioned to `password_reset_required` before the session is
@@ -68,6 +82,7 @@ _(nothing claimed)_
 
 ### Other
 - **ADR-020** — project detail page (frontend, `keyorix-web`), still Proposed.
-- **FinOps / billing** — no `internal/billing/` or equivalent; no
-  chargeback / usage-by-team reporting. Required for enterprise multi-team
-  deployments.
+
+[#1225]: https://github.com/keyorixhq/keyorix/pull/1225
+[#1226]: https://github.com/keyorixhq/keyorix/pull/1226
+[#1227]: https://github.com/keyorixhq/keyorix/pull/1227

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to Keyorix are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+- **FinOps billing report** — `GET /api/v1/admin/billing/report?from=&to=[&project_id=]`
+  and `keyorix billing report --from --to [--project-id] [--format table|json]`.
+  Per-project breakdown of secret counts, reads, writes, rotations, unique human users,
+  and machine reads for a bounded date range. Gated behind the new `FeatureBilling =
+  "billing"` license feature. Zero-activity projects are excluded from the output.
+  ([#1227])
+- **Dashboard stat-card trends** — the `DeploymentStatsSnapshot` GORM model is
+  extended with four previously-missing metrics: `AuditLogins30d`,
+  `AuditSecretReads30d`, `FailedAuthAttempts24h`, and `InactiveUsers`.
+  `DashboardStats` gains prev+trend fields for all six deployment metrics;
+  `saveDeploymentSnapshot` computes trends via `computeTrend`. GORM AutoMigrate
+  handles the schema update with no migration file required. ([#1226])
+- **Secret type update via CLI** — `keyorix secret update --type <new-type>` now
+  actually changes a secret's type; the field is wired through
+  `UpdateSecretRequest.Type` → core → HTTP handler → audit diff
+  (`before`/`after`). Previously the flag was accepted but silently ignored.
+  ([#1225])
+
+### Fixed
+- **SQLite RBAC grant-expiry timezone mismatch** — GORM formats `time.Time` using
+  the process `Location`; mixed UTC/local `ExpiresAt` values broke SQLite string
+  comparisons so grants appeared expired or perpetual depending on the host
+  timezone. Fixed via `BeforeSave` hooks that normalise all `ExpiresAt` fields to
+  UTC before write, and explicit UTC WHERE clauses for expiry queries. ([#1218])
+- **DAST-identified security gaps** — CSP `frame-ancestors 'self'` on all HTML
+  responses (closes clickjacking), `Cross-Origin-Opener-Policy: same-origin`,
+  `Cross-Origin-Embedder-Policy: require-corp`, and a `Permissions-Policy` header
+  removing access to camera/microphone/geolocation. ([#1217])
+- **GitHub crash-report notifications on vCD fuzzing VMs** — GH token env-var
+  lookup and `notified-*` marker cleanup so the fuzzing service correctly fires
+  crash notifications on fleet VMs. ([#1222])
+
+### Security
+- **PAT scope enforcement, WebAuthn identity binding, template injection, K8s sync
+  RBAC, TOTP anti-replay on proxy, operator Helm `clusterScoped`** — five
+  security hardening items from the DAST/SAST backlog (PAT-SCOPE-002, WAUN-001,
+  TMPL-002, K8SSYNC-007, and TOTP anti-replay on the remote-storage proxy path)
+  closed in one bundle. ([#1224])
+
+[#1217]: https://github.com/keyorixhq/keyorix/pull/1217
+[#1218]: https://github.com/keyorixhq/keyorix/pull/1218
+[#1222]: https://github.com/keyorixhq/keyorix/pull/1222
+[#1224]: https://github.com/keyorixhq/keyorix/pull/1224
+[#1225]: https://github.com/keyorixhq/keyorix/pull/1225
+[#1226]: https://github.com/keyorixhq/keyorix/pull/1226
+[#1227]: https://github.com/keyorixhq/keyorix/pull/1227
+
 ## v0.87.4 — 2026-07-07
 
 CI-only patch release: pins the release workflow's cosign binary so signed release

--- a/internal/cli/billing/billing.go
+++ b/internal/cli/billing/billing.go
@@ -1,0 +1,190 @@
+// Package billing provides the `keyorix billing` CLI command and its `report`
+// subcommand, which prints a per-project FinOps billing report.
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/spf13/cobra"
+)
+
+// NewBillingCmd returns the top-level `keyorix billing` command with its
+// subcommands.
+func NewBillingCmd() *cobra.Command {
+	billingCmd := &cobra.Command{
+		Use:   "billing",
+		Short: "FinOps billing and usage reports (requires billing license feature)",
+	}
+	billingCmd.AddCommand(newReportCmd())
+	return billingCmd
+}
+
+var (
+	flagFrom      string
+	flagTo        string
+	flagProjectID string
+	flagFormat    string
+)
+
+func newReportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "report",
+		Short: "Generate a per-project billing report for a date range",
+		Long: `Generate a per-project billing report showing secret counts, reads,
+writes, rotations, unique human users, and machine reads for the
+specified date window. Requires the "billing" license feature.`,
+		RunE: runReport,
+	}
+	cmd.Flags().StringVar(&flagFrom, "from", "", "Start of billing window, RFC3339 (e.g. 2026-01-01T00:00:00Z) — required")
+	cmd.Flags().StringVar(&flagTo, "to", "", "End of billing window, RFC3339 (e.g. 2026-02-01T00:00:00Z) — required")
+	cmd.Flags().StringVar(&flagProjectID, "project-id", "", "Comma-separated project IDs to include (omit for all)")
+	cmd.Flags().StringVar(&flagFormat, "format", "table", "Output format: table or json")
+	if err := cmd.MarkFlagRequired("from"); err != nil {
+		panic(err)
+	}
+	if err := cmd.MarkFlagRequired("to"); err != nil {
+		panic(err)
+	}
+	return cmd
+}
+
+func runReport(_ *cobra.Command, _ []string) error {
+	ctx := context.Background()
+
+	// Validate from/to before making any calls
+	from, err := time.Parse(time.RFC3339, flagFrom)
+	if err != nil {
+		return fmt.Errorf("invalid --from value %q: must be RFC3339 (e.g. 2026-01-01T00:00:00Z)", flagFrom)
+	}
+	to, err := time.Parse(time.RFC3339, flagTo)
+	if err != nil {
+		return fmt.Errorf("invalid --to value %q: must be RFC3339 (e.g. 2026-02-01T00:00:00Z)", flagTo)
+	}
+
+	// Remote mode: proxy to GET /api/v1/admin/billing/report
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runReportRemote(ctx, rc, from, to)
+	}
+
+	// Local/embedded mode: query via core service directly
+	st, err := common.InitializeStorage()
+	if err != nil {
+		return err
+	}
+	svc := core.NewKeyorixCore(st)
+
+	projectIDs, err := parseProjectIDs(flagProjectID)
+	if err != nil {
+		return err
+	}
+
+	report, err := svc.GenerateBillingReport(ctx, from, to, projectIDs)
+	if err != nil {
+		return fmt.Errorf("failed to generate billing report: %w", err)
+	}
+	return printBillingReport(report)
+}
+
+// runReportRemote proxies the billing report fetch to the connected server.
+func runReportRemote(ctx context.Context, rc *common.RemoteClient, from, to time.Time) error {
+	params := url.Values{}
+	params.Set("from", from.UTC().Format(time.RFC3339))
+	params.Set("to", to.UTC().Format(time.RFC3339))
+	if flagProjectID != "" {
+		params.Set("project_id", flagProjectID)
+	}
+	path := "/api/v1/admin/billing/report?" + params.Encode()
+
+	var report storage.BillingReport
+	if err := rc.Get(ctx, path, &report); err != nil {
+		return fmt.Errorf("failed to fetch billing report: %w", err)
+	}
+	return printBillingReport(&report)
+}
+
+func printBillingReport(report *storage.BillingReport) error {
+	if flagFormat == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+
+	// Sort projects by name for stable output
+	sort.Slice(report.Projects, func(i, j int) bool {
+		if report.Projects[i].ProjectName != report.Projects[j].ProjectName {
+			return report.Projects[i].ProjectName < report.Projects[j].ProjectName
+		}
+		return report.Projects[i].ProjectID < report.Projects[j].ProjectID
+	})
+
+	fmt.Printf("Billing report %s – %s (generated %s)\n\n",
+		report.From.Format("2006-01-02"),
+		report.To.Format("2006-01-02"),
+		report.GeneratedAt.Format("2006-01-02 15:04:05 UTC"),
+	)
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "PROJECT\tSECRETS\tREADS\tWRITES\tROTATIONS\tUNIQUE USERS\tMACHINE READS"); err != nil {
+		return err
+	}
+	for _, p := range report.Projects {
+		name := p.ProjectName
+		if name == "" {
+			name = fmt.Sprintf("(project %d)", p.ProjectID)
+		}
+		if _, err := fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t%d\t%d\n",
+			name, p.SecretCount, p.SecretReads, p.SecretWrites,
+			p.SecretRotations, p.UniqueUsers, p.MachineReads); err != nil {
+			return err
+		}
+	}
+	if len(report.Projects) == 0 {
+		if _, err := fmt.Fprintln(w, "(no data)"); err != nil {
+			return err
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	// Print totals line
+	t := report.Totals
+	fmt.Printf("\nTotals (%d project(s)): %d secrets  %d reads  %d writes  %d rotations  %d unique users  %d machine reads\n",
+		t.Projects, t.SecretCount, t.SecretReads, t.SecretWrites,
+		t.SecretRotations, t.UniqueUsers, t.MachineReads,
+	)
+	return nil
+}
+
+// parseProjectIDs parses a comma-separated string of uint project IDs.
+// Returns nil when the string is empty (all projects).
+func parseProjectIDs(s string) ([]uint, error) {
+	if s == "" {
+		return nil, nil
+	}
+	var ids []uint
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		n, err := strconv.ParseUint(part, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid project ID %q: %w", part, err)
+		}
+		ids = append(ids, uint(n))
+	}
+	return ids, nil
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/cli/anomalies"
 	"github.com/keyorixhq/keyorix/internal/cli/audit"
 	"github.com/keyorixhq/keyorix/internal/cli/auth"
+	billingcli "github.com/keyorixhq/keyorix/internal/cli/billing"
 	"github.com/keyorixhq/keyorix/internal/cli/breakglass"
 	bundlecli "github.com/keyorixhq/keyorix/internal/cli/bundle"
 	"github.com/keyorixhq/keyorix/internal/cli/compliance"
@@ -87,6 +88,7 @@ func init() {
 	rootCmd.AddCommand(bundlecli.BundleCmd)
 	rootCmd.AddCommand(licensecli.LicenseCmd)
 	rootCmd.AddCommand(usage.UsageCmd)
+	rootCmd.AddCommand(billingcli.NewBillingCmd())
 	rootCmd.AddCommand(notification.NotificationCmd)
 }
 

--- a/internal/core/billing.go
+++ b/internal/core/billing.go
@@ -1,0 +1,27 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/license"
+)
+
+// GenerateBillingReport returns a per-project usage breakdown for the half-open
+// interval [from, to). Requires the "billing" license feature.
+//
+// projectIDs filters the report to specific projects; pass nil for all projects.
+func (c *KeyorixCore) GenerateBillingReport(ctx context.Context, from, to time.Time, projectIDs []uint) (*storage.BillingReport, error) {
+	if !c.HasLicensedFeature(license.FeatureBilling) {
+		return nil, fmt.Errorf("billing reports require a commercial license (feature: %s)", license.FeatureBilling)
+	}
+	if !from.Before(to) {
+		return nil, fmt.Errorf("billing report: from (%s) must be before to (%s)", from.Format(time.RFC3339), to.Format(time.RFC3339))
+	}
+	if to.Sub(from) > 366*24*time.Hour {
+		return nil, fmt.Errorf("billing report window exceeds the maximum of 366 days")
+	}
+	return c.storage.GetBillingReport(ctx, from.UTC(), to.UTC(), projectIDs)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1591,6 +1591,14 @@ func (m *MockStorage) GetProjectUsageStats(ctx context.Context, projectIDs []uin
 	return args.Get(0).([]storage.ProjectUsageStat), args.Error(1)
 }
 
+func (m *MockStorage) GetBillingReport(ctx context.Context, from, to time.Time, projectIDs []uint) (*storage.BillingReport, error) {
+	args := m.Called(ctx, from, to, projectIDs)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.BillingReport), args.Error(1)
+}
+
 func (m *MockStorage) SaveStatsSnapshot(ctx context.Context, snapshot *models.StatsSnapshot) error {
 	args := m.Called(ctx, snapshot)
 	return args.Error(0)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1276,6 +1276,11 @@ type Storage interface {
 	// ALL projects. The result may omit projects with zero activity and zero secrets.
 	GetProjectUsageStats(ctx context.Context, projectIDs []uint, windowDays int) ([]ProjectUsageStat, error)
 
+	// GetBillingReport returns per-project usage stats for the half-open interval [from, to).
+	// If projectIDs is non-empty, only those projects are included; otherwise all projects
+	// with any activity in the window (or existing secrets) are included.
+	GetBillingReport(ctx context.Context, from, to time.Time, projectIDs []uint) (*BillingReport, error)
+
 	// Secret version comments — free-text annotations on a specific secret version,
 	// providing a human-readable audit trail of why a version was created or changed.
 	CreateSecretVersionComment(ctx context.Context, c *models.SecretVersionComment) error
@@ -1534,6 +1539,38 @@ type UsageReport struct {
 	WindowDays  int                `json:"window_days"`
 	GeneratedAt time.Time          `json:"generated_at"`
 	Projects    []ProjectUsageStat `json:"projects"`
+}
+
+// BillingProjectStat is one project's usage breakdown for a billing period.
+type BillingProjectStat struct {
+	ProjectID       uint   `json:"project_id"`
+	ProjectName     string `json:"project_name"`
+	SecretCount     int64  `json:"secret_count"`     // active leaf secrets at report time
+	SecretReads     int64  `json:"secret_reads"`     // secret.read events in window
+	SecretWrites    int64  `json:"secret_writes"`    // secret.create + secret.update + secret.rotate in window
+	SecretRotations int64  `json:"secret_rotations"` // secret.rotate events in window (subset of writes)
+	UniqueUsers     int    `json:"unique_users"`     // distinct human user_ids
+	MachineReads    int64  `json:"machine_reads"`    // secret.read where actor_type='machine'
+}
+
+// BillingTotals aggregates BillingProjectStat across all projects.
+type BillingTotals struct {
+	Projects        int   `json:"projects"`
+	SecretCount     int64 `json:"secret_count"`
+	SecretReads     int64 `json:"secret_reads"`
+	SecretWrites    int64 `json:"secret_writes"`
+	SecretRotations int64 `json:"secret_rotations"`
+	UniqueUsers     int   `json:"unique_users"`
+	MachineReads    int64 `json:"machine_reads"`
+}
+
+// BillingReport is the response from GetBillingReport.
+type BillingReport struct {
+	From        time.Time            `json:"from"`
+	To          time.Time            `json:"to"`
+	GeneratedAt time.Time            `json:"generated_at"`
+	Projects    []BillingProjectStat `json:"projects"`
+	Totals      BillingTotals        `json:"totals"`
 }
 
 // StorageStats provides statistics about the storage system

--- a/internal/license/features.go
+++ b/internal/license/features.go
@@ -11,4 +11,9 @@ const (
 	// import already requires the embedded update-signing key that only release builds
 	// carry, so a plain `go build` cannot import regardless.
 	FeatureAirgapUpdates = "airgap_updates"
+
+	// FeatureBilling gates the FinOps billing report (GET /api/v1/admin/billing/report
+	// and `keyorix billing report`), which returns per-project secret counts, read/write
+	// activity, and machine-vs-human usage breakdowns for a configurable date range.
+	FeatureBilling = "billing"
 )

--- a/internal/storage/store/local_billing.go
+++ b/internal/storage/store/local_billing.go
@@ -1,0 +1,240 @@
+// local_billing.go — Per-project billing report query for LocalStorage.
+//
+// Covers: GetBillingReport
+//
+// All operations use direct GORM queries.
+// For the remote (HTTP) equivalent see remote_billing.go.
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// GetBillingReport returns per-project usage stats for the half-open interval
+// [from, to). When projectIDs is nil or empty, stats are returned for all
+// non-deleted projects that have at least one active secret or any audit
+// activity in the window. Projects with no secrets and no activity are omitted
+// to keep the report concise.
+func (ls *LocalStorage) GetBillingReport(ctx context.Context, from, to time.Time, projectIDs []uint) (*storage.BillingReport, error) {
+	allProjects := len(projectIDs) == 0
+
+	// --- Step 1: determine the project set ---
+	if allProjects {
+		type idRow struct{ ID uint }
+		var rows []idRow
+		if err := ls.db.WithContext(ctx).
+			Table("projects").
+			Select("id").
+			Where("deleted_at IS NULL").
+			Scan(&rows).Error; err != nil {
+			return nil, err
+		}
+		for _, r := range rows {
+			projectIDs = append(projectIDs, r.ID)
+		}
+	}
+	if len(projectIDs) == 0 {
+		return &storage.BillingReport{
+			From:        from,
+			To:          to,
+			GeneratedAt: time.Now().UTC(),
+			Projects:    []storage.BillingProjectStat{},
+		}, nil
+	}
+
+	// --- Step 2: fetch project names in one query ---
+	type projectRow struct {
+		ID   uint
+		Name string
+	}
+	var projRows []projectRow
+	if err := ls.db.WithContext(ctx).
+		Table("projects").
+		Select("id, name").
+		Where("id IN ?", projectIDs).
+		Scan(&projRows).Error; err != nil {
+		return nil, err
+	}
+	nameMap := make(map[uint]string, len(projRows))
+	for _, p := range projRows {
+		nameMap[p.ID] = p.Name
+	}
+
+	// --- Step 3: aggregate per project ---
+	type counts struct {
+		SecretCount     int64
+		SecretReads     int64
+		SecretWrites    int64
+		SecretRotations int64
+		UniqueUsers     int
+		MachineReads    int64
+	}
+
+	statsMap := make(map[uint]*counts, len(projectIDs))
+	for _, id := range projectIDs {
+		statsMap[id] = &counts{}
+	}
+
+	// 3a. SecretCount — active leaf secrets
+	type secretRow struct {
+		ProjectID uint
+		Count     int64
+	}
+	var secretRows []secretRow
+	if err := ls.db.WithContext(ctx).
+		Table("secret_nodes").
+		Select("project_id, COUNT(*) AS count").
+		Where("project_id IN ? AND is_secret = ? AND deleted_at IS NULL", projectIDs, true).
+		Group("project_id").
+		Scan(&secretRows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range secretRows {
+		if c, ok := statsMap[r.ProjectID]; ok {
+			c.SecretCount = r.Count
+		}
+	}
+
+	// 3b. SecretReads — secret.read events in window
+	type readRow struct {
+		ProjectID uint
+		Count     int64
+	}
+	var readRows []readRow
+	if err := ls.db.WithContext(ctx).
+		Table("audit_events").
+		Select("project_id, COUNT(*) AS count").
+		Where("project_id IN ? AND event_type = ? AND success = ? AND event_time >= ? AND event_time < ?",
+			projectIDs, "secret.read", true, from, to).
+		Group("project_id").
+		Scan(&readRows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range readRows {
+		if c, ok := statsMap[r.ProjectID]; ok {
+			c.SecretReads = r.Count
+		}
+	}
+
+	// 3c. SecretWrites — secret.create + secret.update + secret.rotate
+	var writeRows []readRow
+	if err := ls.db.WithContext(ctx).
+		Table("audit_events").
+		Select("project_id, COUNT(*) AS count").
+		Where("project_id IN ? AND event_type IN ? AND success = ? AND event_time >= ? AND event_time < ?",
+			projectIDs, []string{"secret.create", "secret.update", "secret.rotate"}, true, from, to).
+		Group("project_id").
+		Scan(&writeRows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range writeRows {
+		if c, ok := statsMap[r.ProjectID]; ok {
+			c.SecretWrites = r.Count
+		}
+	}
+
+	// 3d. SecretRotations — secret.rotate only
+	var rotRows []readRow
+	if err := ls.db.WithContext(ctx).
+		Table("audit_events").
+		Select("project_id, COUNT(*) AS count").
+		Where("project_id IN ? AND event_type = ? AND success = ? AND event_time >= ? AND event_time < ?",
+			projectIDs, "secret.rotate", true, from, to).
+		Group("project_id").
+		Scan(&rotRows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range rotRows {
+		if c, ok := statsMap[r.ProjectID]; ok {
+			c.SecretRotations = r.Count
+		}
+	}
+
+	// 3e. UniqueUsers — distinct human user_ids in window
+	type userRow struct {
+		ProjectID uint
+		Count     int
+	}
+	var userRows []userRow
+	if err := ls.db.WithContext(ctx).
+		Table("audit_events").
+		Select("project_id, COUNT(DISTINCT user_id) AS count").
+		Where("project_id IN ? AND actor_type = ? AND event_time >= ? AND event_time < ?",
+			projectIDs, "user", from, to).
+		Group("project_id").
+		Scan(&userRows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range userRows {
+		if c, ok := statsMap[r.ProjectID]; ok {
+			c.UniqueUsers = r.Count
+		}
+	}
+
+	// 3f. MachineReads — secret.read by machine actors
+	var machRows []readRow
+	if err := ls.db.WithContext(ctx).
+		Table("audit_events").
+		Select("project_id, COUNT(*) AS count").
+		Where("project_id IN ? AND event_type = ? AND actor_type = ? AND event_time >= ? AND event_time < ?",
+			projectIDs, "secret.read", "machine", from, to).
+		Group("project_id").
+		Scan(&machRows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range machRows {
+		if c, ok := statsMap[r.ProjectID]; ok {
+			c.MachineReads = r.Count
+		}
+	}
+
+	// --- Step 4: build result, filtering zero-activity / no-secret projects ---
+	var stats []storage.BillingProjectStat
+	var totals storage.BillingTotals
+
+	for _, id := range projectIDs {
+		c := statsMap[id]
+		// Omit projects with no secrets AND no activity
+		if c.SecretCount == 0 && c.SecretReads == 0 && c.SecretWrites == 0 {
+			continue
+		}
+		name := nameMap[id]
+		if name == "" {
+			name = ""
+		}
+		stat := storage.BillingProjectStat{
+			ProjectID:       id,
+			ProjectName:     name,
+			SecretCount:     c.SecretCount,
+			SecretReads:     c.SecretReads,
+			SecretWrites:    c.SecretWrites,
+			SecretRotations: c.SecretRotations,
+			UniqueUsers:     c.UniqueUsers,
+			MachineReads:    c.MachineReads,
+		}
+		stats = append(stats, stat)
+
+		totals.SecretCount += c.SecretCount
+		totals.SecretReads += c.SecretReads
+		totals.SecretWrites += c.SecretWrites
+		totals.SecretRotations += c.SecretRotations
+		totals.UniqueUsers += c.UniqueUsers
+		totals.MachineReads += c.MachineReads
+	}
+	totals.Projects = len(stats)
+
+	if stats == nil {
+		stats = []storage.BillingProjectStat{}
+	}
+
+	return &storage.BillingReport{
+		From:        from,
+		To:          to,
+		GeneratedAt: time.Now().UTC(),
+		Projects:    stats,
+		Totals:      totals,
+	}, nil
+}

--- a/internal/storage/store/remote_billing.go
+++ b/internal/storage/store/remote_billing.go
@@ -1,0 +1,19 @@
+// remote_billing.go — Billing report stub for RemoteStorage.
+//
+// The billing report aggregates data from secret_nodes + audit_events, both
+// of which live server-side. Admin callers use GET /api/v1/admin/billing/report
+// directly instead of going through RemoteStorage.
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// GetBillingReport is not supported in remote mode; billing report queries
+// run server-side against the live database.
+func (rs *RemoteStorage) GetBillingReport(_ context.Context, _, _ time.Time, _ []uint) (*storage.BillingReport, error) {
+	return nil, remoteUnsupported("GetBillingReport")
+}

--- a/internal/storage/store/remote_billing_completeness_test.go
+++ b/internal/storage/store/remote_billing_completeness_test.go
@@ -1,0 +1,8 @@
+package store
+
+func init() {
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		"GetBillingReport": {statusIntentional,
+			"billing report queries run server-side; admin callers use GET /api/v1/admin/billing/report"},
+	})
+}

--- a/server/http/handlers/admin_billing.go
+++ b/server/http/handlers/admin_billing.go
@@ -1,0 +1,87 @@
+// admin_billing.go — GET /api/v1/admin/billing/report handler.
+//
+// Returns a per-project FinOps billing report (secret counts, read/write
+// activity, machine vs. human breakdowns) for a configurable date range.
+// Gated by system.read permission in the router and the "billing" license
+// feature in core.GenerateBillingReport.
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+// AdminBillingHandler serves GET /api/v1/admin/billing/report.
+type AdminBillingHandler struct {
+	coreService *core.KeyorixCore
+}
+
+// NewAdminBillingHandler constructs an AdminBillingHandler.
+func NewAdminBillingHandler(cs *core.KeyorixCore) *AdminBillingHandler {
+	return &AdminBillingHandler{coreService: cs}
+}
+
+// GetBillingReport handles GET /api/v1/admin/billing/report.
+//
+// Query params:
+//
+//	from        string  RFC3339 start of the billing window (required)
+//	to          string  RFC3339 end of the billing window (required)
+//	project_id  string  comma-separated list of project IDs to filter (optional, omit for all)
+func (h *AdminBillingHandler) GetBillingReport(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	// Parse required "from" param
+	fromStr := q.Get("from")
+	if fromStr == "" {
+		sendError(w, "BadRequest", "Missing required query parameter: from", http.StatusBadRequest, nil)
+		return
+	}
+	from, err := time.Parse(time.RFC3339, fromStr)
+	if err != nil {
+		sendError(w, "BadRequest", "Invalid 'from' parameter: must be RFC3339 (e.g. 2026-01-01T00:00:00Z)", http.StatusBadRequest, nil)
+		return
+	}
+
+	// Parse required "to" param
+	toStr := q.Get("to")
+	if toStr == "" {
+		sendError(w, "BadRequest", "Missing required query parameter: to", http.StatusBadRequest, nil)
+		return
+	}
+	to, err := time.Parse(time.RFC3339, toStr)
+	if err != nil {
+		sendError(w, "BadRequest", "Invalid 'to' parameter: must be RFC3339 (e.g. 2026-02-01T00:00:00Z)", http.StatusBadRequest, nil)
+		return
+	}
+
+	// Parse optional comma-separated project_id list
+	var projectIDs []uint
+	if pidStr := q.Get("project_id"); pidStr != "" {
+		for _, part := range strings.Split(pidStr, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			n, err := strconv.ParseUint(part, 10, 32)
+			if err != nil {
+				sendError(w, "BadRequest", "Invalid project_id value: "+part, http.StatusBadRequest, nil)
+				return
+			}
+			projectIDs = append(projectIDs, uint(n))
+		}
+	}
+
+	report, err := h.coreService.GenerateBillingReport(r.Context(), from, to, projectIDs)
+	if err != nil {
+		log.Printf("GetBillingReport: %v", err)
+		sendError(w, "InternalError", err.Error(), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, report, "")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -135,6 +135,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	machineAuditHandler := handlers.NewMachineAuditHandler(coreService)
 	dashboardHandler := handlers.NewDashboardHandler(coreService)
 	adminUsageHandler := handlers.NewAdminUsageHandler(coreService)
+	adminBillingHandler := handlers.NewAdminBillingHandler(coreService)
 	auditHandler := handlers.NewAuditHandler(coreService)
 	licenseHandler := handlers.NewLicenseHandler(coreService)
 	rotationPolicyHandler := handlers.NewRotationPolicyHandler(coreService)
@@ -1935,6 +1936,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// Usage report — per-project secret counts + read activity over a time window.
 		// Deployment-wide aggregation, gated by system.read.
 		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/admin/usage", adminUsageHandler.GetUsageReport)
+
+		// Billing report — per-project FinOps usage breakdown for a date range.
+		// Requires the "billing" license feature (gated in core.GenerateBillingReport).
+		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/admin/billing/report", adminBillingHandler.GetBillingReport)
 
 		// On-demand triggers for the notification/alert jobs that otherwise run only on
 		// their background schedulers — dispatch immediately after an incident or config


### PR DESCRIPTION
## Summary

- Adds `GetBillingReport(ctx, from, to, projectIDs)` to the storage interface with a full SQLite implementation and a `remoteUnsupported` stub
- New `BillingProjectStat`, `BillingTotals`, `BillingReport` structs in `internal/core/storage/interface.go`
- `KeyorixCore.GenerateBillingReport` gated behind the new `FeatureBilling = "billing"` license feature; validates date range (from < to, window ≤ 366 days)
- `GET /api/v1/admin/billing/report?from=&to=[&project_id=]` handler registered with `system.read` permission
- `keyorix billing report --from 2026-01-01T00:00:00Z --to 2026-02-01T00:00:00Z [--project-id 1,2] [--format table|json]` CLI command supporting both embedded and remote modes

Unlike the existing rolling-window `/admin/usage` endpoint, this report uses bounded `[from, to)` date ranges and breaks down activity by event type (reads / writes / rotations) and actor type (human unique users vs. machine reads) — the fields finance teams need for internal chargeback.

## Test plan

- [ ] `go test ./internal/storage/... ./internal/core/... ./server/http/...` passes (pre-existing failures: `TestBulkApproveAccessRequests_ApproveError`, `TestAuthzParity_HTTPvsGRPC_Share*` — catalogued)
- [ ] `keyorix billing report --from 2026-01-01T00:00:00Z --to 2026-07-01T00:00:00Z` in embedded mode produces table output
- [ ] Missing `--from` or invalid RFC3339 gives a clear CLI error
- [ ] `GET /api/v1/admin/billing/report?from=2026-01-01T00:00:00Z&to=2026-07-01T00:00:00Z` returns JSON with `projects` and `totals`
- [ ] Unlicensed instance returns 500 with descriptive message