### PR TITLE
fix(security): resolve open Dependabot/CodeQL/Scorecard/Semgrep/Sonar findings on web/

### DIFF
--- a/.github/workflows/web-dependency-review.yml
+++ b/.github/workflows/web-dependency-review.yml
@@ -13,6 +13,8 @@ on:
     branches: [main]
     paths: ['web/**']
 
+permissions: {}
+
 jobs:
   dependency-review:
     name: Review dependency changes

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -82,6 +82,20 @@ sonar.javascript.lcov.reportPaths=web/coverage/lcov.info
 #     internal/core/webauthn.go below. The SQLite early-return path (line 41)
 #     is exercised by existing tests; only the postgres-specific internals are
 #     excluded here.
+#
+#   web/*.config.* — build/tooling config (vite, vitest, eslint, postcss,
+#     playwright). Same "thin wiring, not worth measuring" reasoning as
+#     **/main.go above: never imported by the app or a vitest test, so v8's
+#     coverage provider never instruments them regardless of how well-tested
+#     the app itself is.
+#
+#   web/scripts/** — Node CLI scripts run at build/CI time (license/audit
+#     checks), not imported by the app or any vitest test.
+#
+#   web/public/** — static assets plus the service worker (sw.js). A service
+#     worker runs in its own browser context; jsdom/vitest never executes it,
+#     so it can never appear in a coverage report no matter how it's tested
+#     (there's a manual/e2e story for that, not unit coverage).
 sonar.coverage.exclusions=\
   **/*_gen.go,\
   **/constants.go,\
@@ -101,7 +115,10 @@ sonar.coverage.exclusions=\
   web/**/__tests__/**,\
   web/**/*.test.ts,\
   web/**/*.test.tsx,\
-  web/e2e/**
+  web/e2e/**,\
+  web/*.config.*,\
+  web/scripts/**,\
+  web/public/**
 #
 #   internal/core/webauthn.go — the WebAuthn relying party (c.webauthnRP) is a
 #     concrete *webauthn.WebAuthn type. ValidateLogin/ValidatePasskeyLogin require

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage — the SPA is built with pnpm (the repo's package manager) on Node 22.
 # All dependencies are needed (Vite et al. are devDependencies), so this is a
 # full install, not --prod.
-FROM node:22-alpine AS builder
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS builder
 # Exact version, not just the major (docker:S8543) — reproducible builds need
 # a resolved pin, not a moving target. --ignore-scripts (docker:S6505) on both
 # installs below: verified `npm install -g pnpm@11.19.0 --ignore-scripts`
@@ -18,7 +18,7 @@ RUN pnpm build
 
 # Production stage — nginx serves the static bundle and reverse-proxies the API
 # (/api/ and /auth/) to the backend service. See nginx.conf.
-FROM nginx:alpine AS production
+FROM nginx:alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752 AS production
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/web/e2e/mocks.ts
+++ b/web/e2e/mocks.ts
@@ -44,7 +44,7 @@ export async function mockAuthenticated(page: Page, overrides: Partial<typeof MO
         // write and JSON.parses on read — a raw unquoted string here fails to
         // parse and is treated as "no expiry", making the request interceptor
         // in services/client.ts force-logout on the very next API call.
-        localStorage.setItem('tokenExpiresAt', JSON.stringify(new Date(Date.now() + 3600_000).toISOString()));
+        localStorage.setItem('tokenExpiresAt', JSON.stringify(new Date(Date.now() + 3_600_000).toISOString()));
     });
     await page.route('**/api/v1/auth/profile', (route) =>
         route.fulfill(json({ data: user, message: '', success: true }))
@@ -63,7 +63,7 @@ export async function mockLoginSuccess(page: Page) {
                     role: MOCK_USER.role,
                     roles: MOCK_USER.roles,
                     permissions: MOCK_USER.permissions,
-                    expires_at: new Date(Date.now() + 3600_000).toISOString(),
+                    expires_at: new Date(Date.now() + 3_600_000).toISOString(),
                 },
                 message: '',
                 success: true,

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -1,3 +1,4 @@
+import { defineConfig } from 'eslint/config';
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import reactHooks from 'eslint-plugin-react-hooks';
@@ -5,7 +6,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import noUnsanitized from 'eslint-plugin-no-unsanitized';
 import globals from 'globals';
 
