### PR TITLE
fix(security): route secret-value disclosure through one guard bundle (G09)

### DIFF
--- a/internal/cli/common/secret_encryption_test.go
+++ b/internal/cli/common/secret_encryption_test.go
@@ -42,7 +42,7 @@ func TestWireSecretEncryption_LocalEncryptsAtRest(t *testing.T) {
 
 	db, err := gorm.Open(sqlite.Open("secrets.db"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.SecretAccessSchedule{}))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "e"}).Error)
 

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -38,6 +38,7 @@ func newBootstrappedCore(t *testing.T) (*KeyorixCore, *store.LocalStorage) {
 		&models.StatsSnapshot{}, &models.DeploymentStatsSnapshot{},
 		&models.MFAStepupToken{}, &models.MFAStepUpGrant{},
 		&models.SecretACL{}, &models.PasswordHistory{},
+		&models.SecretAccessSchedule{},
 	))
 
 	st := store.NewLocalStorage(db)

--- a/internal/core/bulk_rotate.go
+++ b/internal/core/bulk_rotate.go
@@ -178,7 +178,11 @@ func (c *KeyorixCore) bulkRotateOne(ctx context.Context, secretID uint, rotation
 		})
 		return err
 	}
-	if _, err := c.RotateSecretOnDemand(ctx, secretID, []byte(val), rotatedBy); err != nil {
+	// actorID 0: BulkRotateRequest has no per-secret actor field, only the
+	// RotatedBy display string — matches auto-rotation's own "no identifiable
+	// user" sentinel (see RotateSecret's #G09 doc); only degrades the no-op
+	// comparison for a classification-restricted secret, never blocks rotation.
+	if _, err := c.RotateSecretOnDemand(ctx, secretID, []byte(val), 0, rotatedBy); err != nil {
 		result.Failed = append(result.Failed, BulkRotateError{
 			SecretID: secretID,
 			Error:    err.Error(),

--- a/internal/core/certificate.go
+++ b/internal/core/certificate.go
@@ -55,9 +55,18 @@ func (c *KeyorixCore) InspectCertificate(ctx context.Context, actorID, secretID 
 	if err != nil {
 		return nil, fmt.Errorf("%s: secret %d not found", i18n.T("ErrorNotFound", nil), secretID)
 	}
-	// A suspended secret is frozen for incident response; don't decrypt it.
-	if secret.Status == SecretStatusSuspended {
-		return nil, fmt.Errorf("secret is suspended")
+	// #G09: previously only checked suspended status, independently
+	// reimplementing a subset of the guard bundle every other value
+	// disclosure enforces — a caller could inspect a certificate outside its
+	// configured access-schedule window, or without the classification-
+	// restricted step-up/approval a value read of the same secret would
+	// require. enforceSecretReadGuards covers expiration/suspended/
+	// classification-gate/schedule; it deliberately does NOT include
+	// max-reads, since decrypting to inspect PUBLIC certificate metadata is
+	// still not value consumption (see the package doc above) — that one
+	// exemption remains intentional, only the other guards were a gap.
+	if err := c.enforceSecretReadGuards(ctx, secret, actorID); err != nil {
+		return nil, err
 	}
 
 	version, err := c.storage.GetLatestSecretVersion(ctx, secretID)

--- a/internal/core/certificate_rotation_test.go
+++ b/internal/core/certificate_rotation_test.go
@@ -33,7 +33,7 @@ func TestRotateSecret_RefreshesCertNotAfterCache(t *testing.T) {
 	// Rotate to a renewed certificate with a later expiry.
 	newExpiry := now.Add(90 * 24 * time.Hour)
 	cert2, _ := selfSignedPEM(t, "a.example.com", newExpiry)
-	_, err = c.RotateSecret(ctx, 1, cert2, "tester")
+	_, err = c.RotateSecret(ctx, 1, cert2, 0, "tester")
 	require.NoError(t, err)
 
 	got, err := c.storage.GetSecret(ctx, 1)
@@ -51,7 +51,7 @@ func TestRotateSecret_NonCertSecretLeavesCertNotAfterNil(t *testing.T) {
 	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "api-key", IsSecret: true, Status: "active", Type: "api_key"}).Error)
 	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: 1, VersionNumber: 1, EncryptedValue: []byte("old-value")}).Error)
 
-	_, err := c.RotateSecret(ctx, 1, []byte("new-random-value"), "tester")
+	_, err := c.RotateSecret(ctx, 1, []byte("new-random-value"), 0, "tester")
 	require.NoError(t, err)
 
 	got, err := c.storage.GetSecret(ctx, 1)
@@ -70,7 +70,7 @@ func TestRotateSecret_CertRotatedToNonCertClearsCache(t *testing.T) {
 	_, err := c.InspectCertificate(ctx, 9, 1) // prime the cache
 	require.NoError(t, err)
 
-	_, err = c.RotateSecret(ctx, 1, []byte("no-longer-a-certificate"), "tester")
+	_, err = c.RotateSecret(ctx, 1, []byte("no-longer-a-certificate"), 0, "tester")
 	require.NoError(t, err)
 
 	got, err := c.storage.GetSecret(ctx, 1)

--- a/internal/core/certificate_test.go
+++ b/internal/core/certificate_test.go
@@ -105,6 +105,7 @@ func newCertCore(t *testing.T, now time.Time) (*KeyorixCore, *gorm.DB) {
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{},
 		&models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
+		&models.SecretAccessSchedule{},
 	))
 	// CheckSecretPermission gates the owner path on IsProjectMember (RBAC-001): user 9
 	// (the standard cert-test actor) must be a member of project 1 so the read succeeds.
@@ -237,7 +238,7 @@ func TestInspectCertificateEnforcesPerSecretPermission(t *testing.T) {
 	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.SecretAccessSchedule{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
 
 	certPEM, _ := selfSignedPEM(t, "restricted.example.com", now.Add(30*24*time.Hour))

--- a/internal/core/classification.go
+++ b/internal/core/classification.go
@@ -69,6 +69,18 @@ func (c *KeyorixCore) ClassifySecret(ctx context.Context, actorID uint, username
 	if secret.Classification == level {
 		return secret, nil // no-op
 	}
+	// #G09: stripping/downgrading the "restricted" label is at least as
+	// sensitive as a single value read of the secret — it removes the
+	// classification-restricted read-gate (step-up/approval/permission) from
+	// every FUTURE read, not just this one. Require the actor to pass that
+	// same gate before allowing the downgrade, closing an otherwise-trivial
+	// way for any secrets.write holder to unprotect a restricted secret
+	// without ever needing the authority to read it.
+	if secret.Classification == ClassificationRestricted {
+		if err := c.checkRestrictedSecretReadApproval(ctx, secret, actorID); err != nil {
+			return nil, err
+		}
+	}
 	old := secret.Classification
 	secret.Classification = level
 	updated, err := c.storage.UpdateSecret(ctx, secret)

--- a/internal/core/concurrency_max_reads_test.go
+++ b/internal/core/concurrency_max_reads_test.go
@@ -30,7 +30,7 @@ func TestConcurrency_MaxReads_FullReadPathEnforcesCap(t *testing.T) {
 	dsn := "file:" + filepath.Join(t.TempDir(), "c.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.SecretAccessSchedule{}))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "dev"}).Error)
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))

--- a/internal/core/concurrency_rotate_secret_test.go
+++ b/internal/core/concurrency_rotate_secret_test.go
@@ -64,7 +64,7 @@ func TestConcurrency_RotateSecret_NoDuplicateVersionNumbers(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			_, rerr := c.RotateSecret(ctx, sec.ID, []byte(fmt.Sprintf("rotated-value-%d", i)), "rotator")
+			_, rerr := c.RotateSecret(ctx, sec.ID, []byte(fmt.Sprintf("rotated-value-%d", i)), 0, "rotator")
 			errs[i] = rerr
 		}(i)
 	}

--- a/internal/core/env_clone_test.go
+++ b/internal/core/env_clone_test.go
@@ -37,6 +37,7 @@ func newCloneTestCore(t *testing.T) *KeyorixCore {
 		&models.AuditEvent{},
 		&models.SecretAccessLog{},
 		&models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
+		&models.SecretAccessSchedule{},
 	))
 	// CopySecret calls GetSecretValueWithPermissionCheck which gates the owner path on
 	// IsProjectMember (RBAC-001). The first project created in each test gets ID=1;

--- a/internal/core/max_reads_enforce_test.go
+++ b/internal/core/max_reads_enforce_test.go
@@ -24,7 +24,7 @@ func newMaxReadsCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1) // sqlite: serialize connections (statements stay atomic)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.SecretAccessSchedule{}))
 	return &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}, db
 }
 
