### PR TITLE
docs(mutation-testing): document the ad hoc parallel-stream procedure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,10 +517,23 @@ jobs:
     needs: [preflight, test-suite, static-analysis, changes]
     # always() so this still runs (and reports the failure below) even when
     # test-suite/static-analysis genuinely fail, not just when they're
-    # skipped -- combined with the docs_only check so the whole aggregator
-    # itself is skipped (not run at all) on a docs-only PR, matching
-    # test-suite/static-analysis being skipped too.
-    if: always() && needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.go_unaffected != 'true' && needs.changes.outputs.operator_only != 'true'
+    # skipped -- combined with the docs_only/go_unaffected/operator_only
+    # checks so the whole aggregator itself is skipped (not run at all) when
+    # test-suite/static-analysis are skipped too.
+    #
+    # needs.changes.result == 'success' is required too, and NOT redundant
+    # with always(): if the `changes` job itself is cancelled (e.g. a
+    # concurrency-group supersession mid-run) its outputs are unset, so every
+    # `!= 'true'` comparison above reads as true regardless -- always() then
+    # lets build-and-test run anyway, find test-suite/static-analysis
+    # auto-skipped (they have no always(), so they correctly skip when a
+    # dependency is cancelled), and fail with a misleading
+    # "test-suite=skipped" error on a PR that never actually had a code
+    # failure. Gating on changes' own result keeps build-and-test in sync
+    # with test-suite/static-analysis's implicit skip-on-cancelled-dependency
+    # behavior instead of being the one job immune to it. (root-caused on
+    # #1368, whose docs-only CI run hit exactly this.)
+    if: always() && needs.changes.result == 'success' && needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.go_unaffected != 'true' && needs.changes.outputs.operator_only != 'true'
     runs-on: ubuntu-latest
     # download-artifact needs actions: read beyond the workflow-level
     # contents: read default, even for same-run artifacts.

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -1,0 +1,250 @@
+# CI pipeline engineering notes
+
+A working catalog of patterns behind this repo's own GitHub Actions CI (not
+to be confused with [`CI_CD.md`](CI_CD.md), which is about consuming Keyorix
+secrets in *your* pipeline). Written after a round of CI-efficiency work
+across `.github/workflows/ci.yml`, `codeql.yml`, `trivy.yml`,
+`docker-publish.yml`, `web-ci.yml`, `sonarcloud.yml`, `dast.yml`,
+`release.yml`, and `anchore-syft.yml` (9 merged PRs). Every claim below
+traces to a merged PR and a real verification step — a branch-protection API
+call, a source read of a pinned action, an actionlint run, or a real CI
+failure. Where something was tried and reverted, that's included too: the
+failure is as load-bearing as the fix.
+
+## 1. Diff-aware job skipping
+
+The highest-leverage pattern here. A PR touching only five Markdown ADR
+files was still triggering the full 8-way-sharded Go test matrix, static
+analysis, lint, CodeQL, and Helm chart validation — nothing in that diff
+could change any of those outcomes. The fix is a `changes` job at the top of
+`ci.yml`/`codeql.yml` that inspects the PR's file list once and emits
+boolean flags every expensive job then gates on via job-level `if:`.
+
+```yaml
+# One job, computed once, consumed by every downstream job
+changes:
+  outputs:
+    docs_only: ${{ steps.filter.outputs.docs_only }}
+    go_unaffected: ${{ steps.filter.outputs.go_unaffected }}
+    operator_only: ${{ steps.filter.outputs.operator_only }}
+  steps:
+    - id: filter
+      run: |
+        changed=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+          --paginate --jq '.[].filename')
+        # allowlist match: every changed file must fall inside the safe set
+        if [ -z "$changed" ] || echo "$changed" | grep -vE '^(scripts/|\.semgrep/|demo/|...)' > /dev/null; then
+          echo "go_unaffected=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "go_unaffected=true" >> "$GITHUB_OUTPUT"
+        fi
+
+# every job that can't be affected gates on the flag
+test-suite:
+  needs: [changes]
+  if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.go_unaffected != 'true'
+```
+
+### The one rule that makes this safe
+
+**Allowlist, never denylist.** Define what's *provably* safe to skip (a
+narrow, verified set: docs, scripts, rule-config YAML, root metadata files)
+— not what's unsafe. A denylist (`skip unless it touches internal/, cmd/…`)
+fails dangerously: add a new top-level directory later and forget to update
+the filter, and it silently falls outside the denylist and skips tests it
+should have run. An allowlist fails safe — an unrecognized new directory
+just means the full suite runs unnecessarily.
+
+### The mistake this prevents
+
+`paths-ignore` on the workflow trigger looks like the obvious fix and is the
+wrong one whenever a gated job is a **required branch-protection status
+check**. A workflow that never triggers produces *no check-run at all* —
+GitHub shows the PR permanently stuck on "required check pending," because a
+check that never runs can never satisfy the requirement. A job skipped via
+job-level `if:` still reports a check-run with conclusion "skipped," and
+branch protection treats that as satisfying the requirement. Verify which
+mechanism is safe by *calling the branch-protection API directly* — don't
+infer it from a code comment or assume:
+
+```bash
+gh api repos/OWNER/REPO/branches/main/protection \
+  -q '.required_status_checks.contexts'
+```
+
+One workflow's own comment claimed a job named "CodeQL" was required; the
+API said it wasn't (only its two per-language legs were). Comments drift
+from reality — the API doesn't.
+
+### Flags aren't interchangeable across jobs
+
+A second module in the repo (a separate `go.work`-excluded operator
+package) needed its own flag, `operator_only`, and the two flags compose
+*differently per job*:
+
+| Job | Skips on `go_unaffected` | Skips on `operator_only` | Why |
+|---|---|---|---|
+| root test suite | yes | yes | an operator-confined diff can't touch the root module |
+| operator's own job | yes | **no** | this is exactly the job that must still run |
+| license check | yes | **no** | checks both modules' deps — operator-only could add one |
+| Helm chart lint | yes | yes | no chart file lives under the operator module's own tree |
+
+Treat each new flag as a claim ("this diff cannot affect X") and check it
+job by job — copying one job's gate onto another without rechecking the
+claim is how a skip becomes a false negative.
+
+### A matrix job can't use a per-leg condition
+
+A CodeQL job matrixed over `[server, operator]` needed the server leg to
+additionally skip on `operator_only` while the operator leg must not. The
+natural-looking fix —
+
+```yaml
+if: needs.changes.outputs.operator_only == 'true' && matrix.name == 'server'
+```
+
+— fails actionlint outright: `context "matrix" is not allowed here`.
+Job-level `if:` is evaluated once, before the matrix expands. The fix was
+splitting the matrix into two explicit jobs (`analyze-server`,
+`analyze-operator`), each with its own condition, preserving the exact
+`name:` values so branch protection kept matching the same two
+required-check names. Verified with actionlint before and after — this is
+exactly the kind of thing that looks fine until the linter (or a real run)
+says otherwise.
+
+## 2. Cache every pinned, deterministic tool download
+
+Applies almost everywhere security-scanning workflows accumulate "curl a
+release tarball" steps over time. Four tools in `ci.yml` — `actionlint`,
+`gitleaks`, `kubeconform`, `checkov` — downloaded fresh via `curl` +
+`tar`/`unzip` on every single run, while three sibling tools in the same
+file (`govulncheck`, `gosec`, `go-licenses`) already used `actions/cache`.
+Same repo, same convention half-applied. All seven are already
+version-pinned with a checksum, which is exactly what makes them safe,
+deterministic cache keys.
+
+```yaml
+- name: Cache actionlint binary
+  uses: actions/cache@<pinned-sha>
+  with:
+    path: actionlint
+    key: actionlint-${{ env.ACTIONLINT_VERSION }}-${{ runner.os }}
+
+- name: actionlint
+  run: |
+    if [ ! -x ./actionlint ]; then
+      curl ... | sha256sum -c - && tar -xz ...
+    fi
+    ./actionlint
+```
+
+Two variants worth naming explicitly, since they don't fit the simple guard
+above:
+
+- **Tool adds itself to `$GITHUB_PATH`** — the PATH-append line must run
+  every time, cache hit or miss. `$GITHUB_PATH` is a per-run ephemeral file,
+  not something a cache restores.
+- **Playwright's `--with-deps`** — caching the browser binary directory
+  doesn't cover the apt-installed system libraries that flag also pulls in.
+  A cache hit should still run a cheap, idempotent `install-deps`-only pass,
+  not skip setup outright.
+
+**Check the default before "fixing" it.** `actions/setup-go` has cached the
+Go module + build directory by default since its `cache` input defaulted to
+`true` — every job using it already benefits without any extra config.
+Confirmed by reading the action's own `action.yml` rather than assuming;
+this is the number one thing to check before proposing Go build caching as
+a fix, since it's often already solved.
+
+## 3. Read the third-party action's source before patching around it
+
+The SonarCloud case: a proposed fix turned out to already exist one layer
+down. The plan was to add `actions/cache` for the SonarCloud scanner CLI.
+Reading the pinned action's `action.yml` first (not assumed) surfaced two
+things: the action in use, `SonarSource/sonarcloud-github-action`, prints a
+deprecation warning on *every run* and is a thin wrapper around
+`SonarSource/sonarqube-scan-action` — which already has its own
+`actions/cache` step for exactly the scanner CLI, baked into the composite
+action itself.
+
+The real fix was migrating to the non-deprecated action directly (its own
+docs call it a "drop-in replacement"), not adding a redundant cache on top
+of one that already existed two layers down. This is a "verify, don't
+assume" habit as much as a specific fix: any time an optimization targets
+behavior inside a third-party action, read that action's own source at the
+pinned ref first.
+
+## 4. A caution: verifying via source isn't the same as verifying via a run
+
+Included because the failure is exactly as instructive as the successes
+above. `trivy.yml` ran the identical filesystem misconfig scan **twice** —
+once to produce a SARIF upload with no exit-code (so it could never fail the
+job), once with `exit-code: 1` for the actual gate. `format` and
+`exit-code` looked like independent options on paper, and reading the
+action's `entrypoint.sh` confirmed they're both just separate environment
+variables passed to one underlying scanner invocation — so merging the two
+steps into one looked safe.
+
+**What actually happened:** this repo's Helm charts fail to render without
+`--set` overrides supplying required values — expected, since this scan
+targets the whole filesystem, not one rendered chart with test values. The
+scanner logs that as an error either way. With the default table formatter,
+that error is a logged warning; the run continues and passes. With the
+SARIF formatter, the *same* error propagates into a hard non-zero exit with
+no findings printed at all — a different code path inside the tool, not
+documented, not visible from reading the wrapper script.
+
+The fix was reverting to two steps, with a comment on the reverted code in
+`trivy.yml` explaining exactly this, so the same "obvious" merge doesn't get
+re-attempted blind by someone who only reads the entrypoint script the way
+the first attempt did.
+
+> **The transferable lesson:** reading a tool's source to confirm two
+> options are independent CLI flags is necessary. It is not sufficient when
+> the tool has format-specific internal handling that the entrypoint script
+> doesn't surface. Any merge of two previously-separate invocations needs a
+> real CI run before it's considered done — and if it breaks, revert
+> immediately and document why, rather than iterate on guesses against a
+> red build.
+
+## 5. Trigger-scope details worth checking, not assuming
+
+**`paths-ignore` and tag pushes.** `docker-publish.yml` triggered on every
+push to `main` *and* on `v*` tags, with no path filter — a docs-only merge
+still built, signed, and pushed five container images. Adding
+`paths-ignore` to a trigger that also matches tags raised an obvious
+question: could a real release tag get silently skipped if its underlying
+commit happened to look docs-only?
+
+GitHub's own documentation settles it directly: *"Path filters are not
+evaluated for pushes of tags."* A `paths-ignore` on a combined `branches` +
+`tags` trigger only ever constrains the branch case. Checked before
+shipping, not after.
+
+## Applicability checklist for another Go project
+
+Roughly in order of payoff-to-effort. Nothing here is universal — check each
+claim against the target repo before porting it.
+
+- [ ] Does the required-checks list actually match what the workflow file
+      implies? Run the branch-protection API call above before choosing
+      `paths-ignore` vs. job-level `if:` for any given job.
+- [ ] Is there a repo-wide "diff shape" (docs-only, single-module-only,
+      frontend-only) that recurs often enough to be worth a `changes` job?
+      If the repo is single-module with no docs-heavy contribution pattern,
+      this pattern's payoff shrinks a lot.
+- [ ] Grep every workflow for `curl.*-fsSLO` or similar raw downloads and
+      check whether each is already version-pinned (a prerequisite for safe
+      caching) and whether a sibling tool in the same file already shows the
+      right `actions/cache` pattern to copy.
+- [ ] Confirm `actions/setup-go`'s cache is actually active (default true
+      since a few major versions back) rather than proposing to add it.
+- [ ] For any SonarCloud/SonarQube workflow, check whether it still uses the
+      deprecated `sonarcloud-github-action` wrapper — same migration applies
+      verbatim.
+- [ ] For any workflow duplicating a scan for SARIF-vs-blocking reasons,
+      don't merge them without a real CI run, even if the tool's docs say
+      the two options are independent.
+- [ ] Any workflow triggered on both branch and tag pushes can safely take
+      `paths-ignore` for the branch case with zero risk to tag-triggered
+      releases — this is documented GitHub behavior, not repo-specific.

