### PR TITLE
feat: add read-only auth and encryption config endpoints

### DIFF
--- a/server/http/handlers/openapi.yaml
+++ b/server/http/handlers/openapi.yaml
@@ -390,6 +390,26 @@ paths:
       responses:
         '200': {description: 'Runtime, HTTP, database, and secrets metrics'}
         '403': {$ref: '#/components/responses/Error'}
+  /api/v1/system/auth-config:
+    get:
+      tags: [System]
+      summary: Authentication configuration (requires system.read)
+      description: Return session, password policy, login lockout, MFA, WebAuthn, and SSO provider settings (secrets redacted).
+      operationId: getAuthConfig
+      security: [{bearerAuth: []}]
+      responses:
+        '200': {description: 'Authentication configuration summary'}
+        '403': {$ref: '#/components/responses/Error'}
+  /api/v1/system/encryption-config:
+    get:
+      tags: [System]
+      summary: Encryption configuration (requires system.read)
+      description: Return whether encryption is enabled and the key-provider type (key material locations redacted).
+      operationId: getEncryptionConfig
+      security: [{bearerAuth: []}]
+      responses:
+        '200': {description: 'Encryption configuration summary'}
+        '403': {$ref: '#/components/responses/Error'}
   /api/v1/projects:
     get:
       tags: [Projects]

