### PR TITLE
fix(security): wire SecretACL enforcement into per-secret read/write routes (r140)

### DIFF
--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -252,6 +252,34 @@ func (c *KeyorixCore) AuthorizeSecret(ctx context.Context, userID, secretID uint
 	return c.Authorize(ctx, userID, perm, scope)
 }
 
+// AuthorizeSecretPrincipal is the actor-aware counterpart to AuthorizeSecret,
+// mirroring AuthorizePrincipal's split between human users and machine
+// identities (ADR-030). It is the entrypoint the per-secret HTTP routes use
+// (RequireScopedSecretPermission) so a per-secret SecretACL grant (RBAC Phase 3)
+// is honored for the ~15 GET/PUT/DELETE routes gated on a specific secret ID,
+// not just the ListSecrets surface.
+//
+// SecretACL rows are inherently user-scoped (models.SecretACL.UserID; see
+// secret_acl.go's GrantSecretACL, which requires the grantee to be a project
+// member — a concept that doesn't apply to machine identities). A machine
+// identity's principal ID lives in an entirely separate ID space/table from
+// User, so treating it as a userID for the ACL lookup would risk an accidental
+// match against an unrelated human's grant purely by numeric coincidence.
+// Machine/OIDC-federated principals therefore always take the existing
+// role-based AuthorizePrincipal path unchanged — byte-for-byte the behavior
+// before this function existed. Fails closed.
+func (c *KeyorixCore) AuthorizeSecretPrincipal(ctx context.Context, actorType string, principalID, secretID uint, permission string) (bool, error) {
+	if actorType != ActorTypeMachine {
+		return c.AuthorizeSecret(ctx, principalID, secretID, permission)
+	}
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	if err != nil {
+		return false, err
+	}
+	scope := Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
+	return c.AuthorizePrincipal(ctx, actorType, principalID, permission, scope)
+}
+
 // IsGlobalAdmin reports whether userID holds an admin role assigned globally
 // (project 0, environment 0). Used to short-circuit scope-filtered listing.
 //

--- a/internal/core/core_s26_test.go
+++ b/internal/core/core_s26_test.go
@@ -289,6 +289,9 @@ func TestCheckSecretPermission_Denied(t *testing.T) {
 	ms.On("ListSharesBySecret", mock.Anything, uint(5)).Return([]*models.ShareRecord{}, nil)
 	// CheckGroupPermissions calls GetUserGroups
 	ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+	// ACL fallback (r140): no direct grant, and no ancestor folder grant either → deny.
+	ms.On("GetSecretACL", mock.Anything, uint(5), uint(1)).Return(nil, errors.New("record not found"))
+	ms.On("GetSecretAncestors", mock.Anything, uint(5)).Return([]uint{}, nil)
 	// RBAC fallback (r124): no roles → deny.
 	ms.On("GetUserRoleIDsAt", mock.Anything, uint(1), mock.Anything).Return([]uint{}, nil)
 	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(1), mock.Anything).Return([]uint{}, nil)

