### PR TITLE
ci: skip unchanged-ecosystem coverage on PRs, cache Docker builds, scan the web SPA in DAST

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -25,6 +25,32 @@ jobs:
       - name: Build server
         run: go build -o /tmp/keyorix-server ./server
 
+      # Without a built web/dist to point web_assets_path at, the server falls
+      # back to its "Web UI not bundled in this build" placeholder page at /
+      # (see getWebAssetsPath in server/http/router.go) -- Nuclei would only
+      # ever see that placeholder, never the real dashboard. Building it here
+      # and wiring web_assets_path below (single-binary serving mode, same as
+      # an air-gapped production deploy) lets the existing scan below
+      # naturally cover the SPA too: its "exposure"/"misconfig" tags are
+      # generic web-hygiene checks (missing security headers, exposed
+      # .git/.env, etc.), not API-specific, so they now probe real dashboard
+      # content instead of a stub.
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 11
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Build web/
+        working-directory: web
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm build
+
       - name: Write DAST config
         # SC-015: encryption is enabled so the DAST server matches production
         # configuration (authenticated + encrypted surface).  The DEK is derived
@@ -32,7 +58,7 @@ jobs:
         # carries 32 hex-encoded random bytes generated once for this DAST job (see
         # the "Generate DAST KEK" step below); it is never committed or reused.
         run: |
-          cat > /tmp/keyorix-dast.yaml << 'EOF'
+          cat > /tmp/keyorix-dast.yaml << EOF
           environment: "development"
           locale:
             language: "en"
@@ -46,6 +72,7 @@ jobs:
                 enabled: false
               ratelimit:
                 enabled: false
+              web_assets_path: "${GITHUB_WORKSPACE}/web/dist"
             grpc:
               enabled: false
           storage:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -71,15 +71,32 @@ jobs:
             GIT_COMMIT=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # GitHub Actions cache backend, scoped per image so the 5 images in
+          # this workflow don't evict each other's layers under a shared
+          # default scope.
+          cache-from: type=gha,scope=keyorix-server
+          cache-to: type=gha,mode=max,scope=keyorix-server
 
-      # Scans the pushed image DIGEST before it's signed, so a signature only
-      # ever attests to an image that's already cleared this gate.
-      - name: Scan image for vulnerabilities (trivy)
+      # Cached across runs by TRIVY_VERSION — a version bump naturally busts
+      # the cache and re-downloads+re-verifies the checksum.
+      - name: Cache Trivy binary
+        id: trivy-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: trivy
+          key: trivy-${{ env.TRIVY_VERSION }}-${{ runner.os }}
+
+      - name: Download Trivy
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
         run: |
           curl --proto '=https' --tlsv1.2 -fsSLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
           echo "${TRIVY_LINUX_64BIT_SHA256}  trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" | sha256sum -c -
           tar -xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          ./trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 "ghcr.io/keyorixhq/keyorix-server@${{ steps.build.outputs.digest }}"
+
+      # Scans the pushed image DIGEST before it's signed, so a signature only
+      # ever attests to an image that's already cleared this gate.
+      - name: Scan image for vulnerabilities (trivy)
+        run: ./trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 "ghcr.io/keyorixhq/keyorix-server@${{ steps.build.outputs.digest }}"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v3.10.0
@@ -139,13 +156,25 @@ jobs:
             GIT_COMMIT=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=keyorix-k8s-sync
+          cache-to: type=gha,mode=max,scope=keyorix-k8s-sync
 
-      - name: Scan image for vulnerabilities (trivy)
+      - name: Cache Trivy binary
+        id: trivy-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: trivy
+          key: trivy-${{ env.TRIVY_VERSION }}-${{ runner.os }}
+
+      - name: Download Trivy
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
         run: |
           curl --proto '=https' --tlsv1.2 -fsSLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
           echo "${TRIVY_LINUX_64BIT_SHA256}  trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" | sha256sum -c -
           tar -xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          ./trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 "ghcr.io/keyorixhq/keyorix-k8s-sync@${{ steps.build.outputs.digest }}"
+
+      - name: Scan image for vulnerabilities (trivy)
+        run: ./trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 "ghcr.io/keyorixhq/keyorix-k8s-sync@${{ steps.build.outputs.digest }}"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v3.10.0
@@ -199,13 +228,25 @@ jobs:
           sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=keyorix-operator
+          cache-to: type=gha,mode=max,scope=keyorix-operator
 
