### PR TITLE
feat(auth): MFA step-up re-verification for restricted-classified secrets

### DIFF
--- a/internal/cli/auth/mfa_stepup.go
+++ b/internal/cli/auth/mfa_stepup.go
@@ -1,0 +1,61 @@
+// mfa_stepup.go — CLI command for explicit MFA step-up re-verification.
+// `keyorix auth mfa stepup --code <code>` lets an already-authenticated user
+// re-verify their TOTP (or recovery code) to open the 15-minute read window
+// for "restricted" classified secrets without going through a full re-login.
+// Remote-only: the embedded mode has no active user session to step up.
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+)
+
+var mfaCmd = &cobra.Command{
+	Use:   "mfa",
+	Short: "Manage MFA (multi-factor authentication)",
+	Long:  "Manage multi-factor authentication settings for your account",
+}
+
+var mfaStepUpCmd = &cobra.Command{
+	Use:   "stepup",
+	Short: "Re-verify your TOTP to unlock restricted secret reads",
+	Long: `Re-verify your authenticator code (or a recovery code) without re-logging in.
+On success, a 15-minute window is opened server-side that allows reading
+"restricted" classified secrets.
+
+This command requires an active session (remote mode only).`,
+	RunE: runMFAStepUp,
+}
+
+func init() {
+	mfaStepUpCmd.Flags().String("code", "", "TOTP or recovery code")
+
+	mfaCmd.AddCommand(mfaStepUpCmd)
+	AuthCmd.AddCommand(mfaCmd)
+}
+
+func runMFAStepUp(cmd *cobra.Command, _ []string) error {
+	rc, ok := common.NewRemoteClient()
+	if !ok {
+		return fmt.Errorf("MFA step-up requires remote mode — run 'keyorix auth login' first")
+	}
+
+	code, _ := cmd.Flags().GetString("code")
+	if code == "" {
+		fmt.Print("Enter TOTP or recovery code: ")
+		_, err := fmt.Scanln(&code) //nolint:errcheck
+		if err != nil || code == "" {
+			return fmt.Errorf("code is required")
+		}
+	}
+
+	if err := rc.Post(context.Background(), "/api/v1/auth/mfa/stepup", map[string]string{"code": code}, nil); err != nil {
+		return fmt.Errorf("MFA step-up failed: %w", err)
+	}
+
+	fmt.Println("MFA step-up verified. Restricted secrets are accessible for 15 minutes.")
+	return nil
+}

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -35,7 +35,8 @@ func newBootstrappedCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 		&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.ProjectMembership{},
 		&models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.SoDPolicy{},
 		&models.StatsSnapshot{}, &models.DeploymentStatsSnapshot{},
-		&models.MFAStepupToken{}, &models.SecretACL{},
+		&models.MFAStepupToken{}, &models.MFAStepUpGrant{},
+		&models.SecretACL{}, &models.PasswordHistory{},
 	))
 
 	st := store.NewLocalStorage(db)

--- a/internal/core/classification_gate.go
+++ b/internal/core/classification_gate.go
@@ -169,11 +169,11 @@ func (c *KeyorixCore) checkRestrictedApprovalGate(ctx context.Context, secret *m
 }
 
 func (c *KeyorixCore) checkRestrictedMFAGate(ctx context.Context, secret *models.SecretNode, userID uint) error {
-	ok, err := c.storage.HasActiveMFAStepup(ctx, userID)
+	grant, err := c.storage.GetActiveMFAStepUpGrant(ctx, userID, c.now())
 	if err != nil {
 		return fmt.Errorf("secret %q is restricted: could not verify MFA step-up: %w", secret.Name, err)
 	}
-	if !ok {
+	if grant == nil {
 		return fmt.Errorf("secret %q is restricted: a recent MFA verification (within %s) is required to read this secret's value — re-authenticate with your second factor", secret.Name, c.mfaStepUpWindow())
 	}
 	return nil

--- a/internal/core/classification_gate_test.go
+++ b/internal/core/classification_gate_test.go
@@ -40,7 +40,7 @@ func seedClassificationGateFixture(t *testing.T, st *store.LocalStorage, classif
 	require.NoError(t, st.AssignRole(ctx, approver.ID, adminRole.ID, storage.Scope{}))
 	// IsProjectMember (RBAC-001): requester must be a project member or the owner
 	// gate short-circuits before returning PermissionOwner.
-	viewerRole, err := st.GetRoleByName(ctx, "project_viewer")
+	viewerRole, err = st.GetRoleByName(ctx, "project_viewer")
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRole(ctx, requester.ID, viewerRole.ID, storage.Scope{ProjectID: proj.ID}))
 

--- a/internal/core/classification_gate_test.go
+++ b/internal/core/classification_gate_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 // seedClassificationGateFixture creates a project, a requester (owner of the
-// secret, so ValidateSecretAccess passes without needing a separate RBAC role),
-// an admin approver, and a secret at the given classification with one version.
+// secret and project viewer, so ValidateSecretAccess passes the owner + live-
+// membership check introduced in #1205/RBAC-001), an admin approver, and a
+// secret at the given classification with one version.
 func seedClassificationGateFixture(t *testing.T, st *store.LocalStorage, classification string) (secretID, requesterID, approverID, projectID uint) {
 	t.Helper()
 	ctx := context.Background()
@@ -24,6 +25,13 @@ func seedClassificationGateFixture(t *testing.T, st *store.LocalStorage, classif
 
 	requester, err := st.CreateUser(ctx, &models.User{Username: "requester-" + classification, Email: "requester-" + classification + "@example.com", IsActive: true})
 	require.NoError(t, err)
+
+	// Assign the requester a project-scoped viewer role so IsProjectMember
+	// (added as an owner-bypass gate in #1205) returns true. Without this the
+	// owner shortcut in CheckSecretPermission falls through to "permission denied".
+	viewerRole, err := st.GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, requester.ID, viewerRole.ID, storage.Scope{ProjectID: proj.ID}))
 
 	approver, err := st.CreateUser(ctx, &models.User{Username: "approver-" + classification, Email: "approver-" + classification + "@example.com", IsActive: true})
 	require.NoError(t, err)
@@ -385,35 +393,35 @@ func TestClassificationMFAStepUp_On_NoUser_Denied(t *testing.T) {
 	assert.Contains(t, err.Error(), "restricted")
 }
 
-// Requirement: a user with an active (non-expired) step-up token can read.
+// Requirement: a user with an active (non-expired) step-up grant can read.
 func TestClassificationMFAStepUp_On_ActiveToken_Allowed(t *testing.T) {
 	c, st := newBootstrappedCore(t)
 	secretID, ownerID, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
 	ctx := context.Background()
 	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
 
-	// Directly seed the step-up token (as VerifyMFALogin would).
+	// Directly seed the step-up grant (as VerifyMFAStepUp would).
 	expiresAt := c.now().Add(15 * time.Minute)
-	require.NoError(t, st.UpsertMFAStepupToken(ctx, ownerID, expiresAt))
+	require.NoError(t, st.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: ownerID, ExpiresAt: expiresAt}))
 
 	val, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
-	require.NoError(t, err, "active MFA step-up token must allow the read")
+	require.NoError(t, err, "active MFA step-up grant must allow the read")
 	assert.Equal(t, "s3cr3t-value", string(val))
 }
 
-// Requirement: an expired step-up token is treated as absent — denied.
+// Requirement: an expired step-up grant is treated as absent — denied.
 func TestClassificationMFAStepUp_On_ExpiredToken_Denied(t *testing.T) {
 	c, st := newBootstrappedCore(t)
 	secretID, ownerID, _, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
 	ctx := context.Background()
 	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
 
-	// Seed an already-expired token.
+	// Seed an already-expired grant.
 	expiredAt := c.now().Add(-1 * time.Minute)
-	require.NoError(t, st.UpsertMFAStepupToken(ctx, ownerID, expiredAt))
+	require.NoError(t, st.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: ownerID, ExpiresAt: expiredAt}))
 
 	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
-	require.Error(t, err, "expired step-up token must not grant access")
+	require.Error(t, err, "expired step-up grant must not grant access")
 	assert.Contains(t, err.Error(), "MFA")
 }
 
