### PR TITLE
feat(adr-022): domain allowlist for project invitations

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -719,6 +719,9 @@ type MembershipConfig struct {
 	// immediately), "allowlist" (admin steps through each state), or "idp"
 	// (IdP-resolved users skip the early states). Empty = allowlist.
 	ValidationMode string `yaml:"validation_mode"`
+	// DomainAllowlist restricts InviteToProject/InviteGlobal to these email
+	// domains (ADR-022). Empty = no restriction (default, backward compatible).
+	DomainAllowlist []string `yaml:"domain_allowlist"`
 }
 
 // SIEMConfig configures native push of audit events to an external SIEM.

--- a/internal/core/invitation_global_test.go
+++ b/internal/core/invitation_global_test.go
@@ -66,6 +66,21 @@ func TestInviteGlobal_RejectsUnknownRole(t *testing.T) {
 	store.AssertNotCalled(t, "CreateProjectInvitation", mock.Anything, mock.Anything)
 }
 
+// ADR-022: domain allowlist applies to global invites the same way it does to
+// project-scoped invites (TestInviteToProject_RejectsDisallowedDomain).
+func TestInviteGlobal_RejectsDisallowedDomain(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	c.SetMembershipDomainAllowlist([]string{"acme.com"})
+	ctx := context.Background()
+
+	_, err := c.InviteGlobal(ctx, "carol@evil.example", "", nil, 9)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not on the allowlist")
+	store.AssertNotCalled(t, "CreateProjectInvitation", mock.Anything, mock.Anything)
+}
+
 func TestInviteGlobal_RejectsAssignmentMissingRole(t *testing.T) {
 	store := new(MockStorage)
 	c := newInviteCore(store)

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -92,6 +92,9 @@ func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email
 	if projectID == 0 || email == "" || role == "" {
 		return nil, fmt.Errorf("project ID, email, and role are required")
 	}
+	if !c.domainAllowed(email) {
+		return nil, fmt.Errorf("email domain is not on the allowlist")
+	}
 	if _, err := c.storage.GetRoleByName(ctx, role); err != nil {
 		return nil, fmt.Errorf("unknown role %q: %w", role, err)
 	}
@@ -165,6 +168,9 @@ func (c *KeyorixCore) InviteToProjectWithLink(ctx context.Context, projectID uin
 func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string, assignments []ProjectAssignment, invitedBy uint) (*models.ProjectInvitation, error) { // NOSONAR -- cognitive complexity 20, suppress go:S3776
 	if email == "" {
 		return nil, fmt.Errorf("email is required")
+	}
+	if !c.domainAllowed(email) {
+		return nil, fmt.Errorf("email domain is not on the allowlist")
 	}
 	sysRole := systemRole
 	if sysRole == "" {

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -37,6 +37,43 @@ func TestInviteToProject(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
+// ADR-022: domain allowlist. Default (no allowlist configured) imposes no
+// restriction — covered implicitly by TestInviteToProject above, which
+// succeeds with no allowlist set.
+
+func TestInviteToProject_RejectsDisallowedDomain(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	c.SetMembershipDomainAllowlist([]string{"acme.com"})
+	ctx := context.Background()
+
+	_, err := c.InviteToProject(ctx, 1, "a@evil.example", "project_developer", 9)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not on the allowlist")
+	store.AssertNotCalled(t, "CreateProjectInvitation", mock.Anything, mock.Anything)
+}
+
+func TestInviteToProject_AllowsAllowlistedDomain(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	c.SetMembershipDomainAllowlist([]string{"acme.com"})
+	ctx := context.Background()
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5, Name: "project_developer"}, nil)
+	store.On("CreateProjectInvitation", ctx, mock.MatchedBy(func(inv *models.ProjectInvitation) bool {
+		return inv.State == InvitationPending && inv.Email == "a@acme.com"
+	})).Return(&models.ProjectInvitation{ID: 8, State: InvitationPending}, nil)
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == "invitation.created"
+	})).Return(nil)
+
+	inv, err := c.InviteToProject(ctx, 1, "a@acme.com", "project_developer", 9)
+
+	require.NoError(t, err)
+	assert.Equal(t, InvitationPending, inv.State)
+	store.AssertExpectations(t)
+}
+
 func TestRevokeInvitation_RejectsNonPending(t *testing.T) {
 	store := new(MockStorage)
 	c := newInviteCore(store)

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -69,6 +70,33 @@ func (c *KeyorixCore) SetMembershipValidationMode(mode string) {
 	case ValidationModeOpen, ValidationModeAllowlist, ValidationModeIDP:
 		c.membershipValidationMode = mode
 	}
+}
+
+// SetMembershipDomainAllowlist restricts InviteToProject/InviteGlobal to these
+// email domains (ADR-022). Empty = no restriction. The server calls this at
+// startup from config.
+func (c *KeyorixCore) SetMembershipDomainAllowlist(domains []string) {
+	c.membershipDomainAllowlist = domains
+}
+
+// domainAllowed reports whether email's domain passes the configured
+// allowlist. An empty allowlist means no restriction (default, backward
+// compatible).
+func (c *KeyorixCore) domainAllowed(email string) bool {
+	if len(c.membershipDomainAllowlist) == 0 {
+		return true
+	}
+	at := strings.LastIndex(email, "@")
+	if at < 0 {
+		return false
+	}
+	domain := strings.ToLower(email[at+1:])
+	for _, d := range c.membershipDomainAllowlist {
+		if strings.ToLower(d) == domain {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *KeyorixCore) validationMode() string {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -245,6 +245,9 @@ type KeyorixCore struct {
 	// membershipValidationMode is the ADR-022 install-level onboarding mode;
 	// "" = allowlist default. Set via SetMembershipValidationMode.
 	membershipValidationMode string
+	// membershipDomainAllowlist restricts invited emails to these domains
+	// (ADR-022). Empty = no restriction. Set via SetMembershipDomainAllowlist.
+	membershipDomainAllowlist []string
 	// setupTokenTTL is the lifetime of a credential-delivery setup token (ADR-028);
 	// 0 = DefaultSetupTokenTTL. Set from config via SetSetupTokenTTL.
 	setupTokenTTL time.Duration

--- a/server/http/handlers/constants.go
+++ b/server/http/handlers/constants.go
@@ -3,6 +3,7 @@ package handlers
 const (
 	errAccessDenied = "Access denied"
 	errAlreadyExists = "already exists"
+	errDomainNotAllowed = "not on the allowlist"
 	errFailedCreateUser = "Failed to create user"
 	errFailedGetRole = "Failed to get role"
 	errFailedGetUser = "Failed to get user"

--- a/server/http/handlers/global_invitation_test.go
+++ b/server/http/handlers/global_invitation_test.go
@@ -91,6 +91,26 @@ func TestCreateGlobalInvitation(t *testing.T) {
 	})
 }
 
+// ADR-022: a configured domain allowlist rejects an invite to a disallowed
+// domain with 403, and creates no invitation row.
+func TestCreateGlobalInvitation_RejectsDisallowedDomain(t *testing.T) {
+	h, db := setupGlobalInvitationTest(t)
+	h.coreService.SetMembershipDomainAllowlist([]string{"acme.io"})
+
+	t.Run("disallowed domain rejects with 403", func(t *testing.T) {
+		w := postGlobalInvite(t, h, `{"email":"carol@evil.example"}`)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		var n int64
+		require.NoError(t, db.Model(&models.ProjectInvitation{}).Where("email = ?", "carol@evil.example").Count(&n).Error)
+		assert.Equal(t, int64(0), n)
+	})
+
+	t.Run("allowlisted domain still succeeds", func(t *testing.T) {
+		w := postGlobalInvite(t, h, `{"email":"dave@acme.io"}`)
+		assert.Equal(t, http.StatusCreated, w.Code)
+	})
+}
+
 // The invite privilege ceiling: a non-admin actor (holds users.write via the route gate
 // but NOT roles.assign) cannot invite with a system role or a project role — otherwise
 // an onboarding manager could invite themselves as system_admin and own the install.

--- a/server/http/handlers/invitations.go
+++ b/server/http/handlers/invitations.go
@@ -65,9 +65,12 @@ func (h *CatalogHandler) CreateInvitation(w http.ResponseWriter, r *http.Request
 		if inv == nil {
 			status := http.StatusInternalServerError
 			msg := err.Error()
-			if strings.Contains(msg, errUnknownRole) || strings.Contains(msg, "required") {
+			switch {
+			case strings.Contains(msg, errDomainNotAllowed):
+				status = http.StatusForbidden
+			case strings.Contains(msg, errUnknownRole) || strings.Contains(msg, "required"):
 				status = http.StatusBadRequest
-			} else {
+			default:
 				log.Printf("Error inviting %q to project %d: %v", body.Email, id, err)
 				msg = clientSafe(err)
 			}
@@ -136,9 +139,12 @@ func (h *CatalogHandler) CreateGlobalInvitation(w http.ResponseWriter, r *http.R
 		if inv == nil {
 			status := http.StatusInternalServerError
 			msg := err.Error()
-			if strings.Contains(msg, "unknown") || strings.Contains(msg, "required") || strings.Contains(msg, "needs a") {
+			switch {
+			case strings.Contains(msg, errDomainNotAllowed):
+				status = http.StatusForbidden
+			case strings.Contains(msg, "unknown") || strings.Contains(msg, "required") || strings.Contains(msg, "needs a"):
 				status = http.StatusBadRequest
-			} else {
+			default:
 				log.Printf("Error creating global invitation for %q: %v", body.Email, err)
 				msg = clientSafe(err)
 			}

--- a/server/main.go
+++ b/server/main.go
@@ -682,6 +682,10 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	if vm := cfg.Membership.ValidationMode; vm != "" {
 		coreService.SetMembershipValidationMode(vm)
 	}
+	// Apply the invitation domain allowlist (ADR-022). Empty = no restriction.
+	if len(cfg.Membership.DomainAllowlist) > 0 {
+		coreService.SetMembershipDomainAllowlist(cfg.Membership.DomainAllowlist)
+	}
 
 	// Apply the credential-delivery setup-token TTL (ADR-028). GetSetupTokenTTL
 	// falls back to 24h when the block is absent or invalid.


### PR DESCRIPTION
## Summary
- Adds `membership.domain_allowlist` (install-level config, `keyorix.yaml`): restricts `InviteToProject` / `InviteGlobal` to listed email domains. Empty/unset = no restriction (default, fully backward compatible).
- Before this change, every member-add code path (`/members`, `/memberships`, `/invitations`) accepted any email unconditionally — zero identity/domain validation existed anywhere, despite ADR-022 describing this as the install's default security posture.
- Rejection returns `403 Forbidden` with a clear message (`email domain is not on the allowlist`), following this repo's existing plain-`fmt.Errorf` + substring-matched-in-handler idiom (mirrors `errUnknownRole`/`errOnlyPending`).

## Scope-down from full ADR-022
This is intentionally a slice, not the complete ADR. Left out, as separate/larger follow-ups:
- **IdP-verified provisioning** (`idp` validation mode member-add gating an "IdP-resolved" check) — needs real SSO/OIDC group-membership verification, which doesn't exist in this codebase today. The existing `membership.validation_mode`/`idp_resolved` fields are unrelated to this PR — they control the *initial lifecycle state* of the separate `/memberships` endpoint, not whether an invite is validated at all.
- **System-admin override with audited reason** ("Add anyway") — no validation existed to override before this PR, so there was nothing to build an override path against yet.
- **Structured audit metadata** (`metadata.validation_mode`, `validation_passed`, etc.) — `AuditEvent` has no JSON/metadata column; adding one is a bigger schema change.

No frontend change is needed to surface the new rejection: `keyorix-web`'s invite dialogs already do `err?.response?.data?.message ?? err?.response?.data?.error ?? 'fallback'` on failure, so the new error message shows up automatically once this ships.

## Test plan
- [x] `go build` / `go vet` on the affected packages
- [x] `golangci-lint run` — no issues
- [x] `gosec` — no new findings (only pre-existing findings on lines this PR didn't touch)
- [x] New tests: `TestInviteToProject_RejectsDisallowedDomain`, `TestInviteToProject_AllowsAllowlistedDomain`, `TestInviteGlobal_RejectsDisallowedDomain` (core, mock-storage), `TestCreateGlobalInvitation_RejectsDisallowedDomain` (HTTP, SQLite integration) — all passing
- [x] Existing invitation/global-invitation test suites still pass unchanged
- [ ] Note: `go test ./internal/core/...` has ~21 pre-existing failures on `origin/main` unrelated to this change (classification-gate, MFA step-up, secret-accessor tests — confirmed failing in isolation, in files this PR never touches). Flagging so reviewers don't mistake them for a regression introduced here.