### PR TITLE
fix(oidc): close the cold-cache gap in the JWKS refetch rate limit

### DIFF
--- a/internal/core/oidc_jwks.go
+++ b/internal/core/oidc_jwks.go
@@ -188,21 +188,35 @@ func (r *HTTPJWKSResolver) Key(ctx context.Context, issuer, kid string) (interfa
 	}
 	// Past this point a refetch is needed — either because the cache is
 	// stale/missing, or because it's fresh but doesn't have this kid (possible
-	// rotation). BOTH cases are rate-limited the same way: at most one refetch
+	// rotation). ALL of those are rate-limited the same way: at most one refetch
 	// ATTEMPT per jwksMinRefetchInterval per issuer, tracked by lastFetchAttempt
 	// (set on every attempt, success or failure) rather than entry.fetchedAt (set
-	// only on success). Previously only the "fresh cache, unknown kid" case was
-	// gated; the stale-cache path — e.g. during an IdP outage, where every refetch
-	// fails and the cache never becomes fresh again — had NO gate at all, so it
-	// could be hit on every single request to force an unbounded stream of
-	// outbound JWKS fetches: a DoS amplifier against the IdP and against this
-	// server's own outbound budget/latency.
+	// only on success). This also covers the cold-start case — an issuer that has
+	// NEVER had a successful fetch (its JWKS endpoint has been unreachable since
+	// boot, e.g. an air-gapped deployment). That case used to fall through this
+	// gate unconditionally (it required entry != nil), so every verification
+	// attempt fired a live outbound fetch and blocked for the full http.Client
+	// timeout — reachable pre-authentication, since keyfunc runs during JWT parse
+	// BEFORE the signature is verified and only requires the token's iss to name a
+	// configured issuer (a public, guessable value). singleflight already
+	// collapses CONCURRENT callers into one outbound fetch, so this was never an
+	// amplification attack against the IdP; the cost was sequential, on Keyorix
+	// itself — each blocked request held a goroutine and a connection for up to
+	// the timeout, one after another.
+	//
+	// Accepted tradeoff: an issuer whose first-ever fetch fails now fails fast —
+	// rejected immediately, not blocked — for up to jwksMinRefetchInterval before
+	// the next attempt, rather than paying a full blocking fetch on every request
+	// in that window. Intentional: a bounded, fast rejection beats an unbounded
+	// number of full-timeout blocking calls.
 	lastAttempt, attempted := r.lastFetchAttempt[issuer]