-      - name: Scan image for vulnerabilities (trivy)
+      - name: Cache Trivy binary
+        id: trivy-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: trivy
+          key: trivy-${{ env.TRIVY_VERSION }}-${{ runner.os }}
+
+      - name: Download Trivy
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
         run: |
           curl --proto '=https' --tlsv1.2 -fsSLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
           echo "${TRIVY_LINUX_64BIT_SHA256}  trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" | sha256sum -c -
           tar -xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          ./trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 "ghcr.io/keyorixhq/keyorix-operator@${{ steps.build.outputs.digest }}"
+
+      - name: Scan image for vulnerabilities (trivy)
+        run: ./trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 "ghcr.io/keyorixhq/keyorix-operator@${{ steps.build.outputs.digest }}"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v3.10.0
@@ -261,13 +302,25 @@ jobs:
             VERSION=${{ github.ref_name }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=keyorix-mcp
+          cache-to: type=gha,mode=max,scope=keyorix-mcp
 
-      - name: Scan image for vulnerabilities (trivy)
+      - name: Cache Trivy binary
+        id: trivy-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: trivy
+          key: trivy-${{ env.TRIVY_VERSION }}-${{ runner.os }}
+
+      - name: Download Trivy
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
         run: |
           curl --proto '=https' --tlsv1.2 -fsSLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
           echo "${TRIVY_LINUX_64BIT_SHA256}  trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" | sha256sum -c -
           tar -xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          ./trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 "ghcr.io/keyorixhq/keyorix-mcp@${{ steps.build.outputs.digest }}"
+
+      - name: Scan image for vulnerabilities (trivy)
+        run: ./trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 "ghcr.io/keyorixhq/keyorix-mcp@${{ steps.build.outputs.digest }}"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v3.10.0
@@ -327,13 +380,25 @@ jobs:
           sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=keyorix-web
+          cache-to: type=gha,mode=max,scope=keyorix-web
 
-      - name: Scan image for vulnerabilities (trivy)
+      - name: Cache Trivy binary
+        id: trivy-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: trivy
+          key: trivy-${{ env.TRIVY_VERSION }}-${{ runner.os }}
+
+      - name: Download Trivy
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
         run: |
           curl --proto '=https' --tlsv1.2 -fsSLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
           echo "${TRIVY_LINUX_64BIT_SHA256}  trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" | sha256sum -c -
           tar -xzf "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" trivy
-          ./trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 "ghcr.io/keyorixhq/keyorix-web@${{ steps.build.outputs.digest }}"
+
+      - name: Scan image for vulnerabilities (trivy)
+        run: ./trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 "ghcr.io/keyorixhq/keyorix-web@${{ steps.build.outputs.digest }}"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v3.10.0

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,7 +12,51 @@ permissions:
   pull-requests: read
 
 jobs:
+  # Sonar's "New Code Coverage" gate only evaluates lines this PR actually
+  # changed (ADR-070's blended-percentage tradeoff is about the overall
+  # dashboard number, not the gate). So a PR that touches only web/** has
+  # zero new Go lines to score, and vice versa -- generating the other
+  # ecosystem's coverage report is then pure CI time with no effect on the
+  # gate. Mirrors the `changes`/docs_only job in ci.yml (same gh api
+  # approach, no external paths-filter action needed).
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      skip_go: ${{ steps.filter.outputs.skip_go }}
+      skip_web: ${{ steps.filter.outputs.skip_web }}
+    steps:
+      - name: Detect which ecosystem(s) changed
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # A push to main updates the persistent project baseline, not just
+            # a PR's new-code diff -- always regenerate both reports so the
+            # dashboard's overall (not just new-code) numbers stay accurate.
+            echo "skip_go=false" >> "$GITHUB_OUTPUT"
+            echo "skip_web=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
+          echo "Changed files:"
+          echo "$changed"
+          if [ -z "$changed" ] || echo "$changed" | grep -vE '^web/' > /dev/null; then
+            echo "skip_go=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip_go=true" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -z "$changed" ] || echo "$changed" | grep -E '^web/' > /dev/null; then
+            echo "skip_web=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip_web=true" >> "$GITHUB_OUTPUT"
+          fi
+
   Analysis:
+    needs: [changes]
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
     steps:
@@ -21,10 +65,12 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        if: needs.changes.outputs.skip_go != 'true'
         with:
           go-version: '1.26.5'
 
       - name: Generate coverage report
+        if: needs.changes.outputs.skip_go != 'true'
         run: go test -timeout 600s -coverprofile=coverage.out -covermode=set ./...
         continue-on-error: true
 
@@ -33,16 +79,19 @@ jobs:
       # separate SonarCloud project/workflow. --ignore-scripts: see the
       # identical reasoning in web-ci.yml.
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        if: needs.changes.outputs.skip_web != 'true'
         with:
           version: 11
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: needs.changes.outputs.skip_web != 'true'
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Generate web/ coverage report
+        if: needs.changes.outputs.skip_web != 'true'
         working-directory: web
         run: |
           pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,8 +8,7 @@ on:
     branches: [main]
     paths-ignore: ['**/*.md', 'docs/**']
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   # Sonar's "New Code Coverage" gate only evaluates lines this PR actually
@@ -59,6 +58,8 @@ jobs:
     needs: [changes]
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:


