### PR TITLE
fix(cli): stop session-hash corruption in auth migrate, close FixFilePerms TOCTOU, bound remote JSON decodes

### DIFF
--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -23,6 +23,16 @@ const (
 	mimeJSON       = "application/json"
 )
 
+// maxRemoteResponseBytes caps how much of a Keyorix server response body this
+// client will read into memory before decoding. RemoteClient backs every CLI
+// command's remote mode (projects, secrets, environments, users, audit
+// listings…), so a generous cap is used — matching the same 10MB idiom used
+// for the equivalent MCP client response decode (internal/mcp/keyorix.go) —
+// rather than a tight one tuned to any single endpoint's typical payload. This
+// bounds a malicious or misbehaving server response from exhausting client
+// memory via an unbounded json.Decode of resp.Body.
+const maxRemoteResponseBytes = 10 << 20 // 10MB
+
 // ResolveRemote returns the server endpoint and Bearer token from all config sources.
 //
 // Priority: env vars > ~/.keyorix/cli.yaml (written by 'keyorix connect')
@@ -216,7 +226,7 @@ func decodeEnvelope(resp *http.Response, out interface{}, path string) error {
 	var env struct {
 		Data json.RawMessage `json:"data"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxRemoteResponseBytes)).Decode(&env); err != nil {
 		return fmt.Errorf("decode response from %s: %w", path, err)
 	}
 	if env.Data == nil {

--- a/internal/cli/encryption/auth_encrypt_validate_s23_test.go
+++ b/internal/cli/encryption/auth_encrypt_validate_s23_test.go
@@ -5,13 +5,10 @@
 //
 //   - runValidateAuthEncryption: full command path via keyorix.yaml + real SQLite DB
 //     → success (all-clean), → unmigrated rows (error return), → config-load error
-//   - validateSessions: verbose=true with only encrypted rows (no unmigrated)
-//     → decrypt-error path (garbage ciphertext)
 //   - validateAPITokens: verbose=true with only encrypted rows (no unmigrated)
 //     → decrypt-error path
 //   - validatePasswordResetTokens: verbose=true with only encrypted rows (no unmigrated)
 //     → decrypt-error path
-//   - migrateSessions: encrypt-error path via broken authEnc
 //   - migrateAPITokens: encrypt-error path via broken authEnc
 //   - migratePasswordResetTokens: encrypt-error path via broken authEnc
 //   - runMigrateAuthData: full command path via keyorix.yaml + real SQLite DB
@@ -33,28 +30,6 @@ import (
 )
 
 // ── validate helpers: verbose=true with ONLY encrypted rows (no unmigrated) ──
-
-// TestValidateSessions_S23_VerboseNoUnmigrated calls validateSessions with
-// verbose=true when ALL sessions are encrypted (zero unmigrated). This exercises
-// the verbose "Validating N encrypted sessions..." header print and the
-// per-row "✅ Session N: OK" print without hitting any "⚠️ needs migration" path.
-func TestValidateSessions_S23_VerboseNoUnmigrated(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	// Insert a single fully-encrypted session (session_token must be unique, so
-	// we insert only one with an empty string cleared via NULL-equivalent pointer).
-	enc, meta, err := ae.EncryptSessionToken("s23-sess-tok-only", uint(10))
-	require.NoError(t, err)
-	// Use Exec directly to set session_token to NULL (satisfies the unique constraint).
-	require.NoError(t, db.Exec(
-		`INSERT INTO sessions (user_id, session_token, encrypted_session_token, session_token_metadata) VALUES (?, NULL, ?, ?)`,
-		uint(10), enc, meta,
-	).Error)
-
-	n, err := validateSessions(db, ae, true /* verbose */)
-	require.NoError(t, err)
-	assert.Zero(t, n, "zero unmigrated rows expected")
-}
 
 // TestValidateAPITokens_S23_VerboseNoUnmigrated calls validateAPITokens with
 // verbose=true when ALL tokens are encrypted (zero unmigrated).
@@ -110,31 +85,6 @@ func brokenAuthEnc(t *testing.T, db *gorm.DB) *encryption.AuthEncryption {
 	}
 	// Return an uninitialized AuthEncryption so Encrypt* calls will fail.
 	return encryption.NewAuthEncryption(cfg, dir, db)
-}
-
-// TestMigrateSessions_S23_EncryptError drives the "failed to encrypt session
-// token" error path inside migrateSessions by providing a broken (uninitialized)
-// authEnc. The helper must return a non-nil error wrapping the encrypt failure.
-func TestMigrateSessions_S23_EncryptError(t *testing.T) {
-	// Open a fresh DB (not via setupMigrateValidateTest so authEnc is separate).
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "sessions_err.db")
-	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
-	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Session{}))
-	t.Cleanup(func() {
-		if sqlDB, err := db.DB(); err == nil {
-			_ = sqlDB.Close()
-		}
-	})
-
-	// Insert a plaintext session so the "found N … to migrate" branch fires.
-	require.NoError(t, db.Create(&models.Session{UserID: 1, SessionToken: "plain-tok-s23"}).Error)
-
-	ae := brokenAuthEnc(t, db)
-	err = migrateSessions(db, ae, false /* dryRun */)
-	require.Error(t, err, "an uninitialized AuthEncryption must cause an encrypt error")
-	assert.Contains(t, err.Error(), "failed to encrypt session token")
 }
 
 // TestMigrateAPITokens_S23_EncryptError drives the "failed to encrypt API token"
@@ -272,9 +222,6 @@ func TestRunValidateAuthEncryption_S23_UnmigratedRows(t *testing.T) {
 		Name: "plain-s23", ClientID: "plain-client-s23",
 		ClientSecret: "plaintext-secret-s23", IsActive: true,
 	}).Error)
-	require.NoError(t, db.Create(&models.Session{
-		UserID: 99, SessionToken: "plaintext-sess-s23",
-	}).Error)
 
 	if sqlDB, err := db.DB(); err == nil {
 		_ = sqlDB.Close()
@@ -382,23 +329,6 @@ func TestRunMigrateAuthData_S23_DryRunConfigPath(t *testing.T) {
 }
 
 // ── validate helpers: decrypt-error paths ────────────────────────────────────
-
-// TestValidateSessions_S23_DecryptError drives the "failed to decrypt session
-// token" branch in validateSessions by inserting a row with a garbage
-// encrypted_session_token that cannot be decrypted.
-func TestValidateSessions_S23_DecryptError(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	// Insert a row with syntactically-present but garbage ciphertext.
-	require.NoError(t, db.Exec(
-		`INSERT INTO sessions (user_id, session_token, encrypted_session_token, session_token_metadata) VALUES (?, NULL, ?, ?)`,
-		uint(55), `{"data":"bm90cmVhbA==","metadata":{}}`, `{}`,
-	).Error)
-
-	_, err := validateSessions(db, ae, false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to decrypt session token")
-}
 
 // TestValidateAPITokens_S23_DecryptError drives the "failed to decrypt API
 // token" branch in validateAPITokens.

--- a/internal/cli/encryption/auth_encryption_cli_test.go
+++ b/internal/cli/encryption/auth_encryption_cli_test.go
@@ -206,7 +206,7 @@ func TestValidateAuthEncryption_CleanWhenFullyMigrated(t *testing.T) {
 // recomputing that same hash and matching it against this column.
 //
 // A previous version of runMigrateAuthData ran every session through a
-// migrateSessions helper that matched on "session_token != ''" — true for
+// migrateSessions helper that matched on "session_token != ”" — true for
 // every live session, since the column always holds a hash — "encrypted" the
 // hash value as if it were a real secret, and then set session_token to NULL
 // in the same UPDATE. NULL landed on the exact column GetSession keys its

--- a/internal/cli/encryption/auth_encryption_cli_test.go
+++ b/internal/cli/encryption/auth_encryption_cli_test.go
@@ -7,6 +7,7 @@ package encryption
 //     printing an all-clear.
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
 
 // TestAuthEncryptionCmd_WiredIntoCommandTree is the regression test for the
@@ -93,8 +95,10 @@ func TestMigrateAuthData_ClearsPlaintextColumns(t *testing.T) {
 	client := &models.APIClient{Name: "c", ClientID: "client-1", ClientSecret: "plain-client-secret", IsActive: true}
 	require.NoError(t, db.Create(client).Error)
 
-	session := &models.Session{UserID: 1, SessionToken: "plain-session-token"}
-	require.NoError(t, db.Create(session).Error)
+	// Sessions are intentionally NOT part of this migration/table set — see
+	// runMigrateAuthData's comment in auth_encryption_migrate.go: session_token
+	// stores a SHA-256 hash, never plaintext, so there is nothing for
+	// migrateSessions (removed) to have migrated in the first place.
 
 	token := &models.APIToken{ClientID: 1, Token: "plain-api-token"}
 	require.NoError(t, db.Create(token).Error)
@@ -103,7 +107,6 @@ func TestMigrateAuthData_ClearsPlaintextColumns(t *testing.T) {
 	require.NoError(t, db.Create(reset).Error)
 
 	require.NoError(t, migrateAPIClients(db, authEnc, false))
-	require.NoError(t, migrateSessions(db, authEnc, false))
 	require.NoError(t, migrateAPITokens(db, authEnc, false))
 	require.NoError(t, migratePasswordResetTokens(db, authEnc, false))
 
@@ -114,11 +117,6 @@ func TestMigrateAuthData_ClearsPlaintextColumns(t *testing.T) {
 	plain, err := authEnc.DecryptClientSecret(gotClient.EncryptedClientSecret, []byte(gotClient.ClientSecretMetadata))
 	require.NoError(t, err)
 	require.Equal(t, "plain-client-secret", plain)
-
-	var gotSession models.Session
-	require.NoError(t, db.First(&gotSession, session.ID).Error)
-	require.Empty(t, gotSession.SessionToken, "plaintext session_token must be cleared after migration")
-	require.NotEmpty(t, gotSession.EncryptedSessionToken)
 
 	var gotToken models.APIToken
 	require.NoError(t, db.First(&gotToken, token.ID).Error)
@@ -135,31 +133,33 @@ func TestMigrateAuthData_ClearsPlaintextColumns(t *testing.T) {
 	// fail on a unique-constraint collision now that multiple rows share a
 	// cleared (NULL) plaintext column.
 	require.NoError(t, migrateAPIClients(db, authEnc, false))
-	require.NoError(t, migrateSessions(db, authEnc, false))
 	require.NoError(t, migrateAPITokens(db, authEnc, false))
 	require.NoError(t, migratePasswordResetTokens(db, authEnc, false))
 }
 
 // TestMigrateAuthData_ClearsPlaintext_MultipleRowsNoUniqueCollision guards the
-// NULL-not-empty-string choice: session_token/token columns carry a unique
-// index, so clearing two rows to "" would collide on the second UPDATE.
+// NULL-not-empty-string choice: token columns carry a unique index, so
+// clearing two rows to "" would collide on the second UPDATE. (Originally
+// written against sessions; sessions were removed from this migration path
+// since session_token is a hash, never plaintext — api_tokens exercises the
+// identical unique-index-collision hazard.)
 func TestMigrateAuthData_ClearsPlaintext_MultipleRowsNoUniqueCollision(t *testing.T) {
 	authEnc, db := setupMigrateValidateTest(t)
 
-	s1 := &models.Session{UserID: 1, SessionToken: "session-token-one"}
-	s2 := &models.Session{UserID: 2, SessionToken: "session-token-two"}
-	require.NoError(t, db.Create(s1).Error)
-	require.NoError(t, db.Create(s2).Error)
+	t1 := &models.APIToken{ClientID: 1, Token: "api-token-one"}
+	t2 := &models.APIToken{ClientID: 2, Token: "api-token-two"}
+	require.NoError(t, db.Create(t1).Error)
+	require.NoError(t, db.Create(t2).Error)
 
-	require.NoError(t, migrateSessions(db, authEnc, false))
+	require.NoError(t, migrateAPITokens(db, authEnc, false))
 
-	var got1, got2 models.Session
-	require.NoError(t, db.First(&got1, s1.ID).Error)
-	require.NoError(t, db.First(&got2, s2.ID).Error)
-	require.Empty(t, got1.SessionToken)
-	require.Empty(t, got2.SessionToken)
-	require.NotEmpty(t, got1.EncryptedSessionToken)
-	require.NotEmpty(t, got2.EncryptedSessionToken)
+	var got1, got2 models.APIToken
+	require.NoError(t, db.First(&got1, t1.ID).Error)
+	require.NoError(t, db.First(&got2, t2.ID).Error)
+	require.Empty(t, got1.Token)
+	require.Empty(t, got2.Token)
+	require.NotEmpty(t, got1.EncryptedToken)
+	require.NotEmpty(t, got2.EncryptedToken)
 }
 
 // TestValidateAuthEncryption_FlagsUnmigratedRows is the regression test for
@@ -196,4 +196,67 @@ func TestValidateAuthEncryption_CleanWhenFullyMigrated(t *testing.T) {
 	n, err := validateAPIClients(db, authEnc, false)
 	require.NoError(t, err)
 	require.Zero(t, n)
+}
+
+// TestMigrateAuthData_DoesNotCorruptLiveSessionLookup is the regression test
+// for the HIGH-severity migrateSessions defect: sessions.session_token has
+// NEVER stored a plaintext token. store.CreateSession (see
+// internal/storage/store/local_auth.go's hashSessionToken) always writes the
+// SHA-256 hash of the token, and store.GetSession looks a session up by
+// recomputing that same hash and matching it against this column.
+//
+// A previous version of runMigrateAuthData ran every session through a
+// migrateSessions helper that matched on "session_token != ''" — true for
+// every live session, since the column always holds a hash — "encrypted" the
+// hash value as if it were a real secret, and then set session_token to NULL
+// in the same UPDATE. NULL landed on the exact column GetSession keys its
+// WHERE clause on, so every live session silently and permanently became
+// unfindable while the CLI reported success.
+//
+// This test creates a session through the real store.CreateSession path (so
+// the row looks exactly like production data — a hash, not plaintext), runs
+// the auth-encryption migration end to end, and asserts the session can still
+// be looked up by its original plaintext token afterward.
+func TestMigrateAuthData_DoesNotCorruptLiveSessionLookup(t *testing.T) {
+	authEnc, db := setupMigrateValidateTest(t)
+	ls := store.NewLocalStorage(db)
+	ctx := context.Background()
+
+	const plaintextToken = "a-real-session-token-issued-at-login" //nolint:gosec // test fixture, not a credential
+	created, err := ls.CreateSession(ctx, &models.Session{
+		UserID:       7,
+		SessionToken: plaintextToken,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+
+	// Sanity check on the premise the original bug got wrong: the stored row
+	// must hold a hash, not the plaintext token.
+	var stored models.Session
+	require.NoError(t, db.First(&stored, created.ID).Error)
+	require.NotEqual(t, plaintextToken, stored.SessionToken, "session_token must be a hash, not the plaintext token")
+	require.NotEmpty(t, stored.SessionToken)
+
+	// Seed one row in each table that the migration DOES act on, so this test
+	// exercises a full, non-trivial migration pass rather than a no-op.
+	require.NoError(t, db.Create(&models.APIClient{Name: "c", ClientID: "regress-client", ClientSecret: "plain-secret", IsActive: true}).Error)
+	require.NoError(t, db.Create(&models.APIToken{ClientID: 1, Token: "plain-api-token-regress"}).Error)
+	require.NoError(t, db.Create(&models.PasswordReset{UserID: 7, Token: "plain-reset-regress"}).Error)
+
+	require.NoError(t, migrateAPIClients(db, authEnc, false))
+	require.NoError(t, migrateAPITokens(db, authEnc, false))
+	require.NoError(t, migratePasswordResetTokens(db, authEnc, false))
+
+	// The regression check: the session must still be findable by its original
+	// plaintext token after a full migration pass — proving migrate no longer
+	// touches session_token.
+	got, err := ls.GetSession(ctx, plaintextToken)
+	require.NoError(t, err, "session must still be findable by its token after migration — session_token must not have been nulled")
+	require.Equal(t, created.ID, got.ID)
+
+	// And validate must not flag the (correctly untouched, hash-only) session
+	// as needing migration either.
+	unmigratedAPIClients, err := validateAPIClients(db, authEnc, false)
+	require.NoError(t, err)
+	require.Zero(t, unmigratedAPIClients, "the migrated client should no longer be flagged")
 }

--- a/internal/cli/encryption/auth_encryption_migrate.go
+++ b/internal/cli/encryption/auth_encryption_migrate.go
@@ -39,9 +39,24 @@ func runMigrateAuthData(cmd *cobra.Command, args []string) error {
 	if err := migrateAPIClients(db, authEnc, dryRun); err != nil {
 		return fmt.Errorf("failed to migrate API clients: %w", err)
 	}
-	if err := migrateSessions(db, authEnc, dryRun); err != nil {
-		return fmt.Errorf("failed to migrate sessions: %w", err)
-	}
+	// Sessions are deliberately NOT run through this migration. Unlike
+	// api_clients/api_tokens/password_resets, sessions.session_token has NEVER
+	// stored a plaintext value: store.CreateSession/RotateSession (see
+	// internal/storage/store/local_auth.go) hash the token with SHA-256 before
+	// writing it, and GetSession/GetSessionAny look sessions up by recomputing
+	// that hash and matching it against this same column. There is no plaintext
+	// state for this migration to move out of that column.
+	//
+	// A prior version of this file DID call a migrateSessions here. It matched
+	// on "session_token != ''" — which is true for every live session, since the
+	// column always holds a hash — "encrypted" the hash value as if it were a
+	// real secret, and then set session_token to NULL in the same UPDATE. That
+	// NULL landed on the exact column GetSession/GetSessionAny key their WHERE
+	// clause on, so every live session became permanently unfindable: an
+	// operator running this migration against a production database silently
+	// mass-invalidated every logged-in user's session while the CLI reported
+	// success. See git history for the removed migrateSessions/validateSessions
+	// (the latter had the identical false premise) if this ever needs revisiting.
 	if err := migrateAPITokens(db, authEnc, dryRun); err != nil {
 		return fmt.Errorf("failed to migrate API tokens: %w", err)
 	}
@@ -84,33 +99,6 @@ func migrateAPIClients(db *gorm.DB, authEnc *encryption.AuthEncryption, dryRun b
 			"client_secret":           nil,
 		}).Error; err != nil {
 			return fmt.Errorf("failed to update client %s: %w", client.ClientID, err)
-		}
-	}
-	return nil
-}
-
-func migrateSessions(db *gorm.DB, authEnc *encryption.AuthEncryption, dryRun bool) error {
-	var sessions []models.Session
-	if err := db.Where("session_token != '' AND encrypted_session_token IS NULL").Find(&sessions).Error; err != nil {
-		return err
-	}
-	fmt.Printf("🎫 Found %d sessions to migrate\n", len(sessions))
-	if dryRun {
-		return nil
-	}
-	for _, session := range sessions {
-		enc, meta, err := authEnc.EncryptSessionToken(session.SessionToken, session.UserID)
-		if err != nil {
-			return fmt.Errorf("failed to encrypt session token for session %d: %w", session.ID, err)
-		}
-		// See migrateAPIClients for why the plaintext column is cleared (set to
-		// NULL, not "") in the same update as the encrypted write.
-		if err := db.Model(&session).Updates(map[string]interface{}{
-			"encrypted_session_token": enc,
-			"session_token_metadata":  meta,
-			"session_token":           nil,
-		}).Error; err != nil {
-			return fmt.Errorf("failed to update session %d: %w", session.ID, err)
 		}
 	}
 	return nil

--- a/internal/cli/encryption/auth_encryption_validate.go
+++ b/internal/cli/encryption/auth_encryption_validate.go
@@ -42,11 +42,13 @@ func runValidateAuthEncryption(cmd *cobra.Command, args []string) error {
 	}
 	unmigrated += n
 
-	n, err = validateSessions(db, authEnc, verbose)
-	if err != nil {
-		return fmt.Errorf("session validation failed: %w", err)
-	}
-	unmigrated += n
+	// Sessions are deliberately not validated here — see the comment in
+	// auth_encryption_migrate.go's runMigrateAuthData for why: session_token
+	// stores a SHA-256 hash, never plaintext, so there is no "unmigrated
+	// plaintext" state for a session row to be in. A prior validateSessions
+	// queried "session_token != ''" (true for every live session) and reported
+	// every one of them as needing migration — a permanent false positive that
+	// would fail this command on any deployment with active sessions.
 
 	n, err = validateAPITokens(db, authEnc, verbose)
 	if err != nil {
@@ -104,33 +106,6 @@ func validateAPIClients(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose
 	}
 	for _, client := range unmigrated {
 		fmt.Printf("  ⚠️  Client %s: plaintext client_secret with no encrypted counterpart — needs migration\n", client.ClientID)
-	}
-	return len(unmigrated), nil
-}
-
-func validateSessions(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose bool) (int, error) {
-	var sessions []models.Session
-	if err := db.Where("encrypted_session_token IS NOT NULL").Find(&sessions).Error; err != nil {
-		return 0, err
-	}
-	if verbose {
-		fmt.Printf("🎫 Validating %d encrypted sessions...\n", len(sessions))
-	}
-	for _, session := range sessions {
-		if _, err := authEnc.DecryptSessionToken(session.EncryptedSessionToken, []byte(session.SessionTokenMetadata), session.UserID); err != nil {
-			return 0, fmt.Errorf("failed to decrypt session token for session %d: %w", session.ID, err)
-		}
-		if verbose {
-			fmt.Printf("  ✅ Session %d: OK\n", session.ID)
-		}
-	}
-
-	var unmigrated []models.Session
-	if err := db.Where("session_token != '' AND session_token IS NOT NULL AND encrypted_session_token IS NULL").Find(&unmigrated).Error; err != nil {
-		return 0, err
-	}
-	for _, session := range unmigrated {
-		fmt.Printf("  ⚠️  Session %d: plaintext session_token with no encrypted counterpart — needs migration\n", session.ID)
 	}
 	return len(unmigrated), nil
 }

--- a/internal/cli/encryption/encryption_s22_test.go
+++ b/internal/cli/encryption/encryption_s22_test.go
@@ -189,14 +189,15 @@ locale:
 func TestRunMigrateAuthData_S22_DryRunWithRows(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
 
-	// Insert rows for all four tables so the "Found N … to migrate" lines fire.
+	// Insert rows for the three migrated tables so the "Found N … to migrate"
+	// lines fire. Sessions are intentionally excluded — session_token is a
+	// hash, never plaintext, so migrateSessions was removed (see
+	// auth_encryption_migrate.go).
 	require.NoError(t, db.Create(&models.APIClient{Name: "x", ClientID: "c1", ClientSecret: "plain", IsActive: true}).Error)
-	require.NoError(t, db.Create(&models.Session{UserID: 1, SessionToken: "tok"}).Error)
 	require.NoError(t, db.Create(&models.APIToken{ClientID: 1, Token: "api"}).Error)
 	require.NoError(t, db.Create(&models.PasswordReset{UserID: 1, Token: "rst"}).Error)
 
 	require.NoError(t, migrateAPIClients(db, ae, true))
-	require.NoError(t, migrateSessions(db, ae, true))
 	require.NoError(t, migrateAPITokens(db, ae, true))
 	require.NoError(t, migratePasswordResetTokens(db, ae, true))
 
@@ -216,12 +217,10 @@ func TestRunMigrateAuthData_S22_NonDryRunWithAllTables(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
 
 	require.NoError(t, db.Create(&models.APIClient{Name: "a", ClientID: "cli-s22", ClientSecret: "secret-s22", IsActive: true}).Error)
-	require.NoError(t, db.Create(&models.Session{UserID: 10, SessionToken: "sess-s22"}).Error)
 	require.NoError(t, db.Create(&models.APIToken{ClientID: 1, Token: "tok-s22"}).Error)
 	require.NoError(t, db.Create(&models.PasswordReset{UserID: 10, Token: "reset-s22"}).Error)
 
 	require.NoError(t, migrateAPIClients(db, ae, false))
-	require.NoError(t, migrateSessions(db, ae, false))
 	require.NoError(t, migrateAPITokens(db, ae, false))
 	require.NoError(t, migratePasswordResetTokens(db, ae, false))
 
@@ -240,17 +239,14 @@ func TestRunMigrateAuthData_S22_NonDryRunWithAllTables(t *testing.T) {
 func TestRunValidateAuthEncryption_S22_UnmigratedReturnsError(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
 
-	// Insert one unmigrated row in each of the four tables.
+	// Insert one unmigrated row in each of the three validated tables. Sessions
+	// are intentionally excluded — validateSessions was removed since
+	// session_token is a hash, never plaintext (see auth_encryption_validate.go).
 	require.NoError(t, db.Create(&models.APIClient{Name: "u1", ClientID: "um1", ClientSecret: "pt1", IsActive: true}).Error)
-	require.NoError(t, db.Create(&models.Session{UserID: 99, SessionToken: "ptsess"}).Error)
 	require.NoError(t, db.Create(&models.APIToken{ClientID: 2, Token: "ptapi"}).Error)
 	require.NoError(t, db.Create(&models.PasswordReset{UserID: 99, Token: "ptreset"}).Error)
 
 	n, err := validateAPIClients(db, ae, false)
-	require.NoError(t, err)
-	assert.Equal(t, 1, n)
-
-	n, err = validateSessions(db, ae, false)
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
 
@@ -307,13 +303,6 @@ func tamperAPIClientRow(t *testing.T, db *gorm.DB) models.APIClient {
 	return c
 }
 
-func tamperSessionRow(t *testing.T, db *gorm.DB) models.Session {
-	t.Helper()
-	s := models.Session{UserID: 77, EncryptedSessionToken: []byte("not-valid-ciphertext")}
-	require.NoError(t, db.Create(&s).Error)
-	return s
-}
-
 func tamperAPITokenRow(t *testing.T, db *gorm.DB) models.APIToken {
 	t.Helper()
 	tok := models.APIToken{ClientID: 7, EncryptedToken: []byte("not-valid-ciphertext")}
@@ -338,16 +327,6 @@ func TestValidateAPIClients_S22_DecryptError(t *testing.T) {
 	_, err := validateAPIClients(db, ae, false)
 	require.Error(t, err, "decrypt error must propagate")
 	assert.Contains(t, err.Error(), "tamper-client")
-}
-
-// TestValidateSessions_S22_DecryptError drives the DecryptSessionToken error
-// branch in validateSessions.
-func TestValidateSessions_S22_DecryptError(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-	tamperSessionRow(t, db)
-
-	_, err := validateSessions(db, ae, false)
-	require.Error(t, err, "decrypt error must propagate")
 }
 
 // TestValidateAPITokens_S22_DecryptError drives the DecryptAPIToken error

--- a/internal/cli/encryption/encryption_s23_test.go
+++ b/internal/cli/encryption/encryption_s23_test.go
@@ -264,21 +264,6 @@ func TestRunValidateAuthEncryption_S23_APIClientValidationError(t *testing.T) {
 		"error should reference the client or decryption failure: %v", err)
 }
 
-// TestRunValidateAuthEncryption_S23_SessionValidationError drives the
-// "session validation failed" error-wrapping branch.
-func TestRunValidateAuthEncryption_S23_SessionValidationError(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	require.NoError(t, db.Create(&models.Session{
-		UserID:                88,
-		EncryptedSessionToken: []byte("garbage-ciphertext-s23"),
-	}).Error)
-
-	_, err := validateSessions(db, ae, false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "session")
-}
-
 // TestRunValidateAuthEncryption_S23_APITokenValidationError drives the
 // "API token validation failed" error-wrapping branch.
 func TestRunValidateAuthEncryption_S23_APITokenValidationError(t *testing.T) {

--- a/internal/cli/encryption/encryption_s24_test.go
+++ b/internal/cli/encryption/encryption_s24_test.go
@@ -8,7 +8,7 @@
 //     validateWithConfig enabled → ValidateKeyFiles error path
 //   - shamir_split.go:       ssOutDir != "" → commitment.hex symlink → write error
 //   - auth_encryption_migrate.go: migrateAPIClients encrypt error (broken authEnc)
-//   - auth_encryption_validate.go: verbose=true paths for sessions/tokens/resets
+//   - auth_encryption_validate.go: verbose=true paths for tokens/resets
 //     with unmigrated rows
 //   - migrate_provider.go:   copyFile src read OK but dst dir fsync fails (non-existent dir)
 //     migrateProviderWithConfig → oldSvc.Initialize fails
@@ -215,34 +215,6 @@ func TestShamirSplit_S24_CommitmentSymlinkRejected(t *testing.T) {
 // is unconditional (no verbose guard). These tests cover the combined verbose
 // encrypted-row path together with unmigrated rows so the full function body
 // executes in one call.
-
-// TestValidateSessions_S24_VerboseWithUnmigrated calls validateSessions with
-// verbose=true when the DB contains both an encrypted (decryptable) session and
-// a plaintext-only (unmigrated) session. This exercises the verbose header
-// print, the per-row ✅ print, and the ⚠️ unmigrated print in one pass.
-func TestValidateSessions_S24_VerboseWithUnmigrated(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	// Insert one properly encrypted session.
-	encTok, encMeta, err := ae.EncryptSessionToken("s24-session-token", uint(50))
-	require.NoError(t, err)
-	require.NoError(t, db.Create(&models.Session{
-		UserID:                50,
-		SessionToken:          "",
-		EncryptedSessionToken: encTok,
-		SessionTokenMetadata:  encMeta,
-	}).Error)
-
-	// Insert one unmigrated (plaintext-only) session.
-	require.NoError(t, db.Create(&models.Session{
-		UserID:       51,
-		SessionToken: "plaintext-unmigrated-s24",
-	}).Error)
-
-	n, err := validateSessions(db, ae, true /* verbose */)
-	require.NoError(t, err)
-	assert.Equal(t, 1, n, "one unmigrated session must be flagged")
-}
 
 // TestValidateAPITokens_S24_VerboseWithUnmigrated calls validateAPITokens with
 // verbose=true when the DB contains both an encrypted token and a plaintext-only

--- a/internal/cli/encryption/encryption_s27_test.go
+++ b/internal/cli/encryption/encryption_s27_test.go
@@ -9,7 +9,6 @@
 //
 //   - auth_encryption_migrate.go:
 //     migrateAPIClients:          "failed to update client" DB error branch
-//     migrateSessions:            "failed to update session" DB error branch
 //     migrateAPITokens:           "failed to update API token" DB error branch
 //     migratePasswordResetTokens: "failed to update password reset token" DB error branch
 //
@@ -325,29 +324,6 @@ func TestMigrateAPIClients_S27_UpdateFails(t *testing.T) {
 	err := migrateAPIClients(db, ae, false /* dryRun */)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to update client")
-}
-
-// TestMigrateSessions_S27_UpdateFails exercises the
-// "failed to update session %d" error branch inside migrateSessions.
-func TestMigrateSessions_S27_UpdateFails(t *testing.T) {
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "migrate_sess_update_err.db")
-	ae, db := setupMigrateValidateTestAt(t, dir, dbPath)
-
-	require.NoError(t, db.Create(&models.Session{
-		UserID:       1,
-		SessionToken: "s27-sess-plain",
-	}).Error)
-
-	require.NoError(t, db.Exec(
-		`CREATE TRIGGER abort_sessions_update BEFORE UPDATE ON sessions BEGIN
-			SELECT RAISE(ABORT, 'trigger: update aborted for test');
-		END`,
-	).Error)
-
-	err := migrateSessions(db, ae, false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to update session")
 }
 
 // TestMigrateAPITokens_S27_UpdateFails exercises the

--- a/internal/cli/encryption/encryption_s3_test.go
+++ b/internal/cli/encryption/encryption_s3_test.go
@@ -1,5 +1,5 @@
 // encryption_s3_test.go — coverage push for cli/encryption (batch s3).
-// Targets the zero-coverage validate helpers (validateSessions, validateAPITokens,
+// Targets the zero-coverage validate helpers (validateAPITokens,
 // validatePasswordResetTokens) and low-coverage paths in runValidateAuthEncryption,
 // runEnableAuthEncryption, migrate helpers, upgradeAADWithConfig, fixPermsWithConfig.
 //
@@ -70,47 +70,6 @@ func getSharedS3Fixture(t *testing.T) (*encryption.AuthEncryption, *gorm.DB) {
 		s3Fixture = &sharedS3Fixture{authEnc: ae, db: db, tempDir: tempDir}
 	})
 	return s3Fixture.authEnc, s3Fixture.db
-}
-
-// ── validateSessions ──────────────────────────────────────────────────────────
-
-func TestValidateSessions_EmptyDB(t *testing.T) {
-	ae, db := getSharedS3Fixture(t)
-	n, err := validateSessions(db, ae, false)
-	require.NoError(t, err)
-	assert.Equal(t, 0, n)
-}
-
-func TestValidateSessions_VerboseEmptyDB(t *testing.T) {
-	ae, db := getSharedS3Fixture(t)
-	n, err := validateSessions(db, ae, true) // verbose=true covers the Printf path
-	require.NoError(t, err)
-	assert.Equal(t, 0, n)
-}
-
-func TestValidateSessions_UnmigratedRow(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t) // isolated DB — safe to write
-
-	// Insert an unmigrated session (plaintext present, no encrypted counterpart).
-	s := &models.Session{UserID: 42, SessionToken: "plaintext-session"}
-	require.NoError(t, db.Create(s).Error)
-
-	n, err := validateSessions(db, ae, false)
-	require.NoError(t, err)
-	assert.Equal(t, 1, n, "one unmigrated session must be flagged")
-}
-
-func TestValidateSessions_EncryptedRow_Verbose(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	enc, meta, err := ae.EncryptSessionToken("valid-session-token", uint(1))
-	require.NoError(t, err)
-	s := &models.Session{UserID: 1, EncryptedSessionToken: enc, SessionTokenMetadata: meta}
-	require.NoError(t, db.Create(s).Error)
-
-	n, err := validateSessions(db, ae, true)
-	require.NoError(t, err)
-	assert.Equal(t, 0, n)
 }
 
 // ── validateAPITokens ─────────────────────────────────────────────────────────
@@ -229,14 +188,7 @@ func TestShowAuthEncryptionStats_EncryptionEnabled(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// ── migrateSessions dry-run=false ─────────────────────────────────────────────
-
-func TestMigrateSessions_NonDryRun_Empty(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-	// No matching rows → migrate does nothing and returns nil.
-	err := migrateSessions(db, ae, false)
-	require.NoError(t, err)
-}
+// ── migrateAPITokens dry-run=false ────────────────────────────────────────────
 
 func TestMigrateAPITokens_NonDryRun_Empty(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
@@ -250,19 +202,7 @@ func TestMigratePasswordResetTokens_NonDryRun_Empty(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// dry-run=true paths for sessions/tokens/resets (covers the "return nil" early branch)
-
-func TestMigrateSessions_DryRun(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-	s := &models.Session{UserID: 1, SessionToken: "tok"}
-	require.NoError(t, db.Create(s).Error)
-	err := migrateSessions(db, ae, true)
-	require.NoError(t, err)
-	// Token must still be plaintext (dry-run).
-	var got models.Session
-	require.NoError(t, db.First(&got, s.ID).Error)
-	assert.Equal(t, "tok", got.SessionToken)
-}
+// dry-run=true paths for tokens/resets (covers the "return nil" early branch)
 
 func TestMigrateAPITokens_DryRun(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -15,6 +16,15 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/spf13/cobra"
 )
+
+// maxAPIResponseBytes caps how much of a Keyorix server response body this
+// client will read into memory before decoding — the response here is a
+// project's secrets envelope, potentially a large list, so a generous cap is
+// used (matching the same 10MB idiom used elsewhere for Keyorix server
+// response decodes, e.g. internal/cli/common/remote_client.go). This bounds a
+// malicious or misbehaving server response from exhausting client memory via
+// an unbounded json.Decode of resp.Body.
+const maxAPIResponseBytes = 10 << 20 // 10MB
 
 var (
 	runEnv      string
@@ -206,7 +216,7 @@ func (c *apiClient) get(ctx context.Context, path string, out interface{}) error
 	var envelope struct {
 		Data json.RawMessage `json:"data"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxAPIResponseBytes)).Decode(&envelope); err != nil {
 		return fmt.Errorf("decode envelope: %w", err)
 	}
 	if envelope.Data == nil {

--- a/internal/cli/secret/rotate.go
+++ b/internal/cli/secret/rotate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"syscall"
 
@@ -12,6 +13,14 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
+
+// maxSecretListResponseBytes caps how much of the Keyorix server's secrets-list
+// response this command will read into memory before decoding — the response
+// can list every secret in an environment, so a generous cap is used (matching
+// the same 10MB idiom used elsewhere for Keyorix server response decodes).
+// This bounds a malicious or misbehaving server response from exhausting
+// client memory via an unbounded json.Decode of resp.Body.
+const maxSecretListResponseBytes = 10 << 20 // 10MB
 
 var rotateCmd = &cobra.Command{
 	Use:   "rotate <name>",
@@ -80,7 +89,7 @@ func runRotate(cmd *cobra.Command, args []string) error {
 			} `json:"secrets"`
 		} `json:"data"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&listResult); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxSecretListResponseBytes)).Decode(&listResult); err != nil {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 

--- a/internal/cli/secret/source_vault.go
+++ b/internal/cli/secret/source_vault.go
@@ -9,11 +9,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 )
+
+// maxVaultResponseBytes caps how much of a Vault HTTP response body this
+// client will read into memory before decoding. Vault responses read here are
+// either a single KV secret's fields or a LIST of child key names under a
+// path — both normally small, but a generous cap is used to accommodate large
+// KV trees/secrets without tuning per call site, while still bounding a
+// malicious or misbehaving Vault response from exhausting client memory via
+// an unbounded json.Decode of resp.Body.
+const maxVaultResponseBytes = 10 << 20 // 10MB
 
 // vaultClient talks to a Vault KV engine over HTTP.
 type vaultClient struct {
@@ -219,7 +229,7 @@ func (c *vaultClient) do(ctx context.Context, url string, out interface{}) (int,
 	if resp.StatusCode >= 400 {
 		return resp.StatusCode, fmt.Errorf("vault returned HTTP %d for %s", resp.StatusCode, url)
 	}
-	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxVaultResponseBytes)).Decode(out); err != nil {
 		return resp.StatusCode, fmt.Errorf("decode vault response: %w", err)
 	}
 	return resp.StatusCode, nil

--- a/internal/dynamic/kubernetes.go
+++ b/internal/dynamic/kubernetes.go
@@ -50,6 +50,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -63,6 +64,16 @@ const (
 	bearerPrefix = "Bearer "
 	mimeJSON     = "application/json"
 )
+
+// maxK8sAPIResponseBytes caps how much of a Kubernetes API server response
+// body this backend will read into memory before decoding. Both call sites
+// that use it decode a single Kubernetes API object (a TokenRequest result or
+// a created Secret's metadata) — normally tiny — but the cap is kept generous
+// rather than tuned tight, since the API server is a semi-trusted but still
+// network-reachable peer whose response size this client does not otherwise
+// control. This bounds a misbehaving or compromised API server from
+// exhausting client memory via an unbounded json.Decode of resp.Body.
+const maxK8sAPIResponseBytes = 5 << 20 // 5MB
 
 // k8sMinExpirationSeconds is the Kubernetes TokenRequest minimum (10 minutes); the
 // API server silently bumps anything lower, so we floor it for an honest lease TTL.
@@ -366,7 +377,7 @@ func (m *realK8sMinter) mintToken(ctx context.Context, namespace, serviceAccount
 			ExpirationTimestamp string `json:"expirationTimestamp"`
 		} `json:"status"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxK8sAPIResponseBytes)).Decode(&out); err != nil {
 		return "", time.Time{}, fmt.Errorf("decode TokenRequest response: %w", err)
 	}
 	if out.Status.Token == "" {
@@ -426,7 +437,7 @@ func (m *realK8sMinter) createBoundSecret(ctx context.Context, namespace, name s
 			UID string `json:"uid"`
 		} `json:"metadata"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxK8sAPIResponseBytes)).Decode(&out); err != nil {
 		return "", fmt.Errorf("decode Secret response: %w", err)
 	}
 	if out.Metadata.UID == "" {

--- a/internal/rotation/azure.go
+++ b/internal/rotation/azure.go
@@ -28,6 +28,15 @@ const (
 	azureHTTPTimeout = 30 * time.Second
 )
 
+// maxGraphResponseBytes caps how much of a Microsoft Graph API response body
+// this client will read into memory before decoding. azureGraphClient.do is a
+// shared helper for every Graph call this executor makes (list password key
+// IDs, add/remove a password credential) — all normally small objects/lists —
+// but the cap is kept generous rather than tuned per call site, bounding a
+// misbehaving or compromised Graph response from exhausting client memory via
+// an unbounded json.Decode of resp.Body.
+const maxGraphResponseBytes = 5 << 20 // 5MB
+
 // azureGraphAPI is the high-level slice of Microsoft Graph the executor uses — an
 // interface seam so the HTTP/SDK details stay contained and tests inject a fake. appID
 // is the application's object id.
@@ -181,7 +190,7 @@ func (c *azureGraphClient) do(ctx context.Context, method, url string, body, out
 		return fmt.Errorf("graph %s returned %d: %s", method, resp.StatusCode, bytes.TrimSpace(msg))
 	}
 	if out != nil {
-		return json.NewDecoder(resp.Body).Decode(out)
+		return json.NewDecoder(io.LimitReader(resp.Body, maxGraphResponseBytes)).Decode(out)
 	}
 	return nil
 }

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -2,6 +2,7 @@ package securefiles
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -240,21 +241,36 @@ func FixFilePerms(files []FilePermSpec, autofix bool) error { // NOSONAR -- cogn
 	unresolved := false  // a problem REMAINS — stat/chmod/chown failed, so autofix didn't help
 
 	for _, f := range files {
-		// Lstat (not Stat) so a symlink is detected rather than dereferenced: os.Chmod /
-		// os.Chown FOLLOW symlinks, so a symlink planted in the key directory would
-		// otherwise redirect the perm/owner fix to an arbitrary target (an arbitrary chown
-		// when running as root). Refuse to "fix" a symlinked path.
-		info, err := os.Lstat(f.Path)
+		// Open with O_NOFOLLOW so a symlink at the final path component is refused
+		// (ELOOP) rather than followed. This replaces a prior Lstat-then-Chmod/Chown-
+		// by-path design: Lstat correctly detected a symlink up front, but the
+		// subsequent os.Chmod(f.Path, ...) / os.Chown(f.Path, ...) calls re-resolved
+		// the path and FOLLOW a final-component symlink, leaving a TOCTOU window
+		// between the check and the fix — a symlink swapped in after Lstat (or simply
+		// never seen by it, e.g. a race with a concurrent attacker) would redirect the
+		// chmod/chown to an arbitrary target (an arbitrary chown when running as
+		// root). Operating on the returned *os.File's Chmod/Chown (fd-based, not
+		// path-based) closes that window: the fd stays bound to the exact inode
+		// opened here, immune to the path being swapped out from under us afterward —
+		// mirrors SecureWriteFile/SecureWriteFileSync in this file.
+		file, err := os.OpenFile(f.Path, os.O_RDONLY|syscall.O_NOFOLLOW, 0) // #nosec G304 -- caller-controlled key-file list, not network input
 		if err != nil {
-			fmt.Printf("[WARN] Cannot stat file %s: %v\n", f.Path, err)
+			if errors.Is(err, syscall.ELOOP) {
+				fmt.Printf("[WARN] Refusing to fix %s: it is a symlink (won't follow it to an arbitrary target)\n", f.Path)
+			} else {
+				fmt.Printf("[WARN] Cannot open file %s: %v\n", f.Path, err)
+			}
 			hasWarnings = true
 			unresolved = true
 			continue
 		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			fmt.Printf("[WARN] Refusing to fix %s: it is a symlink (won't follow it to an arbitrary target)\n", f.Path)
+
+		info, err := file.Stat()
+		if err != nil {
+			fmt.Printf("[WARN] Cannot stat file %s: %v\n", f.Path, err)
 			hasWarnings = true
 			unresolved = true
+			_ = file.Close()
 			continue
 		}
 
@@ -264,7 +280,7 @@ func FixFilePerms(files []FilePermSpec, autofix bool) error { // NOSONAR -- cogn
 			msg := fmt.Sprintf("File %s has mode %o but expected %o", f.Path, actualMode, f.Mode)
 			hasWarnings = true
 			if autofix {
-				if err := os.Chmod(f.Path, f.Mode); err != nil {
+				if err := file.Chmod(f.Mode); err != nil {
 					fmt.Printf("[ERROR] Failed to chmod %s: %v\n", f.Path, err)
 					unresolved = true
 				} else {
@@ -281,6 +297,7 @@ func FixFilePerms(files []FilePermSpec, autofix bool) error { // NOSONAR -- cogn
 			fmt.Printf("[WARN] Cannot get stat_t for %s\n", f.Path)
 			hasWarnings = true
 			unresolved = true
+			_ = file.Close()
 			continue
 		}
 
@@ -289,7 +306,7 @@ func FixFilePerms(files []FilePermSpec, autofix bool) error { // NOSONAR -- cogn
 			msg := fmt.Sprintf("File %s is owned by uid %d, expected uid %d", f.Path, fileUID, currentUID)
 			hasWarnings = true
 			if autofix {
-				if err := os.Chown(f.Path, currentUID, int(stat.Gid)); err != nil {
+				if err := file.Chown(currentUID, int(stat.Gid)); err != nil {
 					fmt.Printf("[ERROR] Failed to chown %s: %v\n", f.Path, err)
 					unresolved = true
 				} else {
@@ -299,6 +316,8 @@ func FixFilePerms(files []FilePermSpec, autofix bool) error { // NOSONAR -- cogn
 				fmt.Printf("[WARN] %s\n", msg)
 			}
 		}
+
+		_ = file.Close()
 	}
 
 	// Fail closed when a problem remains: either autofix was off and a mismatch exists,

--- a/internal/securefiles/securefiles_test.go
+++ b/internal/securefiles/securefiles_test.go
@@ -3,6 +3,8 @@ package securefiles
 import (
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -135,6 +137,83 @@ func TestFixFilePerms_RefusesSymlink(t *testing.T) {
 	info, statErr := os.Stat(target)
 	require.NoError(t, statErr)
 	assert.Equal(t, os.FileMode(0644), info.Mode().Perm(), "the symlink target's mode must be unchanged")
+}
+
+// TestFixFilePerms_TOCTOUSymlinkSwapNeverFollowed is the regression test for a
+// TOCTOU race: FixFilePerms used to Lstat a path to detect a symlink, then
+// separately call os.Chmod(path, ...) / os.Chown(path, ...) — both of which
+// re-resolve the path and FOLLOW a final-component symlink. A symlink swapped
+// into place after the Lstat check (or a race between the check and the fix)
+// could redirect the chmod/chown to an arbitrary target outside the caller's
+// control (an arbitrary chown when running as root).
+//
+// This test hammers that exact window: one goroutine repeatedly swaps path
+// between a regular file and a symlink pointing at a "sensitive" file outside
+// the directory (via atomic renames, mirroring how an attacker would swing the
+// directory entry), while another goroutine repeatedly calls FixFilePerms on
+// that same path with autofix=true. Throughout, the sensitive file's mode and
+// ownership must never change — proving the fix operates on the fd obtained by
+// an O_NOFOLLOW open (immune to the path being swapped out from under it), not
+// on the path a second time after the initial check.
+func TestFixFilePerms_TOCTOUSymlinkSwapNeverFollowed(t *testing.T) {
+	dir := t.TempDir()
+
+	// The attacker's target: a file outside the directory FixFilePerms is
+	// meant to operate on. If the symlink is ever followed by a fix, this
+	// file's mode changes to 0600 (the spec below) or its owner changes.
+	sensitive := filepath.Join(t.TempDir(), "sensitive-outside-file")
+	require.NoError(t, os.WriteFile(sensitive, []byte("do-not-touch"), 0644))
+
+	path := filepath.Join(dir, "target.key")
+	spec := FilePermSpec{Path: path, Mode: 0600}
+
+	const iterations = 500
+	var stop int32
+
+	// require/assert's fatal ("FailNow") helpers are documented as unsafe to call
+	// from a goroutine other than the test's own, so this goroutine reports setup
+	// failures via plain t.Errorf (safe for concurrent use) instead of require.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer atomic.StoreInt32(&stop, 1)
+		for i := 0; i < iterations; i++ {
+			// Swing path to a regular (wrong-mode) file via an atomic rename.
+			tmp := path + ".regular"
+			if err := os.WriteFile(tmp, []byte("x"), 0644); err != nil {
+				t.Errorf("setup: write regular file: %v", err)
+				return
+			}
+			if err := os.Rename(tmp, path); err != nil {
+				t.Errorf("setup: rename to regular file: %v", err)
+				return
+			}
+
+			// Swing path to a symlink pointing at the sensitive file, also via
+			// an atomic rename — this is the exact swap-after-check shape a
+			// TOCTOU exploit relies on.
+			tmpLink := path + ".link"
+			_ = os.Remove(tmpLink)
+			if err := os.Symlink(sensitive, tmpLink); err != nil {
+				t.Errorf("setup: create symlink: %v", err)
+				return
+			}
+			if err := os.Rename(tmpLink, path); err != nil {
+				t.Errorf("setup: rename to symlink: %v", err)
+				return
+			}
+		}
+	}()
+
+	for atomic.LoadInt32(&stop) == 0 {
+		_ = FixFilePerms([]FilePermSpec{spec}, true) // result ignored — either outcome (fixed regular file, or refused symlink) is valid
+	}
+	wg.Wait()
+
+	info, err := os.Lstat(sensitive)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0644), info.Mode().Perm(), "the sensitive file outside the directory must never be modified, even under a concurrent symlink swap")
 }
 
 func TestSyncDir(t *testing.T) {


### PR DESCRIPTION
## Summary

Three independent adversarial-review findings in `internal/cli/` and `internal/securefiles/`:

- **HIGH — auth-encryption migrate corrupted every live session's lookup key.** `migrateSessions` ran `sessions.session_token` through the same "encrypt plaintext, then null the column" path used for `api_clients`/`api_tokens`/`password_resets`. But `session_token` has never stored plaintext: `store.CreateSession`/`RotateSession` (`internal/storage/store/local_auth.go`) always write its SHA-256 hash, and `GetSession`/`GetSessionAny` key their lookup on that same column (`session_token = sha256(token)`). Since `session_token` is never empty for a real session, `migrateSessions` matched every live session, "encrypted" the hash value as if it were a real secret, and set `session_token` to `NULL` — the exact column the lookup WHERE clause depends on. Running `keyorix encryption auth-encryption migrate` against a live database would have silently and permanently invalidated every logged-in user's session while reporting success.

  Fix: `migrateSessions` (and the equally false-premised `validateSessions`, which would have permanently flagged every live session as "needs migration" and failed the `validate` command on any deployment with active sessions) are removed, with a comment documenting the actual session-token design so this can't recur. A regression test (`TestMigrateAuthData_DoesNotCorruptLiveSessionLookup`) creates a session through the real `store.CreateSession` path and asserts it's still findable by its token after a full migration pass.

  `api_clients`/`api_tokens`/`password_resets` are left untouched — verified these are dead schema (no live construction path outside this migration file, its stats/sweep helpers, and tests; the real password-reset flow uses `SetupToken`, not `PasswordReset`), so any equivalent risk there has zero live blast radius and is out of scope for this fix.

- **MEDIUM — `FixFilePerms` chmod/chown raced past its own symlink check (TOCTOU).** It `Lstat`'d the path to detect a symlink, then called `os.Chmod(path, ...)` / `os.Chown(path, ...)` separately — both of which FOLLOW a final-component symlink, leaving a window between the check and the fix for a symlink to be swapped in. Fixed by opening with `O_NOFOLLOW` and calling `Chmod`/`Chown` on the resulting `*os.File` (fd-based, immune to the path being swapped afterward), mirroring `SecureWriteFile` in the same file. Added `TestFixFilePerms_TOCTOUSymlinkSwapNeverFollowed`, which concurrently swaps the target between a regular file and a symlink to a file outside the directory while calling `FixFilePerms`, and asserts the outside file is never touched.

- **MEDIUM, 6 call sites — unbounded `json.Decode` of remote/untrusted response bodies.** Flagged by a new Semgrep rule. Each site now wraps `resp.Body` in `io.LimitReader` with a size cap (10MB for general Keyorix-server/Vault envelope decodes, 5MB for single Kubernetes/Graph API objects), documented inline:
  - `internal/cli/common/remote_client.go`
  - `internal/cli/run/run.go`
  - `internal/cli/secret/rotate.go`
  - `internal/cli/secret/source_vault.go`
  - `internal/dynamic/kubernetes.go` (two sites)
  - `internal/rotation/azure.go`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/encryption/...` — includes the new session-migration regression test
- [x] `go test ./internal/securefiles/... -race` — includes the new TOCTOU regression test
- [x] `go test ./internal/cli/common/... ./internal/cli/run/... ./internal/dynamic/... ./internal/rotation/...`
- [x] `go test ./internal/cli/secret/...` — rotate/vault-specific tests pass; the package's pre-existing `*_NotConnected`/`*_NoServer` tests fail on this machine only, due to a real `~/.keyorix/cli.yaml` from prior manual CLI usage being picked up instead of "no config" — unrelated to this change (same root cause reproduces across many untouched `internal/cli/*` packages in a full `go test ./...` run)