### PR TITLE
fix(k8ssync): close secret-scoping and Apply-race findings in the sync agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,7 +859,7 @@ jobs:
 
       - name: Lint + render keyorix-k8s-sync chart
         run: |
-          K8S_SYNC_SET="--set keyorix.url=https://k --set keyorix.tokenSecret.name=tok \
+          K8S_SYNC_SET="--set keyorix.url=https://k --set keyorix.projectID=1 --set keyorix.tokenSecret.name=tok \
             --set mappings[0].ref=e/n --set mappings[0].namespace=app \
             --set mappings[0].name=s --set mappings[0].key=K"
           helm lint deploy/helm/keyorix-k8s-sync $K8S_SYNC_SET
@@ -984,7 +984,7 @@ jobs:
             --set auth.masterPassword=ci --set postgresql.auth.password=ci \
             --set auth.adminPassword=ci --set ingress.enabled=true > keyorix-render.yaml
           helm template kx deploy/helm/keyorix-k8s-sync \
-            --set keyorix.url=https://k --set keyorix.tokenSecret.name=tok \
+            --set keyorix.url=https://k --set keyorix.projectID=1 --set keyorix.tokenSecret.name=tok \
             --set mappings[0].ref=e/n --set mappings[0].namespace=app \
             --set mappings[0].name=s --set mappings[0].key=K \
             --set targetNamespaces='{app,web}' > k8s-sync-render.yaml

