### PR TITLE
feat(release): attach per-binary CycloneDX SBOMs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,19 @@ jobs:
         with:
           go-version: '1.26.5'
 
+      # Pinned: supply-chain tooling is itself an attack surface. The Makefile
+      # `release` target shells out to cyclonedx-gomod to emit a per-binary
+      # CycloneDX SBOM (covered by checksums.txt, uploaded with dist/*).
+      - name: Install SBOM generator
+        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0
+
       # VERSION is passed via env, not interpolated into the `run:` string (#115):
       # a tag name can contain shell metacharacters ($, `, ;, |, &, ( ) are all
       # valid in a git ref) that git's own naming rules don't reject, so a
       # template-expression interpolation directly into a shell command line is a
       # script-injection vector. GITHUB_REF_NAME is a runner-provided env var —
       # substituted by the shell, never re-parsed as YAML/template syntax.
-      - name: Cross-compile release binaries
+      - name: Cross-compile release binaries + SBOMs
         run: make release VERSION="$GITHUB_REF_NAME"
 
       # cosign-release pinned: latest (v3.1.1) defaults sign-blob to its new

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       # `release` target shells out to cyclonedx-gomod to emit a per-binary
       # CycloneDX SBOM (covered by checksums.txt, uploaded with dist/*).
       - name: Install SBOM generator
-        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0
+        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0 # NOSONAR githubactions:S8545 -- pinned to v1.10.0; go.sum not applicable for a standalone build-time tool outside the module graph (same pattern as dast.yml's nuclei install)
 
       # VERSION is passed via env, not interpolated into the `run:` string (#115):
       # a tag name can contain shell metacharacters ($, `, ;, |, &, ( ) are all

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -29,37 +29,30 @@ section. For architectural rationale see the ADRs (`docs/` and
   rather than diagnosed at the SQLite-driver level).
   Not fixed here — investigation only.
 
