### PR TITLE
ci(codeql): add custom queries for unbounded-reader and TOCTOU chmod patterns

### DIFF
--- a/.github/codeql/go-queries/PathBasedPermissionChangeTOCTOU.ql
+++ b/.github/codeql/go-queries/PathBasedPermissionChangeTOCTOU.ql
@@ -1,0 +1,41 @@
+/**
+ * @name Path-based chmod/chown after a symlink check (TOCTOU)
+ * @description Calling os.Chmod/os.Chown with a path string, after that same path was
+ *              already checked with os.Lstat (typically to reject a symlink), leaves a
+ *              window between the check and the permission change: the path can be
+ *              swapped for a symlink to an attacker-chosen target in that window, and
+ *              the follow-on os.Chmod/os.Chown call follows a final-component symlink.
+ *              Opening the file first with O_NOFOLLOW and calling Chmod/Chown on the
+ *              resulting *os.File (an fd-based operation) closes the race, since a
+ *              file descriptor cannot be retargeted after open.
+ * @kind problem
+ * @problem.severity warning
+ * @id go/keyorix-path-based-permission-change-toctou
+ * @tags security
+ *       external/cwe/cwe-367
+ */
+
+import go
+
+/** Holds if `call` is a path-based (not fd-based) permission-changing call. */
+predicate isPathBasedPermissionCall(DataFlow::CallNode call) {
+  call.getTarget().hasQualifiedName("os", ["Chmod", "Chown", "Lchown"])
+}
+
+/** Holds if `call` is an os.Lstat call -- the usual way this codebase pre-checks a path is not a symlink before acting on it. */
+predicate isLstatCall(DataFlow::CallNode call) { call.getTarget().hasQualifiedName("os", "Lstat") }
+
+from DataFlow::CallNode lstat, DataFlow::CallNode permCall
+where
+  isLstatCall(lstat) and
+  isPathBasedPermissionCall(permCall) and
+  // Same enclosing function, and the same path expression (by source text) is passed
+  // to both -- a same-function, same-path-variable Lstat-then-Chmod/Chown pattern is
+  // exactly the shape of "we thought we checked this," not a coincidental unrelated
+  // pair of calls.
+  lstat.getEnclosingCallable() = permCall.getEnclosingCallable() and
+  lstat.getArgument(0).asExpr().toString() = permCall.getArgument(0).asExpr().toString() and
+  lstat.asExpr().getLocation().getStartLine() < permCall.asExpr().getLocation().getStartLine()
+select permCall,
+  "This path-based permission change follows an os.Lstat check on the same path in $@, leaving a TOCTOU window -- open with O_NOFOLLOW and use the fd-based Chmod/Chown method instead.",
+  lstat, "this Lstat call"

