### PR TITLE
fix(security): apply csvSafe()/CSVSafe() to remaining CSV exports (G49)

### DIFF
--- a/internal/cli/machine/audit.go
+++ b/internal/cli/machine/audit.go
@@ -80,8 +80,8 @@ func printMachineAuditCSV(report *core.MachineAuditReport) error {
 		}
 		if err := cw.Write([]string{
 			fmt.Sprintf("%d", m.MachineID),
-			m.Name,
-			m.Description,
+			common.CSVSafe(m.Name),
+			common.CSVSafe(m.Description),
 			fmt.Sprintf("%d", m.CredentialCount),
 			lastUsed,
 			fmt.Sprintf("%v", m.IsStale),

--- a/internal/cli/machine/audit_test.go
+++ b/internal/cli/machine/audit_test.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"context"
+	"encoding/csv"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -152,6 +153,36 @@ func TestPrintMachineAuditCSV_NoLastUsed(t *testing.T) {
 	assert.Equal(t, "7", fields[0])
 	assert.Equal(t, "", fields[4]) // last_used_at empty when nil
 	assert.Equal(t, "true", fields[5])
+}
+
+// TestPrintMachineAuditCSV_FormulaInjection — a machine name/description starting with a
+// formula-injection character (=, +, -, @) must be escaped with a leading single quote
+// in the CSV export (G49: CSVSafe() formula-injection escaping).
+func TestPrintMachineAuditCSV_FormulaInjection(t *testing.T) {
+	ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	report := &core.MachineAuditReport{
+		Machines: []core.MachineAuditRow{
+			{
+				MachineID:       1,
+				Name:            "=cmd|' /C calc'!A1",
+				Description:     "@SUM(1+1)",
+				CredentialCount: 1,
+				CreatedAt:       ts,
+			},
+		},
+	}
+
+	out := captureAuditStdout(t, func() {
+		require.NoError(t, printMachineAuditCSV(report))
+	})
+
+	r := csv.NewReader(strings.NewReader(out))
+	records, err := r.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2, "header + 1 data row")
+	// header: machine_id, name, description, credential_count, last_used_at, is_stale, is_revoked, created_at
+	assert.True(t, strings.HasPrefix(records[1][1], "'"), "name formula-injection prefix must be neutralized, got %q", records[1][1])
+	assert.True(t, strings.HasPrefix(records[1][2], "'"), "description formula-injection prefix must be neutralized, got %q", records[1][2])
 }
 
 func TestPrintMachineAuditCSV_Empty(t *testing.T) {

--- a/internal/cli/rbac/export_matrix.go
+++ b/internal/cli/rbac/export_matrix.go
@@ -180,8 +180,8 @@ func writeMatrixEmbedded(out io.Writer, rows []*core.PermissionMatrixRow, format
 				expiresAt = r.ExpiresAt.UTC().Format(time.RFC3339)
 			}
 			_ = w.Write([]string{
-				r.Username, r.Email, r.RoleName, r.PermissionName,
-				r.Resource, r.Action, r.Scope, r.ProjectName, r.EnvironmentName, expiresAt,
+				common.CSVSafe(r.Username), common.CSVSafe(r.Email), common.CSVSafe(r.RoleName), common.CSVSafe(r.PermissionName),
+				common.CSVSafe(r.Resource), common.CSVSafe(r.Action), common.CSVSafe(r.Scope), common.CSVSafe(r.ProjectName), common.CSVSafe(r.EnvironmentName), expiresAt,
 			})
 		}
 		w.Flush()
@@ -235,7 +235,7 @@ func remoteRowToCSV(r remoteMatrixRow) []string {
 		expiresAt = r.ExpiresAt.UTC().Format(time.RFC3339)
 	}
 	return []string{
-		r.Username, r.Email, r.RoleName, r.PermissionName,
-		r.Resource, r.Action, r.Scope, r.ProjectName, r.EnvironmentName, expiresAt,
+		common.CSVSafe(r.Username), common.CSVSafe(r.Email), common.CSVSafe(r.RoleName), common.CSVSafe(r.PermissionName),
+		common.CSVSafe(r.Resource), common.CSVSafe(r.Action), common.CSVSafe(r.Scope), common.CSVSafe(r.ProjectName), common.CSVSafe(r.EnvironmentName), expiresAt,
 	}
 }