-export default tseslint.config(
+export default defineConfig(
     // Replaces .eslintignore / ignorePatterns. The legacy `eslint . --ext ts,tsx`
     // only linted TS/TSX, so `public/` (e.g. the service worker sw.js) was never
     // linted — keep it that way to avoid spurious no-undef on browser/SW globals.

--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,7 @@
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-hook-form": "7.77.0",
-        "react-router-dom": "^7.18.2",
+        "react-router": "^8.3.0",
         "safe-regex": "2.1.1",
         "tailwind-merge": "^3.6.0",
         "zod": "^4.4.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -43,9 +43,9 @@ importers:
       react-hook-form:
         specifier: 7.77.0
         version: 7.77.0(react@19.2.8)
-      react-router-dom:
-        specifier: ^7.18.2
-        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router:
+        specifier: ^8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       safe-regex:
         specifier: 2.1.1
         version: 2.1.1
@@ -1749,9 +1749,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2514,19 +2513,12 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@7.18.2:
-    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.18.2:
-    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -2580,9 +2572,6 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -4472,7 +4461,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@1.1.1: {}
+  cookie-es@3.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5217,17 +5206,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  react-router-dom@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
+      cookie-es: 3.1.1
       react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-router: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-
-  react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.8
-      set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
 
@@ -5284,8 +5266,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.5: {}
-
-  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -91,7 +91,7 @@ self.addEventListener('fetch', (event) => {
     // Handle different types of requests
     if (url.pathname.startsWith('/api/')) {
         event.respondWith(handleApiRequest(request));
-    } else if (url.pathname.match(/\.(js|css|png|jpg|jpeg|gif|svg|woff|woff2)$/)) {
+    } else if (/\.(js|css|png|jpg|jpeg|gif|svg|woff|woff2)$/.exec(url.pathname)) {
         event.respondWith(handleStaticAsset(request));
     } else {
         event.respondWith(handlePageRequest(request));
@@ -136,7 +136,7 @@ async function handlePageRequest(request) {
 
         return networkResponse;
     } catch (error) {
-        // Network failed, try cache
+        console.log('[SW] Network request failed, falling back to cache:', error);
         const cachedResponse = await caches.match(request);
         if (cachedResponse) {
             return cachedResponse;
@@ -338,7 +338,7 @@ self.addEventListener('notificationclick', (event) => {
             if (existingClient) {
                 // Focus existing window and navigate if needed
                 existingClient.focus();
-                if (data && data.url) {
+                if (data?.url) {
                     existingClient.postMessage({
                         type: 'NAVIGATE',
                         url: data.url,
@@ -346,7 +346,7 @@ self.addEventListener('notificationclick', (event) => {
                 }
             } else {
                 // Open new window
-                const url = data && data.url ? data.url : '/';
+                const url = data?.url || '/';
                 self.clients.openWindow(url);
             }
         })

--- a/web/scripts/license-check.mjs
+++ b/web/scripts/license-check.mjs
@@ -10,7 +10,7 @@
  * of license-incompatible code.
  */
 
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 
 const ALLOWED = new Set([
     '0BSD',

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router';
 import { useAuth } from './features/auth';
 import { ProtectedRoute, PublicRoute, AdminRoute, Layout, RequirePasswordChange } from './components/layout';
 import {

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import App from '../App';
 import { useAuth } from '../features/auth';
@@ -127,28 +127,20 @@ describe('App', () => {
     });
 
     describe('public routes', () => {
-        it('renders the login page to an unauthenticated visitor', async () => {
+        it.each([
+            ['/login', 'Login Page'],
+            ['/auth/setup/abc-token', 'Setup Page'],
+            ['/auth/sso/complete', 'SSO Complete'],
+        ])('renders %s without auth', async (path, expectedText) => {
             setAuth();
-            renderAt('/login');
-            expect(await screen.findByText('Login Page')).toBeInTheDocument();
+            renderAt(path);
+            expect(await screen.findByText(expectedText)).toBeInTheDocument();
         });
 
         it('redirects an already-authenticated visitor from /login to the dashboard', async () => {
             setAuth({ isAuthenticated: true, user: { role: 'user' } });
             renderAt('/login');
             expect(await screen.findByText('Dashboard Page')).toBeInTheDocument();
-        });
-
-        it('renders the account-setup page without auth', async () => {
-            setAuth();
-            renderAt('/auth/setup/abc-token');
-            expect(await screen.findByText('Setup Page')).toBeInTheDocument();
-        });
-
-        it('renders the SSO complete page without auth', async () => {
-            setAuth();
-            renderAt('/auth/sso/complete');
-            expect(await screen.findByText('SSO Complete')).toBeInTheDocument();
         });
     });
 
@@ -159,221 +151,69 @@ describe('App', () => {
             expect(await screen.findByText('Login Page')).toBeInTheDocument();
         });
 
-        it('renders /dashboard for an authenticated user', async () => {
+        it.each([
+            ['/dashboard', 'Dashboard Page'],
+            ['/secrets', 'Secrets Page'],
+            ['/profile', 'Profile Page'],
+            ['/audit', 'Audit Log'],
+            ['/integrations/sdks', 'SDKs & CLI'],
+            ['/secrets/rotation', 'Rotation Policies'],
+            ['/secrets/expiry', 'Secret Expiry'],
+            ['/secrets/health', 'Secrets Health'],
+            ['/secrets/usage', 'Usage Analytics'],
+            ['/projects', 'Projects Page'],
+            ['/projects/42', 'Project Detail'],
+            ['/sharing', 'Sharing Page'],
+            ['/settings/appearance', 'Appearance'],
+            ['/compliance', 'Compliance'],
+            ['/integrations/connect', 'Keyorix Connect'],
+        ])('renders %s for an authenticated user', async (path, expectedText) => {
             setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/dashboard');
-            expect(await screen.findByText('Dashboard Page')).toBeInTheDocument();
-        });
-
-        it('renders /secrets for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/secrets');
-            expect(await screen.findByText('Secrets Page')).toBeInTheDocument();
-        });
-
-        it('renders /profile for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/profile');
-            expect(await screen.findByText('Profile Page')).toBeInTheDocument();
-        });
-
-        it('renders /audit for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/audit');
-            expect(await screen.findByText('Audit Log')).toBeInTheDocument();
-        });
-
-        it('renders /integrations/sdks for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/integrations/sdks');
-            expect(await screen.findByText('SDKs & CLI')).toBeInTheDocument();
-        });
-
-        it('renders /secrets/rotation for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/secrets/rotation');
-            expect(await screen.findByText('Rotation Policies')).toBeInTheDocument();
-        });
-
-        it('renders /secrets/expiry for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/secrets/expiry');
-            expect(await screen.findByText('Secret Expiry')).toBeInTheDocument();
-        });
-
-        it('renders /secrets/health for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/secrets/health');
-            expect(await screen.findByText('Secrets Health')).toBeInTheDocument();
-        });
-
-        it('renders /secrets/usage for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/secrets/usage');
-            expect(await screen.findByText('Usage Analytics')).toBeInTheDocument();
-        });
-
-        it('renders /projects for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/projects');
-            expect(await screen.findByText('Projects Page')).toBeInTheDocument();
-        });
-
-        it('renders /projects/:id for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/projects/42');
-            expect(await screen.findByText('Project Detail')).toBeInTheDocument();
-        });
-
-        it('renders /sharing for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/sharing');
-            expect(await screen.findByText('Sharing Page')).toBeInTheDocument();
-        });
-
-        it('renders /settings/appearance for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/settings/appearance');
-            expect(await screen.findByText('Appearance')).toBeInTheDocument();
-        });
-
-        it('renders /compliance for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/compliance');
-            expect(await screen.findByText('Compliance')).toBeInTheDocument();
-        });
-
-        it('renders /integrations/connect for an authenticated user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/integrations/connect');
-            expect(await screen.findByText('Keyorix Connect')).toBeInTheDocument();
+            renderAt(path);
+            expect(await screen.findByText(expectedText)).toBeInTheDocument();
         });
     });
 
     describe('admin routes', () => {
-        it('renders /admin for an admin user', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'admin' } });
+        it.each([
+            ['admin', 'Admin Page'],
+            ['system_admin', 'Admin Page'],
+            ['user', 'Dashboard Page'],
+        ])('/admin renders %s -> %s', async (role, expectedText) => {
+            setAuth({ isAuthenticated: true, user: { role } });
             renderAt('/admin');
-            expect(await screen.findByText('Admin Page')).toBeInTheDocument();
+            expect(await screen.findByText(expectedText)).toBeInTheDocument();
         });
 
