### PR TITLE
fix(adr-022): enforce domain allowlist on SCIM/SSO JIT provisioning

### DIFF
--- a/internal/core/core_s30_test.go
+++ b/internal/core/core_s30_test.go
@@ -91,6 +91,21 @@ func TestProvisionSCIMUser_Success(t *testing.T) {
 	assert.Equal(t, uint(10), u.ID)
 }
 
+// ADR-022's domain allowlist previously only gated the email-based
+// InviteToProject/InviteGlobal flow — a SCIM directory sync from an
+// unapproved domain (e.g. a misconfigured/multi-tenant IdP) could still
+// silently mint an account. Verify it's now enforced here too.
+func TestProvisionSCIMUser_RejectsDisallowedDomain(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.SetMembershipDomainAllowlist([]string{"allowed.com"})
+
+	_, err := c.ProvisionSCIMUser(context.Background(), 0, "eve@evil.com", "", "", "ext-eve", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not on the allowlist")
+	ms.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything)
+}
+
 func TestProvisionSCIMUser_EmailFallback(t *testing.T) {
 	// When email is empty, it defaults to userName.
 	ms := new(MockStorage)

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -140,6 +140,13 @@ func (c *KeyorixCore) ProvisionSCIMUser(ctx context.Context, actorID uint, userN
 	if email == "" {
 		email = userName // SCIM userName is conventionally the email
 	}
+	// ADR-022: the domain allowlist is an install-wide boundary on who may hold an
+	// account at all, not just an invite-flow check — a SCIM directory sync from an
+	// unapproved domain (e.g. a misconfigured/multi-tenant IdP) must not silently
+	// mint an account either.
+	if !c.domainAllowed(email) {
+		return nil, fmt.Errorf("email domain is not on the allowlist")
+	}
 	// Fail CLOSED on a lookup error: swallowing it would let a transient DB error during
 	// the dedup check fall through to CreateUser and mint a SECOND identity with the same
 	// email (there is no DB-level email uniqueness), and SSO/SCIM resolve email via

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -475,6 +475,13 @@ func (c *KeyorixCore) provisionSSOUser(ctx context.Context, p *SSOProvider, sub,
 	if strings.TrimSpace(email) == "" {
 		return nil, fmt.Errorf("the IdP returned no email; cannot auto-provision an account")
 	}
+	// ADR-022: the domain allowlist is an install-wide boundary on who may hold an
+	// account at all, not just an invite-flow check — an SSO login from an
+	// unapproved domain (e.g. a misconfigured/multi-tenant IdP) must not silently
+	// JIT-provision an account either.
+	if !c.domainAllowed(email) {
+		return nil, fmt.Errorf("email domain is not on the allowlist")
+	}
 	// Guard against a race / case where a user materialised between the resolve and here:
 	// reuse it rather than create a duplicate. This MUST go through resolveSSOUser (not a
 	// raw email lookup), so the same guards apply — an EXISTING account is reused via an

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -252,6 +252,20 @@ func TestProvisionSSOUser(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	// ADR-022's domain allowlist previously only gated the email-based
+	// InviteToProject/InviteGlobal flow — an SSO login from an unapproved
+	// domain (e.g. a misconfigured/multi-tenant IdP) could still silently
+	// JIT-provision an account. Verify it's now enforced here too.
+	t.Run("refuses a disallowed email domain", func(t *testing.T) {
+		c, store, _, p := ssoTestCore(t)
+		c.SetMembershipDomainAllowlist([]string{"allowed.com"})
+
+		_, err := c.provisionSSOUser(context.Background(), p, "okta|999", "mallory@evil.com", true, "Mallory")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not on the allowlist")
+		store.AssertNotCalled(t, "CreateUser", mock.Anything, mock.Anything)
+	})
+
 	// CRITICAL regression: the JIT path must NOT reuse an existing account matched by an
 	// UNVERIFIED email — that was an account-takeover (an IdP omitting email_verified could
 	// assert a victim's email and be logged in as the victim). With emailVerified=false the

--- a/server/http/handlers/scim.go
+++ b/server/http/handlers/scim.go
@@ -240,8 +240,11 @@ func (h *SCIMHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	user, err := h.coreService.ProvisionSCIMUser(r.Context(), 0, p.UserName, p.displayName(), p.primaryEmail(), p.ExternalID, active)
 	if err != nil {
 		status := http.StatusBadRequest
-		if strings.Contains(err.Error(), "already exists") {
+		switch {
+		case strings.Contains(err.Error(), "already exists"):
 			status = http.StatusConflict
+		case strings.Contains(err.Error(), errDomainNotAllowed):
+			status = http.StatusForbidden
 		}
 		scimError(w, status, err.Error())
 		return

--- a/server/http/handlers/sso.go
+++ b/server/http/handlers/sso.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-
 // oauthErrorAllowlist is the fixed set of error codes defined by RFC 6749 §4.1.2.1 and
 // RFC 6749 §5.2, plus common OIDC extensions. Any error code NOT in this list is
 // replaced with a generic message to prevent injection via a crafted callback URL.
@@ -62,6 +61,7 @@ func isSafeSSOError(msg string) bool {
 		"the assertion carried no subject or email",
 		"no Keyorix account matches this SSO identity",
 		"the IdP returned no email; cannot auto-provision an account",
+		errDomainNotAllowed,
 	} {
 		if strings.Contains(msg, safe) {
 			return true


### PR DESCRIPTION
## Summary
`InviteToProject`/`InviteGlobal` (email-based) and, as of #1234, the userID-keyed project-membership paths all gate on ADR-022's domain allowlist. `ProvisionSCIMUser` and `provisionSSOUser` — which mint a brand-new account and grant it a global role via SCIM directory sync or SSO JIT provisioning — did not.

Per discussion: this is intentionally extended to cover SCIM/SSO too, not left as invite-only, so the allowlist is an install-wide boundary on who may hold an account at all, regardless of provisioning source.

- `ProvisionSCIMUser` (`internal/core/scim.go`) and `provisionSSOUser` (`internal/core/sso.go`) now reject up front with `"email domain is not on the allowlist"` before any account is created.
- SCIM handler (`server/http/handlers/scim.go`) maps that error to `403`.
- SSO handler (`server/http/handlers/sso.go`) adds the message to `isSafeSSOError`'s allowlist so a rejected login redirects with a clear, safe reason instead of a generic sanitized error.

## Test plan
- [x] `go build ./...`
- [x] New regression tests: `TestProvisionSCIMUser_RejectsDisallowedDomain`, `TestProvisionSSOUser/refuses a disallowed email domain`
- [x] `go test ./internal/core/...` (targeted SCIM/SSO provisioning tests) and `go test ./server/http/handlers/...` pass
- [x] `gofmt -l` / `go vet` clean on changed files