### PR TITLE
fix(security): align endpoint permission tiers with their siblings (G16)

### DIFF
--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -210,11 +210,19 @@ func (s *AuditGRPCService) VerifyAuditChain(ctx context.Context, _ *emptypb.Empt
 }
 
 // WriteAuditCheckpoint signs a checkpoint of the verified audit-chain head on demand
-// (ADR-029). Mirrors POST /api/v1/audit/checkpoint; privileged (system.write). Returns
-// FailedPrecondition when the chain does not verify or encryption is disabled.
+// (ADR-029). Mirrors POST /api/v1/audit/checkpoint, which stacks TWO permissions:
+// the /audit route group's base audit.read (server/http/router.go, RequirePermission
+// on the "/audit" group) plus an extra system.write gate specifically on the
+// /checkpoint route (it's a privileged integrity-control action, gated above the
+// group's audit.read with system.write). Mirror both checks here — checking only
+// system.write let a principal without audit.read reach this RPC directly over
+// gRPC even though every other audit endpoint requires it (G16).
 func (s *AuditGRPCService) WriteAuditCheckpoint(ctx context.Context, _ *emptypb.Empty) (*pb.WriteAuditCheckpointResponse, error) {
 	actor, err := requireUser(ctx)
 	if err != nil {
+		return nil, err
+	}
+	if err := authorizeGlobal(ctx, s.core, actor, permAuditRead); err != nil {
 		return nil, err
 	}
 	if err := authorizeGlobal(ctx, s.core, actor, "system.write"); err != nil {

--- a/server/grpc/services/audit_service_test.go
+++ b/server/grpc/services/audit_service_test.go
@@ -111,6 +111,69 @@ func TestAuditService_WriteAuditCheckpoint_RequiresEncryption(t *testing.T) {
 	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 }
 
+// TestAuditService_WriteAuditCheckpoint_RequiresAuditReadAndSystemWrite is the
+// G16 regression test: the HTTP route stacks TWO permissions on POST
+// /audit/checkpoint — the /audit group's base audit.read plus a route-specific
+// system.write — but the gRPC RPC only checked system.write, letting a
+// system.write-only caller (e.g. an "operations admin" deliberately not
+// granted audit.read) reach the identical core.WriteAuditCheckpoint over gRPC.
+// Verifies: system.write alone is refused, audit.read alone is refused, and
+// holding both clears authorization (surfacing the pre-existing
+// FailedPrecondition from the test DB's disabled encryption, not
+// PermissionDenied).
+func TestAuditService_WriteAuditCheckpoint_RequiresAuditReadAndSystemWrite(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}))
+	svc := NewAuditService(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	require.NoError(t, db.Create(&models.Permission{ID: 100, Name: "system.write", Resource: "system", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 101, Name: "audit.read", Resource: "audit", Action: "read"}).Error)
+
+	// User 2: system.write ONLY (the old, insufficient gate) — must be refused.
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "sysadmin", Email: "sysadmin@example.com"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "system_write_only"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 100}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2, ProjectID: 0}).Error)
+
+	_, err = svc.WriteAuditCheckpoint(authCtx(2, "sysadmin"), &emptypb.Empty{})
+	require.Error(t, err, "system.write alone must NOT be enough to write an audit checkpoint")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	// User 3: audit.read ONLY — also must be refused (system.write is still required).
+	require.NoError(t, db.Create(&models.User{ID: 3, Username: "auditor-only", Email: "auditor-only@example.com"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 3, Name: "audit_read_only"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 3, PermissionID: 101}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 3, ProjectID: 0}).Error)
+
+	_, err = svc.WriteAuditCheckpoint(authCtx(3, "auditor-only"), &emptypb.Empty{})
+	require.Error(t, err, "audit.read alone must NOT be enough to write an audit checkpoint")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	// User 4: BOTH audit.read and system.write — authorization must clear (the
+	// remaining error is the pre-existing disabled-encryption precondition, not
+	// a permission denial).
+	require.NoError(t, db.Create(&models.User{ID: 4, Username: "full-grant", Email: "full-grant@example.com"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 4, Name: "audit_and_system_write"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 4, PermissionID: 100}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 4, PermissionID: 101}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 4, RoleID: 4, ProjectID: 0}).Error)
+
+	_, err = svc.WriteAuditCheckpoint(authCtx(4, "full-grant"), &emptypb.Empty{})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err),
+		"holding both audit.read and system.write should clear authorization, leaving only the disabled-encryption precondition")
+}
+
 func TestAuditService_GetAuditLogs_PermissionDenied(t *testing.T) {
 	svc := newAuditService(t)
 	ctx := authCtx(7, "nobody") // ungranted user → denied

--- a/server/grpc/services/group_service.go
+++ b/server/grpc/services/group_service.go
@@ -116,7 +116,11 @@ func (s *GroupGRPCService) RestoreGroup(ctx context.Context, req *pb.RestoreGrou
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor, permUsersWrite); err != nil {
+	// Restore reinstates every role grant the group carried at deletion — the same
+	// blast radius as a role grant — so gate on roles.assign, not users.write,
+	// matching the HTTP sibling (server/http/router.go: POST /groups/{id}/restore,
+	// gated permRolesAssign, #147) (G16).
+	if err := authorizeGlobal(ctx, s.core, actor, permRolesAssign); err != nil {
 		return nil, err
 	}
 	if err := s.core.RestoreGroup(ctx, actor.UserID, uint(req.GetId())); err != nil {

--- a/server/grpc/services/group_service_test.go
+++ b/server/grpc/services/group_service_test.go
@@ -102,3 +102,47 @@ func TestGroupService_Unauthenticated(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 }
+
+// TestGroupService_RestoreGroup_RequiresRolesAssign is the G16 regression test:
+// RestoreGroup reinstates every role grant the group carried at deletion (the
+// same blast radius as a role grant), so it must require roles.assign — not
+// users.write, which the HTTP sibling (POST /groups/{id}/restore, #147) never
+// accepted either. A users.write-only holder must be refused; a roles.assign
+// holder must succeed.
+func TestGroupService_RestoreGroup_RequiresRolesAssign(t *testing.T) {
+	svc, h := newGroupService(t)
+
+	// A group to soft-delete + attempt restoring with an insufficient grant.
+	g1, err := svc.CreateGroup(groupCtx(), &pb.CreateGroupRequest{Name: "team-a"})
+	require.NoError(t, err)
+	_, err = svc.DeleteGroup(groupCtx(), &pb.DeleteGroupRequest{Id: g1.GetId()})
+	require.NoError(t, err)
+
+	// A second group to soft-delete + restore with a sufficient grant.
+	g2, err := svc.CreateGroup(groupCtx(), &pb.CreateGroupRequest{Name: "team-b"})
+	require.NoError(t, err)
+	_, err = svc.DeleteGroup(groupCtx(), &pb.DeleteGroupRequest{Id: g2.GetId()})
+	require.NoError(t, err)
+
+	// User 2 holds ONLY users.write (the old, too-weak gate) — must be refused.
+	h.CreateTestUser(t, "writer-only", 2)
+	writerRole := h.CreateTestRole(t, "writer_only", "users.write only", 100)
+	h.ExecuteRawSQL(t, `INSERT INTO role_permissions (role_id, permission_id)
+		SELECT ?, id FROM permissions WHERE name = 'users.write'`, writerRole.ID)
+	h.AssignUserRole(t, 2, writerRole.ID, nil)
+
+	_, err = svc.RestoreGroup(authCtx(2, "writer-only"), &pb.RestoreGroupRequest{Id: g1.GetId()})
+	require.Error(t, err, "users.write holder without roles.assign must NOT restore a group")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	// User 3 holds roles.assign (the new, correct gate) — must succeed.
+	h.CreateTestUser(t, "assigner", 3)
+	assignerRole := h.CreateTestRole(t, "assigner_only", "roles.assign only", 101)
+	h.ExecuteRawSQL(t, `INSERT INTO role_permissions (role_id, permission_id)
+		SELECT ?, id FROM permissions WHERE name = 'roles.assign'`, assignerRole.ID)
+	h.AssignUserRole(t, 3, assignerRole.ID, nil)
+
+	restored, err := svc.RestoreGroup(authCtx(3, "assigner"), &pb.RestoreGroupRequest{Id: g2.GetId()})
+	require.NoError(t, err, "roles.assign holder should be allowed to restore a group")
+	assert.Equal(t, g2.GetId(), restored.GetId())
+}

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -269,13 +269,21 @@ func (s *RoleGRPCService) RemoveRole(ctx context.Context, req *pb.RemoveRoleRequ
 	return &emptypb.Empty{}, nil
 }
 
-// GetUserRoles returns all roles assigned to a user.
+// GetUserRoles returns all roles assigned to a user. Calls the identical
+// core.GetUserRoleAssignment the HTTP sibling RBACHandler.GetUserRoles does
+// (server/http/handlers/rbac.go), which is deliberately routed behind
+// permRolesAssign, not permRolesRead (server/http/router.go: GET
+// /roles/user/{userId}) — a stricter permission than the roles.read that gates
+// the rest of the /roles route group, because this discloses an arbitrary
+// user's full role assignment (including admin-tier roles), which is
+// reconnaissance for a targeted privilege-escalation attempt. Match that gate
+// here (G16).
 func (s *RoleGRPCService) GetUserRoles(ctx context.Context, req *pb.GetUserRolesRequest) (*pb.GetUserRolesResponse, error) {
 	actor, err := requireUser(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if err := authorizeGlobal(ctx, s.core, actor, permRolesRead); err != nil {
+	if err := authorizeGlobal(ctx, s.core, actor, permRolesAssign); err != nil {
 		return nil, err
 	}
 	assignment, err := s.core.GetUserRoleAssignment(ctx, uint(req.GetUserId()))

--- a/server/grpc/services/role_service_test.go
+++ b/server/grpc/services/role_service_test.go
@@ -249,6 +249,41 @@ func TestRoleService_AssignAndGetUserRoles(t *testing.T) {
 	assert.GreaterOrEqual(t, len(got.GetRoles()), 1)
 }
 
+// TestRoleService_GetUserRoles_RequiresRolesAssign is the G16 regression test:
+// GetUserRoles calls the identical core.GetUserRoleAssignment the HTTP sibling
+// RBACHandler.GetUserRoles does (server/http/router.go: GET /roles/user/{userId}),
+// which is deliberately gated behind roles.assign, not the weaker roles.read
+// that gates the rest of the /roles group — disclosing an arbitrary user's full
+// role assignment is reconnaissance for a privilege-escalation attempt. A
+// roles.read-only holder (e.g. the seeded auditor role) must be refused; a
+// roles.assign holder must succeed.
+func TestRoleService_GetUserRoles_RequiresRolesAssign(t *testing.T) {
+	svc, h := newRoleService(t)
+	target := h.CreateTestUser(t, "target", 501)
+
+	// User 2 holds ONLY roles.read (the old, too-weak gate) — must be refused.
+	h.CreateTestUser(t, "reader-only", 2)
+	readerRole := h.CreateTestRole(t, "roles_read_only", "roles.read only", 200)
+	h.ExecuteRawSQL(t, `INSERT INTO role_permissions (role_id, permission_id)
+		SELECT ?, id FROM permissions WHERE name = 'roles.read'`, readerRole.ID)
+	h.AssignUserRole(t, 2, readerRole.ID, nil)
+
+	_, err := svc.GetUserRoles(authCtx(2, "reader-only"), &pb.GetUserRolesRequest{UserId: intToU32(int(target.ID))})
+	require.Error(t, err, "roles.read holder without roles.assign must NOT call GetUserRoles")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	// User 3 holds roles.assign (the new, correct gate) — must succeed.
+	h.CreateTestUser(t, "assigner-only", 3)
+	assignerRole := h.CreateTestRole(t, "roles_assign_only", "roles.assign only", 201)
+	h.ExecuteRawSQL(t, `INSERT INTO role_permissions (role_id, permission_id)
+		SELECT ?, id FROM permissions WHERE name = 'roles.assign'`, assignerRole.ID)
+	h.AssignUserRole(t, 3, assignerRole.ID, nil)
+
+	got, err := svc.GetUserRoles(authCtx(3, "assigner-only"), &pb.GetUserRolesRequest{UserId: intToU32(int(target.ID))})
+	require.NoError(t, err, "roles.assign holder should be allowed to call GetUserRoles")
+	assert.Equal(t, "target", got.GetUsername())
+}
+
 // Regression for the flat-vs-scoped gRPC bug: a caller holding admin/roles.assign
 // ONLY at project 1 may assign within project 1 but NOT cross-project into project
 // 2. Before the fix, AssignRole checked the flat global permission union, so a

--- a/server/http/g16_permission_parity_test.go
+++ b/server/http/g16_permission_parity_test.go
@@ -1,0 +1,140 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// g16TestDB builds an in-memory DB migrated with the models the compliance
+// posture/digest builder and the secrets/quota-report path touch, plus the
+// core RBAC + session tables every router-level authz test needs.
+func g16TestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	// A plain ":memory:" DSN hands a fresh, empty database to every new pooled
+	// connection — pin to one connection so every query in this test hits the
+	// same DB (matches the pattern in restore_route_authz_test.go).
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Session{}, &models.Project{}, &models.Environment{},
+		&models.SecretNode{}, &models.RotationPolicy{}, &models.AuditEvent{},
+		&models.AnomalyAlert{}, &models.LegalHold{}, &models.SoDPolicy{},
+		&models.AccessReviewCampaign{}, &models.AccessReviewItem{},
+		&models.BreakGlassActivation{}, &models.AccessRequest{}, &models.RiskException{},
+	))
+	return db
+}
+
+// TestQuotaReportRouteRequiresAuditRead is the G16 regression test: GET
+// /api/v1/secrets/quota-report is a report-viewing endpoint (usage %/status
+// metadata, never a secret value) — the same disclosure family as the other
+// deployment-wide audit reports — so it must require audit.read, not the
+// broader secrets.read (which is scoped for actual secret-value access and is
+// the wrong tier/shape for a report that discloses no value). A secrets.read
+// holder without audit.read must be refused; an audit.read holder must pass.
+func TestQuotaReportRouteRequiresAuditRead(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db := g16TestDB(t)
+	now := time.Now()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "a@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "secretreader", Email: "s@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "secretreader"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 2, Name: "audit.read", Resource: "audit", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 2}).Error) // admin: audit.read
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error) // secretreader: secrets.read ONLY
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2}).Error)
+	seedSession(t, db, 1, "admin-tok")
+	seedSession(t, db, 2, "secretreader-tok")
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	get := func(token string) int {
+		req, err := http.NewRequest("GET", server.URL+"/api/v1/secrets/quota-report", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	assert.Equal(t, http.StatusForbidden, get("secretreader-tok"),
+		"secrets.read holder without audit.read must NOT reach the quota report")
+	assert.NotEqual(t, http.StatusForbidden, get("admin-tok"),
+		"audit.read holder should be allowed past the gate")
+}
+
+// TestComplianceDigestSendRouteRequiresAuditRead is the G16 regression test:
+// POST /api/v1/compliance/digest/send restates the SAME posture data as
+// GET /api/v1/compliance/digest, so it must require the same audit.read the
+// read sibling uses, not the broader system.write. A system.write holder
+// without audit.read must be refused; an audit.read holder must pass.
+func TestComplianceDigestSendRouteRequiresAuditRead(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db := g16TestDB(t)
+	now := time.Now()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "auditor", Email: "a@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "sysadmin", Email: "s@t.com", IsActive: true, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "auditor"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "sysadmin"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "audit.read", Resource: "audit", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 2, Name: "system.write", Resource: "system", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error) // auditor: audit.read ONLY
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 2}).Error) // sysadmin: system.write ONLY
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2}).Error)
+	seedSession(t, db, 1, "auditor-tok")
+	seedSession(t, db, 2, "sysadmin-tok")
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	router, err := NewRouter(&config.Config{}, c)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	post := func(token string) int {
+		req, err := http.NewRequest("POST", server.URL+"/api/v1/compliance/digest/send", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	assert.Equal(t, http.StatusForbidden, post("sysadmin-tok"),
+		"system.write holder without audit.read must NOT trigger the compliance digest send")
+	assert.NotEqual(t, http.StatusForbidden, post("auditor-tok"),
+		"audit.read holder should be allowed past the gate")
+}

--- a/server/http/handlers/read_quota.go
+++ b/server/http/handlers/read_quota.go
@@ -24,7 +24,10 @@ type QuotaReportRow struct {
 
 // GetQuotaReport handles GET /api/v1/secrets/quota-report — returns every live
 // secret with MaxReads > 0 and its current usage percentage and status.
-// Requires secrets.read (enforced by the router).
+// Requires audit.read (enforced by the router) — it's a report-viewing
+// endpoint (usage %/status metadata, no secret values), not secret-value
+// access, so it belongs in the audit-report disclosure family, not
+// secrets.read (G16).
 func (h *SecretHandler) GetQuotaReport(w http.ResponseWriter, r *http.Request) {
 	if middleware.GetUserFromContext(r.Context()) == nil {
 		h.sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -600,9 +600,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// Usage analytics (static paths, before /{id}).
 			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, customMiddleware.ScopeFromQuery)).Get("/usage/most-accessed", secretHandler.UsageMostAccessed)
 			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, customMiddleware.ScopeFromQuery)).Get("/usage/unused", secretHandler.UsageUnused)
