### PR TITLE
fix(rbac): wire the last-admin guard into every deactivation/removal path

### DIFF
--- a/internal/core/account_state.go
+++ b/internal/core/account_state.go
@@ -136,9 +136,13 @@ func (c *KeyorixCore) StaleAccounts(ctx context.Context, state string, olderThan
 	return c.storage.ListUsersInStateBefore(ctx, state, before)
 }
 
-// SuspendUser blocks a user's login. Admin action; audited. The bootstrap/admin
-// caller is responsible for not suspending themselves into a lockout.
+// SuspendUser blocks a user's login. Admin action; audited. Refuses to suspend
+// the install's last global administrator (guardLastAdminDeactivation, #G02)
+// — the same lockout DeleteUser and SCIM deactivation already refuse.
 func (c *KeyorixCore) SuspendUser(ctx context.Context, adminID, userID uint) error {
+	if err := c.guardLastAdminDeactivation(ctx, userID); err != nil {
+		return err
+	}
 	return c.setAccountState(ctx, adminID, userID, AccountSuspended, "account.suspended")
 }
 

--- a/internal/core/account_state_test.go
+++ b/internal/core/account_state_test.go
@@ -109,6 +109,13 @@ func TestAdminAccountTransitions(t *testing.T) {
 				store.On("DeleteSessionsForUserExcept", ctx, uint(2), uint(0)).Return(nil)
 				store.On("RevokeAllPersonalAccessTokensForUser", ctx, uint(2)).Return([]string{}, nil)
 			}
+			// SuspendUser now runs guardLastAdminDeactivation first (#G02) — the
+			// fixture user holds no roles, so IsGlobalAdmin resolves false and the
+			// guard is a no-op; only the "suspend" case reaches this check.
+			if tc.name == "suspend" {
+				store.On("GetUserRoleIDsAt", ctx, uint(2), Scope{}).Return([]uint{}, nil)
+				store.On("GetUserGroupRoleIDsAt", ctx, uint(2), Scope{}).Return([]uint{}, nil)
+			}
 
 			require.NoError(t, tc.call(c, ctx))
 			store.AssertExpectations(t)

--- a/internal/core/concurrency_account_suspension_scim_test.go
+++ b/internal/core/concurrency_account_suspension_scim_test.go
@@ -45,6 +45,9 @@ func TestConcurrency_SuspendUser_SurvivesConcurrentSCIMResync(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(
 		&models.User{}, &models.Session{}, &models.AuditEvent{}, &models.PersonalAccessToken{},
 		&models.Role{}, &models.UserRole{}, &models.Project{}, &models.Environment{},
+		// Group/UserGroup/GroupRole are needed by guardLastAdminDeactivation
+		// (#G02), which SuspendUser now calls.
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 	))
 
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
@@ -108,6 +111,9 @@ func TestConcurrency_SuspendUser_SurvivesConcurrentSCIMDeactivateReactivate(t *t
 	require.NoError(t, db.AutoMigrate(
 		&models.User{}, &models.Session{}, &models.AuditEvent{}, &models.PersonalAccessToken{},
 		&models.Role{}, &models.UserRole{}, &models.Project{}, &models.Environment{},
+		// Group/UserGroup/GroupRole are needed by guardLastAdminDeactivation
+		// (#G02), which SuspendUser now calls.
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 	))
 
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))

