### PR TITLE
fix(fuzzing): keep NTFY_TOPIC out of argv, harden fuzz systemd units

### DIFF
--- a/scripts/fuzzing/heartbeat.sh
+++ b/scripts/fuzzing/heartbeat.sh
@@ -6,6 +6,17 @@ set -euo pipefail
 
 : "${NTFY_TOPIC:?}"
 
+# Scratch file for curl's --config (-K) file, used below to keep the
+# NTFY_TOPIC URL — the bearer secret protecting the ntfy.sh channel; see
+# config.env.example — out of curl's argv, where `ps auxww`/
+# `/proc/<pid>/cmdline` would expose it to any other local account for the
+# life of the curl call.
+ntfy_curl_cfg=""
+cleanup_ntfy_curl_cfg() {
+  [[ -n "$ntfy_curl_cfg" ]] && rm -f "$ntfy_curl_cfg"
+}
+trap cleanup_ntfy_curl_cfg EXIT
+
 if systemctl is-active --quiet keyorix-fuzz.service; then
   status="running"
   tags="heartbeat"
@@ -14,9 +25,14 @@ else
   tags="warning,heartbeat"
 fi
 
+ntfy_curl_cfg="$(mktemp)"
+chmod 600 "$ntfy_curl_cfg"
+printf 'url = "%s"\n' "$NTFY_TOPIC" >"$ntfy_curl_cfg"
+
 curl -fsS \
+  -K "$ntfy_curl_cfg" \
   -H "Title: keyorix fuzz heartbeat: $status" \
   -H "Tags: $tags" \
   -d "keyorix-fuzz.service: $status
 $(date -u +%FT%TZ)" \
-  "$NTFY_TOPIC" >/dev/null
+  >/dev/null

--- a/scripts/fuzzing/notify-on-crash.sh
+++ b/scripts/fuzzing/notify-on-crash.sh
@@ -15,6 +15,17 @@ LOGFILE="${3:?path to the log file for this run}"
 : "${KEYORIX_REPO:?}"
 : "${FUZZ_CORPUS_BRANCH:=fuzz-corpus}"
 
+# Scratch file for curl's --config (-K) file, used below to keep the
+# NTFY_TOPIC URL — the bearer secret protecting the ntfy.sh channel; see
+# config.env.example — out of curl's argv, where `ps auxww`/
+# `/proc/<pid>/cmdline` would expose it to any other local account for the
+# life of the curl call.
+ntfy_curl_cfg=""
+cleanup_ntfy_curl_cfg() {
+  [[ -n "$ntfy_curl_cfg" ]] && rm -f "$ntfy_curl_cfg"
+}
+trap cleanup_ntfy_curl_cfg EXIT
+
 cd "$KEYORIX_REPO"
 
 fail_line="$(grep -m1 -E 'FAIL|panic:' "$LOGFILE" || true)"
@@ -46,7 +57,11 @@ summary="$(grep -m8 -E 'FAIL|panic:|--- FAIL|Fatalf|\.go:[0-9]+' "$LOGFILE" | he
 
 # ntfy.sh push notification (optional — skip if NTFY_TOPIC is unset or empty)
 if [[ -n "${NTFY_TOPIC:-}" ]]; then
+  ntfy_curl_cfg="$(mktemp)"
+  chmod 600 "$ntfy_curl_cfg"
+  printf 'url = "%s"\n' "$NTFY_TOPIC" >"$ntfy_curl_cfg"
   curl -fsS \
+    -K "$ntfy_curl_cfg" \
     -H "Title: keyorix fuzz: $FUNC crashed" \
     -H "Priority: high" \
     -H "Tags: rotating_light" \
@@ -55,7 +70,7 @@ if [[ -n "${NTFY_TOPIC:-}" ]]; then
 ${summary:-see log on the fuzz box}
 
 Reproducer pushed to the $FUZZ_CORPUS_BRANCH branch." \
-    "$NTFY_TOPIC" >/dev/null || true
+    >/dev/null || true
 fi
 
 # GitHub PR — open from fuzz-corpus to main, or comment on the existing one.

