### PR TITLE
fix(mutation-testing): bump service MemoryMax 4G -> 7G to stop swap thrashing

### DIFF
--- a/scripts/mutation-testing/README.md
+++ b/scripts/mutation-testing/README.md
@@ -39,12 +39,26 @@ second box when one already exists for the fuzzing setup's sibling need.
 ## Resource limits
 
 `systemd/keyorix-mutation.service` caps this service to `CPUQuota=400%` and
-`MemoryMax=4G`, alongside `Nice=10` — same shape as
+`MemoryMax=7G`, alongside `Nice=10` — same shape as
 `scripts/fuzzing/systemd/keyorix-fuzz.service`, adjust both to fit your own
 hardware. Unlike fuzzing's `-fuzztime` (wall-clock, so a lower `CPUQuota`
 makes a rotation *shallower*, not longer), a mutation run's total work is
 fixed — every covered mutant gets tested exactly once regardless of quota —
 so a lower `CPUQuota` here only makes a run take longer, never less thorough.
+
+Provision the container/VM itself with at least 8G RAM (some headroom above
+`MemoryMax` for the OS/systemd/other overhead) and set `MUTATION_GOMAXPROCS`
+(`config.env`) so `MUTATION_WORKERS * MUTATION_GOMAXPROCS` roughly matches
+`CPUQuota`'s equivalent core count (400% -> 4 cores; workers=4 ->
+GOMAXPROCS=1 each) — leaving `GOMAXPROCS` unset lets every worker's `go
+build`/`go test` subprocesses assume the host's full visible thread count
+each, oversubscribing the quota and starving individual runs past gremlins'
+per-mutant timeout (every mutant comes back `TIMED OUT` instead of a real
+result). And an undersized `MemoryMax` doesn't fail cleanly either --
+`MemorySwapMax` defaults to `infinity`, so hitting the cap means swapping,
+not an OOM kill: silent thrashing that's easy to mistake for the CPUQuota
+problem above if you haven't also checked
+`systemctl show keyorix-mutation.service -p MemoryCurrent -p MemoryMax`.
 
 ## One-time setup (on the LXC/VM)
 

--- a/scripts/mutation-testing/systemd/keyorix-mutation.service
+++ b/scripts/mutation-testing/systemd/keyorix-mutation.service
@@ -20,7 +20,13 @@ ExecStart=/opt/keyorix-mutation/keyorix/scripts/mutation-testing/run-mutation.sh
 # quota only makes the run take longer, not shallower.
 Nice=10
 CPUQuota=400%
-MemoryMax=4G
+# 7G, not 4G: with MUTATION_WORKERS=4 concurrent `go build`/`go test`
+# invocations, 4G was tight enough to hit this cap on its own (independent
+# of the LXC container's own memory allocation) and MemorySwapMax defaults to
+# infinity, so hitting it meant swapping instead of an OOM kill -- silent
+# thrashing, not a clean failure. Provision the container with at least 8G
+# to leave this real headroom above it (see README.md's sizing guidance).
+MemoryMax=7G
 
 # Process-isolation hardening (mirrors keyorix-fuzz.service's rationale).
 # This service holds a GH_TOKEN with Issues read/write, loaded via


### PR DESCRIPTION
## Summary
- With the GOMAXPROCS fix (#1360) live and confirmed working (CPU oversubscription fixed, runnable-thread count dropped from 26-69 to 1-5), a second, separate bottleneck surfaced: the systemd service's own `MemoryMax=4G` (independent of the LXC container's own memory allocation, which had already been bumped to 8G) turned out to be tight enough for `MUTATION_WORKERS=4` concurrent `go build`/`go test` invocations to hit on its own.
- `MemorySwapMax` defaults to `infinity`, so hitting the cap didn't OOM-kill anything -- it silently swapped instead. Observed 170-200MB/s sustained swap-out on the actual box, easy to mistake for a recurrence of the CPU problem this exact follow-up already looked like it had fixed.
- Bumps `MemoryMax` to 7G and documents the container-level sizing (8G+) this now requires, plus the `MUTATION_WORKERS * MUTATION_GOMAXPROCS` sizing relationship, in `README.md`.

## Test plan
- [x] Manually applied directly to the running box (`/etc/systemd/system/keyorix-mutation.service` + `daemon-reload`) for immediate effect
- [ ] CI green on this PR
- [ ] Confirm a fresh run on the box no longer shows `MemoryCurrent` pinned at `MemoryMax`, and produces real KILLED/LIVED results instead of TIMED OUT