### PR TITLE
fix(sonar): make validatedOutputPath's invalid-path branches unreachable-proof

### DIFF
--- a/web/scripts/build-frontend-sbom.mjs
+++ b/web/scripts/build-frontend-sbom.mjs
@@ -96,10 +96,12 @@ function validatedOutputPath(rawArg) {
     if (!rawArg) {
         console.error('[frontend-sbom] usage: build-frontend-sbom.mjs <output-file>');
         process.exit(1);
+        return undefined; // unreachable -- process.exit() above halts the script
     }
     const resolved = resolve(rawArg);
     if (resolved !== repoRoot && !resolved.startsWith(repoRoot + sep)) {
         fail(`output path resolves outside the repository (${repoRoot}): ${resolved}`);
+        return undefined; // unreachable -- fail() exits the process
     }
     return resolved;
 }


### PR DESCRIPTION
## Summary
- `validatedOutputPath()` in `web/scripts/build-frontend-sbom.mjs` already validated the CLI-supplied output path resolves inside the repo root, but called `fail()`/`process.exit(1)` on failure and then fell through to `return resolved` regardless — Sonar's dataflow analysis doesn't model `process.exit()` as halting control flow, so it still flagged the L214 `writeFileSync()` sink as reachable with an unvalidated path.
- Added an explicit `return undefined` immediately after each `fail()`/`process.exit()` call, matching the same pattern already used in `resolveTrusted()` in this file.
- No behavior change: `process.exit()` still halts before the `return` is ever reached at runtime.

## Test plan
- [x] `node --check` passes
- [x] Verified valid in-repo paths still resolve correctly
- [x] Verified a path-traversal argument (`../../../etc/cron.d/evil`) still exits 1 with the same error message
- [x] Verified the no-argument usage path still exits 1