--- a/internal/core/core_s28_test.go
+++ b/internal/core/core_s28_test.go
@@ -203,6 +203,9 @@ func TestGetSecretValueByVersionWithPermissionCheck_PermissionDenied(t *testing.
 	ms.On("GetSecret", mock.Anything, uint(5)).Return(secret, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(5)).Return([]*models.ShareRecord{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+	// ACL fallback (r140): no direct grant, and no ancestor folder grant either → deny.
+	ms.On("GetSecretACL", mock.Anything, uint(5), uint(2)).Return(nil, errors.New("record not found"))
+	ms.On("GetSecretAncestors", mock.Anything, uint(5)).Return([]uint{}, nil)
 	// RBAC fallback (r124): no roles → deny.
 	ms.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)

--- a/internal/core/core_s29_test.go
+++ b/internal/core/core_s29_test.go
@@ -433,6 +433,9 @@ func TestGetSecretByNameWithPermissionCheck_PermissionDenied(t *testing.T) {
 	ms.On("GetSecret", mock.Anything, uint(5)).Return(secret, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(5)).Return([]*models.ShareRecord{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+	// ACL fallback (r140): no direct grant, and no ancestor folder grant either → deny.
+	ms.On("GetSecretACL", mock.Anything, uint(5), uint(2)).Return(nil, errors.New("record not found"))
+	ms.On("GetSecretAncestors", mock.Anything, uint(5)).Return([]uint{}, nil)
 	// RBAC fallback (r124): no roles → deny.
 	ms.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
@@ -456,6 +459,9 @@ func TestUpdateSecretWithPermissionCheck_PermissionDenied(t *testing.T) {
 	ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 	ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+	// ACL fallback (r140): no direct grant, and no ancestor folder grant either → deny.
+	ms.On("GetSecretACL", mock.Anything, uint(1), uint(2)).Return(nil, errors.New("record not found"))
+	ms.On("GetSecretAncestors", mock.Anything, uint(1)).Return([]uint{}, nil)
 	// RBAC fallback (r124): no roles → deny.
 	ms.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
 	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)

--- a/internal/core/permission_enforcement_test.go
+++ b/internal/core/permission_enforcement_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -106,6 +107,9 @@ func TestCheckSecretPermission(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{share}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+				// ACL fallback (r140): no direct grant, and no ancestor folder grant either — deny.
+				ms.On("GetSecretACL", mock.Anything, uint(1), uint(2)).Return(nil, errors.New("record not found"))
+				ms.On("GetSecretAncestors", mock.Anything, uint(1)).Return([]uint{}, nil)
 				// RBAC fallback: no roles at this scope — deny.
 				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
@@ -141,6 +145,9 @@ func TestCheckSecretPermission(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(4)).Return([]*models.Group{}, nil)
+				// ACL fallback (r140): no direct grant, and no ancestor folder grant either — deny.
+				ms.On("GetSecretACL", mock.Anything, uint(1), uint(4)).Return(nil, errors.New("record not found"))
+				ms.On("GetSecretAncestors", mock.Anything, uint(1)).Return([]uint{}, nil)
 				// RBAC fallback: no roles at this scope — deny.
 				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
@@ -262,6 +269,9 @@ func TestEnforceSecretWritePermission(t *testing.T) {
 		},
 	}, nil)
 	mockStorage.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+	// ACL fallback (r140): no direct grant, and no ancestor folder grant either — deny.
+	mockStorage.On("GetSecretACL", mock.Anything, uint(1), uint(1)).Return(nil, errors.New("record not found"))
+	mockStorage.On("GetSecretAncestors", mock.Anything, uint(1)).Return([]uint{}, nil)
 	// RBAC fallback: no roles — deny.
 	mockStorage.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 	mockStorage.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
@@ -343,6 +353,9 @@ func TestCanUserModifySecret(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{share}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+				// ACL fallback (r140): no direct grant, and no ancestor folder grant either — deny.
+				ms.On("GetSecretACL", mock.Anything, uint(1), uint(1)).Return(nil, errors.New("record not found"))
+				ms.On("GetSecretAncestors", mock.Anything, uint(1)).Return([]uint{}, nil)
 				// RBAC fallback: no roles — deny.
 				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
@@ -516,6 +529,9 @@ func TestGetEffectivePermission(t *testing.T) {
 				ms.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 				ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 				ms.On("GetUserGroups", mock.Anything, uint(1)).Return([]*models.Group{}, nil)
+				// ACL fallback (r140): no direct grant, and no ancestor folder grant either — deny.
+				ms.On("GetSecretACL", mock.Anything, uint(1), uint(1)).Return(nil, errors.New("record not found"))
+				ms.On("GetSecretAncestors", mock.Anything, uint(1)).Return([]uint{}, nil)
 				// RBAC fallback: no roles — deny.
 				ms.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 				ms.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
@@ -659,6 +675,9 @@ func TestGetSecretWithPermissionCheck(t *testing.T) {
 		mockStorage.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 		mockStorage.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 		mockStorage.On("GetUserGroups", mock.Anything, uint(2)).Return([]*models.Group{}, nil)
+		// ACL fallback (r140): no direct grant, and no ancestor folder grant either — deny.
+		mockStorage.On("GetSecretACL", mock.Anything, uint(1), uint(2)).Return(nil, errors.New("record not found"))
+		mockStorage.On("GetSecretAncestors", mock.Anything, uint(1)).Return([]uint{}, nil)
 		// RBAC fallback: no roles — deny.
 		mockStorage.On("GetUserRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
 		mockStorage.On("GetUserGroupRoleIDsAt", mock.Anything, mock.Anything, mock.Anything).Return([]uint{}, nil)
@@ -704,6 +723,10 @@ func TestCheckSecretPermission_RBACFallback_GrantsAccess(t *testing.T) {
 	mockStorage.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
 	mockStorage.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
 	mockStorage.On("GetUserGroups", mock.Anything, uint(7)).Return([]*models.Group{}, nil)
+	// ACL fallback (r140): no direct grant, and no ancestor folder grant either — falls
+	// through to the RBAC fallback below, proving ACL and RBAC compose correctly.
+	mockStorage.On("GetSecretACL", mock.Anything, uint(1), uint(7)).Return(nil, errors.New("record not found"))
+	mockStorage.On("GetSecretAncestors", mock.Anything, uint(1)).Return([]uint{}, nil)
 
 	// RBAC fallback: user 7 has role [55] in this project scope.
 	mockStorage.On("GetUserRoleIDsAt", mock.Anything, uint(7), mock.Anything).Return([]uint{55}, nil)

--- a/internal/core/permission_enforcement_test.go
+++ b/internal/core/permission_enforcement_test.go
@@ -708,6 +708,40 @@ func TestPermissionLevelToRBACPerm(t *testing.T) {
 	}
 }
 
+// TestCheckSecretPermission_ACLFallback_GrantsAccess verifies that a user
+// with no ownership, share record, or project role, but a per-secret
+// SecretACL grant covering the required permission, is admitted via the ACL
+// fallback path (r140) with Source "acl" -- the success branch that
+// TestCheckSecretPermission's own table only ever exercises the deny side of
+// (every case there mocks GetSecretACL to return "not found").
+func TestCheckSecretPermission_ACLFallback_GrantsAccess(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	mockStorage := &MockStorage{}
+	secret := &models.SecretNode{
+		ID: 1, OwnerID: 99, Name: "acl-fallback-secret",
+		ProjectID: 5, EnvironmentID: 10,
+	}
+	mockStorage.On("GetSecret", mock.Anything, uint(1)).Return(secret, nil)
+	mockStorage.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
+	mockStorage.On("GetUserGroups", mock.Anything, uint(8)).Return([]*models.Group{}, nil)
+	// ACL fallback (r140): a direct grant on this exact secret covers read.
+	mockStorage.On("GetSecretACL", mock.Anything, uint(1), uint(8)).Return(&models.SecretACL{
+		SecretID: 1, UserID: 8, Permissions: `["secrets.read"]`,
+	}, nil)
+
+	c := NewKeyorixCore(mockStorage)
+
+	permCtx, err := c.CheckSecretPermission(context.Background(), 1, 8, PermissionRead)
+	require.NoError(t, err)
+	require.NotNil(t, permCtx)
+	assert.Equal(t, "acl", permCtx.Source)
+	assert.Equal(t, PermissionRead, permCtx.Permission)
+	assert.Equal(t, uint(1), permCtx.SecretID)
+	assert.Equal(t, uint(8), permCtx.UserID)
+	mockStorage.AssertExpectations(t)
+}
+
 // TestCheckSecretPermission_RBACFallback_GrantsAccess verifies that a user
 // with no ownership or share record but a project-scoped RBAC role granting
 // secrets.read is still admitted via the RBAC fallback path (#r124).

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -130,6 +130,31 @@ func (c *KeyorixCore) CheckSecretPermission(ctx context.Context, secretID, userI
 		}
 	}
 
+	// Per-secret ACL fallback (RBAC Phase 3, additive — see secret_acl.go's design
+	// doc): a SecretACL grant on this exact secret (or an inherited ancestor
+	// folder, via HasSecretACL) satisfies read/write independently of any
+	// project role. Without this, a caller who only holds an ACL grant passed
+	// the HTTP router's RequireScopedSecretPermission gate but was silently
+	// denied here, because CheckSecretPermission previously recognized only
+	// ownership, share records, and project RBAC (r140) — the same
+	// two-authorization-models gap the RBAC fallback below closed for roles
+	// (#r124). ACL never grants secrets.delete/owner, so PermissionOwner
+	// requests skip this and fall straight to the RBAC fallback. SecretACL rows
+	// are user-scoped (see AuthorizeSecretPrincipal), so a machine-identity actor
+	// skips this and relies on the RBAC fallback exclusively, unchanged from
+	// before.
+	if aclPerm := permissionLevelToRBACPerm(requiredPermission); aclPerm != "" && aclPerm != "secrets.delete" &&
+		actorTypeFromContext(ctx) != ActorTypeMachine {
+		if hasACL, aerr := c.HasSecretACL(ctx, userID, secretID, aclPerm); aerr == nil && hasACL {
+			return &PermissionContext{
+				SecretID:   secretID,
+				UserID:     userID,
+				Permission: requiredPermission,
+				Source:     "acl",
+			}, nil
+		}
+	}
+
 	// RBAC fallback: a project editor/admin whose role grants secrets.write (or
 	// secrets.delete for owner-level operations) passes the HTTP router's
 	// RequireScopedPermission gate but was silently denied here because

--- a/internal/core/secret_acl_test.go
+++ b/internal/core/secret_acl_test.go
@@ -240,6 +240,20 @@ func TestAuthorizeSecretPrincipal_MachineSkipsACL(t *testing.T) {
 	assert.False(t, ok, "a machine identity must never be authorized via a user-scoped SecretACL grant")
 }
 
+// TestAuthorizeSecretPrincipal_MachineGetSecretError covers
+// AuthorizeSecretPrincipal's machine-actor error branch: when the secret
+// itself can't be resolved (e.g. it doesn't exist), the function must
+// propagate the storage error rather than falling through to
+// AuthorizePrincipal with a zero-value scope.
+func TestAuthorizeSecretPrincipal_MachineGetSecretError(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newACLCore(t)
+
+	ok, err := c.AuthorizeSecretPrincipal(ctx, ActorTypeMachine, 1, 999999, "secrets.read")
+	require.Error(t, err)
+	assert.False(t, ok, "an unresolvable secret must never authorize a machine principal")
+}
+
 // TestGrantSecretACL_Upsert verifies that a second grant on the same (secret, user)
 // updates rather than inserting a duplicate.
 func TestGrantSecretACL_Upsert(t *testing.T) {

--- a/internal/core/secret_acl_test.go
+++ b/internal/core/secret_acl_test.go
@@ -26,6 +26,7 @@ func newACLCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 		&models.User{}, &models.Role{}, &models.UserRole{},
 		&models.Permission{}, &models.RolePermission{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.MachineIdentityRole{},
 	))
 	// Seed project + environment.
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
@@ -195,6 +196,48 @@ func TestAuthorizeSecret_ProjectRoleFallback(t *testing.T) {
 	ok, err := c.AuthorizeSecret(ctx, 200, sid, "secrets.read")
 	require.NoError(t, err)
 	assert.True(t, ok, "user with project role should get access via RBAC fallback")
+}
+
+// TestAuthorizeSecretPrincipal_UserACLGrant verifies the actor-aware entrypoint
+// (used by RequireScopedSecretPermission) honors a per-secret ACL grant for a
+// human user with no project role, mirroring TestAuthorizeSecret_ACLGrant.
+func TestAuthorizeSecretPrincipal_UserACLGrant(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "principal-acl-only-secret")
+
+	require.NoError(t, c.GrantSecretACL(ctx, 1, sid, 100, []string{"secrets.read"}))
+
+	ok, err := c.AuthorizeSecretPrincipal(ctx, ActorTypeUser, 100, sid, "secrets.read")
+	require.NoError(t, err)
+	assert.True(t, ok, "user with ACL grant should be allowed via the actor-aware entrypoint")
+
+	// No ACL grant covers write.
+	ok2, err := c.AuthorizeSecretPrincipal(ctx, ActorTypeUser, 100, sid, "secrets.write")
+	require.NoError(t, err)
+	assert.False(t, ok2, "ACL grant covering only read must not authorize write")
+}
+
+// TestAuthorizeSecretPrincipal_MachineSkipsACL verifies that a machine identity
+// principal never consults SecretACL (which is user-scoped), even when a
+// SecretACL row happens to exist for a userID matching the machine's principal
+// ID — machine and user IDs are disjoint spaces, but this proves the isolation
+// is enforced structurally, not by accident of test data. A machine principal
+// with no role grant at the secret's scope must be denied.
+func TestAuthorizeSecretPrincipal_MachineSkipsACL(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "machine-secret")
+
+	// Grant "user" 100 a SecretACL read grant on sid.
+	require.NoError(t, c.GrantSecretACL(ctx, 1, sid, 100, []string{"secrets.read"}))
+
+	// A machine principal with the SAME numeric ID (100) and no machine role
+	// grant must still be denied — the ACL row belongs to a human user, not
+	// this machine identity.
+	ok, err := c.AuthorizeSecretPrincipal(ctx, ActorTypeMachine, 100, sid, "secrets.read")
+	require.NoError(t, err)
+	assert.False(t, ok, "a machine identity must never be authorized via a user-scoped SecretACL grant")
 }
 
 // TestGrantSecretACL_Upsert verifies that a second grant on the same (secret, user)

--- a/internal/core/secret_ownership_history_test.go
+++ b/internal/core/secret_ownership_history_test.go
@@ -129,6 +129,9 @@ func TestGetSecretOwnershipHistory_PermissionDenied(t *testing.T) {
 		Return([]*models.ShareRecord{}, nil)
 	// CheckGroupPermissions → GetUserGroups needed.
 	store.On("GetUserGroups", ctx, uint(42)).Return([]*models.Group{}, nil)
+	// ACL fallback (r140): no direct grant, and no ancestor folder grant either → deny.
+	store.On("GetSecretACL", mock.Anything, uint(100), uint(42)).Return(nil, errors.New("record not found"))
+	store.On("GetSecretAncestors", mock.Anything, uint(100)).Return([]uint{}, nil)
 	// RBAC fallback (r124): no roles → deny.
 	store.On("GetUserRoleIDsAt", mock.Anything, uint(42), mock.Anything).Return([]uint{}, nil)
 	store.On("GetUserGroupRoleIDsAt", mock.Anything, uint(42), mock.Anything).Return([]uint{}, nil)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -580,11 +580,16 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission(permSecretsRead)).Get("/environments", catalogHandler.ListEnvironments)
 
 		// Secrets endpoints. Per-secret routes resolve scope from the secret's
-		// own project/environment. List authorizes against the project_id/
-		// environment_id query filter (a scoped reader must narrow to a project
-		// they can read; the same filter then bounds the returned rows). Create
-		// authorizes in-handler against the project/environment in the body.
-		secretScope := customMiddleware.ScopeFromSecretParam("id")
+		// own project/environment via RequireScopedSecretPermission, which ALSO
+		// consults per-secret SecretACL grants (RBAC Phase 3) in addition to the
+		// project-scope role check that ScopeFromSecretParam +
+		// RequireScopedPermission alone would give — a caller granted
+		// secrets.read/write on this one secret (or an ancestor folder) needs no
+		// project role at all, matching what ListSecrets already honors. List
+		// authorizes against the project_id/environment_id query filter (a
+		// scoped reader must narrow to a project they can read; the same filter
+		// then bounds the returned rows). Create authorizes in-handler against
+		// the project/environment in the body.
 		r.Route("/secrets", func(r chi.Router) {
 			// ListSecrets performs its own authorization inside the handler so that
 			// project-scoped readers receive the union of their accessible scopes
@@ -618,89 +623,89 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// RemoteStorage.GetSecretByName (#497) needs; a caller with only a secret's
 			// name (not its numeric ID) resolves it here. Static path, before /{id}.
 			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, customMiddleware.ScopeFromQuery)).Get("/by-name", secretHandler.GetSecretByName)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}", secretHandler.GetSecret)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/versions", secretHandler.GetSecretVersions)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/versions/{from}/diff/{to}", secretHandler.DiffSecretVersions)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}", secretHandler.GetSecret)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/versions", secretHandler.GetSecretVersions)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/versions/{from}/diff/{to}", secretHandler.DiffSecretVersions)
 
 			// Secret version comments — free-text annotations on a specific version.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/versions/{versionId}/comments", versionCommentHandler.ListComments)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/versions/{versionId}/comments", versionCommentHandler.CreateComment)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/versions/{versionId}/comments", versionCommentHandler.ListComments)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Post("/{id}/versions/{versionId}/comments", versionCommentHandler.CreateComment)
 			// Delete is gated on secrets.manage (admin-only), matching the ACL delete pattern.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Delete("/{id}/versions/{versionId}/comments/{commentId}", versionCommentHandler.DeleteComment)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/risk", secretHandler.GetSecretRisk)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/shares", shareHandler.ListSecretShares)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/access", secretHandler.ListAccessors)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/access-log", secretHandler.AccessHistory)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/access-log/export", secretHandler.ExportAccessLog)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsManage, "id")).Delete("/{id}/versions/{versionId}/comments/{commentId}", versionCommentHandler.DeleteComment)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/risk", secretHandler.GetSecretRisk)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/shares", shareHandler.ListSecretShares)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/access", secretHandler.ListAccessors)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/access-log", secretHandler.AccessHistory)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/access-log/export", secretHandler.ExportAccessLog)
 			// Per-secret read statistics — lifetime total + recent-window summary.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/stats", secretHandler.GetSecretAccessStats)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/audit", secretHandler.AuditTrail)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/ownership-history", secretHandler.OwnershipHistory)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/tags", secretHandler.GetTags)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Put("/{id}/tags", secretHandler.SetTags)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/stats", secretHandler.GetSecretAccessStats)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/audit", secretHandler.AuditTrail)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/ownership-history", secretHandler.OwnershipHistory)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/tags", secretHandler.GetTags)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Put("/{id}/tags", secretHandler.SetTags)
 
 			// Secret dependency graph (ADR-052).
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/dependencies", secretHandler.ListSecretDependencies)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/dependencies", secretHandler.AddSecretDependency)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Delete("/{id}/dependencies/{depId}", secretHandler.RemoveSecretDependency)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/impact", secretHandler.GetSecretImpact)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/dependencies", secretHandler.ListSecretDependencies)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Post("/{id}/dependencies", secretHandler.AddSecretDependency)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Delete("/{id}/dependencies/{depId}", secretHandler.RemoveSecretDependency)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/impact", secretHandler.GetSecretImpact)
 			// Blast-radius report: richer impact view with OwnerID, ProjectID, and risk level.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/blast-radius", secretHandler.GetBlastRadius)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/blast-radius", secretHandler.GetBlastRadius)
 			// Secret read aggregation report: top readers of a secret over a time window.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Get("/{id}/read-summary", secretHandler.GetSecretReadSummary)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsManage, "id")).Get("/{id}/read-summary", secretHandler.GetSecretReadSummary)
 			// Impact preview: flat cascade-delete count/summary before committing a delete.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/impact-preview", secretHandler.GetSecretImpactPreview)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/impact-preview", secretHandler.GetSecretImpactPreview)
 
 			// Rotation state — per-policy execution state (idle/pending/rotating/succeeded/failed).
 			// Gated on secrets.read because it exposes metadata (when rotation last ran, any error)
 			// without disclosing the secret value.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/rotation-state", rotationPolicyHandler.GetRotationState)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/rotation-state", rotationPolicyHandler.GetRotationState)
 
 			// Per-secret ACLs (RBAC Phase 3): fine-grained user grants independent of project RBAC.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Get("/{id}/acl", secretHandler.ListSecretACLs)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Post("/{id}/acl", secretHandler.GrantSecretACL)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Delete("/{id}/acl/{aclId}", secretHandler.RevokeSecretACL)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsManage, "id")).Get("/{id}/acl", secretHandler.ListSecretACLs)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsManage, "id")).Post("/{id}/acl", secretHandler.GrantSecretACL)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsManage, "id")).Delete("/{id}/acl/{aclId}", secretHandler.RevokeSecretACL)
 
 			// Temporal access schedule: restrict a secret's reads to a time window.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Get(pathIDSchedule, secretHandler.GetSecretSchedule)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Put(pathIDSchedule, secretHandler.SetSecretSchedule)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Delete(pathIDSchedule, secretHandler.DeleteSecretSchedule)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsManage, "id")).Get(pathIDSchedule, secretHandler.GetSecretSchedule)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsManage, "id")).Put(pathIDSchedule, secretHandler.SetSecretSchedule)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsManage, "id")).Delete(pathIDSchedule, secretHandler.DeleteSecretSchedule)
 
 			// Per-secret retention policy override: allows operators to give a
 			// specific secret a longer (or shorter) retention window than the global
 			// data-retention policy (ADR-032). Gated by secrets.manage because it
 			// changes how long the secret persists after deletion — a privileged
 			// policy decision, not a routine write.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsManage, secretScope)).Patch("/{id}/retention", secretHandler.SetRetentionOverride)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsManage, "id")).Patch("/{id}/retention", secretHandler.SetRetentionOverride)
 
 			// Certificate inspection (ADR-054) — public X.509 metadata, no value/key.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Get("/{id}/certificate", secretHandler.GetSecretCertificate)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/certificate", secretHandler.GetSecretCertificate)
 
 			// Create: authorized inside the handler (scope comes from the body).
 			r.Post("/", secretHandler.CreateSecret)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Put("/{id}", secretHandler.UpdateSecret)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Patch("/{id}/classification", secretHandler.ClassifySecret)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Patch("/{id}/description", secretHandler.DescribeSecret)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Put("/{id}", secretHandler.UpdateSecret)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Patch("/{id}/classification", secretHandler.ClassifySecret)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Patch("/{id}/description", secretHandler.DescribeSecret)
 			// Copy into another environment: read the source ({id}); the handler also
 			// authorizes secrets.write at the target environment's scope.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Post("/{id}/copy", secretHandler.CopySecret)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Patch("/{id}/auto-rotate", secretHandler.SetAutoRotate)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/rotate", secretHandler.RotateSecret)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Post("/{id}/copy", secretHandler.CopySecret)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Patch("/{id}/auto-rotate", secretHandler.SetAutoRotate)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Post("/{id}/rotate", secretHandler.RotateSecret)
 			// Rotation dry-run / simulation (ADR-047): validates the rotation config without
 			// making any live change. Read-only — requires only secrets.read.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, secretScope)).Post("/{id}/rotation/simulate", secretHandler.SimulateRotation)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/rollback", secretHandler.RollbackSecret)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/transfer-ownership", secretHandler.TransferOwnership)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/move", secretHandler.MoveSecret)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/suspend", secretHandler.SuspendSecret)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/resume", secretHandler.ResumeSecret)