-			// Read-quota report — deployment-wide secrets approaching MaxReads cap.
-			// Gated on global secrets.read (same level as listing all projects).
-			r.With(customMiddleware.RequirePermission(permSecretsRead)).Get("/quota-report", secretHandler.GetQuotaReport)
+			// Read-quota report — deployment-wide secrets approaching MaxReads cap. It
+			// discloses usage-percentage/status metadata, not secret values, so it is a
+			// report-viewing endpoint in the same disclosure family as the other
+			// deployment-wide compliance/audit reports — gate on audit.read (global),
+			// not the broader secrets.read (which is scoped for actual secret-value
+			// access and is the wrong tier/shape for a report that never discloses a
+			// value) (G16).
+			r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/quota-report", secretHandler.GetQuotaReport)
 			// Org-wide secret asset inventory (ISO 27001 A.5.9) — CSV manifest of every
 			// project's secrets, metadata only (no values), but it DOES disclose every
 			// secret's real NAME/classification/owner deployment-wide, so it is gated on
@@ -2004,10 +2009,15 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// Compliance digest — on-demand human-readable summary (the scheduled-broadcast
 		// text); restates the same posture data, same gate.
 		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/compliance/digest", dashboardHandler.GetComplianceDigest)
-		// Compliance digest send — triggers an immediate broadcast to notification channels
-		// (Slack/Teams/webhook/email). Gated by system.write: it's an active dispatch
-		// action, not a read disclosure, even though the content is the same as the GET.
-		r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/compliance/digest/send", dashboardHandler.SendComplianceDigest)
+		// Compliance digest send — triggers an immediate broadcast to notification
+		// channels (Slack/Teams/webhook/email) restating the SAME posture data as GET
+		// /compliance/digest above — gate on audit.read to match that read sibling
+		// (G16). system.write was the wrong tier: the broadcast discloses nothing beyond
+		// what audit.read already permits reading, so it both let a caller lacking the
+		// read view still trigger identical content being dispatched to a channel, and
+		// blocked an audit.read holder (e.g. system_auditor) from an action no more
+		// sensitive than the read they're already trusted with.
+		r.With(customMiddleware.RequirePermission(permAuditRead)).Post("/compliance/digest/send", dashboardHandler.SendComplianceDigest)
 		// Compliance snapshots — on-demand posture capture + history list. POST requires
 		// system.write (triggers a full evaluation + persist); GET only reads stored rows.
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/compliance/snapshots", dashboardHandler.TakeComplianceSnapshot)


