### PR TITLE
fix(operator): wipe on 401/retarget, surface wipe failures, redirect+body hardening

### DIFF
--- a/deploy/helm/keyorix-operator/crds/secrets.keyorix.io_keyorixsecrets.yaml
+++ b/deploy/helm/keyorix-operator/crds/secrets.keyorix.io_keyorixsecrets.yaml
@@ -215,6 +215,16 @@ spec:
                   written.
                 format: date-time
                 type: string
+              lastTargetName:
+                description: |-
+                  LastTargetName is the target Secret name materialised by the most recent
+                  successful sync. spec.target.name is mutable — when it changes, the Secret
+                  previously created under this OLD name would otherwise never be revisited by any
+                  later reconcile (Reconcile only ever looks at the CURRENT secretName) and would
+                  linger in the cluster indefinitely with its last-synced, possibly since-rotated,
+                  plaintext value. Reconcile compares this field against the current target name on
+                  every pass and wipes the orphaned Secret under the old name before proceeding.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the spec generation last reconciled.
                 format: int64

--- a/internal/mcp/keyorix.go
+++ b/internal/mcp/keyorix.go
@@ -39,8 +39,23 @@ func NewKeyorixClient(baseURL, token string) (*KeyorixClient, error) {
 	return &KeyorixClient{
 		baseURL: strings.TrimRight(baseURL, "/"),
 		token:   token,
-		hc:      &http.Client{Timeout: 30 * time.Second},
+		hc:      &http.Client{Timeout: 30 * time.Second, CheckRedirect: refuseRedirect},
 	}, nil
+}
+
+// refuseRedirect blocks the http.Client from following ANY redirect. Go's default
+// redirect behavior only strips the Authorization header when the redirect target's
+// Host differs from the original — it never checks scheme. A same-host redirect from
+// https:// to http:// (a misconfigured reverse proxy in front of the Keyorix server, or
+// a compromised server) would otherwise keep this client's bearer token attached and
+// send it — and the plaintext secret value in the response — over cleartext.
+// requireHTTPSURL above already refuses a non-loopback http:// baseURL up front, but
+// that only checks the INITIAL request's scheme; Go's redirect-following would still
+// happily downgrade mid-request without this. This client only ever talks to a single,
+// fixed, caller-supplied KEYORIX_URL and has no legitimate reason to follow a redirect
+// at all, so refusing every redirect outright is the simplest and safest fix.
+func refuseRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
 }
 
 // requireHTTPSURL rejects a Keyorix base URL that is not https (http is allowed only

--- a/internal/mcp/keyorix_test.go
+++ b/internal/mcp/keyorix_test.go
@@ -97,3 +97,27 @@ func TestNewKeyorixClient_RequiresHTTPS(t *testing.T) {
 		}
 	}
 }