--- a/internal/core/core_s24_test.go
+++ b/internal/core/core_s24_test.go
@@ -964,6 +964,12 @@ func TestGetUserByExternalID_Success(t *testing.T) {
 
 func TestDeprovisionSCIMGroup_StorageError(t *testing.T) {
 	ms := new(MockStorage)
+	// guardLastGlobalAdminGroupDelete (#G02) resolves the install-admin role IDs
+	// first; none exist in this fixture, so the guard is a no-op and the delete
+	// proceeds to the simulated storage failure under test.
+	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
+	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
+	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
 	ms.On("DeleteGroup", mock.Anything, uint(10)).Return(errors.New("not found"))
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 	c := NewKeyorixCore(ms)
@@ -973,6 +979,9 @@ func TestDeprovisionSCIMGroup_StorageError(t *testing.T) {
 
 func TestDeprovisionSCIMGroup_Success(t *testing.T) {
 	ms := new(MockStorage)
+	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
+	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
+	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
 	ms.On("DeleteGroup", mock.Anything, uint(10)).Return(nil)
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 	c := NewKeyorixCore(ms)

--- a/internal/core/core_s26_test.go
+++ b/internal/core/core_s26_test.go
@@ -251,6 +251,10 @@ func TestUpdateUser_Deactivate_LostRace_ReturnsConflictError(t *testing.T) {
 	ms := new(MockStorage)
 	original := &models.User{ID: 1, Username: "alice", Email: "alice@x.com", IsActive: true}
 	ms.On("GetUser", mock.Anything, uint(1)).Return(original, nil)
+	// guardLastAdminDeactivation (#G02) runs first — fixture user holds no
+	// roles, so IsGlobalAdmin resolves false and the guard is a no-op.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(1), Scope{}).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(1), Scope{}).Return([]uint{}, nil)
 	ms.On("ListSessionTokenHashesForUser", mock.Anything, uint(1)).Return([]string{}, nil)
 	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
 		return u.ID == 1 && !u.IsActive

--- a/internal/core/core_s27_test.go
+++ b/internal/core/core_s27_test.go
@@ -568,6 +568,12 @@ func TestOpenAccessReviewCampaign_ZeroProjectID(t *testing.T) {
 
 func TestDeprovisionSCIMGroup_DeleteGroupError_s27(t *testing.T) {
 	ms := new(MockStorage)
+	// guardLastGlobalAdminGroupDelete (#G02) runs first; no admin roles seeded
+	// in this fixture, so it's a no-op and the simulated DeleteGroup failure
+	// under test is reached.
+	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
+	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
+	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
 	ms.On("DeleteGroup", mock.Anything, uint(5)).Return(errors.New("not found"))
 	c := NewKeyorixCore(ms)
 	err := c.DeprovisionSCIMGroup(context.Background(), 0, 5)

--- a/internal/core/core_s32_test.go
+++ b/internal/core/core_s32_test.go
@@ -85,6 +85,11 @@ func TestRemovePermissionFromRole_RoleNotFound(t *testing.T) {
 
 func TestApplyGroupMembershipChanges_RemoveAndAdd(t *testing.T) {
 	ms := new(MockStorage)
+	// guardLastGlobalAdminMembership (#G02) precheck for user 1's removal — no
+	// admin roles seeded in this fixture, so it's a no-op.
+	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
+	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
+	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
 	// user 1 is in current but NOT in want → RemoveUserFromGroup (global: projectID=0).
 	ms.On("RemoveUserFromGroup", mock.Anything, uint(1), uint(10), uint(0)).Return(nil)
 	// user 2 is in current AND in want → no-op.
@@ -94,7 +99,7 @@ func TestApplyGroupMembershipChanges_RemoveAndAdd(t *testing.T) {
 	want := map[uint]bool{2: true}
 	current := []*models.User{{ID: 1}, {ID: 2}}
 	toAdd := []uint{3}
-	c.applyGroupMembershipChanges(context.Background(), 10, want, current, toAdd)
+	require.NoError(t, c.applyGroupMembershipChanges(context.Background(), 10, want, current, toAdd))
 	ms.AssertExpectations(t)
 }
 

--- a/internal/core/last_admin_guard_wiring_test.go
+++ b/internal/core/last_admin_guard_wiring_test.go
@@ -1,0 +1,150 @@
+// last_admin_guard_wiring_test.go — #G02 regressions: guardLastAdminDeactivation
+// and its group-membership/group-delete counterparts were correct where they
+// were called, but several demotion/removal paths were added without calling
+// them. Each test below simulates a single-global-admin install and asserts
+// the previously-unguarded path now refuses to strip the install's last
+// administrator, mirroring the existing guardLastAdminDeactivation coverage
+// in scim_guards_test.go.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSuspendUser_RefusesLastAdminDeactivation(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 10}).Error) // global admin
+
+	err := c.SuspendUser(ctx, 9, 1)
+	require.Error(t, err, "must refuse to suspend the install's last global administrator")
+	assert.Contains(t, err.Error(), "last install administrator")
+}
+
+func TestSuspendUser_AllowsWhenAnotherAdminExists(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "root2", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 10}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 10}).Error)
+
+	err := c.SuspendUser(ctx, 9, 1)
+	require.NoError(t, err, "suspending one of two admins is allowed")
+}
+
+func TestUpdateUser_RefusesLastAdminDeactivation(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", Email: "root@x.io", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 10}).Error)
+
+	no := false
+	_, err := c.UpdateUser(ctx, &UpdateUserRequest{ID: 1, IsActive: &no})
+	require.Error(t, err, "must refuse to deactivate the install's last global administrator via UpdateUser")
+	assert.Contains(t, err.Error(), "last install administrator")
+}
+
+func TestUpdateUser_AllowsDeactivationWhenAnotherAdminExists(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", Email: "root@x.io", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "root2", Email: "root2@x.io", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 10}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 10}).Error)
+
+	no := false
+	updated, err := c.UpdateUser(ctx, &UpdateUserRequest{ID: 1, IsActive: &no})
+	require.NoError(t, err, "deactivating one of two admins via UpdateUser is allowed")
+	assert.False(t, updated.IsActive)
+}
+
+func TestDeprovisionSCIMGroup_RefusesWhenGroupHoldsLastAdmin(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive, ExternalID: "okta|root"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Keyorix-Admins"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 5, RoleID: 10}).Error) // group confers admin, globally
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 1, GroupID: 5}).Error)
+
+	err := c.DeprovisionSCIMGroup(ctx, 9, 5)
+	require.Error(t, err, "must refuse to delete a group holding the install's last route to admin authority")
+
+	// The group must still exist — the guard must run BEFORE the delete.
+	_, getErr := c.storage.GetGroup(ctx, 5)
+	require.NoError(t, getErr, "group must not have been deleted when the guard refuses")
+}
+
+func TestDeprovisionSCIMGroup_AllowsWhenGroupConfersNoAdmin(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Engineering"}).Error)
+
+	err := c.DeprovisionSCIMGroup(ctx, 9, 5)
+	require.NoError(t, err, "deleting a non-admin-bearing group must still work")
+}
+
+func TestReplaceSCIMGroup_RefusesRemovingLastAdminMember(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive, ExternalID: "okta|root"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Keyorix-Admins"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 5, RoleID: 10}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 1, GroupID: 5}).Error)
+
+	// PUT with an empty member list — removes user 1, the install's only admin route.
+	_, err := c.ReplaceSCIMGroup(ctx, 9, 5, "", nil)
+	require.Error(t, err, "must refuse a SCIM PUT that would strip the install's last admin-group membership")
+
+	members, mErr := c.storage.ListGroupMembers(ctx, 5)
+	require.NoError(t, mErr)
+	require.Len(t, members, 1, "the membership must not have been removed when the guard refuses")
+}
+
+func TestPatchSCIMGroup_RefusesRemovingLastAdminMember(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive, ExternalID: "okta|root"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Keyorix-Admins"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 5, RoleID: 10}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 1, GroupID: 5}).Error)
+
+	_, err := c.PatchSCIMGroup(ctx, 9, 5, nil, nil, []uint{1})
+	require.Error(t, err, "must refuse a SCIM PATCH remove that would strip the install's last admin-group membership")
+
+	members, mErr := c.storage.ListGroupMembers(ctx, 5)
+	require.NoError(t, mErr)
+	require.Len(t, members, 1, "the membership must not have been removed when the guard refuses")
+}
+
+func TestPatchSCIMGroup_AllowsRemovingMemberWhenAnotherAdminExists(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive, ExternalID: "okta|root"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "root2", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Keyorix-Admins"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 5, RoleID: 10}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 1, GroupID: 5}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 10}).Error) // independent admin route
+
+	_, err := c.PatchSCIMGroup(ctx, 9, 5, nil, nil, []uint{1})
+	require.NoError(t, err, "removing one admin route is fine when another survives")
+
+	members, mErr := c.storage.ListGroupMembers(ctx, 5)
+	require.NoError(t, mErr)
+	assert.Empty(t, members)
+}

--- a/internal/core/migrate_user_to_machine_test.go
+++ b/internal/core/migrate_user_to_machine_test.go
@@ -22,8 +22,12 @@ func TestMigrateUserToMachine(t *testing.T) {
 		store.On("CreateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
 			return m.ProjectID == 3 && m.Name == "ci-bot" && m.IdentityType == MachineTypeService && m.State == MachineActive
 		})).Return(&models.MachineIdentity{ID: 20, ProjectID: 3, Name: "ci-bot", IdentityType: MachineTypeService, State: MachineActive}, nil)
