### PR TITLE
docs(adr-067): release lifecycle, LTS designation and support periods

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,9 +11,14 @@ configuration and release artifacts.
 | Latest release | ✅ Security fixes |
 | Older releases | ❌ Upgrade to latest |
 
-Keyorix is pre-1.0. A formal backport policy for previous minor versions (relevant
-for air-gapped deployments with slow upgrade cadences) will be published with the
-1.0 release; commercial licence tiers will include extended backport windows.
+Keyorix is pre-1.0 and has **not yet declared a support period** under the EU Cyber
+Resilience Act. Pre-1.0 tags are development releases: they carry no declared support
+period and no Declaration of Conformity.
+
+From v1.0, LTS releases receive **five years of security updates**, delivered to
+air-gapped deployments as signed offline bundles with an SBOM and a VEX document.
+See [SUPPORT.md](SUPPORT.md) for the full policy and
+[ADR-067](docs/adr-067-release-lifecycle-support-policy.md) for the rationale.
 
 ## Reporting a Vulnerability
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,111 @@
+# Support Policy
+
+This document states which Keyorix versions receive security updates, for how long,
+and how those updates reach deployments that cannot reach the internet.
+
+For reporting a vulnerability, see [SECURITY.md](SECURITY.md).
+
+## Current status: pre-1.0
+
+**Keyorix has not yet declared a support period.** Releases before v1.0 are
+development releases. They do not carry a declared support period, a Declaration of
+Conformity, or a CE marking, and they are not offered as products placed on the EU
+market.
+
+Pre-1.0, security fixes land on the latest release only. Upgrade to the latest
+release to receive them.
+
+The policy below takes effect at v1.0.
+
+## Release classes
+
+Keyorix ships continuously from trunk. Not every tag is a supported product.
+
+| Class | What it is | Support |
+|---|---|---|
+| **Development tag** | Cut from trunk between releases | None. No declared support period, no conformity documentation, no update bundle. |
+| **Designated release** | A version placed on the market | Security updates until the next designated release. |
+| **LTS release** | A designated release marked long-term support | **Five years** of security updates from general availability. |
+
+Every designated release states its **end-of-support month and year** on the release
+page, in the release artifacts, and in the Declaration of Conformity.
+
+## LTS releases
+
+An LTS release is designated every **18 to 24 months**. The first is **v1.0**.
+
+Each LTS receives security updates for **five years** from its general availability
+date. At most **three** LTS lines are maintained at any time. If designating a new
+LTS would exceed three, the designation is delayed — we do not maintain more lines
+than we can patch properly, and we will not shorten a period already promised.
+
+### What "security updates" covers
+
+An LTS line receives:
+
+- Fixes for security vulnerabilities in Keyorix
+- Fixes for vulnerabilities in bundled dependencies that are reachable in Keyorix
+- Fixes for defects that can cause data loss or service outage
+
+An LTS line does **not** receive new features, performance improvements, or cosmetic
+fixes. Those land on trunk and reach you at your next LTS upgrade. This scoping is
+deliberate: it is what allows the five-year commitment to be real.
+
+### Upgrade path
+
+Direct upgrade from any LTS to the next LTS is supported and tested. You never need
+to step through intermediate releases. If you upgrade from an LTS to a non-LTS
+designated release, you leave the extended support window — the shorter period for
+that release applies instead.
+
+## Air-gapped and offline deployments
+
+Deployments without internet access receive updates as signed offline bundles: a
+single verifiable file carried across the gap, cryptographically verified against a
+public key embedded in your binary at build time. See
+[ADR-062](docs/adr-062-air-gap-updates.md) and
+[ADR-064](docs/adr-064-air-gap-update-bundles.md).
+
+Every bundle for a designated release contains:
+
+- The release artifacts, each pinned by SHA-256 digest in a signed manifest
+- A **CycloneDX 1.6 SBOM**
+- A **VEX document** stating which known CVEs in bundled dependencies are and are not
+  exploitable in Keyorix
+
+The VEX document matters if you run your own vulnerability scanners. Scanners
+frequently flag CVEs in vendored dependencies whose affected code paths Keyorix never
+executes. The VEX statement tells your scanner, in machine-readable form, which
+findings are genuinely exploitable in Keyorix and which are not — so your security
+team can triage on evidence rather than on our word.
+
+## Regulatory context
+
+Keyorix is developed in the EU by Keyorix SL (Valencia, Spain).
+
+This policy is written to meet the support-period obligations of the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), Article 13(8): a declared support period
+of at least five years, with each security update remaining available for ten years
+after issue or the remainder of the support period, whichever is longer.
+
+Security updates are provided **free of charge** for the declared support period, on
+both the AGPL-3.0 and the commercial licence. Security is never behind a paywall.
+
+Commercial licence holders may additionally receive response-time commitments and
+extended support arrangements. Those are contractual terms in the MSA and Order Form,
+separate from the support period declared here, which applies to everyone.
+
+## Getting help
+
+| Need | Where |
+|---|---|
+| Report a vulnerability | [SECURITY.md](SECURITY.md) — **do not** open a public issue |
+| Bug report or feature request | GitHub Issues |
+| Questions and discussion | GitHub Discussions |
+| Commercial support and licensing | sales@keyorix.com |
+
+## Changes to this policy
+
+A support period, once declared for a release, is never shortened. This policy may
+change for future releases; changes are announced in the CHANGELOG and take effect
+only for releases designated after the change.