+
+// TestKeyorixClient_RefusesRedirect pins the fix for a bearer-token-leak-on-downgrade
+// bug: Go's default http.Client only strips the Authorization header when a redirect's
+// Host differs from the original — never when only the scheme changes, so a same-host
+// https->http redirect would otherwise carry the bearer token (and the plaintext secret
+// value in the response) over cleartext. requireHTTPSURL only guards the INITIAL
+// request's scheme, not a mid-request redirect, so CheckRedirect must refuse every
+// redirect outright.
+func TestKeyorixClient_RefusesRedirect(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(t, "the client must never actually reach the redirect target", "Authorization=%q", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/api/v1/secrets/value", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	_, err := mustClient(t, redirector.URL, "tok").GetSecret(context.Background(), "a/b/c")
+	require.Error(t, err, "a redirect must be refused, not silently followed")
+	assert.Contains(t, err.Error(), "redirect")
+}

--- a/operator/api/v1alpha1/keyorixsecret_types.go
+++ b/operator/api/v1alpha1/keyorixsecret_types.go
@@ -100,6 +100,15 @@ type KeyorixSecretStatus struct {
 	// ObservedGeneration is the spec generation last reconciled.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// LastTargetName is the target Secret name materialised by the most recent
+	// successful sync. spec.target.name is mutable — when it changes, the Secret
+	// previously created under this OLD name would otherwise never be revisited by any
+	// later reconcile (Reconcile only ever looks at the CURRENT secretName) and would
+	// linger in the cluster indefinitely with its last-synced, possibly since-rotated,
+	// plaintext value. Reconcile compares this field against the current target name on
+	// every pass and wipes the orphaned Secret under the old name before proceeding.
+	// +optional
+	LastTargetName string `json:"lastTargetName,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/operator/config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml
+++ b/operator/config/crd/bases/secrets.keyorix.io_keyorixsecrets.yaml
@@ -215,6 +215,16 @@ spec:
                   written.
                 format: date-time
                 type: string
+              lastTargetName:
+                description: |-
+                  LastTargetName is the target Secret name materialised by the most recent
+                  successful sync. spec.target.name is mutable — when it changes, the Secret
+                  previously created under this OLD name would otherwise never be revisited by any
+                  later reconcile (Reconcile only ever looks at the CURRENT secretName) and would
+                  linger in the cluster indefinitely with its last-synced, possibly since-rotated,
+                  plaintext value. Reconcile compares this field against the current target name on
+                  every pass and wipes the orphaned Secret under the old name before proceeding.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the spec generation last reconciled.
                 format: int64

--- a/operator/internal/controller/keyorixsecret_controller.go
+++ b/operator/internal/controller/keyorixsecret_controller.go
@@ -220,23 +220,53 @@ func (r *KeyorixSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		secretName = ks.Name
 	}
 
+	// spec.target.name is mutable — if it changed since the last successful sync, the
+	// Secret materialised under the OLD name is now orphaned: no later reconcile ever
+	// revisits it by name again (Reconcile only ever looks at the CURRENT secretName),
+	// so it would otherwise sit in the cluster forever with its last-synced, possibly
+	// since-rotated, plaintext value, still owned by this (now-repurposed) CR, mountable
+	// by any workload with ordinary Secret-read RBAC in the namespace. Wipe it BEFORE
+	// doing anything else this reconcile, using the same ownership-and-label-checked
+	// wipeTargetSecret used for the confirmed-gone path below — it's a no-op if nothing
+	// exists under the old name, or if this is the CR's first-ever reconcile
+	// (LastTargetName is unset).
+	//
+	// If the wipe itself fails, orphanWipeErr is threaded through to succeed() below:
+	// status.LastTargetName is deliberately NOT advanced to the new name in that case,
+	// so the next reconcile retries the orphan wipe instead of forgetting about it.
+	var orphanWipeErr error
+	if ks.Status.LastTargetName != "" && ks.Status.LastTargetName != secretName {
+		if wipeErr := r.wipeTargetSecret(ctx, &ks, ks.Status.LastTargetName); wipeErr != nil {
+			orphanWipeErr = wipeErr
+			logger.Error(wipeErr, "failed to wipe orphaned target Secret after spec.target.name changed",
+				"oldTargetName", ks.Status.LastTargetName, "newTargetName", secretName)
+		}
+	}
+
 	desired, err := r.buildDesired(ctx, &ks)
 	if err != nil {
 		logger.Error(err, "failed to assemble secret data")
-		if errors.Is(err, keyorix.ErrSecretGone) {
+		switch {
+		case errors.Is(err, keyorix.ErrSecretGone):
 			// The upstream Keyorix server AFFIRMATIVELY reported (404/403) that a
 			// referenced secret no longer exists or is no longer accessible — as
-			// opposed to a transient failure (network error, timeout, 5xx, or a bad
-			// token) where the target Secret must be left untouched. Without this,
-			// a revoked/deleted upstream secret leaves the previously synced target
-			// Secret sitting in the cluster indefinitely, fully readable by every
-			// workload that mounts it, with no indication anything is wrong (#428).
-			if wipeErr := r.wipeTargetSecret(ctx, &ks, secretName); wipeErr != nil {
-				logger.Error(wipeErr, "failed to wipe target Secret after upstream secret became inaccessible")
-			}
-			return r.failGone(ctx, &ks, err)
+			// opposed to a transient failure (network error, timeout, 5xx) where the
+			// target Secret must be left untouched. Without this, a revoked/deleted
+			// upstream secret leaves the previously synced target Secret sitting in
+			// the cluster indefinitely, fully readable by every workload that mounts
+			// it, with no indication anything is wrong (#428).
+			return r.wipeAndFailGone(ctx, &ks, secretName, "UpstreamSecretGone", err)
+		case errors.Is(err, keyorix.ErrUnauthorized):
+			// A 401 doesn't confirm the referenced secret itself is gone, but in
+			// practice it overwhelmingly means the machine-identity credential was
+			// revoked or rotated — an admin deliberately cut this workload's access.
+			// That's the same "stop serving the stale value" signal as a confirmed
+			// 404/403, so it gets the same wipe treatment, just with a distinct
+			// status reason so it's clear from .status which of the two happened.
+			return r.wipeAndFailGone(ctx, &ks, secretName, "UpstreamAccessRevoked", err)
+		default:
+			return r.fail(ctx, &ks, err)
 		}
-		return r.fail(ctx, &ks, err)
 	}
 
 	hash := hashData(r.hashKey, desired)
@@ -246,7 +276,7 @@ func (r *KeyorixSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return r.fail(ctx, &ks, err)
 	}
 
-	if err := r.succeed(ctx, &ks, hash); err != nil {
+	if err := r.succeed(ctx, &ks, hash, secretName, orphanWipeErr); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: interval}, nil
@@ -278,6 +308,14 @@ func (r *KeyorixSecretReconciler) buildDesired(ctx context.Context, ks *secretsv
 		reader = r.Client
 	}
 	if err := reader.Get(ctx, ref, &tokenSecret); err != nil {
+		// Deliberately NOT treated as a wipe-worthy "access confirmed cut" signal (unlike
+		// ErrSecretGone/ErrUnauthorized in Reconcile): a missing/unreadable token Secret
+		// means the operator couldn't even ASK the Keyorix server whether access is still
+		// valid — it could be a typo in tokenSecretRef, an accidental deletion, transient
+		// RBAC drift, or a GC race, none of which confirm the upstream secret or grant was
+		// actually revoked. Wiping the target Secret on a merely-ambiguous "we don't know"
+		// failure would cause an unnecessary outage for every workload depending on it,
+		// the same reasoning that already keeps network errors/5xx out of the wipe path.
 		return nil, fmt.Errorf("read token secret %s: %w", ref, err)
 	}
 	// A CRD-write-only principal (the CRD's own documented least-privilege deployment
@@ -383,13 +421,41 @@ func (r *KeyorixSecretReconciler) fail(ctx context.Context, ks *secretsv1alpha1.
 	return ctrl.Result{}, cause
 }
 
-// failGone is fail's counterpart for a confirmed-gone upstream secret (#428): it
-// records a distinct reason ("UpstreamSecretGone" rather than the generic
-// "SyncError") so the CR's status makes the wipe visible and explicable, rather than
-// looking like an ordinary transient sync failure. The target Secret has already been
-// wiped by wipeTargetSecret before this is called.
-func (r *KeyorixSecretReconciler) failGone(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, cause error) (ctrl.Result, error) {
-	r.setReady(ks, metav1.ConditionFalse, "UpstreamSecretGone", cause.Error())
+// wipeAndFailGone wipes the target Secret and records the failure on the Ready
+// condition via failGone, distinguishing a successful wipe from one that itself failed.
+// Before this, a wipeTargetSecret failure was only passed to logger.Error and otherwise
+// discarded: the CR's Ready condition would still read as an ordinary confirmed-gone
+// sync failure with no indication the stale (possibly revoked/rotated) Secret was NOT
+// actually removed — a delete-blocking admission webhook, RBAC drift, or a transient API
+// error could leave it silently mounted into every workload that references it, with
+// nothing in .status to say so.
+func (r *KeyorixSecretReconciler) wipeAndFailGone(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, secretName, reason string, cause error) (ctrl.Result, error) {
+	var wipeErr error
+	if err := r.wipeTargetSecret(ctx, ks, secretName); err != nil {
+		wipeErr = err
+		log.FromContext(ctx).Error(err, "failed to wipe target Secret after upstream access was confirmed cut off")
+	}
+	return r.failGone(ctx, ks, reason, cause, wipeErr)
+}
+
+// failGone is fail's counterpart for a confirmed access-cut upstream failure (#428): it
+// records a distinct reason ("UpstreamSecretGone" for a confirmed-gone 404/403,
+// "UpstreamAccessRevoked" for a 401 — see the ErrSecretGone/ErrUnauthorized handling in
+// Reconcile) so the CR's status makes the wipe visible and explicable, rather than
+// looking like an ordinary transient sync failure.
+//
+// wipeErr, when non-nil, means wipeTargetSecret itself failed: the reason gets a
+// "WipeFailed" suffix (e.g. "UpstreamSecretGoneWipeFailed") and the message says so
+// explicitly, so a reader of .status alone can tell the stale target Secret may still be
+// sitting in the cluster with revoked/rotated data, not just that the upstream fetch
+// failed.
+func (r *KeyorixSecretReconciler) failGone(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, reason string, cause, wipeErr error) (ctrl.Result, error) {
+	msg := cause.Error()
+	if wipeErr != nil {
+		reason += "WipeFailed"
+		msg = fmt.Sprintf("%s — additionally, wiping the stale target Secret failed, it may still contain revoked/rotated data: %v", cause.Error(), wipeErr)
+	}
+	r.setReady(ks, metav1.ConditionFalse, reason, msg)
 	if err := r.Status().Update(ctx, ks); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -399,8 +465,11 @@ func (r *KeyorixSecretReconciler) failGone(ctx context.Context, ks *secretsv1alp
 }
 
 // wipeTargetSecret deletes the target Secret when the upstream Keyorix reference has
-// been confirmed gone (404/403 — see the ErrSecretGone handling in Reconcile). Only a
-// Secret this operator actually manages AND that THIS CR controls is ever touched. Two
+// been confirmed gone (404/403, or the credential itself was rejected with a 401 — see
+// the ErrSecretGone/ErrUnauthorized handling in Reconcile) or when a retarget
+// (spec.target.name change) has orphaned the Secret previously materialised under an
+// old name. Only a Secret this operator actually manages AND that THIS CR controls is
+// ever touched. Two
 // checks, mirroring applySecret's write-side rigor:
 //   - ManagedByLabel: applySecret already refuses to adopt a pre-existing unmanaged
 //     Secret sharing the target name, so wiping an unlabeled Secret here too would risk
@@ -429,13 +498,32 @@ func (r *KeyorixSecretReconciler) wipeTargetSecret(ctx context.Context, ks *secr
 	return client.IgnoreNotFound(r.Delete(ctx, &secret))
 }
 
-// succeed records Ready=True and the synced fingerprint.
-func (r *KeyorixSecretReconciler) succeed(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, hash string) error {
+// succeed records Ready=True and the synced fingerprint. targetName is the CURRENT
+// target Secret name (secretName in Reconcile); orphanWipeErr, when non-nil, means a
+// retarget (spec.target.name change) was detected this reconcile but wiping the
+// Secret orphaned under the OLD name failed.
+func (r *KeyorixSecretReconciler) succeed(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, hash, targetName string, orphanWipeErr error) error {
 	now := metav1.Now()
 	ks.Status.LastSyncTime = &now
 	ks.Status.SyncedHash = hash
 	ks.Status.ObservedGeneration = ks.Generation
-	r.setReady(ks, metav1.ConditionTrue, "Synced", "target Secret is up to date")
+	if orphanWipeErr == nil {
+		// The common case (no retarget, or the retarget's orphan wipe succeeded):
+		// advance LastTargetName so a later retarget compares against the right name.
+		ks.Status.LastTargetName = targetName
+		r.setReady(ks, metav1.ConditionTrue, "Synced", "target Secret is up to date")
+	} else {
+		// The new target Secret synced fine, but the operator failed to wipe the
+		// Secret orphaned under the OLD target name. Deliberately leave
+		// LastTargetName pointing at the OLD name (NOT targetName) so the next
+		// reconcile retries that wipe instead of silently forgetting about it, and
+		// surface the failure in the message so it isn't lost the way a
+		// log-only wipeErr previously was (mirrors the wipeAndFailGone fix for the
+		// ErrSecretGone/ErrUnauthorized path).
+		r.setReady(ks, metav1.ConditionTrue, "Synced",
+			fmt.Sprintf("target Secret is up to date; WARNING: failed to wipe the orphaned Secret %q left behind by a spec.target.name change, it may still contain stale data: %v",
+				ks.Status.LastTargetName, orphanWipeErr))
+	}
 	return r.Status().Update(ctx, ks)
 }
 

--- a/operator/internal/controller/keyorixsecret_controller_test.go
+++ b/operator/internal/controller/keyorixsecret_controller_test.go
@@ -58,8 +58,6 @@ func (f *fakeFetcher) FetchValue(_ context.Context, ref string) ([]byte, error) 
 	return v, nil
 }
 
-
-
 func testScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()

--- a/operator/internal/controller/keyorixsecret_controller_test.go
+++ b/operator/internal/controller/keyorixsecret_controller_test.go
@@ -29,18 +29,24 @@ import (
 )
 
 // fakeFetcher serves values from a map. Refs in failRefs error with a plain
-// (non-ErrSecretGone) error, simulating a transient failure (network/5xx/401). Refs in
+// (non-ErrSecretGone) error, simulating a transient failure (network/5xx). Refs in
 // goneRefs error wrapping keyorix.ErrSecretGone, simulating a confirmed 404/403 from
-// the upstream Keyorix server (#428).
+// the upstream Keyorix server (#428). Refs in unauthorizedRefs error wrapping
+// keyorix.ErrUnauthorized, simulating a 401 (revoked/rotated machine-identity
+// credential).
 type fakeFetcher struct {
-	values   map[string][]byte
-	failRefs map[string]bool
-	goneRefs map[string]bool
+	values           map[string][]byte
+	failRefs         map[string]bool
+	goneRefs         map[string]bool
+	unauthorizedRefs map[string]bool
 }
 
 func (f *fakeFetcher) FetchValue(_ context.Context, ref string) ([]byte, error) {
 	if f.goneRefs[ref] {
 		return nil, fmt.Errorf("ref %q gone: %w", ref, keyorix.ErrSecretGone)
+	}
+	if f.unauthorizedRefs[ref] {
+		return nil, fmt.Errorf("ref %q unauthorized: %w", ref, keyorix.ErrUnauthorized)
 	}
 	if f.failRefs[ref] {
 		return nil, errors.New("boom")
@@ -51,6 +57,8 @@ func (f *fakeFetcher) FetchValue(_ context.Context, ref string) ([]byte, error) 
 	}
 	return v, nil
 }
+
+
 
 func testScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -261,9 +269,12 @@ func TestReconcile_UpstreamGoneWipesTargetSecret(t *testing.T) {
 }
 
 // TestReconcile_TransientFetchFailureLeavesTargetSecretUntouched pins #428's other
-// half: a transient failure (network error, timeout, 5xx, or an ambiguous 401) must
-// NOT touch a previously synced target Secret. Wiping it on every hiccup would cause
-// unnecessary outages for every workload depending on it.
+// half: a genuinely transient/ambiguous failure (network error, timeout, 5xx — anything
+// that is neither ErrSecretGone nor ErrUnauthorized) must NOT touch a previously synced
+// target Secret. Wiping it on every hiccup would cause unnecessary outages for every
+// workload depending on it. (A 401/ErrUnauthorized is deliberately NOT exercised here
+// any more — see TestReconcile_UnauthorizedWipesTargetSecretWithDistinctReason below,
+// which now DOES wipe on 401, since it's treated as a revoked/rotated credential.)
 func TestReconcile_TransientFetchFailureLeavesTargetSecretUntouched(t *testing.T) {
 	fetcher := &fakeFetcher{values: map[string][]byte{
 		"app/production/db-password": []byte("p4ss"),
@@ -293,6 +304,216 @@ func TestReconcile_TransientFetchFailureLeavesTargetSecretUntouched(t *testing.T
 	require.Len(t, ks.Status.Conditions, 1)
 	assert.Equal(t, metav1.ConditionFalse, ks.Status.Conditions[0].Status)
 	assert.Equal(t, "SyncError", ks.Status.Conditions[0].Reason, "a transient failure keeps the generic SyncError reason")
+}
+
+// TestReconcile_UnauthorizedWipesTargetSecretWithDistinctReason pins the fix for the
+// bug where only a confirmed-gone 404/403 wiped the target Secret: revoking or rotating
+// the machine-identity credential (the overwhelmingly common real-world way an admin
+// cuts a workload's access) surfaces as a 401, not a 404/403, and a 401 was previously
+// routed into the generic r.fail() branch that leaves the previously-synced target
+// Secret untouched — so every Pod mounting it kept reading the revoked value
+// indefinitely. A 401 (keyorix.ErrUnauthorized) must now wipe the target Secret the same
+// way ErrSecretGone does, with a status reason ("UpstreamAccessRevoked") that is still
+// distinguishable from a confirmed-gone secret ("UpstreamSecretGone").
+func TestReconcile_UnauthorizedWipesTargetSecretWithDistinctReason(t *testing.T) {
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"),
+		"app/production/api-key":     []byte("k3y"),
+	}}
+	r, c := newReconciler(t, fetcher, ksFixture(), tokenSecret())
+	_, err := reconcile(t, r)
+	require.NoError(t, err)
+
+	var got corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got),
+		"precondition: the target Secret exists after a successful sync")
+
+	// The bearer token is now rejected (401) — e.g. the machine-identity credential was
+	// revoked or rotated by an admin.
+	fetcher.unauthorizedRefs = map[string]bool{"app/production/db-password": true}
+
+	_, err = reconcile(t, r)
+	require.Error(t, err, "a 401 still requeues with error for backoff")
+	assert.True(t, errors.Is(err, keyorix.ErrUnauthorized))
+
+	err = c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got)
+	assert.Error(t, err, "a 401 must wipe the target Secret the same way a confirmed-gone 404/403 does")
+
+	var ks secretsv1alpha1.KeyorixSecret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &ks))
+	require.Len(t, ks.Status.Conditions, 1)
+	assert.Equal(t, metav1.ConditionFalse, ks.Status.Conditions[0].Status)
+	assert.Equal(t, "UpstreamAccessRevoked", ks.Status.Conditions[0].Reason,
+		"a 401 gets a status reason distinct from a confirmed-gone 404/403")
+}
+
+// deleteBlockingClient wraps a client.Client but fails every Delete call for an object
+// named blockDeleteName, simulating a delete-blocking admission webhook, RBAC drift, or
+// a transient API error during wipeTargetSecret — used to exercise the wipe-failure-
+// surfaced-in-status path (Bug 3) and the retarget-wipe-failure path (Bug 2's failure
+// branch).
+type deleteBlockingClient struct {
+	client.Client
+	blockDeleteName string
+}
+
+func (c *deleteBlockingClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if obj.GetName() == c.blockDeleteName {
+		return fmt.Errorf("simulated delete-blocking webhook rejected deletion of %s", obj.GetName())
+	}
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
+// TestReconcile_WipeFailureSurfacedInStatus pins the fix for the bug where a
+// wipeTargetSecret failure (e.g. a delete-blocking admission webhook, RBAC drift, or a
+// transient API error) was only passed to logger.Error and otherwise discarded: the
+// CR's Ready condition still read as an ordinary confirmed-gone sync failure
+// ("UpstreamSecretGone") with no indication the stale, possibly-revoked target Secret
+// was NOT actually removed. The reason must now carry a distinct "WipeFailed" suffix and
+// the message must say the wipe itself failed.
+func TestReconcile_WipeFailureSurfacedInStatus(t *testing.T) {
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"),
+		"app/production/api-key":     []byte("k3y"),
+	}}
+	s := testScheme(t)
+	inner := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&secretsv1alpha1.KeyorixSecret{}).
+		WithObjects(ksFixture(), tokenSecret()).
+		Build()
+	blocked := &deleteBlockingClient{Client: inner, blockDeleteName: "db-creds"}
+	r := &KeyorixSecretReconciler{
+		Client:         blocked,
+		Scheme:         s,
+		AllowedServers: []string{"https://keyorix.internal"},
+		newClient:      func(_, _ string) valueFetcher { return fetcher },
+		hashKey:        []byte("test-fixture-hmac-key"),
+	}
+
+	_, err := reconcile(t, r)
+	require.NoError(t, err)
+
+	// Confirmed gone on the next reconcile, but Delete is blocked (simulated webhook).
+	fetcher.goneRefs = map[string]bool{"app/production/db-password": true}
+	_, err = reconcile(t, r)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, keyorix.ErrSecretGone))
+
+	// The Secret is still there — the wipe was blocked.
+	var got corev1.Secret
+	require.NoError(t, blocked.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got),
+		"the wipe was blocked, so the stale Secret must still exist")
+
+	var ks secretsv1alpha1.KeyorixSecret
+	require.NoError(t, blocked.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &ks))
+	require.Len(t, ks.Status.Conditions, 1)
+	assert.Equal(t, "UpstreamSecretGoneWipeFailed", ks.Status.Conditions[0].Reason,
+		"a wipe failure must be distinguishable in status from a successful wipe")
+	assert.Contains(t, ks.Status.Conditions[0].Message, "wiping the stale target Secret failed",
+		"the message must say the wipe itself failed, not just that the fetch failed")
+}
+
+// TestReconcile_RetargetWipesOrphanedSecretUnderOldName pins the fix for the bug where
+// changing spec.target.name orphaned the previously-materialised Secret forever: no
+// later reconcile ever revisited it by the OLD name, so it lingered indefinitely with
+// its last-synced (possibly since-rotated) plaintext value. status.LastTargetName must
+// track the materialised name, and a mismatch on the next reconcile must wipe the OLD
+// Secret before syncing the new one.
+func TestReconcile_RetargetWipesOrphanedSecretUnderOldName(t *testing.T) {
+	ks := ksFixture()
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"),
+		"app/production/api-key":     []byte("k3y"),
+	}}
+	r, c := newReconciler(t, fetcher, ks, tokenSecret())
+	_, err := reconcile(t, r)
+	require.NoError(t, err)
+
+	var oldSecret corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &oldSecret),
+		"precondition: the target Secret exists under the original name")
+
+	var got secretsv1alpha1.KeyorixSecret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &got))
+	assert.Equal(t, "db-creds", got.Status.LastTargetName, "LastTargetName tracks the materialised target after a successful sync")
+
+	// Retarget: spec.target.name changes to a brand-new name.
+	got.Spec.Target.Name = "db-creds-v2"
+	require.NoError(t, c.Update(context.Background(), &got))
+
+	_, err = reconcile(t, r)
+	require.NoError(t, err)
+
+	// The Secret orphaned under the OLD name is gone.
+	err = c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &oldSecret)
+	assert.Error(t, err, "the Secret orphaned under the OLD target name must be wiped on retarget")
+
+	// The new Secret exists with the synced data.
+	var newSecret corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds-v2", Namespace: "app"}, &newSecret))
+	assert.Equal(t, []byte("p4ss"), newSecret.Data["DB_PASSWORD"])
+
+	// status.LastTargetName now tracks the new name.
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &got))
+	assert.Equal(t, "db-creds-v2", got.Status.LastTargetName)
+}
+
+// TestReconcile_RetargetWipeFailureKeepsOldLastTargetNameAndWarns exercises Bug 2's
+// failure branch together with Bug 3's status-surfacing fix: if wiping the orphaned OLD
+// Secret fails during a retarget, the new target's sync must still succeed (a blocked
+// cleanup of an unrelated old resource shouldn't hold the CR's real sync hostage), but
+// status.LastTargetName must NOT advance to the new name — so the next reconcile retries
+// the orphan wipe instead of silently forgetting about it — and the Ready message must
+// say so.
+func TestReconcile_RetargetWipeFailureKeepsOldLastTargetNameAndWarns(t *testing.T) {
+	ks := ksFixture()
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"),
+		"app/production/api-key":     []byte("k3y"),
+	}}
+	s := testScheme(t)
+	inner := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&secretsv1alpha1.KeyorixSecret{}).
+		WithObjects(ks, tokenSecret()).
+		Build()
+	blocked := &deleteBlockingClient{Client: inner, blockDeleteName: "db-creds"}
+	r := &KeyorixSecretReconciler{
+		Client:         blocked,
+		Scheme:         s,
+		AllowedServers: []string{"https://keyorix.internal"},
+		newClient:      func(_, _ string) valueFetcher { return fetcher },
+		hashKey:        []byte("test-fixture-hmac-key"),
+	}
+	_, err := reconcile(t, r)
+	require.NoError(t, err)
+
+	var got secretsv1alpha1.KeyorixSecret
+	require.NoError(t, blocked.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &got))
+	require.Equal(t, "db-creds", got.Status.LastTargetName)
+
+	got.Spec.Target.Name = "db-creds-v2"
+	require.NoError(t, blocked.Update(context.Background(), &got))
+
+	_, err = reconcile(t, r)
+	require.NoError(t, err, "the new target's sync must succeed even though the OLD Secret's wipe was blocked")
+
+	// The new Secret exists.
+	var newSecret corev1.Secret
+	require.NoError(t, blocked.Get(context.Background(), types.NamespacedName{Name: "db-creds-v2", Namespace: "app"}, &newSecret))
+
+	// The old Secret still exists — its wipe was blocked.
+	var oldSecret corev1.Secret
+	require.NoError(t, blocked.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &oldSecret))
+
+	require.NoError(t, blocked.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &got))
+	assert.Equal(t, "db-creds", got.Status.LastTargetName,
+		"LastTargetName must stay at the OLD name so the next reconcile retries the orphan wipe")
+	require.Len(t, got.Status.Conditions, 1)
+	assert.Equal(t, metav1.ConditionTrue, got.Status.Conditions[0].Status, "the new target's own sync still succeeded")
+	assert.Contains(t, got.Status.Conditions[0].Message, "failed to wipe the orphaned Secret",
+		"a blocked orphan wipe must be visible in the Ready message, not just logged")
 }
 
 // A target Secret this operator does NOT manage (no ManagedByLabel — applySecret

--- a/operator/internal/keyorix/client.go
+++ b/operator/internal/keyorix/client.go
@@ -8,11 +8,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 )
+
+// maxResponseBodyBytes caps how much of FetchValue's HTTP response body is ever
+// decoded (#428 follow-up). Without a cap, json.NewDecoder(resp.Body) buffers an
+// arbitrarily large (or gzip-bomb-expanded, since Go's transport auto-decompresses)
+// response fully into memory — and this operator runs as a single cluster-wide
+// singleton reconciler (see maxConcurrentReconciles in the controller package), so an
+// OOM here doesn't just fail one reconcile, it halts secret sync for every
+// KeyorixSecret in the cluster. Mirrors the same constant/idiom already used by
+// internal/mcp/keyorix.go's getJSON for the identical by-reference value endpoint.
+const maxResponseBodyBytes = 10 << 20 // 10 MiB
 
 // ErrSecretGone is wrapped into the error FetchValue returns when the Keyorix server
 // AFFIRMATIVELY reports the referenced secret no longer exists or is no longer
@@ -20,11 +31,26 @@ import (
 // "never existed" and "soft-deleted" into 404 — or HTTP 403 Forbidden, meaning the
 // caller's own scope was denied for that specific reference, e.g. a revoked
 // machine-identity role). Callers use errors.Is(err, ErrSecretGone) to distinguish
-// this confirmed case from a transient failure (network error, timeout, 5xx, or a 401
-// — which only says the bearer token itself is bad/expired and says nothing about the
-// referenced secret's fate) where taking a destructive action on a previously synced
-// target would cause an unnecessary outage for workloads that depend on it.
+// this confirmed case from a transient failure (network error, timeout, 5xx) where
+// taking a destructive action on a previously synced target would cause an unnecessary
+// outage for workloads that depend on it.
+//
+// A 401 is deliberately NOT folded into ErrSecretGone: unlike 403, it says the bearer
+// token itself is invalid/expired, not that the referenced secret's own existence or
+// grant was checked and denied. It gets its own sentinel, ErrUnauthorized, below.
 var ErrSecretGone = errors.New("secret reference no longer exists or is not accessible")
+
+// ErrUnauthorized is wrapped into the error FetchValue returns on HTTP 401. A 401 is
+// distinct from 403/404 (see ErrSecretGone) in what it tells us about the referenced
+// secret, but it is NOT merely "transient and ignorable" either: the overwhelmingly
+// common real-world cause of a previously-working bearer token suddenly turning invalid
+// is that an admin revoked or rotated the machine-identity credential — i.e. access was
+// deliberately cut. That is exactly the same "stop serving the stale value" signal as a
+// confirmed-gone 404/403, so callers (the controller's Reconcile) treat
+// errors.Is(err, ErrUnauthorized) the same as ErrSecretGone for the purpose of wiping a
+// previously-materialized target Secret, while still recording a distinct status reason
+// so it's clear from the CR's condition which of the two actually happened.
+var ErrUnauthorized = errors.New("bearer token rejected (unauthorized)")
 
 // Client reads secret values from a Keyorix server with a bearer (machine-identity)
 // token. The token is sent on every request and never logged.
@@ -39,8 +65,22 @@ func New(baseURL, token string) *Client {
 	return &Client{
 		baseURL: strings.TrimRight(baseURL, "/"),
 		token:   token,
-		hc:      &http.Client{Timeout: 30 * time.Second},
+		hc:      &http.Client{Timeout: 30 * time.Second, CheckRedirect: refuseRedirect},
 	}
+}
+
+// refuseRedirect blocks the http.Client from following ANY redirect. Go's default
+// redirect behavior only strips the Authorization header when the redirect target's
+// Host differs from the original — it never checks scheme. A same-host redirect from
+// https:// to http:// (a misconfigured reverse proxy in front of the Keyorix server, or
+// a compromised server) would otherwise keep this client's bearer token attached and
+// send it — and the plaintext secret value in the response — over cleartext. This
+// client only ever talks to a single, fixed, operator-validated base URL (see
+// validateServer in the controller package, which also requires https) and has no
+// legitimate reason to follow a redirect at all, so refusing every redirect outright is
+// the simplest and safest fix.
+func refuseRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
 }
 
 // FetchValue returns the current value of the secret referenced by
@@ -75,8 +115,10 @@ func (c *Client) FetchValue(ctx context.Context, ref string) ([]byte, error) {
 	case resp.StatusCode == http.StatusUnauthorized:
 		// Unlike 403, a 401 says the token itself is invalid/expired — it says
 		// nothing about whether the referenced secret still exists or is still
-		// permitted, so this must NOT be treated as ErrSecretGone.
-		return nil, fmt.Errorf("not authorized (HTTP 401) — check the token is valid")
+		// permitted, so this must NOT be treated as ErrSecretGone. It IS wrapped as
+		// ErrUnauthorized (see its doc comment) so the controller can still treat a
+		// revoked/rotated credential as an access-cut signal worth wiping for.
+		return nil, fmt.Errorf("not authorized (HTTP 401) — check the token is valid: %w", ErrUnauthorized)
 	case resp.StatusCode == http.StatusBadRequest:
 		return nil, fmt.Errorf("invalid reference %q (want project/environment/name)", ref)
 	case resp.StatusCode >= 400:
@@ -88,7 +130,7 @@ func (c *Client) FetchValue(ctx context.Context, ref string) ([]byte, error) {
 			Value string `json:"value"`
 		} `json:"data"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBodyBytes)).Decode(&body); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	return []byte(body.Data.Value), nil

