### PR TITLE
docs: backfill ADRs for cipher choice, GORM, Cobra, dual licence, GitHub Flow

### DIFF
--- a/docs/adr-077-symmetric-cipher-choice.md
+++ b/docs/adr-077-symmetric-cipher-choice.md
@@ -1,0 +1,99 @@
+# ADR-077: Symmetric cipher and key-derivation choice (AES-256-GCM + PBKDF2)
+
+## Status
+
+Accepted, as-built. This is a backfill ADR: the decision was made and shipped long
+before the ADR series started (the encryption layer predates ADR-010, the earliest
+numbered ADR in this repo) and was never separately written up. Recorded now per
+the M2 "ADR backfill" backlog item, to close the gap rather than leave the
+rationale undocumented.
+
+## Context
+
+Every secret value, and a growing list of other sensitive at-rest fields (MFA TOTP
+seeds, session tokens, PATs, password-reset tokens, dynamic-secret configs/leases,
+chunked-secret streams), needs an authenticated symmetric cipher. The requirements
+were, from the start:
+
+- **Authenticated encryption** — tampering with ciphertext must be detectable, not
+  just confidentiality. A bare block cipher (AES-CBC) fails this on its own and
+  needs a separate MAC, which is exactly the class of construction (encrypt-then-MAC
+  done by hand) that produces padding-oracle and other composition bugs when
+  implemented wrong.
+- **No third-party crypto dependency** for the core primitive, consistent with the
+  air-gapped/sovereign deployment story (ADR-048's CGO-free driver work is driven by
+  the same "static binary, few external moving parts" wedge) — Go's standard library
+  already ships a constant-time, audited AES-GCM implementation.
+- **Envelope encryption**, not direct passphrase-to-ciphertext: a per-install Data
+  Encryption Key (DEK) encrypts secret values; a passphrase- or provider-derived Key
+  Encryption Key (KEK) wraps the DEK. This is what makes DEK rotation (ADR-010) and
+  pluggable key sources (ADR-038) possible without re-touching every encrypted row.
+
+## Decision
+
+**Cipher: AES-256-GCM**, via Go's standard library (`crypto/aes` + `crypto/cipher`),
+for both layers of the envelope:
+
+- **Secret values and other sensitive fields** (`internal/encryption/encryption.go`):
+  `NewEncryptionService` requires a 32-byte key, builds an AES cipher +
+  `cipher.NewGCM`, and tags the ciphertext's `EncryptionMetadata.Algorithm` with the
+  constant `"AES-256-GCM"` — checked again on decrypt so a metadata/algorithm
+  mismatch fails loudly rather than silently misinterpreting bytes. Nonces are fresh
+  12 bytes from `crypto/rand` per encryption, stored base64 in the metadata, and
+  nonce length is validated before `gcm.Open` to avoid a panic on corrupt input.
+- **DEK wrapping** (`internal/encryption/keymanager_lifecycle.go`, `wrapKey`/
+  `unwrapKey`): an independent AES-256-GCM call, output format `nonce(12B) ||
+  ciphertext` via `gcm.Seal(nonce, nonce, plainKey, nil)`.
+
+**AAD (Additional Authenticated Data) binds ciphertext to its logical context**, so a
+ciphertext copied to a different row (a different secret, project, or version)
+fails to decrypt even though the raw bytes are otherwise valid. The canonical form
+for secret values, `SecretAAD(secretID, projectID, versionNumber)`, produces
+`"keyorix:v2:<secretID>:<projectID>:<versionNumber>"`; parallel domain-separated AAD
+helpers exist for MFA, sessions, PATs, password-reset tokens, and dynamic-secret
+data. `EncryptionMetadata.AADVersion` records which scheme produced a given row:
+`"v2"` is current (project-scoped, post namespace→project migration); an absent
+version is legacy/no-AAD; `"v1"` (`secretID:namespaceID:versionNumber`) predates the
+project migration and is no longer produced, kept only so old rows still decrypt.
+
+**Key derivation: PBKDF2-HMAC-SHA256** (`golang.org/x/crypto/pbkdf2` — the one
+non-stdlib crypto dependency this layer takes) derives the passphrase-mode KEK.
+Default iteration count is `DefaultKEKIterations = 600000`, explicitly documented
+in-code as matching current OWASP guidance and replacing a prior, weaker default of
+100,000. Salt is 32 random bytes, generated once per install and persisted
+(plaintext, by design — a salt is not a secret) at `keys/kek.salt`.
+
+**Pluggable key sources, not just a passphrase** (ADR-038, `internal/crypto/`):
+`KeyProvider` is a two-method interface (`KEK() ([]byte, error)`, `Name() string`);
+implementations exist for password (default), file, env, AWS/Azure/GCP KMS
+(ADR-041), TPM, exec (shell out to a key-delivery sidecar), and Shamir secret
+sharing across N keyholders, plus a composing `MultiKeyProvider`. Whichever source
+is configured, it only ever has to produce 32 bytes (`KEKSize`) — everything
+downstream (AES-256-GCM, AAD, versioning) is identical regardless of where the KEK
+came from.
+
+**Rejected/not considered further:** ChaCha20-Poly1305 appears in this codebase
+only for TLS cipher-suite configuration (`internal/config/tls_ciphers.go`), an
+unrelated concern (transport, not at-rest) — it was never evaluated as the at-rest
+AEAD, since AES-256-GCM already satisfies every requirement above with zero
+additional dependencies and has hardware acceleration (AES-NI) on essentially every
+target deployment platform, an advantage ChaCha20-Poly1305 exists specifically to
+avoid needing.
+
+## Consequences
+
+- **Positive.** Every at-rest encrypted field goes through one audited stdlib
+  primitive with one AAD-binding discipline, rather than each subsystem picking its
+  own scheme. DEK rotation (ADR-010) and key-source pluggability (ADR-038/041) both
+  build cleanly on the envelope shape described here without touching the cipher
+  itself.
+- **Negative / accepted tradeoff.** AES-256-GCM's 12-byte nonce space is only safe
+  under the standard "never reuse a nonce with the same key" discipline — this repo
+  relies on `crypto/rand` freshness per call rather than a counter, which is correct
+  but means nonce uniqueness is probabilistic, not structurally guaranteed. Not
+  revisited here because the birthday-bound risk at this key's usage volume is
+  negligible and switching to a counter-based nonce would require persisting nonce
+  state, a larger change with no clear benefit.
+- Documented for buyers in `docs/SECURITY.md` and `docs/compliance/SECURITY-FAQ.md`,
+  both of which already describe this scheme at a summary level — this ADR is the
+  engineering-level record those documents point back to.