-	if entry != nil && attempted && time.Since(lastAttempt) < jwksMinRefetchInterval {
+	if attempted && time.Since(lastAttempt) < jwksMinRefetchInterval {
 		r.mu.Unlock()
 		// Still within the stale-grace window: serve the cached key if we have it
 		// rather than paying for (or waiting on) a refetch we've decided to skip.
-		if time.Since(entry.fetchedAt) < jwksCacheTTL+jwksStaleGrace {
+		// entry is nil on the cold-start path (no fetch has ever succeeded), so
+		// this is skipped there and we fall through to the rate-limited error.
+		if entry != nil && time.Since(entry.fetchedAt) < jwksCacheTTL+jwksStaleGrace {
 			if k, ok := entry.keys[kid]; ok {
 				return k, nil
 			}

--- a/internal/core/oidc_jwks_test.go
+++ b/internal/core/oidc_jwks_test.go
@@ -181,6 +181,50 @@ func TestHTTPJWKSResolver_StaleRefetchRateLimited(t *testing.T) {
 	assert.Equal(t, 2, hits, "after the rate-limit window elapses, a call may attempt a refetch again")
 }
 
+// The cold-start refetch path — an issuer that has NEVER had a successful
+// fetch, so entry stays nil — is rate-limited the same way the stale-cache
+// path is: at most one refetch ATTEMPT per jwksMinRefetchInterval per issuer.
+// Before the fix this path had no gate at all: it required entry != nil, so
+// an issuer whose JWKS endpoint has been unreachable since boot (e.g. an
+// air-gapped deployment) fired a live outbound fetch and blocked for the full
+// http.Client timeout on EVERY verification attempt, forever — reachable
+// pre-authentication, since keyfunc runs during JWT parse before the token's
+// signature is checked.
+func TestHTTPJWKSResolver_ColdCacheRefetchRateLimited(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusInternalServerError) // always fails: cache is never seeded
+	}))
+	defer srv.Close()
+	r, err := NewHTTPJWKSResolver(map[string]string{"https://iss": srv.URL})
+	require.NoError(t, err)
+
+	// First-ever call: no prior attempt recorded, so it still attempts (and fails) a fetch.
+	_, err = r.Key(context.Background(), "https://iss", "k1")
+	require.Error(t, err)
+	require.Equal(t, 1, hits, "first-ever call on a cold cache still attempts a fetch")
+
+	// A flood of further calls immediately after, with no cache entry ever
+	// populated: all within jwksMinRefetchInterval of the first attempt, so none
+	// should reach the server again. This is exactly the bug: entry stays nil
+	// forever here, so the old `entry != nil` gate condition never engaged.
+	for i := 0; i < 20; i++ {
+		_, err := r.Key(context.Background(), "https://iss", "k1")
+		require.Error(t, err, "a rate-limited cold cache must fail closed, never return a bypassed result")
+	}
+	assert.Equal(t, 1, hits, "repeated calls on a still-rate-limited cold cache must not fire a second outbound fetch")
+
+	// Once the last-attempt timestamp is old enough, a call is allowed to attempt a
+	// refetch again.
+	r.mu.Lock()
+	r.lastFetchAttempt["https://iss"] = time.Now().Add(-(jwksMinRefetchInterval + time.Second))
+	r.mu.Unlock()
+	_, err = r.Key(context.Background(), "https://iss", "k1")
+	require.Error(t, err)
+	assert.Equal(t, 2, hits, "after the rate-limit window elapses, a call may attempt a refetch again")
+}
+
 // A JWKS with more keys than maxJWKSKeys is capped so a pathological key set can't
 // bloat the cache.
 func TestHTTPJWKSResolver_CapsKeyCount(t *testing.T) {


### PR DESCRIPTION
## Summary
- `Key()`'s refetch rate-limit guard (`entry != nil && attempted && ...`) only engaged after at least one successful fetch. When no fetch has ever succeeded for an issuer (unreachable JWKS endpoint since boot, e.g. an air-gapped deployment), `entry` stays nil forever, so the guard never activated: every verification attempt fired a live outbound fetch and blocked for the full `http.Client` timeout, with no backoff.
- Reachable pre-authentication: `keyfunc` runs during JWT parse before the signature is checked, and only requires the token's `iss` to name a configured issuer (a public, guessable value). Not an amplification attack against the IdP — `singleflight` already collapses concurrent fetches — the cost lands on Keyorix itself, sequentially.
- Fix: drop the `entry != nil` conjunct from the gate so the interval applies on the cold path too, guarding the now-possibly-nil `entry` dereference in the stale-grace serve branch. Preserves: first-ever attempt still fetches; fail-closed when rate-limited with no usable key; existing stale-grace path unchanged. `jwksMinRefetchInterval`/TTL/grace untouched.
- Accepted tradeoff (documented in the code): an issuer whose first-ever fetch fails now fails fast for up to `jwksMinRefetchInterval`, rather than blocking on every request in that window.

Related to ADR-075 (#1320) but independent — this bug is orthogonal to air-gap support and would be worth fixing in a fully-connected deployment too.

## Test plan
- [x] New `TestHTTPJWKSResolver_ColdCacheRefetchRateLimited`: asserts on a fetch counter, not wall-clock — first call still fetches, a 20-call flood on a permanently-cold cache fires exactly one outbound fetch, every rate-limited call fails closed, refetch resumes once the window elapses
- [x] All pre-existing warm-cache/stale-grace tests pass unchanged
- [x] `FuzzOIDCVerifierVerify` (~177k execs, 21s) and `TestValidateOIDCToken_CrossIssuerBindingIsolation` both pass
- [x] `go build ./...`, `gofmt -l`, `go vet` all clean