@@ -126,7 +126,7 @@ func TestMaxReads_SurvivesRotateAndRollback(t *testing.T) {
 
 	// Rotating creates a brand-new version (read_count reset to 0 on THAT row) —
 	// the secret-level counter must still refuse the next read.
-	_, err = c.RotateSecret(ctx, id, []byte("v2"), "actor")
+	_, err = c.RotateSecret(ctx, id, []byte("v2"), 0, "actor")
 	require.NoError(t, err)
 	_, err = c.GetSecretValue(ctx, id)
 	require.Error(t, err, "rotating must not grant a fresh read budget")

--- a/internal/core/rollback_test.go
+++ b/internal/core/rollback_test.go
@@ -29,7 +29,7 @@ func TestRollbackSecret(t *testing.T) {
 		SecretNodeID: 1, VersionNumber: 1, EncryptedValue: []byte("v1-secret"), EncryptionMetadata: []byte("{}"),
 	}).Error)
 	// Rotate to v2 (a "bad" change we'll undo).
-	_, err := c.RotateSecret(ctx, 1, []byte("v2-bad"), "ada")
+	_, err := c.RotateSecret(ctx, 1, []byte("v2-bad"), 0, "ada")
 	require.NoError(t, err)
 
 	// Roll back to v1 → re-instated as a NEW version (v3) with v1's value.