--- a/.github/codeql/go-queries/SSRFUnvalidatedOutboundRequest.ql
+++ b/.github/codeql/go-queries/SSRFUnvalidatedOutboundRequest.ql
@@ -1,0 +1,185 @@
+/**
+ * @name Outbound HTTP request built from an unvalidated destination or sent without a redirect guard
+ * @description An outbound HTTP request (http.Client.Do/Get/Post/PostForm, the package-level
+ *              http.Get/http.Post/http.PostForm/http.Head convenience functions, or
+ *              http.DefaultClient) is sent to a URL/host read from a config- or
+ *              request-derived field (DSN, webhook/callback URL, admin endpoint, ...)
+ *              where either:
+ *               (a) no recognised SSRF-guard call (a private/link-local/loopback/allowlist
+ *                   check, by this repo's naming convention) is ever applied to that same
+ *                   field anywhere in the codebase, so the destination is never validated
+ *                   before use; or
+ *               (b) the http.Client used to send the request has no CheckRedirect set, so
+ *                   even a destination that IS validated at write time can be bounced by a
+ *                   3xx response to an internal host (e.g. cloud IMDS) at request time.
+ *              Both are recurring instances of CWE-918 in this codebase (GRPC-006, SSRF-004,
+ *              and the alert-escalation webhook dispatcher SSRF/redirect fixes).
+ * @kind problem
+ * @problem.severity warning
+ * @id go/keyorix-ssrf-unvalidated-outbound-request
+ * @tags security
+ *       external/cwe/cwe-918
+ */
+
+import go
+
+/**
+ * Holds if `call` is a recognised SSRF-guard / destination-validation call by this
+ * codebase's naming convention: a function whose name mentions "ssrf", or that reads
+ * like "validate...URL/Host/DSN/Endpoint/Webhook" (in either direction, e.g. also
+ * "urlValidator" -- this repo's notification_channels.go calls its guard through a
+ * `urlValidator func(string) error` local variable, defaulting to validateWebhookURL,
+ * so a validator/checker-style name is recognised regardless of word order), or that
+ * reads like an is-private/internal/loopback/disallowed-address check
+ * (validateAdminDSNHost, validateWebhookURL, isChannelDisallowedIP, isPrivateIP,
+ * parseDSNHost feeding one of those; noEscalationRedirect and friends are handled
+ * separately as CheckRedirect funcs, not here). Deliberately name-pattern based (like
+ * the two existing custom queries' isBoundingWrapperCall/isLstatCall) rather than
+ * modelling each guard's internals -- this repo has several independently-implemented
+ * guards with no shared type or interface to hook into.
+ *
+ * Matches against three name sources per call, not just the declared target: a direct
+ * call's target name, the *statically resolved* callee when the call goes through a
+ * local function-valued variable (`getACalleeIncludingExternals`, which is exactly
+ * this repo's `urlValidator(ch.URL)` shape -- `Function.getTarget()` alone returns no
+ * result for a call through a variable), and the syntactic callee name itself
+ * (`getCalleeName`, which for an indirect call is the variable's own name, e.g.
+ * "urlValidator" or "webhookURLValidator").
+ */
+predicate isValidationCall(DataFlow::CallNode call) {
+  exists(string name |
+    name = call.getTarget().getName()
+    or
+    name = call.getACalleeIncludingExternals().asFunction().getName()
+    or
+    name = call.getCalleeName()
+  |
+    name.toLowerCase().matches("%ssrf%")
+    or
+    name.toLowerCase().regexpMatch("(?i).*valid.*(url|host|dsn|endpoint|webhook|target).*")
+    or
+    name.toLowerCase().regexpMatch("(?i)(url|host|dsn|endpoint|webhook|target).*valid.*")
+    or
+    name.toLowerCase()
+        .regexpMatch("(?i)is.*(private|internal|loopback|linklocal|link_local|disallowed).*(ip|host|addr)")
+  )
+}
+
+/**
+ * Holds if `f` is a struct field whose name suggests it holds an outbound request
+ * destination -- a URL, host, DSN, or webhook/callback endpoint. This is the same
+ * name-pattern approach the two existing queries use for their sources (isReaderOrigin's
+ * "Body" field) and sinks (isLstatCall/isPathBasedPermissionCall's os.* names): match
+ * the shape of the known vulnerable fields (NotificationChannel.URL, admin_dsn) rather
+ * than trying to type-model every possible destination-holding struct.
+ */
+predicate isDestinationField(Field f) {
+  f.getName().toLowerCase().regexpMatch(".*(url|host|endpoint|dsn|webhook|callback).*") and
+  // Exclude Go's own net/url.URL.Host field and similar stdlib-shaped noise by name
+  // alone would be too broad a net; instead this is narrowed by requiring (in
+  // isSource below) that the read actually reaches an HTTP client-request sink, which
+  // stdlib-internal Host/URL bookkeeping fields never do on their own.
+  not f.getName() = "Scheme"
+}
+
+/**
+ * Holds if a recognised validation call (isValidationCall) is ever applied directly to
+ * a read of field `f` anywhere in the codebase -- i.e. some call site passes `f`'s
+ * value straight into a validator, by source-text/node identity of the argument. This
+ * models this repo's actual pattern: destination fields are validated once, at
+ * create/update (write) time, in a function that is NOT on the same call path as the
+ * later read-and-dispatch that sends the request (the two are connected only through
+ * storage, which plain dataflow can't see across). Without this, every dispatch-time
+ * read of an already-validated field would flood the query with the exact false
+ * positives this repo's own SSRF fixes were designed to close (see
+ * internal/core/alert_escalation.go's postJSONToURL / dispatchToChannel, guarded by
+ * validateWebhookURL at internal/core/notification_channels.go's Create/Update path,
+ * not at send time) -- treating "validated somewhere, on this exact field" as a
+ * whole-program fact, rather than requiring an in-path barrier, is what keeps this
+ * query's negative-control sites (already-fixed GRPC-006/SSRF-004/#1161) silent.
+ */
+predicate isFieldValidatedAtWriteTime(Field f) {
+  exists(DataFlow::CallNode validate |
+    isValidationCall(validate) and
+    validate.getAnArgument() = f.getARead()
+  )
+}
+
+/** A destination-shaped field read that is never validated anywhere in the codebase. */
+predicate isUnvalidatedDestinationRead(DataFlow::Node source) {
+  exists(Field f | isDestinationField(f) and source = f.getARead() and not isFieldValidatedAtWriteTime(f))
+}
+
+module UnvalidatedConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { isUnvalidatedDestinationRead(source) }
+
+  predicate isSink(DataFlow::Node sink) { sink = any(Http::ClientRequest r).getUrl() }
+
+  predicate isBarrier(DataFlow::Node node) {
+    exists(DataFlow::CallNode v | isValidationCall(v) and node = v.getResult())
+  }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+}
+
+module UnvalidatedFlow = TaintTracking::Global<UnvalidatedConfig>;
+
+/**
+ * Holds if `sink`'s HTTP request goes out through a client this query can prove has no
+ * CheckRedirect set: either one of the package-level convenience functions
+ * (http.Get/http.Post/http.PostForm/http.Head, or http.DefaultClient.Do/Get/Post),
+ * which always follow redirects under Go's default policy, or a `client.Do/Get/Post/
+ * PostForm` call whose receiver flows from a local `&http.Client{...}` literal missing
+ * a CheckRedirect key. A receiver of unknown/external provenance (a struct field set
+ * up elsewhere, e.g. an injected *http.Client) is deliberately NOT flagged here -- this
+ * query can't see whether that client's CheckRedirect was set at its construction
+ * site, and guessing "no" would be a false positive, not a finding.
+ */
+predicate isRedirectUnsafeSink(DataFlow::Node sink) {
+  exists(Http::ClientRequest req | sink = req.getUrl() |
+    // Package-level http.Get/Post/PostForm/Head: Go's http package always follows
+    // redirects here -- there is no per-call CheckRedirect override for these.
+    exists(DataFlow::CallNode call, Function fn |
+      call = req and
+      fn = call.getTarget() and
+      not fn instanceof Method
+    |
+      fn.hasQualifiedName("net/http", ["Get", "Head", "Post", "PostForm"])
+    )
+    or
+    // A client.Do/Get/Post/PostForm/Head method call.
+    exists(DataFlow::CallNode call, DataFlow::Node recv |
+      call = req and
+      recv = call.(DataFlow::MethodCallNode).getReceiver()
+    |
+      // Receiver is (locally derived from) http.DefaultClient, which this repo never
+      // configures a CheckRedirect on (nothing assigns http.DefaultClient.CheckRedirect).
+      exists(Variable v | v.hasQualifiedName("net/http", "DefaultClient") |
+        DataFlow::localFlow(v.getARead(), recv)
+      )
+      or
+      // Receiver is (locally derived from) a local `&http.Client{...}` literal with no
+      // CheckRedirect key.
+      exists(CompositeLit lit |
+        lit.getTypeExpr().getType().hasQualifiedName("net/http", "Client") and
+        DataFlow::localFlow(DataFlow::exprNode(lit), recv) and
+        not exists(int i | lit.getKey(i).toString() = "CheckRedirect")
+      )
+    )
+  )
+}
+
+from DataFlow::Node sink, string reason
+where
+  (
+    exists(DataFlow::Node source | UnvalidatedFlow::flow(source, sink)) and
+    reason =
+      "its destination (URL/host/DSN/endpoint field) is never passed to a recognised SSRF-guard validation call anywhere in this codebase"
+  )
+  or
+  (
+    isRedirectUnsafeSink(sink) and
+    reason =
+      "it is sent through an http.Client with no CheckRedirect, so a 3xx response from the destination can bounce it to an internal host regardless of any upfront validation"
+  )
+select sink, "This outbound HTTP request is unsafe: " + reason + "."

