### PR TITLE
fix(security): web/nginx.conf ships stale pre-hardening CSP (r140)

### DIFF
--- a/server/middleware/nginx_conf_security_test.go
+++ b/server/middleware/nginx_conf_security_test.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNginxConfSecurityHeadersMatchGoMiddleware guards against web/nginx.conf
+// (the Docker+nginx serving mode's config) silently drifting back to the
+// pre-hardening headers this package already enforces for the embedded
+// single-binary serving mode (see SecurityHeaders above).
+//
+// Root cause this guards against (r140): web/nginx.conf arrived wholesale via
+// the web/ subtree merge (18a661b6, ADR-070) AFTER bbc14d97 had already
+// hardened both other serving modes (this package + deploy/helm/keyorix/
+// templates/web-config.yaml) — a sibling site the merge reintroduced with the
+// stale SAMEORIGIN/strict-origin-when-cross-origin/bare-ws-wss policy. DAST
+// never catches this because DAST only exercises the embedded single-binary
+// mode, never web/Dockerfile's nginx.
+//
+// nginx's add_header does not inherit into a location block once that block
+// sets any add_header of its own (see the comment atop web/nginx.conf's http
+// block), so the header set is repeated across all of that file's location
+// blocks — this test checks every occurrence, not just the first, so a
+// partial revert (fixing one block but not another) still fails.
+//
+// Deliberately narrow: this is not a full CSP-string equality check (nginx.conf
+// legitimately differs from the Go middleware's CSP in ways that don't matter
+// here, e.g. img-src's data: scheme), just the handful of properties that have
+// each already caused a real, named vulnerability class in this codebase.
+func TestNginxConfSecurityHeadersMatchGoMiddleware(t *testing.T) {
+	const nginxConfPath = "../../web/nginx.conf"
+	data, err := os.ReadFile(nginxConfPath) // #nosec G304 -- fixed relative path to a repo file, not user input
+	require.NoError(t, err, "web/nginx.conf must exist and be readable")
+	conf := string(data)
+
+	xfoRe := regexp.MustCompile(`add_header X-Frame-Options "([^"]*)"`)
+	xfoMatches := xfoRe.FindAllStringSubmatch(conf, -1)
+	require.NotEmpty(t, xfoMatches, "expected at least one X-Frame-Options add_header in web/nginx.conf")
+	for _, m := range xfoMatches {
+		// Clickjacking (matches server/middleware/security_headers.go and
+		// deploy/helm/keyorix/templates/web-config.yaml): the dashboard must
+		// never be framed by ANY origin, including its own — SAMEORIGIN is not
+		// strict enough.
+		assert.Equal(t, "DENY", m[1], "every X-Frame-Options in web/nginx.conf must be DENY, not %q", m[1])
+	}
+
+	cspRe := regexp.MustCompile(`add_header Content-Security-Policy "([^"]*)"`)
+	cspMatches := cspRe.FindAllStringSubmatch(conf, -1)
+	require.NotEmpty(t, cspMatches, "expected at least one Content-Security-Policy add_header in web/nginx.conf")
+
+	connectSrcRe := regexp.MustCompile(`connect-src ([^;]*);`)
+	for _, m := range cspMatches {
+		csp := m[1]
+
+		// #1214/#1215-class CSP bypass: a bare ws:/wss: scheme in connect-src
+		// permits a WebSocket connection to ANY host, which is a data-
+		// exfiltration channel. 'self' already covers same-origin WebSocket
+		// connections in all modern browsers, so the wildcard is never needed.
+		connectSrcMatch := connectSrcRe.FindStringSubmatch(csp)
+		require.NotEmpty(t, connectSrcMatch, "expected a connect-src directive in CSP %q", csp)
+		assert.NotContains(t, connectSrcMatch[1], "ws:", "connect-src must not allow a bare ws:/wss: scheme (CSP bypass): %q", csp)
+
+		// frame-ancestors does NOT inherit from default-src and must be
+		// explicit, or embedding is left ungoverned by CSP entirely
+		// (X-Frame-Options above is the fallback, but browsers that only
+		// honor CSP would be unprotected).
+		assert.Contains(t, csp, "frame-ancestors 'none'", "CSP must explicitly set frame-ancestors 'none': %q", csp)
+	}
+}

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -60,15 +60,24 @@ http {
     # but the intent here IS to fully own each location's header set rather
     # than rely on inheritance that doesn't work the way the rule assumes.
     # Suppressed per-line below; this comment is the one place explaining why.
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Referrer-Policy "no-referrer" always;
     # script-src is 'self' only: the Vite production bundle ships no inline scripts
     # and invokes no eval()/Function(), so 'unsafe-inline'/'unsafe-eval' are not needed.
-    # Matches the strict policy used on the marketing site. style-src keeps
-    # 'unsafe-inline' for Tailwind/React inline styles.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+    # style-src keeps 'unsafe-inline' for Tailwind/React inline styles. form-action,
+    # base-uri, frame-ancestors do not inherit from default-src and must be explicit;
+    # object-src 'none' blocks Flash/Java plugins. img-src omits the https: wildcard —
+    # all images are same-origin or inline data URIs. This must stay in sync with
+    # server/middleware/security_headers.go and
+    # deploy/helm/keyorix/templates/web-config.yaml — the three serving modes
+    # (embedded single-binary, this Docker+nginx image, Helm/K8s) must present the
+    # same policy to the browser.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; form-action 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none';" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
+    add_header Cross-Origin-Embedder-Policy "require-corp" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
 
     server {
@@ -86,11 +95,14 @@ http {
             # defines its own add_header, so the security headers above must be
             # repeated in every location that sets one (see nginx docs on
             # add_header inheritance).
-            add_header X-Frame-Options "SAMEORIGIN" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header X-Frame-Options "DENY" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
             add_header X-Content-Type-Options "nosniff" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
             add_header X-XSS-Protection "1; mode=block" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
-            add_header Referrer-Policy "strict-origin-when-cross-origin" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Referrer-Policy "no-referrer" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; form-action 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none';" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Cross-Origin-Resource-Policy "same-origin" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Cross-Origin-Embedder-Policy "require-corp" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Cross-Origin-Opener-Policy "same-origin" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
             # Harmless on a plain-HTTP self-host (browsers only honor HSTS over an
             # actual HTTPS connection); takes effect once TLS is terminated here or
             # upstream of here.
@@ -130,11 +142,14 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
 
-            add_header X-Frame-Options "SAMEORIGIN" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header X-Frame-Options "DENY" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
             add_header X-Content-Type-Options "nosniff" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
             add_header X-XSS-Protection "1; mode=block" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
-            add_header Referrer-Policy "strict-origin-when-cross-origin" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Referrer-Policy "no-referrer" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; form-action 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none';" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Cross-Origin-Resource-Policy "same-origin" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Cross-Origin-Embedder-Policy "require-corp" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Cross-Origin-Opener-Policy "same-origin" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
             # Harmless on a plain-HTTP self-host (browsers only honor HSTS over an
             # actual HTTPS connection); takes effect once TLS is terminated here or
             # upstream of here.
@@ -146,11 +161,14 @@ http {
             try_files $uri $uri/ /index.html;
 
             # Security headers for HTML
-            add_header X-Frame-Options "SAMEORIGIN" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header X-Frame-Options "DENY" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
             add_header X-Content-Type-Options "nosniff" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
             add_header X-XSS-Protection "1; mode=block" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
-            add_header Referrer-Policy "strict-origin-when-cross-origin" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Referrer-Policy "no-referrer" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; form-action 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none';" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Cross-Origin-Resource-Policy "same-origin" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Cross-Origin-Embedder-Policy "require-corp" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
+            add_header Cross-Origin-Opener-Policy "same-origin" always; # nosemgrep: generic.nginx.security.header-redefinition.header-redefinition
             # Harmless on a plain-HTTP self-host (browsers only honor HSTS over an
             # actual HTTPS connection); takes effect once TLS is terminated here or
             # upstream of here.


### PR DESCRIPTION
## Summary

- `web/nginx.conf` (the Docker+nginx serving mode) still sent the **pre-hardening** security headers in all 4 of its `location` blocks: `X-Frame-Options SAMEORIGIN` (not `DENY`), `Referrer-Policy strict-origin-when-cross-origin` (not `no-referrer`), a CSP missing `form-action`/`base-uri`/`frame-ancestors`/`object-src`, an `img-src https:` wildcard, a bare `ws:`/`wss:` in `connect-src` (the CSP-bypass class fixed by `bbc14d97`/#1217), and no `Cross-Origin-Resource-Policy`/`Cross-Origin-Embedder-Policy`/`Cross-Origin-Opener-Policy` at all.
- **Root cause**: `web/nginx.conf` arrived wholesale via the `web/` subtree merge (`18a661b6`, ADR-070) *after* `bbc14d97` had already hardened the other two serving modes — `server/middleware/security_headers.go` (embedded single-binary) and `deploy/helm/keyorix/templates/web-config.yaml` (Helm/K8s). The subtree merge reintroduced a sibling site with the stale policy. DAST never caught it because DAST only exercises the embedded single-binary mode, never `web/Dockerfile`'s nginx.
- Copied the exact header values from `security_headers.go` / `web-config.yaml` (which already agree with each other) into all 4 `location` blocks plus the http-level reference block in `web/nginx.conf`, so all three serving modes present the same policy again.
- Added `server/middleware/nginx_conf_security_test.go`: a targeted regression guard that reads `web/nginx.conf` directly and asserts — across *every* `add_header` occurrence in the file (nginx's `add_header` does not inherit once a location sets its own, hence the repetition) — the handful of properties that have each already caused a named vulnerability class here: `X-Frame-Options` must be `DENY`, `connect-src` must not allow a bare `ws:`/`wss:` scheme, and `frame-ancestors 'none'` must be explicit. Deliberately not a full CSP-string diff against the other two files — `nginx.conf` legitimately differs from them in ways that don't matter (e.g. `img-src`'s `data:` scheme).

## Test plan

- [x] `docker run --rm -v .../web/nginx.conf:/etc/nginx/nginx.conf:ro nginx:alpine nginx -t` — syntax ok
- [x] `go test ./server/middleware/...` — 215 tests pass, including the new guard
- [x] `go vet ./server/middleware/...` — clean
- [x] `golangci-lint run ./server/middleware/...` — no issues
- [x] `gosec -severity medium -exclude-generated ./server/middleware/...` — 0 issues
- [x] `go build ./...` — clean