### PR TITLE
feat(web,license): read-only license status settings page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -88,6 +88,7 @@ const AuthenticationPage = React.lazy(() =>
 const EncryptionPage = React.lazy(() =>
     import('./pages/settings/EncryptionPage').then((m) => ({ default: m.EncryptionPage }))
 );
+const LicensePage = React.lazy(() => import('./pages/settings/LicensePage').then((m) => ({ default: m.LicensePage })));
 const CompliancePage = React.lazy(() =>
     import('./pages/compliance/CompliancePage').then((m) => ({ default: m.CompliancePage }))
 );
@@ -239,6 +240,14 @@ function App() {
                                                     element={
                                                         <AdminRoute>
                                                             <EncryptionPage />
+                                                        </AdminRoute>
+                                                    }
+                                                />
+                                                <Route
+                                                    path={ROUTES.SETTINGS_LICENSE}
+                                                    element={
+                                                        <AdminRoute>
+                                                            <LicensePage />
                                                         </AdminRoute>
                                                     }
                                                 />

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -133,6 +133,7 @@ const NAV: NavItem[] = [
             { kind: 'leaf', name: 'Appearance', href: '/settings/appearance' },
             { kind: 'leaf', name: 'Authentication', href: '/settings/auth', adminOnly: true },
             { kind: 'leaf', name: 'Encryption & Keys', href: '/settings/encryption', adminOnly: true },
+            { kind: 'leaf', name: 'License', href: '/settings/license', adminOnly: true },
             { kind: 'leaf', name: 'System Health', href: '/settings/health', adminOnly: true },
         ],
     },

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -93,6 +93,7 @@ export const ROUTES = {
     SETTINGS_AUTH: '/settings/auth',
     SETTINGS_ENCRYPTION: '/settings/encryption',
     SETTINGS_HEALTH: '/settings/health',
+    SETTINGS_LICENSE: '/settings/license',
     ROADMAP: '/roadmap',
 } as const;
 

--- a/web/src/features/license/index.ts
+++ b/web/src/features/license/index.ts
@@ -1,0 +1,1 @@
+export { useLicenseStatus } from './useLicenseStatus';

--- a/web/src/features/license/useLicenseStatus.ts
+++ b/web/src/features/license/useLicenseStatus.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { licenseApi } from '../../services/license';
+
+export function useLicenseStatus() {
+    return useQuery({
+        queryKey: ['license', 'status'],
+        queryFn: () => licenseApi.getStatus(),
+        staleTime: 5 * 60 * 1000,
+    });
+}

--- a/web/src/pages/settings/LicensePage.tsx
+++ b/web/src/pages/settings/LicensePage.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { useLicenseStatus } from '../../features/license';
+import { Spinner } from '../../components/ui';
+import type { LicenseState } from '../../services/license';
+
+// Friendly labels for known commercial feature keys (internal/license/features.go).
+// Falls back to the raw key for a feature this build doesn't recognize yet, so an
+// unmapped future feature still renders instead of disappearing.
+const FEATURE_LABELS: Record<string, string> = {
+    airgap_updates: 'Air-gap update bundles',
+    billing: 'FinOps billing reports',
+};
+
+const STATE_META: Record<LicenseState, { label: string; color: string; bg: string }> = {
+    active: { label: 'Active', color: 'var(--success)', bg: 'var(--success-subtle)' },
+    expiring_soon: { label: 'Expiring soon', color: 'var(--warning)', bg: 'var(--warning-subtle)' },
+    expired: { label: 'Expired', color: 'var(--error)', bg: 'var(--error-subtle)' },
+    invalid: { label: 'Invalid', color: 'var(--error)', bg: 'var(--error-subtle)' },
+    none: { label: 'Community baseline', color: 'var(--text-muted)', bg: 'var(--bg-muted)' },
+};
+
+interface SectionProps {
+    title: string;
+    note?: string;
+    children: React.ReactNode;
+}
+
+const Section: React.FC<SectionProps> = ({ title, note, children }) => (
+    <div
+        className="rounded-xl border overflow-hidden mb-6"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-surface)' }}
+    >
+        <div className="px-6 py-4 border-b" style={{ borderColor: 'var(--border)' }}>
+            <h2 className="text-sm font-semibold uppercase tracking-widest" style={{ color: 'var(--text-muted)' }}>
+                {title}
+            </h2>
+        </div>
+        <div className="px-6 py-5 space-y-3">
+            {children}
+            {note && (
+                <p className="text-xs pt-1" style={{ color: 'var(--text-muted)' }}>
+                    {note}
+                </p>
+            )}
+        </div>
+    </div>
+);
+
+const Row: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+    <div className="flex items-center justify-between gap-4">
+        <span className="text-sm" style={{ color: 'var(--text-muted)' }}>
+            {label}
+        </span>
+        <span className="text-sm font-medium text-right" style={{ color: 'var(--text-primary)' }}>
+            {value}
+        </span>
+    </div>
+);
+
+const StateBadge: React.FC<{ state: LicenseState }> = ({ state }) => {
+    const meta = STATE_META[state] ?? STATE_META.none;
+    return (
+        <span
+            className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+            style={{ color: meta.color, backgroundColor: meta.bg }}
+        >
+            {meta.label}
+        </span>
+    );
+};
+
+// Pinned to en-US/UTC rather than the browser's locale/timezone — this is an
+// ops-facing entitlement date, and a stable rendering (independent of which
+// admin's machine is viewing it) matters more than localization here.
+const formatExpiry = (iso: string): string => {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '—';
+    return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' });
+};
+
+// ReasonBanner surfaces why the entitlement is degraded (expiring, expired, invalid,
+// or no license installed) — mirrors the admin warning the server itself logs at
+// startup. Hidden for a healthy Active license (Reason is empty).
+const ReasonBanner: React.FC<{ state: LicenseState; reason: string }> = ({ state, reason }) => {
+    if (!reason) return null;
+    const tone = state === 'expiring_soon' ? 'warn' : 'error';
+    return (
+        <div
+            className="rounded-xl border mb-6 px-4 py-3 text-sm"
+            style={
+                tone === 'warn'
+                    ? {
+                          borderColor: 'var(--warning)',
+                          backgroundColor: 'var(--warning-subtle)',
+                          color: 'var(--warning)',
+                      }
+                    : { borderColor: 'var(--error)', backgroundColor: 'var(--error-subtle)', color: 'var(--error)' }
+            }
+        >
+            {reason}
+        </div>
+    );
+};
+
+export const LicensePage: React.FC = () => {
+    const { data: license, isLoading, isError } = useLicenseStatus();
+
+    return (
+        <div className="max-w-2xl mx-auto px-6 py-8">
+            <div className="mb-8">
+                <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--text-primary)' }}>
+                    License
+                </h1>
+                <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
+                    The commercial license entitlement evaluated locally for this Keyorix server — read-only. Install or
+                    renew a license by running <code>keyorix license install</code> on the server host.
+                </p>
+            </div>
+
+            {isLoading && (
+                <div className="flex justify-center py-12">
+                    <Spinner />
+                </div>
+            )}
+
+            {!isLoading && isError && (
+                <div
+                    className="rounded-xl border px-6 py-8 text-center text-sm"
+                    style={{
+                        borderColor: 'var(--border)',
+                        backgroundColor: 'var(--bg-surface)',
+                        color: 'var(--text-muted)',
+                    }}
+                >
+                    Unable to load license status. This page requires administrator access, or the server may be
+                    unreachable.
+                </div>
+            )}
+
+            {!isLoading && !isError && license && (
+                <>
+                    <ReasonBanner state={license.state} reason={license.reason} />
+
+                    <Section title="Entitlement">
+                        <Row label="Status" value={<StateBadge state={license.state} />} />
+                        <Row label="Licensee" value={license.licensee || '—'} />
+                        <Row label="Plan" value={license.plan || '—'} />
+                        <Row label="Expires" value={formatExpiry(license.expiresAt)} />
+                        {license.maxSeats > 0 && <Row label="Max seats" value={license.maxSeats} />}
+                    </Section>
+
+                    <Section
+                        title="Granted features"
+                        note="A feature listed here is unlocked only while the entitlement above is Active or Expiring soon — a lapsed or invalid license degrades to the community baseline everywhere the feature is checked."
+                    >
+                        {license.features.length === 0 ? (
+                            <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                                No commercial features granted — running the community baseline.
+                            </p>
+                        ) : (
+                            <div className="flex flex-wrap gap-2">
+                                {license.features.map((f) => (
+                                    <span
+                                        key={f}
+                                        className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium"
+                                        style={{ color: 'var(--accent-text)', backgroundColor: 'var(--accent-subtle)' }}
+                                    >
+                                        {FEATURE_LABELS[f] ?? f}
+                                    </span>
+                                ))}
+                            </div>
+                        )}
+                    </Section>
+                </>
+            )}
+        </div>
+    );
+};