--- a/.github/codeql/go-queries/StateTransitionMissingCAS.ql
+++ b/.github/codeql/go-queries/StateTransitionMissingCAS.ql
@@ -1,0 +1,137 @@
+/**
+ * @name Security-state check-then-act without a compare-and-set
+ * @description A function reads an entity by ID via a Get<Entity>(id)-shaped call,
+ *              branches on one of that entity's security-state fields (a boolean
+ *              toggle like Revoked/Approved/IsActive/Disabled, or a lifecycle
+ *              State/Status/AccountState field on one of a specific list of
+ *              security-sensitive entity types), and then persists the mutated
+ *              entity back via an Update<Entity>(entity)-shaped call keyed only by
+ *              the entity's ID -- a plain "WHERE id = ?" write with no precondition
+ *              on the field just checked. Two callers racing this same
+ *              read-modify-write window (an admin's revoke racing a holder's
+ *              accept/approve, or a suspend racing a resume) can silently clobber
+ *              each other: whichever write lands second wins outright, with no
+ *              error surfaced to either caller -- including the one whose intended
+ *              transition was just discarded.
+ *
+ *              This codebase's own fix for the same bug class elsewhere (#388,
+ *              #412/#277, #306/#307) replaced the plain write with one of two
+ *              patterns, both of which this query treats as safe: (1) a conditional
+ *              "WHERE id = ? AND <field> = ?" persist that reports via an extra
+ *              bool return whether the row actually matched (so the caller can
+ *              detect and handle a lost race), or (2) a row-locked read -- a
+ *              Lock<Entity>ForUpdate call instead of a plain Get, serializing the
+ *              read against a concurrent writer for the lifetime of the
+ *              transaction/mutex. A read via Lock<Entity>ForUpdate is naturally
+ *              excluded here since it doesn't match the Get<Entity> shape this
+ *              query looks for.
+ * @kind problem
+ * @problem.severity warning
+ * @id go/keyorix-state-toctou-missing-cas
+ * @tags security
+ *       external/cwe/cwe-362
+ *       external/cwe/cwe-367
+ */
+
+import go
+
+/** The package declaring the storage-layer entity structs this query cares about. */
+private string modelsPkg() { result = "github.com/keyorixhq/keyorix/internal/storage/models" }
+
+/**
+ * Holds if `f` is one of this codebase's named security-state fields.
+ *
+ * Generically-named boolean toggles (Revoked/IsRevoked/Locked/IsLocked/Active/
+ * IsActive/Approved/IsApproved/Disabled) are matched on ANY declaring type --
+ * confirmed against the real models (internal/storage/models/models.go) to be
+ * specific enough on their own not to need type-scoping: e.g. RiskException.Revoked/
+ * .Approved, User.IsActive, WebAuthnCredential.Disabled. (Locked/IsLocked do not
+ * currently exist as literal field names anywhere in this codebase -- kept for
+ * forward-compatibility, at zero current cost since they simply never match.)
+ *
+ * State/Status/AccountState, by contrast, are also used all over this codebase for
+ * purely non-security bookkeeping (DriftStatus, RotationStatus,
+ * AccessReviewCampaign.State, DynamicSecretLease.Status, SSOLoginState.State, ...),
+ * so those three are scoped to the specific entity types where the field is
+ * actually a security-lifecycle gate, per the real struct definitions:
+ *   - State:        MachineIdentity, ProjectInvitation, AccessRequest,
+ *                    BreakGlassActivation (pending/active/suspended/revoked-shaped
+ *                    state machines)
+ *   - Status:       SecretNode (active/suspended -- see internal/core/secret_suspend.go)
+ *   - AccountState:  User (active/pending_first_login/password_reset_required/suspended)
+ */
+predicate isSecurityStateField(Field f) {
+  f.getName().toLowerCase() =
+    ["revoked", "isrevoked", "locked", "islocked", "active", "isactive", "approved",
+      "isapproved", "disabled"]
+  or
+  f.hasQualifiedName(modelsPkg(),
+    ["MachineIdentity", "ProjectInvitation", "AccessRequest", "BreakGlassActivation"], "State")
+  or
+  f.hasQualifiedName(modelsPkg(), "SecretNode", "Status")
+  or
+  f.hasQualifiedName(modelsPkg(), "User", "AccountState")
+}
+
+/** Holds if `call` is a plain by-ID point-read, shaped like storage.Storage's Get<Entity>(ctx, id) family. A row-locking Lock<Entity>ForUpdate read does not match this (different name), which is deliberate -- see the header doc. */
+predicate isEntityGetCall(DataFlow::CallNode call) { call.getTarget().getName().matches("Get%") }
+
+/** Holds if `call` is a plain by-ID write, shaped like storage.Storage's Update<Entity>(ctx, entity) family. */
+predicate isEntityUpdateCall(DataFlow::CallNode call) {
+  call.getTarget().getName().matches("Update%")
+}
+
+/**
+ * Holds if `call`'s target function returns a bool among its results. This
+ * codebase's established fix for this exact bug class converts the write into a
+ * conditional "WHERE id = ? AND <field> = ?" persist that reports whether the row
+ * actually matched -- UpdateProjectInvitation, UpdateAccessRequest,
+ * UpdateAccessReviewItem, TransitionMachineIdentityState, and
+ * AdvanceWebAuthnCredentialCounter all follow this shape (confirmed by reading
+ * internal/core/storage/interface.go and the corresponding fix commits). A
+ * bool-returning "Update"-named call is therefore treated as already CAS-safe.
+ */
+predicate returnsBool(DataFlow::CallNode call) {
+  exists(int i | call.getTarget().getResultType(i).getUnderlyingType() instanceof BoolType)
+}
+
+/**
+ * Explicit named blessed atomic-transition helpers for this exact bug class, kept
+ * as documentation even though today every one of them is already excluded by
+ * construction -- either it doesn't match the Update%-name filter at all
+ * (RevokeBreakGlassActivation, CreateSecretDependencyExclusive), or it does and
+ * also returns a bool (UpdateProjectInvitation, UpdateAccessRequest,
+ * TransitionMachineIdentityState, AdvanceWebAuthnCredentialCounter). Listed
+ * explicitly so a future rename that drops the bool return (but keeps the name)
+ * doesn't silently re-admit one of these as a false positive.
+ */
+predicate isBlessedTransitionCall(DataFlow::CallNode call) {
+  call.getTarget().getName() =
+    ["TransitionMachineIdentityState", "AdvanceWebAuthnCredentialCounter",
+      "RevokeBreakGlassActivation", "CreateSecretDependencyExclusive", "UpdateProjectInvitation",
+      "UpdateAccessRequest"]
+}
+
+from
+  DataFlow::CallNode getCall, DataFlow::CallNode updateCall, Field stateField,
+  DataFlow::ReadNode fieldRead, DataFlow::Node entityBase
+where
+  isEntityGetCall(getCall) and
+  isEntityUpdateCall(updateCall) and
+  not returnsBool(updateCall) and
+  not isBlessedTransitionCall(updateCall) and
+  getCall.getEnclosingCallable() = updateCall.getEnclosingCallable() and
+  isSecurityStateField(stateField) and
+  fieldRead.readsField(entityBase, stateField) and
+  // The read and write must be operating on the exact same entity object the Get
+  // call returned -- not just any two Get.../Update... calls that happen to share
+  // an enclosing function -- and the field check must sit between the read and the
+  // write, matching the real check-then-act shape rather than a coincidental pair.
+  DataFlow::localFlow(getCall.getResult(0), entityBase) and
+  exists(int argIdx | DataFlow::localFlow(getCall.getResult(0), updateCall.getArgument(argIdx))) and
+  getCall.asExpr().getLocation().getStartLine() <= fieldRead.asExpr().getLocation().getStartLine() and
+  fieldRead.asExpr().getLocation().getStartLine() <= updateCall.asExpr().getLocation().getStartLine()
+select updateCall,
+  "This unconditional by-ID update persists a value read from the " + stateField.getName() +
+    " field obtained via $@, with no compare-and-set guard on that field -- a concurrent transition racing this read-modify-write window can be silently lost.",
+  getCall, "this plain by-ID read"

