### PR TITLE
fix(secrets): cross-check version/comment sub-resource IDs against parent secret

### DIFF
--- a/internal/core/mock_storage_version_comments_test.go
+++ b/internal/core/mock_storage_version_comments_test.go
@@ -11,15 +11,15 @@ func (m *MockStorage) CreateSecretVersionComment(ctx context.Context, c *models.
 	return args.Error(0)
 }
 
-func (m *MockStorage) ListSecretVersionComments(ctx context.Context, versionID uint) ([]models.SecretVersionComment, error) {
-	args := m.Called(ctx, versionID)
+func (m *MockStorage) ListSecretVersionComments(ctx context.Context, secretID, versionID uint) ([]models.SecretVersionComment, error) {
+	args := m.Called(ctx, secretID, versionID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]models.SecretVersionComment), args.Error(1)
 }
 
-func (m *MockStorage) DeleteSecretVersionComment(ctx context.Context, id uint) error {
-	args := m.Called(ctx, id)
+func (m *MockStorage) DeleteSecretVersionComment(ctx context.Context, secretID, versionID, id uint) error {
+	args := m.Called(ctx, secretID, versionID, id)
 	return args.Error(0)
 }

--- a/internal/core/secret_version_comments.go
+++ b/internal/core/secret_version_comments.go
@@ -7,7 +7,9 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -22,10 +24,31 @@ type CreateVersionCommentRequest struct {
 	Username  string
 }
 
+// versionBelongsToSecret confirms versionID is actually one of secretID's own
+// versions, so a caller authorized on secretID (the router already checked
+// that) cannot supply an arbitrary versionID belonging to a different,
+// unauthorized secret and reach its comments (#G53 — BOLA via an
+// un-cross-checked sub-resource ID).
+func (k *KeyorixCore) versionBelongsToSecret(ctx context.Context, secretID, versionID uint) error {
+	versions, err := k.GetSecretVersions(ctx, secretID)
+	if err != nil {
+		return err
+	}
+	for _, v := range versions {
+		if v.ID == versionID {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s: version %d does not belong to secret %d", i18n.T("ErrorVersionNotFound", nil), versionID, secretID)
+}
+
 // CreateSecretVersionComment annotates a secret version with a free-text comment.
 func (k *KeyorixCore) CreateSecretVersionComment(ctx context.Context, req CreateVersionCommentRequest) (*models.SecretVersionComment, error) {
 	if req.Comment == "" {
 		return nil, errors.New("comment is required")
+	}
+	if err := k.versionBelongsToSecret(ctx, req.SecretID, req.VersionID); err != nil {
+		return nil, err
 	}
 	c := &models.SecretVersionComment{
 		VersionID: req.VersionID,
@@ -40,12 +63,22 @@ func (k *KeyorixCore) CreateSecretVersionComment(ctx context.Context, req Create
 	return c, nil
 }
 
-// ListSecretVersionComments returns all comments for a given version, oldest first.
-func (k *KeyorixCore) ListSecretVersionComments(ctx context.Context, versionID uint) ([]models.SecretVersionComment, error) {
-	return k.storage.ListSecretVersionComments(ctx, versionID)
+// ListSecretVersionComments returns all comments for versionID, oldest first —
+// scoped to secretID so the caller (already authorized on secretID by the
+// router) cannot list another secret's comments via its VersionID (#G53).
+func (k *KeyorixCore) ListSecretVersionComments(ctx context.Context, secretID, versionID uint) ([]models.SecretVersionComment, error) {
+	if err := k.versionBelongsToSecret(ctx, secretID, versionID); err != nil {
+		return nil, err
+	}
+	return k.storage.ListSecretVersionComments(ctx, secretID, versionID)
 }
 
-// DeleteSecretVersionComment removes a comment by ID.
-func (k *KeyorixCore) DeleteSecretVersionComment(ctx context.Context, id uint) error {
-	return k.storage.DeleteSecretVersionComment(ctx, id)
+// DeleteSecretVersionComment removes the comment with the given ID, but only if
+// it belongs to secretID/versionID — cross-checked at both this layer and the
+// storage layer (#G53).
+func (k *KeyorixCore) DeleteSecretVersionComment(ctx context.Context, secretID, versionID, id uint) error {
+	if err := k.versionBelongsToSecret(ctx, secretID, versionID); err != nil {
+		return err
+	}
+	return k.storage.DeleteSecretVersionComment(ctx, secretID, versionID, id)
 }

--- a/internal/core/secret_version_comments_test.go
+++ b/internal/core/secret_version_comments_test.go
@@ -15,6 +15,14 @@ func newVersionCommentsCore(store *MockStorage) *KeyorixCore {
 	return &KeyorixCore{storage: store}
 }
 
+// expectSecretWithVersion wires up the GetSecret + GetSecretVersions calls
+// versionBelongsToSecret makes, for a secret that owns versionID.
+func expectSecretWithVersion(store *MockStorage, ctx context.Context, secretID, versionID uint) {
+	store.On("GetSecret", ctx, secretID).Return(&models.SecretNode{ID: secretID}, nil)
+	store.On("GetSecretVersions", ctx, secretID).
+		Return([]*models.SecretVersion{{ID: versionID, SecretNodeID: secretID}}, nil)
+}
+
 func TestCreateSecretVersionComment_EmptyCommentReturnsError(t *testing.T) {
 	store := new(MockStorage)
 	c := newVersionCommentsCore(store)
@@ -37,6 +45,7 @@ func TestCreateSecretVersionComment_Success(t *testing.T) {
 	c := newVersionCommentsCore(store)
 	ctx := context.Background()
 
+	expectSecretWithVersion(store, ctx, 1, 2)
 	store.On("CreateSecretVersionComment", ctx, mock.MatchedBy(func(cm *models.SecretVersionComment) bool {
 		return cm.SecretID == 1 &&
 			cm.VersionID == 2 &&
@@ -62,6 +71,7 @@ func TestCreateSecretVersionComment_StorageError(t *testing.T) {
 	c := newVersionCommentsCore(store)
 	ctx := context.Background()
 
+	expectSecretWithVersion(store, ctx, 1, 2)
 	store.On("CreateSecretVersionComment", ctx, mock.AnythingOfType("*models.SecretVersionComment")).
 		Return(errors.New("write failed"))
 
@@ -71,18 +81,38 @@ func TestCreateSecretVersionComment_StorageError(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestCreateSecretVersionComment_VersionBelongsToOtherSecret is the #G53
+// regression: VersionID 99 belongs to secret 2, not the authorized secret 1 —
+// the write must be refused before it ever reaches storage.
+func TestCreateSecretVersionComment_VersionBelongsToOtherSecret(t *testing.T) {
+	store := new(MockStorage)
+	c := newVersionCommentsCore(store)
+	ctx := context.Background()
+
+	store.On("GetSecret", ctx, uint(1)).Return(&models.SecretNode{ID: 1}, nil)
+	store.On("GetSecretVersions", ctx, uint(1)).
+		Return([]*models.SecretVersion{{ID: 42, SecretNodeID: 1}}, nil)
+
+	_, err := c.CreateSecretVersionComment(ctx, CreateVersionCommentRequest{
+		SecretID: 1, VersionID: 99, Comment: "cross-tenant write", UserID: 1, Username: "attacker",
+	})
+	require.Error(t, err)
+	store.AssertNotCalled(t, "CreateSecretVersionComment")
+}
+
 func TestListSecretVersionComments_Success(t *testing.T) {
 	store := new(MockStorage)
 	c := newVersionCommentsCore(store)
 	ctx := context.Background()
 
+	expectSecretWithVersion(store, ctx, 1, 2)
 	comments := []models.SecretVersionComment{
-		{ID: 1, VersionID: 2, Comment: "initial version", UserID: 10, Username: "alice"},
-		{ID: 2, VersionID: 2, Comment: "patched CVE-2026-001", UserID: 11, Username: "bob"},
+		{ID: 1, SecretID: 1, VersionID: 2, Comment: "initial version", UserID: 10, Username: "alice"},
+		{ID: 2, SecretID: 1, VersionID: 2, Comment: "patched CVE-2026-001", UserID: 11, Username: "bob"},
 	}
-	store.On("ListSecretVersionComments", ctx, uint(2)).Return(comments, nil)
+	store.On("ListSecretVersionComments", ctx, uint(1), uint(2)).Return(comments, nil)
 
-	got, err := c.ListSecretVersionComments(ctx, 2)
+	got, err := c.ListSecretVersionComments(ctx, 1, 2)
 	require.NoError(t, err)
 	require.Len(t, got, 2)
 	assert.Equal(t, "initial version", got[0].Comment)
@@ -94,9 +124,10 @@ func TestListSecretVersionComments_Empty(t *testing.T) {
 	c := newVersionCommentsCore(store)
 	ctx := context.Background()
 
-	store.On("ListSecretVersionComments", ctx, uint(5)).Return([]models.SecretVersionComment{}, nil)
+	expectSecretWithVersion(store, ctx, 5, 5)
+	store.On("ListSecretVersionComments", ctx, uint(5), uint(5)).Return([]models.SecretVersionComment{}, nil)
 
-	got, err := c.ListSecretVersionComments(ctx, 5)
+	got, err := c.ListSecretVersionComments(ctx, 5, 5)
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -106,10 +137,28 @@ func TestListSecretVersionComments_Error(t *testing.T) {
 	c := newVersionCommentsCore(store)
 	ctx := context.Background()
 
-	store.On("ListSecretVersionComments", ctx, uint(3)).Return(nil, errors.New("read error"))
+	expectSecretWithVersion(store, ctx, 3, 3)
+	store.On("ListSecretVersionComments", ctx, uint(3), uint(3)).Return(nil, errors.New("read error"))
 
-	_, err := c.ListSecretVersionComments(ctx, 3)
+	_, err := c.ListSecretVersionComments(ctx, 3, 3)
 	require.Error(t, err)
+}
+
+// TestListSecretVersionComments_CrossSecretVersionRejected is the #G53
+// regression: authorized on secret 1, but the supplied VersionID (99) belongs
+// to secret 2 — must be refused, not silently walk the global VersionID space.
+func TestListSecretVersionComments_CrossSecretVersionRejected(t *testing.T) {
+	store := new(MockStorage)
+	c := newVersionCommentsCore(store)
+	ctx := context.Background()
+
+	store.On("GetSecret", ctx, uint(1)).Return(&models.SecretNode{ID: 1}, nil)
+	store.On("GetSecretVersions", ctx, uint(1)).
+		Return([]*models.SecretVersion{{ID: 7, SecretNodeID: 1}}, nil)
+
+	_, err := c.ListSecretVersionComments(ctx, 1, 99)
+	require.Error(t, err)
+	store.AssertNotCalled(t, "ListSecretVersionComments")
 }
 
 func TestDeleteSecretVersionComment_Success(t *testing.T) {
@@ -117,9 +166,10 @@ func TestDeleteSecretVersionComment_Success(t *testing.T) {
 	c := newVersionCommentsCore(store)
 	ctx := context.Background()
 
-	store.On("DeleteSecretVersionComment", ctx, uint(7)).Return(nil)
+	expectSecretWithVersion(store, ctx, 1, 2)
+	store.On("DeleteSecretVersionComment", ctx, uint(1), uint(2), uint(7)).Return(nil)
 
-	err := c.DeleteSecretVersionComment(ctx, 7)
+	err := c.DeleteSecretVersionComment(ctx, 1, 2, 7)
 	require.NoError(t, err)
 }
 
@@ -128,8 +178,26 @@ func TestDeleteSecretVersionComment_Error(t *testing.T) {
 	c := newVersionCommentsCore(store)
 	ctx := context.Background()
 
-	store.On("DeleteSecretVersionComment", ctx, uint(8)).Return(errors.New("delete failed"))
+	expectSecretWithVersion(store, ctx, 1, 2)
+	store.On("DeleteSecretVersionComment", ctx, uint(1), uint(2), uint(8)).Return(errors.New("delete failed"))
 
-	err := c.DeleteSecretVersionComment(ctx, 8)
+	err := c.DeleteSecretVersionComment(ctx, 1, 2, 8)
 	require.Error(t, err)
+}
+
+// TestDeleteSecretVersionComment_CrossSecretVersionRejected is the #G53
+// regression for delete: authorized on secret 1, but the supplied VersionID
+// belongs to secret 2 — must be refused before any storage delete is attempted.
+func TestDeleteSecretVersionComment_CrossSecretVersionRejected(t *testing.T) {
+	store := new(MockStorage)
+	c := newVersionCommentsCore(store)
+	ctx := context.Background()
+
+	store.On("GetSecret", ctx, uint(1)).Return(&models.SecretNode{ID: 1}, nil)
+	store.On("GetSecretVersions", ctx, uint(1)).
+		Return([]*models.SecretVersion{{ID: 7, SecretNodeID: 1}}, nil)
+
+	err := c.DeleteSecretVersionComment(ctx, 1, 99, 8)
+	require.Error(t, err)
+	store.AssertNotCalled(t, "DeleteSecretVersionComment")
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1413,9 +1413,11 @@ type Storage interface {
 
 	// Secret version comments — free-text annotations on a specific secret version,
 	// providing a human-readable audit trail of why a version was created or changed.
+	// List/Delete are scoped by secretID/versionID (not just the comment's own primary
+	// key) so a caller authorized on one secret cannot reach another's comments (#G53).
 	CreateSecretVersionComment(ctx context.Context, c *models.SecretVersionComment) error
-	ListSecretVersionComments(ctx context.Context, versionID uint) ([]models.SecretVersionComment, error)
-	DeleteSecretVersionComment(ctx context.Context, id uint) error
+	ListSecretVersionComments(ctx context.Context, secretID, versionID uint) ([]models.SecretVersionComment, error)
+	DeleteSecretVersionComment(ctx context.Context, secretID, versionID, id uint) error
 
 	// Notification channel management — runtime-managed outbound destinations
 	// (webhook/slack/teams/email). The REST API is the remote surface; these

--- a/internal/storage/store/local_version_comments.go
+++ b/internal/storage/store/local_version_comments.go
@@ -7,7 +7,9 @@ package store
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -15,12 +17,31 @@ func (ls *LocalStorage) CreateSecretVersionComment(ctx context.Context, c *model
 	return ls.db.WithContext(ctx).Create(c).Error
 }
 
-func (ls *LocalStorage) ListSecretVersionComments(ctx context.Context, versionID uint) ([]models.SecretVersionComment, error) {
+// ListSecretVersionComments returns comments for versionID, scoped to secretID
+// so a caller authorized on one secret cannot walk the globally-shared
+// VersionID space to read another tenant's comments (#G53).
+func (ls *LocalStorage) ListSecretVersionComments(ctx context.Context, secretID, versionID uint) ([]models.SecretVersionComment, error) {
 	var comments []models.SecretVersionComment
-	err := ls.db.WithContext(ctx).Where("version_id = ?", versionID).Order("created_at asc").Find(&comments).Error
+	err := ls.db.WithContext(ctx).
+		Where("secret_id = ? AND version_id = ?", secretID, versionID).
+		Order("created_at asc").Find(&comments).Error
 	return comments, err
 }
 
-func (ls *LocalStorage) DeleteSecretVersionComment(ctx context.Context, id uint) error {
-	return ls.db.WithContext(ctx).Delete(&models.SecretVersionComment{}, id).Error
+// DeleteSecretVersionComment removes the comment with the given ID, but only
+// if it actually belongs to secretID/versionID — cross-checking the
+// sub-resource IDs against their claimed parent instead of trusting id alone
+// (#G53). RowsAffected==0 means either the comment doesn't exist or it
+// belongs to a different secret/version; both are reported as not-found.
+func (ls *LocalStorage) DeleteSecretVersionComment(ctx context.Context, secretID, versionID, id uint) error {
+	result := ls.db.WithContext(ctx).
+		Where("id = ? AND secret_id = ? AND version_id = ?", id, secretID, versionID).
+		Delete(&models.SecretVersionComment{})
+	if result.Error != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	return nil
 }

--- a/internal/storage/store/remote_version_comments.go
+++ b/internal/storage/store/remote_version_comments.go
@@ -17,10 +17,10 @@ func (rs *RemoteStorage) CreateSecretVersionComment(_ context.Context, _ *models
 	return remoteUnsupported("CreateSecretVersionComment")
 }
 
-func (rs *RemoteStorage) ListSecretVersionComments(_ context.Context, _ uint) ([]models.SecretVersionComment, error) {
+func (rs *RemoteStorage) ListSecretVersionComments(_ context.Context, _, _ uint) ([]models.SecretVersionComment, error) {
 	return nil, remoteUnsupported("ListSecretVersionComments")
 }
 
-func (rs *RemoteStorage) DeleteSecretVersionComment(_ context.Context, _ uint) error {
+func (rs *RemoteStorage) DeleteSecretVersionComment(_ context.Context, _, _, _ uint) error {
 	return remoteUnsupported("DeleteSecretVersionComment")
 }

--- a/server/http/handlers/secret_version_comments.go
+++ b/server/http/handlers/secret_version_comments.go
@@ -83,7 +83,7 @@ func (h *SecretVersionCommentHandler) ListComments(w http.ResponseWriter, r *htt
 		return
 	}
 
-	_, ok = mustParseUintParam(w, r, "id", "InvalidParameter", errInvalidSecretID)
+	secretID, ok := mustParseUintParam(w, r, "id", "InvalidParameter", errInvalidSecretID)
 	if !ok {
 		return
 	}
@@ -92,7 +92,7 @@ func (h *SecretVersionCommentHandler) ListComments(w http.ResponseWriter, r *htt
 		return
 	}
 
-	comments, err := h.coreService.ListSecretVersionComments(r.Context(), versionID)
+	comments, err := h.coreService.ListSecretVersionComments(r.Context(), secretID, versionID)
 	if err != nil {
 		log.Printf("Error listing version comments: %v", err)
 		sendError(w, "InternalError", "Failed to list comments", http.StatusInternalServerError, nil)
@@ -109,11 +109,11 @@ func (h *SecretVersionCommentHandler) DeleteComment(w http.ResponseWriter, r *ht
 		return
 	}
 
-	_, ok = mustParseUintParam(w, r, "id", "InvalidParameter", errInvalidSecretID)
+	secretID, ok := mustParseUintParam(w, r, "id", "InvalidParameter", errInvalidSecretID)
 	if !ok {
 		return
 	}
-	_, ok = mustParseUintParam(w, r, "versionId", "InvalidParameter", errInvalidVersionID)
+	versionID, ok := mustParseUintParam(w, r, "versionId", "InvalidParameter", errInvalidVersionID)
 	if !ok {
 		return
 	}
@@ -122,7 +122,7 @@ func (h *SecretVersionCommentHandler) DeleteComment(w http.ResponseWriter, r *ht
 		return
 	}
 
-	if err := h.coreService.DeleteSecretVersionComment(r.Context(), commentID); err != nil {
+	if err := h.coreService.DeleteSecretVersionComment(r.Context(), secretID, versionID, commentID); err != nil {
 		log.Printf("Error deleting version comment: %v", err)
 		sendError(w, "InternalError", "Failed to delete comment", http.StatusInternalServerError, nil)
 		return

--- a/server/http/handlers/secret_version_comments_handler_test.go
+++ b/server/http/handlers/secret_version_comments_handler_test.go
@@ -2,9 +2,11 @@ package handlers
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
 	"github.com/stretchr/testify/assert"
@@ -17,106 +19,190 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
 
-func newVersionCommentTestHandler(t *testing.T) *SecretVersionCommentHandler {
+// versionCommentFixture is a handler wired to two distinct secrets, each with
+// its own version, so cross-secret sub-resource-ID checks (#G53) can be
+// exercised at the handler layer.
+type versionCommentFixture struct {
+	handler               *SecretVersionCommentHandler
+	secretAID, versionAID uint
+	secretBID, versionBID uint
+}
+
+func newVersionCommentTestHandler(t *testing.T) *versionCommentFixture {
 	t.Helper()
 	require.NoError(t, i18n.InitializeForTesting())
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.SecretVersionComment{}))
-	return NewSecretVersionCommentHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.SecretVersionComment{}))
+
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 1, Name: "secret-a", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+	versionA := &models.SecretVersion{SecretNodeID: 1, VersionNumber: 1}
+	require.NoError(t, db.Create(versionA).Error)
+
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 2, Name: "secret-b", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+	versionB := &models.SecretVersion{SecretNodeID: 2, VersionNumber: 1}
+	require.NoError(t, db.Create(versionB).Error)
+
+	return &versionCommentFixture{
+		handler:    NewSecretVersionCommentHandler(core.NewKeyorixCore(store.NewLocalStorage(db))),
+		secretAID:  1,
+		versionAID: versionA.ID,
+		secretBID:  2,
+		versionBID: versionB.ID,
+	}
 }
 
 func TestCreateComment_Unauthorized(t *testing.T) {
-	h := newVersionCommentTestHandler(t)
+	f := newVersionCommentTestHandler(t)
 	w := httptest.NewRecorder()
-	h.CreateComment(w, httptest.NewRequest(http.MethodPost, "/", nil))
+	f.handler.CreateComment(w, httptest.NewRequest(http.MethodPost, "/", nil))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestCreateComment_InvalidSecretID(t *testing.T) {
-	h := newVersionCommentTestHandler(t)
+	f := newVersionCommentTestHandler(t)
 	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodPost, "/", nil), map[string]string{"id": "bad", "versionId": "1"}))
 	w := httptest.NewRecorder()
-	h.CreateComment(w, r)
+	f.handler.CreateComment(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestCreateComment_InvalidVersionID(t *testing.T) {
-	h := newVersionCommentTestHandler(t)
+	f := newVersionCommentTestHandler(t)
 	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodPost, "/", nil), map[string]string{"id": "1", "versionId": "bad"}))
 	w := httptest.NewRecorder()
-	h.CreateComment(w, r)
+	f.handler.CreateComment(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestCreateComment_Success(t *testing.T) {
-	h := newVersionCommentTestHandler(t)
+	f := newVersionCommentTestHandler(t)
 	body := bytes.NewBufferString(`{"comment":"test annotation"}`)
-	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodPost, "/", body), map[string]string{"id": "1", "versionId": "1"}))
+	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodPost, "/", body), chiParamsForVersion(f.secretAID, f.versionAID)))
 	w := httptest.NewRecorder()
-	h.CreateComment(w, r)
+	f.handler.CreateComment(w, r)
 	assert.Equal(t, http.StatusCreated, w.Code)
 }
 
 func TestCreateComment_EmptyComment(t *testing.T) {
-	h := newVersionCommentTestHandler(t)
+	f := newVersionCommentTestHandler(t)
 	body := bytes.NewBufferString(`{"comment":""}`)
-	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodPost, "/", body), map[string]string{"id": "1", "versionId": "1"}))
+	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodPost, "/", body), chiParamsForVersion(f.secretAID, f.versionAID)))
 	w := httptest.NewRecorder()
-	h.CreateComment(w, r)
+	f.handler.CreateComment(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// TestCreateComment_VersionBelongsToAnotherSecret is the #G53 regression:
+// versionId in the URL actually belongs to secret B, not the {id} (secret A)
+// the caller was authorized against — must be refused, not silently written
+// under secret A's authorization.
+func TestCreateComment_VersionBelongsToAnotherSecret(t *testing.T) {
+	f := newVersionCommentTestHandler(t)
+	body := bytes.NewBufferString(`{"comment":"cross-tenant write"}`)
+	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodPost, "/", body), chiParamsForVersion(f.secretAID, f.versionBID)))
+	w := httptest.NewRecorder()
+	f.handler.CreateComment(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
 func TestListComments_InvalidVersionID(t *testing.T) {
-	h := newVersionCommentTestHandler(t)
+	f := newVersionCommentTestHandler(t)
 	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodGet, "/", nil), map[string]string{"id": "1", "versionId": "bad"}))
 	w := httptest.NewRecorder()
-	h.ListComments(w, r)
+	f.handler.ListComments(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestListComments_Unauthorized(t *testing.T) {
-	h := newVersionCommentTestHandler(t)
+	f := newVersionCommentTestHandler(t)
 	w := httptest.NewRecorder()
-	h.ListComments(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	f.handler.ListComments(w, httptest.NewRequest(http.MethodGet, "/", nil))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestListComments_InvalidSecretID(t *testing.T) {
-	h := newVersionCommentTestHandler(t)
+	f := newVersionCommentTestHandler(t)
 	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodGet, "/", nil), map[string]string{"id": "bad", "versionId": "1"}))
 	w := httptest.NewRecorder()
-	h.ListComments(w, r)
+	f.handler.ListComments(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestListComments_Empty(t *testing.T) {
-	h := newVersionCommentTestHandler(t)
-	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodGet, "/", nil), map[string]string{"id": "1", "versionId": "1"}))
+	f := newVersionCommentTestHandler(t)
+	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodGet, "/", nil), chiParamsForVersion(f.secretAID, f.versionAID)))
 	w := httptest.NewRecorder()
-	h.ListComments(w, r)
+	f.handler.ListComments(w, r)
 	require.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestDeleteComment_Unauthorized(t *testing.T) {
-	h := newVersionCommentTestHandler(t)
+// TestListComments_VersionBelongsToAnotherSecret is the #G53 regression: the
+// caller is authorized on secret A ({id}) but supplies secret B's versionId —
+// must be refused rather than disclosing secret B's comments.
+func TestListComments_VersionBelongsToAnotherSecret(t *testing.T) {
+	f := newVersionCommentTestHandler(t)
+	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodGet, "/", nil), chiParamsForVersion(f.secretAID, f.versionBID)))
 	w := httptest.NewRecorder()
-	h.DeleteComment(w, httptest.NewRequest(http.MethodDelete, "/", nil))
+	f.handler.ListComments(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestDeleteComment_Unauthorized(t *testing.T) {
+	f := newVersionCommentTestHandler(t)
+	w := httptest.NewRecorder()
+	f.handler.DeleteComment(w, httptest.NewRequest(http.MethodDelete, "/", nil))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestDeleteComment_InvalidCommentID(t *testing.T) {
-	h := newVersionCommentTestHandler(t)
-	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodDelete, "/", nil), map[string]string{"id": "1", "versionId": "1", "commentId": "bad"}))
+	f := newVersionCommentTestHandler(t)
+	params := chiParamsForVersion(f.secretAID, f.versionAID)
+	params["commentId"] = "bad"
+	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodDelete, "/", nil), params))
 	w := httptest.NewRecorder()
-	h.DeleteComment(w, r)
+	f.handler.DeleteComment(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// TestDeleteComment_NotFound: secret/version are real and authorized, but no
+// comment with that ID exists under them. Since local_version_comments.go's
+// DeleteSecretVersionComment now scopes the delete to secret_id/version_id
+// AND reports RowsAffected==0 as not-found (#G53), this is no longer a silent
+// no-op success — it surfaces as an error, same as any other core failure
+// this handler maps to 500.
 func TestDeleteComment_NotFound(t *testing.T) {
-	h := newVersionCommentTestHandler(t)
-	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodDelete, "/", nil), map[string]string{"id": "1", "versionId": "1", "commentId": "999"}))
+	f := newVersionCommentTestHandler(t)
+	params := chiParamsForVersion(f.secretAID, f.versionAID)
+	params["commentId"] = "999"
+	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodDelete, "/", nil), params))
 	w := httptest.NewRecorder()
