### PR TITLE
feat(operator): fail-closed namespace-scope by default (ADR-076)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -892,7 +892,7 @@ jobs:
           if grep -q '^kind: ClusterRoleBinding$' default-render.yaml; then
             echo "did not expect a ClusterRoleBinding in the default (namespace-scoped) render"; exit 1
           fi
-          if ! grep -B2 '  namespace: default$' default-render.yaml | grep -q 'name: kx-keyorix-operator$'; then
+          if ! grep -A2 '^kind: RoleBinding$' default-render.yaml | grep -q 'name: kx-keyorix-operator$'; then
             echo "expected a RoleBinding named kx-keyorix-operator in the release namespace (default)"; exit 1
           fi
           if ! grep -q '^            - "-watch-namespaces=default"$' default-render.yaml; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,7 +867,7 @@ jobs:
             --set targetNamespaces='{app,web}' \
             | ./kubeconform -strict -summary -kubernetes-version 1.29.0
 
-      - name: Lint + render keyorix-operator chart (ADR-076: all 4 scope paths)
+      - name: "Lint + render keyorix-operator chart (ADR-076: all 4 scope paths)"
         run: |
           helm lint deploy/helm/keyorix-operator
           helm lint deploy/helm/keyorix-operator --set 'watchNamespaces={team-a,team-b}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,30 +867,40 @@ jobs:
             --set targetNamespaces='{app,web}' \
             | ./kubeconform -strict -summary -kubernetes-version 1.29.0
 
-      - name: Lint + render keyorix-operator chart
+      - name: Lint + render keyorix-operator chart (ADR-076: all 4 scope paths)
         run: |
           helm lint deploy/helm/keyorix-operator
           helm lint deploy/helm/keyorix-operator --set 'watchNamespaces={team-a,team-b}'
+          helm lint deploy/helm/keyorix-operator --set rbac.clusterScoped=true
 
-          # Default (cluster-wide) mode: kubeconform-validate the rendered controller
-          # resources (CRDs ship under crds/, not templated, so none rendered here), and
-          # prove the Secret/KeyorixSecret RBAC is still bound via the existing
-          # cluster-wide ClusterRoleBinding — the #327/#427 backward-compatibility
-          # guarantee for deployments that don't opt into namespace scoping.
+          # For each of the 3 renderable paths this asserts the same two things: the
+          # rendered RBAC binding kind+namespace(s), and the rendered manager flag,
+          # actually AGREE with each other — not just that something renders. That
+          # agreement check is what #1224's chart-precedence bug (and the separate,
+          # previously-undocumented RBAC/cache wiring gap ADR-076's investigation found)
+          # would have violated; asserting it directly is what makes this bug class
+          # non-recurring rather than merely fixed once more.
+
+          # Path 1 (ADR-076 DEFAULT): rbac.clusterScoped=false, watchNamespaces=[] --
+          # RoleBinding in the release's own namespace only, matching the manager's own
+          # fail-closed default (operator/cmd/main.go, Commit 1): with no explicit flag,
+          # it would watch only its own namespace via POD_NAMESPACE. No longer the
+          # cluster-wide default this test asserted pre-ADR-076.
           helm template kx deploy/helm/keyorix-operator --set leaderElection=true \
             > default-render.yaml
           ./kubeconform -strict -summary -kubernetes-version 1.29.0 < default-render.yaml
-          if ! grep -q '^kind: ClusterRoleBinding$' default-render.yaml; then
-            echo "expected a ClusterRoleBinding in the default (unscoped) render"; exit 1
+          if grep -q '^kind: ClusterRoleBinding$' default-render.yaml; then
+            echo "did not expect a ClusterRoleBinding in the default (namespace-scoped) render"; exit 1
           fi
-          if grep -A2 '^kind: RoleBinding$' default-render.yaml | grep -q 'name: kx-keyorix-operator$'; then
-            echo "unexpected namespace-scoped RoleBinding for the main Secret/CRD grant in the default render"
-            exit 1
+          if ! grep -B2 '  namespace: default$' default-render.yaml | grep -q 'name: kx-keyorix-operator$'; then
+            echo "expected a RoleBinding named kx-keyorix-operator in the release namespace (default)"; exit 1
+          fi
+          if ! grep -q '^            - "-watch-namespaces=default"$' default-render.yaml; then
+            echo "expected the -watch-namespaces=default flag on the manager Deployment (must agree with the RoleBinding namespace above)"; exit 1
           fi
 
-          # Namespace-scoped mode (opt-in, #327/#427): prove the same RBAC is instead
-          # bound via a RoleBinding in each watchNamespaces entry, with NO cluster-wide
-          # ClusterRoleBinding — least privilege for a per-namespace deployment model.
+          # Path 2 (opt-in multi-namespace): watchNamespaces set -- RoleBinding per listed
+          # namespace, no ClusterRoleBinding.
           helm template kx deploy/helm/keyorix-operator --set 'watchNamespaces={team-a,team-b}' \
             > scoped-render.yaml
           ./kubeconform -strict -summary -kubernetes-version 1.29.0 < scoped-render.yaml
@@ -902,8 +912,40 @@ jobs:
               echo "expected a RoleBinding named kx-keyorix-operator in namespace $ns"; exit 1
             fi
           done
-          if ! grep -q -- '-watch-namespaces=team-a,team-b' scoped-render.yaml; then
-            echo "expected the -watch-namespaces flag on the manager Deployment"; exit 1
+          if ! grep -q '^            - "-watch-namespaces=team-a,team-b"$' scoped-render.yaml; then
+            echo "expected the -watch-namespaces=team-a,team-b flag on the manager Deployment"; exit 1
+          fi
+
+          # Path 3 (explicit cluster-wide opt-in): rbac.clusterScoped=true,
+          # watchNamespaces=[] -- ClusterRoleBinding, -all-namespaces flag. The ONLY route
+          # to cluster-wide (ADR-076) -- no longer reachable via any default.
+          helm template kx deploy/helm/keyorix-operator --set rbac.clusterScoped=true \
+            > cluster-render.yaml
+          ./kubeconform -strict -summary -kubernetes-version 1.29.0 < cluster-render.yaml
+          if ! grep -q '^kind: ClusterRoleBinding$' cluster-render.yaml; then
+            echo "expected a ClusterRoleBinding when rbac.clusterScoped=true"; exit 1
+          fi
+          if grep -A2 '^kind: RoleBinding$' cluster-render.yaml | grep -q 'name: kx-keyorix-operator$'; then
+            echo "unexpected namespace-scoped RoleBinding for the main Secret/CRD grant when rbac.clusterScoped=true"
+            exit 1
+          fi
+          if ! grep -q '^            - "-all-namespaces"$' cluster-render.yaml; then
+            echo "expected the -all-namespaces flag on the manager Deployment"; exit 1
+          fi
+          if grep -q '^            - "-watch-namespaces=' cluster-render.yaml; then
+            echo "did not expect a -watch-namespaces flag when rbac.clusterScoped=true"; exit 1
+          fi
+
+          # Path 4 (contradictory config): rbac.clusterScoped=true AND watchNamespaces set
+          # -- must fail the render outright (ADR-076 decision B: no precedence-based
+          # resolution of this exact combination, since #1224 already showed what that
+          # produces). helm template must exit non-zero and never reach kubeconform.
+          if helm template kx deploy/helm/keyorix-operator --set rbac.clusterScoped=true \
+              --set 'watchNamespaces={team-a}' > contradictory-render.yaml 2> contradictory-error.txt; then
+            echo "expected helm template to fail for rbac.clusterScoped=true + watchNamespaces set"; exit 1
+          fi
+          if ! grep -q 'mutually exclusive' contradictory-error.txt; then
+            echo "expected the failure message to name the contradiction"; cat contradictory-error.txt; exit 1
           fi
 
   # helm-chart (above) validates chart/schema *shape* (helm lint + kubeconform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,23 @@ All notable changes to Keyorix are documented here. This project follows
   (ADR-076)** — an unmodified `helm install deploy/helm/keyorix-operator` now binds a
   namespace-scoped `RoleBinding` in its own release namespace and watches only that
   namespace, instead of the previous default of a cluster-wide `ClusterRoleBinding`