### PR DESCRIPTION
## Summary

Three CI optimizations, all additive/low-risk (no job renames, no required-check name changes):

- **`sonarcloud.yml`**: skip generating the *other* ecosystem's coverage report on PRs that only touch one side. Sonar's New Code Coverage gate only scores lines the PR actually changed — a web-only PR has zero new Go lines to score, so running a full `go test ./...` for it was pure wasted CI time (and vice versa for Go-only PRs still installing pnpm + running the full vitest suite). Push-to-main runs are unaffected — they always regenerate both, since those update the persistent project baseline, not just a PR diff. Complements #1276's `paths-ignore` (docs-only skip) rather than replacing it.
- **`docker-publish.yml`**: added `cache-from`/`cache-to: type=gha` (scoped per image) to all 5 image builds — previously a full from-scratch rebuild every run. Also cache the Trivy binary (keyed by `TRIVY_VERSION`) instead of curl+checksum+extract duplicated verbatim across all 5 jobs.
- **`dast.yml`**: the CI Nuclei job only ever built the bare Go server binary with no `web_assets_path` configured, so `getWebAssetsPath` fell back to the "Web UI not bundled" placeholder page — Nuclei's target was never the real dashboard. Now builds `web/dist` and wires it in via `server.http.web_assets_path` (same single-binary serving mode a production air-gapped deploy uses), so the scan's existing `exposure`/`misconfig` tags — generic web-hygiene checks (missing security headers, exposed `.git`/`.env`, etc.), not API-specific — now actually probe real dashboard content instead of a stub.

Also applied the equivalent fix to the self-hosted DAST rig (`keyorix-dast` LXC): rebuilt its source checkout to current `main`, built `web/dist` there, and wired `web_assets_path` into its running config — verified live (`/` now serves the real "Keyorix Dashboard" with the full CSP/COOP/COEP/CORP/X-Frame-Options header set, not the placeholder). Ran a full ZAP spider scan against it to confirm: ZAP's own "Modern Web Application" fingerprint detection fired, direct proof it scanned the real SPA (impossible against the old placeholder).

### Follow-up: resharded test-suite's `root` leg (4 legs instead of 1)

Measured on a real run: `root` took **1176s** (75 packages, 3311 combined CPU-seconds — only ~2.8x effective parallelism on one runner), now *slower* than `handlers` (931s) despite `handlers` being the leg with the extended timeout — defeats the point of ADR-048's original split.

Bin-packed the 16 heaviest packages (by measured per-package time) across 3 pinned legs (`root-1/2/3`, ~830s each) plus `root-4`, a catch-all computed by *excluding* `root-1/2/3`'s pinned packages from the same list `root` always used — so a newly added package always lands in `root-4` by default rather than silently never running (this repo's ADR-069 no-exclusion testing policy), and only gets promoted to a pinned leg once it's proven slow enough to be worth it. Verified locally: the 4 legs' package sets are disjoint and their union exactly matches the full root-eligible package list (87 packages: 19+19+19+30).

Expected wall-clock floor for `test-suite` drops from ~1176s to ~931s (`handlers`' unchanged runtime becomes the new critical path).

Considered and **skipped**: splitting `static-analysis`'s `govulncheck`+`gosec` into parallel jobs. Measured: `govulncheck` is 10s, `gosec` is 242s — splitting only saves the ~10s prefix, and `static-analysis` was never on `build-and-test`'s critical path anyway (`test-suite`'s slowest leg always dominates), so it wouldn't move overall pipeline wall-clock at all.

## Test plan
- [x] `actionlint` on all three changed workflow files — 0 new issues (4 pre-existing shellcheck notes in `dast.yml`, unrelated to this change, confirmed present on `main` before this PR too)
- [x] `go build ./...`
- [x] Local end-to-end verification: built the server + `web/dist`, wired `web_assets_path`, confirmed `/` serves the real dashboard (not the placeholder) with the full security-header set present
- [x] Self-hosted DAST rig: same fix applied and verified live, plus a full ZAP spider scan confirming real SPA coverage
- [x] `actionlint` on the resharded `ci.yml` — 0 new issues (same 6 pre-existing shellcheck notes, confirmed present on `main` before this change too)
- [x] Extracted and ran the shard-selection bash logic locally: confirmed `root-1`/`root-2`/`root-3`/`root-4` package sets are disjoint and their union exactly equals `root`'s original full package list

