### PR TITLE
fix(cli): route embedded-mode secret/share/rbac commands through core, not raw storage

### DIFF
--- a/internal/cli/rbac/group_role.go
+++ b/internal/cli/rbac/group_role.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/spf13/cobra"
 )
@@ -100,7 +101,12 @@ func runAssignRoleToGroup(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := st.AssignRoleToGroup(ctx, groupID, roleID, scope); err != nil {
+	// core.KeyorixCore.AssignRoleToGroup (not a bare st.AssignRoleToGroup) so this
+	// embedded-mode grant goes through the SAME escalation-by-proxy ceiling
+	// (requireAuthorityForRole) and SoD check (requireGroupGrantNoSoDViolation)
+	// the remote/HTTP path enforces (#G66) — a direct storage write here bypassed
+	// both and skipped the RBAC audit event.
+	if err := core.NewKeyorixCore(st).AssignRoleToGroup(ctx, common.ResolveActorID(), groupID, roleID, scope); err != nil {
 		return fmt.Errorf("failed to assign role: %w", err)
 	}
 
@@ -162,7 +168,11 @@ func runRemoveRoleFromGroup(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := st.RemoveRoleFromGroup(ctx, groupID, roleID, scope); err != nil {
+	// core.KeyorixCore.RemoveRoleFromGroup (not a bare st.RemoveRoleFromGroup) so
+	// this embedded-mode removal goes through the SAME last-global-admin lockout
+	// guard (guardLastGlobalAdminGroupRole) the remote/HTTP path enforces (#G66)
+	// — a direct storage write here bypassed it and skipped the RBAC audit event.
+	if err := core.NewKeyorixCore(st).RemoveRoleFromGroup(ctx, common.ResolveActorID(), groupID, roleID, scope); err != nil {
 		return fmt.Errorf("failed to remove role: %w", err)
 	}
 

--- a/internal/cli/secret/update.go
+++ b/internal/cli/secret/update.go
@@ -65,12 +65,15 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return runUpdateRemote(rc)
 	}
 
-	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
-	st, err := common.InitializeStorage()
+	// InitializeCoreService (not a bare InitializeStorage()+core.NewKeyorixCore
+	// pair) so this embedded-mode write goes through the SAME at-rest
+	// secret-value-encryption wiring the server and every other embedded write
+	// path use (#G66) — a bare core.NewKeyorixCore(st) here silently wrote new
+	// values in plaintext even when storage.encryption.enabled is true.
+	service, err := common.InitializeCoreService()
 	if err != nil {
 		return err
 	}
-	service := core.NewKeyorixCore(st)
 
 	// Create context
 	ctx := context.Background()

--- a/internal/cli/share/create.go
+++ b/internal/cli/share/create.go
@@ -49,6 +49,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runCreateRemote(rc, createSecretID, createRecipientID, createIsGroup, createPermission, expiresAt)
+	}
+
 	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
 	st, err := common.InitializeStorage()
 	if err != nil {

--- a/internal/cli/share/group_shares.go
+++ b/internal/cli/share/group_shares.go
@@ -30,6 +30,17 @@ func init() {
 }
 
 func runGroupShares(cmd *cobra.Command, args []string) error {
+	// KNOWN GAP (tracked, not fixed here): unlike every other command in this
+	// package, this has no `if rc, ok := common.NewRemoteClient(); ok { ... }`
+	// branch — it always reads local embedded storage, silently ignoring a
+	// connected server (#G66). Not fixed alongside the rest of #G66 because the
+	// only way to serve this from a real server today is to expose
+	// core.KeyorixCore.ListGroupShares over HTTP, and that function itself has
+	// no caller-scoping of its own (#G10 — "core-layer function performs zero
+	// authorization") — any principal could list any group's shares. Adding a
+	// remote endpoint for it now would ship a new unauthenticated-scope
+	// disclosure surface before #G10's fix lands. Sequence this with #G10.
+	//
 	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
 	st, err := common.InitializeStorage()
 	if err != nil {

--- a/internal/cli/share/remote.go
+++ b/internal/cli/share/remote.go
@@ -20,6 +20,39 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
+// runCreateRemote shares a secret via POST /api/v1/secrets/{id}/share so the
+// grant is recorded against the connected server's own store, with the
+// server resolving the caller from the session token (#G66 — the embedded
+// path previously ran unconditionally, silently no-opping against local
+// storage even when connected to a real server).
+func runCreateRemote(rc *common.RemoteClient, secretID, recipientID uint, isGroup bool, permission string, expiresAt *time.Time) error {
+	body := struct {
+		RecipientID uint       `json:"recipient_id"`
+		IsGroup     bool       `json:"is_group"`
+		Permission  string     `json:"permission"`
+		ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	}{
+		RecipientID: recipientID,
+		IsGroup:     isGroup,
+		Permission:  permission,
+		ExpiresAt:   expiresAt,
+	}
+	var resp models.ShareRecord
+	if err := rc.Post(context.Background(), fmt.Sprintf("/api/v1/secrets/%d/share", secretID), body, &resp); err != nil {
+		return fmt.Errorf("failed to share secret: %w", err)
+	}
+	fmt.Printf("✅ Secret shared successfully!\n")
+	fmt.Printf("Share ID: %d\n", resp.ID)
+	fmt.Printf("Secret ID: %d\n", resp.SecretID)
+	fmt.Printf("Owner ID: %d\n", resp.OwnerID)
+	fmt.Printf("Recipient ID: %d\n", resp.RecipientID)
+	fmt.Printf("Is Group: %t\n", resp.IsGroup)
+	fmt.Printf("Permission: %s\n", resp.Permission)
+	fmt.Printf("Created At: %s\n", resp.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("Expires At: %s\n", formatShareExpiry(resp.ExpiresAt))
+	return nil
+}
+
 func runListRemote(rc *common.RemoteClient, secretID uint) error {
 	var resp struct {
 		Shares []models.ShareRecord `json:"shares"`

--- a/internal/cli/share/remote_test.go
+++ b/internal/cli/share/remote_test.go
@@ -9,6 +9,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestRunCreateRemote is the #G66 regression: `share create` previously had
+// no remote/local dispatch at all (unlike every sibling command in this
+// package) and always wrote to embedded storage, silently no-opping even
+// when connected to a real server. Confirms runCreateRemote actually reaches
+// POST /api/v1/secrets/{id}/share.
+func TestRunCreateRemote(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/secrets/7/share", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "POST", r.Method)
+		_, _ = w.Write([]byte(`{"data":{
+			"ID":1,"SecretID":7,"OwnerID":1,"RecipientID":5,"IsGroup":false,"Permission":"read","CreatedAt":"2026-06-08T10:00:00Z"
+		}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runCreateRemote(rc, 7, 5, false, "read", nil))
+}
+
 func TestShareReadRemote(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/secrets/7/shares", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Fixes G66 from the adversarial security review (critical, 5 findings): several CLI commands' embedded/local-storage code path was an independent, ad-hoc implementation instead of routing through the same core-layer function (or explicit remote/local mode branch) their sibling commands use — each dropping a different security control only the correctly-routed path provides.

## Changes

- `internal/cli/secret/update.go`: embedded branch now calls `common.InitializeCoreService()` instead of a bare `core.NewKeyorixCore(st)` — this is the only call site that wires the secret-value encryptor, so every value written in embedded mode was silently plaintext even with `storage.encryption.enabled`.
- `internal/cli/rbac/group_role.go`: `assign-role-to-group`/`remove-role-from-group`'s embedded branch now calls `core.KeyorixCore.AssignRoleToGroup`/`RemoveRoleFromGroup` (mirroring the user-role sibling commands) instead of `storage.Storage` directly — restores the escalation-by-proxy ceiling check, the SoD check, the last-global-admin lockout guard, and the RBAC audit event, and now attributes the actor via `common.ResolveActorID()`.
- `internal/cli/share/create.go` + `remote.go`: added the missing `if rc, ok := common.NewRemoteClient(); ok { ... }` dispatch every sibling command in the package already has, plus `runCreateRemote` backing it (`POST /api/v1/secrets/{id}/share`). Previously a security-relevant access grant silently no-opped against unrelated local storage while reporting success, even when connected to a real server.

## Scope note

`share group-shares` (same finding group) is deliberately not fixed here. The only way to serve it remotely is to expose `core.KeyorixCore.ListGroupShares` over HTTP, and that function has no caller-scoping of its own — a separate, already-tracked finding (any principal could list any group's shares). Shipping a new remote endpoint for it now would open a new unauthenticated-scope disclosure surface before that gap is closed. Left as a documented `KNOWN GAP` comment in the code, sequenced with the other fix.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/core/...`, `./internal/storage/...`, `./server/...` — all pass
- [x] `gosec -severity medium -exclude-generated` on touched packages — 0 issues
- [x] `golangci-lint run` on touched packages — 0 issues
- [x] Embedded-mode regression: `TestAssignAndListGroupRoles_Embedded`, `TestRemoveGroupRole_Embedded` — pass
- [x] New remote-dispatch regression: `TestRunCreateRemote` (share create actually reaches `POST /api/v1/secrets/{id}/share`) — pass
- [x] Full `internal/cli/*` test suites could not be run cleanly in this environment (a real leftover `~/.keyorix/cli.yaml` on this machine points at an unreachable server, so every CLI test that resolves remote config times out — confirmed pre-existing and unrelated to this change: the same packages already failed the same way in a full-repo baseline run taken before any of these edits)