### PR TITLE
fix(test): make the 10 handlers_s4-family tests idempotent, not the singleton

### DIFF
--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -808,6 +809,18 @@ var (
 	sharedS4CoreOnce sync.Once
 	sharedS4Core     *core.KeyorixCore
 )
+
+// s4UniqueCounter mints a per-process-unique suffix for literal values (e.g.
+// SSO state tokens, WebAuthn credential IDs, credential token hashes) that a
+// handful of s4/s5/s9 tests insert into the shared sharedS4Core DB. Those
+// tests assert on a fixed-string insert succeeding; under `go test -count=N`
+// the whole binary (and sharedS4Core with it) is reused across iterations, so
+// a hardcoded literal collides with its own prior insert on repeat. Folding
+// this counter into the literal keeps each invocation's value unique without
+// touching the singleton itself. Shared across files (not per-file, unlike
+// the sN DBCounter DSN-uniqueness vars elsewhere in this package) because all
+// of s4/s5/s9 write into the SAME sharedS4Core DB, not independent ones.
+var s4UniqueCounter atomic.Int64
 
 // newHandlerCoreS4 returns a shared *core.KeyorixCore backed by a single
 // in-memory SQLite DB whose schema is migrated exactly once per test binary.
@@ -4539,7 +4552,6 @@ func TestSCIMHandler_PatchGroup_BadID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-
 // ── Batch 3: comprehensive coverage for remaining 0% functions ────────────────
 
 // ── Helper constructors ────────────────────────────────────────────────────────
