### PR TITLE
fix(web): close 4 security findings in auth/session frontend paths

### DIFF
--- a/web/src/pages/auth/SSOCompletePage.tsx
+++ b/web/src/pages/auth/SSOCompletePage.tsx
@@ -1,15 +1,10 @@
 import React, { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router';
 import { useAuthStore } from '../../store/authStore';
-
-// react-router's navigate() can't currently be turned into an open redirect to
-// another origin (browsers reject a cross-origin pushState), but `return_to`
-// still comes from the SSO redirect chain, so require it to look like an
-// in-app relative path as defense-in-depth: a single leading '/' (not '//' or
-// '/\', both of which some browsers treat as protocol-relative).
-function isSafeReturnTo(path: string): boolean {
-    return /^\/(?![/\\])/.test(path);
-}
+// Shared with storeIntendedRoute/getPostLoginRedirect's non-SSO post-login
+// redirect (see utils/routing.ts) so both paths apply the same
+// protocol-relative-path guard instead of maintaining it twice.
+import { isSafeReturnTo } from '../../utils/routing';
 
 // SSOCompletePage is the landing page the OIDC callback redirects the browser to.
 // The backend sets the session cookie directly on its own redirect response (see

--- a/web/src/pages/auth/__tests__/SSOCompletePage.test.tsx
+++ b/web/src/pages/auth/__tests__/SSOCompletePage.test.tsx
@@ -39,6 +39,13 @@ describe('SSOCompletePage', () => {
         expect(mockComplete).not.toHaveBeenCalled();
     });
 
+    it('falls back to / for a protocol-relative return_to (open-redirect guard, shared with utils/routing.ts)', async () => {
+        window.location.hash = '#expires_at=2026-12-31T00:00:00Z&return_to=' + encodeURIComponent('//evil.example/x');
+        render(<SSOCompletePage />);
+        await waitFor(() => expect(mockComplete).toHaveBeenCalledWith('2026-12-31T00:00:00Z', undefined));
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true }));
+    });
+
     it('defaults to / when the fragment has no return_to', async () => {
         window.location.hash = '#expires_at=2026-12-31T00:00:00Z';
         render(<SSOCompletePage />);

--- a/web/src/pages/integrations/KeyorixConnectPage.tsx
+++ b/web/src/pages/integrations/KeyorixConnectPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { ClipboardDocumentIcon, CheckIcon, EyeIcon, EyeSlashIcon, TrashIcon } from '@heroicons/react/24/outline';
 import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
@@ -46,8 +46,26 @@ const FederatedReadPanel: React.FC = () => {
     const [ref, setRef] = useState('');
     const [value, setValue] = useState<string | null>(null);
     const [revealed, setRevealed] = useState(false);
+    // Distinct from `value != null`: tracks whether a value has been fetched
+    // at all (so the value box + Reveal control stay rendered across a
+    // hide-triggered clear), independent of whether the plaintext currently
+    // sits in `value`.
+    const [loaded, setLoaded] = useState(false);
     const [copied, setCopied] = useState(false);
     const [error, setError] = useState('');
+    // The connector/ref of the last successful fetch, kept only to support
+    // re-fetching on re-reveal after `value` has been cleared — never holds
+    // the secret itself.
+    const lastQuery = useRef<{ connector: string; ref: string } | null>(null);
+
+    // The plaintext otherwise lingers in this component's state indefinitely —
+    // visible via React DevTools or a heap snapshot even while the UI renders
+    // only bullets. Clear it (not just the `revealed` flag) whenever the panel
+    // unmounts, mirroring SecretDetailView's eviction of its cached value for
+    // the same reason.
+    useEffect(() => {
+        return () => setValue(null);
+    }, []);
 
     if (isLoading) {
         return (
@@ -75,18 +93,42 @@ const FederatedReadPanel: React.FC = () => {
         setError('');
         setValue(null);
         setRevealed(false);
-        read.mutate(
-            { connector: effectiveConnector, ref: ref.trim() },
-            {
-                onSuccess: (res) => setValue(res.value),
-                onError: (err) =>
-                    setError(
-                        (err as { response?: { data?: { message?: string } } }).response?.data?.message ||
-                            (err as Error).message ||
-                            'Read failed.'
-                    ),
-            }
-        );
+        setLoaded(false);
+        const vars = { connector: effectiveConnector, ref: ref.trim() };
+        read.mutate(vars, {
+            onSuccess: (res) => {
+                lastQuery.current = vars;
+                setValue(res.value);
+                setLoaded(true);
+            },
+            onError: (err) => setError(errMessage(err, 'Read failed.')),
+        });
+    };
+
+    // Reveal/Hide toggle. Hiding clears `value` back to null (not just the
+    // `revealed` flag) so the plaintext doesn't linger in memory while masked.
+    // Re-revealing after a hide has nothing left to show, so it re-fetches
+    // (re-audited, same as the original read) rather than displaying stale or
+    // empty data.
+    const toggleReveal = () => {
+        if (revealed) {
+            setRevealed(false);
+            setValue(null);
+            return;
+        }
+        if (value != null) {
+            setRevealed(true);
+            return;
+        }
+        if (!lastQuery.current) return;
+        setError('');
+        read.mutate(lastQuery.current, {
+            onSuccess: (res) => {
+                setValue(res.value);
+                setRevealed(true);
+            },
+            onError: (err) => setError(errMessage(err, 'Read failed.')),
+        });
     };
 
     const copy = async () => {
@@ -142,7 +184,7 @@ const FederatedReadPanel: React.FC = () => {
                 </Button>
             </div>
 
-            {value != null && (
+            {loaded && (
                 <div
                     className="rounded-lg p-4"
                     style={{ backgroundColor: 'var(--bg-subtle)', border: '1px solid var(--border)' }}
@@ -155,13 +197,21 @@ const FederatedReadPanel: React.FC = () => {
                             <Button
                                 variant="outline"
                                 size="sm"
-                                onClick={() => setRevealed((r) => !r)}
+                                onClick={toggleReveal}
+                                disabled={read.isPending}
                                 type="button"
                                 aria-label={revealed ? 'Hide value' : 'Reveal value'}
                             >
                                 {revealed ? <EyeSlashIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
                             </Button>
-                            <Button variant="outline" size="sm" onClick={copy} type="button" aria-label="Copy value">
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={copy}
+                                type="button"
+                                disabled={value == null}
+                                aria-label="Copy value"
+                            >
                                 {copied ? (
                                     <CheckIcon className="h-4 w-4" />
                                 ) : (
@@ -171,7 +221,9 @@ const FederatedReadPanel: React.FC = () => {
                         </div>
                     </div>
                     <code className="block break-all font-mono text-sm" style={{ color: 'var(--text-primary)' }}>
-                        {revealed ? value : '•'.repeat(Math.min(value.length, 40))}
+                        {revealed && value != null
+                            ? value
+                            : '•'.repeat(value != null ? Math.min(value.length, 40) : 24)}
                     </code>
                 </div>
             )}

--- a/web/src/pages/integrations/__tests__/KeyorixConnectPage.test.tsx
+++ b/web/src/pages/integrations/__tests__/KeyorixConnectPage.test.tsx
@@ -73,6 +73,43 @@ describe('KeyorixConnectPage', () => {
         await waitFor(() => expect(screen.getByText('s3cr3t')).toBeInTheDocument());
     });
 
+    it('clears the fetched value from state on hide, forcing a re-fetch (not a stale display) on re-reveal', async () => {
+        readMutate.mockImplementation((_vars, opts) =>
+            opts.onSuccess({ connector: 'prod-aws', ref: 'prod/db', value: 's3cr3t' })
+        );
+        render(<KeyorixConnectPage />);
+
+        fireEvent.change(screen.getByLabelText('Reference'), { target: { value: 'prod/db' } });
+        fireEvent.click(screen.getByRole('button', { name: /Read secret/i }));
+        expect(readMutate).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole('button', { name: /Reveal value/i }));
+        await waitFor(() => expect(screen.getByText('s3cr3t')).toBeInTheDocument());
+
+        // Hide: the plaintext must be cleared from React state, not just
+        // masked again — proven below by the fact that revealing a second
+        // time has to re-fetch rather than instantly showing the value.
+        fireEvent.click(screen.getByRole('button', { name: /Hide value/i }));
+        expect(screen.queryByText('s3cr3t')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /Reveal value/i }));
+        expect(readMutate).toHaveBeenCalledTimes(2);
+        expect(readMutate).toHaveBeenLastCalledWith({ connector: 'prod-aws', ref: 'prod/db' }, expect.anything());
+        await waitFor(() => expect(screen.getByText('s3cr3t')).toBeInTheDocument());
+    });
+
+    it('clears the fetched value on unmount without throwing', () => {
+        readMutate.mockImplementation((_vars, opts) =>
+            opts.onSuccess({ connector: 'prod-aws', ref: 'prod/db', value: 's3cr3t' })
+        );
+        const { unmount } = render(<KeyorixConnectPage />);
+        fireEvent.change(screen.getByLabelText('Reference'), { target: { value: 'prod/db' } });
+        fireEvent.click(screen.getByRole('button', { name: /Read secret/i }));
+        expect(screen.getByRole('button', { name: /Reveal value/i })).toBeInTheDocument();
+
+        expect(() => unmount()).not.toThrow();
+    });
+
     it('surfaces a read error', () => {
         readMutate.mockImplementation((_vars, opts) =>
             opts.onError({ response: { data: { message: 'ref not permitted' } } })

--- a/web/src/services/__tests__/client.test.ts
+++ b/web/src/services/__tests__/client.test.ts
@@ -281,6 +281,34 @@ describe('response interceptor (error): 401 handling', () => {
         expect(result).toBe(retriedResponse);
     });
 
+    it('does not refresh+retry again when the same request already carries the _retry marker (loop guard)', async () => {
+        const store = makeAuthStore({ isAuthenticated: true });
+        mockGetState.mockReturnValue(store);
+        const retriedResponse = { data: { retried: true }, status: 200 };
+        mockRequest.mockResolvedValueOnce(retriedResponse);
+        const originalConfig: Record<string, unknown> = { url: '/secrets', method: 'get' };
+        const firstErr = axiosErr({ config: originalConfig, response: { status: 401, data: {} } });
+
+        // First 401: refresh + retry once, stamping the config with _retry.
+        const firstResult = await responseOnRejected(firstErr);
+        expect(firstResult).toBe(retriedResponse);
+        expect(store.refreshToken).toHaveBeenCalledTimes(1);
+        expect(mockRequest).toHaveBeenCalledTimes(1);
+        expect(originalConfig['_retry']).toBe(true);
+
+        // Second 401 on the SAME logical request (same config object, now
+        // carrying _retry) — simulates the retried request itself failing with
+        // 401 again despite the refresh having succeeded. Must NOT refresh or
+        // retry a second time, and must not force a logout (the session may
+        // still be valid — this could be an unrelated backend/proxy issue).
+        const secondErr = axiosErr({ config: originalConfig, response: { status: 401, data: {} } });
+        await expect(responseOnRejected(secondErr)).rejects.toBe(secondErr);
+
+        expect(store.refreshToken).toHaveBeenCalledTimes(1);
+        expect(mockRequest).toHaveBeenCalledTimes(1);
+        expect(store.logout).not.toHaveBeenCalled();
+    });
+
     it('refreshes the token but does not retry when the error carries no config to replay', async () => {
         const store = makeAuthStore({ isAuthenticated: true });
         mockGetState.mockReturnValue(store);

--- a/web/src/services/client.ts
+++ b/web/src/services/client.ts
@@ -72,6 +72,12 @@ apiClient.interceptors.request.use(
     }
 );
 
+// Marks a request config as already having gone through one refresh+retry
+// round trip — the conventional axios interceptor loop guard. Kept as a
+// narrow intersection type rather than augmenting AxiosRequestConfig globally,
+// since only handle401 ever reads/writes this flag.
+type RetriableConfig = AxiosRequestConfig & { _retry?: boolean };
+
 const handle401 = async (
     error: AxiosError,
     authStore: ReturnType<typeof useAuthStore.getState>
@@ -84,11 +90,22 @@ const handle401 = async (
         authStore.setError('Your session has expired. Please log in again.');
         return;
     }
+    // Loop guard: this exact request has already been retried once after a
+    // successful refresh and still came back 401. That means the failure
+    // isn't session expiry (refreshToken() would have thrown otherwise) — it's
+    // something else about this endpoint (a backend bug, a step-up-auth
+    // requirement, a flaky proxy). Refreshing and retrying again would loop
+    // forever, hammering /auth/refresh. Don't force a logout either — the
+    // session may still be perfectly valid — just fail through to the caller.
+    if ((error.config as RetriableConfig | undefined)?._retry) {
+        return;
+    }
     try {
         await authStore.refreshToken();
         // The retry rides the rotated session cookie automatically —
         // no header to reattach, unlike the old Bearer-token flow.
         if (error.config) {
+            (error.config as RetriableConfig)._retry = true;
             return apiClient.request(error.config);
         }
     } catch {

--- a/web/src/store/__tests__/authStore.test.ts
+++ b/web/src/store/__tests__/authStore.test.ts
@@ -504,6 +504,59 @@ describe('authStore', () => {
 
             expect(authService.getProfile).toHaveBeenCalled();
         });
+
+        it('resets hasCheckedAuth to false synchronously, before the async re-validation resolves (matches the initial-mount pending-state guard)', async () => {
+            // A same-origin-writable localStorage value (e.g. written by a
+            // malicious extension content script or XSS in a sibling tab)
+            // could claim an elevated role. Route guards (ProtectedRoute/
+            // AdminRoute) gate purely on hasCheckedAuth + isAuthenticated +
+            // user.role, so this must go pending immediately — not just after
+            // checkAuth() eventually corrects it.
+            let resolveProfile!: (v: ReturnType<typeof profileFixture>) => void;
+            vi.mocked(authService.getProfile).mockReturnValueOnce(
+                new Promise((resolve) => {
+                    resolveProfile = resolve;
+                })
+            );
+            useAuthStore.setState({ hasCheckedAuth: true, isAuthenticated: true, user: makeUser({ role: 'user' }) });
+            localStorage.setItem(
+                'auth-storage',
+                JSON.stringify({ state: { isAuthenticated: true, user: makeUser({ role: 'admin' }) }, version: 0 })
+            );
+
+            window.dispatchEvent(mkStorageEvent('auth-storage'));
+
+            // Synchronous assertion — before rehydrate()/checkAuth() have had
+            // any chance to resolve.
+            expect(useAuthStore.getState().hasCheckedAuth).toBe(false);
+
+            resolveProfile(profileFixture(makeUser({ username: 'other-tab', role: 'admin' })));
+            await Promise.resolve();
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(useAuthStore.getState().hasCheckedAuth).toBe(true);
+            expect(authService.getProfile).toHaveBeenCalled();
+        });
+
+        it('settles hasCheckedAuth back to true when the rehydrated state is unauthenticated (checkAuth never runs to do it)', async () => {
+            useAuthStore.setState({ hasCheckedAuth: true, isAuthenticated: true });
+            // e.g. a logout in the other tab clears auth-storage to a logged-out shape.
+            localStorage.setItem(
+                'auth-storage',
+                JSON.stringify({ state: { isAuthenticated: false, user: null }, version: 0 })
+            );
+
+            window.dispatchEvent(mkStorageEvent('auth-storage'));
+            expect(useAuthStore.getState().hasCheckedAuth).toBe(false);
+
+            await Promise.resolve();
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(useAuthStore.getState().hasCheckedAuth).toBe(true);
+            expect(authService.getProfile).not.toHaveBeenCalled();
+        });
     });
 
     describe('isTokenExpired helper (wraps utils/auth isTokenValid)', () => {

--- a/web/src/store/authStore.ts
+++ b/web/src/store/authStore.ts
@@ -336,6 +336,24 @@ export const useAuthStore = create<AuthStore>()(
             // in sequence under isLoading: true, which keeps the guards in the
             // spinner state until the server validates the session.
             skipHydration: true,
+            // Force hasCheckedAuth: false as part of the SAME atomic state
+            // replacement that applies a rehydrated isAuthenticated/user pair
+            // (initial mount OR the cross-tab storage-sync path below) — never
+            // as a separate setState call before/after. A separate call would
+            // (a) itself go through persist's wrapped setState, which
+            // re-serializes and writes the CURRENT (pre-rehydrate) state back
+            // to the 'auth-storage' key, clobbering whatever the other tab
+            // just wrote there before rehydrate() gets a chance to read it,
+            // and (b) leave a render-cycle window where a same-origin-
+            // writable (so potentially tampered) rehydrated value is visible
+            // under a stale hasCheckedAuth. Folding it into merge() keeps both
+            // atomic with the single `set(stateFromStorage, true)` call
+            // zustand's hydrate() performs internally.
+            merge: (persistedState, currentState) => ({
+                ...(currentState as AuthStore),
+                ...(persistedState as Partial<AuthStore>),
+                hasCheckedAuth: false,
+            }),
         }
     )
 );
@@ -351,6 +369,15 @@ export const useAuthStore = create<AuthStore>()(
 if (typeof window !== 'undefined') {
     window.addEventListener('storage', (event) => {
         if (event.key === 'auth-storage' || event.key === null) {
+            // Match the initial-mount defense: rehydrate() applies
+            // hasCheckedAuth: false atomically with the incoming
+            // isAuthenticated/user pair (see the `merge` option above), so
+            // route guards (ProtectedRoute/AdminRoute — gated purely on
+            // hasCheckedAuth + isAuthenticated + user.role) never observe a
+            // same-origin-writable (so potentially tampered — e.g. a
+            // malicious extension content script or XSS in a sibling tab)
+            // rehydrated value before it's marked pending re-validation.
+            //
             // Re-validate with the server after accepting cross-tab state.
             // Rehydrate alone is insufficient: a tampered auth-storage written
             // by another same-origin context would set isAuthenticated: true
@@ -359,6 +386,11 @@ if (typeof window !== 'undefined') {
                 const { isAuthenticated } = useAuthStore.getState();
                 if (isAuthenticated) {
                     useAuthStore.getState().checkAuth();
+                } else {
+                    // Nothing to re-validate (e.g. a cross-tab logout/clear) —
+                    // checkAuth() won't run to flip this back, so settle it
+                    // here instead of leaving guards pending forever.
+                    useAuthStore.setState({ hasCheckedAuth: true });
                 }
             });
         }

--- a/web/src/utils/__tests__/routing.test.ts
+++ b/web/src/utils/__tests__/routing.test.ts
@@ -31,6 +31,7 @@ import {
     getFallbackRoute,
     canAccessRoute,
     createAuthAwareNavigate,
+    isSafeReturnTo,
 } from '../routing';
 import { ROUTES } from '../../constants';
 
@@ -52,6 +53,34 @@ describe('storeIntendedRoute', () => {
     it('stores an ordinary path', () => {
         storeIntendedRoute('/projects/42/secrets');
         expect(getAndClearIntendedRoute()).toBe('/projects/42/secrets');
+    });
+
+    it('does not store a protocol-relative path (open-redirect defense-in-depth)', () => {
+        storeIntendedRoute('//evil.example/x');
+        expect(getAndClearIntendedRoute()).toBeNull();
+    });
+
+    it('does not store a backslash-leading path (some browsers treat "/\\" as protocol-relative too)', () => {
+        storeIntendedRoute('/\\evil.example/x');
+        expect(getAndClearIntendedRoute()).toBeNull();
+    });
+});
+
+describe('isSafeReturnTo', () => {
+    it('accepts an ordinary in-app path', () => {
+        expect(isSafeReturnTo('/secrets/7')).toBe(true);
+    });
+
+    it('rejects a protocol-relative path', () => {
+        expect(isSafeReturnTo('//evil.example/x')).toBe(false);
+    });
+
+    it('rejects a backslash-leading path', () => {
+        expect(isSafeReturnTo('/\\evil.example/x')).toBe(false);
+    });
+
+    it('rejects a path that does not start with a leading slash', () => {
+        expect(isSafeReturnTo('evil.example/x')).toBe(false);
     });
 });
 
@@ -106,6 +135,17 @@ describe('getPostLoginRedirect', () => {
         expect(getPostLoginRedirect('/custom-landing')).toBe('/secrets/7');
         // consumed: a second call falls through to the default again
         expect(getPostLoginRedirect('/custom-landing')).toBe('/custom-landing');
+    });
+
+    it('falls back to the default when a protocol-relative path was written directly to storage, bypassing storeIntendedRoute', () => {
+        // Defense-in-depth: storeIntendedRoute already rejects this, but
+        // getPostLoginRedirect must not trust storage blindly either (e.g. a
+        // stale value from before this fix, or a future write path that
+        // bypasses storeIntendedRoute).
+        memStore.set('intendedRoute', '//evil.example/x');
+        expect(getPostLoginRedirect('/custom-landing')).toBe('/custom-landing');
+        // consumed even though rejected, so it doesn't linger in storage
+        expect(getAndClearIntendedRoute()).toBeNull();
     });
 });
 

--- a/web/src/utils/routing.ts
+++ b/web/src/utils/routing.ts
@@ -4,12 +4,29 @@ import { ADMIN_ROLES } from '../features/auth/roles';
 
 const INTENDED_ROUTE_KEY = 'intendedRoute';
 
+// react-router's navigate() can't currently be turned into an open redirect to
+// another origin (browsers reject a cross-origin pushState), but a stored
+// intended-route path still ends up passed straight to <Navigate> after
+// login, so require it to look like an in-app relative path as
+// defense-in-depth: a single leading '/' (not '//' or '/\', both of which
+// some browsers treat as protocol-relative). Shared with the SSO `return_to`
+// flow (see SSOCompletePage.tsx) so both post-login redirect paths apply the
+// same rule instead of maintaining it twice.
+export const isSafeReturnTo = (path: string): boolean => /^\/(?![/\\])/.test(path);
+
 /**
  * Stores the intended route for redirect after authentication
  */
 export const storeIntendedRoute = (path: string): void => {
     // Don't store login or other auth-related routes
     if (path === ROUTES.LOGIN || path.startsWith('/auth')) {
+        return;
+    }
+
+    // Don't store a protocol-relative (or otherwise unsafe) path — see
+    // isSafeReturnTo. Silently drop it rather than store something a later
+    // getPostLoginRedirect() caller could hand to <Navigate>/window.location.
+    if (!isSafeReturnTo(path)) {
         return;
     }
 
@@ -42,7 +59,13 @@ export const clearIntendedRoute = (): void => {
  */
 export const getPostLoginRedirect = (defaultPath: string = ROUTES.DASHBOARD): string => {
     const intendedRoute = getAndClearIntendedRoute();
-    return intendedRoute || defaultPath;
+    // Re-validate defense-in-depth: storeIntendedRoute already rejects an
+    // unsafe path, but this guards any stale/pre-fix value already sitting in
+    // storage, or a future write path that bypasses storeIntendedRoute.
+    if (intendedRoute && isSafeReturnTo(intendedRoute)) {
+        return intendedRoute;
+    }
+    return defaultPath;
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixes 4 confirmed security findings from an adversarial review of the frontend auth/session paths. The related clipboard-bypass finding was already fixed in a different PR and is untouched here.

- **401-retry loop guard** (`web/src/services/client.ts`): `handle401` re-issued the original request after a successful token refresh with no retry cap. If some other endpoint 401s for a reason unrelated to session expiry (backend bug, step-up-auth, flaky proxy), refresh+retry would loop forever. Added the conventional axios `_retry` marker on `error.config`: a second 401 on the same request after a refresh now fails through instead of refreshing again — without forcing a logout, since the session may still be valid.

- **Federated-read secret value never cleared from React state** (`web/src/pages/integrations/KeyorixConnectPage.tsx`): `FederatedReadPanel` fetched a secret's plaintext into `value` state and only ever masked the *rendered* text on hide — the plaintext stayed in memory indefinitely (visible via React DevTools / a heap snapshot). Now `value` is cleared back to `null` on hide and on unmount, mirroring `SecretDetailView`'s existing cache-eviction pattern. Re-revealing after a clear re-fetches (audited) rather than showing stale/empty data.

- **Post-login redirect missing the SSO flow's safe-path check** (`web/src/utils/routing.ts`): the non-SSO `storeIntendedRoute`/`getPostLoginRedirect` stored and replayed the raw pathname+search with no validation, unlike the SSO `return_to` flow's `isSafeReturnTo` guard against protocol-relative paths (`//host`, `/\host`). Extracted `isSafeReturnTo` into `routing.ts` as a shared export; `SSOCompletePage.tsx` now imports it instead of keeping a private copy. `storeIntendedRoute` rejects an unsafe path before storing it; `getPostLoginRedirect` re-validates on read as defense-in-depth.

- **Cross-tab storage sync trusts localStorage before re-validating** (`web/src/store/authStore.ts`): the `storage` event listener rehydrated `isAuthenticated`/`user` (role, permissions) from a same-origin-writable localStorage value and only re-validated against the server afterward, asynchronously — unlike the initial-mount path, which the code's own comments describe holding in a pending state until `checkAuth()` resolves. Added a custom persist `merge` that forces `hasCheckedAuth: false` atomically with every rehydrate (initial mount and cross-tab), so route guards can't momentarily trust a rehydrated value. (An initial attempt reset `hasCheckedAuth` via a separate `setState` call before `rehydrate()` — that turned out to itself re-persist the current, pre-rehydrate state and clobber the incoming cross-tab value, breaking the existing multi-tab sync tests; the atomic `merge`-based fix avoids that race.)

## Test plan

- [x] `pnpm vitest run` — full suite passes (2940 tests)
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — no issues
- [x] `pnpm run build` — succeeds
- [x] `pnpm run format:check` — clean
- [x] Added/updated tests per bug: `client.test.ts` (retry-loop guard), `KeyorixConnectPage.test.tsx` (state cleared on hide/unmount, forces re-fetch), `routing.test.ts` + `SSOCompletePage.test.tsx` (protocol-relative path rejected), `authStore.test.ts` (`hasCheckedAuth` false synchronously after a cross-tab storage event, settles after `checkAuth()`)