### PR DESCRIPTION
## Summary
Five sites gated the same resource/action at a weaker permission over one transport (usually gRPC) than its sibling required, letting a lower-privileged caller reach data/actions its HTTP or read counterpart deliberately restricted:

- gRPC `RestoreGroup`: `users.write` -> `roles.assign`, matching the HTTP restore route (reinstates every role grant the group held, same blast radius as a role grant).
- `POST /compliance/digest/send`: `system.write` -> `audit.read`, matching `GET /compliance/digest` (the broadcast restates the same posture data).
- `GET /secrets/quota-report`: `secrets.read` -> `audit.read` (a usage-report endpoint that discloses no secret value, wrong tier/shape at `secrets.read`).
- gRPC `RoleService.GetUserRoles`: `roles.read` -> `roles.assign`, matching the HTTP `GET /roles/user/{userId}` sibling that calls the identical `core.GetUserRoleAssignment`.
- gRPC `AuditService.WriteAuditCheckpoint`: added the missing `audit.read` check alongside the existing `system.write` check, matching the HTTP route's stacked `audit.read` + `system.write` gate on `POST /audit/checkpoint`.

Each site's sibling was verified against real router/handler/gRPC code (not assumed) before changing the gate.

## Test plan
- [x] Regression test per site: a principal holding only the old (weaker) permission is refused, one holding the new (correct) permission succeeds
- [x] `go build ./...`, `go vet ./...` clean
- [x] `gosec -severity medium -exclude-generated ./...` clean