### PR TITLE
fix(github-action,install.sh): close 4 adversarial-review findings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,28 +114,31 @@ else
 fi
 
 # Verify SHA-256 checksum of the downloaded binary against the (now-verified) checksums.txt.
+# Both "no matching entry for this platform" and "no sha256 tool available" used
+# to only log an informational line and proceed to install the binary anyway —
+# that fails OPEN exactly where entrypoint.sh's own pinned-install path (see its
+# install_cli comment) is deliberate about failing CLOSED, since a missing
+# checksum entry (naming drift, partial publish) or a missing hash tool leaves
+# no other integrity signal for this download. Abort instead in both cases.
 info "Verifying checksum..."
 EXPECTED=$(awk -v n="$BINARY_NAME" '$2==n {print $1}' "$TMP_CHECKSUMS")
 
-if [ -n "$EXPECTED" ]; then
-    if command -v sha256sum >/dev/null 2>&1; then
-        ACTUAL=$(sha256sum "$TMP_BIN" | awk '{print $1}')
-    elif command -v shasum >/dev/null 2>&1; then
-        ACTUAL=$(shasum -a 256 "$TMP_BIN" | awk '{print $1}')
-    else
-        ACTUAL=""
-    fi
-    if [ -n "$ACTUAL" ] && [ "$ACTUAL" != "$EXPECTED" ]; then
-        error "Checksum mismatch for ${BINARY_NAME}: expected ${EXPECTED}, got ${ACTUAL}. Aborting."
-    fi
-    if [ -n "$ACTUAL" ]; then
-        success "Checksum verified"
-    else
-        info "No sha256 tool found; skipping checksum verification"
-    fi
-else
-    info "No checksum published for ${BINARY_NAME}; skipping verification"
+if [ -z "$EXPECTED" ]; then
+    error "No checksum published for ${BINARY_NAME} in checksums.txt; refusing to install an unverified binary. Check https://github.com/${REPO}/releases/${LATEST}"
 fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL=$(sha256sum "$TMP_BIN" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL=$(shasum -a 256 "$TMP_BIN" | awk '{print $1}')
+else
+    error "No sha256sum or shasum tool found; cannot verify the downloaded binary's checksum — refusing to install unverified. Install coreutils (sha256sum) or perl (shasum) and re-run."
+fi
+
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+    error "Checksum mismatch for ${BINARY_NAME}: expected ${EXPECTED}, got ${ACTUAL}. Aborting."
+fi
+success "Checksum verified"
 
 # Make executable
 chmod +x "$TMP_BIN"

--- a/integrations/github-action/entrypoint.sh
+++ b/integrations/github-action/entrypoint.sh
@@ -44,6 +44,16 @@ OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
 
 install_dir="/usr/local/bin"
 
+# KEYORIX_BIN is set by install_cli to the ABSOLUTE path of the checksum-
+# verified binary it decided to use (either the existing on-PATH binary,
+# once its hash was confirmed to match, or the freshly downloaded/installed
+# copy at $install_dir). Every later invocation of the CLI in this script
+# MUST go through "$KEYORIX_BIN", never a bare `keyorix` — a bare command
+# name re-resolves via $PATH at call time, which can point somewhere else
+# entirely than what was just verified (see install_cli's own comment on
+# why an on-PATH binary can't be trusted blindly).
+KEYORIX_BIN=""
+
 # sha256_of prints the SHA-256 of the given file using whichever of
 # sha256sum/shasum is available, or fails if neither is.
 sha256_of() {
@@ -81,10 +91,10 @@ install_cli() {
     url="https://github.com/keyorixhq/keyorix/releases/download/${VERSION}/${binary_name}"
     checksums_url="https://github.com/keyorixhq/keyorix/releases/download/${VERSION}/checksums.txt"
 
-    # Fetch the expected checksum first, fail closed (rather than
-    # install.sh's skip-if-missing) since this path has no other integrity
-    # signal — this is required whether we end up reusing an existing binary
-    # or downloading a fresh one.
+    # Fetch the expected checksum first and fail closed if none is published
+    # (install.sh does the same for its own download) since this path has no
+    # other integrity signal — this is required whether we end up reusing an
+    # existing binary or downloading a fresh one.
     echo "Verifying checksum..."
     expected="$(curl --proto '=https' --tlsv1.2 -fsSL "$checksums_url" | awk -v n="$binary_name" '$2==n {print $1}')" # NOSONAR -- bash:S6506 false positive: --proto '=https' --tlsv1.2 enforces HTTPS; redirect-following is required for GitHub release CDN
     if [[ -z "$expected" ]]; then
@@ -96,7 +106,8 @@ install_cli() {
     if [[ -n "$existing" ]]; then
       if actual="$(sha256_of "$existing" 2>/dev/null)" && [[ -n "$actual" ]] && [[ "$actual" = "$expected" ]]; then
         echo "Using existing keyorix at ${existing} (checksum verified against ${VERSION})"
-        keyorix --version
+        KEYORIX_BIN="$existing"
+        "$KEYORIX_BIN" --version
         return
       fi
       echo "warning: keyorix already on PATH does not match ${VERSION}'s published checksum; ignoring it and installing a fresh, verified copy" >&2
@@ -134,6 +145,7 @@ install_cli() {
     else
       sudo mv "$tmp_bin" "${install_dir}/keyorix"
     fi
+    KEYORIX_BIN="${install_dir}/keyorix"
   else
     # Latest release via the official installer (verifies the checksum, and
     # itself downloads into its own `mktemp -d`). Pinned to a specific commit
@@ -141,8 +153,10 @@ install_cli() {
     # future main-branch or tag compromise can't alter the code piped into
     # `sh` here. Bump deliberately when install.sh's logic needs to change.
     curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/6dd9e555125500e76b4e2035a867621e416585a3/install.sh | sh # NOSONAR -- bash:S6506 false positive: --proto '=https' --tlsv1.2 enforces HTTPS; commit SHA is pinned not floating
+    # install.sh (pinned above) always installs to this same directory.
+    KEYORIX_BIN="${install_dir}/keyorix"
   fi
-  keyorix --version
+  "$KEYORIX_BIN" --version
 }
 
 # validate_secret_name checks that a Keyorix secret NAME is safe to write verbatim
@@ -155,27 +169,76 @@ install_cli() {
 # trusted by later, more-privileged steps in the same job (#174). Requiring a plain
 # identifier closes this off entirely: no newline, `=`, or other special character
 # can ever reach the file.
+
+# DANGEROUS_ENV_NAMES are environment variable names that are safe ASCII
+# identifiers (so they pass the charset check above) but are interpreted
+# specially by the shell or by interpreters/loaders that a later step in the
+# same job is likely to invoke. The identifier check alone only stops
+# metacharacter/newline injection into $GITHUB_ENV (#174 above) — it says
+# nothing about the NAME itself being one of these. A principal holding only
+# project-scoped secrets.write (not job/workflow admin) could name a secret
+# e.g. "BASH_ENV" pointing at an attacker-controlled script: inject_env would
+# happily write it to $GITHUB_ENV, and every subsequent bash-shell step in
+# the same job sources that script before running its own commands — code
+# execution in a more-privileged step. PATH lets an attacker substitute
+# arbitrary binaries; LD_PRELOAD/LD_LIBRARY_PATH inject native code into any
+# process exec'd afterward; the rest are the equivalent hooks for other
+# interpreters commonly present in CI runners (Node, Python, Perl, Ruby).
+DANGEROUS_ENV_NAMES=(
+  PATH LD_PRELOAD LD_LIBRARY_PATH BASH_ENV ENV IFS SHELLOPTS PS4
+  NODE_OPTIONS NODE_PATH PYTHONPATH PYTHONSTARTUP PERL5LIB RUBYOPT GEM_PATH
+)
+
 validate_secret_name() {
-  local name="$1"
-  [[ "$name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]
+  local name="$1" upper_name candidate
+  [[ "$name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+
+  # Reject denylisted names case-insensitively: GitHub Actions env vars are
+  # themselves case-sensitive, but some shells/tools that consult these
+  # particular names (e.g. loaders on case-insensitive filesystems, or
+  # third-party tooling) aren't reliably consistent about case, so compare
+  # uppercased to be safe rather than relying on exact-case matches only.
+  # `tr` rather than bash 4's `${name^^}` since macOS ships bash 3.2.
+  upper_name="$(printf '%s' "$name" | tr '[:lower:]' '[:upper:]')"
+  for candidate in "${DANGEROUS_ENV_NAMES[@]}"; do
+    [[ "$upper_name" == "$candidate" ]] && return 1
+  done
+
+  return 0
 }
 
-inject_env() {
-  local json key val delim count
-  json="$(keyorix secret export --project "$PROJECT" --env "$ENVIRONMENT" --format json)"
+# fetch_export_json calls `keyorix secret export --format json` (via the
+# checksum-verified $KEYORIX_BIN, never a bare `keyorix`) once and validates
+# the result is well-formed JSON on stdout. This is the SINGLE source of
+# truth for a given run: both inject_env and write_output_file are handed
+# the SAME already-fetched JSON rather than each independently calling the
+# server, so a secret value that changes between calls (rotation, or any
+# concurrent write) can't land in one output but not the other — see
+# write_output_file's comment for the concrete failure mode this closes.
+fetch_export_json() {
+  local json
+  json="$("$KEYORIX_BIN" secret export --project "$PROJECT" --env "$ENVIRONMENT" --format json)"
   if ! printf '%s' "$json" | jq empty 2>/dev/null; then
     echo "error: 'keyorix secret export' did not return valid JSON" >&2
     exit 1
   fi
+  printf '%s' "$json"
+}
+
+inject_env() {
+  local json="$1"
+  local key val delim count
 
   # `keys[]` is newline-delimited; read line-by-line so the loop is whitespace-safe.
   count=0
   while IFS= read -r key; do
     [[ -n "$key" ]] || continue
-    # Reject any secret name that isn't a safe identifier BEFORE it ever reaches
-    # $GITHUB_ENV — see validate_secret_name above (#174).
+    # Reject any secret name that isn't a safe identifier, or that collides
+    # with a security-sensitive reserved env var, BEFORE it ever reaches
+    # $GITHUB_ENV — see validate_secret_name above (#174, and the
+    # DANGEROUS_ENV_NAMES denylist).
     if ! validate_secret_name "$key"; then
-      echo "error: secret name '${key}' is not a valid identifier (must match ^[A-Za-z_][A-Za-z0-9_]*\$) — refusing to export it to \$GITHUB_ENV" >&2
+      echo "error: secret name '${key}' is not safe to export to \$GITHUB_ENV (must match ^[A-Za-z_][A-Za-z0-9_]*\$ and must not be a reserved/security-sensitive env var name such as PATH, LD_PRELOAD, or BASH_ENV) — refusing to export it" >&2
       exit 1
     fi
     val="$(printf '%s' "$json" | jq -r --arg k "$key" '.[$k]')"
@@ -205,35 +268,74 @@ inject_env() {
   echo "Loaded ${count} secret(s) from project '${PROJECT}' environment '${ENVIRONMENT}'."
 }
 
+# write_output_file masks every secret value (independently of inject_env's
+# masking, since inject_env — and its ::add-mask:: calls — is skipped
+# entirely when export-to-env=false, a documented, supported combination
+# with output-file) and writes a dotenv file, DERIVING its content locally
+# from the same already-fetched $json rather than making a second,
+# independent `keyorix secret export --format dotenv` call. Two independent
+# server round-trips could observe two different snapshots of the secrets
+# (rotation, or any concurrent write): masking values read from ONE fetch
+# while writing values from a SECOND, different fetch would let a changed
+# value land in the file without ever being registered via mask_value, so a
+# later step that cats/sources the file would print it in the clear in the
+# job log. Quoting mirrors internal/cli/secret/export.go's writeDotenv so
+# the file matches what `keyorix secret export --format dotenv` itself
+# would have produced from this same data.
+write_output_file() {
+  local json="$1" file="$2" key val escaped
+
+  while IFS= read -r key; do
+    [[ -n "$key" ]] || continue
+    val="$(printf '%s' "$json" | jq -r --arg k "$key" '.[$k]')"
+    mask_value "$val"
+  done < <(printf '%s' "$json" | jq -r 'keys[]')
+
+  # Refuse to write through a pre-existing path — including a symlink an
+  # attacker with write access to a shared directory planted ahead of time —
+  # mirroring internal/cli/secret/export.go's createExportFile (O_EXCL).
+  # `noclobber` makes bash's own `>` redirection use O_EXCL, so this fails
+  # closed the same way rather than silently following/truncating it.
+  if ! (
+    set -o noclobber
+    {
+      printf '# Exported by Keyorix\n'
+      while IFS= read -r key; do
+        [[ -n "$key" ]] || continue
+        val="$(printf '%s' "$json" | jq -r --arg k "$key" '.[$k]')"
+        if [[ "$val" == *[[:space:]]* || "$val" == *"\""* || "$val" == *"'"* || "$val" == *"="* || "$val" == *"\\"* ]]; then
+          escaped="${val//\\/\\\\}"
+          escaped="${escaped//\"/\\\"}"
+          printf '%s="%s"\n' "$key" "$escaped"
+        else
+          printf '%s=%s\n' "$key" "$val"
+        fi
+      done < <(printf '%s' "$json" | jq -r 'keys[]')
+    } >"$file"
+  ); then
+    echo "error: cannot create output file '${file}' (it may already exist — remove it or choose a different path)" >&2
+    exit 1
+  fi
+}
+
 # Only run the action's main flow when this script is executed directly, not when
 # it's sourced (e.g. by a test harness that wants validate_secret_name/inject_env
 # without performing a real CLI install + secret export).
 if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
   install_cli
 
+  # Fetch once, share the result — see fetch_export_json's comment.
+  secrets_json=""
+  if [[ "$EXPORT_TO_ENV" = "true" ]] || [[ -n "$OUTPUT_FILE" ]]; then
+    secrets_json="$(fetch_export_json)"
+  fi
+
   if [[ "$EXPORT_TO_ENV" = "true" ]]; then
-    inject_env
+    inject_env "$secrets_json"
   fi
 
   if [[ -n "$OUTPUT_FILE" ]]; then
-    # Mask every secret value before writing the dotenv file. This must happen
-    # independently of inject_env's masking above, since inject_env (and its
-    # ::add-mask:: calls) is skipped entirely when export-to-env=false, which
-    # is a documented, supported combination with output-file — without this,
-    # a later step that cats/sources the file would print secrets in the clear.
-    output_json="$(keyorix secret export --project "$PROJECT" --env "$ENVIRONMENT" --format json)"
-    if ! printf '%s' "$output_json" | jq empty 2>/dev/null; then
-      echo "error: 'keyorix secret export' did not return valid JSON" >&2
-      exit 1
-    fi
-    while IFS= read -r output_key; do
-      [[ -n "$output_key" ]] || continue
-      output_val="$(printf '%s' "$output_json" | jq -r --arg k "$output_key" '.[$k]')"
-      mask_value "$output_val"
-    done < <(printf '%s' "$output_json" | jq -r 'keys[]')
-
-    # Reuse the CLI's dotenv writer (handles quoting) for the file form.
-    keyorix secret export --project "$PROJECT" --env "$ENVIRONMENT" --format dotenv --output "$OUTPUT_FILE"
+    write_output_file "$secrets_json" "$OUTPUT_FILE"
     echo "Wrote secrets to ${OUTPUT_FILE}"
   fi
 fi

--- a/integrations/github-action/entrypoint_test.sh
+++ b/integrations/github-action/entrypoint_test.sh
@@ -66,6 +66,32 @@ assert_invalid "FOO<<EOF"
 # shellcheck disable=SC2016
 assert_invalid 'FOO$(whoami)'
 
+# --- A secret NAME that's a valid identifier but collides with a reserved,
+# security-sensitive env var (PATH substitution, LD_PRELOAD/BASH_ENV code
+# execution in a later, more-privileged step, etc.) must still be rejected —
+# the charset check above says nothing about the identifier being one of
+# these. Checked case-insensitively. ---
+assert_invalid "PATH"
+assert_invalid "LD_PRELOAD"
+assert_invalid "LD_LIBRARY_PATH"
+assert_invalid "BASH_ENV"
+assert_invalid "bash_env"
+assert_invalid "NODE_OPTIONS"
+assert_invalid "PYTHONPATH"
+assert_invalid "PYTHONSTARTUP"
+assert_invalid "PERL5LIB"
+assert_invalid "RUBYOPT"
+assert_invalid "GEM_PATH"
+assert_invalid "NODE_PATH"
+assert_invalid "IFS"
+assert_invalid "ENV"
+assert_invalid "SHELLOPTS"
+assert_invalid "PS4"
+# A denylisted name as a substring, not an exact match, must still be
+# accepted — only the exact reserved name is unsafe.
+assert_valid "PATH_TO_CONFIG"
+assert_valid "MY_BASH_ENV_VAR"
+
 if [[ "$fail" -ne 0 ]]; then
   echo
   echo "entrypoint_test.sh: FAILED"

--- a/server/grpc/services/audit_stream_test.go
+++ b/server/grpc/services/audit_stream_test.go
@@ -187,9 +187,19 @@ func TestAuditService_StreamAuditLogs_MaxConcurrentPerPrincipal(t *testing.T) {
 	svc, _ := newStreamCore(t)
 
 	var cancels []context.CancelFunc
+	var dones []chan error
 	t.Cleanup(func() {
 		for _, c := range cancels {
 			c()
+		}
+		// Wait for every streaming goroutine to actually return before this test is
+		// considered done — otherwise one can still be reading package-level state
+		// (e.g. auditStreamFallbackInterval) when the next test mutates it, racing.
+		for _, d := range dones {
+			select {
+			case <-d:
+			case <-time.After(time.Second):
+			}
 		}
 	})
 
@@ -198,6 +208,7 @@ func TestAuditService_StreamAuditLogs_MaxConcurrentPerPrincipal(t *testing.T) {
 		cancels = append(cancels, cancel)
 		stream := &fakeAuditStream{ctx: ctx}
 		done := make(chan error, 1)
+		dones = append(dones, done)
 		go func() { done <- svc.StreamAuditLogs(&pb.StreamAuditLogsRequest{}, stream) }()
 		// Give StreamAuditLogs time to reach acquireStreamSlot and register before the
 		// next iteration opens another one.


### PR DESCRIPTION
## Summary

Fixes 4 confirmed security findings in `integrations/github-action/entrypoint.sh` and `install.sh`:

- **CRITICAL** — every `keyorix` CLI invocation after install (`--version`, `secret export`) resolved via a bare `$PATH` lookup instead of the absolute path that was actually checksum-verified. A malicious `keyorix` binary earlier on `$PATH` than `/usr/local/bin` would silently receive `KEYORIX_TOKEN` and the exported secrets while the verified copy sat unused. `install_cli` now captures the verified binary's path into `$KEYORIX_BIN`, and every later call goes through it, never a bare `keyorix`.
- **HIGH** — `validate_secret_name` only enforced the identifier charset, so a secret literally named `PATH`, `LD_PRELOAD`, `BASH_ENV`, `NODE_OPTIONS`, etc. would be written to `$GITHUB_ENV` verbatim. A principal holding only project-scoped `secrets.write` could use this to run code in a later, more-privileged step of the same job. Added a case-insensitive denylist of security-sensitive env var names.
- **MEDIUM** — the output-file path masked secret values from one `keyorix secret export --format json` call but wrote the file from a second, independent `--format dotenv` call. A value that changed between the two round-trips (rotation, concurrent write) could land in the file unmasked. The JSON is now fetched once and shared by `inject_env` and the output-file writer, which derives the dotenv content locally instead of a second server round-trip.
- **HIGH** — `install.sh` proceeded to install the binary with only an informational log line when `checksums.txt` had no entry for the runner's platform, or when neither `sha256sum` nor `shasum` was available — failing open with no integrity signal. Both cases now abort (cosign verification logic, which is intentionally soft when cosign isn't installed, is untouched).

## Test plan

- [x] `integrations/github-action/entrypoint_test.sh` — all checks pass, including new denylist coverage for the reserved env var names
- [x] `integrations/github-action/test/entrypoint_test.sh` (black-box, mocked PATH) — 13/13 pass
- [x] `shellcheck` on both modified shell scripts — clean (no new warnings; install.sh's 3 pre-existing `local`-in-POSIX-sh notes are unrelated and untouched)