### PR TITLE
fix(auth,secrets): three unmapped critical findings from the adversarial review

### DIFF
--- a/internal/core/saml_flow_test.go
+++ b/internal/core/saml_flow_test.go
@@ -221,6 +221,50 @@ func TestCompleteSAML_PasswordExpiredGateError(t *testing.T) {
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
 }
 
+// TestCompleteSAML_JITProvisionDoesNotReuseUnverifiedEmailMatch is the #89
+// regression at the CompleteSAML (not just provisionSSOUser) level, for the
+// AutoProvision=true path specifically: CompleteSAML previously passed a
+// hardcoded emailVerified=true into provisionSSOUser regardless of the
+// provider's own TrustAssertedEmail setting, so provisionSSOUser's internal
+// race-guard re-resolution (reusing an existing account rather than
+// duplicating) would treat the SAML-asserted email as verified and silently
+// take over any account matching that email — reopening the exact
+// account-takeover TestCompleteSAML_NativeAdminTakeoverRejectedByDefault
+// pins for the AutoProvision=false path. With TrustAssertedEmail off (the
+// default), GetUserByEmail must never even be consulted, and a login from an
+// attacker asserting a victim's email must provision a FRESH account bound to
+// the attacker's own subject, never touching (or returning) the victim's.
+func TestCompleteSAML_JITProvisionDoesNotReuseUnverifiedEmailMatch(t *testing.T) {
+	stub := &stubSAML{info: &samlpkg.AssertionInfo{Subject: "corp|evil", Email: "victim@corp.com", Name: "Mallory"}}
+	store := new(MockStorage)
+	p := &SSOProvider{Name: "corp", Type: "saml", SAML: stub, AutoProvision: true, DefaultRole: "system_viewer"}
+	require.False(t, p.TrustAssertedEmail, "precondition: opt-in is off by default")
+	c := &KeyorixCore{storage: store, now: time.Now, ssoProviders: map[string]*SSOProvider{"corp": p}}
+	store.On("ConsumeSSOLoginState", mock.Anything, "relay-8").Return(
+		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|evil").Return((*models.User)(nil), userNotFound())
+	store.On("GetUserByUsername", mock.Anything, "victim").Return((*models.User)(nil), userNotFound())
+	var created *models.User
+	store.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool { created = u; return true })).
+		Return(&models.User{ID: 99, IsActive: true}, nil)
+	store.On("GetRoleByName", mock.Anything, "system_viewer").Return(&models.Role{ID: 3}, nil)
+	store.On("AssignRole", mock.Anything, uint(99), uint(3), mock.Anything).Return(nil)
+	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 99, SessionToken: "tok"}, nil)
+	store.On("UpdateLastLogin", mock.Anything, uint(99), mock.Anything).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	session, user, _, err := c.CompleteSAML(context.Background(), "corp",
+		httptest.NewRequest(http.MethodPost, "/auth/saml/corp/acs", nil), "relay-8", "ua", "1.2.3.4")
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, uint(99), user.ID, "must be the fresh account, never the victim's")
+	assert.Equal(t, "tok", session.SessionToken)
+	require.NotNil(t, created)
+	assert.Equal(t, "sso:corp:corp|evil", created.ExternalID, "fresh account bound to the asserting subject")
+	store.AssertNotCalled(t, "GetUserByEmail", mock.Anything, mock.Anything, "an unverified email must never even be looked up")
+	store.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything, "the victim account must never be claimed")
+}
+
 // TestCompleteSAML_TrustAssertedEmailOptInLinksExistingAccount is the positive
 // control: an operator who has decided to trust a specific SAML provider's
 // asserted email can still opt in, and the existing (never-federated) account

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -368,8 +368,15 @@ func applySCIMActiveState(user *models.User, active *bool, deactivated *bool) {
 
 // guardLastAdminDeactivation refuses an operation that would deactivate/deprovision the
 // only remaining install administrator, so a routine or hostile SCIM push — or an admin
-// DeleteUser call (core.DeleteUser shares this guard) — can't lock everyone out. Mirrors
-// guardLastGlobalAdmin's assignment scan but keyed on the target.
+// DeleteUser call (core.DeleteUser shares this guard) — can't lock everyone out.
+//
+// Uses resolveGlobalAdminHolders (the same group-membership-aware resolver
+// guardLastGlobalAdminGroupDelete/guardLastGlobalAdminMembership use), excluding
+// targetID both as a direct grant holder and as a group member — NOT the previous
+// per-assignment scan, which treated ANY admin-conferring group assignment as
+// "another admin survives" without checking whether targetID was that group's only
+// member. A target whose sole route to admin authority is membership in a
+// single-member admin group was therefore never recognized as the last admin.
 func (c *KeyorixCore) guardLastAdminDeactivation(ctx context.Context, targetID uint) error {
 	isAdmin, err := c.IsGlobalAdmin(ctx, targetID)
 	if err != nil {
@@ -391,18 +398,17 @@ func (c *KeyorixCore) guardLastAdminDeactivation(ctx context.Context, targetID u
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
-	for _, a := range assignments {
-		if !adminIDs[a.RoleID] {
-			continue
-		}
-		// Any OTHER global-admin grant (a different user, or a group) means governance
-		// survives the target's removal.
-		if a.PrincipalType == "user" && a.PrincipalID == targetID {
-			continue
-		}
-		return nil
+	holders, err := c.resolveGlobalAdminHolders(ctx, adminIDs, assignments,
+		func(a storage.RoleAssignment) bool { return a.PrincipalType == "user" && a.PrincipalID == targetID },
+		func(_, userID uint) bool { return userID == targetID },
+	)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
-	return fmt.Errorf("refusing to deactivate the last install administrator")
+	if len(holders) == 0 {
+		return fmt.Errorf("refusing to deactivate the last install administrator")
+	}
+	return nil
 }
 
 // DeprovisionSCIMUser handles a SCIM DELETE: it deprovisions the user (blocks login,

--- a/internal/core/scim_guards_test.go
+++ b/internal/core/scim_guards_test.go
@@ -55,6 +55,48 @@ func TestUpdateSCIMUser_RefusesLastAdminDeactivation(t *testing.T) {
 	assert.Contains(t, err.Error(), "last install administrator")
 }
 
+// TestUpdateSCIMUser_RefusesLastAdminDeactivation_ViaGroupMembership is the
+// unmapped-critical regression: guardLastAdminDeactivation previously scanned
+// role assignments and treated ANY group-type admin-conferring assignment as
+// "another admin survives," without checking whether the target itself was
+// that group's only member. A target whose sole route to admin authority was
+// membership in a single-member admin group was never recognized as the last
+// admin, so SCIM could deactivate them and leave the install with zero admins.
+func TestUpdateSCIMUser_RefusesLastAdminDeactivation_ViaGroupMembership(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive, ExternalID: "okta|root"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Keyorix-Admins"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 5, RoleID: 10}).Error) // group confers admin, globally
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 1, GroupID: 5}).Error)  // user 1 is the group's ONLY member
+
+	no := false
+	_, err := c.UpdateSCIMUser(ctx, 9, 1, nil, nil, &no)
+	require.Error(t, err, "must refuse to deactivate the install's last admin even when their authority is entirely group-derived")
+	assert.Contains(t, err.Error(), "last install administrator")
+}
+
+// TestUpdateSCIMUser_AllowsGroupAdminDeactivationWhenAnotherGroupMemberExists
+// is the positive control: a group with more than one member still has a
+// surviving admin route after one member is deactivated.
+func TestUpdateSCIMUser_AllowsGroupAdminDeactivationWhenAnotherGroupMemberExists(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive, ExternalID: "okta|root"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "root2", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "Keyorix-Admins"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 5, RoleID: 10}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 1, GroupID: 5}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 5}).Error)
+
+	no := false
+	off, err := c.UpdateSCIMUser(ctx, 9, 1, nil, nil, &no)
+	require.NoError(t, err, "deactivating one of two admin-group members is allowed")
+	assert.False(t, off.IsActive)
+}
+
 func TestUpdateSCIMUser_AllowsAdminDeactivationWhenAnotherExists(t *testing.T) {
 	c, db := newSCIMGuardCore(t)
 	ctx := context.Background()

--- a/internal/core/secret_move.go
+++ b/internal/core/secret_move.go
@@ -51,6 +51,18 @@ func (c *KeyorixCore) MoveSecret(ctx context.Context, actorID, secretID uint, ne
 		if parent.IsSecret {
 			return nil, fmt.Errorf("%s: target parent %d is a secret, not a folder", i18n.T("ErrorValidation", nil), *newParentID)
 		}
+		// The destination parent was never authorized or scope-checked: actorID's
+		// secrets.write on secretID says nothing about the target folder, which
+		// this function loaded with a bare, unauthorized GetSecret. Mirroring
+		// CreateSecret's own parent-folder validation (secrets.go), require the
+		// destination to live in the SAME project/environment as the secret being
+		// moved — otherwise an actor who can write one project's secret could
+		// re-parent it into a folder in an entirely different project they have
+		// no access to, and folder-inheriting ACL/sharing resolution would then
+		// apply that other project's grants to it.
+		if parent.ProjectID != secret.ProjectID || parent.EnvironmentID != secret.EnvironmentID {
+			return nil, fmt.Errorf("%s: target parent %d does not belong to the same project/environment", i18n.T("ErrorValidation", nil), *newParentID)
+		}
 		secret.ParentID = newParentID
 	} else {
 		// Move to root (no parent).

--- a/internal/core/secret_move_test.go
+++ b/internal/core/secret_move_test.go
@@ -161,6 +161,30 @@ func TestMoveSecret_SecretNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+// TestMoveSecret_RefusesCrossProjectParent is the unmapped-critical
+// regression: MoveSecret previously loaded the destination parent with a bare,
+// unauthorized GetSecret and never checked it belonged to the same
+// project/environment as the secret being moved — an actor with secrets.write
+// on one project's secret could re-parent it into a folder that lives in an
+// entirely different project, and folder-inheriting ACL/sharing resolution
+// would then apply that other project's grants to it.
+func TestMoveSecret_RefusesCrossProjectParent(t *testing.T) {
+	c, secretID, _, _ := newMoveFixture(t)
+	ctx := context.Background()
+
+	// A folder in a DIFFERENT project (2) that the actor has no stake in.
+	foreignFolder, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "other-project-folder", ProjectID: 2, EnvironmentID: 1,
+		Type: "folder", OwnerID: 1, IsSecret: false, Status: "active",
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	_, err = c.MoveSecret(ctx, 1, secretID, &foreignFolder.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same project/environment")
+}
+
 // TestMoveSecret_ParentNotFound returns a validation error when the parent does not exist.
 func TestMoveSecret_ParentNotFound(t *testing.T) {
 	c, secretID, _, _ := newMoveFixture(t)

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -339,7 +339,14 @@ func (c *KeyorixCore) CompleteSAML(ctx context.Context, name string, r *http.Req
 		if !p.AutoProvision {
 			return nil, nil, "", fmt.Errorf("no Keyorix account matches this SSO identity")
 		}
-		if user, err = c.provisionSSOUser(ctx, p, info.Subject, info.Email, true, info.Name); err != nil {
+		// p.TrustAssertedEmail, not a hardcoded true — provisionSSOUser's own
+		// race-guard re-runs resolveSSOUser with this exact value to decide
+		// whether a just-materialised existing account may be claimed by email
+		// match. Hardcoding true here let that internal re-check treat the
+		// SAML-asserted email as verified regardless of the provider's own
+		// TrustAssertedEmail setting, reopening the #89 SAML account-takeover
+		// through the resolve-then-provision race window specifically.
+		if user, err = c.provisionSSOUser(ctx, p, info.Subject, info.Email, p.TrustAssertedEmail, info.Name); err != nil {
 			return nil, nil, "", err
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes three critical findings from the adversarial security review that didn't fold into any of the leverage-ranked root-cause groups (each a singleton).

## Changes

1. **`internal/core/sso.go`** — `CompleteSAML`'s JIT-provisioning path passed a hardcoded `emailVerified=true` into `provisionSSOUser` regardless of the provider's own `TrustAssertedEmail` setting. `provisionSSOUser`'s internal race-guard re-resolution (reusing an existing account rather than duplicating) then treated the SAML-asserted email as verified unconditionally, reopening the #89 SAML account-takeover through the resolve-then-provision race window specifically. Now passes `p.TrustAssertedEmail`, matching what the initial (already-correct) `resolveSSOUser` call already uses.

2. **`internal/core/scim.go`** — `guardLastAdminDeactivation` scanned role assignments and treated ANY group-type admin-conferring assignment as proof "another admin survives," without checking whether the deactivation target was that group's only member. A target whose sole route to admin authority was membership in a single-member admin-conferring group was therefore never recognized as the last admin. Now uses `resolveGlobalAdminHolders` — the same group-membership-aware resolver `guardLastGlobalAdminGroupDelete`/`guardLastGlobalAdminMembership` already use — excluding the target both as a direct grant holder and as a group member.

3. **`internal/core/secret_move.go`** — `MoveSecret` authorized the actor's write access to the source secret but loaded the destination parent folder with a bare, unauthorized `GetSecret` — no check that it belonged to the same project/environment. An actor with `secrets.write` on one project's secret could re-parent it into a folder in an entirely different project. Now requires the destination parent to share the secret's project/environment, mirroring `CreateSecret`'s own established parent-folder validation.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/core/...` — all pass
- [x] `gosec -severity medium -exclude-generated` — 0 issues
- [x] `golangci-lint run` — 0 issues
- [x] New regression tests: `TestCompleteSAML_JITProvisionDoesNotReuseUnverifiedEmailMatch`, `TestUpdateSCIMUser_RefusesLastAdminDeactivation_ViaGroupMembership` (+ positive control), `TestMoveSecret_RefusesCrossProjectParent` — all failing before the fix, passing after