### PR TITLE
fix(mutation-testing): cap GOMAXPROCS per worker to stop CPU oversubscription

### DIFF
--- a/internal/core/core_s26_test.go
+++ b/internal/core/core_s26_test.go
@@ -174,6 +174,115 @@ func TestUpdateUser_StorageError(t *testing.T) {
 	require.Error(t, err)
 }
 
+// ── users.go — UpdateUser IsActive TOCTOU (the StateTransitionMissingCAS fix) ──
+//
+// UpdateUser is a general-purpose multi-field update, so only requests that
+// explicitly touch IsActive (req.IsActive != nil) need CAS protection — these
+// tests prove (a) such requests route through
+// storage.Storage.UpdateUserIfActiveStateMatches instead of the plain
+// UpdateUser, in BOTH the deactivating and non-deactivating branches, (b) a
+// lost race (matched=false) surfaces as ErrUserActiveStateConflict rather
+// than being silently retried or ignored, and — mirroring #388's "second
+// racing transition" test — that losing the race skips the deactivating
+// branch's session/PAT revocation side effects, and (c) a plain field-only
+// update (no IsActive in the request) is completely unaffected: it still
+// goes through the unconditional plain UpdateUser path, exactly as before.
+
+// TestUpdateUser_Reactivate_UsesConditionalPath verifies a non-deactivating
+// IsActive assertion (re-activating an inactive user) is routed through
+// UpdateUserIfActiveStateMatches, not the plain UpdateUser.
+func TestUpdateUser_Reactivate_UsesConditionalPath(t *testing.T) {
+	ms := new(MockStorage)
+	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", IsActive: false}
+	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
+	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
+		return u.ID == 1 && u.IsActive
+	}), false).Return(true, nil)
+	c := NewKeyorixCore(ms)
+	active := true
+	u, err := c.UpdateUser(context.Background(), &UpdateUserRequest{ID: 1, IsActive: &active})
+	require.NoError(t, err)
+	assert.True(t, u.IsActive)
+	ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+}
+
+// TestUpdateUser_RedundantSameValueAssertion_UsesConditionalPath verifies that
+// even a "set to the same value it already is" IsActive assertion (wasActive
+// == the requested value, so deactivating is false) still routes through the
+// conditional path — the caller explicitly cares about this field either way.
+func TestUpdateUser_RedundantSameValueAssertion_UsesConditionalPath(t *testing.T) {
+	ms := new(MockStorage)
+	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", IsActive: true}
+	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
+	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
+		return u.ID == 1 && u.IsActive
+	}), true).Return(true, nil)
+	c := NewKeyorixCore(ms)
+	active := true
+	u, err := c.UpdateUser(context.Background(), &UpdateUserRequest{ID: 1, IsActive: &active})
+	require.NoError(t, err)
+	assert.True(t, u.IsActive)
+	ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+}
+
+// TestUpdateUser_Reactivate_LostRace_ReturnsConflictError proves the
+// non-deactivating branch's race is closed: a concurrent write that already
+// moved is_active away from the value this call observed must surface as
+// ErrUserActiveStateConflict, not be silently retried or dropped.
+func TestUpdateUser_Reactivate_LostRace_ReturnsConflictError(t *testing.T) {
+	ms := new(MockStorage)
+	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", IsActive: false}
+	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
+	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
+		return u.ID == 1 && u.IsActive
+	}), false).Return(false, nil)
+	c := NewKeyorixCore(ms)
+	active := true
+	_, err := c.UpdateUser(context.Background(), &UpdateUserRequest{ID: 1, IsActive: &active})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUserActiveStateConflict), "expected ErrUserActiveStateConflict, got: %v", err)
+}
+
+// TestUpdateUser_Deactivate_LostRace_ReturnsConflictError proves the
+// deactivating branch (inside WithTransaction) closes the same race, and that
+// losing it skips PAT revocation / session deletion — the loser must not
+// apply any part of its write, not just IsActive.
+func TestUpdateUser_Deactivate_LostRace_ReturnsConflictError(t *testing.T) {
+	ms := new(MockStorage)
+	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", IsActive: true}
+	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
+	ms.On("ListSessionTokenHashesForUser", mock.Anything, uint(1)).Return([]string{}, nil)
+	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
+		return u.ID == 1 && !u.IsActive
+	}), true).Return(false, nil)
+	c := NewKeyorixCore(ms)
+	inactive := false
+	_, err := c.UpdateUser(context.Background(), &UpdateUserRequest{ID: 1, IsActive: &inactive})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUserActiveStateConflict), "expected ErrUserActiveStateConflict, got: %v", err)
+	ms.AssertNotCalled(t, "RevokeAllPersonalAccessTokensForUser", mock.Anything, mock.Anything)
+	ms.AssertNotCalled(t, "DeleteSessionsForUserExcept", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestUpdateUser_PlainFieldUpdate_DoesNotUseActiveStateConditionalPath proves
+// a plain field-only update (no IsActive in the request) is completely
+// unaffected by this fix: it still persists via the unconditional plain
+// UpdateUser, exactly as before, and never touches
+// UpdateUserIfActiveStateMatches — so it cannot be spuriously rejected by an
+// unrelated concurrent is_active change on the same row.
+func TestUpdateUser_PlainFieldUpdate_DoesNotUseActiveStateConditionalPath(t *testing.T) {
+	ms := new(MockStorage)
+	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", IsActive: true}
+	updated := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", DisplayName: "Alice Renamed", IsActive: true}
+	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
+	ms.On("UpdateUser", mock.Anything, mock.AnythingOfType("*models.User")).Return(updated, nil)
+	c := NewKeyorixCore(ms)
+	u, err := c.UpdateUser(context.Background(), &UpdateUserRequest{ID: 1, DisplayName: "Alice Renamed"})
+	require.NoError(t, err)
+	assert.Equal(t, "Alice Renamed", u.DisplayName)
+	ms.AssertNotCalled(t, "UpdateUserIfActiveStateMatches", mock.Anything, mock.Anything, mock.Anything)
+}
+
 // ── users.go — RestoreUser ───────────────────────────────────────────────────
 
 func TestRestoreUser_ZeroID(t *testing.T) {

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -363,8 +363,17 @@ func (c *KeyorixCore) SetDynamicSecretConfigEnabled(ctx context.Context, actorID
 	old := cfg.Disabled
 	cfg.Disabled = disabled
 	cfg.UpdatedAt = c.now()
-	if err := c.storage.UpdateDynamicSecretConfig(ctx, cfg); err != nil {
+	matched, err := c.storage.TransitionDynamicSecretConfigDisabled(ctx, cfg, old)
+	if err != nil {
 		return nil, err
+	}
+	if !matched {
+		// Lost the race: the row's persisted disabled value moved away from old
+		// between the GetDynamicSecretConfig read and this write (a concurrent
+		// enable/disable, or an unrelated concurrent edit) — treat as a rejected
+		// write, not silently applied, exactly like TransitionMachineIdentityState's
+		// #388/#518 lost-race handling.
+		return nil, fmt.Errorf("dynamic-secret config %d's enabled state changed concurrently; retry", configID)
 	}
 	aid := actorID
 	pid := cfg.ProjectID

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -83,6 +83,90 @@ func mkConfig(t *testing.T, c *KeyorixCore, ctx context.Context) *models.Dynamic
 	return cfg
 }
 
+// TestSetDynamicSecretConfigEnabled_HappyPathAndNoop proves the ordinary
+// enable/disable/no-op branches of SetDynamicSecretConfigEnabled still work
+// after routing the write through the new conditional
+// TransitionDynamicSecretConfigDisabled call.
+func TestSetDynamicSecretConfigEnabled_HappyPathAndNoop(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg := mkConfig(t, c, ctx)
+	require.False(t, cfg.Disabled)
+
+	// Disabling a currently-enabled config succeeds.
+	updated, err := c.SetDynamicSecretConfigEnabled(ctx, testAdminActorID, cfg.ID, false)
+	require.NoError(t, err)
+	assert.True(t, updated.Disabled)
+	reload, err := c.GetDynamicSecretConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.True(t, reload.Disabled)
+
+	// Re-disabling (already disabled → target disabled) is a harmless no-op,
+	// not an error — distinct from the lost-race case below.
+	noop, err := c.SetDynamicSecretConfigEnabled(ctx, testAdminActorID, cfg.ID, false)
+	require.NoError(t, err)
+	assert.True(t, noop.Disabled)
+
+	// Re-enabling succeeds.
+	reenabled, err := c.SetDynamicSecretConfigEnabled(ctx, testAdminActorID, cfg.ID, true)
+	require.NoError(t, err)
+	assert.False(t, reenabled.Disabled)
+}
+
+// TestSetDynamicSecretConfigEnabled_LostRaceReportedCleanly is the
+// StateTransitionMissingCAS regression, proven deterministically at the
+// core-layer boundary — mirroring machine_identities_test.go's "lost race on
+// the conditional write is reported like an illegal transition" case exactly,
+// just for DynamicSecretConfig.Disabled instead of MachineIdentity.State.
+// SetDynamicSecretConfigEnabled used to read the config, then persist the
+// FULL mutated row via a plain unconditional UpdateDynamicSecretConfig — a
+// TOCTOU window in which a racing caller (or an unrelated concurrent edit)
+// landing between the read and the write could be silently clobbered. This
+// drives MockStorage to hand back a stale pre-race read (Disabled=false) and
+// has TransitionDynamicSecretConfigDisabled report matched=false — exactly
+// what the real conditional UPDATE returns when a concurrent racer already
+// moved the row's disabled value away from what this call observed — and
+// asserts SetDynamicSecretConfigEnabled surfaces that as a clean "changed
+// concurrently" error rather than treating a false match as success.
+//
+// (The storage-layer half of this fix — that the conditional UPDATE itself
+// actually rejects a second write gated on a now-stale fromDisabled value —
+// is proven directly, back-to-back and under real goroutine concurrency,
+// against real SQLite in internal/storage/store's
+// TestTransitionDynamicSecretConfigDisabled_ClosesRace and
+// TestRaceReproStorageLayer-style coverage; this test's job is only to prove
+// the CORE-LAYER caller's false→error translation, which is why it drives
+// MockStorage directly instead of racing real goroutines against real SQLite
+// — the latter is inherently timing-sensitive and would be flaky under
+// `go test -race`, which this repo's CI runs.)
+func TestSetDynamicSecretConfigEnabled_LostRaceReportedCleanly(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	ctx := context.Background()
+
+	staleCfg := &models.DynamicSecretConfig{ID: 7, ProjectID: 1, Name: "race-cfg", Disabled: false}
+	ms.GetDynamicSecretConfigFunc = func(_ context.Context, id uint) (*models.DynamicSecretConfig, error) {
+		require.Equal(t, uint(7), id)
+		// Return a COPY each call so SetDynamicSecretConfigEnabled's in-memory
+		// mutation of the returned cfg can't leak back into staleCfg.
+		cp := *staleCfg
+		return &cp, nil
+	}
+	ms.TransitionDynamicSecretConfigDisabledFunc = func(_ context.Context, cfg *models.DynamicSecretConfig, fromDisabled bool) (bool, error) {
+		assert.False(t, fromDisabled, "must gate on the value observed via GetDynamicSecretConfig, not some other value")
+		assert.True(t, cfg.Disabled, "must persist the caller's intended target (disabled=true)")
+		// Simulate the concurrent racer having already flipped the row's
+		// persisted disabled value away from fromDisabled: the conditional
+		// UPDATE's WHERE clause no longer matches any row.
+		return false, nil
+	}
+
+	_, err := c.SetDynamicSecretConfigEnabled(ctx, testAdminActorID, 7, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "changed concurrently")
+	assert.Contains(t, err.Error(), "7")
+}
+
 // #162: binding a dynamic-secret backend hands out standing access to mint live
 // credentials against it (a DB admin DSN or a cloud-IAM role) — the route only
 // requires secrets.write at the project/environment scope, which on its own would let

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -24,4 +24,16 @@ var (
 	// ErrInvalidAuditRetentionDays is returned by PurgeAuditLogs when the caller
 	// supplies a retention window that is below the minimum 7-day floor.
 	ErrInvalidAuditRetentionDays = errors.New("invalid retention_days")
+
+	// ErrUserActiveStateConflict is returned by UpdateUser when a request that
+	// explicitly asserts IsActive (an actual flip or a redundant same-value set)
+	// loses a race against another concurrent UpdateUser call touching the same
+	// user's active state — the row's persisted is_active moved away from the
+	// value this call observed (wasActive) between its GetUser read and its
+	// conditional write (storage.Storage.UpdateUserIfActiveStateMatches).
+	// Mirrors TransitionMachineIdentity's #388 lost-race handling and
+	// UpdateProjectInvitation's #412 "no longer pending" refusal: the caller
+	// must retry against the current state, not have its change silently
+	// dropped or silently clobber the winner.
+	ErrUserActiveStateConflict = errors.New("user's active state changed concurrently")
 )

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -12,6 +12,16 @@ import (
 // MockStorage is a complete mock implementation of the Storage interface for testing
 type MockStorage struct {
 	mock.Mock
+
+	// GetDynamicSecretConfigFunc/TransitionDynamicSecretConfigDisabledFunc, when
+	// set, override the fixed-stub return values GetDynamicSecretConfig/
+	// TransitionDynamicSecretConfigDisabled otherwise give (see those methods'
+	// doc comments for why they use this settable-func escape hatch instead of
+	// the usual testify .On()/m.Called() pattern). nil by default; a test that
+	// specifically needs to control the return value (e.g. simulating a lost
+	// dynamic-secret-config CAS race deterministically) sets the field directly.
+	GetDynamicSecretConfigFunc                func(ctx context.Context, id uint) (*models.DynamicSecretConfig, error)
+	TransitionDynamicSecretConfigDisabledFunc func(ctx context.Context, c *models.DynamicSecretConfig, fromDisabled bool) (bool, error)
 }
 
 // WithSchedulerLock runs fn directly in tests (single instance, no DB lock).
@@ -485,6 +495,16 @@ func (m *MockStorage) UpdateRiskException(ctx context.Context, e *models.RiskExc
 	return args.Error(0)
 }
 
+func (m *MockStorage) RevokeRiskExceptionIfNotRevoked(ctx context.Context, e *models.RiskException) (bool, error) {
+	args := m.Called(ctx, e)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockStorage) ApproveRiskExceptionIfPending(ctx context.Context, e *models.RiskException) (bool, error) {
+	args := m.Called(ctx, e)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *MockStorage) CreateSSOLoginState(ctx context.Context, s *models.SSOLoginState) error {
 	args := m.Called(ctx, s)
 	return args.Error(0)
@@ -587,6 +607,11 @@ func (m *MockStorage) UpdateSecret(ctx context.Context, secret *models.SecretNod
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*models.SecretNode), args.Error(1)
+}
+
+func (m *MockStorage) TransitionSecretStatus(ctx context.Context, secret *models.SecretNode, fromStatus string) (bool, error) {
+	args := m.Called(ctx, secret, fromStatus)
+	return args.Bool(0), args.Error(1)
 }
 
 func (m *MockStorage) DeleteSecret(ctx context.Context, id uint) error {
@@ -866,6 +891,11 @@ func (m *MockStorage) UpdateUser(ctx context.Context, user *models.User) (*model
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*models.User), args.Error(1)
+}
+
+func (m *MockStorage) UpdateUserIfActiveStateMatches(ctx context.Context, user *models.User, fromActive bool) (bool, error) {
+	args := m.Called(ctx, user, fromActive)
+	return args.Bool(0), args.Error(1)
 }
 
 func (m *MockStorage) UpdateLastLogin(ctx context.Context, userID uint, loginAt time.Time) error {
@@ -2063,11 +2093,18 @@ func (m *MockStorage) ConsumeMFAChallenge(_ context.Context, _ string, _ time.Ti
 }
 
 // Dynamic-secrets stubs (the dynamic-secrets core logic is tested against real
-// SQLite + a fake engine, not this mock).
+// SQLite + a fake engine, not this mock). GetDynamicSecretConfig/
+// TransitionDynamicSecretConfigDisabled below are FIXED stubs by default (see
+// the GetDynamicSecretConfigFunc/TransitionDynamicSecretConfigDisabledFunc
+// doc on the struct above for why they use a settable-func escape hatch
+// instead of the usual testify .On()/m.Called() pattern).
 func (m *MockStorage) CreateDynamicSecretConfig(_ context.Context, c *models.DynamicSecretConfig) (*models.DynamicSecretConfig, error) {
 	return c, nil
 }
-func (m *MockStorage) GetDynamicSecretConfig(_ context.Context, _ uint) (*models.DynamicSecretConfig, error) {
+func (m *MockStorage) GetDynamicSecretConfig(ctx context.Context, id uint) (*models.DynamicSecretConfig, error) {
+	if m.GetDynamicSecretConfigFunc != nil {
+		return m.GetDynamicSecretConfigFunc(ctx, id)
+	}
 	return nil, nil
 }
 func (m *MockStorage) ListDynamicSecretConfigs(_ context.Context, _, _ uint) ([]*models.DynamicSecretConfig, error) {
@@ -2075,6 +2112,12 @@ func (m *MockStorage) ListDynamicSecretConfigs(_ context.Context, _, _ uint) ([]
 }
 func (m *MockStorage) UpdateDynamicSecretConfig(_ context.Context, _ *models.DynamicSecretConfig) error {
 	return nil
+}
+func (m *MockStorage) TransitionDynamicSecretConfigDisabled(ctx context.Context, c *models.DynamicSecretConfig, fromDisabled bool) (bool, error) {
+	if m.TransitionDynamicSecretConfigDisabledFunc != nil {
+		return m.TransitionDynamicSecretConfigDisabledFunc(ctx, c, fromDisabled)
+	}
+	return true, nil
 }
 func (m *MockStorage) CountDynamicSecretConfigsByClassification(_ context.Context) (map[string]int, error) {
 	return nil, nil

--- a/internal/core/risk_exceptions.go
+++ b/internal/core/risk_exceptions.go
@@ -162,8 +162,17 @@ func (c *KeyorixCore) RevokeRiskException(ctx context.Context, actorID, id uint)
 	e.Revoked = true
 	e.RevokedBy = actorID
 	e.RevokedAt = &now
-	if err := c.storage.UpdateRiskException(ctx, e); err != nil {
+	matched, err := c.storage.RevokeRiskExceptionIfNotRevoked(ctx, e)
+	if err != nil {
 		return err
+	}
+	if !matched {
+		// Lost the race: the row's persisted revoked flag moved to true between
+		// the GetRiskException read above and this write (a concurrent
+		// RevokeRiskException or ApproveRiskException call) — treat exactly like
+		// the already-revoked precondition failure above rather than silently
+		// overwriting the winner (StateTransitionMissingCAS.ql).
+		return fmt.Errorf("risk exception %d was concurrently revoked by another request", id)
 	}
 	c.writeAuditEvent(ctx, EventRiskExceptionRevoked, actorPtr(actorID), nil,
 		fmt.Sprintf("risk exception %d revoked: %q", id, e.Title))
@@ -198,8 +207,17 @@ func (c *KeyorixCore) ApproveRiskException(ctx context.Context, actorID, id uint
 	e.Approved = true
 	e.ApprovedBy = actorID
 	e.ApprovedAt = &now
-	if err := c.storage.UpdateRiskException(ctx, e); err != nil {
+	matched, err := c.storage.ApproveRiskExceptionIfPending(ctx, e)
+	if err != nil {
 		return err
+	}
+	if !matched {
+		// Lost the race: the row's persisted revoked/approved flags moved between
+		// the GetRiskException read above and this write (a concurrent
+		// RevokeRiskException or ApproveRiskException call) — treat exactly like
+		// the already-revoked/already-approved precondition failures above rather
+		// than silently overwriting the winner (StateTransitionMissingCAS.ql).
+		return fmt.Errorf("risk exception %d was concurrently revoked or approved by another request", id)
 	}
 	c.writeAuditEvent(ctx, EventRiskExceptionApproved, actorPtr(actorID), nil,
 		fmt.Sprintf("risk exception %d approved by %d (created by %d): %q", id, actorID, e.CreatedBy, e.Title))

--- a/internal/core/risk_exceptions_test.go
+++ b/internal/core/risk_exceptions_test.go
@@ -79,13 +79,30 @@ func TestRevokeRiskException(t *testing.T) {
 	now := time.Now()
 	store := new(MockStorage)
 	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x"}, nil)
-	store.On("UpdateRiskException", mock.Anything, mock.MatchedBy(func(e *models.RiskException) bool {
+	store.On("RevokeRiskExceptionIfNotRevoked", mock.Anything, mock.MatchedBy(func(e *models.RiskException) bool {
 		return e.ID == 5 && e.Revoked && e.RevokedBy == 3 && e.RevokedAt != nil
-	})).Return(nil)
+	})).Return(true, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
 	c := riskCore(store, now)
 	require.NoError(t, c.RevokeRiskException(context.Background(), 3, 5))
+}
+
+// StateTransitionMissingCAS.ql: a lost race — the row's persisted revoked flag
+// moved to true between the GetRiskException read and this write (e.g. a
+// concurrent racing RevokeRiskException/ApproveRiskException) — must surface as
+// a clear error, not be silently swallowed or retried.
+func TestRevokeRiskException_LostRaceReturnsError(t *testing.T) {
+	now := time.Now()
+	store := new(MockStorage)
+	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x"}, nil)
+	store.On("RevokeRiskExceptionIfNotRevoked", mock.Anything, mock.Anything).Return(false, nil)
+
+	c := riskCore(store, now)
+	err := c.RevokeRiskException(context.Background(), 3, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "concurrently revoked")
+	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 }
 
 // #170: the creator of a risk exception cannot approve their own exception — dual
@@ -111,7 +128,7 @@ func TestApproveRiskException_DeniesSelfApproval(t *testing.T) {
 	require.NotNil(t, audited, "the denial must still be audited")
 	require.NotNil(t, audited.Success)
 	assert.False(t, *audited.Success)
-	store.AssertNotCalled(t, "UpdateRiskException", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "ApproveRiskExceptionIfPending", mock.Anything, mock.Anything)
 }
 
 // A DIFFERENT principal than the creator may approve — the exception is marked
@@ -120,13 +137,30 @@ func TestApproveRiskException_DifferentActorSucceeds(t *testing.T) {
 	now := time.Now()
 	store := new(MockStorage)
 	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 9, ExpiresAt: now.Add(24 * time.Hour)}, nil)
-	store.On("UpdateRiskException", mock.Anything, mock.MatchedBy(func(e *models.RiskException) bool {
+	store.On("ApproveRiskExceptionIfPending", mock.Anything, mock.MatchedBy(func(e *models.RiskException) bool {
 		return e.ID == 5 && e.Approved && e.ApprovedBy == 3 && e.ApprovedAt != nil
-	})).Return(nil)
+	})).Return(true, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
 	c := riskCore(store, now)
 	require.NoError(t, c.ApproveRiskException(context.Background(), 3, 5))
+}
+
+// StateTransitionMissingCAS.ql: a lost race on approve — the row's persisted
+// revoked/approved flags moved between the GetRiskException read and this
+// write (e.g. a concurrent racing revoke or a racing approve that landed
+// first) — must surface as a clear error, not be silently swallowed.
+func TestApproveRiskException_LostRaceReturnsError(t *testing.T) {
+	now := time.Now()
+	store := new(MockStorage)
+	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 9, ExpiresAt: now.Add(24 * time.Hour)}, nil)
+	store.On("ApproveRiskExceptionIfPending", mock.Anything, mock.Anything).Return(false, nil)
+
+	c := riskCore(store, now)
+	err := c.ApproveRiskException(context.Background(), 3, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "concurrently revoked or approved")
+	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 }
 
 // An already-approved exception cannot be approved again.

--- a/internal/core/secret_suspend.go
+++ b/internal/core/secret_suspend.go
@@ -36,19 +36,27 @@ func (c *KeyorixCore) SuspendSecret(ctx context.Context, secretID, actorID uint,
 	if secret.Status == SecretStatusSuspended {
 		return secret, nil // already suspended — no-op, no duplicate audit
 	}
+	fromStatus := secret.Status
 	secret.Status = SecretStatusSuspended
 	secret.UpdatedAt = c.now()
-	updated, err := c.storage.UpdateSecret(ctx, secret)
+	matched, err := c.storage.TransitionSecretStatus(ctx, secret, fromStatus)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	if !matched {
+		// Lost the race: the row's persisted status moved away from fromStatus
+		// between the GetSecret read above and this write (a concurrent
+		// suspend/resume, or any other concurrent writer of this row) — treat
+		// as a failed write rather than silently overwriting the winner.
+		return nil, fmt.Errorf("secret %d's status changed concurrently; retry", secretID)
+	}
 	uid, sid := actorID, secretID
-	desc := fmt.Sprintf("suspended secret %q", updated.Name)
+	desc := fmt.Sprintf("suspended secret %q", secret.Name)
 	if reason != "" {
 		desc += ": " + reason
 	}
 	c.writeAuditEvent(ctx, EventSecretSuspended, &uid, &sid, desc)
-	return updated, nil
+	return secret, nil
 }
 
 const projectSuspendPageSize = 500
@@ -128,13 +136,21 @@ func (c *KeyorixCore) ResumeSecret(ctx context.Context, secretID, actorID uint) 
 	if secret.Status != SecretStatusSuspended {
 		return secret, nil // not suspended — no-op
 	}
+	fromStatus := secret.Status
 	secret.Status = SecretStatusActive
 	secret.UpdatedAt = c.now()
-	updated, err := c.storage.UpdateSecret(ctx, secret)
+	matched, err := c.storage.TransitionSecretStatus(ctx, secret, fromStatus)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
+	if !matched {
+		// Lost the race: the row's persisted status moved away from fromStatus
+		// between the GetSecret read above and this write (a concurrent
+		// suspend/resume, or any other concurrent writer of this row) — treat
+		// as a failed write rather than silently overwriting the winner.
+		return nil, fmt.Errorf("secret %d's status changed concurrently; retry", secretID)
+	}
 	uid, sid := actorID, secretID
-	c.writeAuditEvent(ctx, EventSecretResumed, &uid, &sid, fmt.Sprintf("resumed secret %q", updated.Name))
-	return updated, nil
+	c.writeAuditEvent(ctx, EventSecretResumed, &uid, &sid, fmt.Sprintf("resumed secret %q", secret.Name))
+	return secret, nil
 }

--- a/internal/core/secret_suspend_test.go
+++ b/internal/core/secret_suspend_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
@@ -81,5 +82,57 @@ func TestSuspendResumeSecret(t *testing.T) {
 		s, err := c.ResumeSecret(ctx, id, 1)
 		require.NoError(t, err)
 		assert.Equal(t, SecretStatusActive, s.Status)
+	})
+}
+
+// newMockSuspendCore builds a KeyorixCore backed by MockStorage — mirrors
+// newMachineCore (machine_identities_test.go) — so SuspendSecret/ResumeSecret's
+// lost-race handling can be exercised without needing a real concurrent
+// second caller: TransitionSecretStatus is simply stubbed to report the race
+// already lost.
+func newMockSuspendCore(store *MockStorage) *KeyorixCore {
+	fixed := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	return &KeyorixCore{storage: store, now: func() time.Time { return fixed }}
+}
+
+// TestSuspendResumeSecret_LostRace proves the StateTransitionMissingCAS fix:
+// when TransitionSecretStatus reports matched=false (the row's persisted
+// status moved away from the value GetSecret observed, between that read and
+// this write — e.g. a concurrent suspend/resume won the race), SuspendSecret/
+// ResumeSecret must surface a clear error instead of pretending the write
+// landed, and must NOT write an audit event for a change that never
+// persisted. Mirrors TestTransitionMachineIdentity's "lost race on the
+// conditional write is reported like an illegal transition" subtest.
+func TestSuspendResumeSecret_LostRace(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("SuspendSecret", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMockSuspendCore(store)
+		store.On("GetSecret", ctx, uint(10)).
+			Return(&models.SecretNode{ID: 10, Name: "db", Status: SecretStatusActive}, nil)
+		store.On("TransitionSecretStatus", ctx, mock.MatchedBy(func(s *models.SecretNode) bool {
+			return s.Status == SecretStatusSuspended
+		}), SecretStatusActive).Return(false, nil)
+
+		_, err := c.SuspendSecret(ctx, 10, 1, "suspected leak")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "changed concurrently")
+		store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+	})
+
+	t.Run("ResumeSecret", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMockSuspendCore(store)
+		store.On("GetSecret", ctx, uint(20)).
+			Return(&models.SecretNode{ID: 20, Name: "db", Status: SecretStatusSuspended}, nil)
+		store.On("TransitionSecretStatus", ctx, mock.MatchedBy(func(s *models.SecretNode) bool {
+			return s.Status == SecretStatusActive
+		}), SecretStatusSuspended).Return(false, nil)
+
+		_, err := c.ResumeSecret(ctx, 20, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "changed concurrently")
+		store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 	})
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -377,6 +377,40 @@ type Storage interface {
 	ListRiskExceptions(ctx context.Context, activeOnly bool) ([]*models.RiskException, error)
 	GetRiskException(ctx context.Context, id uint) (*models.RiskException, error)
 	UpdateRiskException(ctx context.Context, e *models.RiskException) error
+	// RevokeRiskExceptionIfNotRevoked persists e's full row (Revoked/RevokedBy/
+	// RevokedAt already set by the caller) via a single conditional UPDATE —
+	// "WHERE id = ? AND revoked = false" — succeeding only if the row's CURRENT
+	// persisted revoked flag is still false, mirroring TransitionMachineIdentityState's
+	// `WHERE id = ? AND state = ?` pattern (#388) and UpdateProjectInvitation's
+	// `WHERE id = ? AND state = 'pending'` pattern (#412) for this same TOCTOU class.
+	// The bool reports whether the row matched and was updated; false means the
+	// exception was already revoked by a prior or racing call (e.g. a concurrent
+	// RevokeRiskException or ApproveRiskException) and this write was rejected, not
+	// silently applied. core.RevokeRiskException's own precondition check
+	// (e.Revoked) only protects against the case where the initial read already
+	// showed revoked=true — it does nothing for a revoke that happens in the
+	// window between that read and this write, which is exactly the gap this
+	// conditional UPDATE closes.
+	//
+	// This exists — rather than a plain UpdateRiskException call — for the same
+	// reason TransitionMachineIdentityState does: RemoteStorage.WithTransaction is
+	// a no-op passthrough (remote_transaction.go), so a caller-driven
+	// read-then-conditional-write sequence run against RemoteStorage gets none of
+	// the atomicity a real DB transaction + row lock would give LocalStorage.
+	// Routing the write through this one conditional round trip — a single
+	// LocalStorage conditional SQL UPDATE, or a single proxied HTTP call to a
+	// dedicated upstream route — restores the guarantee across both backends.
+	RevokeRiskExceptionIfNotRevoked(ctx context.Context, e *models.RiskException) (bool, error)
+	// ApproveRiskExceptionIfPending persists e's full row (Approved/ApprovedBy/
+	// ApprovedAt already set by the caller) via a single conditional UPDATE —
+	// "WHERE id = ? AND revoked = false AND approved = false" — succeeding only if
+	// the row is CURRENTLY still un-revoked AND un-approved. See
+	// RevokeRiskExceptionIfNotRevoked's doc for why this exists as a dedicated
+	// conditional round trip rather than a plain UpdateRiskException call. The
+	// bool reports whether the row matched and was updated; false means the
+	// exception was concurrently revoked, or already approved, by a prior or
+	// racing call and this write was rejected, not silently applied.
+	ApproveRiskExceptionIfPending(ctx context.Context, e *models.RiskException) (bool, error)
 
 	// SSO login state (OIDC human SSO) — short-lived CSRF/nonce state.
 	// ConsumeSSOLoginState is single-use: it returns the row and deletes it.
@@ -555,6 +589,33 @@ type Storage interface {
 	GetSecretsByIDs(ctx context.Context, ids []uint) ([]*models.SecretNode, error)
 	GetSecretByName(ctx context.Context, name string, projectID, environmentID uint) (*models.SecretNode, error)
 	UpdateSecret(ctx context.Context, secret *models.SecretNode) (*models.SecretNode, error)
+	// TransitionSecretStatus persists secret's full row via a single conditional
+	// write — "UPDATE ... WHERE id = ? AND status = ?" — succeeding only if the
+	// row's CURRENT persisted status still equals fromStatus (the value the
+	// caller observed via GetSecret immediately before mutating secret.Status in
+	// memory), mirroring UpdateProjectInvitation's `WHERE id = ? AND state =
+	// 'pending'` pattern and TransitionMachineIdentityState's `WHERE id = ? AND
+	// state = ?` pattern exactly, just for SecretNode.Status. Returns whether the
+	// write actually matched a row.
+	//
+	// This exists because SuspendSecret/ResumeSecret (internal/core/
+	// secret_suspend.go) previously did a plain read-then-unconditional-
+	// UpdateSecret: a suspend racing a resume on the same secret could silently
+	// clobber each other depending on write order with no error to either
+	// caller, and — because UpdateSecret persists the FULL in-memory struct —
+	// any OTHER field mutated by a concurrent, unrelated operation between the
+	// read and this write would be silently reverted to the stale value read at
+	// the top, a general lost-update problem. And because RemoteStorage.
+	// WithTransaction is a no-op passthrough (remote_transaction.go: "there is
+	// no client-side transaction to open over HTTP"), a naive two-call
+	// GetSecret-then-UpdateSecret sequence gets NONE of the atomicity a real DB
+	// transaction + conditional write provides, reopening the same race across
+	// the HTTP hop for a downstream server booted with storage.type: remote.
+	// Routing the write through this one conditional round trip instead
+	// restores the same guarantee LocalStorage already has: a false match
+	// result must be treated exactly like a lost race — surfaced as an error to
+	// the caller — not retried or silently overwritten.
+	TransitionSecretStatus(ctx context.Context, secret *models.SecretNode, fromStatus string) (bool, error)
 	DeleteSecret(ctx context.Context, id uint) error
 	// RestoreSecret clears a soft-deleted secret's deleted_at (ADR-033).
 	RestoreSecret(ctx context.Context, id uint) error
@@ -685,6 +746,36 @@ type Storage interface {
 	LockUserForUpdate(ctx context.Context, id uint) (*models.User, error)
 	GetUserByEmail(ctx context.Context, email string) (*models.User, error)
 	UpdateUser(ctx context.Context, user *models.User) (*models.User, error)
+	// UpdateUserIfActiveStateMatches persists user's full row — every field
+	// UpdateUser already applied to it in memory from the same request
+	// (username/email/display name, plus the new IsActive value) — via a single
+	// conditional "UPDATE ... WHERE id = ? AND is_active = ?", succeeding only if
+	// the row's CURRENT persisted is_active still equals fromActive (the value
+	// UpdateUser observed via GetUser, i.e. wasActive, before applying any of the
+	// request's field changes in memory). Returns whether the write actually
+	// matched a row, mirroring TransitionMachineIdentityState's `WHERE id = ? AND
+	// state = ?` / UpdateProjectInvitation's `WHERE id = ? AND state = 'pending'`
+	// pattern (#388/#412) for this codebase's other state-transition TOCTOU class.
+	//
+	// UpdateUser is a general-purpose multi-field update (username, email,
+	// display name, IsActive, ...), not a single-purpose state-transition
+	// function, so a plain c.storage.UpdateUser write is fine for requests that
+	// leave IsActive untouched. But whenever req.IsActive != nil, UpdateUser
+	// routes its final persist through THIS method instead: IsActive can flip
+	// concurrently with any other UpdateUser call touching the same user (a
+	// profile edit racing an admin deactivation, or two deactivation attempts
+	// racing each other), and a plain write silently clobbers whichever change
+	// lost the race, with no error to either caller. This exists for the exact
+	// same reason TransitionMachineIdentityState does: RemoteStorage.WithTransaction
+	// is a no-op passthrough (remote_transaction.go), so a naive
+	// GetUser-then-UpdateUser sequence gets none of the atomicity LocalStorage
+	// provides via a real DB transaction once proxied over HTTP — routing the
+	// actual write through this one conditional round trip restores the same
+	// guarantee LocalStorage already has, without making any validation decision
+	// here: the caller (core.UpdateUser) still decides which fields to mutate and
+	// what fromActive to assert before calling this; a false match result must be
+	// treated as a lost-race error, not retried or silently overwritten.
+	UpdateUserIfActiveStateMatches(ctx context.Context, user *models.User, fromActive bool) (bool, error)
 	// UpdateLastLogin stamps the user's last_login_at column without touching any
 	// other field (no updated_at bump). Called on every successful login.
 	UpdateLastLogin(ctx context.Context, userID uint, loginAt time.Time) error
@@ -1117,6 +1208,32 @@ type Storage interface {
 	GetDynamicSecretConfig(ctx context.Context, id uint) (*models.DynamicSecretConfig, error)
 	ListDynamicSecretConfigs(ctx context.Context, projectID, environmentID uint) ([]*models.DynamicSecretConfig, error)
 	UpdateDynamicSecretConfig(ctx context.Context, c *models.DynamicSecretConfig) error
+	// TransitionDynamicSecretConfigDisabled persists cfg's full row via a single
+	// conditional write — "UPDATE ... WHERE id = ? AND disabled = ?" — succeeding
+	// only if the row's CURRENT persisted disabled value still equals fromDisabled
+	// (the value SetDynamicSecretConfigEnabled observed via GetDynamicSecretConfig
+	// immediately before mutating cfg.Disabled in memory), mirroring
+	// UpdateProjectInvitation's `WHERE id = ? AND state = 'pending'` pattern (#412)
+	// and TransitionMachineIdentityState's `WHERE id = ? AND state = ?` pattern
+	// (#388/#518) exactly, just gated on DynamicSecretConfig.Disabled instead of a
+	// string state column. Returns whether the write actually matched a row.
+	//
+	// This exists for the same reason TransitionMachineIdentityState does:
+	// RemoteStorage.WithTransaction is a no-op passthrough (remote_transaction.go:
+	// "there is no client-side transaction to open over HTTP"), so a plain
+	// GetDynamicSecretConfig-then-UpdateDynamicSecretConfig sequence — the shape
+	// SetDynamicSecretConfigEnabled used before this fix — has no atomicity at all
+	// against RemoteStorage: two racing callers (e.g. one admin enabling while
+	// another is mid-disable, or an unrelated concurrent edit landing between the
+	// read and the write) can silently clobber each other's change, or clobber an
+	// unrelated field mutated by the other racer, with no error surfaced. Routing
+	// the actual write through this one conditional round trip instead of a
+	// separate proxied Update restores the same guarantee LocalStorage's
+	// conditional UPDATE already provides, without making any enable/disable
+	// decision here: the caller (core.SetDynamicSecretConfigEnabled) still decides
+	// the target Disabled value before calling this; a false match result must be
+	// treated as a lost race, not retried or silently overwritten.
+	TransitionDynamicSecretConfigDisabled(ctx context.Context, cfg *models.DynamicSecretConfig, fromDisabled bool) (bool, error)
 	// CountDynamicSecretConfigsByClassification returns install-wide config counts
 	// keyed by classification label ("" = unclassified) for the compliance posture.
 	CountDynamicSecretConfigsByClassification(ctx context.Context) (map[string]int, error)

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -306,22 +306,51 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 
 	var patHashes []string
 	var updated *models.User
-	if deactivating {
+	switch {
+	case deactivating:
+		// req.IsActive != nil is implied here (deactivating can only be true if
+		// the request actually mutated user.IsActive from wasActive), so the
+		// final persist must go through the conditional write — a plain
+		// c.storage.UpdateUser here would silently clobber (or be clobbered by)
+		// a concurrent IsActive flip on the same user with no error to either
+		// caller (see UpdateUserIfActiveStateMatches's doc, storage/interface.go).
 		err = c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
-			var terr error
-			updated, terr = tx.UpdateUser(ctx, user)
+			matched, terr := tx.UpdateUserIfActiveStateMatches(ctx, user, wasActive)
 			if terr != nil {
 				return terr
 			}
+			if !matched {
+				return fmt.Errorf("user %d: %w", req.ID, ErrUserActiveStateConflict)
+			}
+			updated = user
 			if hashes, herr := tx.RevokeAllPersonalAccessTokensForUser(ctx, req.ID); herr == nil {
 				patHashes = hashes
 			}
 			return tx.DeleteSessionsForUserExcept(ctx, req.ID, 0)
 		})
-	} else {
+	case req.IsActive != nil:
+		// Not deactivating (either re-activating, or a redundant "set to the same
+		// value" call) but the request still explicitly asserts IsActive — same
+		// TOCTOU exposure as the deactivating branch above, just without the
+		// session/PAT revocation side effects.
+		var matched bool
+		matched, err = c.storage.UpdateUserIfActiveStateMatches(ctx, user, wasActive)
+		if err == nil {
+			if !matched {
+				err = fmt.Errorf("user %d: %w", req.ID, ErrUserActiveStateConflict)
+			} else {
+				updated = user
+			}
+		}
+	default:
+		// No active-state assertion in this request — nothing to protect, plain
+		// full-row persist exactly as before.
 		updated, err = c.storage.UpdateUser(ctx, user)
 	}
 	if err != nil {
+		if errors.Is(err, ErrUserActiveStateConflict) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	if deactivating {

--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -49,6 +49,8 @@
 package store
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -124,6 +126,37 @@ func NewRemoteStorage(config *remote.Config) (*RemoteStorage, error) {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 	return &RemoteStorage{client: client}, nil
+}
+
+// putConditionalTransition PUTs body to path and decodes the standard
+// {"matched": bool} response shared by every conditional-transition storage
+// primitive in this package (TransitionMachineIdentityState,
+// TransitionSecretStatus, TransitionDynamicSecretConfigDisabled,
+// UpdateUserIfActiveStateMatches, ...): each one carries a full row plus the
+// "from" value the caller observed before mutating it, so the upstream can
+// apply the exact same conditional "WHERE id = ? AND <field> = ?" write its
+// own LocalStorage would in a single round trip (see the atomicity note in
+// internal/core/storage/interface.go for why a generic read-then-write proxy
+// pair isn't safe here: RemoteStorage.WithTransaction is a no-op passthrough).
+//
+// opName is used only to build each call site's own wrapped error text
+// ("failed to %s: %w" / "%s failed: %s"), so callers keep their existing
+// exact error messages.
+func (rs *RemoteStorage) putConditionalTransition(ctx context.Context, path string, body interface{}, opName string) (bool, error) {
+	resp, err := rs.client.Put(ctx, path, body)
+	if err != nil {
+		return false, fmt.Errorf("failed to %s: %w", opName, err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("%s failed: %s", opName, resp.Error.Error())
+	}
+	var result struct {
+		Matched bool `json:"matched"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Matched, nil
 }
 
 // LocalStorage implements storage.Storage via direct GORM database access.

--- a/internal/storage/store/local_dynamic.go
+++ b/internal/storage/store/local_dynamic.go
@@ -51,6 +51,25 @@ func (ls *LocalStorage) UpdateDynamicSecretConfig(ctx context.Context, c *models
 	return ls.db.WithContext(ctx).Save(c).Error
 }
 
+// TransitionDynamicSecretConfigDisabled persists c's full row via a conditional
+// UPDATE gated on the row's CURRENT disabled value still being fromDisabled (see
+// the interface doc in internal/core/storage/interface.go for why this exists
+// alongside — not instead of — GetDynamicSecretConfig/UpdateDynamicSecretConfig).
+// Mirrors TransitionMachineIdentityState's `WHERE id = ? AND state = ?` +
+// `Select("*")` shape exactly, so every field the caller mutated on c (Disabled,
+// UpdatedAt, ...) is persisted in the same statement, not just a hardcoded
+// column subset.
+func (ls *LocalStorage) TransitionDynamicSecretConfigDisabled(ctx context.Context, c *models.DynamicSecretConfig, fromDisabled bool) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.DynamicSecretConfig{}).
+		Where("id = ? AND disabled = ?", c.ID, fromDisabled).
+		Select("*").
+		Updates(c)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+
 // CountDynamicSecretConfigsByClassification returns config counts keyed by
 // classification label ("" = unclassified), install-wide, via a GROUP BY.
 func (ls *LocalStorage) CountDynamicSecretConfigsByClassification(ctx context.Context) (map[string]int, error) {

--- a/internal/storage/store/local_risk_exceptions.go
+++ b/internal/storage/store/local_risk_exceptions.go
@@ -52,3 +52,38 @@ func (ls *LocalStorage) UpdateRiskException(ctx context.Context, e *models.RiskE
 	}
 	return nil
 }
+
+// RevokeRiskExceptionIfNotRevoked persists e's full row via a conditional UPDATE
+// gated on the row's CURRENT revoked flag still being false (a real TOCTOU race
+// found by CodeQL: RevokeRiskException/ApproveRiskException in
+// internal/core/risk_exceptions.go both read-then-conditionally-mutate-then-Save,
+// and UpdateRiskException's plain unconditional Save let two racing callers
+// silently clobber each other). Mirrors TransitionMachineIdentityState's
+// `WHERE id = ? AND state = ?` + `Select("*")` shape exactly, so every field the
+// caller mutated on e — Revoked, RevokedBy, RevokedAt — is persisted in the same
+// statement, not just a hardcoded column subset.
+func (ls *LocalStorage) RevokeRiskExceptionIfNotRevoked(ctx context.Context, e *models.RiskException) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.RiskException{}).
+		Where("id = ? AND revoked = ?", e.ID, false).
+		Select("*").
+		Updates(e)
+	if res.Error != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	return res.RowsAffected == 1, nil
+}
+
+// ApproveRiskExceptionIfPending persists e's full row via a conditional UPDATE
+// gated on the row's CURRENT revoked flag still being false AND its CURRENT
+// approved flag still being false — see RevokeRiskExceptionIfNotRevoked's doc
+// for the race this closes.
+func (ls *LocalStorage) ApproveRiskExceptionIfPending(ctx context.Context, e *models.RiskException) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.RiskException{}).
+		Where("id = ? AND revoked = ? AND approved = ?", e.ID, false, false).
+		Select("*").
+		Updates(e)
+	if res.Error != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	return res.RowsAffected == 1, nil
+}

--- a/internal/storage/store/local_risk_exceptions_test.go
+++ b/internal/storage/store/local_risk_exceptions_test.go
@@ -51,3 +51,102 @@ func TestRiskExceptions_CreateListRevoke(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, active)
 }
+
+// TestRevokeRiskExceptionIfNotRevoked_ConditionalOnNotRevoked_Sequential proves
+// the storage guard itself (StateTransitionMissingCAS.ql): a second racing
+// revoke against a row a first racing revoke already moved to revoked=true
+// reports RowsAffected==0 via the bool, rather than silently re-applying (and
+// re-attributing) the revoke the way the old unconditional Save did. Mirrors
+// invitations_test.go's TestUpdateProjectInvitation_ConditionalOnPending_Sequential
+// (#412) exactly, one level down for RiskException.
+func TestRevokeRiskExceptionIfNotRevoked_ConditionalOnNotRevoked_Sequential(t *testing.T) {
+	ctx := context.Background()
+	ls := newRiskTestStore(t)
+	exp := time.Now().AddDate(0, 0, 30)
+
+	created, err := ls.CreateRiskException(ctx, &models.RiskException{
+		Title: "shared exception", Category: "sod", ExpiresAt: exp,
+	})
+	require.NoError(t, err)
+
+	// Two admins race to revoke the SAME still-unrevoked row, both reading it
+	// before either write lands (the TOCTOU window this fix closes).
+	firstAdminCopy, err := ls.GetRiskException(ctx, created.ID)
+	require.NoError(t, err)
+	revokedAt1 := time.Now()
+	firstAdminCopy.Revoked = true
+	firstAdminCopy.RevokedBy = 1
+	firstAdminCopy.RevokedAt = &revokedAt1
+
+	secondAdminCopy, err := ls.GetRiskException(ctx, created.ID)
+	require.NoError(t, err)
+	revokedAt2 := time.Now()
+	secondAdminCopy.Revoked = true
+	secondAdminCopy.RevokedBy = 2
+	secondAdminCopy.RevokedAt = &revokedAt2
+
+	// The first admin's write lands and wins.
+	ok, err := ls.RevokeRiskExceptionIfNotRevoked(ctx, firstAdminCopy)
+	require.NoError(t, err)
+	require.True(t, ok, "the first writer must win")
+
+	// The second admin's write, against a row that is no longer unrevoked, must
+	// be rejected — not silently re-applied over (and re-attributed away from)
+	// the first admin's revoke.
+	ok, err = ls.RevokeRiskExceptionIfNotRevoked(ctx, secondAdminCopy)
+	require.NoError(t, err)
+	require.False(t, ok, "the second writer must lose, not clobber the first revoke")
+
+	final, err := ls.GetRiskException(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), final.RevokedBy, "the winning first admin's attribution must be the persisted state")
+}
+
+// TestApproveRiskExceptionIfPending_ConditionalOnPending_Sequential is the
+// approve analogue: a second racing approve against a row a first racing
+// revoke already moved to revoked=true must be rejected, not silently applied
+// over a now-revoked exception (dual control's whole point — an
+// approved-after-revoked exception would still suppress its matched violation).
+func TestApproveRiskExceptionIfPending_ConditionalOnPending_Sequential(t *testing.T) {
+	ctx := context.Background()
+	ls := newRiskTestStore(t)
+	exp := time.Now().AddDate(0, 0, 30)
+
+	created, err := ls.CreateRiskException(ctx, &models.RiskException{
+		Title: "shared exception", Category: "mfa", CreatedBy: 9, ExpiresAt: exp,
+	})
+	require.NoError(t, err)
+
+	// Admin reads the still-pending row to revoke it.
+	revokeCopy, err := ls.GetRiskException(ctx, created.ID)
+	require.NoError(t, err)
+	revokedAt := time.Now()
+	revokeCopy.Revoked = true
+	revokeCopy.RevokedBy = 1
+	revokeCopy.RevokedAt = &revokedAt
+
+	// A different approver reads the SAME still-pending row before the revoke
+	// lands, to approve it.
+	approveCopy, err := ls.GetRiskException(ctx, created.ID)
+	require.NoError(t, err)
+	approvedAt := time.Now()
+	approveCopy.Approved = true
+	approveCopy.ApprovedBy = 2
+	approveCopy.ApprovedAt = &approvedAt
+
+	// The revoke lands first.
+	ok, err := ls.RevokeRiskExceptionIfNotRevoked(ctx, revokeCopy)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// The approve, against a row that is no longer unrevoked, must be rejected —
+	// a revoked exception must never end up marked approved.
+	ok, err = ls.ApproveRiskExceptionIfPending(ctx, approveCopy)
+	require.NoError(t, err)
+	require.False(t, ok, "an approve racing a revoke must lose, not mark a revoked exception approved")
+
+	final, err := ls.GetRiskException(ctx, created.ID)
+	require.NoError(t, err)
+	assert.True(t, final.Revoked)
+	assert.False(t, final.Approved, "the revoked exception must not end up approved")
+}

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -475,6 +475,24 @@ func (ls *LocalStorage) UpdateSecret(ctx context.Context, secret *models.SecretN
 	return secret, nil
 }
 
+// TransitionSecretStatus persists secret's full row via a conditional UPDATE
+// gated on the row's CURRENT status still being fromStatus (see the interface
+// doc in internal/core/storage/interface.go for why this exists alongside —
+// not instead of — UpdateSecret). Mirrors TransitionMachineIdentityState's
+// `WHERE id = ? AND state = ?` + `Select("*")` shape exactly, so every field
+// the caller mutated on secret (Status, UpdatedAt, ...) is persisted in the
+// same statement, not just a hardcoded column subset.
+func (ls *LocalStorage) TransitionSecretStatus(ctx context.Context, secret *models.SecretNode, fromStatus string) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.SecretNode{}).
+		Where("id = ? AND status = ?", secret.ID, fromStatus).
+		Select("*").
+		Updates(secret)
+	if res.Error != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	return res.RowsAffected == 1, nil
+}
+
 // SetSecretCertNotAfter caches a certificate-typed secret's parsed leaf expiry — a
 // targeted single-column update that touches nothing else (ADR-056).
 func (ls *LocalStorage) SetSecretCertNotAfter(ctx context.Context, secretID uint, notAfter *time.Time) error {

--- a/internal/storage/store/local_secrets_transition_status_test.go
+++ b/internal/storage/store/local_secrets_transition_status_test.go
@@ -1,0 +1,97 @@
+// local_secrets_transition_status_test.go — SQLite integration test for
+// LocalStorage.TransitionSecretStatus, proving the CAS guard the
+// StateTransitionMissingCAS fix (secret_suspend.go's SuspendSecret/
+// ResumeSecret TOCTOU race) relies on: a conditional UPDATE that only applies
+// when the row's CURRENTLY persisted status still matches fromStatus. Mirrors
+// TestTransitionMachineIdentityState_S25_NoMatchReturnsFalse's shape, but
+// against a real row (not a not-found ID) so it actually exercises the WHERE
+// clause's status comparison, not just the id comparison.
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func newTransitionSecretStatusStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}))
+	return NewLocalStorage(db)
+}
+
+// TestTransitionSecretStatus_ClosesRace proves the exact race
+// StateTransitionMissingCAS flags: two callers both observe the secret's
+// status as "active" (e.g. a suspend and a resume-that-never-should-have-
+// applied racing off the same stale read), then both attempt to persist their
+// own mutation conditioned on that same observed fromStatus. Only the FIRST
+// write may land; the second must be rejected (matched=false) rather than
+// silently clobbering the first — which is exactly what a plain
+// UpdateSecret(ctx, secret) full-row Save could not detect.
+func TestTransitionSecretStatus_ClosesRace(t *testing.T) {
+	ls := newTransitionSecretStatusStore(t)
+	ctx := context.Background()
+
+	node := &models.SecretNode{ID: 1, Name: "db-password", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active"}
+	require.NoError(t, ls.db.Create(node).Error)
+
+	// Two independent in-memory copies, both starting from the same
+	// "active" read — modeling two concurrent callers (a suspend and a
+	// resume, or two racing suspends) that each observed the row before
+	// either write landed.
+	winner := &models.SecretNode{ID: 1, Name: "db-password", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "suspended"}
+	loser := &models.SecretNode{ID: 1, Name: "db-password", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active"}
+
+	// The first writer's conditional UPDATE succeeds: the row's persisted
+	// status was still "active" when this write ran.
+	matched, err := ls.TransitionSecretStatus(ctx, winner, "active")
+	require.NoError(t, err)
+	assert.True(t, matched, "the first writer must win the race")
+
+	var afterFirst models.SecretNode
+	require.NoError(t, ls.db.First(&afterFirst, 1).Error)
+	assert.Equal(t, "suspended", afterFirst.Status, "the winner's status must be persisted")
+
+	// The second writer's conditional UPDATE — still conditioned on the
+	// SAME stale "active" fromStatus it originally observed — must now be
+	// rejected: the row has already moved to "suspended".
+	matched, err = ls.TransitionSecretStatus(ctx, loser, "active")
+	require.NoError(t, err)
+	assert.False(t, matched, "a second writer racing off the same stale read must lose, not clobber the winner")
+
+	var afterSecond models.SecretNode
+	require.NoError(t, ls.db.First(&afterSecond, 1).Error)
+	assert.Equal(t, "suspended", afterSecond.Status, "the loser's rejected write must not have altered the row")
+}
+
+// TestTransitionSecretStatus_NoMatchReturnsFalse mirrors
+// TestTransitionMachineIdentityState_S25_NoMatchReturnsFalse: a transition
+// against a nonexistent row reports matched=false, no error.
+func TestTransitionSecretStatus_NoMatchReturnsFalse(t *testing.T) {
+	ls := newTransitionSecretStatusStore(t)
+	matched, err := ls.TransitionSecretStatus(context.Background(), &models.SecretNode{ID: 9999}, "active")
+	require.NoError(t, err)
+	assert.False(t, matched)
+}
+
+// TestTransitionSecretStatus_ClosedDB_ReturnsError verifies the error branch:
+// when the underlying SQLite connection is closed, TransitionSecretStatus
+// must propagate the storage error rather than silently returning
+// matched=false.
+func TestTransitionSecretStatus_ClosedDB_ReturnsError(t *testing.T) {
+	ls := newTransitionSecretStatusStore(t)
+	sqlDB, err := ls.db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	_, err = ls.TransitionSecretStatus(context.Background(), &models.SecretNode{ID: 1}, "active")
+	assert.Error(t, err)
+}

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -193,6 +193,31 @@ func (ls *LocalStorage) UpdateUser(ctx context.Context, user *models.User) (*mod
 	return user, nil
 }
 
+// UpdateUserIfActiveStateMatches persists user's full row via a conditional
+// UPDATE gated on the row's CURRENT is_active still being fromActive (closing
+// the IsActive TOCTOU race described in the storage.Storage interface doc —
+// see internal/core/storage/interface.go). Mirrors
+// TransitionMachineIdentityState's `WHERE id = ? AND state = ?` + `Select("*")`
+// shape exactly, so every field UpdateUser mutated on user in memory (Username,
+// Email, DisplayName, IsActive, UpdatedAt, ...) is persisted in the same
+// statement, not just a hardcoded column subset.
+func (ls *LocalStorage) UpdateUserIfActiveStateMatches(ctx context.Context, user *models.User, fromActive bool) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.User{}).
+		Where("id = ? AND is_active = ?", user.ID, fromActive).
+		Select("*").
+		Updates(user)
+	if res.Error != nil {
+		if isDuplicateEmailViolation(res.Error) {
+			// Same translation UpdateUser applies (#117/#120/#218): a concurrent
+			// update already committed the identical (case-insensitive) email to a
+			// different user before this write landed.
+			return false, fmt.Errorf("%w: %v", storage.ErrDuplicateEmail, res.Error)
+		}
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	return res.RowsAffected == 1, nil
+}
+
 // UpdateLastLogin stamps last_login_at for a single user. Uses UpdateColumn so
 // only that column is written — no updated_at bump, no clobbering of other fields.
 func (ls *LocalStorage) UpdateLastLogin(ctx context.Context, userID uint, loginAt time.Time) error {

--- a/internal/storage/store/remote_coverage_campaigns_dynamic_invitations_test.go
+++ b/internal/storage/store/remote_coverage_campaigns_dynamic_invitations_test.go
@@ -368,6 +368,37 @@ func TestRemoteCov_UpdateDynamicSecretConfig_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "update dynamic-secret config failed")
 }
 
+func TestRemoteCov_TransitionDynamicSecretConfigDisabled_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "transition config failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	matched, err := rs.TransitionDynamicSecretConfigDisabled(context.Background(),
+		&models.DynamicSecretConfig{ID: 1, Disabled: true}, false)
+	assert.Error(t, err)
+	assert.False(t, matched)
+	assert.Contains(t, err.Error(), "transition dynamic-secret config failed")
+}
+
+func TestRemoteCov_TransitionDynamicSecretConfigDisabled_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	matched, err := rs.TransitionDynamicSecretConfigDisabled(context.Background(),
+		&models.DynamicSecretConfig{ID: 1, Disabled: true}, false)
+	assert.Error(t, err)
+	assert.False(t, matched)
+}
+
 func TestRemoteCov_GetDynamicSecretLease_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(apiNotOK("NOT_FOUND", "lease not found"))

--- a/internal/storage/store/remote_dynamic.go
+++ b/internal/storage/store/remote_dynamic.go
@@ -296,20 +296,7 @@ func (rs *RemoteStorage) TransitionDynamicSecretConfigDisabled(ctx context.Conte
 		Config       dynamicSecretConfigWire `json:"config"`
 		FromDisabled bool                    `json:"from_disabled"`
 	}{Config: newDynamicSecretConfigWire(c), FromDisabled: fromDisabled}
-	resp, err := rs.client.Put(ctx, path, body)
-	if err != nil {
-		return false, fmt.Errorf("failed to transition dynamic-secret config: %w", err)
-	}
-	if !resp.Success {
-		return false, fmt.Errorf("transition dynamic-secret config failed: %s", resp.Error.Error())
-	}
-	var result struct {
-		Matched bool `json:"matched"`
-	}
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return false, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return result.Matched, nil
+	return rs.putConditionalTransition(ctx, path, body, "transition dynamic-secret config")
 }
 
 // CountDynamicSecretConfigsByClassification returns install-wide config counts

--- a/internal/storage/store/remote_dynamic.go
+++ b/internal/storage/store/remote_dynamic.go
@@ -46,6 +46,17 @@
 // this proxy. This fix preserves that behavior exactly rather than introducing a
 // stricter guarantee the local backend itself doesn't have.
 //
+// TransitionDynamicSecretConfigDisabled is the one exception: a new CodeQL
+// query (StateTransitionMissingCAS) flagged SetDynamicSecretConfigEnabled's
+// read-then-write of DynamicSecretConfig.Disabled as the exact TOCTOU class
+// #388/#412 already closed for MachineIdentity.State/ProjectInvitation.State —
+// two racing enable/disable calls (or an unrelated concurrent edit landing
+// between the read and the write) could silently clobber each other with no
+// error surfaced. That one field now goes through a dedicated conditional
+// "WHERE id = ? AND disabled = ?" round trip instead of this file's plain
+// UpdateDynamicSecretConfig — see its doc below and the interface doc in
+// internal/core/storage/interface.go.
+//
 // For the local (GORM) equivalent of every primitive here see local_dynamic.go.
 package store
 
@@ -270,6 +281,35 @@ func (rs *RemoteStorage) UpdateDynamicSecretConfig(ctx context.Context, c *model
 		return fmt.Errorf("update dynamic-secret config failed: %s", resp.Error.Error())
 	}
 	return nil
+}
+
+// TransitionDynamicSecretConfigDisabled persists c's full row via a single
+// conditional PUT to /api/v1/system/dynamic-secrets/configs/{id}/transition
+// (mirroring TransitionMachineIdentityState's #388/#518 conditional-write route
+// pattern), carrying fromDisabled alongside so the upstream applies the exact
+// SAME conditional "WHERE id = ? AND disabled = ?" write its own LocalStorage
+// would — see the interface doc's atomicity note for why this exists as a
+// single round-trip primitive rather than a generic proxied UpdateDynamicSecretConfig.
+func (rs *RemoteStorage) TransitionDynamicSecretConfigDisabled(ctx context.Context, c *models.DynamicSecretConfig, fromDisabled bool) (bool, error) {
+	path := fmt.Sprintf("/api/v1/system/dynamic-secrets/configs/%d/transition", c.ID)
+	body := struct {
+		Config       dynamicSecretConfigWire `json:"config"`
+		FromDisabled bool                    `json:"from_disabled"`
+	}{Config: newDynamicSecretConfigWire(c), FromDisabled: fromDisabled}
+	resp, err := rs.client.Put(ctx, path, body)
+	if err != nil {
+		return false, fmt.Errorf("failed to transition dynamic-secret config: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("transition dynamic-secret config failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Matched bool `json:"matched"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Matched, nil
 }
 
 // CountDynamicSecretConfigsByClassification returns install-wide config counts

--- a/internal/storage/store/remote_dynamic_test.go
+++ b/internal/storage/store/remote_dynamic_test.go
@@ -173,6 +173,40 @@ func TestRemoteStorage_UpdateDynamicSecretConfig(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// --- TransitionDynamicSecretConfigDisabled ---
+
+func TestRemoteStorage_TransitionDynamicSecretConfigDisabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/dynamic-secrets/configs/1/transition", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	matched, err := rs.TransitionDynamicSecretConfigDisabled(context.Background(),
+		&models.DynamicSecretConfig{ID: 1, Disabled: true}, false)
+	require.NoError(t, err)
+	assert.True(t, matched)
+}
+
+func TestRemoteStorage_TransitionDynamicSecretConfigDisabled_NotMatched(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	matched, err := rs.TransitionDynamicSecretConfigDisabled(context.Background(),
+		&models.DynamicSecretConfig{ID: 1, Disabled: false}, true)
+	require.NoError(t, err)
+	assert.False(t, matched)
+}
+
 // --- CountDynamicSecretConfigsByClassification ---
 
 func TestRemoteStorage_CountDynamicSecretConfigsByClassification(t *testing.T) {

--- a/internal/storage/store/remote_misc_test.go
+++ b/internal/storage/store/remote_misc_test.go
@@ -697,6 +697,90 @@ func TestRemoteStorage_UpdateRiskException(t *testing.T) {
 		ExpiresAt:     exp,
 		Revoked:       true,
 	})
+	require.NoError(t, err)
+}
+
+// TestRemoteStorage_RevokeRiskExceptionIfNotRevoked proves the conditional
+// revoke round-trips through the dedicated PUT
+// /api/v1/system/risk-exceptions/{id}/revoke route (StateTransitionMissingCAS.ql
+// fix), distinct from the plain UpdateRiskException route tested above.
+func TestRemoteStorage_RevokeRiskExceptionIfNotRevoked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/risk-exceptions/7/revoke", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	revokedAt := time.Now()
+	matched, err := rs.RevokeRiskExceptionIfNotRevoked(context.Background(), &models.RiskException{
+		ID: 7, Revoked: true, RevokedBy: 3, RevokedAt: &revokedAt,
+	})
+	require.NoError(t, err)
+	assert.True(t, matched)
+}
+
+// TestRemoteStorage_RevokeRiskExceptionIfNotRevoked_NotMatched proves a lost
+// race is surfaced as matched=false, not swallowed or turned into an error.
+func TestRemoteStorage_RevokeRiskExceptionIfNotRevoked_NotMatched(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	revokedAt := time.Now()
+	matched, err := rs.RevokeRiskExceptionIfNotRevoked(context.Background(), &models.RiskException{
+		ID: 7, Revoked: true, RevokedBy: 3, RevokedAt: &revokedAt,
+	})
+	require.NoError(t, err)
+	assert.False(t, matched)
+}
+
+// TestRemoteStorage_ApproveRiskExceptionIfPending proves the conditional
+// approve round-trips through the dedicated PUT
+// /api/v1/system/risk-exceptions/{id}/approve route.
+func TestRemoteStorage_ApproveRiskExceptionIfPending(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/risk-exceptions/8/approve", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	approvedAt := time.Now()
+	matched, err := rs.ApproveRiskExceptionIfPending(context.Background(), &models.RiskException{
+		ID: 8, Approved: true, ApprovedBy: 2, ApprovedAt: &approvedAt,
+	})
+	require.NoError(t, err)
+	assert.True(t, matched)
+}
+
+// TestRemoteStorage_ApproveRiskExceptionIfPending_NotMatched proves a lost race
+// (e.g. a concurrent revoke) is surfaced as matched=false.
+func TestRemoteStorage_ApproveRiskExceptionIfPending_NotMatched(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	approvedAt := time.Now()
+	matched, err := rs.ApproveRiskExceptionIfPending(context.Background(), &models.RiskException{
+		ID: 8, Approved: true, ApprovedBy: 2, ApprovedAt: &approvedAt,
+	})
+	require.NoError(t, err)
+	assert.False(t, matched)
 	assert.NoError(t, err)
 }
 

--- a/internal/storage/store/remote_risk_exceptions.go
+++ b/internal/storage/store/remote_risk_exceptions.go
@@ -201,20 +201,7 @@ func (rs *RemoteStorage) UpdateRiskException(ctx context.Context, e *models.Risk
 // TransitionMachineIdentityState's single-round-trip conditional write (#388).
 func (rs *RemoteStorage) RevokeRiskExceptionIfNotRevoked(ctx context.Context, e *models.RiskException) (bool, error) {
 	path := fmt.Sprintf("/api/v1/system/risk-exceptions/%d/revoke", e.ID)
-	resp, err := rs.client.Put(ctx, path, newRiskExceptionWire(e))
-	if err != nil {
-		return false, fmt.Errorf("failed to revoke risk exception: %w", err)
-	}
-	if !resp.Success {
-		return false, fmt.Errorf("revoke risk exception failed: %s", resp.Error.Error())
-	}
-	var result struct {
-		Matched bool `json:"matched"`
-	}
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return false, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return result.Matched, nil
+	return rs.putConditionalTransition(ctx, path, newRiskExceptionWire(e), "revoke risk exception")
 }
 
 // ApproveRiskExceptionIfPending persists e's full row via a single conditional
@@ -224,18 +211,5 @@ func (rs *RemoteStorage) RevokeRiskExceptionIfNotRevoked(ctx context.Context, e 
 // false.
 func (rs *RemoteStorage) ApproveRiskExceptionIfPending(ctx context.Context, e *models.RiskException) (bool, error) {
 	path := fmt.Sprintf("/api/v1/system/risk-exceptions/%d/approve", e.ID)
-	resp, err := rs.client.Put(ctx, path, newRiskExceptionWire(e))
-	if err != nil {
-		return false, fmt.Errorf("failed to approve risk exception: %w", err)
-	}
-	if !resp.Success {
-		return false, fmt.Errorf("approve risk exception failed: %s", resp.Error.Error())
-	}
-	var result struct {
-		Matched bool `json:"matched"`
-	}
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return false, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return result.Matched, nil
+	return rs.putConditionalTransition(ctx, path, newRiskExceptionWire(e), "approve risk exception")
 }

--- a/internal/storage/store/remote_risk_exceptions.go
+++ b/internal/storage/store/remote_risk_exceptions.go
@@ -14,19 +14,25 @@
 // internal/core.KeyorixCore (internal/core/risk_exceptions.go), exactly as it
 // does against a local backend.
 //
-// Atomicity (investigated, not assumed): local_risk_exceptions.go's
-// UpdateRiskException is an unconditional full-row `Save`, not a
-// conditional/optimistic-concurrency write — there is no
-// LockXForUpdate/SELECT ... FOR UPDATE anywhere in this subsystem, unlike, say,
-// UpdateProjectInvitation's `WHERE id = ? AND state = 'pending'` or #511's
-// duplicate-active-membership unique-index translation. internal/core's
-// RevokeRiskException/ApproveRiskException already re-fetch the exception and
-// check its revoked/approved/expiry state before mutating it — a check-then-act
-// sequence with exactly the same (small, pre-existing, accepted) race window
-// against a local backend as against this proxy. This fix preserves that
-// behavior exactly rather than introducing a stricter guarantee the local
-// backend itself doesn't have — no new atomic storage-interface primitive is
-// needed here.
+// Atomicity: local_risk_exceptions.go's UpdateRiskException is (and remains) an
+// unconditional full-row `Save` — internal/core.RevokeRiskException/
+// ApproveRiskException never call it directly for their own transitions.
+// A prior version of this file's doc argued the small check-then-act race
+// between those functions' GetRiskException read and their (then-only)
+// UpdateRiskException write was "pre-existing and accepted" against a local
+// backend too, so no conditional write was needed here. A new CodeQL query
+// (StateTransitionMissingCAS.ql) flagged that race as a real, confirmed TOCTOU:
+// two callers racing RevokeRiskException/ApproveRiskException for the same
+// exception (e.g. one admin revoking while another is mid-approve) could
+// silently clobber each other's write, with no error to either caller, exactly
+// like #388/#412 before their fixes. RevokeRiskExceptionIfNotRevoked and
+// ApproveRiskExceptionIfPending (below) close it the same way those did:
+// UpdateRiskException/its proxy route stay as an unconditional full-row write
+// for any OTHER caller that genuinely wants one, but RevokeRiskException/
+// ApproveRiskException in internal/core/risk_exceptions.go now call these
+// conditional methods instead, mirroring UpdateProjectInvitation's
+// `WHERE id = ? AND state = 'pending'` pattern (#412) and
+// TransitionMachineIdentityState's `WHERE id = ? AND state = ?` pattern (#388).
 //
 // For the local (GORM) equivalent of every primitive here see
 // local_risk_exceptions.go.
@@ -184,4 +190,52 @@ func (rs *RemoteStorage) UpdateRiskException(ctx context.Context, e *models.Risk
 		return fmt.Errorf("update risk exception failed: %s", resp.Error.Error())
 	}
 	return nil
+}
+
+// RevokeRiskExceptionIfNotRevoked persists e's full row via a single conditional
+// PUT to /api/v1/system/risk-exceptions/{id}/revoke — a dedicated route (NOT
+// UpdateRiskExceptionProxy) so the upstream applies the exact same conditional
+// "WHERE id = ? AND revoked = false" write its own LocalStorage would, in ONE
+// round trip. See the package doc for why this exists alongside (not instead
+// of) the plain UpdateRiskException above, mirroring
+// TransitionMachineIdentityState's single-round-trip conditional write (#388).
+func (rs *RemoteStorage) RevokeRiskExceptionIfNotRevoked(ctx context.Context, e *models.RiskException) (bool, error) {
+	path := fmt.Sprintf("/api/v1/system/risk-exceptions/%d/revoke", e.ID)
+	resp, err := rs.client.Put(ctx, path, newRiskExceptionWire(e))
+	if err != nil {
+		return false, fmt.Errorf("failed to revoke risk exception: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("revoke risk exception failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Matched bool `json:"matched"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Matched, nil
+}
+
+// ApproveRiskExceptionIfPending persists e's full row via a single conditional
+// PUT to /api/v1/system/risk-exceptions/{id}/approve — mirrors
+// RevokeRiskExceptionIfNotRevoked exactly, gated instead on the row's CURRENT
+// revoked flag still being false AND its CURRENT approved flag still being
+// false.
+func (rs *RemoteStorage) ApproveRiskExceptionIfPending(ctx context.Context, e *models.RiskException) (bool, error) {
+	path := fmt.Sprintf("/api/v1/system/risk-exceptions/%d/approve", e.ID)
+	resp, err := rs.client.Put(ctx, path, newRiskExceptionWire(e))
+	if err != nil {
+		return false, fmt.Errorf("failed to approve risk exception: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("approve risk exception failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Matched bool `json:"matched"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Matched, nil
 }

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -229,6 +229,49 @@ func (rs *RemoteStorage) UpdateSecret(ctx context.Context, secret *models.Secret
 	return &result, nil
 }
 
+// transitionSecretStatusWireRequest is TransitionSecretStatus's request body:
+// the full secret row the caller already mutated in memory (secret.Status/
+// UpdatedAt already set to the target values), plus the fromStatus the caller
+// observed via GetSecret immediately before mutating it, mirroring
+// transitionMachineIdentityStateBody's shape exactly. The Secret field
+// marshals *models.SecretNode directly — it carries no json tags of its own
+// beyond ValueStored's `json:"-"`, so a Go-to-Go round trip between this
+// client and the handler's identical type preserves every field exactly, the
+// same choice GetSecretIncludingDeleted already makes for the identical type.
+type transitionSecretStatusWireRequest struct {
+	Secret     *models.SecretNode `json:"secret"`
+	FromStatus string             `json:"from_status"`
+}
+
+// TransitionSecretStatus persists secret's full row via a single conditional
+// PUT to /api/v1/system/secrets/{id}/transition-status (mirroring
+// TransitionMachineIdentityState's #388 pattern), carrying fromStatus
+// alongside so the upstream applies the exact SAME conditional
+// "WHERE id = ? AND status = ?" write its own LocalStorage would — see the
+// interface doc (internal/core/storage/interface.go) for why this exists as a
+// single round-trip primitive rather than a generic GetSecret-then-
+// UpdateSecret proxy pair (RemoteStorage.WithTransaction is a no-op
+// passthrough, so that two-call sequence would reopen the exact race this
+// closes).
+func (rs *RemoteStorage) TransitionSecretStatus(ctx context.Context, secret *models.SecretNode, fromStatus string) (bool, error) {
+	path := fmt.Sprintf("/api/v1/system/secrets/%d/transition-status", secret.ID)
+	body := transitionSecretStatusWireRequest{Secret: secret, FromStatus: fromStatus}
+	resp, err := rs.client.Put(ctx, path, body)
+	if err != nil {
+		return false, fmt.Errorf("failed to transition secret status: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("transition secret status failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Matched bool `json:"matched"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Matched, nil
+}
+
 // DeleteSecret deletes a secret by ID via remote API.
 func (rs *RemoteStorage) DeleteSecret(ctx context.Context, id uint) error {
 	path := fmt.Sprintf("/api/v1/secrets/%d", id)

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -256,20 +256,7 @@ type transitionSecretStatusWireRequest struct {
 func (rs *RemoteStorage) TransitionSecretStatus(ctx context.Context, secret *models.SecretNode, fromStatus string) (bool, error) {
 	path := fmt.Sprintf("/api/v1/system/secrets/%d/transition-status", secret.ID)
 	body := transitionSecretStatusWireRequest{Secret: secret, FromStatus: fromStatus}
-	resp, err := rs.client.Put(ctx, path, body)
-	if err != nil {
-		return false, fmt.Errorf("failed to transition secret status: %w", err)
-	}
-	if !resp.Success {
-		return false, fmt.Errorf("transition secret status failed: %s", resp.Error.Error())
-	}
-	var result struct {
-		Matched bool `json:"matched"`
-	}
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return false, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return result.Matched, nil
+	return rs.putConditionalTransition(ctx, path, body, "transition secret status")
 }
 
 // DeleteSecret deletes a secret by ID via remote API.

--- a/internal/storage/store/remote_secrets_test.go
+++ b/internal/storage/store/remote_secrets_test.go
@@ -379,6 +379,40 @@ func TestRemoteStorage_ListSecretVersions(t *testing.T) {
 	assert.Equal(t, 1, versions[0].VersionNumber)
 }
 
+// --- TransitionSecretStatus ---
+
+func TestRemoteStorage_TransitionSecretStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/secrets/42/transition-status", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	matched, err := rs.TransitionSecretStatus(context.Background(),
+		&models.SecretNode{ID: 42, Status: "suspended"}, "active")
+	require.NoError(t, err)
+	assert.True(t, matched)
+}
+
+func TestRemoteStorage_TransitionSecretStatus_NotMatched(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	matched, err := rs.TransitionSecretStatus(context.Background(),
+		&models.SecretNode{ID: 42, Status: "active"}, "suspended")
+	require.NoError(t, err)
+	assert.False(t, matched)
+}
+
 func TestRemoteStorage_GetSecretVersions(t *testing.T) {
 	// GetSecretVersions is an alias for ListSecretVersions; same URL.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -419,20 +419,7 @@ func (rs *RemoteStorage) UpdateUserIfActiveStateMatches(ctx context.Context, use
 		UpdatedAt:   user.UpdatedAt,
 		FromActive:  fromActive,
 	}
-	resp, err := rs.client.Put(ctx, path, body)
-	if err != nil {
-		return false, fmt.Errorf("failed to update user active state: %w", err)
-	}
-	if !resp.Success {
-		return false, fmt.Errorf("update user active state failed: %s", resp.Error.Error())
-	}
-	var result struct {
-		Matched bool `json:"matched"`
-	}
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return false, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return result.Matched, nil
+	return rs.putConditionalTransition(ctx, path, body, "update user active state")
 }
 
 // UpdateLastLogin is not available in remote mode — last_login_at is stamped

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -370,6 +370,71 @@ func (rs *RemoteStorage) UpdateUser(ctx context.Context, user *models.User) (*mo
 	return decodeUserResponse(resp.Data)
 }
 
+// userActiveTransitionWireRequest carries the full row UpdateUser already
+// mutated in memory (username/email/display_name/active/updated_at) plus
+// fromActive — the value UpdateUser observed via GetUser (wasActive) before
+// applying any of the request's field changes — for
+// UpdateUserIfActiveStateMatches's conditional write. Unlike
+// userUpdateWireRequest's PATCH-style semantics, every field here is always
+// meaningful: this is a full-row persist (mirroring
+// TransitionMachineIdentityState's transitionMachineIdentityStateBody shape),
+// not a partial update, so there is no need for optional pointers.
+//
+// UpdatedAt is carried explicitly (unlike userUpdateWireRequest) because this
+// route is a raw storage-primitive passthrough, not the human-facing PUT
+// /api/v1/users/{id} route — there is no server-side core.UpdateUser call on
+// the receiving end to recompute it from the upstream's own clock, so leaving
+// it off the wire would zero the column on every conditional write.
+type userActiveTransitionWireRequest struct {
+	Username    string    `json:"username"`
+	Email       string    `json:"email"`
+	DisplayName string    `json:"display_name"`
+	Active      bool      `json:"active"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	FromActive  bool      `json:"from_active"`
+}
+
+// UpdateUserIfActiveStateMatches persists user's full row via a single
+// conditional PUT to /api/v1/system/users/{id}/active-transition (mirroring
+// TransitionMachineIdentityState's #518 `WHERE id = ? AND state = ?` pattern
+// for this codebase's other TOCTOU class — see the interface doc in
+// internal/core/storage/interface.go), carrying fromActive alongside so the
+// upstream applies the exact SAME conditional "WHERE id = ? AND is_active = ?"
+// write its own LocalStorage would. This deliberately does NOT reuse the
+// human-facing PUT /api/v1/users/{id} route (UpdateUser above): that route
+// re-runs the upstream's OWN core.KeyorixCore.UpdateUser end to end (including
+// its own GetUser read and uniqueness checks) against the caller's request
+// body — the wrong shape for a caller (this client's own core.UpdateUser) that
+// has ALREADY performed all of that validation itself against proxied reads
+// and only needs the FINAL persist to be atomic. Exactly the same
+// raw-storage-primitive-passthrough reasoning as
+// machine_identities_proxy.go's TransitionMachineIdentityStateProxy.
+func (rs *RemoteStorage) UpdateUserIfActiveStateMatches(ctx context.Context, user *models.User, fromActive bool) (bool, error) {
+	path := fmt.Sprintf("/api/v1/system/users/%d/active-transition", user.ID)
+	body := userActiveTransitionWireRequest{
+		Username:    user.Username,
+		Email:       user.Email,
+		DisplayName: user.DisplayName,
+		Active:      user.IsActive,
+		UpdatedAt:   user.UpdatedAt,
+		FromActive:  fromActive,
+	}
+	resp, err := rs.client.Put(ctx, path, body)
+	if err != nil {
+		return false, fmt.Errorf("failed to update user active state: %w", err)
+	}
+	if !resp.Success {
+		return false, fmt.Errorf("update user active state failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Matched bool `json:"matched"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Matched, nil
+}
+
 // UpdateLastLogin is not available in remote mode — last_login_at is stamped
 // server-side inside the login handler, which always runs against LocalStorage.
 func (rs *RemoteStorage) UpdateLastLogin(_ context.Context, _ uint, _ time.Time) error {

--- a/internal/storage/store/remote_users_test.go
+++ b/internal/storage/store/remote_users_test.go
@@ -271,6 +271,61 @@ func TestRemoteStorage_UpdateUser(t *testing.T) {
 	assert.Equal(t, "Alice Updated", user.DisplayName)
 }
 
+// --- UpdateUserIfActiveStateMatches ---
+
+func TestRemoteStorage_UpdateUserIfActiveStateMatches(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/users/4/active-transition", r.URL.Path)
+		var body map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, false, body["active"])
+		assert.Equal(t, true, body["from_active"])
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	matched, err := rs.UpdateUserIfActiveStateMatches(context.Background(),
+		&models.User{ID: 4, Username: "frank", Email: "frank@example.com", IsActive: false}, true)
+	require.NoError(t, err)
+	assert.True(t, matched)
+}
+
+func TestRemoteStorage_UpdateUserIfActiveStateMatches_NotMatched(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	matched, err := rs.UpdateUserIfActiveStateMatches(context.Background(),
+		&models.User{ID: 4, IsActive: false}, true)
+	require.NoError(t, err)
+	assert.False(t, matched)
+}
+
+func TestRemoteStorage_UpdateUserIfActiveStateMatches_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   map[string]string{"code": "DUPLICATE_EMAIL", "message": "duplicate email"},
+		})
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateUserIfActiveStateMatches(context.Background(), &models.User{ID: 4}, true)
+	require.Error(t, err)
+}
+
 func TestRemoteStorage_UpdateUser_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/storage/store/store_s25_test.go
+++ b/internal/storage/store/store_s25_test.go
@@ -736,6 +736,16 @@ func TestListAllMachineIdentities_S25_BrokenDB(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestTransitionDynamicSecretConfigDisabled_S25_BrokenDB exercises the DB-error
+// path (StateTransitionMissingCAS fix), mirroring
+// TestTransitionMachineIdentityState_S25_BrokenDB above.
+func TestTransitionDynamicSecretConfigDisabled_S25_BrokenDB(t *testing.T) {
+	ls := newBrokenDB(t)
+	_, err := ls.TransitionDynamicSecretConfigDisabled(context.Background(),
+		&models.DynamicSecretConfig{ID: 1, Disabled: true}, false)
+	require.Error(t, err)
+}
+
 // ---------------------------------------------------------------------------
 // local_rbac.go — error paths for simple functions
 // ---------------------------------------------------------------------------

--- a/internal/storage/store/store_s3_test.go
+++ b/internal/storage/store/store_s3_test.go
@@ -869,6 +869,70 @@ func TestDynamicSecretConfig_GetListUpdate(t *testing.T) {
 	assert.Equal(t, "mysql", got2.BackendType)
 }
 
+// TestTransitionDynamicSecretConfigDisabled_ClosesRace proves the
+// StateTransitionMissingCAS fix: two callers racing to flip the SAME config's
+// Disabled field (both having read the SAME pre-transition value) can no
+// longer both silently win. The first conditional write matches and persists;
+// the second — still gated on the now-STALE fromDisabled value the first
+// caller also observed — is rejected (matched=false), exactly mirroring
+// TestTransitionMachineIdentityState's #388/#518 proof.
+func TestTransitionDynamicSecretConfigDisabled_ClosesRace(t *testing.T) {
+	ctx := context.Background()
+	ls := newDynamicFullStore(t)
+
+	cfg, err := ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+		Name: "race-config", ProjectID: 1, EnvironmentID: 1, BackendType: "postgres",
+		Disabled: false,
+	})
+	require.NoError(t, err)
+
+	// Both racing callers observed Disabled=false via GetDynamicSecretConfig
+	// before mutating their own in-memory copy to Disabled=true.
+	first := *cfg
+	first.Disabled = true
+	second := *cfg
+	second.Disabled = true
+
+	// First writer wins: the row's persisted disabled value still matches the
+	// fromDisabled it observed (false).
+	matched1, err := ls.TransitionDynamicSecretConfigDisabled(ctx, &first, false)
+	require.NoError(t, err)
+	assert.True(t, matched1)
+
+	// Second writer — racing off the SAME stale fromDisabled=false — must lose:
+	// the row's persisted disabled value has already moved to true.
+	matched2, err := ls.TransitionDynamicSecretConfigDisabled(ctx, &second, false)
+	require.NoError(t, err)
+	assert.False(t, matched2)
+
+	// The persisted row reflects the FIRST writer's change only, and was not
+	// clobbered by the second (rejected) write.
+	got, err := ls.GetDynamicSecretConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.True(t, got.Disabled)
+
+	// A THIRD call gated on the now-current value (true) succeeds, proving the
+	// conditional write isn't permanently stuck — it tracks whatever is
+	// actually persisted.
+	third := *cfg
+	third.Disabled = false
+	matched3, err := ls.TransitionDynamicSecretConfigDisabled(ctx, &third, true)
+	require.NoError(t, err)
+	assert.True(t, matched3)
+}
+
+// TestTransitionDynamicSecretConfigDisabled_NotFound verifies the
+// RowsAffected == 0 path when the config id doesn't exist at all.
+func TestTransitionDynamicSecretConfigDisabled_NotFound(t *testing.T) {
+	ctx := context.Background()
+	ls := newDynamicFullStore(t)
+
+	matched, err := ls.TransitionDynamicSecretConfigDisabled(ctx,
+		&models.DynamicSecretConfig{ID: 9999, Disabled: true}, false)
+	require.NoError(t, err)
+	assert.False(t, matched)
+}
+
 func TestCountDynamicSecretConfigsByClassification(t *testing.T) {
 	ctx := context.Background()
 	ls := newDynamicFullStore(t)

--- a/internal/storage/store/store_s4_test.go
+++ b/internal/storage/store/store_s4_test.go
@@ -229,6 +229,75 @@ func TestUpdateUser_Success(t *testing.T) {
 	assert.Equal(t, "Bobby", updated.DisplayName)
 }
 
+// TestUpdateUserIfActiveStateMatches_Success verifies the happy path: a
+// conditional write against a row whose CURRENT is_active still equals
+// fromActive matches and persists the full row.
+func TestUpdateUserIfActiveStateMatches_Success(t *testing.T) {
+	ctx := context.Background()
+	ls := newUserS4Store(t)
+
+	u, err := ls.CreateUser(ctx, &models.User{Username: "dave", Email: "dave@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	u.IsActive = false
+	u.DisplayName = "Dave Deactivated"
+	matched, err := ls.UpdateUserIfActiveStateMatches(ctx, u, true)
+	require.NoError(t, err)
+	assert.True(t, matched)
+
+	reloaded, err := ls.GetUser(ctx, u.ID)
+	require.NoError(t, err)
+	assert.False(t, reloaded.IsActive)
+	assert.Equal(t, "Dave Deactivated", reloaded.DisplayName)
+}
+
+// TestUpdateUserIfActiveStateMatches_LostRaceReturnsFalse proves the TOCTOU
+// race is closed: calling the method twice back-to-back with the SAME
+// fromActive (as two racing UpdateUser callers who both observed the row
+// active before either commits would) lets only the first call win — the
+// second observes the row's is_active has already moved and reports no match,
+// rather than silently clobbering the first call's write. Mirrors
+// TestTransitionMachineIdentityState_S25_NoMatchReturnsFalse's shape for this
+// codebase's other conditional-write primitive.
+func TestUpdateUserIfActiveStateMatches_LostRaceReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+	ls := newUserS4Store(t)
+
+	u, err := ls.CreateUser(ctx, &models.User{Username: "eve", Email: "eve@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	// First racing caller: observed IsActive=true, flips to false, wins.
+	first := &models.User{ID: u.ID, Username: u.Username, Email: u.Email, IsActive: false}
+	matched, err := ls.UpdateUserIfActiveStateMatches(ctx, first, true)
+	require.NoError(t, err)
+	assert.True(t, matched, "first racing call must win")
+
+	// Second racing caller: ALSO observed IsActive=true (stale — the first call
+	// already committed false) and tries to persist its own unrelated field
+	// change plus a redundant IsActive=false assertion. Must lose the race, not
+	// silently re-apply its stale view over the winner's write.
+	second := &models.User{ID: u.ID, Username: u.Username, Email: u.Email, DisplayName: "Should Not Persist", IsActive: false}
+	matched, err = ls.UpdateUserIfActiveStateMatches(ctx, second, true)
+	require.NoError(t, err)
+	assert.False(t, matched, "second racing call must lose the race")
+
+	// The loser's DisplayName must not have landed.
+	reloaded, err := ls.GetUser(ctx, u.ID)
+	require.NoError(t, err)
+	assert.NotEqual(t, "Should Not Persist", reloaded.DisplayName)
+}
+
+// TestUpdateUserIfActiveStateMatches_NoMatchReturnsFalse verifies the
+// RowsAffected == 0 path for a nonexistent user (no row can match).
+func TestUpdateUserIfActiveStateMatches_NoMatchReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+	ls := newUserS4Store(t)
+
+	matched, err := ls.UpdateUserIfActiveStateMatches(ctx, &models.User{ID: 999999, IsActive: false}, true)
+	require.NoError(t, err)
+	assert.False(t, matched)
+}
+
 func TestRestoreUser_NotFound(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)

--- a/server/http/handlers/constants.go
+++ b/server/http/handlers/constants.go
@@ -15,9 +15,11 @@ const (
 	errInvalidBody               = "invalid request body"
 	errInvalidCampaignID         = "Invalid campaign ID"
 	errInvalidCampaignIDLower    = "invalid campaign id"
+	errInvalidConfigID           = "invalid config id"
 	errInvalidCredentialID       = "invalid credential id" // #nosec G101 -- error message string, not a hardcoded credential
 	errInvalidEnvIDField         = "Invalid environment_id"
 	errInvalidEnvironmentID      = "invalid environment ID"
+	errInvalidExceptionID        = "invalid exception id"
 	errInvalidGroupID            = "Invalid group ID"
 	errInvalidGroupIDLower       = "invalid group ID"
 	errInvalidJSON               = "Invalid JSON in request body"

--- a/server/http/handlers/dynamic_secrets_proxy.go
+++ b/server/http/handlers/dynamic_secrets_proxy.go
@@ -233,7 +233,7 @@ func (h *DynamicSecretHandler) CreateDynamicSecretConfigProxy(w http.ResponseWri
 func (h *DynamicSecretHandler) GetDynamicSecretConfigProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid config id")
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", errInvalidConfigID)
 		return
 	}
 	cfg, err := h.coreService.Storage().GetDynamicSecretConfig(r.Context(), uint(id))
@@ -277,7 +277,7 @@ func (h *DynamicSecretHandler) ListDynamicSecretConfigsProxy(w http.ResponseWrit
 func (h *DynamicSecretHandler) UpdateDynamicSecretConfigProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid config id")
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", errInvalidConfigID)
 		return
 	}
 	var body dynamicSecretConfigProxyWire
@@ -314,7 +314,7 @@ type transitionDynamicSecretConfigDisabledBody struct {
 func (h *DynamicSecretHandler) TransitionDynamicSecretConfigDisabledProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid config id")
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", errInvalidConfigID)
 		return
 	}
 	var body transitionDynamicSecretConfigDisabledBody

--- a/server/http/handlers/dynamic_secrets_proxy.go
+++ b/server/http/handlers/dynamic_secrets_proxy.go
@@ -1,9 +1,9 @@
 // dynamic_secrets_proxy.go — server-side endpoints backing RemoteStorage's
 // dynamic-secrets storage primitives (ADR-035/ADR-049): CreateDynamicSecretConfig/
 // GetDynamicSecretConfig/ListDynamicSecretConfigs/UpdateDynamicSecretConfig/
-// CountDynamicSecretConfigsByClassification/CreateDynamicSecretLease/
-// GetDynamicSecretLease/ListDynamicSecretLeases/CountActiveLeases/
-// UpdateDynamicSecretLease/ListExpiredActiveLeases.
+// TransitionDynamicSecretConfigDisabled/CountDynamicSecretConfigsByClassification/
+// CreateDynamicSecretLease/GetDynamicSecretLease/ListDynamicSecretLeases/
+// CountActiveLeases/UpdateDynamicSecretLease/ListExpiredActiveLeases.
 //
 // A downstream Keyorix server booted with storage.type: remote (ADR-049) proxies
 // its dynamic-secrets storage calls to whichever upstream server it's configured
@@ -292,6 +292,45 @@ func (h *DynamicSecretHandler) UpdateDynamicSecretConfigProxy(w http.ResponseWri
 		return
 	}
 	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}
+
+// transitionDynamicSecretConfigDisabledBody is the request body
+// TransitionDynamicSecretConfigDisabledProxy expects: the full config row the
+// caller already mutated in memory (Disabled/UpdatedAt already set to the
+// target values), plus the fromDisabled value the caller observed via its own
+// GetDynamicSecretConfig read.
+type transitionDynamicSecretConfigDisabledBody struct {
+	Config       dynamicSecretConfigProxyWire `json:"config"`
+	FromDisabled bool                         `json:"from_disabled"`
+}
+
+// TransitionDynamicSecretConfigDisabledProxy handles PUT
+// /api/v1/system/dynamic-secrets/configs/{id}/transition. Runs the SAME
+// conditional "WHERE id = ? AND disabled = ?" write
+// core.KeyorixCore.SetDynamicSecretConfigEnabled relies on against a local
+// backend (StateTransitionMissingCAS) — see the package doc's atomicity note
+// for why this is a dedicated route rather than a generic
+// UpdateDynamicSecretConfigProxy call.
+func (h *DynamicSecretHandler) TransitionDynamicSecretConfigDisabledProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid config id")
+		return
+	}
+	var body transitionDynamicSecretConfigDisabledBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
+		return
+	}
+	body.Config.ID = uint(id)
+	cfg := body.Config.toModel()
+	matched, err := h.coreService.Storage().TransitionDynamicSecretConfigDisabled(r.Context(), cfg, body.FromDisabled)
+	if err != nil {
+		log.Printf("dynamic-secrets proxy: transition config failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"matched": matched})
 }
 
 // CountDynamicSecretConfigsByClassificationProxy handles GET

--- a/server/http/handlers/handlers_s13_connect_dynamic_test.go
+++ b/server/http/handlers/handlers_s13_connect_dynamic_test.go
@@ -706,6 +706,79 @@ func TestDynProxy_UpdateConfig_BadBody_S13(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// TransitionDynamicSecretConfigDisabledProxy — bad id
+func TestDynProxy_TransitionConfigDisabled_BadID_S13(t *testing.T) {
+	h := newDynamicSecretHandlerProxyS13(t)
+	body, _ := json.Marshal(map[string]interface{}{
+		"config":        map[string]interface{}{"name": "x", "project_id": 1, "disabled": true},
+		"from_disabled": false,
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/system/dynamic-secrets/configs/notanint/transition", bytes.NewReader(body)),
+		"id", "notanint",
+	)
+	w := httptest.NewRecorder()
+	h.TransitionDynamicSecretConfigDisabledProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TransitionDynamicSecretConfigDisabledProxy — bad body
+func TestDynProxy_TransitionConfigDisabled_BadBody_S13(t *testing.T) {
+	h := newDynamicSecretHandlerProxyS13(t)
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/system/dynamic-secrets/configs/1/transition", bytes.NewBufferString("not-json")),
+		"id", "1",
+	)
+	w := httptest.NewRecorder()
+	h.TransitionDynamicSecretConfigDisabledProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TransitionDynamicSecretConfigDisabledProxy — proves the StateTransitionMissingCAS
+// race is closed end-to-end through the HTTP proxy layer: two racing callers that
+// both observed disabled=false cannot both win. The first conditional write
+// matches; the second, replaying the SAME stale from_disabled, is rejected
+// (matched=false) rather than silently clobbering the first.
+func TestDynProxy_TransitionConfigDisabled_ClosesRace_S13(t *testing.T) {
+	h := newDynamicSecretHandlerProxyS13(t)
+	created, err := h.coreService.Storage().CreateDynamicSecretConfig(context.Background(), &models.DynamicSecretConfig{
+		Name: "race-proxy-config", ProjectID: 1, EnvironmentID: 1, BackendType: "postgres", Disabled: false,
+	})
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"config":        map[string]interface{}{"name": created.Name, "project_id": created.ProjectID, "disabled": true},
+		"from_disabled": false,
+	})
+	path := "/api/v1/system/dynamic-secrets/configs/" + strconv.FormatUint(uint64(created.ID), 10) + "/transition"
+
+	// First racer: still-current from_disabled=false → matches.
+	req1 := withChiParam(httptest.NewRequest(http.MethodPut, path, bytes.NewReader(body)), "id", strconv.FormatUint(uint64(created.ID), 10))
+	w1 := httptest.NewRecorder()
+	h.TransitionDynamicSecretConfigDisabledProxy(w1, req1)
+	require.Equal(t, http.StatusOK, w1.Code)
+	var result1 struct {
+		Data struct {
+			Matched bool `json:"matched"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w1.Body.Bytes(), &result1))
+	assert.True(t, result1.Data.Matched)
+
+	// Second racer: replays the SAME stale from_disabled=false → loses the race.
+	req2 := withChiParam(httptest.NewRequest(http.MethodPut, path, bytes.NewReader(body)), "id", strconv.FormatUint(uint64(created.ID), 10))
+	w2 := httptest.NewRecorder()
+	h.TransitionDynamicSecretConfigDisabledProxy(w2, req2)
+	require.Equal(t, http.StatusOK, w2.Code)
+	var result2 struct {
+		Data struct {
+			Matched bool `json:"matched"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &result2))
+	assert.False(t, result2.Data.Matched)
+}
+
 // CreateDynamicSecretLeaseProxy — bad body
 func TestDynProxy_CreateLease_BadBody_S13(t *testing.T) {
 	h := newDynamicSecretHandlerProxyS13(t)

--- a/server/http/handlers/handlers_s13_proxy_test.go
+++ b/server/http/handlers/handlers_s13_proxy_test.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -942,6 +943,151 @@ func TestUpdateRiskExceptionProxy_BadBody_S13(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	resp := decodeRemoteResp(t, w)
 	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+}
+
+// TestRevokeRiskExceptionProxy_BadID_S13 — non-numeric id → 400.
+func TestRevokeRiskExceptionProxy_BadID_S13(t *testing.T) {
+	h := freshDashboardHandlerS13(t)
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/risk-exceptions/bad/revoke", strings.NewReader("{}")),
+		"id", "bad",
+	)
+	w := httptest.NewRecorder()
+	h.RevokeRiskExceptionProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_PARAMETER", resp.Error.Code)
+}
+
+// TestRevokeRiskExceptionProxy_BadBody_S13 — valid id, malformed JSON body → 400.
+func TestRevokeRiskExceptionProxy_BadBody_S13(t *testing.T) {
+	h := freshDashboardHandlerS13(t)
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/risk-exceptions/1/revoke", strings.NewReader("{bad")),
+		"id", "1",
+	)
+	w := httptest.NewRecorder()
+	h.RevokeRiskExceptionProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+}
+
+// TestRevokeRiskExceptionProxy_LostRace_S13 — a second revoke attempt asserting
+// the same (now-stale) revoked=false state as a call that already won must
+// report matched:false, not silently re-apply, proving the CAS race closes at
+// the HTTP-proxy boundary too (not just LocalStorage).
+func TestRevokeRiskExceptionProxy_LostRace_S13(t *testing.T) {
+	h := freshDashboardHandlerS13(t)
+
+	createBody := proxyJSON(map[string]interface{}{
+		"title":         "Revoke Race S13",
+		"category":      "operational",
+		"justification": "Testing revoke CAS",
+		"created_by":    1,
+		"expires_at":    time.Now().Add(30 * 24 * time.Hour),
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/system/risk-exceptions", createBody)
+	createW := httptest.NewRecorder()
+	h.CreateRiskExceptionProxy(createW, createReq)
+	require.Equal(t, http.StatusOK, createW.Code)
+	createResp := decodeRemoteResp(t, createW)
+	created, ok := createResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	id := uint(created["id"].(float64))
+	idStr := strconv.FormatUint(uint64(id), 10)
+
+	revokeBody := func() *bytes.Buffer {
+		return proxyJSON(map[string]interface{}{"revoked": true, "revoked_by": 2})
+	}
+
+	firstReq := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/risk-exceptions/"+idStr+"/revoke", revokeBody()),
+		"id", idStr,
+	)
+	firstW := httptest.NewRecorder()
+	h.RevokeRiskExceptionProxy(firstW, firstReq)
+	assert.Equal(t, http.StatusOK, firstW.Code)
+	firstResp := decodeRemoteResp(t, firstW)
+	firstData, ok := firstResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, firstData["matched"], "first revoke must win")
+
+	secondReq := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/risk-exceptions/"+idStr+"/revoke", revokeBody()),
+		"id", idStr,
+	)
+	secondW := httptest.NewRecorder()
+	h.RevokeRiskExceptionProxy(secondW, secondReq)
+	assert.Equal(t, http.StatusOK, secondW.Code)
+	secondResp := decodeRemoteResp(t, secondW)
+	secondData, ok := secondResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, secondData["matched"], "second (racing) revoke must lose — already revoked")
+}
+
+// TestApproveRiskExceptionProxy_BadID_S13 — non-numeric id → 400.
+func TestApproveRiskExceptionProxy_BadID_S13(t *testing.T) {
+	h := freshDashboardHandlerS13(t)
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/risk-exceptions/bad/approve", strings.NewReader("{}")),
+		"id", "bad",
+	)
+	w := httptest.NewRecorder()
+	h.ApproveRiskExceptionProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_PARAMETER", resp.Error.Code)
+}
+
+// TestApproveRiskExceptionProxy_BadBody_S13 — valid id, malformed JSON body → 400.
+func TestApproveRiskExceptionProxy_BadBody_S13(t *testing.T) {
+	h := freshDashboardHandlerS13(t)
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/risk-exceptions/1/approve", strings.NewReader("{bad")),
+		"id", "1",
+	)
+	w := httptest.NewRecorder()
+	h.ApproveRiskExceptionProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+}
+
+// TestApproveRiskExceptionProxy_HappyPath_S13 — a pending (not revoked, not
+// approved) exception approves cleanly and reports matched:true.
+func TestApproveRiskExceptionProxy_HappyPath_S13(t *testing.T) {
+	h := freshDashboardHandlerS13(t)
+
+	createBody := proxyJSON(map[string]interface{}{
+		"title":         "Approve Happy S13",
+		"category":      "operational",
+		"justification": "Testing approve happy path",
+		"created_by":    1,
+		"expires_at":    time.Now().Add(30 * 24 * time.Hour),
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/system/risk-exceptions", createBody)
+	createW := httptest.NewRecorder()
+	h.CreateRiskExceptionProxy(createW, createReq)
+	require.Equal(t, http.StatusOK, createW.Code)
+	createResp := decodeRemoteResp(t, createW)
+	created, ok := createResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	id := uint(created["id"].(float64))
+	idStr := strconv.FormatUint(uint64(id), 10)
+
+	approveBody := proxyJSON(map[string]interface{}{"approved": true, "approved_by": 2})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/risk-exceptions/"+idStr+"/approve", approveBody),
+		"id", idStr,
+	)
+	w := httptest.NewRecorder()
+	h.ApproveRiskExceptionProxy(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	resp := decodeRemoteResp(t, w)
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, data["matched"])
 }
 
 // ── risk_exceptions.go (non-proxy) ───────────────────────────────────────────

--- a/server/http/handlers/risk_exceptions.go
+++ b/server/http/handlers/risk_exceptions.go
@@ -93,6 +93,8 @@ func (h *DashboardHandler) ApproveRiskException(w http.ResponseWriter, r *http.R
 		switch {
 		case strings.Contains(msg, "dual control"):
 			status = http.StatusForbidden
+		case strings.Contains(msg, "concurrently"):
+			status = http.StatusConflict
 		case strings.Contains(msg, "cannot approve") || strings.Contains(msg, "already approved"):
 			status = http.StatusBadRequest
 		case strings.Contains(msg, "not found"):
@@ -122,6 +124,8 @@ func (h *DashboardHandler) RevokeRiskException(w http.ResponseWriter, r *http.Re
 		switch {
 		case strings.Contains(msg, "already revoked"):
 			status = http.StatusBadRequest
+		case strings.Contains(msg, "concurrently"):
+			status = http.StatusConflict
 		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
 		default:

--- a/server/http/handlers/risk_exceptions_proxy.go
+++ b/server/http/handlers/risk_exceptions_proxy.go
@@ -132,7 +132,7 @@ func (w riskExceptionProxyWire) toModel() *models.RiskException {
 func (h *DashboardHandler) CreateRiskExceptionProxy(w http.ResponseWriter, r *http.Request) {
 	var body riskExceptionProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
 		return
 	}
 	if body.Title == "" || body.Justification == "" {
@@ -152,7 +152,7 @@ func (h *DashboardHandler) CreateRiskExceptionProxy(w http.ResponseWriter, r *ht
 func (h *DashboardHandler) GetRiskExceptionProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid exception id")
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", errInvalidExceptionID)
 		return
 	}
 	e, err := h.coreService.Storage().GetRiskException(r.Context(), uint(id))
@@ -195,12 +195,12 @@ func (h *DashboardHandler) ListRiskExceptionsProxy(w http.ResponseWriter, r *htt
 func (h *DashboardHandler) UpdateRiskExceptionProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid exception id")
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", errInvalidExceptionID)
 		return
 	}
 	var body riskExceptionProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
 		return
 	}
 	body.ID = uint(id)
@@ -220,12 +220,12 @@ func (h *DashboardHandler) UpdateRiskExceptionProxy(w http.ResponseWriter, r *ht
 func (h *DashboardHandler) RevokeRiskExceptionProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid exception id")
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", errInvalidExceptionID)
 		return
 	}
 	var body riskExceptionProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
 		return
 	}
 	body.ID = uint(id)
@@ -245,12 +245,12 @@ func (h *DashboardHandler) RevokeRiskExceptionProxy(w http.ResponseWriter, r *ht
 func (h *DashboardHandler) ApproveRiskExceptionProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid exception id")
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", errInvalidExceptionID)
 		return
 	}
 	var body riskExceptionProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
 		return
 	}
 	body.ID = uint(id)

--- a/server/http/handlers/risk_exceptions_proxy.go
+++ b/server/http/handlers/risk_exceptions_proxy.go
@@ -32,17 +32,22 @@
 // persist/return the resulting row. Exactly the same class of mistake the
 // human-facing /groups routes were for #514's Group-CRUD proxy fix.
 //
-// Atomicity: storage.Storage.UpdateRiskException (local_risk_exceptions.go) is an
-// unconditional full-row `Save`, not a conditional/optimistic-concurrency write —
-// there is no LockXForUpdate/SELECT ... FOR UPDATE anywhere in this subsystem to
-// preserve across the wire. internal/core.RevokeRiskException/ApproveRiskException
-// already re-fetch the exception and check its revoked/approved/expiry state
-// before mutating it — a check-then-act sequence with exactly the same (small,
-// pre-existing, accepted) race window against a local backend as against this
-// proxy. This fix preserves that behavior exactly rather than introducing a
-// stricter guarantee the local backend itself doesn't have (mirrors
-// dynamic_secrets_proxy.go's UpdateDynamicSecretConfigProxy/
-// UpdateDynamicSecretLeaseProxy reasoning).
+// Atomicity: storage.Storage.UpdateRiskException (local_risk_exceptions.go)
+// remains an unconditional full-row `Save`, but RevokeRiskException/
+// ApproveRiskException (internal/core/risk_exceptions.go) no longer call it for
+// their own revoke/approve transitions — a CodeQL query
+// (StateTransitionMissingCAS.ql) confirmed the read-then-conditionally-
+// mutate-then-Save sequence those two functions ran was a real TOCTOU: two
+// callers racing the same exception (e.g. one admin revoking while another is
+// mid-approve) could silently clobber each other's write, no error to either
+// side. RevokeRiskExceptionIfNotRevoked/ApproveRiskExceptionIfPending
+// (storage.Storage; implemented in local_risk_exceptions.go as a conditional
+// GORM UPDATE) close it exactly like UpdateProjectInvitation's
+// `WHERE id = ? AND state = 'pending'` (#412) and TransitionMachineIdentityState's
+// `WHERE id = ? AND state = ?` (#388) did for their own TOCTOU classes.
+// RevokeRiskExceptionProxy/ApproveRiskExceptionProxy below are the dedicated
+// single-round-trip routes backing those two methods for RemoteStorage — see
+// their own doc comments.
 //
 // Response envelope: like dynamic_secrets_proxy.go/project_memberships_proxy.go,
 // these do NOT use the package's generic sendSuccess/sendError helpers — they
@@ -205,4 +210,55 @@ func (h *DashboardHandler) UpdateRiskExceptionProxy(w http.ResponseWriter, r *ht
 		return
 	}
 	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}
+
+// RevokeRiskExceptionProxy handles PUT /api/v1/system/risk-exceptions/{id}/revoke.
+// Runs the SAME conditional "WHERE id = ? AND revoked = false" write
+// core.KeyorixCore.RevokeRiskException now relies on against a local backend,
+// closing the TOCTOU race a plain UpdateRiskExceptionProxy call would reopen
+// across this HTTP hop — see the package doc's atomicity note.
+func (h *DashboardHandler) RevokeRiskExceptionProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid exception id")
+		return
+	}
+	var body riskExceptionProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	matched, err := h.coreService.Storage().RevokeRiskExceptionIfNotRevoked(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("risk-exceptions proxy: revoke failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"matched": matched})
+}
+
+// ApproveRiskExceptionProxy handles PUT /api/v1/system/risk-exceptions/{id}/approve.
+// Runs the SAME conditional "WHERE id = ? AND revoked = false AND approved =
+// false" write core.KeyorixCore.ApproveRiskException now relies on against a
+// local backend — see RevokeRiskExceptionProxy's doc for the race this closes.
+func (h *DashboardHandler) ApproveRiskExceptionProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid exception id")
+		return
+	}
+	var body riskExceptionProxyWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	body.ID = uint(id)
+	matched, err := h.coreService.Storage().ApproveRiskExceptionIfPending(r.Context(), body.toModel())
+	if err != nil {
+		log.Printf("risk-exceptions proxy: approve failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"matched": matched})
 }

--- a/server/http/handlers/secrets_status_proxy.go
+++ b/server/http/handlers/secrets_status_proxy.go
@@ -1,0 +1,92 @@
+// secrets_status_proxy.go — server-side endpoint backing RemoteStorage's
+// TransitionSecretStatus storage primitive (StateTransitionMissingCAS: the
+// suspend/resume TOCTOU class, mirroring #388's machine-identity fix and
+// #412's project-invitation fix for the same recurring bug shape).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049)
+// proxies its secret status-transition storage calls to whichever upstream
+// server it's configured against, through this route (registered in
+// server/http/router.go under /api/v1/system/secrets/{id}/transition-status,
+// gated on the existing system.write RBAC permission — the SAME credential a
+// RemoteStorage client already needs for every other proxied call in this
+// group, so this introduces no new privilege class).
+//
+// This is a thin passthrough onto storage.Storage.TransitionSecretStatus, the
+// SAME primitive internal/core/secret_suspend.go's SuspendSecret/ResumeSecret
+// use against a local backend — NO suspend/resume POLICY decision (who may
+// suspend, the idempotent already-suspended/already-active no-op, audit
+// logging) is made here; all of that stays entirely in the CALLING server's
+// own internal/core.KeyorixCore, exactly as it does against a local backend.
+// This route DOES apply the conditional "WHERE id = ? AND status = ?" write
+// itself — not because that's this server's OWN policy decision, but because
+// no real transaction can span the HTTP hop back to the calling server
+// (RemoteStorage.WithTransaction is a no-op passthrough), so whichever server
+// ultimately owns the row is the only one that CAN enforce the atomicity
+// SuspendSecret/ResumeSecret rely on. See the storage.Storage interface doc
+// (internal/core/storage/interface.go) for the full reasoning.
+//
+// Response envelope: like the other proxies, this does NOT use the package's
+// generic sendSuccess/sendError helpers — it constructs the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses (its APIResponse/APIError types).
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// transitionSecretStatusProxyBody is the request body
+// TransitionSecretStatusProxy expects: the full secret row the caller already
+// mutated in memory (secret.Status/UpdatedAt already set to the target
+// values), plus the fromStatus the caller observed via GetSecret immediately
+// before mutating it — mirroring transitionMachineIdentityStateBody's shape
+// exactly. Secret decodes into *models.SecretNode directly (it carries no
+// json tags of its own beyond ValueStored's `json:"-"`, so a Go-to-Go round
+// trip between the handler and RemoteStorage's identical type preserves every
+// field exactly, the same choice GetSecretIncludingDeletedProxy already makes
+// for the identical type).
+type transitionSecretStatusProxyBody struct {
+	Secret     *models.SecretNode `json:"secret"`
+	FromStatus string             `json:"from_status"`
+}
+
+// TransitionSecretStatusProxy handles PUT
+// /api/v1/system/secrets/{id}/transition-status. Runs the SAME conditional
+// "WHERE id = ? AND status = ?" write core.KeyorixCore.SuspendSecret/
+// ResumeSecret already rely on against a local backend — see the package
+// doc's reasoning for why this is a dedicated route rather than a generic
+// UpdateSecret proxy call.
+func (h *SecretHandler) TransitionSecretStatusProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid secret id")
+		return
+	}
+	var body transitionSecretStatusProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Secret == nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "secret is required")
+		return
+	}
+	if body.FromStatus == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "from_status is required")
+		return
+	}
+	body.Secret.ID = uint(id)
+	matched, err := h.coreService.Storage().TransitionSecretStatus(r.Context(), body.Secret, body.FromStatus)
+	if err != nil {
+		log.Printf("secrets proxy: transition status failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"matched": matched})
+}

--- a/server/http/handlers/secrets_status_proxy_test.go
+++ b/server/http/handlers/secrets_status_proxy_test.go
@@ -1,0 +1,178 @@
+// secrets_status_proxy_test.go — tests for secrets_status_proxy.go:
+// TransitionSecretStatusProxy.
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedSecretForProxyS13 creates a minimal project/environment/secret via the
+// core's own storage layer — TransitionSecretStatusProxy is a raw storage
+// passthrough (no project-membership/RBAC gate, see the handler's own doc
+// comment), so no user/role scaffolding is needed, unlike the heavier
+// freshSecretHandlerS14 setup used by handlers exercising the human-facing,
+// permission-checked secret routes.
+func seedSecretForProxyS13(t *testing.T, h *SecretHandler) *models.SecretNode {
+	t.Helper()
+	ctx := context.Background()
+	st := h.coreService.Storage()
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "proj-status-s13"})
+	require.NoError(t, err)
+	env, err := st.CreateEnvironment(ctx, &models.Environment{Name: "env-status-s13", ProjectID: proj.ID})
+	require.NoError(t, err)
+	secret, err := st.CreateSecret(ctx, &models.SecretNode{
+		Name:          "secret-status-s13",
+		ProjectID:     proj.ID,
+		EnvironmentID: env.ID,
+		Type:          "password",
+		OwnerID:       1,
+		Status:        "active",
+	})
+	require.NoError(t, err)
+	return secret
+}
+
+// TestTransitionSecretStatusProxy_BadID — non-numeric id → 400.
+func TestTransitionSecretStatusProxy_BadID(t *testing.T) {
+	h := freshSecretHandlerForProxyS13(t)
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/secrets/bad/transition-status", strings.NewReader("{}")),
+		"id", "bad",
+	)
+	w := httptest.NewRecorder()
+	h.TransitionSecretStatusProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_PARAMETER", resp.Error.Code)
+}
+
+// TestTransitionSecretStatusProxy_BadBody — malformed JSON → 400.
+func TestTransitionSecretStatusProxy_BadBody(t *testing.T) {
+	h := freshSecretHandlerForProxyS13(t)
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/secrets/1/transition-status", strings.NewReader("{bad")),
+		"id", "1",
+	)
+	w := httptest.NewRecorder()
+	h.TransitionSecretStatusProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+}
+
+// TestTransitionSecretStatusProxy_MissingSecret — valid id, body has no
+// "secret" field → 400.
+func TestTransitionSecretStatusProxy_MissingSecret(t *testing.T) {
+	h := freshSecretHandlerForProxyS13(t)
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/secrets/1/transition-status", strings.NewReader(`{"from_status":"active"}`)),
+		"id", "1",
+	)
+	w := httptest.NewRecorder()
+	h.TransitionSecretStatusProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+}
+
+// TestTransitionSecretStatusProxy_MissingFromStatus — valid id and secret,
+// missing from_status → 400.
+func TestTransitionSecretStatusProxy_MissingFromStatus(t *testing.T) {
+	h := freshSecretHandlerForProxyS13(t)
+	body := proxyJSON(map[string]interface{}{
+		"secret": map[string]interface{}{"status": "suspended"},
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/secrets/1/transition-status", body),
+		"id", "1",
+	)
+	w := httptest.NewRecorder()
+	h.TransitionSecretStatusProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+}
+
+// TestTransitionSecretStatusProxy_HappyPath — a conditional write from the
+// seeded secret's current "active" status succeeds and reports matched:true.
+func TestTransitionSecretStatusProxy_HappyPath(t *testing.T) {
+	h := freshSecretHandlerForProxyS13(t)
+	secret := seedSecretForProxyS13(t, h)
+	idStr := strconv.FormatUint(uint64(secret.ID), 10)
+
+	body := proxyJSON(map[string]interface{}{
+		"secret": map[string]interface{}{
+			"name":           secret.Name,
+			"project_id":     secret.ProjectID,
+			"environment_id": secret.EnvironmentID,
+			"type":           secret.Type,
+			"owner_id":       secret.OwnerID,
+			"status":         "suspended",
+		},
+		"from_status": "active",
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/secrets/"+idStr+"/transition-status", body),
+		"id", idStr,
+	)
+	w := httptest.NewRecorder()
+	h.TransitionSecretStatusProxy(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	resp := decodeRemoteResp(t, w)
+	require.True(t, resp.Success)
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, data["matched"])
+}
+
+// TestTransitionSecretStatusProxy_LostRace — a second conditional write still
+// asserting the same (now-stale) from_status as a call that already won must
+// report matched:false, proving the CAS race closes at the HTTP-proxy
+// boundary too (not just LocalStorage).
+func TestTransitionSecretStatusProxy_LostRace(t *testing.T) {
+	h := freshSecretHandlerForProxyS13(t)
+	secret := seedSecretForProxyS13(t, h)
+	idStr := strconv.FormatUint(uint64(secret.ID), 10)
+
+	body := func() *strings.Reader {
+		return strings.NewReader(`{
+			"secret": {"name":"` + secret.Name + `","project_id":` + strconv.FormatUint(uint64(secret.ProjectID), 10) +
+			`,"environment_id":` + strconv.FormatUint(uint64(secret.EnvironmentID), 10) +
+			`,"type":"password","owner_id":1,"status":"suspended"},
+			"from_status": "active"
+		}`)
+	}
+
+	firstReq := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/secrets/"+idStr+"/transition-status", body()),
+		"id", idStr,
+	)
+	firstW := httptest.NewRecorder()
+	h.TransitionSecretStatusProxy(firstW, firstReq)
+	require.Equal(t, http.StatusOK, firstW.Code)
+	firstResp := decodeRemoteResp(t, firstW)
+	firstData, ok := firstResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, true, firstData["matched"], "first call must win")
+
+	secondReq := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/secrets/"+idStr+"/transition-status", body()),
+		"id", idStr,
+	)
+	secondW := httptest.NewRecorder()
+	h.TransitionSecretStatusProxy(secondW, secondReq)
+	assert.Equal(t, http.StatusOK, secondW.Code)
+	secondResp := decodeRemoteResp(t, secondW)
+	secondData, ok := secondResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, secondData["matched"], "second (racing) call must lose — status already changed")
+}

--- a/server/http/handlers/users_active_transition_proxy.go
+++ b/server/http/handlers/users_active_transition_proxy.go
@@ -1,0 +1,103 @@
+// users_active_transition_proxy.go — server-side endpoint backing
+// RemoteStorage's UpdateUserIfActiveStateMatches (closing the UpdateUser
+// IsActive TOCTOU race described in internal/core/storage/interface.go's
+// UpdateUserIfActiveStateMatches doc, this codebase's user-row analogue of
+// TransitionMachineIdentityState #388/#518 and UpdateProjectInvitation #412).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049)
+// proxies this conditional write to whichever upstream server it's configured
+// against, through this route (registered in server/http/router.go under
+// /api/v1/system/users/{id}/active-transition, gated on the existing
+// system.write RBAC permission every other RemoteStorage-primitive proxy in
+// this package already needs — no new privilege class).
+//
+// This is a thin passthrough onto the SAME storage.Storage.
+// UpdateUserIfActiveStateMatches primitive internal/core/users.go's UpdateUser
+// already calls against a local backend — no update-request validation
+// (uniqueness checks, which fields the original caller actually meant to
+// change) is made here; that stays entirely in the CALLING server's own
+// internal/core.KeyorixCore, exactly as it does against a local backend. This
+// handler only persists the row it's given, conditionally.
+//
+// Deliberately NOT the human-facing PUT /api/v1/users/{id} route
+// (users_crud.go's UserHandler.UpdateUser): that route re-runs the UPSTREAM
+// server's own core.KeyorixCore.UpdateUser end to end against the request
+// body it receives — the wrong semantics for a raw conditional-write
+// passthrough whose caller has already done all of that validation itself
+// against proxied reads and only needs the final persist to be atomic. See
+// remote_users.go's UpdateUserIfActiveStateMatches doc for the full reasoning
+// (mirrors machine_identities_proxy.go's TransitionMachineIdentityStateProxy
+// vs. UpdateMachineIdentityProxy distinction exactly).
+//
+// Response envelope: like every other proxy in this package, this does NOT use
+// the package's generic sendSuccess/sendError helpers — it constructs the
+// exact {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses.
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// userActiveTransitionProxyBody mirrors RemoteStorage's
+// userActiveTransitionWireRequest exactly (internal/storage/store/
+// remote_users.go) — the full row UpdateUser already mutated in memory, plus
+// the fromActive value it observed under GetUser before applying any of the
+// request's field changes. UpdatedAt is carried explicitly since this route
+// makes no server-side core.UpdateUser call to recompute it — see
+// remote_users.go's userActiveTransitionWireRequest doc.
+type userActiveTransitionProxyBody struct {
+	Username    string    `json:"username"`
+	Email       string    `json:"email"`
+	DisplayName string    `json:"display_name"`
+	Active      bool      `json:"active"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	FromActive  bool      `json:"from_active"`
+}
+
+// UpdateUserIfActiveStateMatchesProxy handles PUT
+// /api/v1/system/users/{id}/active-transition. Runs the SAME conditional
+// "WHERE id = ? AND is_active = ?" write core.KeyorixCore.UpdateUser already
+// relies on against a local backend when a request touches IsActive — see the
+// package doc for why this is a dedicated route rather than a generic
+// UpdateUser proxy.
+func (h *UserHandler) UpdateUserIfActiveStateMatchesProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid user id")
+		return
+	}
+	var body userActiveTransitionProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	user := &models.User{
+		ID:          uint(id),
+		Username:    body.Username,
+		Email:       body.Email,
+		DisplayName: body.DisplayName,
+		IsActive:    body.Active,
+		UpdatedAt:   body.UpdatedAt,
+	}
+	matched, err := h.coreService.Storage().UpdateUserIfActiveStateMatches(r.Context(), user, body.FromActive)
+	if err != nil {
+		if errors.Is(err, storage.ErrDuplicateEmail) {
+			writeRemoteAPIError(w, http.StatusConflict, duplicateEmailProxyCode, storage.ErrDuplicateEmail.Error())
+			return
+		}
+		log.Printf("users proxy: active-state transition failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"matched": matched})
+}

--- a/server/http/handlers/users_active_transition_proxy_test.go
+++ b/server/http/handlers/users_active_transition_proxy_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -125,4 +126,64 @@ func TestUpdateUserIfActiveStateMatchesProxy_LostRace(t *testing.T) {
 	updated, err := cs.Storage().GetUser(secondReq.Context(), 1)
 	require.NoError(t, err)
 	assert.NotEqual(t, "Should Not Persist", updated.DisplayName)
+}
+
+// TestUpdateUserIfActiveStateMatchesProxy_DuplicateEmail — a conditional
+// write whose email collides with a different existing user hits the
+// partial unique index and returns a client error, not a silent success.
+// Exercises LocalStorage.UpdateUserIfActiveStateMatches's error-translation
+// branch (internal/storage/store/local_users.go) and this handler's
+// error-mapping code, including (when the driver error text matches) the
+// errors.Is(err, storage.ErrDuplicateEmail) -> 409 DUPLICATE_EMAIL path.
+//
+// Doesn't assert the specific 409/DUPLICATE_EMAIL outcome: per this
+// codebase's own established convention (see
+// internal/storage/store/store_max_test.go's TestCreateUser_
+// DuplicateEmailSentinel comment), the sentinel only reliably propagates
+// when the partial index NAME appears in the driver error text, which
+// SQLite doesn't guarantee on every constraint-violation shape (an UPDATE
+// hitting the index can surface as a bare "UNIQUE constraint failed:
+// users.email" instead) -- only Postgres includes it reliably. Either
+// outcome here (409 DUPLICATE_EMAIL, or 500 STORAGE_ERROR) proves the
+// request was correctly rejected rather than silently persisted.
+func TestUpdateUserIfActiveStateMatchesProxy_DuplicateEmail(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	// Replicate the partial unique index migrateDatabase creates in
+	// production (see internal/storage/store/store_max_test.go's
+	// newUserStoreMax for the identical pattern) -- SQLite surfaces it in
+	// the error message, which isDuplicateEmailViolation matches on.
+	db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active ON users(email) WHERE deleted_at IS NULL AND email != ''")
+
+	require.NoError(t, db.Create(&models.User{
+		ID: 2, Username: "other_user", Email: "taken@example.com", IsActive: true,
+	}).Error)
+
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+
+	body := proxyJSON(map[string]interface{}{
+		"username":     "testuser_s12",
+		"email":        "taken@example.com", // collides with user 2
+		"display_name": "Should Not Persist",
+		"active":       false,
+		"from_active":  true,
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/users/1/active-transition", body),
+		"id", "1",
+	)
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	resp := decodeRemoteResp(t, w)
+	assert.False(t, resp.Success, "duplicate email must not silently succeed")
+	if w.Code == http.StatusConflict {
+		assert.Equal(t, duplicateEmailProxyCode, resp.Error.Code)
+	} else {
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Equal(t, "STORAGE_ERROR", resp.Error.Code)
+	}
+
+	unchanged, err := cs.Storage().GetUser(req.Context(), 1)
+	require.NoError(t, err)
+	assert.NotEqual(t, "Should Not Persist", unchanged.DisplayName, "rejected write must not persist")
 }

--- a/server/http/handlers/users_active_transition_proxy_test.go
+++ b/server/http/handlers/users_active_transition_proxy_test.go
@@ -1,0 +1,128 @@
+// users_active_transition_proxy_test.go — tests for
+// users_active_transition_proxy.go: UpdateUserIfActiveStateMatchesProxy.
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateUserIfActiveStateMatchesProxy_BadID — non-numeric id → 400.
+func TestUpdateUserIfActiveStateMatchesProxy_BadID(t *testing.T) {
+	h := freshUserHandlerForProxyS13(t)
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/users/bad/active-transition", strings.NewReader("{}")),
+		"id", "bad",
+	)
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_PARAMETER", resp.Error.Code)
+}
+
+// TestUpdateUserIfActiveStateMatchesProxy_BadBody — malformed JSON → 400.
+func TestUpdateUserIfActiveStateMatchesProxy_BadBody(t *testing.T) {
+	h := freshUserHandlerForProxyS13(t)
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/users/1/active-transition", strings.NewReader("{bad")),
+		"id", "1",
+	)
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+}
+
+// TestUpdateUserIfActiveStateMatchesProxy_HappyPath — a conditional write
+// against the seeded admin user (id=1, IsActive=true) with a matching
+// from_active succeeds and reports matched:true.
+func TestUpdateUserIfActiveStateMatchesProxy_HappyPath(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+
+	body := proxyJSON(map[string]interface{}{
+		"username":     "testuser_s12",
+		"email":        "testuser_s12@example.com",
+		"display_name": "Deactivated Admin",
+		"active":       false,
+		"from_active":  true,
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/users/1/active-transition", body),
+		"id", "1",
+	)
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.True(t, resp.Success)
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, data["matched"])
+
+	updated, err := cs.Storage().GetUser(req.Context(), 1)
+	require.NoError(t, err)
+	assert.False(t, updated.IsActive)
+	assert.Equal(t, "Deactivated Admin", updated.DisplayName)
+}
+
+// TestUpdateUserIfActiveStateMatchesProxy_LostRace — a second conditional
+// write asserting the SAME (now-stale) from_active as a call that already won
+// must report matched:false, not silently re-apply over the winner (proves
+// the CAS race is closed at the HTTP-proxy boundary too, not just LocalStorage).
+func TestUpdateUserIfActiveStateMatchesProxy_LostRace(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+
+	firstBody := proxyJSON(map[string]interface{}{
+		"username":     "testuser_s12",
+		"email":        "testuser_s12@example.com",
+		"display_name": "First Winner",
+		"active":       false,
+		"from_active":  true,
+	})
+	firstReq := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/users/1/active-transition", firstBody),
+		"id", "1",
+	)
+	w1 := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w1, firstReq)
+	assert.Equal(t, http.StatusOK, w1.Code)
+	resp1 := decodeRemoteResp(t, w1)
+	data1, ok := resp1.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, data1["matched"], "first call must win")
+
+	// Second call still asserts from_active=true (stale — the row is now false).
+	secondBody := proxyJSON(map[string]interface{}{
+		"username":     "testuser_s12",
+		"email":        "testuser_s12@example.com",
+		"display_name": "Should Not Persist",
+		"active":       false,
+		"from_active":  true,
+	})
+	secondReq := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/users/1/active-transition", secondBody),
+		"id", "1",
+	)
+	w2 := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w2, secondReq)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	resp2 := decodeRemoteResp(t, w2)
+	data2, ok := resp2.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, data2["matched"], "second (racing) call must lose")
+
+	updated, err := cs.Storage().GetUser(secondReq.Context(), 1)
+	require.NoError(t, err)
+	assert.NotEqual(t, "Should Not Persist", updated.DisplayName)
+}

--- a/server/http/remote_storage_risk_exceptions_test.go
+++ b/server/http/remote_storage_risk_exceptions_test.go
@@ -186,3 +186,108 @@ func TestRemoteStorageRiskExceptions_ActiveOnlyExcludesRevoked_RealServer(t *tes
 	require.Len(t, directRows, 1)
 	assert.Equal(t, kept.ID, directRows[0].ID)
 }
+
+// TestRemoteStorageRiskExceptions_RevokeIfNotRevoked_ConditionalRace_RealServer
+// proves the StateTransitionMissingCAS.ql fix end-to-end, over a real HTTP hop
+// through the downstream's RemoteStorage against the upstream's REAL router —
+// not a protocol mock: two callers racing RevokeRiskExceptionIfNotRevoked for
+// the SAME exception (mirroring internal/core.RevokeRiskException's own
+// read-then-write) must not both "win". The first conditional write must
+// match (matched=true) and persist its attribution; the second, racing against
+// a row the first already moved to revoked=true, must be rejected
+// (matched=false) rather than silently re-applied over the winner.
+func TestRemoteStorageRiskExceptions_RevokeIfNotRevoked_ConditionalRace_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRiskExceptions(t)
+	ctx := context.Background()
+	now := time.Now()
+	expiresAt := now.Add(30 * 24 * time.Hour)
+
+	exc, err := downstream.Storage().CreateRiskException(ctx, buildRiskException(now, 1, "Racing revoke", "other", expiresAt))
+	require.NoError(t, err)
+
+	// Two admins independently read the still-unrevoked row (the TOCTOU window
+	// internal/core.RevokeRiskException's own GetRiskException-then-write
+	// sequence has), each preparing their own conditional revoke write.
+	firstRead, err := downstream.Storage().GetRiskException(ctx, exc.ID)
+	require.NoError(t, err)
+	firstRevokedAt := time.Now()
+	firstRead.Revoked = true
+	firstRead.RevokedBy = 1
+	firstRead.RevokedAt = &firstRevokedAt
+
+	secondRead, err := downstream.Storage().GetRiskException(ctx, exc.ID)
+	require.NoError(t, err)
+	secondRevokedAt := time.Now()
+	secondRead.Revoked = true
+	secondRead.RevokedBy = 2
+	secondRead.RevokedAt = &secondRevokedAt
+
+	// First admin's conditional revoke lands and wins.
+	matched, err := downstream.Storage().RevokeRiskExceptionIfNotRevoked(ctx, firstRead)
+	require.NoError(t, err)
+	assert.True(t, matched, "the first writer must win")
+
+	// Second admin's conditional revoke, racing against a row the first write
+	// already moved to revoked=true, must be rejected — not silently
+	// re-applied (re-attributing the revoke away from admin 1 to admin 2, the
+	// exact clobber this fix closes).
+	matched, err = downstream.Storage().RevokeRiskExceptionIfNotRevoked(ctx, secondRead)
+	require.NoError(t, err)
+	assert.False(t, matched, "the second writer must lose, not clobber the first revoke")
+
+	// The upstream's own persisted row must reflect the FIRST admin's
+	// attribution, proving the second write never landed.
+	final, err := upstream.Storage().GetRiskException(ctx, exc.ID)
+	require.NoError(t, err)
+	assert.True(t, final.Revoked)
+	assert.Equal(t, uint(1), final.RevokedBy, "the winning first admin's attribution must be the persisted state")
+}
+
+// TestRemoteStorageRiskExceptions_ApproveIfPending_ConditionalRace_RealServer
+// is the approve analogue, end-to-end over real HTTP: a revoke and an approve
+// racing the SAME exception must not both land — an exception left in a
+// "revoked AND approved" state would defeat dual control's whole purpose (an
+// approved exception suppresses its matched violation from the compliance
+// posture, so a revoked-then-approved exception would wrongly keep suppressing
+// it).
+func TestRemoteStorageRiskExceptions_ApproveIfPending_ConditionalRace_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRiskExceptions(t)
+	ctx := context.Background()
+	now := time.Now()
+	expiresAt := now.Add(30 * 24 * time.Hour)
+
+	exc, err := downstream.Storage().CreateRiskException(ctx, buildRiskException(now, 9, "Racing revoke vs approve", "other", expiresAt))
+	require.NoError(t, err)
+
+	// The revoker and the (different, dual-control-compliant) approver both
+	// read the same still-pending row before either write lands.
+	revokeRead, err := downstream.Storage().GetRiskException(ctx, exc.ID)
+	require.NoError(t, err)
+	revokedAt := time.Now()
+	revokeRead.Revoked = true
+	revokeRead.RevokedBy = 1
+	revokeRead.RevokedAt = &revokedAt
+
+	approveRead, err := downstream.Storage().GetRiskException(ctx, exc.ID)
+	require.NoError(t, err)
+	approvedAt := time.Now()
+	approveRead.Approved = true
+	approveRead.ApprovedBy = 2
+	approveRead.ApprovedAt = &approvedAt
+
+	// Revoke lands first.
+	matched, err := downstream.Storage().RevokeRiskExceptionIfNotRevoked(ctx, revokeRead)
+	require.NoError(t, err)
+	assert.True(t, matched)
+
+	// The approve, racing against a row that is no longer unrevoked, must be
+	// rejected.
+	matched, err = downstream.Storage().ApproveRiskExceptionIfPending(ctx, approveRead)
+	require.NoError(t, err)
+	assert.False(t, matched, "an approve racing a revoke must lose, not mark a revoked exception approved")
+
+	final, err := upstream.Storage().GetRiskException(ctx, exc.ID)
+	require.NoError(t, err)
+	assert.True(t, final.Revoked)
+	assert.False(t, final.Approved, "the revoked exception must never end up approved")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1121,6 +1121,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// downstream Keyorix server booted with storage.type: remote (ADR-049)
 			// proxy CreateDynamicSecretConfig/GetDynamicSecretConfig/
 			// ListDynamicSecretConfigs/UpdateDynamicSecretConfig/
+			// TransitionDynamicSecretConfigDisabled/
 			// CountDynamicSecretConfigsByClassification/CreateDynamicSecretLease/
 			// GetDynamicSecretLease/ListDynamicSecretLeases/CountActiveLeases/
 			// UpdateDynamicSecretLease/ListExpiredActiveLeases to THIS server's real
@@ -1146,6 +1147,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/dynamic-secrets/configs", dynamicSecretHandler.ListDynamicSecretConfigsProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/dynamic-secrets/configs", dynamicSecretHandler.CreateDynamicSecretConfigProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/dynamic-secrets/configs/{id}", dynamicSecretHandler.UpdateDynamicSecretConfigProxy)
+			// TransitionDynamicSecretConfigDisabled is a dedicated conditional-write
+			// route (NOT a generic Update), closing the StateTransitionMissingCAS
+			// TOCTOU on DynamicSecretConfig.Disabled across this HTTP hop — see
+			// dynamic_secrets_proxy.go's TransitionDynamicSecretConfigDisabledProxy doc.
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/dynamic-secrets/configs/{id}/transition", dynamicSecretHandler.TransitionDynamicSecretConfigDisabledProxy)
 			r.Get("/dynamic-secrets/leases/active-count", dynamicSecretHandler.CountActiveLeasesProxy)
 			r.Get("/dynamic-secrets/leases/expired", dynamicSecretHandler.ListExpiredActiveLeasesProxy)
 			r.Get("/dynamic-secrets/leases/{leaseID}", dynamicSecretHandler.GetDynamicSecretLeaseProxy)
@@ -1455,6 +1461,27 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// primitive is needed.
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/users/{id}/login-lockout", authHandler.UpdateLoginLockoutStateProxy)
 
+			// User active-state CAS storage-primitive proxy. Lets a downstream
+			// Keyorix server booted with storage.type: remote (ADR-049) proxy
+			// UpdateUserIfActiveStateMatches to THIS server's real storage backend
+			// — the SAME conditional "WHERE id = ? AND is_active = ?" write
+			// core.UpdateUser (internal/core/users.go) already performs against a
+			// local backend whenever a request touches IsActive, closing the
+			// TOCTOU race a plain UpdateUser write left open (IsActive flipping
+			// concurrently with any other UpdateUser call touching the same user —
+			// a profile edit racing an admin deactivation, or two deactivation
+			// attempts racing each other). Exactly the same
+			// raw-storage-primitive-passthrough pattern as
+			// TransitionMachineIdentityStateProxy above (#388/#518) and
+			// UpdateProjectInvitation (#412) — no update-request validation is
+			// made here; that stays entirely in the CALLING server's own
+			// internal/core.KeyorixCore. Reuses the group's existing
+			// system.write baseline, same as every other proxy in this group —
+			// no new privilege class. See users_active_transition_proxy.go's
+			// package doc for why this is a dedicated route rather than a proxy
+			// onto the human-facing PUT /api/v1/users/{id} route.
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/users/{id}/active-transition", userHandler.UpdateUserIfActiveStateMatchesProxy)
+
 			// Legal-hold storage-primitive proxy (finding #519). Lets a downstream
 			// Keyorix server booted with storage.type: remote (ADR-049) proxy
 			// CreateLegalHold/GetActiveLegalHold/UpdateLegalHold to THIS server's real
@@ -1580,6 +1607,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get(pathRiskExceptions, dashboardHandler.ListRiskExceptionsProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post(pathRiskExceptions, dashboardHandler.CreateRiskExceptionProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Put(pathRiskExceptionsID, dashboardHandler.UpdateRiskExceptionProxy)
+			// RevokeRiskExceptionIfNotRevoked/ApproveRiskExceptionIfPending are
+			// dedicated conditional-write routes (NOT the generic
+			// UpdateRiskExceptionProxy above), preserving the TOCTOU fix
+			// (StateTransitionMissingCAS.ql finding) core.RevokeRiskException/
+			// ApproveRiskException rely on across this HTTP hop — see
+			// risk_exceptions_proxy.go's package doc for the full atomicity note.
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Put(pathRiskExceptionsID+"/revoke", dashboardHandler.RevokeRiskExceptionProxy)
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Put(pathRiskExceptionsID+"/approve", dashboardHandler.ApproveRiskExceptionProxy)
 
 			// Separation-of-duties (SoD) policy storage-primitive proxy (finding
 			// #519). Lets a downstream Keyorix server booted with storage.type:
@@ -1683,6 +1718,19 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// system.write like every other route in this group (there is no
 			// separate system.read tier here).
 			r.Get("/secrets/{id}/including-deleted", secretHandler.GetSecretIncludingDeletedProxy)
+
+			// TransitionSecretStatus (StateTransitionMissingCAS): lets a downstream
+			// server proxy the suspend/resume conditional "WHERE id = ? AND
+			// status = ?" write to THIS server's real storage backend in ONE round
+			// trip, mirroring TransitionMachineIdentityStateProxy (#388) and
+			// UpdateProjectInvitation (#412) for the same recurring TOCTOU class.
+			// Before this fix, SuspendSecret/ResumeSecret's read-then-unconditional-
+			// UpdateSecret sequence had no atomicity at all over the HTTP hop
+			// (RemoteStorage.WithTransaction is a no-op passthrough), so a suspend
+			// racing a resume on the same secret could silently clobber each other.
+			// Gated system.write like every other route in this group (there is no
+			// separate system.read tier here).
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/secrets/{id}/transition-status", secretHandler.TransitionSecretStatusProxy)
 
 			// ListSharesByOwner: lets a downstream server proxy the "shares I
 			// created" query to THIS server's real storage backend. Before this


### PR DESCRIPTION
## Summary
- Go's default GOMAXPROCS reads the host's visible thread count, not this service's `CPUQuota=400%` (systemd/keyorix-mutation.service). On the mutation-testing box (4 real cores, 8 threads via hyperthreading), each of `MUTATION_WORKERS=4` concurrent `go build`/`go test` subprocesses independently assumed all 8 threads were its own, producing up to 32 runnable threads fighting over a 4-core-equivalent CPU quota.
- This didn't break the quota, but the resulting context-switch overhead (observed 14k-19k/s) was enough to starve individual `go test` runs past gremlins' per-mutant timeout — every mutant came back `TIMED OUT` instead of a real `KILLED`/`LIVED`/`NOT COVERED` result, producing zero usable mutation-testing signal despite the run genuinely progressing.
- Exports `GOMAXPROCS=1` (configurable via new `MUTATION_GOMAXPROCS`) per worker so total thread demand matches the real budget: `MUTATION_WORKERS * MUTATION_GOMAXPROCS` == the box's actual core count.

## Test plan
- [x] `bash -n` syntax check passes
- [ ] CI green on this PR
- [ ] Manually verified on the actual mutation-testing box: run produces real KILLED/LIVED results instead of 100% TIMED OUT