--- a/internal/cli/rbac/export_matrix_test.go
+++ b/internal/cli/rbac/export_matrix_test.go
@@ -3,6 +3,7 @@ package rbac
 import (
 	"bytes"
 	"context"
+	"encoding/csv"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -218,6 +219,53 @@ func TestWriteMatrixEmbedded_CSV(t *testing.T) {
 	assert.Contains(t, out, "carol")
 	assert.Contains(t, out, "2028-06-15T00:00:00Z")
 	assert.Contains(t, out, "never") // nil ExpiresAt → "never"
+}
+
+// TestWriteMatrixEmbedded_CSV_FormulaInjection — a project name starting with a
+// formula-injection character (=, +, -, @) must be escaped with a leading single quote
+// in the embedded CSV export (G49: CSVSafe() formula-injection escaping).
+func TestWriteMatrixEmbedded_CSV_FormulaInjection(t *testing.T) {
+	rows := []*core.PermissionMatrixRow{
+		{
+			Username: "mallory", Email: "mallory@example.com",
+			RoleName: "viewer", PermissionName: "secrets.read",
+			Resource: "secrets", Action: "read",
+			Scope: "project", ProjectName: "=cmd|' /C calc'!A1",
+		},
+	}
+	var buf bytes.Buffer
+	err := writeMatrixEmbedded(&buf, rows, "csv")
+	require.NoError(t, err)
+
+	r := csv.NewReader(&buf)
+	records, err := r.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2, "header + 1 data row")
+	// header: username, email, role, permission, resource, action, scope, project, environment, expires_at
+	projectCell := records[1][7]
+	assert.True(t, strings.HasPrefix(projectCell, "'"), "formula-injection prefix must be neutralized, got %q", projectCell)
+}
+
+// TestWriteMatrixRemote_CSV_FormulaInjection — same escaping guarantee on the
+// embedded-JSON-then-locally-rendered CSV remote path (writeMatrixRemote / remoteRowToCSV).
+func TestWriteMatrixRemote_CSV_FormulaInjection(t *testing.T) {
+	rows := []remoteMatrixRow{
+		{
+			Username: "=SUM(A1:A9)", Email: "eve@example.com",
+			RoleName: "jit", PermissionName: "secrets.read",
+			Scope: "global",
+		},
+	}
+	var buf bytes.Buffer
+	err := writeMatrixRemote(&buf, rows, "csv")
+	require.NoError(t, err)
+
+	r := csv.NewReader(&buf)
+	records, err := r.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2, "header + 1 data row")
+	usernameCell := records[1][0]
+	assert.True(t, strings.HasPrefix(usernameCell, "'"), "formula-injection prefix must be neutralized, got %q", usernameCell)
 }
 
 // TestWriteMatrixEmbedded_TableEmpty — empty rows print "No permission grants found."

--- a/server/http/handlers/audit_export_csv.go
+++ b/server/http/handlers/audit_export_csv.go
@@ -52,7 +52,7 @@ func (h *AuditHandler) ExportAuditLogsCSV(w http.ResponseWriter, r *http.Request
 			e.EventTime.UTC().Format(time.RFC3339),
 			csvSafe(e.EventType),
 			csvSafe(auditCSVActorName(actorNames, e.UserID)),
-			actorTypeOrDefault(e.ActorType),
+			csvSafe(actorTypeOrDefault(e.ActorType)),
 			auditCSVUintStr(e.UserID),
 			auditCSVUintStr(e.ProjectID),
 			auditCSVUintStr(e.SecretNodeID),

--- a/server/http/handlers/audit_export_csv_test.go
+++ b/server/http/handlers/audit_export_csv_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/csv"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -59,4 +60,39 @@ func TestExportAuditLogsCSV(t *testing.T) {
 		h.ExportAuditLogsCSV(w, req)
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
 	})