--- a/web/src/pages/settings/__tests__/LicensePage.test.tsx
+++ b/web/src/pages/settings/__tests__/LicensePage.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '../../../test/test-utils';
+import { LicensePage } from '../LicensePage';
+
+const useLicenseStatus = vi.fn();
+
+vi.mock('../../../features/license', () => ({
+    useLicenseStatus: (...args: any[]) => useLicenseStatus(...args),
+}));
+
+const activeLicense = {
+    state: 'active' as const,
+    licensee: 'ACME GmbH',
+    plan: 'enterprise',
+    features: ['billing', 'airgap_updates'],
+    grants: true,
+    expiresAt: '2027-01-01T00:00:00Z',
+    maxSeats: 50,
+    reason: '',
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    useLicenseStatus.mockReturnValue({ data: activeLicense, isLoading: false, isError: false });
+});
+
+describe('LicensePage — loading and error states', () => {
+    it('shows a spinner while data is loading', () => {
+        useLicenseStatus.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+        render(<LicensePage />);
+        expect(document.querySelector('.animate-spin')).toBeTruthy();
+    });
+
+    it('shows an error message when the fetch fails', () => {
+        useLicenseStatus.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+        render(<LicensePage />);
+        expect(screen.getByText(/Unable to load license status/)).toBeInTheDocument();
+    });
+});
+
+describe('LicensePage — success state', () => {
+    it('shows the entitlement details for an active license', () => {
+        render(<LicensePage />);
+        expect(screen.getByText('Active')).toBeInTheDocument();
+        expect(screen.getByText('ACME GmbH')).toBeInTheDocument();
+        expect(screen.getByText('enterprise')).toBeInTheDocument();
+        expect(screen.getByText('January 1, 2027')).toBeInTheDocument();
+        expect(screen.getByText('50')).toBeInTheDocument();
+    });
+
+    it('renders friendly labels for known feature keys', () => {
+        render(<LicensePage />);
+        expect(screen.getByText('FinOps billing reports')).toBeInTheDocument();
+        expect(screen.getByText('Air-gap update bundles')).toBeInTheDocument();
+    });
+
+    it('falls back to the raw key for an unrecognized feature', () => {
+        useLicenseStatus.mockReturnValue({
+            data: { ...activeLicense, features: ['some_future_feature'] },
+            isLoading: false,
+            isError: false,
+        });
+        render(<LicensePage />);
+        expect(screen.getByText('some_future_feature')).toBeInTheDocument();
+    });
+
+    it('does not show a reason banner for a healthy active license', () => {
+        render(<LicensePage />);
+        // The page's own static help text mentions "renew" too, so assert on the
+        // absence of an actual reason message rather than that word alone.
+        expect(
+            screen.queryByText(/license expires on|license expired on|no license installed/i)
+        ).not.toBeInTheDocument();
+    });
+
+    it('hides the max-seats row when unset', () => {
+        useLicenseStatus.mockReturnValue({
+            data: { ...activeLicense, maxSeats: 0 },
+            isLoading: false,
+            isError: false,
+        });
+        render(<LicensePage />);
+        expect(screen.queryByText('Max seats')).not.toBeInTheDocument();
+    });
+
+    it('shows the community-baseline empty state when no features are granted', () => {
+        useLicenseStatus.mockReturnValue({
+            data: {
+                state: 'none',
+                licensee: '',
+                plan: '',
+                features: [],
+                grants: false,
+                expiresAt: '',
+                maxSeats: 0,
+                reason: 'no license installed — running the community baseline',
+            },
+            isLoading: false,
+            isError: false,
+        });
+        render(<LicensePage />);
+        expect(screen.getByText('Community baseline')).toBeInTheDocument();
+        expect(
+            screen.getByText('No commercial features granted — running the community baseline.')
+        ).toBeInTheDocument();
+        expect(screen.getAllByText('—')).toHaveLength(3); // licensee, plan, expiry all fall back
+    });
+
+    it('shows a warning-toned reason banner for an expiring-soon license', () => {
+        useLicenseStatus.mockReturnValue({
+            data: { ...activeLicense, state: 'expiring_soon', reason: 'license expires on 2026-09-01 — renew soon' },
+            isLoading: false,
+            isError: false,
+        });
+        render(<LicensePage />);
+        expect(screen.getByText('Expiring soon')).toBeInTheDocument();
+        expect(screen.getByText('license expires on 2026-09-01 — renew soon')).toBeInTheDocument();
+    });
+
+    it('shows an error-toned reason banner for an expired license', () => {
+        useLicenseStatus.mockReturnValue({
+            data: {
+                ...activeLicense,
+                state: 'expired',
+                features: [],
+                reason: 'license expired on 2026-01-01 — running the community baseline',
+            },
+            isLoading: false,
+            isError: false,
+        });
+        render(<LicensePage />);
+        expect(screen.getByText('Expired')).toBeInTheDocument();
+        expect(screen.getByText('license expired on 2026-01-01 — running the community baseline')).toBeInTheDocument();
+    });
+});