--- a/.github/codeql/go-queries/UnboundedDecoderRead.ql
+++ b/.github/codeql/go-queries/UnboundedDecoderRead.ql
@@ -1,0 +1,92 @@
+/**
+ * @name Unbounded reader passed to json.NewDecoder
+ * @description An io.Reader carrying untrusted/remote data (an HTTP response body, a
+ *              network connection, process stdin) is passed to json.NewDecoder without
+ *              first being bounded by io.LimitReader, http.MaxBytesReader, or this
+ *              repo's own maxMessageReader wrapper. The full body is buffered into
+ *              memory before any application-level size check ever runs -- a
+ *              self-inflicted memory-exhaustion DoS if the remote end (or an
+ *              untrusted local process) sends an oversized payload.
+ * @kind path-problem
+ * @problem.severity warning
+ * @id go/keyorix-unbounded-decoder-read
+ * @tags security
+ *       external/cwe/cwe-400
+ */
+
+import go
+
+/**
+ * Holds if `call` is one of this codebase's sanctioned size-bounding wrappers around
+ * an io.Reader: io.LimitReader, http.MaxBytesReader, or the repo-local
+ * newMaxMessageReader (internal/mcp/server.go). The RESULT of any of these is treated
+ * as a barrier -- taint from the underlying unbounded reader must not propagate past
+ * the wrapping call to whatever consumes the wrapper's return value.
+ */
+predicate isBoundingWrapperCall(DataFlow::CallNode call) {
+  call.getTarget().hasQualifiedName("io", "LimitReader")
+  or
+  call.getTarget().hasQualifiedName("net/http", "MaxBytesReader")
+  or
+  call.getTarget().getName() = "newMaxMessageReader"
+}
+
+/**
+ * Holds if `sink`'s enclosing file is under server/http/handlers/, where
+ * server/middleware's MaxBodyBytes middleware already rewrites the incoming
+ * request's Body field (`r.Body = http.MaxBytesReader(w, r.Body, limit)`, see
+ * server/middleware/body_limit.go) to a bounded reader before any handler ever
+ * runs -- a request-lifecycle fact this query's pure dataflow analysis can't see,
+ * since the bounding happens in a different function on the same *http.Request
+ * earlier in the middleware chain. Excluded to match this repo's existing
+ * .semgrep/keyorix-rules.yml scoping for the same reason.
+ */
+predicate isMiddlewareProtected(DataFlow::Node sink) {
+  sink.getFile().getRelativePath().matches("server/http/handlers/%")
+}
+
+/**
+ * Holds if `source` is a value this query treats as an origin of an unbounded
+ * io.Reader: a `.Body` field read (covers *http.Response.Body on an outbound client
+ * call -- CodeQL's built-in ActiveThreatModelSource only models the INBOUND
+ * *http.Request.Body case, not a response this process's own client received, which
+ * is exactly the shape of every real finding this query exists to catch), or an
+ * io.Reader-typed function parameter (covers a stdin-fed entrypoint like
+ * internal/mcp/server.go's Serve(ctx, r io.Reader, w io.Writer)).
+ */
+predicate isReaderOrigin(DataFlow::Node source) {
+  exists(Field f | f.getName() = "Body" | source = f.getARead())
+  or
+  exists(DataFlow::ParameterNode p |
+    exists(p.getType().getUnderlyingType().(InterfaceType).getMethodType("Read"))
+  |
+    source = p
+  )
+}
+
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { isReaderOrigin(source) }
+
+  predicate isSink(DataFlow::Node sink) {
+    exists(DataFlow::CallNode call |
+      call.getTarget().hasQualifiedName("encoding/json", "NewDecoder") and
+      sink = call.getArgument(0) and
+      not isMiddlewareProtected(sink)
+    )
+  }
+
+  predicate isBarrier(DataFlow::Node node) {
+    exists(DataFlow::CallNode wrap | isBoundingWrapperCall(wrap) and node = wrap.getResult())
+  }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink, source, sink,
+  "This reader carries untrusted data and reaches json.NewDecoder without a size bound (io.LimitReader / http.MaxBytesReader / newMaxMessageReader)."

