### PR TITLE
fix(deps): bump brace-expansion override to 5.0.9 (GHSA-rgw5-rvv9-x895)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -813,9 +813,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "@stoplight/spectral-cli": "6.16.1"
   },
   "overrides": {
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   }
 }


### PR DESCRIPTION
## Summary

Fixes Dependabot alert #6 — `brace-expansion` DoS, CVE-2026-69152, high (CVSS 7.5).

`package.json` already had a `brace-expansion` override at `5.0.8` — a mitigation for an earlier advisory. This new advisory shows that mitigation was incomplete: two intermediate arrays feeding `combine()` were never bounded by `maxLength`, so a ~25KB crafted input still causes an uncatchable OOM crash (can't be caught with `try/catch`), and a ~400KB input can block the event loop for 2+ minutes. `5.0.9` bounds both paths.

This is root's own CI-tooling `package.json` (Spectral, used by the `openapi-lint` job) — unrelated to `web/`'s dependency tree, which is unaffected.

## Test plan

- [x] Confirmed `brace-expansion@5.0.9` exists on the registry and is outside every vulnerable range the advisory lists
- [x] `npm ci --ignore-scripts` (CI's exact install command) succeeds cleanly
- [x] `spectral lint --ruleset .spectral.yaml server/http/handlers/openapi.yaml` (CI's exact lint command) passes, same result as before the bump