--- a/docs/adr-067-release-lifecycle-support-policy.md
+++ b/docs/adr-067-release-lifecycle-support-policy.md
@@ -1,0 +1,170 @@
+# ADR-067: Release lifecycle, LTS designation & support periods
+
+## Status
+
+Accepted. Policy layer above [ADR-062](adr-062-air-gap-updates.md) (offline trust
+foundation) and [ADR-064](adr-064-air-gap-update-bundles.md) (signed update bundles).
+ADR-064 decided *how* an update crosses an air gap; this ADR decides *which* versions
+get one, *for how long*, and what is promised to whom. Public expression of this
+policy lives in [`SUPPORT.md`](../SUPPORT.md).
+
+## Context
+
+Keyorix ships from trunk. Main is linear, squash-merged, and fast: 88 tags cut to
+date, ~750 commits to main in the last 30 days, median PR time-to-merge under an hour.
+That cadence is an asset and this ADR does not change it.
+
+What is missing is the lifecycle layer. Three forces make its absence a liability:
+
+**1. Air-gapped customers cannot upgrade on our cadence.** The data-sovereignty
+segment (defence, finance, government) upgrades quarterly at best, often annually,
+through a change-approval process measured in weeks. A customer pinned to an old
+version who hits a CVE has exactly two options: take a backported patch, or run
+knowingly vulnerable. Today we can offer neither, because no maintenance line exists.
+
+**2. The Cyber Resilience Act makes the support period a legal artifact, not a
+marketing one.** Article 13(8) requires a declared support period of at least five
+years unless the product is expected to be in use for less time — which a secrets
+manager inside a regulated enclave is not. Each security update must remain available
+for ten years after issue or the remainder of the support period, whichever is longer.
+The end date (month and year) must be stated at the time of purchase.
+
+The Commission's March 2026 draft guidance adds the sharp edge: for software that
+evolves through multiple versions, **each version placed on the market is expected to
+carry its own defined support period**. Read naively against 88 tags, that is 88
+concurrent five-year obligations. Unmanaged, this is an existential documentation and
+engineering burden for a small team.
+
+**3. It is a competitive opening.** Vault's Community Edition receives fixes only on
+the current release. HashiCorp's two-year LTS programme covers only versions released
+before April 2026; later versions moved to IBM's Support Cycle-2 framework following
+the acquisition. Conjur sits inside Palo Alto Networks. A published five-year support
+period on an AGPL binary is a commitment none of them currently match, and after
+CRA's main obligations apply it becomes something EU buyers are required to ask about.
+
+**Open question, deliberately not resolved here.** The CRA excludes free and open
+source software supplied outside commercial activity. Keyorix is AGPL-3.0 with a
+private dual commercial licence. Whether our AGPL binary distribution falls inside
+CRA scope is a question for counsel, not for this ADR. This ADR is written so the
+answer does not change the engineering: we adopt the stricter posture regardless,
+because we intend to sell the support period as a feature.
+
+## Decision
+
+### 1. Tagged is not "placed on the market"
+
+We distinguish two artifact classes, and the distinction is stated on every release:
+
+- **Development tags** — cut freely from main, as today. No Declaration of
+  Conformity, no CE marking, no declared support period, no update bundle. Release
+  notes carry an explicit notice to this effect.
+- **Designated releases** — the only artifacts placed on the market. Each carries a
+  declared support period with an end month and year, a Declaration of Conformity, a
+  signed ADR-064 update bundle, an SBOM, and a VEX document.
+
+This is the load-bearing decision. Everything else follows from it.
+
+### 2. Lifecycle parameters
+
+| Parameter | Decision |
+|---|---|
+| Trunk cadence | Unchanged — tag freely from main |
+| LTS designation | One every **18–24 months** |
+| Support period | **5 years, security-only**, from LTS general availability |
+| Concurrent maintained lines | **Maximum 3** (N, N-1, N-2) — a hard ceiling |
+| First LTS | **v1.0**, cut at first paying production deployment |
+| Non-LTS designated releases | Supported until the next designated release |
+| Pre-1.0 | No support period declared; stated explicitly on every release |
+
+**Why 18–24 months and not annual.** Annual LTS against a five-year period yields
+five concurrent maintenance lines at steady state. At current team size that is not
+survivable, and a promise we cannot keep is worse than a shorter one we can. An
+18–24-month cadence caps concurrency at three. If the ceiling is ever reached, the
+correct response is to lengthen the LTS interval, never to breach the ceiling.
+
+**Why security-only.** The CRA mandates security updates, not feature parity. An LTS
+line receives fixes for vulnerabilities and outage-class defects. It does not receive
+features, performance work, or cosmetic fixes. Scoping this tightly is what makes a
+five-year commitment affordable; leaving it vague is what makes it ruinous.
+
+**Why five years rather than a shorter declared period.** Five years is the Article
+13(8) floor for a product of this expected lifetime, so there is little room to argue
+down. It is also our strongest structural advantage over competitors who have just
+lost theirs. Declaring less would concede that advantage to save effort we are
+largely obliged to spend anyway.
+
+### 3. Branch model
+
+Maintenance lines are `release/X.Y.x`, cut at the LTS tag. They are **never merged
+back into main**.
+
+- **Fix forward first, always.** A fix lands on main, then is cherry-picked down to
+  every live LTS line. Fixing on a maintenance line first is prohibited: it is the
+  mechanism by which lines silently diverge from trunk.
+- **Label-triggered backport.** A `backport/X.Y.x` label on a merged PR triggers an
+  automated cherry-pick PR against that line. Conflicts fall back to a manual PR.
+- **Full CI per line.** Every maintenance line runs the complete workflow matrix on
+  every backport. A maintenance line with a weaker gate than main is not a supported
+  line.
+- **Additive-only migrations within an LTS line.** No column drops, no type changes,
+  no destructive rewrites within a maintained major. This is the single architectural
+  constraint that keeps backports cheap, and it is what makes five years tractable.
+  It is a design obligation on every schema change, not a release-time concern.
+
+### 4. Definition of done for a security fix
+
+A security fix is not complete until **all** of the following hold:
+
+1. Merged on main
+2. Cherry-picked to every live LTS line, with CI green on each
+3. Advisory published (GitHub Security Advisory + CVE where applicable)
+4. **VEX document updated** and republished
+5. Update bundles rebuilt and signed for each affected line (ADR-064)
+6. CHANGELOG updated on main and on each affected line
+
+### 5. VEX is mandatory, not optional
+
+Air-gapped customers run their own scanners against our images and binaries. Those
+scanners will flag CVEs in vendored Go dependencies that our code paths never reach.
+Without a machine-readable VEX statement, each false positive becomes a support
+conversation — the failure mode that scales worst for a small team, and one that
+lands hardest precisely with the regulated customers we are courting.
+
+We already emit CycloneDX 1.6, which carries VEX natively. VEX generation is added to
+`make release` alongside SBOM generation and shipped inside the ADR-064 bundle
+manifest as a pinned component.
+
+### 6. Upgrade path guarantee
+
+Direct upgrade from any LTS to the next LTS is supported and tested. Customers on an
+LTS line never need to traverse intermediate designated releases. ADR-064's
+`min_upgrade_from` manifest field is the enforcement point: it is set to the previous
+LTS, not the previous release.
+
+## Consequences
+
+**Positive.** A published support policy is a sales artifact before it is an
+engineering one — it is what procurement asks for in the first month, and it is an
+answer Vault Community Edition cannot give. The three-line ceiling bounds the
+maintenance burden explicitly rather than letting it grow by accident. Separating
+development tags from designated releases converts a potential 88-version compliance
+surface into a handful.
+
+**Negative.** Additive-only migrations constrain schema design inside a maintained
+major; some refactors must wait for the next LTS. Maintenance-line CI multiplies
+runner minutes by the number of live lines. Cherry-pick conflicts will require
+manual work as lines age — this is the recurring cost, and it is why the concurrency
+ceiling is a hard limit rather than a target.
+
+**Deferred.** Whether extended support beyond five years becomes a paid commercial
+tier is not decided here; the policy leaves room for it. The CRA scope question for
+AGPL distribution goes to counsel before any support period is formally declared.
+
+## Follow-ups
+
+- `SUPPORT.md` — public expression of this policy (this change)
+- Pre-1.0 disclaimer wired into the release-notes template
+- VEX generation in `make release` — separate ADR if the tooling choice is contested
+- Backport automation workflow — deferred until the first LTS line exists
+- Coordinated vulnerability disclosure runbook: the 24h/72h/14-day ENISA reporting
+  chain, documented before the first commercial deployment


### PR DESCRIPTION
## Summary
- Adds ADR-067, defining the release lifecycle and LTS support policy: 5 years of security updates for LTS releases from v1.0, delivered as signed offline bundles with SBOM + VEX for air-gapped deployments.
- Adds SUPPORT.md as the canonical policy document.
- Updates SECURITY.md to point at both.

Stranded on a local branch since 2026-07-30; landing now because ADR-074 (in review) and other already-merged ADRs cite it.

## Test plan
- [x] Rebased cleanly onto current main, no conflicts
- Docs-only change, no code/CI impact