--- a/scripts/fuzzing/systemd/keyorix-fuzz-heartbeat.service
+++ b/scripts/fuzzing/systemd/keyorix-fuzz-heartbeat.service
@@ -7,3 +7,15 @@ User=fuzzer
 Group=fuzzer
 EnvironmentFile=/etc/keyorix-fuzz/config.env
 ExecStart=/opt/keyorix-fuzz/keyorix/scripts/fuzzing/heartbeat.sh
+
+# Process-isolation hardening (see keyorix-fuzz.service for the full
+# rationale). heartbeat.sh only runs `systemctl is-active` and `curl`s
+# ntfy.sh -- unlike keyorix-fuzz.service it never touches git, ~/.ssh, or
+# ~/.gitconfig, so ProtectHome can be the stricter "true" here. It writes
+# nothing outside the curl config scratch file it creates under the private
+# /tmp PrivateTmp=true provides, so no ReadWritePaths= entry is needed.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+RestrictSUIDSGID=true

--- a/scripts/fuzzing/systemd/keyorix-fuzz.service
+++ b/scripts/fuzzing/systemd/keyorix-fuzz.service
@@ -23,5 +23,53 @@ Nice=10
 CPUQuota=400%
 MemoryMax=2G
 
+# Process-isolation hardening. This service holds a GH_TOKEN with
+# Pull-Requests read/write (and per config.env.example, potentially Contents
+# read/write) loaded via EnvironmentFile, and spends nearly all its time
+# running `go test -fuzz` against security-critical parsers (KEK
+# reconstruction, SAML XML, ASN.1/PKCS7, bundle verification). The realistic
+# worst case is a fuzz-discovered memory-corruption bug (or a
+# supply-chain-compromised test dependency) achieving code execution inside
+# the `go test` process -- these directives cap the blast radius of that.
+NoNewPrivileges=true
+ProtectSystem=strict
+# NOT "true": every git invocation in run-rotation.sh/notify-on-crash.sh
+# reads ~/.gitconfig for the `credential.helper` and `safe.directory` entries
+# README.md step 4 has the fuzzer user set up (ProtectHome=true makes /home/
+# fully inaccessible, including reads, which breaks git outright with a
+# "dubious ownership" refusal). The SSH deploy-key setup in README.md step 3
+# also reads ~/.ssh/id_ed25519. "read-only" keeps all of that working while
+# still blocking any write into /home, /root, or /run/user.
+ProtectHome=read-only
+PrivateTmp=true
+RestrictSUIDSGID=true
+# `go test -fuzz` needs a writable build/module cache; left unset it defaults
+# under $HOME, which ProtectHome=read-only above makes unwritable. Redirect
+# it under /opt/keyorix-fuzz instead of relying on $HOME -- `go` creates
+# these directories itself on first use, no manual `mkdir` needed as long as
+# /opt/keyorix-fuzz (already chowned to fuzzer per README.md step 2) is
+# writable.
+Environment=GOCACHE=/opt/keyorix-fuzz/go-cache
+Environment=GOMODCACHE=/opt/keyorix-fuzz/go-mod
+Environment=GOPATH=/opt/keyorix-fuzz/gopath
+# ProtectSystem=strict makes the entire filesystem read-only except what's
+# listed here. Every directory the scripts in this service actually write to,
+# matching config.env.example's defaults -- update this list if a deployment
+# overrides KEYORIX_REPO / FUZZ_CORPUS_WORKTREE / NOTIFIED_STATE_DIR away from
+# those defaults:
+#   - KEYORIX_REPO: run-rotation.sh does `git fetch`/`checkout`/`reset --hard`
+#     here and `go test` writes testdata/fuzz/<Func>/ on a crash;
+#     notify-on-crash.sh also `git fetch`s the fuzz-corpus branch here. The
+#     linked worktree's git-dir for FUZZ_CORPUS_WORKTREE lives under
+#     KEYORIX_REPO/.git/worktrees/, so it's covered by this entry too.
+#   - FUZZ_CORPUS_WORKTREE: sync-corpus.sh rsyncs new corpus files in and
+#     commits/pushes from here.
+#   - NOTIFIED_STATE_DIR: notify-on-crash.sh writes per-target logs, gh-error
+#     logs, and dedup marker files here.
+#   - the GOCACHE/GOMODCACHE/GOPATH dirs set above (also includes the
+#     non-crashing fuzz corpus cache under $GOCACHE/fuzz -- see
+#     sync-corpus.sh's comments).
+ReadWritePaths=/opt/keyorix-fuzz/keyorix /opt/keyorix-fuzz/keyorix-fuzz-corpus /opt/keyorix-fuzz/state /opt/keyorix-fuzz/go-cache /opt/keyorix-fuzz/go-mod /opt/keyorix-fuzz/gopath
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Two findings from the fuzzing-infra security review (`scripts/fuzzing/`):

