### PR TITLE
fix(operator): add imagePullSecrets support to keyorix-operator chart

### DIFF
--- a/deploy/helm/keyorix-operator/README.md
+++ b/deploy/helm/keyorix-operator/README.md
@@ -17,6 +17,7 @@ helm install keyorix-operator deploy/helm/keyorix-operator -n keyorix-system --c
 | Key | Description |
 | --- | --- |
 | `image.repository` / `image.tag` | Operator image (tag defaults to the chart's appVersion) |
+| `imagePullSecrets` | Names of existing `docker-registry` Secrets to pull the operator image from a private/mirrored registry — see [Private registries](#private-registries) |
 | `replicas` | Manager replicas (keep at 1 unless `leaderElection` is on) |
 | `leaderElection` | Run >1 replica safely via a lease in the release namespace (default `false`) |
 | `metricsPort` / `healthPort` | Manager metrics (`/metrics`) and probe (`/healthz`,`/readyz`) ports |
@@ -48,6 +49,23 @@ namespaces too) and swaps the cluster-wide `ClusterRoleBinding` for a namespace-
 `RoleBinding` in each listed namespace — the same `ClusterRole` stays cluster-scoped (a
 Kubernetes RBAC object type), but its granted access is limited to the bound namespaces. Do
 not deploy more than one instance watching the same namespace with different configs.
+
+## Private registries
+
+For an air-gapped deployment that mirrors `keyorix-operator`'s image to a private,
+authenticated registry, create a `docker-registry` Secret in the release namespace and
+reference it via `imagePullSecrets`:
+
+```sh
+kubectl create secret docker-registry my-registry-cred \
+  -n keyorix-system \
+  --docker-server=my-mirror.example.com \
+  --docker-username=... --docker-password=...
+
+helm install keyorix-operator deploy/helm/keyorix-operator -n keyorix-system \
+  --set image.repository=my-mirror.example.com/keyorix-operator \
+  --set 'imagePullSecrets[0].name=my-registry-cred'
+```
 
 ## Uninstalling
 

--- a/deploy/helm/keyorix-operator/templates/deployment.yaml
+++ b/deploy/helm/keyorix-operator/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         {{- include "kxop.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "kxop.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532  # matches the distroless:nonroot image user

--- a/deploy/helm/keyorix-operator/values.yaml
+++ b/deploy/helm/keyorix-operator/values.yaml
@@ -11,6 +11,14 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+# imagePullSecrets: names of existing Secrets (docker-registry type) in the release
+# namespace to pull the operator image from a private/mirrored registry -- required for
+# air-gapped installs that mirror ghcr.io/keyorixhq/keyorix-operator behind auth. Empty by
+# default (matches the keyorix chart's own imagePullSecrets convention).
+#   imagePullSecrets:
+#     - name: my-registry-cred
+imagePullSecrets: []
+
 # replicas: keep at 1 unless leaderElection is enabled (only one replica reconciles).
 replicas: 1
 # leaderElection: enable to run more than one replica safely (HA standby). Requires the

--- a/docs/k8s-operator.md
+++ b/docs/k8s-operator.md
@@ -57,6 +57,11 @@ helm install keyorix-operator-team-a deploy/helm/keyorix-operator -n team-a \
 
 See the chart's [README](../deploy/helm/keyorix-operator/README.md#rbac) for details.
 
+For an air-gapped install that mirrors the operator image to a private, authenticated
+registry, set `image.repository` to the mirror and `imagePullSecrets` to a
+`docker-registry` Secret in the release namespace — see the chart's
+[README](../deploy/helm/keyorix-operator/README.md#private-registries).
+
 ## Usage
 
 1. Create a least-privilege machine-identity token (ADR-030) Secret in your app


### PR DESCRIPTION
## Summary
- Closes #1334 — the `keyorix-operator` chart hardcoded `image.repository` with no chart-level mechanism to supply pull credentials. Confirmed by grepping `values.yaml`, `templates/deployment.yaml`, and `templates/serviceaccount.yaml`: zero `imagePullSecrets` support anywhere. This blocked air-gapped installs that mirror the operator image to a private, authenticated registry.
- Added `imagePullSecrets: []` to `values.yaml`, rendered into the Deployment's pod spec — matching the exact convention already used by the sibling `keyorix` chart's server/web/postgresql deployments (`{{- with .Values.imagePullSecrets }} imagePullSecrets: {{- toYaml . | nindent 8 }} {{- end }}`).
- Documented the private-mirror-registry path in the chart `README.md` (new "Private registries" section + values table row) and cross-referenced from `docs/k8s-operator.md`.

## Test plan
- [x] `helm lint deploy/helm/keyorix-operator` (default and `--set 'watchNamespaces={team-a,team-b}'`)
- [x] `helm template` renders correctly both with and without `imagePullSecrets` set
- [x] `kubeconform -strict -kubernetes-version 1.29.0` passes on both the default and `watchNamespaces`-scoped renders
- [x] Verified the existing default-mode `ClusterRoleBinding` / no-unexpected-`RoleBinding` invariants still hold