### PR TITLE
fix(test): pin secret_templates test's SQLite pool to 1 connection

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -14,21 +14,6 @@ section. For architectural rationale see the ADRs (`docs/` and
   touching `web/**`. `keyorixhq_keyorix-web` now has nothing pointing at it.
   Org-admin action in the SonarCloud UI, not fixable from this repo.
 
-- **Investigate: `stunit` on-disk SQLite leak + suspected connection-pool
-  unbounded growth** — `server/http/handlers/secret_templates_unit_test.go:83`
-  constructs `file:stunit<N>?mode=memory&cache=private`, but a run left an
-  on-disk SQLite file named `stunit` (no counter suffix) containing table
-  `secret_templates`. Two defects to investigate under ADR-069:
-  (a) the DSN is materializing to disk despite `mode=memory`, and the counter
-  suffix is absent from the produced filename;
-  (b) `cache=private` gives each pooled connection a separate, empty database,
-  so without `SetMaxOpenConns(1)` the pool can grow unbounded — candidate root
-  cause for the `server/http` connection-pool leak seen elsewhere this
-  session (see `server/grpc/services`' `:memory:` connection-pool test
-  flakiness, same underlying class of bug, fixed there via `SetMaxOpenConns(1)`
-  rather than diagnosed at the SQLite-driver level).
-  Not fixed here — investigation only.
-
 - **Stranded: per-binary CycloneDX SBOMs for release binaries.** Commit
   `9eceffe4` "build(release): attach per-binary CycloneDX SBOMs" (2026-07-03)
   sits unmerged on branch `chore/dev-guidance`. It touches
@@ -60,6 +45,30 @@ section. For architectural rationale see the ADRs (`docs/` and
   patterns in `.gitleaks.toml` for why).
 
 ## Done
+
+- **`stunit` connection-pool safety fix (ADR-069 investigation closed).**
+  `server/http/handlers/secret_templates_unit_test.go`'s `newFailingSTHandler`
+  was missing `SetMaxOpenConns(1)` on its `cache=private` in-memory SQLite
+  connection — the same class of gap already fixed in
+  `internal/storage/store/local_transaction_test.go` and
+  `local_usage_test.go` for the identical pattern (`cache=private` gives each
+  new physical connection its own empty database; without pinning to one
+  connection, a pool-rotated connection from a later handler call in the same
+  test could see neither the migrated schema nor the seed row). Fixed to
+  match. The originally-reported symptom — an actual on-disk file named
+  `stunit` (no counter suffix) — could **not** be reproduced despite an
+  extensive attempt: isolated `database/sql` DSN test, isolated
+  GORM+dialector+AutoMigrate test, this file's tests run alone, the full
+  `server/http/handlers` package, all four both with and without `-race`,
+  and on both macOS and Linux (`golang:1.26.5-alpine`, matching the CI
+  runner). No other file in the repo uses this DSN pattern. Most likely a
+  one-off/environmental artifact from whenever it was originally observed,
+  not a live, reproducible bug in the current code — closing the
+  investigation rather than leaving it open indefinitely, but flagging that
+  if a stray `stunit` file is ever seen again, this fix's own reasoning
+  (connection-pool rotation touching a "private" cache) is the first thing
+  to revisit, not the DSN string construction, which was verified correct
+  across every reproduction attempt.
 
 - **OpenAPI sync (RBAC scope fields)** — `project_id` / `environment_id` are
   documented on `POST /user-roles`, `PUT /users/{id}/roles`, and

--- a/server/http/handlers/secret_templates_unit_test.go
+++ b/server/http/handlers/secret_templates_unit_test.go
@@ -83,8 +83,16 @@ func newFailingSTHandler(t *testing.T, flags failingSecretTemplateStore) *Secret
 	dsn := "file:stunit" + string(rune('0'+stUnitCounter)) + "?mode=memory&cache=private"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	// cache=private gives each new physical connection its own empty
+	// in-memory database — without this, a pool-rotated connection opened by
+	// a later handler call in the same test would see neither the migrated
+	// schema nor the seed row below. Matches local_transaction_test.go /
+	// local_usage_test.go's identical fix for the same cache=private pattern.
+	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(&models.SecretTemplate{}))
-	t.Cleanup(func() { sqlDB, _ := db.DB(); _ = sqlDB.Close() })
+	t.Cleanup(func() { _ = sqlDB.Close() })
 
 	// Seed a template so GET/UPDATE/DELETE have a valid ID to work with before
 	// the injected error fires at the storage layer.


### PR DESCRIPTION
## Summary

Closes the ADR-069 "stunit on-disk SQLite leak" investigation logged in BACKLOG.md.

`server/http/handlers/secret_templates_unit_test.go`'s `newFailingSTHandler` was missing `SetMaxOpenConns(1)` on its `cache=private` in-memory SQLite connection — the same gap already fixed in `internal/storage/store/local_transaction_test.go` and `local_usage_test.go` for the identical pattern. `cache=private` gives each new physical connection its own empty database; without pinning to one connection, a pool-rotated connection opened by a later handler call in the same test could see neither the migrated schema nor the seed row — a latent source of test flakiness. Fixed to match the established pattern.

The originally-reported symptom (an actual on-disk file named `stunit`, no counter suffix) could **not** be reproduced despite an extensive attempt — see BACKLOG.md's "Done" entry for the full list of what was tried (isolated driver test, isolated GORM test, scoped/full/`-race` test runs, macOS and Linux). No other file in the repo uses this DSN pattern. Closing the investigation as documented-not-reproduced rather than leaving it open indefinitely; the connection-pool fix stands on its own regardless, since it matches an established, already-proven-necessary pattern in this exact package.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` — all clean
- [x] `go test -race -run TestSecretTemplate ./server/http/handlers/...` — passes
- [x] `go test -race ./server/http/handlers/...` (full package) — passes (354s)