### PR TITLE
ci: cache Playwright/Nuclei/SBOM tools, migrate off deprecated SonarCloud action, gate anchore-syft on docs-only

### DIFF
--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -3,6 +3,7 @@ name: Anchore Syft SBOM scan
 on:
   push:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**']
 
 permissions: {}
 

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -111,8 +111,14 @@ jobs:
           done
           curl -sf http://localhost:8080/health || { echo "Server did not become healthy"; exit 1; }
 
+      - name: Cache Nuclei binary
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/bin/nuclei
+          key: nuclei-v3.3.9-${{ runner.os }}
+
       - name: Install Nuclei
-        run: go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.3.9 # NOSONAR githubactions:S6437 -- pinned to v3.3.9; go.sum not applicable for standalone DAST tool binaries outside the module graph
+        run: '[ -x ~/go/bin/nuclei ] || go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.3.9' # NOSONAR githubactions:S6437 -- pinned to v3.3.9; go.sum not applicable for standalone DAST tool binaries outside the module graph
 
       - name: Update Nuclei templates
         run: nuclei -update-templates -silent

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,24 @@ jobs:
       # Pinned: supply-chain tooling is itself an attack surface. The Makefile
       # `release` target shells out to cyclonedx-gomod to emit a per-binary
       # CycloneDX SBOM (covered by checksums.txt, uploaded with dist/*).
+      - name: Cache cyclonedx-gomod binary
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/go/bin/cyclonedx-gomod
+          key: cyclonedx-gomod-v1.10.0-${{ runner.os }}
+
       - name: Install SBOM generator
-        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0 # NOSONAR githubactions:S8545 -- pinned to v1.10.0; go.sum not applicable for a standalone build-time tool outside the module graph (same pattern as dast.yml's nuclei install)
+        run: '[ -x ~/go/bin/cyclonedx-gomod ] || go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0' # NOSONAR githubactions:S8545 -- pinned to v1.10.0; go.sum not applicable for a standalone build-time tool outside the module graph (same pattern as dast.yml's nuclei install)
+
+      # actions/setup-node's own `cache:` input above is already spent on pnpm
+      # (keyed to web/pnpm-lock.yaml, one cache slot per action call) -- this
+      # is a second, independent cache for npm's own package cache, keyed to
+      # the ROOT package-lock.json that `npm ci` below actually reads.
+      - name: Cache npm packages (root package-lock.json)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       # Pinned via the root package-lock.json + npm ci, same pattern as
       # openapi-lint's Spectral install (Scorecard #533): `npm install -g` has

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -125,8 +125,19 @@ jobs:
         run: sed -i 's|^SF:|SF:web/|' web/coverage/lcov.info
         if: hashFiles('web/coverage/lcov.info') != ''
 
+      # Was SonarSource/sonarcloud-github-action, which is itself deprecated (its
+      # own action.yml prints a warning on every run: "This action is deprecated
+      # ... Please use the sonarqube-scan-action action instead") and was already
+      # just a thin wrapper delegating straight to this same action -- confirmed
+      # by reading both actions' source at their pinned refs before migrating,
+      # not assumed. Also resolves the original "cache the scanner CLI" ask a
+      # different way than proposed: sonarqube-scan-action already caches the
+      # scanner CLI internally via its own actions/cache step (path keyed on
+      # scannerVersion+os+arch), so no additional caching needs adding here --
+      # wrapping another cache around this would just duplicate what's already
+      # inside the action.
       - name: Analyze with SonarCloud
-        uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8
+        uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d # v5.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -128,9 +128,28 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      # Keyed on the lockfile hash, not a hand-extracted Playwright version --
+      # ANY dependency bump invalidates this (coarser than strictly necessary,
+      # but simpler and correct: a change to the pinned Playwright version
+      # always changes pnpm-lock.yaml too). Caching the browser binary dir
+      # alone doesn't cover --with-deps' apt-installed system libraries, so a
+      # cache hit still runs the cheap, idempotent install-deps-only pass
+      # below rather than skipping browser setup entirely.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
+
       # Chromium-only (playwright.config.ts) to keep this job fast.
       - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright OS dependencies (cache hit -- browser binary already present)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
 
       - name: E2E tests
         run: pnpm test:e2e


### PR DESCRIPTION
## Summary
Follow-up to #1366, covering the remaining items (4-8) from the earlier CI research pass.

- **`web-ci.yml`**: caches Playwright's browser binaries (`~/.cache/ms-playwright`, keyed on the `pnpm-lock.yaml` hash). A cache hit still runs the cheap, idempotent `install-deps`-only pass, since caching the browser binary dir alone doesn't cover `--with-deps`' apt-installed system libraries.
- **`sonarcloud.yml`**: the proposed fix (cache the scanner CLI) turned out to already exist -- verified by reading both actions' source at their pinned refs before touching anything. `SonarSource/sonarcloud-github-action` is itself deprecated (prints a warning every run) and was already just a thin wrapper delegating to `SonarSource/sonarqube-scan-action`, which has its own built-in `actions/cache` step for the scanner CLI. Migrates directly to the non-deprecated action instead (its own docs call it a "drop-in replacement") rather than adding a redundant cache on top of one that already exists internally.
- **`dast.yml`**: caches the pinned Nuclei binary (`go install`), same pattern as `ci.yml`'s govulncheck/gosec.
- **`release.yml`**: caches `cyclonedx-gomod` (`go install`, same pattern) AND fixes a second, more specific gap found while investigating -- the "cdxgen" frontend SBOM tool isn't `npm install -g` as originally assumed, it's `npm ci` against the ROOT `package-lock.json`, but the job's only Node cache (`actions/setup-node`'s `cache: pnpm`) is scoped to `web/pnpm-lock.yaml`. Adds a second, independent `actions/cache` for npm's own cache dir keyed to the root lockfile.
- **`anchore-syft.yml`**: adds the same `paths-ignore` every other push-triggered security-scan workflow in this repo already has; this was the only one missing it. Push-only, no PR/required-check involved, so a plain workflow-level `paths-ignore` (not job-level `if:`) is safe here.

## Test plan
- [x] `actionlint` passes on all 5 modified files
- [x] Verified `sonarqube-scan-action`'s built-in caching and the deprecation notice by reading both actions' source at their pinned refs before migrating
- [ ] CI green on this PR
- [ ] Confirm on a follow-up run that Playwright/Nuclei/cyclonedx-gomod/npm all show a cache hit