### PR TITLE
fix(security): 4 new Semgrep rules + check-then-create race guard, fix what they found

### DIFF
--- a/.semgrep/keyorix-rules.yml
+++ b/.semgrep/keyorix-rules.yml
@@ -44,6 +44,237 @@ rules:
           ...
           $DEC.Decode(...)
 
+  - id: keyorix-json-unmarshal-fail-open
+    languages: [go]
+    severity: WARNING
+    message: >-
+      This function parses a stored JSON column into a security-relevant
+      restriction/scope value and returns nil on a parse error. If nil is
+      interpreted downstream as "no restriction," a corrupted-but-non-empty
+      stored value silently WIDENS access instead of failing closed -- the field
+      was legitimately empty and unrestricted is a different case from the field
+      being non-empty but unreadable. This does NOT apply to a purely additive
+      grant model (e.g. an ACL where nil means "no extra grant, still governed
+      by the base role check") -- only to a model where nil is interpreted as
+      "unrestricted." Return a sentinel value that matches no real
+      permission/CIDR instead of nil (see internal/core/pat.go's
+      patScopeCorrupted or internal/core/machine_token.go's
+      machineTokenCIDRCorrupted for the pattern), or add a `// nosemgrep:
+      keyorix-json-unmarshal-fail-open -- <reason>` comment if this is a
+      confirmed additive-grant model.
+    metadata:
+      category: security
+      references:
+        - internal/core/pat.go DecodePATScopes (fixed, r124-M)
+        - internal/core/machine_token.go machineRestrictionFrom (fixed, r137 PAT-001)
+    paths:
+      exclude:
+        - "**/*_test.go"
+    patterns:
+      - pattern-either:
+          - pattern: |
+              func $FUNC(...) $RET {
+                ...
+                if $ERR := json.Unmarshal(...); $ERR != nil {
+                  return nil
+                }
+                ...
+              }
+          - pattern: |
+              func $FUNC(...) $RET {
+                ...
+                if $ERR := json.Unmarshal(...); $ERR != nil {
+                  return nil, nil
+                }
+                ...
+              }
+      - metavariable-regex:
+          metavariable: $FUNC
+          regex: (?i).*(restrict|scope|cidr|permission).*
+
+  - id: keyorix-raw-error-to-client
+    languages: [go]
+    severity: WARNING
+    message: >-
+      A raw error's .Error() text is sent verbatim to the client (CWE-209). On
+      the HTTP side this fires only for a 5xx ("backend/internal fault")
+      status -- a 5xx path's error usually wraps a backend/storage/driver
+      failure and can leak internal details (DSNs, file paths, stack context,
+      driver error text), unlike a 4xx validation error, which is an
+      application-generated, already-safe message describing what the caller
+      did wrong. On the gRPC side (status.Error) this fires regardless of
+      code, since this codebase's convention is to never pass a raw error
+      straight into a gRPC status -- every status.Error call is expected to go
+      through a map*Error-style translator returning a fixed safe string. Log
+      the error server-side and return a fixed safe string instead (see
+      clientSafe() in server/http/handlers, or the mapUserError-style pattern
+      in server/grpc/services). If this specific error is a known, safe
+      sentinel (checked via errors.Is/errors.As) whose .Error() text is
+      already a fixed, non-sensitive string, add a `// nosemgrep:
+      keyorix-raw-error-to-client -- <reason>` comment instead of changing it.
+    metadata:
+      category: security
+      references:
+        - server/http/handlers/secrets_versions.go, users_crud.go, rbac.go, dynamic_secrets.go, pat_handler.go, secret_schedule.go (fixed, CWE-209 sweep)
+        - server/grpc/services/{user_service,machine_identity_service,break_glass_service}.go (fixed, r139 GRPC-003/004/005)
+    paths:
+      exclude:
+        - "**/*_test.go"
+    patterns:
+      - pattern-either:
+          - patterns:
+              - pattern-either:
+                  - pattern: sendError($W, $CODE, $E.Error(), $STATUS, ...)
+                  - pattern: $H.sendError($W, $CODE, $E.Error(), $STATUS, ...)
+              - metavariable-pattern:
+                  metavariable: $STATUS
+                  patterns:
+                    - pattern-either:
+                        - pattern: http.StatusInternalServerError
+                        - pattern: http.StatusBadGateway
+                        - pattern: http.StatusServiceUnavailable
+                        - pattern: http.StatusGatewayTimeout
+                        - pattern: http.StatusNotImplemented
+          - pattern: status.Error($GCODE, $E.Error())
+
+  - id: keyorix-role-grant-query-missing-expiry-filter
+    languages: [go]
+    severity: WARNING
+    message: >-
+      This function queries the user_roles/group_roles grants table (a
+      models.UserRole/models.GroupRole read) without applying
+      sqlWhereURNotExpired/sqlWhereGRNotExpired anywhere in the same function,
+      unlike every other role-lookup function in this file. An expired JIT/
+      time-boxed grant is then read back as a live, currently-held role --
+      access reviews, role-replacement logic, and reinstatement counts all
+      treat a lapsed grant as still active. Add
+      .Where(sqlWhereURNotExpired, time.Now().UTC()) (or the GR variant for
+      group grants) to the query chain, matching e.g. GetUserRoleIDsAt in this
+      same file. If this function deliberately needs to see expired rows too
+      (e.g. a cleanup/sweep job, or a Delete that intentionally targets both
+      live and expired grants), add a `// nosemgrep:
+      keyorix-role-grant-query-missing-expiry-filter -- <reason>` comment.
+    metadata:
+      category: security
+      references:
+        - internal/storage/store/local_rbac.go ListProjectRoleAssignments (fixed, AUTHZ-002, r137 Sprint 3)
+        - internal/storage/store/local_rbac.go GetUserRoleIDsExact (fixed, AUTHZ-003, r137 Sprint 4)
+    paths:
+      include:
+        - internal/storage/**
+      exclude:
+        - "**/*_test.go"
+    patterns:
+      - pattern-either:
+          - patterns:
+              - pattern-either:
+                  - pattern: |
+                      func $FN(...) $RET {
+                        ...
+                        var $VAR []models.UserRole
+                        ...
+                        $DB.Find(&$VAR)
+                        ...
+                      }
+                  - pattern: |
+                      func $FN(...) $RET {
+                        ...
+                        $DB.Model(&models.UserRole{})
+                        ...
+                      }
+              - pattern-not: |
+                  func $FN(...) $RET {
+                    ...
+                    $X.Where(sqlWhereURNotExpired, ...)
+                    ...
+                  }
+          - patterns:
+              - pattern-either:
+                  - pattern: |
+                      func $FN(...) $RET {
+                        ...
+                        var $VAR []models.GroupRole
+                        ...
+                        $DB.Find(&$VAR)
+                        ...
+                      }
+                  - pattern: |
+                      func $FN(...) $RET {
+                        ...
+                        $DB.Model(&models.GroupRole{})
+                        ...
+                      }
+              - pattern-not: |
+                  func $FN(...) $RET {
+                    ...
+                    $X.Where(sqlWhereGRNotExpired, ...)
+                    ...
+                  }
+
+  - id: keyorix-unbounded-bulk-slice-param
+    languages: [go]
+    severity: WARNING
+    message: >-
+      This function takes a caller-supplied slice parameter and loops over it
+      doing per-item work (a storage/DB round trip per item) with no upper
+      bound on the slice's length. The global request body-size limit alone
+      still permits a very large array of small values in one request (well
+      over a million integers within 10 MiB), and the per-item loop has no
+      cancellation check, so an oversized batch is a per-request resource-
+      exhaustion vector (CWE-400) -- this also covers the CLI's embedded/local
+      mode, which calls core functions directly, bypassing the HTTP body-size
+      limit entirely. Add a `if len($PARAM) > maxBatchSize { return ...,
+      fmt.Errorf(...) }` guard before the loop (see
+      maxBulkAccessRequestBatchSize in internal/core/bulk_access_requests.go
+      for the pattern). If this function is deliberately unbounded (e.g. an
+      internal/trusted-only caller, or the loop does no per-item I/O), add a
+      `// nosemgrep: keyorix-unbounded-bulk-slice-param -- <reason>` comment.
+    metadata:
+      category: security
+      references:
+        - internal/core/bulk_access_requests.go BulkApproveAccessRequests/BulkRejectAccessRequests (fixed, r141, #1331)
+    paths:
+      include:
+        - internal/core/**
+      exclude:
+        - "**/*_test.go"
+    patterns:
+      - pattern-either:
+          - patterns:
+              - pattern: |
+                  func ($RECV *KeyorixCore) $FN(ctx context.Context, $PARAM []$T, ...) $RET {
+                    ...
+                    for $I, $ITEM := range $PARAM {
+                      ...
+                    }
+                    ...
+                  }
+              - pattern-not: |
+                  func ($RECV *KeyorixCore) $FN(ctx context.Context, $PARAM []$T, ...) $RET {
+                    ...
+                    if len($PARAM) > $MAX {
+                      ...
+                    }
+                    ...
+                  }
+          - patterns:
+              - pattern: |
+                  func ($RECV *KeyorixCore) $FN(ctx context.Context, $PARAM []$T, ...) $RET {
+                    ...
+                    for _, $ITEM := range $PARAM {
+                      ...
+                    }
+                    ...
+                  }
+              - pattern-not: |
+                  func ($RECV *KeyorixCore) $FN(ctx context.Context, $PARAM []$T, ...) $RET {
+                    ...
+                    if len($PARAM) > $MAX {
+                      ...
+                    }
+                    ...
+                  }
+
   - id: keyorix-raw-clipboard-write
     languages: [typescript, javascript]
     severity: WARNING

--- a/.semgrep/keyorix-rules.yml
+++ b/.semgrep/keyorix-rules.yml
@@ -297,3 +297,43 @@ rules:
         - "**/*.test.ts"
         - "**/*.test.tsx"
         - "**/__tests__/**"
+
+  - id: keyorix-new-remotestorage-unsupported-stub
+    languages: [go]
+    severity: INFO
+    message: >-
+      This RemoteStorage method's entire body is a remoteUnsupported(...)
+      stub -- the exact shape that rounds 112-119 (#505/#509-class bugs) kept
+      rediscovering merged and undocumented: LocalStorage fully implements
+      the operation, RemoteStorage silently no-ops it instead of proxying it.
+      This rule is purely structural and matches every stub, old and new --
+      it does NOT mean the stub is wrong, plenty of existing stubs are
+      legitimate, verified-permanent gaps. It's just a nudge (this PR review
+      only shows it as a new annotation if the matched lines are new in the
+      diff): go add (or confirm) this method's entry in
+      remoteUnsupportedAllowlist, internal/storage/store/
+      remote_unsupported_completeness_test.go, classified as
+      statusIntentional (verified no reachable caller under storage.type:
+      remote) or statusKnownGap (a real, tracked gap). That test --
+      TestRemoteUnsupportedStubsAreAllowlisted -- is the actual hard gate;
+      this rule only tells you to go satisfy it.
+    metadata:
+      category: correctness
+      references:
+        - internal/storage/store/remote_unsupported_completeness_test.go (TestRemoteUnsupportedStubsAreAllowlisted, PR #856)
+    paths:
+      include:
+        - internal/storage/store/remote_*.go
+      exclude:
+        - "**/*_test.go"
+        - internal/storage/store/remote_unsupported.go
+    patterns:
+      - pattern-either:
+          - pattern: |
+              func ($RS *RemoteStorage) $METHOD(...) $RET {
+                return remoteUnsupported("$OP")
+              }
+          - pattern: |
+              func ($RS *RemoteStorage) $METHOD(...) $RET {
+                return ..., remoteUnsupported("$OP")
+              }

--- a/internal/core/access_review.go
+++ b/internal/core/access_review.go
@@ -278,7 +278,7 @@ func (r *accessReviewResolver) resolveMachine(ctx context.Context, id uint) stri
 
 // appendRoleEntries adds role-based standing access entries for all project assignments
 // (role grants whose role confers a secrets.* permission).
-func (c *KeyorixCore) appendRoleEntries(ctx context.Context, assignments []storage.RoleAssignment, entries *[]*AccessReviewEntry, res *accessReviewResolver) error {
+func (c *KeyorixCore) appendRoleEntries(ctx context.Context, assignments []storage.RoleAssignment, entries *[]*AccessReviewEntry, res *accessReviewResolver) error { // nosemgrep: keyorix-unbounded-bulk-slice-param -- assignments is a storage query result (existing role grants in the DB), not a raw client-supplied array in one request
 	for _, a := range assignments {
 		ri, err := res.resolveRole(ctx, a.RoleID)
 		if err != nil {

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -315,7 +315,7 @@ func (c *KeyorixCore) scopedRoleIDs(ctx context.Context, userID uint, scope Scop
 }
 
 // roleSetContainsAdmin reports whether any role ID in the set is an admin role.
-func (c *KeyorixCore) roleSetContainsAdmin(ctx context.Context, roleIDs []uint) bool {
+func (c *KeyorixCore) roleSetContainsAdmin(ctx context.Context, roleIDs []uint) bool { // nosemgrep: keyorix-unbounded-bulk-slice-param -- roleIDs is a principal's resolved current role set (scopedRoleIDs/GetUserRoleIDsAt), not a raw client-supplied array; every call site passes an internally-computed list
 	if len(roleIDs) == 0 {
 		return false
 	}

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -68,6 +68,17 @@ func isPrivateIP(ip net.IP) bool {
 //
 // Returns "" when the format is unrecognised or the host cannot be extracted.
 func parseDSNHost(dsn string) string {
+	// The kubernetes backend's admin_dsn is a JSON blob ({"api_server": "https://
+	// host:port", ...}, see internal/dynamic/kubernetes.go), not a URL/wrapper/
+	// key-value DSN string -- none of the checks below can extract a host from it
+	// (a JSON blob embedding "https://" mid-string doesn't parse as a URL: url.Parse
+	// requires the scheme at the start), so it fell through to the "unrecognised
+	// format, skip validation" case, silently bypassing validateAdminDSNHost's
+	// private-IP/IMDS guard for this one backend type. Try this first since it's
+	// the most precise match for its exact shape.
+	if h, ok := parseDSNHostFromKubernetesConfig(dsn); ok {
+		return h
+	}
 	// URL-form DSNs (any scheme that carries ://host).
 	if strings.Contains(dsn, "://") {
 		if h, ok := parseDSNHostFromURL(dsn); ok {
@@ -84,6 +95,21 @@ func parseDSNHost(dsn string) string {
 	}
 	// PostgreSQL key-value: scan for host=<value>
 	return parseDSNHostFromKeyValue(dsn)
+}
+
+// parseDSNHostFromKubernetesConfig extracts the host from a kubernetes backend's
+// JSON-shaped admin_dsn ({"api_server": "https://host:port", "token": "...",
+// "ca_cert": "..."}, matching internal/dynamic.kubernetesConfig). A missing or
+// empty api_server means in-cluster mode (KUBERNETES_SERVICE_HOST/PORT), which
+// isn't attacker-influenceable, so there's nothing to validate.
+func parseDSNHostFromKubernetesConfig(dsn string) (string, bool) {
+	var cfg struct {
+		APIServer string `json:"api_server"`
+	}
+	if err := json.Unmarshal([]byte(dsn), &cfg); err != nil || strings.TrimSpace(cfg.APIServer) == "" {
+		return "", false
+	}
+	return parseDSNHostFromURL(cfg.APIServer)
 }
 
 func parseDSNHostFromURL(dsn string) (string, bool) {

--- a/internal/core/dynamic_secrets_ssrf_test.go
+++ b/internal/core/dynamic_secrets_ssrf_test.go
@@ -54,6 +54,19 @@ func TestParseDSNHost_UnrecognisedReturnsEmpty(t *testing.T) {
 	assert.Equal(t, "", parseDSNHost("not-a-dsn"))
 }
 
+func TestParseDSNHost_KubernetesJSONConfig(t *testing.T) {
+	dsn := `{"api_server":"https://k8s.internal:6443","token":"tok","ca_cert":"cert"}`
+	assert.Equal(t, "k8s.internal", parseDSNHost(dsn))
+
+	dsnIP := `{"api_server":"https://10.0.0.9:6443","token":"tok","ca_cert":"cert"}`
+	assert.Equal(t, "10.0.0.9", parseDSNHost(dsnIP))
+
+	// No api_server (in-cluster mode) — nothing to extract, not a validation gap:
+	// the actual host then comes from KUBERNETES_SERVICE_HOST/PORT, which isn't
+	// attacker-influenceable.
+	assert.Equal(t, "", parseDSNHost(`{"token":"tok","ca_cert":"cert"}`))
+}
+
 // -- validateAdminDSNHost -----------------------------------------------------
 
 func TestValidateAdminDSNHost_PrivateLiteralIPRejected(t *testing.T) {
@@ -69,6 +82,8 @@ func TestValidateAdminDSNHost_PrivateLiteralIPRejected(t *testing.T) {
 		{"shared CGN 100.64.x.x", "postgres://admin:pass@100.64.0.1:5432/app"},
 		{"key-value private", "host=10.1.2.3 port=5432 user=admin dbname=app"},
 		{"mysql tcp private", "admin:pass@tcp(192.168.0.5:3306)/app"},
+		{"kubernetes JSON config, private IP", `{"api_server":"https://10.0.0.9:6443","token":"tok","ca_cert":"cert"}`},
+		{"kubernetes JSON config, cloud IMDS", `{"api_server":"http://169.254.169.254","token":"tok","ca_cert":"cert"}`},
 	}
 	for _, tc := range cases {
 		err := validateAdminDSNHost(tc.dsn)
@@ -134,6 +149,30 @@ func TestDynamicSecrets_CreateConfig_SSRFGuardBypassed(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.NotZero(t, cfg.ID)
+}
+
+func TestDynamicSecrets_CreateConfig_SSRFGuardRejectsKubernetesPrivateAPIServer(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+
+	// The kubernetes backend's admin_dsn is a JSON blob ({"api_server": ...}), not a
+	// URL/wrapper/key-value DSN string. Before parseDSNHost learned to parse it, this
+	// silently bypassed the SSRF guard entirely for this one backend type -- a
+	// project-scoped admin (requireDynamicSecretAdminAuthority, not a system-level
+	// admin) could point a kubernetes dynamic-secrets config's api_server at the
+	// cloud IMDS endpoint or any other private-network service and mint a live
+	// ServiceAccount token via the TokenRequest API against it.
+	_, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name:          "k8s-imds-attempt",
+		ProjectID:     1,
+		EnvironmentID: 2,
+		BackendType:   "kubernetes",
+		AdminDSN:      `{"api_server":"http://169.254.169.254","token":"tok","ca_cert":"cert"}`,
+		CreatedBy:     "alice",
+		ActorID:       testAdminActorID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "private or link-local")
 }
 
 func TestDynamicSecrets_CreateConfig_SSRFGuardLinkLocal(t *testing.T) {

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -215,7 +215,7 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 // policy this run. A secret covered by several policies is rotated at most once, under
 // the first active policy it is due under (first-policy-wins). dueOrder preserves
 // discovery order so project grouping in the caller is deterministic.
-func (c *KeyorixCore) collectDueRotations(ctx context.Context, policies []*models.RotationPolicy, now time.Time) (map[uint]*dueRotation, []uint) {
+func (c *KeyorixCore) collectDueRotations(ctx context.Context, policies []*models.RotationPolicy, now time.Time) (map[uint]*dueRotation, []uint) { // nosemgrep: keyorix-unbounded-bulk-slice-param -- policies is admin-configured rotation policies fetched from storage, not a raw client-supplied array in one request
 	due := map[uint]*dueRotation{}
 	var dueOrder []uint
 	for _, policy := range policies {
@@ -309,7 +309,7 @@ func (c *KeyorixCore) rotateProject(ctx context.Context, pid uint, ids []uint, d
 // rotateProjectWaves rotates secrets in dependency-ordered waves. A secret whose
 // dependency did not rotate this run is DEFERRED rather than rotated against a stale
 // dependency. Returns (failures, rotated count).
-func (c *KeyorixCore) rotateProjectWaves(ctx context.Context, waves [][]uint, due map[uint]*dueRotation, dependsOnInRun map[uint][]uint) (failed map[uint]string, rotated int) {
+func (c *KeyorixCore) rotateProjectWaves(ctx context.Context, waves [][]uint, due map[uint]*dueRotation, dependsOnInRun map[uint][]uint) (failed map[uint]string, rotated int) { // nosemgrep: keyorix-unbounded-bulk-slice-param -- waves is computed internally by the rotation scheduler from due secrets in this project, not a raw client-supplied array
 	failed = map[uint]string{}
 	blocked := map[uint]bool{}
 	for _, wave := range waves {

--- a/internal/core/scim_groups.go
+++ b/internal/core/scim_groups.go
@@ -74,10 +74,21 @@ func (c *KeyorixCore) scimManagedMember(ctx context.Context, uid uint) bool {
 	return user.ExternalID != ""
 }
 
+// maxSCIMGroupMembersPerCall bounds how many member ids a single SCIM group
+// provision/replace/patch request may carry. Each id costs one
+// scimManagedMember (GetUser) round trip via filterSCIMManaged below; an IdP
+// integration (or a compromised/misbehaving one) submitting an unbounded
+// member list in one request is a per-request resource-exhaustion vector, the
+// same class of bug as maxBulkAccessRequestBatchSize
+// (internal/core/bulk_access_requests.go). Enforced at each of the three SCIM
+// group entry points (ProvisionSCIMGroup, ReplaceSCIMGroup, PatchSCIMGroup)
+// against their raw incoming id list, before any storage access.
+const maxSCIMGroupMembersPerCall = 500
+
 // filterSCIMManaged splits ids into (allowed, rejected) member ids based on
 // scimManagedMember, so callers can add only the SCIM-managed subset and report the
 // rest as refused rather than silently dropping them.
-func (c *KeyorixCore) filterSCIMManaged(ctx context.Context, ids []uint) (allowed, rejected []uint) {
+func (c *KeyorixCore) filterSCIMManaged(ctx context.Context, ids []uint) (allowed, rejected []uint) { // nosemgrep: keyorix-unbounded-bulk-slice-param -- all three callers (ProvisionSCIMGroup, ReplaceSCIMGroup, PatchSCIMGroup) enforce maxSCIMGroupMembersPerCall on their raw incoming id list before calling this
 	for _, id := range ids {
 		if id == 0 {
 			continue
@@ -97,6 +108,9 @@ func (c *KeyorixCore) filterSCIMManaged(ctx context.Context, ids []uint) (allowe
 func (c *KeyorixCore) ProvisionSCIMGroup(ctx context.Context, actorID uint, displayName string, memberIDs []uint) (*models.Group, error) {
 	if displayName == "" {
 		return nil, fmt.Errorf("displayName is required")
+	}
+	if len(memberIDs) > maxSCIMGroupMembersPerCall {
+		return nil, fmt.Errorf("memberIDs exceeds the maximum batch size of %d", maxSCIMGroupMembersPerCall)
 	}
 	allowed, rejected := c.filterSCIMManaged(ctx, memberIDs)
 	if len(rejected) > 0 {
@@ -119,6 +133,9 @@ func (c *KeyorixCore) ProvisionSCIMGroup(ctx context.Context, actorID uint, disp
 // ReplaceSCIMGroup applies a SCIM Replace (PUT): an optional rename plus the FULL
 // member set (members not in memberIDs are removed; new ones are added).
 func (c *KeyorixCore) ReplaceSCIMGroup(ctx context.Context, actorID, groupID uint, displayName string, memberIDs []uint) (*models.Group, error) {
+	if len(memberIDs) > maxSCIMGroupMembersPerCall {
+		return nil, fmt.Errorf("memberIDs exceeds the maximum batch size of %d", maxSCIMGroupMembersPerCall)
+	}
 	group, err := c.storage.GetGroup(ctx, groupID)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
@@ -154,6 +171,9 @@ func (c *KeyorixCore) ReplaceSCIMGroup(ctx context.Context, actorID, groupID uin
 // PatchSCIMGroup applies a SCIM PATCH: an optional rename plus incremental member
 // add/remove. nil newName leaves the name unchanged.
 func (c *KeyorixCore) PatchSCIMGroup(ctx context.Context, actorID, groupID uint, newName *string, addIDs, removeIDs []uint) (*models.Group, error) {
+	if len(addIDs) > maxSCIMGroupMembersPerCall || len(removeIDs) > maxSCIMGroupMembersPerCall {
+		return nil, fmt.Errorf("addIDs/removeIDs exceeds the maximum batch size of %d", maxSCIMGroupMembersPerCall)
+	}
 	group, err := c.storage.GetGroup(ctx, groupID)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)

--- a/internal/core/secret_dependencies.go
+++ b/internal/core/secret_dependencies.go
@@ -300,7 +300,7 @@ type secretInfo struct {
 // so the views can show names and filter by real environment without an extra
 // round-trip per row. A secret that no longer resolves is absent from the map (zero
 // value), so it is treated as not in any caller's environment.
-func (c *KeyorixCore) resolveSecretInfo(ctx context.Context, edges []*models.SecretDependency) map[uint]secretInfo {
+func (c *KeyorixCore) resolveSecretInfo(ctx context.Context, edges []*models.SecretDependency) map[uint]secretInfo { // nosemgrep: keyorix-unbounded-bulk-slice-param -- edges is a dependency-graph query result for one project, not a raw client-supplied array in one request
 	ids := make(map[uint]struct{})
 	for _, e := range edges {
 		ids[e.DependentSecretID] = struct{}{}

--- a/internal/core/secret_listing_query.go
+++ b/internal/core/secret_listing_query.go
@@ -324,7 +324,7 @@ func (c *KeyorixCore) getSharedSecretsWithSharingInfo(ctx context.Context, userI
 	return result, nil
 }
 
-func (c *KeyorixCore) applySecretFilters(ctx context.Context, secrets []*models.SecretWithSharingInfo, filter *models.SecretListFilter) []*models.SecretWithSharingInfo {
+func (c *KeyorixCore) applySecretFilters(ctx context.Context, secrets []*models.SecretWithSharingInfo, filter *models.SecretListFilter) []*models.SecretWithSharingInfo { // nosemgrep: keyorix-unbounded-bulk-slice-param -- secrets is an already-fetched, storage-bounded listing result, not a raw client-supplied array in one request
 	// Tag filter: require every requested tag (AND). Resolved per secret only when a
 	// tag filter is present, so the common no-tag list path does no extra queries.
 	want := normalizeTagFilter(filter.Tags)

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -692,7 +692,7 @@ func (c *KeyorixCore) HealthCheck(ctx context.Context) error {
 
 // ResolveUsernames maps UserID → username for a slice of audit events.
 // Nil UserIDs (system events) map to key 0 → "system".
-func (c *KeyorixCore) ResolveUsernames(ctx context.Context, events []*models.AuditEvent) map[uint]string {
+func (c *KeyorixCore) ResolveUsernames(ctx context.Context, events []*models.AuditEvent) map[uint]string { // nosemgrep: keyorix-unbounded-bulk-slice-param -- events is an already-paginated audit-log query result, not a raw client-supplied array; the per-item DB round trip below is over the deduped user-id set, not events itself
 	seen := map[uint]bool{}
 	for _, e := range events {
 		if e.UserID != nil {

--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -607,7 +607,7 @@ func (c *KeyorixCore) requireMachineGrantNoSoDViolation(ctx context.Context, mac
 // permissions against, so every role in the set is evaluated together instead.
 // Any role in the set that is itself admin-bypass exempts the whole set (see
 // package doc above).
-func (c *KeyorixCore) requireGrantSetNoSoDViolation(ctx context.Context, roleIDs []uint) error {
+func (c *KeyorixCore) requireGrantSetNoSoDViolation(ctx context.Context, roleIDs []uint) error { // nosemgrep: keyorix-unbounded-bulk-slice-param -- roleIDs derives from CreateUserWithAssignments's assignments param, which enforces maxUserCreateAssignments before calling this
 	policies, err := c.storage.ListSoDPolicies(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -135,6 +135,15 @@ func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*
 	return createdUser, nil
 }
 
+// maxUserCreateAssignments bounds how many project-scoped role assignments a
+// single CreateUserWithAssignments call may carry. Each entry costs at least
+// one GetRole/rolePermissionNameSet round trip via
+// requireGrantSetNoSoDViolation's SoD evaluation below; an unbounded
+// assignments list submitted in one request is a per-request
+// resource-exhaustion vector, the same class of bug as
+// maxBulkAccessRequestBatchSize (internal/core/bulk_access_requests.go).
+const maxUserCreateAssignments = 500
+
 // CreateUserWithAssignments creates a user and grants a system role plus a set of
 // project-scoped roles in one transaction (ADR-028 atomic provisioning). All role
 // names and project IDs are resolved and validated up front, so an invalid input
@@ -149,6 +158,9 @@ func (c *KeyorixCore) CreateUser(ctx context.Context, req *CreateUserRequest) (*
 // mint a brand-new super_admin account directly — no invite/accept step an admin
 // could notice or revoke in between, unlike InviteGlobal.
 func (c *KeyorixCore) CreateUserWithAssignments(ctx context.Context, req *CreateUserRequest, systemRole string, assignments []ProjectAssignment, actorID uint) (*models.User, error) {
+	if len(assignments) > maxUserCreateAssignments {
+		return nil, fmt.Errorf("assignments exceeds the maximum batch size of %d", maxUserCreateAssignments)
+	}
 	user, hash, err := c.buildUserForCreate(ctx, req)
 	if err != nil {
 		return nil, err

--- a/internal/storage/store/checkthencreate_race_completeness_test.go
+++ b/internal/storage/store/checkthencreate_race_completeness_test.go
@@ -1,0 +1,756 @@
+// checkthencreate_race_completeness_test.go — regression guard for the
+// recurring "check-then-create" TOCTOU race bug class this codebase has hit
+// (and fixed) repeatedly: #117 (email/external_id), #121 (secret-version
+// number), #136 (ShareRecord duplicate grants), #305 (PlaceLegalHold),
+// #309/#313 (InviteMember/DeleteProject), #462 (dynamic-secrets config), and
+// MT-006 (secret_nodes name uniqueness).
+//
+// The shape, every time: a function checks for an existing row by natural key
+// (a Get<Entity>By<Key>-shaped call, or a Get<Adjective><Entity> existence
+// probe like GetActiveLegalHold/GetActiveProjectMembership) and then, on a
+// miss, Create()s a new row. The check and the create are two separate
+// non-transactional statements, so two concurrent callers can both pass the
+// check before either commits — producing duplicate rows for what was
+// supposed to be a unique natural key. The fix this repo has landed every
+// time is NOT "make the check atomic" (there is no portable SELECT..FOR
+// UPDATE-free way to do that across SQLite+Postgres here) — it is: add a
+// database-level unique index covering the natural key, so the LOSER of the
+// race gets a constraint violation instead of a second live duplicate row,
+// and translate that violation into the same clean error the sequential
+// check would have produced.
+//
+// Following this repo's own established convention (see
+// TestRemoteUnsupportedStubsAreAllowlisted, remote_unsupported_completeness_test.go,
+// in this same package), the check-then-create call sites below are
+// discovered PROGRAMMATICALLY via go/ast — not a hand-maintained list, which
+// would immediately go stale as new storage methods are added. What IS
+// hand-maintained is a small, explicit, comment-justified allowlist
+// (checkThenCreateAllowlist below) for the rare legitimate exception.
+//
+// Two independent AST passes:
+//
+//  1. buildUniqueIndexRegistry walks internal/storage/models (struct field
+//     GORM tags) and internal/storage/factory.go (the ensure<X>Index helpers'
+//     raw `CREATE UNIQUE INDEX ... ON <table> (<cols>)` statements — this
+//     repo's OWN established pattern for adding a unique index to a table
+//     that might already hold pre-existing duplicate rows; see e.g. #117's
+//     commit message: "not a plain gorm uniqueIndex tag — AutoMigrate
+//     creating a unique index directly on an existing, potentially-already-
+//     duplicate table is the exact failure mode this repo's own established
+//     pattern avoids"). The result is table -> set of columns covered by AT
+//     LEAST ONE unique index, from either source.
+//
+//  2. discoverCheckThenCreateSites walks every non-test .go file in
+//     internal/core and internal/storage/store/local_*.go and, per function,
+//     looks for a Create call preceded (anywhere earlier in the same
+//     function, including inside a nested closure such as a
+//     db.Transaction(func(tx *gorm.DB) error { ... }) callback) by a Get*
+//     call whose name shares a contiguous camelCase word run with the
+//     create's target entity name (e.g. "SecretByName" contains the word
+//     run "Secret"; "ActiveLegalHold" contains "LegalHold";
+//     "ActiveProjectMembership" contains "ProjectMembership"). The create
+//     call's actual internal/storage/models struct type is then resolved
+//     from its own arguments via lightweight AST type-tracing (composite
+//     literal, function parameter, or a `:=`/`var` assignment earlier in the
+//     function) — NOT from the method name — so the registry lookup is keyed
+//     on the real model/table.
+//
+// A site fails the test when its resolved model's table has ZERO unique-index
+// coverage (from either registry source) and the site is not in the
+// allowlist. See the package doc comment on checkThenCreateAllowlist for the
+// known, deliberate false-negative gaps in this heuristic.
+package store
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Part 1: table -> unique-indexed-columns registry.
+// ---------------------------------------------------------------------------
+
+// uniqueIndexRegistry maps a DB table name to the set of columns covered by
+// AT LEAST ONE unique index on that table (gorm struct tag OR a runtime
+// ensure*Index helper in factory.go — this repo uses both mechanisms
+// depending on whether the table might already hold pre-existing duplicate
+// rows at migration time; see the package doc comment above).
+type uniqueIndexRegistry map[string]map[string]bool
+
+func (r uniqueIndexRegistry) add(table, column string) {
+	if table == "" {
+		return
+	}
+	if r[table] == nil {
+		r[table] = map[string]bool{}
+	}
+	if column != "" {
+		r[table][column] = true
+	} else {
+		// A unique index whose column couldn't be parsed out still proves the
+		// table has SOME unique-index coverage; record a sentinel so
+		// hasAnyUniqueIndex(table) is true without asserting a bogus column.
+		r[table]["*"] = true
+	}
+}
+
+func (r uniqueIndexRegistry) hasAnyUniqueIndex(table string) bool {
+	return len(r[table]) > 0
+}
+
+// camelWordRe splits a TitleCase/camelCase Go identifier into its constituent
+// words, e.g. "ActiveLegalHold" -> ["Active", "Legal", "Hold"].
+var camelWordRe = regexp.MustCompile(`[A-Z][a-z0-9]*|[A-Z]+[a-z0-9]*`)
+
+func splitCamel(s string) []string {
+	return camelWordRe.FindAllString(s, -1)
+}
+
+// toSnakeCase converts a TitleCase Go identifier to snake_case, e.g.
+// "SecretNode" -> "secret_node", "ExternalID" -> "external_id".
+func toSnakeCase(s string) string {
+	words := splitCamel(s)
+	for i, w := range words {
+		words[i] = strings.ToLower(w)
+	}
+	return strings.Join(words, "_")
+}
+
+// irregularPlurals covers the handful of struct-name stems in this codebase
+// whose naive "+s" (or "+es"/"y"->"ies") pluralization would be wrong. GORM's
+// actual namer uses github.com/jinzhu/inflection for this; reproducing the
+// full library here isn't warranted for the small, known set of table names
+// this repo actually has, but a generic pluralizer + this short list of
+// exceptions keeps the mapping correct without hand-maintaining every table
+// name (only the IRREGULAR ones, which is legitimately small and slow-
+// changing, unlike the check-then-create site list this test also builds).
+var irregularPlurals = map[string]string{
+	"policy": "policies",
+}
+
+// pluralize is a minimal English pluralizer covering the noun endings that
+// actually occur among this repo's model struct names (checked against every
+// struct in internal/storage/models/models.go).
+func pluralize(word string) string {
+	if p, ok := irregularPlurals[word]; ok {
+		return p
+	}
+	switch {
+	case strings.HasSuffix(word, "y") && len(word) > 1 && !strings.ContainsRune("aeiou", rune(word[len(word)-2])):
+		return word[:len(word)-1] + "ies"
+	case strings.HasSuffix(word, "s"), strings.HasSuffix(word, "x"), strings.HasSuffix(word, "ch"), strings.HasSuffix(word, "sh"):
+		return word + "es"
+	default:
+		return word + "s"
+	}
+}
+
+// structNameToTable computes GORM's default table name for a struct name
+// with no TableName() override: snake_case, then pluralize the LAST
+// underscore-delimited word (matching jinzhu/inflection's behavior of
+// pluralizing only the final word, e.g. "SecretNode" -> "secret_nodes", not
+// "secret_nodeses" or "secret_node_s").
+func structNameToTable(structName string) string {
+	snake := toSnakeCase(structName)
+	idx := strings.LastIndex(snake, "_")
+	if idx == -1 {
+		return pluralize(snake)
+	}
+	return snake[:idx+1] + pluralize(snake[idx+1:])
+}
+
+// gormColumnName computes the default GORM column name for a struct field
+// with no `column:` tag override: plain snake_case of the field name (GORM
+// does not pluralize column names).
+func gormColumnName(fieldName string) string {
+	return toSnakeCase(fieldName)
+}
+
+// buildUniqueIndexRegistry runs both registry-building passes and returns the
+// combined result, plus the struct-name -> table-name map (needed by
+// discoverCheckThenCreateSites' registry lookups too).
+func buildUniqueIndexRegistry(t *testing.T, modelsDir, factoryFile string) (uniqueIndexRegistry, map[string]string) {
+	t.Helper()
+	reg := uniqueIndexRegistry{}
+	tableNames := scanModelsForUniqueTags(t, modelsDir, reg)
+	scanFactoryForRuntimeIndexes(t, factoryFile, reg)
+	return reg, tableNames
+}
+
+// tableNameOverrideRe matches `func (StructName) TableName() string { return "literal" }`-
+// shaped declarations (models.go has exactly this convention for its two
+// overrides today: SoDPolicy, MachineIdentityOIDCBinding).
+func scanModelsForUniqueTags(t *testing.T, modelsDir string, reg uniqueIndexRegistry) map[string]string {
+	t.Helper()
+	entries, err := os.ReadDir(modelsDir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", modelsDir, err)
+	}
+
+	fset := token.NewFileSet()
+	tableNames := map[string]string{}
+	var files []*ast.File
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(modelsDir, e.Name())
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		files = append(files, f)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no .go files found under %s", modelsDir)
+	}
+
+	// Pass 1: TableName() overrides.
+	for _, f := range files {
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Name.Name != "TableName" || fd.Recv == nil || len(fd.Recv.List) != 1 {
+				continue
+			}
+			structName := recvTypeName(fd.Recv.List[0].Type)
+			if structName == "" || fd.Body == nil {
+				continue
+			}
+			for _, stmt := range fd.Body.List {
+				ret, ok := stmt.(*ast.ReturnStmt)
+				if !ok || len(ret.Results) != 1 {
+					continue
+				}
+				lit, ok := ret.Results[0].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				tableNames[structName] = strings.Trim(lit.Value, `"`)
+			}
+		}
+	}
+
+	// Pass 2: every struct type -> its table name (override or computed),
+	// plus every field's gorm tag scanned for uniqueIndex/unique coverage.
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			ts, ok := n.(*ast.TypeSpec)
+			if !ok {
+				return true
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok || st.Fields == nil {
+				return true
+			}
+			structName := ts.Name.Name
+			table, ok := tableNames[structName]
+			if !ok {
+				table = structNameToTable(structName)
+				tableNames[structName] = table
+			}
+			for _, field := range st.Fields.List {
+				if field.Tag == nil {
+					continue
+				}
+				tagVal := strings.Trim(field.Tag.Value, "`")
+				gormTag := extractStructTagValue(tagVal, "gorm")
+				if gormTag == "" || !gormTagHasUniqueness(gormTag) {
+					continue
+				}
+				column := extractGormColumnOverride(gormTag)
+				for _, name := range field.Names {
+					col := column
+					if col == "" {
+						col = gormColumnName(name.Name)
+					}
+					reg.add(table, col)
+				}
+				// Embedded/anonymous fields with a unique tag (none exist today, but
+				// don't silently drop coverage if one appears).
+				if len(field.Names) == 0 && column != "" {
+					reg.add(table, column)
+				}
+			}
+			return true
+		})
+	}
+	return tableNames
+}
+
+func recvTypeName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return recvTypeName(t.X)
+	}
+	return ""
+}
+
+// gormUniquenessRe matches the `uniqueIndex` (with or without :name/priority
+// options) or bare `unique` gorm tag options that mark a column as part of a
+// DB-level unique constraint.
+var gormUniquenessRe = regexp.MustCompile(`(^|;)(uniqueIndex\b|unique\b)`)
+
+func gormTagHasUniqueness(gormTag string) bool {
+	return gormUniquenessRe.MatchString(gormTag)
+}
+
+// extractStructTagValue pulls the value of one key out of a raw Go struct tag
+// string (e.g. `gorm:"not null;uniqueIndex" json:"name"` -> "not
+// null;uniqueIndex" for key "gorm"). Minimal hand-rolled parser (avoids
+// reflect.StructTag, which needs the tag as a real struct field to Get from);
+// good enough for this repo's tags, which are always `key:"value"` pairs
+// separated by single spaces with no escaped quotes inside gorm values.
+func extractStructTagValue(tag, key string) string {
+	re := regexp.MustCompile(key + `:"([^"]*)"`)
+	m := re.FindStringSubmatch(tag)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// extractGormColumnOverride pulls the column name out of a `column:xxx` gorm
+// tag option, if present.
+func extractGormColumnOverride(gormTag string) string {
+	for _, part := range strings.Split(gormTag, ";") {
+		if strings.HasPrefix(part, "column:") {
+			return strings.TrimPrefix(part, "column:")
+		}
+	}
+	return ""
+}
+
+// onTableColsRe finds a `... ON <table> (<cols>) ...` fragment within a
+// db.Exec(...) call's argument text.
+var onTableColsRe = regexp.MustCompile(`(?s)\bON\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(([^()]*(?:\([^()]*\)[^()]*)*)\)`)
+
+// scanFactoryForRuntimeIndexes scans internal/storage/factory.go's source
+// text for every `db.Exec(...)` call whose argument text builds a
+// `CREATE UNIQUE INDEX ... ON <table> (<cols>) ...` statement — this repo's
+// own pattern for adding a unique index to a table that might already hold
+// pre-existing duplicate rows, rather than a plain gorm struct tag (see the
+// package doc comment). Anchored on `db.Exec(` rather than the literal text
+// "UNIQUE INDEX" because every ensure*Index helper builds the SQL from the
+// shared `sqlCreateUniqueIdx` constant ("CREATE UNIQUE INDEX IF NOT EXISTS ")
+// concatenated with a table-specific suffix — the literal words "UNIQUE
+// INDEX" appear exactly once in the whole file, at that constant's
+// definition, not at each call site. Scanning db.Exec(...) call bodies (and
+// requiring EITHER the sqlCreateUniqueIdx identifier OR the literal "UNIQUE
+// INDEX" text to appear inside them, so ordinary ALTER TABLE / non-unique
+// CREATE INDEX Execs elsewhere in this migration file are correctly
+// excluded) works on raw source text rather than go/ast because the SQL
+// itself is just a Go string/string-concatenation expression, which go/ast
+// would hand back as opaque, individually-useless *ast.BasicLit fragments
+// anyway; scanning the literal text is both simpler and correctly
+// reassembles a multi-line `+`-concatenated statement.
+func scanFactoryForRuntimeIndexes(t *testing.T, factoryFile string, reg uniqueIndexRegistry) {
+	t.Helper()
+	b, err := os.ReadFile(factoryFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v", factoryFile, err)
+	}
+	src := string(b)
+
+	const execMarker = "db.Exec("
+	found := 0
+	for idx := strings.Index(src, execMarker); idx != -1; {
+		start := idx + len(execMarker)
+		windowEnd := start + 500
+		if windowEnd > len(src) {
+			windowEnd = len(src)
+		}
+		window := src[start:windowEnd]
+		// Stop the window at the end of this db.Exec(...) call so we never bleed
+		// into the NEXT statement's unrelated "ON ..." text.
+		if end := strings.Index(window, ").Error"); end != -1 {
+			window = window[:end]
+		}
+		if strings.Contains(window, "sqlCreateUniqueIdx") || strings.Contains(window, "UNIQUE INDEX") {
+			m := onTableColsRe.FindStringSubmatch(window)
+			if m != nil {
+				table := m[1]
+				cols := splitSQLColumns(m[2])
+				if len(cols) == 0 {
+					reg.add(table, "")
+				}
+				for _, c := range cols {
+					reg.add(table, c)
+				}
+				found++
+			}
+		}
+		next := strings.Index(src[idx+len(execMarker):], execMarker)
+		if next == -1 {
+			break
+		}
+		idx = idx + len(execMarker) + next
+	}
+	if found == 0 {
+		t.Fatalf("scanned %s for db.Exec(...) calls building a CREATE UNIQUE INDEX statement but extracted zero table/column pairs — the parsing regex is almost certainly broken, not that every runtime unique index was removed", factoryFile)
+	}
+}
+
+// sqlColumnRe pulls the bare column identifier out of a column expression
+// that may be wrapped in a SQL function call, e.g. "LOWER(email)" -> "email".
+var sqlColumnRe = regexp.MustCompile(`[a-zA-Z_][a-zA-Z0-9_]*`)
+
+func splitSQLColumns(raw string) []string {
+	var cols []string
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		// Take the LAST identifier in the expression (handles "LOWER(email)" and
+		// plain "email" uniformly; SQL function names like LOWER also match the
+		// identifier regex, so the last match is the actual column).
+		matches := sqlColumnRe.FindAllString(part, -1)
+		if len(matches) == 0 {
+			continue
+		}
+		cols = append(cols, matches[len(matches)-1])
+	}
+	return cols
+}
+
+// ---------------------------------------------------------------------------
+// Part 2: check-then-create call-site discovery.
+// ---------------------------------------------------------------------------
+
+type ctcSite struct {
+	File       string
+	Line       int
+	Func       string
+	CheckCall  string
+	CreateCall string
+	Model      string // resolved internal/storage/models struct name; "" if unresolved
+}
+
+func (s ctcSite) key() string {
+	return filepath.Base(s.File) + ":" + s.Func
+}
+
+// callSite is one Get*/Create* method call found in a function body, in
+// source order.
+type callSite struct {
+	pos  token.Pos
+	name string
+	call *ast.CallExpr
+}
+
+var getCallRe = regexp.MustCompile(`^Get[A-Z]`)
+
+func isCreateCallName(name string) bool {
+	return name == "Create" || (strings.HasPrefix(name, "Create") && len(name) > len("Create") && name[len("Create")] >= 'A' && name[len("Create")] <= 'Z')
+}
+
+// collectMethodCalls returns every `<x>.Name(...)` call within body, in
+// source-position order (descends into nested closures, e.g. a
+// db.Transaction(func(tx *gorm.DB) error {...}) callback, since the race this
+// test guards against is exactly as real inside one of those).
+func collectMethodCalls(body ast.Node) []callSite {
+	var calls []callSite
+	ast.Inspect(body, func(n ast.Node) bool {
+		ce, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := ce.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		calls = append(calls, callSite{pos: ce.Pos(), name: sel.Sel.Name, call: ce})
+		return true
+	})
+	sort.Slice(calls, func(i, j int) bool { return calls[i].pos < calls[j].pos })
+	return calls
+}
+
+// containsWordSequence reports whether needle appears as a contiguous run
+// within haystack (both already split into camelCase words).
+func containsWordSequence(haystack, needle []string) bool {
+	if len(needle) == 0 || len(needle) > len(haystack) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j, w := range needle {
+			if haystack[i+j] != w {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// discoverCheckThenCreateSites walks every non-test .go file directly under
+// each of dirs and returns every discovered check-then-create call site.
+func discoverCheckThenCreateSites(t *testing.T, fset *token.FileSet, dirs ...string) []ctcSite {
+	t.Helper()
+	var sites []ctcSite
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("reading %s: %v", dir, err)
+		}
+		for _, e := range entries {
+			name := e.Name()
+			if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			path := filepath.Join(dir, name)
+			f, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				t.Fatalf("parsing %s: %v", path, err)
+			}
+			sites = append(sites, findSitesInFile(fset, f, path)...)
+		}
+	}
+	return sites
+}
+
+func findSitesInFile(fset *token.FileSet, f *ast.File, path string) []ctcSite {
+	var sites []ctcSite
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		calls := collectMethodCalls(fn.Body)
+
+		for ci := len(calls) - 1; ci >= 0; ci-- {
+			create := calls[ci]
+			if !isCreateCallName(create.name) {
+				continue
+			}
+			model := resolveEntityModel(create.call, fn)
+
+			var stemWords []string
+			if create.name != "Create" {
+				stemWords = splitCamel(strings.TrimPrefix(create.name, "Create"))
+			} else if model != "" {
+				stemWords = splitCamel(model)
+			}
+			if len(stemWords) == 0 {
+				continue
+			}
+
+			// Nearest preceding Get* call whose name contains stemWords as a
+			// contiguous run.
+			var matched *callSite
+			for pi := ci - 1; pi >= 0; pi-- {
+				prev := calls[pi]
+				if prev.pos >= create.pos || !getCallRe.MatchString(prev.name) {
+					continue
+				}
+				checkWords := splitCamel(strings.TrimPrefix(prev.name, "Get"))
+				if containsWordSequence(checkWords, stemWords) {
+					matched = &calls[pi]
+					break
+				}
+			}
+			if matched == nil {
+				continue
+			}
+
+			pos := fset.Position(create.pos)
+			sites = append(sites, ctcSite{
+				File:       path,
+				Line:       pos.Line,
+				Func:       fn.Name.Name,
+				CheckCall:  matched.name,
+				CreateCall: create.name,
+				Model:      model,
+			})
+		}
+	}
+	return sites
+}
+
+// resolveEntityModel finds the internal/storage/models struct type of
+// create's target row by tracing its arguments: a composite literal
+// (`&models.X{...}` or `models.X{...}`) either inline in the call, or
+// assigned to a variable (function parameter, `:=`, or `var`) earlier in fn.
+func resolveEntityModel(call *ast.CallExpr, fn *ast.FuncDecl) string {
+	for _, arg := range call.Args {
+		if name := modelTypeOfExpr(arg, fn); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func modelTypeOfExpr(expr ast.Expr, fn *ast.FuncDecl) string {
+	switch e := expr.(type) {
+	case *ast.UnaryExpr:
+		if e.Op == token.AND {
+			return modelTypeOfExpr(e.X, fn)
+		}
+	case *ast.CompositeLit:
+		return modelsSelectorName(e.Type)
+	case *ast.Ident:
+		if fn.Type.Params != nil {
+			for _, field := range fn.Type.Params.List {
+				for _, n := range field.Names {
+					if n.Name == e.Name {
+						if name := modelsSelectorNameFromTypeExpr(field.Type); name != "" {
+							return name
+						}
+					}
+				}
+			}
+		}
+		found := ""
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			if found != "" {
+				return false
+			}
+			switch s := n.(type) {
+			case *ast.AssignStmt:
+				for i, lhs := range s.Lhs {
+					id, ok := lhs.(*ast.Ident)
+					if !ok || id.Name != e.Name || i >= len(s.Rhs) {
+						continue
+					}
+					if name := modelTypeOfExpr(s.Rhs[i], fn); name != "" {
+						found = name
+					}
+				}
+			case *ast.ValueSpec:
+				for i, id := range s.Names {
+					if id.Name != e.Name {
+						continue
+					}
+					if s.Type != nil {
+						if name := modelsSelectorNameFromTypeExpr(s.Type); name != "" {
+							found = name
+						}
+					} else if i < len(s.Values) {
+						if name := modelTypeOfExpr(s.Values[i], fn); name != "" {
+							found = name
+						}
+					}
+				}
+			}
+			return found == ""
+		})
+		return found
+	}
+	return ""
+}
+
+func modelsSelectorNameFromTypeExpr(t ast.Expr) string {
+	if star, ok := t.(*ast.StarExpr); ok {
+		t = star.X
+	}
+	return modelsSelectorName(t)
+}
+
+func modelsSelectorName(t ast.Expr) string {
+	sel, ok := t.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	pkgIdent, ok := sel.X.(*ast.Ident)
+	if !ok || pkgIdent.Name != "models" {
+		return ""
+	}
+	return sel.Sel.Name
+}
+
+// ---------------------------------------------------------------------------
+// Part 3: allowlist + the test itself.
+// ---------------------------------------------------------------------------
+
+// checkThenCreateAllowlist is the exhaustive, reasoned list of check-then-
+// create sites that are deliberately NOT backed by a database-level unique
+// index. Empty today: every check-then-create site this heuristic currently
+// discovers on main is already index-backed (that's the negative control —
+// #117/#121/#136/#305/#309/#313/#462/MT-006 are all fixed). Add an entry only
+// for a genuinely reasoned exception (e.g. a natural key intentionally
+// enforced by an application-level lock instead of a DB constraint — see the
+// false-negative/false-positive discussion in this file's package doc
+// comment for why that combination is NOT something this heuristic can
+// verify on its own, so an allowlist entry for it needs a human-checked
+// reason, not just "the check exists").
+var checkThenCreateAllowlist = map[string]string{
+	// "<file basename>:<enclosing func name>": "reason",
+}
+
+func TestCheckThenCreateSitesAreUniqueIndexBacked(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed — cannot locate sibling packages relative to this test file")
+	}
+	storeDir := filepath.Dir(thisFile)
+	storageDir := filepath.Join(storeDir, "..")
+	modelsDir := filepath.Join(storageDir, "models")
+	factoryFile := filepath.Join(storageDir, "factory.go")
+	coreDir := filepath.Join(storeDir, "..", "..", "core")
+
+	registry, tableNames := buildUniqueIndexRegistry(t, modelsDir, factoryFile)
+
+	fset := token.NewFileSet()
+	sites := discoverCheckThenCreateSites(t, fset, coreDir, storeDir)
+
+	if len(sites) == 0 {
+		t.Fatal("discovered zero check-then-create sites across internal/core and internal/storage/store — the AST walk is almost certainly broken (CreateSecret/GetSecretByName in internal/core/secrets.go alone should match), not that every check-then-create pattern was rewritten away")
+	}
+
+	var violations []string
+	var unresolved []string
+	for _, s := range sites {
+		if s.Model == "" {
+			unresolved = append(unresolved, formatSite(s)+" (model type not statically resolved)")
+			continue
+		}
+		table, ok := tableNames[s.Model]
+		if !ok {
+			table = structNameToTable(s.Model)
+		}
+		if registry.hasAnyUniqueIndex(table) {
+			continue
+		}
+		if reason, ok := checkThenCreateAllowlist[s.key()]; ok {
+			t.Logf("allowlisted check-then-create site %s (table %q has no unique index): %s", formatSite(s), table, reason)
+			continue
+		}
+		violations = append(violations, formatSite(s)+
+			": model "+s.Model+" / table "+table+" has NO unique index (gorm uniqueIndex tag or factory.go ensure*Index)")
+	}
+	sort.Strings(violations)
+	sort.Strings(unresolved)
+
+	if len(unresolved) > 0 {
+		t.Logf("%d check-then-create site(s) found but their model type could not be statically resolved (skipped, not failed — see false-negative note in this file's doc comment):\n%s",
+			len(unresolved), strings.Join(unresolved, "\n"))
+	}
+
+	if len(violations) > 0 {
+		t.Errorf("found %d check-then-create site(s) (existence check via a Get*-shaped call, followed by a Create call) whose target model's table has NO database-level unique index, and which are not in checkThenCreateAllowlist:\n%s\n"+
+			"Two concurrent callers can both pass the check before either commits, creating duplicate rows for what should be a unique natural key (this repo's own history: #117/#121/#136/#305/#309/#313/#462/MT-006). "+
+			"Fix by adding a unique index — either a `uniqueIndex` gorm struct tag in internal/storage/models/models.go (safe only for a table that can never already hold duplicates), or, for an existing table, a runtime "+
+			"ensure<X>Index helper in internal/storage/factory.go following the warnIfDuplicatesExist + partial-unique-index pattern the fixes above all use — then translate the resulting constraint violation into a clean "+
+			"sentinel error at the storage layer. If this site is a deliberate, reasoned exception, add it to checkThenCreateAllowlist with a comment explaining why.",
+			len(violations), strings.Join(violations, "\n"))
+	}
+}
+
+func formatSite(s ctcSite) string {
+	return filepath.Base(s.File) + ":" + strconv.Itoa(s.Line) + " " + s.Func + "() [" + s.CheckCall + " -> " + s.CreateCall + "]"
+}

--- a/internal/storage/store/checkthencreate_race_synthetic_test.go
+++ b/internal/storage/store/checkthencreate_race_synthetic_test.go
@@ -1,0 +1,128 @@
+// checkthencreate_race_synthetic_test.go — positive control for
+// checkthencreate_race_completeness_test.go: proves the detector actually
+// catches the unguarded check-then-create shape (not just that it passes
+// vacuously against main, where every real site happens to already be
+// fixed) by running it against a minimal synthetic source snippet that
+// reproduces the bug pattern, both without and with a backing unique index.
+package store
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// syntheticCheckThenCreateSrc reproduces the exact shape this repo's own
+// history hit repeatedly (#117/#121/#136/#305/#309/#313/#462/MT-006): an
+// existence check via a Get<Entity>By<Key>-shaped call, immediately followed
+// by a Create<Entity> call building the row from a models.X composite
+// literal. Syntactically self-contained — go/parser only needs valid syntax,
+// not a resolvable "models" import, so this never touches the real package.
+const syntheticCheckThenCreateSrc = `package synthetic
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+type fakeStorage struct{}
+
+func (s *fakeStorage) GetWidgetByName(ctx context.Context, name string) (*models.Widget, error) {
+	return nil, nil
+}
+
+func (s *fakeStorage) CreateWidget(ctx context.Context, w *models.Widget) (*models.Widget, error) {
+	return w, nil
+}
+
+// CreateWidgetIfMissing is the unguarded check-then-create shape: two
+// concurrent callers can both pass the GetWidgetByName check before either
+// commits the CreateWidget insert, unless widgets carries a DB-level unique
+// index on name.
+func CreateWidgetIfMissing(ctx context.Context, s *fakeStorage, name string) (*models.Widget, error) {
+	existing, err := s.GetWidgetByName(ctx, name)
+	if err == nil && existing != nil {
+		return nil, fmt.Errorf("widget %q already exists", name)
+	}
+	w := &models.Widget{Name: name}
+	return s.CreateWidget(ctx, w)
+}
+`
+
+func parseSynthetic(t *testing.T) (*token.FileSet, []ctcSite) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "synthetic.go", syntheticCheckThenCreateSrc, 0)
+	if err != nil {
+		t.Fatalf("parsing synthetic source: %v", err)
+	}
+	sites := findSitesInFile(fset, f, "synthetic.go")
+	return fset, sites
+}
+
+// TestCheckThenCreate_SyntheticSite_IsDiscovered proves discoverCheckThenCreateSites'
+// underlying per-file scan (findSitesInFile) actually recognizes the
+// check-then-create shape at all: without this, a bug in the AST walk could
+// make the real completeness test above pass vacuously (zero sites found ==
+// zero violations, for the wrong reason).
+func TestCheckThenCreate_SyntheticSite_IsDiscovered(t *testing.T) {
+	_, sites := parseSynthetic(t)
+	if len(sites) != 1 {
+		t.Fatalf("expected exactly 1 check-then-create site in the synthetic fixture, got %d: %+v", len(sites), sites)
+	}
+	got := sites[0]
+	if got.Func != "CreateWidgetIfMissing" {
+		t.Errorf("Func = %q, want CreateWidgetIfMissing", got.Func)
+	}
+	if got.CheckCall != "GetWidgetByName" {
+		t.Errorf("CheckCall = %q, want GetWidgetByName", got.CheckCall)
+	}
+	if got.CreateCall != "CreateWidget" {
+		t.Errorf("CreateCall = %q, want CreateWidget", got.CreateCall)
+	}
+	if got.Model != "Widget" {
+		t.Errorf("Model = %q, want Widget (resolved from the &models.Widget{} composite literal, not the method name)", got.Model)
+	}
+}
+
+// TestCheckThenCreate_SyntheticSite_FlaggedWhenUnindexed is the actual
+// negative-case proof: feed the synthetic site's resolved model into a
+// registry that has NO unique index for "widgets" (reproducing the exact
+// pre-fix state of, e.g., secret_nodes before MT-006, or legal_holds before
+// #305) and confirm the guard's own pass/fail predicate — hasAnyUniqueIndex —
+// says "unguarded", i.e. this site WOULD fail TestCheckThenCreateSitesAreUniqueIndexBacked.
+func TestCheckThenCreate_SyntheticSite_FlaggedWhenUnindexed(t *testing.T) {
+	_, sites := parseSynthetic(t)
+	if len(sites) != 1 {
+		t.Fatalf("expected exactly 1 check-then-create site, got %d", len(sites))
+	}
+	registry := uniqueIndexRegistry{} // deliberately empty: "widgets" has no unique index anywhere
+	table := structNameToTable(sites[0].Model)
+	if table != "widgets" {
+		t.Fatalf("structNameToTable(%q) = %q, want widgets", sites[0].Model, table)
+	}
+	if registry.hasAnyUniqueIndex(table) {
+		t.Fatal("expected hasAnyUniqueIndex(widgets) to be false against an empty registry — the positive control is broken")
+	}
+}
+
+// TestCheckThenCreate_SyntheticSite_PassesWhenIndexed is the corresponding
+// positive case: the same site, but the registry now carries a unique index
+// on widgets.name (as if a `uniqueIndex` gorm tag or a factory.go
+// ensure*Index helper had been added, mirroring every real fix in this
+// repo's history) — confirms the guard does NOT flag a properly-fixed site,
+// i.e. it isn't trivially failing on everything.
+func TestCheckThenCreate_SyntheticSite_PassesWhenIndexed(t *testing.T) {
+	_, sites := parseSynthetic(t)
+	if len(sites) != 1 {
+		t.Fatalf("expected exactly 1 check-then-create site, got %d", len(sites))
+	}
+	registry := uniqueIndexRegistry{}
+	table := structNameToTable(sites[0].Model)
+	registry.add(table, "name")
+	if !registry.hasAnyUniqueIndex(table) {
+		t.Fatal("expected hasAnyUniqueIndex(widgets) to be true once a unique index on widgets.name is registered")
+	}
+}

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -249,7 +249,7 @@ func (ls *LocalStorage) GetUserRoleScopes(ctx context.Context, userID uint) ([]s
 	if err := ls.db.WithContext(ctx).Model(&models.UserRole{}).
 		Select("project_id, environment_id").
 		Where("user_id = ?", userID).
-		Where("expires_at IS NULL OR expires_at > ?", time.Now().UTC()).
+		Where(sqlWhereURNotExpired, time.Now().UTC()).
 		Group("project_id, environment_id").
 		Scan(&direct).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -358,6 +358,7 @@ func (ls *LocalStorage) ListGlobalAdminAssignmentsForUpdate(ctx context.Context,
 	}
 	var userRows []models.UserRole
 	if err := userQ.Where("project_id = 0 AND environment_id = 0 AND role_id IN ?", adminRoleIDs).
+		Where(sqlWhereURNotExpired, time.Now().UTC()).
 		Find(&userRows).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
@@ -374,6 +375,7 @@ func (ls *LocalStorage) ListGlobalAdminAssignmentsForUpdate(ctx context.Context,
 	}
 	var groupRows []models.GroupRole
 	if err := groupQ.Where("project_id = 0 AND environment_id = 0 AND role_id IN ?", adminRoleIDs).
+		Where(sqlWhereGRNotExpired, time.Now().UTC()).
 		Find(&groupRows).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
@@ -447,7 +449,7 @@ func (ls *LocalStorage) IsProjectMember(ctx context.Context, userID, projectID u
 	var direct int64
 	if err := ls.db.WithContext(ctx).Model(&models.UserRole{}).
 		Where("user_id = ? AND project_id = ?", userID, projectID).
-		Where("expires_at IS NULL OR expires_at > ?", now).
+		Where(sqlWhereURNotExpired, now).
 		Count(&direct).Error; err != nil {
 		return false, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
@@ -620,12 +622,18 @@ func (ls *LocalStorage) GetGroupRoleGrants(ctx context.Context, groupID uint) ([
 	return grants, nil
 }
 
-// ListGroupRoleAssignments returns every role grant held by groupID across all
+// ListGroupRoleAssignments returns every LIVE role grant held by groupID across all
 // scopes, unlike GetGroupRoles/GetGroupRoleGrants which return the role but not
-// which scope it was granted at.
+// which scope it was granted at. Excludes expired grants -- matching every other
+// role-lookup function in this file -- since callers (validateGroupJoinRoles's
+// SoD/escalation checks, the admin group-roles view) treat this as "what does the
+// group currently confer," not a historical record.
 func (ls *LocalStorage) ListGroupRoleAssignments(ctx context.Context, groupID uint) ([]storage.RoleAssignment, error) {
 	var rows []models.GroupRole
-	if err := ls.db.WithContext(ctx).Where("group_id = ?", groupID).Find(&rows).Error; err != nil {
+	if err := ls.db.WithContext(ctx).
+		Where("group_id = ?", groupID).
+		Where(sqlWhereGRNotExpired, time.Now().UTC()).
+		Find(&rows).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	out := make([]storage.RoleAssignment, 0, len(rows))
@@ -700,7 +708,7 @@ func (ls *LocalStorage) assignGroupRole(ctx context.Context, groupID, roleID uin
 // non-NULL and at or before the cutoff, returning the removed grants so the caller
 // can audit each expiry. Runs in a transaction so the rows it reports are exactly
 // the rows it deleted.
-func (ls *LocalStorage) DeleteExpiredRoleGrants(ctx context.Context, before time.Time) ([]storage.RoleAssignment, error) { // NOSONAR -- cognitive complexity 19, suppress go:S3776
+func (ls *LocalStorage) DeleteExpiredRoleGrants(ctx context.Context, before time.Time) ([]storage.RoleAssignment, error) { // NOSONAR -- cognitive complexity 19, suppress go:S3776 // nosemgrep: keyorix-role-grant-query-missing-expiry-filter -- this IS the expiry sweep job; it intentionally selects expired rows to delete them
 	cutoff := before.UTC()
 	var removed []storage.RoleAssignment
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {

--- a/internal/storage/store/local_role_expiry.go
+++ b/internal/storage/store/local_role_expiry.go
@@ -12,7 +12,7 @@ import (
 // ListExpiringUserRoles returns every UserRole whose ExpiresAt is non-nil and
 // before the given cutoff. Grants that have already expired (ExpiresAt in the
 // past) are included so the critical-window check can catch them too.
-func (ls *LocalStorage) ListExpiringUserRoles(ctx context.Context, before time.Time) ([]models.UserRole, error) {
+func (ls *LocalStorage) ListExpiringUserRoles(ctx context.Context, before time.Time) ([]models.UserRole, error) { // nosemgrep: keyorix-role-grant-query-missing-expiry-filter -- this IS the expiry-notification query; it intentionally includes already-expired grants (see doc comment above)
 	var grants []models.UserRole
 	return grants, ls.db.WithContext(ctx).
 		Where("expires_at IS NOT NULL AND expires_at < ?", before).

--- a/server/http/handlers/admin_billing.go
+++ b/server/http/handlers/admin_billing.go
@@ -80,7 +80,7 @@ func (h *AdminBillingHandler) GetBillingReport(w http.ResponseWriter, r *http.Re
 	report, err := h.coreService.GenerateBillingReport(r.Context(), from, to, projectIDs)
 	if err != nil {
 		log.Printf("GetBillingReport: %v", err)
-		sendError(w, "InternalError", err.Error(), http.StatusInternalServerError, nil)
+		sendError(w, "InternalError", clientSafe(err), http.StatusInternalServerError, nil)
 		return
 	}
 	sendSuccess(w, report, "")

--- a/server/http/handlers/webauthn.go
+++ b/server/http/handlers/webauthn.go
@@ -267,7 +267,7 @@ func (h *AuthHandler) FinishWebAuthnPasswordlessLogin(w http.ResponseWriter, r *
 // writeWebAuthnErr maps a core error to an HTTP status: disabled → 501, else 400.
 func (h *AuthHandler) writeWebAuthnErr(w http.ResponseWriter, err error) {
 	if errors.Is(err, core.ErrWebAuthnDisabled) {
-		sendError(w, "NotImplemented", err.Error(), http.StatusNotImplemented, nil)
+		sendError(w, "NotImplemented", err.Error(), http.StatusNotImplemented, nil) // nosemgrep: keyorix-raw-error-to-client -- ErrWebAuthnDisabled is a fixed sentinel with a known-safe message, not a raw backend/driver error
 		return
 	}
 	sendError(w, "Error", err.Error(), http.StatusBadRequest, nil)


### PR DESCRIPTION
## Summary
Follow-up to the local-scanner rollout (#1348): mined the adversarial-review campaign's fix history for bug classes that recurred 3+ times with a clean, mechanically-checkable shape, and built a detector for each.

**4 new Semgrep rules** in `.semgrep/keyorix-rules.yml` (all validated zero-noise on current `main`, positive-controlled against each bug class's real pre-fix commit):
- `keyorix-json-unmarshal-fail-open` — a stored JSON restriction/scope column that fails to parse returns `nil`, read downstream as "unrestricted" instead of failing closed (PAT-scope / machine-CIDR bug shape).
- `keyorix-raw-error-to-client` — a raw error's `.Error()` text reaches a client response verbatim on an HTTP 5xx path or any gRPC `status.Error` call (CWE-209).
- `keyorix-role-grant-query-missing-expiry-filter` — a `user_roles`/`group_roles` query missing the not-expired filter its sibling functions apply, so an expired JIT grant reads back as live.
- `keyorix-unbounded-bulk-slice-param` — a core function taking a caller-supplied slice with no length cap, one DB round trip per item (CWE-400).

Plus **2 more tools** from the same pass:
- `keyorix-new-remotestorage-unsupported-stub` (Semgrep, INFO) — a structural nudge on every `RemoteStorage` stub method, old and new, pointing a new one at the existing `TestRemoteUnsupportedStubsAreAllowlisted` hard gate. Matches all 72 current stub sites with zero noise.
- `checkthencreate_race_completeness_test.go` / `checkthencreate_race_synthetic_test.go` — a Go-AST-based regression guard for the check-then-create TOCTOU class (missing DB-level unique index behind an existence-check-then-create), following the same discovery convention as the RemoteStorage guard. Currently zero violations, empty allowlist.

## Bugs the new rules found and fixed here
- `internal/storage/store/local_rbac.go`: `ListGlobalAdminAssignmentsForUpdate` and `ListGroupRoleAssignments` were missing the expiry filter their siblings already apply. The former backs the "don't strand the last admin" guard — an expired admin grant could let the actual last live admin be removed while the guard believed another admin still existed. Two more sites used an inline literal instead of the shared constant; switched to it.
- `server/http/handlers/admin_billing.go`: `GetBillingReport`'s 500 path leaked a raw backend error to the client.
- `internal/core/scim_groups.go`: `ProvisionSCIMGroup`/`ReplaceSCIMGroup`/`PatchSCIMGroup` accepted an unbounded SCIM member-id list, one `GetUser` round trip per id — added `maxSCIMGroupMembersPerCall`.
- `internal/core/users.go`: `CreateUserWithAssignments` accepted an unbounded project-assignments list feeding a per-role SoD check — added `maxUserCreateAssignments`.

Remaining rule hits were confirmed-safe (internal-computation slices, a cleanup job intentionally selecting expired rows, a known-safe sentinel error) and annotated with `// nosemgrep: <rule-id> -- <reason>`.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/core/... ./internal/storage/store/...` — full pass
- [x] `gosec -severity medium -exclude-generated` on all touched packages — 0 issues
- [x] Each Semgrep rule validated: zero findings on current `main`, fires on the real pre-fix commit for its bug class (positive control)
- [x] `checkthencreate_race_completeness_test.go` — all 4 tests pass, including a synthetic positive control proving the detector isn't vacuous