### PR TITLE
fix(test): sweep repo for the shared-cache SQLite DSN-collision bug

### DIFF
--- a/internal/cli/migrate/migrate_s24_test.go
+++ b/internal/cli/migrate/migrate_s24_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -22,6 +23,11 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+// migrateS24DBSeq makes each in-memory DB unique within the process, so that
+// repeated invocations of the same test (go test -count=N) don't attach to a
+// live leftover DB from a prior iteration.
+var migrateS24DBSeq atomic.Int64
 
 // captureStdout redirects os.Stdout for the duration of fn and returns what was
 // written to it.
@@ -139,7 +145,7 @@ func bootstrapFileDBWithProjectAndUser(t *testing.T, dbPath, projectName, userna
 // the requested name. This uses an in-memory core with no projects seeded, so
 // the list returns an empty slice.
 func TestResolveProjectID_NotFoundAfterListSucceeds(t *testing.T) {
-	dsn := "file:test_migrate_s24_" + t.Name() + "?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:test_migrate_s24_%s_%d?mode=memory&cache=shared", t.Name(), migrateS24DBSeq.Add(1))
 	require.NoError(t, i18n.Initialize(&config.Config{
 		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
 	}))
@@ -180,7 +186,7 @@ func TestResolveProjectID_NotFoundAfterListSucceeds(t *testing.T) {
 // roles.assign check. This is a complementary angle to the authority_test
 // coverage using the shared newBootstrappedCore helper.
 func TestRequireMigrationAuthority_RolesAssignDenied(t *testing.T) {
-	dsn := "file:test_migrate_s24_" + t.Name() + "?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:test_migrate_s24_%s_%d?mode=memory&cache=shared", t.Name(), migrateS24DBSeq.Add(1))
 	require.NoError(t, i18n.Initialize(&config.Config{
 		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
 	}))

--- a/internal/cli/migrate/migrate_s3_test.go
+++ b/internal/cli/migrate/migrate_s3_test.go
@@ -2,8 +2,10 @@ package migrate
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -17,6 +19,11 @@ import (
 	"gorm.io/gorm"
 )
 
+// migrateS3DBSeq makes each in-memory DB unique within the process, so that
+// repeated invocations of the same test (go test -count=N) don't attach to a
+// live leftover DB from a prior iteration.
+var migrateS3DBSeq atomic.Int64
+
 // newBootstrappedCore creates an in-memory core with RBAC fully seeded,
 // mirroring newTestMigrateCore in user_to_machine_authority_test.go.
 func newBootstrappedCore(t *testing.T) (*core.KeyorixCore, *store.LocalStorage) {
@@ -26,7 +33,7 @@ func newBootstrappedCore(t *testing.T) (*core.KeyorixCore, *store.LocalStorage) 
 	}))
 
 	// Use a unique per-test DSN so parallel tests don't share state.
-	dsn := "file:test_migrate_s3_" + t.Name() + "?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:test_migrate_s3_%s_%d?mode=memory&cache=shared", t.Name(), migrateS3DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
@@ -64,7 +71,7 @@ func resetU2MVars(t *testing.T) {
 	t.Helper()
 	orig := struct {
 		project, typ, name, by string
-		keepUser                bool
+		keepUser               bool
 	}{u2mProject, u2mType, u2mName, u2mBy, u2mKeepUser}
 	t.Cleanup(func() {
 		u2mProject = orig.project

--- a/internal/core/audit_log_retention_test.go
+++ b/internal/core/audit_log_retention_test.go
@@ -3,6 +3,8 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,12 +17,19 @@ import (
 	"gorm.io/gorm"
 )
 
+// purgeTestDBSeq makes each in-memory DB unique within the process so that
+// repeated invocations of the same test (e.g. `go test -count=N`) don't
+// attach to the same SQLite shared-cache in-memory database as a prior
+// iteration and see its leftover rows.
+var purgeTestDBSeq atomic.Int64
+
 // newPurgeTestCore opens a fresh in-memory SQLite DB, migrates AuditEvent and
 // LegalHold (needed by the legalHoldGuard that PurgeAuditLogs now calls),
 // and returns a KeyorixCore with a fixed clock so retention cutoffs are stable.
 func newPurgeTestCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open("file::memory:?mode=memory&cache=shared&_busy_timeout=5000"), &gorm.Config{})
+	dsn := fmt.Sprintf("file:kx_purge_%d?mode=memory&cache=shared&_busy_timeout=5000", purgeTestDBSeq.Add(1))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.LegalHold{}))
 	fixed := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
