### PR TITLE
fix(remote-storage): stop silently dropping fields on the RemoteStorage wire

### DIFF
--- a/internal/storage/store/remote_machine_identities.go
+++ b/internal/storage/store/remote_machine_identities.go
@@ -133,11 +133,11 @@ func decodeMachineIdentityResponse(data []byte) (*models.MachineIdentity, error)
 }
 
 type machineIdentityCredentialWire struct {
-	ID                uint       `json:"id"`
-	MachineIdentityID uint       `json:"machine_identity_id"`
-	Name              string     `json:"name"`
-	TokenHash         string     `json:"token_hash"`
-	TokenPrefix       string     `json:"token_prefix"`
+	ID                uint   `json:"id"`
+	MachineIdentityID uint   `json:"machine_identity_id"`
+	Name              string `json:"name"`
+	TokenHash         string `json:"token_hash"`
+	TokenPrefix       string `json:"token_prefix"`
 	// AllowedCIDRs (#G80) must round-trip: omitting it here silently strips the
 	// machine-token IP allowlist on every RemoteStorage read/write, and
 	// ClassifyMachineToken's read-mutate-Save cycle would actively WIPE a

--- a/internal/storage/store/remote_machine_identities.go
+++ b/internal/storage/store/remote_machine_identities.go
@@ -138,11 +138,16 @@ type machineIdentityCredentialWire struct {
 	Name              string     `json:"name"`
 	TokenHash         string     `json:"token_hash"`
 	TokenPrefix       string     `json:"token_prefix"`
-	LastUsedAt        *time.Time `json:"last_used_at"`
-	ExpiresAt         *time.Time `json:"expires_at"`
-	Revoked           bool       `json:"revoked"`
-	CreatedAt         time.Time  `json:"created_at"`
-	Classification    string     `json:"classification"`
+	// AllowedCIDRs (#G80) must round-trip: omitting it here silently strips the
+	// machine-token IP allowlist on every RemoteStorage read/write, and
+	// ClassifyMachineToken's read-mutate-Save cycle would actively WIPE a
+	// previously-set allowlist on the next classification change.
+	AllowedCIDRs   string     `json:"allowed_cidrs"`
+	LastUsedAt     *time.Time `json:"last_used_at"`
+	ExpiresAt      *time.Time `json:"expires_at"`
+	Revoked        bool       `json:"revoked"`
+	CreatedAt      time.Time  `json:"created_at"`
+	Classification string     `json:"classification"`
 }
 
 func newMachineIdentityCredentialWire(c *models.MachineIdentityCredential) machineIdentityCredentialWire {
@@ -152,6 +157,7 @@ func newMachineIdentityCredentialWire(c *models.MachineIdentityCredential) machi
 		Name:              c.Name,
 		TokenHash:         c.TokenHash,
 		TokenPrefix:       c.TokenPrefix,
+		AllowedCIDRs:      c.AllowedCIDRs,
 		LastUsedAt:        c.LastUsedAt,
 		ExpiresAt:         c.ExpiresAt,
 		Revoked:           c.Revoked,
@@ -167,6 +173,7 @@ func (w machineIdentityCredentialWire) toModel() *models.MachineIdentityCredenti
 		Name:              w.Name,
 		TokenHash:         w.TokenHash,
 		TokenPrefix:       w.TokenPrefix,
+		AllowedCIDRs:      w.AllowedCIDRs,
 		LastUsedAt:        w.LastUsedAt,
 		ExpiresAt:         w.ExpiresAt,
 		Revoked:           w.Revoked,

--- a/internal/storage/store/remote_machine_identities_test.go
+++ b/internal/storage/store/remote_machine_identities_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -231,6 +232,36 @@ func TestRemoteStorage_CreateMachineIdentityCredential(t *testing.T) {
 	assert.Equal(t, uint(11), cred.ID)
 	assert.Equal(t, "prod-token", cred.Name)
 	assert.Equal(t, "abc123", cred.TokenHash)
+}
+
+// TestRemoteStorage_CreateMachineIdentityCredential_RoundTripsAllowedCIDRs is
+// the #G80 regression: AllowedCIDRs (the machine-token IP allowlist) was
+// omitted from the wire struct entirely, so it was silently stripped on every
+// RemoteStorage credential read/write.
+func TestRemoteStorage_CreateMachineIdentityCredential_RoundTripsAllowedCIDRs(t *testing.T) {
+	const cidrs = `["10.0.0.0/8","192.0.2.4/32"]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			AllowedCIDRs string `json:"allowed_cidrs"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, cidrs, body.AllowedCIDRs, "AllowedCIDRs must be sent on the request leg")
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"id": 11, "machine_identity_id": 4, "name": "prod-token",
+			"token_hash": "abc123", "token_prefix": "kx_machine_ab",
+			"allowed_cidrs": cidrs, "created_at": time.Now(),
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	cred, err := rs.CreateMachineIdentityCredential(context.Background(), &models.MachineIdentityCredential{
+		MachineIdentityID: 4, Name: "prod-token", TokenHash: "abc123", AllowedCIDRs: cidrs,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, cidrs, cred.AllowedCIDRs, "AllowedCIDRs must survive the response leg too")
 }
 
 func TestRemoteStorage_GetMachineIdentityCredentialByHash(t *testing.T) {

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -649,9 +649,16 @@ func (rs *RemoteStorage) AssignRoleToGroup(ctx context.Context, groupID, roleID 
 	return nil
 }
 
-// RemoveRoleFromGroup removes a role from a group via remote API.
-func (rs *RemoteStorage) RemoveRoleFromGroup(ctx context.Context, groupID, roleID uint, _ storage.Scope) error {
-	path := fmt.Sprintf("/api/v1/groups/%d/roles/%d", groupID, roleID)
+// RemoveRoleFromGroup removes a role from a group at scope via remote API.
+// scope must be sent as query params (DELETE has no body) — RemoveRoleFromGroup's
+// server-side handler (server/http/handlers/rbac.go) reads project_id/environment_id
+// exactly like its AssignRoleToGroup sibling; silently discarding scope here (#G80)
+// meant a scoped revocation could never hit its target grant.
+func (rs *RemoteStorage) RemoveRoleFromGroup(ctx context.Context, groupID, roleID uint, scope storage.Scope) error {
+	q := url.Values{}
+	q.Set("project_id", strconv.FormatUint(uint64(scope.ProjectID), 10))
+	q.Set("environment_id", strconv.FormatUint(uint64(scope.EnvironmentID), 10))
+	path := fmt.Sprintf("/api/v1/groups/%d/roles/%d?%s", groupID, roleID, q.Encode())
 	resp, err := rs.client.Delete(ctx, path)
 	if err != nil {
 		return fmt.Errorf("failed to remove role from group: %w", err)

--- a/internal/storage/store/remote_rbac_test.go
+++ b/internal/storage/store/remote_rbac_test.go
@@ -533,6 +533,28 @@ func TestRemoteStorage_RemoveRoleFromGroup(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestRemoteStorage_RemoveRoleFromGroup_SendsScope is the #G80 regression:
+// scope was previously discarded entirely (the parameter was named `_`), so a
+// scoped revocation (e.g. project 5's roles.assign grant) could never hit its
+// target — the server-side handler reads project_id/environment_id from the
+// query string, so the client must actually send them.
+func TestRemoteStorage_RemoveRoleFromGroup_SendsScope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/groups/8/roles/2", r.URL.Path)
+		assert.Equal(t, "5", r.URL.Query().Get("project_id"))
+		assert.Equal(t, "3", r.URL.Query().Get("environment_id"))
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemoveRoleFromGroup(context.Background(), 8, 2, corestorage.Scope{ProjectID: 5, EnvironmentID: 3})
+	require.NoError(t, err)
+}
+
 // --- Server-internal authorization primitives (unsupported in remote mode) ---
 
 func TestRemoteStorage_GetUserRoleIDsAt_Unsupported(t *testing.T) {

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -55,12 +55,15 @@ import (
 //     SecretNode argument. Left as a documented residual gap; UpdateSecret was
 //     out of #499's scope (CreateUser/CreateSecret only).
 type secretCreateWireRequest struct {
-	Name           string      `json:"name"`
-	Value          string      `json:"value"`
-	ProjectID      uint        `json:"project_id"`
-	EnvironmentID  uint        `json:"environment_id"`
-	Type           string      `json:"type"`
-	MaxReads       *int        `json:"max_reads,omitempty"`
+	Name          string `json:"name"`
+	Value         string `json:"value"`
+	ProjectID     uint   `json:"project_id"`
+	EnvironmentID uint   `json:"environment_id"`
+	Type          string `json:"type"`
+	MaxReads      *int   `json:"max_reads,omitempty"`
+	// ParentID (#G80) — omitting it silently created every secret at project
+	// root regardless of the folder the caller placed it in.
+	ParentID       *uint       `json:"parent_id,omitempty"`
 	Metadata       models.JSON `json:"metadata,omitempty"`
 	Classification string      `json:"classification,omitempty"`
 }
@@ -73,6 +76,7 @@ func newSecretCreateWireRequest(secret *models.SecretNode, plaintextValue string
 		EnvironmentID:  secret.EnvironmentID,
 		Type:           secret.Type,
 		MaxReads:       secret.MaxReads,
+		ParentID:       secret.ParentID,
 		Metadata:       secret.Metadata,
 		Classification: secret.Classification,
 	}

--- a/internal/storage/store/remote_storage_test.go
+++ b/internal/storage/store/remote_storage_test.go
@@ -70,6 +70,30 @@ func TestRemoteStorage_CreateSecret(t *testing.T) {
 	assert.Equal(t, "test-secret", result.Name)
 }
 
+// TestRemoteStorage_CreateSecret_SendsParentID is the #G80 regression:
+// ParentID was omitted from the wire request entirely, so every secret
+// created inside a folder under storage.type: remote was silently created at
+// project root instead.
+func TestRemoteStorage_CreateSecret_SendsParentID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			ParentID *uint `json:"parent_id"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.NotNil(t, body.ParentID)
+		assert.Equal(t, uint(42), *body.ParentID)
+		_, _ = w.Write(apiOK(map[string]interface{}{"id": 1, "name": "test-secret", "type": "password"}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	parentID := uint(42)
+	_, err = rs.CreateSecret(context.Background(), &models.SecretNode{Name: "test-secret", Type: "password", ParentID: &parentID})
+	require.NoError(t, err)
+}
+
 func TestRemoteStorage_GetSecret(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/api/v1/secrets/1", r.URL.Path)

--- a/server/http/handlers/handlers_s13_project_test.go
+++ b/server/http/handlers/handlers_s13_project_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -549,6 +550,31 @@ func TestUpdateProjectProxy_HappyPath_S13(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.UpdateProjectProxy(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestUpdateProjectProxy_PreservesTimestamps_G80 is the #G80 regression:
+// projectProxyWire.toModel() previously dropped CreatedAt/UpdatedAt/DeletedAt
+// even though the wire struct (and its response-leg constructor) carry them,
+// so every proxied update silently zeroed the project's CreatedAt.
+func TestUpdateProjectProxy_PreservesTimestamps_G80(t *testing.T) {
+	t.Parallel()
+	cs := freshCoreS12(t)
+	h := NewCatalogHandler(cs)
+	proj, err := cs.CreateProject(context.Background(), "s13g80timestamps", "")
+	require.NoError(t, err)
+	require.False(t, proj.CreatedAt.IsZero(), "fixture project must have a real CreatedAt to prove it survives")
+
+	body := fmt.Sprintf(`{"id":%d,"name":"s13g80timestamps-new","description":"updated","created_at":%q}`,
+		proj.ID, proj.CreatedAt.Format(time.RFC3339Nano))
+	r := withChiParam(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body)), "id", fmt.Sprintf("%d", proj.ID))
+	w := httptest.NewRecorder()
+	h.UpdateProjectProxy(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	updated, err := cs.Storage().GetProject(context.Background(), proj.ID)
+	require.NoError(t, err)
+	assert.False(t, updated.CreatedAt.IsZero(), "CreatedAt must not be zeroed by the proxy update")
+	assert.WithinDuration(t, proj.CreatedAt, updated.CreatedAt, time.Second)
 }
 
 // TestDeleteProjectProxy_BadID_S13 — non-numeric id → 400.

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -180,11 +180,11 @@ func (w machineIdentityProxyWire) toModel() *models.MachineIdentity {
 // for why sending this SHA-256 hash (never the raw token) across this internal
 // boundary is safe.
 type machineIdentityCredentialProxyWire struct {
-	ID                uint       `json:"id"`
-	MachineIdentityID uint       `json:"machine_identity_id"`
-	Name              string     `json:"name"`
-	TokenHash         string     `json:"token_hash"`
-	TokenPrefix       string     `json:"token_prefix"`
+	ID                uint   `json:"id"`
+	MachineIdentityID uint   `json:"machine_identity_id"`
+	Name              string `json:"name"`
+	TokenHash         string `json:"token_hash"`
+	TokenPrefix       string `json:"token_prefix"`
 	// AllowedCIDRs (#G80) — see remote_machine_identities.go's identical wire
 	// struct on the client leg; this is the server-side half of the same omission.
 	AllowedCIDRs   string     `json:"allowed_cidrs"`

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -185,11 +185,14 @@ type machineIdentityCredentialProxyWire struct {
 	Name              string     `json:"name"`
 	TokenHash         string     `json:"token_hash"`
 	TokenPrefix       string     `json:"token_prefix"`
-	LastUsedAt        *time.Time `json:"last_used_at"`
-	ExpiresAt         *time.Time `json:"expires_at"`
-	Revoked           bool       `json:"revoked"`
-	CreatedAt         time.Time  `json:"created_at"`
-	Classification    string     `json:"classification"`
+	// AllowedCIDRs (#G80) — see remote_machine_identities.go's identical wire
+	// struct on the client leg; this is the server-side half of the same omission.
+	AllowedCIDRs   string     `json:"allowed_cidrs"`
+	LastUsedAt     *time.Time `json:"last_used_at"`
+	ExpiresAt      *time.Time `json:"expires_at"`
+	Revoked        bool       `json:"revoked"`
+	CreatedAt      time.Time  `json:"created_at"`
+	Classification string     `json:"classification"`
 }
 
 func newMachineIdentityCredentialProxyWire(c *models.MachineIdentityCredential) machineIdentityCredentialProxyWire {
@@ -199,6 +202,7 @@ func newMachineIdentityCredentialProxyWire(c *models.MachineIdentityCredential) 
 		Name:              c.Name,
 		TokenHash:         c.TokenHash,
 		TokenPrefix:       c.TokenPrefix,
+		AllowedCIDRs:      c.AllowedCIDRs,
 		LastUsedAt:        c.LastUsedAt,
 		ExpiresAt:         c.ExpiresAt,
 		Revoked:           c.Revoked,
@@ -214,6 +218,7 @@ func (w machineIdentityCredentialProxyWire) toModel() *models.MachineIdentityCre
 		Name:              w.Name,
 		TokenHash:         w.TokenHash,
 		TokenPrefix:       w.TokenPrefix,
+		AllowedCIDRs:      w.AllowedCIDRs,
 		LastUsedAt:        w.LastUsedAt,
 		ExpiresAt:         w.ExpiresAt,
 		Revoked:           w.Revoked,

--- a/server/http/handlers/project_catalog_proxy.go
+++ b/server/http/handlers/project_catalog_proxy.go
@@ -80,12 +80,23 @@ func newProjectProxyWire(p *models.Project) projectProxyWire {
 }
 
 func (w projectProxyWire) toModel() *models.Project {
-	return &models.Project{
+	p := &models.Project{
 		ID:          w.ID,
 		Name:        w.Name,
 		Description: w.Description,
 		RequireMFA:  w.RequireMFA,
+		// CreatedAt/UpdatedAt/DeletedAt (#G80) — dropping these on the request
+		// leg silently zeroed CreatedAt (and lost DeletedAt) on every proxied
+		// update, even though the wire struct and newProjectProxyWire (the
+		// response leg) already carry them correctly.
+		CreatedAt: w.CreatedAt,
+		UpdatedAt: w.UpdatedAt,
 	}
+	if w.DeletedAt != nil {
+		p.DeletedAt.Time = *w.DeletedAt
+		p.DeletedAt.Valid = true
+	}
+	return p
 }
 
 // isProjectNotFound reports whether err is a errProjectNotFound error from


### PR DESCRIPTION
## Summary

Fixes G80 from the adversarial security review (critical, 6 findings): four independent hand-written wire structs/converters under `storage.type: remote` each enumerated most fields correctly but silently omitted one security-relevant field, stripping it on every hop.

## Changes

- `machineIdentityCredentialWire` (client, `remote_machine_identities.go`) and `machineIdentityCredentialProxyWire` (server, `machine_identities_proxy.go`) both omitted `AllowedCIDRs` — the machine-token IP allowlist was silently lost on every RemoteStorage credential read/write, and `ClassifyMachineToken`'s read-mutate-Save cycle actively wiped a previously-set allowlist. Fixed on both legs.
- `RemoteStorage.RemoveRoleFromGroup` discarded its `scope` parameter entirely (it was named `_`), so a scoped role revocation could never reach its target grant. The server-side handler already reads `project_id`/`environment_id` from the query string exactly like its `AssignRoleToGroup` sibling — the client just never sent them.
- `secretCreateWireRequest` omitted `parent_id`, so secrets created inside a folder under `storage.type: remote` were silently created at project root instead. The server already supports it.
- `projectProxyWire.toModel()` (the request-decode leg) dropped `CreatedAt`/`UpdatedAt`/`DeletedAt` even though the wire struct and its response-leg constructor (`newProjectProxyWire`) already carry them correctly — every proxied project update silently zeroed `CreatedAt`.

Each fix adds the missing field to its wire struct/constructor/converter, plus a regression test proving the field survives the round trip.

## Scope note

The same finding group also names `RemoteStorage.UpdateSecret`'s wire DTO dropping `OwnerID`/`ParentID`/`Type`/`Classification`/`Metadata` on update. Deliberately not fixed here: `UpdateSecret` proxies onto the human-facing `PUT /api/v1/secrets/{id}` endpoint, which only accepts a narrow, explicit field set by design (value/type/max_reads/expiration) — naively widening it to accept a full `SecretNode` row would recreate the exact full-row-overwrite vulnerability G79 already flags on the sibling `*_proxy.go` surface, since both are reached over the same under-scoped `system.write` permission. This needs G79's structural fix (narrower permission + node-identity credential) first, not a field-by-field patch layered on top of a permission model already flagged as too broad. Tracked as a follow-up in the private remediation status doc, sequenced with G79.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/core/...`, `./internal/storage/...`, `./server/http/...` — all pass
- [x] `gosec -severity medium -exclude-generated` on touched packages — 0 issues
- [x] `golangci-lint run` on touched packages — 0 issues
- [x] New regression tests: `TestRemoteStorage_CreateMachineIdentityCredential_RoundTripsAllowedCIDRs`, `TestRemoteStorage_RemoveRoleFromGroup_SendsScope`, `TestRemoteStorage_CreateSecret_SendsParentID`, `TestUpdateProjectProxy_PreservesTimestamps_G80` — all failing before the fix, passing after