### PR TITLE
fix(sonar): dedupe JSON content-type, extract nested ternary, parameterize tests

### DIFF
--- a/internal/k8ssync/rest_sink.go
+++ b/internal/k8ssync/rest_sink.go
@@ -33,6 +33,8 @@ type RESTSink struct {
 const (
 	saTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" // #nosec G101 -- well-known k8s path, not a credential
 	saCAPath    = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+	contentTypeJSON = "application/json"
 )
 
 // maxResponseBodyBytes (keyorix_fetcher.go) caps how much of a single Kubernetes
@@ -196,7 +198,7 @@ func (s *RESTSink) createSecret(ctx context.Context, namespace, name string, pay
 		return fmt.Errorf("marshal secret %s/%s: %w", namespace, name, err)
 	}
 	path := fmt.Sprintf("/api/v1/namespaces/%s/secrets", url.PathEscape(namespace))
-	req, err := s.newRequest(ctx, http.MethodPost, path, "application/json", bytes.NewReader(raw))
+	req, err := s.newRequest(ctx, http.MethodPost, path, contentTypeJSON, bytes.NewReader(raw))
 	if err != nil {
 		return err
 	}
@@ -301,7 +303,7 @@ func (s *RESTSink) Delete(ctx context.Context, namespace, name string) error {
 	if err != nil {
 		return fmt.Errorf("marshal delete options %s/%s: %w", namespace, name, err)
 	}
-	req, err := s.newRequest(ctx, http.MethodDelete, s.secretPath(namespace, name), "application/json", bytes.NewReader(raw))
+	req, err := s.newRequest(ctx, http.MethodDelete, s.secretPath(namespace, name), contentTypeJSON, bytes.NewReader(raw))
 	if err != nil {
 		return err
 	}
@@ -372,7 +374,7 @@ func (s *RESTSink) newRequest(ctx context.Context, method, path, contentType str
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 	r.Header.Set("Authorization", "Bearer "+s.token)
-	r.Header.Set("Accept", "application/json")
+	r.Header.Set("Accept", contentTypeJSON)
 	if contentType != "" {
 		r.Header.Set("Content-Type", contentType)
 	}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,6 +6,21 @@ sonar.organization=keyorixhq
 # "There are problems with file encoding" warning.
 sonar.sourceEncoding=UTF-8
 
+# Pin the Python version analyzed by SonarPython to match the interpreter CI
+# actually runs (.github/workflows/sonarcloud.yml pins python-version: '3.14'
+# for the mutation-testing coverage step). Without this, Sonar analyzes
+# scripts/mutation-testing/*.py as compatible with every Python 3.x version,
+# which is less precise than pinning to the one version that's ever run.
+sonar.python.version=3.14
+
+# scripts/mutation-testing/summarize_test.py is the only pytest test file in
+# the repo; without sonar.tests configured, SonarPython flags it as
+# test-shaped code analyzed under production-code rules. Point sonar.tests at
+# just this file (not the whole scripts/mutation-testing/ directory) so its
+# sibling summarize.py stays classified as production source and keeps
+# getting production-code rules.
+sonar.tests=scripts/mutation-testing/summarize_test.py
+
 # Completely exclude files that should never be analyzed by any SonarCloud
 # language plugin. This is separate from sonar.coverage.exclusions, which only
 # hides files from the coverage panel but still lets language analyzers run.

--- a/web/src/features/secrets/__tests__/useSecretReveal.test.ts
+++ b/web/src/features/secrets/__tests__/useSecretReveal.test.ts
@@ -158,7 +158,12 @@ describe('useSecretReveal', () => {
 
         const { result } = renderHook(() => useSecretReveal());
 
+        // Sonar flags this as a redundant act() call, but it isn't: handleCopySecretValue
+        // sets copyingSecretId synchronously before its first await, and without this
+        // wrapper React 18's act-environment defers that flush past the assertion below
+        // (verified: removing the wrapper makes the next expect() read null, not 11).
         act(() => {
+            // NOSONAR: not redundant, see comment above
             void result.current.handleCopySecretValue(secret);
         });
 

--- a/web/src/pages/integrations/KeyorixConnectPage.tsx
+++ b/web/src/pages/integrations/KeyorixConnectPage.tsx
@@ -138,6 +138,8 @@ const FederatedReadPanel: React.FC = () => {
         setTimeout(() => setCopied(false), 1500);
     };
 
+    const maskLength = value != null ? Math.min(value.length, 40) : 24;
+
     return (
         <form onSubmit={submit} className="space-y-4">
             <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
@@ -221,9 +223,7 @@ const FederatedReadPanel: React.FC = () => {
                         </div>
                     </div>
                     <code className="block break-all font-mono text-sm" style={{ color: 'var(--text-primary)' }}>
-                        {revealed && value != null
-                            ? value
-                            : '•'.repeat(value != null ? Math.min(value.length, 40) : 24)}
+                        {revealed && value != null ? value : '•'.repeat(maskLength)}
                     </code>
                 </div>
             )}

--- a/web/src/utils/__tests__/routing.test.ts
+++ b/web/src/utils/__tests__/routing.test.ts
@@ -45,24 +45,18 @@ describe('storeIntendedRoute', () => {
         expect(getAndClearIntendedRoute()).toBeNull();
     });
 
-    it('does not store any /auth-prefixed route', () => {
-        storeIntendedRoute('/auth/callback');
+    it.each([
+        ['an /auth-prefixed route', '/auth/callback'],
+        ['a protocol-relative path (open-redirect defense-in-depth)', '//evil.example/x'],
+        ['a backslash-leading path (some browsers treat "/\\" as protocol-relative too)', '/\\evil.example/x'],
+    ])('does not store %s', (_description, path) => {
+        storeIntendedRoute(path);
         expect(getAndClearIntendedRoute()).toBeNull();
     });
 
     it('stores an ordinary path', () => {
         storeIntendedRoute('/projects/42/secrets');
         expect(getAndClearIntendedRoute()).toBe('/projects/42/secrets');
-    });
-
-    it('does not store a protocol-relative path (open-redirect defense-in-depth)', () => {
-        storeIntendedRoute('//evil.example/x');
-        expect(getAndClearIntendedRoute()).toBeNull();
-    });
-
-    it('does not store a backslash-leading path (some browsers treat "/\\" as protocol-relative too)', () => {
-        storeIntendedRoute('/\\evil.example/x');
-        expect(getAndClearIntendedRoute()).toBeNull();
     });
 });
 


### PR DESCRIPTION
## Summary
- `internal/k8ssync/rest_sink.go`: extract a `contentTypeJSON` constant to remove the 3x duplicated `"application/json"` literal (Sonar: design/maintainability).
- `KeyorixConnectPage.tsx`: extract the nested ternary computing the masked-value placeholder length into a `maskLength` variable.
- `routing.test.ts`: collapse 3 structurally-identical "rejects a bad path" tests into a single `it.each` parameterized test.
- `useSecretReveal.test.ts`: Sonar's "redundant `act()`" suggestion at this call site is a false positive — removing it makes the test read `null` instead of `11`, since `handleCopySecretValue` sets state synchronously before its first `await` and needs the flush. Documented with a `NOSONAR` + explanatory comment instead of applying the literal but incorrect fix.
- `sonar-project.properties`: pin `sonar.python.version` to 3.14 (matches CI's pin in `sonarcloud.yml`) and point `sonar.tests` at the repo's one pytest file (`scripts/mutation-testing/summarize_test.py`) so SonarPython stops flagging "tests not configured" — without reclassifying its sibling `summarize.py` as test code.

## Test plan
- [x] `go build ./internal/k8ssync/...`, `go vet`, `go test` — all pass
- [x] `pnpm type-check`, `pnpm lint`, `pnpm format:check` — all pass
- [x] `pnpm test --run` — full suite, 2940 tests pass