### PR TITLE
feat(web,billing): FinOps billing dashboard + license-error masking fix

### DIFF
--- a/server/http/handlers/admin_billing.go
+++ b/server/http/handlers/admin_billing.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/license"
 )
 
 // AdminBillingHandler serves GET /api/v1/admin/billing/report.
@@ -75,6 +76,15 @@ func (h *AdminBillingHandler) GetBillingReport(w http.ResponseWriter, r *http.Re
 			}
 			projectIDs = append(projectIDs, uint(n))
 		}
+	}
+
+	// Checked here (not just inside core.GenerateBillingReport) so the client gets a
+	// distinguishable 403 "license required" response instead of the generic 500
+	// clientSafe() masks every other error behind — a caller building a billing UI
+	// needs to tell "not licensed" apart from "server broke" to render correctly.
+	if !h.coreService.HasLicensedFeature(license.FeatureBilling) {
+		sendError(w, "Forbidden", "FinOps billing reports require a commercial license (feature: billing)", http.StatusForbidden, nil)
+		return
 	}
 
 	report, err := h.coreService.GenerateBillingReport(r.Context(), from, to, projectIDs)

--- a/server/http/handlers/admin_billing_test.go
+++ b/server/http/handlers/admin_billing_test.go
@@ -1,0 +1,142 @@
+package handlers
+
+import (
+	"crypto/ed25519"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/license"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/internal/trust"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newBillingTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.SecretNode{}, &models.AuditEvent{}))
+	return db
+}
+
+func licensedBillingCore(t *testing.T, db *gorm.DB) *core.KeyorixCore {
+	t.Helper()
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeLicense, "license-2026", pub))
+	token, err := license.Issue(license.License{
+		Licensee: "ACME GmbH", Plan: "enterprise",
+		Features: []string{license.FeatureBilling},
+		IssuedAt: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(365 * 24 * time.Hour),
+		KeyID: "license-2026",
+	}, priv)
+	require.NoError(t, err)
+	c.SetLicenseGate(license.NewGate(token, reg, "", 0))
+	return c
+}
+
+func billingReportURL(from, to, projectID string) string {
+	u := "/api/v1/admin/billing/report?from=" + from + "&to=" + to
+	if projectID != "" {
+		u += "&project_id=" + projectID
+	}
+	return u
+}
+
+func TestAdminBillingHandler_MissingFromParam(t *testing.T) {
+	db := newBillingTestDB(t)
+	h := NewAdminBillingHandler(licensedBillingCore(t, db))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/billing/report?to=2026-02-01T00:00:00Z", nil)
+	w := httptest.NewRecorder()
+	h.GetBillingReport(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminBillingHandler_MissingToParam(t *testing.T) {
+	db := newBillingTestDB(t)
+	h := NewAdminBillingHandler(licensedBillingCore(t, db))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/billing/report?from=2026-01-01T00:00:00Z", nil)
+	w := httptest.NewRecorder()
+	h.GetBillingReport(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminBillingHandler_InvalidFromParam(t *testing.T) {
+	db := newBillingTestDB(t)
+	h := NewAdminBillingHandler(licensedBillingCore(t, db))
+
+	req := httptest.NewRequest(http.MethodGet, billingReportURL("not-a-date", "2026-02-01T00:00:00Z", ""), nil)
+	w := httptest.NewRecorder()
+	h.GetBillingReport(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminBillingHandler_InvalidProjectID(t *testing.T) {
+	db := newBillingTestDB(t)
+	h := NewAdminBillingHandler(licensedBillingCore(t, db))
+
+	req := httptest.NewRequest(http.MethodGet,
+		billingReportURL("2026-01-01T00:00:00Z", "2026-02-01T00:00:00Z", "abc"), nil)
+	w := httptest.NewRecorder()
+	h.GetBillingReport(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestAdminBillingHandler_Unlicensed asserts the license gate is checked BEFORE
+// the report is generated, and returns a distinguishable 403 — not the generic
+// 500 clientSafe() masks every other error behind. A billing UI needs to tell
+// "not licensed" apart from "server broke" to render correctly.
+func TestAdminBillingHandler_Unlicensed(t *testing.T) {
+	db := newBillingTestDB(t)
+	// No SetLicenseGate call: nil gate → HasLicensedFeature is always false.
+	h := NewAdminBillingHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := httptest.NewRequest(http.MethodGet,
+		billingReportURL("2026-01-01T00:00:00Z", "2026-02-01T00:00:00Z", ""), nil)
+	w := httptest.NewRecorder()
+	h.GetBillingReport(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "commercial license")
+}
+
+func TestAdminBillingHandler_Licensed_ReturnsReport(t *testing.T) {
+	db := newBillingTestDB(t)
+	require.NoError(t, db.Create(&models.Project{Name: "acme-prod"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{Name: "db-password", ProjectID: 1, IsSecret: true}).Error)
+
+	inWindow := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	success := true
+	projectID := uint(1)
+	userID := uint(7)
+	require.NoError(t, db.Create(&models.AuditEvent{
+		ProjectID: &projectID, EventType: "secret.read", Success: &success, ActorType: "user",
+		UserID: &userID, EventTime: inWindow,
+	}).Error)
+
+	h := NewAdminBillingHandler(licensedBillingCore(t, db))
+	req := httptest.NewRequest(http.MethodGet,
+		billingReportURL("2026-01-01T00:00:00Z", "2026-02-01T00:00:00Z", ""), nil)
+	w := httptest.NewRecorder()
+	h.GetBillingReport(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "acme-prod")
+	assert.Contains(t, body, `"secret_reads":1`)
+	assert.Contains(t, body, `"secret_count":1`)
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,6 +56,7 @@ const SharingManagementPage = React.lazy(() =>
 const ProfilePage = React.lazy(() => import('./pages/profile').then((m) => ({ default: m.ProfilePage })));
 
 const AdminPage = React.lazy(() => import('./pages/admin/AdminPage').then((m) => ({ default: m.AdminPage })));
+const BillingPage = React.lazy(() => import('./pages/billing/BillingPage').then((m) => ({ default: m.BillingPage })));
 const UserDetailPage = React.lazy(() =>
     import('./pages/admin/UserDetailPage').then((m) => ({ default: m.UserDetailPage }))
 );
@@ -166,6 +167,14 @@ function App() {
                                                     element={
                                                         <AdminRoute>
                                                             <AdminPage />
+                                                        </AdminRoute>
+                                                    }
+                                                />
+                                                <Route
+                                                    path={ROUTES.ADMIN_BILLING}
+                                                    element={
+                                                        <AdminRoute>
+                                                            <BillingPage />
                                                         </AdminRoute>
                                                     }
                                                 />

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
     ScaleIcon,
     RocketLaunchIcon,
     ShareIcon,
+    BanknotesIcon,
 } from '@heroicons/react/24/outline';
 import { useUIStore } from '../../store/uiStore';
 import { useAuth } from '../../features/auth';
@@ -117,6 +118,13 @@ const NAV: NavItem[] = [
         name: 'Compliance',
         href: '/compliance',
         icon: ScaleIcon,
+    },
+    {
+        kind: 'leaf',
+        name: 'Billing',
+        href: '/admin/billing',
+        icon: BanknotesIcon,
+        adminOnly: true,
     },
     {
         kind: 'leaf',

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -82,6 +82,7 @@ export const ROUTES = {
     SECURITY: '/security',
     AUDIT: '/audit',
     ADMIN: '/admin',
+    ADMIN_BILLING: '/admin/billing',
     ADMIN_USERS: '/admin/users',
     ADMIN_USER_DETAIL: (id: number | string) => `/admin/users/${id}`,
     ADMIN_ROLES: '/admin/roles',

--- a/web/src/features/billing/index.ts
+++ b/web/src/features/billing/index.ts
@@ -1,0 +1,1 @@
+export { useBillingReport } from './useBillingReport';

--- a/web/src/features/billing/useBillingReport.ts
+++ b/web/src/features/billing/useBillingReport.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { billingApi, BillingLicenseRequiredError, type BillingReportParams } from '../../services/billing';
+
+// useBillingReport wraps GET /api/v1/admin/billing/report. retry:false because
+// the two failure modes that matter here (no billing license, no system.read
+// permission) are both permanent for the current session — retrying a 403
+// three times before the page can render its explanation just delays it.
+export function useBillingReport(params: BillingReportParams) {
+    const { data, isLoading, isError, error } = useQuery({
+        queryKey: ['billing', 'report', params.from, params.to, params.projectIds],
+        queryFn: () => billingApi.getReport(params),
+        staleTime: 60_000,
+        retry: false,
+    });
+
+    return {
+        report: data,
+        isLoading,
+        isError,
+        error,
+        isLicenseRequired: error instanceof BillingLicenseRequiredError,
+    };
+}

--- a/web/src/pages/billing/BillingPage.tsx
+++ b/web/src/pages/billing/BillingPage.tsx
@@ -1,0 +1,302 @@
+import React, { useMemo, useState } from 'react';
+import { BanknotesIcon, LockClosedIcon } from '@heroicons/react/24/outline';
+import { useBillingReport } from '../../features/billing';
+import type { BillingProjectStat } from '../../services/billing';
+
+// ── date-range presets ──────────────────────────────────────────────────────
+
+type PresetKey = 'this-month' | 'last-month' | 'last-30' | 'last-90' | 'custom';
+
+const PRESETS: { key: PresetKey; label: string }[] = [
+    { key: 'this-month', label: 'This month' },
+    { key: 'last-month', label: 'Last month' },
+    { key: 'last-30', label: 'Last 30 days' },
+    { key: 'last-90', label: 'Last 90 days' },
+];
+
+const toDateInput = (d: Date): string => d.toISOString().slice(0, 10);
+
+// presetRange returns the [from, to) window for a preset, as Date objects at
+// UTC midnight — "to" is exclusive (matches the server's half-open interval).
+function presetRange(key: Exclude<PresetKey, 'custom'>, now: Date): { from: Date; to: Date } {
+    const startOfUTCDay = (d: Date) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+    const today = startOfUTCDay(now);
+    switch (key) {
+        case 'this-month':
+            return { from: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)), to: today };
+        case 'last-month': {
+            const from = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1));
+            const to = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+            return { from, to };
+        }
+        case 'last-30':
+            return { from: new Date(today.getTime() - 30 * 86_400_000), to: today };
+        case 'last-90':
+            return { from: new Date(today.getTime() - 90 * 86_400_000), to: today };
+    }
+}
+
+// ── small presentational pieces ─────────────────────────────────────────────
+
+const Tile: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+    <div
+        className="rounded-lg border px-4 py-3"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-app)' }}
+    >
+        <div className="text-xl font-semibold tabular-nums" style={{ color: 'var(--text-primary)' }}>
+            {value}
+        </div>
+        <div className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
+            {label}
+        </div>
+    </div>
+);
+
+const skeletonPlaceholder = (): React.ReactElement => (
+    <div
+        className="rounded-xl border p-6"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-surface)' }}
+    >
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+            {[1, 2, 3, 4].map((i) => (
+                <div key={i} className="h-16 rounded-lg animate-pulse" style={{ backgroundColor: 'var(--bg-muted)' }} />
+            ))}
+        </div>
+        <div className="h-48 rounded-lg animate-pulse" style={{ backgroundColor: 'var(--bg-muted)' }} />
+    </div>
+);
+
+const LicenseRequiredNotice: React.FC = () => (
+    <div
+        className="rounded-xl border p-8 text-center"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-surface)' }}
+    >
+        <LockClosedIcon className="h-8 w-8 mx-auto mb-3" style={{ color: 'var(--text-muted)' }} />
+        <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            FinOps billing reports are a commercial feature
+        </p>
+        <p className="text-sm mt-1 max-w-md mx-auto" style={{ color: 'var(--text-muted)' }}>
+            Per-project usage and chargeback reporting requires a Keyorix commercial license with the billing feature
+            enabled. Contact your Keyorix representative to enable it.
+        </p>
+    </div>
+);
+
+const GenericErrorNotice: React.FC<{ message: string }> = ({ message }) => (
+    <div
+        className="rounded-xl border p-6 text-sm text-center"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-surface)', color: 'var(--text-muted)' }}
+    >
+        {message}
+    </div>
+);
+
+// ── project table ────────────────────────────────────────────────────────
+
+const fmt = (n: number) => n.toLocaleString();
+
+const ProjectTable: React.FC<{ projects: BillingProjectStat[] }> = ({ projects }) => {
+    if (projects.length === 0) {
+        return (
+            <div className="py-10 text-center text-sm" style={{ color: 'var(--text-muted)' }}>
+                No secrets or activity recorded for any project in this window.
+            </div>
+        );
+    }
+    const sorted = [...projects].sort((a, b) => b.secretReads - a.secretReads);
+    return (
+        <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+                <thead>
+                    <tr className="text-left border-b" style={{ borderColor: 'var(--border)' }}>
+                        {['Project', 'Secrets', 'Reads', 'Writes', 'Rotations', 'Unique users', 'Machine reads'].map(
+                            (h, i) => (
+                                <th
+                                    key={h}
+                                    className={`py-2 px-3 text-xs font-semibold uppercase tracking-wider ${i > 0 ? 'text-right' : ''}`}
+                                    style={{ color: 'var(--text-muted)' }}
+                                >
+                                    {h}
+                                </th>
+                            )
+                        )}
+                    </tr>
+                </thead>
+                <tbody className="divide-y" style={{ borderColor: 'var(--border)' }}>
+                    {sorted.map((p) => (
+                        <tr key={p.projectId}>
+                            <td
+                                className="py-2 px-3 font-medium truncate max-w-[220px]"
+                                style={{ color: 'var(--text-primary)' }}
+                            >
+                                {p.projectName || `(project ${p.projectId})`}
+                            </td>
+                            <td
+                                className="py-2 px-3 text-right tabular-nums"
+                                style={{ color: 'var(--text-secondary)' }}
+                            >
+                                {fmt(p.secretCount)}
+                            </td>
+                            <td
+                                className="py-2 px-3 text-right tabular-nums"
+                                style={{ color: 'var(--text-secondary)' }}
+                            >
+                                {fmt(p.secretReads)}
+                            </td>
+                            <td
+                                className="py-2 px-3 text-right tabular-nums"
+                                style={{ color: 'var(--text-secondary)' }}
+                            >
+                                {fmt(p.secretWrites)}
+                            </td>
+                            <td
+                                className="py-2 px-3 text-right tabular-nums"
+                                style={{ color: 'var(--text-secondary)' }}
+                            >
+                                {fmt(p.secretRotations)}
+                            </td>
+                            <td
+                                className="py-2 px-3 text-right tabular-nums"
+                                style={{ color: 'var(--text-secondary)' }}
+                            >
+                                {fmt(p.uniqueUsers)}
+                            </td>
+                            <td
+                                className="py-2 px-3 text-right tabular-nums"
+                                style={{ color: 'var(--text-secondary)' }}
+                            >
+                                {fmt(p.machineReads)}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+// ── page ─────────────────────────────────────────────────────────────────
+
+export const BillingPage: React.FC = () => {
+    const now = useMemo(() => new Date(), []);
+    const [preset, setPreset] = useState<PresetKey>('this-month');
+    const [customFrom, setCustomFrom] = useState(() => toDateInput(presetRange('last-30', now).from));
+    const [customTo, setCustomTo] = useState(() => toDateInput(presetRange('last-30', now).to));
+
+    const { from, to } = useMemo(() => {
+        if (preset === 'custom') {
+            return { from: `${customFrom}T00:00:00Z`, to: `${customTo}T00:00:00Z` };
+        }
+        const range = presetRange(preset, now);
+        return { from: range.from.toISOString(), to: range.to.toISOString() };
+    }, [preset, customFrom, customTo, now]);
+
+    const { report, isLoading, isError, error, isLicenseRequired } = useBillingReport({ from, to });
+
+    const onCustomDateChange = (which: 'from' | 'to', value: string) => {
+        setPreset('custom');
+        if (which === 'from') setCustomFrom(value);
+        else setCustomTo(value);
+    };
+
+    return (
+        <div className="max-w-5xl mx-auto px-6 py-8">
+            <div className="mb-6 flex items-start justify-between gap-4 flex-wrap">
+                <div>
+                    <h1
+                        className="text-2xl font-bold tracking-tight flex items-center gap-2"
+                        style={{ color: 'var(--text-primary)' }}
+                    >
+                        <BanknotesIcon className="h-6 w-6" style={{ color: 'var(--text-muted)' }} />
+                        Billing
+                    </h1>
+                    <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
+                        Per-project secret counts and activity for chargeback and usage reporting.
+                    </p>
+                </div>
+            </div>
+
+            {/* Date range controls */}
+            <div className="mb-6 flex flex-wrap items-center gap-2">
+                <div className="inline-flex rounded-lg border overflow-hidden" style={{ borderColor: 'var(--border)' }}>
+                    {PRESETS.map((p) => (
+                        <button
+                            key={p.key}
+                            type="button"
+                            onClick={() => setPreset(p.key)}
+                            className="px-3 py-1.5 text-sm font-medium transition-colors"
+                            style={{
+                                backgroundColor: preset === p.key ? 'var(--accent)' : 'var(--bg-surface)',
+                                color: preset === p.key ? 'var(--accent-contrast, #fff)' : 'var(--text-secondary)',
+                            }}
+                        >
+                            {p.label}
+                        </button>
+                    ))}
+                </div>
+                <div className="flex items-center gap-2 text-sm" style={{ color: 'var(--text-muted)' }}>
+                    <input
+                        type="date"
+                        value={customFrom}
+                        onChange={(e) => onCustomDateChange('from', e.target.value)}
+                        aria-label="From date"
+                        className="rounded-lg px-2.5 py-1.5 text-sm outline-hidden"
+                        style={{
+                            backgroundColor: 'var(--bg-app)',
+                            border: '1px solid var(--border)',
+                            color: 'var(--text-primary)',
+                        }}
+                    />
+                    <span>–</span>
+                    <input
+                        type="date"
+                        value={customTo}
+                        onChange={(e) => onCustomDateChange('to', e.target.value)}
+                        aria-label="To date"
+                        className="rounded-lg px-2.5 py-1.5 text-sm outline-hidden"
+                        style={{
+                            backgroundColor: 'var(--bg-app)',
+                            border: '1px solid var(--border)',
+                            color: 'var(--text-primary)',
+                        }}
+                    />
+                </div>
+            </div>
+
+            {isLoading && skeletonPlaceholder()}
+
+            {!isLoading && isError && isLicenseRequired && <LicenseRequiredNotice />}
+            {!isLoading && isError && !isLicenseRequired && (
+                <GenericErrorNotice
+                    message={
+                        (error as any)?.response?.status === 403
+                            ? 'Billing reports are available to administrators (system.read).'
+                            : 'Could not load the billing report. Try again shortly.'
+                    }
+                />
+            )}
+
+            {!isLoading && !isError && report && (
+                <div
+                    className="rounded-xl border overflow-hidden"
+                    style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-surface)' }}
+                >
+                    <div className="px-6 py-4 border-b" style={{ borderColor: 'var(--border)' }}>
+                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                            <Tile label="Projects" value={fmt(report.totals.projects)} />
+                            <Tile label="Secrets" value={fmt(report.totals.secretCount)} />
+                            <Tile label="Reads" value={fmt(report.totals.secretReads)} />
+                            <Tile label="Writes" value={fmt(report.totals.secretWrites)} />
+                            <Tile label="Rotations" value={fmt(report.totals.secretRotations)} />
+                            <Tile label="Unique users" value={fmt(report.totals.uniqueUsers)} />
+                            <Tile label="Machine reads" value={fmt(report.totals.machineReads)} />
+                        </div>
+                    </div>
+                    <div className="px-2 py-2">
+                        <ProjectTable projects={report.projects} />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/web/src/pages/billing/__tests__/BillingPage.test.tsx
+++ b/web/src/pages/billing/__tests__/BillingPage.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '../../../test/test-utils';
+import { BillingPage } from '../BillingPage';
+import type { BillingReport } from '../../../services/billing';
+
+const { useBillingReportMock } = vi.hoisted(() => ({ useBillingReportMock: vi.fn() }));
+
+vi.mock('../../../features/billing', () => ({
+    useBillingReport: (params: unknown) => useBillingReportMock(params),
+}));
+
+function defaultState() {
+    return {
+        report: undefined as BillingReport | undefined,
+        isLoading: false,
+        isError: false,
+        error: null as unknown,
+        isLicenseRequired: false,
+    };
+}
+
+const reportState = (overrides?: Partial<ReturnType<typeof defaultState>>) => ({
+    ...defaultState(),
+    ...overrides,
+});
+
+const sampleReport = (): BillingReport => ({
+    from: '2026-01-01T00:00:00Z',
+    to: '2026-02-01T00:00:00Z',
+    generatedAt: '2026-02-01T00:00:00Z',
+    totals: {
+        projects: 2,
+        secretCount: 12,
+        secretReads: 340,
+        secretWrites: 20,
+        secretRotations: 3,
+        uniqueUsers: 5,
+        machineReads: 100,
+    },
+    projects: [
+        {
+            projectId: 1,
+            projectName: 'acme-prod',
+            secretCount: 8,
+            secretReads: 300,
+            secretWrites: 15,
+            secretRotations: 2,
+            uniqueUsers: 4,
+            machineReads: 90,
+        },
+        {
+            projectId: 2,
+            projectName: 'acme-staging',
+            secretCount: 4,
+            secretReads: 40,
+            secretWrites: 5,
+            secretRotations: 1,
+            uniqueUsers: 2,
+            machineReads: 10,
+        },
+    ],
+});
+
+beforeEach(() => {
+    useBillingReportMock.mockReset();
+    useBillingReportMock.mockReturnValue(reportState());
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-15T12:00:00.000Z'));
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('BillingPage', () => {
+    it('shows a loading skeleton while the report is loading', () => {
+        useBillingReportMock.mockReturnValue(reportState({ isLoading: true }));
+        const { container } = render(<BillingPage />);
+
+        expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
+        expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+
+    it('shows the commercial-license notice when the report is license-gated', () => {
+        useBillingReportMock.mockReturnValue(
+            reportState({ isError: true, error: new Error('license'), isLicenseRequired: true })
+        );
+        render(<BillingPage />);
+
+        expect(screen.getByText('FinOps billing reports are a commercial feature')).toBeInTheDocument();
+        expect(screen.queryByText(/administrators \(system\.read\)/)).not.toBeInTheDocument();
+    });
+
+    it('shows a permission-specific message on a non-license 403', () => {
+        useBillingReportMock.mockReturnValue(
+            reportState({
+                isError: true,
+                error: { response: { status: 403 } },
+                isLicenseRequired: false,
+            })
+        );
+        render(<BillingPage />);
+
+        expect(screen.getByText('Billing reports are available to administrators (system.read).')).toBeInTheDocument();
+        expect(screen.queryByText('FinOps billing reports are a commercial feature')).not.toBeInTheDocument();
+    });
+
+    it('shows a generic message for a non-403 error', () => {
+        useBillingReportMock.mockReturnValue(
+            reportState({ isError: true, error: new Error('boom'), isLicenseRequired: false })
+        );
+        render(<BillingPage />);
+
+        expect(screen.getByText('Could not load the billing report. Try again shortly.')).toBeInTheDocument();
+    });
+
+    it('renders totals and a per-project table sorted by reads descending', () => {
+        useBillingReportMock.mockReturnValue(reportState({ report: sampleReport() }));
+        render(<BillingPage />);
+
+        expect(screen.getByText('340')).toBeInTheDocument(); // totals.secretReads
+        expect(screen.getByText('12')).toBeInTheDocument(); // totals.secretCount
+
+        const rows = screen.getAllByRole('row').slice(1); // drop header row
+        expect(rows[0]).toHaveTextContent('acme-prod');
+        expect(rows[1]).toHaveTextContent('acme-staging');
+    });
+
+    it('shows the empty state when the report has no project activity', () => {
+        useBillingReportMock.mockReturnValue(
+            reportState({
+                report: { ...sampleReport(), projects: [], totals: { ...sampleReport().totals, projects: 0 } },
+            })
+        );
+        render(<BillingPage />);
+
+        expect(screen.getByText('No secrets or activity recorded for any project in this window.')).toBeInTheDocument();
+    });
+
+    it('defaults to the "This month" preset and recomputes the window on preset change', () => {
+        render(<BillingPage />);
+
+        const firstCall = useBillingReportMock.mock.calls[0][0];
+        expect(firstCall.from).toBe(new Date(Date.UTC(2026, 1, 1)).toISOString());
+        expect(firstCall.to).toBe(new Date(Date.UTC(2026, 1, 15)).toISOString());
+
+        fireEvent.click(screen.getByRole('button', { name: 'Last 30 days' }));
+
+        const lastCall = useBillingReportMock.mock.calls[useBillingReportMock.mock.calls.length - 1][0];
+        expect(lastCall.from).toBe(new Date(Date.UTC(2026, 1, 15) - 30 * 86_400_000).toISOString());
+        expect(lastCall.to).toBe(new Date(Date.UTC(2026, 1, 15)).toISOString());
+    });
+
+    it('switches to a custom range when a date input is edited directly', () => {
+        render(<BillingPage />);
+
+        fireEvent.change(screen.getByLabelText('From date'), { target: { value: '2026-01-05' } });
+
+        const lastCall = useBillingReportMock.mock.calls[useBillingReportMock.mock.calls.length - 1][0];
+        expect(lastCall.from).toBe('2026-01-05T00:00:00Z');
+    });
+});

--- a/web/src/services/__tests__/billing.test.ts
+++ b/web/src/services/__tests__/billing.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../client', () => ({
+    apiClient: {
+        get: vi.fn(),
+    },
+}));
+
+import { apiClient } from '../client';
+import { billingApi, BillingLicenseRequiredError } from '../billing';
+
+const mock = apiClient as unknown as { get: ReturnType<typeof vi.fn> };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('billingApi.getReport', () => {
+    it('normalizes a snake_case report payload and joins project_id filters', async () => {
+        mock.get.mockResolvedValueOnce({
+            data: {
+                data: {
+                    from: '2026-01-01T00:00:00Z',
+                    to: '2026-02-01T00:00:00Z',
+                    generated_at: '2026-02-01T00:00:00Z',
+                    totals: {
+                        projects: 1,
+                        secret_count: 3,
+                        secret_reads: 10,
+                        secret_writes: 2,
+                        secret_rotations: 1,
+                        unique_users: 2,
+                        machine_reads: 4,
+                    },
+                    projects: [
+                        {
+                            project_id: 5,
+                            project_name: 'acme-prod',
+                            secret_count: 3,
+                            secret_reads: 10,
+                            secret_writes: 2,
+                            secret_rotations: 1,
+                            unique_users: 2,
+                            machine_reads: 4,
+                        },
+                    ],
+                },
+            },
+        });
+
+        const report = await billingApi.getReport({
+            from: '2026-01-01T00:00:00Z',
+            to: '2026-02-01T00:00:00Z',
+            projectIds: [5, 6],
+        });
+
+        expect(mock.get).toHaveBeenCalledWith('/api/v1/admin/billing/report', {
+            params: { from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z', project_id: '5,6' },
+        });
+        expect(report.totals.secretReads).toBe(10);
+        expect(report.projects[0]).toEqual({
+            projectId: 5,
+            projectName: 'acme-prod',
+            secretCount: 3,
+            secretReads: 10,
+            secretWrites: 2,
+            secretRotations: 1,
+            uniqueUsers: 2,
+            machineReads: 4,
+        });
+    });
+
+    it('omits project_id from the query when no filter is given', async () => {
+        mock.get.mockResolvedValueOnce({ data: { data: { projects: [], totals: {} } } });
+
+        await billingApi.getReport({ from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' });
+
+        expect(mock.get).toHaveBeenCalledWith('/api/v1/admin/billing/report', {
+            params: { from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' },
+        });
+    });
+
+    it('throws BillingLicenseRequiredError on a 403 whose message mentions a license', async () => {
+        mock.get.mockRejectedValueOnce({
+            isAxiosError: true,
+            response: {
+                status: 403,
+                data: { message: 'FinOps billing reports require a commercial license (feature: billing)' },
+            },
+        });
+
+        await expect(
+            billingApi.getReport({ from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' })
+        ).rejects.toBeInstanceOf(BillingLicenseRequiredError);
+    });
+
+    it('rethrows a plain permission 403 as-is (not a license error)', async () => {
+        const err = {
+            isAxiosError: true,
+            response: { status: 403, data: { message: 'Insufficient permissions' } },
+        };
+        mock.get.mockRejectedValueOnce(err);
+
+        await expect(
+            billingApi.getReport({ from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' })
+        ).rejects.not.toBeInstanceOf(BillingLicenseRequiredError);
+    });
+
+    it('rethrows a non-403 error unchanged', async () => {
+        const err = { isAxiosError: true, response: { status: 500, data: {} } };
+        mock.get.mockRejectedValueOnce(err);
+
+        await expect(billingApi.getReport({ from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' })).rejects.toBe(
+            err
+        );
+    });
+});

--- a/web/src/services/billing.ts
+++ b/web/src/services/billing.ts
@@ -1,0 +1,99 @@
+import axios from 'axios';
+import { apiClient } from './client';
+
+// One project's usage breakdown for a billing period, served by
+// GET /api/v1/admin/billing/report (gated by system.read + the "billing"
+// commercial license feature).
+export interface BillingProjectStat {
+    projectId: number;
+    projectName: string;
+    secretCount: number;
+    secretReads: number;
+    secretWrites: number;
+    secretRotations: number;
+    uniqueUsers: number;
+    machineReads: number;
+}
+
+export interface BillingTotals {
+    projects: number;
+    secretCount: number;
+    secretReads: number;
+    secretWrites: number;
+    secretRotations: number;
+    uniqueUsers: number;
+    machineReads: number;
+}
+
+export interface BillingReport {
+    from: string;
+    to: string;
+    generatedAt: string;
+    projects: BillingProjectStat[];
+    totals: BillingTotals;
+}
+
+const num = (v: any): number => (typeof v === 'number' ? v : 0);
+
+const normalizeProjectStat = (p: any): BillingProjectStat => ({
+    projectId: num(p.project_id ?? p.projectId),
+    projectName: p.project_name ?? p.projectName ?? '',
+    secretCount: num(p.secret_count ?? p.secretCount),
+    secretReads: num(p.secret_reads ?? p.secretReads),
+    secretWrites: num(p.secret_writes ?? p.secretWrites),
+    secretRotations: num(p.secret_rotations ?? p.secretRotations),
+    uniqueUsers: num(p.unique_users ?? p.uniqueUsers),
+    machineReads: num(p.machine_reads ?? p.machineReads),
+});
+
+const normalizeTotals = (t: any): BillingTotals => ({
+    projects: num(t?.projects),
+    secretCount: num(t?.secret_count ?? t?.secretCount),
+    secretReads: num(t?.secret_reads ?? t?.secretReads),
+    secretWrites: num(t?.secret_writes ?? t?.secretWrites),
+    secretRotations: num(t?.secret_rotations ?? t?.secretRotations),
+    uniqueUsers: num(t?.unique_users ?? t?.uniqueUsers),
+    machineReads: num(t?.machine_reads ?? t?.machineReads),
+});
+
+const normalizeReport = (d: any): BillingReport => ({
+    from: d.from ?? '',
+    to: d.to ?? '',
+    generatedAt: d.generated_at ?? d.generatedAt ?? '',
+    projects: (d.projects ?? []).map(normalizeProjectStat),
+    totals: normalizeTotals(d.totals),
+});
+
+// BillingLicenseRequiredError distinguishes "not licensed" from any other
+// failure (a plain 403 insufficient-permission, a 500). Both the license gate
+// and the permission gate return HTTP 403 with error:"Forbidden", so the only
+// way to tell them apart is the message text the server deliberately chose
+// ("... commercial license ...") — see server/http/handlers/admin_billing.go.
+export class BillingLicenseRequiredError extends Error {}
+
+export interface BillingReportParams {
+    from: string; // RFC3339
+    to: string; // RFC3339
+    projectIds?: number[];
+}
+
+export const billingApi = {
+    async getReport(params: BillingReportParams): Promise<BillingReport> {
+        const query: Record<string, string> = { from: params.from, to: params.to };
+        if (params.projectIds?.length) {
+            query.project_id = params.projectIds.join(',');
+        }
+        try {
+            const response = await apiClient.get('/api/v1/admin/billing/report', { params: query });
+            return normalizeReport(response.data.data ?? response.data);
+        } catch (err) {
+            if (axios.isAxiosError(err) && err.response?.status === 403) {
+                const message = (err.response.data as { message?: string } | undefined)?.message ?? '';
+                if (message.toLowerCase().includes('license')) {
+                    throw new BillingLicenseRequiredError(message);
+                }
+            }
+            throw err;
+        }
+    },
+};


### PR DESCRIPTION
## Summary
- New `/admin/billing` dashboard (date-range presets, totals tiles, per-project usage table) over the existing `GET /api/v1/admin/billing/report` endpoint.
- Backend fix: the handler masked "not licensed" and "server error" behind the same generic `500 InternalError` (`clientSafe()` strips all detail). Added an explicit `HasLicensedFeature` check that returns a distinguishable `403 Forbidden` with a "commercial license" message, so the page can render the correct commercial-feature state instead of an opaque error.
- 6 new Go handler tests (this handler previously had zero coverage) + 13 new frontend tests (8 page, 5 service).

## Test plan
- [x] `go build ./...`, `go test ./server/http/handlers/...` green
- [x] Frontend gate green: type-check, lint, format:check, full test suite (2953 tests), production build
- [x] Verified live in a real Chrome browser against a real backend/Postgres — logged in, navigated to Billing, confirmed the commercial-license notice renders with the exact backend-driven message