### PR TITLE
fix(operator): bound reconcile fan-out — MaxItems cap + concurrency limit + reconcile deadline (r143)

### DIFF
--- a/deploy/helm/keyorix-operator/crds/secrets.keyorix.io_keyorixsecrets.yaml
+++ b/deploy/helm/keyorix-operator/crds/secrets.keyorix.io_keyorixsecrets.yaml
@@ -55,15 +55,31 @@ spec:
               where.
             properties:
               data:
-                description: Data lists the Keyorix references to materialise into
-                  the target Secret.
+                description: |-
+                  Data lists the Keyorix references to materialise into the target Secret.
+                  MaxItems bounds per-reconcile fan-out (r143): buildDesired fetches every entry
+                  sequentially over HTTP (internal/keyorix.Client, 30s timeout per call) while
+                  SetupWithManager runs reconciles on a small, fixed worker pool shared across every
+                  namespace in the cluster — an unbounded array from any single, least-privileged,
+                  CR-create-capable tenant could otherwise stall a shared worker for an unbounded
+                  time, starving reconciliation of every other tenant's KeyorixSecret. 50 mirrors
+                  this codebase's existing bulk-operation cap (maxEnvNamesPerCreate in
+                  internal/core/catalog.go) — comfortably enough keys for one Kubernetes Secret
+                  (which itself caps out around 1MiB total) while keeping worst-case per-reconcile
+                  fan-out in the tens, not thousands.
                 items:
                   description: KeyorixSecretData maps one Keyorix secret reference
                     to a key in the target Secret.
                   properties:
                     ref:
-                      description: Ref is the Keyorix "project/environment/name" reference
-                        to read (ADR-059).
+                      description: |-
+                        Ref is the Keyorix "project/environment/name" reference to read (ADR-059).
+                        Bounded well above any realistic project/environment/name combination (the main
+                        module caps individual project/environment names at 200 chars each — see
+                        maxProjectNameLen/maxEnvironmentNameLen in internal/core/catalog.go) but far below
+                        unbounded, so a CR author can't inflate a single reconcile's request/response size
+                        with an arbitrarily long string (r143).
+                      maxLength: 512
                       type: string
                     secretKey:
                       description: |-
@@ -75,6 +91,7 @@ spec:
                   - ref
                   - secretKey
                   type: object
+                maxItems: 50
                 minItems: 1
                 type: array
               refreshInterval:

--- a/operator/api/v1alpha1/keyorixsecret_types.go
+++ b/operator/api/v1alpha1/keyorixsecret_types.go
@@ -22,6 +22,12 @@ type KeyorixSecretData struct {
 	// +kubebuilder:validation:Pattern=`^[-._a-zA-Z0-9]+$`
 	SecretKey string `json:"secretKey"`
 	// Ref is the Keyorix "project/environment/name" reference to read (ADR-059).
+	// Bounded well above any realistic project/environment/name combination (the main
+	// module caps individual project/environment names at 200 chars each — see
+	// maxProjectNameLen/maxEnvironmentNameLen in internal/core/catalog.go) but far below
+	// unbounded, so a CR author can't inflate a single reconcile's request/response size
+	// with an arbitrarily long string (r143).
+	// +kubebuilder:validation:MaxLength=512
 	Ref string `json:"ref"`
 }
 
@@ -62,7 +68,18 @@ type KeyorixSecretSpec struct {
 	// +optional
 	Target KeyorixSecretTarget `json:"target,omitempty"`
 	// Data lists the Keyorix references to materialise into the target Secret.
+	// MaxItems bounds per-reconcile fan-out (r143): buildDesired fetches every entry
+	// sequentially over HTTP (internal/keyorix.Client, 30s timeout per call) while
+	// SetupWithManager runs reconciles on a small, fixed worker pool shared across every
+	// namespace in the cluster — an unbounded array from any single, least-privileged,
+	// CR-create-capable tenant could otherwise stall a shared worker for an unbounded
+	// time, starving reconciliation of every other tenant's KeyorixSecret. 50 mirrors
+	// this codebase's existing bulk-operation cap (maxEnvNamesPerCreate in
+	// internal/core/catalog.go) — comfortably enough keys for one Kubernetes Secret
+	// (which itself caps out around 1MiB total) while keeping worst-case per-reconcile
+	// fan-out in the tens, not thousands.
 	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=50
 	Data []KeyorixSecretData `json:"data"`
 }
 

