### PR TITLE
chore(deps): bump @stoplight/spectral-cli 6.16.1 -> 6.16.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "keyorix-ci-tools",
       "version": "1.0.0",
       "dependencies": {
-        "@stoplight/spectral-cli": "6.16.1"
+        "@stoplight/spectral-cli": "6.16.3"
       }
     },
     "node_modules/@asyncapi/specs": {
@@ -234,9 +234,9 @@
       }
     },
     "node_modules/@stoplight/spectral-cli": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.16.1.tgz",
-      "integrity": "sha512-6DdYx94d+BNVTdgJRkb1KJIcqYQsOxstAZtH7Kh63SDUsXFRkdfsBKsL7l6csxLRYYh5Qm6CSBF7AUFYBFJ23w==",
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.16.3.tgz",
+      "integrity": "sha512-corAOQ/WhGoPJOQ3Tcipyn64TgKYDkEhsDplS6vNSGys3kzi9+zzxiVOlbzk9mWuafovzoW+TpGCoNwIZvFf5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "CI tooling dependencies (pinned for Scorecard supply-chain compliance)",
   "dependencies": {
-    "@stoplight/spectral-cli": "6.16.1"
+    "@stoplight/spectral-cli": "6.16.3"
   },
   "overrides": {
     "brace-expansion": "5.0.9"


### PR DESCRIPTION
## Summary
- Patch bump, exact-pinned per this repo's convention.
- Secondary purpose: Dependabot alerts #6 (brace-expansion) and #7 (fast-uri) are already fixed on `main` — `package-lock.json` only has the patched versions (5.0.9/3.1.5) — but stuck open. GitHub's `dependency-graph/sbom` API still reports stale versions that don't match the actual lockfile content, well past the usual rescan turnaround despite several pushes to `main` since the fixes merged. This is a real, in-scope lockfile change (not a fake no-op) that should force GitHub to re-parse the whole manifest.

## Test plan
- [x] `npm ci --ignore-scripts` (CI's exact install command) succeeds
- [x] `spectral lint --ruleset .spectral.yaml server/http/handlers/openapi.yaml` (CI's exact lint command) still passes against 6.16.3