### PR TITLE
fix: repair flaky/panicking TestSharingHTTPIntegration

### DIFF
--- a/server/http/sharing_integration_test.go
+++ b/server/http/sharing_integration_test.go
@@ -50,6 +50,7 @@ func newSharingTestCore(t *testing.T) *core.KeyorixCore {
 		&models.SecretAccessLog{},
 		&models.SecretMetadataHistory{},
 		&models.ShareRecord{},
+		&models.SecretACL{},
 		&models.Session{},
 		&models.PasswordReset{},
 		&models.Tag{},
@@ -103,6 +104,12 @@ func newSharingTestCore(t *testing.T) *core.KeyorixCore {
 	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "viewer", Description: "Reader"}).Error)
 	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2}).Error)
+	// Also grant it scoped to project 1: ShareSecret rejects a non-group share to a
+	// recipient who isn't a member of the secret's project (sharing.go's
+	// IsProjectMember gate), and IsProjectMember only counts a project-scoped role
+	// grant (UserRole.ProjectID), not the global grant above. Without this, every
+	// "Share Secret" step below fails with "permission denied".
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2, ProjectID: 1}).Error)
 
 	// Seed sessions for "valid-token" and "owner-token" (user 1, admin), "recipient-token" (user 2, reader).
 	seedSession(t, db, 1, "valid-token")
@@ -202,7 +209,10 @@ func TestSharingHTTPIntegration(t *testing.T) {
 			require.NoError(t, err)
 			defer func() { _ = resp.Body.Close() }()
 
-			assert.Equal(t, http.StatusCreated, resp.StatusCode)
+			// require, not assert: a wrong status code here means the rest of this
+			// block's unchecked type assertions on the response body would panic
+			// and crash the whole test binary instead of failing this one subtest.
+			require.Equal(t, http.StatusCreated, resp.StatusCode)
 
 			var response map[string]interface{}
 			err = json.NewDecoder(resp.Body).Decode(&response)
@@ -233,7 +243,9 @@ func TestSharingHTTPIntegration(t *testing.T) {
 
 			data := response["data"].(map[string]interface{})
 			shares := data["shares"].([]interface{})
-			assert.Len(t, shares, 1)
+			// require, not assert: shares[0] just below would panic on an empty
+			// slice instead of failing this subtest cleanly.
+			require.Len(t, shares, 1)
 
 			share := shares[0].(map[string]interface{})
 			assert.Equal(t, float64(shareID), share["ID"])


### PR DESCRIPTION
## Summary

`TestSharingHTTPIntegration` was deterministically panicking (not flaking), which was crashing SonarCloud's own `go test ./...` coverage-generation step for the `server/http` package -- the root cause of the `new_coverage: 0.0%` quality-gate failure seen on unrelated PRs #1280 and #1281.

Two stale-fixture bugs, root-caused via `-count=N` reruns and the handlers' own `log.Printf` output:

- `newSharingTestCore` granted the share recipient (user 2) only a *global*-scope role, never a *project*-scoped one. `ShareSecret`'s `IsProjectMember` gate only counts project-scoped grants, so every "Share Secret" step failed with `"permission denied"` -- and since that failure was checked with `assert` followed immediately by an unchecked type assertion on the response body, it crashed the whole test binary with a panic instead of failing the subtest cleanly.
- The fixture's `AutoMigrate` list was missing `models.SecretACL`, so once the panic above was fixed, `DeleteSecret`'s ACL-revocation-on-delete step failed every cleanup step with `"no such table: secret_acls"`.

Fix: add the missing project-scoped `UserRole` grant and the missing `SecretACL` model to the fixture, and convert the two proximate `assert`-then-unchecked-access call sites to `require` so a genuine future regression fails cleanly instead of panicking.

## Test plan

- [x] `go test ./server/http/ -run 'TestSharingHTTPIntegration' -count=10 -v` -- 340/340 subtests pass, no panic
- [x] `go test ./server/http/... -timeout 300s` -- full package suite green except one pre-existing, unrelated failure (`TestRemoteStorageMFAManagement_FullLifecycle_RealServer`, confirmed present on `origin/main` independent of this change)
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./server/http/...`, `govulncheck ./server/http/...` all clean
- [x] `gofmt -l` on the touched file -- no drift