--- a/operator/api/v1alpha1/keyorixsecret_types_test.go
+++ b/operator/api/v1alpha1/keyorixsecret_types_test.go
@@ -1,0 +1,100 @@
+package v1alpha1
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+// crdSchema is a narrow projection of just the pieces of the generated CRD's
+// openAPIV3Schema this test cares about.
+type crdSchema struct {
+	Spec struct {
+		Versions []struct {
+			Name   string `json:"name"`
+			Schema struct {
+				OpenAPIV3Schema struct {
+					Properties struct {
+						Spec struct {
+							Properties struct {
+								Data struct {
+									MaxItems int `json:"maxItems"`
+									MinItems int `json:"minItems"`
+									Items    struct {
+										Properties struct {
+											Ref struct {
+												MaxLength int `json:"maxLength"`
+											} `json:"ref"`
+										} `json:"properties"`
+									} `json:"items"`
+								} `json:"data"`
+							} `json:"properties"`
+						} `json:"spec"`
+					} `json:"properties"`
+				} `json:"openAPIV3Schema"`
+			} `json:"schema"`
+		} `json:"versions"`
+	} `json:"spec"`
+}
+
+// The kubebuilder validation markers on KeyorixSecretSpec.Data and KeyorixSecretData.Ref
+// (r143) are enforced by the Kubernetes API server against the GENERATED CRD manifest, not
+// against the Go struct tags directly — a CR create/update request never goes through this
+// Go type's markers at runtime, only through whatever schema `make manifests`
+// (controller-gen) baked into config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml. This
+// module has no envtest wired up (see operator/Makefile: "Run unit/controller tests (fake
+// client; no envtest required)"), so a fake-client reconciler test can't exercise real
+// admission validation. This test instead asserts the actual artifact the API server would
+// load, catching both (a) a marker value regressing and (b) someone editing the Go type
+// without regenerating the CRD (a stale/missing maxItems here would silently reopen the
+// unbounded-fan-out DoS this cap exists to close).
+func TestGeneratedCRD_DataMaxItemsAndRefMaxLength(t *testing.T) {
+	raw, err := os.ReadFile("../../config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml")
+	require.NoError(t, err, "generated CRD manifest must exist — run `make manifests` in operator/")
+
+	var doc crdSchema
+	require.NoError(t, yaml.Unmarshal(raw, &doc))
+
+	var found bool
+	for _, v := range doc.Spec.Versions {
+		if v.Name != "v1alpha1" {
+			continue
+		}
+		found = true
+		data := v.Schema.OpenAPIV3Schema.Properties.Spec.Properties.Data
+		assert.Equal(t, 50, data.MaxItems,
+			"spec.data must stay bounded (r143): an unbounded array lets a single tenant's "+
+				"KeyorixSecret stall the reconciler's (small, shared) worker pool for an "+
+				"unbounded time, starving every other tenant's reconciliation")
+		assert.Equal(t, 1, data.MinItems, "spec.data must still require at least one entry")
+		assert.Equal(t, 512, data.Items.Properties.Ref.MaxLength,
+			"spec.data[].ref must stay bounded (r143) so a single entry can't inflate "+
+				"request/response size arbitrarily")
+	}
+	require.True(t, found, "CRD manifest must define the v1alpha1 version")
+}
+
+// A regenerated CRD (operator/config/crd/bases) that isn't also copied into the Helm
+// chart (deploy/helm/keyorix-operator/crds, per the `manifests` Makefile target's final
+// `cp` step) means a Helm-deployed operator would enforce a DIFFERENT, stale schema than
+// the one actually generated from the Go types — silently reopening whatever gap the
+// latest markers were meant to close. Skips (rather than fails) if the sibling repo layout
+// isn't present, since this module can in principle be built standalone.
+func TestHelmChartCRD_MatchesGeneratedCRD(t *testing.T) {
+	generated, err := os.ReadFile("../../config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml")
+	require.NoError(t, err)
+
+	chartPath := "../../../deploy/helm/keyorix-operator/crds/secrets.keyorix.io_keyorixsecrets.yaml"
+	chart, err := os.ReadFile(chartPath)
+	if os.IsNotExist(err) {
+		t.Skip("deploy/helm/keyorix-operator not present in this checkout; skipping cross-module drift check")
+	}
+	require.NoError(t, err)
+
+	assert.Equal(t, string(generated), string(chart),
+		"deploy/helm/keyorix-operator/crds must be an exact copy of operator/config/crd/bases "+
+			"(re-run `make manifests` in operator/, which syncs both)")
+}

--- a/operator/config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml
+++ b/operator/config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml
@@ -55,15 +55,31 @@ spec:
               where.
             properties:
               data:
-                description: Data lists the Keyorix references to materialise into
-                  the target Secret.
+                description: |-
+                  Data lists the Keyorix references to materialise into the target Secret.
+                  MaxItems bounds per-reconcile fan-out (r143): buildDesired fetches every entry
+                  sequentially over HTTP (internal/keyorix.Client, 30s timeout per call) while
+                  SetupWithManager runs reconciles on a small, fixed worker pool shared across every
+                  namespace in the cluster — an unbounded array from any single, least-privileged,
+                  CR-create-capable tenant could otherwise stall a shared worker for an unbounded
+                  time, starving reconciliation of every other tenant's KeyorixSecret. 50 mirrors
+                  this codebase's existing bulk-operation cap (maxEnvNamesPerCreate in
+                  internal/core/catalog.go) — comfortably enough keys for one Kubernetes Secret
+                  (which itself caps out around 1MiB total) while keeping worst-case per-reconcile
+                  fan-out in the tens, not thousands.
                 items:
                   description: KeyorixSecretData maps one Keyorix secret reference
                     to a key in the target Secret.
                   properties:
                     ref:
-                      description: Ref is the Keyorix "project/environment/name" reference
-                        to read (ADR-059).
+                      description: |-
+                        Ref is the Keyorix "project/environment/name" reference to read (ADR-059).
+                        Bounded well above any realistic project/environment/name combination (the main
+                        module caps individual project/environment names at 200 chars each — see
+                        maxProjectNameLen/maxEnvironmentNameLen in internal/core/catalog.go) but far below
+                        unbounded, so a CR author can't inflate a single reconcile's request/response size
+                        with an arbitrarily long string (r143).
+                      maxLength: 512
                       type: string
                     secretKey:
                       description: |-
@@ -75,6 +91,7 @@ spec:
                   - ref
                   - secretKey
                   type: object