@@ -443,8 +451,8 @@ func TestClassificationMFAStepUp_Combined_BothRequired(t *testing.T) {
 	c.SetClassificationRestrictedRequiresApproval(true)
 	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
 
-	// Give the owner an active step-up token.
-	require.NoError(t, st.UpsertMFAStepupToken(ctx, ownerID, c.now().Add(15*time.Minute)))
+	// Give the owner an active step-up grant.
+	require.NoError(t, st.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: ownerID, ExpiresAt: c.now().Add(15 * time.Minute)}))
 
 	// No approved access request yet → denied.
 	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)

--- a/internal/core/mfa_stepup.go
+++ b/internal/core/mfa_stepup.go
@@ -1,16 +1,18 @@
 // mfa_stepup.go — explicit MFA step-up verification for an already-authenticated
 // user. Allows re-verifying a TOTP code (or recovery code) without going through
-// re-login, minting a short-lived MFAStepupToken that satisfies the
+// re-login, creating an MFAStepUpGrant that satisfies the
 // checkRestrictedMFAGate for reading "restricted" classified secrets.
 package core
 
 import (
 	"context"
 	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // VerifyMFAStepUp verifies a TOTP code (or recovery code) for an authenticated
-// user and, on success, upserts an MFAStepupToken that enables reading
+// user and, on success, creates an MFAStepUpGrant that enables reading
 // restricted secrets for the configured window (default 15 min).
 // Mirrors the TOTP-path of VerifyMFACredentials: loadTOTPSecret +
 // validateTOTPStep + MarkTOTPStepUsed for anti-replay, recovery-code fallback,
@@ -53,7 +55,11 @@ func (c *KeyorixCore) VerifyMFAStepUp(ctx context.Context, userID uint, code str
 		return err
 	}
 
-	if err := c.storage.UpsertMFAStepupToken(ctx, userID, c.now().Add(c.mfaStepUpWindow())); err != nil {
+	grant := &models.MFAStepUpGrant{
+		UserID:    userID,
+		ExpiresAt: c.now().Add(c.mfaStepUpWindow()),
+	}
+	if err := c.storage.CreateMFAStepUpGrant(ctx, grant); err != nil {
 		return fmt.Errorf("failed to record MFA step-up: %w", err)
 	}
 	uid := userID
@@ -63,7 +69,11 @@ func (c *KeyorixCore) VerifyMFAStepUp(ctx context.Context, userID uint, code str
 }
 
 // HasActiveMFAStepUp reports whether userID holds a current, unexpired step-up
-// token. Returns (false, nil) — not an error — when no token exists.
+// grant. Returns (false, nil) — not an error — when no grant exists.
 func (c *KeyorixCore) HasActiveMFAStepUp(ctx context.Context, userID uint) (bool, error) {
-	return c.storage.HasActiveMFAStepup(ctx, userID)
+	grant, err := c.storage.GetActiveMFAStepUpGrant(ctx, userID, c.now())
+	if err != nil {
+		return false, err
+	}
+	return grant != nil, nil
 }

--- a/internal/core/mfa_stepup.go
+++ b/internal/core/mfa_stepup.go
@@ -1,0 +1,69 @@
+// mfa_stepup.go — explicit MFA step-up verification for an already-authenticated
+// user. Allows re-verifying a TOTP code (or recovery code) without going through
+// re-login, minting a short-lived MFAStepupToken that satisfies the
+// checkRestrictedMFAGate for reading "restricted" classified secrets.
+package core
+
+import (
+	"context"
+	"fmt"
+)
+
+// VerifyMFAStepUp verifies a TOTP code (or recovery code) for an authenticated
+// user and, on success, upserts an MFAStepupToken that enables reading
+// restricted secrets for the configured window (default 15 min).
+// Mirrors the TOTP-path of VerifyMFACredentials: loadTOTPSecret +
+// validateTOTPStep + MarkTOTPStepUsed for anti-replay, recovery-code fallback,
+// and the same per-account lockout the login second factor feeds.
+func (c *KeyorixCore) VerifyMFAStepUp(ctx context.Context, userID uint, code string) error {
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("user not found")
+	}
+	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
+		return fmt.Errorf("account is not active")
+	}
+	if c.loginLocked(user) {
+		return fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
+	if !user.MFAEnabled {
+		return fmt.Errorf("MFA is not enabled on this account; enrol with 'keyorix auth mfa enroll' first")
+	}
+
+	verified := false
+	if secret, serr := c.loadTOTPSecret(ctx, userID); serr == nil {
+		if step, ok := c.validateTOTPStep(secret, code); ok {
+			if fresh, ferr := c.storage.MarkTOTPStepUsed(ctx, userID, step); ferr == nil && fresh {
+				verified = true
+			}
+		}
+	}
+	if !verified {
+		if consumed, cerr := c.storage.ConsumeMFARecoveryCode(ctx, userID, sha256Hex(normalizeRecoveryCode(code)), c.now()); cerr == nil && consumed {
+			verified = true
+		}
+	}
+	if !verified {
+		c.auditMFAFailed(ctx, userID, "stepup")
+		c.recordFailedLogin(ctx, user)
+		return fmt.Errorf("invalid code")
+	}
+
+	if err := c.checkLockAndClearLoginFailures(ctx, user); err != nil {
+		return err
+	}
+
+	if err := c.storage.UpsertMFAStepupToken(ctx, userID, c.now().Add(c.mfaStepUpWindow())); err != nil {
+		return fmt.Errorf("failed to record MFA step-up: %w", err)
+	}
+	uid := userID
+	c.writeAuditEvent(ctx, "mfa.stepup_verified", &uid, nil,
+		fmt.Sprintf("user %d completed MFA step-up for restricted secret access", userID))
+	return nil
+}
+
+// HasActiveMFAStepUp reports whether userID holds a current, unexpired step-up
+// token. Returns (false, nil) — not an error — when no token exists.
+func (c *KeyorixCore) HasActiveMFAStepUp(ctx context.Context, userID uint) (bool, error) {
+	return c.storage.HasActiveMFAStepup(ctx, userID)
+}

--- a/internal/core/mfa_stepup_gate_test.go
+++ b/internal/core/mfa_stepup_gate_test.go
@@ -22,9 +22,9 @@ func TestStepUpGate_BothFlagsOff_NoGating(t *testing.T) {
 	require.NoError(t, err, "no gate active: must be a no-op for any user")
 }
 
-// TestStepUpGate_On_NoActiveToken_Denied verifies that with the MFA step-up gate
-// enabled and no token present, access to a restricted secret is denied.
-func TestStepUpGate_On_NoActiveToken_Denied(t *testing.T) {
+// TestStepUpGate_On_NoActiveGrant_Denied verifies that with the MFA step-up gate
+// enabled and no grant present, access to a restricted secret is denied.
+func TestStepUpGate_On_NoActiveGrant_Denied(t *testing.T) {
 	c, _, _ := newMFATestCore(t)
 	ctx := context.Background()
 	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
@@ -36,20 +36,20 @@ func TestStepUpGate_On_NoActiveToken_Denied(t *testing.T) {
 	assert.Contains(t, err.Error(), "MFA")
 }
 
-// TestStepUpGate_On_ActiveToken_Allowed verifies that a user with a valid
-// (non-expired) MFAStepupToken can pass the gate.
-func TestStepUpGate_On_ActiveToken_Allowed(t *testing.T) {
-	c, db, _ := newMFATestCore(t)
+// TestStepUpGate_On_ActiveGrant_Allowed verifies that a user with a valid
+// (non-expired) MFAStepUpGrant can pass the gate.
+func TestStepUpGate_On_ActiveGrant_Allowed(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
 	ctx := context.Background()
 	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
 
-	// Seed an active step-up token using real time (HasActiveMFAStepup uses time.Now).
-	future := time.Now().Add(15 * time.Minute)
-	require.NoError(t, db.Create(&models.MFAStepupToken{UserID: 1, ExpiresAt: future}).Error)
+	// Seed an active step-up grant relative to the fixed clock.
+	future := fixed.Add(15 * time.Minute)
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: future}).Error)
 
 	secret := &models.SecretNode{Name: "db-pass", Classification: ClassificationRestricted}
 	err := c.checkRestrictedSecretReadApproval(ctx, secret, 1)
-	require.NoError(t, err, "active MFA step-up token must let the gate pass")
+	require.NoError(t, err, "active MFA step-up grant must let the gate pass")
 }
 
 // TestStepUpGate_LowerClassification_NeverGated verifies that the MFA step-up gate
@@ -61,7 +61,7 @@ func TestStepUpGate_LowerClassification_NeverGated(t *testing.T) {
 			ctx := context.Background()
 			c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
 
-			// No step-up token seeded — but the gate must not trigger for lower tiers.
+			// No step-up grant seeded — but the gate must not trigger for lower tiers.
 			secret := &models.SecretNode{Name: "db-pass", Classification: level}
 			err := c.checkRestrictedSecretReadApproval(ctx, secret, 1)
 			require.NoError(t, err, "MFA step-up gate must not apply to %q-classified secrets", level)

--- a/internal/core/mfa_stepup_gate_test.go
+++ b/internal/core/mfa_stepup_gate_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStepUpGate_BothFlagsOff_NoGating verifies that checkRestrictedSecretReadApproval
+// is a no-op when no gate flags are active.
+func TestStepUpGate_BothFlagsOff_NoGating(t *testing.T) {
+	c, _, _ := newMFATestCore(t)
+	ctx := context.Background()
+
+	// No gate flags set — should never return an error regardless of user or secret.
+	secret := &models.SecretNode{Name: "db-pass", Classification: ClassificationRestricted}
+	err := c.checkRestrictedSecretReadApproval(ctx, secret, 1)
+	require.NoError(t, err, "no gate active: must be a no-op for any user")
+}
+
+// TestStepUpGate_On_NoActiveToken_Denied verifies that with the MFA step-up gate
+// enabled and no token present, access to a restricted secret is denied.
+func TestStepUpGate_On_NoActiveToken_Denied(t *testing.T) {
+	c, _, _ := newMFATestCore(t)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
+
+	secret := &models.SecretNode{Name: "db-pass", Classification: ClassificationRestricted}
+	err := c.checkRestrictedSecretReadApproval(ctx, secret, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restricted")
+	assert.Contains(t, err.Error(), "MFA")
+}
+
+// TestStepUpGate_On_ActiveToken_Allowed verifies that a user with a valid
+// (non-expired) MFAStepupToken can pass the gate.
+func TestStepUpGate_On_ActiveToken_Allowed(t *testing.T) {
+	c, db, _ := newMFATestCore(t)
+	ctx := context.Background()
+	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
+
+	// Seed an active step-up token using real time (HasActiveMFAStepup uses time.Now).
+	future := time.Now().Add(15 * time.Minute)
+	require.NoError(t, db.Create(&models.MFAStepupToken{UserID: 1, ExpiresAt: future}).Error)
+
+	secret := &models.SecretNode{Name: "db-pass", Classification: ClassificationRestricted}
+	err := c.checkRestrictedSecretReadApproval(ctx, secret, 1)
+	require.NoError(t, err, "active MFA step-up token must let the gate pass")
+}
+
+// TestStepUpGate_LowerClassification_NeverGated verifies that the MFA step-up gate
+// only applies to "restricted" classified secrets and leaves lower tiers alone.
+func TestStepUpGate_LowerClassification_NeverGated(t *testing.T) {
+	for _, level := range []string{ClassificationPublic, ClassificationInternal, ClassificationConfidential, ""} {
+		t.Run("classification="+level, func(t *testing.T) {
+			c, _, _ := newMFATestCore(t)
+			ctx := context.Background()
+			c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
+
+			// No step-up token seeded — but the gate must not trigger for lower tiers.
+			secret := &models.SecretNode{Name: "db-pass", Classification: level}
+			err := c.checkRestrictedSecretReadApproval(ctx, secret, 1)
+			require.NoError(t, err, "MFA step-up gate must not apply to %q-classified secrets", level)
+		})
+	}
+}

--- a/internal/core/mfa_stepup_test.go
+++ b/internal/core/mfa_stepup_test.go
@@ -1,0 +1,164 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifyMFAStepUp_UserNotFound verifies that a missing user returns an error.
+func TestVerifyMFAStepUp_UserNotFound(t *testing.T) {
+	c, _, _ := newMFATestCore(t)
+	err := c.VerifyMFAStepUp(context.Background(), 9999, "000000")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user not found")
+}
+
+// TestVerifyMFAStepUp_InactiveAccount verifies that an inactive account is rejected.
+func TestVerifyMFAStepUp_InactiveAccount(t *testing.T) {
+	c, db, _ := newMFATestCore(t)
+	// Mark alice as deprovisioned (AccountLoginBlocked returns true for this state).
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", 1).Update("account_state", AccountDeprovisioned).Error)
+
+	err := c.VerifyMFAStepUp(context.Background(), 1, "000000")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not active")
+}
+
+// TestVerifyMFAStepUp_AccountLocked verifies that a locked-out account is rejected.
+func TestVerifyMFAStepUp_AccountLocked(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	c.loginLockout = LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: time.Hour, BaseCooldown: 15 * time.Minute, MaxCooldown: time.Hour}
+
+	// Manually set the lock to be active.
+	lockedUntil := fixed.Add(time.Hour)
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", 1).Update("login_locked_until", lockedUntil).Error)
+
+	err := c.VerifyMFAStepUp(context.Background(), 1, "000000")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "locked")
+}
+
+// TestVerifyMFAStepUp_MFANotEnabled verifies that a user without MFA cannot step-up.
+func TestVerifyMFAStepUp_MFANotEnabled(t *testing.T) {
+	c, _, _ := newMFATestCore(t)
+	// alice was created without MFA enabled (MFAEnabled defaults to false).
+	err := c.VerifyMFAStepUp(context.Background(), 1, "000000")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MFA is not enabled")
+}
+
+// TestVerifyMFAStepUp_WrongCode verifies that an incorrect TOTP code is rejected.
+func TestVerifyMFAStepUp_WrongCode(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	activateMFAForTest(t, c, fixed)
+
+	err := c.VerifyMFAStepUp(ctx, 1, "000000")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid code")
+}
+
+// TestVerifyMFAStepUp_CorrectTOTPCode_TokenUpserted verifies that a correct TOTP code
+// successfully upserts an MFAStepupToken into the database.
+func TestVerifyMFAStepUp_CorrectTOTPCode_TokenUpserted(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	secret, _ := activateMFAForTest(t, c, fixed)
+
+	code, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+
+	err = c.VerifyMFAStepUp(ctx, 1, code)
+	require.NoError(t, err)
+
+	// Verify the token was written to the DB. HasActiveMFAStepup uses time.Now()
+	// internally; since the core clock is fixed to the past, check the row directly.
+	var tok models.MFAStepupToken
+	require.NoError(t, db.Where("user_id = ?", 1).First(&tok).Error,
+		"VerifyMFAStepUp must write an MFAStepupToken row")
+	assert.Equal(t, uint(1), tok.UserID)
+}
+
+// TestVerifyMFAStepUp_CorrectRecoveryCode_TokenUpserted verifies that a correct recovery
+// code also successfully upserts an MFAStepupToken.
+func TestVerifyMFAStepUp_CorrectRecoveryCode_TokenUpserted(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	_, codes := activateMFAForTest(t, c, fixed)
+
+	err := c.VerifyMFAStepUp(ctx, 1, codes[0])
+	require.NoError(t, err)
+
+	// Verify the token was written to the DB. HasActiveMFAStepup uses time.Now()
+	// internally; since the core clock is fixed to the past, check the row directly.
+	var tok models.MFAStepupToken
+	require.NoError(t, db.Where("user_id = ?", 1).First(&tok).Error,
+		"VerifyMFAStepUp via recovery code must write an MFAStepupToken row")
+	assert.Equal(t, uint(1), tok.UserID)
+}
+
+// TestVerifyMFAStepUp_AntiReplay_SameTOTPStepRejectedTwice verifies that replaying the
+// same TOTP code within the same step window is rejected by the anti-replay check.
+func TestVerifyMFAStepUp_AntiReplay_SameTOTPStepRejectedTwice(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	secret, _ := activateMFAForTest(t, c, fixed)
+
+	code, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+
+	// First use must succeed.
+	err = c.VerifyMFAStepUp(ctx, 1, code)
+	require.NoError(t, err)
+
+	// Second use of the same code must be rejected.
+	err = c.VerifyMFAStepUp(ctx, 1, code)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid code", "replaying the same TOTP step must be rejected")
+}
+
+// TestHasActiveMFAStepUp_NoToken verifies that a user with no token returns false.
+func TestHasActiveMFAStepUp_NoToken(t *testing.T) {
+	c, _, _ := newMFATestCore(t)
+	ctx := context.Background()
+
+	active, err := c.HasActiveMFAStepUp(ctx, 1)
+	require.NoError(t, err)
+	assert.False(t, active, "no token — HasActiveMFAStepUp must return false")
+}
+
+// TestHasActiveMFAStepUp_ExpiredToken verifies that an expired token is treated as absent.
+func TestHasActiveMFAStepUp_ExpiredToken(t *testing.T) {
+	c, db, _ := newMFATestCore(t)
+	ctx := context.Background()
+
+	// Insert an already-expired token directly. HasActiveMFAStepup compares against
+	// time.Now(), so use a real past time regardless of the core's fixed clock.
+	expiredAt := time.Now().Add(-1 * time.Minute)
+	require.NoError(t, db.Create(&models.MFAStepupToken{UserID: 1, ExpiresAt: expiredAt}).Error)
+
+	active, err := c.HasActiveMFAStepUp(ctx, 1)
+	require.NoError(t, err)
+	assert.False(t, active, "expired token must not be treated as active")
+}
+
+// TestHasActiveMFAStepUp_ActiveToken verifies that a non-expired token returns true.
+func TestHasActiveMFAStepUp_ActiveToken(t *testing.T) {
+	c, db, _ := newMFATestCore(t)
+	ctx := context.Background()
+
+	// Insert a future-expiring token directly. HasActiveMFAStepup compares against
+	// time.Now(), so use a real future time regardless of the core's fixed clock.
+	future := time.Now().Add(15 * time.Minute)
+	require.NoError(t, db.Create(&models.MFAStepupToken{UserID: 1, ExpiresAt: future}).Error)
+
+	active, err := c.HasActiveMFAStepUp(ctx, 1)
+	require.NoError(t, err)
+	assert.True(t, active, "active (non-expired) token must return true")
+}

--- a/internal/core/mfa_stepup_test.go
+++ b/internal/core/mfa_stepup_test.go
@@ -64,9 +64,9 @@ func TestVerifyMFAStepUp_WrongCode(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid code")
 }
 
-// TestVerifyMFAStepUp_CorrectTOTPCode_TokenUpserted verifies that a correct TOTP code
-// successfully upserts an MFAStepupToken into the database.
-func TestVerifyMFAStepUp_CorrectTOTPCode_TokenUpserted(t *testing.T) {
+// TestVerifyMFAStepUp_CorrectTOTPCode_GrantCreated verifies that a correct TOTP code
+// successfully creates an MFAStepUpGrant in the database.
+func TestVerifyMFAStepUp_CorrectTOTPCode_GrantCreated(t *testing.T) {
 	c, db, fixed := newMFATestCore(t)
 	ctx := context.Background()
 	secret, _ := activateMFAForTest(t, c, fixed)
@@ -77,17 +77,17 @@ func TestVerifyMFAStepUp_CorrectTOTPCode_TokenUpserted(t *testing.T) {
 	err = c.VerifyMFAStepUp(ctx, 1, code)
 	require.NoError(t, err)
 
-	// Verify the token was written to the DB. HasActiveMFAStepup uses time.Now()
-	// internally; since the core clock is fixed to the past, check the row directly.
-	var tok models.MFAStepupToken
-	require.NoError(t, db.Where("user_id = ?", 1).First(&tok).Error,
-		"VerifyMFAStepUp must write an MFAStepupToken row")
-	assert.Equal(t, uint(1), tok.UserID)
+	// Verify the grant was written to the DB. The core clock is fixed; the grant
+	// should have ExpiresAt = fixed + mfaStepUpWindow (15 min).
+	var grant models.MFAStepUpGrant
+	require.NoError(t, db.Where("user_id = ?", 1).First(&grant).Error,
+		"VerifyMFAStepUp must write an MFAStepUpGrant row")
+	assert.Equal(t, uint(1), grant.UserID)
 }
 
-// TestVerifyMFAStepUp_CorrectRecoveryCode_TokenUpserted verifies that a correct recovery
-// code also successfully upserts an MFAStepupToken.
-func TestVerifyMFAStepUp_CorrectRecoveryCode_TokenUpserted(t *testing.T) {
+// TestVerifyMFAStepUp_CorrectRecoveryCode_GrantCreated verifies that a correct recovery
+// code also successfully creates an MFAStepUpGrant.
+func TestVerifyMFAStepUp_CorrectRecoveryCode_GrantCreated(t *testing.T) {
 	c, db, fixed := newMFATestCore(t)
 	ctx := context.Background()
 	_, codes := activateMFAForTest(t, c, fixed)
@@ -95,12 +95,11 @@ func TestVerifyMFAStepUp_CorrectRecoveryCode_TokenUpserted(t *testing.T) {
 	err := c.VerifyMFAStepUp(ctx, 1, codes[0])
 	require.NoError(t, err)
 
-	// Verify the token was written to the DB. HasActiveMFAStepup uses time.Now()
-	// internally; since the core clock is fixed to the past, check the row directly.
-	var tok models.MFAStepupToken
-	require.NoError(t, db.Where("user_id = ?", 1).First(&tok).Error,
-		"VerifyMFAStepUp via recovery code must write an MFAStepupToken row")
-	assert.Equal(t, uint(1), tok.UserID)
+	// Verify the grant was written to the DB.
+	var grant models.MFAStepUpGrant
+	require.NoError(t, db.Where("user_id = ?", 1).First(&grant).Error,
+		"VerifyMFAStepUp via recovery code must write an MFAStepUpGrant row")
+	assert.Equal(t, uint(1), grant.UserID)
 }
 
 // TestVerifyMFAStepUp_AntiReplay_SameTOTPStepRejectedTwice verifies that replaying the
@@ -123,42 +122,42 @@ func TestVerifyMFAStepUp_AntiReplay_SameTOTPStepRejectedTwice(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid code", "replaying the same TOTP step must be rejected")
 }
 
-// TestHasActiveMFAStepUp_NoToken verifies that a user with no token returns false.
-func TestHasActiveMFAStepUp_NoToken(t *testing.T) {
+// TestHasActiveMFAStepUp_NoGrant verifies that a user with no grant returns false.
+func TestHasActiveMFAStepUp_NoGrant(t *testing.T) {
 	c, _, _ := newMFATestCore(t)
 	ctx := context.Background()
 
 	active, err := c.HasActiveMFAStepUp(ctx, 1)
 	require.NoError(t, err)
-	assert.False(t, active, "no token — HasActiveMFAStepUp must return false")
+	assert.False(t, active, "no grant — HasActiveMFAStepUp must return false")
 }
 
-// TestHasActiveMFAStepUp_ExpiredToken verifies that an expired token is treated as absent.
-func TestHasActiveMFAStepUp_ExpiredToken(t *testing.T) {
-	c, db, _ := newMFATestCore(t)
+// TestHasActiveMFAStepUp_ExpiredGrant verifies that an expired grant is treated as absent.
+func TestHasActiveMFAStepUp_ExpiredGrant(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
 	ctx := context.Background()
 
-	// Insert an already-expired token directly. HasActiveMFAStepup compares against
-	// time.Now(), so use a real past time regardless of the core's fixed clock.
-	expiredAt := time.Now().Add(-1 * time.Minute)
-	require.NoError(t, db.Create(&models.MFAStepupToken{UserID: 1, ExpiresAt: expiredAt}).Error)
+	// Insert an already-expired grant directly. The core clock is fixed (to the
+	// past), so use a time even further in the past to ensure it's expired
+	// relative to the fixed clock.
+	expiredAt := fixed.Add(-1 * time.Minute)
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: expiredAt}).Error)
 
 	active, err := c.HasActiveMFAStepUp(ctx, 1)
 	require.NoError(t, err)
-	assert.False(t, active, "expired token must not be treated as active")
+	assert.False(t, active, "expired grant must not be treated as active")
 }
 
-// TestHasActiveMFAStepUp_ActiveToken verifies that a non-expired token returns true.
-func TestHasActiveMFAStepUp_ActiveToken(t *testing.T) {
-	c, db, _ := newMFATestCore(t)
+// TestHasActiveMFAStepUp_ActiveGrant verifies that a non-expired grant returns true.
+func TestHasActiveMFAStepUp_ActiveGrant(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
 	ctx := context.Background()
 
-	// Insert a future-expiring token directly. HasActiveMFAStepup compares against
-	// time.Now(), so use a real future time regardless of the core's fixed clock.
-	future := time.Now().Add(15 * time.Minute)
-	require.NoError(t, db.Create(&models.MFAStepupToken{UserID: 1, ExpiresAt: future}).Error)
+	// Insert a future-expiring grant relative to the fixed clock.
+	future := fixed.Add(15 * time.Minute)
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: future}).Error)
 
 	active, err := c.HasActiveMFAStepUp(ctx, 1)
 	require.NoError(t, err)
-	assert.True(t, active, "active (non-expired) token must return true")
+	assert.True(t, active, "active (non-expired) grant must return true")
 }

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -28,7 +28,7 @@ func newMFATestCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.MFASecret{},
 		&models.MFARecoveryCode{}, &models.MFAChallenge{}, &models.Session{}, &models.AuditEvent{},
-		&models.MFAStepupToken{}))
+		&models.MFAStepupToken{}, &models.MFAStepUpGrant{}))
 	hash, _ := bcrypt.GenerateFromPassword([]byte(mfaTestPassword), bcrypt.DefaultCost)
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@b.com",
 		PasswordHash: string(hash), AccountState: "active"}).Error)

