### PR TITLE
docs: qualify air-gapped claim for OIDC federation Shape A/Shape B

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,17 @@ On-premise. Air-gapped ready. Single binary. No Vault admin required.
 | | Vault | Doppler | Keyorix |
 |---|---|---|---|
 | On-premise | Yes | No | **Yes** |
-| Air-gapped | Yes | No | **Yes** |
+| Air-gapped¹ | Yes | No | **Yes** |
 | Simple ops | No | Yes | **Yes** |
 | EU company | No | No | **Yes** |
 | Open source | BSL | No | **AGPL** |
 | Single binary | Yes | N/A | **Yes** |
+
+¹ The core product needs no internet access. Optional integrations that delegate to
+an external identity provider — OIDC machine-identity federation, SSO login — need
+network reachability to that provider (which can itself live entirely inside a
+private network with no internet egress). See [Configuration](docs/CONFIGURATION.md#oidc)
+for what's required.
 
 Vault is powerful but requires a dedicated admin. Doppler is simple but SaaS-only. Keyorix is both simple and runs entirely in your infrastructure.
 
@@ -160,7 +166,10 @@ Single binary. HTTP REST API on port 8080. Web UI on port 3000.
 
 SQLite for development and small teams. PostgreSQL for production.
 
-Air-gapped deployment: copy the binary and run. No internet required.
+Air-gapped deployment: copy the binary and run. No internet required. (Optional
+features that delegate to an external identity provider — OIDC federation, SSO
+login — need network reachability to that provider; see
+[Configuration](docs/CONFIGURATION.md#oidc).)
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -468,6 +468,20 @@ Machine-identity federation: trust external OIDC issuers (e.g. Kubernetes
 projected service-account tokens) and map verified JWTs to machine identities
 (ADR-031). Disabled = OIDC auth off.
 
+**Network reachability, for air-gapped deployments.** Every configuration
+below verifies tokens by fetching `jwks_uri` live from the issuer — this
+requires an identity provider that's reachable from wherever Keyorix runs,
+even if that reachability stays entirely inside a private network with no
+internet egress ("**Shape A**": an enclave with a reachable internal IdP —
+Keycloak, ADFS, Entra ID on-prem/hybrid, or an in-cluster Kubernetes issuer;
+see ADR-075). This is the deployment this section documents, and it's what
+"air-gapped" means for OIDC federation today. A stricter, genuinely
+disconnected deployment with **no** identity provider reachable at all
+("**Shape B**") — the bar a strict zero-network-calls interpretation of
+air-gapped would require — is not yet supported for OIDC federation; if
+that's your requirement, use ADR-030 opaque machine tokens or ADR-027 PATs
+instead, neither of which calls out to any external service.
+
 ```yaml
 oidc:
   enabled: true
@@ -999,6 +1013,13 @@ and maps the identity to a Keyorix user — by the IdP subject (matched against 
 `externalId`) first, then by email. By default there is **no auto-provisioning**: the
 account must already exist (provision it via SCIM or invite). A suspended user is
 refused.
+
+Same network-reachability caveat as [`oidc`](#oidc) above: SSO login needs live
+discovery + JWKS reachability to the IdP on every login, so it needs a reachable
+identity provider (Shape A) — a fully disconnected deployment with no IdP at all
+(Shape B) isn't supported for SSO login either. A provider whose discovery fails
+doesn't take the whole server down (see below), but login via that provider won't
+work until the IdP is reachable again.
 
 ```yaml
 sso:


### PR DESCRIPTION
## Summary
- README's "no internet required" / "Air-gapped: Yes" claims are accurate for the core product but don't qualify which optional features they cover. OIDC machine-identity federation and SSO login both verify tokens by fetching JWKS/discovery documents live from the issuer — they need a reachable identity provider, even one confined entirely to a private network with no internet egress (ADR-075's "Shape A"). A genuinely disconnected deployment with no reachable IdP at all ("Shape B") isn't supported for either feature yet.
- Adds a footnote to README's comparison table and a qualifier next to the "no internet required" line, both pointing to `docs/CONFIGURATION.md`.
- Adds the Shape A/Shape B distinction to `CONFIGURATION.md`'s `oidc` and `sso` sections (where the config actually lives), naming which shape today's config supports and which it doesn't — so a strict zero-network-calls buyer isn't misled by omission — and pointing to ADR-030 opaque machine tokens / ADR-027 PATs as the actual zero-network-call alternative for that requirement.
- Checked existing air-gap sales/compliance collateral (`docs/compliance/*.md`, `SECURITY.md`, `SUPPORT.md`): none currently pairs an air-gap claim with OIDC federation specifically, so none needed the same qualification.

Closes #1325

## Test plan
- [x] Docs-only change; no code paths affected
- [x] Verified no markdown-link-check or markdownlint CI gate exists that would need re-running
- [x] Read the full diff for accuracy against ADR-075's actual (Proposed-status) design — confirmed `jwks_file`/Shape-B static config doesn't exist in `internal/config` yet, so the new text describes only currently-shipped behavior, not unshipped config fields