### PR TITLE
fix(ci): resolve failing checks across open PRs (flaky test, codeql grouping, false fuzz-crash PRs)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,17 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      # codeql-action ships init/analyze/upload-sarif as separate dependency
+      # names (one per sub-action path), so an ungrouped bump lands as
+      # separate PRs — merging just one leaves workflows mixing versions,
+      # which CodeQL treats as a hard configuration error ("Loaded a
+      # configuration file for version X, but running version Y"), failing
+      # CI on PRs that have nothing to do with the bump itself (#1257,
+      # #1260). Group them so every sub-action bumps atomically in one PR.
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
   # #478: without a gomod entry, Go dependency/toolchain-minimum drift (e.g. #477)
   # has no automated forcing function and depends on someone noticing manually.
   - package-ecosystem: gomod

--- a/scripts/fuzzing/notify-on-crash.sh
+++ b/scripts/fuzzing/notify-on-crash.sh
@@ -15,12 +15,31 @@ LOGFILE="${3:?path to the log file for this run}"
 : "${KEYORIX_REPO:?}"
 : "${FUZZ_CORPUS_BRANCH:=fuzz-corpus}"
 
+cd "$KEYORIX_REPO"
+
 fail_line="$(grep -m1 -E 'FAIL|panic:' "$LOGFILE" || true)"
 fail_hash="$(printf '%s' "${fail_line:-unknown}" | sha256sum | cut -c1-16)"
 marker="$NOTIFIED_STATE_DIR/notified-$FUNC-$fail_hash"
 
 if [[ -f "$marker" ]]; then
   exit 0 # already alerted for this exact failure
+fi
+
+# `go test -fuzz` can exit non-zero for reasons that never produce a
+# testdata/fuzz/<Func>/ reproducer — e.g. the process running out of disk or
+# memory near the end of a multi-hour run, rather than the fuzzing engine
+# actually finding and minimizing a new failing input. sync-corpus.sh only
+# commits+pushes when it finds real new content, so if nothing landed on
+# $FUZZ_CORPUS_BRANCH for this func, there is no reproducer to open a PR
+# about — doing so anyway produces a PR whose body falsely claims a crash
+# input was committed, and whose branch (unchanged) drifts further from main
+# every cycle until its CI fails on staleness alone. Confirmed root cause of
+# keyorixhq/keyorix#1243 and #1248: both claimed a committed reproducer that
+# was never actually pushed.
+git fetch origin "$FUZZ_CORPUS_BRANCH" --quiet 2>>"$NOTIFIED_STATE_DIR/gh-error-$FUNC-$fail_hash.log" || true
+if ! git ls-tree -r --name-only "origin/$FUZZ_CORPUS_BRANCH" 2>/dev/null | grep -q "^testdata/fuzz/$FUNC/"; then
+  echo "notify-on-crash: $FUNC exited non-zero (hash $fail_hash) but no testdata/fuzz/$FUNC/ reproducer exists on $FUZZ_CORPUS_BRANCH — treating as an infra failure, not a crash. Not opening a PR or alert. See $LOGFILE." >&2
+  exit 0
 fi
 
 summary="$(grep -m8 -E 'FAIL|panic:|--- FAIL|Fatalf|\.go:[0-9]+' "$LOGFILE" | head -c 1500 || true)"
@@ -64,7 +83,6 @@ The crashing input is committed to the \`$FUZZ_CORPUS_BRANCH\` branch and will b
 # crashes that were never actually reported, permanently suppressing them.
 gh_err="$NOTIFIED_STATE_DIR/gh-error-$FUNC-$fail_hash.log"
 
-cd "$KEYORIX_REPO"
 pr_notified=false
 existing_pr="$(gh pr list --head "$FUZZ_CORPUS_BRANCH" --state open --json number --jq '.[0].number' 2>>"$gh_err" || true)"
 if [[ -n "$existing_pr" ]]; then

--- a/server/server_s4_test.go
+++ b/server/server_s4_test.go
@@ -2163,11 +2163,16 @@ func TestStartHTTPServer_ShortLive(t *testing.T) {
 		done <- startHTTPServer(ctx, cfg)
 	}()
 
+	// 11 schedulers all fire on this 200ms window; under a loaded CI runner
+	// running the rest of the suite in parallel, waiting for all of them to
+	// settle and the server to shut down can take longer than a tight ceiling
+	// allows (observed flake: keyorixhq/keyorix#1257, #1258, #1263) even
+	// though the goroutine itself completes in well under 1s locally.
 	select {
 	case err := <-done:
 		_ = err
-	case <-time.After(2 * time.Second):
-		t.Fatal("startHTTPServer did not return within 2s")
+	case <-time.After(10 * time.Second):
+		t.Fatal("startHTTPServer did not return within 10s")
 	}
 }
 


### PR DESCRIPTION
## Summary
Investigated why the currently-open PRs (dependabot batch + fuzz-crash PRs) were failing CI. Three distinct, unrelated root causes:

- **`build-and-test` flake** (#1258, #1263, and likely others): `TestStartHTTPServer_ShortLive` enables all 11 schedulers on a 1ms cadence and waits up to 2s for `startHTTPServer` to shut down. Locally this takes ~0.2s, but a loaded CI runner running the rest of the suite in parallel can blow past 2s. Raised the ceiling to 10s — no change to what's being asserted.
- **CodeQL "configuration error"** (#1257, #1260): `github/codeql-action/init`, `/analyze`, and `/upload-sarif` are tracked as separate Dependabot dependencies, so a version bump lands as separate PRs. Merging just one leaves workflow steps on mismatched codeql-action versions, which CodeQL hard-fails on ("Loaded a configuration file for version X, but running version Y"). Added a Dependabot `groups:` entry so all `github/codeql-action/*` bumps land in one PR going forward.
- **False "crash reproducer" PRs** (#1243, #1248): `notify-on-crash.sh` opened a PR on any non-zero `go test -fuzz` exit, without verifying `sync-corpus.sh` actually pushed a reproducer to `fuzz-corpus`. A fuzz run can exit non-zero without producing a `testdata/fuzz/<Func>/` file (e.g. disk/memory exhaustion near the end of a multi-hour run) — the resulting PR then claimed a committed crash input that was never there, off a `fuzz-corpus` branch that hasn't moved since 2026-07-28 and is now hundreds of commits behind `main` (which is why its own CI fails — DCO on old pre-DCO-era commits pulled in by the staleness, and `build-and-test` against a schema hundreds of migrations old). Fixed to verify the reproducer actually landed on `fuzz-corpus` before opening a PR or sending an alert. #1243 and #1248 should be closed as invalid — no real reproducer exists.

## Test plan
- [x] `go build ./...`
- [x] `go test ./server/ -run TestStartHTTPServer_ShortLive -v` — passes, 0.2s
- [x] `bash -n scripts/fuzzing/notify-on-crash.sh`
- [x] `gosec -severity medium -exclude-generated ./server/...` — 0 issues