--- a/server/http/handlers/settings.go
+++ b/server/http/handlers/settings.go
@@ -1,0 +1,189 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// SessionSummary mirrors config.SessionConfig, using the effective
+// (defaulted) TTLs rather than the possibly-empty raw YAML strings.
+type SessionSummary struct {
+	AccessTTL   string `json:"access_ttl"`
+	AbsoluteTTL string `json:"absolute_ttl"`
+}
+
+// PasswordPolicySummary mirrors config.PasswordPolicyConfig verbatim — none
+// of its fields are sensitive.
+type PasswordPolicySummary struct {
+	MinLength             int  `json:"min_length"`
+	RequireUppercase      bool `json:"require_uppercase"`
+	RequireLowercase      bool `json:"require_lowercase"`
+	RequireDigit          bool `json:"require_digit"`
+	RequireSpecial        bool `json:"require_special"`
+	RejectPersonalInfo    bool `json:"reject_personal_info"`
+	RejectCommonPasswords bool `json:"reject_common_passwords"`
+	HistoryCount          int  `json:"history_count"`
+	MaxAgeDays            int  `json:"max_age_days"`
+}
+
+// LoginLockoutSummary reports the EFFECTIVE lockout state, not the raw
+// config.LoginLockoutConfig.Enabled field — lockout is on by default and
+// Disabled is the actual opt-out (see config.go's own comment on
+// LoginLockoutConfig), so Enabled here is computed as !cfg.Disabled.
+type LoginLockoutSummary struct {
+	Enabled      bool   `json:"enabled"`
+	MaxAttempts  int    `json:"max_attempts"`
+	Window       string `json:"window"`
+	BaseCooldown string `json:"base_cooldown"`
+	MaxCooldown  string `json:"max_cooldown"`
+}
+
+// WebAuthnSummary mirrors config.WebAuthnConfig verbatim — public
+// relying-party metadata, nothing sensitive.
+type WebAuthnSummary struct {
+	Enabled       bool     `json:"enabled"`
+	RPID          string   `json:"rp_id"`
+	RPDisplayName string   `json:"rp_display_name"`
+	RPOrigins     []string `json:"rp_origins"`
+}
+
+// SSOProviderSummary is a deliberately narrow view of config.SSOProviderConfig:
+// it excludes Issuer, ClientID, ClientSecret, RedirectURL, Scopes,
+// DefaultRole, GroupsClaim, GroupRoleMap, and the entire SAML block (which
+// embeds the IdP's signing certificate) — none of that belongs in an HTTP
+// response. Mirrors the redaction precedent in sso.go's ListSSOProviders,
+// which never marshals SSOProviderConfig directly for the same reason.
+type SSOProviderSummary struct {
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	AutoProvision bool   `json:"auto_provision"`
+	GroupSync     bool   `json:"group_sync"`
+}
+
+type SSOSummary struct {
+	Enabled   bool                 `json:"enabled"`
+	Providers []SSOProviderSummary `json:"providers"`
+}
+
+// AuthConfigResponse is the response body for GET /api/v1/system/auth-config.
+type AuthConfigResponse struct {
+	Session        SessionSummary        `json:"session"`
+	PasswordPolicy PasswordPolicySummary `json:"password_policy"`
+	LoginLockout   LoginLockoutSummary   `json:"login_lockout"`
+	RequireMFA     bool                  `json:"require_mfa"`
+	WebAuthn       WebAuthnSummary       `json:"webauthn"`
+	SSO            SSOSummary            `json:"sso"`
+}
+
+// MakeAuthConfigHandler returns a handler serving a read-only, redacted
+// summary of the server's authentication configuration (session TTLs,
+// password policy, login lockout, MFA/WebAuthn/SSO settings). No secrets —
+// SSO client secrets, SAML metadata, and per-provider OIDC details are
+// deliberately excluded.
+func MakeAuthConfigHandler(cfg *config.Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userCtx := middleware.GetUserFromContext(r.Context())
+		if userCtx == nil {
+			sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+			return
+		}
+
+		ll := cfg.Security.LoginLockout
+		providers := make([]SSOProviderSummary, 0, len(cfg.SSO.Providers))
+		for _, p := range cfg.SSO.Providers {
+			providers = append(providers, SSOProviderSummary{
+				Name:          p.Name,
+				Type:          p.Type,
+				AutoProvision: p.AutoProvision,
+				GroupSync:     p.GroupSync,
+			})
+		}
+
+		resp := AuthConfigResponse{
+			Session: SessionSummary{
+				AccessTTL:   cfg.Session.GetAccessTTL().String(),
+				AbsoluteTTL: cfg.Session.GetAbsoluteTTL().String(),
+			},
+			PasswordPolicy: PasswordPolicySummary{
+				MinLength:             cfg.PasswordPolicy.MinLength,
+				RequireUppercase:      cfg.PasswordPolicy.RequireUppercase,
+				RequireLowercase:      cfg.PasswordPolicy.RequireLowercase,
+				RequireDigit:          cfg.PasswordPolicy.RequireDigit,
+				RequireSpecial:        cfg.PasswordPolicy.RequireSpecial,
+				RejectPersonalInfo:    cfg.PasswordPolicy.RejectPersonalInfo,
+				RejectCommonPasswords: cfg.PasswordPolicy.RejectCommonPasswords,
+				HistoryCount:          cfg.PasswordPolicy.HistoryCount,
+				MaxAgeDays:            cfg.PasswordPolicy.MaxAgeDays,
+			},
+			LoginLockout: LoginLockoutSummary{
+				Enabled:      !ll.Disabled,
+				MaxAttempts:  ll.GetMaxAttempts(),
+				Window:       ll.GetWindow().String(),
+				BaseCooldown: ll.GetBaseCooldown().String(),
+				MaxCooldown:  ll.GetMaxCooldown().String(),
+			},
+			RequireMFA: cfg.Security.RequireMFA,
+			WebAuthn: WebAuthnSummary{
+				Enabled:       cfg.WebAuthn.Enabled,
+				RPID:          cfg.WebAuthn.RPID,
+				RPDisplayName: cfg.WebAuthn.RPDisplayName,
+				RPOrigins:     cfg.WebAuthn.RPOrigins,
+			},
+			SSO: SSOSummary{
+				Enabled:   cfg.SSO.Enabled,
+				Providers: providers,
+			},
+		}
+
+		sendSuccess(w, resp, "")
+	}
+}
+
+// KeyProviderSummary is a deliberately narrow view of config.KeyProviderConfig:
+// it excludes FilePath, WrappedKeyPath, ExecCommand, ShamirShareFiles,
+// ShamirShareEnv, TPMDevice (all disclose exact filesystem/command locations
+// of key material), EnvVar (names the env var holding raw key material), and
+// KMSKeyID/KMSEncryptionContext (cloud resource identifiers with no
+// legitimate need to be exposed here). ShamirCommitment is safe to expose —
+// it's a one-way HMAC commitment that reveals nothing about the KEK itself
+// (see the field's own doc comment in config.go).
+type KeyProviderSummary struct {
+	Type             string `json:"type"`
+	ShamirCommitment string `json:"shamir_commitment,omitempty"`
+	FallbackCount    int    `json:"fallback_count"`
+}
+
+// EncryptionConfigResponse is the response body for GET /api/v1/system/encryption-config.
+type EncryptionConfigResponse struct {
+	Enabled     bool               `json:"enabled"`
+	KeyProvider KeyProviderSummary `json:"key_provider"`
+}
+
+// MakeEncryptionConfigHandler returns a handler serving a read-only,
+// redacted summary of the server's encryption configuration: whether
+// envelope encryption is enabled and the KEK provider type. Key material
+// locations (file paths, exec commands, env var names, KMS key IDs) are
+// deliberately excluded.
+func MakeEncryptionConfigHandler(cfg *config.Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userCtx := middleware.GetUserFromContext(r.Context())
+		if userCtx == nil {
+			sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
+			return
+		}
+
+		kp := cfg.Storage.Encryption.KeyProvider
+		resp := EncryptionConfigResponse{
+			Enabled: cfg.Storage.Encryption.Enabled,
+			KeyProvider: KeyProviderSummary{
+				Type:             kp.Type,
+				ShamirCommitment: kp.ShamirCommitment,
+				FallbackCount:    len(kp.Fallbacks),
+			},
+		}
+
+		sendSuccess(w, resp, "")
+	}
+}