-			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, secretScope)).Post("/{id}/share", shareHandler.ShareSecret)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Post("/{id}/rotation/simulate", secretHandler.SimulateRotation)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Post("/{id}/rollback", secretHandler.RollbackSecret)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Post("/{id}/transfer-ownership", secretHandler.TransferOwnership)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Post("/{id}/move", secretHandler.MoveSecret)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Post("/{id}/suspend", secretHandler.SuspendSecret)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Post("/{id}/resume", secretHandler.ResumeSecret)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Post("/{id}/share", shareHandler.ShareSecret)
 			// Self-service: a recipient removes their OWN direct share. No scoped
 			// permission — the action is on the caller's own grant (core only removes a
 			// share whose RecipientID == the caller), so it needs just authentication.
 			r.Delete("/{id}/self-share", shareHandler.RemoveSelfFromShare)
 
-			r.With(customMiddleware.RequireScopedPermission(permSecretsDelete, secretScope)).Delete("/{id}", secretHandler.DeleteSecret)
+			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsDelete, "id")).Delete("/{id}", secretHandler.DeleteSecret)
 			// Restore resolves scope from the (soft-deleted) secret via the unscoped resolver.
 			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, customMiddleware.ScopeFromDeletedSecretParam("id"))).Post(pathIDRestore, secretHandler.RestoreSecret)
 		})

