### PR TITLE
fix(test): give each in-memory shared-cache SQLite DB a unique DSN per run

### DIFF
--- a/internal/core/audit_log_retention_test.go
+++ b/internal/core/audit_log_retention_test.go
@@ -3,6 +3,8 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,12 +17,19 @@ import (
 	"gorm.io/gorm"
 )
 
+// purgeTestDBSeq makes each in-memory DB unique within the process so that
+// repeated invocations of the same test (e.g. `go test -count=N`) don't
+// attach to the same SQLite shared-cache in-memory database as a prior
+// iteration and see its leftover rows.
+var purgeTestDBSeq atomic.Int64
+
 // newPurgeTestCore opens a fresh in-memory SQLite DB, migrates AuditEvent and
 // LegalHold (needed by the legalHoldGuard that PurgeAuditLogs now calls),
 // and returns a KeyorixCore with a fixed clock so retention cutoffs are stable.
 func newPurgeTestCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open("file::memory:?mode=memory&cache=shared&_busy_timeout=5000"), &gorm.Config{})
+	dsn := fmt.Sprintf("file:kx_purge_%d?mode=memory&cache=shared&_busy_timeout=5000", purgeTestDBSeq.Add(1))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.LegalHold{}))
 	fixed := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
@@ -45,7 +54,7 @@ func TestPurgeAuditLogs_HappyPath(t *testing.T) {
 
 	// Five events older than 30 days.
 	for i := 0; i < 5; i++ {
-		seedRetentionAuditEvent(t, db, fixed.AddDate(0, 0, -(31 + i)))
+		seedRetentionAuditEvent(t, db, fixed.AddDate(0, 0, -(31+i)))
 	}
 	// Three recent events within the retention window.
 	for i := 0; i < 3; i++ {

--- a/internal/core/bulk_access_requests_integration_test.go
+++ b/internal/core/bulk_access_requests_integration_test.go
@@ -7,6 +7,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +19,12 @@ import (
 	"gorm.io/gorm"
 )
 
+// bulkAccessDBSeq makes each in-memory DB unique within the process. t.Name()
+// alone repeats across `go test -count=N` iterations of the same test, which
+// would otherwise attach to the same SQLite shared-cache in-memory database
+// left open by a prior iteration and collide on the seeded fixture rows.
+var bulkAccessDBSeq atomic.Int64
+
 // setupBulkAccessDB opens a uniquely-named in-memory SQLite DB, migrates all
 // tables needed for access-request approval/rejection (roles, permissions,
 // assignments, SoD, access schedules, audit), and seeds minimal RBAC fixtures.
@@ -26,7 +33,7 @@ func setupBulkAccessDB(t *testing.T) (k *KeyorixCore, db *gorm.DB, approverID, r
 	t.Helper()
 	require.NoError(t, i18n.InitializeForTesting())
 
-	dsn := fmt.Sprintf("file:bulkaccess_%s?mode=memory&cache=shared&_busy_timeout=5000", t.Name())
+	dsn := fmt.Sprintf("file:bulkaccess_%s_%d?mode=memory&cache=shared&_busy_timeout=5000", t.Name(), bulkAccessDBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()

--- a/internal/core/sharing_integration_simple_test.go
+++ b/internal/core/sharing_integration_simple_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,6 +16,11 @@ import (
 	"gorm.io/gorm"
 )
 
+// sharingIntegrationDBSeq makes each in-memory DB unique within the process
+// so that repeated invocations (e.g. `go test -count=N`) don't attach to the
+// same SQLite shared-cache in-memory database left open by a prior iteration.
+var sharingIntegrationDBSeq atomic.Int64
+
 // TestSharingIntegrationSimple tests the complete sharing workflow with real storage
 func TestSharingIntegrationSimple(t *testing.T) {
 	// Initialize i18n for testing
@@ -25,7 +31,8 @@ func TestSharingIntegrationSimple(t *testing.T) {
 	// Create test database (in-memory for isolation).
 	// Use WAL journal mode to allow concurrent reads alongside writes,
 	// and limit to a single connection so SQLite doesn't deadlock itself.
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_journal_mode=WAL"), &gorm.Config{})
+	dsn := fmt.Sprintf("file:kx_sharing_simple_%d?mode=memory&cache=shared&_journal_mode=WAL", sharingIntegrationDBSeq.Add(1))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 
 	sqlDB, err := db.DB()

--- a/internal/core/update_user_deactivation_test.go
+++ b/internal/core/update_user_deactivation_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +16,13 @@ import (
 	"gorm.io/gorm"
 )
 
+// updateUserDeactivationDBSeq makes each in-memory DB unique within the
+// process. Both tests below previously used the exact same literal DSN, so
+// under `go test -count=N` each repeated call attached to the same SQLite
+// shared-cache in-memory database left open by a prior call and collided on
+// the seeded fixture user IDs.
+var updateUserDeactivationDBSeq atomic.Int64
+
 // TestUpdateUser_Deactivation_RevokesSessionsAndPATs verifies that setting
 // IsActive=false via UpdateUser immediately terminates the user's active
 // sessions and PATs and evicts them from the auth cache (#r124-M).
@@ -23,7 +32,8 @@ import (
 func TestUpdateUser_Deactivation_RevokesSessionsAndPATs(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=5000"), &gorm.Config{})
+	dsn := fmt.Sprintf("file:kx_update_user_deactivation_%d?mode=memory&cache=shared&_journal_mode=WAL&_busy_timeout=5000", updateUserDeactivationDBSeq.Add(1))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
@@ -104,7 +114,8 @@ func TestUpdateUser_Deactivation_RevokesSessionsAndPATs(t *testing.T) {
 func TestUpdateUser_NoRevocation_WhenAlreadyInactive(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=5000"), &gorm.Config{})
+	dsn := fmt.Sprintf("file:kx_update_user_deactivation_%d?mode=memory&cache=shared&_journal_mode=WAL&_busy_timeout=5000", updateUserDeactivationDBSeq.Add(1))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)


### PR DESCRIPTION
## Summary
Follow-up to #1237 — root-causes the second flakiness cluster it flagged as pre-existing/out-of-scope: `TestPurgeAuditLogs_HappyPath`, `TestBulkApproveAccessRequests_SuccessPath`, `TestBulkRejectAccessRequests_SuccessPath`, `TestSharingIntegrationSimple`, and both `TestUpdateUser_Deactivation_*` tests, all only flaky under `go test -count=N` (not a single run).

Each opened its in-memory SQLite DB with a fixed literal DSN, or a DSN built from `t.Name()` alone (which is identical across repeated invocations of the same test within one `-count=N` process). GORM never closes the pooled connection, so under `cache=shared` a repeated invocation attached to the *same live database* the prior iteration left open instead of getting a fresh one:
- `TestPurgeAuditLogs_HappyPath`: leftover "recent" audit rows from the prior iteration inflated the retained-count assertion.
- The other four: fixed seed IDs (`roles.id=1`, `users.id=1/42/43`) collided with rows the prior iteration already inserted → `UNIQUE constraint failed`.

This is a test-only defect — not a production bug — and matches a pattern this same package already has an established fix for elsewhere (`patExpiryDBSeq`/`aclListDBCounter` atomic sequences). Added the same idiom to each affected file: a package-level `atomic.Int64` folded into the DSN so every invocation gets a guaranteed-fresh database.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/core/... -run '<all 6 test names>' -count=5` — 55 passed, no flakiness (confirmed across two separate runs)
- [x] `gofmt -l` / `go vet` clean on changed files

## Note
`bulk_delete_test.go` uses the same `t.Name()`-only DSN pattern and has latent exposure to this same bug class, but wasn't part of the flagged cluster — left untouched for a follow-up.