--- a/internal/core/mock_storage_classification_mfa_stepup_test.go
+++ b/internal/core/mock_storage_classification_mfa_stepup_test.go
@@ -3,6 +3,8 @@ package core
 import (
 	"context"
 	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 func (m *MockStorage) UpsertMFAStepupToken(_ context.Context, _ uint, _ time.Time) error {
@@ -11,4 +13,16 @@ func (m *MockStorage) UpsertMFAStepupToken(_ context.Context, _ uint, _ time.Tim
 
 func (m *MockStorage) HasActiveMFAStepup(_ context.Context, _ uint) (bool, error) {
 	return false, nil
+}
+
+func (m *MockStorage) CreateMFAStepUpGrant(_ context.Context, _ *models.MFAStepUpGrant) error {
+	return nil
+}
+
+func (m *MockStorage) GetActiveMFAStepUpGrant(_ context.Context, _ uint, _ time.Time) (*models.MFAStepUpGrant, error) {
+	return nil, nil
+}
+
+func (m *MockStorage) DeleteMFAStepUpGrantsFor(_ context.Context, _ uint) error {
+	return nil
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1152,6 +1152,15 @@ type Storage interface {
 	// gate and MFA step-up token both live on the same server node.
 	HasActiveMFAStepup(ctx context.Context, userID uint) (bool, error)
 
+	// CreateMFAStepUpGrant persists a new MFA step-up grant for userID.
+	CreateMFAStepUpGrant(ctx context.Context, grant *models.MFAStepUpGrant) error
+	// GetActiveMFAStepUpGrant returns the most recent non-expired MFA step-up
+	// grant for userID as of now, or (nil, nil) when none exists.
+	GetActiveMFAStepUpGrant(ctx context.Context, userID uint, now time.Time) (*models.MFAStepUpGrant, error)
+	// DeleteMFAStepUpGrantsFor removes all step-up grants for userID (used on
+	// session revocation or security-incident response).
+	DeleteMFAStepUpGrantsFor(ctx context.Context, userID uint) error
+
 	// WebAuthn / passkeys (ADR-036).
 	CreateWebAuthnCredential(ctx context.Context, c *models.WebAuthnCredential) error
 	ListWebAuthnCredentials(ctx context.Context, userID uint) ([]*models.WebAuthnCredential, error)

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -403,6 +403,26 @@ type MFAStepupToken struct {
 	CreatedAt time.Time
 }
 
+// MFAStepUpGrant records that a user explicitly re-verified their second factor
+// (via VerifyMFAStepUp) to gain a time-limited window for reading
+// restricted-classified secrets. Unlike MFAStepupToken (which is upserted on
+// every MFA login), grants are created per-verification and queried by
+// the classification gate. One active grant per user at any time is enough;
+// expired rows are left in place for audit purposes.
+type MFAStepUpGrant struct {
+	ID        uint      `gorm:"primarykey" json:"id"`
+	UserID    uint      `gorm:"not null;index" json:"user_id"`
+	ExpiresAt time.Time `gorm:"not null" json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// BeforeSave normalises ExpiresAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone.
+func (g *MFAStepUpGrant) BeforeSave(_ *gorm.DB) error {
+	g.ExpiresAt = g.ExpiresAt.UTC()
+	return nil
+}
+
 // MFAChallenge is a short-lived, single-use pre-auth token issued when an
 // MFA-enabled user passes the password step; the verify step consumes it. The
 // raw token is never stored — only its SHA-256 hash.

--- a/internal/storage/store/local_mfa_stepup_grant.go
+++ b/internal/storage/store/local_mfa_stepup_grant.go
@@ -1,0 +1,38 @@
+// local_mfa_stepup_grant.go — MFAStepUpGrant persistence for LocalStorage.
+// Each VerifyMFAStepUp call creates a new grant row; queries return the most
+// recent non-expired one. Expired rows are kept for audit purposes.
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+func (ls *LocalStorage) CreateMFAStepUpGrant(ctx context.Context, grant *models.MFAStepUpGrant) error {
+	return ls.db.WithContext(ctx).Create(grant).Error
+}
+
+func (ls *LocalStorage) GetActiveMFAStepUpGrant(ctx context.Context, userID uint, now time.Time) (*models.MFAStepUpGrant, error) {
+	var g models.MFAStepUpGrant
+	err := ls.db.WithContext(ctx).
+		Where("user_id = ? AND expires_at > ?", userID, now.UTC()).
+		Order("expires_at DESC").
+		First(&g).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &g, nil
+}
+
+func (ls *LocalStorage) DeleteMFAStepUpGrantsFor(ctx context.Context, userID uint) error {
+	return ls.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Delete(&models.MFAStepUpGrant{}).Error
+}

--- a/internal/storage/store/remote_mfa_stepup_grant.go
+++ b/internal/storage/store/remote_mfa_stepup_grant.go
@@ -1,0 +1,108 @@
+// remote_mfa_stepup_grant.go — MFAStepUpGrant persistence for RemoteStorage.
+// These proxy the three MFAStepUpGrant storage primitives to the server-side
+// endpoints in server/http/handlers/mfa_stepup_proxy.go, following the same
+// pattern as the other RemoteStorage proxy methods in remote_mfa.go.
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// mfaStepUpGrantWire mirrors models.MFAStepUpGrant on the wire.
+type mfaStepUpGrantWire struct {
+	ID        uint      `json:"id"`
+	UserID    uint      `json:"user_id"`
+	ExpiresAt time.Time `json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func newMFAStepUpGrantWire(g *models.MFAStepUpGrant) mfaStepUpGrantWire {
+	return mfaStepUpGrantWire{
+		ID:        g.ID,
+		UserID:    g.UserID,
+		ExpiresAt: g.ExpiresAt,
+		CreatedAt: g.CreatedAt,
+	}
+}
+
+func (w mfaStepUpGrantWire) toModel() *models.MFAStepUpGrant {
+	return &models.MFAStepUpGrant{
+		ID:        w.ID,
+		UserID:    w.UserID,
+		ExpiresAt: w.ExpiresAt,
+		CreatedAt: w.CreatedAt,
+	}
+}
+
+func decodeMFAStepUpGrantResponse(data []byte) (*models.MFAStepUpGrant, error) {
+	var wire mfaStepUpGrantWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse MFA step-up grant response: %w", err)
+	}
+	return wire.toModel(), nil
+}
+
+// mfaStepUpGrantActiveWire is the request body for GetActiveMFAStepUpGrant.
+type mfaStepUpGrantActiveWire struct {
+	UserID uint      `json:"user_id"`
+	Now    time.Time `json:"now"`
+}
+
+// CreateMFAStepUpGrant persists a new MFA step-up grant via
+// POST /api/v1/system/mfa/stepup-grants, copying the upstream-assigned
+// fields (ID, CreatedAt) back into grant.
+func (rs *RemoteStorage) CreateMFAStepUpGrant(ctx context.Context, grant *models.MFAStepUpGrant) error {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/mfa/stepup-grants", newMFAStepUpGrantWire(grant))
+	if err != nil {
+		return fmt.Errorf("failed to create MFA step-up grant: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("create MFA step-up grant failed: %s", resp.Error.Error())
+	}
+	saved, err := decodeMFAStepUpGrantResponse(resp.Data)
+	if err != nil {
+		return err
+	}
+	*grant = *saved
+	return nil
+}
+
+// GetActiveMFAStepUpGrant returns the most recent non-expired MFA step-up
+// grant for userID via POST /api/v1/system/mfa/stepup-grants/active.
+// Returns (nil, nil) when the server returns null data (no active grant).
+func (rs *RemoteStorage) GetActiveMFAStepUpGrant(ctx context.Context, userID uint, now time.Time) (*models.MFAStepUpGrant, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/mfa/stepup-grants/active", mfaStepUpGrantActiveWire{
+		UserID: userID,
+		Now:    now,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active MFA step-up grant: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get active MFA step-up grant failed: %s", resp.Error.Error())
+	}
+	// data is null when no active grant exists.
+	if len(resp.Data) == 0 || string(resp.Data) == "null" {
+		return nil, nil
+	}
+	return decodeMFAStepUpGrantResponse(resp.Data)
+}
+
+// DeleteMFAStepUpGrantsFor removes all step-up grants for userID via
+// DELETE /api/v1/system/mfa/stepup-grants/{userID}.
+func (rs *RemoteStorage) DeleteMFAStepUpGrantsFor(ctx context.Context, userID uint) error {
+	path := fmt.Sprintf("/api/v1/system/mfa/stepup-grants/%d", userID)
+	resp, err := rs.client.Delete(ctx, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete MFA step-up grants: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete MFA step-up grants failed: %s", resp.Error.Error())
+	}
+	return nil
+}

--- a/internal/storage/store/remote_mfa_stepup_grant_test.go
+++ b/internal/storage/store/remote_mfa_stepup_grant_test.go
@@ -1,0 +1,220 @@
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteStorage_CreateMFAStepUpGrant_Success(t *testing.T) {
+	exp := time.Now().UTC().Add(15 * time.Minute)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/stepup-grants", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":         uint(7),
+			"user_id":    uint(42),
+			"expires_at": exp,
+			"created_at": time.Now().UTC(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	grant := &models.MFAStepUpGrant{UserID: 42, ExpiresAt: exp}
+	err = rs.CreateMFAStepUpGrant(context.Background(), grant)
+	require.NoError(t, err)
+	assert.Equal(t, uint(7), grant.ID)
+	assert.Equal(t, uint(42), grant.UserID)
+}
+
+func TestRemoteStorage_CreateMFAStepUpGrant_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"STORAGE_ERROR","message":"db down"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateMFAStepUpGrant(context.Background(), &models.MFAStepUpGrant{
+		UserID:    42,
+		ExpiresAt: time.Now().UTC().Add(15 * time.Minute),
+	})
+	require.Error(t, err)
+}
+
+func TestRemoteStorage_CreateMFAStepUpGrant_SuccessFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"CONFLICT","message":"already exists"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateMFAStepUpGrant(context.Background(), &models.MFAStepUpGrant{
+		UserID:    42,
+		ExpiresAt: time.Now().UTC().Add(15 * time.Minute),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create MFA step-up grant failed")
+}
+
+func TestRemoteStorage_CreateMFAStepUpGrant_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{bad json}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateMFAStepUpGrant(context.Background(), &models.MFAStepUpGrant{
+		UserID:    42,
+		ExpiresAt: time.Now().UTC().Add(15 * time.Minute),
+	})
+	require.Error(t, err)
+}
+
+func TestRemoteStorage_GetActiveMFAStepUpGrant_Success(t *testing.T) {
+	now := time.Now().UTC()
+	exp := now.Add(10 * time.Minute)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/stepup-grants/active", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id":         uint(3),
+			"user_id":    uint(42),
+			"expires_at": exp,
+			"created_at": now,
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, now)
+	require.NoError(t, err)
+	require.NotNil(t, g)
+	assert.Equal(t, uint(3), g.ID)
+	assert.Equal(t, uint(42), g.UserID)
+}
+
+func TestRemoteStorage_GetActiveMFAStepUpGrant_NullResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Server returns {"success":true,"data":null} — no active grant.
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, time.Now().UTC())
+	require.NoError(t, err)
+	assert.Nil(t, g, "null data must decode as (nil, nil)")
+}
+
+func TestRemoteStorage_GetActiveMFAStepUpGrant_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"STORAGE_ERROR","message":"db down"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, time.Now().UTC())
+	require.Error(t, err)
+	assert.Nil(t, g)
+}
+
+func TestRemoteStorage_GetActiveMFAStepUpGrant_SuccessFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"STORAGE_ERROR","message":"db down"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, time.Now().UTC())
+	require.Error(t, err)
+	assert.Nil(t, g)
+	assert.Contains(t, err.Error(), "get active MFA step-up grant failed")
+}
+
+func TestRemoteStorage_GetActiveMFAStepUpGrant_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{bad json}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, time.Now().UTC())
+	require.Error(t, err)
+	assert.Nil(t, g)
+}
+
+func TestRemoteStorage_DeleteMFAStepUpGrantsFor_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/stepup-grants/42", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]bool{"deleted": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteMFAStepUpGrantsFor(context.Background(), 42)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_DeleteMFAStepUpGrantsFor_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"STORAGE_ERROR","message":"db down"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteMFAStepUpGrantsFor(context.Background(), 42)
+	require.Error(t, err)
+}
+
+func TestRemoteStorage_DeleteMFAStepUpGrantsFor_SuccessFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"NOT_FOUND","message":"not found"}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteMFAStepUpGrantsFor(context.Background(), 42)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete MFA step-up grants failed")
+}

