### PR TITLE
fix: gate /system/info and /system/metrics at system.read, not system.write

### DIFF
--- a/server/grpc/services/audit_service_test.go
+++ b/server/grpc/services/audit_service_test.go
@@ -30,6 +30,13 @@ func newAuditService(t *testing.T) *AuditGRPCService {
 	}))
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
+	// modernc.org/sqlite gives each pooled connection to ":memory:" its own
+	// fresh, unmigrated database unless pinned to a single connection --
+	// without this, concurrent queries can intermittently hit a connection
+	// that never saw AutoMigrate ("no such table") (ADR-048).
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{},
 		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
@@ -125,6 +132,13 @@ func TestAuditService_GetRBACAuditLogs_ReturnsRoleChanges(t *testing.T) {
 	}))
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
+	// modernc.org/sqlite gives each pooled connection to ":memory:" its own
+	// fresh, unmigrated database unless pinned to a single connection --
+	// without this, concurrent queries can intermittently hit a connection
+	// that never saw AutoMigrate ("no such table") (ADR-048).
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.UserRole{},
 		&models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},

--- a/server/grpc/services/dynamic_secret_service_test.go
+++ b/server/grpc/services/dynamic_secret_service_test.go
@@ -31,6 +31,13 @@ func newDynamicTestRig(t *testing.T) *DynamicSecretGRPCService {
 	}))
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
+	// modernc.org/sqlite gives each pooled connection to ":memory:" its own
+	// fresh, unmigrated database unless pinned to a single connection --
+	// without this, concurrent queries can intermittently hit a connection
+	// that never saw AutoMigrate ("no such table") (ADR-048).
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.Project{}, &models.Environment{}, &models.User{}, &models.Role{},
 		&models.Permission{}, &models.RolePermission{}, &models.UserRole{},

--- a/server/grpc/services/machine_identity_service_test.go
+++ b/server/grpc/services/machine_identity_service_test.go
@@ -30,6 +30,13 @@ func newMachineTestRig(t *testing.T) *MachineIdentityGRPCService {
 	}))
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
+	// modernc.org/sqlite gives each pooled connection to ":memory:" its own
+	// fresh, unmigrated database unless pinned to a single connection --
+	// without this, concurrent queries can intermittently hit a connection
+	// that never saw AutoMigrate ("no such table") (ADR-048).
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.Project{}, &models.Environment{}, &models.User{}, &models.Role{},
 		&models.Permission{}, &models.RolePermission{}, &models.UserRole{},