--- a/docs/adr-020-project-detail-page.md
+++ b/docs/adr-020-project-detail-page.md
@@ -1,0 +1,80 @@
+# ADR-020: Project detail page — tabbed single page over separate top-level pages
+
+## Status
+
+Accepted, as-built. Backfill ADR — this decision predates the ADR series (it
+sits chronologically between ADR-019's project cascade-delete and ADR-021's
+RBAC Phase 2 roles catalog, both from the same May 2026 project-CRUD work).
+Recorded now per the M2 "ADR backfill" backlog item, after a private-backlog
+memory claim that this page was "still Proposed, blocked on a co-founder"
+turned out to be stale — verified 2026-08-06 by reading the code directly and
+driving the live page in a real browser: it is fully built, has been for
+some time, and needed no new engineering work, only this missing document.
+
+## Context
+
+A project in Keyorix is the top-level unit almost everything else hangs off
+of: its environments, its secrets, its human and machine members, its access-
+review campaigns, and its own audit trail. Once `keyorix project describe`
+(ADR-016) and `keyorix project env *` (ADR-017) existed on the CLI, the web
+frontend needed an equivalent single place to manage a project's full
+surface — not just view it.
+
+The alternative to a single page was a set of separate top-level routes
+(`/project-members`, `/project-secrets`, `/project-settings`, …), each
+re-deriving which project it's scoped to from a query param or a picker.
+That fragments a project's identity across the URL space and makes "which
+project am I looking at right now" ambiguous outside a shared shell.
+
+## Decision
+
+One route, `/projects/:id/*`, rendered by `ProjectDetailPage.tsx`. It:
+
+- Resolves the project once (`useProject(projectId)`), renders a breadcrumb
+  (`Projects › {name}`) and a header (name + description), then hands off to
+  a client-side tab bar backed by nested `react-router` `<Routes>` — so each
+  tab is still its own bookmarkable/deep-linkable URL
+  (`/projects/1/members`, `/projects/1/settings`, …), not client-only state.
+- Records the visit in the ADR-018 MRU store (`useProjectMruStore`) on load,
+  so both switcher-driven and direct-URL navigation feed the sidebar
+  switcher's "Recent" ordering.
+- Ships five tabs, each its own component under `web/src/pages/projects/`:
+  - **Secrets** (`ProjectSecretsTab`, the largest at ~900 lines) — per-
+    environment secret listing/search/filtering, plus the drift-check
+    (`SecretsDriftPanel`, ADR-052-adjacent) and rotation-plan
+    (`SecretsRotationPlanPanel`, ADR-053) panels embedded inline rather than
+    as further sub-tabs.
+  - **Members** (`ProjectMembersTab`) — human and machine-identity
+    membership, project-scoped roles.
+  - **Activity** (`ProjectActivityTab`) — the project's slice of the audit
+    log, paginated.
+  - **Access Review** (`ProjectAccessReviewTab` +
+    `ProjectAccessReviewCampaigns`) — attest/revoke workflow and campaign
+    tracking.
+  - **Settings** (`ProjectSettingsTab`, the largest file at ~1,500 lines) —
+    project metadata, per-environment lifecycle (restore, promote, delete),
+    freeze-style controls, and the project delete flow (fronting the
+    ADR-019 cascade-restrict endpoint with its confirmation modal).
+- Defaults an index visit (`/projects/1`) to the Secrets tab via a redirect,
+  rather than a separate "overview" tab — the secrets list *is* the
+  overview for how this page is actually used.
+
+## Consequences
+
+- **Positive.** A project's full management surface lives at one URL prefix,
+  keeps its identity in the URL (shareable/bookmarkable per-tab links), and
+  shares one project-load + breadcrumb + MRU-recording path instead of
+  five. New project-scoped concerns (drift, rotation planning, access-review
+  campaigns) were added as more panels/tabs on this page rather than new
+  top-level routes, and that pattern has held through several rounds of
+  feature growth without needing to revisit the page's shape.
+- **Negative / accepted tradeoff.** `ProjectSettingsTab.tsx` in particular
+  has grown to ~1,500 lines by accumulating every project-lifecycle concern
+  (metadata, environments, freeze, delete) in one component rather than
+  splitting settings into its own sub-navigation. Not revisited here — it
+  works and is tested, and splitting it is a refactor with no reported bug
+  behind it, not a decision this ADR needs to make.
+- Not built, and not implied by this decision: a dedicated "overview"/
+  dashboard tab distinct from the Secrets tab. If a future need for
+  project-level summary stats (beyond what the Secrets tab already shows)
+  emerges, that's a new tab, not a change to this ADR's shape.

--- a/docs/adr-051-ens-control-framework.md
+++ b/docs/adr-051-ens-control-framework.md
@@ -65,8 +65,15 @@ confirmable mapping, consistent with how the other four regimes are treated.
 
 ## Deferred follow-ups
 
-- Surface the ENS column in the web/ compliance UI — the matrix
-  page renders ISO/SOC2/NIS2/DORA today; ENS is carried in the API already.
-- Optional per-regime filtering of the matrix (show only the ENS view).
+- ~~Surface the ENS column in the web/ compliance UI~~ — **done.** The ENS tab, per-
+  control ENS reference line, and ENS section card were built in the (then-separate)
+  keyorix-web repo and folded in unchanged by the ADR-070 monorepo merge; this note
+  wasn't updated at the time. Verified 2026-08-06: `web/src/pages/compliance/CompliancePage.tsx`
+  `FRAMEWORKS` includes an `ens` entry, `ControlMatrixPanel`'s `refLine` includes ENS
+  refs, `web/src/services/compliance.ts` carries `frameworks.ens` end to end, and
+  `CompliancePage.test.tsx` covers the ENS tab (29/29 tests green).
+- Optional per-regime filtering of the matrix (show only the ENS view) — the tab bar
+  already does this (`activeFramework` filters `visibleControls`); nothing further
+  needed unless a dedicated `?framework=ens`-style deep link is wanted.
 - Map any future controls (e.g. backup/continuity `op.cont`, comms `mp.com`) as those
   postures become first-class matrix entries.

