### PR TITLE
fix(security): DAST #1245 — JSON 404 for non-HTML Accept on SPA fallback

### DIFF
--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -2038,6 +2039,16 @@ func isBackendRoute(p string) bool {
 	return false
 }
 
+// writeJSONNotFound sends a JSON 404, for a NotFound request whose Accept
+// header indicates the caller is not a browser expecting the SPA shell.
+func writeJSONNotFound(w http.ResponseWriter) {
+	w.Header().Set(hdrContentType, "application/json")
+	w.WriteHeader(http.StatusNotFound)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": "NotFound", "message": "not found", "code": http.StatusNotFound,
+	})
+}
+
 // noDirListing wraps a static file handler so a request that resolves to a
 // directory (no index file inside it) returns 404 instead of falling through to
 // Go's default http.FileServer directory listing (#213). dist/assets has no
@@ -2099,6 +2110,16 @@ func registerWebUI(r chi.Router, fsys http.FileSystem) {
 		// A mutating method to a non-backend, unmatched path is not a page load.
 		if req.Method != http.MethodGet && req.Method != http.MethodHead {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		// A client asking for something other than HTML — an OpenAPI-driven
+		// scanner or API client hitting a fuzzed/mistyped path, for example —
+		// should get a JSON 404, not the SPA shell's text/html (ZAP/100001:
+		// "Unexpected Content-Type"). Real browsers always include text/html
+		// or */* in Accept; a client that names application/json and nothing
+		// else never accepted an HTML response.
+		if accept := req.Header.Get("Accept"); accept != "" && !strings.Contains(accept, "text/html") && !strings.Contains(accept, "*/*") {
+			writeJSONNotFound(w)
 			return
 		}
 		f, err := fsys.Open("index.html")

--- a/server/http/static_hardening_test.go
+++ b/server/http/static_hardening_test.go
@@ -163,3 +163,38 @@ func TestNotFound_BackendRoutePrefixesReturn404(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, body, "Keyorix")
 }
+
+// TestNotFound_NonHTMLAcceptReturnsJSON404 pins #1245 (ZAP/100001, "Unexpected
+// Content-Type was returned"): a fuzzed/mistyped path that doesn't exactly
+// prefix-match a known backend route family still falls through to this
+// NotFound handler, and previously always served the SPA shell's text/html —
+// including to a scanner or API client that explicitly asked for JSON and
+// never accepted HTML. The handler must honor Accept and return a JSON 404 for
+// those callers, while browsers (which always send text/html or */* in
+// Accept, or send no Accept header at all) keep getting the SPA shell.
+func TestNotFound_NonHTMLAcceptReturnsJSON404(t *testing.T) {
+	srv := newOnDiskWebUIRouter(t)
+	client := &http.Client{}
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/does-not-exist-and-not-a-prefix-match", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	body := readAll(t, resp.Body)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get(hdrContentType))
+	assert.NotContains(t, body, "<html", "a JSON-Accept client must never receive the SPA shell")
+
+	// A browser-style Accept header still gets the SPA shell (unchanged behavior).
+	req, err = http.NewRequest(http.MethodGet, srv.URL+"/admin/users", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	body = readAll(t, resp.Body)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, body, "Keyorix")
+}


### PR DESCRIPTION
## Summary
- Fixes #1245 (ZAP/100001, "Unexpected Content-Type was returned"). ZAP's OpenAPI-driven scan (`zap-api-scan.py`) hits declared API endpoints unauthenticated and expects JSON. A fuzzed/mutated path variant that misses the `backendRoutePrefixes` prefix check in `server/http/router.go`'s `NotFound` handler fell through to the SPA shell (`text/html`) instead of a JSON response.
- The `NotFound` handler now honors `Accept`: a request that doesn't include `text/html` or `*/*` gets a JSON 404 instead of the HTML shell. Browsers (which always send `text/html`/`*/*`, or no `Accept` header at all) are unaffected and still get the SPA shell for client-side routes.
- Investigated #1244 (CORP header missing) alongside this: `Cross-Origin-Resource-Policy: same-origin` is already set unconditionally by `server/middleware/security_headers.go`, wired into the single router all traffic goes through — no bypass path exists. That fix merged 2026-07-29 (#1216/#1217), two days before the 2026-07-31 scan that filed #1244, so it's very likely stale. Recommend re-running the scan to confirm before closing #1244 — no code change needed there.

## Test plan
- [x] `go build ./server/...`
- [x] `go test ./server/http/ -run 'TestNotFound|TestAssetDirListing|TestOpenAPISpec' -v` — added `TestNotFound_NonHTMLAcceptReturnsJSON404`, all pass
- [x] `go test ./server/http/...` — no new failures; pre-existing local-only flakes (`TestSharingHTTPIntegration`, `TestRemoteStorageMFAManagement_FullLifecycle_RealServer`, `TestScopedRBACEnforcement`, `TestSharingHTTPConcurrency`) reproduce identically on `main` without this change
- [x] `gosec -severity medium -exclude-generated ./server/http/...` — 0 issues