-	h.DeleteComment(w, r)
-	assert.Equal(t, http.StatusNoContent, w.Code)
+	f.handler.DeleteComment(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestDeleteComment_VersionBelongsToAnotherSecret is the #G53 regression for
+// delete: the caller is authorized on secret A but supplies secret B's
+// versionId — must be refused before any delete is attempted.
+func TestDeleteComment_VersionBelongsToAnotherSecret(t *testing.T) {
+	f := newVersionCommentTestHandler(t)
+	params := chiParamsForVersion(f.secretAID, f.versionBID)
+	params["commentId"] = "1"
+	r := withUserCtx(withChiParams(httptest.NewRequest(http.MethodDelete, "/", nil), params))
+	w := httptest.NewRecorder()
+	f.handler.DeleteComment(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func chiParamsForVersion(secretID, versionID uint) map[string]string {
+	return map[string]string{
+		"id":        fmt.Sprintf("%d", secretID),
+		"versionId": fmt.Sprintf("%d", versionID),
+	}
 }


### PR DESCRIPTION
## Summary

Fixes G53 from the adversarial security review (critical, 10 findings across
router/core/storage/handler layers): `ListSecretVersionComments`,
`CreateSecretVersionComment`, and `DeleteSecretVersionComment` authorized only
the top-level `SecretID` from the URL and never verified that the `VersionID`
(and `CommentID` for delete) supplied in the same request actually belonged to
that authorized secret. A caller authorized on one secret could walk the
globally-shared `VersionID` space to read, annotate, or delete another
tenant's version comments — a classic BOLA via an un-cross-checked
sub-resource ID.

## Changes

- `internal/core/secret_version_comments.go`: new `versionBelongsToSecret`
  helper, called before every create/list/delete.
- `internal/storage/store/local_version_comments.go`: `List`/`Delete` now
  scope their queries to `secret_id`+`version_id` (not just the comment's own
  primary key), so an out-of-scope ID also fails at the DB layer, not only at
  core.
- `internal/core/storage/interface.go` + `remote_version_comments.go`: updated
  signatures to match.
- `server/http/handlers/secret_version_comments.go`: handler now threads
  `secretID` through to `List`/`Delete` (previously discarded after the URL
  param check).
- Regression tests at both the core layer and the handler layer asserting a
  cross-secret `VersionID`/`CommentID` is refused, per the finding's own
  `detection_idea`.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/core/...`, `./internal/storage/...`, `./server/http/...` — all pass
- [x] `gosec -severity medium -exclude-generated` on touched packages — 0 issues
- [x] `golangci-lint run` on touched packages — 0 issues
- [x] New tests: `TestCreateSecretVersionComment_VersionBelongsToOtherSecret`,
      `TestListSecretVersionComments_CrossSecretVersionRejected`,
      `TestDeleteSecretVersionComment_CrossSecretVersionRejected` (core) +
      handler-layer equivalents, all failing before the fix and passing after