--- a/internal/core/rotate_noop_test.go
+++ b/internal/core/rotate_noop_test.go
@@ -27,7 +27,7 @@ func newRotateNoopFixture(t *testing.T) (*core.KeyorixCore, uint, *gorm.DB) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.SecretAccessSchedule{}))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "dev"}).Error)
 
@@ -51,7 +51,7 @@ func TestRotateSecret_SameValue_DoesNotBumpLastRotatedAt(t *testing.T) {
 	ctx := context.Background()
 
 	// First rotation: a genuinely new value, so LastRotatedAt must be set.
-	updated, err := c.RotateSecret(ctx, secretID, []byte("rotated-value-A"), "rotator")
+	updated, err := c.RotateSecret(ctx, secretID, []byte("rotated-value-A"), 0, "rotator")
 	require.NoError(t, err)
 	require.NotNil(t, updated.LastRotatedAt)
 	firstRotatedAt := *updated.LastRotatedAt
@@ -65,7 +65,7 @@ func TestRotateSecret_SameValue_DoesNotBumpLastRotatedAt(t *testing.T) {
 
 	// Second "rotation" resubmits the exact same value — must be a no-op for the
 	// timestamp, but must still store a new version row.
-	updated, err = c.RotateSecret(ctx, secretID, []byte("rotated-value-A"), "rotator")
+	updated, err = c.RotateSecret(ctx, secretID, []byte("rotated-value-A"), 0, "rotator")
 	require.NoError(t, err, "rotating to an unchanged value must not be refused")
 	require.NotNil(t, updated.LastRotatedAt)
 	assert.True(t, updated.LastRotatedAt.Equal(firstRotatedAt),
@@ -84,7 +84,7 @@ func TestRotateSecret_SameValue_DoesNotBumpLastRotatedAt(t *testing.T) {
 	// A subsequent rotation to a genuinely different value must resume bumping
 	// LastRotatedAt normally.
 	time.Sleep(5 * time.Millisecond)
-	updated, err = c.RotateSecret(ctx, secretID, []byte("rotated-value-B"), "rotator")
+	updated, err = c.RotateSecret(ctx, secretID, []byte("rotated-value-B"), 0, "rotator")
 	require.NoError(t, err)
 	require.NotNil(t, updated.LastRotatedAt)
 	assert.True(t, updated.LastRotatedAt.After(firstRotatedAt),
@@ -101,7 +101,7 @@ func TestRotateSecret_DifferentValue_AlwaysBumpsLastRotatedAt(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, before.LastRotatedAt, "a freshly created secret has never been rotated")
 
-	updated, err := c.RotateSecret(ctx, secretID, []byte("a-genuinely-different-value"), "rotator")
+	updated, err := c.RotateSecret(ctx, secretID, []byte("a-genuinely-different-value"), 0, "rotator")
 	require.NoError(t, err)
 	require.NotNil(t, updated.LastRotatedAt)
 }

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -399,7 +399,7 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 			storeVal = upstreamVal
 		}
 	}
-	if _, rerr := c.RotateSecret(ctx, secret.ID, []byte(storeVal), "system:auto-rotation"); rerr != nil {
+	if _, rerr := c.RotateSecret(ctx, secret.ID, []byte(storeVal), 0, "system:auto-rotation"); rerr != nil {
 		log.Printf("auto-rotation: rotate secret %d: %v", secret.ID, rerr)
 		failed[secret.ID] = fmt.Sprintf("%q: store new version: %v", secret.Name, rerr)
 		sid := secret.ID
@@ -489,13 +489,19 @@ func (c *KeyorixCore) applyBackendRotation(ctx context.Context, secret *models.S
 // returns key material only once) but an error is still returned, so the HTTP response is
 // never a clean "success" while a leftover credential needs manual operator removal; the
 // audit trail records the partial state distinctly either way.
-func (c *KeyorixCore) RotateSecretOnDemand(ctx context.Context, id uint, newValue []byte, rotatedBy string) (*models.SecretNode, error) {
+// actorID (added for #G09) threads through to RotateSecret's read-guard
+// check on the no-op-detection comparison — 0 for callers with no single
+// identifiable user (e.g. a bulk operation not yet threading a per-secret
+// actor), which only means that comparison is skipped for a
+// classification-restricted secret with a gate enabled, never that the
+// rotation itself is blocked.
+func (c *KeyorixCore) RotateSecretOnDemand(ctx context.Context, id uint, newValue []byte, actorID uint, rotatedBy string) (*models.SecretNode, error) {
 	secret, err := c.storage.GetSecret(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("secret not found: %w", err)
 	}
 	if secret.RotationBackend == "" {
-		return c.RotateSecret(ctx, id, newValue, rotatedBy)
+		return c.RotateSecret(ctx, id, newValue, actorID, rotatedBy)
 	}
 
 	// ROTATION-001: emit before calling upstream so a crash between upstream success
@@ -511,7 +517,7 @@ func (c *KeyorixCore) RotateSecretOnDemand(ctx context.Context, id uint, newValu
 		// The upstream minted the new credential but a prior, possibly compromised one
 		// could not be removed. Store the new value (discarding it would orphan a live,
 		// untracked credential) but still fail the call — the leftover needs an operator.
-		updated, serr := c.RotateSecret(ctx, id, []byte(partial.Value), rotatedBy)
+		updated, serr := c.RotateSecret(ctx, id, []byte(partial.Value), actorID, rotatedBy)
 		if serr != nil {
 			return nil, serr
 		}
@@ -527,7 +533,7 @@ func (c *KeyorixCore) RotateSecretOnDemand(ctx context.Context, id uint, newValu
 			fmt.Sprintf("on-demand rotation FAILED for secret %q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, berr))
 		return nil, fmt.Errorf("backend %q rotation failed for secret %q (upstream credential NOT rotated): %w", secret.RotationBackend, secret.Name, berr)
 	default:
-		return c.RotateSecret(ctx, id, []byte(upstreamVal), rotatedBy)
+		return c.RotateSecret(ctx, id, []byte(upstreamVal), actorID, rotatedBy)
 	}
 }
 

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -813,7 +813,7 @@ func TestRotateSecretOnDemand_NoBackendStoresCallerValue(t *testing.T) {
 	c, db, fixed := rotationExecCore(t)
 	seedRotatableSecret(t, db, 1, "plain", false, fixed.Add(-24*time.Hour))
 
-	updated, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("caller-value"), "alice")
+	updated, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("caller-value"), 0, "alice")
 	require.NoError(t, err)
 	assert.NotNil(t, updated.LastRotatedAt)
 	v := latestVersion(t, db, 1)
@@ -829,7 +829,7 @@ func TestRotateSecretOnDemand_AppliesBackend(t *testing.T) {
 	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
 	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-24*time.Hour))
 
-	updated, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("operator-supplied"), "alice")
+	updated, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("operator-supplied"), 0, "alice")
 	require.NoError(t, err)
 
 	require.True(t, fake.called, "the manual rotate must actually invoke the backend executor")
@@ -850,7 +850,7 @@ func TestRotateSecretOnDemand_GenerateUpstreamIgnoresCandidate(t *testing.T) {
 	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
 	seedBackendSecret(t, db, 1, "cloud", "svc-app", fixed.Add(-24*time.Hour))
 
-	_, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("ignored-candidate"), "alice")
+	_, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("ignored-candidate"), 0, "alice")
 	require.NoError(t, err)
 	assert.Equal(t, "svc-app", fake.gotRef)
 	v := latestVersion(t, db, 1)
@@ -865,7 +865,7 @@ func TestRotateSecretOnDemand_BackendFailureRefused(t *testing.T) {
 	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
 	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-24*time.Hour))
 
-	_, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("operator-supplied"), "alice")
+	_, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("operator-supplied"), 0, "alice")
 	require.Error(t, err, "an upstream rotation failure must never look like success")
 	assert.Contains(t, err.Error(), "backend")
 	assert.Contains(t, err.Error(), "NOT rotated")
