### PR TITLE
fix(mcp): cap JSON-RPC message size, fail-close empty ref allowlist, default max-reads

### DIFF
--- a/cmd/keyorix-mcp/main.go
+++ b/cmd/keyorix-mcp/main.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -24,6 +25,56 @@ import (
 
 // version is overridden at build time via -ldflags.
 var version = "dev"
+
+// defaultMaxReads is the per-process keyorix_get_secret ceiling applied when
+// KEYORIX_MCP_MAX_READS is left unset. The documented minimal setup is KEYORIX_URL +
+// KEYORIX_TOKEN only, which previously left the cap at 0 ("unlimited") — a
+// prompt-injected agent with a broadly-scoped token got zero backstop against sweeping
+// every secret the token can read. 100 is chosen as generous-but-bounded: comfortably
+// above what a normal single-task agent session needs, while still giving a hard,
+// non-infinite ceiling by default. Not safety-critical as an exact number — operators
+// with legitimate high-volume needs raise it via KEYORIX_MCP_MAX_READS.
+const defaultMaxReads = 100
+
+// resolveMaxReads parses KEYORIX_MCP_MAX_READS. An empty raw value (the variable unset
+// or blank) applies defaultMaxReads rather than "unlimited". A non-empty value that
+// isn't a positive integer is a fatal misconfiguration, not a silent fallback —
+// usedDefault reports whether the default was applied, for logging.
+func resolveMaxReads(raw string) (n int, usedDefault bool, err error) {
+	if raw == "" {
+		return defaultMaxReads, true, nil
+	}
+	n, perr := strconv.Atoi(raw)
+	if perr != nil || n <= 0 {
+		return 0, false, fmt.Errorf("KEYORIX_MCP_MAX_READS must be a positive integer, got %q", raw)
+	}
+	return n, false, nil
+}
+
+// resolveAllowedRefs parses KEYORIX_MCP_ALLOWED_REFS. An empty raw value means "not
+// configured" (nil patterns, no error) — unchanged, no restriction. A non-empty raw
+// value that parses to zero usable patterns (e.g. a bare "," or all-whitespace/empty
+// segments, such as from templating an empty list) is a misconfiguration: passing that
+// nil/empty slice through to Server.SetAllowedRefs would be silently treated as "no
+// restriction" — identical to never setting the variable — while a log line claiming
+// "ref allowlist active: 0 pattern(s)" reads as confirmation the restriction IS in
+// effect. Fail closed instead: refuse to start rather than run unrestricted while
+// claiming otherwise.
+func resolveAllowedRefs(raw string) ([]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var patterns []string
+	for _, p := range strings.Split(raw, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			patterns = append(patterns, p)
+		}
+	}
+	if len(patterns) == 0 {
+		return nil, fmt.Errorf("KEYORIX_MCP_ALLOWED_REFS is set but contains no usable patterns after parsing %q — refusing to start unrestricted; unset the variable entirely if no restriction is intended", raw)
+	}
+	return patterns, nil
+}
 
 func main() {
 	// Logs go to stderr so they never corrupt the JSON-RPC stream on stdout.
@@ -45,29 +96,30 @@ func main() {
 	}
 	server := mcp.NewServer(client, version)
 
-	// Optional, opt-in defense-in-depth (#122) — neither replaces the token's own
-	// server-side RBAC scope: KEYORIX_MCP_ALLOWED_REFS further restricts which refs
-	// this process will touch, and KEYORIX_MCP_MAX_READS bounds how many secret
-	// VALUES it will serve in its lifetime, so a manipulated agent (steered by an
-	// injected instruction inside some OTHER secret's returned value) has a hard
-	// ceiling on how much it can sweep even if it tries.
+	// Defense-in-depth (#122) — neither replaces the token's own server-side RBAC
+	// scope: KEYORIX_MCP_ALLOWED_REFS (opt-in, off by default) further restricts which
+	// refs this process will touch, and KEYORIX_MCP_MAX_READS (on by default —
+	// defaultMaxReads applies when unset) bounds how many secret VALUES it will serve
+	// in its lifetime, so a manipulated agent (steered by an injected instruction
+	// inside some OTHER secret's returned value) has a hard ceiling on how much it can
+	// sweep even if it tries.
 	if raw := strings.TrimSpace(os.Getenv("KEYORIX_MCP_ALLOWED_REFS")); raw != "" {
-		var patterns []string
-		for _, p := range strings.Split(raw, ",") {
-			if p = strings.TrimSpace(p); p != "" {
-				patterns = append(patterns, p)
-			}
+		patterns, rerr := resolveAllowedRefs(raw)
+		if rerr != nil {
+			log.Fatal(rerr)
 		}
 		server.SetAllowedRefs(patterns)
 		log.Printf("ref allowlist active: %d pattern(s)", len(patterns))
 	}
-	if raw := strings.TrimSpace(os.Getenv("KEYORIX_MCP_MAX_READS")); raw != "" {
-		n, perr := strconv.Atoi(raw)
-		if perr != nil || n <= 0 {
-			log.Fatalf("KEYORIX_MCP_MAX_READS must be a positive integer, got %q", raw)
-		}
-		server.SetMaxReads(n)
-		log.Printf("per-process read cap active: %d", n)
+	maxReads, usedDefault, merr := resolveMaxReads(strings.TrimSpace(os.Getenv("KEYORIX_MCP_MAX_READS")))
+	if merr != nil {
+		log.Fatal(merr)
+	}
+	server.SetMaxReads(maxReads)
+	if usedDefault {
+		log.Printf("KEYORIX_MCP_MAX_READS not set — applying default per-process read cap of %d (override via KEYORIX_MCP_MAX_READS)", maxReads)
+	} else {
+		log.Printf("per-process read cap active: %d", maxReads)
 	}
 
 	log.Printf("ready (server %s) — read-only Keyorix tools over stdio", version)

--- a/cmd/keyorix-mcp/main_test.go
+++ b/cmd/keyorix-mcp/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// KEYORIX_MCP_MAX_READS unset must apply defaultMaxReads (a bounded, non-infinite
+// ceiling) rather than "unlimited" — see the defaultMaxReads comment for rationale.
+func TestResolveMaxReads_UnsetAppliesDefault(t *testing.T) {
+	n, usedDefault, err := resolveMaxReads("")
+	require.NoError(t, err)
+	assert.True(t, usedDefault)
+	assert.Equal(t, defaultMaxReads, n)
+}
+
+func TestResolveMaxReads_ValidOverride(t *testing.T) {
+	n, usedDefault, err := resolveMaxReads("500")
+	require.NoError(t, err)
+	assert.False(t, usedDefault)
+	assert.Equal(t, 500, n)
+}
+
+func TestResolveMaxReads_InvalidIsFatal(t *testing.T) {
+	for _, raw := range []string{"not-a-number", "0", "-5", "3.5"} {
+		_, _, err := resolveMaxReads(raw)
+		assert.Error(t, err, "raw=%q must be rejected, not silently fall back to unlimited", raw)
+	}
+}
+
+// An unset KEYORIX_MCP_ALLOWED_REFS means "not configured" — no restriction, no error.
+func TestResolveAllowedRefs_UnsetIsNoRestriction(t *testing.T) {
+	patterns, err := resolveAllowedRefs("")
+	require.NoError(t, err)
+	assert.Nil(t, patterns)
+}
+
+func TestResolveAllowedRefs_ValidPatterns(t *testing.T) {
+	patterns, err := resolveAllowedRefs("app/production/*, app/staging/db-*")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"app/production/*", "app/staging/db-*"}, patterns)
+}
+
+// A set-but-empty-after-parsing value (e.g. a stray trailing comma from templating an
+// empty list) must be a fatal misconfiguration, not a silent fail-open to "no
+// restriction" — see the resolveAllowedRefs comment for why (#122 finding).
+func TestResolveAllowedRefs_ZeroPatternsIsFatal(t *testing.T) {
+	for _, raw := range []string{",", ",,", "   ", " , "} {
+		patterns, err := resolveAllowedRefs(raw)
+		assert.Error(t, err, "raw=%q must be rejected, not silently allow everything", raw)
+		assert.Nil(t, patterns)
+	}
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -32,18 +32,24 @@ The server needs two environment variables:
   `keyorix machine create …`. The token is read from the environment, never from a tool
   argument, so the model can't coax it out.
 
-Two more are optional, opt-in **defense-in-depth on top of** (never instead of) the
-token's own server-side RBAC scope — useful when an agent's task only needs a narrow
-slice of what the token can technically reach:
+Two more provide **defense-in-depth on top of** (never instead of) the token's own
+server-side RBAC scope — `KEYORIX_MCP_ALLOWED_REFS` is optional and opt-in;
+`KEYORIX_MCP_MAX_READS` applies a safe default even when left unset:
 
 - `KEYORIX_MCP_ALLOWED_REFS` — a comma-separated list of `project/environment/name`
   glob patterns (e.g. `app/production/*,app/staging/db-*`). When set, both tools refuse
   any ref that doesn't match at least one pattern — `keyorix_list_secrets` also omits
-  non-matching refs from its output, so they're never even named to the agent.
+  non-matching refs from its output, so they're never even named to the agent. If set,
+  it must contain at least one usable pattern after parsing (e.g. not just a stray
+  comma) — the server refuses to start otherwise, rather than silently running
+  unrestricted while logging that a restriction is active.
 - `KEYORIX_MCP_MAX_READS` — a positive integer capping how many `keyorix_get_secret`
   calls this server process will serve for its whole session. Once reached, every
   further read is refused (a fresh MCP server process — e.g. the next agent session —
-  gets a fresh budget). See "Prompt injection" below for why this exists.
+  gets a fresh budget). **Defaults to 100 when left unset** — the cap is a backstop
+  against a manipulated agent sweeping every secret a broadly-scoped token can read, so
+  it is on by default rather than opt-in; raise it if a legitimate task needs more
+  reads in one session. See "Prompt injection" below for why this exists.
 
 ### Claude Desktop / Claude Code
 
@@ -121,7 +127,7 @@ remain the primary controls.
 
 | Symptom | Likely cause |
 |---|---|
-| Server exits immediately | `KEYORIX_URL` or `KEYORIX_TOKEN` unset, `KEYORIX_URL` is not https (and not loopback), or `KEYORIX_MCP_MAX_READS` is not a positive integer — it logs which to stderr. |
+| Server exits immediately | `KEYORIX_URL` or `KEYORIX_TOKEN` unset, `KEYORIX_URL` is not https (and not loopback), `KEYORIX_MCP_MAX_READS` is not a positive integer, or `KEYORIX_MCP_ALLOWED_REFS` is set but has no usable patterns after parsing — it logs which to stderr. |
 | `could not read the requested secret` from `keyorix_get_secret` | The token lacks `secrets.read` for that ref, the ref doesn't exist, the ref is outside `KEYORIX_MCP_ALLOWED_REFS`, or the per-process read cap is exhausted — check stderr for the specific reason. |
 | `could not list secrets` | The token's `ListSecrets` call failed — check stderr for the specific reason. |
 | `invalid request …` | `ref` is not a three-part `project/environment/name`. |

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"sync/atomic"
 )
