### PR TITLE
ADR-048 follow-up: sqlitedialect tests + fix CreateConstraint/Translate

### DIFF
--- a/docs/adr-048-cgo-free-sqlite-driver.md
+++ b/docs/adr-048-cgo-free-sqlite-driver.md
@@ -89,6 +89,31 @@ fixed (not routed around):
   `break` in a state-machine switch, one genuinely-unused method). Held to the same
   lint bar as the rest of the repo per this ADR's own task list — all 29 fixed,
   none suppressed.
+- `Dialector.Translate()` (used only when a caller opts into
+  `gorm.Config{TranslateError: true}`) mapped raw driver errors to
+  `gorm.ErrDuplicatedKey`/`gorm.ErrForeignKeyViolated` by `json.Marshal`-ing the
+  error and reading exported `Code`/`ExtendedCode` fields — present on
+  `mattn/go-sqlite3`'s error type, absent on `modernc.org/sqlite`'s (which stores
+  its result code in an unexported field, exposed only via a `Code() int`
+  method). Fixed by checking that method first, falling back to the original
+  JSON path. This app does not currently set `TranslateError: true` anywhere
+  (confirmed by grep), so nothing in production was silently broken by this, but
+  it's now correct rather than silently a no-op for modernc if anyone opts in.
+- Writing direct tests for the forked package (added to close the coverage gap
+  below) surfaced a real, pre-existing bug, **not introduced by this driver
+  swap**: `ddl.getColumns()` (`ddlmod.go`, unchanged, driver-agnostic string
+  logic present identically in upstream `go-gorm/sqlite`) failed to recognize a
+  constraint clause added by `Migrator.CreateConstraint` as anything other than
+  a column, because `constraint.Build()` returns an unsubstituted `CONSTRAINT ?
+  ...` SQL template at that point (substitution happens later, inside GORM's own
+  `tx.Exec`) — which never matches `constraintRegexp`'s literal-backtick-quoted-
+  name pattern. Any future migration adding a new constraint to an existing
+  table (e.g. via `AutoMigrate` picking up a new `gorm:"unique"` field — 6 real
+  fields in `internal/storage/models/models.go` already use this tag) would hit
+  this and corrupt the table-recreation data copy, on `mattn` today just as much
+  as on `modernc.org/sqlite`. Fixed by recognizing the `CONSTRAINT ` keyword
+  prefix directly, the same way `getColumns()` already handles `PRIMARY KEY`/
+  `FOREIGN KEY`, rather than relying solely on the quoted-name regex.
 
 No other behavior gap from the ADR's risk list materialized: the `ALTER TABLE`
 migration-sequencing bug class (ent/ent#2209) did not reproduce, `SQLITE_BUSY`
@@ -120,6 +145,22 @@ license-text wording and reports it as disallowed — a tool limitation, confirm
 by reproducing the same failure locally against the exact pinned version, not an
 actual licensing concern. `modernc.org/mathutil` was added to the job's `--ignore`
 list alongside this repo's own module path.
+
+SonarCloud's quality gate also failed on this PR: `new_coverage` measured 2.4%
+against the 80% threshold, because `internal/storage/sqlitedialect` had no tests
+of its own (Go's default per-package coverage attribution credits none of the
+execution it gets indirectly from every other SQLite-backed test in the suite —
+confirmed 35.1% of its statements are exercised by `internal/storage/store`'s
+tests alone, via a scratch `-coverpkg` measurement, none of it counted). Rather
+than reach for `-coverpkg` (which would have REPLACED, not added to, every other
+package's own coverage self-attribution in the same `go test` invocation — a much
+larger and riskier change, caught before it was committed), the honest fix was to
+add real unit and integration tests for the forked package directly
+(`sqlite_test.go`, `migrator_test.go`, `ddlmod_parse_all_columns_test.go`),
+covering the dialector's exported surface, the `Migrator`'s table/column/index/
+constraint lifecycle against a real in-memory database, and the DDL string
+helpers. This reached 81.3% self-coverage and is what surfaced the
+`CreateConstraint`/`getColumns()` and `Translate()` findings above.
 
 ## Tasks
 

--- a/internal/storage/sqlitedialect/ddlmod.go
+++ b/internal/storage/sqlitedialect/ddlmod.go
@@ -235,7 +235,6 @@ func (d *ddl) addConstraint(name string, sql string) {
 
 func (d *ddl) removeConstraint(name string) bool {
 	reg := compileConstraintRegexp(name)
-
 	for i := 0; i < len(d.fields); i++ {
 		if reg.MatchString(d.fields[i]) {
 			d.fields = append(d.fields[:i], d.fields[i+1:]...)
@@ -252,6 +251,15 @@ func (d *ddl) getColumns() []string {
 		fUpper := strings.ToUpper(f)
 		if strings.HasPrefix(fUpper, "PRIMARY KEY") ||
 			strings.HasPrefix(fUpper, "FOREIGN KEY") ||
+			// A freshly-added constraint field (CreateConstraint's
+			// constraint.Build(), via addConstraint) is still an
+			// unsubstituted "CONSTRAINT ? ..." SQL template at this point --
+			// substitution happens later in GORM's own tx.Exec -- so it
+			// never matches constraintRegexp's literal-backtick-quoted-name
+			// pattern below. Catch it by keyword prefix first, same as
+			// PRIMARY KEY/FOREIGN KEY above, so it isn't mistaken for a
+			// column named "CONSTRAINT".
+			strings.HasPrefix(fUpper, "CONSTRAINT ") ||
 			strings.Contains(fUpper, "GENERATED ALWAYS AS") {
 			continue
 		}

--- a/internal/storage/sqlitedialect/ddlmod_parse_all_columns_test.go
+++ b/internal/storage/sqlitedialect/ddlmod_parse_all_columns_test.go
@@ -1,0 +1,48 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAllColumns(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"single unquoted", "(id)", []string{"id"}},
+		{"multiple unquoted", "(id, name, email)", []string{"id", "name", "email"}},
+		{"quoted names", "(`id`, `name`)", []string{"id", "name"}},
+		{"mixed quote styles", `("id", 'name')`, []string{"id", "name"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseAllColumns(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseAllColumns_UnexpectedToken(t *testing.T) {
+	_, err := parseAllColumns("()")
+	require.Error(t, err)
+}
+
+func TestIsSpaceIsQuoteIsSeparator(t *testing.T) {
+	assert.True(t, isSpace(' '))
+	assert.True(t, isSpace('\t'))
+	assert.False(t, isSpace('a'))
+
+	assert.True(t, isQuote('`'))
+	assert.True(t, isQuote('"'))
+	assert.True(t, isQuote('\''))
+	assert.False(t, isQuote('a'))
+
+	assert.True(t, isSeparator(','))
+	assert.False(t, isSeparator(';'))
+}

--- a/internal/storage/sqlitedialect/error_translator.go
+++ b/internal/storage/sqlitedialect/error_translator.go
@@ -22,6 +22,16 @@ type ErrMessage struct {
 // Translate it will translate the error to native gorm errors.
 // We are not using go-sqlite3 error type intentionally here because it will need the CGO_ENABLED=1 and cross-C-compiler.
 func (dialector Dialector) Translate(err error) error {
+	// modernc.org/sqlite's *Error (ADR-048) stores the SQLite extended result
+	// code in an unexported field, exposed only via this Code() method -- it
+	// has no exported Code/ExtendedCode fields for json.Marshal below to see,
+	// unlike mattn/go-sqlite3's error type. Check it first.
+	if coder, ok := err.(interface{ Code() int }); ok {
+		if translatedErr, found := errCodes[coder.Code()]; found {
+			return translatedErr
+		}
+	}
+
 	parsedErr, marshalErr := json.Marshal(err)
 	if marshalErr != nil {
 		return err

--- a/internal/storage/sqlitedialect/migrator_test.go
+++ b/internal/storage/sqlitedialect/migrator_test.go
@@ -1,0 +1,151 @@
+package sqlite
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type migratorTestModel struct {
+	ID    uint   `gorm:"primaryKey"`
+	Name  string `gorm:"uniqueIndex:idx_migrator_name"`
+	Email string
+	Score int `gorm:"check:chk_migrator_score,score >= 0"`
+}
+
+type constraintTestModel struct {
+	ID   uint   `gorm:"primaryKey"`
+	Slug string `gorm:"unique"`
+}
+
+func TestMigrator_HasTable(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	assert.True(t, m.HasTable(&migratorTestModel{}))
+	assert.False(t, m.HasTable("does_not_exist"))
+}
+
+func TestMigrator_HasColumnAndDropColumn(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	assert.True(t, m.HasColumn(&migratorTestModel{}, "Email"))
+	assert.False(t, m.HasColumn(&migratorTestModel{}, "DoesNotExist"))
+
+	require.NoError(t, m.DropColumn(&migratorTestModel{}, "Email"))
+	assert.False(t, m.HasColumn(&migratorTestModel{}, "Email"))
+}
+
+func TestMigrator_IndexLifecycle(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	require.True(t, m.HasIndex(&migratorTestModel{}, "idx_migrator_name"))
+
+	indexes, err := m.GetIndexes(&migratorTestModel{})
+	require.NoError(t, err)
+	found := false
+	for _, idx := range indexes {
+		if idx.Name() == "idx_migrator_name" {
+			found = true
+		}
+	}
+	assert.True(t, found, "GetIndexes should report the declared unique index")
+
+	require.NoError(t, m.DropIndex(&migratorTestModel{}, "idx_migrator_name"))
+	assert.False(t, m.HasIndex(&migratorTestModel{}, "idx_migrator_name"))
+
+	require.NoError(t, m.CreateIndex(&migratorTestModel{}, "idx_migrator_name"))
+	assert.True(t, m.HasIndex(&migratorTestModel{}, "idx_migrator_name"))
+
+	require.NoError(t, m.RenameIndex(&migratorTestModel{}, "idx_migrator_name", "idx_migrator_name_v2"))
+	assert.False(t, m.HasIndex(&migratorTestModel{}, "idx_migrator_name"))
+	assert.True(t, m.HasIndex(&migratorTestModel{}, "idx_migrator_name_v2"))
+}
+
+func TestMigrator_HasConstraint(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	assert.True(t, m.HasConstraint(&migratorTestModel{}, "chk_migrator_score"))
+	assert.False(t, m.HasConstraint(&migratorTestModel{}, "chk_does_not_exist"))
+
+	require.NoError(t, m.DropConstraint(&migratorTestModel{}, "chk_migrator_score"))
+	assert.False(t, m.HasConstraint(&migratorTestModel{}, "chk_migrator_score"))
+
+	require.NoError(t, m.CreateConstraint(&migratorTestModel{}, "chk_migrator_score"))
+	assert.True(t, m.HasConstraint(&migratorTestModel{}, "chk_migrator_score"))
+}
+
+func TestMigrator_ConstraintLifecycle(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&constraintTestModel{}))
+	m := db.Migrator()
+
+	var createSQL string
+	require.NoError(t, db.Raw(
+		"SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?", "constraint_test_models",
+	).Row().Scan(&createSQL))
+	constraintName := extractConstraintName(t, createSQL)
+
+	require.True(t, m.HasConstraint(&constraintTestModel{}, constraintName))
+
+	require.NoError(t, m.DropConstraint(&constraintTestModel{}, constraintName))
+	assert.False(t, m.HasConstraint(&constraintTestModel{}, constraintName))
+
+	require.NoError(t, m.CreateConstraint(&constraintTestModel{}, constraintName))
+	assert.True(t, m.HasConstraint(&constraintTestModel{}, constraintName))
+}
+
+// extractConstraintName pulls the name out of the single `CONSTRAINT <name>
+// UNIQUE (...)` clause GORM generates for a `gorm:"unique"` field, so the test
+// doesn't have to hardcode GORM's constraint-naming convention.
+func extractConstraintName(t *testing.T, createSQL string) string {
+	t.Helper()
+	const marker = "CONSTRAINT "
+	idx := strings.Index(createSQL, marker)
+	require.NotEqual(t, -1, idx, "expected a CONSTRAINT clause in: %s", createSQL)
+	rest := createSQL[idx+len(marker):]
+	end := strings.IndexAny(rest, " \t")
+	require.NotEqual(t, -1, end)
+	return strings.Trim(rest[:end], "`\"")
+}
+
+func TestMigrator_AlterColumn(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	require.NoError(t, m.AlterColumn(&migratorTestModel{}, "Name"))
+	assert.True(t, m.HasColumn(&migratorTestModel{}, "Name"))
+
+	require.NoError(t, db.Create(&migratorTestModel{Name: "still-works", Score: 1}).Error)
+}
+
+func TestMigrator_ColumnTypesAndTablesAndCurrentDatabase(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	columnTypes, err := m.ColumnTypes(&migratorTestModel{})
+	require.NoError(t, err)
+	names := make(map[string]bool)
+	for _, ct := range columnTypes {
+		names[ct.Name()] = true
+	}
+	assert.True(t, names["name"])
+	assert.True(t, names["email"])
+
+	tables, err := m.GetTables()
+	require.NoError(t, err)
+	assert.Contains(t, tables, "migrator_test_models")
+
+	assert.NotEmpty(t, m.CurrentDatabase())
+}

--- a/internal/storage/sqlitedialect/sqlite.go
+++ b/internal/storage/sqlitedialect/sqlite.go
@@ -24,12 +24,12 @@ import (
 
 	"gorm.io/gorm/callbacks"
 
-	_ "modernc.org/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"
 	"gorm.io/gorm/migrator"
 	"gorm.io/gorm/schema"
+	_ "modernc.org/sqlite"
 )
 
 // DriverName is the default driver name for SQLite (modernc.org/sqlite's

--- a/internal/storage/sqlitedialect/sqlite_test.go
+++ b/internal/storage/sqlitedialect/sqlite_test.go
@@ -1,0 +1,204 @@
+package sqlite
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
+)
+
+func openTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	return db
+}
+
+func TestOpenAndNew(t *testing.T) {
+	d := Open("file::memory:")
+	dialector, ok := d.(*Dialector)
+	require.True(t, ok)
+	assert.Equal(t, "file::memory:", dialector.DSN)
+	assert.Equal(t, "sqlite", dialector.Name())
+
+	d2 := New(Config{DSN: "file::memory:", DriverName: "sqlite"})
+	dialector2, ok := d2.(*Dialector)
+	require.True(t, ok)
+	assert.Equal(t, "sqlite", dialector2.DriverName)
+	assert.Equal(t, "file::memory:", dialector2.DSN)
+}
+
+func TestInitialize_RealDB(t *testing.T) {
+	db := openTestDB(t)
+
+	var version string
+	require.NoError(t, db.Raw("select sqlite_version()").Row().Scan(&version))
+	assert.NotEmpty(t, version)
+}
+
+func TestDataTypeOf(t *testing.T) {
+	d := Dialector{}
+
+	cases := []struct {
+		name  string
+		field *schema.Field
+		want  string
+	}{
+		{"bool", &schema.Field{DataType: schema.Bool}, "numeric"},
+		{"int autoincrement", &schema.Field{DataType: schema.Int, AutoIncrement: true}, "integer PRIMARY KEY AUTOINCREMENT"},
+		{"int plain", &schema.Field{DataType: schema.Int}, "integer"},
+		{"uint plain", &schema.Field{DataType: schema.Uint}, "integer"},
+		{"float", &schema.Field{DataType: schema.Float}, "real"},
+		{"string", &schema.Field{DataType: schema.String}, "text"},
+		{"time default", &schema.Field{DataType: schema.Time}, "datetime"},
+		{"time with TYPE tag", &schema.Field{DataType: schema.Time, TagSettings: map[string]string{"TYPE": "date"}}, "date"},
+		{"bytes", &schema.Field{DataType: schema.Bytes}, "blob"},
+		{"unknown falls back to raw DataType", &schema.Field{DataType: schema.DataType("custom")}, "custom"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, d.DataTypeOf(tc.field))
+		})
+	}
+}
+
+func TestDefaultValueOf(t *testing.T) {
+	d := Dialector{}
+	assert.Equal(t, clause.Expr{SQL: "NULL"}, d.DefaultValueOf(&schema.Field{AutoIncrement: true}))
+	assert.Equal(t, clause.Expr{SQL: "DEFAULT"}, d.DefaultValueOf(&schema.Field{AutoIncrement: false}))
+}
+
+func TestQuoteTo(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"simple identifier", "users", "`users`"},
+		{"qualified identifier", "users.name", "`users`.`name`"},
+		{"identifier with embedded backtick", "a`b", "`a``b`"},
+	}
+
+	d := Dialector{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var w strings.Builder
+			d.QuoteTo(&w, tc.input)
+			assert.Equal(t, tc.want, w.String())
+		})
+	}
+}
+
+func TestBindVarTo(t *testing.T) {
+	d := Dialector{}
+	var w strings.Builder
+	d.BindVarTo(&w, nil, nil)
+	assert.Equal(t, "?", w.String())
+}
+
+func TestExplain(t *testing.T) {
+	d := Dialector{}
+	got := d.Explain("SELECT * FROM x WHERE y = ?", "z")
+	assert.NotContains(t, got, "?")
+	assert.Contains(t, got, "z")
+}
+
+func TestSavePointAndRollbackTo(t *testing.T) {
+	db := openTestDB(t)
+	type spModel struct {
+		ID   uint `gorm:"primaryKey"`
+		Name string
+	}
+	require.NoError(t, db.AutoMigrate(&spModel{}))
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		require.NoError(t, tx.Create(&spModel{Name: "before-savepoint"}).Error)
+		require.NoError(t, tx.SavePoint("sp1").Error)
+		require.NoError(t, tx.Create(&spModel{Name: "after-savepoint"}).Error)
+		require.NoError(t, tx.RollbackTo("sp1").Error)
+		return nil
+	})
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, db.Model(&spModel{}).Count(&count).Error)
+	assert.Equal(t, int64(1), count, "the row created after the savepoint should have been rolled back")
+}
+
+func TestClauseBuilders_ViaGeneratedSQL(t *testing.T) {
+	db := openTestDB(t)
+	type clauseModel struct {
+		ID   uint `gorm:"primaryKey"`
+		Name string
+	}
+	require.NoError(t, db.AutoMigrate(&clauseModel{}))
+
+	insertSQL := db.Session(&gorm.Session{DryRun: true}).Create(&clauseModel{Name: "x"}).Statement.SQL.String()
+	assert.Contains(t, insertSQL, "INSERT INTO")
+	assert.Contains(t, insertSQL, "`clause_models`")
+
+	var results []clauseModel
+	limitSQL := db.Session(&gorm.Session{DryRun: true}).Limit(5).Offset(10).Find(&results).Statement.SQL.String()
+	assert.Contains(t, limitSQL, "LIMIT 5")
+	assert.Contains(t, limitSQL, "OFFSET 10")
+
+	lockSQL := db.Session(&gorm.Session{DryRun: true}).Clauses(clause.Locking{Strength: "UPDATE"}).Find(&results).Statement.SQL.String()
+	assert.NotContains(t, lockSQL, "FOR UPDATE", "SQLite does not support row-level locking; the FOR clause must be a no-op")
+}
+
+func TestTranslate_DuplicateKey(t *testing.T) {
+	db, err := gorm.Open(Open(":memory:"), &gorm.Config{TranslateError: true})
+	require.NoError(t, err)
+
+	type uniqueModel struct {
+		ID   uint   `gorm:"primaryKey"`
+		Name string `gorm:"uniqueIndex"`
+	}
+	require.NoError(t, db.AutoMigrate(&uniqueModel{}))
+	require.NoError(t, db.Create(&uniqueModel{Name: "dup"}).Error)
+
+	err = db.Create(&uniqueModel{Name: "dup"}).Error
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gorm.ErrDuplicatedKey)
+}
+
+func TestTranslate_UnrelatedError(t *testing.T) {
+	d := Dialector{}
+	original := errors.New("some unrelated error")
+	assert.Equal(t, original, d.Translate(original))
+}
+
+func TestMigrator_DropTable(t *testing.T) {
+	db := openTestDB(t)
+	type dropTableModel struct {
+		ID uint `gorm:"primaryKey"`
+	}
+	require.NoError(t, db.AutoMigrate(&dropTableModel{}))
+	m := db.Migrator()
+
+	require.True(t, m.HasTable(&dropTableModel{}))
+	require.NoError(t, m.DropTable(&dropTableModel{}))
+	assert.False(t, m.HasTable(&dropTableModel{}))
+}
+
+func TestCompareVersion(t *testing.T) {
+	cases := []struct {
+		v1, v2 string
+		want   int
+	}{
+		{"3.35.0", "3.35.0", 0},
+		{"3.36.0", "3.35.0", 1},
+		{"3.34.0", "3.35.0", -1},
+		{"3.35.1", "3.35.0", 1},
+		{"3.5.0", "3.35.0", -1},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, compareVersion(tc.v1, tc.v2), "compareVersion(%q, %q)", tc.v1, tc.v2)
+	}
+}