+}
+
+// TestExportAuditLogsCSV_FormulaInjection — an event whose actor_type begins with a
+// formula-injection character (=, +, -, @) must be escaped with a leading single quote
+// in the CSV export (G49: csvSafe() formula-injection escaping on the actor_type column).
+func TestExportAuditLogsCSV_FormulaInjection(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@t.com"}).Error)
+
+	uid := uint(1)
+	tru := true
+	require.NoError(t, db.Create(&models.AuditEvent{
+		EventType: "secret.created", UserID: &uid, Success: &tru,
+		Description: "created db", IPAddress: "10.0.0.1", EventTime: time.Now(),
+		ActorType: "=cmd|' /C calc'!A1",
+	}).Error)
+
+	h := NewAuditHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/audit/export.csv", nil))
+	w := httptest.NewRecorder()
+	h.ExportAuditLogsCSV(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	records, err := csv.NewReader(w.Body).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2, "CSV must have header + 1 data row")
+
+	// header: id, event_time, event_type, actor, actor_type, user_id, project_id,
+	// secret_id, ip_address, success, description
+	actorTypeCell := records[1][4]
+	assert.True(t, strings.HasPrefix(actorTypeCell, "'"), "formula-injection prefix must be neutralized with a leading quote, got %q", actorTypeCell)
+	assert.Equal(t, "'=cmd|' /C calc'!A1", actorTypeCell)
 }

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -1011,15 +1011,15 @@ func (h *RBACHandler) GetPermissionMatrix(w http.ResponseWriter, r *http.Request
 				expiresAt = row.ExpiresAt.UTC().Format(time.RFC3339)
 			}
 			_ = cw.Write([]string{
-				row.Username,
-				row.Email,
-				row.RoleName,
-				row.PermissionName,
-				row.Resource,
-				row.Action,
-				row.Scope,
-				row.ProjectName,
-				row.EnvironmentName,
+				csvSafe(row.Username),
+				csvSafe(row.Email),
+				csvSafe(row.RoleName),
+				csvSafe(row.PermissionName),
+				csvSafe(row.Resource),
+				csvSafe(row.Action),
+				csvSafe(row.Scope),
+				csvSafe(row.ProjectName),
+				csvSafe(row.EnvironmentName),
 				expiresAt,
 			})
 		}

--- a/server/http/handlers/rbac_permission_matrix_test.go
+++ b/server/http/handlers/rbac_permission_matrix_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -139,6 +140,35 @@ func TestGetPermissionMatrixHandler_CSVWithExpiry(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	body := w.Body.String()
 	assert.Contains(t, body, "2028-06-01T12:00:00Z", "CSV must contain formatted ExpiresAt")
+}
+
+// TestGetPermissionMatrixHandler_CSVFormulaInjection — a project name starting with a
+// formula-injection character (=, +, -, @) must be escaped with a leading single quote
+// in the CSV export (G49: csvSafe() formula-injection escaping).
+func TestGetPermissionMatrixHandler_CSVFormulaInjection(t *testing.T) {
+	h, db := newMatrixHandlerCore(t)
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "alice@example.com"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 9, Name: "=cmd|' /C calc'!A1"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 9, EnvironmentID: 0}).Error)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/system/rbac/permission-matrix?format=csv", nil))
+	w := httptest.NewRecorder()
+	h.GetPermissionMatrix(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	records, err := csv.NewReader(w.Body).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2, "CSV must have header + 1 data row")
+
+	// project is column index 7 in the header:
+	// username, email, role, permission, resource, action, scope, project, environment, expires_at
+	projectCell := records[1][7]
+	assert.True(t, strings.HasPrefix(projectCell, "'"), "formula-injection prefix must be neutralized with a leading quote, got %q", projectCell)
+	assert.Equal(t, "'=cmd|' /C calc'!A1", projectCell)
 }
 
 // TestGetPermissionMatrixHandler_StorageError — a storage failure produces HTTP 500.


### PR DESCRIPTION
## Summary
- `server/http/handlers/rbac.go`'s `GetPermissionMatrix` CSV export and `audit_export_csv.go`'s actor_type column wrote user-controlled fields without the `csvSafe()` formula-injection escaping already used by sibling exports (e.g. `permission_baseline.go`).
- `internal/cli/rbac/export_matrix.go`'s embedded and remote CSV writers (`writeMatrixEmbedded`, `remoteRowToCSV`) and `internal/cli/machine/audit.go`'s `printMachineAuditCSV` wrote user-controlled fields (username, role, project/environment name, machine name/description) without the equivalent `CSVSafe()` escaping.
- `internal/core/permission_matrix.go` (also flagged as a G49 member) needs no change — `GetPermissionMatrix` only builds structured rows; its two consumers are the CLI and handler exports fixed here.
- A field starting with `=`, `+`, `-`, or `@` could be interpreted as a formula by Excel/Sheets when the export is opened (CSV formula injection).

## Test plan
- [x] Regression tests asserting a formula-injection payload gets the leading single-quote escape on the handler CSV exports (`audit_export_csv_test.go`, `rbac_permission_matrix_test.go`)
- [x] Regression tests for the embedded and remote CLI CSV paths (`export_matrix_test.go`, `audit_test.go`)
- [x] `go build ./...`, `go vet ./...` clean
- [x] `gosec -severity medium -exclude-generated ./...` clean