--- a/.github/codeql/go-queries/codeql-pack.lock.yml
+++ b/.github/codeql/go-queries/codeql-pack.lock.yml
@@ -1,0 +1,24 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/concepts:
+    version: 0.0.28
+  codeql/controlflow:
+    version: 2.0.38
+  codeql/dataflow:
+    version: 2.1.10
+  codeql/go-all:
+    version: 7.2.2
+  codeql/mad:
+    version: 1.0.54
+  codeql/ssa:
+    version: 2.0.30
+  codeql/threat-models:
+    version: 1.0.54
+  codeql/tutorial:
+    version: 1.0.54
+  codeql/typetracking:
+    version: 2.0.38
+  codeql/util:
+    version: 2.0.41
+compiled: false

--- a/.github/codeql/go-queries/qlpack.yml
+++ b/.github/codeql/go-queries/qlpack.yml
@@ -1,0 +1,5 @@
+name: keyorixhq/go-custom-queries
+version: 0.1.0
+description: Custom CodeQL queries for patterns specific to this repo, run alongside the standard security-and-quality suite.
+dependencies:
+  codeql/go-all: "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,6 +54,15 @@ jobs:
         with:
           languages: go
           build-mode: manual
+          # `+` appends to (doesn't replace) CodeQL's default Go query suite. The
+          # custom pack (.github/codeql/go-queries) covers bug classes the default
+          # suite doesn't: an io.Reader from an outbound client response or a stdin
+          # parameter reaching json.NewDecoder unbounded, and a path-based
+          # chmod/chown that follows an os.Lstat check on the same path (TOCTOU).
+          # Applies to both matrix legs (server, operator) -- init always resolves
+          # this path against the repo-root checkout, independent of each leg's
+          # later build working-directory.
+          queries: +./.github/codeql/go-queries
 
       - name: Build (${{ matrix.name }})
         working-directory: ${{ matrix.working-directory }}


