### PR TITLE
fix(security): resolve global-admin/group-membership status by scope (G01, 8 of 8 members)

### DIFF
--- a/internal/core/concurrency_legal_hold_test.go
+++ b/internal/core/concurrency_legal_hold_test.go
@@ -33,7 +33,12 @@ func TestConcurrency_PlaceLegalHold_OnlyOneWins(t *testing.T) {
 	dsn := "file:" + filepath.Join(t.TempDir(), "c.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}, &models.Role{}, &models.UserRole{}))
+	// #G01: PlaceLegalHold now resolves admin authority via isGlobalAdminRoleName
+	// (scopedRoleIDs), which LEFT JOINs projects/environments and unions in
+	// group-inherited roles (user_groups/groups/group_roles) — all must be
+	// migrated even though this test grants the role directly, not via a group.
+	require.NoError(t, db.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}, &models.Role{}, &models.UserRole{},
+		&models.Project{}, &models.Environment{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{}))
 	// The production migration (storage.ensureLegalHoldActiveIndex) creates this;
 	// replicate it for the test DB.
 	require.NoError(t, db.Exec(

--- a/internal/core/legal_hold.go
+++ b/internal/core/legal_hold.go
@@ -77,7 +77,7 @@ func (c *KeyorixCore) PlaceLegalHold(ctx context.Context, actorID uint, reason s
 	if reason == "" {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a reason is required to place a legal hold")
 	}
-	if c.adminRoleName(ctx, actorID) == "" {
+	if c.isGlobalAdminRoleName(ctx, actorID) == "" {
 		c.writeAuditEventFailed(ctx, EventLegalHoldPlaced, actorPtr(actorID), "",
 			fmt.Sprintf("legal hold placement DENIED: actor %d is not an admin-tier principal", actorID))
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
@@ -133,7 +133,7 @@ func (c *KeyorixCore) LiftLegalHold(ctx context.Context, actorID uint, reason st
 	if hold == nil {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "no legal hold is active")
 	}
-	if actorID != hold.PlacedBy && c.adminRoleName(ctx, actorID) == "" {
+	if actorID != hold.PlacedBy && c.isGlobalAdminRoleName(ctx, actorID) == "" {
 		c.writeAuditEventFailed(ctx, EventLegalHoldLifted, actorPtr(actorID), "",
 			fmt.Sprintf("legal hold %d lift DENIED: actor %d is neither the placer (%d) nor an admin-tier principal", hold.ID, actorID, hold.PlacedBy))
 		return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),

--- a/internal/core/legal_hold_external_test.go
+++ b/internal/core/legal_hold_external_test.go
@@ -84,6 +84,29 @@ func TestLegalHold_PlaceDeniedForNonAdmin(t *testing.T) {
 	assert.False(t, hold.Released)
 }
 
+// TestLegalHold_PlaceDeniedForProjectScopedAdmin is the #G01 regression: an
+// admin-tier role granted only at a specific project must not be treated as
+// install-wide admin-bypass authority — PlaceLegalHold is a deployment-wide
+// control, and a project-scoped admin does not hold "all permissions" the
+// way a true global admin does.
+func TestLegalHold_PlaceDeniedForProjectScopedAdmin(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}, &models.User{}, &models.UserRole{}))
+	ctx := context.Background()
+
+	// Actor 30 holds "admin" (role 2), but scoped ONLY to project 5 — not global.
+	projectID := uint(5)
+	h.AssignUserRole(t, 30, 2, &projectID)
+
+	_, err := h.CoreService.PlaceLegalHold(ctx, 30, "bogus decoy hold from project-scoped admin")
+	require.Error(t, err, "a project-scoped admin must not be able to place a deployment-wide legal hold")
+
+	active, aerr := h.CoreService.IsLegalHoldActive(ctx)
+	require.NoError(t, aerr)
+	assert.False(t, active, "the denied placement must not create a hold")
+}
+
 // #380: lifting a hold records the WHY, not just the who/when — the reason is
 // persisted on the row (ReleaseReason) and appears in the audit description, and an
 // empty reason is rejected just like placement's.

--- a/internal/core/license_expiry.go
+++ b/internal/core/license_expiry.go
@@ -14,12 +14,6 @@ import (
 // commercial license that is expiring soon or has expired (ADR-065 Phase 2c).
 const NotificationLicenseExpiry = "license.expiry_reminder"
 
-// globalAdminRoleNames are the install-wide admin roles. A license is install-wide, so its
-// expiry is notified to these admins — NOT project_admin, which is project-scoped.
-var globalAdminRoleNames = map[string]struct{}{
-	"super_admin": {}, "admin": {}, "system_admin": {},
-}
-
 // ScanLicenseExpiry checks the installed offline license and, when it is within leadDays of
 // expiry or already expired, notifies every install-wide admin (deduped so it does not spam
 // on each tick). It also compares the newly computed severity (an actually-expired license is
@@ -92,6 +86,12 @@ func licenseExpirySeverity(st license.Status) models.NotificationSeverity {
 const globalAdminIDsPageSize = 500
 
 // globalAdminIDs returns the user IDs of every active install-wide admin.
+//
+// #G01: each active user's admin status is now resolved via
+// isGlobalAdminRoleName (scopedRoleIDs at the global scope), not a raw,
+// scope-blind GetUserRoles name match — a role named like an admin role but
+// granted only at a specific project no longer misclassifies that user as an
+// install-wide admin here.
 func (c *KeyorixCore) globalAdminIDs(ctx context.Context) ([]uint, error) { // NOSONAR -- cognitive complexity 18, suppress go:S3776
 	active := true
 	var ids []uint
@@ -101,15 +101,8 @@ func (c *KeyorixCore) globalAdminIDs(ctx context.Context) ([]uint, error) { // N
 			return nil, err
 		}
 		for _, u := range users {
-			roles, rerr := c.storage.GetUserRoles(ctx, u.ID)
-			if rerr != nil {
-				continue
-			}
-			for _, r := range roles {
-				if _, ok := globalAdminRoleNames[r.Name]; ok {
-					ids = append(ids, u.ID)
-					break
-				}
+			if c.isGlobalAdminRoleName(ctx, u.ID) != "" {
+				ids = append(ids, u.ID)
 			}
 		}
 		if len(users) < globalAdminIDsPageSize || int64(page*globalAdminIDsPageSize) >= total {

--- a/internal/core/license_expiry_test.go
+++ b/internal/core/license_expiry_test.go
@@ -58,7 +58,9 @@ func TestScanLicenseExpiry_Expiring_NotifiesGlobalAdmins(t *testing.T) {
 
 	admin := &models.User{ID: 2, Email: "admin@acme.test"}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin}, int64(1), nil)
-	ms.On("GetUserRoles", ctx, uint(2)).Return([]*models.Role{{Name: "system_admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(2), storage.Scope{}).Return([]uint{10}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(2), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(10)).Return(&models.Role{ID: 10, Name: "system_admin"}, nil)
 	ms.On("ListNotifications", ctx, uint(2), true, 100).Return([]*models.Notification{}, nil)
 	ms.On("CreateNotification", ctx, mock.MatchedBy(func(n *models.Notification) bool {
 		return n.Type == NotificationLicenseExpiry && n.UserID == 2 && n.ProjectID == nil
@@ -78,7 +80,9 @@ func TestScanLicenseExpiry_Dedup_NoResend(t *testing.T) {
 
 	admin := &models.User{ID: 2, Email: "admin@acme.test"}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin}, int64(1), nil)
-	ms.On("GetUserRoles", ctx, uint(2)).Return([]*models.Role{{Name: "admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(2), storage.Scope{}).Return([]uint{10}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(2), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(10)).Return(&models.Role{ID: 10, Name: "admin"}, nil)
 	// Already an unread license-expiry reminder, already at the severity this
 	// (not-yet-expired) gate warrants → must not re-create or escalate.
 	ms.On("ListNotifications", ctx, uint(2), true, 100).
@@ -103,7 +107,9 @@ func TestScanLicenseExpiry_EscalatesOnExpiry(t *testing.T) {
 
 	admin := &models.User{ID: 2, Email: "admin@acme.test"}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin}, int64(1), nil)
-	ms.On("GetUserRoles", ctx, uint(2)).Return([]*models.Role{{Name: "admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(2), storage.Scope{}).Return([]uint{10}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(2), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(10)).Return(&models.Role{ID: 10, Name: "admin"}, nil)
 	// Standing reminder was created back when the license was merely expiring soon.
 	existing := &models.Notification{ID: 9, UserID: 2, Type: NotificationLicenseExpiry, Severity: models.NotificationSeverityWarning}
 	ms.On("ListNotifications", ctx, uint(2), true, 100).Return([]*models.Notification{existing}, nil)
@@ -145,9 +151,13 @@ func TestGlobalAdminIDs_PaginatesActiveUsersBeyondOnePage(t *testing.T) {
 
 	// Every user on page 1 is a non-admin; only the page-2 user is a global admin.
 	for i := range firstPage {
-		ms.On("GetUserRoles", ctx, firstPage[i].ID).Return([]*models.Role{{Name: "member"}}, nil)
+		ms.On("GetUserRoleIDsAt", ctx, firstPage[i].ID, storage.Scope{}).Return([]uint{20}, nil)
+		ms.On("GetUserGroupRoleIDsAt", ctx, firstPage[i].ID, storage.Scope{}).Return([]uint{}, nil)
 	}
-	ms.On("GetUserRoles", ctx, lateAdminID).Return([]*models.Role{{Name: "super_admin"}}, nil)
+	ms.On("GetRole", ctx, uint(20)).Return(&models.Role{ID: 20, Name: "member"}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, lateAdminID, storage.Scope{}).Return([]uint{10}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, lateAdminID, storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(10)).Return(&models.Role{ID: 10, Name: "super_admin"}, nil)
 	ms.On("ListNotifications", ctx, lateAdminID, true, 100).Return([]*models.Notification{}, nil)
 	ms.On("CreateNotification", ctx, mock.MatchedBy(func(n *models.Notification) bool {
 		return n.Type == NotificationLicenseExpiry && n.UserID == lateAdminID
@@ -159,16 +169,47 @@ func TestGlobalAdminIDs_PaginatesActiveUsersBeyondOnePage(t *testing.T) {
 	ms.AssertNumberOfCalls(t, "ListUsers", 2)
 }
 
+// TestScanLicenseExpiry_SkipsProjectScopedAdmin is the #G01 regression: a
+// project_admin role GRANTED ONLY AT A SPECIFIC PROJECT (not globally) must
+// not count as an install-wide admin — isGlobalAdminRoleName's global-scope
+// query (GetUserRoleIDsAt/GetUserGroupRoleIDsAt with Scope{}) returns nothing
+// for this user, exactly as the real storage layer would for a role held only
+// at project scope, since project_admin's grant never appears in the
+// project_id=0 rows those queries select.
 func TestScanLicenseExpiry_SkipsProjectScopedAdmin(t *testing.T) {
 	ctx := context.Background()
 	ms := new(MockStorage)
 	c := NewKeyorixCore(ms)
 	c.SetLicenseGate(gateWithExpiry(t, time.Now().Add(5*24*time.Hour)))
 
-	// project_admin is project-scoped, not an install-wide admin → not a license recipient.
+	// project_admin is granted only at project 7, not globally → not an
+	// install-wide admin → not a license recipient.
 	user := &models.User{ID: 3, Email: "padmin@acme.test"}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{user}, int64(1), nil)
-	ms.On("GetUserRoles", ctx, uint(3)).Return([]*models.Role{{Name: "project_admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(3), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(3), storage.Scope{}).Return([]uint{}, nil)
+
+	n, err := c.ScanLicenseExpiry(ctx, 30)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+	ms.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+}
+
+// TestScanLicenseExpiry_SkipsGloballyGrantedNonAdminRole verifies the sibling
+// case: a non-admin role (e.g. "member") granted globally still correctly
+// does not count — isGlobalAdminRoleName's scope-awareness is orthogonal to
+// its role-name filtering, and both must hold.
+func TestScanLicenseExpiry_SkipsGloballyGrantedNonAdminRole(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.SetLicenseGate(gateWithExpiry(t, time.Now().Add(5*24*time.Hour)))
+
+	user := &models.User{ID: 4, Email: "member@acme.test"}
+	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{user}, int64(1), nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(4), storage.Scope{}).Return([]uint{20}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(4), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(20)).Return(&models.Role{ID: 20, Name: "member"}, nil)
 
 	n, err := c.ScanLicenseExpiry(ctx, 30)
 	require.NoError(t, err)

--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -217,7 +217,7 @@ func (c *KeyorixCore) appendUserSoDViolations(ctx context.Context, report *SoDVi
 // the caller (DetectSoDViolations) must record that the scan is incomplete instead of
 // looking clean.
 func (c *KeyorixCore) userSoDViolations(ctx context.Context, u *models.User, policies []*models.SoDPolicy) ([]SoDViolation, error) {
-	if adminRole := c.adminRoleName(ctx, u.ID); adminRole != "" {
+	if adminRole := c.isGlobalAdminRoleName(ctx, u.ID); adminRole != "" {
 		out := make([]SoDViolation, 0, len(policies))
 		detail := fmt.Sprintf("holds all permissions via admin role %q", adminRole)
 		for _, pol := range policies {
@@ -338,33 +338,37 @@ func (c *KeyorixCore) machineSoDViolations(ctx context.Context, report *SoDViola
 	}
 }
 
-// adminRoleName returns the name of an admin (permission-bypass) role the user holds
-// in ANY scope — direct or group-inherited — or "" if none. The SoD scan is
-// scope-agnostic, so both direct and group-inherited admin grants must be checked:
-// a user who is a member of an admin-role group effectively holds all permissions
-// and must be flagged, exactly like a directly-granted admin.
-func (c *KeyorixCore) adminRoleName(ctx context.Context, userID uint) string {
-	roles, err := c.storage.GetUserRoles(ctx, userID)
-	if err == nil {
-		for _, r := range roles {
-			if isAdminRoleName(r.Name) {
-				return r.Name
-			}
-		}
-	}
-	groups, err := c.storage.GetUserGroups(ctx, userID)
+// isGlobalAdminRoleName returns the name of an admin (permission-bypass) role
+// the user holds at GLOBAL SCOPE specifically (ProjectID 0) — direct or
+// group-inherited — or "" if none.
+//
+// #G01: this replaces the former adminRoleName, which checked the role NAME
+// only and ignored the grant's own scope — so a role named like an admin role
+// but granted (directly, or via a group's role grant, or via the user's own
+// group MEMBERSHIP) at a single project was wrongly treated as install-wide
+// admin-bypass authority everywhere it was checked (legal-hold placement/lift,
+// the SoD preventive gate's admin-bypass exemption). A project-scoped admin
+// does not hold "all permissions" the way a true global admin does, so it must
+// not exempt a principal from a deployment-wide control or a deployment-wide
+// SoD policy. scopedRoleIDs(ctx, userID, Scope{}) — the same primitive
+// requireAdminAuthorityAt already uses for its own scope-aware admin check —
+// unions direct (GetUserRoleIDsAt) and group-inherited (GetUserGroupRoleIDsAt)
+// roles, and BOTH of those storage queries already correctly filter to
+// project_id=0 rows (and, for the group-inherited case, ALSO require the
+// user's own group membership to be project_id=0) when called with the global
+// scope — so this call is scope-correct for free, reusing already-tested code.
+func (c *KeyorixCore) isGlobalAdminRoleName(ctx context.Context, userID uint) string {
+	ids, err := c.scopedRoleIDs(ctx, userID, Scope{})
 	if err != nil {
 		return ""
 	}
-	for _, g := range groups {
-		groupRoles, err := c.storage.GetGroupRoles(ctx, g.ID)
-		if err != nil {
+	for _, id := range ids {
+		role, rerr := c.storage.GetRole(ctx, id)
+		if rerr != nil {
 			continue
 		}
-		for _, r := range groupRoles {
-			if isAdminRoleName(r.Name) {
-				return r.Name
-			}
+		if isAdminRoleName(role.Name) {
+			return role.Name
 		}
 	}
 	return ""
@@ -476,7 +480,7 @@ func (c *KeyorixCore) requireNoSoDViolation(ctx context.Context, userID, roleID 
 	if len(policies) == 0 {
 		return nil
 	}
-	if c.adminRoleName(ctx, userID) != "" {
+	if c.isGlobalAdminRoleName(ctx, userID) != "" {
 		return nil // already holds admin-bypass — see package doc above
 	}
 	role, err := c.storage.GetRole(ctx, roleID)
@@ -538,7 +542,7 @@ func (c *KeyorixCore) requireGroupGrantNoSoDViolation(ctx context.Context, group
 		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
 	}
 	for _, m := range members {
-		if !m.IsActive || c.adminRoleName(ctx, m.ID) != "" {
+		if !m.IsActive || c.isGlobalAdminRoleName(ctx, m.ID) != "" {
 			continue
 		}
 		held, err := c.userHeldPermissionSet(ctx, m.ID)

--- a/internal/core/sod_degraded_test.go
+++ b/internal/core/sod_degraded_test.go
@@ -32,11 +32,11 @@ func TestDetectSoDViolations_DegradedOnUserPermissionsError(t *testing.T) {
 		{ID: 11, Username: "bob", IsActive: true},
 	}, int64(2), nil)
 
-	// Neither user holds an admin permission-bypass role (direct or via group — #1185 added group check).
-	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
-	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil)
-	store.On("GetUserRoles", ctx, uint(11)).Return([]*models.Role{}, nil)
-	store.On("GetUserGroups", ctx, uint(11)).Return([]*models.Group{}, nil)
+	// Neither user holds an admin permission-bypass role at global scope (direct or via group).
+	store.On("GetUserRoleIDsAt", ctx, uint(10), storage.Scope{}).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(10), storage.Scope{}).Return([]uint{}, nil)
+	store.On("GetUserRoleIDsAt", ctx, uint(11), storage.Scope{}).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(11), storage.Scope{}).Return([]uint{}, nil)
 
 	// alice: a real, detectable violation.
 	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
@@ -87,8 +87,8 @@ func TestDetectSoDViolations_DegradedOnMachineRolesError(t *testing.T) {
 	store.On("ListUsers", ctx, mock.Anything).Return([]*models.User{
 		{ID: 10, Username: "alice", IsActive: true},
 	}, int64(1), nil)
-	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
-	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil)
+	store.On("GetUserRoleIDsAt", ctx, uint(10), storage.Scope{}).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(10), storage.Scope{}).Return([]uint{}, nil)
 	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
 		{Name: "secrets.write"}, {Name: "users.read"},
 	}, nil)
@@ -156,8 +156,8 @@ func TestDetectSoDViolations_NotDegradedOnCleanScan(t *testing.T) {
 	store.On("ListUsers", ctx, mock.Anything).Return([]*models.User{
 		{ID: 10, Username: "alice", IsActive: true},
 	}, int64(1), nil)
-	store.On("GetUserRoles", ctx, uint(10)).Return([]*models.Role{}, nil)
-	store.On("GetUserGroups", ctx, uint(10)).Return([]*models.Group{}, nil)
+	store.On("GetUserRoleIDsAt", ctx, uint(10), storage.Scope{}).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(10), storage.Scope{}).Return([]uint{}, nil)
 	store.On("GetUserPermissions", ctx, uint(10)).Return([]*storage.Permission{
 		{Name: "secrets.read"},
 	}, nil)

--- a/internal/core/sod_preventive_gate_external_test.go
+++ b/internal/core/sod_preventive_gate_external_test.go
@@ -290,3 +290,32 @@ func TestAssignUserRole_AdminBypassNotBlockedBySoD(t *testing.T) {
 	err = h.CoreService.AssignUserRole(ctx, 0, 17, 3, core.Scope{}) // editor
 	require.NoError(t, err, "granting a role to an existing admin-bypass holder must not be refused by the SoD gate")
 }
+
+// TestAssignUserRole_ProjectScopedAdminNotExemptFromSoD is the #G01
+// regression: an admin role granted only at a specific project must NOT
+// exempt the holder from the SoD preventive gate the way a true global admin
+// is exempted — SoD policies are principal-level and scope-agnostic by
+// design ("a user must never hold both sides ANYWHERE"), so a project-scoped
+// admin's own bundled permissions can still combine with a new grant to
+// complete a policy, and that must be blocked like any non-admin grant.
+func TestAssignUserRole_ProjectScopedAdminNotExemptFromSoD(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "kim", 18)
+	// "admin" (role 2) bundles secrets.write but NOT audit.admin — grant it to
+	// kim scoped ONLY to project 9, not globally.
+	projectID := uint(9)
+	h.AssignUserRole(t, 18, 2, &projectID)
+
+	// Policy pairs secrets.write (already in kim's project-scoped admin bundle)
+	// with audit.admin (only "auditor", role 5, bundles it).
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-audit-admin", "", "secrets.write", "audit.admin")
+	require.NoError(t, err)
+
+	err = h.CoreService.AssignUserRole(ctx, 0, 18, 5, core.Scope{}) // auditor
+	require.Error(t, err, "a project-scoped admin must still be blocked by the SoD gate, unlike a true global admin")
+	assert.Contains(t, err.Error(), "separation-of-duties")
+}

--- a/internal/core/token_expiry_remind_test.go
+++ b/internal/core/token_expiry_remind_test.go
@@ -234,7 +234,9 @@ func TestCheckTokenExpiry_MachineCredExpiringIn3Days_Warning(t *testing.T) {
 
 	admin := &models.User{ID: 5}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin}, int64(1), nil)
-	ms.On("GetUserRoles", ctx, uint(5)).Return([]*models.Role{{Name: "admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(5), storage.Scope{}).Return([]uint{51}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(5), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(51)).Return(&models.Role{ID: 51, Name: "admin"}, nil)
 	ms.On("ListNotifications", ctx, uint(5), true, 200).
 		Return([]*models.Notification{}, nil)
 	ms.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).
@@ -265,7 +267,9 @@ func TestCheckTokenExpiry_MachineCredExpiringIn12Hours_Critical(t *testing.T) {
 
 	admin := &models.User{ID: 6}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin}, int64(1), nil)
-	ms.On("GetUserRoles", ctx, uint(6)).Return([]*models.Role{{Name: "super_admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(6), storage.Scope{}).Return([]uint{61}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(6), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(61)).Return(&models.Role{ID: 61, Name: "super_admin"}, nil)
 	ms.On("ListNotifications", ctx, uint(6), true, 200).
 		Return([]*models.Notification{}, nil)
 	ms.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).
@@ -337,7 +341,9 @@ func TestCheckTokenExpiry_MachineCredDeduplication(t *testing.T) {
 
 	admin := &models.User{ID: 7}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin}, int64(1), nil)
-	ms.On("GetUserRoles", ctx, uint(7)).Return([]*models.Role{{Name: "admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(7), storage.Scope{}).Return([]uint{71}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(7), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(71)).Return(&models.Role{ID: 71, Name: "admin"}, nil)
 
 	existingMsg := `Machine credential "runner-cred" expires on 2026-06-14 12:00 UTC.`
 	ms.On("ListNotifications", ctx, uint(7), true, 200).
@@ -373,7 +379,9 @@ func TestCheckTokenExpiry_MachineCredUpgradeWarningToCritical(t *testing.T) {
 
 	admin := &models.User{ID: 8}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin}, int64(1), nil)
-	ms.On("GetUserRoles", ctx, uint(8)).Return([]*models.Role{{Name: "admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(8), storage.Scope{}).Return([]uint{81}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(8), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(81)).Return(&models.Role{ID: 81, Name: "admin"}, nil)
 
 	existing := &models.Notification{
 		ID:       88,
@@ -422,7 +430,9 @@ func TestCheckTokenExpiry_BothPATAndMachineCred(t *testing.T) {
 	// Admin for machine cred
 	admin := &models.User{ID: 30}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin}, int64(1), nil)
-	ms.On("GetUserRoles", ctx, uint(30)).Return([]*models.Role{{Name: "admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(30), storage.Scope{}).Return([]uint{301}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(30), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(301)).Return(&models.Role{ID: 301, Name: "admin"}, nil)
 	ms.On("ListNotifications", ctx, uint(30), true, 200).
 		Return([]*models.Notification{}, nil)
 	ms.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).
@@ -592,7 +602,9 @@ func TestCheckTokenExpiry_MachineCredNilExpiresAt(t *testing.T) {
 
 	admin := &models.User{ID: 70}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin}, int64(1), nil)
-	ms.On("GetUserRoles", ctx, uint(70)).Return([]*models.Role{{Name: "admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(70), storage.Scope{}).Return([]uint{701}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(70), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(701)).Return(&models.Role{ID: 701, Name: "admin"}, nil)
 
 	result, err := c.CheckTokenExpiry(ctx)
 	require.NoError(t, err)
@@ -623,8 +635,12 @@ func TestCheckTokenExpiry_MachineCredMultipleAdmins_OnlyCountsOnce(t *testing.T)
 	admin1 := &models.User{ID: 80}
 	admin2 := &models.User{ID: 81}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin1, admin2}, int64(2), nil)
-	ms.On("GetUserRoles", ctx, uint(80)).Return([]*models.Role{{Name: "admin"}}, nil)
-	ms.On("GetUserRoles", ctx, uint(81)).Return([]*models.Role{{Name: "super_admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(80), storage.Scope{}).Return([]uint{801}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(80), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(801)).Return(&models.Role{ID: 801, Name: "admin"}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(81), storage.Scope{}).Return([]uint{811}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(81), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(811)).Return(&models.Role{ID: 811, Name: "super_admin"}, nil)
 	ms.On("ListNotifications", ctx, uint(80), true, 200).Return([]*models.Notification{}, nil)
 	ms.On("ListNotifications", ctx, uint(81), true, 200).Return([]*models.Notification{}, nil)
 	ms.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).
@@ -660,8 +676,12 @@ func TestCheckTokenExpiry_MachineCredUpgradeCountsOnceAcrossAdmins(t *testing.T)
 	admin1 := &models.User{ID: 90}
 	admin2 := &models.User{ID: 91}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin1, admin2}, int64(2), nil)
-	ms.On("GetUserRoles", ctx, uint(90)).Return([]*models.Role{{Name: "admin"}}, nil)
-	ms.On("GetUserRoles", ctx, uint(91)).Return([]*models.Role{{Name: "admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(90), storage.Scope{}).Return([]uint{901}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(90), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(901)).Return(&models.Role{ID: 901, Name: "admin"}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(91), storage.Scope{}).Return([]uint{911}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(91), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(911)).Return(&models.Role{ID: 911, Name: "admin"}, nil)
 
 	existMsg := `Machine credential "escalating-cred" expires on 2026-06-11 08:00 UTC.`
 	existing90 := &models.Notification{ID: 90, Type: NotificationMachineCredExpiry, Message: existMsg, Severity: models.NotificationSeverityWarning}
@@ -697,7 +717,9 @@ func TestCheckTokenExpiry_MachineCredUpgradeFailNotCounted(t *testing.T) {
 
 	admin := &models.User{ID: 95}
 	ms.On("ListUsers", ctx, mock.Anything).Return([]*models.User{admin}, int64(1), nil)
-	ms.On("GetUserRoles", ctx, uint(95)).Return([]*models.Role{{Name: "admin"}}, nil)
+	ms.On("GetUserRoleIDsAt", ctx, uint(95), storage.Scope{}).Return([]uint{951}, nil)
+	ms.On("GetUserGroupRoleIDsAt", ctx, uint(95), storage.Scope{}).Return([]uint{}, nil)
+	ms.On("GetRole", ctx, uint(951)).Return(&models.Role{ID: 951, Name: "admin"}, nil)
 
 	existMsg := `Machine credential "fail-upgrade-cred" expires on 2026-06-11 08:00 UTC.`
 	existing := &models.Notification{ID: 95, Type: NotificationMachineCredExpiry, Message: existMsg, Severity: models.NotificationSeverityWarning}

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -271,6 +271,13 @@ func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*
 
 	// JOIN groups … deleted_at IS NULL: a soft-deleted group's shares grant nothing,
 	// even though the share/membership rows are kept for restore.
+	//
+	// #G01: ug.project_id = 0 OR ug.project_id = s.project_id — a membership
+	// scoped to a DIFFERENT project than the secret being listed must not
+	// confer access to it. Without this, a user who is only a project-scoped
+	// member of a group in project X could see secrets shared with that group
+	// in every other project too (mirrors GetUserRoleIDsAt/
+	// GetUserGroupRoleIDsAt's own project_id=0-OR-exact-match convention).
 	groupQuery := `
 		SELECT s.* FROM secret_nodes s
 		JOIN share_records sr ON s.id = sr.secret_id
@@ -279,6 +286,7 @@ func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*
 		JOIN users u ON u.id = ug.user_id AND u.deleted_at IS NULL
 		WHERE ug.user_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL AND s.deleted_at IS NULL
 		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
+		  AND (ug.project_id = 0 OR ug.project_id = s.project_id)
 	`
 	var groupSecrets []*models.SecretNode
 	if err := ls.db.Raw(groupQuery, userID, true, now).Scan(&groupSecrets).Error; err != nil {
@@ -333,6 +341,10 @@ func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, user
 		return "", fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 
+	// #G01: ug.project_id = 0 OR ug.project_id = ? (secret.ProjectID) — a
+	// membership scoped to a DIFFERENT project than this secret must not
+	// confer the group's share permission on it. See ListSharedSecrets's
+	// identical fix above for the full reasoning.
 	var groupShare models.ShareRecord
 	groupQuery := `
 		SELECT sr.* FROM share_records sr
@@ -341,9 +353,10 @@ func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, user
 		JOIN users u ON u.id = ug.user_id AND u.deleted_at IS NULL
 		WHERE sr.secret_id = ? AND ug.user_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL
 		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
+		  AND (ug.project_id = 0 OR ug.project_id = ?)
 		LIMIT 1
 	`
-	res := ls.db.Raw(groupQuery, secretID, userID, true, now).Scan(&groupShare)
+	res := ls.db.Raw(groupQuery, secretID, userID, true, now, secret.ProjectID).Scan(&groupShare)
 	haveGroup := res.Error == nil && groupShare.ID != 0
 	if res.Error != nil && !errors.Is(res.Error, gorm.ErrRecordNotFound) {
 		return "", fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), res.Error)

--- a/internal/storage/store/local_sharing_test.go
+++ b/internal/storage/store/local_sharing_test.go
@@ -432,6 +432,39 @@ func TestCheckSharePermission_DirectVsGroupConflict_StrongestWins(t *testing.T) 
 	})
 }
 
+// TestCheckSharePermission_ProjectScopedMembershipDoesNotCrossProjects is the
+// #G01 regression: a group MEMBERSHIP scoped to one project must not confer
+// that group's share permission on a secret in a DIFFERENT project.
+func TestCheckSharePermission_ProjectScopedMembershipDoesNotCrossProjects(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner2", Email: "o2@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 3, Username: "member2", Email: "m2@x.io"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 11, Name: "team2"}).Error)
+	// member2's membership in group 11 is scoped ONLY to project 7.
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 3, GroupID: 11, ProjectID: 7}).Error)
+
+	// The secret is in project 9 — a DIFFERENT project than the membership.
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 200, Name: "s3", ProjectID: 9, EnvironmentID: 1, OwnerID: 1, Status: "active", Type: "password",
+	}).Error)
+	_, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: 200, RecipientID: 11, IsGroup: true, OwnerID: 1, Permission: "write",
+	})
+	require.NoError(t, err)
+
+	perm, err := ls.CheckSharePermission(ctx, 200, 3)
+	require.Error(t, err, "a membership scoped to project 7 must not grant access to a secret in project 9")
+	assert.Empty(t, perm)
+
+	secrets, err := ls.ListSharedSecrets(ctx, 3)
+	require.NoError(t, err)
+	for _, s := range secrets {
+		assert.NotEqual(t, uint(200), s.ID, "ListSharedSecrets must not surface a secret reached only via a cross-project membership")
+	}
+}
+
 // CWE-284 / sibling of #370: DeleteSecret must also delete SecretACL rows in the
 // same transaction so that ACL-based access cannot silently reactivate when the
 // secret is later restored from the recycle bin (the same class of bug fixed for


### PR DESCRIPTION
## Summary
Multiple independent helpers that check "does this principal hold admin-tier authority" or "is this a legitimate share via this group" checked the ROLE NAME or the fact of GROUP MEMBERSHIP, but never checked the ProjectID/scope attached to the grant record — so a role or membership legitimately scoped to one project was silently treated as install-wide/global.

**Part 1 — role-NAME scope-blindness (4 members):** `legal_hold.go`, `sod.go` (x2), `license_expiry.go`. Fixed via a new `isGlobalAdminRoleName` helper that resolves admin-tier status via `scopedRoleIDs(ctx, userID, Scope{})`, reusing the existing scope-aware `GetUserRoleIDsAt`/`GetUserGroupRoleIDsAt` — no new storage plumbing needed.

**Part 2a — group-membership scope-blindness, storage layer (1 member):** `local_sharing.go`'s `CheckSharePermission`/`ListSharedSecrets` — fixed inline with a `project_id = 0 OR project_id = <target>` SQL filter, since the target project ID was already available at each call site.

**Part 2 — remaining group-membership scope-blindness (3 members, this update):**
- `permissions.go`'s `CheckGroupPermissions` resolved group-share access via the unscoped `GetUserGroups`, so a user whose membership in a group was scoped to project X could still reach a secret shared with that group in a completely different project Y.
- `authz.go`'s `resolveGroupAdminMembers` (shared by `guardLastGlobalAdminGroupDelete`/`guardLastGlobalAdminMembership`/`guardLastGlobalAdminGroupRole`) used the unscoped `ListGroupMembers` — a member whose OWN membership in an admin-conferring group was project-scoped got counted as holding GLOBAL admin authority via that group's GLOBAL role grant, over-counting admin holders and letting the group holding the install's true last global admin route be deleted while the guard reported success.

Added two new scope-aware storage methods, mirroring the existing `GetUserGroupRoleIDsAt` convention exactly (`project_id = 0 OR project_id = ?`): `GetUserGroupsAt` and `ListGroupMembersAt`. Both are LocalStorage-only for now (RemoteStorage stubs registered in the existing `remoteUnsupported` allowlist test) — the checks they back only run against the server's own `KeyorixCore` over a local backend; no `storage.type: remote` caller reaches them today.

**G01 is now fully addressed — 8 of 8 members.**

## Test plan
- [x] New regression tests: `TestCheckGroupPermissions_ProjectScopedMembershipDoesNotCrossProjects`, `TestDeleteGroup_ProjectScopedSoleMemberNotCountedAsGlobalAdmin`, `TestDeleteGroup_GlobalMemberCountedAsGlobalAdmin`, plus part 1's earlier regression tests
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/core/... ./internal/storage/... ./server/...` clean
- [x] `gosec -severity medium -exclude-generated ./...` clean on touched packages
- [x] `golangci-lint run` clean on touched packages