@@ -46,6 +47,11 @@ type Server struct {
 	maxReads int64
 	// readCount is incremented atomically per successful keyorix_get_secret call.
 	readCount atomic.Int64
+	// maxMessageBytes caps a single inbound JSON-RPC message (see maxMessageReader).
+	// 0 (the default, i.e. never set by NewServer) means "use defaultMaxMessageBytes" —
+	// tests may override this field directly to exercise the cap without transferring
+	// megabytes of data.
+	maxMessageBytes int64
 }
 
 // NewServer builds a server over the given reader; version is reported in serverInfo.
@@ -99,19 +105,78 @@ const (
 	codeInvalidParams  = -32602
 )
 
+// defaultMaxMessageBytes bounds a single inbound JSON-RPC message, matching the
+// order-of-magnitude cap internal/mcp/keyorix.go's getJSON already applies to HTTP
+// response bodies (10<<20). Without it, a single oversized message (e.g. a multi-GB
+// string inside params) is fully buffered by json.Decoder before any of the tool's own
+// length checks ever run — a self-inflicted DoS on stdin, which a host process feeds
+// this binary with no size guarantee of its own.
+const defaultMaxMessageBytes = 10 << 20
+
+// maxMessageReader enforces a PER-MESSAGE byte budget on top of a single underlying
+// io.Reader that Serve's loop decodes many sequential JSON-RPC messages from. Naively
+// wrapping r once in io.LimitReader(r, N) before constructing the json.Decoder would
+// only bound the first N bytes read from the stream FOR ITS ENTIRE LIFETIME — once a
+// session's cumulative reads crossed N (routine after enough small messages), every
+// later message would fail to decode even though no single message was oversized.
+//
+// Instead, the Serve loop calls reset() before every dec.Decode() call, restoring a
+// full budget for that decode attempt. json.Decoder reads from the underlying reader in
+// internal chunks and may buffer a little past one JSON value's boundary when data is
+// immediately available, but Read here never returns more than the remaining budget in
+// a single call, so a decode attempt can never pull more than `limit` bytes from the
+// wire — a message that needs more than that fails with a explicit "too large" error
+// instead of growing an unbounded in-memory buffer, while a following normal-sized
+// message gets its own fresh budget on the next reset() and is unaffected.
+type maxMessageReader struct {
+	r         io.Reader
+	limit     int64
+	remaining int64
+}
+
+func newMaxMessageReader(r io.Reader, limit int64) *maxMessageReader {
+	return &maxMessageReader{r: r, limit: limit, remaining: limit}
+}
+
+// reset restores the full per-message budget; call before each dec.Decode().
+func (m *maxMessageReader) reset() {
+	m.remaining = m.limit
+}
+
+func (m *maxMessageReader) Read(p []byte) (int, error) {
+	if m.remaining <= 0 {
+		return 0, fmt.Errorf("mcp: message exceeds maximum size of %d bytes", m.limit)
+	}
+	if int64(len(p)) > m.remaining {
+		p = p[:m.remaining]
+	}
+	n, err := m.r.Read(p)
+	m.remaining -= int64(n)
+	return n, err
+}
+
 // Serve reads JSON-RPC messages from r and writes responses to w until EOF. It returns
 // nil on a clean EOF. Diagnostics must go to stderr (never to w); values are never
