### PR TITLE
fix(operator): wipeTargetSecret ownership check + prune unused finalizers RBAC (r143)

### DIFF
--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -1,4 +1,3 @@
----
 # NOTE (#327/#427): this is a ClusterRole/ClusterRoleBinding, not a namespaced Role, because
 # by DEFAULT the operator is deployed as a single cluster-wide instance that watches
 # KeyorixSecret CRs (a namespaced CRD) across every namespace -- with no static namespace
@@ -26,6 +25,12 @@
 # secretCacheOptions in operator/cmd/main.go), so a compromised operator process can't
 # trivially dump every cluster Secret straight out of its own in-memory cache -- only ones
 # it already owns via this same RBAC.
+#
+# No RBAC is granted for keyorixsecrets/finalizers: this controller has no finalizer logic
+# (garbage collection of the target Secret relies solely on the Kubernetes owner-reference
+# GC, not a finalizer), so the marker previously here was unused, excess RBAC -- pruned for
+# least privilege.
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -51,12 +56,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - secrets.keyorix.io
-  resources:
-  - keyorixsecrets/finalizers
-  verbs:
-  - update
 - apiGroups:
   - secrets.keyorix.io
   resources:

--- a/operator/internal/controller/keyorixsecret_controller.go
+++ b/operator/internal/controller/keyorixsecret_controller.go
@@ -122,7 +122,6 @@ type valueFetcher interface {
 
 // +kubebuilder:rbac:groups=secrets.keyorix.io,resources=keyorixsecrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=secrets.keyorix.io,resources=keyorixsecrets/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=secrets.keyorix.io,resources=keyorixsecrets/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reads the referenced Keyorix values and writes them into the target Secret.
@@ -328,10 +327,20 @@ func (r *KeyorixSecretReconciler) failGone(ctx context.Context, ks *secretsv1alp
 
 // wipeTargetSecret deletes the target Secret when the upstream Keyorix reference has
 // been confirmed gone (404/403 — see the ErrSecretGone handling in Reconcile). Only a
-// Secret this operator actually manages (carries ManagedByLabel) is ever touched:
-// applySecret already refuses to adopt a pre-existing unmanaged Secret sharing the
-// target name, so wiping it here too would risk deleting an unrelated workload's own
-// Secret that merely happens to collide on name. A missing target Secret is a no-op.
+// Secret this operator actually manages AND that THIS CR controls is ever touched. Two
+// checks, mirroring applySecret's write-side rigor:
+//   - ManagedByLabel: applySecret already refuses to adopt a pre-existing unmanaged
+//     Secret sharing the target name, so wiping an unlabeled Secret here too would risk
+//     deleting an unrelated workload's own Secret that merely happens to collide on name.
+//   - metav1.IsControlledBy(&secret, ks): ks.Spec.Target.Name is attacker-controlled —
+//     it comes straight from the caller's OWN CR spec. Without this check, an attacker
+//     with only ordinary namespaced KeyorixSecret-create RBAC could set spec.target.name
+//     to the name of a Secret already owned by a DIFFERENT, victim CR and spec.data[0].ref
+//     to any nonexistent Keyorix ref: their reconcile would hit ErrSecretGone and delete
+//     the victim's Secret on every reconcile, despite never owning it — a sustained,
+//     cross-tenant availability attack. Checking ownership, not just the shared label,
+//     closes it: only the CR that actually owns the Secret (via SetControllerReference in
+//     applySecret) may wipe it. A missing target Secret is a no-op.
 func (r *KeyorixSecretReconciler) wipeTargetSecret(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, name string) error {
 	var secret corev1.Secret
 	key := types.NamespacedName{Namespace: ks.Namespace, Name: name}
@@ -339,6 +348,9 @@ func (r *KeyorixSecretReconciler) wipeTargetSecret(ctx context.Context, ks *secr
 		return client.IgnoreNotFound(err)
 	}
 	if secret.Labels[ManagedByLabel] != ManagedByValue {
+		return nil
+	}
+	if !metav1.IsControlledBy(&secret, ks) {
 		return nil
 	}
 	return client.IgnoreNotFound(r.Delete(ctx, &secret))

--- a/operator/internal/controller/keyorixsecret_controller_test.go
+++ b/operator/internal/controller/keyorixsecret_controller_test.go
@@ -314,6 +314,53 @@ func TestReconcile_UpstreamGoneDoesNotDeleteUnmanagedSecret(t *testing.T) {
 	assert.Equal(t, []byte("do-not-touch"), got.Data["OTHER"])
 }
 
+// TestReconcile_UpstreamGoneDoesNotDeleteSecretOwnedByAnotherCR pins the cross-tenant
+// delete confused-deputy fixed alongside #428's wipe feature: ks.Spec.Target.Name is
+// taken directly from the reconciling CR's OWN spec, fully attacker-controlled. Before
+// this fix, wipeTargetSecret only checked the SHARED ManagedByLabel before deleting —
+// which every Secret this operator manages carries, regardless of which CR owns it. An
+// attacker with only ordinary namespaced KeyorixSecret-create RBAC could set their own
+// CR's spec.target.name to the name of a Secret already owned by a DIFFERENT, victim
+// CR, and point spec.data[0].ref at any nonexistent Keyorix ref: their reconcile would
+// hit ErrSecretGone and delete the victim's Secret — despite never owning it — on every
+// requeue, a sustained cross-tenant availability attack. This mirrors
+// TestReconcile_RefusesToAdoptSecretOwnedByAnotherCR (the write-side sibling) but for
+// the delete path: the fix adds metav1.IsControlledBy(&secret, ks) alongside the
+// existing label check.
+func TestReconcile_UpstreamGoneDoesNotDeleteSecretOwnedByAnotherCR(t *testing.T) {
+	victim := &secretsv1alpha1.KeyorixSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "victim-cr", Namespace: "app", UID: "victim-uid"},
+	}
+	owned := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "db-creds",
+			Namespace: "app",
+			Labels:    map[string]string{ManagedByLabel: ManagedByValue},
+		},
+		Data: map[string][]byte{"OTHER": []byte("owned-by-victim-cr")},
+	}
+	// Give `owned` a real controller owner reference to `victim`, mirroring what a prior
+	// reconcile of the victim CR would have set via applySecret.
+	s := testScheme(t)
+	require.NoError(t, controllerutil.SetControllerReference(victim, owned, s))
+
+	// The attacker's own CR ("db", from ksFixture) targets the SAME Secret name, and its
+	// own upstream ref is confirmed gone — driving Reconcile into the wipe path.
+	fetcher := &fakeFetcher{goneRefs: map[string]bool{"app/production/db-password": true}}
+	r, c := newReconciler(t, fetcher, ksFixture(), tokenSecret(), owned)
+
+	_, err := reconcile(t, r)
+	require.Error(t, err, "a confirmed-gone upstream ref still requeues with error for backoff")
+	assert.True(t, errors.Is(err, keyorix.ErrSecretGone))
+
+	var got corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got),
+		"a Secret controlled by a DIFFERENT CR must not be deleted just because the shared managed-by label matches")
+	assert.Equal(t, []byte("owned-by-victim-cr"), got.Data["OTHER"], "the victim CR's Secret data must be untouched")
+	require.Len(t, got.OwnerReferences, 1)
+	assert.Equal(t, "victim-cr", got.OwnerReferences[0].Name, "ownership must not have moved or been disturbed")
+}
+
 // TestReconcile_TokenSecretReadUsesAPIReader pins #124: the token Secret lookup
 // must go through the uncached APIReader (when set), not the shared/cached
 // Client — the shared cache is scoped to only Secrets this operator manages, so


