### PR TITLE
docs(adr-074): correct enforced baseline from ~7 to ~6

### DIFF
--- a/docs/adr-074-openapi-contract-test-harness.md
+++ b/docs/adr-074-openapi-contract-test-harness.md
@@ -106,15 +106,19 @@ since `kin-openapi` cannot load a 3.1 document at all. `kin-openapi` is the
 defensible choice for the spec as it exists today, not a permanent one
 regardless of spec version.
 
-## The honest enforced baseline is ~7, not 10
+## The honest enforced baseline is ~6, not 10
 
-Three of the ten schema'd operations validate close to nothing:
+Four of the ten schema'd operations validate close to nothing:
 
-- `exportAuditLogsCSV` and `exportAccessReviewCampaignCSV` declare
-  `text/csv` bodies as `{type: string, format: binary}` — a schema
-  satisfied by any non-empty byte stream. Wiring the harness to these two
-  checks "a response body exists with the right content-type," not "the
-  response matches its contract."
+- `exportAuditLogsCSV`, `exportAccessReviewCampaignCSV`, and
+  `exportSecretAccessLog` all declare their bodies as `{type: string,
+  format: binary}` — a schema satisfied by any non-empty byte stream.
+  `exportSecretAccessLog` declares this for **both** of its content types
+  (`application/json` and `text/csv`), not just its CSV side — its JSON
+  response carries exactly the same near-zero signal as the two dedicated
+  CSV endpoints. Wiring the harness to these three checks "a response body
+  exists with the right content-type," not "the response matches its
+  contract."
 - `prometheusMetrics` (`GET /metrics`) is `promhttp.Handler()` — third-party
   code, not a handler this repo owns, and no client is or will be generated
   against Prometheus exposition format. It is **out of scope**, and recorded
@@ -124,14 +128,14 @@ Three of the ten schema'd operations validate close to nothing:
   indistinguishable from one nobody thought about yet, which is the same
   false-control shape this ADR exists to prevent.
 
-That leaves **7 operations with actual JSON-Schema signal enforced on day
+That leaves **6 operations with actual JSON-Schema signal enforced on day
 one**: `authGetSetupToken`, `authLogin`, `authRefresh`, `healthCheck`,
-`listSecretACLs`, `systemInit`, and `exportSecretAccessLog`'s JSON side (see
-below). Phase 2 wires the harness to all 10 schema'd operations — the CSV
-pair still gets real value from content-type and non-empty-body checks, and
-`prometheusMetrics` is explicitly registered out-of-scope rather than
-omitted — but the ADR states the number that reflects actual verification
-strength, not the number that looks best.
+`listSecretACLs`, and `systemInit`. Phase 2 wires the harness to all 10
+schema'd operations — the three near-zero-signal ones still get real value
+from content-type and non-empty-body checks, and `prometheusMetrics` is
+explicitly registered out-of-scope rather than omitted — but the ADR states
+the number that reflects actual verification strength, not the number that
+looks best.
 
 ## `exportSecretAccessLog`'s dual content-type is a deliberate case, not an incidental one
 


### PR DESCRIPTION
## Summary
`exportSecretAccessLog`'s schema declares `{type: string, format: binary}` for BOTH its content types (`application/json` and `text/csv`), not just its CSV side — the same near-zero-signal shape as the two dedicated CSV export endpoints. This was confirmed while implementing Phase 2 (#1321). ADR-074's original count of "7 meaningfully-enforced" operations counted its JSON side as carrying real structured signal; it doesn't.

Corrected count: **6** (`authGetSetupToken`, `authLogin`, `authRefresh`, `healthCheck`, `listSecretACLs`, `systemInit`).

The ADR explicitly states it reports the number reflecting actual verification strength rather than the flattering one — that claim next to a wrong number is worse than either alone. Scoped to the count and its stated reason only; the decision itself (kin-openapi, fail-closed registry, coverage assertion, wiring all 10 schema'd operations regardless of signal strength) is unaffected.

## Test plan
Docs-only change, no code/CI impact.