--- a/scripts/mutation-testing/README.md
+++ b/scripts/mutation-testing/README.md
@@ -183,6 +183,93 @@ Same base requirements as `scripts/fuzzing/README.md` (Go matching `go.mod`,
   "current vs. immediately-previous" by design (that's all the regression
   check needs). Copy a result out first if you want to keep it longer.
 
+## Running additional packages in parallel (manual, ad hoc)
+
+`run-mutation.sh` itself processes `PACKAGES` strictly sequentially, one
+`gremlins` invocation at a time (`MUTATION_WORKERS` controls parallelism
+*within* one package's mutants, not across packages) — by design, see that
+script's own comment. On a box with real spare CPU/RAM, you can still run
+an *additional* package's mutation testing concurrently with whatever
+`keyorix-mutation.service` is already doing, without touching it.
+
+### Why this might be worth doing
+
+Each package's mutant count and per-mutant cost is measurable before you
+commit to running it — use a `--dry-run` pass (finds/counts mutants,
+executes no tests, takes seconds) to get a real number instead of guessing:
+
+```
+gremlins unleash --dry-run --workers 1 -o /tmp/dryrun.json ./internal/some/package
+# prints e.g. "Runnable: 4139, Not covered: 248"
+```
+
+Combine that with an observed current pace (two `grep -c` counts of
+`last-<label>.log` a few minutes apart) to get a rough completion estimate
+before deciding whether waiting for the sequential run to reach that
+package is actually going to take longer than you want. Measured on this
+box (single worker, `GOMAXPROCS=8`, Intel i7-6700, see "Resource limits"
+above): roughly 1 mutant per ~60s, meaning a large package (`internal/core`:
+4,139 runnable mutants, ~99k lines) is a multi-day job on its own, and the
+full non-test Go codebase (~163k lines across `internal/`, `server/`,
+`cmd/`, extrapolated from two packages' measured mutant-per-line density)
+would be roughly 1-2 weeks sequentially at this pace.
+
+### How to do it safely
+
+`gremlins` mutates source files in place during testing. Two instances
+**must never share a checkout** — running a second stream against the same
+`KEYORIX_REPO` path as the primary service is a real risk of one run's
+mutation colliding with the other's compile/test cycle. Give the new
+stream its own clone instead:
+
+```
+sudo -u mutation git clone --quiet /opt/keyorix-mutation/keyorix \
+  /opt/keyorix-mutation/keyorix-<label>-stream
+```
+
+`GOCACHE`/`GOMODCACHE` *are* safe to share across concurrent `go build`/
+`go test` invocations (standard Go toolchain behavior — this is exactly
+how a CI fleet shares one cache across many runners) — point the new
+stream at the same `/opt/keyorix-mutation/go-cache` and
+`/opt/keyorix-mutation/go-mod` rather than cloning those too. The
+[cache-trim timer](#disk-gocache-grows-without-bound) already keeps that
+shared cache's disk usage bounded regardless of how many streams are
+writing to it.
+
+Size `GOMAXPROCS` for the new stream so the total across all concurrent
+streams stays near the box's real thread count — the primary service was
+already running with `GOMAXPROCS=8` (the box's full thread count) when a
+second stream was added at `GOMAXPROCS=4` alongside it here, accepting
+mild, likely-tolerable oversubscription rather than restarting the primary
+run (which would only have cost its single in-flight mutant, not any
+completed results, but wasn't judged worth the disruption -- see the
+`keyorix-mutation.service`'s `MemoryMax`/`CPUQuota` for what genuine
+oversubscription looks like when it *isn't* tolerable). Launch as a
+transient unit rather than writing a new permanent `.service` file for
+what's a one-off, exploratory run:
+
+```
+systemd-run --uid=mutation --gid=mutation \
+  --unit=keyorix-mutation-<label>-adhoc \
+  --setenv=GOCACHE=/opt/keyorix-mutation/go-cache \
+  --setenv=GOMODCACHE=/opt/keyorix-mutation/go-mod \
+  --setenv=GOPATH=/opt/keyorix-mutation/gopath \
+  --setenv=PATH=/opt/keyorix-mutation/gopath/bin:/usr/local/go/bin:/usr/bin:/bin \
+  --setenv=GOMAXPROCS=4 \
+  --setenv=HOME=/home/mutation \
+  --working-directory=/opt/keyorix-mutation/keyorix-<label>-stream \
+  --property=Nice=10 \
+  /bin/bash -c "gremlins unleash --workers 1 -o /opt/keyorix-mutation/state/adhoc-<label>.json ./internal/some/package > /opt/keyorix-mutation/state/adhoc-<label>.log 2>&1"
+```
+
+Check progress the same way as the primary run (`grep -c KILLED
+/opt/keyorix-mutation/state/adhoc-<label>.log`, etc.) and
+`systemctl status keyorix-mutation-<label>-adhoc.service` for whether it's
+still running. It does not survive a reboot and is not enabled/persistent
+by design — this is for "run this one package now, in parallel," not a
+replacement for widening `PACKAGES` in `run-mutation.sh` if the intent is
+to cover it on an ongoing weekly basis.
+
 ## Design notes
 
 - Read-only against the repo: unlike the fuzzing box (which pushes corpus

--- a/scripts/mutation-testing/README.md
+++ b/scripts/mutation-testing/README.md
@@ -60,6 +60,29 @@ not an OOM kill: silent thrashing that's easy to mistake for the CPUQuota
 problem above if you haven't also checked
 `systemctl show keyorix-mutation.service -p MemoryCurrent -p MemoryMax`.
 
+### Disk: `GOCACHE` grows without bound
+
+Mutation testing is inherently cache-hostile -- gremlins recompiles a new,
+distinct source variant per mutant, and Go's build cache is content-
+addressed, so nearly every mutant produces a brand-new cache entry with
+little reuse. Go's own automatic cache GC is age-based (days), not
+size-based, so it doesn't kick in fast enough for a workload that can
+generate double-digit GiB within hours -- this has filled a container's
+disk to 100% (and stalled the in-progress run) before this existed.
+
+`trim-gocache.sh`, run periodically via `keyorix-mutation-cache-trim.timer`
+(every 10 minutes, independent of `keyorix-mutation.timer`'s own weekly
+schedule), checks disk usage and, only once it's over
+`TRIM_DISK_THRESHOLD_PCT` (default 85%), deletes the *oldest* files under
+`GOCACHE` until usage drops back to `TRIM_DISK_TARGET_PCT` (default 65%).
+Most firings are a no-op `df` check. Deliberately not a periodic
+`go clean -cache` (a full wipe): that needs an exclusive lock on the whole
+cache, so running it unconditionally on a fixed interval would frequently
+collide with gremlins' own in-flight compiles over a run lasting hours.
+Deleting the oldest files individually is much less likely to touch
+anything actively in use -- a live compile's own cache writes are, by
+definition, the newest files on disk.
+
 ## One-time setup (on the LXC/VM)
 
 Same base requirements as `scripts/fuzzing/README.md` (Go matching `go.mod`,
@@ -121,6 +144,7 @@ Same base requirements as `scripts/fuzzing/README.md` (Go matching `go.mod`,
    cp scripts/mutation-testing/systemd/*.service scripts/mutation-testing/systemd/*.timer /etc/systemd/system/
    systemctl daemon-reload
    systemctl enable --now keyorix-mutation.timer
+   systemctl enable --now keyorix-mutation-cache-trim.timer
    ```
    **If this is an unprivileged Proxmox LXC**, see
    `scripts/fuzzing/README.md` step 7's journald note — the same

--- a/scripts/mutation-testing/systemd/keyorix-mutation-cache-trim.service
+++ b/scripts/mutation-testing/systemd/keyorix-mutation-cache-trim.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Trim keyorix mutation-testing's GOCACHE when disk usage runs high
+
+[Service]
+Type=oneshot
+User=mutation
+Group=mutation
+ExecStart=/opt/keyorix-mutation/keyorix/scripts/mutation-testing/trim-gocache.sh
+
+# Deliberately no Nice=/CPUQuota=/MemoryMax= here, unlike keyorix-mutation.service
+# -- this is a lightweight `df` check plus, on the rare over-threshold run, a
+# `find`+`rm` pass, not a CPU/memory-heavy compile-and-test workload.
+
+# Process-isolation hardening (mirrors keyorix-mutation.service's rationale).
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+RestrictSUIDSGID=true
+Environment=GOCACHE=/opt/keyorix-mutation/go-cache
+# Only GOCACHE itself needs to be writable -- this script never touches the
+# git checkout, state dir, module cache, or GOPATH that keyorix-mutation.service
+# also needs write access to.
+ReadWritePaths=/opt/keyorix-mutation/go-cache

--- a/scripts/mutation-testing/systemd/keyorix-mutation-cache-trim.timer
+++ b/scripts/mutation-testing/systemd/keyorix-mutation-cache-trim.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Periodic check for keyorix-mutation-cache-trim.service
+
+[Timer]
+# Frequent enough to catch runaway growth well before disk fills (a run has
+# hit 100% within a matter of hours before this existed), infrequent enough
+# that the vast majority of firings are a cheap no-op `df` check that finds
+# usage under threshold and exits immediately -- see trim-gocache.sh's own
+# comment for why this is a periodic threshold check, not a blind interval
+# wipe.
+OnCalendar=*:0/10
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/mutation-testing/trim-gocache.sh
+++ b/scripts/mutation-testing/trim-gocache.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Threshold-triggered GOCACHE trim, run periodically (see
+# systemd/keyorix-mutation-cache-trim.timer) independent of
+# run-mutation.sh's own lifecycle.
+#
+# Mutation testing is inherently cache-hostile: gremlins recompiles a new,
+# distinct source variant per mutant, and Go's build cache is content-
+# addressed, so nearly every mutant produces a brand-new cache entry with
+# little reuse. Go's own automatic cache GC is age-based (days), not
+# size-based, so it doesn't kick in fast enough for a workload that can
+# generate double-digit GiB within hours -- this filled the container's
+# disk to 100% once already.
+#
+# Deliberately NOT `go clean -cache` (a full wipe): that needs an exclusive
+# lock on the whole cache, so running it unconditionally on a fixed
+# interval would frequently collide with gremlins' own in-flight compiles
+# over a run lasting hours, stalling them for no reason on cycles where
+# there was nothing worth reclaiming anyway. Deleting the OLDEST files
+# individually is much less likely to touch anything actively in use (a
+# live compile's own cache writes are, by definition, the newest files),
+# and this script only touches disk at all when actually over threshold --
+# most invocations of this timer should be a no-op.
+set -euo pipefail
+
+# `find` below tries to restore its starting cwd when it's done traversing;
+# if that cwd isn't readable by this script's caller (e.g. invoked via
+# `sudo -u mutation` from a root shell sitting in /root), find exits
+# non-zero purely over that, which -- combined with `set -e` -- aborts the
+# whole script before it ever reaches the deletion loop. systemd's own
+# invocation already defaults WorkingDirectory to `/` (always accessible),
+# but cd there explicitly so this script is robust to any caller, not just
+# the one it's currently wired to.
+cd /
+
+: "${GOCACHE:?set GOCACHE to the mutation-testing build cache dir}"
+: "${TRIM_DISK_THRESHOLD_PCT:=85}" # trigger trimming at this usage%
+: "${TRIM_DISK_TARGET_PCT:=65}"    # trim until usage drops back to this%
+: "${TRIM_CHECK_EVERY_N_FILES:=200}" # how often to re-check usage while trimming
+
+usage_pct() {
+  df --output=pcent "$GOCACHE" | tail -1 | tr -dc '0-9'
+}
+
+current="$(usage_pct)"
+if [ "$current" -lt "$TRIM_DISK_THRESHOLD_PCT" ]; then
+  echo "$(date -u +%FT%TZ) disk usage ${current}% below threshold ${TRIM_DISK_THRESHOLD_PCT}%, nothing to do"
+  exit 0
+fi
+
+echo "$(date -u +%FT%TZ) disk usage ${current}% >= threshold ${TRIM_DISK_THRESHOLD_PCT}%, trimming oldest GOCACHE entries toward ${TRIM_DISK_TARGET_PCT}%..."
+
+# Sorted-oldest-first file list goes to a real temp file, not a `| while
+# read` pipe -- a pipe's right-hand side runs in a subshell in bash, so
+# `exit 0` inside the loop below would only end that subshell, silently
+# falling through to the "exhausted" message afterward instead of actually
+# stopping the script once the target is reached.
+file_list="$(mktemp)"
+trap 'rm -f "$file_list"' EXIT
+find "$GOCACHE" -type f -printf '%T@ %p\n' | sort -n | cut -d' ' -f2- > "$file_list"
+
+deleted=0
+checked=0
+while IFS= read -r path; do
+  rm -f -- "$path"
+  deleted=$((deleted + 1))
+  checked=$((checked + 1))
+  if [ "$checked" -ge "$TRIM_CHECK_EVERY_N_FILES" ]; then
+    checked=0
+    current="$(usage_pct)"
+    if [ "$current" -lt "$TRIM_DISK_TARGET_PCT" ]; then
+      echo "$(date -u +%FT%TZ) usage back to ${current}% after deleting $deleted files, target reached"
+      exit 0
+    fi
+  fi
+done < "$file_list"
+
+echo "$(date -u +%FT%TZ) exhausted all cache files (deleted $deleted), usage still $(usage_pct)%"

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -316,8 +316,11 @@ func validateGRPCMachineToken(ctx context.Context, coreService *core.KeyorixCore
 		ActorType:         core.ActorTypeMachine,
 		MachineIdentityID: machine.ID,
 	}
-	// Enforce machine token IP allowlist via gRPC peer IP.
-	if restriction != nil && len(restriction.AllowedCIDRs) > 0 {
+	// Enforce machine token IP allowlist via gRPC peer IP. restriction is nil
+	// unless machineRestrictionFrom found at least one CIDR (it never returns
+	// a non-nil restriction with an empty AllowedCIDRs), so a non-nil check
+	// alone is sufficient here — no separate length guard needed.
+	if restriction != nil {
 		if !core.IPInCIDRs(PeerIP(ctx), restriction.AllowedCIDRs) {
 			return nil, nil, status.Errorf(codes.PermissionDenied, "token not permitted from this network")
 		}

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -324,6 +324,38 @@ func TestAuthInterceptor_PATNetworkAllowlistOverGRPC(t *testing.T) {
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }
 
+// A machine token's IP allowlist (validateGRPCMachineToken) is enforced over gRPC
+// via the peer address, the same as a PAT's allowlist above — in-range peer is
+// allowed; off-network is PermissionDenied. TestAuthInterceptor_MachineTokenAuthenticatesAndUsesMachineRBAC
+// never sets AllowedCIDRs, so that check's boundary/negation was previously
+// exercised by no test at all (found by mutation testing: both mutants LIVED).
+func TestAuthInterceptor_MachineTokenNetworkAllowlistOverGRPC(t *testing.T) {
+	h := setupAuthHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(
+		&models.MachineIdentity{}, &models.MachineIdentityCredential{}, &models.MachineIdentityRole{}))
+
+	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot-cidr", "service", "", "", 1)
+	require.NoError(t, err)
+	tok, err := h.CoreService.IssueMachineToken(context.Background(), 2, m.ID, 1, core.IssueMachineTokenParams{
+		Name:         "tok-cidr",
+		AllowedCIDRs: []string{"10.0.0.0/8"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, h.CoreService.AssignMachineRole(context.Background(), m.ID, 4, core.Scope{ProjectID: 2}, 1))
+
+	interceptor := AuthInterceptor(h.CoreService, false)
+
+	_, err = interceptor(bearerCtxFromIP(tok.PlainToken, "10.1.2.3"), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
+	require.NoError(t, err, "in-range source IP is allowed over gRPC")
+
+	_, err = interceptor(bearerCtxFromIP(tok.PlainToken, "203.0.113.9"), nil,
+		&grpc.UnaryServerInfo{FullMethod: secretMethod}, okHandler(nil))
+	require.Error(t, err, "off-network source IP must be denied over gRPC")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
 // setUserFields fetches a user by id, applies mutate, and persists — used to put a
 // test user into a restricted account state or flip its MFA flag.
 func setUserFields(t *testing.T, h *testhelper.RBACTestHelper, userID uint, mutate func(*models.User)) {

--- a/server/grpc/interceptors/logging.go
+++ b/server/grpc/interceptors/logging.go
@@ -40,12 +40,22 @@ func LoggingInterceptor() grpc.UnaryServerInterceptor {
 		)
 
 		// Log slow requests
-		if duration > 1*time.Second {
+		if isSlowRequest(duration) {
 			log.Printf("SLOW gRPC REQUEST: %s took %v", info.FullMethod, duration)
 		}
 
 		return resp, err
 	}
+}
+
+// slowRequestThreshold is the handler duration past which a request is logged
+// as slow. A named constant (rather than the literal inline) so
+// isSlowRequest's boundary is exercisable by a unit test with a synthetic
+// duration, not only by a real sleep timed against wall-clock precision.
+const slowRequestThreshold = 1 * time.Second
+
+func isSlowRequest(duration time.Duration) bool {
+	return duration > slowRequestThreshold
 }
 
 // StreamLoggingInterceptor returns a stream server interceptor for logging

--- a/server/grpc/interceptors/logging_test.go
+++ b/server/grpc/interceptors/logging_test.go
@@ -1,12 +1,30 @@
 package interceptors
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
+	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 )
+
+// captureLog redirects the standard logger's output for the duration of fn and
+// returns what it wrote — the only way to observe LoggingInterceptor's status
+// ("OK"/"ERROR") and slow-request line, both local to the closure and never
+// part of the interceptor's return value.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+	fn()
+	return buf.String()
+}
 
 // TestLoggingInterceptor_SuccessPath ensures the logging interceptor passes through
 // the handler's result without modifying it on a successful call.
@@ -47,6 +65,109 @@ func TestLoggingInterceptor_ErrorPath(t *testing.T) {
 		t.Fatalf("expected nil response on error, got %v", resp)
 	}
 }
+
+// The logged status line reports "OK" or "ERROR" matching the handler's actual
+// outcome -- previously unverified: the earlier success/error-path tests above
+// only checked the interceptor's return value, which doesn't depend on the
+// local "status" variable used purely for the log line (found by mutation
+// testing: negating "if err != nil" survived with no test noticing).
+func TestLoggingInterceptor_LogsStatusMatchingOutcome(t *testing.T) {
+	interceptor := LoggingInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/keyorix.v1.SecretService/GetSecret"}
+
+	okLog := captureLog(t, func() {
+		_, _ = interceptor(context.Background(), nil, info,
+			func(_ context.Context, _ interface{}) (interface{}, error) { return "ok", nil })
+	})
+	if !strings.Contains(okLog, " OK ") || strings.Contains(okLog, "ERROR") {
+		t.Fatalf("expected a status of OK, not ERROR, got log line: %q", okLog)
+	}
+
+	errLog := captureLog(t, func() {
+		_, _ = interceptor(context.Background(), nil, info,
+			func(_ context.Context, _ interface{}) (interface{}, error) { return nil, errors.New("boom") })
+	})
+	if !strings.Contains(errLog, " ERROR ") || strings.Contains(errLog, " OK ") {
+		t.Fatalf("expected a status of ERROR, not OK, got log line: %q", errLog)
+	}
+}
+
+// StreamLoggingInterceptor's status line has the same OK/ERROR split as the
+// unary path, on its own local "status" variable and its own "if err != nil"
+// (a separate LIVED mutant from the unary one above).
+func TestStreamLoggingInterceptor_LogsStatusMatchingOutcome(t *testing.T) {
+	interceptor := StreamLoggingInterceptor()
+	info := &grpc.StreamServerInfo{FullMethod: "/keyorix.v1.SecretService/ListSecrets"}
+	stream := &fakeServerStream{ctx: context.Background()}
+
+	okLog := captureLog(t, func() {
+		_ = interceptor(nil, stream, info, func(interface{}, grpc.ServerStream) error { return nil })
+	})
+	if !strings.Contains(okLog, " OK ") || strings.Contains(okLog, "ERROR") {
+		t.Fatalf("expected a status of OK, not ERROR, got log line: %q", okLog)
+	}
+
+	errLog := captureLog(t, func() {
+		_ = interceptor(nil, stream, info, func(interface{}, grpc.ServerStream) error { return errors.New("boom") })
+	})
+	if !strings.Contains(errLog, " ERROR ") || strings.Contains(errLog, " OK ") {
+		t.Fatalf("expected a status of ERROR, not OK, got log line: %q", errLog)
+	}
+}
+
+// isSlowRequest's boundary is tested directly against synthetic durations,
+// not through a real sleep timed against wall-clock precision -- exact at
+// the 1-second threshold itself (not-slow at exactly 1s, slow just past it),
+// which a real-sleep test structurally can't assert without flakiness.
+// Kills the CONDITIONALS_BOUNDARY (">" vs ">=") and ARITHMETIC_BASE
+// (slowRequestThreshold's own definition) mutants a real-sleep version of
+// this test left LIVED: a >=100ms-off sleep can't distinguish the original
+// 1-second threshold from nearby mutations of it, only an exact synthetic
+// duration can.
+func TestIsSlowRequest(t *testing.T) {
+	cases := []struct {
+		name     string
+		duration time.Duration
+		want     bool
+	}{
+		{"well under threshold", 100 * time.Millisecond, false},
+		{"exactly at threshold", 1 * time.Second, false},
+		{"just past threshold", 1*time.Second + time.Millisecond, true},
+		{"well past threshold", 5 * time.Second, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSlowRequest(tc.duration); got != tc.want {
+				t.Errorf("isSlowRequest(%v) = %v, want %v", tc.duration, got, tc.want)
+			}
+		})
+	}
+}
+
+// The interceptor actually wires isSlowRequest's result into the log line —
+// checked end to end (not just the predicate in isolation) with a real, fast
+// call that must not be reported as slow.
+func TestLoggingInterceptor_FastRequestNotLoggedAsSlow(t *testing.T) {
+	interceptor := LoggingInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/keyorix.v1.SecretService/GetSecret"}
+
+	fastLog := captureLog(t, func() {
+		_, _ = interceptor(context.Background(), nil, info,
+			func(_ context.Context, _ interface{}) (interface{}, error) { return "ok", nil })
+	})
+	if strings.Contains(fastLog, "SLOW gRPC REQUEST") {
+		t.Fatalf("a fast handler must not be logged as slow, got: %q", fastLog)
+	}
+}
+
+// fakeServerStream is a minimal grpc.ServerStream for exercising
+// StreamLoggingInterceptor directly, without a real gRPC connection.
+type fakeServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *fakeServerStream) Context() context.Context { return s.ctx }
 
 // TestGetErrorMessage verifies the helper returns the error string or empty for nil.
 func TestGetErrorMessage(t *testing.T) {

--- a/server/grpc/interceptors/prometheus_test.go
+++ b/server/grpc/interceptors/prometheus_test.go
@@ -44,6 +44,31 @@ keyorix_grpc_requests_total{status="success"} 2
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "keyorix_grpc_requests_total"))
 }
 
+// The cumulative-duration counter converts the atomic's nanoseconds to seconds
+// (dividing by 1e9), matching Prometheus' convention for a *_seconds metric.
+// Deliberately drives TotalDuration directly rather than through the
+// interceptor's real wall-clock timing (as TestGRPCPrometheusCollector above
+// does for the other two counters) so the expected value is exact, not just
+// "some positive number" -- an ARITHMETIC_BASE mutant turning /1e9 into
+// *1e9 or +1e9 previously survived because no test asserted this counter's
+// value at all.
+func TestGRPCPrometheusCollector_DurationConvertsNanosecondsToSeconds(t *testing.T) {
+	atomic.StoreInt64(&grpcMetrics.TotalRequests, 0)
+	atomic.StoreInt64(&grpcMetrics.SuccessRequests, 0)
+	atomic.StoreInt64(&grpcMetrics.ErrorRequests, 0)
+	atomic.StoreInt64(&grpcMetrics.TotalDuration, 5_000_000_000) // exactly 5s in ns
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(newGRPCCollector())
+
+	expected := `
+# HELP keyorix_grpc_request_duration_seconds_total Cumulative gRPC unary handler time in seconds; divide its rate by the request rate for average latency.
+# TYPE keyorix_grpc_request_duration_seconds_total counter
+keyorix_grpc_request_duration_seconds_total 5
+`
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "keyorix_grpc_request_duration_seconds_total"))
+}
+
 // RegisterPrometheusMetrics is safe to call repeatedly (it would otherwise panic on
 // a duplicate registration).
 func TestRegisterPrometheusMetricsIdempotent(t *testing.T) {

--- a/server/grpc/interceptors/rate_limit_test.go
+++ b/server/grpc/interceptors/rate_limit_test.go
@@ -1,0 +1,179 @@
+package interceptors
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+// grpcCtxForUser attaches a UserContext the same way AuthInterceptor does, for
+// tests that exercise GRPCRateLimitInterceptor directly without a real token.
+func grpcCtxForUser(userID, machineID uint) context.Context {
+	return context.WithValue(context.Background(), GetUserContextKey(), &UserContext{
+		UserID:            userID,
+		MachineIdentityID: machineID,
+	})
+}
+
+// grpcCtxForIP attaches a gRPC peer with the given source IP and no UserContext,
+// exercising the unauthenticated IP-fallback path.
+func grpcCtxForIP(ip string) context.Context {
+	return peer.NewContext(context.Background(), &peer.Peer{Addr: &net.TCPAddr{IP: net.ParseIP(ip), Port: 5555}})
+}
+
+func rlHandler() grpc.UnaryHandler {
+	return func(_ context.Context, _ interface{}) (interface{}, error) { return "ok", nil }
+}
+
+// Disabled (the config zero value, or an explicit Enabled: false) is a
+// transparent no-op — GRPCRateLimitInterceptor returns a pass-through
+// interceptor, not a limiter with an effectively-infinite budget. Also covers
+// RequestsPerSecond <= 0 while Enabled is true, the OTHER half of the
+// disabling condition.
+func TestGRPCRateLimitInterceptor_DisabledIsNoOp(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  config.RateLimitConfig
+	}{
+		{"zero value", config.RateLimitConfig{}},
+		{"explicitly disabled", config.RateLimitConfig{Enabled: false, RequestsPerSecond: 100}},
+		{"enabled but non-positive rps", config.RateLimitConfig{Enabled: true, RequestsPerSecond: 0}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			interceptor := GRPCRateLimitInterceptor(tc.cfg)
+			for i := 0; i < 50; i++ {
+				_, err := interceptor(grpcCtxForUser(1, 0), nil, nil, rlHandler())
+				require.NoError(t, err, "request %d must pass through unlimited", i)
+			}
+		})
+	}
+}
+
+// A principal exceeding their burst gets ResourceExhausted; a DIFFERENT
+// principal is unaffected — budgets are per-principal, not shared. Also
+// confirms the enabled path is actually reached (the inverse of the
+// disabled-is-no-op case above).
+func TestGRPCRateLimitInterceptor_EnforcesPerPrincipalBudget(t *testing.T) {
+	interceptor := GRPCRateLimitInterceptor(config.RateLimitConfig{Enabled: true, RequestsPerSecond: 1, Burst: 3})
+
+	for i := 0; i < 3; i++ {
+		_, err := interceptor(grpcCtxForUser(1, 0), nil, nil, rlHandler())
+		require.NoError(t, err, "request %d within burst must pass", i)
+	}
+	_, err := interceptor(grpcCtxForUser(1, 0), nil, nil, rlHandler())
+	require.Error(t, err, "the 4th request within the same instant must be limited")
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+
+	_, err = interceptor(grpcCtxForUser(2, 0), nil, nil, rlHandler())
+	assert.NoError(t, err, "a different principal must have an independent budget")
+}
+
+// Burst defaults to RequestsPerSecond when unset (Burst <= 0) — the token
+// bucket accepts exactly RequestsPerSecond requests up front, not 0 (which
+// would deny every request outright) and not unlimited.
+func TestGRPCRateLimitInterceptor_BurstDefaultsToRequestsPerSecond(t *testing.T) {
+	interceptor := GRPCRateLimitInterceptor(config.RateLimitConfig{Enabled: true, RequestsPerSecond: 3})
+
+	for i := 0; i < 3; i++ {
+		_, err := interceptor(grpcCtxForUser(1, 0), nil, nil, rlHandler())
+		require.NoError(t, err, "request %d within the defaulted burst of 3 must pass", i)
+	}
+	_, err := interceptor(grpcCtxForUser(1, 0), nil, nil, rlHandler())
+	assert.Error(t, err, "the 4th request must be limited once the defaulted burst is exhausted")
+}
+
+// A machine-identity principal is keyed by machine ID, ahead of any user ID on
+// the same UserContext (mirrors AuthInterceptor's convention that a machine
+// request never carries a UserID) -- and independently of a same-numbered user.
+func TestGRPCRateLimitInterceptor_MachineIdentityKeyedSeparatelyFromUser(t *testing.T) {
+	interceptor := GRPCRateLimitInterceptor(config.RateLimitConfig{Enabled: true, RequestsPerSecond: 1, Burst: 1})
+
+	_, err := interceptor(grpcCtxForUser(0, 7), nil, nil, rlHandler())
+	require.NoError(t, err, "machine 7's first request must pass")
+	_, err = interceptor(grpcCtxForUser(0, 7), nil, nil, rlHandler())
+	assert.Error(t, err, "machine 7's second request within burst=1 must be limited")
+
+	// A user whose numeric ID happens to equal the machine ID has an
+	// independent budget -- the key must be "machine:7" vs "user:7", not the
+	// same bucket by coincidence of numeric value.
+	_, err = interceptor(grpcCtxForUser(7, 0), nil, nil, rlHandler())
+	assert.NoError(t, err, "user 7 must not share machine 7's exhausted budget")
+}
+
+// An unauthenticated request (no UserContext, e.g. a public method) falls back
+// to an IP-keyed budget rather than panicking or bypassing the limiter. A
+// request with no resolvable peer at all still gets a (shared) "ip:unknown"
+// budget rather than crashing.
+func TestGRPCRateLimitInterceptor_FallsBackToIPForUnauthenticated(t *testing.T) {
+	interceptor := GRPCRateLimitInterceptor(config.RateLimitConfig{Enabled: true, RequestsPerSecond: 1, Burst: 1})
+
+	ctx := grpcCtxForIP("203.0.113.5")
+	_, err := interceptor(ctx, nil, nil, rlHandler())
+	require.NoError(t, err)
+	_, err = interceptor(ctx, nil, nil, rlHandler())
+	assert.Error(t, err, "a second request from the same IP within burst=1 must be limited")
+
+	_, err = interceptor(context.Background(), nil, nil, rlHandler())
+	assert.NoError(t, err, "no UserContext and no peer must still resolve to a real key (\"ip:unknown\"), not panic")
+}
+
+// sweepLocked evicts only entries idle past grpcPrincipalLimiterIdleTTL (10
+// minutes), not everything and not nothing -- constructed directly against
+// the unexported type (white-box) since driving real 10-minute idleness
+// through the public API isn't practical. Deliberately asserts against
+// hardcoded 9m/11m offsets, not the constant itself, so a mutation to the
+// constant's own definition (an ARITHMETIC_BASE flip of "10 * time.Minute",
+// or an INVERT_NEGATIVES flip of the cutoff's leading "-") changes the
+// asserted behavior instead of silently reading back its own mutated value.
+func TestGRPCRateLimiter_SweepEvictsOnlyIdleEntries(t *testing.T) {
+	rl := &grpcRateLimiter{limiters: make(map[string]*grpcPrincipalBucket)}
+	rl.limiters["stale"] = &grpcPrincipalBucket{lastSeen: time.Now().Add(-11 * time.Minute)}
+	rl.limiters["fresh"] = &grpcPrincipalBucket{lastSeen: time.Now().Add(-9 * time.Minute)}
+
+	rl.sweepLocked()
+
+	_, staleStillPresent := rl.limiters["stale"]
+	_, freshStillPresent := rl.limiters["fresh"]
+	assert.False(t, staleStillPresent, "an entry idle past the 10-minute TTL must be evicted")
+	assert.True(t, freshStillPresent, "an entry within the 10-minute TTL must survive")
+}
+
+// The sweep runs every grpcPrincipalLimiterSweepEvery (1000) requests, not on
+// every request and not never -- verified by observing its side effect (a
+// stale entry's eventual eviction) rather than the private counter directly,
+// so an INCREMENT_DECREMENT mutant on "rl.requests++" (which would make the
+// modulo check never land on exactly 0 starting from 0) or a mutant on the
+// modulo condition itself is caught by the sweep visibly failing to run.
+func TestGRPCRateLimiter_SweepsEveryNRequests(t *testing.T) {
+	rl := &grpcRateLimiter{
+		rps:      rate.Limit(1000),
+		burst:    1000,
+		limiters: make(map[string]*grpcPrincipalBucket),
+	}
+	rl.limiters["stale"] = &grpcPrincipalBucket{lastSeen: time.Now().Add(-11 * time.Minute)}
+
+	for i := 0; i < grpcPrincipalLimiterSweepEvery-1; i++ {
+		rl.allow("churn")
+	}
+	rl.mu.Lock()
+	_, stillPresentBeforeSweep := rl.limiters["stale"]
+	rl.mu.Unlock()
+	require.True(t, stillPresentBeforeSweep, "the sweep must not run before the Nth request")
+
+	rl.allow("churn") // the Nth request
+	rl.mu.Lock()
+	_, presentAfterSweep := rl.limiters["stale"]
+	rl.mu.Unlock()
+	assert.False(t, presentAfterSweep, "the sweep must run on exactly the Nth request and evict the stale entry")
+}

--- a/server/http/handlers/admin_billing.go
+++ b/server/http/handlers/admin_billing.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/license"
 )
 
 // AdminBillingHandler serves GET /api/v1/admin/billing/report.
@@ -75,6 +76,15 @@ func (h *AdminBillingHandler) GetBillingReport(w http.ResponseWriter, r *http.Re
 			}
 			projectIDs = append(projectIDs, uint(n))
 		}
+	}
+
+	// Checked here (not just inside core.GenerateBillingReport) so the client gets a
+	// distinguishable 403 "license required" response instead of the generic 500
+	// clientSafe() masks every other error behind — a caller building a billing UI
+	// needs to tell "not licensed" apart from "server broke" to render correctly.
+	if !h.coreService.HasLicensedFeature(license.FeatureBilling) {
+		sendError(w, "Forbidden", "FinOps billing reports require a commercial license (feature: billing)", http.StatusForbidden, nil)
+		return
 	}
 
 	report, err := h.coreService.GenerateBillingReport(r.Context(), from, to, projectIDs)

--- a/server/http/handlers/admin_billing_test.go
+++ b/server/http/handlers/admin_billing_test.go
@@ -1,0 +1,142 @@
+package handlers
+
+import (
+	"crypto/ed25519"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/license"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/internal/trust"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newBillingTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.SecretNode{}, &models.AuditEvent{}))
+	return db
+}
+
+func licensedBillingCore(t *testing.T, db *gorm.DB) *core.KeyorixCore {
+	t.Helper()
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeLicense, "license-2026", pub))
+	token, err := license.Issue(license.License{
+		Licensee: "ACME GmbH", Plan: "enterprise",
+		Features: []string{license.FeatureBilling},
+		IssuedAt: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(365 * 24 * time.Hour),
+		KeyID: "license-2026",
+	}, priv)
+	require.NoError(t, err)
+	c.SetLicenseGate(license.NewGate(token, reg, "", 0))
+	return c
+}
+
+func billingReportURL(from, to, projectID string) string {
+	u := "/api/v1/admin/billing/report?from=" + from + "&to=" + to
+	if projectID != "" {
+		u += "&project_id=" + projectID
+	}
+	return u
+}
+
+func TestAdminBillingHandler_MissingFromParam(t *testing.T) {
+	db := newBillingTestDB(t)
+	h := NewAdminBillingHandler(licensedBillingCore(t, db))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/billing/report?to=2026-02-01T00:00:00Z", nil)
+	w := httptest.NewRecorder()
+	h.GetBillingReport(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminBillingHandler_MissingToParam(t *testing.T) {
+	db := newBillingTestDB(t)
+	h := NewAdminBillingHandler(licensedBillingCore(t, db))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/billing/report?from=2026-01-01T00:00:00Z", nil)
+	w := httptest.NewRecorder()
+	h.GetBillingReport(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminBillingHandler_InvalidFromParam(t *testing.T) {
+	db := newBillingTestDB(t)
+	h := NewAdminBillingHandler(licensedBillingCore(t, db))
+
+	req := httptest.NewRequest(http.MethodGet, billingReportURL("not-a-date", "2026-02-01T00:00:00Z", ""), nil)
+	w := httptest.NewRecorder()
+	h.GetBillingReport(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminBillingHandler_InvalidProjectID(t *testing.T) {
+	db := newBillingTestDB(t)
+	h := NewAdminBillingHandler(licensedBillingCore(t, db))
+
+	req := httptest.NewRequest(http.MethodGet,
+		billingReportURL("2026-01-01T00:00:00Z", "2026-02-01T00:00:00Z", "abc"), nil)
+	w := httptest.NewRecorder()
+	h.GetBillingReport(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestAdminBillingHandler_Unlicensed asserts the license gate is checked BEFORE
+// the report is generated, and returns a distinguishable 403 — not the generic
+// 500 clientSafe() masks every other error behind. A billing UI needs to tell
+// "not licensed" apart from "server broke" to render correctly.
+func TestAdminBillingHandler_Unlicensed(t *testing.T) {
+	db := newBillingTestDB(t)
+	// No SetLicenseGate call: nil gate → HasLicensedFeature is always false.
+	h := NewAdminBillingHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := httptest.NewRequest(http.MethodGet,
+		billingReportURL("2026-01-01T00:00:00Z", "2026-02-01T00:00:00Z", ""), nil)
+	w := httptest.NewRecorder()
+	h.GetBillingReport(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "commercial license")
+}
+
+func TestAdminBillingHandler_Licensed_ReturnsReport(t *testing.T) {
+	db := newBillingTestDB(t)
+	require.NoError(t, db.Create(&models.Project{Name: "acme-prod"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{Name: "db-password", ProjectID: 1, IsSecret: true}).Error)
+
+	inWindow := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	success := true
+	projectID := uint(1)
+	userID := uint(7)
+	require.NoError(t, db.Create(&models.AuditEvent{
+		ProjectID: &projectID, EventType: "secret.read", Success: &success, ActorType: "user",
+		UserID: &userID, EventTime: inWindow,
+	}).Error)
+
+	h := NewAdminBillingHandler(licensedBillingCore(t, db))
+	req := httptest.NewRequest(http.MethodGet,
+		billingReportURL("2026-01-01T00:00:00Z", "2026-02-01T00:00:00Z", ""), nil)
+	w := httptest.NewRecorder()
+	h.GetBillingReport(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "acme-prod")
+	assert.Contains(t, body, `"secret_reads":1`)
+	assert.Contains(t, body, `"secret_count":1`)
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -89,6 +89,7 @@ const AuthenticationPage = React.lazy(() =>
 const EncryptionPage = React.lazy(() =>
     import('./pages/settings/EncryptionPage').then((m) => ({ default: m.EncryptionPage }))
 );
+const LicensePage = React.lazy(() => import('./pages/settings/LicensePage').then((m) => ({ default: m.LicensePage })));
 const CompliancePage = React.lazy(() =>
     import('./pages/compliance/CompliancePage').then((m) => ({ default: m.CompliancePage }))
 );
@@ -248,6 +249,14 @@ function App() {
                                                     element={
                                                         <AdminRoute>
                                                             <EncryptionPage />
+                                                        </AdminRoute>
+                                                    }
+                                                />
+                                                <Route
+                                                    path={ROUTES.SETTINGS_LICENSE}
+                                                    element={
+                                                        <AdminRoute>
+                                                            <LicensePage />
                                                         </AdminRoute>
                                                     }
                                                 />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,6 +56,7 @@ const SharingManagementPage = React.lazy(() =>
 const ProfilePage = React.lazy(() => import('./pages/profile').then((m) => ({ default: m.ProfilePage })));
 
 const AdminPage = React.lazy(() => import('./pages/admin/AdminPage').then((m) => ({ default: m.AdminPage })));
+const BillingPage = React.lazy(() => import('./pages/billing/BillingPage').then((m) => ({ default: m.BillingPage })));
 const UserDetailPage = React.lazy(() =>
     import('./pages/admin/UserDetailPage').then((m) => ({ default: m.UserDetailPage }))
 );
@@ -166,6 +167,14 @@ function App() {
                                                     element={
                                                         <AdminRoute>
                                                             <AdminPage />
+                                                        </AdminRoute>
+                                                    }
+                                                />
+                                                <Route
+                                                    path={ROUTES.ADMIN_BILLING}
+                                                    element={
+                                                        <AdminRoute>
+                                                            <BillingPage />
                                                         </AdminRoute>
                                                     }
                                                 />

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
     ScaleIcon,
     RocketLaunchIcon,
     ShareIcon,
+    BanknotesIcon,
 } from '@heroicons/react/24/outline';
 import { useUIStore } from '../../store/uiStore';
 import { useAuth } from '../../features/auth';
@@ -117,6 +118,13 @@ const NAV: NavItem[] = [
         name: 'Compliance',
         href: '/compliance',
         icon: ScaleIcon,
+    },
+    {
+        kind: 'leaf',
+        name: 'Billing',
+        href: '/admin/billing',
+        icon: BanknotesIcon,
+        adminOnly: true,
     },
     {
         kind: 'leaf',

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -141,6 +141,7 @@ const NAV: NavItem[] = [
             { kind: 'leaf', name: 'Appearance', href: '/settings/appearance' },
             { kind: 'leaf', name: 'Authentication', href: '/settings/auth', adminOnly: true },
             { kind: 'leaf', name: 'Encryption & Keys', href: '/settings/encryption', adminOnly: true },
+            { kind: 'leaf', name: 'License', href: '/settings/license', adminOnly: true },
             { kind: 'leaf', name: 'System Health', href: '/settings/health', adminOnly: true },
         ],
     },

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -82,6 +82,7 @@ export const ROUTES = {
     SECURITY: '/security',
     AUDIT: '/audit',
     ADMIN: '/admin',
+    ADMIN_BILLING: '/admin/billing',
     ADMIN_USERS: '/admin/users',
     ADMIN_USER_DETAIL: (id: number | string) => `/admin/users/${id}`,
     ADMIN_ROLES: '/admin/roles',

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -94,6 +94,7 @@ export const ROUTES = {
     SETTINGS_AUTH: '/settings/auth',
     SETTINGS_ENCRYPTION: '/settings/encryption',
     SETTINGS_HEALTH: '/settings/health',
+    SETTINGS_LICENSE: '/settings/license',
     ROADMAP: '/roadmap',
 } as const;
 

--- a/web/src/features/billing/index.ts
+++ b/web/src/features/billing/index.ts
@@ -1,0 +1,1 @@
+export { useBillingReport } from './useBillingReport';

--- a/web/src/features/billing/useBillingReport.ts
+++ b/web/src/features/billing/useBillingReport.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { billingApi, BillingLicenseRequiredError, type BillingReportParams } from '../../services/billing';
+
+// useBillingReport wraps GET /api/v1/admin/billing/report. retry:false because
+// the two failure modes that matter here (no billing license, no system.read
+// permission) are both permanent for the current session — retrying a 403
+// three times before the page can render its explanation just delays it.
+export function useBillingReport(params: BillingReportParams) {
+    const { data, isLoading, isError, error } = useQuery({
+        queryKey: ['billing', 'report', params.from, params.to, params.projectIds],
+        queryFn: () => billingApi.getReport(params),
+        staleTime: 60_000,
+        retry: false,
+    });
+
+    return {
+        report: data,
+        isLoading,
+        isError,
+        error,
+        isLicenseRequired: error instanceof BillingLicenseRequiredError,
+    };
+}

--- a/web/src/features/license/index.ts
+++ b/web/src/features/license/index.ts
@@ -1,0 +1,1 @@
+export { useLicenseStatus } from './useLicenseStatus';

--- a/web/src/features/license/useLicenseStatus.ts
+++ b/web/src/features/license/useLicenseStatus.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { licenseApi } from '../../services/license';
+
+export function useLicenseStatus() {
+    return useQuery({
+        queryKey: ['license', 'status'],
+        queryFn: () => licenseApi.getStatus(),
+        staleTime: 5 * 60 * 1000,
+    });
+}

--- a/web/src/pages/billing/BillingPage.tsx
+++ b/web/src/pages/billing/BillingPage.tsx
@@ -1,0 +1,302 @@
+import React, { useMemo, useState } from 'react';
+import { BanknotesIcon, LockClosedIcon } from '@heroicons/react/24/outline';
+import { useBillingReport } from '../../features/billing';
+import type { BillingProjectStat } from '../../services/billing';
+
+// ── date-range presets ──────────────────────────────────────────────────────
+
+type PresetKey = 'this-month' | 'last-month' | 'last-30' | 'last-90' | 'custom';
+
+const PRESETS: { key: PresetKey; label: string }[] = [
+    { key: 'this-month', label: 'This month' },
+    { key: 'last-month', label: 'Last month' },
+    { key: 'last-30', label: 'Last 30 days' },
+    { key: 'last-90', label: 'Last 90 days' },
+];
+
+const toDateInput = (d: Date): string => d.toISOString().slice(0, 10);
+
+// presetRange returns the [from, to) window for a preset, as Date objects at
+// UTC midnight — "to" is exclusive (matches the server's half-open interval).
+function presetRange(key: Exclude<PresetKey, 'custom'>, now: Date): { from: Date; to: Date } {
+    const startOfUTCDay = (d: Date) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+    const today = startOfUTCDay(now);
+    switch (key) {
+        case 'this-month':
+            return { from: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)), to: today };
+        case 'last-month': {
+            const from = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1));
+            const to = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+            return { from, to };
+        }
+        case 'last-30':
+            return { from: new Date(today.getTime() - 30 * 86_400_000), to: today };
+        case 'last-90':
+            return { from: new Date(today.getTime() - 90 * 86_400_000), to: today };
+    }
+}
+
+// ── small presentational pieces ─────────────────────────────────────────────
+
+const Tile: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+    <div
+        className="rounded-lg border px-4 py-3"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-app)' }}
+    >
+        <div className="text-xl font-semibold tabular-nums" style={{ color: 'var(--text-primary)' }}>
+            {value}
+        </div>
+        <div className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
+            {label}
+        </div>
+    </div>
+);
+
+const skeletonPlaceholder = (): React.ReactElement => (
+    <div
+        className="rounded-xl border p-6"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-surface)' }}
+    >
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+            {[1, 2, 3, 4].map((i) => (
+                <div key={i} className="h-16 rounded-lg animate-pulse" style={{ backgroundColor: 'var(--bg-muted)' }} />
+            ))}
+        </div>
+        <div className="h-48 rounded-lg animate-pulse" style={{ backgroundColor: 'var(--bg-muted)' }} />
+    </div>
+);
+
+const LicenseRequiredNotice: React.FC = () => (
+    <div
+        className="rounded-xl border p-8 text-center"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-surface)' }}
+    >
+        <LockClosedIcon className="h-8 w-8 mx-auto mb-3" style={{ color: 'var(--text-muted)' }} />
+        <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            FinOps billing reports are a commercial feature
+        </p>
+        <p className="text-sm mt-1 max-w-md mx-auto" style={{ color: 'var(--text-muted)' }}>
+            Per-project usage and chargeback reporting requires a Keyorix commercial license with the billing feature
+            enabled. Contact your Keyorix representative to enable it.
+        </p>
+    </div>
+);
+
+const GenericErrorNotice: React.FC<{ message: string }> = ({ message }) => (
+    <div
+        className="rounded-xl border p-6 text-sm text-center"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-surface)', color: 'var(--text-muted)' }}
+    >
+        {message}
+    </div>
+);
+
+// ── project table ────────────────────────────────────────────────────────
+
+const fmt = (n: number) => n.toLocaleString();
+
+const ProjectTable: React.FC<{ projects: BillingProjectStat[] }> = ({ projects }) => {
+    if (projects.length === 0) {
+        return (
+            <div className="py-10 text-center text-sm" style={{ color: 'var(--text-muted)' }}>
+                No secrets or activity recorded for any project in this window.
+            </div>
+        );
+    }
+    const sorted = [...projects].sort((a, b) => b.secretReads - a.secretReads);
+    return (
+        <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+                <thead>
+                    <tr className="text-left border-b" style={{ borderColor: 'var(--border)' }}>
+                        {['Project', 'Secrets', 'Reads', 'Writes', 'Rotations', 'Unique users', 'Machine reads'].map(
+                            (h, i) => (
+                                <th
+                                    key={h}
+                                    className={`py-2 px-3 text-xs font-semibold uppercase tracking-wider ${i > 0 ? 'text-right' : ''}`}
+                                    style={{ color: 'var(--text-muted)' }}
+                                >
+                                    {h}
+                                </th>
+                            )
+                        )}
+                    </tr>
+                </thead>
+                <tbody className="divide-y" style={{ borderColor: 'var(--border)' }}>
+                    {sorted.map((p) => (
+                        <tr key={p.projectId}>
+                            <td
+                                className="py-2 px-3 font-medium truncate max-w-[220px]"
+                                style={{ color: 'var(--text-primary)' }}
+                            >
+                                {p.projectName || `(project ${p.projectId})`}
+                            </td>
+                            <td
+                                className="py-2 px-3 text-right tabular-nums"
+                                style={{ color: 'var(--text-secondary)' }}
+                            >
+                                {fmt(p.secretCount)}
+                            </td>
+                            <td
+                                className="py-2 px-3 text-right tabular-nums"
+                                style={{ color: 'var(--text-secondary)' }}
+                            >
+                                {fmt(p.secretReads)}
+                            </td>
+                            <td
+                                className="py-2 px-3 text-right tabular-nums"
+                                style={{ color: 'var(--text-secondary)' }}
+                            >
+                                {fmt(p.secretWrites)}
+                            </td>
+                            <td
+                                className="py-2 px-3 text-right tabular-nums"
+                                style={{ color: 'var(--text-secondary)' }}
+                            >
+                                {fmt(p.secretRotations)}
+                            </td>
+                            <td
+                                className="py-2 px-3 text-right tabular-nums"
+                                style={{ color: 'var(--text-secondary)' }}
+                            >
+                                {fmt(p.uniqueUsers)}
+                            </td>
+                            <td
+                                className="py-2 px-3 text-right tabular-nums"
+                                style={{ color: 'var(--text-secondary)' }}
+                            >
+                                {fmt(p.machineReads)}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+// ── page ─────────────────────────────────────────────────────────────────
+
+export const BillingPage: React.FC = () => {
+    const now = useMemo(() => new Date(), []);
+    const [preset, setPreset] = useState<PresetKey>('this-month');
+    const [customFrom, setCustomFrom] = useState(() => toDateInput(presetRange('last-30', now).from));
+    const [customTo, setCustomTo] = useState(() => toDateInput(presetRange('last-30', now).to));
+
+    const { from, to } = useMemo(() => {
+        if (preset === 'custom') {
+            return { from: `${customFrom}T00:00:00Z`, to: `${customTo}T00:00:00Z` };
+        }
+        const range = presetRange(preset, now);
+        return { from: range.from.toISOString(), to: range.to.toISOString() };
+    }, [preset, customFrom, customTo, now]);
+
+    const { report, isLoading, isError, error, isLicenseRequired } = useBillingReport({ from, to });
+
+    const onCustomDateChange = (which: 'from' | 'to', value: string) => {
+        setPreset('custom');
+        if (which === 'from') setCustomFrom(value);
+        else setCustomTo(value);
+    };
+
+    return (
+        <div className="max-w-5xl mx-auto px-6 py-8">
+            <div className="mb-6 flex items-start justify-between gap-4 flex-wrap">
+                <div>
+                    <h1
+                        className="text-2xl font-bold tracking-tight flex items-center gap-2"
+                        style={{ color: 'var(--text-primary)' }}
+                    >
+                        <BanknotesIcon className="h-6 w-6" style={{ color: 'var(--text-muted)' }} />
+                        Billing
+                    </h1>
+                    <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
+                        Per-project secret counts and activity for chargeback and usage reporting.
+                    </p>
+                </div>
+            </div>
+
+            {/* Date range controls */}
+            <div className="mb-6 flex flex-wrap items-center gap-2">
+                <div className="inline-flex rounded-lg border overflow-hidden" style={{ borderColor: 'var(--border)' }}>
+                    {PRESETS.map((p) => (
+                        <button
+                            key={p.key}
+                            type="button"
+                            onClick={() => setPreset(p.key)}
+                            className="px-3 py-1.5 text-sm font-medium transition-colors"
+                            style={{
+                                backgroundColor: preset === p.key ? 'var(--accent)' : 'var(--bg-surface)',
+                                color: preset === p.key ? 'var(--accent-contrast, #fff)' : 'var(--text-secondary)',
+                            }}
+                        >
+                            {p.label}
+                        </button>
+                    ))}
+                </div>
+                <div className="flex items-center gap-2 text-sm" style={{ color: 'var(--text-muted)' }}>
+                    <input
+                        type="date"
+                        value={customFrom}
+                        onChange={(e) => onCustomDateChange('from', e.target.value)}
+                        aria-label="From date"
+                        className="rounded-lg px-2.5 py-1.5 text-sm outline-hidden"
+                        style={{
+                            backgroundColor: 'var(--bg-app)',
+                            border: '1px solid var(--border)',
+                            color: 'var(--text-primary)',
+                        }}
+                    />
+                    <span>–</span>
+                    <input
+                        type="date"
+                        value={customTo}
+                        onChange={(e) => onCustomDateChange('to', e.target.value)}
+                        aria-label="To date"
+                        className="rounded-lg px-2.5 py-1.5 text-sm outline-hidden"
+                        style={{
+                            backgroundColor: 'var(--bg-app)',
+                            border: '1px solid var(--border)',
+                            color: 'var(--text-primary)',
+                        }}
+                    />
+                </div>
+            </div>
+
+            {isLoading && skeletonPlaceholder()}
+
+            {!isLoading && isError && isLicenseRequired && <LicenseRequiredNotice />}
+            {!isLoading && isError && !isLicenseRequired && (
+                <GenericErrorNotice
+                    message={
+                        (error as any)?.response?.status === 403
+                            ? 'Billing reports are available to administrators (system.read).'
+                            : 'Could not load the billing report. Try again shortly.'
+                    }
+                />
+            )}
+
+            {!isLoading && !isError && report && (
+                <div
+                    className="rounded-xl border overflow-hidden"
+                    style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-surface)' }}
+                >
+                    <div className="px-6 py-4 border-b" style={{ borderColor: 'var(--border)' }}>
+                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                            <Tile label="Projects" value={fmt(report.totals.projects)} />
+                            <Tile label="Secrets" value={fmt(report.totals.secretCount)} />
+                            <Tile label="Reads" value={fmt(report.totals.secretReads)} />
+                            <Tile label="Writes" value={fmt(report.totals.secretWrites)} />
+                            <Tile label="Rotations" value={fmt(report.totals.secretRotations)} />
+                            <Tile label="Unique users" value={fmt(report.totals.uniqueUsers)} />
+                            <Tile label="Machine reads" value={fmt(report.totals.machineReads)} />
+                        </div>
+                    </div>
+                    <div className="px-2 py-2">
+                        <ProjectTable projects={report.projects} />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/web/src/pages/billing/__tests__/BillingPage.test.tsx
+++ b/web/src/pages/billing/__tests__/BillingPage.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '../../../test/test-utils';
+import { BillingPage } from '../BillingPage';
+import type { BillingReport } from '../../../services/billing';
+
+const { useBillingReportMock } = vi.hoisted(() => ({ useBillingReportMock: vi.fn() }));
+
+vi.mock('../../../features/billing', () => ({
+    useBillingReport: (params: unknown) => useBillingReportMock(params),
+}));
+
+function defaultState() {
+    return {
+        report: undefined as BillingReport | undefined,
+        isLoading: false,
+        isError: false,
+        error: null as unknown,
+        isLicenseRequired: false,
+    };
+}
+
+const reportState = (overrides?: Partial<ReturnType<typeof defaultState>>) => ({
+    ...defaultState(),
+    ...overrides,
+});
+
+const sampleReport = (): BillingReport => ({
+    from: '2026-01-01T00:00:00Z',
+    to: '2026-02-01T00:00:00Z',
+    generatedAt: '2026-02-01T00:00:00Z',
+    totals: {
+        projects: 2,
+        secretCount: 12,
+        secretReads: 340,
+        secretWrites: 20,
+        secretRotations: 3,
+        uniqueUsers: 5,
+        machineReads: 100,
+    },
+    projects: [
+        {
+            projectId: 1,
+            projectName: 'acme-prod',
+            secretCount: 8,
+            secretReads: 300,
+            secretWrites: 15,
+            secretRotations: 2,
+            uniqueUsers: 4,
+            machineReads: 90,
+        },
+        {
+            projectId: 2,
+            projectName: 'acme-staging',
+            secretCount: 4,
+            secretReads: 40,
+            secretWrites: 5,
+            secretRotations: 1,
+            uniqueUsers: 2,
+            machineReads: 10,
+        },
+    ],
+});
+
+beforeEach(() => {
+    useBillingReportMock.mockReset();
+    useBillingReportMock.mockReturnValue(reportState());
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-15T12:00:00.000Z'));
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('BillingPage', () => {
+    it('shows a loading skeleton while the report is loading', () => {
+        useBillingReportMock.mockReturnValue(reportState({ isLoading: true }));
+        const { container } = render(<BillingPage />);
+
+        expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
+        expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+
+    it('shows the commercial-license notice when the report is license-gated', () => {
+        useBillingReportMock.mockReturnValue(
+            reportState({ isError: true, error: new Error('license'), isLicenseRequired: true })
+        );
+        render(<BillingPage />);
+
+        expect(screen.getByText('FinOps billing reports are a commercial feature')).toBeInTheDocument();
+        expect(screen.queryByText(/administrators \(system\.read\)/)).not.toBeInTheDocument();
+    });
+
+    it('shows a permission-specific message on a non-license 403', () => {
+        useBillingReportMock.mockReturnValue(
+            reportState({
+                isError: true,
+                error: { response: { status: 403 } },
+                isLicenseRequired: false,
+            })
+        );
+        render(<BillingPage />);
+
+        expect(screen.getByText('Billing reports are available to administrators (system.read).')).toBeInTheDocument();
+        expect(screen.queryByText('FinOps billing reports are a commercial feature')).not.toBeInTheDocument();
+    });
+
+    it('shows a generic message for a non-403 error', () => {
+        useBillingReportMock.mockReturnValue(
+            reportState({ isError: true, error: new Error('boom'), isLicenseRequired: false })
+        );
+        render(<BillingPage />);
+
+        expect(screen.getByText('Could not load the billing report. Try again shortly.')).toBeInTheDocument();
+    });
+
+    it('renders totals and a per-project table sorted by reads descending', () => {
+        useBillingReportMock.mockReturnValue(reportState({ report: sampleReport() }));
+        render(<BillingPage />);
+
+        expect(screen.getByText('340')).toBeInTheDocument(); // totals.secretReads
+        expect(screen.getByText('12')).toBeInTheDocument(); // totals.secretCount
+
+        const rows = screen.getAllByRole('row').slice(1); // drop header row
+        expect(rows[0]).toHaveTextContent('acme-prod');
+        expect(rows[1]).toHaveTextContent('acme-staging');
+    });
+
+    it('shows the empty state when the report has no project activity', () => {
+        useBillingReportMock.mockReturnValue(
+            reportState({
+                report: { ...sampleReport(), projects: [], totals: { ...sampleReport().totals, projects: 0 } },
+            })
+        );
+        render(<BillingPage />);
+
+        expect(screen.getByText('No secrets or activity recorded for any project in this window.')).toBeInTheDocument();
+    });
+
+    it('defaults to the "This month" preset and recomputes the window on preset change', () => {
+        render(<BillingPage />);
+
+        const firstCall = useBillingReportMock.mock.calls[0][0];
+        expect(firstCall.from).toBe(new Date(Date.UTC(2026, 1, 1)).toISOString());
+        expect(firstCall.to).toBe(new Date(Date.UTC(2026, 1, 15)).toISOString());
+
+        fireEvent.click(screen.getByRole('button', { name: 'Last 30 days' }));
+
+        const lastCall = useBillingReportMock.mock.calls[useBillingReportMock.mock.calls.length - 1][0];
+        expect(lastCall.from).toBe(new Date(Date.UTC(2026, 1, 15) - 30 * 86_400_000).toISOString());
+        expect(lastCall.to).toBe(new Date(Date.UTC(2026, 1, 15)).toISOString());
+    });
+
+    it('switches to a custom range when a date input is edited directly', () => {
+        render(<BillingPage />);
+
+        fireEvent.change(screen.getByLabelText('From date'), { target: { value: '2026-01-05' } });
+
+        const lastCall = useBillingReportMock.mock.calls[useBillingReportMock.mock.calls.length - 1][0];
+        expect(lastCall.from).toBe('2026-01-05T00:00:00Z');
+    });
+});

--- a/web/src/pages/settings/LicensePage.tsx
+++ b/web/src/pages/settings/LicensePage.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { useLicenseStatus } from '../../features/license';
+import { Spinner } from '../../components/ui';
+import type { LicenseState } from '../../services/license';
+
+// Friendly labels for known commercial feature keys (internal/license/features.go).
+// Falls back to the raw key for a feature this build doesn't recognize yet, so an
+// unmapped future feature still renders instead of disappearing.
+const FEATURE_LABELS: Record<string, string> = {
+    airgap_updates: 'Air-gap update bundles',
+    billing: 'FinOps billing reports',
+};
+
+const STATE_META: Record<LicenseState, { label: string; color: string; bg: string }> = {
+    active: { label: 'Active', color: 'var(--success)', bg: 'var(--success-subtle)' },
+    expiring_soon: { label: 'Expiring soon', color: 'var(--warning)', bg: 'var(--warning-subtle)' },
+    expired: { label: 'Expired', color: 'var(--error)', bg: 'var(--error-subtle)' },
+    invalid: { label: 'Invalid', color: 'var(--error)', bg: 'var(--error-subtle)' },
+    none: { label: 'Community baseline', color: 'var(--text-muted)', bg: 'var(--bg-muted)' },
+};
+
+interface SectionProps {
+    title: string;
+    note?: string;
+    children: React.ReactNode;
+}
+
+const Section: React.FC<SectionProps> = ({ title, note, children }) => (
+    <div
+        className="rounded-xl border overflow-hidden mb-6"
+        style={{ borderColor: 'var(--border)', backgroundColor: 'var(--bg-surface)' }}
+    >
+        <div className="px-6 py-4 border-b" style={{ borderColor: 'var(--border)' }}>
+            <h2 className="text-sm font-semibold uppercase tracking-widest" style={{ color: 'var(--text-muted)' }}>
+                {title}
+            </h2>
+        </div>
+        <div className="px-6 py-5 space-y-3">
+            {children}
+            {note && (
+                <p className="text-xs pt-1" style={{ color: 'var(--text-muted)' }}>
+                    {note}
+                </p>
+            )}
+        </div>
+    </div>
+);
+
+const Row: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+    <div className="flex items-center justify-between gap-4">
+        <span className="text-sm" style={{ color: 'var(--text-muted)' }}>
+            {label}
+        </span>
+        <span className="text-sm font-medium text-right" style={{ color: 'var(--text-primary)' }}>
+            {value}
+        </span>
+    </div>
+);
+
+const StateBadge: React.FC<{ state: LicenseState }> = ({ state }) => {
+    const meta = STATE_META[state] ?? STATE_META.none;
+    return (
+        <span
+            className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+            style={{ color: meta.color, backgroundColor: meta.bg }}
+        >
+            {meta.label}
+        </span>
+    );
+};
+
+// Pinned to en-US/UTC rather than the browser's locale/timezone — this is an
+// ops-facing entitlement date, and a stable rendering (independent of which
+// admin's machine is viewing it) matters more than localization here.
+const formatExpiry = (iso: string): string => {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '—';
+    return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' });
+};
+
+// ReasonBanner surfaces why the entitlement is degraded (expiring, expired, invalid,
+// or no license installed) — mirrors the admin warning the server itself logs at
+// startup. Hidden for a healthy Active license (Reason is empty).
+const ReasonBanner: React.FC<{ state: LicenseState; reason: string }> = ({ state, reason }) => {
+    if (!reason) return null;
+    const tone = state === 'expiring_soon' ? 'warn' : 'error';
+    return (
+        <div
+            className="rounded-xl border mb-6 px-4 py-3 text-sm"
+            style={
+                tone === 'warn'
+                    ? {
+                          borderColor: 'var(--warning)',
+                          backgroundColor: 'var(--warning-subtle)',
+                          color: 'var(--warning)',
+                      }
+                    : { borderColor: 'var(--error)', backgroundColor: 'var(--error-subtle)', color: 'var(--error)' }
+            }
+        >
+            {reason}
+        </div>
+    );
+};
+
+export const LicensePage: React.FC = () => {
+    const { data: license, isLoading, isError } = useLicenseStatus();
+
+    return (
+        <div className="max-w-2xl mx-auto px-6 py-8">
+            <div className="mb-8">
+                <h1 className="text-2xl font-bold tracking-tight" style={{ color: 'var(--text-primary)' }}>
+                    License
+                </h1>
+                <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
+                    The commercial license entitlement evaluated locally for this Keyorix server — read-only. Install or
+                    renew a license by running <code>keyorix license install</code> on the server host.
+                </p>
+            </div>
+
+            {isLoading && (
+                <div className="flex justify-center py-12">
+                    <Spinner />
+                </div>
+            )}
+
+            {!isLoading && isError && (
+                <div
+                    className="rounded-xl border px-6 py-8 text-center text-sm"
+                    style={{
+                        borderColor: 'var(--border)',
+                        backgroundColor: 'var(--bg-surface)',
+                        color: 'var(--text-muted)',
+                    }}
+                >
+                    Unable to load license status. This page requires administrator access, or the server may be
+                    unreachable.
+                </div>
+            )}
+
+            {!isLoading && !isError && license && (
+                <>
+                    <ReasonBanner state={license.state} reason={license.reason} />
+
+                    <Section title="Entitlement">
+                        <Row label="Status" value={<StateBadge state={license.state} />} />
+                        <Row label="Licensee" value={license.licensee || '—'} />
+                        <Row label="Plan" value={license.plan || '—'} />
+                        <Row label="Expires" value={formatExpiry(license.expiresAt)} />
+                        {license.maxSeats > 0 && <Row label="Max seats" value={license.maxSeats} />}
+                    </Section>
+
+                    <Section
+                        title="Granted features"
+                        note="A feature listed here is unlocked only while the entitlement above is Active or Expiring soon — a lapsed or invalid license degrades to the community baseline everywhere the feature is checked."
+                    >
+                        {license.features.length === 0 ? (
+                            <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                                No commercial features granted — running the community baseline.
+                            </p>
+                        ) : (
+                            <div className="flex flex-wrap gap-2">
+                                {license.features.map((f) => (
+                                    <span
+                                        key={f}
+                                        className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium"
+                                        style={{ color: 'var(--accent-text)', backgroundColor: 'var(--accent-subtle)' }}
+                                    >
+                                        {FEATURE_LABELS[f] ?? f}
+                                    </span>
+                                ))}
+                            </div>
+                        )}
+                    </Section>
+                </>
+            )}
+        </div>
+    );
+};

--- a/web/src/pages/settings/__tests__/LicensePage.test.tsx
+++ b/web/src/pages/settings/__tests__/LicensePage.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '../../../test/test-utils';
+import { LicensePage } from '../LicensePage';
+
+const useLicenseStatus = vi.fn();
+
+vi.mock('../../../features/license', () => ({
+    useLicenseStatus: (...args: any[]) => useLicenseStatus(...args),
+}));
+
+const activeLicense = {
+    state: 'active' as const,
+    licensee: 'ACME GmbH',
+    plan: 'enterprise',
+    features: ['billing', 'airgap_updates'],
+    grants: true,
+    expiresAt: '2027-01-01T00:00:00Z',
+    maxSeats: 50,
+    reason: '',
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    useLicenseStatus.mockReturnValue({ data: activeLicense, isLoading: false, isError: false });
+});
+
+describe('LicensePage — loading and error states', () => {
+    it('shows a spinner while data is loading', () => {
+        useLicenseStatus.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+        render(<LicensePage />);
+        expect(document.querySelector('.animate-spin')).toBeTruthy();
+    });
+
+    it('shows an error message when the fetch fails', () => {
+        useLicenseStatus.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+        render(<LicensePage />);
+        expect(screen.getByText(/Unable to load license status/)).toBeInTheDocument();
+    });
+});
+
+describe('LicensePage — success state', () => {
+    it('shows the entitlement details for an active license', () => {
+        render(<LicensePage />);
+        expect(screen.getByText('Active')).toBeInTheDocument();
+        expect(screen.getByText('ACME GmbH')).toBeInTheDocument();
+        expect(screen.getByText('enterprise')).toBeInTheDocument();
+        expect(screen.getByText('January 1, 2027')).toBeInTheDocument();
+        expect(screen.getByText('50')).toBeInTheDocument();
+    });
+
+    it('renders friendly labels for known feature keys', () => {
+        render(<LicensePage />);
+        expect(screen.getByText('FinOps billing reports')).toBeInTheDocument();
+        expect(screen.getByText('Air-gap update bundles')).toBeInTheDocument();
+    });
+
+    it('falls back to the raw key for an unrecognized feature', () => {
+        useLicenseStatus.mockReturnValue({
+            data: { ...activeLicense, features: ['some_future_feature'] },
+            isLoading: false,
+            isError: false,
+        });
+        render(<LicensePage />);
+        expect(screen.getByText('some_future_feature')).toBeInTheDocument();
+    });
+
+    it('does not show a reason banner for a healthy active license', () => {
+        render(<LicensePage />);
+        // The page's own static help text mentions "renew" too, so assert on the
+        // absence of an actual reason message rather than that word alone.
+        expect(
+            screen.queryByText(/license expires on|license expired on|no license installed/i)
+        ).not.toBeInTheDocument();
+    });
+
+    it('hides the max-seats row when unset', () => {
+        useLicenseStatus.mockReturnValue({
+            data: { ...activeLicense, maxSeats: 0 },
+            isLoading: false,
+            isError: false,
+        });
+        render(<LicensePage />);
+        expect(screen.queryByText('Max seats')).not.toBeInTheDocument();
+    });
+
+    it('shows the community-baseline empty state when no features are granted', () => {
+        useLicenseStatus.mockReturnValue({
+            data: {
+                state: 'none',
+                licensee: '',
+                plan: '',
+                features: [],
+                grants: false,
+                expiresAt: '',
+                maxSeats: 0,
+                reason: 'no license installed — running the community baseline',
+            },
+            isLoading: false,
+            isError: false,
+        });
+        render(<LicensePage />);
+        expect(screen.getByText('Community baseline')).toBeInTheDocument();
+        expect(
+            screen.getByText('No commercial features granted — running the community baseline.')
+        ).toBeInTheDocument();
+        expect(screen.getAllByText('—')).toHaveLength(3); // licensee, plan, expiry all fall back
+    });
+
+    it('shows a warning-toned reason banner for an expiring-soon license', () => {
+        useLicenseStatus.mockReturnValue({
+            data: { ...activeLicense, state: 'expiring_soon', reason: 'license expires on 2026-09-01 — renew soon' },
+            isLoading: false,
+            isError: false,
+        });
+        render(<LicensePage />);
+        expect(screen.getByText('Expiring soon')).toBeInTheDocument();
+        expect(screen.getByText('license expires on 2026-09-01 — renew soon')).toBeInTheDocument();
+    });
+
+    it('shows an error-toned reason banner for an expired license', () => {
+        useLicenseStatus.mockReturnValue({
+            data: {
+                ...activeLicense,
+                state: 'expired',
+                features: [],
+                reason: 'license expired on 2026-01-01 — running the community baseline',
+            },
+            isLoading: false,
+            isError: false,
+        });
+        render(<LicensePage />);
+        expect(screen.getByText('Expired')).toBeInTheDocument();
+        expect(screen.getByText('license expired on 2026-01-01 — running the community baseline')).toBeInTheDocument();
+    });
+});

--- a/web/src/services/__tests__/billing.test.ts
+++ b/web/src/services/__tests__/billing.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../client', () => ({
+    apiClient: {
+        get: vi.fn(),
+    },
+}));
+
+import { apiClient } from '../client';
+import { billingApi, BillingLicenseRequiredError } from '../billing';
+
+const mock = apiClient as unknown as { get: ReturnType<typeof vi.fn> };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('billingApi.getReport', () => {
+    it('normalizes a snake_case report payload and joins project_id filters', async () => {
+        mock.get.mockResolvedValueOnce({
+            data: {
+                data: {
+                    from: '2026-01-01T00:00:00Z',
+                    to: '2026-02-01T00:00:00Z',
+                    generated_at: '2026-02-01T00:00:00Z',
+                    totals: {
+                        projects: 1,
+                        secret_count: 3,
+                        secret_reads: 10,
+                        secret_writes: 2,
+                        secret_rotations: 1,
+                        unique_users: 2,
+                        machine_reads: 4,
+                    },
+                    projects: [
+                        {
+                            project_id: 5,
+                            project_name: 'acme-prod',
+                            secret_count: 3,
+                            secret_reads: 10,
+                            secret_writes: 2,
+                            secret_rotations: 1,
+                            unique_users: 2,
+                            machine_reads: 4,
+                        },
+                    ],
+                },
+            },
+        });
+
+        const report = await billingApi.getReport({
+            from: '2026-01-01T00:00:00Z',
+            to: '2026-02-01T00:00:00Z',
+            projectIds: [5, 6],
+        });
+
+        expect(mock.get).toHaveBeenCalledWith('/api/v1/admin/billing/report', {
+            params: { from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z', project_id: '5,6' },
+        });
+        expect(report.totals.secretReads).toBe(10);
+        expect(report.projects[0]).toEqual({
+            projectId: 5,
+            projectName: 'acme-prod',
+            secretCount: 3,
+            secretReads: 10,
+            secretWrites: 2,
+            secretRotations: 1,
+            uniqueUsers: 2,
+            machineReads: 4,
+        });
+    });
+
+    it('omits project_id from the query when no filter is given', async () => {
+        mock.get.mockResolvedValueOnce({ data: { data: { projects: [], totals: {} } } });
+
+        await billingApi.getReport({ from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' });
+
+        expect(mock.get).toHaveBeenCalledWith('/api/v1/admin/billing/report', {
+            params: { from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' },
+        });
+    });
+
+    it('throws BillingLicenseRequiredError on a 403 whose message mentions a license', async () => {
+        mock.get.mockRejectedValueOnce({
+            isAxiosError: true,
+            response: {
+                status: 403,
+                data: { message: 'FinOps billing reports require a commercial license (feature: billing)' },
+            },
+        });
+
+        await expect(
+            billingApi.getReport({ from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' })
+        ).rejects.toBeInstanceOf(BillingLicenseRequiredError);
+    });
+
+    it('rethrows a plain permission 403 as-is (not a license error)', async () => {
+        const err = {
+            isAxiosError: true,
+            response: { status: 403, data: { message: 'Insufficient permissions' } },
+        };
+        mock.get.mockRejectedValueOnce(err);
+
+        await expect(
+            billingApi.getReport({ from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' })
+        ).rejects.not.toBeInstanceOf(BillingLicenseRequiredError);
+    });
+
+    it('rethrows a non-403 error unchanged', async () => {
+        const err = { isAxiosError: true, response: { status: 500, data: {} } };
+        mock.get.mockRejectedValueOnce(err);
+
+        await expect(billingApi.getReport({ from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' })).rejects.toBe(
+            err
+        );
+    });
+});

--- a/web/src/services/__tests__/license.test.ts
+++ b/web/src/services/__tests__/license.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../client', () => ({
+    apiClient: {
+        get: vi.fn(),
+    },
+}));
+
+import { apiClient } from '../client';
+import { licenseApi } from '../license';
+
+const mock = apiClient as unknown as { get: ReturnType<typeof vi.fn> };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('licenseApi.getStatus', () => {
+    it('normalizes a full snake_case status payload', async () => {
+        mock.get.mockResolvedValueOnce({
+            data: {
+                data: {
+                    state: 'active',
+                    licensee: 'ACME GmbH',
+                    plan: 'enterprise',
+                    features: ['billing'],
+                    grants: true,
+                    expires_at: '2027-01-01T00:00:00Z',
+                    max_seats: 50,
+                    reason: '',
+                },
+            },
+        });
+
+        const status = await licenseApi.getStatus();
+
+        expect(mock.get).toHaveBeenCalledWith('/api/v1/license/status');
+        expect(status).toEqual({
+            state: 'active',
+            licensee: 'ACME GmbH',
+            plan: 'enterprise',
+            features: ['billing'],
+            grants: true,
+            expiresAt: '2027-01-01T00:00:00Z',
+            maxSeats: 50,
+            reason: '',
+        });
+    });
+
+    it('defaults to the community-baseline shape when fields are absent', async () => {
+        mock.get.mockResolvedValueOnce({ data: { data: { state: 'none', features: [], grants: false } } });
+
+        const status = await licenseApi.getStatus();
+
+        expect(status.licensee).toBe('');
+        expect(status.plan).toBe('');
+        expect(status.expiresAt).toBe('');
+        expect(status.maxSeats).toBe(0);
+        expect(status.features).toEqual([]);
+    });
+});

--- a/web/src/services/billing.ts
+++ b/web/src/services/billing.ts
@@ -1,0 +1,99 @@
+import axios from 'axios';
+import { apiClient } from './client';
+
+// One project's usage breakdown for a billing period, served by
+// GET /api/v1/admin/billing/report (gated by system.read + the "billing"
+// commercial license feature).
+export interface BillingProjectStat {
+    projectId: number;
+    projectName: string;
+    secretCount: number;
+    secretReads: number;
+    secretWrites: number;
+    secretRotations: number;
+    uniqueUsers: number;
+    machineReads: number;
+}
+
+export interface BillingTotals {
+    projects: number;
+    secretCount: number;
+    secretReads: number;
+    secretWrites: number;
+    secretRotations: number;
+    uniqueUsers: number;
+    machineReads: number;
+}
+
+export interface BillingReport {
+    from: string;
+    to: string;
+    generatedAt: string;
+    projects: BillingProjectStat[];
+    totals: BillingTotals;
+}
+
+const num = (v: any): number => (typeof v === 'number' ? v : 0);
+
+const normalizeProjectStat = (p: any): BillingProjectStat => ({
+    projectId: num(p.project_id ?? p.projectId),
+    projectName: p.project_name ?? p.projectName ?? '',
+    secretCount: num(p.secret_count ?? p.secretCount),
+    secretReads: num(p.secret_reads ?? p.secretReads),
+    secretWrites: num(p.secret_writes ?? p.secretWrites),
+    secretRotations: num(p.secret_rotations ?? p.secretRotations),
+    uniqueUsers: num(p.unique_users ?? p.uniqueUsers),
+    machineReads: num(p.machine_reads ?? p.machineReads),
+});
+
+const normalizeTotals = (t: any): BillingTotals => ({
+    projects: num(t?.projects),
+    secretCount: num(t?.secret_count ?? t?.secretCount),
+    secretReads: num(t?.secret_reads ?? t?.secretReads),
+    secretWrites: num(t?.secret_writes ?? t?.secretWrites),
+    secretRotations: num(t?.secret_rotations ?? t?.secretRotations),
+    uniqueUsers: num(t?.unique_users ?? t?.uniqueUsers),
+    machineReads: num(t?.machine_reads ?? t?.machineReads),
+});
+
+const normalizeReport = (d: any): BillingReport => ({
+    from: d.from ?? '',
+    to: d.to ?? '',
+    generatedAt: d.generated_at ?? d.generatedAt ?? '',
+    projects: (d.projects ?? []).map(normalizeProjectStat),
+    totals: normalizeTotals(d.totals),
+});
+
+// BillingLicenseRequiredError distinguishes "not licensed" from any other
+// failure (a plain 403 insufficient-permission, a 500). Both the license gate
+// and the permission gate return HTTP 403 with error:"Forbidden", so the only
+// way to tell them apart is the message text the server deliberately chose
+// ("... commercial license ...") — see server/http/handlers/admin_billing.go.
+export class BillingLicenseRequiredError extends Error {}
+
+export interface BillingReportParams {
+    from: string; // RFC3339
+    to: string; // RFC3339
+    projectIds?: number[];
+}
+
+export const billingApi = {
+    async getReport(params: BillingReportParams): Promise<BillingReport> {
+        const query: Record<string, string> = { from: params.from, to: params.to };
+        if (params.projectIds?.length) {
+            query.project_id = params.projectIds.join(',');
+        }
+        try {
+            const response = await apiClient.get('/api/v1/admin/billing/report', { params: query });
+            return normalizeReport(response.data.data ?? response.data);
+        } catch (err) {
+            if (axios.isAxiosError(err) && err.response?.status === 403) {
+                const message = (err.response.data as { message?: string } | undefined)?.message ?? '';
+                if (message.toLowerCase().includes('license')) {
+                    throw new BillingLicenseRequiredError(message);
+                }
+            }
+            throw err;
+        }
+    },
+};

--- a/web/src/services/license.ts
+++ b/web/src/services/license.ts
@@ -1,0 +1,36 @@
+import { apiClient } from './client';
+
+// The locally-evaluated offline-license entitlement (ADR-065), served by
+// GET /api/v1/license/status (gated by system.read). Read-only — there is no
+// install/upload endpoint; a new license is installed via `keyorix license
+// install` on the server host.
+export type LicenseState = 'active' | 'expiring_soon' | 'expired' | 'invalid' | 'none';
+
+export interface LicenseStatus {
+    state: LicenseState;
+    licensee: string;
+    plan: string;
+    features: string[];
+    grants: boolean;
+    expiresAt: string;
+    maxSeats: number;
+    reason: string;
+}
+
+const normalize = (d: any): LicenseStatus => ({
+    state: (d.state as LicenseState) ?? 'none',
+    licensee: d.licensee ?? '',
+    plan: d.plan ?? '',
+    features: Array.isArray(d.features) ? d.features : [],
+    grants: !!d.grants,
+    expiresAt: d.expires_at ?? d.expiresAt ?? '',
+    maxSeats: typeof d.max_seats === 'number' ? d.max_seats : (d.maxSeats ?? 0),
+    reason: d.reason ?? '',
+});
+
+export const licenseApi = {
+    async getStatus(): Promise<LicenseStatus> {
+        const response = await apiClient.get('/api/v1/license/status');
+        return normalize(response.data.data ?? response.data);
+    },
+};


### PR DESCRIPTION
## Summary
Records today's real, executed procedure. `internal/core`'s mutation run (single worker, `GOMAXPROCS=8`) was estimated at multiple days on its own, and the full non-test Go codebase at roughly 1-2 weeks sequentially -- ran a second, independent `gremlins` stream against `internal/storage/store` in parallel rather than waiting, using a transient `systemd-run` unit and a separate checkout (`gremlins` mutates source in place; two instances must never share one).

Documents the real numbers this was based on (dry-run mutant counts, measured pace), the safety requirement (separate checkout per stream, shared `GOCACHE` is fine), and the resource-sizing tradeoff actually made (added `GOMAXPROCS=4` alongside the existing `GOMAXPROCS=8` primary stream, accepting mild oversubscription rather than restarting the primary run to rebalance it).

Stacked on #1372 (references its new "Disk: GOCACHE grows without bound" section) -- will show only this PR's own diff once that one merges.

## Test plan
- [x] Docs-only change
- [x] Anchor link verified against the actual heading slug in #1372's content