### PR TITLE
fix(sonar): exclude web/public/fonts/** from analysis (encoding warning)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,11 +19,16 @@ sonar.sourceEncoding=UTF-8
 #     locally-present build artefacts. The scanner has no useful rules for
 #     minified JS/CSS bundles and reports encoding warnings on binary font files.
 #
+#   web/public/fonts/** — committed binary .woff2 font files. Same encoding
+#     warning as server/webui/dist/** above ("Invalid character encountered
+#     ... at line 1 for encoding UTF-8"): the scanner has no source-analysis
+#     rules for font binaries, it just needs to not try to read them as text.
+#
 #   web/node_modules/**, web/dist/** — dependency tree and build output, not
 #     source. Not strictly needed (the scanner respects .gitignore by default,
 #     which already covers both), but explicit here since everything else in
 #     this file is.
-sonar.exclusions=**/*.sql,server/webui/dist/**,web/node_modules/**,web/dist/**
+sonar.exclusions=**/*.sql,server/webui/dist/**,web/public/fonts/**,web/node_modules/**,web/dist/**
 
 # web/ (ADR-070) is analyzed as part of THIS project, not a separate one.
 # keyorixhq_keyorix-web (the frontend's original standalone-repo project) was


### PR DESCRIPTION
## Summary
- SonarCloud's "Warnings in last analysis" banner ("There are problems with file encoding in the source code") traced to the SonarCloud Analysis GitHub Actions job log, not guessed from the UI message:
  ```
  WARN  Invalid character encountered in file .../web/public/fonts/inter.woff2 at line 1 for encoding UTF-8.
  WARN  Invalid character encountered in file .../web/public/fonts/jetbrains-mono.woff2 at line 1 for encoding UTF-8.
  ```
- Both are committed binary `.woff2` font files under `web/public/fonts/`, a source directory not already covered by the existing `server/webui/dist/**` exclusion (which handles the same class of warning for a different binary-font location).
- Added `web/public/fonts/**` to `sonar.exclusions`. Left `sonar.coverage.exclusions`' existing `web/public/**` entry untouched — different property, hides `sw.js`/`favicon.svg` from the coverage panel, not from analysis.

## Test plan
- [x] Confirmed via the actual SonarCloud Analysis workflow log (`gh run view --job <id> --log`) that these are the only two files producing the warning, not a guess