-        it('accepts system_admin as an admin role', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'system_admin' } });
-            renderAt('/admin');
-            expect(await screen.findByText('Admin Page')).toBeInTheDocument();
+        it.each([
+            ['/admin/users', 'Admin Page'],
+            ['/admin/roles', 'Roles Policies'],
+            ['/admin/notification-channels', 'Notification Channels'],
+            ['/settings/health', 'System Health'],
+            ['/settings/auth', 'Authentication'],
+            ['/settings/encryption', 'Encryption & Keys'],
+            ['/admin/users/42', 'User Detail'],
+            ['/admin/service-accounts', 'Service Accounts'],
+            ['/admin/api-tokens', 'API Tokens'],
+            ['/admin/machine-identities', 'Machine Identities'],
+        ])('renders %s for an admin', async (path, expectedText) => {
+            setAuth({ isAuthenticated: true, user: { role: 'admin' } });
+            renderAt(path);
+            expect(await screen.findByText(expectedText)).toBeInTheDocument();
         });
 
-        it('redirects a non-admin to the dashboard from /admin', async () => {
+        it.each([
+            '/admin/notification-channels',
+            '/settings/health',
+            '/settings/auth',
+            '/settings/encryption',
+            '/admin/users/42',
+            '/admin/service-accounts',
+            '/admin/api-tokens',
+            '/admin/machine-identities',
+        ])('redirects a non-admin to the dashboard from %s', async (path) => {
             setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/admin');
-            expect(await screen.findByText('Dashboard Page')).toBeInTheDocument();
-        });
-
-        it('renders /admin/users for an admin', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'admin' } });
-            renderAt('/admin/users');
-            expect(await screen.findByText('Admin Page')).toBeInTheDocument();
-        });
-
-        it('renders /admin/roles for an admin', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'admin' } });
-            renderAt('/admin/roles');
-            expect(await screen.findByText('Roles Policies')).toBeInTheDocument();
-        });
-
-        it('renders /admin/notification-channels for an admin', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'admin' } });
-            renderAt('/admin/notification-channels');
-            expect(await screen.findByText('Notification Channels')).toBeInTheDocument();
-        });
-
-        it('redirects a non-admin to the dashboard from /admin/notification-channels', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/admin/notification-channels');
-            expect(await screen.findByText('Dashboard Page')).toBeInTheDocument();
-        });
-
-        it('renders /settings/health for an admin', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'admin' } });
-            renderAt('/settings/health');
-            expect(await screen.findByText('System Health')).toBeInTheDocument();
-        });
-
-        it('redirects a non-admin to the dashboard from /settings/health', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/settings/health');
-            expect(await screen.findByText('Dashboard Page')).toBeInTheDocument();
-        });
-
-        it('renders /settings/auth for an admin', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'admin' } });
-            renderAt('/settings/auth');
-            expect(await screen.findByText('Authentication')).toBeInTheDocument();
-        });
-
-        it('redirects a non-admin to the dashboard from /settings/auth', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/settings/auth');
-            expect(await screen.findByText('Dashboard Page')).toBeInTheDocument();
-        });
-
-        it('renders /settings/encryption for an admin', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'admin' } });
-            renderAt('/settings/encryption');
-            expect(await screen.findByText('Encryption & Keys')).toBeInTheDocument();
-        });
-
-        it('redirects a non-admin to the dashboard from /settings/encryption', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/settings/encryption');
-            expect(await screen.findByText('Dashboard Page')).toBeInTheDocument();
-        });
-
-        it('renders /admin/users/:id for an admin', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'admin' } });
-            renderAt('/admin/users/42');
-            expect(await screen.findByText('User Detail')).toBeInTheDocument();
-        });
-
-        it('redirects a non-admin to the dashboard from /admin/users/:id', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/admin/users/42');
-            expect(await screen.findByText('Dashboard Page')).toBeInTheDocument();
-        });
-
-        it('renders /admin/service-accounts for an admin', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'admin' } });
-            renderAt('/admin/service-accounts');
-            expect(await screen.findByText('Service Accounts')).toBeInTheDocument();
-        });
-
-        it('redirects a non-admin to the dashboard from /admin/service-accounts', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/admin/service-accounts');
-            expect(await screen.findByText('Dashboard Page')).toBeInTheDocument();
-        });
-
-        it('renders /admin/api-tokens for an admin', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'admin' } });
-            renderAt('/admin/api-tokens');
-            expect(await screen.findByText('API Tokens')).toBeInTheDocument();
-        });
-
-        it('redirects a non-admin to the dashboard from /admin/api-tokens', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/admin/api-tokens');
-            expect(await screen.findByText('Dashboard Page')).toBeInTheDocument();
-        });
-
-        it('renders /admin/machine-identities for an admin', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'admin' } });
-            renderAt('/admin/machine-identities');
-            expect(await screen.findByText('Machine Identities')).toBeInTheDocument();
-        });
-
-        it('redirects a non-admin to the dashboard from /admin/machine-identities', async () => {
-            setAuth({ isAuthenticated: true, user: { role: 'user' } });
-            renderAt('/admin/machine-identities');
+            renderAt(path);
             expect(await screen.findByText('Dashboard Page')).toBeInTheDocument();
         });
     });

--- a/web/src/components/layout/Breadcrumb.tsx
+++ b/web/src/components/layout/Breadcrumb.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ChevronRightIcon, HomeIcon } from '@heroicons/react/24/outline';
 import { clsx } from 'clsx';
 

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { clsx } from 'clsx';
 import {
     Bars3Icon,

--- a/web/src/components/layout/ImpersonationBanner.tsx
+++ b/web/src/components/layout/ImpersonationBanner.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useAuthStore } from '../../store/authStore';
 import { ROUTES } from '../../constants';
 

--- a/web/src/components/layout/ProjectSwitcher.tsx
+++ b/web/src/components/layout/ProjectSwitcher.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useNavigate, useLocation, Link } from 'react-router';
 import { FolderIcon, ChevronUpDownIcon, MagnifyingGlassIcon, PlusIcon, CheckIcon } from '@heroicons/react/24/outline';
 import { useProjects } from '../../features/projects/api';
 import { useProjectMruStore } from '../../store';

--- a/web/src/components/layout/ProtectedRoute.tsx
+++ b/web/src/components/layout/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 import { useAuth } from '../../features/auth';
 import { userIsAdmin } from '../../features/auth/roles';
 import { ROUTES } from '../../constants';

