### PR TITLE
fix(web): use RegExp.exec() instead of String.match() in ProjectSwitcher

### DIFF
--- a/web/src/components/layout/ProjectSwitcher.tsx
+++ b/web/src/components/layout/ProjectSwitcher.tsx
@@ -8,7 +8,7 @@ import { useProjectMruStore } from '../../store';
 
 function useCurrentProjectId(): number | null {
     const { pathname } = useLocation();
-    const match = pathname.match(/^\/projects\/(\d+)/);
+    const match = /^\/projects\/(\d+)/.exec(pathname);
     return match?.[1] ? Number.parseInt(match[1], 10) : null;
 }
 


### PR DESCRIPTION
## Summary
- Sonar code smell fix: `pathname.match(/^\/projects\/(\d+)/)` → `/^\/projects\/(\d+)/.exec(pathname)`, the idiomatic form for a non-global regex single match.

## Test plan
- [x] `npx vitest run src/components/layout/__tests__/ProjectSwitcher.test.tsx` — 20/20 pass
- [x] `npx eslint web/src/components/layout/ProjectSwitcher.tsx` — no issues