@@ -5097,7 +5109,11 @@ func TestCreateSSOLoginStateProxy_MissingFields(t *testing.T) {
 
 func TestCreateSSOLoginStateProxy_HappyPath(t *testing.T) {
 	h := newAuthHandlerWithWebAuthn(t)
-	body := `{"state":"s1","nonce":"n1","provider":"oidc","expires_at":"2099-01-01T00:00:00Z"}`
+	// state carries a DB-level uniqueIndex (models.SSOLoginState.State); fold in
+	// a counter so a repeat invocation against the shared DB (see s4UniqueCounter)
+	// doesn't collide with its own prior insert.
+	state := fmt.Sprintf("s1-%d", s4UniqueCounter.Add(1))
+	body := fmt.Sprintf(`{"state":%q,"nonce":"n1","provider":"oidc","expires_at":"2099-01-01T00:00:00Z"}`, state)
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	h.CreateSSOLoginStateProxy(w, req)
@@ -6714,11 +6730,16 @@ func TestAuthHandler_Profile_UnauthorizedV2(t *testing.T) {
 
 func TestAuthHandler_Profile_UserNotFound(t *testing.T) {
 	h := newAuthHandlerWithWebAuthn(t)
-	// userCtx with a non-existent user
-	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/auth/profile", nil))
+	// userCtx with a non-existent user. UserID 1 is NOT safe here: other happy-path
+	// tests sharing this DB (sharedS4Core) legitimately create the first-ever user
+	// row, which lands on ID 1 — a fixed low ID risks colliding with that real
+	// data (especially across `-count=N` repeats). Use a large, out-of-range ID
+	// that can never collide, matching the convention other "not found" tests in
+	// this package use (e.g. TestGetActiveMembershipProxy_NotFound_S13's 99999).
+	req := withUserCtxID(httptest.NewRequest(http.MethodGet, "/auth/profile", nil), 999999999, "nonexistent-user")
 	w := httptest.NewRecorder()
 	h.Profile(w, req)
-	// User ID=1 doesn't exist → 404
+	// User doesn't exist → 404
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
@@ -9939,7 +9960,12 @@ func TestCatalogHandler_GetActiveMembershipProxy_BadUserID(t *testing.T) {
 
 func TestCatalogHandler_GetActiveMembershipProxy_NotFound(t *testing.T) {
 	h := newCatalogHandlerS4(t)
-	req := httptest.NewRequest(http.MethodGet, "/?project_id=1&user_id=1", nil)
+	// project_id=1&user_id=1 is NOT safe here: other happy-path tests sharing this
+	// DB (sharedS4Core) legitimately create an active membership for project 1 /
+	// user 1 (e.g. TestCatalogHandler_CreateMembershipProxy_HappyPath below) and
+	// never tear it down. Use out-of-range IDs that can never collide, matching
+	// TestGetActiveMembershipProxy_NotFound_S13's existing 99999 convention.
+	req := httptest.NewRequest(http.MethodGet, "/?project_id=99999&user_id=99999", nil)
 	w := httptest.NewRecorder()
 	h.GetActiveMembershipProxy(w, req)
 	// not found → 404
@@ -11740,7 +11766,6 @@ func TestAuthHandler_AcquireSchedulerLockProxy_BadJSON(t *testing.T) {
 
 // ── login_attempts_proxy.go: CountLoginAttemptsProxy ─────────────────────────
 
-
 func TestAuthHandler_CountLoginAttemptsProxy_HappyPath(t *testing.T) {
 	h := newAuthHandlerWithWebAuthn(t)
 	req := httptest.NewRequest(http.MethodGet, "/?ip=127.0.0.1&since=2026-01-01T00:00:00Z", nil)
@@ -11944,6 +11969,7 @@ func TestDashboardHandler_CreateLegalHoldProxy_MissingReason(t *testing.T) {
 
 func TestDashboardHandler_CreateLegalHoldProxy_HappyPath(t *testing.T) {
 	h := NewDashboardHandler(newHandlerCoreS4(t))
+	t.Cleanup(func() { releaseActiveLegalHoldS4(t, h) })
 	body := `{"reason":"Litigation hold","placed_by":1}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	w := httptest.NewRecorder()
@@ -11969,11 +11995,37 @@ func TestDashboardHandler_UpdateLegalHoldProxy_BadID(t *testing.T) {
 
 func TestDashboardHandler_UpdateLegalHoldProxy_HappyPath(t *testing.T) {
 	h := NewDashboardHandler(newHandlerCoreS4(t))
+	t.Cleanup(func() { releaseActiveLegalHoldS4(t, h) })
+	// NOTE: UpdateLegalHoldProxy is a raw full-row Save (see legal_hold_proxy.go) —
+	// this body omits "released"/"placed_by", so it zeroes those fields out on the
+	// row with id=1 (created by TestDashboardHandler_CreateLegalHoldProxy_HappyPath
+	// just above). Without the Cleanup above, that leaves a permanently "active"
+	// hold with no valid placer in the shared sharedS4Core DB, which breaks
+	// TestLiftLegalHold_NoActiveHold on any later run against the same process
+	// (e.g. `go test -count=2`).
 	body := `{"reason":"Updated hold reason"}`
 	req := withChiParam(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body)), "id", "1")
 	w := httptest.NewRecorder()
 	h.UpdateLegalHoldProxy(w, req)
 	assert.NotEqual(t, http.StatusBadRequest, w.Code)
+}
+
+// releaseActiveLegalHoldS4 marks any currently-active legal hold in the shared
+// sharedS4Core DB as released, restoring the "no active hold" invariant that
+// TestLiftLegalHold_NoActiveHold (and similar) depend on. Several happy-path
+// legal-hold proxy tests (Create/UpdateLegalHoldProxy) intentionally leave a
+// hold row behind to exercise their success path; because sharedS4Core lives
+// for the whole test binary (see sharedS4CoreOnce above), that row would
+// otherwise persist into every later test and every `-count=N` repeat.
+func releaseActiveLegalHoldS4(t *testing.T, h *DashboardHandler) {
+	t.Helper()
+	ctx := context.Background()
+	hold, err := h.coreService.Storage().GetActiveLegalHold(ctx)
+	if err != nil || hold == nil {
+		return
+	}
+	hold.Released = true
+	_ = h.coreService.Storage().UpdateLegalHold(ctx, hold)
 }
 
 // ── rbac_role_grants_proxy.go: RemoveGlobalAdminRoleGuardedProxy ──────────────

--- a/server/http/handlers/handlers_s5_test.go
+++ b/server/http/handlers/handlers_s5_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -697,8 +698,11 @@ func notificationToAPIInternal(n *notificationModel) map[string]any {
 
 func TestCreateSSOLoginStateProxy_HappyPath_S5(t *testing.T) {
 	h := newAuthHandlerWithWebAuthn(t)
+	// state carries a DB-level uniqueIndex (models.SSOLoginState.State); fold in
+	// a counter (see s4UniqueCounter) so a repeat invocation against the shared
+	// sharedS4Core DB doesn't collide with its own prior insert.
 	body, _ := json.Marshal(map[string]any{
-		"state":    "teststate",
+		"state":    fmt.Sprintf("teststate-%d", s4UniqueCounter.Add(1)),
 		"nonce":    "testnonce",
 		"provider": "google",
 	})
@@ -2900,7 +2904,11 @@ func TestCreateMachineIdentityCredentialProxy_HappyPath(t *testing.T) {
 	h.CreateMachineIdentityProxy(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	body := `{"machine_identity_id":1,"token_hash":"deadbeefdeadbeefdeadbeefdeadbeef","name":"cred1"}`
+	// token_hash carries a DB-level unique constraint; fold in a counter (see
+	// s4UniqueCounter) so a repeat invocation against the shared sharedS4Core DB
+	// doesn't collide with its own prior insert.
+	tokenHash := fmt.Sprintf("deadbeefdeadbeefdeadbeefdeadbeef%d", s4UniqueCounter.Add(1))
+	body := fmt.Sprintf(`{"machine_identity_id":1,"token_hash":%q,"name":"cred1"}`, tokenHash)
 	req2 := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	w2 := httptest.NewRecorder()
 	h.CreateMachineIdentityCredentialProxy(w2, req2)
@@ -3521,8 +3529,6 @@ func TestSupersedeSetupTokensProxy_HappyPath(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-
-
 // ── webauthn_proxy.go — additional paths ─────────────────────────────────────
 
 // TestListWebAuthnCredentialsProxy_HappyPath already in s4
@@ -3547,6 +3553,11 @@ func TestDeleteWebAuthnCredentialProxy_NotFound(t *testing.T) {
 
 func TestCreateLegalHoldProxy_HappyPathS5(t *testing.T) {
 	h := newDashboardHandlerS5(t)
+	// This body has no "placed_by", so a successful create leaves an active hold
+	// with PlacedBy=0 in the shared sharedS4Core DB — release it afterward so it
+	// doesn't leak into later tests (e.g. TestLiftLegalHold_NoActiveHold) or
+	// persist across a `-count=N` repeat of the whole binary.
+	t.Cleanup(func() { releaseActiveLegalHoldS4(t, h) })
 	body := `{"user_id":1,"secret_id":1,"reason":"compliance review"}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	w := httptest.NewRecorder()
@@ -3585,7 +3596,6 @@ func TestCreateBreakGlassActivationProxy_HappyPath(t *testing.T) {
 	h.CreateBreakGlassActivationProxy(w, req)
 	assert.NotEqual(t, http.StatusBadRequest, w.Code)
 }
-
 
 func TestRevokeBreakGlassActivationProxy_HappyPath(t *testing.T) {
 	h := newCatalogHandlerS4(t)

--- a/server/http/handlers/handlers_s9_test.go
+++ b/server/http/handlers/handlers_s9_test.go
@@ -1,11 +1,13 @@
 package handlers
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -150,7 +152,9 @@ func TestUpdateAccessRequestProxy_Success_S9(t *testing.T) {
 	require.Equal(t, http.StatusOK, createW.Code)
 
 	var createResp struct {
-		Data struct{ ID uint `json:"id"` } `json:"data"`
+		Data struct {
+			ID uint `json:"id"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(createW.Body).Decode(&createResp))
 	require.NotZero(t, createResp.Data.ID)
@@ -192,7 +196,9 @@ func TestCreateAccessRequestApprovalProxy_Success_S9(t *testing.T) {
 	require.Equal(t, http.StatusOK, createW.Code)
 
 	var createResp struct {
-		Data struct{ ID uint `json:"id"` } `json:"data"`
+		Data struct {
+			ID uint `json:"id"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(createW.Body).Decode(&createResp))
 	require.NotZero(t, createResp.Data.ID)
@@ -217,7 +223,9 @@ func TestListAccessRequestApprovalsProxy_WithData_S9(t *testing.T) {
 	require.Equal(t, http.StatusOK, createW.Code)
 
 	var createResp struct {
-		Data struct{ ID uint `json:"id"` } `json:"data"`
+		Data struct {
+			ID uint `json:"id"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(createW.Body).Decode(&createResp))
 	require.NotZero(t, createResp.Data.ID)
@@ -267,7 +275,9 @@ func TestGetAccessReviewCampaignProxy_Success_S9(t *testing.T) {
 	require.Equal(t, http.StatusOK, createW.Code)
 
 	var createResp struct {
-		Data struct{ ID uint `json:"id"` } `json:"data"`
+		Data struct {
+			ID uint `json:"id"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(createW.Body).Decode(&createResp))
 	require.NotZero(t, createResp.Data.ID)
@@ -325,7 +335,9 @@ func TestUpdateAccessReviewCampaignProxy_Success_S9(t *testing.T) {
 	require.Equal(t, http.StatusOK, createW.Code)
 
 	var createResp struct {
-		Data struct{ ID uint `json:"id"` } `json:"data"`
+		Data struct {
+			ID uint `json:"id"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(createW.Body).Decode(&createResp))
 	require.NotZero(t, createResp.Data.ID)
@@ -350,7 +362,9 @@ func TestCreateAccessReviewItemsProxy_Success_S9(t *testing.T) {
 	require.Equal(t, http.StatusOK, createW.Code)
 
 	var createResp struct {
-		Data struct{ ID uint `json:"id"` } `json:"data"`
+		Data struct {
+			ID uint `json:"id"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(createW.Body).Decode(&createResp))
 	require.NotZero(t, createResp.Data.ID)
@@ -375,7 +389,9 @@ func TestListAccessReviewItemsProxy_WithData_S9(t *testing.T) {
 	require.Equal(t, http.StatusOK, createW.Code)
 
 	var createResp struct {
-		Data struct{ ID uint `json:"id"` } `json:"data"`
+		Data struct {
+			ID uint `json:"id"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(createW.Body).Decode(&createResp))
 	require.NotZero(t, createResp.Data.ID)
@@ -400,7 +416,9 @@ func TestCountPendingAccessReviewItemsProxy_S9(t *testing.T) {
 	require.Equal(t, http.StatusOK, createW.Code)
 
 	var createResp struct {
-		Data struct{ ID uint `json:"id"` } `json:"data"`
+		Data struct {
+			ID uint `json:"id"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(createW.Body).Decode(&createResp))
 	require.NotZero(t, createResp.Data.ID)
@@ -433,7 +451,13 @@ func TestImpersonationHandler_End_NoAdminCookie_S9(t *testing.T) {
 
 func TestCreateWebAuthnCredentialProxy_Success_S9(t *testing.T) {
 	h := newAuthHandlerWithWebAuthn(t)
-	body := `{"user_id":1,"credential_id":"dGVzdC1jcmVkLXM5","public_key":"cHVia2V5LXM5","aaguid":"00000000-0000-0000-0000-000000000000","sign_count":0,"transports":["internal"]}`
+	// credential_id is a []byte field (base64 on the wire) carrying a DB-level
+	// unique constraint; fold in a counter (see s4UniqueCounter) so a repeat
+	// invocation against the shared sharedS4Core DB doesn't collide with its own
+	// prior insert. Must stay valid base64, so encode the unique string rather
+	// than appending raw text to the existing base64 literal.
+	credID := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("test-cred-s9-%d", s4UniqueCounter.Add(1))))
+	body := fmt.Sprintf(`{"user_id":1,"credential_id":%q,"public_key":"cHVia2V5LXM5","aaguid":"00000000-0000-0000-0000-000000000000","sign_count":0,"transports":["internal"]}`, credID)
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	h.CreateWebAuthnCredentialProxy(w, req)
@@ -443,8 +467,12 @@ func TestCreateWebAuthnCredentialProxy_Success_S9(t *testing.T) {
 func TestListWebAuthnCredentialsProxy_WithData_S9(t *testing.T) {
 	h := newAuthHandlerWithWebAuthn(t)
 
-	// Create a credential first
-	body := `{"user_id":77,"credential_id":"dGVzdC1jcmVkLXM5Mg==","public_key":"cHVia2V5LXM5Mg==","aaguid":"00000000-0000-0000-0000-000000000000","sign_count":0,"transports":["usb"]}`
+	// Create a credential first. credential_id is a []byte field (base64 on the
+	// wire) carrying a DB-level unique constraint; fold in a counter (see
+	// s4UniqueCounter) so a repeat invocation against the shared sharedS4Core DB
+	// doesn't collide with its own prior insert.
+	credID := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("test-cred-s92-%d", s4UniqueCounter.Add(1))))
+	body := fmt.Sprintf(`{"user_id":77,"credential_id":%q,"public_key":"cHVia2V5LXM5Mg==","aaguid":"00000000-0000-0000-0000-000000000000","sign_count":0,"transports":["usb"]}`, credID)
 	createReq := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	createW := httptest.NewRecorder()
 	h.CreateWebAuthnCredentialProxy(createW, createReq)
@@ -460,8 +488,12 @@ func TestListWebAuthnCredentialsProxy_WithData_S9(t *testing.T) {
 func TestCountWebAuthnCredentialsProxy_WithData_S9(t *testing.T) {
 	h := newAuthHandlerWithWebAuthn(t)
 
-	// Create a credential
-	body := `{"user_id":88,"credential_id":"dGVzdC1jcmVkLXM5Mw==","public_key":"cHVia2V5LXM5Mw==","aaguid":"00000000-0000-0000-0000-000000000000","sign_count":0,"transports":["nfc"]}`
+	// Create a credential. credential_id is a []byte field (base64 on the wire)
+	// carrying a DB-level unique constraint; fold in a counter (see
+	// s4UniqueCounter) so a repeat invocation against the shared sharedS4Core DB
+	// doesn't collide with its own prior insert.
+	credID := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("test-cred-s93-%d", s4UniqueCounter.Add(1))))
+	body := fmt.Sprintf(`{"user_id":88,"credential_id":%q,"public_key":"cHVia2V5LXM5Mw==","aaguid":"00000000-0000-0000-0000-000000000000","sign_count":0,"transports":["nfc"]}`, credID)
 	createReq := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	createW := httptest.NewRecorder()
 	h.CreateWebAuthnCredentialProxy(createW, createReq)
@@ -485,7 +517,9 @@ func TestUpdateWebAuthnCredentialProxy_Success_S9(t *testing.T) {
 	require.Equal(t, http.StatusOK, createW.Code)
 
 	var createResp struct {
-		Data struct{ ID uint `json:"id"` } `json:"data"`
+		Data struct {
+			ID uint `json:"id"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(createW.Body).Decode(&createResp))
 	require.NotZero(t, createResp.Data.ID)
@@ -510,7 +544,9 @@ func TestDeleteWebAuthnCredentialProxy_Success_S9(t *testing.T) {
 	require.Equal(t, http.StatusOK, createW.Code)
 
 	var createResp struct {
-		Data struct{ ID uint `json:"id"` } `json:"data"`
+		Data struct {
+			ID uint `json:"id"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(createW.Body).Decode(&createResp))
 	require.NotZero(t, createResp.Data.ID)
@@ -536,7 +572,11 @@ func TestSetUserWebAuthnEnabledProxy_Success_S9(t *testing.T) {
 
 func TestCreateWebAuthnSessionProxy_Success_S9(t *testing.T) {
 	h := newAuthHandlerWithWebAuthn(t)
-	body := `{"user_id":66,"token_hash":"s9-test-token-hash-unique","expires_at":"2030-01-01T00:00:00Z"}`
+	// token_hash carries a DB-level unique constraint; fold in a counter (see
+	// s4UniqueCounter) so a repeat invocation against the shared sharedS4Core DB
+	// doesn't collide with its own prior insert.
+	tokenHash := fmt.Sprintf("s9-test-token-hash-unique-%d", s4UniqueCounter.Add(1))
+	body := fmt.Sprintf(`{"user_id":66,"token_hash":%q,"expires_at":"2030-01-01T00:00:00Z"}`, tokenHash)
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	h.CreateWebAuthnSessionProxy(w, req)


### PR DESCRIPTION
## Summary
Follow-up to #1239, which flagged 10 tests in the `handlers_s4`/`s5`/`s9` family that fail under `-count=N` because they share one `sync.Once`-backed singleton DB (`sharedS4Core`, ~180 call sites across 5 files) that deliberately never resets, to avoid a ~2min CI timeout from repeated `AutoMigrate`. Rather than touching that singleton (which would reintroduce the timeout risk), fixed the individual tests to tolerate a shared, persistent DB:

- **6 tests** inserted a fixed literal under a DB-level unique constraint (SSO login state, machine-credential `token_hash`, WebAuthn `credential_id`, WebAuthn session `token_hash`) and collided with their own prior insert on repeat. Folded a new `s4UniqueCounter atomic.Int64` into each literal.
- **2 "not found" tests** probed a low fixed ID/key (`user_id=1`, `project_id=1&user_id=1`) that a legitimate happy-path test elsewhere in the shared DB creates and never tears down. Switched to large out-of-range values, matching the existing `99999` convention other not-found tests already use.
- **1 test** (`TestLiftLegalHold_NoActiveHold`) expects no active legal hold globally; two happy-path tests in s4/s5 each leave one behind (one via a raw full-row `Save` that zeroes `PlacedBy`). Added a shared `releaseActiveLegalHoldS4` helper, wired via `t.Cleanup` on the three offending tests, restoring the "no active hold" invariant afterward.

No production code touched; the singleton itself is untouched.

## Test plan
- [x] `go build ./...`
- [x] All 10 target tests pass individually at `-count=5` (50/50)
- [x] Full `server/http/handlers` package passes at `-count=3` with **zero failures**
- [x] `gofmt -l` / `go vet` clean on changed files

## Note
This commit was originally pushed as a second commit onto #1239's branch, but landed *after* that PR had already been squash-merged, so it never made it into `main`. Re-opening as its own PR against current `main` (which already includes #1239).