@@ -890,7 +890,7 @@ func TestRotateSecretOnDemand_PartialFailureStoresButErrors(t *testing.T) {
 	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
 	seedBackendSecret(t, db, 1, "cloud", "svc-app", fixed.Add(-24*time.Hour))
 
-	updated, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("ignored"), "alice")
+	updated, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("ignored"), 0, "alice")
 	require.Error(t, err, "a partial upstream cleanup failure must not report success")
 	assert.NotNil(t, updated, "the new value is still returned/stored — never orphan a freshly minted credential")
 
@@ -910,7 +910,7 @@ func TestRotateSecretOnDemand_UnknownBackendRefused(t *testing.T) {
 	c.SetRotationManager(rotation.NewManager([]rotation.Executor{&fakeExecutor{name: "other"}}))
 	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-24*time.Hour))
 
-	_, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("x"), "alice")
+	_, err := c.RotateSecretOnDemand(context.Background(), 1, []byte("x"), 0, "alice")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown rotation backend")
 	v := latestVersion(t, db, 1)

--- a/internal/core/secret_copy_environment_test.go
+++ b/internal/core/secret_copy_environment_test.go
@@ -21,7 +21,7 @@ func TestCopyEnvironmentSecrets(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}, &models.SecretAccessSchedule{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
 	p, _ := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})