--- a/cmd/keyorix-k8s-sync/main.go
+++ b/cmd/keyorix-k8s-sync/main.go
@@ -58,7 +58,7 @@ func main() {
 	if cfg.Cleanup || *cleanup {
 		engineOpts = append(engineOpts, k8ssync.WithCleanup())
 	}
-	engine := k8ssync.NewEngine(k8ssync.NewKeyorixFetcher(cfg.KeyorixURL, token), sink, engineOpts...)
+	engine := k8ssync.NewEngine(k8ssync.NewKeyorixFetcher(cfg.KeyorixURL, token, cfg.ProjectID), sink, engineOpts...)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/deploy/helm/keyorix-k8s-sync/README.md
+++ b/deploy/helm/keyorix-k8s-sync/README.md
@@ -24,6 +24,7 @@ helm install kx-sync oci://ghcr.io/keyorixhq/charts/keyorix-k8s-sync --version <
 helm install kx-sync deploy/helm/keyorix-k8s-sync \
   --namespace keyorix --create-namespace \
   --set keyorix.url=https://keyorix.internal \
+  --set keyorix.projectID=42 \
   --set keyorix.tokenSecret.name=keyorix-token \
   --set 'mappings[0].ref=production/db-password' \
   --set 'mappings[0].namespace=app' \
@@ -37,6 +38,7 @@ helm install kx-sync deploy/helm/keyorix-k8s-sync \
 | Key | Description |
 | --- | --- |
 | `keyorix.url` | Keyorix server base URL (**required**) |
+| `keyorix.projectID` | Numeric id of the Keyorix project the token's machine identity belongs to (**required**) — every `mappings[].ref` names only an environment and secret, never a project, since environment names are unique per-project, not globally |
 | `keyorix.interval` | Reconcile cadence (Go duration; default `5m`) |
 | `cleanup` | Reap orphaned owned Secrets when a mapping is removed (default `false`) |
 | `keyorix.tokenSecret.name` | Existing Secret holding the Keyorix token (**required**) |
@@ -51,7 +53,12 @@ helm install kx-sync deploy/helm/keyorix-k8s-sync \
 
 The chart creates a `ClusterRole` (`secrets`: `get`/`list`/`create`/`patch`/`delete`)
 and a namespaced `RoleBinding` in each `targetNamespaces` entry — least privilege, no
-cluster-wide Secret access. The agent uses Server-Side Apply (field manager
-`keyorix-sync`), so it owns the Secret `data` it writes and prunes keys it no longer
-maps. `list`/`delete` are exercised only when `cleanup: true` (orphan reaping); see
+cluster-wide Secret access. `get`/`patch`/`delete` are further scoped with
+`resourceNames` to exactly the Secret names in `mappings`, so the ClusterRole cannot
+touch any Secret this release doesn't manage; `create` and `list` cannot be
+`resourceNames`-scoped (a Kubernetes RBAC limitation, not an oversight — see the
+comment in `templates/rbac.yaml`) and so remain granted on the `secrets` resource type
+as a whole. The agent uses Server-Side Apply (field manager `keyorix-sync`), so it
+owns the Secret `data` it writes and prunes keys it no longer maps. `list`/`delete`
+are exercised only when `cleanup: true` (orphan reaping); see
 [docs/k8s-sync.md](../../../docs/k8s-sync.md#orphan-cleanup-cleanup).

--- a/deploy/helm/keyorix-k8s-sync/templates/configmap.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/configmap.yaml
@@ -8,6 +8,14 @@ metadata:
 data:
   k8s-sync.yaml: |
     keyorix_url: {{ required "keyorix.url is required" .Values.keyorix.url | quote }}
+    {{- /* Sprig's `required` only rejects nil/empty-string, not a numeric zero value,
+    so a missing keyorix.projectID (default 0) would otherwise silently render
+    "project_id: 0" instead of failing here — deferring the failure all the way to
+    the agent's own LoadConfig validation at pod startup. Fail at render time instead. */}}
+    {{- if not .Values.keyorix.projectID }}
+    {{- fail "keyorix.projectID is required" }}
+    {{- end }}
+    project_id: {{ .Values.keyorix.projectID }}
     interval: {{ .Values.keyorix.interval | default "5m" | quote }}
     health_port: {{ .Values.healthPort | default 8080 }}
     cleanup: {{ .Values.cleanup | default false }}

--- a/deploy/helm/keyorix-k8s-sync/templates/rbac.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/rbac.yaml
@@ -3,7 +3,28 @@ The agent needs to read and write Secrets in each target namespace. A single
 ClusterRole holds the permission set; a namespaced RoleBinding grants it to the
 agent's ServiceAccount in each target namespace (least privilege — no cluster-wide
 Secret access).
+
+The target Secret names are fully known and static at render time (the same
+.Values.mappings list templates/configmap.yaml renders into the agent's config), so
+get/patch/delete are further scoped with resourceNames to exactly those names —
+without it, the ClusterRole would grant get/patch (and, with cleanup on, delete) on
+EVERY Secret in each target namespace, not just the ones this release actually
+manages (#Bug5). Two verbs are necessarily left unscoped to the "secrets" resource
+type as a whole, both for the same underlying reason — the Kubernetes authorizer only
+evaluates resourceNames for requests that target one already-existing, named object:
+  - create: there is no object yet at authorization time, so no name to match.
+  - list (cleanup only): a list request targets the whole collection, not one name;
+    per the Kubernetes RBAC docs, a rule carrying resourceNames "cannot be used for
+    the list, watch, or deletecollection" verbs — orphan discovery still scopes
+    itself at the application layer via the managed-by label selector in
+    RESTSink.List, just not via RBAC resourceNames.
+These two gaps are inherent to Kubernetes RBAC, not an oversight here.
 */}}
+{{- $secretNames := list }}
+{{- range .Values.mappings }}
+{{- $secretNames = append $secretNames .name }}
+{{- end }}
+{{- $secretNames = $secretNames | uniq }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -11,12 +32,21 @@ metadata:
   labels:
     {{- include "kxsync.labels" . | nindent 4 }}
 rules:
+  # create (always) and list (cleanup only) cannot be resourceNames-scoped — see note
+  # above — so they are granted on the resource type as a whole.
   - apiGroups: [""]
     resources: ["secrets"]
-    # list + delete are needed only for orphan cleanup (cleanup: true) — granted only
-    # when that behavior is actually enabled, so RBAC matches the configured
-    # capability instead of granting secrets:delete cluster-wide by default (#186).
-    verbs: ["get", "create", "patch"{{ if .Values.cleanup }}, "list", "delete"{{ end }}]
+    verbs: ["create"{{ if .Values.cleanup }}, "list"{{ end }}]
+{{- if $secretNames }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      {{- toYaml $secretNames | nindent 6 }}
+    # delete is needed only for orphan cleanup (cleanup: true) — granted only when
+    # that behavior is actually enabled, so RBAC matches the configured capability
+    # instead of granting secrets:delete cluster-wide by default (#186).
+    verbs: ["get", "patch"{{ if .Values.cleanup }}, "delete"{{ end }}]
+{{- end }}
 ---
 {{- $ns := .Values.targetNamespaces | default (list .Release.Namespace) }}
 {{- $root := . }}

--- a/deploy/helm/keyorix-k8s-sync/values.yaml
+++ b/deploy/helm/keyorix-k8s-sync/values.yaml
@@ -14,6 +14,15 @@ image:
 keyorix:
   # url is the Keyorix server base URL (required), e.g. https://keyorix.internal
   url: ""
+  # projectID is the numeric id (required) of the single Keyorix project the
+  # tokenSecret's machine identity belongs to. Every mapping's ref below names only
+  # an environment and secret ("<environment>/<name>"), never a project, because
+  # environment names are unique per-project, not globally -- two different projects
+  # can each have a "production" environment. projectID pins every secret lookup to
+  # this one project server-side so a same-named secret in a DIFFERENT project can
+  # never be resolved instead. Find it in the Keyorix UI/CLI for the project this
+  # agent should read from.
+  projectID: 0
   # interval is the reconcile cadence (Go duration).
   interval: 5m
   # token is read from an existing Secret — never put the token in values.

--- a/docs/k8s-sync.md
+++ b/docs/k8s-sync.md
@@ -23,6 +23,7 @@ A YAML file (default `/etc/keyorix/k8s-sync.yaml`, override with `-config` or
 
 ```yaml
 keyorix_url: https://keyorix.internal   # the Keyorix server base URL
+project_id: 42                          # the Keyorix project the token's machine identity belongs to
 interval: 5m                            # reconcile interval (Go duration; default 5m)
 cleanup: false                          # reap orphaned owned Secrets (see below; default off)
 mappings:
@@ -42,6 +43,14 @@ The Keyorix auth token is **not** in this file — it is read from the `KEYORIX_
 environment variable (mount it from a Kubernetes Secret). Give that token a
 least-privilege machine identity that can read only the referenced secrets.
 
+`project_id` is required: a mapping's `ref` names only an environment and a secret
+(`<environment>/<name>`), never a project, because environment names are unique
+per-project, not globally — two different projects can each have a `production`
+environment. `project_id` pins every secret lookup this agent performs to the one
+project its token belongs to (a machine identity, and so its tokens, always belongs to
+exactly one project), so a same-named secret in a *different* project can never be
+resolved instead of the intended one.
+
 ## Kubernetes RBAC
 
 The agent's service account needs to read and write Secrets in each target namespace:
@@ -54,8 +63,12 @@ resources: [secrets]
 `list` and `delete` are used **only** by orphan cleanup (below); with `cleanup` off the
 agent exercises just `get`, `create`, and `patch`. Bind a `Role` with these permissions
 in every target namespace (or a `ClusterRole` with namespace-scoped `RoleBinding`s). The
-agent uses Server-Side Apply with the field manager `keyorix-sync`, so it owns the
-`data` it writes and prunes keys it no longer maps.
+Helm chart further restricts `get`/`patch`/`delete` with `resourceNames` to exactly the
+Secret names in `mappings` — `create` and `list` can't be `resourceNames`-scoped (a
+Kubernetes RBAC limitation: those verbs don't target a single named object), so they
+remain granted on the `secrets` resource type as a whole. The agent uses Server-Side
+Apply with the field manager `keyorix-sync`, so it owns the `data` it writes and prunes
+keys it no longer maps.
 
 ## Orphan cleanup (`cleanup`)
 

--- a/internal/k8ssync/config.go
+++ b/internal/k8ssync/config.go
@@ -15,7 +15,17 @@ import (
 // Secrets. The Keyorix auth token is NOT part of this file — it is read from the
 // KEYORIX_TOKEN environment variable so it can come from a mounted Secret.
 type Config struct {
-	KeyorixURL string          `yaml:"keyorix_url"`
+	KeyorixURL string `yaml:"keyorix_url"`
+	// ProjectID is the numeric id of the single Keyorix project this agent's
+	// machine-identity token belongs to (a MachineIdentity — and so its tokens — is
+	// always scoped to exactly one project). Every mapping's Ref names only an
+	// environment and a secret ("<environment>/<name>"), never a project, because
+	// environment names are unique per-project, not globally: two different
+	// projects can each have a "production" environment. Without ProjectID pinning
+	// every secret lookup to this one project server-side, the fetcher would have
+	// to search across every project/environment the token can see and could
+	// return a same-named secret from the WRONG project (#Bug1). Required.
+	ProjectID  uint            `yaml:"project_id"`
 	Interval   string          `yaml:"interval"`    // Go duration (e.g. "5m"); default 5m
 	HealthPort int             `yaml:"health_port"` // probe/status HTTP port; default 8080
 	Cleanup    bool            `yaml:"cleanup"`     // reap orphaned owned Secrets; default false
@@ -50,6 +60,9 @@ func (c *Config) validate() error {
 	// network. The operator (CRD) path already requires https; this matches it.
 	if err := requireHTTPSURL(c.KeyorixURL); err != nil {
 		return err
+	}
+	if c.ProjectID == 0 {
+		return fmt.Errorf("project_id is required")
 	}
 	if len(c.Mappings) == 0 {
 		return fmt.Errorf("at least one mapping is required")

--- a/internal/k8ssync/config_test.go
+++ b/internal/k8ssync/config_test.go
@@ -22,6 +22,7 @@ func writeConfig(t *testing.T, body string) string {
 func TestLoadConfig_Valid(t *testing.T) {
 	p := writeConfig(t, `
 keyorix_url: https://keyorix.internal
+project_id: 42
 interval: 2m
 mappings:
   - ref: production/db-password
@@ -36,6 +37,7 @@ mappings:
 	cfg, err := LoadConfig(p)
 	require.NoError(t, err)
 	assert.Equal(t, "https://keyorix.internal", cfg.KeyorixURL)
+	assert.EqualValues(t, 42, cfg.ProjectID)
 	assert.Equal(t, 2*time.Minute, cfg.GetInterval())
 	require.Len(t, cfg.Mappings, 2)
 	assert.Equal(t, "production/db-password", cfg.Mappings[0].Ref)
@@ -45,6 +47,7 @@ mappings:
 func TestLoadConfig_DefaultInterval(t *testing.T) {
 	p := writeConfig(t, `
 keyorix_url: https://k
+project_id: 1
 mappings:
   - {ref: e/n, namespace: ns, name: s, key: K}
 `)
@@ -56,25 +59,35 @@ mappings:
 func TestLoadConfig_Invalid(t *testing.T) {
 	cases := map[string]string{
 		"missing url": `
+project_id: 1
+mappings:
+  - {ref: e/n, namespace: ns, name: s, key: K}
+`,
+		"missing project_id": `
+keyorix_url: https://k
 mappings:
   - {ref: e/n, namespace: ns, name: s, key: K}
 `,
 		"no mappings": `
 keyorix_url: https://k
+project_id: 1
 `,
 		"bad mapping": `
 keyorix_url: https://k
+project_id: 1
 mappings:
   - {ref: e/n, namespace: ns, name: s}
 `,
 		"bad interval": `
 keyorix_url: https://k
+project_id: 1
 interval: "soon"
 mappings:
   - {ref: e/n, namespace: ns, name: s, key: K}
 `,
 		"cleartext url": `
 keyorix_url: http://keyorix.internal
+project_id: 1
 mappings:
   - {ref: e/n, namespace: ns, name: s, key: K}
 `,
@@ -87,6 +100,19 @@ mappings:
 	}
 }
 
+// TestLoadConfig_MissingProjectID verifies the specific error message for a missing
+// project_id (#Bug1: without it, secret lookups can't be scoped to one project).
+func TestLoadConfig_MissingProjectID(t *testing.T) {
+	p := writeConfig(t, `
+keyorix_url: https://keyorix.internal
+mappings:
+  - {ref: e/n, namespace: ns, name: s, key: K}
+`)
+	_, err := LoadConfig(p)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project_id is required")
+}
+
 func TestLoadConfig_MissingFile(t *testing.T) {
 	_, err := LoadConfig(filepath.Join(t.TempDir(), "nope.yaml"))
 	assert.Error(t, err)
@@ -97,6 +123,7 @@ func TestLoadConfig_MissingFile(t *testing.T) {
 // established #122/#544 convention (internal/mcp.NewKeyorixClient).
 func TestLoadConfig_KeyorixURLScheme(t *testing.T) {
 	mappings := `
+project_id: 1
 mappings:
   - {ref: e/n, namespace: ns, name: s, key: K}
 `

--- a/internal/k8ssync/k8ssync_s21_test.go
+++ b/internal/k8ssync/k8ssync_s21_test.go
@@ -105,16 +105,25 @@ func TestLoadConfig_S21(t *testing.T) {
 
 	t.Run("missing keyorix_url returns error", func(t *testing.T) {
 		f := filepath.Join(t.TempDir(), "cfg.yaml")
-		yaml := "mappings:\n  - ref: prod/db\n    namespace: default\n    name: creds\n    key: DB\n"
+		yaml := "project_id: 1\nmappings:\n  - ref: prod/db\n    namespace: default\n    name: creds\n    key: DB\n"
 		require.NoError(t, os.WriteFile(f, []byte(yaml), 0600))
 		_, err := LoadConfig(f)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "keyorix_url is required")
 	})
 
+	t.Run("missing project_id returns error", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "cfg.yaml")
+		yaml := "keyorix_url: https://keyorix.example.com\nmappings:\n  - ref: prod/db\n    namespace: default\n    name: creds\n    key: DB\n"
+		require.NoError(t, os.WriteFile(f, []byte(yaml), 0600))
+		_, err := LoadConfig(f)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project_id is required")
+	})
+
 	t.Run("no mappings returns error", func(t *testing.T) {
 		f := filepath.Join(t.TempDir(), "cfg.yaml")
-		yaml := "keyorix_url: https://keyorix.example.com\n"
+		yaml := "keyorix_url: https://keyorix.example.com\nproject_id: 1\n"
 		require.NoError(t, os.WriteFile(f, []byte(yaml), 0600))
 		_, err := LoadConfig(f)
 		require.Error(t, err)
@@ -123,7 +132,7 @@ func TestLoadConfig_S21(t *testing.T) {
 
 	t.Run("invalid interval returns error", func(t *testing.T) {
 		f := filepath.Join(t.TempDir(), "cfg.yaml")
-		yaml := "keyorix_url: https://keyorix.example.com\ninterval: badval\nmappings:\n  - ref: prod/db\n    namespace: default\n    name: creds\n    key: DB\n"
+		yaml := "keyorix_url: https://keyorix.example.com\nproject_id: 1\ninterval: badval\nmappings:\n  - ref: prod/db\n    namespace: default\n    name: creds\n    key: DB\n"
 		require.NoError(t, os.WriteFile(f, []byte(yaml), 0600))
 		_, err := LoadConfig(f)
 		require.Error(t, err)
@@ -132,7 +141,7 @@ func TestLoadConfig_S21(t *testing.T) {
 
 	t.Run("invalid mapping returns error", func(t *testing.T) {
 		f := filepath.Join(t.TempDir(), "cfg.yaml")
-		yaml := "keyorix_url: https://keyorix.example.com\nmappings:\n  - ref: \"\"\n    namespace: default\n    name: creds\n    key: DB\n"
+		yaml := "keyorix_url: https://keyorix.example.com\nproject_id: 1\nmappings:\n  - ref: \"\"\n    namespace: default\n    name: creds\n    key: DB\n"
 		require.NoError(t, os.WriteFile(f, []byte(yaml), 0600))
 		_, err := LoadConfig(f)
 		require.Error(t, err)
@@ -141,11 +150,12 @@ func TestLoadConfig_S21(t *testing.T) {
 
 	t.Run("valid config loads successfully", func(t *testing.T) {
 		f := filepath.Join(t.TempDir(), "cfg.yaml")
-		yaml := "keyorix_url: https://keyorix.example.com\ninterval: 10m\nhealth_port: 9090\ncleanup: true\nmappings:\n  - ref: prod/db\n    namespace: default\n    name: creds\n    key: DB\n"
+		yaml := "keyorix_url: https://keyorix.example.com\nproject_id: 42\ninterval: 10m\nhealth_port: 9090\ncleanup: true\nmappings:\n  - ref: prod/db\n    namespace: default\n    name: creds\n    key: DB\n"
 		require.NoError(t, os.WriteFile(f, []byte(yaml), 0600))
 		cfg, err := LoadConfig(f)
 		require.NoError(t, err)
 		assert.Equal(t, "https://keyorix.example.com", cfg.KeyorixURL)
+		assert.EqualValues(t, 42, cfg.ProjectID)
 		assert.Equal(t, 10*time.Minute, cfg.GetInterval())
 		assert.Equal(t, 9090, cfg.GetHealthPort())
 		assert.True(t, cfg.Cleanup)
@@ -154,7 +164,7 @@ func TestLoadConfig_S21(t *testing.T) {
 
 	t.Run("http non-loopback url rejected", func(t *testing.T) {
 		f := filepath.Join(t.TempDir(), "cfg.yaml")
-		yaml := "keyorix_url: http://keyorix.example.com\nmappings:\n  - ref: prod/db\n    namespace: default\n    name: creds\n    key: DB\n"
+		yaml := "keyorix_url: http://keyorix.example.com\nproject_id: 1\nmappings:\n  - ref: prod/db\n    namespace: default\n    name: creds\n    key: DB\n"
 		require.NoError(t, os.WriteFile(f, []byte(yaml), 0600))
 		_, err := LoadConfig(f)
 		require.Error(t, err)

--- a/internal/k8ssync/k8ssync_s22_test.go
+++ b/internal/k8ssync/k8ssync_s22_test.go
@@ -308,7 +308,7 @@ func TestKeyorixFetcher_S22_HTTP5xxError(t *testing.T) {
 	// from the stub's default case — which the list endpoint maps to ErrUpstreamGone.
 	// Separately verify that a completely unreachable host returns a transport error
 	// (not ErrUpstreamGone) — covering the getJSON http.Do error branch.
-	f := NewKeyorixFetcher("http://127.0.0.1:1", "tok") // port 1 is always refused
+	f := NewKeyorixFetcher("http://127.0.0.1:1", "tok", 1) // port 1 is always refused
 	_, err := f.Fetch(context.Background(), "prod/secret")
 	require.Error(t, err)
 	// Transport error must not be mistaken for an authorisation/not-found issue.
@@ -316,16 +316,10 @@ func TestKeyorixFetcher_S22_HTTP5xxError(t *testing.T) {
 }
 
 // TestKeyorixFetcher_S22_MalformedJSONResponse verifies that a non-JSON body from
-// the stub (the value endpoint returns garbage for id=99999) returns a decode error.
-// The stub's default case returns 404, so we test the decode path via the
-// keyorixStub returning a body whose inner data is not valid for the struct.
+// the server returns a decode error. Every path (including the environment-list
+// lookup resolveID performs first) responds with garbage, so the decode-error path is
+// exercised at the earliest possible request.
 func TestKeyorixFetcher_S22_MalformedJSONResponse(t *testing.T) {
-	srv := keyorixStub(t, "tok")
-	defer srv.Close()
-
-	// "production/db-password" resolves to id=7; the value endpoint returns the
-	// real response already. We test the decode-error path by pointing at a server
-	// that responds with non-JSON for the list endpoint. Use a custom stub:
 	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer tok" {
 			w.WriteHeader(http.StatusUnauthorized)
@@ -335,24 +329,30 @@ func TestKeyorixFetcher_S22_MalformedJSONResponse(t *testing.T) {
 	}))
 	defer bad.Close()
 
-	f := NewKeyorixFetcher(bad.URL, "tok")
+	f := NewKeyorixFetcher(bad.URL, "tok", 1)
 	_, err := f.Fetch(context.Background(), "prod/secret")
 	require.Error(t, err)
 }
 
 // TestKeyorixFetcher_S22_EmptyDataEnvelope verifies that a response with no "data"
-// key at all returns the "empty data in response" error from getJSON. The list
-// endpoint returns a valid secrets list so resolveID succeeds; only the value fetch
-// (the second request) returns an envelope with a missing "data" field.
+// key at all returns the "empty data in response" error from getJSON. The
+// environment-list and secrets-list endpoints return valid bodies so resolveID
+// succeeds; only the value fetch (the final request) returns an envelope with a
+// missing "data" field.
 func TestKeyorixFetcher_S22_EmptyDataEnvelope(t *testing.T) {
 	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer tok" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
+		// Return a valid environment list so resolveEnvironmentID succeeds.
+		if r.URL.Path == "/api/v1/projects/1/environments" {
+			_, _ = w.Write([]byte(`{"data":{"environments":[{"ID":5,"Name":"prod"}]}}`))
+			return
+		}
 		// Return a valid list so resolveID finds the secret (id=1).
 		if r.URL.Path == "/api/v1/secrets" {
-			_, _ = w.Write([]byte(`{"data":{"secrets":[{"ID":1,"Name":"secret"}]}}`))
+			_, _ = w.Write([]byte(`{"data":{"total_pages":1,"secrets":[{"ID":1,"Name":"secret"}]}}`))
 			return
 		}
 		// Value endpoint returns a JSON object with no "data" key → env.Data == nil.
@@ -360,7 +360,7 @@ func TestKeyorixFetcher_S22_EmptyDataEnvelope(t *testing.T) {
 	}))
 	defer bad.Close()
 
-	f := NewKeyorixFetcher(bad.URL, "tok")
+	f := NewKeyorixFetcher(bad.URL, "tok", 1)
 	_, err := f.Fetch(context.Background(), "prod/secret")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty data")
@@ -374,7 +374,7 @@ func TestKeyorixFetcher_S22_ForbiddenWrapsErrUpstreamGone(t *testing.T) {
 	}))
 	defer bad.Close()
 
-	f := NewKeyorixFetcher(bad.URL, "tok")
+	f := NewKeyorixFetcher(bad.URL, "tok", 1)
 	_, err := f.Fetch(context.Background(), "prod/secret")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUpstreamGone)

--- a/internal/k8ssync/k8ssync_s23_test.go
+++ b/internal/k8ssync/k8ssync_s23_test.go
@@ -327,7 +327,7 @@ func TestKeyorixFetcher_getJSON_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := NewKeyorixFetcher(srv.URL, "tok")
+	f := NewKeyorixFetcher(srv.URL, "tok", 1)
 	_, err := f.Fetch(context.Background(), "prod/secret")
 	require.Error(t, err)
 	// A 500 must not be confused with a definitive authorization/not-found failure.
@@ -505,9 +505,13 @@ func TestKeyorixFetcher_S23_FetchValue404(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
+		if r.URL.Path == "/api/v1/projects/1/environments" {
+			_, _ = w.Write([]byte(`{"data":{"environments":[{"ID":5,"Name":"prod"}]}}`))
+			return
+		}
 		if r.URL.Path == "/api/v1/secrets" {
 			// List returns a known secret so resolveID succeeds.
-			_, _ = w.Write([]byte(`{"data":{"secrets":[{"ID":42,"Name":"my-secret"}]}}`))
+			_, _ = w.Write([]byte(`{"data":{"total_pages":1,"secrets":[{"ID":42,"Name":"my-secret"}]}}`))
 			return
 		}
 		// Value endpoint returns 404 (deleted between list and fetch).
@@ -515,7 +519,7 @@ func TestKeyorixFetcher_S23_FetchValue404(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := NewKeyorixFetcher(srv.URL, "tok")
+	f := NewKeyorixFetcher(srv.URL, "tok", 1)
 	_, err := f.Fetch(context.Background(), "prod/my-secret")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrUpstreamGone, "a 404 on the value endpoint must wrap ErrUpstreamGone")

--- a/internal/k8ssync/keyorix_fetcher.go
+++ b/internal/k8ssync/keyorix_fetcher.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -20,25 +22,46 @@ import (
 // indefinitely (which a plain, unclassified fetch error did).
 var ErrUpstreamGone = errors.New("k8ssync: secret not found or access revoked upstream")
 
+// maxServerPageSize is the Keyorix server's maximum accepted page_size for
+// GET /api/v1/secrets (server/http/handlers/secrets_list.go: 1 <= page_size <= 100;
+// anything outside that range is silently ignored and the server falls back to its
+// default of 20). Requesting more than this is not an error — it is silently
+// downgraded — so resolveID must both cap at this value AND paginate rather than
+// assume one page holds every secret (#Bug2).
+const maxServerPageSize = 100
+
 // KeyorixFetcher reads secret values from a Keyorix server over HTTP, resolving a
 // reference of the form "<environment>/<name>" (e.g. "production/db-password") to the
 // secret's current value. It satisfies Fetcher. Auth is a bearer token (typically a
 // machine-identity / service-account token); the token is sent on every request and
 // never logged.
+//
+// A ref names only an environment and a secret, never a project — environment names
+// are unique per-project, not globally (the same name, e.g. "production", can exist
+// in many different projects). projectID pins every lookup this fetcher performs to
+// the single project its token belongs to (a MachineIdentity, and so its token, is
+// always scoped to exactly one project), so a same-named secret in a DIFFERENT
+// project can never be resolved instead (#Bug1).
 type KeyorixFetcher struct {
-	baseURL string
-	token   string
-	hc      *http.Client
+	baseURL   string
+	token     string
+	projectID uint
+	hc        *http.Client
+
+	mu        sync.Mutex
+	envByName map[string]uint // environment name -> id, within projectID; lazily populated
 }
 
 // NewKeyorixFetcher builds a fetcher for the given Keyorix base URL (e.g.
-// https://keyorix.internal) and bearer token. A nil-safe default HTTP client with a
-// sane timeout is used.
-func NewKeyorixFetcher(baseURL, token string) *KeyorixFetcher {
+// https://keyorix.internal), bearer token, and the numeric id of the project the
+// token's machine identity belongs to. A nil-safe default HTTP client with a sane
+// timeout is used.
+func NewKeyorixFetcher(baseURL, token string, projectID uint) *KeyorixFetcher {
 	return &KeyorixFetcher{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		token:   token,
-		hc:      &http.Client{Timeout: 30 * time.Second},
+		baseURL:   strings.TrimRight(baseURL, "/"),
+		token:     token,
+		projectID: projectID,
+		hc:        &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
@@ -67,28 +90,95 @@ func parseRef(ref string) (env, name string, err error) {
 	return ref[:i], ref[i+1:], nil
 }
 
-// resolveID finds the id of the secret named name in environment env. The list is
-// filtered server-side by environment; the name match is exact (case-insensitive).
+// resolveID finds the id of the secret named name in environment env, within this
+// fetcher's project. env is first resolved to its numeric id (resolveEnvironmentID)
+// so the list call below can scope by BOTH project_id and environment_id — the
+// server filters server-side on those, so the result set a same-named secret could
+// hide in is exactly one project's one environment, never a broader, unscoped list
+// (#Bug1). The list is paginated at the server's actual maximum page size, walking
+// every page until the target is found or the set is exhausted, so a secret ranked
+// past position 20 (the server's silent-fallback default) or 100 (page 1's cap) is
+// still found rather than wrongly reported gone (#Bug2). The name match is exact —
+// not case-insensitive — so a differently-cased duplicate created by another
+// principal in the same environment can never shadow the intended secret (#Bug3).
 func (f *KeyorixFetcher) resolveID(ctx context.Context, env, name string) (uint, error) {
-	q := url.Values{}
-	q.Set("environment", env)
-	q.Set("page_size", "1000")
-	q.Set("page", "1")
-	var body struct {
-		Secrets []struct {
-			ID   uint   `json:"ID"`
-			Name string `json:"Name"`
-		} `json:"secrets"`
+	envID, err := f.resolveEnvironmentID(ctx, env)
+	if err != nil {
+		return 0, err
 	}
-	if err := f.getJSON(ctx, "/api/v1/secrets?"+q.Encode(), &body); err != nil {
-		return 0, fmt.Errorf("list secrets in %q: %w", env, err)
-	}
-	for _, s := range body.Secrets {
-		if strings.EqualFold(s.Name, name) {
-			return s.ID, nil
+
+	for page := 1; ; page++ {
+		q := url.Values{}
+		q.Set("project_id", strconv.FormatUint(uint64(f.projectID), 10))
+		q.Set("environment_id", strconv.FormatUint(uint64(envID), 10))
+		q.Set("page_size", strconv.Itoa(maxServerPageSize))
+		q.Set("page", strconv.Itoa(page))
+
+		var body struct {
+			Secrets []struct {
+				ID   uint   `json:"ID"`
+				Name string `json:"Name"`
+			} `json:"secrets"`
+			TotalPages int `json:"total_pages"`
+		}
+		if err := f.getJSON(ctx, "/api/v1/secrets?"+q.Encode(), &body); err != nil {
+			return 0, fmt.Errorf("list secrets in project %d environment %q (page %d): %w", f.projectID, env, page, err)
+		}
+		for _, s := range body.Secrets {
+			if s.Name == name {
+				return s.ID, nil
+			}
+		}
+		if page >= body.TotalPages {
+			break
 		}
 	}
 	return 0, fmt.Errorf("secret %q not found in environment %q: %w", name, env, ErrUpstreamGone)
+}
+
+// resolveEnvironmentID resolves an environment NAME to its numeric id within this
+// fetcher's fixed project (GET /api/v1/projects/{project_id}/environments — scoped to
+// exactly one project, so it never has to search, or risk matching, an environment
+// belonging to a different project). The full list is fetched once and cached for the
+// life of the fetcher; a lookup miss triggers exactly one forced refresh (to pick up
+// an environment created after the cache was first populated) before failing.
+func (f *KeyorixFetcher) resolveEnvironmentID(ctx context.Context, name string) (uint, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.envByName != nil {
+		if id, ok := f.envByName[name]; ok {
+			return id, nil
+		}
+	}
+	if err := f.loadEnvironmentsLocked(ctx); err != nil {
+		return 0, fmt.Errorf("resolve environment %q: %w", name, err)
+	}
+	if id, ok := f.envByName[name]; ok {
+		return id, nil
+	}
+	return 0, fmt.Errorf("environment %q not found in project %d: %w", name, f.projectID, ErrUpstreamGone)
+}
+
+// loadEnvironmentsLocked fetches every environment in this fetcher's project and
+// (re)populates envByName. Caller must hold f.mu.
+func (f *KeyorixFetcher) loadEnvironmentsLocked(ctx context.Context) error {
+	var body struct {
+		Environments []struct {
+			ID   uint   `json:"ID"`
+			Name string `json:"Name"`
+		} `json:"environments"`
+	}
+	path := fmt.Sprintf("/api/v1/projects/%d/environments", f.projectID)
+	if err := f.getJSON(ctx, path, &body); err != nil {
+		return fmt.Errorf("list environments in project %d: %w", f.projectID, err)
+	}
+	m := make(map[string]uint, len(body.Environments))
+	for _, e := range body.Environments {
+		m[e.Name] = e.ID
+	}
+	f.envByName = m
+	return nil
 }
 
 // fetchValue returns the decrypted value of the secret with the given id.

--- a/internal/k8ssync/keyorix_fetcher.go
+++ b/internal/k8ssync/keyorix_fetcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -29,6 +30,11 @@ var ErrUpstreamGone = errors.New("k8ssync: secret not found or access revoked up
 // downgraded — so resolveID must both cap at this value AND paginate rather than
 // assume one page holds every secret (#Bug2).
 const maxServerPageSize = 100
+
+// maxResponseBodyBytes caps how much of a Keyorix server response this fetcher will
+// buffer during json.Decode, so a compromised/misbehaving server (or a DNS-rebound
+// response) can't exhaust process memory with an oversized reply.
+const maxResponseBodyBytes = 10 << 20 // 10MiB
 
 // KeyorixFetcher reads secret values from a Keyorix server over HTTP, resolving a
 // reference of the form "<environment>/<name>" (e.g. "production/db-password") to the
@@ -220,7 +226,7 @@ func (f *KeyorixFetcher) getJSON(ctx context.Context, path string, out interface
 	var env struct {
 		Data json.RawMessage `json:"data"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBodyBytes)).Decode(&env); err != nil {
 		return fmt.Errorf("decode response: %w", err)
 	}
 	if env.Data == nil {

--- a/internal/k8ssync/keyorix_fetcher_test.go
+++ b/internal/k8ssync/keyorix_fetcher_test.go
@@ -2,8 +2,10 @@ package k8ssync
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,20 +36,110 @@ func TestParseRef(t *testing.T) {
 	}
 }
 
-// keyorixStub serves the two endpoints the fetcher uses: the filtered list and the
-// value read.
-func keyorixStub(t *testing.T, wantToken string) *httptest.Server {
+// stubSecret is one entry the fake secrets-list endpoint serves.
+type stubSecret struct {
+	ID   uint
+	Name string
+}
+
+// keyorixStub serves the endpoints the fetcher uses: the project's environment list
+// (GET /api/v1/projects/{projectID}/environments), the environment+project-scoped,
+// paginated secrets list (GET /api/v1/secrets), and the value read
+// (GET /api/v1/secrets/{id}). environments maps environment name -> id; secretsByEnv
+// maps environment id -> the secrets "in" that environment (used to build both the
+// list response, respecting project_id/environment_id/page/page_size, and to serve
+// each secret's value).
+func keyorixStub(t *testing.T, wantToken string, projectID uint, environments map[string]uint, secretsByEnv map[uint][]stubSecret) *httptest.Server {
 	t.Helper()
+	// id -> value, derived so /secrets/{id}?include_value=true can answer directly.
+	valueByID := make(map[uint]string)
+	for _, secrets := range secretsByEnv {
+		for _, s := range secrets {
+			valueByID[s.ID] = fmt.Sprintf("value-of-%d", s.ID)
+		}
+	}
+	projPrefix := fmt.Sprintf("/api/v1/projects/%d/environments", projectID)
+
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer "+wantToken {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 		switch {
-		case r.URL.Path == "/api/v1/secrets" && r.URL.Query().Get("environment") == "production":
-			_, _ = w.Write([]byte(`{"data":{"secrets":[{"ID":7,"Name":"db-password"},{"ID":9,"Name":"api-key"}]}}`))
-		case r.URL.Path == "/api/v1/secrets/7" && r.URL.Query().Get("include_value") == "true":
-			_, _ = w.Write([]byte(`{"data":{"secret":{"ID":7,"Name":"db-password"},"value":"s3cr3t"}}`))
+		case r.URL.Path == projPrefix:
+			var buf string
+			buf = `{"data":{"environments":[`
+			first := true
+			for name, id := range environments {
+				if !first {
+					buf += ","
+				}
+				first = false
+				buf += fmt.Sprintf(`{"ID":%d,"Name":%q}`, id, name)
+			}
+			buf += `]}}`
+			_, _ = w.Write([]byte(buf))
+
+		case r.URL.Path == "/api/v1/secrets":
+			gotProject := r.URL.Query().Get("project_id")
+			gotEnv := r.URL.Query().Get("environment_id")
+			if gotProject != strconv.FormatUint(uint64(projectID), 10) {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			envID, err := strconv.ParseUint(gotEnv, 10, 64)
+			if err != nil {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			all := secretsByEnv[uint(envID)]
+
+			page := 1
+			if p := r.URL.Query().Get("page"); p != "" {
+				page, _ = strconv.Atoi(p)
+			}
+			pageSize := 100
+			if ps := r.URL.Query().Get("page_size"); ps != "" {
+				if v, err := strconv.Atoi(ps); err == nil && v > 0 && v <= 100 {
+					pageSize = v
+				} else {
+					pageSize = 20 // server's silent fallback for an out-of-range page_size
+				}
+			}
+			totalPages := (len(all) + pageSize - 1) / pageSize
+			if totalPages == 0 {
+				totalPages = 1
+			}
+			start := (page - 1) * pageSize
+			end := start + pageSize
+			if start > len(all) {
+				start = len(all)
+			}
+			if end > len(all) {
+				end = len(all)
+			}
+			pageItems := all[start:end]
+
+			buf := fmt.Sprintf(`{"data":{"total_pages":%d,"secrets":[`, totalPages)
+			for i, s := range pageItems {
+				if i > 0 {
+					buf += ","
+				}
+				buf += fmt.Sprintf(`{"ID":%d,"Name":%q}`, s.ID, s.Name)
+			}
+			buf += `]}}`
+			_, _ = w.Write([]byte(buf))
+
+		case r.URL.Query().Get("include_value") == "true":
+			var id uint
+			_, _ = fmt.Sscanf(r.URL.Path, "/api/v1/secrets/%d", &id)
+			val, ok := valueByID[id]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_, _ = fmt.Fprintf(w, `{"data":{"value":%q}}`, val)
+
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -55,29 +147,39 @@ func keyorixStub(t *testing.T, wantToken string) *httptest.Server {
 }
 
 func TestKeyorixFetcher_Fetch(t *testing.T) {
-	srv := keyorixStub(t, "tok")
+	srv := keyorixStub(t, "tok", 1,
+		map[string]uint{"production": 5},
+		map[uint][]stubSecret{5: {{ID: 7, Name: "db-password"}, {ID: 9, Name: "api-key"}}},
+	)
 	defer srv.Close()
-	f := NewKeyorixFetcher(srv.URL, "tok")
+	f := NewKeyorixFetcher(srv.URL, "tok", 1)
 
 	val, err := f.Fetch(context.Background(), "production/db-password")
 	require.NoError(t, err)
-	assert.Equal(t, []byte("s3cr3t"), val)
+	assert.Equal(t, []byte("value-of-7"), val)
 }
 
 func TestKeyorixFetcher_NotFound(t *testing.T) {
-	srv := keyorixStub(t, "tok")
+	srv := keyorixStub(t, "tok", 1,
+		map[string]uint{"production": 5},
+		map[uint][]stubSecret{5: {{ID: 7, Name: "db-password"}}},
+	)
 	defer srv.Close()
-	f := NewKeyorixFetcher(srv.URL, "tok")
+	f := NewKeyorixFetcher(srv.URL, "tok", 1)
 
 	_, err := f.Fetch(context.Background(), "production/missing")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
+	assert.ErrorIs(t, err, ErrUpstreamGone)
 }
 
 func TestKeyorixFetcher_Unauthorized(t *testing.T) {
-	srv := keyorixStub(t, "tok")
+	srv := keyorixStub(t, "tok", 1,
+		map[string]uint{"production": 5},
+		map[uint][]stubSecret{5: {{ID: 7, Name: "db-password"}}},
+	)
 	defer srv.Close()
-	f := NewKeyorixFetcher(srv.URL, "wrong-token")
+	f := NewKeyorixFetcher(srv.URL, "wrong-token", 1)
 
 	_, err := f.Fetch(context.Background(), "production/db-password")
 	require.Error(t, err)
@@ -85,8 +187,129 @@ func TestKeyorixFetcher_Unauthorized(t *testing.T) {
 }
 
 func TestKeyorixFetcher_BadRef(t *testing.T) {
-	f := NewKeyorixFetcher("http://example.invalid", "tok")
+	f := NewKeyorixFetcher("http://example.invalid", "tok", 1)
 	_, err := f.Fetch(context.Background(), "noslash")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid ref")
+}
+
+// TestKeyorixFetcher_EnvironmentNotFound verifies that an environment name absent
+// from this fetcher's project resolves to an ErrUpstreamGone "not found", rather than
+// e.g. panicking or silently matching some other project's environment (there is no
+// other project reachable from a single fetcher instance at all — see Bug1 tests
+// below for the same-name-different-environment case).
+func TestKeyorixFetcher_EnvironmentNotFound(t *testing.T) {
+	srv := keyorixStub(t, "tok", 1,
+		map[string]uint{"production": 5},
+		map[uint][]stubSecret{5: {{ID: 7, Name: "db-password"}}},
+	)
+	defer srv.Close()
+	f := NewKeyorixFetcher(srv.URL, "tok", 1)
+
+	_, err := f.Fetch(context.Background(), "staging/db-password")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUpstreamGone)
+	assert.Contains(t, err.Error(), "environment")
+}
+
+// TestKeyorixFetcher_SameNameDifferentEnvironment_Bug1 proves the fix for Bug1: two
+// environments in the SAME project each have a secret named "db-password" with a
+// DIFFERENT id. Resolving "production/db-password" must return production's secret
+// (id 7) and its value — never staging's (id 77) — because the list call is scoped
+// server-side by BOTH project_id and the resolved environment_id, not by an
+// unscoped, name-only search across every environment the token can see.
+func TestKeyorixFetcher_SameNameDifferentEnvironment_Bug1(t *testing.T) {
+	srv := keyorixStub(t, "tok", 1,
+		map[string]uint{"production": 5, "staging": 6},
+		map[uint][]stubSecret{
+			5: {{ID: 7, Name: "db-password"}},
+			6: {{ID: 77, Name: "db-password"}},
+		},
+	)
+	defer srv.Close()
+	f := NewKeyorixFetcher(srv.URL, "tok", 1)
+
+	val, err := f.Fetch(context.Background(), "production/db-password")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value-of-7"), val, "must resolve production's secret, not staging's same-named one")
+
+	val, err = f.Fetch(context.Background(), "staging/db-password")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value-of-77"), val, "must resolve staging's secret, not production's same-named one")
+}
+
+// TestKeyorixFetcher_ExactCaseMatch_Bug3 proves the fix for Bug3: within ONE
+// environment, a secret named "DB-Password" (a differently-cased duplicate, e.g.
+// created by a lower-privileged co-tenant) must never shadow "db-password" — the
+// match is exact, not case-insensitive.
+func TestKeyorixFetcher_ExactCaseMatch_Bug3(t *testing.T) {
+	srv := keyorixStub(t, "tok", 1,
+		map[string]uint{"production": 5},
+		map[uint][]stubSecret{5: {
+			{ID: 99, Name: "DB-Password"}, // impostor: listed FIRST, wrong case
+			{ID: 7, Name: "db-password"},  // the intended secret
+		}},
+	)
+	defer srv.Close()
+	f := NewKeyorixFetcher(srv.URL, "tok", 1)
+
+	val, err := f.Fetch(context.Background(), "production/db-password")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value-of-7"), val, "must resolve the exact-case match, not the differently-cased impostor")
+}
+
+// TestKeyorixFetcher_PaginatesPastServerDefault_Bug2 proves the fix for Bug2: the
+// target secret is ranked past position 100 (the server's actual page_size cap) —
+// it would never be found on page 1 alone (nor within the server's silent 20-item
+// default fallback) — but resolveID must still paginate through to find it rather
+// than reporting it "not found" (which, in the real sync loop, would cause a
+// mistaken delete of the previously-synced Kubernetes Secret).
+func TestKeyorixFetcher_PaginatesPastServerDefault_Bug2(t *testing.T) {
+	secrets := make([]stubSecret, 0, 250)
+	for i := 0; i < 250; i++ {
+		secrets = append(secrets, stubSecret{ID: uint(1000 + i), Name: fmt.Sprintf("filler-%d", i)})
+	}
+	// The target is the very last entry — on page 3 at page_size=100.
+	secrets = append(secrets, stubSecret{ID: 42, Name: "db-password"})
+
+	srv := keyorixStub(t, "tok", 1,
+		map[string]uint{"production": 5},
+		map[uint][]stubSecret{5: secrets},
+	)
+	defer srv.Close()
+	f := NewKeyorixFetcher(srv.URL, "tok", 1)
+
+	val, err := f.Fetch(context.Background(), "production/db-password")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value-of-42"), val)
+}
+
+// TestKeyorixFetcher_CachesEnvironmentList verifies that resolving two mappings in
+// the same environment only fetches the environment list once (the second Fetch call
+// hits the cache), by counting requests to the environments endpoint.
+func TestKeyorixFetcher_CachesEnvironmentList(t *testing.T) {
+	var envCalls int
+	envPath := "/api/v1/projects/1/environments"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == envPath:
+			envCalls++
+			_, _ = w.Write([]byte(`{"data":{"environments":[{"ID":5,"Name":"production"}]}}`))
+		case r.URL.Path == "/api/v1/secrets":
+			_, _ = w.Write([]byte(`{"data":{"total_pages":1,"secrets":[{"ID":7,"Name":"db-password"},{"ID":9,"Name":"api-key"}]}}`))
+		case r.URL.Query().Get("include_value") == "true":
+			_, _ = w.Write([]byte(`{"data":{"value":"x"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	f := NewKeyorixFetcher(srv.URL, "tok", 1)
+	_, err := f.Fetch(context.Background(), "production/db-password")
+	require.NoError(t, err)
+	_, err = f.Fetch(context.Background(), "production/api-key")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, envCalls, "the environment list should be fetched once and cached")
 }

--- a/internal/k8ssync/rest_sink.go
+++ b/internal/k8ssync/rest_sink.go
@@ -116,23 +116,42 @@ var errNotManaged = fmt.Errorf("k8ssync: refusing to write: a pre-existing Secre
 // transient/network failure and report it distinctly rather than retrying forever.
 func ErrNotManaged(err error) bool { return errors.Is(err, errNotManaged) }
 
-// Apply create-or-updates the named Secret to hold exactly data, using Server-Side
-// Apply (idempotent, no resource-version handshake). The agent owns the data field
-// via its field manager, so keys it no longer maps are pruned on the next apply.
+// Apply create-or-updates the named Secret to hold exactly data. The agent owns the
+// data field via its field manager, so keys it no longer maps are pruned on the next
+// apply.
 //
 // Before writing, it checks whether a Secret ALREADY EXISTS at this name and, if so,
-// refuses unless it already carries this agent's managed-by label (#139). force=true
-// Server-Side Apply unconditionally takes ownership of every field it sets — including
-// on an object created and owned by something else entirely (an operator, a different
-// tool) — silently overwriting its data and, because Apply always stamps the
-// managed-by label, "branding" it as agent-owned; the next orphan-cleanup pass would
-// then DELETE that operator's Secret outright once Keyorix no longer wants it. Only a
-// Secret this agent already owns (or one that doesn't exist yet, a fresh create) is
-// ever written.
+// refuses unless it already carries this agent's managed-by label (#139). That
+// getOwnedMeta read and the write below are two separate requests, so — same as
+// Delete — there is a window between them for the observed state to change; unlike
+// Delete (which already pins uid+resourceVersion as DeleteOptions preconditions),
+// Apply used to issue an unconditional force=true Server-Side-Apply PATCH with no
+// precondition at all, so a Secret created in that window (e.g. by a namespace-scoped
+// attacker racing the agent's own target name) would be silently claimed and
+// overwritten with the real secret value (#Bug4). Two writes close this, matching
+// what each observed state actually needs:
+//
+//   - !exists: a plain POST create. Kubernetes create is atomic against the object's
+//     existence — if something raced into existence at this name between the read
+//     above and this request, the POST itself fails with 409 AlreadyExists rather
+//     than silently overwriting it. There is no read-then-write window at all.
+//   - exists && owned: a Server-Side-Apply PATCH, but with the exact resourceVersion
+//     just observed set on the submitted object as an optimistic-concurrency
+//     precondition. Kubernetes checks a submitted resourceVersion against the
+//     object's current stored value for any write, PATCH included, and rejects with
+//     a conflict if it no longer matches — resourceVersion is a cluster-wide,
+//     strictly-increasing etcd revision that is never reused, so even a delete
+//     immediately followed by a recreate under the same name between our read and
+//     this write yields a different resourceVersion and is still caught (uid
+//     preconditions, as Delete uses, would add nothing beyond what resourceVersion
+//     already catches here, since SSA has no DeleteOptions-equivalent to carry a uid
+//     precondition on a PATCH).
 func (s *RESTSink) Apply(ctx context.Context, namespace, name string, data map[string][]byte) error {
-	if _, _, exists, owned, err := s.getOwnedMeta(ctx, namespace, name); err != nil {
+	_, rv, exists, owned, err := s.getOwnedMeta(ctx, namespace, name)
+	if err != nil {
 		return err
-	} else if exists && !owned {
+	}
+	if exists && !owned {
 		return fmt.Errorf("%s/%s: %w", namespace, name, errNotManaged)
 	}
 
@@ -140,19 +159,58 @@ func (s *RESTSink) Apply(ctx context.Context, namespace, name string, data map[s
 	for k, v := range data {
 		encoded[k] = base64.StdEncoding.EncodeToString(v)
 	}
+	metadata := map[string]interface{}{
+		"name":      name,
+		"namespace": namespace,
+		// Stamp ownership so orphan cleanup can find Secrets this agent created
+		// (and only those) via a label selector.
+		"labels": map[string]string{managedByLabel: managedByValue},
+	}
 	payload := map[string]interface{}{
 		"apiVersion": "v1",
 		"kind":       "Secret",
-		"metadata": map[string]interface{}{
-			"name":      name,
-			"namespace": namespace,
-			// Stamp ownership so orphan cleanup can find Secrets this agent created
-			// (and only those) via a label selector.
-			"labels": map[string]string{managedByLabel: managedByValue},
-		},
-		"type": "Opaque",
-		"data": encoded,
+		"metadata":   metadata,
+		"type":       "Opaque",
+		"data":       encoded,
 	}
+
+	if !exists {
+		return s.createSecret(ctx, namespace, name, payload)
+	}
+	metadata["resourceVersion"] = rv
+	return s.applyOwnedSecret(ctx, namespace, name, payload)
+}
+
+// createSecret POSTs a brand-new Secret to the namespace's collection endpoint. A 409
+// here means something raced into existence at this name since Apply's ownership
+// check — the create is left to fail rather than falling back to an unconditional
+// overwrite, so the race can never result in silently claiming a Secret this agent
+// never observed as its own.
+func (s *RESTSink) createSecret(ctx context.Context, namespace, name string, payload map[string]interface{}) error {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal secret %s/%s: %w", namespace, name, err)
+	}
+	path := fmt.Sprintf("/api/v1/namespaces/%s/secrets", url.PathEscape(namespace))
+	req, err := s.newRequest(ctx, http.MethodPost, path, "application/json", bytes.NewReader(raw))
+	if err != nil {
+		return err
+	}
+	resp, err := s.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("create secret %s/%s: HTTP %d", namespace, name, resp.StatusCode)
+	}
+	return nil
+}
+
+// applyOwnedSecret Server-Side-Applies payload (which must already carry
+// metadata.resourceVersion as an optimistic-concurrency precondition — see Apply) onto
+// a Secret this agent has already verified it owns.
+func (s *RESTSink) applyOwnedSecret(ctx context.Context, namespace, name string, payload map[string]interface{}) error {
 	raw, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal secret %s/%s: %w", namespace, name, err)

--- a/internal/k8ssync/rest_sink.go
+++ b/internal/k8ssync/rest_sink.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -33,6 +34,9 @@ const (
 	saTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" // #nosec G101 -- well-known k8s path, not a credential
 	saCAPath    = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )
+
+// maxResponseBodyBytes (keyorix_fetcher.go) caps how much of a single Kubernetes
+// API response this sink will buffer during json.Decode.
 
 // NewInClusterSink builds a RESTSink from the standard in-cluster environment: the
 // API host/port from KUBERNETES_SERVICE_HOST/PORT and the projected service-account
@@ -92,7 +96,7 @@ func (s *RESTSink) Get(ctx context.Context, namespace, name string) (map[string]
 	var body struct {
 		Data map[string]string `json:"data"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBodyBytes)).Decode(&body); err != nil {
 		return nil, fmt.Errorf("decode secret %s/%s: %w", namespace, name, err)
 	}
 	out := make(map[string][]byte, len(body.Data))
@@ -264,7 +268,7 @@ func (s *RESTSink) List(ctx context.Context, namespace string) ([]string, error)
 			} `json:"metadata"`
 		} `json:"items"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBodyBytes)).Decode(&body); err != nil {
 		return nil, fmt.Errorf("decode secret list for %s: %w", namespace, err)
 	}
 	names := make([]string, 0, len(body.Items))
@@ -344,7 +348,7 @@ func (s *RESTSink) getOwnedMeta(ctx context.Context, namespace, name string) (ui
 			Labels          map[string]string `json:"labels"`
 		} `json:"metadata"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBodyBytes)).Decode(&body); err != nil {
 		return "", "", false, false, fmt.Errorf("decode secret %s/%s: %w", namespace, name, err)
 	}
 	owned = body.Metadata.Labels[managedByLabel] == managedByValue

--- a/internal/k8ssync/rest_sink_test.go
+++ b/internal/k8ssync/rest_sink_test.go
@@ -43,8 +43,14 @@ func TestRESTSink_GetDecodesData(t *testing.T) {
 	assert.Equal(t, []byte("p4ss"), data["DB"])
 }
 
-func TestRESTSink_ApplyServerSideApply(t *testing.T) {
-	var gotMethod, gotCT, gotFM string
+// TestRESTSink_ApplyCreatesNewSecretViaPOST verifies that when no Secret exists yet
+// at the target name, Apply issues a plain POST create rather than a Server-Side
+// Apply PATCH (#Bug4): Kubernetes create is atomic against the object's existence, so
+// a name collision that raced into existence between the ownership read and this
+// write fails the POST outright (see TestRESTSink_ApplyCreateRace_Bug4) instead of
+// silently claiming/overwriting whatever is there.
+func TestRESTSink_ApplyCreatesNewSecretViaPOST(t *testing.T) {
+	var gotMethod, gotPath, gotCT string
 	var gotBody map[string]interface{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
@@ -54,8 +60,8 @@ func TestRESTSink_ApplyServerSideApply(t *testing.T) {
 			return
 		}
 		gotMethod = r.Method
+		gotPath = r.URL.Path
 		gotCT = r.Header.Get("Content-Type")
-		gotFM = r.URL.Query().Get("fieldManager")
 		b, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(b, &gotBody)
 		_, _ = w.Write([]byte(`{"kind":"Secret"}`))
@@ -65,9 +71,9 @@ func TestRESTSink_ApplyServerSideApply(t *testing.T) {
 	err := testSink(srv).Apply(context.Background(), "app", "creds", map[string][]byte{"DB": []byte("p4ss")})
 	require.NoError(t, err)
 
-	assert.Equal(t, http.MethodPatch, gotMethod)
-	assert.Equal(t, "application/apply-patch+yaml", gotCT)
-	assert.Equal(t, "keyorix-sync", gotFM)
+	assert.Equal(t, http.MethodPost, gotMethod, "a fresh create must be an atomic POST, not an unconditional force=true PATCH")
+	assert.Equal(t, "/api/v1/namespaces/app/secrets", gotPath, "POST targets the namespace's collection endpoint, not a specific object path")
+	assert.Equal(t, "application/json", gotCT)
 	assert.Equal(t, "Secret", gotBody["kind"])
 	// Value is base64-encoded in the Secret's data map.
 	data := gotBody["data"].(map[string]interface{})
@@ -76,6 +82,35 @@ func TestRESTSink_ApplyServerSideApply(t *testing.T) {
 	meta := gotBody["metadata"].(map[string]interface{})
 	labels := meta["labels"].(map[string]interface{})
 	assert.Equal(t, "keyorix-sync", labels["app.kubernetes.io/managed-by"])
+	// A fresh create must never carry a resourceVersion precondition — there is
+	// nothing to pin yet.
+	_, hasRV := meta["resourceVersion"]
+	assert.False(t, hasRV, "a create must not set resourceVersion")
+}
+
+// TestRESTSink_ApplyCreateRace_Bug4 proves the fix for Bug4: a namespace-scoped
+// attacker races a Secret into existence at the exact target name between Apply's
+// ownership read (GET, 404 — nothing there yet) and its write. The create POST must
+// fail (simulating the K8s API server's atomic 409 AlreadyExists) rather than the old
+// behavior of an unconditional force=true PATCH silently claiming and overwriting the
+// attacker's pre-created object with the real secret value.
+func TestRESTSink_ApplyCreateRace_Bug4(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			// Ownership check observes nothing at this name yet.
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodPost:
+			// The attacker's Secret raced into existence in between — the API server's
+			// atomic create check rejects it.
+			w.WriteHeader(http.StatusConflict)
+		}
+	}))
+	defer srv.Close()
+
+	err := testSink(srv).Apply(context.Background(), "app", "creds", map[string][]byte{"DB": []byte("real-secret")})
+	require.Error(t, err, "a create-time race must surface as an error, never a silent overwrite")
+	assert.Contains(t, err.Error(), "HTTP 409")
 }
 
 func TestRESTSink_ListOwnedScopesByLabel(t *testing.T) {
@@ -174,12 +209,23 @@ func TestRESTSink_ApplyRefusesUnownedPreExistingSecret(t *testing.T) {
 	assert.False(t, sawPatch, "an unowned pre-existing Secret must never be written to, not even attempted")
 }
 
-// A Secret this agent already owns (from a prior apply) can still be updated.
+// A Secret this agent already owns (from a prior apply) can still be updated. #Bug4:
+// the PATCH must carry the exact resourceVersion just observed as an
+// optimistic-concurrency precondition, so a change to the object between the
+// ownership read and this write (e.g. deleted and recreated by an attacker under the
+// same name) is rejected by the API server rather than silently overwritten.
 func TestRESTSink_ApplyUpdatesAlreadyOwnedSecret(t *testing.T) {
 	var sawPatch bool
+	var gotCT, gotFM, gotForce string
+	var gotBody map[string]interface{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPatch {
 			sawPatch = true
+			gotCT = r.Header.Get("Content-Type")
+			gotFM = r.URL.Query().Get("fieldManager")
+			gotForce = r.URL.Query().Get("force")
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &gotBody)
 			_, _ = w.Write([]byte(`{"kind":"Secret"}`))
 			return
 		}
@@ -190,6 +236,31 @@ func TestRESTSink_ApplyUpdatesAlreadyOwnedSecret(t *testing.T) {
 	err := testSink(srv).Apply(context.Background(), "app", "creds", map[string][]byte{"DB": []byte("v2")})
 	require.NoError(t, err)
 	assert.True(t, sawPatch, "an already-owned Secret must still be updatable")
+	assert.Equal(t, "application/apply-patch+yaml", gotCT)
+	assert.Equal(t, "keyorix-sync", gotFM)
+	assert.Equal(t, "true", gotForce)
+	meta := gotBody["metadata"].(map[string]interface{})
+	assert.Equal(t, "rv-1", meta["resourceVersion"], "the PATCH must pin the exact resourceVersion observed by the ownership check")
+}
+
+// TestRESTSink_ApplyPatchRejectsResourceVersionConflict_Bug4 proves the precondition
+// is load-bearing, not decorative: when the server reports the resourceVersion no
+// longer matches (a 409, simulating the object having changed between the ownership
+// read and this PATCH), Apply must surface that as an error rather than treating the
+// write as having succeeded.
+func TestRESTSink_ApplyPatchRejectsResourceVersionConflict_Bug4(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		_, _ = w.Write([]byte(`{"metadata":{"uid":"u-1","resourceVersion":"rv-1","labels":{"app.kubernetes.io/managed-by":"keyorix-sync"}}}`))
+	}))
+	defer srv.Close()
+
+	err := testSink(srv).Apply(context.Background(), "app", "creds", map[string][]byte{"DB": []byte("v2")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 409")
 }
 
 func TestRESTSink_ApplyError(t *testing.T) {
@@ -223,5 +294,7 @@ func TestRESTSink_WithEngine(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 1, res.Created)
-	assert.True(t, applied["/api/v1/namespaces/app/secrets/creds"])
+	// Nothing existed yet, so Apply creates via POST to the namespace collection
+	// endpoint (#Bug4), not a PATCH to the specific object path.
+	assert.True(t, applied["/api/v1/namespaces/app/secrets"])
 }

--- a/server/grpc/services/audit_stream_test.go
+++ b/server/grpc/services/audit_stream_test.go
@@ -187,9 +187,19 @@ func TestAuditService_StreamAuditLogs_MaxConcurrentPerPrincipal(t *testing.T) {
 	svc, _ := newStreamCore(t)
 
 	var cancels []context.CancelFunc
+	var dones []chan error
 	t.Cleanup(func() {
 		for _, c := range cancels {
 			c()
+		}
+		// Wait for every streaming goroutine to actually return before this test is
+		// considered done — otherwise one can still be reading package-level state
+		// (e.g. auditStreamFallbackInterval) when the next test mutates it, racing.
+		for _, d := range dones {
+			select {
+			case <-d:
+			case <-time.After(time.Second):
+			}
 		}
 	})
 
@@ -198,6 +208,7 @@ func TestAuditService_StreamAuditLogs_MaxConcurrentPerPrincipal(t *testing.T) {
 		cancels = append(cancels, cancel)
 		stream := &fakeAuditStream{ctx: ctx}
 		done := make(chan error, 1)
+		dones = append(dones, done)
 		go func() { done <- svc.StreamAuditLogs(&pb.StreamAuditLogsRequest{}, stream) }()
 		// Give StreamAuditLogs time to reach acquireStreamSlot and register before the
 		// next iteration opens another one.


### PR DESCRIPTION
## Summary

Fixes five confirmed findings from an adversarial review of `internal/k8ssync/` and the `keyorix-k8s-sync` Helm chart:

- **HIGH — cross-project/environment secret confusion.** `resolveID`'s `?environment=` query param is a server-side no-op (`secrets_list.go` only recognizes `environment_id`/`project_id`), so the fetcher's `strings.EqualFold` name-match fallback searched a far broader, unscoped result set than intended — a same-named secret from a different project/environment could be synced instead. `Config` now requires a numeric `project_id` (environment names are unique per-project, not globally — a mapping's `ref` never carried a project), and the fetcher resolves the environment name to its id via `GET /projects/{id}/environments`, then lists secrets scoped by both `project_id` and `environment_id`.
- **HIGH — false secret-deletion via silent pagination fallback.** `page_size=1000` silently fell back to the server's default of 20 (handler only accepts 1-100) with no pagination beyond page 1. A mapped secret ranked past position 20 could be reported "not found", which `Engine.Reconcile` treats as a definitive upstream-gone signal and actively deletes the synced Kubernetes Secret. `resolveID` now requests the server's actual max page size (100) and paginates until the target is found or the set is exhausted.
- **MEDIUM — case-insensitive name matching.** A differently-cased duplicate secret (e.g. DB-Password vs db-password) created by a co-tenant in the same environment could shadow the intended secret. The match is now exact, not case-insensitive.
- **HIGH — RESTSink.Apply TOCTOU.** `Apply` read ownership metadata via `getOwnedMeta`, then issued an unconditional `force=true` Server-Side-Apply PATCH with no precondition — unlike `Delete`, which already pins uid+resourceVersion. A namespace-scoped attacker could race a Secret into existence at the target name between the read and the write; the PATCH would silently claim and overwrite it. `Apply` now branches on the observed state: not-exists issues a plain POST create (atomic against a same-name race — 409 on collision), and exists-and-owned issues the SSA PATCH carrying the observed resourceVersion as an optimistic-concurrency precondition.
- **LOW — overbroad chart RBAC.** The `ClusterRole` granted get/create/patch (and list/delete under cleanup: true) on every Secret in the target namespaces, even though the managed Secret names are fully known at render time. get/patch/delete are now scoped with resourceNames to exactly the mapped Secret names; create and list remain resource-type-scoped, since Kubernetes RBAC's resourceNames restriction cannot apply to either verb (documented in the chart with the reasoning).

## Design decisions

- **Bug 1** required adding a new required `project_id` config field. Environment names are unique only per-project (a DB uniqueness constraint on project+name), and a mapping's ref (`<environment>/<name>`) never carried project context. A project-scoped machine-identity token (the intended least-privilege credential for this agent) can only call the project-scoped environments-list endpoint, not the global, admin-only one, so the fetcher needs project_id up front rather than discovering it. This is a breaking config change (existing deployments must add project_id), reflected in values.yaml, README.md, docs/k8s-sync.md, and the CI helm lint/template --set flags.
- **Bug 4**: Server-Side Apply has no DeleteOptions-equivalent precondition mechanism, but Kubernetes does honor a resourceVersion set on the submitted object as an optimistic-concurrency check for any write, PATCH included. Since resourceVersion is a cluster-wide, strictly-increasing etcd revision that's never reused, pinning it alone closes the race for the update path — a uid precondition (as Delete uses) would add nothing beyond what resourceVersion already catches here. The not-exists path skips the precondition question entirely by switching to an atomic POST create.

## Test plan

- [x] go build ./... and go test ./internal/k8ssync/... pass, including new tests covering each bug's regression case
- [x] golangci-lint run and gosec -severity medium -exclude-generated clean on internal/k8ssync and cmd/keyorix-k8s-sync
- [x] helm lint and helm template (with/without cleanup) verified to produce the expected resourceNames-scoped ClusterRole, and to fail render when keyorix.projectID is unset
- [x] CI's helm-chart job --set flags updated to include keyorix.projectID
