### PR TITLE
refactor(encryption): remove deprecated RotateDEK

### DIFF
--- a/internal/encryption/encryption_s24_test.go
+++ b/internal/encryption/encryption_s24_test.go
@@ -12,7 +12,6 @@
 //   - Service.EncryptSecret/EncryptSecretWithAAD not-initialized guard
 //   - Service.DecryptSecretWithAAD: legacy (no AADVersion) fallback path
 //   - NewKeyProviderFromConfig: file, env, exec, shamir, tpm, unknown-type branches
-//   - KeyManager.RotateDEK error paths (bad passphrase)
 //   - deleteBackupFiles: glob match removes files
 //   - KeyManager.RewrapDEK: nil provider, wrong-size KEK, stale snapshot
 //   - AuthEncryption: disabled service paths
@@ -676,17 +675,6 @@ func TestNewKeyProviderFromConfig_PasswordExplicit(t *testing.T) {
 	assert.NotNil(t, p)
 }
 
-// ─── Service.RotateDEK: not initialized ──────────────────────────────────────
-
-func TestService_RotateDEK_NotInitialized_Error(t *testing.T) {
-	dir := t.TempDir()
-	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
-	svc := NewService(cfg, dir)
-	err := svc.RotateDEK("any-pass")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not initialized")
-}
-
 // ─── KeyManager.deleteBackupFiles: removes matching backup files ──────────────
 
 func TestKeyManager_DeleteBackupFiles_RemovesMatches(t *testing.T) {
@@ -1181,26 +1169,6 @@ func TestSweepMFASecrets_SkipsEmptySecret(t *testing.T) {
 	swept, _, err := sweepMFASecrets(db, es, es, "v1", false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, swept)
-}
-
-// ─── RotateDEK (deprecated): round-trip happy path ───────────────────────────
-
-func TestService_RotateDEK_HappyPath(t *testing.T) {
-	dir := t.TempDir()
-	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
-	svc := NewService(cfg, dir)
-	require.NoError(t, svc.Initialize("pass"))
-
-	oldVersion := svc.GetKeyVersion()
-	require.NoError(t, svc.RotateDEK("pass"))
-	newVersion := svc.GetKeyVersion()
-	assert.NotEqual(t, oldVersion, newVersion)
-
-	// Check backup file was created
-	backups, err := filepath.Glob(filepath.Join(dir, "dek.key.backup.*"))
-	require.NoError(t, err)
-	assert.NotEmpty(t, backups)
-	svc.Shutdown()
 }
 
 // ─── SecretAAD format ─────────────────────────────────────────────────────────

--- a/internal/encryption/encryption_s25_test.go
+++ b/internal/encryption/encryption_s25_test.go
@@ -1065,28 +1065,6 @@ func TestKeyManager_RotateDEKWithSweep_UnreadableDEKFile_Error(t *testing.T) {
 	svc.Shutdown()
 }
 
-// ─── RotateDEK (deprecated): unreadable DEK file → SafeReadFile error ─────────
-
-func TestKeyManager_RotateDEK_UnreadableDEKFile_Error(t *testing.T) {
-	if os.Getuid() == 0 {
-		t.Skip("root can read any file")
-	}
-	dir := t.TempDir()
-	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
-	svc := NewService(cfg, dir)
-	require.NoError(t, svc.Initialize("pass-s25"))
-
-	// Make the dek.key file unreadable.
-	dekPath := filepath.Join(dir, "dek.key")
-	require.NoError(t, os.Chmod(dekPath, 0000))
-	t.Cleanup(func() { _ = os.Chmod(dekPath, 0600) })
-
-	err := svc.keyManager.RotateDEK("pass-s25")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to read old DEK")
-	svc.Shutdown()
-}
-
 // ─── sweepSessions: Updates() error (DB closed mid-sweep) ────────────────────
 
 func TestSweepSessions_UpdatesError(t *testing.T) {

--- a/internal/encryption/encryption_s2_test.go
+++ b/internal/encryption/encryption_s2_test.go
@@ -889,26 +889,6 @@ func TestService_PreviewRotationSweep(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
-func TestService_RotateDEK_NotInitialized(t *testing.T) {
-	dir := t.TempDir()
-	cfg := &config.EncryptionConfig{
-		Enabled:  true,
-		DEKPath:  "dek.key",
-		SaltPath: "salt.key",
-	}
-	svc := NewService(cfg, dir)
-	err := svc.RotateDEK("passphrase")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not initialized")
-}
-
-func TestService_RotateDEK_Initialized(t *testing.T) {
-	svc := newInitializedService(t)
-	// RotateDEK without a sweep — must succeed.
-	err := svc.RotateDEK("test-passphrase-service")
-	require.NoError(t, err)
-}
-
 // TestService_RotateDEKWithSweep_AuthTables verifies that sweepSessions,
 // sweepAPITokens, and sweepPasswordResets re-encrypt seeded rows correctly
 // (exercising the inner loop bodies that are at 17.9% coverage).

--- a/internal/encryption/keymanager_lifecycle.go
+++ b/internal/encryption/keymanager_lifecycle.go
@@ -44,7 +44,7 @@ type KeyManager struct {
 	baseDir    string
 	currentDEK []byte
 	// dekSnapshot is the raw wrapped-DEK bytes read from disk at the moment
-	// currentDEK was last set (Initialize/RotateDEKWithSweep/RotateDEK). It
+	// currentDEK was last set (Initialize/RotateDEKWithSweep). It
 	// lets RewrapDEK detect — under the exclusive key lock — whether another
 	// process has changed dek.key since, so it never overwrites a
 	// concurrently-completed rotation with a stale value (#195).

--- a/internal/encryption/keymanager_rotation.go
+++ b/internal/encryption/keymanager_rotation.go
@@ -1,6 +1,6 @@
 // keymanager_rotation.go — DEK rotation with full re-encryption sweep (ADR-010).
 //
-// RotateDEKWithSweep (preferred), RotateDEK (deprecated), CleanPendingDEK, deleteBackupFiles.
+// RotateDEKWithSweep, CleanPendingDEK, deleteBackupFiles.
 // For initialisation see keymanager_lifecycle.go. For get/validate/wipe see keymanager_io.go.
 package encryption
 
@@ -142,52 +142,4 @@ func (km *KeyManager) CleanPendingDEK() {
 		log.Printf("[WARN] found leftover pending DEK file %s — removing (previous rotation was interrupted)", pendingPath)
 		_ = os.Remove(pendingPath)
 	}
-}
-
-// RotateDEK generates a new DEK and writes it to disk without re-encrypting existing secrets.
-//
-// DEPRECATED: Use RotateDEKWithSweep instead. This method causes key proliferation —
-// existing secrets remain encrypted with the old DEK and backup files accumulate.
-// See ADR-010.
-func (km *KeyManager) RotateDEK(passphrase string) error {
-	km.mu.Lock()
-	defer km.mu.Unlock()
-
-	kek, err := km.deriveKEK(passphrase)
-	if err != nil {
-		return fmt.Errorf("failed to derive KEK for DEK rotation: %w", err)
-	}
-	defer wipeBytes(kek)
-
-	newDEK, err := GenerateRandomKey(32)
-	if err != nil {
-		return fmt.Errorf("failed to generate new DEK: %w", err)
-	}
-
-	oldDEKPath := fmt.Sprintf("%s.backup.%d", km.dekPath, time.Now().Unix())
-	oldWrapped, err := securefiles.SafeReadFile(km.baseDir, km.dekPath)
-	if err != nil {
-		return fmt.Errorf("failed to read old DEK for backup: %w", err)
-	}
-	// Durable backup BEFORE overwriting the active DEK below, so a crash always
-	// leaves at least one recoverable wrapped DEK on disk.
-	if err := securefiles.SecureWriteFileSync(km.baseDir, oldDEKPath, oldWrapped, 0600); err != nil {
-		return fmt.Errorf("failed to backup old DEK: %w", err)
-	}
-
-	wrapped, err := wrapKey(newDEK, kek)
-	if err != nil {
-		return fmt.Errorf("failed to wrap new DEK: %w", err)
-	}
-	if err := securefiles.SecureWriteFileSync(km.baseDir, km.dekPath, wrapped, 0600); err != nil {
-		return fmt.Errorf("failed to write new wrapped DEK: %w", err)
-	}
-
-	wipeBytes(km.currentDEK)
-	km.currentDEK = newDEK
-	km.dekSnapshot = append([]byte(nil), wrapped...)
-	km.keyVersion = fmt.Sprintf("v%d", time.Now().Unix())
-
-	fmt.Printf("✅ DEK rotated successfully. New version: %s\n", km.keyVersion)
-	return nil
 }

--- a/internal/encryption/keyprovider_compat_test.go
+++ b/internal/encryption/keyprovider_compat_test.go
@@ -128,7 +128,9 @@ func TestKeyProvider_DEKRotationUnderProvider(t *testing.T) {
 	require.NoError(t, km.Initialize(""))
 	before := append([]byte(nil), km.GetDEK()...)
 
-	require.NoError(t, km.RotateDEK("")) // deprecated path, but exercises re-wrap under a provider
+	require.NoError(t, km.RotateDEKWithSweep("", func(_, _ *EncryptionService, _ string) error {
+		return nil
+	})) // exercises re-wrap under a provider
 	after := km.GetDEK()
 	assert.NotEqual(t, before, after, "rotation must produce a new DEK")
 

--- a/internal/encryption/service_rotation.go
+++ b/internal/encryption/service_rotation.go
@@ -1,6 +1,6 @@
 // service_rotation.go — DEK rotation, key ops, and shutdown for Service.
 //
-// RotateDEKWithSweep, RotateDEK, ValidateKeyFiles, FixKeyFilePermissions,
+// RotateDEKWithSweep, ValidateKeyFiles, FixKeyFilePermissions,
 // GetKeyVersion, CleanPendingDEK, Shutdown.
 // For encrypt/decrypt see service.go.
 package encryption
@@ -196,27 +196,6 @@ func (s *Service) UpgradeAuthAAD(db *gorm.DB) (*SweepResult, error) {
 	log.Printf("✅ AAD upgrade committed: %d mfa_secrets, %d dynamic_secret_configs, %d dynamic_secret_leases re-encrypted (%d legacy AAD upgraded)",
 		result.MFASecretsSwept, result.DynamicSecretConfigsSwept, result.DynamicSecretLeasesSwept, result.LegacyAADUpgraded)
 	return result, nil
-}
-
-// RotateDEK rotates the DEK without re-encrypting existing secrets.
-// DEPRECATED: Use RotateDEKWithSweep instead. See ADR-010.
-func (s *Service) RotateDEK(passphrase string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if !s.initialized {
-		return fmt.Errorf("encryption service not initialized")
-	}
-	if err := s.keyManager.RotateDEK(passphrase); err != nil {
-		return fmt.Errorf("failed to rotate DEK: %w", err)
-	}
-	dek := s.keyManager.GetDEK()
-	encSvc, err := NewEncryptionService(dek)
-	if err != nil {
-		return fmt.Errorf("failed to recreate encryption service: %w", err)
-	}
-	s.encryptionService = encSvc
-	return nil
 }
 
 // RotateKEKPassphrase changes the master passphrase without re-encrypting the


### PR DESCRIPTION
## Summary

`RotateDEK` (both `KeyManager.RotateDEK` and `Service.RotateDEK`) rotates the DEK without re-encrypting existing secrets — it's been marked deprecated since ADR-010's addendum introduced `RotateDEKWithSweep`, which performs the same operation correctly: a full transactional re-encryption sweep of every DEK-encrypted table, so no secret is ever left encrypted under a key about to be wiped.

ADR-010's addendum explicitly says to keep `RotateDEK` around only until "we are confident no internal caller uses it." Confirmed via repo-wide search: the CLI (`keyorix encryption rotate`) already calls `RotateDEKWithSweep` exclusively, and there are zero production callers of `RotateDEK` anywhere in `server/`, `cmd/`, `internal/cli/`, or `operator/` — only its own tests still called it directly.

## Changes

- Removed `KeyManager.RotateDEK` (`keymanager_rotation.go`) and `Service.RotateDEK` (`service_rotation.go`), plus their file-header doc comments.
- Removed five tests that only existed to exercise the deprecated function directly — three of them duplicated coverage that already exists for `RotateDEKWithSweep`'s equivalent not-initialized / happy-path / unreadable-DEK-file scenarios.
- **Retargeted, not deleted**: `TestKeyProvider_DEKRotationUnderProvider` now calls `RotateDEKWithSweep` with a no-op `sweepFn` instead of `RotateDEK`, preserving its actual unique coverage (verifying DEK re-wrap under a pluggable key provider rather than a passphrase-derived KEK) — nothing else in the `RotateDEKWithSweep` test suite covered that path.
- Left in place: comments that reference `RotateDEK` purely as historical context for why `deleteBackupFiles`/backup-file cleanup exists in `RotateDEKWithSweep` — they remain accurate even with the function gone.

No behavior change for any live code path — `RotateDEKWithSweep` was already the only mechanism ever invoked in production.

## Test plan

- [x] `go build ./...` — success (repo-wide; confirms no other caller of the removed symbols)
- [x] `go vet ./internal/encryption/... ./internal/cli/encryption/...` — clean
- [x] `go test -race ./internal/encryption/... ./internal/cli/encryption/...` — 694 passed
- [x] `golangci-lint run ./internal/encryption/... ./internal/cli/encryption/...` — no issues
- [x] `gofmt -l` on all changed files — clean