### PR DESCRIPTION
## Summary

PR #1246 (ADR-048, the mattn->modernc.org/sqlite driver swap) merged at an earlier commit than intended: its squash-merge captured the driver swap, the CI timeout fix, and the go-licenses fix, but not the final commit adding tests for the new `internal/storage/sqlitedialect` package and fixing two real bugs that commit's tests found. This PR carries that missing commit forward cleanly onto current `main` (verified: clean cherry-pick, no conflicts).

- `internal/storage/sqlitedialect` had no tests of its own, which is why SonarCloud's `new_coverage` gate read 2.4% on #1246 (Go's default per-package coverage attribution credits none of the execution this package gets indirectly from every other SQLite-backed test in the suite). Adds direct unit/integration tests (`sqlite_test.go`, `migrator_test.go`, `ddlmod_parse_all_columns_test.go`) against a real in-memory database, reaching 81.3% self-coverage.
- Writing those tests surfaced two real bugs, fixed rather than routed around:
  - `ddl.getColumns()` failed to recognize a constraint clause added by `Migrator.CreateConstraint` as anything other than a column, because `constraint.Build()` returns an unsubstituted `CONSTRAINT ? ...` SQL template at that point (substitution happens later in GORM's own `tx.Exec`), which never matches `constraintRegexp`'s literal-backtick-quoted-name pattern. This is pre-existing, driver-agnostic logic unchanged from upstream `go-gorm/sqlite` — not introduced by the driver swap — and would corrupt any future migration adding a new constraint to a table with an existing `gorm:"unique"` field (6 real fields in `internal/storage/models/models.go` use this tag). Fixed by recognizing the `CONSTRAINT` keyword prefix directly, the same way `PRIMARY KEY`/`FOREIGN KEY` are already handled.
  - `Dialector.Translate()` mapped driver errors to GORM's sentinel errors via `json.Marshal`, reading exported `Code`/`ExtendedCode` fields present on `mattn/go-sqlite3`'s error type but absent on `modernc.org/sqlite`'s (unexported fields, exposed only via a `Code() int` method). Fixed by checking that method first. This app doesn't set `gorm.Config{TranslateError: true}` anywhere today, so nothing in production was silently broken, but the fork is now correct if anyone opts in later.
- Updates `docs/adr-048-cgo-free-sqlite-driver.md` to record both findings.

## Test plan

- [x] Clean cherry-pick onto current `main`, no conflicts
- [x] `go build ./...` clean
- [x] `go test ./internal/storage/sqlitedialect/...` — 23/23 pass, 81.3% coverage (up from 0%/"no test files")
- [x] `golangci-lint run ./...` — 0 issues