-- **Stranded: per-binary CycloneDX SBOMs for release binaries.** Commit
-  `9eceffe4` "build(release): attach per-binary CycloneDX SBOMs" (2026-07-03)
-  sits unmerged on branch `chore/dev-guidance`. It touches
-  `.github/workflows/release.yml` and `Makefile` (adds a `make sbom` target,
-  pins `cyclonedx-gomod` v1.10.0). `git log -S cyclonedx origin/main --
-  Makefile` returns nothing, so v0.87.x and v0.88.0 shipped release binaries
-  with no SBOM. Container images are covered by BuildKit attestations
-  (`provenance: mode=max` / `sbom: true` in `docker-publish.yml`); the binary
-  tarballs — the delivery path for air-gapped customers — are not. CRA Annex
-  I Part II expects an SBOM for the product as placed on the market. Land
-  `chore/dev-guidance` or reimplement. Not fixed here.
-
-- **Verify: two gitleaks findings from the `keyorix-web` import may re-flag.**
-  `web/.gitleaksignore` (deleted when `web/.gitleaks.toml` was merged into
-  root's, ADR-070 Phase 5) suppressed two `generic-api-key` findings by
-  commit-SHA fingerprint: `src/services/__tests__/users.test.ts:112` and a
-  historical `keyorix.yaml:48` (file no longer present in `web/`). Root's
-  `gitleaks` CI job scans full history reachable from HEAD
-  (`--log-opts="HEAD"`), and the DCO retrofit (ADR-070 Decision) rewrote
-  every non-bot `keyorix-web` commit's SHA — so both fingerprints are stale
-  on arrival and would not suppress a rescan of the same historical commits.
-  The general test-fixture path patterns added to root's `.gitleaks.toml`
-  (`web/.*__tests__.*`, etc.) likely already cover the first; the second
-  references a file that no longer exists, so its trigger could be
-  anywhere in that file's history. Not verified here — no network access to
-  run gitleaks in this environment. If the `gitleaks` CI check fails on this
-  branch's PR, add a path/regex `.gitleaks.toml` allowlist entry for the
-  specific finding (not a SHA fingerprint — see the comment above the web/
-  patterns in `.gitleaks.toml` for why).
-
 ## Done
+
+- **Per-binary CycloneDX SBOMs for release binaries.** Reimplemented commit
+  `9eceffe4`'s intent (it had drifted too far from current `Makefile`/
+  `release.yml` — 14 commits touched those files since it forked — to
+  cherry-pick cleanly): `make release` now generates a CycloneDX 1.6 SBOM per
+  binary (`keyorix_sbom.cdx.json`, `keyorix-server_sbom.cdx.json`, via
+  `cyclonedx-gomod app` in app mode) before the checksums step, so both are
+  covered by `checksums.txt` and uploaded with the existing `dist/*` glob. A
+  standalone `make sbom` target does the same outside a full release.
+  `release.yml` installs `cyclonedx-gomod@v1.10.0` (confirmed still the
+  latest available version) on PATH first. SECURITY.md documents this.
+  Verified: ran the actual tool locally, not just the Makefile syntax — both
+  SBOMs are valid CycloneDX 1.6 with real dependency graphs (112/125
+  components for CLI/server) and full license evidence (112/112 and
+  125/125 components carry `evidence.licenses`), and a full `make release`
+  run confirms both SBOM files land in `checksums.txt` and the web-UI
+  placeholder restore still leaves a clean working tree.
+
+- **Verified: the two gitleaks findings flagged as possibly re-flagging from
+  the `keyorix-web` import (ADR-070) do not.** Ran `gitleaks detect --source .
+  --verbose --redact --log-opts="HEAD"` (CI's exact invocation) against
+  current history: "no leaks found". The path-based allowlist patterns added
+  to root's `.gitleaks.toml` during the merge cover it.
 
 - **OpenAPI sync (RBAC scope fields)** — `project_id` / `environment_id` are
   documented on `POST /user-roles`, `PUT /users/{id}/roles`, and

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TRUST_LICENSE_KEYS?=
 # deterministic per source revision, so release builds stay reproducible (no build date).
 LDFLAGS=-ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=$(VERSION) -X github.com/keyorixhq/keyorix/internal/version.Version=$(VERSION) -X github.com/keyorixhq/keyorix/internal/version.Commit=$(GIT_COMMIT) -X github.com/keyorixhq/keyorix/internal/trust.updateKeysB64=$(TRUST_UPDATE_KEYS) -X github.com/keyorixhq/keyorix/internal/trust.licenseKeysB64=$(TRUST_LICENSE_KEYS)"
 
-.PHONY: build build-cli build-server build-ui populate-webui-dist install install-cli install-server clean run db-up dev docker-build docker-up docker-down docker-logs proto proto-deps proto-lint release
+.PHONY: build build-cli build-server build-ui populate-webui-dist install install-cli install-server clean run db-up dev docker-build docker-up docker-down docker-logs proto proto-deps proto-lint release sbom
 
 # Pinned protoc-gen plugin versions (match google.golang.org/{protobuf,grpc} in go.mod).
 PROTOC_GEN_GO_VERSION=v1.36.11
@@ -119,9 +119,22 @@ release: populate-webui-dist
 	GOOS=linux  GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_linux_arm64  ./server
 	GOOS=darwin GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_darwin_amd64 ./server
 	GOOS=darwin GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_darwin_arm64 ./server
+	@echo "→ Generating CycloneDX SBOMs (per binary, app mode)"
+	cyclonedx-gomod app -json -main .      -licenses -output dist/$(BINARY_CLI)_sbom.cdx.json    .
+	cyclonedx-gomod app -json -main server -licenses -output dist/$(BINARY_SERVER)_sbom.cdx.json .
 	@cd dist && (sha256sum * > checksums.txt 2>/dev/null || shasum -a 256 * > checksums.txt)
 	@git checkout -- server/webui/dist/index.html 2>/dev/null || true
-	@echo "✅ Release binaries in dist/"
+	@echo "✅ Release binaries + SBOMs in dist/"
+
+# CycloneDX SBOM per shipped binary (app mode: exactly the deps linked into that
+# binary + Go stdlib). Feed to govulncheck/grype to answer "are we affected by
+# CVE-X?" — the core CRA Article 14 question. Requires cyclonedx-gomod on PATH
+# (go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0).
+sbom:
+	@mkdir -p dist
+	cyclonedx-gomod app -json -main .      -licenses -output dist/$(BINARY_CLI)_sbom.cdx.json    .
+	cyclonedx-gomod app -json -main server -licenses -output dist/$(BINARY_SERVER)_sbom.cdx.json .
+	@echo "✅ SBOMs in dist/"
 
 clean:
 	rm -rf $(BUILD_DIR) dist/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,6 +60,11 @@ Every release ships with `checksums.txt`:
 sha256sum --check --ignore-missing checksums.txt
 ```
 
+Every release also ships a **CycloneDX SBOM** per binary
+(`keyorix_sbom.cdx.json`, `keyorix-server_sbom.cdx.json`) — a full dependency and
+licence inventory, the component list needed to assess CVE exposure under the EU
+CRA. Both SBOMs are covered by `checksums.txt`.
+
 Release binaries are built with `-trimpath` and `CGO_ENABLED=0` from the tagged
 commit. `checksums.txt` and every container image are keylessly signed with
 [Sigstore/cosign](https://www.sigstore.dev/) via GitHub's OIDC token — no


### PR DESCRIPTION
## Summary

Closes the "Stranded: per-binary CycloneDX SBOMs for release binaries" item in BACKLOG.md.

Commit `9eceffe4` (2026-07-03) attempted this on branch `chore/dev-guidance` but never landed. That branch had drifted too far from current `Makefile`/`release.yml` (14 commits touched those files since it forked) to cherry-pick cleanly, so this is a clean reimplementation of the same intent against current `main`.

`make release` now generates a CycloneDX 1.6 SBOM per binary (`keyorix_sbom.cdx.json`, `keyorix-server_sbom.cdx.json`, via `cyclonedx-gomod` app mode — exactly the deps linked into that binary + Go stdlib, with license evidence) before the checksums step, so both are covered by `checksums.txt` and uploaded with the existing `dist/*` glob. A standalone `make sbom` target does the same outside a full release. `release.yml` installs `cyclonedx-gomod@v1.10.0` (confirmed still the latest available version) on PATH first.

Container images already had SBOM coverage via BuildKit attestations (`docker-publish.yml`'s `provenance: mode=max` / `sbom: true`); this closes the gap for the binary tarballs — the delivery path for air-gapped customers — ahead of EU CRA Article 14 reporting (from 11 Sep 2026).

Also verifies and closes two other stale-looking BACKLOG.md entries: the two gitleaks findings flagged as possibly re-flagging from the ADR-070 `keyorix-web` import don't (`gitleaks detect` with CI's exact invocation returns "no leaks found").

## Test plan

- [x] Actually ran `cyclonedx-gomod` locally, not just checked Makefile syntax — both SBOMs are valid CycloneDX 1.6 with real dependency graphs (112 components for the CLI, 125 for the server)
- [x] Verified full license evidence present (112/112 and 125/125 components carry `evidence.licenses`) by inspecting the raw JSON — not assumed from the `-licenses` flag alone
- [x] Full `make release` run confirms both SBOM files land in `checksums.txt` alongside all 8 cross-compiled binaries, and the `server/webui/dist` placeholder restore still leaves a clean working tree afterward
- [x] `go build ./...` clean