-// written anywhere but a tool result requested by the client.
+// written anywhere but a tool result requested by the client. Each message is bounded
+// to s.maxMessageBytes (see maxMessageReader) — an oversized message is a fatal parse
+// error for the session, same as any other unparseable input.
 func (s *Server) Serve(ctx context.Context, r io.Reader, w io.Writer) error {
-	dec := json.NewDecoder(r)
+	limit := s.maxMessageBytes
+	if limit <= 0 {
+		limit = defaultMaxMessageBytes
+	}
+	mr := newMaxMessageReader(r, limit)
+	dec := json.NewDecoder(mr)
 	enc := json.NewEncoder(w)
 	for {
+		mr.reset()
 		var req rpcRequest
 		if err := dec.Decode(&req); err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
-			// The stream is no longer parseable; report once and stop (id unknown).
+			// The stream is no longer parseable (including "message too large"); report
+			// once and stop (id unknown).
 			_ = enc.Encode(rpcResponse{JSONRPC: jsonrpcVersion, ID: json.RawMessage("null"),
 				Error: &rpcError{Code: codeParseError, Message: "parse error"}})
 			return err

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -166,7 +166,7 @@ func (s *Server) Serve(ctx context.Context, r io.Reader, w io.Writer) error {
 		limit = defaultMaxMessageBytes
 	}
 	mr := newMaxMessageReader(r, limit)
-	dec := json.NewDecoder(mr)
+	dec := json.NewDecoder(mr) // nosemgrep: keyorix-unbounded-json-decoder -- mr is maxMessageReader, a bespoke bounded reader (reset() per message below); semgrep's multi-line pattern-not can't see across the for-loop boundary to dec.Decode(), see .semgrep/keyorix-rules.yml
 	enc := json.NewEncoder(w)
 	for {
 		mr.reset()

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -197,6 +198,55 @@ func TestServe_MaxReadsUnsetIsUnlimited(t *testing.T) {
 	for _, r := range resps {
 		assert.NotEqual(t, true, resultMap(t, r)["isError"])
 	}
+}
+
+// A single oversized JSON-RPC message must not be fully buffered in memory: the
+// per-message size cap rejects it and Serve stops (parse-error semantics), rather than
+// letting json.Decoder grow an unbounded buffer for a multi-gigabyte params value.
+func TestServe_OversizedMessageRejected(t *testing.T) {
+	s := NewServer(&fakeReader{}, "")
+	s.maxMessageBytes = 200
+
+	pad := strings.Repeat("a", 1000)
+	msg := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"ping","params":{"pad":%q}}`, pad)
+
+	var out bytes.Buffer
+	err := s.Serve(context.Background(), strings.NewReader(msg), &out)
+	require.Error(t, err, "an oversized single message must be rejected, not buffered")
+	assert.NotErrorIs(t, err, io.EOF)
+}
+
+// The per-message cap is a PER-MESSAGE budget, not a cumulative one across the whole
+// session: a message that consumes nearly the whole budget must not starve the next
+// message's decode — each dec.Decode() call gets a freshly reset allowance. This proves
+// the maxMessageReader reset-per-iteration approach (as opposed to a single
+// io.LimitReader wrapping the whole stream once, which would exhaust after the first
+// message and silently break every later one).
+func TestServe_MaxMessageBudgetResetsPerMessage(t *testing.T) {
+	s := NewServer(&fakeReader{}, "")
+	s.maxMessageBytes = 200
+
+	pad := strings.Repeat("a", 130) // total message size sits just under the 200 cap
+	msg1 := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"ping","params":{"pad":%q}}`, pad)
+	msg2 := `{"jsonrpc":"2.0","id":2,"method":"ping"}`
+	msg3 := `{"jsonrpc":"2.0","id":3,"method":"ping"}`
+	require.Less(t, len(msg1), 200, "test setup: msg1 must fit under the cap on its own")
+
+	resps := run(t, s, msg1, msg2, msg3)
+	require.Len(t, resps, 3, "every message must be served — one near-cap message must not exhaust a shared budget")
+	for i, r := range resps {
+		assert.Nil(t, r.Error, "message %d must decode successfully", i+1)
+	}
+}
+
+// With no override, Serve falls back to defaultMaxMessageBytes (10MB) — well above any
+// normal JSON-RPC message — so ordinary traffic is unaffected by the new cap.
+func TestServe_DefaultMaxMessageBytesAllowsNormalMessages(t *testing.T) {
+	fr := &fakeReader{value: "p4ss"}
+	resps := run(t, NewServer(fr, ""),
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"keyorix_get_secret","arguments":{"ref":"app/prod/db"}}}`)
+	require.Len(t, resps, 1)
+	assert.Nil(t, resps[0].Error)
 }
 
 func TestServe_GetSecretRequiresRef(t *testing.T) {


### PR DESCRIPTION
## Summary

Three MEDIUM findings from an adversarial review of the MCP server subsystem (`internal/mcp/server.go`, `cmd/keyorix-mcp/main.go`):

- **Unbounded stdin JSON-RPC decode.** `Server.Serve` had no size cap on a single inbound message, so an oversized message (e.g. a multi-GB string inside `params`) was fully buffered by `json.Decoder` before any tool-level length checks ran. Added `maxMessageReader`, a per-message byte budget (default 10MB, matching `keyorix.go`'s `getJSON` response cap) that is reset before every `dec.Decode()` call — a single oversized message is rejected without exhausting the budget for later normal-sized messages in the same session.
- **`KEYORIX_MCP_ALLOWED_REFS` fails open on zero valid patterns.** If the env var was set but every comma-separated segment trimmed to empty (e.g. a stray trailing comma from templating an empty list), `SetAllowedRefs(nil)` was silently equivalent to never setting the variable, while the log line ("ref allowlist active: 0 pattern(s)") read as confirmation the restriction was active. Now fatal at startup.
- **Exfiltration-limiting controls opt-in and off by default.** The documented minimal setup (`KEYORIX_URL` + `KEYORIX_TOKEN` only) left `KEYORIX_MCP_MAX_READS` at 0 ("unlimited"), giving a prompt-injected agent with a broadly-scoped token zero backstop against sweeping every secret it can read. `KEYORIX_MCP_MAX_READS` now defaults to 100 reads per process lifetime when unset, still overridable via the existing env var. `KEYORIX_MCP_ALLOWED_REFS` remains unset-by-default (no sane universal glob default), per design intent — the read cap now provides the real backstop.

`docs/mcp.md` updated to describe the new default and the fail-closed allowlist behavior.

Note: `internal/mcp/keyorix.go`'s redirect-leak and response-decode-size findings are out of scope here — being fixed in a separate PR.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/keyorix-mcp/... ./internal/mcp/...` — all pass, including new tests:
  - `TestServe_OversizedMessageRejected` — a single message over the cap is rejected
  - `TestServe_MaxMessageBudgetResetsPerMessage` — a near-cap message doesn't starve the next message's budget
  - `TestServe_DefaultMaxMessageBytesAllowsNormalMessages` — default 10MB cap doesn't affect normal traffic
  - `TestResolveMaxReads_UnsetAppliesDefault` / `_ValidOverride` / `_InvalidIsFatal`
  - `TestResolveAllowedRefs_UnsetIsNoRestriction` / `_ValidPatterns` / `_ZeroPatternsIsFatal`
- [x] `go test ./...` — full suite green aside from pre-existing local-only network-dependent failures in `internal/cli/system` and `internal/cli/user` (tests hitting an unreachable remote IP), unrelated to this change.