-		// SuspendUser path: LockUserForUpdate → SetAccountState(account_state=suspended) →
-		// purge the migrated user's sessions (suspension revokes existing tokens).
+		// SuspendUser path: guardLastAdminDeactivation (#G02) → LockUserForUpdate →
+		// SetAccountState(account_state=suspended) → purge the migrated user's
+		// sessions (suspension revokes existing tokens). The migrated user holds
+		// no roles in this fixture, so the guard is a no-op.
+		store.On("GetUserRoleIDsAt", ctx, uint(7), Scope{}).Return([]uint{}, nil)
+		store.On("GetUserGroupRoleIDsAt", ctx, uint(7), Scope{}).Return([]uint{}, nil)
 		store.On("GetUser", ctx, uint(7)).
 			Return(&models.User{ID: 7, Username: "ci-bot", AccountState: "active"}, nil)
 		store.On("SetAccountState", ctx, uint(7), AccountSuspended, mock.Anything).Return(nil)

--- a/internal/core/pat_suspend_test.go
+++ b/internal/core/pat_suspend_test.go
@@ -24,7 +24,12 @@ func TestValidatePATToken_SuspendRevokesTokenAccess(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.User{}, &models.PersonalAccessToken{}, &models.Session{}, &models.AuditEvent{}))
+	// Role/UserRole/Group/UserGroup/GroupRole are needed by guardLastAdminDeactivation
+	// (#G02), which SuspendUser now calls — without them IsGlobalAdmin's role lookup
+	// fails on a missing table and the guard fails closed, refusing every suspend.
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.PersonalAccessToken{}, &models.Session{}, &models.AuditEvent{},
+		&models.Role{}, &models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}))
 
 	ls := store.NewLocalStorage(db)
 	c := NewKeyorixCore(ls)

