### PR TITLE
fix(adr-022): enforce domain allowlist on userID-keyed membership paths

### DIFF
--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -99,6 +99,24 @@ func (c *KeyorixCore) domainAllowed(email string) bool {
 	return false
 }
 
+// domainAllowedForUser is domainAllowed for the userID-keyed onboarding paths
+// (InviteMember, AddProjectMember, SetProjectMemberRole) — every place that
+// grants a project-scope role directly by user ID rather than by email, and
+// so doesn't otherwise pass through InviteToProject/InviteGlobal's check.
+func (c *KeyorixCore) domainAllowedForUser(ctx context.Context, userID uint) error {
+	if len(c.membershipDomainAllowlist) == 0 {
+		return nil
+	}
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("user not found")
+	}
+	if !c.domainAllowed(user.Email) {
+		return fmt.Errorf("email domain is not on the allowlist")
+	}
+	return nil
+}
+
 func (c *KeyorixCore) validationMode() string {
 	if c.membershipValidationMode == "" {
 		return ValidationModeAllowlist
@@ -127,6 +145,9 @@ func (c *KeyorixCore) inviteMemberWithMode(ctx context.Context, projectID, userI
 	}
 	if _, err := c.storage.GetRoleByName(ctx, role); err != nil {
 		return nil, fmt.Errorf("unknown role %q: %w", role, err)
+	}
+	if err := c.domainAllowedForUser(ctx, userID); err != nil {
+		return nil, err
 	}
 	// The parent project must be live. GetProject is soft-delete-scoped, so this refuses
 	// onboarding into a soft-deleted project — otherwise accepting an invitation that was

--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -91,6 +91,24 @@ func TestInviteMember_OpenGrantsRoleImmediately(t *testing.T) {
 	store.AssertCalled(t, "AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1})
 }
 
+// ADR-022's domain allowlist previously only gated the email-based
+// InviteToProject/InviteGlobal flow — InviteMember (the userID-keyed invite
+// path) bypassed it entirely. Verify it's now enforced here too.
+func TestInviteMember_RejectsDisallowedDomain(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	c.membershipDomainAllowlist = []string{"allowed.com"}
+	ctx := context.Background()
+
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5, Name: "project_developer"}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Email: "outsider@evil.com"}, nil)
+
+	_, err := c.InviteMember(ctx, 1, 2, "project_developer", 9, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not on the allowlist")
+	store.AssertNotCalled(t, "CreateProjectMembership", mock.Anything, mock.Anything)
+}
+
 func TestInviteMember_RejectsDuplicate(t *testing.T) {
 	store := new(MockStorage)
 	c := newMembershipCore(store)

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -15,7 +15,6 @@ import (
 	"github.com/keyorixhq/keyorix/internal/i18n"
 )
 
-
 // ListProjectMembers returns the users with a role at the project's scope.
 func (c *KeyorixCore) ListProjectMembers(ctx context.Context, projectID uint) ([]storage.ProjectMember, error) {
 	return c.storage.ListProjectMembers(ctx, projectID)
@@ -29,6 +28,9 @@ func (c *KeyorixCore) ListProjectMembers(ctx context.Context, projectID uint) ([
 // mint a project_admin (or any role bundling permissions they don't hold) through
 // this direct entry point.
 func (c *KeyorixCore) AddProjectMember(ctx context.Context, actorID, projectID, userID uint, roleName string) error {
+	if err := c.domainAllowedForUser(ctx, userID); err != nil {
+		return err
+	}
 	role, err := c.storage.GetRoleByName(ctx, roleName)
 	if err != nil {
 		return fmt.Errorf("unknown role %q: %w", roleName, err)
@@ -48,6 +50,14 @@ func (c *KeyorixCore) SetProjectMemberRole(ctx context.Context, actorID, project
 	existing, err := c.storage.GetUserRoleIDsExact(ctx, userID, scope)
 	if err != nil {
 		return err
+	}
+	// Only re-run the domain check when this call is establishing NEW project
+	// membership (the user holds no role at this scope yet) — an existing
+	// member changing roles already passed the check when they joined.
+	if len(existing) == 0 {
+		if err := c.domainAllowedForUser(ctx, userID); err != nil {
+			return err
+		}
 	}
 	// Refuse a demotion that would leave the project with no roles.assign holder
 	// (#236): after this call the user's only project-scope role is roleName, so

--- a/internal/core/project_members_test.go
+++ b/internal/core/project_members_test.go
@@ -85,6 +85,73 @@ func TestAddProjectMemberUnknownRole(t *testing.T) {
 	require.Error(t, c.AddProjectMember(ctx, 99, 1, u.ID, "no_such_role"))
 }
 
+// ADR-022's domain allowlist previously only gated the email-based
+// InviteToProject/InviteGlobal flow — AddProjectMember (the userID-keyed
+// direct-add path, e.g. an admin or SCIM caller with roles.assign) bypassed
+// it entirely. Verify it's now enforced here too.
+func TestAddProjectMember_RejectsDisallowedDomain(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+	c.SetMembershipDomainAllowlist([]string{"allowed.com"})
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "mallory", Email: "mallory@evil.com", IsActive: true})
+	require.NoError(t, err)
+
+	err = c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not on the allowlist")
+
+	members, err := c.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	assert.Empty(t, members)
+}
+
+// Same guard, but for SetProjectMemberRole's "adds the member if they had
+// none" path — a second userID-keyed entry point that must not bypass the
+// allowlist either.
+func TestSetProjectMemberRole_RejectsDisallowedDomainForNewMember(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+	c.SetMembershipDomainAllowlist([]string{"allowed.com"})
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "trent", Email: "trent@evil.com", IsActive: true})
+	require.NoError(t, err)
+
+	err = c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_viewer")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not on the allowlist")
+}
+
+// A role change for an ALREADY-established member must not re-run the domain
+// check — the allowlist governs who can join, not every subsequent role edit
+// for someone who already legitimately joined.
+func TestSetProjectMemberRole_AllowsRoleChangeForExistingMemberRegardlessOfDomain(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "peggy", Email: "peggy@evil.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
+
+	// The allowlist is only turned on AFTER peggy already joined.
+	c.SetMembershipDomainAllowlist([]string{"allowed.com"})
+
+	require.NoError(t, c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_developer"))
+	members, err := c.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, "project_developer", members[0].RoleName)
+}
+
 // AddProjectMember/SetProjectMemberRole/RemoveProjectMember grant/revoke the same
 // underlying role assignment as /user-roles, so they must land in the RBAC audit
 // trail identically (#234) — previously these bypassed AssignUserRole/RemoveUserRole

--- a/server/http/handlers/project_members.go
+++ b/server/http/handlers/project_members.go
@@ -11,7 +11,6 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core"
 )
 
-
 // ListProjectMembers handles GET /api/v1/projects/{id}/members
 func (h *CatalogHandler) ListProjectMembers(w http.ResponseWriter, r *http.Request) {
 	id, ok := mustParseProjectID(w, r)
@@ -160,6 +159,8 @@ func (h *CatalogHandler) AddProjectMember(w http.ResponseWriter, r *http.Request
 		status := http.StatusInternalServerError
 		msg := err.Error()
 		switch {
+		case strings.Contains(msg, errDomainNotAllowed):
+			status = http.StatusForbidden
 		case strings.Contains(msg, "already"):
 			status = http.StatusConflict
 		case strings.Contains(msg, "unknown role"):
@@ -204,6 +205,8 @@ func (h *CatalogHandler) UpdateProjectMember(w http.ResponseWriter, r *http.Requ
 		status := http.StatusInternalServerError
 		msg := err.Error()
 		switch {
+		case strings.Contains(msg, errDomainNotAllowed):
+			status = http.StatusForbidden
 		case strings.Contains(msg, "unknown role"):
 			status = http.StatusBadRequest
 		case strings.Contains(msg, "last administrator"):

--- a/server/http/handlers/project_memberships.go
+++ b/server/http/handlers/project_memberships.go
@@ -19,7 +19,6 @@ import (
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
-
 // staleInviteThreshold is when an unaccepted invite is surfaced as stale (ADR-022).
 const staleInviteThreshold = 7 * 24 * time.Hour
 
@@ -87,6 +86,8 @@ func (h *CatalogHandler) InviteMember(w http.ResponseWriter, r *http.Request) {
 		status := http.StatusInternalServerError
 		msg := err.Error()
 		switch {
+		case strings.Contains(msg, errDomainNotAllowed):
+			status = http.StatusForbidden
 		case strings.Contains(msg, "already has"):
 			status = http.StatusConflict
 		case strings.Contains(msg, "unknown role"), strings.Contains(msg, "required"):


### PR DESCRIPTION
## Summary
`InviteToProject`/`InviteGlobal` (email-based) already gate on ADR-022's domain allowlist, but three other entry points that grant project membership by `user_id` never checked it:
- `InviteMember` → `POST /api/v1/projects/{id}/memberships`
- `AddProjectMember` → `POST /api/v1/projects/{id}/members`
- `SetProjectMemberRole` → `PUT /api/v1/projects/{id}/members/{userId}` (only the "adds the member if they had none" path)

An admin, or an IdP/SCIM-driven caller holding `roles.assign`, could add a user from any email domain to a project through these by-ID endpoints, sidestepping the allowlist entirely.

- Added `domainAllowedForUser` (resolves the target user, then reuses the existing `domainAllowed` check) and wired it into all three entry points.
- `SetProjectMemberRole` only re-runs the check when it's establishing brand-new membership (`existing` roles empty) — a role change for an already-established member doesn't re-check, so tightening the allowlist later doesn't retroactively lock out existing members.
- Mapped the resulting error to `403` in both HTTP handlers, matching the existing `errDomainNotAllowed` pattern used by the invitation endpoints.

## Test plan
- [x] `go build ./...`
- [x] New regression tests: `TestInviteMember_RejectsDisallowedDomain`, `TestAddProjectMember_RejectsDisallowedDomain`, `TestSetProjectMemberRole_RejectsDisallowedDomainForNewMember`, `TestSetProjectMemberRole_AllowsRoleChangeForExistingMemberRegardlessOfDomain`
- [x] `go test ./internal/core/...` (targeted membership/invite tests) and `go test ./server/http/handlers/...` pass
- [x] `gofmt -l` / `go vet` clean on changed files