+                maxItems: 50
                 minItems: 1
                 type: array
               refreshInterval:

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -8,6 +8,7 @@ require (
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -61,5 +62,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/operator/internal/controller/keyorixsecret_controller.go
+++ b/operator/internal/controller/keyorixsecret_controller.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -40,6 +41,28 @@ const (
 	// cluster.
 	minRefreshInterval = 30 * time.Second
 	conditionReady     = "Ready"
+	// maxConcurrentReconciles bounds how many KeyorixSecret reconciles run in parallel
+	// (r143). ctrl.NewControllerManagedBy defaults to exactly 1 with no override — the
+	// operator is deployed as a single cluster-wide instance (see cmd/main.go), so that
+	// default means ONE shared worker services every KeyorixSecret in every namespace: a
+	// single slow or malicious reconcile (a large Data array, or an entry pointed at an
+	// allow-listed-but-slow server) stalls the sole worker and starves reconciliation of
+	// every other tenant's KeyorixSecret cluster-wide. A small, fixed pool bounds how much
+	// one bad reconcile can crowd out — kept low (rather than "unbounded") because higher
+	// concurrency multiplies simultaneous outbound calls to the (trusted, but still
+	// external) Keyorix server and simultaneous token-Secret reads; nothing else in this
+	// module exposes reconciler tuning via a flag (cf. minRefreshInterval above), so this
+	// follows the same fixed-constant convention rather than adding a new --flag.
+	maxConcurrentReconciles = 5
+	// reconcileTimeout bounds the total wall-clock time a single Reconcile call may run,
+	// as defense in depth alongside KeyorixSecretSpec.Data's MaxItems=50 cap (r143):
+	// buildDesired fetches every Data entry sequentially, each over HTTP with its own 30s
+	// timeout (internal/keyorix.Client), so even a MaxItems-bounded array of entries that
+	// are each slow-but-within-timeout could otherwise occupy a worker for up to
+	// 50*30s=25m. 5 minutes is comfortably above any realistic sync (fetches normally
+	// complete in well under a second each) while capping the worst case to a fraction of
+	// that 25-minute ceiling.
+	reconcileTimeout = 5 * time.Minute
 )
 
 // KeyorixSecretReconciler reconciles KeyorixSecret objects.
@@ -127,6 +150,13 @@ type valueFetcher interface {
 
 // Reconcile reads the referenced Keyorix values and writes them into the target Secret.
 func (r *KeyorixSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Bound total reconcile time (r143): defense in depth alongside spec.data's MaxItems
+	// cap, so a pathological case (many entries, each near its individual 30s HTTP
+	// timeout) still can't monopolize this reconciler's limited worker pool
+	// (maxConcurrentReconciles) indefinitely.
+	ctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
+	defer cancel()
+
 	logger := log.FromContext(ctx)
 
 	var ks secretsv1alpha1.KeyorixSecret
@@ -373,10 +403,23 @@ func (r *KeyorixSecretReconciler) setReady(ks *secretsv1alpha1.KeyorixSecret, st
 // on changes to them, while arbitrary other namespace Secrets (including every token
 // Secret CR authors reference) are never pulled into the operator's memory.
 func (r *KeyorixSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	_, err := r.setupController(mgr)
+	return err
+}
+
+// setupController is the guts of SetupWithManager, split out so a test can inspect the
+// built controller.Controller (e.g. its MaxConcurrentReconciles) without needing to
+// duplicate this exact builder chain — SetupWithManager itself just discards the
+// returned controller, matching what builder.Builder.Complete does internally.
+func (r *KeyorixSecretReconciler) setupController(mgr ctrl.Manager) (controller.Controller, error) {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&secretsv1alpha1.KeyorixSecret{}).
 		Owns(&corev1.Secret{}).
-		Complete(r)
+		// See maxConcurrentReconciles (r143): without this, controller-runtime's default
+		// of exactly 1 concurrent reconcile means a single shared worker services every
+		// KeyorixSecret in every namespace cluster-wide.
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
+		Build(r)
 }
 
 // hashData fingerprints the desired data deterministically (sorted keys) so an

--- a/operator/internal/controller/keyorixsecret_controller_test.go
+++ b/operator/internal/controller/keyorixsecret_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -16,10 +17,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	secretsv1alpha1 "github.com/keyorixhq/keyorix/operator/api/v1alpha1"
 	"github.com/keyorixhq/keyorix/operator/internal/keyorix"
@@ -534,4 +537,40 @@ func TestReconcile_RefusesToAdoptSecretOwnedByAnotherCR(t *testing.T) {
 	assert.NotContains(t, got.Data, "DB_PASSWORD")
 	require.Len(t, got.OwnerReferences, 1)
 	assert.Equal(t, "other-cr", got.OwnerReferences[0].Name, "ownership must not have moved to the new CR")
+}
+
+// SetupWithManager must configure a small, fixed MaxConcurrentReconciles (r143). Without
+// it, controller-runtime's default of exactly 1 means one shared worker services every
+// KeyorixSecret in every namespace cluster-wide — a single slow/malicious CR (large Data
+// array, or an entry pointed at an allow-listed-but-slow server) can stall reconciliation
+// of every other tenant. This builds a real manager/controller (never Start()ed, so no
+// network/API-server access happens) via setupController — the exact function
+// SetupWithManager itself calls — and inspects the constructed controller-runtime
+// controller. Because controller-runtime's own controller.Controller interface exposes no
+// public accessor for MaxConcurrentReconciles (it's a field on an internal-package
+// struct), this reads it via reflection on the concrete value — a legitimate technique
+// here since we only need runtime reflection, not a compile-time import of the internal
+// package.
+func TestSetupController_SetsMaxConcurrentReconciles(t *testing.T) {
+	s := testScheme(t)
+	mgr, err := ctrl.NewManager(&rest.Config{Host: "https://127.0.0.1:1"}, ctrl.Options{
+		Scheme:                 s,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	require.NoError(t, err, "manager construction must not require a live API server connection")
+
+	r := &KeyorixSecretReconciler{Client: fake.NewClientBuilder().WithScheme(s).Build(), Scheme: s, hashKey: []byte("test-fixture-hmac-key")}
+	c, err := r.setupController(mgr)
+	require.NoError(t, err)
+
+	v := reflect.ValueOf(c)
+	for v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	field := v.FieldByName("MaxConcurrentReconciles")
+	require.True(t, field.IsValid(), "controller-runtime's controller type must still expose a MaxConcurrentReconciles field (reflection target); if this fails after a controller-runtime upgrade, the field/type may have been renamed")
+	assert.EqualValues(t, maxConcurrentReconciles, field.Int(),
+		"the constructed controller must run with the operator's small, fixed reconcile-concurrency bound, not controller-runtime's default of 1")
+	assert.Equal(t, 5, maxConcurrentReconciles, "documents the chosen bound so a future change to the constant is a deliberate, reviewed diff here too")
 }

--- a/operator/internal/controller/keyorixsecret_controller_test.go
+++ b/operator/internal/controller/keyorixsecret_controller_test.go
@@ -565,7 +565,7 @@ func TestSetupController_SetsMaxConcurrentReconciles(t *testing.T) {
 	require.NoError(t, err)
 
 	v := reflect.ValueOf(c)
-	for v.Kind() == reflect.Ptr {
+	for v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 	field := v.FieldByName("MaxConcurrentReconciles")


### PR DESCRIPTION
## Summary

Cross-tenant availability/DoS in the operator's reconcile loop, from two compounding gaps:

1. `operator/internal/controller/keyorixsecret_controller.go`'s `SetupWithManager` (~line 375-380 before this change) called `.Complete(r)` with no `MaxConcurrentReconciles` override. Nothing else in the module set it either, so controller-runtime's default of exactly 1 applied cluster-wide: a single shared workqueue/worker services every `KeyorixSecret` CR in every namespace.
2. `KeyorixSecretSpec.Data` (`operator/api/v1alpha1/keyorixsecret_types.go`, ~line 64-66) had `+kubebuilder:validation:MinItems=1` but no `MaxItems`, and `Data[].Ref` (~line 25-26) had no `MaxLength`. `buildDesired` fetches every `Data` entry sequentially over HTTP with a per-call 30s timeout (`operator/internal/keyorix/client.go`, ~line 42), with no overall per-reconcile deadline bounding the total time.

**Impact:** because the whole cluster shared one reconcile worker, any single namespace's KeyorixSecret-create-capable tenant (ordinary, least-privileged RBAC — not cluster-admin) could submit a CR with a very large `Data` array, or one entry pointed at an allow-listed-but-slow server, and stall the sole worker for a long time — starving reconciliation of every OTHER tenant's KeyorixSecret cluster-wide.

## Changes

- Bounded `spec.data` at 50 entries (`+kubebuilder:validation:MaxItems=50`) and `spec.data[].ref` at 512 characters (`+kubebuilder:validation:MaxLength=512`). 50 mirrors this codebase's existing bulk-operation cap precedent (`maxEnvNamesPerCreate` in `internal/core/catalog.go`); 512 is comfortably above any realistic `project/environment/name` combination (the main module caps individual project/environment names at 200 chars each) but far below unbounded. Regenerated the CRD via `controller-gen crd` (per `operator/Makefile`'s `manifests` target) and synced the copy into `deploy/helm/keyorix-operator/crds`.
- Added `.WithOptions(controller.Options{MaxConcurrentReconciles: 5})` to the controller builder. 5 is a small, defensible pool: enough that one bad reconcile no longer crowds out every tenant, low enough to bound simultaneous outbound calls to the (trusted, but still external) Keyorix server and simultaneous token-Secret reads. Nothing else in this module exposes reconciler tuning via a flag, so this follows the module's existing fixed-constant convention (cf. `minRefreshInterval`) rather than adding a new `--flag`.
- Wrapped `Reconcile` with a 5-minute `context.WithTimeout`, as defense in depth alongside the `MaxItems` cap: even a `MaxItems`-bounded array of entries that are each slow-but-within-their-individual-30s-timeout could otherwise occupy a worker for up to `50*30s=25m`.

## Tests

- `operator/api/v1alpha1/keyorixsecret_types_test.go` (new): this module has no envtest wired up (fake-client controller tests only), so CRD admission validation can't be exercised end-to-end. Instead asserts the actual generated CRD artifact (`config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml`) carries `maxItems: 50` / `minItems: 1` on `spec.data` and `maxLength: 512` on `spec.data[].ref` — catching both a marker regressing and a Go-type edit that wasn't followed by `make manifests`. A second test guards that the Helm chart's CRD copy stays byte-identical to the generated one (skips if the sibling `deploy/` path isn't present).
- `operator/internal/controller/keyorixsecret_controller_test.go`: `TestSetupController_SetsMaxConcurrentReconciles` builds a real controller-runtime `Controller` via `setupController` (the exact function `SetupWithManager` calls, split out for testability) against a manager that's constructed but never `Start()`ed (no network/API-server access), then asserts `MaxConcurrentReconciles` via reflection — controller-runtime's public `controller.Controller` interface exposes no accessor for it, and the concrete type lives in an internal package, so reflection on the already-obtained interface value is the only feasible technique without a new envtest harness.

## Test plan

- [x] `cd operator && GOWORK=off go build ./...`
- [x] `cd operator && GOWORK=off go test ./...` (all packages pass, including the 2 new tests)
- [x] `cd operator && GOWORK=off go vet ./...`
- [x] `cd operator && gofmt -l .` (clean)
- [x] `cd operator && GOWORK=off gosec -severity medium -exclude-generated ./...` (0 issues)
- [x] Regenerated CRD YAML included in the diff (`operator/config/crd/bases/...` and `deploy/helm/keyorix-operator/crds/...`)

Scoped to fan-out/bounding only — does not touch `wipeTargetSecret` (a separate ownership-check fix is being handled elsewhere).