--- a/docs/adr-078-gorm-storage-layer.md
+++ b/docs/adr-078-gorm-storage-layer.md
@@ -1,0 +1,90 @@
+# ADR-078: GORM as the storage-layer ORM
+
+## Status
+
+Accepted, as-built. Backfill ADR — GORM's adoption predates the ADR series and has
+always been treated as settled fact by later ADRs (ADR-048, ADR-049 both assume and
+build on it rather than re-justifying it). Recorded now per the M2 "ADR backfill"
+backlog item.
+
+## Context
+
+Keyorix supports three storage backends behind a single interface
+(`internal/storage/factory.go`, `DefaultStorageFactory.CreateStorage`): PostgreSQL
+(production / HA default), SQLite (embedded, single-node, air-gapped, and the test
+suite's default), and `remote` (an HTTP client to a running Keyorix server, for the
+CLI's client mode). `cfg.Storage.Type` selects among them; an unrecognized value is
+a hard error rather than a silent fallback.
+
+The storage-layer needs, from the earliest design, were:
+
+- **One model definition, two SQL dialects.** `internal/storage/models/models.go`
+  defines roughly 76 struct types that must map identically onto Postgres and
+  SQLite without hand-written dialect-specific SQL in application code.
+- **Migrations that work for both an operator-managed Postgres instance and an
+  embedded single-file SQLite database**, without a separate migration-file
+  toolchain to maintain per backend.
+- **A local vs. remote split that stays structurally identical** — `local_*.go`
+  files (GORM-backed) and `remote_*.go` files (HTTP calls to a running server)
+  implement the same Go interface, so core business logic never needs to know which
+  backend it's talking to.
+
+## Decision
+
+Adopted **`gorm.io/gorm`** (currently v1.31.2) with `gorm.io/driver/postgres` for
+production/HA and a SQLite path for the embedded/air-gapped/test backend, reached
+through `internal/storage/store/`'s `local_*.go` files. `remote_*.go` files
+implement the same storage interface over HTTP for the CLI's client mode
+(`internal/storage/remote/client.go`), so `core` business logic is written once
+against the interface and never branches on backend.
+
+**The SQLite path is not GORM's stock driver** — `internal/storage/sqlitedialect`
+is a small local fork of `go-gorm/sqlite`'s `sqlite.go` (MIT-licensed, attribution
+preserved), with the underlying `database/sql` driver swapped to
+`modernc.org/sqlite` (pure Go, CGO-free) per ADR-048. That ADR covers the driver
+swap itself in detail; this ADR is the missing piece it assumed — why GORM was the
+ORM being forked in the first place, rather than switched away from.
+
+**AutoMigrate is used for schema management**, not a separate migration-file
+toolchain — `migrateDatabase` (`factory.go`) is the entry point, driving roughly 34
+individual `db.AutoMigrate(&models.X{})` calls plus one loop over the bulk model
+set. This has one well-documented, recurring footgun, called out at ~15 call sites
+in `factory.go`'s own comments: running a full `AutoMigrate` against an existing
+table whose columns were already hand-altered (via targeted `db.Migrator()` column
+additions) can poison pgx's prepared-statement cache and make subsequent
+`information_schema` existence checks spuriously return false — which then
+re-triggers full AutoMigrate against a table it shouldn't touch, corrupting state.
+The house rule, repeated at every call site rather than solved once centrally:
+**never full-AutoMigrate an existing table once it has been column-altered outside
+AutoMigrate** — migrate it via targeted `db.Migrator()` calls instead.
+`columnExists`/`tableExists` (`factory.go`) deliberately avoid GORM's own
+`HasTable`/information-schema helpers for the same reason.
+
+**Rejected alternatives, implicitly rather than via formal comparison** (no
+contemporaneous doc weighing these exists — this is stated here as the honest
+backfill, not a reconstruction of a debate that happened): `sqlc`/`sqlx` would
+require hand-written SQL per dialect for all ~76 models, reintroducing exactly the
+dual-dialect burden GORM removes; `ent` is a heavier code-generation-first ORM with
+its own migration story that would have meant rewriting the storage layer rather
+than adopting it incrementally; raw `database/sql` was rejected for the same reason
+as `sqlc`/`sqlx` — it pushes dialect differences into application code instead of
+the ORM layer.
+
+## Consequences
+
+- **Positive.** One model definition serves Postgres, SQLite, and (indirectly, via
+  the shared struct shapes) the remote client's JSON encoding. ADR-048's
+  CGO-free driver swap and ADR-049's "route all storage access through the
+  factory" rule were both straightforward to layer on top precisely because GORM
+  already centralized backend selection in one place.
+- **Negative / accepted tradeoff.** AutoMigrate's pgx prepared-statement-cache
+  interaction is a genuine footgun with no framework-level fix — the mitigation is
+  procedural (the "never re-AutoMigrate an altered table" rule) rather than
+  structural, and depends on every future migration author knowing and following
+  it. This ADR exists partly to make that rule discoverable instead of tribal
+  knowledge scattered across `factory.go` comments.
+- Not revisited: switching ORMs now would mean rewriting `internal/storage/store/`
+  end to end for no functional gain — GORM has not blocked any shipped feature
+  (dynamic secrets, machine identities, and every other post-2026 feature are all
+  plain GORM tables), so there is no open question this ADR needs to leave for a
+  future decision.

