### PR TITLE
fix(test): remove duplicate role-assignment inserts causing test flakiness

### DIFF
--- a/internal/core/classification_gate_test.go
+++ b/internal/core/classification_gate_test.go
@@ -38,11 +38,6 @@ func seedClassificationGateFixture(t *testing.T, st *store.LocalStorage, classif
 	adminRole, err := st.GetRoleByName(ctx, "admin")
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRole(ctx, approver.ID, adminRole.ID, storage.Scope{}))
-	// IsProjectMember (RBAC-001): requester must be a project member or the owner
-	// gate short-circuits before returning PermissionOwner.
-	viewerRole, err = st.GetRoleByName(ctx, "project_viewer")
-	require.NoError(t, err)
-	require.NoError(t, st.AssignRole(ctx, requester.ID, viewerRole.ID, storage.Scope{ProjectID: proj.ID}))
 
 	secret, err := st.CreateSecret(ctx, &models.SecretNode{
 		Name: "db-password", ProjectID: proj.ID, EnvironmentID: 1, Type: "password",

--- a/internal/core/secret_access_list_test.go
+++ b/internal/core/secret_access_list_test.go
@@ -42,8 +42,6 @@ func TestListSecretAccessors(t *testing.T) {
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "platform"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 3, GroupID: 10}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 4, GroupID: 10}).Error)
-	// IsProjectMember check (added in #1185): alice (user 2) must be a project member.
-	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 
 	now := time.Now()
 	st := store.NewLocalStorage(db)
@@ -104,8 +102,6 @@ func TestListSecretAccessors_StrongestGrantWins(t *testing.T) {
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "g"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 10}).Error)
-	// IsProjectMember check (added in #1185): alice (user 2) must be a project member.
-	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 
 	now := time.Now()
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}


### PR DESCRIPTION
## Summary
Two test-fixture defects, both the same pattern — inserting the identical role-assignment row twice within a single test/fixture — were causing spurious failures across ~20 `internal/core` subtests, reproducibly on a clean `main` checkout:

- `seedClassificationGateFixture` (`internal/core/classification_gate_test.go`) called `st.AssignRole(ctx, requester.ID, viewerRole.ID, storage.Scope{ProjectID: proj.ID})` twice for the same requester/role/project — the second call (added under an RBAC-001 comment) duplicated an identical assignment a few lines above it. `AssignRole` correctly rejects re-assigning a still-live grant with `"Role already assigned"`, so every `TestClassificationGate*`/`TestClassificationPermissionGate*`/`TestClassificationMFAStepUp*`/`TestApproveSecretAccessRequest_Guards` subtest using the shared fixture failed.
- `TestListSecretAccessors` and `TestListSecretAccessors_StrongestGrantWins` (`internal/core/secret_access_list_test.go`) each had a raw `db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1})` duplicated later in the same function (both under a `#1185` comment), tripping the `user_roles` unique constraint on `(user_id, role_id, project_id, environment_id)`.

Fix: removed the redundant second insert in each case — the earlier assignment already does what the later duplicate was trying to (re-)achieve. Test-only change, no production code touched.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/core/... -run 'TestClassificationGate|TestClassificationPermissionGate|TestClassificationMFAStepUp|TestApproveSecretAccessRequest_Guards|TestListSecretAccessors' -count=3` — 108 passed, no flakiness
- [x] `gofmt -l` / `go vet` clean on changed files

## Note
A separate, unrelated flakiness cluster was found in the same package (`TestPurgeAuditLogs_HappyPath`, `TestBulkApproveAccessRequests_SuccessPath`, `TestBulkRejectAccessRequests_SuccessPath`, `TestSharingIntegrationSimple`, `TestUpdateUser_Deactivation_RevokesSessionsAndPATs`, `TestUpdateUser_NoRevocation_WhenAlreadyInactive`) under `-count=3`. Confirmed pre-existing and reproduces on unmodified `main`, but out of scope for this PR — left untouched, worth a separate investigation.