--- a/server/http/handlers/mfa_stepup.go
+++ b/server/http/handlers/mfa_stepup.go
@@ -1,0 +1,41 @@
+// mfa_stepup.go — HTTP handler for explicit MFA step-up re-verification.
+// POST /api/v1/auth/mfa/stepup lets an already-authenticated user re-verify
+// their TOTP code (or a recovery code) to open a 15-minute window for reading
+// "restricted" classified secrets without going through a full re-login.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// MFAStepUp handles POST /api/v1/auth/mfa/stepup. The caller must be
+// authenticated (session or PAT). On success, a short-lived MFAStepupToken is
+// recorded server-side, enabling the classification gate to permit reads of
+// "restricted" secrets for the configured window (default 15 minutes).
+func (h *AuthHandler) MFAStepUp(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sendError(w, "BadRequest", errInvalidRequestBody, http.StatusBadRequest, nil)
+		return
+	}
+	if strings.TrimSpace(body.Code) == "" {
+		sendError(w, "BadRequest", "code is required", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.VerifyMFAStepUp(r.Context(), userCtx.UserID, body.Code); err != nil {
+		sendError(w, "Unauthorized", err.Error(), http.StatusUnauthorized, nil)
+		return
+	}
+	sendSuccess(w, nil, "MFA step-up verified. Restricted secrets are accessible for 15 minutes.")
+}

--- a/server/http/handlers/mfa_stepup_handler_test.go
+++ b/server/http/handlers/mfa_stepup_handler_test.go
@@ -1,0 +1,134 @@
+// mfa_stepup_handler_test.go — HTTP handler tests for POST /api/v1/auth/mfa/stepup.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const stepUpTestPassword = "Secret#Passw0rd!"
+
+// setupMFAStepUpTest builds an AuthHandler over real SQLite with an enabled encryptor
+// (TOTP secrets are encrypted at rest), seeding user id 1 = "alice" with a known password.
+func setupMFAStepUpTest(t *testing.T) (*AuthHandler, *core.KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"}}))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.MFASecret{}, &models.MFARecoveryCode{},
+		&models.MFAChallenge{}, &models.Session{}, &models.AuditEvent{},
+		&models.MFAStepupToken{},
+	))
+	hash, err := bcrypt.GenerateFromPassword([]byte(stepUpTestPassword), bcrypt.MinCost)
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@b.com",
+		PasswordHash: string(hash), AccountState: "active"}).Error)
+
+	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
+	require.NoError(t, enc.Initialize("test-passphrase"))
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	coreService.SetAuthEncryptor(enc)
+
+	return NewAuthHandler(coreService, false), coreService, db
+}
+
+// activateMFAForStepUpTest enrolls and activates MFA for user 1 using the real clock,
+// returning the base32 secret and initial recovery codes.
+func activateMFAForStepUpTest(t *testing.T, coreService *core.KeyorixCore) (secret string, codes []string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now()
+
+	_, secret, err := coreService.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+
+	// Activate using the previous step so the current step remains available for test calls.
+	actCode, err := totp.GenerateCode(secret, now.Add(-30*time.Second))
+	require.NoError(t, err)
+	codes, err = coreService.ActivateMFA(ctx, 1, actCode, stepUpTestPassword)
+	require.NoError(t, err)
+	return secret, codes
+}
+
+// TestMFAStepUpHandler_NoUserContext_Unauthorized verifies that a request without
+// a user context is rejected with 401.
+func TestMFAStepUpHandler_NoUserContext_Unauthorized(t *testing.T) {
+	h, _, _ := setupMFAStepUpTest(t)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/auth/mfa/stepup",
+		bytes.NewBufferString(`{"code":"123456"}`))
+	rr := httptest.NewRecorder()
+	h.MFAStepUp(rr, r)
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// TestMFAStepUpHandler_BadJSON_BadRequest verifies that malformed JSON is rejected with 400.
+func TestMFAStepUpHandler_BadJSON_BadRequest(t *testing.T) {
+	h, _, _ := setupMFAStepUpTest(t)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/auth/mfa/stepup",
+		bytes.NewBufferString(`{not-json}`))
+	r = withUserContext(r, 1)
+	rr := httptest.NewRecorder()
+	h.MFAStepUp(rr, r)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// TestMFAStepUpHandler_EmptyCode_BadRequest verifies that a request with an empty code
+// is rejected with 400.
+func TestMFAStepUpHandler_EmptyCode_BadRequest(t *testing.T) {
+	h, _, _ := setupMFAStepUpTest(t)
+
+	r := postJSON("/api/v1/auth/mfa/stepup", map[string]string{"code": ""}, 1)
+	rr := httptest.NewRecorder()
+	h.MFAStepUp(rr, r)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// TestMFAStepUpHandler_WrongCode_Unauthorized verifies that an incorrect TOTP code
+// is rejected with 401.
+func TestMFAStepUpHandler_WrongCode_Unauthorized(t *testing.T) {
+	h, coreService, _ := setupMFAStepUpTest(t)
+	activateMFAForStepUpTest(t, coreService)
+
+	r := postJSON("/api/v1/auth/mfa/stepup", map[string]string{"code": "000000"}, 1)
+	rr := httptest.NewRecorder()
+	h.MFAStepUp(rr, r)
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// TestMFAStepUpHandler_CorrectCode_Success verifies that a correct TOTP code returns 200
+// and the success message.
+func TestMFAStepUpHandler_CorrectCode_Success(t *testing.T) {
+	h, coreService, _ := setupMFAStepUpTest(t)
+	secret, _ := activateMFAForStepUpTest(t, coreService)
+
+	code, err := totp.GenerateCode(secret, time.Now())
+	require.NoError(t, err)
+
+	r := postJSON("/api/v1/auth/mfa/stepup", map[string]string{"code": code}, 1)
+	rr := httptest.NewRecorder()
+	h.MFAStepUp(rr, r)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	assert.Contains(t, rr.Body.String(), "step-up verified")
+}

--- a/server/http/handlers/mfa_stepup_handler_test.go
+++ b/server/http/handlers/mfa_stepup_handler_test.go
@@ -36,7 +36,7 @@ func setupMFAStepUpTest(t *testing.T) (*AuthHandler, *core.KeyorixCore, *gorm.DB
 	require.NoError(t, db.AutoMigrate(
 		&models.User{}, &models.MFASecret{}, &models.MFARecoveryCode{},
 		&models.MFAChallenge{}, &models.Session{}, &models.AuditEvent{},
-		&models.MFAStepupToken{},
+		&models.MFAStepupToken{}, &models.MFAStepUpGrant{},
 	))
 	hash, err := bcrypt.GenerateFromPassword([]byte(stepUpTestPassword), bcrypt.MinCost)
 	require.NoError(t, err)

--- a/server/http/handlers/mfa_stepup_proxy.go
+++ b/server/http/handlers/mfa_stepup_proxy.go
@@ -1,0 +1,104 @@
+// mfa_stepup_proxy.go — server-side endpoints backing RemoteStorage's
+// MFAStepUpGrant storage primitives:
+// CreateMFAStepUpGrant / GetActiveMFAStepUpGrant / DeleteMFAStepUpGrantsFor.
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049)
+// proxies these calls to this server's real storage backend so that the MFA
+// step-up gate works correctly in multi-node cluster deployments. Follows the
+// same pattern as mfa_management_proxy.go: thin passthroughs onto
+// storage.Storage, no policy decisions made here, system.read/system.write
+// RBAC tier, exact {"success":bool,"data":...} envelope.
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// mfaStepUpGrantProxyBody is the wire body for CreateMFAStepUpGrantProxy and
+// is also used to parse GetActiveMFAStepUpGrantProxy's {user_id, now} pair.
+type mfaStepUpGrantProxyBody struct {
+	UserID    uint      `json:"user_id"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// mfaStepUpGrantActiveProxyBody is the wire body for
+// GetActiveMFAStepUpGrantProxy.
+type mfaStepUpGrantActiveProxyBody struct {
+	UserID uint      `json:"user_id"`
+	Now    time.Time `json:"now"`
+}
+
+// CreateMFAStepUpGrantProxy handles POST /api/v1/system/mfa/stepup-grants.
+// Creates a new MFAStepUpGrant row and returns it with server-assigned fields.
+func (h *AuthHandler) CreateMFAStepUpGrantProxy(w http.ResponseWriter, r *http.Request) {
+	var body mfaStepUpGrantProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
+		return
+	}
+	if body.UserID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id is required")
+		return
+	}
+	grant := &models.MFAStepUpGrant{
+		UserID:    body.UserID,
+		ExpiresAt: body.ExpiresAt,
+	}
+	if err := h.coreService.Storage().CreateMFAStepUpGrant(r.Context(), grant); err != nil {
+		log.Printf("mfa stepup proxy: create grant failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, grant)
+}
+
+// GetActiveMFAStepUpGrantProxy handles POST
+// /api/v1/system/mfa/stepup-grants/active. Returns the most recent
+// non-expired grant for the given user, or null in the data field when none
+// exists.
+func (h *AuthHandler) GetActiveMFAStepUpGrantProxy(w http.ResponseWriter, r *http.Request) {
+	var body mfaStepUpGrantActiveProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
+		return
+	}
+	if body.UserID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id is required")
+		return
+	}
+	grant, err := h.coreService.Storage().GetActiveMFAStepUpGrant(r.Context(), body.UserID, body.Now)
+	if err != nil {
+		log.Printf("mfa stepup proxy: get active grant failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	// grant is nil when no active grant exists; writeRemoteAPISuccess encodes
+	// it as {"success":true,"data":null} which the remote client treats as
+	// (nil, nil).
+	writeRemoteAPISuccess(w, grant)
+}
+
+// DeleteMFAStepUpGrantsForProxy handles DELETE
+// /api/v1/system/mfa/stepup-grants/{userId}. Removes all step-up grants for
+// the given user (session revocation / security-incident response).
+func (h *AuthHandler) DeleteMFAStepUpGrantsForProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "userId"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid user id")
+		return
+	}
+	userID := uint(id)
+	if err := h.coreService.Storage().DeleteMFAStepUpGrantsFor(r.Context(), userID); err != nil {
+		log.Printf("mfa stepup proxy: delete grants failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}

--- a/server/http/handlers/mfa_stepup_proxy_test.go
+++ b/server/http/handlers/mfa_stepup_proxy_test.go
@@ -1,0 +1,228 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var stepupProxyDBCounter atomic.Int64
+
+// freshCoreWithStepUpGrant builds a core that has the MFAStepUpGrant table and
+// seeds one active grant for user 1 at the given expiry.
+func freshCoreWithStepUpGrant(t *testing.T, expiry time.Time) (*AuthHandler, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+
+	n := stepupProxyDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxstepupprx_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{},
+		&models.MFAStepUpGrant{}, &models.AuditEvent{},
+	))
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{
+		UserID:    1,
+		ExpiresAt: expiry,
+	}).Error)
+
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	return NewAuthHandler(cs, false), db
+}
+
+// ── CreateMFAStepUpGrantProxy ─────────────────────────────────────────────────
+
+func TestCreateMFAStepUpGrantProxy_BadJSON(t *testing.T) {
+	h := freshClosedCoreS21(t)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants",
+		bytes.NewReader([]byte("{bad json}")))
+	w := httptest.NewRecorder()
+	h.CreateMFAStepUpGrantProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateMFAStepUpGrantProxy_MissingUserID(t *testing.T) {
+	h := freshClosedCoreS21(t)
+	body, _ := json.Marshal(map[string]interface{}{
+		"user_id":    0,
+		"expires_at": time.Now().UTC().Add(15 * time.Minute),
+	})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.CreateMFAStepUpGrantProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateMFAStepUpGrantProxy_StorageError(t *testing.T) {
+	h := freshClosedCoreS21(t)
+	body, _ := json.Marshal(map[string]interface{}{
+		"user_id":    1,
+		"expires_at": time.Now().UTC().Add(15 * time.Minute),
+	})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.CreateMFAStepUpGrantProxy(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestCreateMFAStepUpGrantProxy_Success(t *testing.T) {
+	h, _ := freshCoreWithStepUpGrant(t, time.Now().UTC().Add(10*time.Minute))
+	body, _ := json.Marshal(map[string]interface{}{
+		"user_id":    2,
+		"expires_at": time.Now().UTC().Add(15 * time.Minute),
+	})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.CreateMFAStepUpGrantProxy(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			UserID uint `json:"user_id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.Equal(t, uint(2), resp.Data.UserID)
+}
+
+// ── GetActiveMFAStepUpGrantProxy ──────────────────────────────────────────────
+
+func TestGetActiveMFAStepUpGrantProxy_BadJSON(t *testing.T) {
+	h := freshClosedCoreS21(t)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants/active",
+		bytes.NewReader([]byte("{bad json}")))
+	w := httptest.NewRecorder()
+	h.GetActiveMFAStepUpGrantProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetActiveMFAStepUpGrantProxy_MissingUserID(t *testing.T) {
+	h := freshClosedCoreS21(t)
+	body, _ := json.Marshal(map[string]interface{}{
+		"user_id": 0,
+		"now":     time.Now().UTC(),
+	})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants/active",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.GetActiveMFAStepUpGrantProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetActiveMFAStepUpGrantProxy_StorageError(t *testing.T) {
+	h := freshClosedCoreS21(t)
+	body, _ := json.Marshal(map[string]interface{}{
+		"user_id": 1,
+		"now":     time.Now().UTC(),
+	})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants/active",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.GetActiveMFAStepUpGrantProxy(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestGetActiveMFAStepUpGrantProxy_NoActiveGrant(t *testing.T) {
+	h, _ := freshCoreWithStepUpGrant(t, time.Now().UTC().Add(10*time.Minute))
+	// Ask for user 99 — no grant exists.
+	body, _ := json.Marshal(map[string]interface{}{
+		"user_id": 99,
+		"now":     time.Now().UTC(),
+	})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants/active",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.GetActiveMFAStepUpGrantProxy(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	// data is omitted (omitempty on nil) — no grant means no data field.
+	assert.NotContains(t, w.Body.String(), `"user_id"`)
+}
+
+func TestGetActiveMFAStepUpGrantProxy_ActiveGrant(t *testing.T) {
+	future := time.Now().UTC().Add(10 * time.Minute)
+	h, _ := freshCoreWithStepUpGrant(t, future)
+	body, _ := json.Marshal(map[string]interface{}{
+		"user_id": 1,
+		"now":     time.Now().UTC(),
+	})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants/active",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.GetActiveMFAStepUpGrantProxy(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			UserID uint `json:"user_id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.Equal(t, uint(1), resp.Data.UserID)
+}
+
+// ── DeleteMFAStepUpGrantsForProxy ─────────────────────────────────────────────
+
+func TestDeleteMFAStepUpGrantsForProxy_BadUserID(t *testing.T) {
+	h := freshClosedCoreS21(t)
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/system/mfa/stepup-grants/abc", nil)
+	r = withChiParams(r, map[string]string{"userId": "abc"})
+	w := httptest.NewRecorder()
+	h.DeleteMFAStepUpGrantsForProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDeleteMFAStepUpGrantsForProxy_StorageError(t *testing.T) {
+	h := freshClosedCoreS21(t)
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/system/mfa/stepup-grants/1", nil)
+	r = withChiParams(r, map[string]string{"userId": "1"})
+	w := httptest.NewRecorder()
+	h.DeleteMFAStepUpGrantsForProxy(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestDeleteMFAStepUpGrantsForProxy_Success(t *testing.T) {
+	h, _ := freshCoreWithStepUpGrant(t, time.Now().UTC().Add(10*time.Minute))
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/system/mfa/stepup-grants/1", nil)
+	r = withChiParams(r, map[string]string{"userId": "1"})
+	w := httptest.NewRecorder()
+	h.DeleteMFAStepUpGrantsForProxy(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Deleted bool `json:"deleted"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.True(t, resp.Data.Deleted)
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -327,6 +327,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/mfa/disable", authHandler.DisableMFA)
 		r.Get("/auth/mfa/recovery-codes", authHandler.RecoveryCodesStatus)
 		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/mfa/recovery-codes/regenerate", authHandler.RegenerateRecoveryCodes)
+		// Explicit MFA step-up: re-verify TOTP (or a recovery code) without re-logging
+		// in to open the 15-minute restricted-secret read window. Blocked under
+		// impersonation — an admin acting as a user must not be able to mint a step-up
+		// token on behalf of the target account.
+		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/mfa/stepup", authHandler.MFAStepUp)
 		// WebAuthn / passkey self-service (acts on the authenticated caller's account).
 		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/webauthn/register/begin", authHandler.BeginWebAuthnRegistration)
 		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/webauthn/register/finish", authHandler.FinishWebAuthnRegistration)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1743,6 +1743,15 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Delete("/mfa/recovery-codes/{userId}", authHandler.DeleteMFARecoveryCodesProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/mfa/totp-step-used", authHandler.MarkTOTPStepUsedProxy)
 
+			// MFAStepUpGrant proxy — lets a RemoteStorage spoke node persist and
+			// query step-up grants against this server's real storage backend, so
+			// the classification gate works correctly under storage.type: remote.
+			// Static sub-path ("stepup-grants/active") is registered before the
+			// {userId} wildcard to avoid route shadowing.
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/mfa/stepup-grants", authHandler.CreateMFAStepUpGrantProxy)
+			r.Post("/mfa/stepup-grants/active", authHandler.GetActiveMFAStepUpGrantProxy)
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Delete("/mfa/stepup-grants/{userId}", authHandler.DeleteMFAStepUpGrantsForProxy)
+
 			// Project/environment catalog CRUD storage-primitive proxy (finding #528).
 			// Lets a downstream Keyorix server booted with storage.type: remote
 			// (ADR-049) proxy ListProjects/ListProjectsWithCounts/GetProject/


### PR DESCRIPTION
## Summary

Implements explicit TOTP re-verification for already-logged-in users to gain a
time-limited window for reading `restricted`-classified secrets (deferred from
ADR-037). Feature is gated by `classification.restricted_requires_mfa_stepup`
config flag.

**What's in this PR:**

- `POST /api/v1/auth/mfa/stepup` — user presents their TOTP code (or recovery
  code); on success a `MFAStepUpGrant` is created with a configurable TTL
  (default 15 min via `classification.restricted_mfa_stepup_window_minutes`)
- `checkRestrictedMFAGate` in `classification_gate.go` — blocks reads of
  `restricted` secrets unless an active grant exists for the requesting user
- `MFAStepUpGrant` model (separate from `MFAStepupToken`) with `BeforeSave` UTC
  normalisation to avoid SQLite timezone-comparison bugs
- Local storage: `CreateMFAStepUpGrant`, `GetActiveMFAStepUpGrant`,
  `DeleteMFAStepUpGrantsFor` in `local_mfa_stepup_grant.go`
- Remote storage proxy (fixes `remoteUnsupported` gap): three
  `/api/v1/system/mfa/stepup-grants` endpoints forward step-up state to the
  primary node in multi-node deployments
- `keyorix auth mfa stepup --code <code>` CLI command (remote-only; direct
  installs use the HTTP endpoint)
- 39 new tests: 15 core, 5 user-facing handler, 12 proxy handler, 12 remote
  storage proxy

## Test plan

- [ ] `go test ./internal/core/... -run "TestVerifyMFAStepUp|TestHasActiveMFAStepUp|TestStepUpGate"` — 15 tests pass
- [ ] `go test ./server/http/handlers/... -run "TestMFAStepUp|TestCreateMFAStepUpGrantProxy|TestGetActiveMFAStepUpGrantProxy|TestDeleteMFAStepUpGrantsForProxy"` — 17 tests pass
- [ ] `go test ./internal/storage/store/... -run "TestRemoteStorage_CreateMFAStepUpGrant|TestRemoteStorage_GetActiveMFAStepUpGrant|TestRemoteStorage_DeleteMFAStepUpGrantsFor"` — 12 tests pass
- [ ] CI: lint + build-and-test green