--- a/web/src/services/__tests__/license.test.ts
+++ b/web/src/services/__tests__/license.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../client', () => ({
+    apiClient: {
+        get: vi.fn(),
+    },
+}));
+
+import { apiClient } from '../client';
+import { licenseApi } from '../license';
+
+const mock = apiClient as unknown as { get: ReturnType<typeof vi.fn> };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('licenseApi.getStatus', () => {
+    it('normalizes a full snake_case status payload', async () => {
+        mock.get.mockResolvedValueOnce({
+            data: {
+                data: {
+                    state: 'active',
+                    licensee: 'ACME GmbH',
+                    plan: 'enterprise',
+                    features: ['billing'],
+                    grants: true,
+                    expires_at: '2027-01-01T00:00:00Z',
+                    max_seats: 50,
+                    reason: '',
+                },
+            },
+        });
+
+        const status = await licenseApi.getStatus();
+
+        expect(mock.get).toHaveBeenCalledWith('/api/v1/license/status');
+        expect(status).toEqual({
+            state: 'active',
+            licensee: 'ACME GmbH',
+            plan: 'enterprise',
+            features: ['billing'],
+            grants: true,
+            expiresAt: '2027-01-01T00:00:00Z',
+            maxSeats: 50,
+            reason: '',
+        });
+    });
+
+    it('defaults to the community-baseline shape when fields are absent', async () => {
+        mock.get.mockResolvedValueOnce({ data: { data: { state: 'none', features: [], grants: false } } });
+
+        const status = await licenseApi.getStatus();
+
+        expect(status.licensee).toBe('');
+        expect(status.plan).toBe('');
+        expect(status.expiresAt).toBe('');
+        expect(status.maxSeats).toBe(0);
+        expect(status.features).toEqual([]);
+    });
+});