@@ -45,7 +54,7 @@ func TestPurgeAuditLogs_HappyPath(t *testing.T) {
 
 	// Five events older than 30 days.
 	for i := 0; i < 5; i++ {
-		seedRetentionAuditEvent(t, db, fixed.AddDate(0, 0, -(31 + i)))
+		seedRetentionAuditEvent(t, db, fixed.AddDate(0, 0, -(31+i)))
 	}
 	// Three recent events within the retention window.
 	for i := 0; i < 3; i++ {

--- a/internal/core/bulk_access_requests_integration_test.go
+++ b/internal/core/bulk_access_requests_integration_test.go
@@ -7,6 +7,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +19,12 @@ import (
 	"gorm.io/gorm"
 )
 
+// bulkAccessDBSeq makes each in-memory DB unique within the process. t.Name()
+// alone repeats across `go test -count=N` iterations of the same test, which
+// would otherwise attach to the same SQLite shared-cache in-memory database
+// left open by a prior iteration and collide on the seeded fixture rows.
+var bulkAccessDBSeq atomic.Int64
+
 // setupBulkAccessDB opens a uniquely-named in-memory SQLite DB, migrates all
 // tables needed for access-request approval/rejection (roles, permissions,
 // assignments, SoD, access schedules, audit), and seeds minimal RBAC fixtures.
@@ -26,7 +33,7 @@ func setupBulkAccessDB(t *testing.T) (k *KeyorixCore, db *gorm.DB, approverID, r
 	t.Helper()
 	require.NoError(t, i18n.InitializeForTesting())
 
-	dsn := fmt.Sprintf("file:bulkaccess_%s?mode=memory&cache=shared&_busy_timeout=5000", t.Name())
+	dsn := fmt.Sprintf("file:bulkaccess_%s_%d?mode=memory&cache=shared&_busy_timeout=5000", t.Name(), bulkAccessDBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()

--- a/internal/core/bulk_delete_test.go
+++ b/internal/core/bulk_delete_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,14 +18,18 @@ import (
 	"gorm.io/gorm"
 )
 
+// bulkDeleteDBSeq makes each in-memory DB unique within the process.
+var bulkDeleteDBSeq atomic.Int64
+
 // setupBulkDeleteDB opens an in-memory SQLite DB, migrates the necessary models,
 // and returns a core instance plus a factory for creating test secrets.
 func setupBulkDeleteDB(t *testing.T) (*KeyorixCore, func(name string) uint) {
 	t.Helper()
 	require.NoError(t, i18n.InitializeForTesting())
 
-	// Use a unique in-memory DSN per test to avoid shared state across tests.
-	dsn := "file:bulkdelete_" + t.Name() + "?mode=memory&cache=shared&_busy_timeout=5000"
+	// Use a unique in-memory DSN per invocation to avoid shared state across tests
+	// and across repeated invocations of the same test (e.g. go test -count=N).
+	dsn := fmt.Sprintf("file:bulkdelete_%d?mode=memory&cache=shared&_busy_timeout=5000", bulkDeleteDBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
@@ -191,7 +196,7 @@ func TestBulkDeleteSecrets_CrossProjectGuard(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 	ctx := context.Background()
 
-	dsn := "file:bulkdelete_crossproject_" + t.Name() + "?mode=memory&cache=shared&_busy_timeout=5000"
+	dsn := fmt.Sprintf("file:bulkdelete_crossproject_%d?mode=memory&cache=shared&_busy_timeout=5000", bulkDeleteDBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()

--- a/internal/core/bulk_rotate_test.go
+++ b/internal/core/bulk_rotate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,6 +17,9 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+// bulkRotateDBSeq makes each in-memory DB unique within the process.
+var bulkRotateDBSeq atomic.Int64
 
 // bulkRotateDBRaw sets up an isolated in-memory SQLite DB and returns the core and the
 // raw LocalStorage for tests that need more granular control (cross-project, folder-node,
@@ -41,7 +45,8 @@ func bulkRotateDBRaw(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 // tests and returns a core + a helper to create test secrets.
 func bulkRotateDB(t *testing.T) (*KeyorixCore, func(name, classification string, autoRotate bool) uint) {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_journal_mode=WAL"), &gorm.Config{})
+	dsn := fmt.Sprintf("file:bulk_rotate_shared_%d?mode=memory&cache=shared&_journal_mode=WAL", bulkRotateDBSeq.Add(1))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)

--- a/internal/core/compliance_snapshots_test.go
+++ b/internal/core/compliance_snapshots_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,9 +16,12 @@ import (
 	"gorm.io/gorm"
 )
 
+// complianceSnapDBSeq makes each in-memory DB unique within the process.
+var complianceSnapDBSeq atomic.Int64
+
 func newSnapshotCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
-	dsn := fmt.Sprintf("file:kx_snap_core_%s?mode=memory&cache=shared&_timeout=30000", t.Name())
+	dsn := fmt.Sprintf("file:kx_snap_core_%d?mode=memory&cache=shared&_timeout=30000", complianceSnapDBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(

--- a/internal/core/sharing_integration_simple_test.go
+++ b/internal/core/sharing_integration_simple_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,6 +16,11 @@ import (
 	"gorm.io/gorm"
 )
 
+// sharingIntegrationDBSeq makes each in-memory DB unique within the process
+// so that repeated invocations (e.g. `go test -count=N`) don't attach to the
+// same SQLite shared-cache in-memory database left open by a prior iteration.
+var sharingIntegrationDBSeq atomic.Int64
+
 // TestSharingIntegrationSimple tests the complete sharing workflow with real storage
 func TestSharingIntegrationSimple(t *testing.T) {
 	// Initialize i18n for testing
@@ -25,7 +31,8 @@ func TestSharingIntegrationSimple(t *testing.T) {
 	// Create test database (in-memory for isolation).
 	// Use WAL journal mode to allow concurrent reads alongside writes,
 	// and limit to a single connection so SQLite doesn't deadlock itself.
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_journal_mode=WAL"), &gorm.Config{})
+	dsn := fmt.Sprintf("file:kx_sharing_simple_%d?mode=memory&cache=shared&_journal_mode=WAL", sharingIntegrationDBSeq.Add(1))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 
 	sqlDB, err := db.DB()

--- a/internal/core/update_user_deactivation_test.go
+++ b/internal/core/update_user_deactivation_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +16,13 @@ import (
 	"gorm.io/gorm"
 )
 
+// updateUserDeactivationDBSeq makes each in-memory DB unique within the
+// process. Both tests below previously used the exact same literal DSN, so
+// under `go test -count=N` each repeated call attached to the same SQLite
+// shared-cache in-memory database left open by a prior call and collided on
+// the seeded fixture user IDs.
+var updateUserDeactivationDBSeq atomic.Int64
+
 // TestUpdateUser_Deactivation_RevokesSessionsAndPATs verifies that setting
 // IsActive=false via UpdateUser immediately terminates the user's active
 // sessions and PATs and evicts them from the auth cache (#r124-M).
@@ -23,7 +32,8 @@ import (
 func TestUpdateUser_Deactivation_RevokesSessionsAndPATs(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=5000"), &gorm.Config{})
+	dsn := fmt.Sprintf("file:kx_update_user_deactivation_%d?mode=memory&cache=shared&_journal_mode=WAL&_busy_timeout=5000", updateUserDeactivationDBSeq.Add(1))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
@@ -104,7 +114,8 @@ func TestUpdateUser_Deactivation_RevokesSessionsAndPATs(t *testing.T) {
 func TestUpdateUser_NoRevocation_WhenAlreadyInactive(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=5000"), &gorm.Config{})
+	dsn := fmt.Sprintf("file:kx_update_user_deactivation_%d?mode=memory&cache=shared&_journal_mode=WAL&_busy_timeout=5000", updateUserDeactivationDBSeq.Add(1))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)

--- a/internal/encryption/encryption_s25_test.go
+++ b/internal/encryption/encryption_s25_test.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -38,6 +39,11 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+// s25DBSeq makes each in-memory DB unique within the process, so that
+// repeated invocations of the same test (go test -count=N) don't attach to a
+// live leftover DB from a prior iteration.
+var s25DBSeq atomic.Int64
+
 // ─── local helpers ────────────────────────────────────────────────────────────
 
 func s25ES(t *testing.T) *EncryptionService {
@@ -49,7 +55,7 @@ func s25ES(t *testing.T) *EncryptionService {
 
 func s25DB(t *testing.T) *gorm.DB {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file::s25_%s:?mode=memory&cache=shared", t.Name())),
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file::s25_%s_%d:?mode=memory&cache=shared", t.Name(), s25DBSeq.Add(1))),
 		&gorm.Config{Logger: logger.Discard})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
@@ -91,8 +97,8 @@ func TestSweepSecretVersions_DeserializeError(t *testing.T) {
 
 	// Store a version with corrupt (non-parseable) encrypted value.
 	ver := &models.SecretVersion{
-		SecretNodeID:  node.ID,
-		VersionNumber: 1,
+		SecretNodeID:   node.ID,
+		VersionNumber:  1,
 		EncryptedValue: []byte(`{bad json`),
 	}
 	require.NoError(t, db.Create(ver).Error)
@@ -119,10 +125,10 @@ func TestSweepSecretVersions_NoProjectFound_Error(t *testing.T) {
 
 	// Insert a version that references a SecretNodeID that has NO matching SecretNode row.
 	ver := &models.SecretVersion{
-		SecretNodeID:        9999, // no such node
-		VersionNumber:       1,
-		EncryptedValue:      encBytes,
-		EncryptionMetadata:  models.JSON(metaBytes),
+		SecretNodeID:       9999, // no such node
+		VersionNumber:      1,
+		EncryptedValue:     encBytes,
+		EncryptionMetadata: models.JSON(metaBytes),
 	}
 	require.NoError(t, db.Create(ver).Error)
 
@@ -1092,7 +1098,7 @@ func TestSweepSessions_UpdatesError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Open a fresh DB just for this test.
-	db, err := gorm.Open(sqlite.Open("file::s25_sweep_sess_close?mode=memory&cache=shared"),
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file::s25_sweep_sess_close_%d?mode=memory&cache=shared", s25DBSeq.Add(1))),
 		&gorm.Config{Logger: logger.Discard})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.Session{}))
@@ -1127,7 +1133,7 @@ func TestSweepAPITokens_UpdatesError(t *testing.T) {
 	metaBytes, err := json.Marshal(enc.Metadata)
 	require.NoError(t, err)
 
-	db, err := gorm.Open(sqlite.Open("file::s25_sweep_apitoken_close?mode=memory&cache=shared"),
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file::s25_sweep_apitoken_close_%d?mode=memory&cache=shared", s25DBSeq.Add(1))),
 		&gorm.Config{Logger: logger.Discard})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.APIToken{}))
@@ -1158,7 +1164,7 @@ func TestSweepAPIClients_UpdatesError(t *testing.T) {
 	metaBytes, err := json.Marshal(enc.Metadata)
 	require.NoError(t, err)
 
-	db, err := gorm.Open(sqlite.Open("file::s25_sweep_apiclient_close?mode=memory&cache=shared"),
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file::s25_sweep_apiclient_close_%d?mode=memory&cache=shared", s25DBSeq.Add(1))),
 		&gorm.Config{Logger: logger.Discard})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.APIClient{}))
@@ -1191,7 +1197,7 @@ func TestSweepPasswordResets_UpdatesError(t *testing.T) {
 	metaBytes, err := json.Marshal(enc.Metadata)
 	require.NoError(t, err)
 
-	db, err := gorm.Open(sqlite.Open("file::s25_sweep_pwreset_close?mode=memory&cache=shared"),
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file::s25_sweep_pwreset_close_%d?mode=memory&cache=shared", s25DBSeq.Add(1))),
 		&gorm.Config{Logger: logger.Discard})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.PasswordReset{}))
@@ -1225,7 +1231,7 @@ func TestSweepMFASecrets_UpdatesError(t *testing.T) {
 	metaBytes, err := json.Marshal(enc.Metadata)
 	require.NoError(t, err)
 
-	db, err := gorm.Open(sqlite.Open("file::s25_sweep_mfa_close?mode=memory&cache=shared"),
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file::s25_sweep_mfa_close_%d?mode=memory&cache=shared", s25DBSeq.Add(1))),
 		&gorm.Config{Logger: logger.Discard})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.MFASecret{}))
@@ -1246,7 +1252,7 @@ func TestSweepMFASecrets_UpdatesError(t *testing.T) {
 func TestSweepDynamicSecretConfigs_UpdatesError(t *testing.T) {
 	es := s25ES(t)
 
-	db, err := gorm.Open(sqlite.Open("file::s25_sweep_dynconfig_close?mode=memory&cache=shared"),
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file::s25_sweep_dynconfig_close_%d?mode=memory&cache=shared", s25DBSeq.Add(1))),
 		&gorm.Config{Logger: logger.Discard})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.DynamicSecretConfig{}))
@@ -1278,7 +1284,7 @@ func TestSweepDynamicSecretConfigs_UpdatesError(t *testing.T) {
 func TestSweepDynamicSecretLeases_UpdatesError(t *testing.T) {
 	es := s25ES(t)
 
-	db, err := gorm.Open(sqlite.Open("file::s25_sweep_dynlease_close?mode=memory&cache=shared"),
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file::s25_sweep_dynlease_close_%d?mode=memory&cache=shared", s25DBSeq.Add(1))),
 		&gorm.Config{Logger: logger.Discard})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.DynamicSecretLease{}))
@@ -1590,7 +1596,7 @@ type mockKeyProvider struct {
 }
 
 func (m *mockKeyProvider) KEK() ([]byte, error) { return m.kek, m.err }
-func (m *mockKeyProvider) Name() string          { return "mock" }
+func (m *mockKeyProvider) Name() string         { return "mock" }
 
 // ─── unwrapKey: too-short wrapped key returns error ───────────────────────────
 

--- a/internal/storage/storage_s27_test.go
+++ b/internal/storage/storage_s27_test.go
@@ -50,7 +50,9 @@ package storage
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -59,6 +61,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
+
+// s27ExistingQSDSNSeq makes the in-memory DSN unique per invocation so that
+// repeated test runs (go test -count=N) don't attach to a live leftover DB
+// from a prior iteration.
+var s27ExistingQSDSNSeq atomic.Int64
 
 // ---------------------------------------------------------------------------
 // withMigrationLock — isPostgres=true on a SQLite DB triggers error branch
@@ -453,7 +460,7 @@ func TestCreateLocalStorage_S27_ExistingDSNQueryString(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Storage.Type = "local"
 	// A named in-memory DSN that already has a query-string component.
-	cfg.Storage.Database.Path = "file:creates27_existing_qs?mode=memory&cache=shared"
+	cfg.Storage.Database.Path = fmt.Sprintf("file:creates27_existing_qs_%d?mode=memory&cache=shared", s27ExistingQSDSNSeq.Add(1))
 
 	s, err := NewStorageFactory().CreateStorage(cfg)
 	require.NoError(t, err, "createLocalStorage must succeed with a pre-existing DSN query string")

--- a/internal/storage/store/like_escape_integration_test.go
+++ b/internal/storage/store/like_escape_integration_test.go
@@ -6,6 +6,8 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,11 +19,15 @@ import (
 	"gorm.io/gorm"
 )
 
+// likeEscapeDBSeq makes each in-memory DB unique within the process, even
+// across repeated invocations of the same test (e.g. `go test -count=N`).
+var likeEscapeDBSeq atomic.Int64
+
 // TestGetAuditLogs_LIKEEscape_ActorUsername verifies that the escapeLIKE applied
 // to actor_username filter prevents SQL wildcard injection: a search for
 // "alice%admin" must NOT match a user whose name is "alice-admin" (#r124-M).
 func TestGetAuditLogs_LIKEEscape_ActorUsername(t *testing.T) {
-	db, err := gorm.Open(sqlite.Open("file:kxlikeescape_actor?mode=memory&cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:kxlikeescape_actor_%d?mode=memory&cache=shared", likeEscapeDBSeq.Add(1))), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{}))
 
@@ -72,7 +78,7 @@ func TestGetAuditLogs_LIKEEscape_ActorUsername(t *testing.T) {
 // containing SQL LIKE metacharacters is escaped so it matches only the intended
 // resource prefix and not unrelated event types (#r124-M).
 func TestGetAuditLogs_LIKEEscape_ResourceType(t *testing.T) {
-	db, err := gorm.Open(sqlite.Open("file:kxlikeescape_restype?mode=memory&cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:kxlikeescape_restype_%d?mode=memory&cache=shared", likeEscapeDBSeq.Add(1))), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{}))
 
@@ -123,7 +129,7 @@ func TestGetAuditLogs_LIKEEscape_ResourceType(t *testing.T) {
 // is silently clamped to maxStoragePage rather than generating an enormous OFFSET
 // (#r124-M pagination DoS).
 func TestGetAuditLogs_ClampPage(t *testing.T) {
-	db, err := gorm.Open(sqlite.Open("file:kxlikeescape_clamppage?mode=memory&cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:kxlikeescape_clamppage_%d?mode=memory&cache=shared", likeEscapeDBSeq.Add(1))), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{}))
 
@@ -143,7 +149,7 @@ func TestGetAuditLogs_ClampPage(t *testing.T) {
 // parameter is escaped so a caller-supplied "%" or "_" in a search term does
 // not expand unexpectedly (#r124-M LIKE injection in ListSecrets).
 func TestListSecrets_LIKEEscape_Search(t *testing.T) {
-	db, err := gorm.Open(sqlite.Open("file:kxlikeescape_search?mode=memory&cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:kxlikeescape_search_%d?mode=memory&cache=shared", likeEscapeDBSeq.Add(1))), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}))
 

--- a/internal/storage/store/local_bulk_access_test.go
+++ b/internal/storage/store/local_bulk_access_test.go
@@ -4,6 +4,8 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -13,11 +15,15 @@ import (
 	"gorm.io/gorm"
 )
 
+// bulkAccessDBSeq makes each in-memory DB unique within the process, even
+// across repeated invocations of the same test (e.g. `go test -count=N`).
+var bulkAccessDBSeq atomic.Int64
+
 // newBulkAccessStore returns a LocalStorage backed by an in-memory SQLite DB
 // migrated with the tables required for bulk-access operations.
 func newBulkAccessStore(t *testing.T) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_bulkaccess?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_bulkaccess_%d?mode=memory&cache=shared", t.Name(), bulkAccessDBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
@@ -42,7 +48,7 @@ func newBulkAccessStore(t *testing.T) *LocalStorage {
 // so every call returns "no such table" errors.
 func newBulkAccessBrokenStore(t *testing.T) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_bulkbroken?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_bulkbroken_%d?mode=memory&cache=shared", t.Name(), bulkAccessDBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	return NewLocalStorage(db)

--- a/internal/storage/store/local_coverage_test.go
+++ b/internal/storage/store/local_coverage_test.go
@@ -18,7 +18,9 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -33,10 +35,14 @@ import (
 // helpers
 // ---------------------------------------------------------------------------
 
+// coverageDBSeq makes each in-memory DB unique within the process, even
+// across repeated invocations of the same test (e.g. `go test -count=N`).
+var coverageDBSeq atomic.Int64
+
 // newCovStore opens a unique in-memory SQLite and migrates the provided models.
 func newCovStore(t *testing.T, ms ...any) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_cov?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_cov_%d?mode=memory&cache=shared", t.Name(), coverageDBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	if len(ms) > 0 {
@@ -50,7 +56,7 @@ func newCovStore(t *testing.T, ms ...any) *LocalStorage {
 // such table".
 func newSecretOnlyStore(t *testing.T) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_seconly?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_seconly_%d?mode=memory&cache=shared", t.Name(), coverageDBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}))

--- a/internal/storage/store/local_usage_test.go
+++ b/internal/storage/store/local_usage_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,11 +14,15 @@ import (
 	"gorm.io/gorm"
 )
 
+// usageDBSeq makes each in-memory DB unique within the process, even across
+// repeated invocations of the same test (e.g. `go test -count=N`).
+var usageDBSeq atomic.Int64
+
 // newUsageStore opens a unique named in-memory SQLite DB, migrates the
 // tables needed for GetProjectUsageStats, and returns a LocalStorage.
 func newUsageStore(t *testing.T) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_usage?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_usage_%d?mode=memory&cache=shared", t.Name(), usageDBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 

--- a/internal/storage/store/store_max_test.go
+++ b/internal/storage/store/store_max_test.go
@@ -18,6 +18,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -33,9 +34,13 @@ import (
 // helper: newMaxStore — unique in-memory SQLite DB auto-migrated for many models
 // ---------------------------------------------------------------------------
 
+// maxStoreDBSeq makes each in-memory DB unique within the process, even
+// across repeated invocations of the same test (e.g. `go test -count=N`).
+var maxStoreDBSeq atomic.Int64
+
 func newMaxStore(t *testing.T, tag string, ms ...any) *LocalStorage {
 	t.Helper()
-	dsn := fmt.Sprintf("file:max_%s_%s?mode=memory&cache=shared", tag, t.Name())
+	dsn := fmt.Sprintf("file:max_%s_%s_%d?mode=memory&cache=shared", tag, t.Name(), maxStoreDBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	if len(ms) > 0 {

--- a/internal/storage/store/store_s21_test.go
+++ b/internal/storage/store/store_s21_test.go
@@ -4,12 +4,14 @@
 //   - local_scheduler_lock.go      WithSchedulerLock — happy path (fn=nil), panic recovery
 //   - local_audit_checkpoint_lock.go WithAuditCheckpointLock — happy path (fn=nil)
 //   - local_sharing.go             CreateShareRecord — validation error, owner mismatch,
-//                                  group recipient path, upsert (existing share updated)
+//     group recipient path, upsert (existing share updated)
 package store
 
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -19,11 +21,15 @@ import (
 	"gorm.io/gorm"
 )
 
+// s21DBSeq makes each in-memory DB unique within the process, even across
+// repeated invocations of the same test (e.g. `go test -count=N`).
+var s21DBSeq atomic.Int64
+
 // newS21UniqueStore opens a fresh in-memory SQLite DB with a per-test unique DSN
 // so parallel tests don't share the same in-memory instance.
 func newS21UniqueStore(t *testing.T, mods ...interface{}) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s21_%d?mode=memory&cache=shared", t.Name(), s21DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	if len(mods) > 0 {

--- a/internal/storage/store/store_s22_test.go
+++ b/internal/storage/store/store_s22_test.go
@@ -2,43 +2,45 @@
 //
 // Targets (all 0 % or low-% from the post-s21 coverage run):
 //
-//   local_auth.go
-//     EnforceSessionLimit          (0%)
-//     TouchSession                 (0%)
-//     CleanupExpiredSessions       (0%)
-//     GetPersonalAccessTokenByID   (0%)
-//     GetPersonalAccessTokenByHash (0%)
-//     RevokeAllPersonalAccessTokensForUser (0%)
-//     TouchPersonalAccessToken     (0%)
-//     CreateSetupToken             (0%)
-//     GetSetupTokenByHash          (0%)
-//     SupersedeActiveSetupTokens   (0%)
-//     MarkSetupTokenConsumed       (0%)
-//     MarkSetupTokenExpired        (0%)
-//     CountSetupTokensSince        (0%)
+//	local_auth.go
+//	  EnforceSessionLimit          (0%)
+//	  TouchSession                 (0%)
+//	  CleanupExpiredSessions       (0%)
+//	  GetPersonalAccessTokenByID   (0%)
+//	  GetPersonalAccessTokenByHash (0%)
+//	  RevokeAllPersonalAccessTokensForUser (0%)
+//	  TouchPersonalAccessToken     (0%)
+//	  CreateSetupToken             (0%)
+//	  GetSetupTokenByHash          (0%)
+//	  SupersedeActiveSetupTokens   (0%)
+//	  MarkSetupTokenConsumed       (0%)
+//	  MarkSetupTokenExpired        (0%)
+//	  CountSetupTokensSince        (0%)
 //
-//   local_break_glass.go
-//     CreateBreakGlassActivation   (0%)
-//     GetBreakGlassActivation      (0%)
-//     RevokeBreakGlassActivation   (0%)
+//	local_break_glass.go
+//	  CreateBreakGlassActivation   (0%)
+//	  GetBreakGlassActivation      (0%)
+//	  RevokeBreakGlassActivation   (0%)
 //
-//   local_login_attempts.go
-//     PruneLoginAttempts           (0%)
+//	local_login_attempts.go
+//	  PruneLoginAttempts           (0%)
 //
-//   local_webauthn.go
-//     LockWebAuthnCredentialForUpdate (0% — SQLite path)
-//     UpdateWebAuthnCredential     (0%)
-//     AdvanceWebAuthnCredentialCounter (0%)
-//     DeleteWebAuthnCredential     (0%)
-//     CountWebAuthnCredentials     (0%)
-//     SetUserWebAuthnEnabled       (0%)
-//     CreateWebAuthnSession        (0%)
-//     ConsumeWebAuthnSession       (0%)
+//	local_webauthn.go
+//	  LockWebAuthnCredentialForUpdate (0% — SQLite path)
+//	  UpdateWebAuthnCredential     (0%)
+//	  AdvanceWebAuthnCredentialCounter (0%)
+//	  DeleteWebAuthnCredential     (0%)
+//	  CountWebAuthnCredentials     (0%)
+//	  SetUserWebAuthnEnabled       (0%)
+//	  CreateWebAuthnSession        (0%)
+//	  ConsumeWebAuthnSession       (0%)
 package store
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -49,11 +51,15 @@ import (
 	"gorm.io/gorm"
 )
 
+// s22DBSeq makes each in-memory DB unique within the process, even across
+// repeated invocations of the same test (e.g. `go test -count=N`).
+var s22DBSeq atomic.Int64
+
 // newS22Store opens a unique in-memory SQLite DB, migrates the supplied models
 // and returns the LocalStorage. It mirrors the s21 helper pattern.
 func newS22Store(t *testing.T, mods ...interface{}) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_s22?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s22_%d?mode=memory&cache=shared", t.Name(), s22DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	if len(mods) > 0 {

--- a/internal/storage/store/store_s23_test.go
+++ b/internal/storage/store/store_s23_test.go
@@ -20,6 +20,8 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,12 +33,16 @@ import (
 	"gorm.io/gorm"
 )
 
+// s23DBSeq makes each in-memory DB unique within the process, even across
+// repeated invocations of the same test (e.g. `go test -count=N`).
+var s23DBSeq atomic.Int64
+
 // newS23Store opens a unique in-memory SQLite DB, migrates the supplied models
 // and returns the LocalStorage. Mirrors the s21/s22 helper pattern, using a
 // "_s23" suffix so test-name-based DSNs cannot collide with other sweeps.
 func newS23Store(t *testing.T, mods ...interface{}) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_s23?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s23_%d?mode=memory&cache=shared", t.Name(), s23DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	if len(mods) > 0 {
@@ -51,7 +57,7 @@ func newS23Store(t *testing.T, mods ...interface{}) *LocalStorage {
 // ErrDuplicateReminderNotification path in CreateNotification.
 func newS23NotifStore(t *testing.T) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_s23notif?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s23notif_%d?mode=memory&cache=shared", t.Name(), s23DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.Notification{}))

--- a/internal/storage/store/store_s24_test.go
+++ b/internal/storage/store/store_s24_test.go
@@ -17,7 +17,9 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,12 +28,16 @@ import (
 	"gorm.io/gorm"
 )
 
+// s24DBSeq makes each in-memory DB unique within the process, even across
+// repeated invocations of the same test (e.g. `go test -count=N`).
+var s24DBSeq atomic.Int64
+
 // newS24Store opens a unique in-memory SQLite DB and returns a LocalStorage.
 // Uses a "_s24" suffix in the DSN so test-name-based DSNs cannot collide with
 // other sweeps.
 func newS24Store(t *testing.T) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_s24?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s24_%d?mode=memory&cache=shared", t.Name(), s24DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	return NewLocalStorage(db)

--- a/internal/storage/store/store_s25_test.go
+++ b/internal/storage/store/store_s25_test.go
@@ -58,6 +58,8 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -69,12 +71,16 @@ import (
 	"gorm.io/gorm"
 )
 
+// s25DBSeq makes each in-memory DB unique within the process, even across
+// repeated invocations of the same test (e.g. `go test -count=N`).
+var s25DBSeq atomic.Int64
+
 // newS25Store opens a fresh in-memory SQLite DB, runs AutoMigrate on the
 // supplied model types, and returns the LocalStorage. Using a "_s25" DSN
 // suffix prevents collisions with other sweeps' test-name-keyed DSNs.
 func newS25Store(t *testing.T, mods ...interface{}) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_s25?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s25_%d?mode=memory&cache=shared", t.Name(), s25DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	if len(mods) > 0 {

--- a/internal/storage/store/store_s26_test.go
+++ b/internal/storage/store/store_s26_test.go
@@ -52,6 +52,8 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -63,12 +65,16 @@ import (
 	"gorm.io/gorm"
 )
 
+// s26DBSeq makes each in-memory DB unique within the process, even across
+// repeated invocations of the same test (e.g. `go test -count=N`).
+var s26DBSeq atomic.Int64
+
 // newS26Store opens a unique in-memory SQLite DB with the requested models
 // auto-migrated. The "_s26" suffix in the DSN prevents collisions with other
 // test files that use the same test-name-keyed DSN pattern.
 func newS26Store(t *testing.T, mods ...interface{}) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_s26?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s26_%d?mode=memory&cache=shared", t.Name(), s26DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	if len(mods) > 0 {

--- a/internal/storage/store/store_s27_test.go
+++ b/internal/storage/store/store_s27_test.go
@@ -78,6 +78,8 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -93,11 +95,15 @@ import (
 // helpers
 // ---------------------------------------------------------------------------
 
+// s27DBSeq makes each in-memory DB unique within the process, even across
+// repeated invocations of the same test (e.g. `go test -count=N`).
+var s27DBSeq atomic.Int64
+
 // newS27Store opens a unique in-memory SQLite DB with the requested models
 // auto-migrated.
 func newS27Store(t *testing.T, mods ...interface{}) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_s27?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s27_%d?mode=memory&cache=shared", t.Name(), s27DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	if len(mods) > 0 {
@@ -109,7 +115,7 @@ func newS27Store(t *testing.T, mods ...interface{}) *LocalStorage {
 // brokenS27Store returns a LocalStorage whose DB is closed so every query fails.
 func brokenS27Store(t *testing.T) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_s27broken?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s27broken_%d?mode=memory&cache=shared", t.Name(), s27DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, err := db.DB()

--- a/internal/storage/store/store_s27b_test.go
+++ b/internal/storage/store/store_s27b_test.go
@@ -45,6 +45,8 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -56,12 +58,16 @@ import (
 	"gorm.io/gorm"
 )
 
+// s27bDBSeq makes each in-memory DB unique within the process, even across
+// repeated invocations of the same test (e.g. `go test -count=N`).
+var s27bDBSeq atomic.Int64
+
 // newS27bStore opens a unique in-memory SQLite DB, auto-migrates the supplied
 // model types, and returns a LocalStorage. The "_s27b" suffix avoids DSN
 // collisions with store_s27_test.go's "_s27" suffix.
 func newS27bStore(t *testing.T, mods ...interface{}) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_s27b?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s27b_%d?mode=memory&cache=shared", t.Name(), s27bDBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	if len(mods) > 0 {
@@ -284,8 +290,8 @@ func TestCountProjectMembershipsByUsers_S27b_HappyPath(t *testing.T) {
 	rows := []*models.ProjectMembership{
 		{ProjectID: 1, UserID: 10, State: "active", InvitedAt: now},
 		{ProjectID: 2, UserID: 10, State: "active", InvitedAt: now},
-		{ProjectID: 3, UserID: 10, State: "invited", InvitedAt: now},  // non-revoked but not active
-		{ProjectID: 4, UserID: 10, State: "revoked", InvitedAt: now},  // revoked — excluded from total
+		{ProjectID: 3, UserID: 10, State: "invited", InvitedAt: now}, // non-revoked but not active
+		{ProjectID: 4, UserID: 10, State: "revoked", InvitedAt: now}, // revoked — excluded from total
 	}
 	for _, r := range rows {
 		require.NoError(t, ls.db.Create(r).Error)

--- a/internal/storage/store/store_s28_test.go
+++ b/internal/storage/store/store_s28_test.go
@@ -96,8 +96,10 @@ package store_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -109,6 +111,10 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+// s28DBSeq makes each in-memory DB unique within the process, even across
+// repeated invocations of the same test (e.g. `go test -count=N`).
+var s28DBSeq atomic.Int64
 
 // ---------------------------------------------------------------------------
 // helpers
@@ -122,7 +128,7 @@ func apiErrResp(code, message string) []byte {
 // newS28Store opens a unique in-memory SQLite DB with the requested models auto-migrated.
 func newS28Store(t *testing.T, mods ...interface{}) *store.LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_s28?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s28_%d?mode=memory&cache=shared", t.Name(), s28DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	if len(mods) > 0 {
@@ -134,7 +140,7 @@ func newS28Store(t *testing.T, mods ...interface{}) *store.LocalStorage {
 // brokenS28Store returns a LocalStorage whose underlying DB is already closed.
 func brokenS28Store(t *testing.T) *store.LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_s28broken?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s28broken_%d?mode=memory&cache=shared", t.Name(), s28DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, err := db.DB()

--- a/internal/storage/store/store_s29_test.go
+++ b/internal/storage/store/store_s29_test.go
@@ -63,6 +63,8 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -78,10 +80,14 @@ import (
 // helpers
 // ---------------------------------------------------------------------------
 
+// s29DBSeq makes each in-memory DB unique within the process, even across
+// repeated invocations of the same test (e.g. `go test -count=N`).
+var s29DBSeq atomic.Int64
+
 // newS29Store opens a unique in-memory SQLite DB with requested models migrated.
 func newS29Store(t *testing.T, mods ...any) *LocalStorage {
 	t.Helper()
-	dsn := "file:" + t.Name() + "_s29?mode=memory&cache=shared"
+	dsn := fmt.Sprintf("file:%s_s29_%d?mode=memory&cache=shared", t.Name(), s29DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	if len(mods) > 0 {

--- a/internal/storage/store/store_s3_test.go
+++ b/internal/storage/store/store_s3_test.go
@@ -8,6 +8,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,11 +24,15 @@ import (
 // helpers
 // ---------------------------------------------------------------------------
 
+// storeS3DBSeq makes each in-memory DB unique within the process, even
+// across repeated invocations of the same test (e.g. `go test -count=N`).
+var storeS3DBSeq atomic.Int64
+
 // newStoreS3 returns a LocalStorage over a unique in-memory SQLite database,
 // auto-migrated for a given set of GORM models.
 func newStoreS3(t *testing.T, name string, migrateModels ...any) *LocalStorage {
 	t.Helper()
-	dsn := fmt.Sprintf("file:store_s3_%s?mode=memory&cache=shared", name)
+	dsn := fmt.Sprintf("file:store_s3_%s_%d?mode=memory&cache=shared", name, storeS3DBSeq.Add(1))
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	if len(migrateModels) > 0 {
@@ -903,10 +908,10 @@ func TestDynamicSecretLease_CRUD(t *testing.T) {
 
 	now := time.Now()
 	lease, err := ls.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
-		LeaseID:  "lease-001",
-		ConfigID: cfg.ID,
-		Status:   "active",
-		IssuedAt: now,
+		LeaseID:   "lease-001",
+		ConfigID:  cfg.ID,
+		Status:    "active",
+		IssuedAt:  now,
 		ExpiresAt: now.Add(time.Hour),
 	})
 	require.NoError(t, err)
@@ -940,10 +945,10 @@ func TestDynamicSecretLease_CRUD(t *testing.T) {
 
 	// Create an active lease.
 	_, err = ls.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
-		LeaseID:  "lease-002",
-		ConfigID: cfg.ID,
-		Status:   "active",
-		IssuedAt: now,
+		LeaseID:   "lease-002",
+		ConfigID:  cfg.ID,
+		Status:    "active",
+		IssuedAt:  now,
 		ExpiresAt: now.Add(time.Hour),
 	})
 	require.NoError(t, err)
@@ -967,30 +972,30 @@ func TestListExpiredActiveLeases(t *testing.T) {
 
 	// Expired active lease.
 	_, err = ls.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
-		LeaseID:  "exp-active",
-		ConfigID: cfg.ID,
-		Status:   "active",
-		IssuedAt: past,
+		LeaseID:   "exp-active",
+		ConfigID:  cfg.ID,
+		Status:    "active",
+		IssuedAt:  past,
 		ExpiresAt: past,
 	})
 	require.NoError(t, err)
 
 	// Expired revoke_failed lease.
 	_, err = ls.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
-		LeaseID:  "exp-failed",
-		ConfigID: cfg.ID,
-		Status:   "revoke_failed",
-		IssuedAt: past,
+		LeaseID:   "exp-failed",
+		ConfigID:  cfg.ID,
+		Status:    "revoke_failed",
+		IssuedAt:  past,
 		ExpiresAt: past,
 	})
 	require.NoError(t, err)
 
 	// Non-expired active lease.
 	_, err = ls.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
-		LeaseID:  "live-active",
-		ConfigID: cfg.ID,
-		Status:   "active",
-		IssuedAt: now,
+		LeaseID:   "live-active",
+		ConfigID:  cfg.ID,
+		Status:    "active",
+		IssuedAt:  now,
 		ExpiresAt: now.Add(time.Hour),
 	})
 	require.NoError(t, err)

--- a/server/http/handlers/audit_retention_handler_test.go
+++ b/server/http/handlers/audit_retention_handler_test.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -17,12 +19,17 @@ import (
 	"gorm.io/gorm"
 )
 
+// auditRetentionDBCounter makes each in-memory DB unique within the process.
+var auditRetentionDBCounter atomic.Int64
+
 // newAuditRetentionHandler builds an AdminJobsHandler backed by a fresh
 // in-memory SQLite DB with the AuditEvent schema migrated.
 func newAuditRetentionHandler(t *testing.T) *AdminJobsHandler {
 	t.Helper()
 	require.NoError(t, i18n.InitializeForTesting())
-	db, err := gorm.Open(sqlite.Open("file::memory:?mode=memory&cache=shared&_busy_timeout=5000"), &gorm.Config{})
+	n := auditRetentionDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhandlers_auditretention_%d?mode=memory&cache=shared&_busy_timeout=5000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(models.AllTestModels()...))
 	return NewAdminJobsHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
@@ -91,7 +98,9 @@ func TestPurgeAuditLogsHandler_InvalidJSON(t *testing.T) {
 // TestPurgeAuditLogsHandler_StorageError verifies 500 when the DB is closed.
 func TestPurgeAuditLogsHandler_StorageError(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
-	db, err := gorm.Open(sqlite.Open("file::memory:?mode=memory&cache=shared&_busy_timeout=5000"), &gorm.Config{})
+	n := auditRetentionDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhandlers_auditretention_%d?mode=memory&cache=shared&_busy_timeout=5000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(models.AllTestModels()...))
 

--- a/server/http/handlers/rotation_state_handler_test.go
+++ b/server/http/handlers/rotation_state_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -19,6 +20,9 @@ import (
 	"gorm.io/gorm"
 )
 
+// rotationStateDBCounter makes each in-memory DB unique within the process.
+var rotationStateDBCounter atomic.Int64
+
 func setupRotationStateTest(t *testing.T) (*RotationPolicyHandler, *gorm.DB) {
 	t.Helper()
 
@@ -30,7 +34,8 @@ func setupRotationStateTest(t *testing.T) (*RotationPolicyHandler, *gorm.DB) {
 	}
 	require.NoError(t, i18n.Initialize(cfg))
 
-	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	n := rotationStateDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:%s_%d?mode=memory&cache=shared", t.Name(), n)
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 

--- a/server/http/secret_value_by_ref_scope_test.go
+++ b/server/http/secret_value_by_ref_scope_test.go
@@ -28,7 +28,10 @@ func setupByRefScopeCore(t *testing.T) *core.KeyorixCore {
 	// A uniquely-NAMED shared-cache in-memory DB: shared-cache keeps the connection pool
 	// on one DB (a plain ":memory:" pool gives each connection its own empty DB), and the
 	// unique name isolates it from other tests that use the default shared ":memory:".
-	db, err := gorm.Open(sqlite.Open("file:byref_scope_test?mode=memory&cache=shared"), &gorm.Config{})
+	// uniqueMemDSN (defined in integration_test.go) folds in an atomic counter so repeated
+	// invocations within one process (e.g. go test -count=N) each get a fresh DB instead of
+	// re-attaching to a prior iteration's live leftover.
+	db, err := gorm.Open(sqlite.Open(uniqueMemDSN("")), &gorm.Config{})
 	require.NoError(t, err)
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
@@ -59,8 +62,8 @@ func setupByRefScopeCore(t *testing.T) *core.KeyorixCore {
 	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "viewer"}).Error)
 	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
 	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
-	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)                 // admin: global
-	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2, ProjectID: 1}).Error)   // viewerA: project A only
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)               // admin: global
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2, ProjectID: 1}).Error) // viewerA: project A only
 
 	seedSession(t, db, 1, "admin-tok")
 	seedSession(t, db, 2, "viewerA-tok")

--- a/server/middleware/auth_s23_test.go
+++ b/server/middleware/auth_s23_test.go
@@ -2,8 +2,10 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -17,6 +19,11 @@ import (
 	"gorm.io/gorm"
 )
 
+// scopedTestDBSeq makes each in-memory DB unique within the process, so that
+// repeated invocations of the same test (go test -count=N) don't attach to a
+// live leftover DB from a prior iteration.
+var scopedTestDBSeq atomic.Int64
+
 // newScopedTestDB creates an in-memory SQLite DB suitable for scope resolver
 // and handleScopedPermissionRequest tests. It migrates only the tables needed
 // for the paths under test (RBAC, environments, secrets, shares, rotation
@@ -26,7 +33,7 @@ func newScopedTestDB(t *testing.T) *gorm.DB {
 	// i18n is needed by the local storage layer for error messages.
 	require.NoError(t, i18n.InitializeForTesting())
 	// Use a unique per-test file URI so parallel subtests don't share state.
-	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:%s_%d?mode=memory&cache=shared", t.Name(), scopedTestDBSeq.Add(1))), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.Role{},

--- a/server/middleware/auth_s24_test.go
+++ b/server/middleware/auth_s24_test.go
@@ -6,10 +6,12 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,6 +24,11 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+// authS24DBSeq makes each in-memory DB unique within the process, so that
+// repeated invocations of the same test (go test -count=N) don't attach to a
+// live leftover DB from a prior iteration.
+var authS24DBSeq atomic.Int64
 
 // ── validateToken branches ────────────────────────────────────────────────────
 
@@ -189,7 +196,7 @@ func TestPruneLocked_TimeBasedSweep(t *testing.T) {
 // not errTargetNotFound (404).
 func TestScopeFromRefQuery_InvalidRefFormat(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
-	db, err := gorm.Open(sqlite.Open("file:scopeRefInvalid?mode=memory&cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:scopeRefInvalid_%d?mode=memory&cache=shared", authS24DBSeq.Add(1))), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.Project{}, &models.Environment{}, &models.SecretNode{},
@@ -207,7 +214,7 @@ func TestScopeFromRefQuery_InvalidRefFormat(t *testing.T) {
 // a non-existent secret returns errTargetNotFound.
 func TestScopeFromRefQuery_NotFound(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
-	db, err := gorm.Open(sqlite.Open("file:scopeRefNotFound?mode=memory&cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:scopeRefNotFound_%d?mode=memory&cache=shared", authS24DBSeq.Add(1))), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.Project{}, &models.Environment{}, &models.SecretNode{},


### PR DESCRIPTION
## Summary
Follow-up to #1238, which fixed 4 files hitting this bug in `internal/core`. Audited all 98 `*_test.go` files repo-wide using `cache=shared` in-memory SQLite for the same defect class: a DSN built from a fixed literal or `t.Name()` alone is not guaranteed unique across repeated invocations of the same test (`go test -count=N`) — or, in a couple of cases, across different tests in the same package that happened to reuse an identical literal. Since GORM never closes the pooled connection, a later invocation attaches to the *same live database* a prior one left open instead of getting a fresh one, either inflating row counts or colliding on fixed seed IDs.

**Fixed 28 files** (of 98 audited — the rest already used the established `atomic.Int64`-counter-in-DSN idiom, don't use `cache=shared`, or don't open a DB at all):
- `internal/core`: `bulk_delete_test.go`, `bulk_rotate_test.go`, `compliance_snapshots_test.go`
- `internal/storage` / `internal/cli/migrate` / `internal/encryption` / `server/middleware`: `storage_s27_test.go`, `migrate_s3_test.go`, `migrate_s24_test.go`, `encryption_s25_test.go`, `auth_s23_test.go`, `auth_s24_test.go`
- `internal/storage/store` (16 files): `store_s21`–`s29_test.go`, `store_s27b_test.go`, `local_bulk_access_test.go`, `local_usage_test.go`, `local_coverage_test.go`, `store_max_test.go`, `store_s3_test.go`, `like_escape_integration_test.go`
- `server/http(/handlers)`: `secret_value_by_ref_scope_test.go`, `audit_retention_handler_test.go`, `rotation_state_handler_test.go`

Same fix pattern throughout, matching the codebase's own established idiom: a package-level `atomic.Int64` sequence folded into the DSN.

## Test plan
- [x] `go build ./...`
- [x] `go vet` clean on every touched package; `gofmt -l` clean
- [x] Full test suite at `-count=2` for every affected package (`internal/core`, `internal/storage/...`, `server/middleware`, `server/http/...`) — zero new failures vs. an unmodified-`main` baseline captured the same way

## Notes on remaining `-count=2` failures (pre-existing, NOT part of this fix)
- `server/middleware/scheduler_metrics_test.go`: global Prometheus-counter accumulation, unrelated to SQLite.
- `server/http/handlers/handlers_s4_test.go`: a deliberate `sync.Once`-backed singleton DB shared by ~180 call sites across 5 files (to avoid a ~2min CI timeout from repeated `AutoMigrate`). A handful of tests insert non-idempotent fixed data, so they only pass on the *first* invocation of that singleton per process — breaks under `-count=N`, not a normal single CI run. The straightforward DSN-counter fix would defeat the singleton's purpose; fixing it properly needs a design call (rework the singleton's lifecycle vs. make the offending tests idempotent). Flagging separately rather than guessing — see follow-up discussion.
- `TestRemoteStorageMFAManagement_FullLifecycle_RealServer`, `TestScopedRBACEnforcement`, `TestSharingHTTPIntegration`: pre-existing, unrelated, already catalogued as known local-only failures.