--- a/internal/core/secret_copy_test.go
+++ b/internal/core/secret_copy_test.go
@@ -21,7 +21,7 @@ func TestCopySecret(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.Project{}, &models.Environment{}, &models.AuditEvent{}, &models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{}, &models.SecretAccessSchedule{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}

--- a/internal/core/secret_render_test.go
+++ b/internal/core/secret_render_test.go
@@ -32,6 +32,7 @@ func newRenderFixture(t *testing.T) (*KeyorixCore, *gorm.DB, uint, uint) {
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{},
 		&models.Project{}, &models.Environment{}, &models.SecretAccessLog{}, &models.AuditEvent{},
 		&models.ShareRecord{}, &models.SecretACL{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
+		&models.SecretAccessSchedule{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@test.com"}).Error)
 

--- a/internal/core/secret_schedule_test.go
+++ b/internal/core/secret_schedule_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -94,6 +96,7 @@ func newScheduleCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{},
 		&models.SecretAccessSchedule{},
+		&models.SecretVersion{},
 		&models.AuditEvent{},
 		&models.Project{},
 		&models.Environment{},
@@ -151,6 +154,92 @@ func TestCheckSecretAccessSchedule_Denied(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, sched)
 	assert.ErrorIs(t, enforceSchedule(sched, frozenMonday), ErrAccessOutsideSchedule)
+}
+
+// ── #G09 regression: value-read paths must honor the access schedule too ────
+//
+// Before the fix, checkSecretAccessSchedule was wired only into the metadata
+// read path (GetSecretWithPermissionCheck), never into GetSecretValue /
+// GetSecretValueByVersion — so a secret whose metadata read was correctly
+// refused outside its configured window could still have its VALUE read
+// through GetSecretValue. These tests pin the value-read paths to the same
+// guard, using a schedule that excludes today's ISO weekday (deterministic
+// regardless of what hour/day the suite runs).
+
+// allowedDaysExcludingToday returns a comma-separated day list (ISO 1=Mon..7=Sun)
+// that excludes today, guaranteeing enforceSchedule denies on the day check
+// alone — independent of the current hour.
+func allowedDaysExcludingToday() string {
+	today := int(time.Now().Weekday())
+	if today == 0 {
+		today = 7
+	}
+	var days []string
+	for d := 1; d <= 7; d++ {
+		if d == today {
+			continue
+		}
+		days = append(days, strconv.Itoa(d))
+	}
+	return strings.Join(days, ",")
+}
+
+func TestGetSecretValue_DeniedOutsideAccessSchedule(t *testing.T) {
+	c, db := newScheduleCore(t)
+	ctx := context.Background()
+	s := &models.SecretNode{ProjectID: 10, EnvironmentID: 10, Name: "sched-value-gate", IsSecret: true, Status: "active", Type: "generic"}
+	require.NoError(t, db.Create(s).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: s.ID, VersionNumber: 1, EncryptedValue: []byte("topsecret")}).Error)
+
+	require.NoError(t, db.Create(&models.SecretAccessSchedule{
+		SecretNodeID: s.ID,
+		AllowedDays:  allowedDaysExcludingToday(),
+		StartHour:    0,
+		EndHour:      24,
+		Timezone:     "UTC",
+	}).Error)
+
+	_, err := c.GetSecretValue(ctx, s.ID)
+	assert.ErrorIs(t, err, ErrAccessOutsideSchedule, "GetSecretValue must enforce the same schedule window as metadata reads")
+}
+
+func TestGetSecretValueByVersion_DeniedOutsideAccessSchedule(t *testing.T) {
+	c, db := newScheduleCore(t)
+	ctx := context.Background()
+	s := &models.SecretNode{ProjectID: 10, EnvironmentID: 10, Name: "sched-value-byver-gate", IsSecret: true, Status: "active", Type: "generic"}
+	require.NoError(t, db.Create(s).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: s.ID, VersionNumber: 1, EncryptedValue: []byte("topsecret")}).Error)
+
+	require.NoError(t, db.Create(&models.SecretAccessSchedule{
+		SecretNodeID: s.ID,
+		AllowedDays:  allowedDaysExcludingToday(),
+		StartHour:    0,
+		EndHour:      24,
+		Timezone:     "UTC",
+	}).Error)
+
+	_, err := c.GetSecretValueByVersion(ctx, s.ID, 1)
+	assert.ErrorIs(t, err, ErrAccessOutsideSchedule, "GetSecretValueByVersion must enforce the same schedule window as metadata reads")
+}
+
+func TestGetSecretValue_AllowedWithinSchedule(t *testing.T) {
+	c, db := newScheduleCore(t)
+	ctx := context.Background()
+	s := &models.SecretNode{ProjectID: 10, EnvironmentID: 10, Name: "sched-value-allow", IsSecret: true, Status: "active", Type: "generic"}
+	require.NoError(t, db.Create(s).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{SecretNodeID: s.ID, VersionNumber: 1, EncryptedValue: []byte("topsecret")}).Error)
+
+	require.NoError(t, db.Create(&models.SecretAccessSchedule{
+		SecretNodeID: s.ID,
+		AllowedDays:  "*",
+		StartHour:    0,
+		EndHour:      24,
+		Timezone:     "UTC",
+	}).Error)
+
+	val, err := c.GetSecretValue(ctx, s.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "topsecret", string(val))
 }
 
 // ── SetSecretSchedule / GetSecretSchedule / DeleteSecretSchedule ─────────────

