### PR TITLE
fix(security): close CodeQL SSRF/check-then-act gaps, bump stale semgrep pin

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       security-events: write
     container:
-      image: semgrep/semgrep:1.93.0@sha256:9927548daa9013430d2c6c67e9513fc1b9e9e87003f6e914f95e54dcb567e800
+      image: semgrep/semgrep:1.172.0@sha256:65dcd4408adda7c183a6b4550cb1e9b19f7f627a6fbb7e0559bd466bedc44d7b
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 

--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -133,8 +133,18 @@ func NewRemoteClient() (*RemoteClient, bool) {
 		// machine/rotation/project/dynamic etc. use undecorated contexts — a hung
 		// or misconfigured KEYORIX_SERVER would otherwise hang the CLI forever
 		// with no way out. Mirrors the storage-layer remote client's default.
-		hc: &http.Client{Timeout: defaultRemoteClientTimeout},
+		//
+		// CheckRedirect: without it, a 3xx response from the configured server
+		// (including a CWD-planted ./keyorix.yaml — see ResolveRemote's warning
+		// above) could bounce the bearer-token-bearing request to an internal
+		// host (e.g. cloud IMDS) at request time (CWE-918). This client backs
+		// essentially all CLI remote-mode traffic, so this one guard covers it.
+		hc: &http.Client{Timeout: defaultRemoteClientTimeout, CheckRedirect: refuseRemoteClientRedirect},
 	}, true
+}
+
+func refuseRemoteClientRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
 }
 
 // defaultRemoteClientTimeout matches internal/storage/remote's default

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -173,6 +173,14 @@ func runTestConnection(cmd *cobra.Command, args []string) error {
 	}
 }
 
+// refuseConfigRedirect stops the connectivity-test client from following any
+// redirect: without this, a 3xx response from the configured server could
+// bounce the request to an internal host (e.g. cloud IMDS) at request time,
+// even though BaseURL itself looked fine when it was set (CWE-918).
+func refuseConfigRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
+}
+
 func testRemoteConnection(cfg *config.Config) error {
 	if cfg.Storage.Remote == nil {
 		return fmt.Errorf("remote configuration not found")
@@ -192,6 +200,7 @@ func testRemoteConnection(cfg *config.Config) error {
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.Storage.Remote.VerifyTLS()}, // #nosec G402 — honors tls_verify (secure by default)
 		},
+		CheckRedirect: refuseConfigRedirect,
 	}
 
 	// Any HTTP response (even 401) proves the server is reachable; only a

--- a/internal/cli/connect/connect.go
+++ b/internal/cli/connect/connect.go
@@ -260,6 +260,16 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// connectHTTPClient is used instead of http.DefaultClient so a 3xx response from
+// the target server can't bounce the credential/token-bearing request to an
+// internal host (e.g. cloud IMDS) — CWE-918. Matches the CheckRedirect idiom
+// used by this codebase's other Keyorix API clients.
+var connectHTTPClient = &http.Client{CheckRedirect: refuseConnectRedirect}
+
+func refuseConnectRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
+}
+
 // loginWithCredentials calls the login endpoint and returns a session token.
 func loginWithCredentials(endpoint, username, password string, timeout time.Duration) (string, error) {
 	body, _ := json.Marshal(map[string]string{
@@ -276,7 +286,7 @@ func loginWithCredentials(endpoint, username, password string, timeout time.Dura
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := connectHTTPClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("request failed: %w", err)
 	}
@@ -315,7 +325,7 @@ func testServerConnection(endpoint, apiKey string, timeout time.Duration) error 
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := connectHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("server unreachable: %w", err)
 	}

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
@@ -194,6 +195,13 @@ type apiClient struct {
 	http     *http.Client
 }
 
+// refuseRedirect stops apiClient from following any redirect: without this, a
+// 3xx response from the configured server could bounce the bearer-token-bearing
+// request to an internal host (e.g. cloud IMDS) at request time (CWE-918).
+func refuseRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
+}
+
 // get performs a GET, strips the {"data":…} wrapper, and unmarshals into out.
 func (c *apiClient) get(ctx context.Context, path string, out interface{}) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+path, nil)
