### PR TITLE
fix(security): apply escalation-ceiling check to AssignUserRoleWithExpiry (G15)

### DIFF
--- a/internal/core/authz_admin_ceiling_group_test.go
+++ b/internal/core/authz_admin_ceiling_group_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/stretchr/testify/assert"
@@ -57,6 +58,39 @@ func TestSetProjectMemberRole_EscalationByProxyBlocked(t *testing.T) {
 	err := c.SetProjectMemberRole(ctx, attacker, 1, victim, "project_admin")
 	require.Error(t, err, "a non-admin actor must not be able to promote a member to project_admin")
 	assert.Contains(t, err.Error(), "cannot grant this role")
+}
+
+// #G15/#93/#107/#141: AssignUserRoleWithExpiry (the JIT/time-bound grant path)
+// must be gated by the exact same escalation-by-proxy ceiling as its permanent
+// sibling AssignUserRole — previously it wrote directly via storage with no
+// ceiling check at all (see jit_access.go's history), so a roles.assign holder
+// could bundle-grant a time-bound role carrying a permission they don't hold
+// themselves.
+func TestAssignUserRoleWithExpiry_EscalationByProxyBlocked(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	attacker := seedUserWithRole(t, st, "jit-attacker", "project_viewer", storage.Scope{ProjectID: 1})
+	victim := seedUserWithRole(t, st, "jit-victim", "project_viewer", storage.Scope{ProjectID: 1})
+	role, err := st.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+
+	err = c.AssignUserRoleWithExpiry(ctx, attacker, victim, role.ID, storage.Scope{ProjectID: 1}, time.Now().Add(time.Hour))
+	require.Error(t, err, "a non-admin actor must not be able to grant the admin role via a time-bound JIT grant")
+	assert.Contains(t, err.Error(), "cannot grant this role")
+}
+
+// #G15: the non-regression counterpart — a time-bound grant of a role the actor
+// already holds every bundled permission of must still succeed unimpeded.
+func TestAssignUserRoleWithExpiry_NonAdminRoleAllowed(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "jit-actor", "project_developer", storage.Scope{ProjectID: 1})
+	victim := seedUserWithRole(t, st, "jit-victim2", "project_viewer", storage.Scope{ProjectID: 2})
+	role, err := st.GetRoleByName(ctx, "project_developer")
+	require.NoError(t, err)
+
+	err = c.AssignUserRoleWithExpiry(ctx, actor, victim, role.ID, storage.Scope{ProjectID: 1}, time.Now().Add(time.Hour))
+	require.NoError(t, err, "granting a role the actor already holds every permission of must not be blocked")
 }
 
 // #93: AssignMachineRole must refuse a non-admin actor granting an admin role to