--- a/server/http/handlers/settings_test.go
+++ b/server/http/handlers/settings_test.go
@@ -1,0 +1,217 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── MakeAuthConfigHandler ────────────────────────────────────────────────
+
+func TestMakeAuthConfigHandler_Unauthenticated(t *testing.T) {
+	cfg := &config.Config{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/system/auth-config", nil)
+	rr := httptest.NewRecorder()
+	MakeAuthConfigHandler(cfg)(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestMakeAuthConfigHandler_Authenticated(t *testing.T) {
+	cfg := &config.Config{}
+	req := userCtxForTest(httptest.NewRequest(http.MethodGet, "/api/v1/system/auth-config", nil))
+	rr := httptest.NewRecorder()
+	MakeAuthConfigHandler(cfg)(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.True(t, resp["success"].(bool), "response must carry success:true")
+
+	data, ok := resp["data"].(map[string]interface{})
+	require.True(t, ok, "data field must be a JSON object")
+	assert.Contains(t, data, "session")
+	assert.Contains(t, data, "password_policy")
+	assert.Contains(t, data, "login_lockout")
+	assert.Contains(t, data, "require_mfa")
+	assert.Contains(t, data, "webauthn")
+	assert.Contains(t, data, "sso")
+}
+
+func TestMakeAuthConfigHandler_ReflectsConfig(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.PasswordPolicy.MinLength = 16
+	cfg.PasswordPolicy.RequireUppercase = true
+	cfg.Security.RequireMFA = true
+	cfg.Security.LoginLockout.Disabled = true
+	cfg.Session.AccessTTL = "30m"
+	cfg.WebAuthn.Enabled = true
+	cfg.WebAuthn.RPID = "keyorix.example.com"
+
+	req := userCtxForTest(httptest.NewRequest(http.MethodGet, "/api/v1/system/auth-config", nil))
+	rr := httptest.NewRecorder()
+	MakeAuthConfigHandler(cfg)(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	data := resp["data"].(map[string]interface{})
+
+	passwordPolicy := data["password_policy"].(map[string]interface{})
+	assert.Equal(t, float64(16), passwordPolicy["min_length"])
+	assert.Equal(t, true, passwordPolicy["require_uppercase"])
+
+	assert.Equal(t, true, data["require_mfa"])
+
+	loginLockout := data["login_lockout"].(map[string]interface{})
+	assert.Equal(t, false, loginLockout["enabled"], "Disabled: true must resolve to enabled: false")
+
+	session := data["session"].(map[string]interface{})
+	assert.Equal(t, "30m0s", session["access_ttl"])
+
+	webauthn := data["webauthn"].(map[string]interface{})
+	assert.Equal(t, true, webauthn["enabled"])
+	assert.Equal(t, "keyorix.example.com", webauthn["rp_id"])
+}
+
+func TestMakeAuthConfigHandler_LoginLockoutDefaultsToEnabled(t *testing.T) {
+	cfg := &config.Config{} // Disabled left at its zero value (false) — lockout is on by default.
+	req := userCtxForTest(httptest.NewRequest(http.MethodGet, "/api/v1/system/auth-config", nil))
+	rr := httptest.NewRecorder()
+	MakeAuthConfigHandler(cfg)(rr, req)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	data := resp["data"].(map[string]interface{})
+	loginLockout := data["login_lockout"].(map[string]interface{})
+	assert.Equal(t, true, loginLockout["enabled"])
+	assert.Equal(t, float64(5), loginLockout["max_attempts"], "must reflect the GetMaxAttempts() default")
+}
+
+func TestMakeAuthConfigHandler_NeverLeaksSecrets(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.SSO.Enabled = true
+	cfg.SSO.Providers = []config.SSOProviderConfig{
+		{
+			Name:         "okta",
+			Type:         "oidc",
+			Issuer:       "https://example.okta.com",
+			ClientID:     "the-client-id",
+			ClientSecret: "super-secret-client-value",
+			RedirectURL:  "https://keyorix.example.com/auth/sso/callback",
+			SAML: &config.SAMLProviderConfig{
+				IDPMetadataXML: "<EntityDescriptor>fake-signing-cert-blob</EntityDescriptor>",
+			},
+		},
+	}
+
+	req := userCtxForTest(httptest.NewRequest(http.MethodGet, "/api/v1/system/auth-config", nil))
+	rr := httptest.NewRecorder()
+	MakeAuthConfigHandler(cfg)(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.NotContains(t, body, "super-secret-client-value")
+	assert.NotContains(t, body, "the-client-id")
+	assert.NotContains(t, body, "https://example.okta.com")
+	assert.NotContains(t, body, "https://keyorix.example.com/auth/sso/callback")
+	assert.NotContains(t, body, "fake-signing-cert-blob")
+
+	// The safe fields must still be present, so this isn't just an empty response.
+	assert.Contains(t, body, "\"name\":\"okta\"")
+	assert.Contains(t, body, "\"type\":\"oidc\"")
+}
+
+// ── MakeEncryptionConfigHandler ──────────────────────────────────────────
+
+func TestMakeEncryptionConfigHandler_Unauthenticated(t *testing.T) {
+	cfg := &config.Config{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/system/encryption-config", nil)
+	rr := httptest.NewRecorder()
+	MakeEncryptionConfigHandler(cfg)(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestMakeEncryptionConfigHandler_Authenticated(t *testing.T) {
+	cfg := &config.Config{}
+	req := userCtxForTest(httptest.NewRequest(http.MethodGet, "/api/v1/system/encryption-config", nil))
+	rr := httptest.NewRecorder()
+	MakeEncryptionConfigHandler(cfg)(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.True(t, resp["success"].(bool))
+
+	data, ok := resp["data"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, data, "enabled")
+	assert.Contains(t, data, "key_provider")
+}
+
+func TestMakeEncryptionConfigHandler_ReflectsConfig(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Storage.Encryption.Enabled = true
+	cfg.Storage.Encryption.KeyProvider.Type = "aws-kms"
+	cfg.Storage.Encryption.KeyProvider.ShamirCommitment = "deadbeef"
+	cfg.Storage.Encryption.KeyProvider.Fallbacks = []config.KeyProviderConfig{{Type: "password"}}
+
+	req := userCtxForTest(httptest.NewRequest(http.MethodGet, "/api/v1/system/encryption-config", nil))
+	rr := httptest.NewRecorder()
+	MakeEncryptionConfigHandler(cfg)(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	data := resp["data"].(map[string]interface{})
+	assert.Equal(t, true, data["enabled"])
+
+	keyProvider := data["key_provider"].(map[string]interface{})
+	assert.Equal(t, "aws-kms", keyProvider["type"])
+	assert.Equal(t, "deadbeef", keyProvider["shamir_commitment"])
+	assert.Equal(t, float64(1), keyProvider["fallback_count"])
+}
+
+func TestMakeEncryptionConfigHandler_NeverLeaksSecrets(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Storage.Encryption.Enabled = true
+	cfg.Storage.Encryption.DEKPath = "/var/lib/keyorix/dek.bin"
+	cfg.Storage.Encryption.SaltPath = "/var/lib/keyorix/salt.bin"
+	cfg.Storage.Encryption.KeyProvider = config.KeyProviderConfig{
+		Type:           "exec",
+		FilePath:       "/etc/keyorix/kek.key",
+		EnvVar:         "KEYORIX_KEK_MATERIAL",
+		WrappedKeyPath: "/var/lib/keyorix/wrapped-kek.bin",
+		ExecCommand:    []string{"op", "read", "op://vault/kek/value"},
+		KMSKeyID:       "arn:aws:kms:us-east-1:123456789012:key/abc-def",
+		TPMDevice:      "/dev/tpmrm0",
+	}
+
+	req := userCtxForTest(httptest.NewRequest(http.MethodGet, "/api/v1/system/encryption-config", nil))
+	rr := httptest.NewRecorder()
+	MakeEncryptionConfigHandler(cfg)(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.NotContains(t, body, "/var/lib/keyorix/dek.bin")
+	assert.NotContains(t, body, "/var/lib/keyorix/salt.bin")
+	assert.NotContains(t, body, "/etc/keyorix/kek.key")
+	assert.NotContains(t, body, "KEYORIX_KEK_MATERIAL")
+	assert.NotContains(t, body, "/var/lib/keyorix/wrapped-kek.bin")
+	assert.NotContains(t, body, "op://vault/kek/value")
+	assert.NotContains(t, body, "arn:aws:kms:us-east-1:123456789012:key/abc-def")
+	assert.NotContains(t, body, "/dev/tpmrm0")
+
+	// The safe field must still be present.
+	assert.Contains(t, body, "\"type\":\"exec\"")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -395,6 +395,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// (Per-user dashboard stats scope their own recent-activity in core.)
 		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/dashboard/activity", dashboardHandler.GetActivity)
 
+		// Read-only, redacted config summaries for an admin UI to display (never edit —
+		// config stays YAML-only to change). Deliberately NOT inside the /system route
+		// group below: that group is the RemoteStorage server-to-server proxy API
+		// (machine credentials only, system.write-gated) — these are human-facing reads,
+		// so they sit here alongside /dashboard/stats at system.read instead.
+		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/system/auth-config", handlers.MakeAuthConfigHandler(cfg))
+		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/system/encryption-config", handlers.MakeEncryptionConfigHandler(cfg))
+
 		// Catalog endpoints (projects, environments).
 		// List endpoints need global read (browse everything); accessing a
 		// specific project/environment is scoped to that project. Creating a


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/system/auth-config` and `GET /api/v1/system/encryption-config` — read-only, so a future admin UI can display (not edit) authentication and encryption configuration that today is only visible via filesystem access to `keyorix.yaml`.
- Both gated behind `system.read` (held by `system_viewer`/`system_auditor`/`admin`/`system_admin`), registered as standalone routes alongside `/dashboard/stats` — deliberately **not** inside the existing `/system` route group, which is `system.write`-gated and is actually the RemoteStorage server-to-server proxy API (ADR-049), not a human-facing config-read group.
- Response bodies are hand-built DTOs with explicit `json` tags, populated field-by-field — never a direct `sendSuccess(w, cfg.SSO, "")`-style dump of the config structs, which carry SSO client secrets, SAML IdP certificates, and KEK file/exec/env-var locations that must never leave the server. See `settings.go`'s doc comments for the exact field-by-field inclusion/exclusion reasoning.
- `login_lockout.enabled` in the response reflects the actual runtime-effective state (`!cfg.Security.LoginLockout.Disabled`, matching `server/main.go`'s own resolution logic) rather than echoing the vestigial, unused `Enabled` field.
- Config remains YAML-only to edit — this PR is read-only, nothing more.

## Test plan
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (both scoped to changed packages and full repo)
- [x] `go build ./...`
- [x] `gosec ./server/http/handlers/...` — 50 pre-existing findings, none in the new/changed files
- [x] `govulncheck ./...`
- [x] New `settings_test.go`: unauthenticated (401), authenticated (200 + envelope shape), config-reflection, and — the actual point of this PR — a raw-response-body sweep asserting sensitive values (SSO client secret, KEK file paths/exec commands/env var names) never appear anywhere in the JSON, not just that the DTO's known-safe fields are correct
- [x] `go test -race ./server/http/handlers/...` — full package passes (5385 tests)

Note: a full-repo `go test -race ./...` run surfaced two unrelated failures (`TestRemoteStorageMFAManagement_FullLifecycle_RealServer`, apparently TOTP-timing-sensitive under load, and a transient `TestMFAStepUpHandler_WrongCode_Unauthorized` failure that passed cleanly on retry) — both confirmed to reproduce identically against a clean, unmodified `origin/main` checkout, so unrelated to this change.

## Explicitly out of scope
- Any write/edit capability for this config (stays YAML-only).
- Relocating `/system/info`/`/system/metrics` from `system.write` to `system.read` — noted in code comments as a related, worthwhile follow-up, not done here to keep this PR minimal.
- New granular permissions — reuses the existing `system.read` permission.
- The frontend page(s) that would consume these endpoints.