--- a/web/src/services/license.ts
+++ b/web/src/services/license.ts
@@ -1,0 +1,36 @@
+import { apiClient } from './client';
+
+// The locally-evaluated offline-license entitlement (ADR-065), served by
+// GET /api/v1/license/status (gated by system.read). Read-only — there is no
+// install/upload endpoint; a new license is installed via `keyorix license
+// install` on the server host.
+export type LicenseState = 'active' | 'expiring_soon' | 'expired' | 'invalid' | 'none';
+
+export interface LicenseStatus {
+    state: LicenseState;
+    licensee: string;
+    plan: string;
+    features: string[];
+    grants: boolean;
+    expiresAt: string;
+    maxSeats: number;
+    reason: string;
+}
+
+const normalize = (d: any): LicenseStatus => ({
+    state: (d.state as LicenseState) ?? 'none',
+    licensee: d.licensee ?? '',
+    plan: d.plan ?? '',
+    features: Array.isArray(d.features) ? d.features : [],
+    grants: !!d.grants,
+    expiresAt: d.expires_at ?? d.expiresAt ?? '',
+    maxSeats: typeof d.max_seats === 'number' ? d.max_seats : (d.maxSeats ?? 0),
+    reason: d.reason ?? '',
+});
+
+export const licenseApi = {
+    async getStatus(): Promise<LicenseStatus> {
+        const response = await apiClient.get('/api/v1/license/status');
+        return normalize(response.data.data ?? response.data);
+    },
+};


### PR DESCRIPTION
## Summary
- New read-only `/settings/license` page: entitlement state badge, licensee, plan, expiry, seat count, granted-features badge list, and a degraded-state reason banner.
- Backed by the pre-existing `GET /api/v1/license/status` endpoint — no backend changes.
- Deliberately scoped read-only (explicit product decision): a license install/upload flow is a write path with real security implications (changes paid-feature entitlement) and stays CLI-only (`keyorix license install`) for now.

## Test plan
- [x] Frontend gate green: type-check, lint, format:check, full test suite (2952 tests, +12 new), production build
- [x] Verified live in a real Chrome browser against a real backend/Postgres — logged in, navigated to Settings > License, confirmed the community-baseline state, reason banner, and empty-features message all render correctly