--- a/internal/core/secret_suspend_test.go
+++ b/internal/core/secret_suspend_test.go
@@ -23,7 +23,7 @@ func newSuspendFixture(t *testing.T) (*KeyorixCore, uint, *gorm.DB) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.SecretAccessSchedule{}))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
 	secret, err := c.storage.CreateSecret(ctx, &models.SecretNode{

--- a/internal/core/secret_value_crypto_test.go
+++ b/internal/core/secret_value_crypto_test.go
@@ -26,7 +26,7 @@ func newEncryptedCore(t *testing.T) (*KeyorixCore, uint, uint) {
 
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.SecretAccessSchedule{}))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "e"}).Error)
 

--- a/internal/core/secret_value_policy_enforce_test.go
+++ b/internal/core/secret_value_policy_enforce_test.go
@@ -55,7 +55,7 @@ func TestSecretValuePolicy_EnforcedOnAllWritePaths(t *testing.T) {
 
 	t.Run("RotateSecret rejects a weak value", func(t *testing.T) {
 		c, _, secretID := newPolicyEnforceFixture(t)
-		_, err := c.RotateSecret(ctx, secretID, []byte("password"), "u")
+		_, err := c.RotateSecret(ctx, secretID, []byte("password"), 0, "u")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "weak or placeholder")
 	})

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -361,7 +361,12 @@ const EventSecretRotateNoop = "secret.rotate_noop"
 // backend, or a rollback landing on a value the current version already holds) into an
 // automation-breaking failure. The event is still recorded via EventSecretRotateNoop
 // so the no-op is auditable rather than fully silent.
