### PR TITLE
fix(sonar): put NOSONAR as first comment token on CIDR literals

### DIFF
--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -35,10 +35,10 @@ const defaultMaxLeaseTTL = 90 * 24 * time.Hour
 var privateNetworkCIDRs = func() []*net.IPNet {
 	var nets []*net.IPNet
 	for _, cidr := range []string{ // NOSONAR -- these are the SSRF-guard blocklist ranges themselves (RFC-1918/1122/6598 + IPv6 equivalents), not a live endpoint; hardcoding them is the point of isPrivateIP
-		"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", // RFC-1918 NOSONAR
+		"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", // NOSONAR -- RFC-1918
 		"127.0.0.0/8",    // loopback
-		"169.254.0.0/16", // link-local / cloud IMDS NOSONAR
-		"100.64.0.0/10",  // shared address space (RFC 6598) NOSONAR
+		"169.254.0.0/16", // NOSONAR -- link-local / cloud IMDS
+		"100.64.0.0/10",  // NOSONAR -- shared address space (RFC 6598)
 		"::1/128",        // IPv6 loopback
 		"fc00::/7",       // IPv6 unique local
 		"fe80::/10",      // IPv6 link-local


### PR DESCRIPTION
## Summary
Follow-up to #1232, which added `// TEXT NOSONAR` (NOSONAR as a trailing suffix) to suppress the "hardcoded IP address" hotspot findings on the SSRF-guard CIDR blocklist literals in `internal/core/dynamic_secrets.go`. That PR merged, but SonarCloud is still showing all 5 findings as Open a day later — the trailing-suffix placement isn't being recognized as a valid NOSONAR marker for this rule.

Switches to `// NOSONAR -- TEXT` (NOSONAR as the first token in the comment) on the 3 affected lines (L38 x3, L40, L41), matching the format already used successfully on the enclosing `for` line's own suppression comment.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l` / `go vet` clean
- [ ] Confirm on next SonarCloud scan that the 5 hardcoded-IP findings resolve as Fixed