### PR TITLE
feat(dashboard): extend deployment stats snapshot to cover all admin metrics

### DIFF
--- a/internal/core/dashboard.go
+++ b/internal/core/dashboard.go
@@ -51,10 +51,18 @@ type DashboardStats struct {
 	TotalSecretsTrend      *StatTrend `json:"totalSecretsTrend,omitempty"`
 	SharedSecretsTrend     *StatTrend `json:"sharedSecretsTrend,omitempty"`
 	SharedWithMeTrend      *StatTrend `json:"sharedWithMeTrend,omitempty"`
-	PrevActiveUsers        *int64     `json:"prevActiveUsers,omitempty"`
-	ActiveUsersTrend       *StatTrend `json:"activeUsersTrend,omitempty"`
-	PrevAuditEvents30d     *int64     `json:"prevAuditEvents30d,omitempty"`
-	AuditEvents30dTrend    *StatTrend `json:"auditEvents30dTrend,omitempty"`
+	PrevActiveUsers              *int64     `json:"prevActiveUsers,omitempty"`
+	ActiveUsersTrend             *StatTrend `json:"activeUsersTrend,omitempty"`
+	PrevAuditEvents30d           *int64     `json:"prevAuditEvents30d,omitempty"`
+	AuditEvents30dTrend          *StatTrend `json:"auditEvents30dTrend,omitempty"`
+	PrevAuditLogins30d           *int64     `json:"prevAuditLogins30d,omitempty"`
+	AuditLogins30dTrend          *StatTrend `json:"auditLogins30dTrend,omitempty"`
+	PrevAuditSecretReads30d      *int64     `json:"prevAuditSecretReads30d,omitempty"`
+	AuditSecretReads30dTrend     *StatTrend `json:"auditSecretReads30dTrend,omitempty"`
+	PrevFailedAuthAttempts24h    *int64     `json:"prevFailedAuthAttempts24h,omitempty"`
+	FailedAuthAttempts24hTrend   *StatTrend `json:"failedAuthAttempts24hTrend,omitempty"`
+	PrevInactiveUsers            *int64     `json:"prevInactiveUsers,omitempty"`
+	InactiveUsersTrend           *StatTrend `json:"inactiveUsersTrend,omitempty"`
 	ExpiringSecrets       []ExpiringSecret `json:"expiringSecrets,omitempty"`
 	RecentActivity        []ActivityItem   `json:"recentActivity"`
 	// Degraded is true when one or more sub-checks above could not be queried —
@@ -190,9 +198,13 @@ func (c *KeyorixCore) saveDeploymentSnapshot(ctx context.Context, stats *Dashboa
 		return // best-effort; tolerate failure
 	}
 	newSnap := &models.DeploymentStatsSnapshot{
-		ActiveUsers:    stats.ActiveUsers,
-		AuditEvents30d: stats.AuditEvents30d,
-		SnapshotDate:   todayDate,
+		ActiveUsers:           stats.ActiveUsers,
+		AuditEvents30d:        stats.AuditEvents30d,
+		AuditLogins30d:        stats.AuditLogins30d,
+		AuditSecretReads30d:   stats.AuditSecretReads30d,
+		FailedAuthAttempts24h: stats.FailedAuthAttempts24h,
+		InactiveUsers:         stats.InactiveUsers,
+		SnapshotDate:          todayDate,
 	}
 	_ = c.storage.SaveDeploymentStatsSnapshot(ctx, newSnap)
 	if prevSnap != nil {
@@ -200,6 +212,14 @@ func (c *KeyorixCore) saveDeploymentSnapshot(ctx context.Context, stats *Dashboa
 		stats.ActiveUsersTrend = computeTrend(float64(prevSnap.ActiveUsers), float64(stats.ActiveUsers))
 		stats.PrevAuditEvents30d = &prevSnap.AuditEvents30d
 		stats.AuditEvents30dTrend = computeTrend(float64(prevSnap.AuditEvents30d), float64(stats.AuditEvents30d))
+		stats.PrevAuditLogins30d = &prevSnap.AuditLogins30d
+		stats.AuditLogins30dTrend = computeTrend(float64(prevSnap.AuditLogins30d), float64(stats.AuditLogins30d))
+		stats.PrevAuditSecretReads30d = &prevSnap.AuditSecretReads30d
+		stats.AuditSecretReads30dTrend = computeTrend(float64(prevSnap.AuditSecretReads30d), float64(stats.AuditSecretReads30d))
+		stats.PrevFailedAuthAttempts24h = &prevSnap.FailedAuthAttempts24h
+		stats.FailedAuthAttempts24hTrend = computeTrend(float64(prevSnap.FailedAuthAttempts24h), float64(stats.FailedAuthAttempts24h))
+		stats.PrevInactiveUsers = &prevSnap.InactiveUsers
+		stats.InactiveUsersTrend = computeTrend(float64(prevSnap.InactiveUsers), float64(stats.InactiveUsers))
 	}
 }
 

--- a/internal/core/dashboard_trends_test.go
+++ b/internal/core/dashboard_trends_test.go
@@ -24,6 +24,10 @@ func TestDashboardTrends_NoPreviousSnapshot_NoTrend(t *testing.T) {
 
 	assert.Nil(t, stats.ActiveUsersTrend, "no previous snapshot → ActiveUsersTrend must be nil")
 	assert.Nil(t, stats.AuditEvents30dTrend, "no previous snapshot → AuditEvents30dTrend must be nil")
+	assert.Nil(t, stats.AuditLogins30dTrend, "no previous snapshot → AuditLogins30dTrend must be nil")
+	assert.Nil(t, stats.AuditSecretReads30dTrend, "no previous snapshot → AuditSecretReads30dTrend must be nil")
+	assert.Nil(t, stats.FailedAuthAttempts24hTrend, "no previous snapshot → FailedAuthAttempts24hTrend must be nil")
+	assert.Nil(t, stats.InactiveUsersTrend, "no previous snapshot → InactiveUsersTrend must be nil")
 }
 
 // TestDashboardTrends_WithPreviousSnapshot_ComputesTrend verifies that when a
@@ -36,9 +40,13 @@ func TestDashboardTrends_WithPreviousSnapshot_ComputesTrend(t *testing.T) {
 	// fewer active users and fewer audit events than there will be now.
 	twoDaysAgo := time.Now().UTC().Add(-48 * time.Hour)
 	err := st.SaveDeploymentStatsSnapshot(context.Background(), &models.DeploymentStatsSnapshot{
-		ActiveUsers:    1, // will grow: BootstrapSystem already created "admin" + we added "trend_auditor2"
-		AuditEvents30d: 0,
-		SnapshotDate:   twoDaysAgo,
+		ActiveUsers:           1, // will grow: BootstrapSystem already created "admin" + we added "trend_auditor2"
+		AuditEvents30d:        0,
+		AuditLogins30d:        0,
+		AuditSecretReads30d:   0,
+		FailedAuthAttempts24h: 0,
+		InactiveUsers:         0,
+		SnapshotDate:          twoDaysAgo,
 	})
 	require.NoError(t, err)
 
@@ -57,6 +65,16 @@ func TestDashboardTrends_WithPreviousSnapshot_ComputesTrend(t *testing.T) {
 	}
 	// PrevAuditEvents30d is always set when prevSnap != nil.
 	require.NotNil(t, stats.PrevAuditEvents30d)
+
+	// New fields must also be set when prevSnap != nil.
+	require.NotNil(t, stats.PrevAuditLogins30d, "PrevAuditLogins30d must be set")
+	assert.Equal(t, int64(0), *stats.PrevAuditLogins30d)
+	require.NotNil(t, stats.PrevAuditSecretReads30d, "PrevAuditSecretReads30d must be set")
+	assert.Equal(t, int64(0), *stats.PrevAuditSecretReads30d)
+	require.NotNil(t, stats.PrevFailedAuthAttempts24h, "PrevFailedAuthAttempts24h must be set")
+	assert.Equal(t, int64(0), *stats.PrevFailedAuthAttempts24h)
+	require.NotNil(t, stats.PrevInactiveUsers, "PrevInactiveUsers must be set")
+	assert.Equal(t, int64(0), *stats.PrevInactiveUsers)
 }
 
 // TestDashboardTrends_SnapshotSavedAfterAdminCall verifies that the first call

--- a/internal/core/permission_enforcement_test.go
+++ b/internal/core/permission_enforcement_test.go
@@ -718,3 +718,54 @@ func TestCheckSecretPermission_RBACFallback_GrantsAccess(t *testing.T) {
 	assert.Equal(t, PermissionRead, permCtx.Permission)
 	mockStorage.AssertExpectations(t)
 }
+
+// TestShareActive directly exercises the shareActive predicate at every expiry
+// boundary case. This is a security-critical helper: a nil ExpiresAt is permanent
+// (never expires), a non-nil ExpiresAt denies access the instant the clock reaches
+// or passes it (using strict Before - equal means expired).
+func TestShareActive(t *testing.T) {
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	justBefore := now.Add(-time.Nanosecond)
+	justAfter := now.Add(time.Nanosecond)
+
+	cases := []struct {
+		name      string
+		expiresAt *time.Time
+		now       time.Time
+		want      bool
+	}{
+		{
+			name:      "nil ExpiresAt is permanent",
+			expiresAt: nil,
+			now:       now,
+			want:      true,
+		},
+		{
+			name:      "future expiry is active",
+			expiresAt: &justAfter,
+			now:       now,
+			want:      true,
+		},
+		{
+			name:      "expiry exactly at now is expired (strict Before)",
+			expiresAt: &now,
+			now:       now,
+			want:      false,
+		},
+		{
+			name:      "expiry just before now is expired",
+			expiresAt: &justBefore,
+			now:       now,
+			want:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			share := &models.ShareRecord{ExpiresAt: tc.expiresAt}
+			got := shareActive(share, tc.now)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -1120,11 +1120,15 @@ type StatsSnapshot struct {
 // Unlike StatsSnapshot (per-user secret counts), this is a singleton per day
 // (no UserID field).
 type DeploymentStatsSnapshot struct {
-	ID             uint      `gorm:"primarykey"`
-	ActiveUsers    int64     `json:"active_users"`
-	AuditEvents30d int64     `json:"audit_events_30d"`
-	SnapshotDate   time.Time `gorm:"index"` // UTC date (truncated to day)
-	CreatedAt      time.Time
+	ID                    uint      `gorm:"primarykey"`
+	ActiveUsers           int64     `json:"active_users"`
+	AuditEvents30d        int64     `json:"audit_events_30d"`
+	AuditLogins30d        int64     `json:"audit_logins_30d"`
+	AuditSecretReads30d   int64     `json:"audit_secret_reads_30d"`
+	FailedAuthAttempts24h int64     `json:"failed_auth_attempts_24h"`
+	InactiveUsers         int64     `json:"inactive_users"`
+	SnapshotDate          time.Time `gorm:"index"` // UTC date (truncated to day)
+	CreatedAt             time.Time
 }
 
 // HygieneTrendSnapshot captures one day's credential-hygiene counts for

--- a/internal/storage/store/local_stats_trends_test.go
+++ b/internal/storage/store/local_stats_trends_test.go
@@ -19,9 +19,13 @@ func TestSaveAndGetPreviousDeploymentStatsSnapshot(t *testing.T) {
 	// Save a snapshot 2 days ago (well outside the 20-hour cutoff).
 	twoDaysAgo := time.Now().UTC().Add(-48 * time.Hour)
 	snap := &models.DeploymentStatsSnapshot{
-		ActiveUsers:    10,
-		AuditEvents30d: 200,
-		SnapshotDate:   twoDaysAgo,
+		ActiveUsers:           10,
+		AuditEvents30d:        200,
+		AuditLogins30d:        50,
+		AuditSecretReads30d:   150,
+		FailedAuthAttempts24h: 5,
+		InactiveUsers:         2,
+		SnapshotDate:          twoDaysAgo,
 	}
 	require.NoError(t, ls.SaveDeploymentStatsSnapshot(ctx, snap))
 
@@ -39,9 +43,13 @@ func TestGetPreviousDeploymentStatsSnapshot_RecentSnapshotExcluded(t *testing.T)
 	// Save a snapshot 10 hours ago — inside the 20-hour cutoff, should be excluded.
 	tenHoursAgo := time.Now().UTC().Add(-10 * time.Hour)
 	snap := &models.DeploymentStatsSnapshot{
-		ActiveUsers:    5,
-		AuditEvents30d: 100,
-		SnapshotDate:   tenHoursAgo,
+		ActiveUsers:           5,
+		AuditEvents30d:        100,
+		AuditLogins30d:        25,
+		AuditSecretReads30d:   75,
+		FailedAuthAttempts24h: 2,
+		InactiveUsers:         1,
+		SnapshotDate:          tenHoursAgo,
 	}
 	require.NoError(t, ls.SaveDeploymentStatsSnapshot(ctx, snap))
 
@@ -69,14 +77,22 @@ func TestGetPreviousDeploymentStatsSnapshot_ReturnsLatestOlderThan20h(t *testing
 	fiveDaysAgo := time.Now().UTC().Add(-5 * 24 * time.Hour)
 
 	require.NoError(t, ls.SaveDeploymentStatsSnapshot(ctx, &models.DeploymentStatsSnapshot{
-		ActiveUsers:    3,
-		AuditEvents30d: 50,
-		SnapshotDate:   fiveDaysAgo,
+		ActiveUsers:           3,
+		AuditEvents30d:        50,
+		AuditLogins30d:        15,
+		AuditSecretReads30d:   35,
+		FailedAuthAttempts24h: 1,
+		InactiveUsers:         1,
+		SnapshotDate:          fiveDaysAgo,
 	}))
 	require.NoError(t, ls.SaveDeploymentStatsSnapshot(ctx, &models.DeploymentStatsSnapshot{
-		ActiveUsers:    8,
-		AuditEvents30d: 150,
-		SnapshotDate:   twoDaysAgo,
+		ActiveUsers:           8,
+		AuditEvents30d:        150,
+		AuditLogins30d:        45,
+		AuditSecretReads30d:   105,
+		FailedAuthAttempts24h: 3,
+		InactiveUsers:         2,
+		SnapshotDate:          twoDaysAgo,
 	}))
 
 	got, err := ls.GetPreviousDeploymentStatsSnapshot(ctx)


### PR DESCRIPTION
## Summary
- `DeploymentStatsSnapshot` previously only captured `ActiveUsers` and `AuditEvents30d`. Adds `AuditLogins30d`, `AuditSecretReads30d`, `FailedAuthAttempts24h`, and `InactiveUsers` so the dashboard can show trend arrows (↑/↓) for every deployment-wide stat card, not just two.
- `DashboardStats` gains `Prev*`/`Trend` pairs for each new field; `saveDeploymentSnapshot` wires them through `computeTrend()`. `AutoMigrate` adds the new columns without a manual migration.
- Test coverage: snapshot tests updated to create complete records and assert trend fields are set correctly when a previous snapshot exists.
- Also restores `internal/core/secret_listing_test.go` to its pre-Haiku-regression state (mock-backed tests exercising real code paths) and adds a direct unit test for the `shareActive` predicate (security-critical boundary logic previously untested), while removing 8 no-op placeholder test files a prior automated pass had added.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/core/...` / `./internal/storage/...` (one pre-existing local-only failure retained: `TestBulkApproveAccessRequests_ApproveError`, predates this branch)