### PR DESCRIPTION
## Summary
- Adds two custom CodeQL Go queries to `.github/codeql/go-queries/`, wired into the existing `codeql.yml` workflow via the `queries: +...` append syntax (applies to both `server` and `operator` matrix legs).
- **UnboundedDecoderRead.ql**: flags an `io.Reader` carrying untrusted data (an HTTP response body from an outbound client call, or an `io.Reader`-typed function parameter such as a stdin-fed entrypoint) reaching `json.NewDecoder` without first passing through `io.LimitReader`, `http.MaxBytesReader`, or this repo's `newMaxMessageReader` wrapper. Excludes `server/http/handlers/` since `server/middleware`'s body-limit middleware already bounds `r.Body` before any handler runs (a request-lifecycle fact outside pure dataflow analysis, matching the existing Semgrep rule's scoping).
- **PathBasedPermissionChangeTOCTOU.ql**: flags a path-based `os.Chmod`/`os.Chown`/`os.Lchown` call on the same path string as a preceding `os.Lstat` check in the same function — the TOCTOU window between the check and the fd-less permission change.

Both bug classes recurred multiple times in the last adversarial review round and weren't caught by CodeQL's default Go query suite. Each query was hand-validated against known ground truth from that review (12 real unbounded-decoder sites, 2 real TOCTOU sites) with zero false positives and zero false negatives after two rounds of query iteration (documented via `codeql database analyze --rerun` locally).

## Test plan
- [x] `go build ./...` clean in the CI-equivalent checkout
- [x] Queries locally validated with `codeql database create` / `codeql database analyze --format=csv --rerun` against the current `main` — exact match to known ground truth, no noise
- [ ] CI CodeQL workflow run on this PR (both `server` and `operator` matrix legs) — confirms the queries compile and run under the actual Action, not just local CLI