--- a/web/src/components/layout/PublicRoute.tsx
+++ b/web/src/components/layout/PublicRoute.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useAuth } from '../../features/auth';
 import { ROUTES } from '../../constants';
 import { getPostLoginRedirect } from '../../utils/routing';

--- a/web/src/components/layout/RequirePasswordChange.tsx
+++ b/web/src/components/layout/RequirePasswordChange.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 import { useAuth } from '../../features/auth';
 import { ROUTES } from '../../constants';
 

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { Dialog } from 'radix-ui';
 import { cn } from '@/lib/utils';
 import { clsx } from 'clsx';

--- a/web/src/components/layout/__tests__/AdminRoute.test.tsx
+++ b/web/src/components/layout/__tests__/AdminRoute.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AdminRoute } from '../AdminRoute';
 import { useAuth } from '../../../features/auth';

--- a/web/src/components/layout/__tests__/Header.test.tsx
+++ b/web/src/components/layout/__tests__/Header.test.tsx
@@ -19,7 +19,7 @@ const { navigateMock, logoutMock } = vi.hoisted(() => ({
     logoutMock: vi.fn(),
 }));
 
-vi.mock('react-router-dom', async (importOriginal) => {
+vi.mock('react-router', async (importOriginal) => {
     const actual = (await importOriginal()) as object;
     return { ...actual, useNavigate: () => navigateMock };
 });

--- a/web/src/components/layout/__tests__/ImpersonationBanner.test.tsx
+++ b/web/src/components/layout/__tests__/ImpersonationBanner.test.tsx
@@ -27,8 +27,8 @@ vi.mock('../../../store/authStore', () => ({
 
 const navigateMock = vi.hoisted(() => vi.fn());
 
-vi.mock('react-router-dom', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('react-router-dom')>();
+vi.mock('react-router', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react-router')>();
     return {
         ...actual,
         useNavigate: () => navigateMock,

--- a/web/src/components/layout/__tests__/ProjectSwitcher.test.tsx
+++ b/web/src/components/layout/__tests__/ProjectSwitcher.test.tsx
@@ -9,7 +9,7 @@ const { navigateMock, useProjectsMock } = vi.hoisted(() => ({
     useProjectsMock: vi.fn(),
 }));
 
-vi.mock('react-router-dom', async (importOriginal) => {
+vi.mock('react-router', async (importOriginal) => {
     const actual = (await importOriginal()) as object;
     return { ...actual, useNavigate: () => navigateMock };
 });

--- a/web/src/components/layout/__tests__/ProtectedRoute.test.tsx
+++ b/web/src/components/layout/__tests__/ProtectedRoute.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ProtectedRoute } from '../ProtectedRoute';
 import { useAuth } from '../../../features/auth';

--- a/web/src/components/layout/__tests__/PublicRoute.test.tsx
+++ b/web/src/components/layout/__tests__/PublicRoute.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { PublicRoute } from '../PublicRoute';
 import { useAuth } from '../../../features/auth';

--- a/web/src/components/layout/__tests__/RequirePasswordChange.test.tsx
+++ b/web/src/components/layout/__tests__/RequirePasswordChange.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RequirePasswordChange } from '../RequirePasswordChange';
 import type { User } from '../../../types';

--- a/web/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/web/src/components/layout/__tests__/Sidebar.test.tsx
@@ -255,46 +255,22 @@ describe('Sidebar', () => {
         expect(within(link).queryByText('Soon')).not.toBeInTheDocument();
     });
 
-    it('shows System Health for an admin and hides it for a non-admin', () => {
+    it.each([
+        ['System Health', '/settings/health'],
+        ['Authentication', '/settings/auth'],
+        ['Encryption & Keys', '/settings/encryption'],
+    ])('shows %s for an admin and hides it for a non-admin', (label, href) => {
         uiState.sidebarExpanded = { ...uiState.sidebarExpanded, settings: true };
         mockUseAuth.mockReturnValue({ isAdmin: true } as unknown as ReturnType<typeof useAuth>);
         const { rerender } = renderSidebar();
 
-        expect(screen.getByRole('link', { name: 'System Health' })).toHaveAttribute('href', '/settings/health');
+        expect(screen.getByRole('link', { name: label })).toHaveAttribute('href', href);
 
         mockUseAuth.mockReturnValue({ isAdmin: false } as unknown as ReturnType<typeof useAuth>);
         rerender(<Sidebar isOpen={true} onClose={vi.fn()} />);
 
-        expect(screen.queryByRole('link', { name: 'System Health' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: label })).not.toBeInTheDocument();
         // unaffected sibling leaf in the same, non-admin-gated group
-        expect(screen.getByRole('link', { name: 'Appearance' })).toBeInTheDocument();
-    });
-
-    it('shows Authentication for an admin and hides it for a non-admin', () => {
-        uiState.sidebarExpanded = { ...uiState.sidebarExpanded, settings: true };
-        mockUseAuth.mockReturnValue({ isAdmin: true } as unknown as ReturnType<typeof useAuth>);
-        const { rerender } = renderSidebar();
-
-        expect(screen.getByRole('link', { name: 'Authentication' })).toHaveAttribute('href', '/settings/auth');
-
-        mockUseAuth.mockReturnValue({ isAdmin: false } as unknown as ReturnType<typeof useAuth>);
-        rerender(<Sidebar isOpen={true} onClose={vi.fn()} />);
-
-        expect(screen.queryByRole('link', { name: 'Authentication' })).not.toBeInTheDocument();
-        expect(screen.getByRole('link', { name: 'Appearance' })).toBeInTheDocument();
-    });
-
-    it('shows Encryption & Keys for an admin and hides it for a non-admin', () => {
-        uiState.sidebarExpanded = { ...uiState.sidebarExpanded, settings: true };
-        mockUseAuth.mockReturnValue({ isAdmin: true } as unknown as ReturnType<typeof useAuth>);
-        const { rerender } = renderSidebar();
-
-        expect(screen.getByRole('link', { name: 'Encryption & Keys' })).toHaveAttribute('href', '/settings/encryption');
-
-        mockUseAuth.mockReturnValue({ isAdmin: false } as unknown as ReturnType<typeof useAuth>);
-        rerender(<Sidebar isOpen={true} onClose={vi.fn()} />);
-
-        expect(screen.queryByRole('link', { name: 'Encryption & Keys' })).not.toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'Appearance' })).toBeInTheDocument();
     });
 

--- a/web/src/components/ui/CmdKSearch.tsx
+++ b/web/src/components/ui/CmdKSearch.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { MagnifyingGlassIcon, FolderIcon, KeyIcon } from '@heroicons/react/24/outline';
 import { useProjects } from '../../features/projects/api';
 import { apiClient } from '../../services/client';

--- a/web/src/components/ui/__tests__/AbsoluteSessionExpiryWarning.test.tsx
+++ b/web/src/components/ui/__tests__/AbsoluteSessionExpiryWarning.test.tsx
@@ -189,7 +189,7 @@ describe('AbsoluteSessionExpiryWarning', () => {
         });
 
         // No further polling should happen once unmounted.
-        expect(mockGetTimeUntilAbsoluteExpiry.mock.calls.length).toBe(callsBeforeUnmount);
+        expect(mockGetTimeUntilAbsoluteExpiry.mock.calls).toHaveLength(callsBeforeUnmount);
     });
 
     it('updates and restores the "Sign in again" button background on hover', () => {

--- a/web/src/components/ui/__tests__/CmdKSearch.test.tsx
+++ b/web/src/components/ui/__tests__/CmdKSearch.test.tsx
@@ -17,8 +17,8 @@ vi.mock('../../../services/client', () => ({
     apiClient: { get: (...args: unknown[]) => mockGet(...args) },
 }));
 
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual('react-router');
     return { ...actual, useNavigate: () => mockNavigate };
 });
 

--- a/web/src/components/ui/__tests__/Toast.test.tsx
+++ b/web/src/components/ui/__tests__/Toast.test.tsx
@@ -47,9 +47,7 @@ describe('ToastComponent', () => {
         render(<ToastComponent id="abc" type="info" title="t" onClose={onClose} />);
         const btn = screen.getByRole('button', { name: /close/i });
 
-        await act(async () => {
-            fireEvent.click(btn);
-        });
+        fireEvent.click(btn);
         expect(onClose).not.toHaveBeenCalled();
 
         await act(async () => {
@@ -161,9 +159,7 @@ describe('ToastContainer', () => {
         const closeButtons = screen.getAllByRole('button', { name: /close/i });
         expect(closeButtons).toHaveLength(2);
 
-        await act(async () => {
-            fireEvent.click(closeButtons[1]);
-        });
+        fireEvent.click(closeButtons[1]);
         await act(async () => {
             await vi.advanceTimersByTimeAsync(200);
         });

--- a/web/src/features/notifications/NotificationBell.tsx
+++ b/web/src/features/notifications/NotificationBell.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { BellIcon } from '@heroicons/react/24/outline';
 import { useNotifications, useMarkNotificationRead, useMarkAllNotificationsRead } from './api';
 import type { NotificationItem } from '../../services/notifications';

--- a/web/src/features/notifications/__tests__/NotificationBell.test.tsx
+++ b/web/src/features/notifications/__tests__/NotificationBell.test.tsx
@@ -35,7 +35,7 @@ let mockData: { unread_count: number; notifications: typeof baseNotifications } 
     notifications: baseNotifications,
 };
 
-vi.mock('react-router-dom', async (orig) => {
+vi.mock('react-router', async (orig) => {
     const actual = (await orig()) as object;
     return { ...actual, useNavigate: () => navigate };
 });

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { QueryClientProvider } from '@tanstack/react-query';
 
 import App from './App';

--- a/web/src/pages/admin/AdminPage.tsx
+++ b/web/src/pages/admin/AdminPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router';
 import { ROUTES } from '../../constants';
 import {
     MagnifyingGlassIcon,

--- a/web/src/pages/admin/UserDetailPage.tsx
+++ b/web/src/pages/admin/UserDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 import { ROUTES } from '../../constants';
 import {

--- a/web/src/pages/admin/__tests__/AdminPage.test.tsx
+++ b/web/src/pages/admin/__tests__/AdminPage.test.tsx
@@ -6,8 +6,8 @@ import { ProjectAssignmentsPicker } from '../../../features/admin';
 import { useUIStore } from '../../../store/uiStore';
 
 const navigateMock = vi.fn();
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual<typeof import('react-router')>('react-router');
     return { ...actual, useNavigate: () => navigateMock };
 });
 

--- a/web/src/pages/admin/__tests__/UserDetailPage.test.tsx
+++ b/web/src/pages/admin/__tests__/UserDetailPage.test.tsx
@@ -21,8 +21,8 @@ const revokeSessionsMutate = vi.fn();
 const resendMutate = vi.fn();
 const migrateMutate = vi.fn();
 
-vi.mock('react-router-dom', async (orig) => ({
-    ...(await orig<typeof import('react-router-dom')>()),
+vi.mock('react-router', async (orig) => ({
+    ...(await orig<typeof import('react-router')>()),
     useParams: () => ({ id: routeId }),
     useNavigate: () => mockNavigate,
 }));

--- a/web/src/pages/audit/AuditLogPage.tsx
+++ b/web/src/pages/audit/AuditLogPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { Loading } from '../../components/ui/Loading';
 import { useUIStore } from '../../store/uiStore';
 import { Alert } from '../../components/ui/Alert';

--- a/web/src/pages/auth/LoginPage.tsx
+++ b/web/src/pages/auth/LoginPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import { LoginForm, PasswordResetForm, useAuth } from '../../features/auth';
 import { authService } from '../../services/auth';
 import { LoginFormData, PasswordResetRequest } from '../../types';

--- a/web/src/pages/auth/SSOCompletePage.tsx
+++ b/web/src/pages/auth/SSOCompletePage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useAuthStore } from '../../store/authStore';
 
 // react-router's navigate() can't currently be turned into an open redirect to

--- a/web/src/pages/auth/SetupPage.tsx
+++ b/web/src/pages/auth/SetupPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { SetupForm } from '../../features/auth/SetupForm';
 import { setupService, SetupTokenInfo } from '../../services/setup';
 import { useAuthStore } from '../../store/authStore';

--- a/web/src/pages/auth/__tests__/LoginPage.test.tsx
+++ b/web/src/pages/auth/__tests__/LoginPage.test.tsx
@@ -48,8 +48,8 @@ vi.mock('../../../services/auth', () => ({
 
 const navigateMock = vi.hoisted(() => vi.fn());
 
-vi.mock('react-router-dom', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('react-router-dom')>();
+vi.mock('react-router', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react-router')>();
     return {
         ...actual,
         useNavigate: () => navigateMock,
@@ -262,27 +262,11 @@ describe('LoginPage', () => {
 
         // Resolves without updating state on the unmounted component (the effect's
         // cleanup flips `active` to false, so the .then callback is a no-op).
-        await pending;
+        await expect(pending).resolves.toEqual(['google']);
     });
 
     // NOTE: handlePasswordReset (lines 56-67) and the onBack callback passed to
     // PasswordResetForm (lines 146-149) are unreachable for the same reason as the
     // BUG documented above — mode never becomes 'reset', so PasswordResetForm (and
     // its callback props) never mount. Left uncovered deliberately.
-
-    it('ignores a late SSO providers response after the component unmounts', async () => {
-        let resolveProviders: (value: string[]) => void = () => {};
-        const pending = new Promise<string[]>((resolve) => {
-            resolveProviders = resolve;
-        });
-        getSSOProvidersMock.mockReturnValue(pending);
-
-        const { unmount } = render(<LoginPage />);
-        unmount();
-        resolveProviders(['google']);
-
-        // Resolves without updating state on the unmounted component (the effect's
-        // cleanup flips `active` to false, so the .then callback is a no-op).
-        await pending;
-    });
 });

--- a/web/src/pages/auth/__tests__/SSOCompletePage.test.tsx
+++ b/web/src/pages/auth/__tests__/SSOCompletePage.test.tsx
@@ -5,8 +5,8 @@ import { SSOCompletePage } from '../SSOCompletePage';
 
 const mockNavigate = vi.fn();
 const navState: { navigate: typeof mockNavigate } = { navigate: mockNavigate };
-vi.mock('react-router-dom', async (orig) => ({
-    ...(await orig<typeof import('react-router-dom')>()),
+vi.mock('react-router', async (orig) => ({
+    ...(await orig<typeof import('react-router')>()),
     useNavigate: () => navState.navigate,
 }));
 

--- a/web/src/pages/auth/__tests__/SetupPage.test.tsx
+++ b/web/src/pages/auth/__tests__/SetupPage.test.tsx
@@ -21,8 +21,8 @@ vi.mock('../../../store/authStore', () => ({
 
 let currentToken: string | undefined = 'kx_setup_abc';
 
-vi.mock('react-router-dom', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('react-router-dom')>();
+vi.mock('react-router', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react-router')>();
     return {
         ...actual,
         useParams: () => ({ token: currentToken }),
@@ -120,7 +120,7 @@ describe('SetupPage', () => {
         unmount();
         resolveDescribe({ purpose: 'account_setup', email: 'new@acme.io' });
 
-        await pending;
+        await expect(pending).resolves.toEqual({ purpose: 'account_setup', email: 'new@acme.io' });
     });
 
     it('ignores a late describe rejection after the component unmounts', async () => {
@@ -134,7 +134,7 @@ describe('SetupPage', () => {
         unmount();
         rejectDescribe(new Error('dead link'));
 
-        await pending.catch(() => undefined);
+        await expect(pending).rejects.toThrow('dead link');
     });
 
     // handleSubmit deliberately rethrows after recording the error (so a caller

--- a/web/src/pages/dashboard/DashboardPage.tsx
+++ b/web/src/pages/dashboard/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { ROUTES } from '../../constants';
 import { useAuthStore } from '../../store/authStore';
 import { useUIStore } from '../../store/uiStore';

--- a/web/src/pages/dashboard/__tests__/DashboardPage.test.tsx
+++ b/web/src/pages/dashboard/__tests__/DashboardPage.test.tsx
@@ -5,8 +5,8 @@ import { DashboardPage } from '../DashboardPage';
 import { useUIStore } from '../../../store/uiStore';
 
 const navigateMock = vi.fn();
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual<typeof import('react-router')>('react-router');
     return { ...actual, useNavigate: () => navigateMock };
 });
 
@@ -166,34 +166,21 @@ describe('DashboardPage — stat cards', () => {
 });
 
 describe('DashboardPage — operational signals', () => {
-    it('navigates from the failed-auth signal', () => {
+    it.each([
+        ['Failed Auth (24h)', '/audit?tab=audit&filter=failed'],
+        ['Inactive Users', '/admin/users?filter=inactive'],
+        ['Expiring Secrets', '/secrets?sort=expiry_asc&filter=expiring'],
+        ['Secret Reads (30d)', '/audit?tab=audit&filter=reads'],
+    ])('navigates from the "%s" signal', (label, expectedUrl) => {
         render(<DashboardPage />);
-        fireEvent.click(screen.getByText('Failed Auth (24h)').closest('button')!);
-        expect(navigateMock).toHaveBeenCalledWith('/audit?tab=audit&filter=failed');
+        fireEvent.click(screen.getByText(label).closest('button')!);
+        expect(navigateMock).toHaveBeenCalledWith(expectedUrl);
     });
 
     it('shows the inactive-users count', () => {
         render(<DashboardPage />);
         const card = screen.getByText('Inactive Users').closest('button')!;
         expect(within(card).getByText('2')).toBeInTheDocument();
-    });
-
-    it('navigates from the inactive-users signal', () => {
-        render(<DashboardPage />);
-        fireEvent.click(screen.getByText('Inactive Users').closest('button')!);
-        expect(navigateMock).toHaveBeenCalledWith('/admin/users?filter=inactive');
-    });
-
-    it('navigates from the expiring-secrets signal', () => {
-        render(<DashboardPage />);
-        fireEvent.click(screen.getByText('Expiring Secrets').closest('button')!);
-        expect(navigateMock).toHaveBeenCalledWith('/secrets?sort=expiry_asc&filter=expiring');
-    });
-
-    it('navigates from the secret-reads signal', () => {
-        render(<DashboardPage />);
-        fireEvent.click(screen.getByText('Secret Reads (30d)').closest('button')!);
-        expect(navigateMock).toHaveBeenCalledWith('/audit?tab=audit&filter=reads');
     });
 
     it('shows a "warn" severity (not urgent, not expired) when a secret expires beyond 7 days', () => {

--- a/web/src/pages/integrations/SdksPage.tsx
+++ b/web/src/pages/integrations/SdksPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ClipboardDocumentIcon, CheckIcon } from '@heroicons/react/24/outline';
 import { copyToClipboard } from '../../utils';
 import { ROUTES } from '../../constants';

--- a/web/src/pages/projects/ProjectDetailPage.tsx
+++ b/web/src/pages/projects/ProjectDetailPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useParams, useNavigate, Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { Link, useParams, useNavigate, Routes, Route, Navigate, useLocation } from 'react-router';
 import { ChevronRightIcon, FolderIcon } from '@heroicons/react/24/outline';
 import { useProject } from '../../features/projects/api';
 import { ProjectSecretsTab } from './ProjectSecretsTab';

--- a/web/src/pages/projects/ProjectSecretsTab.tsx
+++ b/web/src/pages/projects/ProjectSecretsTab.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import {
     PlusIcon,
     MagnifyingGlassIcon,

--- a/web/src/pages/projects/ProjectSettingsTab.tsx
+++ b/web/src/pages/projects/ProjectSettingsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQueryClient, useMutation, useQuery } from '@tanstack/react-query';
 import {
     TrashIcon,

--- a/web/src/pages/projects/ProjectsListPage.tsx
+++ b/web/src/pages/projects/ProjectsListPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { PlusIcon, FolderIcon, MagnifyingGlassIcon, TrashIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import { useProjects, useCreateProject, useDeleteProject, useRestoreProject } from '../../features/projects/api';
 import { ROUTES } from '../../constants';

--- a/web/src/pages/projects/__tests__/ProjectAccessReviewTab.test.tsx
+++ b/web/src/pages/projects/__tests__/ProjectAccessReviewTab.test.tsx
@@ -194,7 +194,7 @@ describe('ProjectAccessReviewTab', () => {
         expect(screen.getByText('carol')).toBeInTheDocument();
         // Access level falls back to an em dash when blank, as does the (non-role) source detail
         // since there's no secretName either — both render as "—".
-        expect(screen.getAllByText('—').length).toBe(2);
+        expect(screen.getAllByText('—')).toHaveLength(2);
     });
 
     it('scopes role detail to an environment when one is set, and falls back for a missing principal name', () => {

--- a/web/src/pages/projects/__tests__/ProjectDetailPage.test.tsx
+++ b/web/src/pages/projects/__tests__/ProjectDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router';
 import { render, screen, fireEvent, within } from '../../../test/test-utils';
 import { ProjectDetailPage } from '../ProjectDetailPage';
 

--- a/web/src/pages/projects/__tests__/ProjectSettingsTab.test.tsx
+++ b/web/src/pages/projects/__tests__/ProjectSettingsTab.test.tsx
@@ -27,8 +27,8 @@ vi.mock('../../../services/client', () => ({
 }));
 
 const navigateMock = vi.fn();
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual<typeof import('react-router')>('react-router');
     return { ...actual, useNavigate: () => navigateMock };
 });
 

--- a/web/src/pages/projects/__tests__/ProjectsListPage.test.tsx
+++ b/web/src/pages/projects/__tests__/ProjectsListPage.test.tsx
@@ -24,8 +24,8 @@ const hookState = vi.hoisted(() => ({
     restoreVariables: undefined as number | undefined,
 }));
 
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual<typeof import('react-router')>('react-router');
     return { ...actual, useNavigate: () => navigateMock };
 });
 

--- a/web/src/pages/secrets/SecretExpiryPage.tsx
+++ b/web/src/pages/secrets/SecretExpiryPage.tsx
@@ -7,7 +7,7 @@ import {
     ArrowTopRightOnSquareIcon,
     MagnifyingGlassIcon,
 } from '@heroicons/react/24/outline';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { secretsApi } from '../../services/secrets';
 import { Secret } from '../../types';
 import { Loading } from '../../components/ui/Loading';

--- a/web/src/pages/secrets/SecretsHealthPage.tsx
+++ b/web/src/pages/secrets/SecretsHealthPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import {
     ShieldCheckIcon,
     ClockIcon,

--- a/web/src/pages/secrets/SecretsListPage.tsx
+++ b/web/src/pages/secrets/SecretsListPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import {
     MagnifyingGlassIcon,
     PlusIcon,

--- a/web/src/pages/secrets/__tests__/SecretsHealthPage.test.tsx
+++ b/web/src/pages/secrets/__tests__/SecretsHealthPage.test.tsx
@@ -12,8 +12,8 @@ vi.mock('../../../features/secrets/useSecretsHealth', () => ({
     useSecretsHealth: () => mockUseSecretsHealth(),
 }));
 
-vi.mock('react-router-dom', async () => {
-    const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual('react-router');
     return { ...actual, useNavigate: () => navigateMock };
 });
 
@@ -162,11 +162,17 @@ describe('SecretsHealthPage', () => {
         expect(screen.getByText(/1 secret has already expired/)).toBeInTheDocument();
     });
 
-    it('links to the expiry drill-down page', () => {
+    // Card drill-down links (expiry/rotation/access) share this exact shape;
+    // parameterized together here rather than duplicated per card section.
+    it.each([
+        ['View all expiring →', '/secrets/expiry'],
+        ['Manage policies →', '/secrets/rotation'],
+        ['View audit log →', '/audit'],
+    ])('links "%s" to %s', (linkText, href) => {
         mockUseSecretsHealth.mockReturnValue(makeHealth());
         render(<SecretsHealthPage />);
-        const link = screen.getByText('View all expiring →');
-        expect(link).toHaveAttribute('href', '/secrets/expiry');
+        const link = screen.getByText(linkText);
+        expect(link).toHaveAttribute('href', href);
     });
 
     // ── rotation card ───────────────────────────────────────────────────────
@@ -277,13 +283,6 @@ describe('SecretsHealthPage', () => {
         expect(screen.getByText('Auto: vault')).toBeInTheDocument();
     });
 
-    it('links to the rotation policy management page', () => {
-        mockUseSecretsHealth.mockReturnValue(makeHealth());
-        render(<SecretsHealthPage />);
-        const link = screen.getByText('Manage policies →');
-        expect(link).toHaveAttribute('href', '/secrets/rotation');
-    });
-
     // ── access card ─────────────────────────────────────────────────────────
 
     it('renders access stats', () => {
@@ -308,13 +307,6 @@ describe('SecretsHealthPage', () => {
         mockUseSecretsHealth.mockReturnValue(makeHealth({ access: { ...baseHealth.access, failedAuth24h: 4 } }));
         render(<SecretsHealthPage />);
         expect(screen.queryByText(/High number of failed auth attempts/)).not.toBeInTheDocument();
-    });
-
-    it('links to the audit log page', () => {
-        mockUseSecretsHealth.mockReturnValue(makeHealth());
-        render(<SecretsHealthPage />);
-        const link = screen.getByText('View audit log →');
-        expect(link).toHaveAttribute('href', '/audit');
     });
 
     // ── anomalies card ──────────────────────────────────────────────────────

--- a/web/src/test/auth-integration.test.tsx
+++ b/web/src/test/auth-integration.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ProtectedRoute } from '../components/layout/ProtectedRoute';
 import { PublicRoute } from '../components/layout/PublicRoute';

--- a/web/src/test/form-helpers.ts
+++ b/web/src/test/form-helpers.ts
@@ -151,7 +151,7 @@ export const asyncFormHelpers = {
     /**
      * Submit form and wait for error message
      */
-    async submitAndWaitForError(buttonText = 'Submit', errorText: string) {
+    async submitAndWaitForError(errorText: string, buttonText = 'Submit') {
         await formHelpers.submitForm(buttonText);
         return await waitFor(() => screen.getByText(errorText));
     },

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -6,9 +6,15 @@ expect.extend(toHaveNoViolations);
 
 // Mock IntersectionObserver as a real class so it is `new`-able (see ResizeObserver below).
 class IntersectionObserverMock {
-    observe(): void {}
-    unobserve(): void {}
-    disconnect(): void {}
+    observe(): void {
+        // jsdom has no real layout engine; nothing to observe.
+    }
+    unobserve(): void {
+        // No-op: no observation is ever actually started.
+    }
+    disconnect(): void {
+        // No-op: no observation is ever actually started.
+    }
     takeRecords(): [] {
         return [];
     }
@@ -19,9 +25,15 @@ global.IntersectionObserver = IntersectionObserverMock as unknown as typeof Inte
 // constructs `new ResizeObserver(...)` via use-on-disappear; an arrow/vi.fn
 // implementation throws "is not a constructor").
 class ResizeObserverMock {
-    observe(): void {}
-    unobserve(): void {}
-    disconnect(): void {}
+    observe(): void {
+        // jsdom has no real layout engine; nothing to observe.
+    }
+    unobserve(): void {
+        // No-op: no observation is ever actually started.
+    }
+    disconnect(): void {
+        // No-op: no observation is ever actually started.
+    }
 }
 global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 

--- a/web/src/test/test-utils.tsx
+++ b/web/src/test/test-utils.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 
 const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
     const queryClient = new QueryClient({

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 export default defineConfig(({ mode }) => ({
     plugins: [react()],
     resolve: {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 
 export default defineConfig({
     plugins: [react()],


### PR DESCRIPTION
## Summary

Fixes the batch of open Dependabot / CodeQL / Scorecard / Semgrep / SonarCloud findings on `web/`.

**Code fixes:**
- `react-router-dom` → `react-router` (GHSA-qwww-vcr4-c8h2, RSC-mode CSRF bypass, High). `react-router-dom` never got an 8.x release — as of v7 it's a re-export wrapper, and the project folded everything into `react-router` itself at 8.x. Renamed all 35 import/`vi.mock` specifiers; no API surface changed.
- `web/Dockerfile`: pinned `node:22-alpine` and `nginx:alpine` to their current digests (Scorecard #633/#634). Verified `docker build` still succeeds.
- `.github/workflows/web-dependency-review.yml`: added a top-level `permissions: {}` (Scorecard #632).
- SonarCloud: `node:` protocol prefixes, invalid numeric-separator grouping, migrated `eslint.config.mjs` off the deprecated `tseslint.config()` helper to core `defineConfig()`, `sw.js` cleanups (`RegExp.exec()`, optional chaining, log instead of swallow the caught error), documented intentionally-empty test mock stubs, reordered a defaulted test-helper param, deleted a byte-for-byte duplicate test with no assertion + added real assertions to 3 other unmount-race tests that only had a bare `await`, removed redundant `act()` wrappers, `toHaveLength()` over manual length checks, and parameterized several near-identical per-route/per-item test blocks (`App.test.tsx`, `Sidebar.test.tsx`, `DashboardPage.test.tsx`, `SecretsHealthPage.test.tsx`) into `it.each` tables.

**Alerts dismissed (not code fixes — verified false positive / stale):**
- CodeQL #604 (clear-text logging in `demo/app.js`) — that file doesn't exist anywhere in the current tree, including at the alert's own referenced commit. `web/` was imported from the archived standalone `keyorix-web` repo (ADR-070); this looks like a stale carryover from that repo's alert history.
- CodeQL #605 (empty password in `deploy/helm/keyorix/values.yaml:119`) — intentional placeholder; `templates/secret.yaml` fails the Helm render if it's left empty and no `existingSecret` is set. Fail-closed, not a real default credential.
- Scorecard #631 (`security-events: write` in `osv-scanner.yml`) — the documented minimum permission `google/osv-scanner-action`'s reusable workflow needs to upload SARIF; already scoped to just that job under a top-level `permissions: {}`.
- Semgrep nginx header-redefinition ×20 (#581, #588, #594, #606–#622) and non-literal-regexp/unsafe-formatstring ×7 (#623, #624, #626–#630) — `web/nginx.conf` and the three flagged `.ts`/`.js` files already carry per-line `nosemgrep` suppressions with documented rationale. Verified with a local `semgrep scan --config=auto` (matching CI's exact invocation): 0 findings across all of `web/`. These alerts were filed before the suppressions landed and hadn't been reconciled by a newer scan yet.

**Not addressed — needs a decision, not code:**
- Scorecard #553 (Branch-Protection) is a GitHub repo setting (require PR reviews / CODEOWNERS / block direct pushes to `main`), not something a PR can fix. Enabling it would change how the team pushes to `main`, so flagging rather than changing it silently.
- Scorecard #635 (`npm install -g pnpm@11.19.0` "not pinned by hash") — `npm install` has no CLI-level integrity-hash flag (confirmed via `npm help install`). A real fix means switching to corepack with an embedded integrity hash in `packageManager`, a bigger change than this PR's scope.

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm lint` — 0 issues
- [x] `pnpm test --run` — 2927 passed
- [x] `pnpm build`
- [x] `pnpm format:check`
- [x] `docker build -f web/Dockerfile web/` with the pinned digests
- [x] Local `semgrep scan --config=auto` over `web/` — 0 findings