### PR DESCRIPTION
## Summary

- **Confirmed cross-tenant deletion vulnerability**: `wipeTargetSecret` (`operator/internal/controller/keyorixsecret_controller.go:335`) deleted a target `corev1.Secret` after checking only the shared `ManagedByLabel` — it never checked `metav1.IsControlledBy(&secret, ks)`. The sibling write path, `applySecret` (`keyorixsecret_controller.go:253`), gets this right and refuses to adopt a Secret already owned by a different CR (proven by the existing `TestReconcile_RefusesToAdoptSecretOwnedByAnotherCR`).
- **Exploit path**: `secretName := ks.Spec.Target.Name` (`Reconcile`, `keyorixsecret_controller.go:146`) comes straight from the reconciling CR's own spec — fully attacker-controlled. An attacker with only ordinary namespaced `KeyorixSecret`-create RBAC could set their own CR's `spec.target.name` to the name of a Secret already owned by a **different, victim CR**, and point `spec.data[0].ref` at any nonexistent Keyorix ref. Their reconcile then hits the `ErrSecretGone` branch (`keyorixsecret_controller.go:154`) and calls `wipeTargetSecret` with the attacker-chosen name, deleting the victim's Secret despite never owning it. Because the attacker's own ref stays gone forever, this repeats on every reconcile requeue — a sustained, attacker-controlled, cross-tenant deletion/availability attack.
- **Fix**: add `metav1.IsControlledBy(&secret, ks)` alongside the existing label check in `wipeTargetSecret`, mirroring `applySecret`'s ownership rigor.
- **Bundled LOW cleanup**: pruned the unused `+kubebuilder:rbac:groups=secrets.keyorix.io,resources=keyorixsecrets/finalizers,verbs=update` marker — a grep across the whole `operator/` module found zero finalizer logic anywhere. Regenerated `config/rbac/role.yaml` via `make manifests` (controller-gen) and restored the hand-written ClusterRole documentation comment (controller-gen doesn't preserve custom headers), adding a note explaining why finalizers RBAC isn't granted.

## Regression test

`TestReconcile_UpstreamGoneDoesNotDeleteSecretOwnedByAnotherCR` (`operator/internal/controller/keyorixsecret_controller_test.go`) mirrors `TestReconcile_RefusesToAdoptSecretOwnedByAnotherCR` (the write-side sibling) but for the delete path: a Secret owned by a victim CR (real owner reference + `ManagedByLabel`) must survive an attacker CR's wipe attempt when the attacker's own upstream ref goes gone. Verified by temporarily reverting the `IsControlledBy` check — the test fails (`secrets "db-creds" not found`), confirming it actually catches the vulnerability; it passes with the fix restored. The existing positive case (`TestReconcile_UpstreamGoneWipesTargetSecret` — a CR correctly wiping its own target Secret) still passes unmodified.

## Test plan

- [x] `cd operator && GOWORK=off go build ./...`
- [x] `GOWORK=off go test ./... -count=1`
- [x] `GOWORK=off go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `GOWORK=off gosec -severity medium -exclude-generated ./...` (0 issues)
- [x] Regression test manually verified to fail against the unfixed code and pass against the fix