--- a/docs/adr-079-cobra-cli-framework.md
+++ b/docs/adr-079-cobra-cli-framework.md
@@ -1,0 +1,94 @@
+# ADR-079: Cobra as the CLI framework
+
+## Status
+
+Accepted, as-built. Backfill ADR — Cobra's adoption predates the ADR series.
+Recorded now per the M2 "ADR backfill" backlog item.
+
+## Context
+
+`keyorix` (the CLI binary) is a large, growing command surface: 37 command-group
+subdirectories under `internal/cli/` (accessreview, audit, auth, billing,
+bundle, compliance, connect, dynamic, encryption, group, invite, license, machine,
+migrate, pat, project, rbac, request, risk, rotation, secret, share, sod, system,
+trust, usage, user, and more), roughly 306 individual `cobra.Command` definitions
+across 169 files. It needs to support:
+
+- **Nested command groups** (`keyorix secret get`, `keyorix rotation plan
+  --all-projects`, `keyorix machine token issue`) rather than a flat list of
+  top-level flags.
+- **Two structurally different execution modes per command** — "local"/embedded
+  (talk directly to a local SQLite/Postgres-backed core service, no server running)
+  and "remote"/client (talk to a running Keyorix server over HTTP), selected by
+  `internal/cli/modes.go`'s `detectMode()`. Every command needs to work in both
+  without duplicating its logic.
+- **Per-command flags that still need consistent names and behavior** across the
+  whole surface (`--project`, `--by <admin-email>` for audited-actor commands with
+  no session, `--format`/`--json` for structured output) even though, as built,
+  these are not wired through Cobra's `PersistentFlags()` inheritance — each leaf
+  command declares its own `Flags().StringVar(...)` and the consistency comes from
+  convention plus shared resolver helpers (`common.ResolveProject`,
+  `common.ResolveRemote`), not from the framework enforcing it structurally.
+
+## Decision
+
+Adopted **`github.com/spf13/cobra`** (currently v1.10.2) as the CLI framework.
+`internal/cli/main.go`'s `init()` registers roughly 30 top-level command groups
+onto `rootCmd`; each group's own package wires its leaf subcommands (e.g.
+`internal/cli/secret/secret.go` wires 10 subcommands under `secret`). Cobra's
+nested-command-tree model maps directly onto the CLI's natural
+noun-then-verb shape (`keyorix <resource> <action>`) without a hand-rolled
+subcommand dispatcher.
+
+**Viper was deliberately not adopted alongside Cobra**, despite being Cobra's most
+common config-binding companion. Config binding is hand-rolled instead:
+`internal/config` (`config.Load`/`config.LoadConfig`) for the server/embedded-mode
+config and `internal/cli/config` (`cliconfig.LoadCLIConfig`) for the CLI's own
+`~/.keyorix/cli.yaml`. ADR-049 records this explicitly for the storage-factory path
+("No `KEYORIX_STORAGE_TYPE` or Viper `AutomaticEnv` is introduced") — this ADR
+generalizes that as the standing rule: environment-variable and config-file
+resolution stays explicit and grep-able in this codebase's own resolver functions,
+not implicit through Viper's automatic env-binding, which would make it harder to
+audit exactly which env vars a given command reads.
+
+**Local/remote dual-mode is not implemented via Cobra flag inheritance.** As built,
+no production command uses `PersistentFlags()` (confirmed absent from
+`internal/cli` outside tests) — `internal/cli/modes.go`'s `CLIMode` enum
+(`EmbeddedMode`/`ClientMode`) and per-command calls into
+`common.ResolveProject()`/`common.ResolveRemote()` carry the mode-resolution logic
+instead. Cobra's contribution here is structural (a command tree that both modes'
+`RunE` functions can share) rather than Cobra-specific plumbing (inherited flags,
+built-in config binding) — the framework provides the tree, the codebase provides
+its own resolution conventions on top.
+
+**Rejected alternatives, implicitly rather than via formal comparison** (no
+contemporaneous doc weighing these exists): `urfave/cli` and `kingpin` offer
+similar nested-command support but smaller ecosystems and less precedent in
+comparable Go CLI tools (`kubectl`, `helm`, `docker` — all Cobra-based, a relevant
+signal for a CLI whose users are the same operator audience); the stdlib `flag`
+package alone would mean hand-rolling subcommand dispatch, help text, and usage
+generation for 300+ commands — a maintenance burden Cobra removes essentially for
+free.
+
+## Consequences
+
+- **Positive.** A 37-group, 300+-command surface stays navigable — Cobra's built-in
+  help/usage generation means every command gets `--help` output for free, and the
+  nested tree keeps `internal/cli/main.go`'s registration simple even as the
+  surface has grown roughly 3x since the CLI's early days (project/environment
+  commands only, per the backlog's ADR-016/017 entries) to today's scope (billing,
+  compliance, dynamic secrets, machine identities, rotation planning, and more).
+- **Negative / accepted tradeoff.** Because `PersistentFlags()` was never adopted,
+  cross-cutting flags like `--project`/`--by` are declared per-leaf-command rather
+  than inherited once at a group root — every new command author has to know to
+  wire the shared resolver helpers themselves rather than getting them free from
+  the command tree. This is a deliberate tradeoff already implicit in the
+  as-built code (not newly decided here), and not revisited: retrofitting
+  `PersistentFlags()` across 300+ existing commands would be a large,
+  purely-mechanical change for a consistency gain that hasn't caused a reported
+  bug.
+- Not currently used: Cobra's completion (`GenBashCompletion` etc.) and
+  Markdown-doc-generation (`GenMarkdownTree`) helpers are available but unwired —
+  `keyorix completion` presumably works via Cobra's own default subcommand, but
+  there's no custom completion or generated-docs tooling in this repo today. Left
+  as a genuinely open, low-priority follow-up rather than claimed as done here.