--- a/server/http/scoped_rbac_integration_test.go
+++ b/server/http/scoped_rbac_integration_test.go
@@ -252,7 +252,7 @@ func TestSecretACL_EndToEnd_PerSecretRoutes(t *testing.T) {
 	// Admin grants user 3 secrets.read AND secrets.write on secretWithACL only,
 	// through the real HTTP ACL endpoint (exercising the same grant path an
 	// operator would use).
-	grantBody := fmt.Sprintf(`{"user_id":3,"permissions":["secrets.read","secrets.write"]}`)
+	grantBody := `{"user_id":3,"permissions":["secrets.read","secrets.write"]}`
 	assert.Equal(t, http.StatusOK, do(t, "POST", fmt.Sprintf("/api/v1/secrets/%d/acl", secretWithACL), "admin-tok3", grantBody),
 		"admin grants the ACL")
 

--- a/server/http/scoped_rbac_integration_test.go
+++ b/server/http/scoped_rbac_integration_test.go
@@ -1,7 +1,9 @@
 package http
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -154,4 +156,119 @@ func TestScopedRBACEnforcement(t *testing.T) {
 	// Write is denied to viewer-A even in project A (delete a secret it can read).
 	assert.Equal(t, http.StatusForbidden, do(t, "DELETE", "/api/v1/secrets/1", "viewerA-tok"),
 		"viewer-A has no delete permission")
+}
+
+// setupACLOnlyRBACCore builds a core with one project/environment and TWO
+// secrets in it, plus an "acl-only" user (ID 3) who holds a project-membership
+// role that grants NO permissions at all (mirroring the membership-only
+// UserRole pattern internal/core/secret_acl_test.go's newACLCore uses to seed a
+// GrantSecretACL target: GrantSecretACL requires the grantee to already be a
+// project member, but that membership role need not itself confer secrets.read/
+// write). User 3's only possible path to secrets.read/write is therefore a
+// SecretACL grant. Sessions: "admin-tok3" -> user 1 (global admin, used to
+// perform the grant through the real HTTP ACL endpoint), "aclonly-tok" -> user 3.
+func setupACLOnlyRBACCore(t *testing.T) (cs *core.KeyorixCore, secretWithACL, secretWithoutACL uint) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{}, &models.User{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.SecretNode{}, &models.ShareRecord{}, &models.Session{},
+		&models.SecretACL{}, &models.AuditEvent{},
+		&models.SecretAccessSchedule{}, &models.Tag{}, &models.SecretTag{},
+	))
+
+	now := time.Now()
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "project-acl"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "prod"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, ProjectID: 1, EnvironmentID: 1, Name: "acl-granted-secret", OwnerID: 1, CreatedBy: "admin", Status: "active", IsSecret: true}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 2, ProjectID: 1, EnvironmentID: 1, Name: "no-acl-secret", OwnerID: 1, CreatedBy: "admin", Status: "active", IsSecret: true}).Error)
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "admin3@test.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 3, Username: "aclonly", Email: "aclonly@test.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)
+	// member-noperm: gives user 3 project membership (so GrantSecretACL's
+	// IsProjectMember precondition passes) WITHOUT granting any RBAC permission
+	// — no RolePermission row exists for this role. This is what proves the ACL
+	// grant, not a role, is what authorizes user 3 below.
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "member-noperm"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 2, ProjectID: 1}).Error)
+
+	seedSession(t, db, 1, "admin-tok3")
+	seedSession(t, db, 3, "aclonly-tok")
+
+	return core.NewKeyorixCore(store.NewLocalStorage(db)), 1, 2
+}
+
+// TestSecretACL_EndToEnd_PerSecretRoutes is the r140 regression test: it proves
+// that a per-secret SecretACL grant — documented since RBAC Phase 3 as usable
+// "without needing a project role at all" — actually authorizes the per-secret
+// GET/write HTTP routes, not just ListSecrets. Before this fix, AuthorizeSecret
+// (the ACL-aware check) had zero production callers: an ACL-only user was 403'd
+// on every per-secret route despite holding a valid grant.
+func TestSecretACL_EndToEnd_PerSecretRoutes(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cs, secretWithACL, secretWithoutACL := setupACLOnlyRBACCore(t)
+	router, err := NewRouter(&config.Config{}, cs)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	do := func(t *testing.T, method, path, token string, body string) int {
+		t.Helper()
+		var reqBody *bytes.Reader
+		if body != "" {
+			reqBody = bytes.NewReader([]byte(body))
+		} else {
+			reqBody = bytes.NewReader(nil)
+		}
+		req, err := http.NewRequest(method, server.URL+path, reqBody)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	// Sanity: before any grant, the ACL-only user (project member, zero-permission
+	// role) is denied read on BOTH secrets — proves the negative case (neither a
+	// qualifying role nor an ACL grant) still 403s, i.e. nothing was loosened.
+	assert.Equal(t, http.StatusForbidden, do(t, "GET", fmt.Sprintf("/api/v1/secrets/%d", secretWithACL), "aclonly-tok", ""),
+		"acl-only user must be denied before any grant exists")
+	assert.Equal(t, http.StatusForbidden, do(t, "GET", fmt.Sprintf("/api/v1/secrets/%d", secretWithoutACL), "aclonly-tok", ""),
+		"acl-only user must be denied on a secret it is never granted")
+
+	// Admin grants user 3 secrets.read AND secrets.write on secretWithACL only,
+	// through the real HTTP ACL endpoint (exercising the same grant path an
+	// operator would use).
+	grantBody := fmt.Sprintf(`{"user_id":3,"permissions":["secrets.read","secrets.write"]}`)
+	assert.Equal(t, http.StatusOK, do(t, "POST", fmt.Sprintf("/api/v1/secrets/%d/acl", secretWithACL), "admin-tok3", grantBody),
+		"admin grants the ACL")
+
+	// The ACL-only user can now GET the granted secret (middleware layer +
+	// GetSecretWithPermissionCheck's core.CheckSecretPermission both must honor
+	// the grant) ...
+	assert.Equal(t, http.StatusOK, do(t, "GET", fmt.Sprintf("/api/v1/secrets/%d", secretWithACL), "aclonly-tok", ""),
+		"acl-only user reads the secret it was granted, with no project role")
+	// ... and a write-tier route (tags) also succeeds, proving the grant covers
+	// secrets.write end to end through core.SetSecretTags -> EnforceSecretWritePermission.
+	assert.Equal(t, http.StatusOK, do(t, "PUT", fmt.Sprintf("/api/v1/secrets/%d/tags", secretWithACL), "aclonly-tok", `{"tags":["env:prod"]}`),
+		"acl-only user writes tags on the secret it was granted write on")
+
+	// The grant is scoped to exactly that one secret: the ACL-only user is still
+	// denied on the sibling secret in the SAME project that carries no grant —
+	// proves the fix is additive/per-secret, not an accidental project-wide loosening.
+	assert.Equal(t, http.StatusForbidden, do(t, "GET", fmt.Sprintf("/api/v1/secrets/%d", secretWithoutACL), "aclonly-tok", ""),
+		"acl-only user remains denied on a secret it was never granted")
 }

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -364,33 +364,101 @@ func RequireScopedPermission(permission string, resolve ScopeResolver) func(http
 }
 
 func handleScopedPermissionRequest(next http.Handler, w http.ResponseWriter, r *http.Request, permission string, resolve ScopeResolver) {
-	userCtx := GetUserFromContext(r.Context())
-	if userCtx == nil {
-		unauthorizedResponse(w, "User context not found")
-		return
-	}
-	cs := GetCoreServiceFromContext(r.Context())
-	if cs == nil {
-		forbiddenResponse(w, "Authorization unavailable")
+	userCtx, cs, ok := requireUserAndCore(w, r)
+	if !ok {
 		return
 	}
 	scope, err := resolve(r, cs)
 	if err != nil {
-		if errors.Is(err, errTargetNotFound) {
-			// Reveal "not found" only to callers who hold the permission
-			// globally; otherwise deny without confirming the resource
-			// exists (avoids existence enumeration by unprivileged users).
-			if ok, aerr := cs.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), permission, core.Scope{}); aerr == nil && ok {
-				notFoundResponse(w, "Resource not found")
-			} else {
-				forbiddenResponse(w, "Insufficient permissions")
-			}
-			return
-		}
-		badRequestResponse(w, "Invalid target")
+		handleScopeResolutionError(w, r, cs, userCtx, permission, err)
 		return
 	}
 	allowed, err := cs.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), permission, scope)