- **MEDIUM — NTFY_TOPIC leaked via curl argv.** `notify-on-crash.sh` and
  `heartbeat.sh` passed the ntfy.sh topic URL — the sole bearer secret
  protecting that notification channel (see `config.env.example`'s "pick
  something long and random" comment) — as a plain positional argument to
  `curl`. That made the full secret URL visible in the process table
  (`ps auxww`, `/proc/PID/cmdline`) to any other local account for the life
  of each curl call. Both scripts now write the URL into a private,
  mode-600, `mktemp`'d curl `--config` (`-K`) file and clean it up via an
  `EXIT` trap, matching the temp-file pattern already used in
  `scripts/demo-keyorix.sh` for the same class of issue.

- **LOW — `keyorix-fuzz.service` had no systemd process-isolation
  hardening**, despite holding a repo-write-capable `GH_TOKEN` and spending
  nearly all its runtime executing `go test -fuzz` against security-critical
  parsers (KEK reconstruction, SAML XML, ASN.1/PKCS7, bundle verification).
  Added `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome`,
  `PrivateTmp`, and `RestrictSUIDSGID` to both `keyorix-fuzz.service` and its
  `keyorix-fuzz-heartbeat.service` sibling, plus a `ReadWritePaths=` scoped
  to exactly the directories `run-rotation.sh` / `notify-on-crash.sh` /
  `sync-corpus.sh` actually write to.

## One deliberate deviation worth a reviewer's eyes

`keyorix-fuzz.service` uses **`ProtectHome=read-only`**, not the stricter
`true` a first pass might reach for. `ProtectHome=true` makes `/home`
*fully inaccessible, including reads* — but every git invocation in
`run-rotation.sh`/`notify-on-crash.sh` reads `~/.gitconfig` for the
`credential.helper` and `safe.directory` entries README.md step 4 has the
`fuzzer` user set up, and the SSH-deploy-key auth path (README.md step 3,
option 1 — the *recommended* option) reads `~/.ssh/id_ed25519`. Under
`ProtectHome=true` git fails outright with a "dubious ownership" refusal on
its very first invocation, silently breaking the whole service.
`read-only` preserves those reads while still blocking any write into
`/home`, `/root`, or `/run/user`. `keyorix-fuzz-heartbeat.service` never
touches git, so it keeps the stricter `ProtectHome=true`.

Also added `Environment=GOCACHE=/opt/keyorix-fuzz/go-cache`,
`GOMODCACHE=/opt/keyorix-fuzz/go-mod`, `GOPATH=/opt/keyorix-fuzz/gopath` to
`keyorix-fuzz.service` — `go test -fuzz`'s build/module cache (and per
`sync-corpus.sh`'s own comments, the non-crashing fuzz corpus cache under
`$GOCACHE/fuzz`) defaults under `$HOME`, which `ProtectHome=read-only`
would otherwise make unwritable. `go` creates these directories itself on
first use.

## Test plan

- [x] `shellcheck` on both modified scripts — clean, no new warnings.
- [x] Manually verified curl's `-K` config-file mechanism parses the
      `url = "..."` directive correctly (dummy unreachable target returned
      curl's connection-error exit code 7, not a usage/parse error).
- [ ] No automated way to exercise the systemd units in this environment —
      reviewed by cross-referencing every path `run-rotation.sh`,
      `notify-on-crash.sh`, `sync-corpus.sh`, and `heartbeat.sh` write to
      against `ReadWritePaths=`; would appreciate a second pair of eyes on
      the `ProtectHome=read-only` call before this rolls out to the live
      fuzz box.