### PR TITLE
fix(ci): bump codeql-action init/analyze to v4.37.3 to match upload-sarif

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: go
           build-mode: manual
@@ -64,7 +64,7 @@ jobs:
           go test -run=^$ ./...
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: '/language:go-${{ matrix.name }}'
 


### PR DESCRIPTION
## Summary
- #1257 (`codeql-action/analyze` 4.37.1 → 4.37.3) was opened before the codeql-action Dependabot grouping fix (#1264) landed, so it bumps `analyze` alone while `init` stays at 4.37.1.
- Every CodeQL run on that PR fails with `Loaded a configuration file for version '4.37.1', but running version '4.37.3'` — the exact config-error mode the grouping fix was meant to prevent.
- `upload-sarif` was already bumped to 4.37.3 separately via #1260 (merged before grouping took effect), so this brings `init`/`analyze` in `codeql.yml` up to the same version, restoring consistency.
- #1257 is now superseded by this PR and should be closed.

## Test plan
- [x] `codeql.yml` init/analyze pinned to the same SHA/version as the already-merged upload-sarif bump
- [ ] CI CodeQL job (Analyze (server)/(operator)) passes on this PR