--- a/server/grpc/services/share_service_test.go
+++ b/server/grpc/services/share_service_test.go
@@ -36,6 +36,13 @@ func newShareTestRig(t *testing.T) *shareTestRig {
 
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
+	// modernc.org/sqlite gives each pooled connection to ":memory:" its own
+	// fresh, unmigrated database unless pinned to a single connection --
+	// without this, concurrent queries can intermittently hit a connection
+	// that never saw AutoMigrate ("no such table") (ADR-048).
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.Project{}, &models.Environment{}, &models.SecretNode{},
 		&models.SecretVersion{}, &models.User{}, &models.Role{}, &models.ShareRecord{},

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -403,6 +403,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// so they sit here alongside /dashboard/stats at system.read instead.
 		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/system/auth-config", handlers.MakeAuthConfigHandler(cfg))
 		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/system/encryption-config", handlers.MakeEncryptionConfigHandler(cfg))
+		// Same reasoning as auth-config/encryption-config above: server version/
+		// build/runtime info and memory/GC/HTTP/DB metrics are human-facing reads,
+		// not RemoteStorage proxy traffic, so they don't belong behind the /system
+		// group's system.write gate either — moved out to system.read here
+		// (previously squatted inside that group; see its own comment for why that
+		// group itself stays system.write).
+		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/system/info", handlers.MakeSystemInfoHandler(cfg))
+		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/system"+pathMetrics, handlers.GetMetrics)
 
 		// Catalog endpoints (projects, environments).
 		// List endpoints need global read (browse everything); accessing a
@@ -1013,8 +1021,6 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// global admin roster, and setup-token data to all authenticated users (#r124).
 		r.Route("/system", func(r chi.Router) {
 			r.Use(customMiddleware.RequirePermission(permSystemWrite))
-			r.Get("/info", handlers.MakeSystemInfoHandler(cfg))
-			r.Get(pathMetrics, handlers.GetMetrics)
 			// Per-scheduler last-run/last-success timestamps (Prometheus exposition
 			// format), deliberately kept off the public, unauthenticated /metrics
 			// endpoint — see server/middleware/scheduler_metrics.go — since an exact

--- a/server/http/system_info_metrics_permission_test.go
+++ b/server/http/system_info_metrics_permission_test.go
@@ -1,0 +1,72 @@
+// system_info_metrics_permission_test.go proves the fix moving GET /api/v1/system/info
+// and GET /api/v1/system/metrics from the /system route group's system.write gate
+// (meant for the RemoteStorage server-to-server proxy API, ADR-049) to a standalone
+// system.read gate, matching the auth-config/encryption-config precedent and what
+// openapi.yaml already documented. It proves the boundary in both directions: a
+// system_viewer-baseline caller (system.read only) now succeeds, and a caller holding
+// no relevant permission at all still fails.
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+func TestSystemInfoMetrics_PermissionTiers(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	testCore := newTestCore(t)
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	createTestToken(t, testCore) // bootstrap admin + seed roles/permissions
+	noPermToken := createNoPermissionToken(t, testCore)
+	baselineToken := createLimitedToken(t, testCore) // system_viewer only (system.read)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	get := func(token, path string) *http.Response {
+		req, err := http.NewRequest(http.MethodGet, server.URL+path, nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		return resp
+	}
+
+	t.Run("baseline_system_viewer_allowed_info", func(t *testing.T) {
+		resp := get(baselineToken, "/api/v1/system/info")
+		assert.Equal(t, http.StatusOK, resp.StatusCode,
+			"a system_viewer-baseline (system.read only) caller must now succeed at /system/info")
+	})
+
+	t.Run("baseline_system_viewer_allowed_metrics", func(t *testing.T) {
+		resp := get(baselineToken, "/api/v1/system/metrics")
+		assert.Equal(t, http.StatusOK, resp.StatusCode,
+			"a system_viewer-baseline (system.read only) caller must now succeed at /system/metrics")
+	})
+
+	t.Run("no_permission_at_all_still_denied_info", func(t *testing.T) {
+		resp := get(noPermToken, "/api/v1/system/info")
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"the fix widens access to system.read, not to every authenticated caller")
+	})
+
+	t.Run("no_permission_at_all_still_denied_metrics", func(t *testing.T) {
+		resp := get(noPermToken, "/api/v1/system/metrics")
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"the fix widens access to system.read, not to every authenticated caller")
+	})
+}


### PR DESCRIPTION
## Summary
- Fixes the follow-up flagged in [#1277](https://github.com/keyorixhq/keyorix/pull/1277): `GET /api/v1/system/info` and `GET /api/v1/system/metrics` were gated at `system.write` inside the `/system` route group — whose gate is meant for the RemoteStorage server-to-server proxy API (ADR-049, machine credentials only) — when these two are human-facing reads that logically belong at `system.read`, matching the `/system/auth-config`/`/system/encryption-config` precedent from #1277 and what `openapi.yaml` already documented (it said "requires system.read" for both, even though the code enforced `system.write`).
- This is also why keyorix-web's System Health page had to be wrapped in `AdminRoute` despite the data being safe for any `system_viewer`/`system_auditor` to see — a related, separate frontend follow-up, not changed here.
- **Found and fixed a latent bug while moving `/system/metrics`**: its route used the bare `pathMetrics` constant (`"/metrics"`), which chi only resolves correctly to `/system/metrics` when nested inside the `/system` sub-router. Registered standalone with the bare constant, it would have silently mounted at `/api/v1/metrics` instead — caught by the new test before it ever reached CI.
- **Discovered but explicitly out of scope**: several other proxy-endpoint groups added since #1277 (login-attempts, invitations, access-requests, dynamic-secrets) carry comments claiming "read is system.read baseline," which is actually false today — their GET routes have no `.With()` override, so they inherit the same group-level `system.write` via `r.Use()`. Unlike info/metrics, those groups are genuinely meant to be machine-credential-only per the group's own design, so loosening them needs its own careful look — flagging here, not touched in this PR.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./server/http/...`
- [x] `govulncheck ./server/http/...`
- [x] New `system_info_metrics_permission_test.go` — proves the fix in both directions: a `system_viewer`-baseline (system.read only) caller now gets 200 from both routes; a caller with no permission at all still gets 403 (i.e. this widens access to system.read, not to every authenticated caller)
- [x] Existing `integration_test.go` "System Information" subtests still pass (admin token, unaffected)
- [x] Full `go test ./server/http/...` run — 3 pre-existing failures (`TestRemoteStorageMFAManagement_FullLifecycle_RealServer`, `TestScopedRBACEnforcement`, `TestSharingHTTPIntegration`) confirmed to reproduce identically on a clean, unmodified `origin/main` checkout — unrelated to this change