### PR TITLE
fix(mutation-testing): cap GOMAXPROCS per worker to stop CPU oversubscription

### DIFF
--- a/scripts/mutation-testing/config.env.example
+++ b/scripts/mutation-testing/config.env.example
@@ -16,6 +16,17 @@ MUTATION_STATE_DIR=/opt/keyorix-mutation/state
 # (leaving headroom -- see CPUQuota in systemd/keyorix-mutation.service).
 MUTATION_WORKERS=4
 
+# GOMAXPROCS applied to EACH worker's go build/test subprocesses (exported by
+# run-mutation.sh). Go's default reads the host's visible thread count, not
+# this service's CPUQuota, so it does not divide fairly among
+# MUTATION_WORKERS concurrent workers on its own -- leaving it unset lets
+# every worker try to use every visible thread, oversubscribing the CPUQuota
+# and starving individual `go test` runs past gremlins' per-mutant timeout
+# (every mutant comes back TIMED OUT instead of a real KILLED/LIVED result).
+# Keep MUTATION_WORKERS * MUTATION_GOMAXPROCS roughly equal to the box's real
+# core budget (CPUQuota=400% here -> 4 workers * 1 = 4).
+MUTATION_GOMAXPROCS=1
+
 # Percentage-point drop in test efficacy (killed / (killed+lived)) versus the
 # previous recorded run for the same package that triggers a high-priority
 # ntfy alert + GitHub issue instead of just a normal-priority summary.

--- a/scripts/mutation-testing/run-mutation.sh
+++ b/scripts/mutation-testing/run-mutation.sh
@@ -24,6 +24,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${MUTATION_WORKERS:=4}"
 : "${MUTATION_EFFICACY_DROP_THRESHOLD:=5}" # percentage points
 
+# Go's default GOMAXPROCS reads the host's visible thread count, not this
+# service's CPUQuota (systemd/keyorix-mutation.service) or the container's
+# actual core budget -- so each of MUTATION_WORKERS concurrent `go build`/
+# `go test` subprocesses independently spins up threads for ALL visible
+# threads, not its fair share. With workers=4 on an 8-thread host that's up
+# to 32 runnable threads fighting over a 4-core CPUQuota, which doesn't
+# break the quota but does starve individual `go test` runs long enough to
+# blow gremlins' per-mutant timeout -- every mutant comes back TIMED OUT
+# instead of KILLED/LIVED. Cap each worker to its fair share so total
+# demand matches the real budget instead of oversubscribing it 8x.
+export GOMAXPROCS="${MUTATION_GOMAXPROCS:-1}"
+
 # summarize.py (invoked below as a child process) reads MUTATION_STATE_DIR
 # itself to locate its input file -- a plain `:` default-assignment doesn't
 # export to child processes, so make sure it's actually visible there even


### PR DESCRIPTION
## Summary
- Go's default GOMAXPROCS reads the host's visible thread count, not this service's `CPUQuota=400%` (systemd/keyorix-mutation.service). On the mutation-testing box (4 real cores, 8 threads via hyperthreading), each of `MUTATION_WORKERS=4` concurrent `go build`/`go test` subprocesses independently assumed all 8 threads were its own, producing up to 32 runnable threads fighting over a 4-core-equivalent CPU quota.
- This didn't break the quota, but the resulting context-switch overhead (observed 14k-19k/s) was enough to starve individual `go test` runs past gremlins' per-mutant timeout — every mutant came back `TIMED OUT` instead of a real `KILLED`/`LIVED`/`NOT COVERED` result, producing zero usable mutation-testing signal despite the run genuinely progressing.
- Exports `GOMAXPROCS=1` (configurable via new `MUTATION_GOMAXPROCS`) per worker so total thread demand matches the real budget: `MUTATION_WORKERS * MUTATION_GOMAXPROCS` == the box's actual core count.

## Test plan
- [x] `bash -n` syntax check passes
- [ ] CI green on this PR
- [ ] Manually verified on the actual mutation-testing box: run produces real KILLED/LIVED results instead of 100% TIMED OUT