--- a/docs/adr-080-agpl-dual-licensing-model.md
+++ b/docs/adr-080-agpl-dual-licensing-model.md
@@ -1,0 +1,111 @@
+# ADR-080: AGPL-3.0 dual-licensing model
+
+## Status
+
+Accepted, as-built. Backfill ADR — the licensing model was ratified June 12, 2026
+(recorded in the private strategy doc, not previously as a public-repo ADR) and has
+been the standing model since. Recorded now per the M2 "ADR backfill" backlog item.
+See ADR-065 for the offline license-validation *mechanism* this ADR's commercial
+tier relies on — this ADR covers the business/licensing *model* decision itself,
+not the technical enforcement.
+
+## Context
+
+Keyorix needed a licensing model that satisfies three simultaneous, partly-tense
+goals: be genuinely open source (not open-core-with-a-locked-`ee/`-directory,
+which is Keyorix's own stated competitive line against Infisical's
+audit-logs-paywalled-on-self-hosted positioning); have a real path to commercial
+revenue without engineering an ongoing feature-gate maintenance burden a solo
+founder can't sustain; and give enterprise legal teams — the actual buyer, in a
+security-tooling category — a way to adopt the product without a viral-copyleft
+review blocking the deal.
+
+Options considered (recorded in the private strategy doc; summarized here since
+that document isn't part of the public repo):
+
+- **MIT/Apache-2.0** — permissive. Rejected: no leverage for a commercial tier;
+  nothing stops a cloud provider from re-hosting the product as a competing managed
+  service with zero obligation back to the project.
+- **Business Source License (BSL)** — time-delayed open source, HashiCorp's chosen
+  model. Rejected: not OSI-approved, which some enterprise legal teams reject
+  outright regardless of the specific terms; and the 2023 HashiCorp BSL backlash
+  (Terraform → OpenTofu fork) is treated as *Keyorix's* recruiting and community
+  opportunity — positioning as "the open one" relative to a HashiCorp-alumni
+  audience specifically, rather than repeating HashiCorp's own move.
+- **Open core** (permissive core + proprietary `ee/` add-ons) — the Infisical/most
+  common competitor model. Rejected on two grounds: it requires an ongoing
+  feature-gate engineering discipline (deciding, for every new feature, which side
+  of the line it falls on, and maintaining that boundary in code) that doesn't fit
+  a solo-founder engineering capacity; and it directly undercuts the competitive
+  claim that security capability itself should never be paywalled.
+- **AGPL-3.0 core + private commercial license** — the adopted model, detailed
+  below.
+
+## Decision
+
+**The entire repository is licensed AGPL-3.0** (`LICENSE`, full GNU AGPLv3 text;
+`COPYRIGHT` adds a "Network Copyleft Notice" explaining the SaaS-loophole closure
+AGPL provides over plain GPL — running a modified version as a network service
+counts as distribution, triggering the source-disclosure obligation). There is no
+`ee/` directory, no license-gated *security* feature, and no code path that
+behaves differently based on who is running it, for anything security-relevant.
+This is stated as a standing principle in `LICENSING.md`: "Security is never
+paywalled."
+
+**Two features are commercially gated**, and only two — deliberately narrow, and
+both non-security: `internal/license/features.go` defines exactly
+`FeatureAirgapUpdates` ("airgap_updates", gating `keyorix bundle import`) and
+`FeatureBilling` ("billing", gating the FinOps billing report). `Gate.HasFeature`
+fails safe — a nil `*Gate` (no license installed) returns the community baseline,
+never a hard failure. This is intentionally the inverse failure direction from the
+update-bundle *signature* verification (which fails closed, per ADR-062/064) — a
+missing or invalid commercial license degrades functionality, it never bricks a
+deployment or blocks access to already-stored data.
+
+**Organizations that cannot or prefer not to operate under AGPL terms** — the
+actual target of the commercial tier — can license the same code under a private
+bilateral commercial agreement (MSA + Order Form, not a second source-available
+license like BSL or Elastic's). The commercial license's substantive offering is
+*removal of AGPL's obligations*, plus a warranty and IP indemnity AGPL doesn't
+provide — the Grafana/MinIO/pre-SSPL-MongoDB model. Structure: annual subscription
+with a perpetual fallback, self-certified node counts, an offline signed license
+file (ADR-065's mechanism) that never phones home.
+
+**The redistribution guard is trademark, not license terms.** AGPL's copyleft
+covers the *code* — anyone may fork, modify, and redistribute it under AGPL. What
+AGPL doesn't prevent is a third party redistributing a modified fork *under the
+Keyorix name*, implying an affiliation or quality bar that doesn't exist.
+`LICENSING.md` states this directly: "'Keyorix' is a trademark of Keyorix SL... The
+AGPL licence covers the code, not the name... distributing modified versions or
+commercial offerings under the Keyorix name requires our written agreement."
+Trademark registration itself (EUIPO, classes 9/42) remains an open backlog item as
+of this writing — the *policy* is decided and documented; the registration filing
+is a separate, still-pending action tracked in the private backlog, not blocked on
+this ADR.
+
+**Contributor terms.** `CONTRIBUTING.md` requires DCO sign-off (enforced in CI, per
+this repo's own commit conventions) on every commit — "your contribution will be
+under the same license" (AGPL-3.0). `LICENSING.md` separately references a signed
+CLA. These are two different mechanisms (DCO is a per-commit attestation; a CLA is
+a separate signed agreement) stated in two different documents — worth reconciling
+into one contributor-terms story in a future doc pass, noted here rather than
+silently left inconsistent.
+
+## Consequences
+
+- **Positive.** The "security paywalled on self-hosted" competitive line against
+  open-core competitors holds structurally, not just as marketing copy — there is
+  no code path to audit that contradicts it, because the gate only ever checks two
+  named non-security features. Feature development doesn't carry an ongoing
+  "which license tier does this belong to" tax, since the default for every new
+  feature is simply AGPL/open unless a maintainer deliberately adds it to
+  `features.go`.
+- **Negative / accepted tradeoff.** AGPL is a real adoption friction for exactly
+  the population (enterprise legal, regulated sectors) the product also needs as
+  customers — but that friction is the intended mechanism, not a side effect: it's
+  what makes the commercial license a genuine choice rather than a redundant
+  upsell on top of an already-permissive license.
+- Trademark registration is a genuine open action item (tracked in the private
+  backlog), not yet filed as of this ADR — the policy `LICENSING.md` states is
+  ahead of the legal registration that would make it enforceable. Flagged here so
+  it isn't mistaken for already-complete because the policy document exists.

--- a/docs/adr-081-github-flow-branching.md
+++ b/docs/adr-081-github-flow-branching.md
@@ -1,0 +1,81 @@
+# ADR-081: GitHub Flow branching and merge model
+
+## Status
+
+Accepted, as-built. Backfill ADR — trunk-based GitHub Flow has been the working
+model since before the ADR series started; the LTS/`release/X.Y.x` amendment in
+ADR-067 is the one place it has since been deliberately narrowed. Recorded now per
+the M2 "ADR backfill" backlog item.
+
+## Context
+
+A solo-founder-plus-agents project with a high commit cadence (main has taken on
+the order of 1,500 commits total, with roughly 750 in a recent 30-day window per
+ADR-067's own count) needs a branching model that stays out of the way rather than
+adding process overhead a small team can't sustain — no separate `develop`
+integration branch to keep in sync, no release-branch cutting ceremony for every
+version, and a merge path simple enough that CI can gate it unambiguously.
+
+The alternative most explicitly not chosen — GitFlow (long-lived `develop`,
+`release/*`, `hotfix/*` branches with scheduled merge-backs) — was never adopted
+and is not discussed in any doc as a rejected option; there is no contemporaneous
+record of a GitFlow-vs-GitHub-Flow debate. This ADR states the as-built model
+directly rather than reconstructing a decision debate that left no paper trail.
+
+## Decision
+
+**Single trunk: `main`, no `develop`/`release`/`staging` branch.** Every CI
+workflow (`ci.yml`, `codeql.yml`, `sonarcloud.yml`, `trivy.yml`, `semgrep.yml`,
+`web-ci.yml`, `scorecard.yml`, `dco.yml`, `osv-scanner.yml`) triggers only on
+`push`/`pull_request` against `branches: [main]` — no workflow references any other
+long-lived branch. Feature work happens on short-lived branches (or, for
+Claude-Code-driven parallel sessions, git worktrees under `.claude/worktrees/` —
+an operational convention layered on top of this model, not itself part of the
+branching decision) merged back to `main` via PR.
+
+**Branch protection is real, not aspirational.** `CONTRIBUTING.md` states it
+directly: "Open a PR against `main`. CI must pass in full before it can merge
+(branch protection enforces this — there's no bypass, including for maintainers)."
+Eleven required checks gate every merge (go vet/build/test, gosec, golangci-lint,
+govulncheck, gitleaks, CodeQL, Helm lint/kubeconform, checkov, go-licenses, per
+`CONTRIBUTING.md`'s own enumeration). `.github/CODEOWNERS` scopes mandatory review
+to security-sensitive paths (crypto, auth, middleware, storage migrations, CI
+workflow files themselves).
+
+**Squash-merge is the merge strategy** — `CLAUDE.md`'s git conventions section
+notes this explicitly in the context of PR trailers ("squash-merge folds commit
+trailers into the PR's merge commit"), which is also why that same doc forbids
+`Co-Authored-By: Claude` trailers on commits: a trailer on any commit in a
+multi-commit PR branch survives into the single squashed merge commit on `main`.
+
+**Releases are tag-based, not branch-based**, layered on top of the trunk model:
+`docker-publish.yml` and `release.yml` both trigger on `push: tags: ['v*']` — no
+release-cutting branch, just a tag on a commit already on `main`.
+
+**The one deliberate amendment to pure trunk-based development** is ADR-067's LTS
+policy: designated LTS releases every 18–24 months get a `release/X.Y.x`
+maintenance branch, fixed forward-only via cherry-pick and **never merged back into
+`main`**. This is a narrower, later addition on top of the model this ADR
+describes, not a contradiction of it — `main` remains the only branch normal
+feature work ever targets; `release/X.Y.x` branches exist solely to receive
+backported security fixes for a line no longer receiving new features. See
+ADR-067 for the full support-line policy; this ADR is the trunk-model foundation
+it builds on.
+
+## Consequences
+
+- **Positive.** No integration-branch drift to manage, no release-branch cutting
+  ceremony for ordinary releases, and a merge-to-`main` path that CI can gate
+  unambiguously (one branch, one required-checks list). This has scaled to a high
+  commit cadence and many concurrent worktree-based agent sessions without process
+  overhead growing to match.
+- **Negative / accepted tradeoff.** Every merged PR ships to `main` immediately —
+  there is no integration branch to catch a defect before it reaches the branch
+  release tags are cut from. This is mitigated, not eliminated, by the eleven
+  required CI checks and by ADR-067's LTS lines existing specifically to give
+  long-term customers a branch that doesn't take ongoing `main` churn.
+- The `release/X.Y.x` amendment (ADR-067) means this is no longer *pure* GitHub
+  Flow in the strictest sense once an LTS line exists — worth stating plainly here
+  so a future reader doesn't find the two ADRs in apparent tension. They aren't:
+  ADR-067 narrows this ADR's model for a specific, bounded case (long-term security
+  support) without changing how ordinary feature work flows through `main`.


### PR DESCRIPTION
## Summary
Five foundational engineering/business decisions were made and shipped long before the ADR series started and were never separately written up. Closes the M2 "ADR backfill" backlog item.

- `docs/adr-077-symmetric-cipher-choice.md` — AES-256-GCM + PBKDF2-HMAC-SHA256 (600k iterations) + the ADR-038 KeyProvider abstraction for at-rest encryption.
- `docs/adr-078-gorm-storage-layer.md` — GORM as the storage-layer ORM across Postgres/SQLite/remote, including the documented AutoMigrate/pgx prepared-statement-cache footgun and the house rule around it.
- `docs/adr-079-cobra-cli-framework.md` — Cobra as the CLI framework (37 command groups, ~306 commands), and the deliberate non-adoption of Viper and `PersistentFlags()` inheritance.
- `docs/adr-080-agpl-dual-licensing-model.md` — the AGPL-3.0 dual-licensing model (open core, two narrowly-gated commercial features, trademark as the redistribution guard), referencing the private June 12 licensing decision and ADR-065's offline validation mechanism.
- `docs/adr-081-github-flow-branching.md` — trunk-based GitHub Flow (single `main`, squash-merge, tag-based releases), with ADR-067's LTS `release/X.Y.x` branches noted as the one deliberate amendment.

Each ADR is grounded in a direct read of the current codebase (exact file paths, dependency versions, existing related ADRs) rather than reconstructed from memory.

## Test plan
- [x] Docs-only change — no code touched
- [x] Verified cited dependency versions (`spf13/cobra v1.10.2`, `gorm.io/gorm v1.31.2`, `golang.org/x/crypto v0.54.0`) against `go.mod`
- [x] Verified cited file paths (`internal/encryption/`, `internal/crypto/`, `internal/storage/sqlitedialect`, `internal/cli/`, `LICENSE`, `LICENSING.md`) exist in the repo