### PR TITLE
docs(dast): document ZAP/100001 SPA-root suppression as a known exception

### DIFF
--- a/docs/DAST.md
+++ b/docs/DAST.md
@@ -123,9 +123,11 @@ For findings that will reappear on every scan (e.g. `style-src 'unsafe-inline'`
 required by the SPA's CSS-in-JS runtime), close the issue with an explanation
 and leave a note in this file under **Known accepted exceptions**.
 
-There is currently no per-URL suppression list in the scan scripts; add one to
-`scan-zap.sh` / `scan-zap-full.sh` via ZAP's `-c` config-file option if the
-volume of false positives warrants it.
+`scan-zap.sh` scopes the stock "Unexpected Content Types" rule (100001) away
+from the SPA shell via `zap-api-scope-hook.py`, loaded through zap-api-scan.py's
+`--hook` option — see **Known accepted exceptions** below. Add further per-URL
+suppressions the same way (a global alert filter in the hook) or via ZAP's `-c`
+config-file option if the volume of false positives warrants it.
 
 ## Running a scan manually
 
@@ -181,3 +183,4 @@ postgres volume — the KEK is bound to the encrypted data on disk.
 | Issue | Finding | Reason |
 |-------|---------|--------|
 | #1213 (closed) | `CSP: style-src unsafe-inline` | Required by the SPA's CSS-in-JS / Tailwind runtime. `script-src` does not carry `unsafe-inline`, so inline script injection (the primary XSS vector) remains blocked. |
+| #1210, #1245, #1249 (closed) | `ZAP/100001: Unexpected Content-Type was returned`, for the bare target URL (`/`) and random top-level paths | zap-api-scan.py's "Unexpected Content Types" rule checks every URL ZAP visits, not just declared OpenAPI operations — including the base target URL it always hits first and assorted spider/connectivity probes. Those URLs correctly fall through to the SPA shell (`text/html`) per `server/http/router.go`'s `NotFound` handler, since they're not under any backend route prefix and must stay servable as client-side routes. Suppressed via a global alert filter in `zap-api-scope-hook.py` (see above) rather than relaxing the router, which would break SPA routing. Genuine API paths (`/api/`, `/auth/`, etc.) are unaffected and still enforce JSON-only content types (#1245/#1247 fixed that case in application code). |


### PR DESCRIPTION
## Summary
- Closes #1249. Investigated why `[DAST] ZAP/100001: Unexpected Content-Type was returned` kept recurring (#1210, #1245, #1249) despite #1216/#1247 already fixing the API-path case in `server/http/router.go`.
- Root cause for this recurrence: `zap-api-scan.py`'s "Unexpected Content Types" passive rule checks *every* URL ZAP visits during the scan, not just declared OpenAPI operations — including the base target URL (`/`) it always hits first and a couple of random top-level paths from its spider/connectivity probes. Those correctly fall through to the SPA shell (`text/html`) per the router's `NotFound` handler, since they're outside any backend route prefix and must stay servable as client-side routes — this is correct behavior, not a bug, so it can't be fixed in application code without breaking SPA routing.
- `scan-zap.sh` on the DAST rig already referenced a `--hook zap-api-scope-hook.py` with comments citing #1245/#1249, but the hook file was an empty 0-byte stub — someone had started this fix and left it unfinished. Filled it in: a `zap_started` hook that adds a ZAP global alert filter suppressing rule 100001 for any URL not under a declared backend prefix (kept in sync with `backendRoutePrefixes` in `router.go`).
- Also fixed a bug in `create-issues.sh` on the rig: its jq filter only checked `riskcode >= 1`, but ZAP's alert filter marks suppressed instances as a "False Positive" without changing `riskcode` — it just zeroes out `.instances`. Without also excluding `False Positive`/empty-instances alerts, the very next scan would have re-filed a fresh duplicate issue against the now-empty alert. Verified against both the pre-fix report (still files real findings) and the post-fix report (correctly excluded).
- This repo-side PR documents the exception in `docs/DAST.md`'s "Known accepted exceptions" table, matching the existing pattern for the CSP `style-src unsafe-inline` case (#1213). The actual scan-side files (`zap-api-scope-hook.py`, `create-issues.sh`) live on the DAST rig itself (`/opt/keyorix-dast/`), not in this repo.

## Verification
- Ran `scan-zap.sh` manually on the rig against the fixed hook: `FAIL-NEW: 0, WARN-NEW: 0` for rule 100001 (previously 4 instances: `/`, `http://keyorix:8080`, and 2 random top-level paths).
- Confirmed the alert survives in the JSON report only as an empty, `riskdesc: "Low (False Positive)"`, zero-instance entry.
- Re-ran `create-issues.sh` against that report with the fixed jq filter: no mention of ZAP/100001 at all (previously logged a spurious "skip (already open #1249)" match).
- Also found and recovered an unrelated issue while on the rig: the `keyorix` DAST target container was stopped, then came back up hung (no port 8080 listener, zero logs) after a `pct start` — a clean `docker compose restart keyorix` resolved it; both containers are healthy now.

## Test plan
- [x] `docs/DAST.md` renders correctly, no broken table formatting
- [x] No application code changed — this PR is docs-only