+	finishScopedPermissionRequest(next, w, r, cs, scope, allowed, err)
+}
+
+// RequireScopedSecretPermission is RequireScopedPermission specialized for the
+// per-secret routes (GET/PUT/PATCH/DELETE .../secrets/{id}[/...]): it resolves
+// scope from the secret named by idParam exactly like ScopeFromSecretParam (same
+// 400/404 behavior), but the final authorization check also consults per-secret
+// SecretACL grants (RBAC Phase 3) via core.AuthorizeSecretPrincipal — so a caller
+// who holds NO project-scope role but was explicitly granted the permission on
+// this one secret (or an ancestor folder, via HasSecretACL's inheritance walk) is
+// let through, closing the gap where SecretACL was honored by ListSecrets but
+// dead on arrival for every per-secret GET/write route. ACL grants remain
+// strictly additive: AuthorizeSecretPrincipal still falls back to the existing
+// role-based check, so a caller with neither a role nor a covering grant is
+// denied exactly as before. Machine/OIDC principals are unaffected — SecretACL
+// rows are user-scoped, so AuthorizeSecretPrincipal skips the ACL lookup for them
+// and takes the same role-based path as always.
+func RequireScopedSecretPermission(permission, idParam string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handleScopedSecretPermissionRequest(next, w, r, permission, idParam)
+		})
+	}
+}
+
+func handleScopedSecretPermissionRequest(next http.Handler, w http.ResponseWriter, r *http.Request, permission, idParam string) {
+	userCtx, cs, ok := requireUserAndCore(w, r)
+	if !ok {
+		return
+	}
+	secretID, err := scopePathUint(r, idParam)
+	if err != nil {
+		badRequestResponse(w, "Invalid target")
+		return
+	}
+	secret, err := cs.Storage().GetSecret(r.Context(), secretID)
+	if err != nil {
+		handleScopeResolutionError(w, r, cs, userCtx, permission, errTargetNotFound)
+		return
+	}
+	scope := core.Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
+	allowed, err := cs.AuthorizeSecretPrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), secretID, permission)
+	finishScopedPermissionRequest(next, w, r, cs, scope, allowed, err)
+}
+
+// requireUserAndCore fetches the authenticated user and core service from the
+// request context, writing the appropriate error response and returning
+// ok=false if either is missing. Shared by RequireScopedPermission and
+// RequireScopedSecretPermission.
+func requireUserAndCore(w http.ResponseWriter, r *http.Request) (*UserContext, *core.KeyorixCore, bool) {
+	userCtx := GetUserFromContext(r.Context())
+	if userCtx == nil {
+		unauthorizedResponse(w, "User context not found")
+		return nil, nil, false
+	}
+	cs := GetCoreServiceFromContext(r.Context())
+	if cs == nil {
+		forbiddenResponse(w, "Authorization unavailable")
+		return nil, nil, false
+	}
+	return userCtx, cs, true
+}
+
+// handleScopeResolutionError writes the response for a scope-resolution failure,
+// shared by RequireScopedPermission and RequireScopedSecretPermission. An
+// errTargetNotFound reveals "not found" only to callers who hold the permission
+// globally; otherwise it denies without confirming the resource exists (avoids
+// existence enumeration by unprivileged users). Any other error is treated as an
+// unparseable target (400).
+func handleScopeResolutionError(w http.ResponseWriter, r *http.Request, cs *core.KeyorixCore, userCtx *UserContext, permission string, err error) {
+	if errors.Is(err, errTargetNotFound) {
+		if ok, aerr := cs.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), permission, core.Scope{}); aerr == nil && ok {
+			notFoundResponse(w, "Resource not found")
+		} else {
+			forbiddenResponse(w, "Insufficient permissions")
+		}
+		return
+	}
+	badRequestResponse(w, "Invalid target")
+}
+
+// finishScopedPermissionRequest applies the authorize result and, on success,
+// the per-project MFA policy (ADR-037), before serving next. Shared by
+// RequireScopedPermission and RequireScopedSecretPermission.
+func finishScopedPermissionRequest(next http.Handler, w http.ResponseWriter, r *http.Request, cs *core.KeyorixCore, scope core.Scope, allowed bool, err error) {
 	if err != nil || !allowed {
 		forbiddenResponse(w, "Insufficient permissions")
 		return

--- a/server/middleware/auth_s23_test.go
+++ b/server/middleware/auth_s23_test.go
@@ -447,3 +447,166 @@ func TestScopeFromRotationPolicyParam_NotFound(t *testing.T) {
 	_, err := ScopeFromRotationPolicyParam("policyId")(req, cs)
 	assert.Error(t, err)
 }
+
+// --- RequireScopedSecretPermission / handleScopedSecretPermissionRequest coverage ---
+//
+// server/http/scoped_rbac_integration_test.go already proves this middleware
+// works correctly end to end over real HTTP, but that test lives in a
+// different package (server/http) and this repo's coverage run doesn't pass
+// -coverpkg=./... (see Makefile/ci.yml), so a cross-package call is never
+// attributed to server/middleware's own coverage. These unit tests exercise
+// the same branches directly, in-package, so they actually count.
+
+// newScopedSecretTestDB is newScopedTestDB plus the SecretACL table, needed
+// because handleScopedSecretPermissionRequest's authorization path
+// (AuthorizeSecretPrincipal -> AuthorizeSecret) unconditionally consults
+// SecretACL before falling back to RBAC.
+func newScopedSecretTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db := newScopedTestDB(t)
+	require.NoError(t, db.AutoMigrate(&models.SecretACL{}))
+	return db
+}
+
+// TestRequireScopedSecretPermission_WrapsHandler covers the middleware
+// constructor itself (RequireScopedSecretPermission), proving it builds a
+// working http.Handler chain that delegates to
+// handleScopedSecretPermissionRequest rather than testing that function
+// directly, as every other test in this section does.
+func TestRequireScopedSecretPermission_WrapsHandler(t *testing.T) {
+	db := newScopedSecretTestDB(t)
+	seedAdmin(t, db, 1)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 7, ProjectID: 1, EnvironmentID: 1, Name: "KEY"}).Error)
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	userCtx := &UserContext{UserID: 1, ActorType: core.ActorTypeUser}
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := RequireScopedSecretPermission("secrets.read", "id")(next)
+	req := makeRequest(t, http.MethodGet, "/secrets/7", map[string]string{"id": "7"}, userCtx, cs)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.True(t, nextCalled, "next handler must be called for an authorized admin")
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestHandleScopedSecretPermission_NoUserContext covers the requireUserAndCore
+// failure branch: no user in context must 401 without calling next.
+func TestHandleScopedSecretPermission_NoUserContext(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := makeRequest(t, http.MethodGet, "/secrets/7", map[string]string{"id": "7"}, nil, nil)
+	rec := httptest.NewRecorder()
+	handleScopedSecretPermissionRequest(next, rec, req, "secrets.read", "id")
+
+	assert.False(t, nextCalled, "next must not be called without a user context")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestHandleScopedSecretPermission_InvalidTarget covers scopePathUint's error
+// branch: a non-numeric id param must 400.
+func TestHandleScopedSecretPermission_InvalidTarget(t *testing.T) {
+	db := newScopedSecretTestDB(t)
+	seedAdmin(t, db, 1)
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	userCtx := &UserContext{UserID: 1, ActorType: core.ActorTypeUser}
+
+	req := makeRequest(t, http.MethodGet, "/secrets/xyz", map[string]string{"id": "xyz"}, userCtx, cs)
+	rec := httptest.NewRecorder()
+	handleScopedSecretPermissionRequest(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), rec, req, "secrets.read", "id")
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestHandleScopedSecretPermission_SecretNotFound covers the GetSecret error
+// branch: an id that resolves to no row must reach
+// handleScopeResolutionError's errTargetNotFound path (403, since this admin
+// test user actually holds the permission globally — the "reveal only to
+// privileged callers" case is already covered by
+// TestHandleScopedPermission_NotFoundWithPermission for the shared helper).
+func TestHandleScopedSecretPermission_SecretNotFound(t *testing.T) {
+	db := newScopedSecretTestDB(t)
+	seedAdmin(t, db, 1)
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	userCtx := &UserContext{UserID: 1, ActorType: core.ActorTypeUser}
+
+	req := makeRequest(t, http.MethodGet, "/secrets/999", map[string]string{"id": "999"}, userCtx, cs)
+	rec := httptest.NewRecorder()
+	handleScopedSecretPermissionRequest(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), rec, req, "secrets.read", "id")
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestHandleScopedSecretPermission_AllowedViaACL is the middleware-layer
+// counterpart to internal/core's TestAuthorizeSecretPrincipal_UserACLGrant and
+// server/http's TestSecretACL_EndToEnd_PerSecretRoutes: it proves a caller
+// with a per-secret SecretACL grant and NO project role reaches next()
+// through this exact function, covering the scope-construction and
+// AuthorizeSecretPrincipal call (lines specific to
+// handleScopedSecretPermissionRequest, not shared with
+// handleScopedPermissionRequest).
+func TestHandleScopedSecretPermission_AllowedViaACL(t *testing.T) {
+	db := newScopedSecretTestDB(t)
+	require.NoError(t, db.Create(&models.User{ID: 5, Username: "aclonly", AccountState: "active"}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 7, ProjectID: 1, EnvironmentID: 1, Name: "KEY", IsSecret: true, Status: "active"}).Error)
+	// GrantSecretACL requires the grantee to already be a project member.
+	// RoleID 999 is a placeholder — IsProjectMember only filters on
+	// user_id + project_id, not role_id (see internal/core/secret_acl_test.go's
+	// newACLCore, which uses the same pattern).
+	require.NoError(t, db.Create(&models.UserRole{UserID: 5, RoleID: 999, ProjectID: 1}).Error)
+
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	require.NoError(t, cs.GrantSecretACL(context.Background(), 1, 7, 5, []string{"secrets.read"}))
+
+	userCtx := &UserContext{UserID: 5, ActorType: core.ActorTypeUser}
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := makeRequest(t, http.MethodGet, "/secrets/7", map[string]string{"id": "7"}, userCtx, cs)
+	rec := httptest.NewRecorder()
+	handleScopedSecretPermissionRequest(next, rec, req, "secrets.read", "id")
+
+	assert.True(t, nextCalled, "an ACL-only grantee with no project role must reach next()")
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestHandleScopedSecretPermission_Denied covers the disallowed branch of
+// AuthorizeSecretPrincipal's result: a user with neither a role nor an ACL
+// grant on the secret must be forbidden.
+func TestHandleScopedSecretPermission_Denied(t *testing.T) {
+	db := newScopedSecretTestDB(t)
+	require.NoError(t, db.Create(&models.User{ID: 6, Username: "nobody", AccountState: "active"}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 7, ProjectID: 1, EnvironmentID: 1, Name: "KEY"}).Error)
+
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	userCtx := &UserContext{UserID: 6, ActorType: core.ActorTypeUser}
+
+	req := makeRequest(t, http.MethodGet, "/secrets/7", map[string]string{"id": "7"}, userCtx, cs)
+	rec := httptest.NewRecorder()
+	handleScopedSecretPermissionRequest(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), rec, req, "secrets.read", "id")
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}