--- a/internal/core/jit_access.go
+++ b/internal/core/jit_access.go
@@ -17,27 +17,27 @@ import (
 // stops authorizing once expiresAt passes) and records the assignment. actorID is
 // the granting principal (0 = unauthenticated/system).
 //
-// KNOWN GAP (tracked, not fixed here): unlike AssignUserRole, this does NOT run
-// requireGranterHoldsRolePermissions (#93/#107/#141) — it writes directly via
-// storage, bypassing the grant-ceiling check entirely. The HTTP JIT-assign-with-
-// expiry path (POST /user-roles with expires_at) and the access-request TTL-grant
-// path (invitations.go) both reach this unguarded, so a roles.assign holder can
-// currently bundle-grant a time-bound role with a permission they don't hold. Left
-// unfixed in this change deliberately: break_glass.go's self-service emergency
-// grant also calls this, and legitimately MUST elevate a user beyond their current
-// permissions (that's break-glass's entire purpose) — closing this gap needs a
-// break-glass-aware carve-out, which is its own follow-up, not a mechanical mirror
-// of AssignUserRole's fix.
-//
-// #419: the separation-of-duties preventive gate (requireNoSoDViolation) DOES
-// apply here by default, unlike the ceiling check above — this is precisely the
-// JIT-timing-evasion vector the finding describes ("a toxic-permission overlap
-// that both starts and fully expires between two SoD digest runs ... concretely
-// constructible by arranging two overlapping short-lived grants"). Break-glass
-// is the one caller that legitimately cannot be blocked by it (same reasoning as
-// the ceiling-check gap above): see assignUserRoleWithExpirySkipSoD, which
-// break_glass.go calls instead.
+// #G15: mirrors AssignUserRole's two gates exactly —
+// requireGranterHoldsRolePermissions (#93/#107/#141, the escalation-by-proxy
+// grant-ceiling: a roles.assign holder cannot bundle-grant a time-bound role
+// carrying a permission they don't hold themselves) and requireNoSoDViolation
+// (#419, the separation-of-duties preventive gate — this is precisely the
+// JIT-timing-evasion vector the finding describes: "a toxic-permission overlap
+// that both starts and fully expires between two SoD digest runs ...
+// concretely constructible by arranging two overlapping short-lived grants").
+// The HTTP JIT-assign-with-expiry path (POST /user-roles with expires_at) and
+// the access-request TTL-grant path (invitations.go) both go through this
+// function, so both gates now apply there. Break-glass is the one caller that
+// legitimately cannot be blocked by either — its self-service emergency grant
+// MUST elevate a user beyond their current permissions (that's break-glass's
+// entire purpose), and a false-positive SoD block during a genuine incident is
+// an unacceptable failure mode for the control that exists to remediate
+// incidents — so break_glass.go calls assignUserRoleWithExpirySkipSoD
+// directly instead, never this function.
 func (c *KeyorixCore) AssignUserRoleWithExpiry(ctx context.Context, actorID, userID, roleID uint, scope Scope, expiresAt time.Time) error {
+	if err := c.requireGranterHoldsRolePermissions(ctx, actorID, roleID, scope); err != nil {
+		return err
+	}
 	if err := c.requireNoSoDViolation(ctx, userID, roleID); err != nil {
 		return err
 	}
@@ -45,17 +45,18 @@ func (c *KeyorixCore) AssignUserRoleWithExpiry(ctx context.Context, actorID, use
 }
 
 // assignUserRoleWithExpirySkipSoD performs the identical time-bound grant as
-// AssignUserRoleWithExpiry but deliberately SKIPS the #419 separation-of-duties
-// preventive check. Use it ONLY where the action is break-glass's self-service
-// emergency access (break_glass.go's ActivateBreakGlass): break-glass is
-// documented as "Deliberately un-gated by RBAC — the whole point is access the
-// user does NOT already have", so a false-positive SoD block during a genuine
-// incident is an unacceptable failure mode for the control that exists to
-// remediate incidents — mirroring the exact reasoning already established above
-// for the escalation-by-proxy ceiling check this function also (deliberately)
-// skips. Never call this from any other path — the HTTP JIT-assign endpoint and
-// the access-request TTL-approval path must go through AssignUserRoleWithExpiry
-// so the SoD gate applies.
+// AssignUserRoleWithExpiry but deliberately SKIPS both the #93/#107/#141
+// grant-ceiling check and the #419 separation-of-duties preventive check. Use
+// it ONLY where the action is break-glass's self-service emergency access
+// (break_glass.go's ActivateBreakGlass): break-glass is documented as
+// "Deliberately un-gated by RBAC — the whole point is access the user does
+// NOT already have", so both the ceiling check (which would refuse the very
+// elevation break-glass exists to grant) and the SoD block (a false positive
+// during a genuine incident is an unacceptable failure mode for the control
+// that exists to remediate incidents) would defeat break-glass's purpose.
+// Never call this from any other path — the HTTP JIT-assign endpoint and the
+// access-request TTL-approval path must go through AssignUserRoleWithExpiry
+// so both gates apply.
 func (c *KeyorixCore) assignUserRoleWithExpirySkipSoD(ctx context.Context, actorID, userID, roleID uint, scope Scope, expiresAt time.Time) error {
 	if err := c.storage.AssignRoleWithExpiry(ctx, userID, roleID, scope, expiresAt); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)

--- a/internal/core/jit_access_external_test.go
+++ b/internal/core/jit_access_external_test.go
@@ -115,6 +115,10 @@ func TestApproveAccessRequestWithExpiry_TimeBound(t *testing.T) {
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10) // requester
 	h.CreateTestUser(t, "admin", 1)  // approver
+	// #G15/#93/#107/#141: the approver must themselves hold every permission of
+	// the role being granted — grant "admin" globally so the ceiling check's
+	// admin bypass applies, mirroring TestApproveAccessRequest_PermanentByDefault.
+	h.AssignUserRole(t, 1, 2, nil)
 
 	created, err := h.Storage.CreateAccessRequest(ctx, &models.AccessRequest{
 		ProjectID: proj, UserID: 10, SuggestedRole: "editor", State: core.AccessRequestPending,

--- a/internal/core/sod_preventive_gate_external_test.go
+++ b/internal/core/sod_preventive_gate_external_test.go
@@ -93,6 +93,11 @@ func TestAssignUserRoleWithExpiry_BlocksJITSoDViolation(t *testing.T) {
 
 	h.CreateTestUser(t, "carol", 12)
 	h.AssignUserRole(t, 12, 4, nil) // viewer → secrets.read
+	// #G15/#93/#107/#141: the granting actor must themselves hold every
+	// permission of the role being granted — grant "admin" globally so the
+	// ceiling check's admin bypass applies (this test targets the SoD gate
+	// specifically, not the ceiling check).
+	h.AssignUserRole(t, 1, 2, nil)
 
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
@@ -117,6 +122,10 @@ func TestAssignUserRoleWithExpiry_AllowsNonViolatingGrant(t *testing.T) {
 
 	h.CreateTestUser(t, "dave", 13)
 	h.AssignUserRole(t, 13, 4, nil) // viewer
+	// #G15/#93/#107/#141: the granting actor must themselves hold every
+	// permission of the role being granted — grant "admin" globally so the
+	// ceiling check's admin bypass applies.
+	h.AssignUserRole(t, 1, 2, nil)
 
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Fixes G15 from the adversarial security review: `AssignUserRoleWithExpiry` (the JIT/time-bound role-grant path) wrote directly via storage with no escalation-by-proxy ceiling check, unlike its permanent sibling `AssignUserRole` (which runs `requireGranterHoldsRolePermissions`). The gap was already documented in the function's own "KNOWN GAP" comment.

Two call sites reached this unguarded:
- The HTTP JIT-assign-with-expiry endpoint (`POST /user-roles` with `expires_at`).
- The access-request TTL-approval path (`finalizeAccessRequestApproval`, `invitations.go`) — notably, this function's own permanent-grant sibling branch (the `else` case, calling `AssignUserRole` directly) already had the ceiling check; only the TTL branch was missing it.

Either way, a `roles.assign` holder could bundle-grant a time-bound role carrying a permission they don't hold themselves.

## Fix

Add the same `requireGranterHoldsRolePermissions` call `AssignUserRole` already makes, to `AssignUserRoleWithExpiry`.

Break-glass remains the one legitimate carve-out: it calls `assignUserRoleWithExpirySkipSoD` directly (bypassing `AssignUserRoleWithExpiry` entirely) — already the established skip path for the SoD check (#419), now documented as skipping both gates for the same reason: break-glass's self-service emergency grant MUST elevate a user beyond their current permissions by design ("Deliberately un-gated by RBAC").

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/core/... ./server/http/handlers/...` — all pass
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues
- [x] `golangci-lint run ./internal/core/...` — 0 issues
- [x] New regressions: `TestAssignUserRoleWithExpiry_EscalationByProxyBlocked`, `TestAssignUserRoleWithExpiry_NonAdminRoleAllowed` — mirror the existing `AssignUserRole`/`AddProjectMember` ceiling tests, confirmed failing before the fix and passing after
- [x] Existing tests updated where fixtures needed the granting actor to hold the granted role's permissions (matching the same pattern already established for `AssignUserRole`'s own tests): `TestApproveAccessRequestWithExpiry_TimeBound`, `TestAssignUserRoleWithExpiry_BlocksJITSoDViolation`, `TestAssignUserRoleWithExpiry_AllowsNonViolatingGrant`