### PR TITLE
docs(adr-010): annotate the never-shipped rotate-dek CLI as superseded

### DIFF
--- a/docs/adr-010-kek-rotation-reencryption-sweep.md
+++ b/docs/adr-010-kek-rotation-reencryption-sweep.md
@@ -99,7 +99,12 @@ For installations with large numbers of secrets, the sweep processes `secret_ver
 
 Changing `KEYORIX_MASTER_PASSWORD` is a separate concern: new salt + new PBKDF2 derivation → new KEK → re-wrap same DEK with new KEK. This does **not** require a database re-encryption sweep (the DEK is unchanged; only its wrapper changes). Implement as `RotateKEK(oldPassphrase, newPassphrase)` in `keymanager.go`. This ADR covers DEK rotation (the sweep). KEK rotation (passphrase change) is a follow-on item.
 
-### CLI surface
+### CLI surface (original proposal — superseded, see Addendum below)
+
+**This `key rotate-dek` command was never shipped.** It was superseded before
+implementation by extending the existing `keyorix encryption rotate` command
+instead — see "Addendum — CLI Wiring" below for the actual shipped surface
+and why. Kept here only as the historical record of the original proposal.
 
 ```
 keyorix-server key rotate-dek   # triggers RotateDEKWithSweep; requires KEYORIX_MASTER_PASSWORD
@@ -141,7 +146,7 @@ Alternatively exposed as a protected admin API endpoint (operator-only, no user-
 | `internal/encryption/keymanager.go` | Add `RotateDEKWithSweep` (core algorithm). Mark `RotateDEK` deprecated. Add `GetOldDEKForSweep() []byte` helper (returns copy of current DEK before rotation). |
 | `internal/encryption/service.go` | Add `RotateDEKWithSweep(passphrase string, db *gorm.DB) error`. Wire it through from `keymanager`. |
 | `internal/encryption/sweep.go` | **New file.** `SweepSecretVersions`, `SweepAuthTokens`. Handles batched re-encryption, AAD reconstruction for secret_versions, and the auth token tables. |
-| `internal/cli/system/system.go` | Add `key` subcommand with `rotate-dek` action. |
+| `internal/cli/system/system.go` | ~~Add `key` subcommand with `rotate-dek` action.~~ **Superseded** — wired to the existing `keyorix encryption rotate` command instead; see Addendum below. |
 
 ### Test plan
 


### PR DESCRIPTION
## Summary
Closes the backlog item "`keyorix-server key rotate-dek` CLI command — superseded May 2026 — remove once confirmed no operator documentation references it."

That precondition wasn't actually met: `docs/adr-010-kek-rotation-reencryption-sweep.md`'s "CLI surface" section and Implementation Plan table presented `keyorix-server key rotate-dek` as the planned command with no indication it was never shipped. An operator reading only that section (not the later "Addendum — CLI Wiring" section further down) would try to run a command that doesn't exist. The real, shipped surface is `keyorix encryption rotate`, extended to call `RotateDEKWithSweep` instead of the deprecated `RotateDEK`.

Annotated both the original CLI surface code block and the Implementation Plan table row as superseded, pointing to the Addendum for the actual command — kept as the historical record of the original proposal rather than deleted.

No code change. Confirmed via repo-wide grep that this ADR was the only remaining reference to the dead command name.

## Test plan
- [x] `grep -rn "rotate-dek"` confirms all remaining references are now clearly annotated as historical/superseded
- [x] Docs-only change, no application code touched