-func (c *KeyorixCore) RotateSecret(ctx context.Context, id uint, newValue []byte, rotatedBy string) (*models.SecretNode, error) {
+// actorID is the acting principal for the read-guard check the no-op
+// comparison below requires (#G09) — 0 for system-triggered callers
+// (auto-rotation), which is the same "no identifiable user" sentinel
+// enforceSecretReadGuards' classification gate already denies restricted
+// reads for.
+func (c *KeyorixCore) RotateSecret(ctx context.Context, id uint, newValue []byte, actorID uint, rotatedBy string) (*models.SecretNode, error) {
 	if err := c.secretValuePolicy.Validate(newValue); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
@@ -378,11 +383,25 @@ func (c *KeyorixCore) RotateSecret(ctx context.Context, id uint, newValue []byte
 	// secret's budget on every rotation attempt). subtle.ConstantTimeCompare matches
 	// this codebase's convention for comparing genuine secret material (see mfa.go,
 	// auth_bootstrap.go, encryption/auth_encryption.go).
+	//
+	// #G09: this decrypt-and-compare is itself a value disclosure — its RESULT
+	// (whether EventSecretRotateNoop fires, and whether LastRotatedAt moves) is
+	// an oracle for "does the caller's guess equal the current secret value."
+	// Gate it on the SAME read guards (classification-restricted step-up/
+	// approval, access-schedule) a real value read of this secret would
+	// require; if the actor couldn't pass them, skip the comparison entirely
+	// rather than decrypt-to-compare without authorization — this only
+	// degrades the no-op-detection optimization (the rotation itself still
+	// proceeds and always records a real rotation), it never blocks the
+	// rotation outright, so auto-rotation (actorID 0, only relevant for
+	// "restricted"-classified secrets with a gate enabled) keeps working.
 	valueUnchanged := false
-	if latestVersion, verr := c.storage.GetLatestSecretVersion(ctx, id); verr == nil && latestVersion != nil {
-		currentValue, rerr := c.decryptVersionValue(secret, latestVersion)
-		if rerr == nil && subtle.ConstantTimeCompare(currentValue, newValue) == 1 {
-			valueUnchanged = true
+	if c.enforceSecretReadGuards(ctx, secret, actorID) == nil {
+		if latestVersion, verr := c.storage.GetLatestSecretVersion(ctx, id); verr == nil && latestVersion != nil {
+			currentValue, rerr := c.decryptVersionValue(secret, latestVersion)
+			if rerr == nil && subtle.ConstantTimeCompare(currentValue, newValue) == 1 {
+				valueUnchanged = true
+			}
 		}
 	}
 

--- a/internal/core/versions.go
+++ b/internal/core/versions.go
@@ -104,6 +104,35 @@ func (c *KeyorixCore) GetSecretValue(ctx context.Context, secretID uint) ([]byte
 	return c.getSecretValueForUser(ctx, secretID, 0)
 }
 
+// enforceSecretReadGuards runs every read-time guard a secret-value
+// disclosure must pass EXCEPT max-reads (which is inherently tied to the
+// specific counting read call via readVersionValue, not a reusable "may I
+// read" predicate): expiration, suspended status, the classification-
+// restricted gate bundle (step-up/approval/permission), and the temporal
+// access-schedule window.
+//
+// #G09: several secret-value-disclosing functions (InspectCertificate,
+// RotateSecret's confirmation check) were written as independent
+// implementations that only replicated SOME of this bundle — most
+// consequentially, checkSecretAccessSchedule (the temporal window) was
+// wired into the METADATA read path (GetSecretWithPermissionCheck) but never
+// into the actual VALUE read path below, so a caller could read a secret's
+// value outside its configured access window even though a metadata read of
+// the same secret correctly refused. Route every value-disclosing function
+// through this one guard bundle instead of re-implementing a subset of it.
+func (c *KeyorixCore) enforceSecretReadGuards(ctx context.Context, secret *models.SecretNode, userID uint) error {
+	if secret.Expiration != nil && time.Now().After(*secret.Expiration) {
+		return fmt.Errorf("%s", i18n.T("ErrorSecretExpired", nil))
+	}
+	if secret.Status == SecretStatusSuspended {
+		return fmt.Errorf("secret is suspended")
+	}
+	if err := c.checkRestrictedSecretReadApproval(ctx, secret, userID); err != nil {
+		return err
+	}
+	return c.checkSecretAccessSchedule(ctx, secret.ID)
+}
+
 // getSecretValueForUser is GetSecretValue's real body, plus the classification
 // gate keyed on userID (0 = no identifiable user). Kept unexported and separate
 // from GetSecretValue's public, userID-less signature so *WithPermissionCheck
@@ -117,13 +146,7 @@ func (c *KeyorixCore) getSecretValueForUser(ctx context.Context, secretID, userI
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
 	}
-	if secret.Expiration != nil && time.Now().After(*secret.Expiration) {
-		return nil, fmt.Errorf("%s", i18n.T("ErrorSecretExpired", nil))
-	}
-	if secret.Status == SecretStatusSuspended {
-		return nil, fmt.Errorf("secret is suspended")
-	}
-	if err := c.checkRestrictedSecretReadApproval(ctx, secret, userID); err != nil {
+	if err := c.enforceSecretReadGuards(ctx, secret, userID); err != nil {
 		return nil, err
 	}
 	version, err := c.storage.GetLatestSecretVersion(ctx, secretID)
@@ -167,13 +190,7 @@ func (c *KeyorixCore) getSecretValueByVersionForUser(ctx context.Context, secret
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
 	}
-	if secret.Expiration != nil && time.Now().After(*secret.Expiration) {
-		return nil, fmt.Errorf("%s", i18n.T("ErrorSecretExpired", nil))
-	}
-	if secret.Status == SecretStatusSuspended {
-		return nil, fmt.Errorf("secret is suspended")
-	}
-	if err := c.checkRestrictedSecretReadApproval(ctx, secret, userID); err != nil {
+	if err := c.enforceSecretReadGuards(ctx, secret, userID); err != nil {
 		return nil, err
 	}
 	version, err := c.GetSecretVersion(ctx, secretID, versionNumber)
@@ -213,7 +230,7 @@ func (c *KeyorixCore) RollbackSecret(ctx context.Context, secretID uint, targetV
 	if err != nil {
 		return nil, fmt.Errorf("failed to read version %d: %w", targetVersion, err)
 	}
-	secret, err := c.RotateSecret(ctx, secretID, val, actorName)
+	secret, err := c.RotateSecret(ctx, secretID, val, actorID, actorName)
 	if err != nil {
 		return nil, err
 	}

--- a/server/http/copy_environment_secrets_rbac_test.go
+++ b/server/http/copy_environment_secrets_rbac_test.go
@@ -38,7 +38,7 @@ func TestCopyEnvironmentSecretsRequiresSourceRead(t *testing.T) {
 		&models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{}, &models.Session{},
-		&models.AuditEvent{}, &models.SecretAccessLog{},
+		&models.AuditEvent{}, &models.SecretAccessLog{}, &models.SecretAccessSchedule{},
 	))
 
 	now := time.Now()

--- a/server/http/handlers/handlers_s10_test.go
+++ b/server/http/handlers/handlers_s10_test.go
@@ -65,6 +65,7 @@ func newIsolatedCoreS10(t *testing.T) *core.KeyorixCore {
 		&models.SecretAccessLog{},
 		// s10 addition — required for CreateSecret / GetSecret / value reads
 		&models.SecretVersion{},
+		&models.SecretAccessSchedule{},
 	)
 	require.NoError(t, err, "AutoMigrate isolated s10 DB")
 	return core.NewKeyorixCore(store.NewLocalStorage(db))

--- a/server/http/handlers/secrets_versions.go
+++ b/server/http/handlers/secrets_versions.go
@@ -95,7 +95,7 @@ func (h *SecretHandler) RotateSecret(w http.ResponseWriter, r *http.Request) {
 	// credential too (the same machinery the auto-rotation scheduler uses) rather than
 	// just overwriting the stored value — never report success while the real,
 	// potentially compromised credential is still live untouched upstream.
-	secret, err := h.coreService.RotateSecretOnDemand(r.Context(), uint(id), []byte(reqBody.NewValue), userCtx.Username)
+	secret, err := h.coreService.RotateSecretOnDemand(r.Context(), uint(id), []byte(reqBody.NewValue), userCtx.UserID, userCtx.Username)
 	if err != nil {
 		switch {
 		case strings.Contains(err.Error(), errNotFound):

--- a/server/http/secret_value_by_ref_scope_test.go
+++ b/server/http/secret_value_by_ref_scope_test.go
@@ -42,6 +42,7 @@ func setupByRefScopeCore(t *testing.T) *core.KeyorixCore {
 		&models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{}, &models.Session{},
+		&models.SecretAccessSchedule{},
 	))
 
 	now := time.Now()


### PR DESCRIPTION
## Summary
Several secret-value-disclosing functions (`getSecretValueForUser`, `getSecretValueByVersionForUser`, `InspectCertificate`, `RotateSecret`'s no-op confirmation check) were independent implementations that each replicated only SOME of the read-time guard bundle. Most consequentially, `checkSecretAccessSchedule` (the temporal access-window guard) was wired into the metadata read path (`GetSecretWithPermissionCheck`) but never into the actual value read path — so a secret's value could be read outside its configured access window even though a metadata read of the same secret correctly refused.

- Added `enforceSecretReadGuards` (`internal/core/versions.go`), a single helper bundling expiration + suspended-status + the classification-restricted read-approval gate + the temporal access-schedule check (deliberately excludes max-reads, which stays tied to `readVersionValue`'s counting increment, not a reusable "may I read" predicate).
- `getSecretValueForUser` / `getSecretValueByVersionForUser` now call the shared bundle instead of a hand-rolled subset.
- `InspectCertificate` now runs the bundle too, while explicitly preserving its documented max-reads exemption (reading public certificate metadata is not value consumption, per its existing package doc).
- `RotateSecret`'s no-op-detection decrypt (used to skip creating a new version when the caller's value matches the current one) is gated on the guard bundle: if the actor can't be confirmed to have read authority, skip the optimization rather than block rotation — auto-rotation (actorID 0) and non-restricted secrets are unaffected. Required threading a new `actorID` parameter through `RotateSecret`/`RotateSecretOnDemand` and updating all callers.
- `ClassifySecret` now runs the read-approval check before downgrading a secret away from "restricted", matching the same gate already applied to a value read of a restricted secret.
- `RollbackSecret`'s own internal decrypt is intentionally left unguarded — it's a write (restoring a historical version), not a value disclosure to the caller, matching its existing doc comment.

Several test fixtures' `AutoMigrate` calls predated the `secret_access_schedules` table and needed it added now that `enforceSecretReadGuards` queries it from paths that never used to.

## Test plan
- [x] New regression tests (`internal/core/secret_schedule_test.go`): `TestGetSecretValue_DeniedOutsideAccessSchedule`, `TestGetSecretValueByVersion_DeniedOutsideAccessSchedule`, `TestGetSecretValue_AllowedWithinSchedule` — pin the exact gap the review's detection_idea describes (value read now honors the same schedule window metadata reads already did)
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/core/... ./server/http/... ./internal/cli/common/...` clean
- [x] `gosec -severity medium -exclude-generated ./...` clean
- [x] `golangci-lint run` clean on touched packages