-  granting full CRUD on every Secret in the cluster. **Upgrading an existing install that
-  relies on the old default? Add `--set rbac.clusterScoped=true` to your `helm upgrade`**
-  to preserve current behavior — without it, the operator stops reconciling
-  `KeyorixSecret` CRs outside its own release namespace after the upgrade. Two opt-in
-  modes cover broader deployments: `watchNamespaces: [ns, ...]` for a bounded
-  multi-namespace instance, or `rbac.clusterScoped: true` for the original cluster-wide
-  behavior — see the [operator docs](docs/k8s-operator.md#choosing-a-namespace-scope-adr-076)
-  for detail. See ADR-076 for the full rationale, including why this is the third attempt
-  at this narrowing and what's different this time.
+  granting full CRUD on every Secret in the cluster. **Relied on the old default (set
+  neither value)? Add `--set rbac.clusterScoped=true` to your `helm upgrade`** to preserve
+  current behavior — without it, the operator stops reconciling `KeyorixSecret` CRs outside
+  its own release namespace after the upgrade. **Already set `watchNamespaces`?**
+  `rbac.clusterScoped` defaulted to `true` before this release, and a plain `helm upgrade`
+  (without `--reset-values`) carries forward a release's previously-recorded values by
+  default — so your install is very likely already in the now-rejected combination
+  (`rbac.clusterScoped=true` + `watchNamespaces` set), and the upgrade will refuse to
+  render at all: `rbac.clusterScoped=true and watchNamespaces=[...] are both set -- these
+  are mutually exclusive (ADR-076)`. **Add `--set rbac.clusterScoped=false` explicitly to
+  your `helm upgrade`** (or the equivalent in your values file) to clear it — this is a
+  hard block on the upgrade, not a permissions change, until you do. Two opt-in modes cover
+  broader deployments: `watchNamespaces: [ns, ...]` for a bounded multi-namespace instance,
+  or `rbac.clusterScoped: true` for the original cluster-wide behavior — see the [operator
+  docs](docs/k8s-operator.md#choosing-a-namespace-scope-adr-076) for detail. See ADR-076
+  for the full rationale, including why this is the third attempt at this narrowing and
+  what's different this time.
 - **Frontend monorepo consolidation (ADR-070)** — `keyorix-web` (the dashboard)
   is folded into this repository at `web/`, full commit history preserved via
   `git subtree`. One `vX.Y.Z` tag now triggers both the server and web image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to Keyorix are documented here. This project follows
 ## Unreleased
 
 ### Changed
+- **BREAKING: keyorix-operator default RBAC/watch scope narrowed to own-namespace-only
+  (ADR-076)** — an unmodified `helm install deploy/helm/keyorix-operator` now binds a
+  namespace-scoped `RoleBinding` in its own release namespace and watches only that
+  namespace, instead of the previous default of a cluster-wide `ClusterRoleBinding`
+  granting full CRUD on every Secret in the cluster. **Upgrading an existing install that
+  relies on the old default? Add `--set rbac.clusterScoped=true` to your `helm upgrade`**
+  to preserve current behavior — without it, the operator stops reconciling
+  `KeyorixSecret` CRs outside its own release namespace after the upgrade. Two opt-in
+  modes cover broader deployments: `watchNamespaces: [ns, ...]` for a bounded
+  multi-namespace instance, or `rbac.clusterScoped: true` for the original cluster-wide
+  behavior — see the [operator docs](docs/k8s-operator.md#choosing-a-namespace-scope-adr-076)
+  for detail. See ADR-076 for the full rationale, including why this is the third attempt
+  at this narrowing and what's different this time.
 - **Frontend monorepo consolidation (ADR-070)** — `keyorix-web` (the dashboard)
   is folded into this repository at `web/`, full commit history preserved via
   `git subtree`. One `vX.Y.Z` tag now triggers both the server and web image
@@ -34,6 +47,15 @@ All notable changes to Keyorix are documented here. This project follows
   ([#1225])
 
 ### Fixed
+- **keyorix-operator `rbac.clusterScoped: false` never actually worked (ADR-076)** — this
+  opt-out (added in [#1224]) bound namespace-scoped RBAC without ever telling the manager
+  to narrow its own watch scope correspondingly, so it silently attempted a cluster-wide
+  watch against namespace-scoped RBAC — in practice, repeated `Forbidden` errors on every
+  namespace outside the release namespace, likely fatal to controller startup. Never
+  worked correctly; fixed as part of ADR-076's broader scope-resolution rework before its
+  first tagged release — `git tag --contains` confirms no released version ever shipped
+  it (it landed three days after `v0.88.0`, the most recent tag at the time), so no
+  affected versions to name.
 - **SQLite RBAC grant-expiry timezone mismatch** — GORM formats `time.Time` using
   the process `Location`; mixed UTC/local `ExpiresAt` values broke SQLite string
   comparisons so grants appeared expired or perpetual depending on the host

--- a/deploy/helm/keyorix-operator/README.md
+++ b/deploy/helm/keyorix-operator/README.md
@@ -21,7 +21,8 @@ helm install keyorix-operator deploy/helm/keyorix-operator -n keyorix-system --c
 | `leaderElection` | Run >1 replica safely via a lease in the release namespace (default `false`) |
 | `metricsPort` / `healthPort` | Manager metrics (`/metrics`) and probe (`/healthz`,`/readyz`) ports |
 | `serviceAccount.create` / `serviceAccount.name` | ServiceAccount control |
-| `watchNamespaces` | Restrict this instance (and its RBAC) to these namespaces instead of the whole cluster — see [RBAC](#rbac) |
+| `watchNamespaces` | Restrict this instance (and its RBAC) to these namespaces instead of just its own — see [RBAC](#rbac) |
+| `rbac.clusterScoped` | `true` for a genuinely cluster-wide instance (default `false`) — see [RBAC](#rbac) |
 | `resources`, `nodeSelector`, `tolerations`, `affinity`, `podAnnotations` | Standard pod scheduling/resourcing |
 
 ## RBAC
@@ -33,21 +34,35 @@ grants the lease + event access leader election needs. The operator reads secret
 only through the Keyorix API (with each `KeyorixSecret`'s machine token) — never from the
 cluster.
 
-By default a single operator instance watches `KeyorixSecret` CRs across every namespace in
-the cluster, so the `ClusterRole` above is bound cluster-wide via a `ClusterRoleBinding`. If
-you instead run one operator instance per namespace (or per bounded tenant set), set
-`watchNamespaces` to that instance's namespace(s):
+**By default (ADR-076) a single operator instance watches `KeyorixSecret` CRs in its own
+release namespace only**, and the `ClusterRole` above is bound via a namespace-scoped
+`RoleBinding` in that namespace — an unmodified `helm install` never grants access outside
+where you installed it. Two opt-in modes, mutually exclusive with each other (setting both
+makes the chart refuse to render, naming both values in the error):
+
+- **`watchNamespaces: [team-a, team-b]`** — one instance managing a bounded, known set of
+  namespaces. Binds a `RoleBinding` in each listed namespace.
+- **`rbac.clusterScoped: true`** — one instance managing every namespace in the cluster,
+  with no static list (the only way to reach this; it is no longer the default). Binds a
+  cluster-wide `ClusterRoleBinding`.
 
 ```sh
+# Bounded multi-namespace
 helm install keyorix-operator-team-a deploy/helm/keyorix-operator -n team-a \
   --set 'watchNamespaces={team-a}'
+
+# Cluster-wide (preserves the pre-ADR-076 default; see the CHANGELOG's BREAKING entry
+# if you're upgrading an existing install that relied on it)
+helm install keyorix-operator deploy/helm/keyorix-operator -n keyorix-system \
+  --create-namespace --set rbac.clusterScoped=true
 ```
 
-This passes `-watch-namespaces` to the manager (restricting its own watch/cache to those
-namespaces too) and swaps the cluster-wide `ClusterRoleBinding` for a namespace-scoped
-`RoleBinding` in each listed namespace — the same `ClusterRole` stays cluster-scoped (a
-Kubernetes RBAC object type), but its granted access is limited to the bound namespaces. Do
-not deploy more than one instance watching the same namespace with different configs.
+Both values feed a single named template (`_helpers.tpl`'s `kxop.scope`) that both
+`rbac.yaml` and `deployment.yaml` render from, so the RBAC binding and the manager's own
+`-watch-namespaces`/`-all-namespaces` flag can't drift apart — the same `ClusterRole`
+object always exists (a Kubernetes RBAC object type, needed for manifest reusability
+across modes), but what it's actually *bound* to is what determines real access. Do not
+deploy more than one instance watching the same namespace with different configs.
 
 ## Uninstalling
 

--- a/deploy/helm/keyorix-operator/templates/_helpers.tpl
+++ b/deploy/helm/keyorix-operator/templates/_helpers.tpl
@@ -35,3 +35,39 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "kxop.image" -}}
 {{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
 {{- end -}}
+
+{{/*
+kxop.scope resolves the operator's effective namespace scope ONCE, from
+rbac.clusterScoped and watchNamespaces (ADR-076) -- rbac.yaml and deployment.yaml both
+`include` this and `fromYaml` the result, rather than each independently branching on
+the same two values. That independent-branching shape is exactly how #1224 produced a
+silent no-RBAC-binding misrender: fixing it here means there is exactly one place that
+decides "cluster" vs "namespaces", not two that must be kept in sync by hand.
+
+Returns YAML the caller parses with `fromYaml` into a dict with:
+  mode:       "cluster" | "namespaces"
+  namespaces: (list, only when mode == "namespaces") -- ALWAYS populated with at least
+              one entry when mode is "namespaces": the explicit watchNamespaces list, or
+              [.Release.Namespace] when that's empty (ADR-076's own-namespace default).
+              Never empty in this mode, so consuming templates need no further
+              "namespaces happens to be empty" branch of their own.
+  flag:       the exact manager CLI flag to render verbatim in deployment.yaml's args
+              (-all-namespaces, or -watch-namespaces=a,b,c).
+
+The fourth, contradictory combination (rbac.clusterScoped=true AND watchNamespaces set)
+is a hard `fail` naming both values -- ADR-076 rejects resolving it by precedence, since
+precedence-based resolution of exactly this contradiction is what #1224 got wrong.
+*/}}
+{{- define "kxop.scope" -}}
+{{- if and .Values.rbac.clusterScoped .Values.watchNamespaces -}}
+{{- fail (printf "keyorix-operator: rbac.clusterScoped=true and watchNamespaces=%s are both set -- these are mutually exclusive (ADR-076). Set exactly one: rbac.clusterScoped=true for a cluster-wide instance, or watchNamespaces for a bounded multi-namespace instance. Leave both unset/false for the namespace-scoped default (this release's own namespace only)." (toJson .Values.watchNamespaces)) -}}
+{{- else if .Values.rbac.clusterScoped -}}
+mode: cluster
+flag: "-all-namespaces"
+{{- else -}}
+{{- $namespaces := .Values.watchNamespaces | default (list .Release.Namespace) -}}
+mode: namespaces
+namespaces: {{ toJson $namespaces }}
+flag: {{ printf "-watch-namespaces=%s" (join "," $namespaces) | quote }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/keyorix-operator/templates/deployment.yaml
+++ b/deploy/helm/keyorix-operator/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $scope := include "kxop.scope" . | fromYaml }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,9 +37,24 @@ spec:
             - "-health-probe-bind-address=:{{ .Values.healthPort | default 8081 }}"
             - "-metrics-bind-address=:{{ .Values.metricsPort | default 8080 }}"
             - "-leader-elect={{ .Values.leaderElection | default false }}"
-            {{- if .Values.watchNamespaces }}
-            - "-watch-namespaces={{ join "," .Values.watchNamespaces }}"
-            {{- end }}
+            # The single flag kxop.scope resolved (_helpers.tpl, ADR-076): either
+            # -all-namespaces or -watch-namespaces=a,b,c. Always rendered explicitly here
+            # (never left for the binary's own POD_NAMESPACE fallback to decide) for
+            # manifest readability, and because the CI chart-render assertion (Commit 3)
+            # needs an actual flag value to assert agrees with the rendered RBAC binding.
+            - {{ $scope.flag | quote }}
+          env:
+            # Backs the manager's own fail-closed default (operator/cmd/main.go,
+            # ADR-076): if neither -watch-namespaces nor -all-namespaces is set, it
+            # watches only this value. Always set, even though this chart always renders
+            # an explicit flag above -- this is what makes that default SAFE under a
+            # version-skewed chart/image pair (an old chart or hand-rolled deployment
+            # that forgets the flag still fails closed to its own namespace instead of
+            # falling back to a cluster-wide watch).
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - name: metrics
               containerPort: {{ .Values.metricsPort | default 8080 }}

--- a/deploy/helm/keyorix-operator/templates/rbac.yaml
+++ b/deploy/helm/keyorix-operator/templates/rbac.yaml
@@ -5,28 +5,33 @@ generated RBAC (operator/config/rbac/role.yaml) -- including `delete`, which
 `wipeTargetSecret` uses to remove the target Secret once the upstream Keyorix reference is
 confirmed gone (#428).
 
-NOTE (#327/#427): a single ClusterRole definition is always used (for manifest
-reusability), but how it's BOUND depends on `watchNamespaces`:
+NOTE (ADR-076, superseding the #327/#427 default): a single ClusterRole definition is
+always used (for manifest reusability), but how it's BOUND is resolved ONCE by the
+`kxop.scope` helper (_helpers.tpl) and rendered here from its result -- this template does
+not read `.Values.rbac.clusterScoped` / `.Values.watchNamespaces` directly, so it cannot
+diverge from what deployment.yaml's `-watch-namespaces`/`-all-namespaces` flag actually
+tells the manager to watch (the #1224 failure mode this ADR exists to close).
 
-  - Default (`watchNamespaces` empty): bound cluster-wide via a `ClusterRoleBinding`. This
-    matches the operator's default deployment model -- a single cluster-wide instance
-    watching KeyorixSecret CRs (a namespaced CRD) across every namespace, with no static
-    namespace list configured, so it genuinely cannot predict ahead of time which namespace
-    the next CR (and its TokenSecretRef/target Secret) will land in. Kubernetes RBAC has no
-    way to scope list/watch by resourceNames or to a dynamically changing namespace set, so
-    per-namespace RoleBindings aren't possible in this mode.
-
+  - Default (`rbac.clusterScoped: false`, `watchNamespaces` empty): bound via a
+    namespace-scoped `RoleBinding` in this release's own namespace -- least privilege,
+    matching the manager's own fail-closed default (operator/cmd/main.go, ADR-076): with
+    no explicit flag set, it watches only its own namespace (read from `POD_NAMESPACE`).
   - `watchNamespaces` set: bound via a namespace-scoped `RoleBinding` in each listed
-    namespace instead -- least privilege for deployments that run one operator instance per
-    namespace/tenant set (matching the corresponding `-watch-namespaces` flag passed to the
-    manager in deployment.yaml, which restricts the manager's own watch/cache to the same
-    namespaces).
+    namespace instead -- for deployments that run one operator instance per bounded
+    namespace/tenant set.
+  - `rbac.clusterScoped: true` (and `watchNamespaces` empty): bound cluster-wide via a
+    `ClusterRoleBinding` -- the explicit opt-in for a single instance watching every
+    namespace in the cluster, with no static namespace list. Kubernetes RBAC has no way to
+    scope list/watch by resourceNames or to a dynamically changing namespace set, so this
+    is the only way to support that deployment model.
+  - `rbac.clusterScoped: true` AND `watchNamespaces` set: rejected by `kxop.scope` with a
+    `fail` naming both values, not resolved by precedence.
 
-To further bound the blast radius of this (in the default mode, necessarily cluster-wide)
-Secret grant (e.g. if the operator process is ever compromised via #184/#240),
-operator/cmd/main.go also scopes the manager's Secret informer cache to only Secrets
-carrying the operator's managed-by label, so the operator does not hold an in-memory cache
-of every Secret it can see -- only the ones it already owns via this same RBAC.
+To further bound the blast radius of this Secret grant (e.g. if the operator process is
+ever compromised via #184/#240), operator/cmd/main.go also scopes the manager's Secret
+informer cache to only Secrets carrying the operator's managed-by label, so the operator
+does not hold an in-memory cache of every Secret it can see -- only the ones it already
+owns via this same RBAC.
 */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -48,9 +53,26 @@ rules:
     resources: ["keyorixsecrets/finalizers"]
     verbs: ["update"]
 ---
-{{- if .Values.watchNamespaces }}
+{{- $scope := include "kxop.scope" . | fromYaml }}
+{{- if eq $scope.mode "cluster" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kxop.fullname" . }}
+  labels:
+    {{- include "kxop.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kxop.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kxop.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+{{- else }}
 {{- $root := . }}
-{{- range .Values.watchNamespaces }}
+{{- range $scope.namespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -68,39 +90,6 @@ subjects:
     namespace: {{ $root.Release.Namespace }}
 ---
 {{- end }}
-{{- else if .Values.rbac.clusterScoped }}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "kxop.fullname" . }}
-  labels:
-    {{- include "kxop.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "kxop.fullname" . }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "kxop.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
----
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "kxop.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kxop.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "kxop.fullname" . }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "kxop.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
----
 {{- end }}
 # Leader election (used when replicas > 1 / leaderElection=true) and event emission.
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm/keyorix-operator/values.yaml
+++ b/deploy/helm/keyorix-operator/values.yaml
@@ -21,22 +21,27 @@ leaderElection: false
 metricsPort: 8080
 healthPort: 8081
 
-# watchNamespaces (OPTIONAL, #327/#427): restricts this operator instance to reconciling
+# watchNamespaces (OPTIONAL, ADR-076): restricts this operator instance to reconciling
 # KeyorixSecret CRs (and their target Secrets) in only the listed namespaces, instead of
-# the default cluster-wide behavior. When set, RBAC is scoped accordingly: the chart's
-# ClusterRole is bound via a namespace-scoped RoleBinding in each listed namespace instead
-# of a cluster-wide ClusterRoleBinding -- least privilege for deployments that run one
-# operator instance per namespace/tenant set. When empty (the default), a single instance
-# watches every namespace and needs the broader ClusterRoleBinding to do so.
+# the DEFAULT (this release's own namespace only). When set, RBAC is scoped accordingly:
+# the chart's ClusterRole is bound via a namespace-scoped RoleBinding in each listed
+# namespace instead -- for deployments that run one operator instance per bounded
+# namespace/tenant set (more than just its own, but still not cluster-wide). Mutually
+# exclusive with rbac.clusterScoped: true (the chart refuses to render if both are set).
 #   watchNamespaces: [team-a, team-b]
 watchNamespaces: []
 
 rbac:
-  # clusterScoped: ignored when watchNamespaces is set (that path always uses per-namespace
-  # RoleBindings). When watchNamespaces is empty, true (the default) preserves the original
-  # cluster-wide ClusterRoleBinding; set to false to instead use a RoleBinding scoped to the
-  # release namespace only — least-privilege for single-namespace deployments.
-  clusterScoped: true
+  # clusterScoped (ADR-076): the ONLY way to get a genuinely cluster-wide instance --
+  # watching every namespace in the cluster with no static list, bound via a
+  # ClusterRoleBinding. Ignored/rejected when watchNamespaces is also set (mutually
+  # exclusive, see watchNamespaces above). Defaults to false: an unmodified `helm install`
+  # now gets a namespace-scoped RoleBinding in its own release namespace only, not the
+  # broader cluster-wide grant this used to default to. Existing installs upgrading from a
+  # prior chart version that relied on the old cluster-wide default must set this to
+  # `true` explicitly to preserve that behavior across the upgrade -- see the CHANGELOG's
+  # BREAKING entry for this release.
+  clusterScoped: false
 
 serviceAccount:
   create: true

--- a/docs/adr-076-operator-rbac-scope.md
+++ b/docs/adr-076-operator-rbac-scope.md
@@ -1,0 +1,222 @@
+# ADR-076: Kubernetes operator RBAC/watch scope — fail-closed to own-namespace by default
+
+## Status
+
+Accepted. Implementation follows in subsequent commits on this same branch
+(`fix/adr-070-operator-rbac-scope`).
+
+## Context
+
+The `keyorix-operator` (ADR-060, `operator/`) ships with a `ClusterRole` granting full
+CRUD (`get/list/watch/create/update/patch/delete`) on core `Secrets`, bound **cluster-wide**
+via a `ClusterRoleBinding`, **by default**. The reconcile loop only ever touches Secrets in
+the same namespace as the triggering `KeyorixSecret` CR — the grant is broader than the
+code's own behavior requires, in every deployment except the one where a single instance
+genuinely must watch every namespace with no static list.
+
+**This is the third attempt to narrow it, and the first two both left the default
+unchanged:**
+
+1. **`0869bd91`** (#429, ADR-060) — the operator's original introduction. Cluster-wide
+   only; no opt-out existed.
+2. **`dc36f3e4`** (#327, #613) — scoped the manager's Secret *informer cache* to
+   label-matched Secrets only. A real mitigation (bounds what a compromised operator
+   process can dump from its own memory), but it narrows nothing at the RBAC layer — the
+   ServiceAccount's live API grant is untouched.
+3. **`9171e86f`** (#327/#427, #790) — added the first opt-in: a `watchNamespaces` Helm
+   value and matching `-watch-namespaces` flag, narrowing both cache and RBAC together
+   when set. Explicit in the commit message: *"The default (unset) behavior, including the
+   rendered manifests, is unchanged."* A real opt-in, deliberately not a default change.
+4. **`4b8a2614`** (#1224) — attempted the exact default flip this ADR now makes: a
+   sub-commit set `rbac.clusterScoped` to default `false` (namespace-scoped). A **later
+   sub-commit in the same PR** reverted it, titled `fix(helm): correct operator
+   rbac.clusterScoped default and template precedence` — the chart's `if`/`else if`/`else`
+   ordering was backwards, and the default render emitted **neither** a `RoleBinding` nor a
+   `ClusterRoleBinding` at all: a silent no-RBAC misrender, caught pre-merge only because
+   `9171e86f`'s CI chart-render assertion happened to exist. Rather than fix the template
+   ordering, the default was reverted to `true` to restore exact prior behavior as a
+   stopgap.
+
+**What's different this time:** both prior narrowing attempts treated this as a *chart*
+problem — a Helm value default and a template `if` chain. The chart is where both attempts
+broke, in two different ways (a silent no-binding misrender in #1224; a live wiring gap
+described below that neither attempt closed). This ADR moves the fail-closed behavior into
+the **binary** instead: the manager's own default scope becomes own-namespace regardless of
+what the chart renders, so a future chart defect produces an operator that is *broken*
+(fails to start, or watches too little), never one that is silently *over-privileged*. This
+is the same fail-closed posture already applied to this codebase's auth/RBAC/AAD paths —
+the failure direction is chosen deliberately, not left to whichever path happens to be
+checked first.
+
+**The live wiring gap referenced above** (found during this ADR's investigation, not
+previously documented): the chart's *other* narrowing option, `rbac.clusterScoped: false`
+(added by `4b8a2614`, survived the revert), binds a namespace-scoped `RoleBinding` — but
+nothing in `deployment.yaml` passes `-watch-namespaces` in that path; the flag is rendered
+**only** when `.Values.watchNamespaces` is non-empty, a separate value `clusterScoped: false`
+doesn't touch. So `rbac.clusterScoped: false` alone today produces a manager that still
+defaults to watching **all namespaces** (`operator/cmd/main.go`'s `secretCacheOptions`
+leaves `cache.Options.DefaultNamespaces` unset whenever `-watch-namespaces` is empty) against
+RBAC that only grants **one**. In a real cluster this means repeated `Forbidden` errors on
+every list/watch outside the release namespace, likely fatal to controller startup. This has
+apparently shipped, unnoticed, since `4b8a2614`.
+
+**Investigation finding: no residual `ClusterRole` is justified by anything other than the
+"watch every namespace with no static list" mechanism itself.** Checked directly, not
+assumed:
+- `KeyorixSecretSpec` (`operator/api/v1alpha1/keyorixsecret_types.go`) has no namespace
+  field anywhere — `tokenSecretRef`/`target` resolve only against `ks.Namespace` (the
+  watch-derived `req.NamespacedName`), never an attacker- or cross-namespace-supplied value.
+- No webhooks exist in the module.
+- No cluster-scoped Kubernetes resource type (`Node`, `Namespace`, `CustomResourceDefinition`)
+  is read anywhere in `operator/` — grepped and confirmed absent.
+- The operator's only external call (`operator/internal/keyorix/client.go`) is a single
+  `GET /api/v1/secrets/value` HTTP request to the configured Keyorix server — an
+  out-of-cluster API call, not an in-cluster cross-namespace K8s operation. Any secret
+  sharing / cross-project authorization gap that exists lives in that server's own
+  authorization for that endpoint, not in this operator's Kubernetes RBAC footprint — out of
+  scope for this ADR.
+
+Once the default stops requiring "watch every namespace with no static list," the only
+reason a `ClusterRole`/`ClusterRoleBinding` exists at all is the explicit, opt-in
+cluster-wide deployment mode this ADR keeps available.
+
+## Decision
+
+### A. The binary is the fail-closed boundary, not the chart
+
+`operator/cmd/main.go` gets a new, explicit contract:
+
+| Flags passed | Resulting scope |
+|---|---|
+| neither flag set, `POD_NAMESPACE` non-empty | **Own namespace only**, read from `POD_NAMESPACE` (populated via the Kubernetes Downward API, `fieldRef: metadata.namespace`, in the chart's Deployment spec) |
+| `-watch-namespaces=a,b,c` | Exactly those namespaces |
+| `-all-namespaces` | Cluster-wide — the **only** route to cluster-wide; there is no other way to make the manager watch every namespace |
+| both `-watch-namespaces` and `-all-namespaces` set | Startup validation error, non-zero exit — contradictory config is rejected, never silently resolved by precedence |
+| neither flag set, `POD_NAMESPACE` unset or empty | Startup validation error, non-zero exit, message naming `POD_NAMESPACE` specifically |
+
+The current behavior — unset `-watch-namespaces` defaults to all-namespaces — is the root
+fail-open every chart-level defect found during investigation is downstream of. Every failure
+mode in the reversal history (the #1224 no-binding misrender, and the live RBAC/cache wiring
+gap above) is a chart bug that happened to matter *because* the binary's own default was
+permissive. Fixing the default here means the failure direction of a future chart defect is
+always "the operator doesn't watch enough" or "the operator fails to start," never "the
+operator silently holds more access than intended."
+
+**Why an empty `POD_NAMESPACE` is a hard failure, not a silent fallback to all-namespaces**:
+falling back would rebuild exactly the fail-open this ADR exists to remove — but there's a
+second, sharper reason beyond that symmetry argument. `controller-runtime` treats an
+empty-string key in `cache.Options.DefaultNamespaces` as all-namespaces. An unchecked blank
+`POD_NAMESPACE` wouldn't even fail loudly on its own: it would silently produce a
+cluster-wide watch through code that *reads* as correctly scoped — a map literally
+constructed as `{"": {}}` looks, at the call site, like "watch namespace `\"\"`," not "watch
+everything." That is precisely the shape of bug this ADR is written to stop reintroducing.
+Refuse to start instead of guessing.
+
+**This makes the binary's own default dependent on the chart** — row 1 only holds if the
+chart actually supplies `POD_NAMESPACE` via the Downward API (`deployment.yaml`,
+`fieldRef: metadata.namespace`); that dependency is real, not just documentation. The hard
+fail in row 5 is what makes it *safe*: under a version-skewed chart/image pair (an old chart
+missing the env-var wiring paired with a new image, or a hand-rolled non-Helm deployment that
+forgets it entirely), the operator fails to start immediately and loudly instead of silently
+reverting to cluster-wide.
+
+### B. Chart: one named template computes effective scope once
+
+`rbac.yaml` and `deployment.yaml` currently each branch on `.Values.watchNamespaces` /
+`.Values.rbac.clusterScoped` independently — the exact shape of divergence that produced the
+#1224 misrender and the live wiring gap. Both templates instead render from a single named
+helper (in `_helpers.tpl`) that resolves the effective scope once and returns it in a form
+both templates consume — neither template reads `.Values.watchNamespaces` /
+`.Values.rbac.clusterScoped` directly again. Four paths, no fifth:
+
+| `rbac.clusterScoped` | `watchNamespaces` | RBAC binding | `-watch-namespaces` / `-all-namespaces` flag |
+|---|---|---|---|
+| `false` (default) | `[]` (default) | `RoleBinding` in `.Release.Namespace` | `-watch-namespaces={{ .Release.Namespace }}` |
+| `false` | set | `RoleBinding` per listed namespace | `-watch-namespaces={{ join "," .Values.watchNamespaces }}` |
+| `true` | `[]` | `ClusterRoleBinding` | `-all-namespaces` |
+| `true` | set | Helm `fail`, naming both `rbac.clusterScoped` and `watchNamespaces` in the message | — (render aborts) |
+
+No precedence-based resolution of the fourth (contradictory) combination — `4b8a2614`
+demonstrated precedence ordering is exactly how this class of chart produces a silent
+misrender. Reject it explicitly instead.
+
+### C. Rejected alternative: collapse into a single `scope` enum
+
+Considered replacing `rbac.clusterScoped` + `watchNamespaces` with one Helm value (e.g.
+`scope: namespace | multi-namespace | cluster`). Cleaner schema on its own — but it breaks
+values compatibility for the existing `watchNamespaces`/`rbac.clusterScoped` keys
+(`4b8a2614` already shipped and documented `rbac.clusterScoped`) for no security benefit:
+once the single named helper in (B) makes divergence between the two values structurally
+impossible, a two-value schema is exactly as safe as an enum, at zero migration cost to
+whoever already set `rbac.clusterScoped: true`. Rejected; keep both existing values, resolved
+through the shared helper.
+
+### D. Testing: extend the chart-render assertion, and add direct binary-level coverage of the fail-closed default
+
+`9171e86f` (#790) added a CI chart-render assertion that already caught the `4b8a2614`
+misrender before merge — the mechanism worked exactly as intended once. Extend that same
+assertion to cover all four rows of the table in (B), asserting in each case that the
+rendered RBAC binding kind (`RoleBinding` vs `ClusterRoleBinding`, and its namespace(s)) and
+the rendered manager flag (`-watch-namespaces=...` vs `-all-namespaces`) actually agree with
+each other — not just that *something* renders. That agreement check is what (B)'s failure
+mode would have violated; asserting it directly is what makes this bug class non-recurring
+rather than merely fixed once more.
+
+That chart-render assertion, however, can never exercise (A)'s own fail-closed default: row 1
+of (B)'s table renders `-watch-namespaces={{ .Release.Namespace }}` explicitly, so a real
+Helm-deployed instance always receives an explicit flag — it never falls through to (A) row
+1's `POD_NAMESPACE` path. Keeping the explicit flag in the chart is a deliberate, separate
+choice (manifest readability — the rendered Deployment shows its own scope without
+cross-referencing a Downward API env var — and (D)'s own flag-agrees-with-binding assertion
+needs an actual flag value to compare against), but it means the binary's fail-closed default
+needs test coverage that doesn't route through the chart at all. Two new unit tests in
+`operator/cmd`:
+- no flags set, `POD_NAMESPACE=foo` → the constructed cache options scope to `foo` only.
+- no flags set, `POD_NAMESPACE` empty/unset → non-zero exit, exercising (A) row 5 directly.
+
+### E. Out of scope for this ADR, noted so it isn't rediscovered as new
+
+- The dead `keyorixsecrets/finalizers` RBAC grant (round-143 finding #535, fix already
+  pending in unmerged PR #1329) — unrelated axis (verb/resource hygiene, not namespace
+  scope), left to that PR.
+- The full CRUD verb set on core `Secrets` (`create/update/patch/delete`, not just
+  `get/list/watch`) — a real, separate question (`delete` in particular is a likely finding
+  on its own, scoped to `wipeTargetSecret`'s use of it per #428). Verb scope and namespace
+  scope are independent axes; conflating them here would block this fix on a second, larger
+  design discussion. Deferred to its own future ADR.
+
+## Consequences
+
+**This is a deployment-behavior change, not a pure bug fix — it changes what an unmodified
+`helm install` grants by default.** Two separate CHANGELOG entries, not one:
+
+- **`BREAKING`**: default scope changes from cluster-wide to own-namespace-only. Existing
+  installs that rely on today's default (a single cluster-wide instance, no values
+  overridden) must set `rbac.clusterScoped: true` explicitly to preserve current behavior
+  across the upgrade; the upgrade note states this exactly, not just "review your RBAC."
+- **`Fixed`**: `rbac.clusterScoped: false` has been non-functional since `4b8a2614` — it
+  binds namespace-scoped RBAC while the manager continues watching all namespaces (the live
+  wiring gap documented in Context). Checked tags/release history directly rather than
+  assuming: `4b8a2614` landed 2026-07-29, three days *after* the most recent tag, `v0.88.0`
+  (2026-07-26); `git tag --contains 4b8a2614` returns no tags. **No released version has ever
+  shipped this option** — it has only ever existed on trunk. The CHANGELOG entry can state
+  this plainly (e.g. "never worked correctly; fixed before its first release") rather than
+  naming affected versions, since there are none.
+
+**Why now, specifically.** Per ADR-067, Keyorix is pre-1.0 with no paying production
+deployment yet and no LTS line — the migration cost of a breaking default change is at its
+lowest point it will ever be. Once the first LTS line exists (ADR-067: cut at v1.0, first
+paying production deployment), a change to this operator's default RBAC scope becomes a
+five-year-obligation-affecting change under CRA Article 13(8) for every customer already on
+that line, not a values-file adjustment made once before anyone depends on the old default.
+This is the last point at which the fix is cheap.
+
+**Positive.** Closes the actual gap round 143's audit found (cluster-wide-by-default full
+Secret CRUD) at its root — the binary's own default — rather than only in the chart, where
+it has now failed to stay fixed twice. The chart-render assertion in (D) converts a bug class
+that has recurred twice into one CI catches by construction.
+
+**Negative.** Multi-namespace operators (today implicitly served by the permissive default)
+must now set `watchNamespaces` explicitly, or `rbac.clusterScoped: true` for the genuinely
+cluster-wide case — a required action on upgrade for that population, not a silent
+improvement.

--- a/docs/k8s-operator.md
+++ b/docs/k8s-operator.md
@@ -80,12 +80,24 @@ can never disagree with each other (`_helpers.tpl`'s `kxop.scope` — see the ch
   to render (`helm template`/`helm install` fails with an error naming both values), rather
   than silently picking one.
 
-**Upgrading from a chart version older than this default change?** An unmodified prior
-install relied on the old cluster-wide default. To preserve that behavior across the
-upgrade, add `--set rbac.clusterScoped=true` to your `helm upgrade` — see the CHANGELOG's
-`BREAKING` entry for this release for the full detail. Without it, the upgrade narrows the
-operator to its own release namespace only, which may stop it from reconciling
-`KeyorixSecret` CRs in other namespaces it previously watched.
+**Upgrading from a chart version older than this default change?** Two scenarios:
+
+- **You relied on the old cluster-wide default (neither value set).** Add
+  `--set rbac.clusterScoped=true` to your `helm upgrade` to preserve that behavior across
+  the upgrade. Without it, the operator narrows to its own release namespace only, which
+  may stop it from reconciling `KeyorixSecret` CRs in other namespaces it previously
+  watched.
+- **You already set `watchNamespaces`.** `rbac.clusterScoped` defaulted to `true` before
+  this release, and a plain `helm upgrade` (without `--reset-values`) carries forward a
+  release's previously-recorded values by default — so your install is very likely already
+  in the now-rejected combination (`rbac.clusterScoped=true` + `watchNamespaces` set). The
+  upgrade will refuse to render at all, with an error containing:
+  `rbac.clusterScoped=true and watchNamespaces=[...] are both set -- these are mutually
+  exclusive (ADR-076)`. This is a hard block on the upgrade itself, not a permissions
+  change — add `--set rbac.clusterScoped=false` explicitly to your `helm upgrade` (or the
+  equivalent in your values file) to clear it.
+
+See the CHANGELOG's `BREAKING` entry for this release for the full detail.
 
 ## Usage
 

--- a/docs/k8s-operator.md
+++ b/docs/k8s-operator.md
@@ -43,19 +43,49 @@ helm upgrade keyorix-operator deploy/helm/keyorix-operator -n keyorix-system \
   --set replicas=2 --set leaderElection=true
 ```
 
-By default a single operator instance watches `KeyorixSecret` CRs across every namespace in
-the cluster, so its RBAC (`ClusterRole`) is bound cluster-wide via a `ClusterRoleBinding` —
-the only way to grant access to a namespace it can't predict ahead of time. If your
-deployment instead runs one operator instance per namespace (or per bounded tenant set), set
-`watchNamespaces` to scope both the manager's watch and its RBAC binding down to a
-namespace-scoped `RoleBinding` per listed namespace:
+### Choosing a namespace scope (ADR-076)
 
-```sh
-helm install keyorix-operator-team-a deploy/helm/keyorix-operator -n team-a \
-  --set 'watchNamespaces={team-a}'
-```
+**By default, a single operator instance watches `KeyorixSecret` CRs in its own release
+namespace only** — its RBAC (a `Role`/`RoleBinding` pair) is scoped accordingly, and the
+manager itself defaults to the same namespace (read from `POD_NAMESPACE`, set via the
+Downward API). This is the least-privilege choice: an unmodified `helm install` never
+grants the operator access to Secrets outside the namespace you installed it into.
 
-See the chart's [README](../deploy/helm/keyorix-operator/README.md#rbac) for details.
+Two opt-in modes cover broader deployments, both resolved from the same two values so they
+can never disagree with each other (`_helpers.tpl`'s `kxop.scope` — see the chart's
+[README](../deploy/helm/keyorix-operator/README.md#rbac) for the underlying mechanism):
+
+- **Bounded multi-namespace** — one operator instance managing a known, fixed set of
+  namespaces (e.g. all of one team's tenants). Set `watchNamespaces`:
+
+  ```sh
+  helm install keyorix-operator-team-a deploy/helm/keyorix-operator -n team-a \
+    --set 'watchNamespaces={team-a,team-b}'
+  ```
+
+  RBAC is bound via a namespace-scoped `RoleBinding` in each listed namespace; the manager
+  watches exactly those namespaces.
+
+- **Cluster-wide** — one operator instance managing `KeyorixSecret` CRs in *every*
+  namespace, with no static list. Set `rbac.clusterScoped: true` explicitly:
+
+  ```sh
+  helm install keyorix-operator deploy/helm/keyorix-operator -n keyorix-system \
+    --create-namespace --set rbac.clusterScoped=true
+  ```
+
+  RBAC is bound via a cluster-wide `ClusterRoleBinding` — this is now the **only** way to
+  get that grant; it is no longer the default. `watchNamespaces` and
+  `rbac.clusterScoped: true` are mutually exclusive — setting both makes the chart refuse
+  to render (`helm template`/`helm install` fails with an error naming both values), rather
+  than silently picking one.
+
+**Upgrading from a chart version older than this default change?** An unmodified prior
+install relied on the old cluster-wide default. To preserve that behavior across the
+upgrade, add `--set rbac.clusterScoped=true` to your `helm upgrade` — see the CHANGELOG's
+`BREAKING` entry for this release for the full detail. Without it, the upgrade narrows the
+operator to its own release namespace only, which may stop it from reconciling
+`KeyorixSecret` CRs in other namespaces it previously watched.
 
 ## Usage
 

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 
@@ -30,28 +31,79 @@ func init() {
 	utilruntime.Must(secretsv1alpha1.AddToScheme(scheme))
 }
 
+// namespaceScope is the fully-validated outcome of resolving -watch-namespaces,
+// -all-namespaces, and POD_NAMESPACE (ADR-076). It has exactly two valid shapes: a
+// concrete, non-empty list of namespaces to watch, or explicit all-namespaces. There is
+// no third, ambiguous state — resolveScope never returns a zero-value namespaceScope
+// without an error, and callers must not construct one directly outside a test.
+type namespaceScope struct {
+	namespaces    []string // non-empty unless allNamespaces is true
+	allNamespaces bool
+}
+
+// resolveScope implements ADR-076's fail-closed namespace-scope contract:
+//
+//   - -watch-namespaces set (and -all-namespaces not): watch exactly those namespaces.
+//   - -all-namespaces set (and -watch-namespaces not): watch every namespace in the
+//     cluster. This is the ONLY route to a cluster-wide watch — there is no implicit one.
+//   - both set: a startup validation error, never resolved by precedence. #1224 already
+//     demonstrated what precedence-based resolution of contradictory chart config does
+//     (a silent no-RBAC-binding render); the binary does not repeat that mistake.
+//   - neither set: fall back to the pod's OWN namespace, read from podNamespaceEnv
+//     (POD_NAMESPACE, populated by the Helm chart via the Kubernetes Downward API) — never
+//     to all-namespaces. If podNamespaceEnv is also empty, this is a startup validation
+//     error naming POD_NAMESPACE specifically, not a silent cluster-wide fallback:
+//     controller-runtime treats an empty-string key in cache.Options.DefaultNamespaces as
+//     cache.AllNamespaces (= metav1.NamespaceAll = ""), so passing through an unchecked
+//     blank POD_NAMESPACE would silently produce a cluster-wide watch through code that
+//     reads, at the call site, as correctly namespace-scoped.
+func resolveScope(watchNamespacesFlag string, allNamespacesFlag bool, podNamespaceEnv string) (namespaceScope, error) {
+	var watchNS []string
+	for _, ns := range strings.Split(watchNamespacesFlag, ",") {
+		if ns = strings.TrimSpace(ns); ns != "" {
+			watchNS = append(watchNS, ns)
+		}
+	}
+
+	switch {
+	case len(watchNS) > 0 && allNamespacesFlag:
+		return namespaceScope{}, fmt.Errorf(
+			"-watch-namespaces and -all-namespaces are mutually exclusive; set exactly one, " +
+				"or set neither to default to the pod's own namespace (POD_NAMESPACE)")
+	case allNamespacesFlag:
+		return namespaceScope{allNamespaces: true}, nil
+	case len(watchNS) > 0:
+		return namespaceScope{namespaces: watchNS}, nil
+	}
+
+	podNamespace := strings.TrimSpace(podNamespaceEnv)
+	if podNamespace == "" {
+		return namespaceScope{}, fmt.Errorf(
+			"neither -watch-namespaces nor -all-namespaces is set, and POD_NAMESPACE is " +
+				"empty or unset -- refusing to start with an ambiguous scope rather than " +
+				"defaulting to a cluster-wide watch (ADR-076). Set -watch-namespaces, pass " +
+				"-all-namespaces explicitly, or ensure POD_NAMESPACE is populated (the Helm " +
+				"chart does this via the Downward API; a hand-rolled deployment must too)")
+	}
+	return namespaceScope{namespaces: []string{podNamespace}}, nil
+}
+
 // secretCacheOptions scopes the manager's Secret informer to only Secrets the operator
 // itself manages, and routes every other Secret read straight to the API server instead
-// of through that (now-restricted) cache.
+// of through that (now-restricted) cache. The namespace scope itself (s) is resolved
+// beforehand by resolveScope per ADR-076 — this function only ever renders an
+// already-validated scope into cache.Options, it does not decide the scope itself.
 //
-// By DEFAULT the operator is deployed as a single cluster-wide instance: it watches
-// KeyorixSecret CRs (a namespaced CRD) across every namespace, so its ClusterRole
-// necessarily grants Secret get/list/watch/create/update/patch/delete cluster-wide too —
-// with no static namespace list configured, the operator genuinely cannot predict which
-// namespace the next CR (and its TokenSecretRef/target Secret) will land in, and
-// Kubernetes RBAC has no way to scope list/watch by resourceNames or to a dynamically
-// changing namespace set. See #327/#427 and operator/config/rbac/role.yaml /
-// deploy/helm/keyorix-operator/templates/rbac.yaml for the fuller writeup.
+// By DEFAULT (ADR-076) the operator watches only its own namespace — s.allNamespaces is
+// false and s.namespaces holds exactly one entry, the pod's own namespace. Operators who
+// need one instance to watch a bounded set of tenants set -watch-namespaces explicitly;
+// operators who need a single cluster-wide instance (the ORIGINAL default, see #327/#427
+// and ADR-076 for the reversal history) must pass -all-namespaces explicitly, which is the
+// only way s.allNamespaces becomes true. See operator/config/rbac/role.yaml /
+// deploy/helm/keyorix-operator/templates/rbac.yaml for how the corresponding RBAC binding
+// (RoleBinding vs ClusterRoleBinding) is kept in lockstep with this same scope.
 //
-// Operators who instead run one instance PER namespace (or per bounded tenant set) can
-// opt into the -watch-namespaces flag: it restricts every cached type (KeyorixSecret CRs
-// AND Secrets) to just those namespaces via cache.Options.DefaultNamespaces, and the Helm
-// chart's watchNamespaces value correspondingly swaps the cluster-wide ClusterRoleBinding
-// for a namespace-scoped RoleBinding per watched namespace (still against the same
-// ClusterRole definition, for manifest reusability) — the least-privilege choice for that
-// deployment model, without forcing it on the default multi-tenant one.
-//
-// What IS always avoidable, regardless of namespace scoping, is controller-runtime's
+// What IS always avoided, regardless of namespace scoping, is controller-runtime's
 // default behavior of caching every Secret in the cluster in the operator's own process
 // memory just because SetupWithManager calls Owns(&corev1.Secret{}) to watch the Secrets
 // it owns. That default cache would hold the full contents of every Secret it can see —
@@ -65,7 +117,7 @@ func init() {
 // Token Secrets (read via TokenSecretRef) and not-yet-adopted target Secrets never carry
 // that label, so DisableFor routes their reads around the label-restricted cache to a live
 // API call — they stay correctly readable on every reconcile, just uncached.
-func secretCacheOptions(watchNamespaces []string) (cache.Options, client.Options) {
+func secretCacheOptions(s namespaceScope) (cache.Options, client.Options) {
 	managedByThisOperator := labels.SelectorFromSet(map[string]string{
 		controller.ManagedByLabel: controller.ManagedByValue,
 	})
@@ -74,9 +126,12 @@ func secretCacheOptions(watchNamespaces []string) (cache.Options, client.Options
 			&corev1.Secret{}: {Label: managedByThisOperator},
 		},
 	}
-	if len(watchNamespaces) > 0 {
-		defaultNamespaces := make(map[string]cache.Config, len(watchNamespaces))
-		for _, ns := range watchNamespaces {
+	if !s.allNamespaces {
+		// s.namespaces is guaranteed non-empty here by resolveScope's contract — never
+		// constructed from an unvalidated/possibly-empty string, so this map never ends
+		// up with the "" (cache.AllNamespaces) sentinel key by accident.
+		defaultNamespaces := make(map[string]cache.Config, len(s.namespaces))
+		for _, ns := range s.namespaces {
 			defaultNamespaces[ns] = cache.Config{}
 		}
 		// Left unset on the Secret ByObject entry above so it defaults from
@@ -85,6 +140,9 @@ func secretCacheOptions(watchNamespaces []string) (cache.Options, client.Options
 		// overriding the other.
 		opts.DefaultNamespaces = defaultNamespaces
 	}
+	// s.allNamespaces == true is the ONLY path that leaves DefaultNamespaces unset
+	// (cluster-wide, controller-runtime's own len(DefaultNamespaces) > 0 check) — always
+	// the result of an explicit, validated -all-namespaces flag, never a fallback.
 	return opts, client.Options{
 		Cache: &client.CacheOptions{
 			DisableFor: []client.Object{&corev1.Secret{}},
@@ -94,7 +152,7 @@ func secretCacheOptions(watchNamespaces []string) (cache.Options, client.Options
 
 func main() {
 	var metricsAddr, probeAddr, allowedServers, watchNamespaces string
-	var enableLeaderElection bool
+	var enableLeaderElection, allNamespaces bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "address the metric endpoint binds to")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "address the probe endpoint binds to")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -104,9 +162,12 @@ func main() {
 			"REQUIRED: without it every CR is rejected, so the operator never sends a token to a CR-chosen destination.")
 	flag.StringVar(&watchNamespaces, "watch-namespaces", os.Getenv("KEYORIX_WATCH_NAMESPACES"),
 		"OPTIONAL comma-separated list of namespaces this instance manages KeyorixSecret CRs and their target "+
-			"Secrets in. Leave empty (the default) to watch every namespace in the cluster, which requires a "+
-			"cluster-wide RBAC grant (#327/#427). Set this to run one operator instance per namespace/tenant set "+
-			"with a namespace-scoped RBAC grant instead — see deploy/helm/keyorix-operator's watchNamespaces value.")
+			"Secrets in. Mutually exclusive with -all-namespaces. Leave both unset (the default) to watch only the "+
+			"pod's own namespace (read from POD_NAMESPACE, e.g. via the Downward API) — see -all-namespaces for a "+
+			"genuinely cluster-wide watch (ADR-076).")
+	flag.BoolVar(&allNamespaces, "all-namespaces", false,
+		"Watch every namespace in the cluster. The ONLY way to run in cluster-wide mode (ADR-076) — requires a "+
+			"cluster-wide ClusterRoleBinding (#327/#427). Mutually exclusive with -watch-namespaces.")
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
@@ -114,17 +175,18 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	setupLog := ctrl.Log.WithName("setup")
 
-	var watchNS []string
-	for _, ns := range strings.Split(watchNamespaces, ",") {
-		if ns = strings.TrimSpace(ns); ns != "" {
-			watchNS = append(watchNS, ns)
-		}
+	scope, err := resolveScope(watchNamespaces, allNamespaces, os.Getenv("POD_NAMESPACE"))
+	if err != nil {
+		setupLog.Error(err, "invalid namespace-scope configuration")
+		os.Exit(1)
 	}
-	if len(watchNS) > 0 {
-		setupLog.Info("restricting watched namespaces", "namespaces", watchNS)
+	if scope.allNamespaces {
+		setupLog.Info("watching all namespaces (-all-namespaces)")
+	} else {
+		setupLog.Info("restricting watched namespaces", "namespaces", scope.namespaces)
 	}
 
-	secretCache, secretClient := secretCacheOptions(watchNS)
+	secretCache, secretClient := secretCacheOptions(scope)
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},

--- a/operator/cmd/main_test.go
+++ b/operator/cmd/main_test.go
@@ -26,11 +26,11 @@ func secretByObject(opts cache.Options) (cache.ByObject, bool) {
 
 // secretCacheOptions is the operator's #327 mitigation: without it, the manager's default
 // cache backs Owns(&corev1.Secret{}) by listing/watching/caching EVERY Secret in the
-// cluster in the operator's own process memory, even though the RBAC ClusterRole (required
-// because this is a single cluster-wide operator instance, see cmd/main.go's doc comment)
-// grants access far beyond what any one reconcile touches.
+// cluster in the operator's own process memory, even though a cluster-wide-mode RBAC
+// ClusterRole (see cmd/main.go's doc comment and ADR-076) grants access far beyond what any
+// one reconcile touches.
 func TestSecretCacheOptions_ScopesInformerToManagedSecrets(t *testing.T) {
-	cacheOpts, _ := secretCacheOptions(nil)
+	cacheOpts, _ := secretCacheOptions(namespaceScope{allNamespaces: true})
 
 	byObj, ok := secretByObject(cacheOpts)
 	require.True(t, ok, "the Secret informer must have an explicit ByObject scope, not the cluster-wide default")
@@ -53,7 +53,7 @@ func TestSecretCacheOptions_ScopesInformerToManagedSecrets(t *testing.T) {
 // Secrets, which never carry the managed-by label) unreadable: direct client reads for
 // Secrets must bypass that cache and go live to the API server instead.
 func TestSecretCacheOptions_DisablesCacheForDirectSecretReads(t *testing.T) {
-	_, clientOpts := secretCacheOptions(nil)
+	_, clientOpts := secretCacheOptions(namespaceScope{allNamespaces: true})
 
 	require.NotNil(t, clientOpts.Cache, "direct Secret reads must be excluded from the label-restricted cache")
 	found := false
@@ -68,7 +68,7 @@ func TestSecretCacheOptions_DisablesCacheForDirectSecretReads(t *testing.T) {
 // Guard against the cache options silently reverting to controller-runtime's cluster-wide
 // default (a nil/empty ByObject map caches everything with no restriction at all).
 func TestSecretCacheOptions_IsNotClusterWideDefault(t *testing.T) {
-	cacheOpts, _ := secretCacheOptions(nil)
+	cacheOpts, _ := secretCacheOptions(namespaceScope{allNamespaces: true})
 	assert.NotEmpty(t, cacheOpts.ByObject, "cache.Options.ByObject must not be empty, or Secret caching silently reverts to the cluster-wide default")
 }
 
@@ -78,7 +78,7 @@ func TestSecretCacheOptions_IsNotClusterWideDefault(t *testing.T) {
 // access — must be limited to exactly those namespaces, not silently fall back to
 // cluster-wide.
 func TestSecretCacheOptions_RestrictsToWatchNamespacesWhenSet(t *testing.T) {
-	cacheOpts, _ := secretCacheOptions([]string{"team-a", "team-b"})
+	cacheOpts, _ := secretCacheOptions(namespaceScope{namespaces: []string{"team-a", "team-b"}})
 
 	require.NotNil(t, cacheOpts.DefaultNamespaces, "DefaultNamespaces must be set when watch namespaces are configured")
 	assert.Len(t, cacheOpts.DefaultNamespaces, 2)
@@ -95,10 +95,79 @@ func TestSecretCacheOptions_RestrictsToWatchNamespacesWhenSet(t *testing.T) {
 	assert.True(t, byObj.Label.Matches(managed))
 }
 
-// The default (cluster-wide) behavior must be preserved when no namespaces are configured —
-// this is what the existing default Helm chart install (and existing deployments upgrading
-// without setting watchNamespaces) rely on.
-func TestSecretCacheOptions_DefaultsToClusterWideWhenUnset(t *testing.T) {
-	cacheOpts, _ := secretCacheOptions(nil)
-	assert.Empty(t, cacheOpts.DefaultNamespaces, "DefaultNamespaces must be unset by default, preserving cluster-wide watch behavior")
+// ADR-076: -all-namespaces is the ONLY path that leaves DefaultNamespaces unset (which
+// controller-runtime treats as cluster-wide, via its own len(DefaultNamespaces) > 0 check).
+// Superseded TestSecretCacheOptions_DefaultsToClusterWideWhenUnset, which asserted the
+// pre-ADR-076 behavior (nil/unset input defaulted to cluster-wide) that this ADR removes —
+// namespaceScope has no "unset" input shape anymore; resolveScope is what used to own that
+// default, and it no longer produces cluster-wide without an explicit -all-namespaces flag
+// (see TestResolveScope_* below).
+func TestSecretCacheOptions_AllNamespacesLeavesDefaultNamespacesUnset(t *testing.T) {
+	cacheOpts, _ := secretCacheOptions(namespaceScope{allNamespaces: true})
+	assert.Empty(t, cacheOpts.DefaultNamespaces, "DefaultNamespaces must stay unset for an explicit -all-namespaces scope")
+}
+
+// ADR-076's fail-closed contract: with neither -watch-namespaces nor -all-namespaces set,
+// the operator watches only its own namespace, read from POD_NAMESPACE — never
+// all-namespaces. This is the specific case the ADR calls out as needing direct test
+// coverage: the Helm chart's default render always passes an explicit
+// -watch-namespaces={{ .Release.Namespace }} flag (see deploy/helm/keyorix-operator), so a
+// real deployment never actually exercises this fallback path — only a direct unit test
+// does.
+func TestResolveScope_DefaultsToPodNamespaceWhenNeitherFlagSet(t *testing.T) {
+	scope, err := resolveScope("", false, "foo")
+	require.NoError(t, err)
+	assert.False(t, scope.allNamespaces)
+	assert.Equal(t, []string{"foo"}, scope.namespaces)
+
+	// End-to-end through secretCacheOptions too, matching what main() actually does with
+	// the resolved scope: the cache must be scoped to "foo" only, nothing broader.
+	cacheOpts, _ := secretCacheOptions(scope)
+	require.NotNil(t, cacheOpts.DefaultNamespaces)
+	assert.Len(t, cacheOpts.DefaultNamespaces, 1)
+	_, hasFoo := cacheOpts.DefaultNamespaces["foo"]
+	assert.True(t, hasFoo)
+}
+
+// ADR-076: an empty or unset POD_NAMESPACE with neither flag set must be a startup
+// validation error naming POD_NAMESPACE, not a silent fallback to all-namespaces —
+// controller-runtime treats an empty-string DefaultNamespaces key as cache.AllNamespaces, so
+// passing an unvalidated blank POD_NAMESPACE through would silently produce a cluster-wide
+// watch via code that reads as correctly scoped. main() treats this error as fatal
+// (setupLog.Error + os.Exit(1)); this test proves the condition that drives that exit, which
+// is the level main.go's own one-line error branch is actually worth testing at.
+func TestResolveScope_EmptyPodNamespaceFailsClosed(t *testing.T) {
+	_, err := resolveScope("", false, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "POD_NAMESPACE")
+
+	_, err = resolveScope("", false, "   ")
+	require.Error(t, err, "a whitespace-only POD_NAMESPACE must also fail closed, not resolve to a blank namespace")
+}
+
+// ADR-076: -watch-namespaces and -all-namespaces are mutually exclusive, rejected outright
+// rather than resolved by precedence — #1224 already showed precedence-based resolution of
+// contradictory config is exactly how this class of bug produces a silent misrender.
+func TestResolveScope_BothFlagsSetIsAnError(t *testing.T) {
+	_, err := resolveScope("team-a,team-b", true, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// -watch-namespaces set (without -all-namespaces) takes the explicit list, regardless of
+// POD_NAMESPACE — the flag is authoritative over the pod's own namespace when set.
+func TestResolveScope_WatchNamespacesSetIgnoresPodNamespace(t *testing.T) {
+	scope, err := resolveScope("team-a, team-b", false, "some-other-namespace")
+	require.NoError(t, err)
+	assert.False(t, scope.allNamespaces)
+	assert.Equal(t, []string{"team-a", "team-b"}, scope.namespaces)
+}
+
+// -all-namespaces set (without -watch-namespaces) resolves to allNamespaces regardless of
+// POD_NAMESPACE, and ignores an empty POD_NAMESPACE too — the flag is authoritative.
+func TestResolveScope_AllNamespacesSetIgnoresPodNamespace(t *testing.T) {
+	scope, err := resolveScope("", true, "")
+	require.NoError(t, err)
+	assert.True(t, scope.allNamespaces)
+	assert.Empty(t, scope.namespaces)
 }


### PR DESCRIPTION
## Summary

Narrows the keyorix-operator's default RBAC/watch scope from cluster-wide (full CRUD on every core Secret, ClusterRoleBinding) to own-namespace-only by default, with explicit opt-in for multi-namespace and cluster-wide deployment. Closes the operator default-RBAC-scope finding flagged (and deliberately not auto-fixed) in the round-143 adversarial security review.

This is the third attempt at this narrowing — see ADR-076 for the full reversal history (`0869bd91`/#429, `dc36f3e4`/#327, `9171e86f`/#790, `4b8a2614`/#1224) and what's different this time: the fail-closed behavior now lives in the **binary**, not only the chart, so a future chart defect produces a broken operator rather than a silently over-privileged one.

Investigation (prior to implementation) also found and fixed a previously-undocumented live bug: `rbac.clusterScoped: false` (added in #1224) bound namespace-scoped RBAC without ever telling the manager to narrow its own watch scope — it has never worked correctly, and never shipped in a released version (confirmed via `git tag --contains`).

## Commits

1. **`docs(adr-076)`** — the ADR itself, written and reviewed before any implementation.
2. **`feat(operator)`** — binary scope contract (`operator/cmd/main.go`): new `-all-namespaces` flag, fail-closed default to `POD_NAMESPACE` when neither flag is set, hard validation errors (never silent fallback) for both an empty `POD_NAMESPACE` and contradictory flags.
3. **`feat(helm)`** — single named template (`_helpers.tpl`'s `kxop.scope`) resolves the effective scope once; `rbac.yaml` and `deployment.yaml` both render from it instead of independently branching on the same two values (the exact shape that produced #1224's silent misrender). `rbac.clusterScoped` default flipped `true` → `false`.
4. **`ci`** — extends the existing chart-render assertion (#790) to all 4 paths from the ADR's table, asserting the RBAC binding and the rendered manager flag actually agree with each other in each case.
5. **`docs`** — deployment guide section on scope selection, CHANGELOG `BREAKING` + `Fixed` entries with the exact upgrade action stated (`--set rbac.clusterScoped=true`).

## Breaking change

Yes — see the CHANGELOG `Unreleased` → `Changed` entry. An unmodified `helm install` now grants only the release's own namespace, not the cluster. Existing installs relying on the old default must add `--set rbac.clusterScoped=true` on upgrade.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l .`, `gosec -severity medium -exclude-generated ./...` (0 issues) — all via `GOWORK=off` from within `operator/`
- [x] `helm lint` on all 3 valid value combinations
- [x] `helm template` run locally for all 4 paths (default, multi-namespace, cluster-wide, contradictory-fails) against `kubeconform`, before writing the same assertions into CI — caught and fixed one real bug this way (a flag-presence check that false-matched a comment)
- [x] New/updated unit tests in `operator/cmd/main_test.go` covering the fail-closed default, the mutual-exclusion validation, and flag-priority

Does not touch the dead `keyorixsecrets/finalizers` RBAC grant (separate, unrelated PR #1329) or the core Secrets verb set (deferred to a future ADR per ADR-076 section E).