--- a/operator/internal/keyorix/client_test.go
+++ b/operator/internal/keyorix/client_test.go
@@ -91,3 +91,45 @@ func TestClient_FetchValueNetworkErrorIsNotGone(t *testing.T) {
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, ErrSecretGone), "a connection-refused error must not be classified as ErrSecretGone")
 }
+
+// TestClient_FetchValueUnauthorizedWrapsErrUnauthorized pins the 401 classification the
+// operator controller relies on: a 401 must wrap ErrUnauthorized (distinct from
+// ErrSecretGone, which stays reserved for a confirmed 404/403) so the controller can
+// treat a revoked/rotated bearer token as an access-cut signal worth wiping the target
+// Secret for, while still recording a status reason distinct from a confirmed-gone
+// secret.
+func TestClient_FetchValueUnauthorizedWrapsErrUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL, "tok").FetchValue(context.Background(), "a/b/c")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnauthorized), "a 401 must wrap ErrUnauthorized")
+	assert.False(t, errors.Is(err, ErrSecretGone), "a 401 must NOT wrap ErrSecretGone — it says nothing about the referenced secret's own fate")
+}
+
+// TestClient_RefusesRedirect pins the fix for a bearer-token-leak-on-downgrade bug: Go's
+// default http.Client only strips the Authorization header when a redirect's Host
+// differs from the original — never when only the scheme changes, so a same-host
+// https->http redirect would otherwise carry the bearer token (and the plaintext secret
+// value in the response) over cleartext. This client has no legitimate reason to follow
+// any redirect, so CheckRedirect must refuse every one outright.
+func TestClient_RefusesRedirect(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// If a redirect were followed, the Authorization header would land here.
+		assert.Fail(t, "the client must never actually reach the redirect target", "Authorization=%q", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/api/v1/secrets/value", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	_, err := New(redirector.URL, "tok").FetchValue(context.Background(), "a/b/c")
+	require.Error(t, err, "a redirect must be refused, not silently followed")
+	assert.Contains(t, err.Error(), "redirect")
+}


### PR DESCRIPTION
## Summary

Four confirmed findings in the KeyorixSecret controller/client, follow-up to the r140 security hardening round:

- **Bug 1 (HIGH):** The materialized target Secret was only wiped on a confirmed-gone 404/403 upstream response. A revoked/rotated machine-identity credential surfaces as HTTP 401 instead, and that path fell into the generic `r.fail()` branch that leaves the previously-synced Secret untouched — so every Pod mounting it kept reading a revoked value indefinitely. `internal/keyorix.Client` now wraps 401 as a new `ErrUnauthorized` sentinel (kept distinct from `ErrSecretGone`), and `Reconcile` wipes the target Secret on it too, recording a distinct `UpstreamAccessRevoked` status reason. The `TokenSecretRef` Get-failure path deliberately stays as `r.fail()` (documented in a comment) — a missing/unreadable token Secret means the operator couldn't even ask the server whether access is still valid, unlike a confirmed 401/403/404.

- **Bug 2 (HIGH):** Changing `spec.target.name` orphaned the previously-materialized Secret forever — no later reconcile ever revisited it by the old name. `KeyorixSecretStatus` gains a new `LastTargetName` field; `Reconcile` now wipes the Secret under the OLD name before syncing the new one whenever they differ, and only advances `LastTargetName` once that wipe (or the whole sync) succeeds — a failed orphan-wipe keeps retrying on subsequent reconciles instead of being forgotten.

- **Bug 3 (MEDIUM):** A `wipeTargetSecret` failure (blocked by an admission webhook, RBAC drift, a transient API error) was only passed to `logger.Error` and otherwise discarded — `.status` still read as an ordinary confirmed-gone failure with no indication the stale Secret was NOT actually removed. Both the `ErrSecretGone`/`ErrUnauthorized` wipe path and the retarget-orphan wipe path now surface a wipe failure explicitly: the status reason gets a `WipeFailed` suffix (e.g. `UpstreamSecretGoneWipeFailed`) and the message states the wipe itself failed.

- **Bug 4 (HIGH):** Both Keyorix HTTP clients (`operator/internal/keyorix` and `internal/mcp`) now set `CheckRedirect` to refuse every redirect outright. Go's default `http.Client` only strips the `Authorization` header when a redirect's Host differs from the original — never on a scheme change — so a same-host `https://` -> `http://` redirect (misconfigured proxy, or a compromised server) would otherwise carry the bearer token, and the plaintext secret value in the response, over cleartext.

- **Bug 5 (HIGH, bundled with Bug 4 since both are in the same client):** `operator/internal/keyorix.Client.FetchValue` now caps its response body with `io.LimitReader` (10 MiB), matching the idiom already used by `internal/mcp/keyorix.go`'s `getJSON`. Without it, a compromised/buggy server could return an unbounded or gzip-bombed body, fully buffered into memory — this operator runs as a single cluster-wide singleton reconciler, so an OOM here halts secret sync for every `KeyorixSecret` in the cluster.

The CRD schema (`operator/config/crd/bases` + the Helm chart's synced copy under `deploy/helm/keyorix-operator/crds`) is hand-updated to add `status.lastTargetName`, matching the exact `controller-gen` output style, since regenerating via `make manifests` in this environment also rewrote unrelated RBAC output (stripped the hand-maintained comment header in `config/rbac/role.yaml`) — out of scope for this PR per the recent ADR-076 RBAC work, so left untouched.

## Test plan

- [x] `cd operator && GOWORK=off go build ./...` - builds clean
- [x] `cd operator && GOWORK=off go test ./...` - all packages pass, including new tests:
  - `TestClient_FetchValueUnauthorizedWrapsErrUnauthorized`, `TestClient_RefusesRedirect` (client_test.go)
  - `TestReconcile_UnauthorizedWipesTargetSecretWithDistinctReason`, `TestReconcile_WipeFailureSurfacedInStatus`, `TestReconcile_RetargetWipesOrphanedSecretUnderOldName`, `TestReconcile_RetargetWipeFailureKeepsOldLastTargetNameAndWarns` (keyorixsecret_controller_test.go)
- [x] `go build ./internal/mcp/...` and `go test ./internal/mcp/...` - pass, including new `TestKeyorixClient_RefusesRedirect`
- [x] `gosec -severity medium -exclude-generated` clean on both `operator/...` and `internal/mcp/...`
- [x] All pre-existing tests pass unmodified except one stale doc-comment update (401 was previously described as "ambiguous/transient" in a test comment; updated to reflect the new wipe behavior)