### PR DESCRIPTION
## Summary

`SecretACL` grants (RBAC Phase 3) were honored by `ListSecrets` but dead on
arrival for every per-secret GET/write route. `AuthorizeSecret` — the
ACL-aware authorize function — had zero production callers despite
`internal/core/secret_acl.go`'s doc comment explicitly promising that
"a CI token can be granted secrets.read on exactly one secret without
needing a project role at all." A user granted a per-secret ACL was
403'd on `GET /secrets/{id}` and its ~15 sibling routes (versions,
dependencies, impact, blast-radius, shares, access, audit, tags, acl,
schedule, retention, certificate) — fails closed rather than open, but
defeats a shipped least-privilege primitive.

Per-secret routes turned out to be authorized **twice** — once by HTTP
middleware, once again inside several handlers — so two independent
gaps had to be closed:

- **`server/middleware/auth.go`**: add `RequireScopedSecretPermission`,
  a secret-ID-aware sibling of `RequireScopedPermission` that resolves
  the secret and calls the new `core.AuthorizeSecretPrincipal` instead
  of `AuthorizePrincipal`. `router.go` now wires all ~30
  `secretScope`-gated routes under `/secrets/{id}/...` through it (the
  ACL grant/revoke routes are unaffected in practice, since `SecretACL`
  never grants `secrets.manage`). The shared not-found-leak-avoidance
  and per-project MFA logic was factored out of
  `handleScopedPermissionRequest` so both middleware entrypoints stay
  byte-for-byte identical outside the ACL check itself.