@@ -230,7 +238,7 @@ func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env strin
 	api := &apiClient{
 		endpoint: endpoint,
 		token:    token,
-		http:     &http.Client{},
+		http:     &http.Client{Timeout: 30 * time.Second, CheckRedirect: refuseRedirect},
 	}
 
 	// ── 1. Resolve project name → ID ─────────────────────────────────────────

--- a/internal/cli/secret/rotate.go
+++ b/internal/cli/secret/rotate.go
@@ -22,6 +22,16 @@ import (
 // client memory via an unbounded json.Decode of resp.Body.
 const maxSecretListResponseBytes = 10 << 20 // 10MB
 
+// rotateHTTPClient is used instead of http.DefaultClient so a 3xx response from
+// the configured server can't bounce the bearer-token-bearing request to an
+// internal host (e.g. cloud IMDS) — CWE-918. Matches the CheckRedirect idiom
+// used by this codebase's other Keyorix API clients.
+var rotateHTTPClient = &http.Client{CheckRedirect: refuseRotateRedirect}
+
+func refuseRotateRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
+}
+
 var rotateCmd = &cobra.Command{
 	Use:   "rotate <name>",
 	Short: "Rotate a secret by providing a new value",
@@ -75,7 +85,7 @@ func runRotate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Client.Auth.GetAPIKey())
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := rotateHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
@@ -113,7 +123,7 @@ func runRotate(cmd *cobra.Command, args []string) error {
 	}
 	req2.Header.Set("Authorization", "Bearer "+cfg.Client.Auth.GetAPIKey())
 	req2.Header.Set("Content-Type", "application/json")
-	resp2, err := http.DefaultClient.Do(req2)
+	resp2, err := rotateHTTPClient.Do(req2)
 	if err != nil {
 		return fmt.Errorf("rotate request failed: %w", err)
 	}

--- a/internal/core/account_test.go
+++ b/internal/core/account_test.go
@@ -25,7 +25,7 @@ func TestUpdateOwnProfile(t *testing.T) {
 
 		ms.On("GetUser", ctx, uint(1)).Return(existing, nil)
 		ms.On("GetUserByEmail", ctx, "alice@new.com").Return(nil, nil)
-		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(existing, nil)
+		ms.On("UpdateUserIfActiveStateMatches", ctx, mock.AnythingOfType("*models.User"), false).Return(true, nil)
 
 		_, err := c.UpdateOwnProfile(ctx, 1, "Alice New", "alice@new.com", "Current#Passw0rd!")
 		require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestUpdateOwnProfile(t *testing.T) {
 		existing := &models.User{ID: 1, Username: acctTestUser, Email: "alice@old.com", DisplayName: "Alice", PasswordHash: string(hash)}
 
 		ms.On("GetUser", ctx, uint(1)).Return(existing, nil)
-		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(existing, nil)
+		ms.On("UpdateUserIfActiveStateMatches", ctx, mock.AnythingOfType("*models.User"), false).Return(true, nil)
 
 		_, err := c.UpdateOwnProfile(ctx, 1, "Alice New", "", "")
 		require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestUpdateOwnProfile(t *testing.T) {
 		existing := &models.User{ID: 1, Username: acctTestUser, Email: "alice@old.com", PasswordHash: string(hash)}
 
 		ms.On("GetUser", ctx, uint(1)).Return(existing, nil)
-		ms.On("UpdateUser", ctx, mock.AnythingOfType("*models.User")).Return(existing, nil)
+		ms.On("UpdateUserIfActiveStateMatches", ctx, mock.AnythingOfType("*models.User"), false).Return(true, nil)
 
 		_, err := c.UpdateOwnProfile(ctx, 1, "", "alice@old.com", "")
 		require.NoError(t, err)

--- a/internal/core/core_s26_test.go
+++ b/internal/core/core_s26_test.go
@@ -155,9 +155,8 @@ func TestUpdateUser_EmailAlreadyExists(t *testing.T) {
 func TestUpdateUser_Success(t *testing.T) {
 	ms := new(MockStorage)
 	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com"}
-	updated := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", DisplayName: "Alice Smith"}
 	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
-	ms.On("UpdateUser", mock.Anything, mock.AnythingOfType("*models.User")).Return(updated, nil)
+	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.AnythingOfType("*models.User"), false).Return(true, nil)
 	c := NewKeyorixCore(ms)
 	u, err := c.UpdateUser(context.Background(), &UpdateUserRequest{ID: 1, DisplayName: "Alice Smith"})
 	require.NoError(t, err)
@@ -168,7 +167,7 @@ func TestUpdateUser_StorageError(t *testing.T) {
 	ms := new(MockStorage)
 	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com"}
 	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
-	ms.On("UpdateUser", mock.Anything, mock.AnythingOfType("*models.User")).Return(nil, errors.New("db error"))
+	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.AnythingOfType("*models.User"), false).Return(false, errors.New("db error"))
 	c := NewKeyorixCore(ms)
 	_, err := c.UpdateUser(context.Background(), &UpdateUserRequest{ID: 1, DisplayName: "X"})
 	require.Error(t, err)
@@ -176,17 +175,18 @@ func TestUpdateUser_StorageError(t *testing.T) {
 
 // ── users.go — UpdateUser IsActive TOCTOU (the StateTransitionMissingCAS fix) ──
 //
-// UpdateUser is a general-purpose multi-field update, so only requests that
-// explicitly touch IsActive (req.IsActive != nil) need CAS protection — these
-// tests prove (a) such requests route through
-// storage.Storage.UpdateUserIfActiveStateMatches instead of the plain
-// UpdateUser, in BOTH the deactivating and non-deactivating branches, (b) a
-// lost race (matched=false) surfaces as ErrUserActiveStateConflict rather
-// than being silently retried or ignored, and — mirroring #388's "second
-// racing transition" test — that losing the race skips the deactivating
-// branch's session/PAT revocation side effects, and (c) a plain field-only
-// update (no IsActive in the request) is completely unaffected: it still
-// goes through the unconditional plain UpdateUser path, exactly as before.
+// Every UpdateUser call is a check-then-act (GetUser, mutate in memory, write
+// back) racing any concurrent write to the same row, so every branch routes
+// the final persist through storage.Storage.UpdateUserIfActiveStateMatches
+// (asserting the wasActive value observed at the top of the call) instead of
+// a plain unconditional UpdateUser/Save — including a plain field-only edit
+// that never touches IsActive in the request. These tests prove (a) all three
+// branches (deactivating, non-deactivating IsActive assertion, and the
+// default no-IsActive-in-request case) route through the conditional write,
+// (b) a lost race (matched=false) surfaces as ErrUserActiveStateConflict
+// rather than being silently retried or ignored, and — mirroring #388's
+// "second racing transition" test — (c) losing the race skips the
+// deactivating branch's session/PAT revocation side effects.
 
 // TestUpdateUser_Reactivate_UsesConditionalPath verifies a non-deactivating
 // IsActive assertion (re-activating an inactive user) is routed through
@@ -270,17 +270,38 @@ func TestUpdateUser_Deactivate_LostRace_ReturnsConflictError(t *testing.T) {
 // UpdateUser, exactly as before, and never touches
 // UpdateUserIfActiveStateMatches — so it cannot be spuriously rejected by an
 // unrelated concurrent is_active change on the same row.
-func TestUpdateUser_PlainFieldUpdate_DoesNotUseActiveStateConditionalPath(t *testing.T) {
+// TestUpdateUser_PlainFieldUpdate_UsesActiveStateConditionalPath verifies a
+// request that never touches IsActive still routes its persist through
+// UpdateUserIfActiveStateMatches (asserting the unchanged wasActive value) —
+// a plain unconditional UpdateUser/Save here would be exactly the check-then-act
+// race this fix closes, since GetUser's read and this write are not atomic.
+func TestUpdateUser_PlainFieldUpdate_UsesActiveStateConditionalPath(t *testing.T) {
 	ms := new(MockStorage)
 	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", IsActive: true}
-	updated := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", DisplayName: "Alice Renamed", IsActive: true}
 	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
-	ms.On("UpdateUser", mock.Anything, mock.AnythingOfType("*models.User")).Return(updated, nil)
+	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
+		return u.ID == 1 && u.DisplayName == "Alice Renamed"
+	}), true).Return(true, nil)
 	c := NewKeyorixCore(ms)
 	u, err := c.UpdateUser(context.Background(), &UpdateUserRequest{ID: 1, DisplayName: "Alice Renamed"})
 	require.NoError(t, err)
 	assert.Equal(t, "Alice Renamed", u.DisplayName)
-	ms.AssertNotCalled(t, "UpdateUserIfActiveStateMatches", mock.Anything, mock.Anything, mock.Anything)
+	ms.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+}
+
+// TestUpdateUser_PlainFieldUpdate_LostRace_ReturnsConflictError verifies that
+// when the conditional write's precondition (is_active unchanged since
+// GetUser) no longer holds at write time, a plain field-only update also
+// surfaces ErrUserActiveStateConflict rather than silently overwriting a
+// concurrent IsActive flip.
+func TestUpdateUser_PlainFieldUpdate_LostRace_ReturnsConflictError(t *testing.T) {
+	ms := new(MockStorage)
+	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", IsActive: true}
+	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
+	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.AnythingOfType("*models.User"), true).Return(false, nil)
+	c := NewKeyorixCore(ms)
+	_, err := c.UpdateUser(context.Background(), &UpdateUserRequest{ID: 1, DisplayName: "Alice Renamed"})
+	require.ErrorIs(t, err, ErrUserActiveStateConflict)
 }
 
 // ── users.go — RestoreUser ───────────────────────────────────────────────────

--- a/internal/core/core_s27_test.go
+++ b/internal/core/core_s27_test.go
@@ -190,9 +190,8 @@ func TestUpdateOwnProfile_ZeroUserID(t *testing.T) {
 func TestUpdateOwnProfile_NoEmailChange(t *testing.T) {
 	ms := new(MockStorage)
 	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", DisplayName: "Alice"}
-	updated := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", DisplayName: "Alice S."}
 	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
-	ms.On("UpdateUser", mock.Anything, mock.AnythingOfType("*models.User")).Return(updated, nil)
+	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.AnythingOfType("*models.User"), false).Return(true, nil)
 	c := NewKeyorixCore(ms)
 	// email is empty → no email change branch → no password check → just UpdateUser
 	u, err := c.UpdateOwnProfile(context.Background(), 1, "Alice S.", "", "")

--- a/internal/core/core_s28_test.go
+++ b/internal/core/core_s28_test.go
@@ -265,9 +265,8 @@ func TestListSharesByUser_OwnedError(t *testing.T) {
 func TestUpdateOwnProfile_EmailSameAsCurrentNoPasswordCheck(t *testing.T) {
 	ms := new(MockStorage)
 	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", DisplayName: "Alice"}
-	updated := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", DisplayName: "Alice"}
 	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
-	ms.On("UpdateUser", mock.Anything, mock.AnythingOfType("*models.User")).Return(updated, nil)
+	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.AnythingOfType("*models.User"), false).Return(true, nil)
 	c := NewKeyorixCore(ms)
 	// Passing same email as current → no password check needed.
 	u, err := c.UpdateOwnProfile(context.Background(), 1, "", "alice@x.com", "")
@@ -384,9 +383,8 @@ func TestWriteAuditCheckpointLocked_ValidChain_NoExistingCP(t *testing.T) {
 func TestUpdateUser_EmailSameAsCurrentSkipsCheck(t *testing.T) {
 	ms := new(MockStorage)
 	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com"}
-	updated := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", DisplayName: "New Name"}
 	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
-	ms.On("UpdateUser", mock.Anything, mock.AnythingOfType("*models.User")).Return(updated, nil)
+	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.AnythingOfType("*models.User"), false).Return(true, nil)
 	c := NewKeyorixCore(ms)
 	// Same email as current → skip email uniqueness check.
 	u, err := c.UpdateUser(context.Background(), &UpdateUserRequest{

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -355,9 +355,20 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 			}
 		}
 	default:
-		// No active-state assertion in this request — nothing to protect, plain
-		// full-row persist exactly as before.
-		updated, err = c.storage.UpdateUser(ctx, user)
+		// No active-state assertion in this request, but a plain c.storage.UpdateUser
+		// (unconditional Save) is still a check-then-act race against any concurrent
+		// IsActive flip observed between the GetUser above and this write — same
+		// TOCTOU shape as the two branches above, just asserting the unchanged
+		// wasActive value as the precondition instead of a new one.
+		var matched bool
+		matched, err = c.storage.UpdateUserIfActiveStateMatches(ctx, user, wasActive)
+		if err == nil {
+			if !matched {
+				err = fmt.Errorf("user %d: %w", req.ID, ErrUserActiveStateConflict)
+			} else {
+				updated = user
+			}
+		}
 	}
 	if err != nil {
 		if errors.Is(err, ErrUserActiveStateConflict) {

--- a/internal/dynamic/kubernetes.go
+++ b/internal/dynamic/kubernetes.go
@@ -316,8 +316,18 @@ func newRealK8sMinter(cfg k8sConfig) (*realK8sMinter, error) {
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
 			},
+			CheckRedirect: refuseRedirect,
 		},
 	}, nil
+}
+
+// refuseRedirect stops the TokenRequest/Secret-create/Secret-delete client from
+// following any redirect: without this, a 3xx response from the configured API
+// server (validated at config-write time, but not re-checked per request) could
+// bounce the bearer-token-bearing request to an internal host (e.g. cloud IMDS)
+// at request time (CWE-918).
+func refuseRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("kubernetes: refusing to follow redirect to %q", req.URL)
 }
 
 func (m *realK8sMinter) mintToken(ctx context.Context, namespace, serviceAccount string, audiences []string, expiration time.Duration, bound *boundObjectRef) (string, time.Time, error) {

--- a/internal/k8ssync/keyorix_fetcher.go
+++ b/internal/k8ssync/keyorix_fetcher.go
@@ -67,8 +67,16 @@ func NewKeyorixFetcher(baseURL, token string, projectID uint) *KeyorixFetcher {
 		baseURL:   strings.TrimRight(baseURL, "/"),
 		token:     token,
 		projectID: projectID,
-		hc:        &http.Client{Timeout: 30 * time.Second},
+		hc:        &http.Client{Timeout: 30 * time.Second, CheckRedirect: refuseRedirect},
 	}
+}
+
+// refuseRedirect stops this fetcher from following any redirect: without this, a
+// 3xx response from a compromised/misconfigured Keyorix server could bounce the
+// bearer-token-bearing request to an internal host (e.g. cloud IMDS) at request
+// time, even though baseURL itself was validated at config-load time (CWE-918).
+func refuseRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("k8ssync: refusing to follow redirect to %q", req.URL)
 }
 
 // Fetch resolves ref ("<environment>/<name>") to the secret's id and returns its

--- a/internal/mcp/keyorix.go
+++ b/internal/mcp/keyorix.go
@@ -138,7 +138,13 @@ func (c *KeyorixClient) ListSecrets(ctx context.Context, environment string) ([]
 
 // getJSON performs an authenticated GET and decodes the {"data": …} envelope into out.
 func (c *KeyorixClient) getJSON(ctx context.Context, path string, out interface{}) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	// c.hc (built in NewKeyorixClient above) already sets CheckRedirect to
+	// refuseRedirect, and baseURL is scheme-validated by requireHTTPSURL before
+	// this client is ever constructed. The query can't see either: CheckRedirect
+	// is set on the same composite literal in a different function, and
+	// requireHTTPSURL's argument is the constructor's baseURL parameter, not a
+	// read of the baseURL field it's later stored into.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil) // codeql[go/keyorix-ssrf-unvalidated-outbound-request]
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}

--- a/internal/notary/rfc3161.go
+++ b/internal/notary/rfc3161.go
@@ -34,7 +34,15 @@ func NewRFC3161(url string, timeout time.Duration) *RFC3161 {
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
-	return &RFC3161{url: url, client: &http.Client{Timeout: timeout}}
+	return &RFC3161{url: url, client: &http.Client{Timeout: timeout, CheckRedirect: refuseRedirect}}
+}
+
+// refuseRedirect stops the TSA client from following any redirect: without this,
+// a 3xx response from a compromised/misconfigured TSA endpoint could bounce the
+// request to an internal host (e.g. cloud IMDS) even though the configured URL
+// itself was fine at setup time (CWE-918).
+func refuseRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("rfc3161: refusing to follow redirect to %q", req.URL)
 }
 
 func (r *RFC3161) Provider() string { return "rfc3161:" + r.url }

--- a/internal/storage/remote/client.go
+++ b/internal/storage/remote/client.go
@@ -221,7 +221,14 @@ func (c *HTTPClient) makeRequest(ctx context.Context, method, path string, body 
 		reqBody = bytes.NewBuffer(jsonBody)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	// c.client (built in NewHTTPClient above) already sets CheckRedirect to reject
+	// a cross-host redirect, and config.BaseURL is scheme/host validated by
+	// Config.Validate (rejecting non-https except for a loopback host) before
+	// this client is ever constructed. The query can't see either: CheckRedirect
+	// is set on the same composite literal in a different function, and
+	// Validate's argument is u.Hostname() (a method-call result), not a direct
+	// read of the BaseURL field.
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody) // codeql[go/keyorix-ssrf-unvalidated-outbound-request]
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/operator/internal/keyorix/client.go
+++ b/operator/internal/keyorix/client.go
@@ -88,7 +88,16 @@ func refuseRedirect(req *http.Request, _ []*http.Request) error {
 func (c *Client) FetchValue(ctx context.Context, ref string) ([]byte, error) {
 	q := url.Values{}
 	q.Set("ref", ref)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v1/secrets/value?"+q.Encode(), nil)
+	// c.hc (built in New above) already sets CheckRedirect to refuseRedirect, and
+	// the caller (KeyorixSecretReconciler.buildDesired) validates ks.Spec.Server
+	// against an operator-configured --allowed-servers allowlist via
+	// validateServer BEFORE ever constructing this Client — see
+	// keyorixsecret_controller.go. The query can't see either: CheckRedirect is
+	// set on the same composite literal in a different function, and the
+	// validated field (KeyorixSecretSpec.Server) is three frames upstream of
+	// Client.baseURL with no name overlap the query's field-identity check can
+	// follow.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v1/secrets/value?"+q.Encode(), nil) // codeql[go/keyorix-ssrf-unvalidated-outbound-request]
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -39,8 +39,8 @@ COPY --from=builder /app/bin/keyorix-server .
 COPY --from=builder /app/server/entrypoint.sh .
 RUN chmod +x entrypoint.sh && \
     mkdir -p data keys && chown -R keyorix:keyorix /app
-USER keyorix
+USER 1001:1001
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+    CMD ["sh", "-c", "wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1"]
 CMD ["./entrypoint.sh"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # independent of the non-root change below (reproduced against the original
 # root-running image too).
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget -q --spider http://127.0.0.1/health || exit 1
+  CMD ["sh", "-c", "wget -q --spider http://127.0.0.1/health || exit 1"]
 
 # Run as nginx:alpine's own built-in non-root user (uid 101) rather than root.
 # The Helm deployment (deploy/helm/keyorix/templates/web-deployment.yaml)
@@ -54,7 +54,7 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 # symlink-to-stdout/stderr setup, so both need to be writable by uid 101
 # before dropping to it.
 RUN chown -R nginx:nginx /var/cache/nginx /var/log/nginx /run
-USER nginx
+USER 101
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary

Addresses the 40 open code-scanning alerts (#676-793):

- **users.go check-then-act (#789)**: `UpdateUser`'s default branch (no `IsActive` in the request) did a plain unconditional `Save`, unlike its two sibling branches. Routed it through the same `UpdateUserIfActiveStateMatches` atomic conditional write.
- **CodeQL SSRF (22 alerts, #761-788)**: added `CheckRedirect` to every `http.Client`/`apiClient` that was missing one (`internal/notary/rfc3161.go`, `internal/k8ssync/keyorix_fetcher.go`, `internal/dynamic/kubernetes.go`, `internal/cli/secret/rotate.go`, `internal/cli/connect/connect.go`, `internal/cli/run/run.go`, `internal/cli/config/config.go`, and `internal/cli/common/remote_client.go` — the shared client backing ~100+ CLI call sites). Added `codeql[...]` suppression comments with justification for the 3 sites that already have a working `CheckRedirect` + destination guard elsewhere in the same file, which the query's naming-pattern matching just can't connect to the flagged line.
- **Hadolint (#790-793)**: fixed `HEALTHCHECK CMD` to JSON-array form and switched both Dockerfiles' `USER` to a numeric UID.
- **Semgrep (13 alerts, #677-687)**: these were already fixed/suppressed in code (commit `4ac11764`, 3 days before these alerts even opened) — verified the blocking `--error` CI step passes clean with zero findings. The alerts stayed open because the pinned `semgrep/semgrep:1.93.0` CI image doesn't correctly encode `nosemgrep` suppressions in its `--sarif` output. Bumped the pin to `1.172.0` and verified locally that both the blocking scan and the advisory SARIF-generating scan produce zero results for these 13 locations.

**Deferred, not guessed at:** `internal/connect/vault.go`'s connector `Address` field has no destination validator anywhere in the repo. Unlike the 3 suppressed sites, this is a genuine gap — but connectors are admin-configured and commonly point at on-prem/private-network Vault instances by design, mirroring this codebase's own `allow_private_network_targets` escape hatch for the dynamic-secrets DSN guard. Blocking private IPs here without that same kind of explicit opt-in would break legitimate deployments, so it needs a product decision rather than a unilateral hard block.

## Test plan

- [x] `go build ./...` (main module) and `go build ./...` (operator submodule) — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l` on all changed files — clean
- [x] `gosec -severity medium -exclude-generated` on changed packages — 0 issues
- [x] `go test ./internal/core/...` — full pass, including new/updated `UpdateUser` CAS tests
- [x] `go test ./internal/notary/... ./internal/k8ssync/... ./internal/dynamic/... ./internal/cli/... ./internal/storage/remote/... ./internal/mcp/...` — pass (one pre-existing local-environment-only failure in `internal/cli/user`, unrelated: a stale `~/.keyorix/cli.yaml` on this dev machine points at an unreachable private IP)
- [x] `go test -C operator ./...` — pass
- [x] `hadolint server/Dockerfile web/Dockerfile` — the 4 targeted findings gone; only pre-existing, out-of-scope `DL3018` (unpinned `apk add` versions) remains
- [x] `semgrep scan --config=.semgrep/keyorix-rules.yml --severity=WARNING --severity=ERROR --error` with the new pinned version (1.172.0) — clean, matching CI's blocking step