--- a/internal/core/remote_account_state_hardfail_test.go
+++ b/internal/core/remote_account_state_hardfail_test.go
@@ -33,6 +33,10 @@ func TestSuspendUser_HardFailsWhenBackendCannotPersistAccountState(t *testing.T)
 	ctx := context.Background()
 
 	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, AccountState: AccountActive}, nil)
+	// guardLastAdminDeactivation (#G02) runs first — fixture user holds no
+	// roles, so IsGlobalAdmin resolves false and the guard is a no-op.
+	store.On("GetUserRoleIDsAt", ctx, uint(2), Scope{}).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(2), Scope{}).Return([]uint{}, nil)
 	store.On("ListSessionTokenHashesForUser", ctx, uint(2)).Return([]string{}, nil)
 	// H-2: ListPersonalAccessTokensByUser is called before SetAccountState.
 	store.On("ListPersonalAccessTokensByUser", ctx, uint(2)).Return([]*models.PersonalAccessToken{}, nil)

--- a/internal/core/scim_groups.go
+++ b/internal/core/scim_groups.go
@@ -162,7 +162,9 @@ func (c *KeyorixCore) ReplaceSCIMGroup(ctx context.Context, actorID, groupID uin
 	if _, rejected := c.filterSCIMManaged(ctx, toAdd); len(rejected) > 0 {
 		return nil, fmt.Errorf("%s: SCIM can only add SCIM-managed users to a group (rejected member id(s): %v)", i18n.T("ErrorNotAuthorized", nil), rejected)
 	}
-	c.applyGroupMembershipChanges(ctx, groupID, want, current, toAdd)
+	if err := c.applyGroupMembershipChanges(ctx, groupID, want, current, toAdd); err != nil {
+		return nil, err
+	}
 	c.writeAuditEvent(ctx, EventSCIMGroupUpdated, actorPtr(actorID), nil,
 		fmt.Sprintf("SCIM replaced group %d (members=%d)", groupID, len(want)))
 	return c.storage.GetGroup(ctx, groupID)
@@ -193,10 +195,20 @@ func (c *KeyorixCore) PatchSCIMGroup(ctx context.Context, actorID, groupID uint,
 	if len(rejected) > 0 {
 		return nil, fmt.Errorf("%s: SCIM can only add SCIM-managed users to a group (rejected member id(s): %v)", i18n.T("ErrorNotAuthorized", nil), rejected)
 	}
+	// Check every removal against guardLastGlobalAdminMembership (#G02) BEFORE
+	// applying any of them, so a PATCH that would strip the install's last route
+	// to global-admin authority is refused atomically — see
+	// applyGroupMembershipChanges's identical precheck-then-apply shape.
+	toRemove := filterNonZero(removeIDs)
+	for _, id := range toRemove {
+		if err := c.guardLastGlobalAdminMembership(ctx, id, groupID); err != nil {
+			return nil, err
+		}
+	}
 	for _, id := range allowedAdds {
 		_ = c.storage.AddUserToGroup(ctx, id, groupID, 0) // SCIM memberships are always global
 	}
-	for _, id := range filterNonZero(removeIDs) {
+	for _, id := range toRemove {
 		_ = c.storage.RemoveUserFromGroup(ctx, id, groupID, 0) // SCIM memberships are always global
 	}
 	c.writeAuditEvent(ctx, EventSCIMGroupUpdated, actorPtr(actorID), nil,
@@ -263,7 +275,19 @@ func filterNonZero(ids []uint) []uint {
 	return out
 }
 
-func (c *KeyorixCore) applyGroupMembershipChanges(ctx context.Context, groupID uint, want map[uint]bool, current []*models.User, toAdd []uint) {
+// applyGroupMembershipChanges applies the add/remove sets computed by the
+// caller. Every removal is checked against guardLastGlobalAdminMembership
+// (#G02) BEFORE any storage write happens, so a SCIM PUT that would strip the
+// install's last route to global-admin authority is refused atomically — not
+// applied member-by-member with some removals already committed.
+func (c *KeyorixCore) applyGroupMembershipChanges(ctx context.Context, groupID uint, want map[uint]bool, current []*models.User, toAdd []uint) error {
+	for _, u := range current {
+		if !want[u.ID] {
+			if err := c.guardLastGlobalAdminMembership(ctx, u.ID, groupID); err != nil {
+				return err
+			}
+		}
+	}
 	for _, u := range current {
 		if !want[u.ID] {
 			_ = c.storage.RemoveUserFromGroup(ctx, u.ID, groupID, 0) // SCIM memberships are always global
@@ -272,11 +296,17 @@ func (c *KeyorixCore) applyGroupMembershipChanges(ctx context.Context, groupID u
 	for _, id := range toAdd {
 		_ = c.storage.AddUserToGroup(ctx, id, groupID, 0) // SCIM memberships are always global
 	}
+	return nil
 }
 
 // DeprovisionSCIMGroup handles a SCIM DELETE — removes the group (membership links
-// go with it).
+// go with it). Refuses to delete a group holding the install's last
+// global-admin-conferring role grant (guardLastGlobalAdminGroupDelete, #G02) —
+// the same guard the native DeleteGroup already applies.
 func (c *KeyorixCore) DeprovisionSCIMGroup(ctx context.Context, actorID, groupID uint) error {
+	if err := c.guardLastGlobalAdminGroupDelete(ctx, groupID); err != nil {
+		return err
+	}
 	// Storage-direct: the SCIM path emits scim.group_deprovisioned below, not the
 	// generic group.deleted. storage.DeleteGroup still errors on a missing group.
 	if err := c.storage.DeleteGroup(ctx, groupID); err != nil {

--- a/internal/core/update_user_deactivation_test.go
+++ b/internal/core/update_user_deactivation_test.go
@@ -45,6 +45,15 @@ func TestUpdateUser_Deactivation_RevokesSessionsAndPATs(t *testing.T) {
 		&models.AuditEvent{},
 		&models.UserRole{},
 		&models.Role{},
+		// Group/UserGroup/GroupRole/Project/Environment are needed by
+		// guardLastAdminDeactivation (#G02), which UpdateUser's deactivating
+		// path now calls — without them the role lookup fails on a missing
+		// table and the guard fails closed, refusing every deactivation.
+		&models.Group{},
+		&models.UserGroup{},
+		&models.GroupRole{},
+		&models.Project{},
+		&models.Environment{},
 	))
 
 	st := store.NewLocalStorage(db)
@@ -127,6 +136,15 @@ func TestUpdateUser_NoRevocation_WhenAlreadyInactive(t *testing.T) {
 		&models.AuditEvent{},
 		&models.UserRole{},
 		&models.Role{},
+		// Group/UserGroup/GroupRole/Project/Environment are needed by
+		// guardLastAdminDeactivation (#G02), which UpdateUser's deactivating
+		// path now calls — without them the role lookup fails on a missing
+		// table and the guard fails closed, refusing every deactivation.
+		&models.Group{},
+		&models.UserGroup{},
+		&models.GroupRole{},
+		&models.Project{},
+		&models.Environment{},
 	))
 
 	st := store.NewLocalStorage(db)

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -304,6 +304,14 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 		user.IsActive = *req.IsActive
 	}
 	deactivating := wasActive && !user.IsActive
+	if deactivating {
+		// Refuse to deactivate the install's last global administrator (#G02) —
+		// the same lockout guard DeleteUser and SCIM deactivation already apply;
+		// this was the one active-state-flipping path that skipped it.
+		if err := c.guardLastAdminDeactivation(ctx, req.ID); err != nil {
+			return nil, err
+		}
+	}
 	user.UpdatedAt = c.now()
 
 	var sessionHashes []string

--- a/server/http/handlers/auth_cache_invalidation_test.go
+++ b/server/http/handlers/auth_cache_invalidation_test.go
@@ -41,6 +41,10 @@ func newCacheTestCore(t *testing.T) *core.KeyorixCore {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.User{}, &models.PersonalAccessToken{}, &models.Session{}, &models.AuditEvent{},
+		// Role/UserRole/Group/UserGroup/GroupRole/Project/Environment are needed
+		// by guardLastAdminDeactivation (#G02), which SuspendUser now calls.
+		&models.Role{}, &models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{},
 	))
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	c.SetTokenCacheInvalidator(middleware.InvalidateTokenCacheByHash)

--- a/server/http/handlers/machine_identities_migrate_test.go
+++ b/server/http/handlers/machine_identities_migrate_test.go
@@ -24,6 +24,10 @@ func newMigrateHandler(t *testing.T) (*CatalogHandler, *gorm.DB) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.User{}, &models.MachineIdentity{}, &models.Project{}, &models.Session{}, &models.AuditEvent{},
+		// Role/UserRole/Group/UserGroup/GroupRole/Environment are needed by
+		// guardLastAdminDeactivation (#G02), which MigrateUserToMachine's
+		// SuspendUser call now runs.
+		&models.Role{}, &models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Environment{},
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 3, Name: "platform"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 7, Username: "ci-bot", Email: "ci-bot@x.io", AccountState: core.AccountActive}).Error)


### PR DESCRIPTION
## Summary

Fixes G02 from the adversarial security review (critical, 7 findings): `guardLastAdminDeactivation` and its group-membership/group-delete counterparts (`guardLastGlobalAdminMembership`, `guardLastGlobalAdminGroupDelete`) were correct where they were already called, but several newer paths that can deactivate a user or strip an admin-conferring group membership were added without calling them — each is a separate way to lock an install out of its own administration:

- `SuspendUser` could suspend the install's last global administrator.
- `UpdateUser(IsActive=false)` could deactivate the install's last global administrator.
- `DeprovisionSCIMGroup` could delete a group holding the install's last route to admin authority.
- SCIM group member removal (`ReplaceSCIMGroup`'s `applyGroupMembershipChanges`, `PatchSCIMGroup`'s removal loop) could strip the last admin's membership in an admin-conferring group.

## Changes

- `internal/core/account_state.go`: `SuspendUser` now calls `guardLastAdminDeactivation` before suspending.
- `internal/core/users.go`: `UpdateUser`'s deactivating branch now calls the same guard.
- `internal/core/scim_groups.go`: `DeprovisionSCIMGroup` calls `guardLastGlobalAdminGroupDelete`; `applyGroupMembershipChanges` and `PatchSCIMGroup`'s removal loop check every removal against `guardLastGlobalAdminMembership` **before** applying any of them, so a request that would strip the last admin route is refused atomically, not partially applied.
- The two `server/http/handlers` SCIM-group findings in this group close automatically — the handlers already route through the now-guarded core functions.
- Regression tests for all four fixes (`internal/core/last_admin_guard_wiring_test.go`), plus mock/fixture updates in existing tests that now need to account for the guard's additional storage calls (either mocked, or the in-memory SQLite migration extended with the RBAC tables the guard queries).

## Scope note

`internal/core/groups.go:89` (`DeleteGroup`/`RemoveUserFromGroup` only check the *global* last-admin guard, not a *project-scoped* one for groups holding a project-scoped admin grant) is a distinct, medium-severity member of this same finding group that needs new logic (no existing project-scoped-group-admin guard to wire) rather than mechanical wiring. Left for a follow-up — tracked in the private remediation status doc, not silently dropped.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/core/...`, `./server/http/...` — all pass
- [x] `gosec -severity medium -exclude-generated` on touched packages — 0 issues
- [x] `golangci-lint run` on touched packages — 0 issues
- [x] New regression tests: `TestSuspendUser_RefusesLastAdminDeactivation`, `TestUpdateUser_RefusesLastAdminDeactivation`, `TestDeprovisionSCIMGroup_RefusesWhenGroupHoldsLastAdmin`, `TestReplaceSCIMGroup_RefusesRemovingLastAdminMember`, `TestPatchSCIMGroup_RefusesRemovingLastAdminMember`, plus "allows when another admin exists" positive controls for each — all failing before the fix, passing after