### PR TITLE
feat(mutation-testing): add periodic threshold-triggered GOCACHE trim

### DIFF
--- a/scripts/mutation-testing/README.md
+++ b/scripts/mutation-testing/README.md
@@ -60,6 +60,29 @@ not an OOM kill: silent thrashing that's easy to mistake for the CPUQuota
 problem above if you haven't also checked
 `systemctl show keyorix-mutation.service -p MemoryCurrent -p MemoryMax`.
 
+### Disk: `GOCACHE` grows without bound
+
+Mutation testing is inherently cache-hostile -- gremlins recompiles a new,
+distinct source variant per mutant, and Go's build cache is content-
+addressed, so nearly every mutant produces a brand-new cache entry with
+little reuse. Go's own automatic cache GC is age-based (days), not
+size-based, so it doesn't kick in fast enough for a workload that can
+generate double-digit GiB within hours -- this has filled a container's
+disk to 100% (and stalled the in-progress run) before this existed.
+
+`trim-gocache.sh`, run periodically via `keyorix-mutation-cache-trim.timer`
+(every 10 minutes, independent of `keyorix-mutation.timer`'s own weekly
+schedule), checks disk usage and, only once it's over
+`TRIM_DISK_THRESHOLD_PCT` (default 85%), deletes the *oldest* files under
+`GOCACHE` until usage drops back to `TRIM_DISK_TARGET_PCT` (default 65%).
+Most firings are a no-op `df` check. Deliberately not a periodic
+`go clean -cache` (a full wipe): that needs an exclusive lock on the whole
+cache, so running it unconditionally on a fixed interval would frequently
+collide with gremlins' own in-flight compiles over a run lasting hours.
+Deleting the oldest files individually is much less likely to touch
+anything actively in use -- a live compile's own cache writes are, by
+definition, the newest files on disk.
+
 ## One-time setup (on the LXC/VM)
 
 Same base requirements as `scripts/fuzzing/README.md` (Go matching `go.mod`,
@@ -121,6 +144,7 @@ Same base requirements as `scripts/fuzzing/README.md` (Go matching `go.mod`,
    cp scripts/mutation-testing/systemd/*.service scripts/mutation-testing/systemd/*.timer /etc/systemd/system/
    systemctl daemon-reload
    systemctl enable --now keyorix-mutation.timer
+   systemctl enable --now keyorix-mutation-cache-trim.timer
    ```
    **If this is an unprivileged Proxmox LXC**, see
    `scripts/fuzzing/README.md` step 7's journald note — the same

--- a/scripts/mutation-testing/systemd/keyorix-mutation-cache-trim.service
+++ b/scripts/mutation-testing/systemd/keyorix-mutation-cache-trim.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Trim keyorix mutation-testing's GOCACHE when disk usage runs high
+
+[Service]
+Type=oneshot
+User=mutation
+Group=mutation
+ExecStart=/opt/keyorix-mutation/keyorix/scripts/mutation-testing/trim-gocache.sh
+
+# Deliberately no Nice=/CPUQuota=/MemoryMax= here, unlike keyorix-mutation.service
+# -- this is a lightweight `df` check plus, on the rare over-threshold run, a
+# `find`+`rm` pass, not a CPU/memory-heavy compile-and-test workload.
+
+# Process-isolation hardening (mirrors keyorix-mutation.service's rationale).
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+RestrictSUIDSGID=true
+Environment=GOCACHE=/opt/keyorix-mutation/go-cache
+# Only GOCACHE itself needs to be writable -- this script never touches the
+# git checkout, state dir, module cache, or GOPATH that keyorix-mutation.service
+# also needs write access to.
+ReadWritePaths=/opt/keyorix-mutation/go-cache

--- a/scripts/mutation-testing/systemd/keyorix-mutation-cache-trim.timer
+++ b/scripts/mutation-testing/systemd/keyorix-mutation-cache-trim.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Periodic check for keyorix-mutation-cache-trim.service
+
+[Timer]
+# Frequent enough to catch runaway growth well before disk fills (a run has
+# hit 100% within a matter of hours before this existed), infrequent enough
+# that the vast majority of firings are a cheap no-op `df` check that finds
+# usage under threshold and exits immediately -- see trim-gocache.sh's own
+# comment for why this is a periodic threshold check, not a blind interval
+# wipe.
+OnCalendar=*:0/10
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/mutation-testing/trim-gocache.sh
+++ b/scripts/mutation-testing/trim-gocache.sh
@@ -22,6 +22,16 @@
 # most invocations of this timer should be a no-op.
 set -euo pipefail
 
+# `find` below tries to restore its starting cwd when it's done traversing;
+# if that cwd isn't readable by this script's caller (e.g. invoked via
+# `sudo -u mutation` from a root shell sitting in /root), find exits
+# non-zero purely over that, which -- combined with `set -e` -- aborts the
+# whole script before it ever reaches the deletion loop. systemd's own
+# invocation already defaults WorkingDirectory to `/` (always accessible),
+# but cd there explicitly so this script is robust to any caller, not just
+# the one it's currently wired to.
+cd /
+
 : "${GOCACHE:?set GOCACHE to the mutation-testing build cache dir}"
 : "${TRIM_DISK_THRESHOLD_PCT:=85}" # trigger trimming at this usage%
 : "${TRIM_DISK_TARGET_PCT:=65}"    # trim until usage drops back to this%

--- a/scripts/mutation-testing/trim-gocache.sh
+++ b/scripts/mutation-testing/trim-gocache.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Threshold-triggered GOCACHE trim, run periodically (see
+# systemd/keyorix-mutation-cache-trim.timer) independent of
+# run-mutation.sh's own lifecycle.
+#
+# Mutation testing is inherently cache-hostile: gremlins recompiles a new,
+# distinct source variant per mutant, and Go's build cache is content-
+# addressed, so nearly every mutant produces a brand-new cache entry with
+# little reuse. Go's own automatic cache GC is age-based (days), not
+# size-based, so it doesn't kick in fast enough for a workload that can
+# generate double-digit GiB within hours -- this filled the container's
+# disk to 100% once already.
+#
+# Deliberately NOT `go clean -cache` (a full wipe): that needs an exclusive
+# lock on the whole cache, so running it unconditionally on a fixed
+# interval would frequently collide with gremlins' own in-flight compiles
+# over a run lasting hours, stalling them for no reason on cycles where
+# there was nothing worth reclaiming anyway. Deleting the OLDEST files
+# individually is much less likely to touch anything actively in use (a
+# live compile's own cache writes are, by definition, the newest files),
+# and this script only touches disk at all when actually over threshold --
+# most invocations of this timer should be a no-op.
+set -euo pipefail
+
+: "${GOCACHE:?set GOCACHE to the mutation-testing build cache dir}"
+: "${TRIM_DISK_THRESHOLD_PCT:=85}" # trigger trimming at this usage%
+: "${TRIM_DISK_TARGET_PCT:=65}"    # trim until usage drops back to this%
+: "${TRIM_CHECK_EVERY_N_FILES:=200}" # how often to re-check usage while trimming
+
+usage_pct() {
+  df --output=pcent "$GOCACHE" | tail -1 | tr -dc '0-9'
+}
+
+current="$(usage_pct)"
+if [ "$current" -lt "$TRIM_DISK_THRESHOLD_PCT" ]; then
+  echo "$(date -u +%FT%TZ) disk usage ${current}% below threshold ${TRIM_DISK_THRESHOLD_PCT}%, nothing to do"
+  exit 0
+fi
+
+echo "$(date -u +%FT%TZ) disk usage ${current}% >= threshold ${TRIM_DISK_THRESHOLD_PCT}%, trimming oldest GOCACHE entries toward ${TRIM_DISK_TARGET_PCT}%..."
+
+# Sorted-oldest-first file list goes to a real temp file, not a `| while
+# read` pipe -- a pipe's right-hand side runs in a subshell in bash, so
+# `exit 0` inside the loop below would only end that subshell, silently
+# falling through to the "exhausted" message afterward instead of actually
+# stopping the script once the target is reached.
+file_list="$(mktemp)"
+trap 'rm -f "$file_list"' EXIT
+find "$GOCACHE" -type f -printf '%T@ %p\n' | sort -n | cut -d' ' -f2- > "$file_list"
+
+deleted=0
+checked=0
+while IFS= read -r path; do
+  rm -f -- "$path"
+  deleted=$((deleted + 1))
+  checked=$((checked + 1))
+  if [ "$checked" -ge "$TRIM_CHECK_EVERY_N_FILES" ]; then
+    checked=0
+    current="$(usage_pct)"
+    if [ "$current" -lt "$TRIM_DISK_TARGET_PCT" ]; then
+      echo "$(date -u +%FT%TZ) usage back to ${current}% after deleting $deleted files, target reached"
+      exit 0
+    fi
+  fi
+done < "$file_list"
+
+echo "$(date -u +%FT%TZ) exhausted all cache files (deleted $deleted), usage still $(usage_pct)%"


### PR DESCRIPTION
## Summary
Mutation testing is inherently cache-hostile -- gremlins recompiles a new, distinct source variant per mutant, and Go's build cache is content-addressed, so nearly every mutant produces a brand-new cache entry with little reuse. Go's own automatic cache GC is age-based (days), not size-based, so it doesn't kick in fast enough for a workload that can generate double-digit GiB within hours -- this filled the mutation-testing box's disk to 100% and stalled an in-progress run today.

Adds `trim-gocache.sh`, run every 10 minutes via a new `keyorix-mutation-cache-trim.timer` independent of the weekly mutation run's own schedule: checks disk usage and, only once over `TRIM_DISK_THRESHOLD_PCT` (default 85%), deletes the OLDEST files under `GOCACHE` until usage drops back to `TRIM_DISK_TARGET_PCT` (default 65%). Most firings are a no-op `df` check.

Deliberately not a periodic `go clean -cache` (a full wipe): that needs an exclusive lock on the whole cache, so running it unconditionally on a fixed interval would frequently collide with gremlins' own in-flight compiles over a run lasting hours, stalling them for no reason on cycles where there was nothing worth reclaiming anyway. Deleting the oldest files individually is much less likely to touch anything actively in use -- a live compile's own cache writes are, by definition, the newest files on disk.

## Test plan
- [x] `bash -n` and `shellcheck` both pass clean
- [ ] Local functional testing wasn't feasible (the script's `find -printf` is GNU-only and this was written/checked on macOS) -- will verify directly on the target Debian/Ubuntu box before enabling the live timer
- [ ] CI green on this PR