- **`internal/core/authz.go`**: add `AuthorizeSecretPrincipal`, the
  actor-aware counterpart to the existing `AuthorizeSecret`. A
  machine/OIDC principal always takes the pre-existing role-based path
  unchanged — `SecretACL` rows are user-scoped, and a machine
  identity's principal ID lives in a disjoint ID space from `User`, so
  treating it as a userID for the ACL lookup could accidentally match
  an unrelated human's grant by numeric coincidence.

- **`internal/core/permissions.go`**: `CheckSecretPermission` — the
  second-layer check that `GetSecretWithPermissionCheck`,
  `SetSecretTags`, and many other handler-called `Enforce*Permission`
  wrappers funnel through — now also consults `HasSecretACL`,
  additively, alongside its existing owner/share/RBAC checks (mirroring
  the `#r124` RBAC-fallback pattern already in this function). Without
  this, the middleware fix alone was insufficient: `GetSecret`'s
  handler re-checks permission via `GetSecretWithPermissionCheck`,
  which has its own independent authorization path that never knew
  about ACLs.

ACL grants remain strictly additive in both layers, per the existing
design doc: a caller with neither a qualifying role nor a covering ACL
grant is still denied exactly as before.

## Test plan

- [x] `internal/core`: `TestAuthorizeSecretPrincipal_UserACLGrant`,
      `TestAuthorizeSecretPrincipal_MachineSkipsACL` (proves a machine
      identity never inherits a same-numbered user's ACL grant)
- [x] `server/http`: `TestSecretACL_EndToEnd_PerSecretRoutes` — full
      HTTP-router regression test: grants `secrets.read`+`secrets.write`
      via ACL to a user whose only project-membership role confers zero
      permissions, then asserts `GET /secrets/{id}` and
      `PUT /secrets/{id}/tags` succeed with no project role, a sibling
      secret with no grant stays 403, and the pre-grant state is 403 on
      both secrets (proves nothing was loosened)
- [x] Updated ~9 pre-existing `MockStorage`-based permission tests
      (`TestCheckSecretPermission_Denied` and siblings across
      `core_s26/s28/s29_test.go`, `permission_enforcement_test.go`,
      `secret_ownership_history_test.go`) to mock the new
      `GetSecretACL`/`GetSecretAncestors` calls `CheckSecretPermission`
      now makes on its deny path
- [x] `go test ./internal/core/...` — pass
- [x] `go test ./server/...` — pass (all 10 packages)
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues