### PR TITLE
fix(security): cap bulk access-request batch size to prevent resource exhaustion (r141)

### DIFF
--- a/internal/cli/request/bulk_test.go
+++ b/internal/cli/request/bulk_test.go
@@ -6,6 +6,8 @@ package request
 import (
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
@@ -334,6 +336,43 @@ func TestRunBulkApprove_BulkApproveError(t *testing.T) {
 	err := runBulkApprove(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bulk approve failed")
+}
+
+func TestRunBulkApprove_TooManyIDs(t *testing.T) {
+	// The per-request batch-size cap is enforced in core, so it applies to the
+	// CLI's embedded/local path too, not just HTTP callers. A batch over the
+	// cap must be rejected before any storage access is attempted — the
+	// partial service (users table only) would otherwise fail with a generic
+	// "no such table" error on the access_requests lookup, so seeing the
+	// specific cap message here proves the cap check runs first.
+	origIDs, origBy := bulkApproveIDs, bulkApproveBy
+	defer func() { bulkApproveIDs = origIDs; bulkApproveBy = origBy }()
+	ids := make([]string, 501)
+	for i := range ids {
+		ids[i] = strconv.Itoa(i + 1)
+	}
+	bulkApproveIDs = strings.Join(ids, ",")
+	bulkApproveBy = "partial@example.com"
+	withUserSeededPartialService(t, "partial@example.com")
+	err := runBulkApprove(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "maximum batch size")
+}
+
+func TestRunBulkReject_TooManyIDs(t *testing.T) {
+	origIDs, origBy, origReason := bulkRejectIDs, bulkRejectBy, bulkRejectReason
+	defer func() { bulkRejectIDs = origIDs; bulkRejectBy = origBy; bulkRejectReason = origReason }()
+	ids := make([]string, 501)
+	for i := range ids {
+		ids[i] = strconv.Itoa(i + 1)
+	}
+	bulkRejectIDs = strings.Join(ids, ",")
+	bulkRejectBy = "partial@example.com"
+	bulkRejectReason = "too many"
+	withUserSeededPartialService(t, "partial@example.com")
+	err := runBulkReject(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "maximum batch size")
 }
 
 func TestRunBulkReject_BulkRejectError(t *testing.T) {

--- a/internal/core/bulk_access_requests.go
+++ b/internal/core/bulk_access_requests.go
@@ -10,6 +10,17 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
+// maxBulkAccessRequestBatchSize bounds how many request IDs a single bulk
+// approve/reject call may process. Enforced here in core (not just at the
+// HTTP layer) so the CLI's embedded/local mode, which calls these functions
+// directly, is covered too. The global request body-size limit alone still
+// permits well over a million small integers in one JSON array, and the
+// per-item loop below does one DB round trip per ID with no cancellation
+// check — an unbounded batch is a per-request resource-exhaustion vector.
+// 500 comfortably covers any legitimate UI-driven bulk action while bounding
+// worst-case handler runtime and DB load.
+const maxBulkAccessRequestBatchSize = 500
+
 // ── Result types ─────────────────────────────────────────────────────────────
 
 // BulkApproveResult is the outcome of a bulk-approve call.
@@ -42,6 +53,9 @@ type BulkAccessError struct {
 func (k *KeyorixCore) BulkApproveAccessRequests(ctx context.Context, requestIDs []uint, approverID uint) (*BulkApproveResult, error) {
 	if len(requestIDs) == 0 {
 		return nil, errors.New("request_ids is required")
+	}
+	if len(requestIDs) > maxBulkAccessRequestBatchSize {
+		return nil, fmt.Errorf("request_ids exceeds the maximum batch size of %d", maxBulkAccessRequestBatchSize)
 	}
 
 	// Pre-fetch all requests in one query so we can resolve projectID per item
@@ -105,6 +119,9 @@ func (k *KeyorixCore) BulkApproveAccessRequests(ctx context.Context, requestIDs 
 func (k *KeyorixCore) BulkRejectAccessRequests(ctx context.Context, requestIDs []uint, approverID uint, reason string) (*BulkRejectResult, error) {
 	if len(requestIDs) == 0 {
 		return nil, errors.New("request_ids is required")
+	}
+	if len(requestIDs) > maxBulkAccessRequestBatchSize {
+		return nil, fmt.Errorf("request_ids exceeds the maximum batch size of %d", maxBulkAccessRequestBatchSize)
 	}
 	if reason == "" {
 		return nil, errors.New("reason is required")

--- a/internal/core/bulk_access_requests_integration_test.go
+++ b/internal/core/bulk_access_requests_integration_test.go
@@ -147,3 +147,33 @@ func TestBulkRejectAccessRequests_SuccessPath(t *testing.T) {
 	require.Contains(t, result.Rejected, reqID, "request must be in the rejected list")
 	require.Empty(t, result.Failed, "no failures expected")
 }
+
+// TestBulkApproveAccessRequests_AtBatchLimit_RealApprovals proves the new
+// maxBulkAccessRequestBatchSize cap is a pure size gate, not a regression on
+// legitimate use: a batch of exactly the cap size goes through the FULL real
+// approval chain (role lookup, role grant, audit) against a real SQLite-backed
+// core and every single request succeeds, exactly as it did before the cap
+// was added.
+func TestBulkApproveAccessRequests_AtBatchLimit_RealApprovals(t *testing.T) {
+	k, db, approverID, _, projectID := setupBulkAccessDB(t)
+	ctx := context.Background()
+
+	// Each request needs a DISTINCT requester: granting the same role to the
+	// same user twice fails with "Role already assigned" (correct, unrelated
+	// pre-existing behavior), which would make every request after the first
+	// fail here for a reason that has nothing to do with the batch-size cap.
+	ids := make([]uint, maxBulkAccessRequestBatchSize)
+	for i := range ids {
+		userID := uint(1000 + i)
+		require.NoError(t, db.Exec(
+			"INSERT INTO users (id,username,email) VALUES (?,?,?)",
+			userID, fmt.Sprintf("requester%d", i), fmt.Sprintf("requester%d@example.com", i),
+		).Error)
+		ids[i] = seedPendingRequest(t, k, projectID, userID, "editor")
+	}
+
+	result, err := k.BulkApproveAccessRequests(ctx, ids, approverID)
+	require.NoError(t, err)
+	require.Empty(t, result.Failed, "no failures expected at exactly the cap")
+	require.Len(t, result.Approved, maxBulkAccessRequestBatchSize)
+}

--- a/internal/core/bulk_access_requests_test.go
+++ b/internal/core/bulk_access_requests_test.go
@@ -98,6 +98,52 @@ func TestBulkApproveAccessRequests_ApproveError(t *testing.T) {
 	assert.Equal(t, uint(5), result.Failed[0].RequestID)
 }
 
+func TestBulkApproveAccessRequests_TooManyIDs(t *testing.T) {
+	k := newBulkTestCore(t)
+	m := k.storage.(*MockStorage)
+
+	ids := make([]uint, maxBulkAccessRequestBatchSize+1)
+	for i := range ids {
+		ids[i] = uint(i + 1)
+	}
+
+	result, err := k.BulkApproveAccessRequests(context.Background(), ids, 2)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "exceeds the maximum batch size")
+	// The cap is checked before any storage access — no partial processing.
+	m.AssertNotCalled(t, "ListAccessRequestsByIDs", mock.Anything, mock.Anything)
+}
+
+func TestBulkApproveAccessRequests_AtBatchLimit(t *testing.T) {
+	// A batch exactly AT the cap must not be rejected by the size check, and every
+	// item must still reach the per-item processing loop as before (no regression
+	// on legitimate use). Permission is denied for all items (as in
+	// TestBulkApproveAccessRequests_MixedResults) purely to keep the mock setup
+	// simple; what this test verifies is that the cap itself does not trip and
+	// that all items are attempted, not that approval succeeds.
+	k := newBulkTestCore(t)
+	m := k.storage.(*MockStorage)
+
+	ids := make([]uint, maxBulkAccessRequestBatchSize)
+	reqs := make([]*models.AccessRequest, maxBulkAccessRequestBatchSize)
+	for i := range ids {
+		ids[i] = uint(i + 1)
+		reqs[i] = pendingReq(uint(i + 1))
+	}
+	m.On("ListAccessRequestsByIDs", mock.Anything, ids).Return(reqs, nil)
+	// Empty roles → Authorize denies every item → each lands in Failed, but the
+	// loop still runs to completion for the full batch.
+	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+
+	result, err := k.BulkApproveAccessRequests(context.Background(), ids, 2)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Approved)
+	assert.Len(t, result.Failed, maxBulkAccessRequestBatchSize)
+}
+
 func TestBulkApproveAccessRequests_MixedResults(t *testing.T) {
 	// ID 1 will succeed (found), ID 99 will fail (not found in pre-fetch).
 	k := newBulkTestCore(t)
@@ -209,6 +255,48 @@ func TestBulkRejectAccessRequests_RejectNonPending(t *testing.T) {
 	require.Len(t, result.Failed, 1)
 	assert.Equal(t, uint(8), result.Failed[0].RequestID)
 	assert.Contains(t, result.Failed[0].Error, "pending")
+}
+
+func TestBulkRejectAccessRequests_TooManyIDs(t *testing.T) {
+	k := newBulkTestCore(t)
+	m := k.storage.(*MockStorage)
+
+	ids := make([]uint, maxBulkAccessRequestBatchSize+1)
+	for i := range ids {
+		ids[i] = uint(i + 1)
+	}
+
+	result, err := k.BulkRejectAccessRequests(context.Background(), ids, 2, "denied")
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "exceeds the maximum batch size")
+	// The cap is checked before any storage access — no partial processing.
+	m.AssertNotCalled(t, "ListAccessRequestsByIDs", mock.Anything, mock.Anything)
+}
+
+func TestBulkRejectAccessRequests_AtBatchLimit(t *testing.T) {
+	// A batch exactly AT the cap must not be rejected by the size check, and every
+	// item must still reach the per-item processing loop as before (no regression
+	// on legitimate use). See TestBulkApproveAccessRequests_AtBatchLimit for why
+	// permission-denied is used to keep the mock setup simple.
+	k := newBulkTestCore(t)
+	m := k.storage.(*MockStorage)
+
+	ids := make([]uint, maxBulkAccessRequestBatchSize)
+	reqs := make([]*models.AccessRequest, maxBulkAccessRequestBatchSize)
+	for i := range ids {
+		ids[i] = uint(i + 1)
+		reqs[i] = pendingReq(uint(i + 1))
+	}
+	m.On("ListAccessRequestsByIDs", mock.Anything, ids).Return(reqs, nil)
+	m.On("GetUserRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+	m.On("GetUserGroupRoleIDsAt", mock.Anything, uint(2), mock.Anything).Return([]uint{}, nil)
+
+	result, err := k.BulkRejectAccessRequests(context.Background(), ids, 2, "denied")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Rejected)
+	assert.Len(t, result.Failed, maxBulkAccessRequestBatchSize)
 }
 
 func TestBulkRejectAccessRequests_MixedResults(t *testing.T) {

--- a/server/http/handlers/bulk_access_requests.go
+++ b/server/http/handlers/bulk_access_requests.go
@@ -31,7 +31,7 @@ func (h *CatalogHandler) BulkApproveAccessRequests(w http.ResponseWriter, r *htt
 	if err != nil {
 		msg := err.Error()
 		status := http.StatusBadRequest
-		if !strings.Contains(msg, "required") {
+		if !strings.Contains(msg, "required") && !strings.Contains(msg, "exceeds the maximum batch size") {
 			log.Printf("Error bulk-approving access requests: %v", err)
 			msg = clientSafe(err)
 			status = http.StatusInternalServerError
@@ -61,7 +61,7 @@ func (h *CatalogHandler) BulkRejectAccessRequests(w http.ResponseWriter, r *http
 	if err != nil {
 		msg := err.Error()
 		status := http.StatusBadRequest
-		if !strings.Contains(msg, "required") {
+		if !strings.Contains(msg, "required") && !strings.Contains(msg, "exceeds the maximum batch size") {
 			log.Printf("Error bulk-rejecting access requests: %v", err)
 			msg = clientSafe(err)
 			status = http.StatusInternalServerError

--- a/server/http/handlers/bulk_access_requests_test.go
+++ b/server/http/handlers/bulk_access_requests_test.go
@@ -84,6 +84,22 @@ func TestBulkApprove_EmptyIDs(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestBulkApprove_TooManyIDs(t *testing.T) {
+	h := newBulkAccessTestHandler(t)
+	// One over core.maxBulkAccessRequestBatchSize (500) — the cap is unexported,
+	// so this mirrors that value rather than importing it.
+	ids := make([]string, 501)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("%d", i+1)
+	}
+	body := fmt.Sprintf(`{"request_ids":[%s]}`, strings.Join(ids, ","))
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body)))
+	w := httptest.NewRecorder()
+	h.BulkApproveAccessRequests(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "maximum batch size")
+}
+
 func TestBulkApprove_NotFound_ReturnsSuccess(t *testing.T) {
 	h := newBulkAccessTestHandler(t)
 	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"request_ids":[9999]}`)))
@@ -117,6 +133,22 @@ func TestBulkReject_EmptyIDs(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.BulkRejectAccessRequests(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestBulkReject_TooManyIDs(t *testing.T) {
+	h := newBulkAccessTestHandler(t)
+	// One over core.maxBulkAccessRequestBatchSize (500) — the cap is unexported,
+	// so this mirrors that value rather than importing it.
+	ids := make([]string, 501)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("%d", i+1)
+	}
+	body := fmt.Sprintf(`{"request_ids":[%s],"reason":"too risky"}`, strings.Join(ids, ","))
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body)))
+	w := httptest.NewRecorder()
+	h.BulkRejectAccessRequests(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "maximum batch size")
 }
 
 func TestBulkReject_NotFound_ReturnsSuccess(t *testing.T) {


### PR DESCRIPTION
## Finding

`BulkApproveAccessRequests` and `BulkRejectAccessRequests`
(`internal/core/bulk_access_requests.go:42-95,105-151`) accepted a
caller-supplied `[]uint` of **unlimited length**. The HTTP handlers
(`server/http/handlers/bulk_access_requests.go:19-43,48-73`) decode the
request body directly into `RequestIDs []uint` with no length check.

The only indirect bound was the global 10 MiB body-size middleware
(`server/middleware/body_limit.go`, wired at `server/http/router.go:99`,
default from `internal/config/config.go:338`) — that still permits well
over a million small integers in one JSON array.

The core loop does one DB round trip per ID (delegating to
`ApproveAccessRequest`/`RejectAccessRequest` in
`internal/core/invitations.go`), and never checks `ctx.Err()`/`ctx.Done()`.
The router's global 60s `middleware.Timeout`
(`server/http/router.go:100`) only cancels the client-facing response —
chi's `Timeout` does not stop the handler goroutine, which keeps running
to completion regardless, holding a DB connection and CPU for the whole
batch. Per-request resource exhaustion.

## Fix

Add `maxBulkAccessRequestBatchSize = 500` in
`internal/core/bulk_access_requests.go`, enforced at the top of both
core functions **before any storage access**, so an oversized batch is
rejected with a clear, specific error
(`"request_ids exceeds the maximum batch size of 500"`) and no partial
processing occurs.

This is enforced in core (not just the HTTP layer) so the CLI's
embedded/local mode (`internal/cli/request/bulk.go`), which calls these
functions directly, is covered too — not just HTTP callers.

`server/http/handlers/bulk_access_requests.go` is updated to classify
the new error as `400 Bad Request` rather than `500`, consistent with
the existing `"required"` validation-error handling — otherwise the
specific error message would be swallowed behind a generic
`clientSafe` 500 response.

500 comfortably covers any legitimate UI-driven bulk action while
bounding worst-case handler runtime and DB load. No existing "bulk"
precedent in the codebase (`bulk_rotate.go`, `users_roles.go`)
establishes a different numeric convention, so this is a
defensible, judgment-based cap rather than one derived from an
existing constant.

Per-item authorization, partial-success/failure reporting, and
per-item audit logging are **unchanged** — this fix is scoped solely
to the missing size cap.

## Tests

- `internal/core/bulk_access_requests_test.go`: `TestBulkApproveAccessRequests_TooManyIDs` /
  `TestBulkRejectAccessRequests_TooManyIDs` — a batch over the cap is rejected with the
  specific error and `ListAccessRequestsByIDs` is never called (no partial processing).
- `internal/core/bulk_access_requests_test.go`: `TestBulkApproveAccessRequests_AtBatchLimit` /
  `TestBulkRejectAccessRequests_AtBatchLimit` — a batch exactly AT the cap is not
  rejected by the size check and the full per-item loop still runs.
- `internal/core/bulk_access_requests_integration_test.go`:
  `TestBulkApproveAccessRequests_AtBatchLimit_RealApprovals` — a batch of exactly
  500 distinct requesters goes through the full real approval chain (SQLite-backed,
  role lookup, role grant, audit) and every request succeeds — proving no regression
  on legitimate use.
- `server/http/handlers/bulk_access_requests_test.go`: `TestBulkApprove_TooManyIDs` /
  `TestBulkReject_TooManyIDs` — HTTP-level 400 with the batch-size message in the body.
- `internal/cli/request/bulk_test.go`: `TestRunBulkApprove_TooManyIDs` /
  `TestRunBulkReject_TooManyIDs` — proves the cap applies to the CLI's direct/embedded
  call path, not just HTTP.

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./internal/core/... ./server/http/... ./internal/cli/...` — pass for all
  touched packages (`internal/core`, `server/http`, `server/http/handlers`,
  `internal/cli/request`). Unrelated pre-existing failures in other `internal/cli/*`
  subpackages (accessreview, audit, breakglass, dynamic, group, user) are all due to
  an unreachable local test endpoint (`http://192.168.10.62:8088`), not touched by
  this change.
- `golangci-lint run ./internal/core/... ./server/http/... ./internal/cli/...` — 0 issues
- `gosec -severity medium -exclude-generated ./internal/core/... ./server/http/... ./internal/cli/...` — 0 issues