### PR TITLE
fix(dashboard): scope TotalSecrets deployment-wide for audit.read callers

### DIFF
--- a/internal/core/dashboard.go
+++ b/internal/core/dashboard.go
@@ -165,9 +165,12 @@ func (c *KeyorixCore) GetDashboardStats(ctx context.Context, userID uint, userna
 		stats.degrade("expiring_secrets", err)
 	}
 
-	var activeUsers, auditCount, auditLogins, auditSecretReads, failedAuth24h, inactiveUsers int64
+	var activeUsers, auditCount, auditLogins, auditSecretReads, failedAuth24h, inactiveUsers, deploymentTotalSecrets int64
 	if hasAuditRead {
-		activeUsers, auditCount, auditLogins, auditSecretReads, failedAuth24h, inactiveUsers = c.fetchAdminDashboardStats(ctx, stats)
+		activeUsers, auditCount, auditLogins, auditSecretReads, failedAuth24h, inactiveUsers, deploymentTotalSecrets = c.fetchAdminDashboardStats(ctx, stats)
+		// Mirror ActiveUsers/AuditEvents: a caller with audit.read sees the
+		// deployment-wide secret count, not just secrets they personally created.
+		total = deploymentTotalSecrets
 	}
 
 	stats.TotalSecrets = total
@@ -249,9 +252,10 @@ func (c *KeyorixCore) saveUserSnapshot(ctx context.Context, userID uint, stats *
 // callers holding audit.read (active-user count, audit-event counts, failed-auth
 // count, inactive-user count). Errors degrade the stats struct; all counts default
 // to 0. Extracted from GetDashboardStats to reduce its cognitive complexity.
-func (c *KeyorixCore) fetchAdminDashboardStats(ctx context.Context, stats *DashboardStats) (activeUsers, auditCount, auditLogins, auditSecretReads, failedAuth24h, inactiveUsers int64) {
+func (c *KeyorixCore) fetchAdminDashboardStats(ctx context.Context, stats *DashboardStats) (activeUsers, auditCount, auditLogins, auditSecretReads, failedAuth24h, inactiveUsers, totalSecrets int64) {
 	if storageStats, err := c.storage.GetStats(ctx); err == nil {
 		activeUsers = storageStats.TotalUsers
+		totalSecrets = storageStats.TotalSecrets
 	} else {
 		stats.degrade("active_users", err)
 	}

--- a/internal/core/dashboard_test.go
+++ b/internal/core/dashboard_test.go
@@ -237,6 +237,61 @@ func TestGetDashboardStats_DegradedOnRecentActivityQueryError(t *testing.T) {
 	assert.True(t, containsSubstring(stats.DegradedReasons, "recent_activity"), "expected a recent_activity entry, got %v", stats.DegradedReasons)
 }
 
+// TotalSecrets must mirror ActiveUsers/AuditEvents30d: a caller with audit.read
+// sees the deployment-wide secret count, not just secrets they personally
+// created. Before this fix, GetDashboardStats always filtered ListSecrets by
+// CreatedBy regardless of the caller's RBAC role, so even a system_admin's
+// dashboard undercounted every secret another user had created.
+func TestGetDashboardStats_TotalSecretsIsDeploymentWideForAuditReadCaller(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	auditorID := seedUserWithRole(t, st, "auditor5", "system_auditor", storage.Scope{})
+
+	project, err := c.CreateProject(ctx, "other-project", "")
+	require.NoError(t, err)
+	envs, err := st.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+
+	// Created by a DIFFERENT user than the caller.
+	_, err = st.CreateSecret(ctx, &models.SecretNode{
+		ProjectID: project.ID, EnvironmentID: envs[0].ID,
+		Name: "OTHER_USERS_SECRET", CreatedBy: "someone-else",
+	})
+	require.NoError(t, err)
+
+	stats, err := c.GetDashboardStats(ctx, auditorID, "auditor5")
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 1, stats.TotalSecrets, "auditor5 personally created 0 secrets, but with audit.read the count must be deployment-wide")
+}
+
+// A baseline caller (no audit.read) must keep the pre-existing, privacy-preserving
+// behavior: their own home dashboard reflects only secrets they personally
+// created, not the whole deployment.
+func TestGetDashboardStats_TotalSecretsIsPersonalForBaselineCaller(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	viewerID := seedUserWithRole(t, st, "viewer6", "system_viewer", storage.Scope{})
+
+	project, err := c.CreateProject(ctx, "other-project2", "")
+	require.NoError(t, err)
+	envs, err := st.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+
+	_, err = st.CreateSecret(ctx, &models.SecretNode{
+		ProjectID: project.ID, EnvironmentID: envs[0].ID,
+		Name: "OTHER_USERS_SECRET", CreatedBy: "someone-else",
+	})
+	require.NoError(t, err)
+
+	stats, err := c.GetDashboardStats(ctx, viewerID, "viewer6")
+	require.NoError(t, err)
+
+	assert.Zero(t, stats.TotalSecrets, "a baseline caller without audit.read must still see only secrets they personally created, not the deployment-wide count")
+}
+
 // A fully-healthy storage must never report Degraded.
 func TestGetDashboardStats_NotDegradedOnSuccess(t *testing.T) {
 	c, st := newBootstrappedCore(t)


### PR DESCRIPTION
## Summary
- `GetDashboardStats` always filtered `TotalSecrets` by `CreatedBy = <caller>`, regardless of RBAC role — unlike its sibling stats (`ActiveUsers`, `AuditEvents30d`), which already switch to a deployment-wide view for a caller holding `audit.read`.
- An admin's dashboard undercounted every secret another user had created — found on a freshly seeded demo instance where it showed `1` instead of `98`.
- Fix reuses the `TotalSecrets` field `storage.GetStats()` already computes (previously only `ActiveUsers` was read from it) and applies it under the same `hasAuditRead` gate the other admin-only aggregates use. A caller without `audit.read` keeps the pre-existing, privacy-preserving personal-only count.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/core/...` (full package, includes 2 new regression tests: deployment-wide count for an `audit.read` caller, personal-only count preserved for a baseline caller)