### PR TITLE
fix(security): introduce a shared bounding convention across core/storage/handlers/mcp/cli (G44)

### DIFF
--- a/cmd/keyorix-mcp/main.go
+++ b/cmd/keyorix-mcp/main.go
@@ -36,6 +36,12 @@ var version = "dev"
 // with legitimate high-volume needs raise it via KEYORIX_MCP_MAX_READS.
 const defaultMaxReads = 100
 
+// defaultMaxListCalls is the per-process keyorix_list_secrets ceiling applied when
+// KEYORIX_MCP_MAX_LIST_CALLS is left unset — the same reasoning as defaultMaxReads
+// (#G44): a listing call does no per-item value disclosure, but a manipulated agent
+// can still be driven to repeat it an unbounded number of times in one session.
+const defaultMaxListCalls = 100
+
 // resolveMaxReads parses KEYORIX_MCP_MAX_READS. An empty raw value (the variable unset
 // or blank) applies defaultMaxReads rather than "unlimited". A non-empty value that
 // isn't a positive integer is a fatal misconfiguration, not a silent fallback —
@@ -47,6 +53,18 @@ func resolveMaxReads(raw string) (n int, usedDefault bool, err error) {
 	n, perr := strconv.Atoi(raw)
 	if perr != nil || n <= 0 {
 		return 0, false, fmt.Errorf("KEYORIX_MCP_MAX_READS must be a positive integer, got %q", raw)
+	}
+	return n, false, nil
+}
+
+// resolveMaxListCalls parses KEYORIX_MCP_MAX_LIST_CALLS, mirroring resolveMaxReads.
+func resolveMaxListCalls(raw string) (n int, usedDefault bool, err error) {
+	if raw == "" {
+		return defaultMaxListCalls, true, nil
+	}
+	n, perr := strconv.Atoi(raw)
+	if perr != nil || n <= 0 {
+		return 0, false, fmt.Errorf("KEYORIX_MCP_MAX_LIST_CALLS must be a positive integer, got %q", raw)
 	}
 	return n, false, nil
 }
@@ -120,6 +138,17 @@ func main() {
 		log.Printf("KEYORIX_MCP_MAX_READS not set — applying default per-process read cap of %d (override via KEYORIX_MCP_MAX_READS)", maxReads)
 	} else {
 		log.Printf("per-process read cap active: %d", maxReads)
+	}
+
+	maxListCalls, usedListDefault, lerr := resolveMaxListCalls(strings.TrimSpace(os.Getenv("KEYORIX_MCP_MAX_LIST_CALLS")))
+	if lerr != nil {
+		log.Fatal(lerr)
+	}
+	server.SetMaxListCalls(maxListCalls)
+	if usedListDefault {
+		log.Printf("KEYORIX_MCP_MAX_LIST_CALLS not set — applying default per-process list-call cap of %d (override via KEYORIX_MCP_MAX_LIST_CALLS)", maxListCalls)
+	} else {
+		log.Printf("per-process list-call cap active: %d", maxListCalls)
 	}
 
 	log.Printf("ready (server %s) — read-only Keyorix tools over stdio", version)

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -280,6 +280,12 @@ func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env strin
 	// ── 3+4. Page through ALL secrets and fetch each value ─────────────────────
 	// (a single capped page would inject only the first page's env vars).
 	const pageSize = 500
+	// maxRunInjectedSecrets bounds the total number of secrets injected as child-
+	// process env vars (#G44): with no cap, a project holding a very large number of
+	// secrets can exhaust CLI memory fetching them one by one, or overrun the OS's
+	// environment-block size limit (ARG_MAX) when they're handed to the child
+	// process, silently truncating or failing the launch instead of a clear error.
+	const maxRunInjectedSecrets = 2000
 	result := make(map[string]string)
 	for page := 1; ; page++ {
 		listPath := fmt.Sprintf(
@@ -294,6 +300,9 @@ func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env strin
 		}
 		if err := api.get(ctx, listPath, &secretsBody); err != nil {
 			return nil, fmt.Errorf("list secrets: %w", err)
+		}
+		if len(result)+len(secretsBody.Secrets) > maxRunInjectedSecrets {
+			return nil, fmt.Errorf("project %q/environment %q has more than %d secrets — 'keyorix run' injects every secret as an env var and refuses to continue past this cap; narrow the environment or use a different injection method", project, env, maxRunInjectedSecrets)
 		}
 		for _, s := range secretsBody.Secrets {
 			var secretBody struct {

--- a/internal/core/anomaly_config.go
+++ b/internal/core/anomaly_config.go
@@ -2,10 +2,40 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// Anomaly config knob ceilings (#G44) — without an upper bound, a caller-supplied
+// value drives real per-scan work: LookbackDays widens the audit_events window
+// scanned every detection tick, and MLNumTrees/MLSampleSize scale the isolation-
+// forest training cost directly, so an unbounded value is a resource-exhaustion
+// vector each time the detector runs.
+const (
+	maxAnomalyLookbackDays  = 365
+	maxAnomalyQuarantineHrs = 24 * 90 // 90 days
+	maxAnomalyMLNumTrees    = 1000
+	maxAnomalyMLSampleSize  = 100000
+)
+
+// validateAnomalyConfig bounds the knobs that drive per-scan detector cost.
+func validateAnomalyConfig(cfg *models.AnomalyConfigRecord) error {
+	if cfg.LookbackDays > maxAnomalyLookbackDays {
+		return fmt.Errorf("lookback_days exceeds the maximum of %d", maxAnomalyLookbackDays)
+	}
+	if cfg.QuarantineHours > maxAnomalyQuarantineHrs {
+		return fmt.Errorf("quarantine_hours exceeds the maximum of %d", maxAnomalyQuarantineHrs)
+	}
+	if cfg.MLNumTrees > maxAnomalyMLNumTrees {
+		return fmt.Errorf("ml_num_trees exceeds the maximum of %d", maxAnomalyMLNumTrees)
+	}
+	if cfg.MLSampleSize > maxAnomalyMLSampleSize {
+		return fmt.Errorf("ml_sample_size exceeds the maximum of %d", maxAnomalyMLSampleSize)
+	}
+	return nil
+}
 
 // ApplyAnomalyConfig loads the persisted anomaly config and applies it to the
 // given detector. Call at startup and before each detection scan so runtime
@@ -59,6 +89,9 @@ func (c *KeyorixCore) GetAnomalyConfig(ctx context.Context) (*models.AnomalyConf
 // purposes); the caller is responsible for applying the new config to the live
 // detector via ApplyAnomalyConfig if one is running.
 func (c *KeyorixCore) UpdateAnomalyConfig(ctx context.Context, cfg *models.AnomalyConfigRecord, updatedBy string) error {
+	if err := validateAnomalyConfig(cfg); err != nil {
+		return err
+	}
 	cfg.UpdatedBy = updatedBy
 	cfg.UpdatedAt = time.Now()
 	return c.storage.SaveAnomalyConfig(ctx, cfg)

--- a/internal/core/blast_radius.go
+++ b/internal/core/blast_radius.go
@@ -37,6 +37,10 @@ type BlastRadiusReport struct {
 	Dependents       []BlastRadiusNode `json:"dependents"`
 	TotalImpact      int               `json:"total_impact"` // == len(Dependents)
 	MaxDepth         int               `json:"max_depth"`
+	// Truncated is true when the true dependent count exceeds maxBlastRadiusNodes
+	// and Dependents/TotalImpact reflect only the first maxBlastRadiusNodes nodes
+	// found — never silently reported as a complete picture (#G44).
+	Truncated bool `json:"truncated"`
 }
 
 // blastBFSNode is an internal BFS traversal node.
@@ -45,15 +49,24 @@ type blastBFSNode struct {
 	depth int
 }
 
+// maxBlastRadiusNodes bounds the total number of dependent nodes blastBFS will
+// return (#G44) — depth alone (maxDepth below) doesn't bound BREADTH: a secret
+// with a very wide fan-out at a single depth can still produce an unbounded node
+// count, and GetBlastRadius does one storage.GetSecret call PER node afterward
+// (an N+1 query pattern), so an unbounded node count is a per-request
+// resource-exhaustion vector.
+const maxBlastRadiusNodes = 2000
+
 // blastBFS performs a bounded BFS over the dependents adjacency map starting
-// from rootID, returning nodes ordered by (depth, id). Max depth is 10.
+// from rootID, returning nodes ordered by (depth, id). Max depth is 10; max
+// total nodes is maxBlastRadiusNodes.
 func blastBFS(rootID uint, adj map[uint][]uint) []blastBFSNode {
 	const maxDepth = 10
 	visited := map[uint]bool{rootID: true}
 	queue := []blastBFSNode{{id: rootID, depth: 0}}
 	var ordered []blastBFSNode
 
-	for len(queue) > 0 {
+	for len(queue) > 0 && len(ordered) < maxBlastRadiusNodes {
 		cur := queue[0]
 		queue = queue[1:]
 		for _, dep := range adj[cur.id] {
@@ -65,6 +78,9 @@ func blastBFS(rootID uint, adj map[uint][]uint) []blastBFSNode {
 			ordered = append(ordered, next)
 			if next.depth < maxDepth {
 				queue = append(queue, next)
+			}
+			if len(ordered) >= maxBlastRadiusNodes {
+				break
 			}
 		}
 	}
@@ -129,6 +145,7 @@ func (k *KeyorixCore) GetBlastRadius(ctx context.Context, secretID uint) (*Blast
 		Dependents:       nodes,
 		TotalImpact:      len(nodes),
 		MaxDepth:         maxDepthSeen,
+		Truncated:        len(ordered) >= maxBlastRadiusNodes,
 	}, nil
 }
 

--- a/internal/core/bulk_delete.go
+++ b/internal/core/bulk_delete.go
@@ -15,6 +15,12 @@ type BulkDeleteRequest struct {
 	SecretIDs []uint `json:"secret_ids"`
 }
 
+// maxBulkDeleteBatchSize bounds how many secret IDs a single bulk-delete call
+// accepts — each ID does a per-item storage round trip (GetSecret + DeleteSecret),
+// so an unbounded list is a per-request resource-exhaustion vector (#G44), the
+// same class of bug as maxBulkAccessRequestBatchSize (bulk_access_requests.go).
+const maxBulkDeleteBatchSize = 500
+
 // BulkOpError captures why a single secret in a bulk operation could not be processed.
 type BulkOpError struct {
 	SecretID uint   `json:"secret_id"`
@@ -41,6 +47,9 @@ type BulkDeleteResult struct {
 func (c *KeyorixCore) BulkDeleteSecrets(ctx context.Context, req BulkDeleteRequest, projectID uint, deletedBy string, actorID uint, ip, ua string) (*BulkDeleteResult, error) {
 	if len(req.SecretIDs) == 0 {
 		return nil, fmt.Errorf("at least one secret ID is required")
+	}
+	if len(req.SecretIDs) > maxBulkDeleteBatchSize {
+		return nil, fmt.Errorf("secret_ids exceeds the maximum batch size of %d", maxBulkDeleteBatchSize)
 	}
 
 	result := &BulkDeleteResult{

--- a/internal/core/bulk_delete_test.go
+++ b/internal/core/bulk_delete_test.go
@@ -122,6 +122,25 @@ func TestBulkDeleteSecrets_EmptyRequest(t *testing.T) {
 	assert.Contains(t, err.Error(), "required")
 }
 
+// TestBulkDeleteSecrets_ExceedsMaxBatchSize is the #G44 regression: before the
+// fix, req.SecretIDs had no upper bound, and each ID drives a per-item
+// GetSecret+DeleteSecret storage round trip — an unbounded list is a per-request
+// resource-exhaustion vector, the same class of bug maxBulkAccessRequestBatchSize
+// already guards against elsewhere in this package.
+func TestBulkDeleteSecrets_ExceedsMaxBatchSize(t *testing.T) {
+	c, _ := setupBulkDeleteDB(t)
+	ctx := context.Background()
+
+	ids := make([]uint, maxBulkDeleteBatchSize+1)
+	for i := range ids {
+		ids[i] = uint(i + 1)
+	}
+	req := BulkDeleteRequest{SecretIDs: ids}
+	_, err := c.BulkDeleteSecrets(ctx, req, 0, "tester", 1, "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds the maximum batch size")
+}
+
 func TestBulkDeleteSecrets_AlreadyDeleted(t *testing.T) {
 	c, mk := setupBulkDeleteDB(t)
 	ctx := context.Background()

--- a/internal/core/bulk_rotate.go
+++ b/internal/core/bulk_rotate.go
@@ -56,6 +56,13 @@ type BulkRotateError struct {
 	Error    string `json:"error"`
 }
 
+// maxBulkRotateBatchSize bounds an explicit req.SecretIDs list — each ID does a
+// per-item rotation round trip, so an unbounded list is a per-request resource-
+// exhaustion vector (#G44), the same class of bug as maxBulkAccessRequestBatchSize
+// (bulk_access_requests.go). The project-wide path (SecretIDs empty) is already
+// bounded by bulkRotatePageSize below.
+const maxBulkRotateBatchSize = 500
+
 // BulkRotateSecrets schedules rotation for all matching secrets.
 //
 // When req.SecretIDs is non-empty, only those secrets are processed. Each is
@@ -78,6 +85,9 @@ func (c *KeyorixCore) BulkRotateSecrets(ctx context.Context, req BulkRotateReque
 	}
 	if req.RotatedBy == "" {
 		req.RotatedBy = "system:bulk-rotate"
+	}
+	if len(req.SecretIDs) > maxBulkRotateBatchSize {
+		return nil, fmt.Errorf("secret_ids exceeds the maximum batch size of %d", maxBulkRotateBatchSize)
 	}
 
 	result := &BulkRotateResult{

--- a/internal/core/inactivity_suspend.go
+++ b/internal/core/inactivity_suspend.go
@@ -12,10 +12,18 @@ import (
 	"time"
 )
 
+// MaxInactiveDays bounds cfg.InactiveDays (#G44). Without a ceiling, a large
+// enough value overflows the int64 nanosecond Duration computed below
+// (time.Duration(cfg.InactiveDays) * 24 * time.Hour), wrapping around to a
+// NEGATIVE duration — c.now().Add(-negativeDuration) then lands in the
+// FUTURE, making every user in the deployment appear "inactive" and
+// suspending them all in one call.
+const MaxInactiveDays = 36500 // 100 years
+
 // InactivitySuspendConfig controls the suspension threshold.
 type InactivitySuspendConfig struct {
 	// InactiveDays is the minimum number of days without a login before a
-	// user is considered inactive.  Must be > 0.
+	// user is considered inactive.  Must be > 0 and <= MaxInactiveDays.
 	InactiveDays int
 
 	// DryRun, when true, causes SuspendInactiveUsers to evaluate every user
@@ -41,6 +49,9 @@ type InactivitySuspendResult struct {
 func (c *KeyorixCore) SuspendInactiveUsers(ctx context.Context, cfg InactivitySuspendConfig) (*InactivitySuspendResult, error) {
 	if cfg.InactiveDays <= 0 {
 		return nil, fmt.Errorf("inactive_days must be greater than 0")
+	}
+	if cfg.InactiveDays > MaxInactiveDays {
+		return nil, fmt.Errorf("inactive_days exceeds the maximum of %d", MaxInactiveDays)
 	}
 
 	threshold := c.now().Add(-time.Duration(cfg.InactiveDays) * 24 * time.Hour)

--- a/internal/core/inactivity_suspend_test.go
+++ b/internal/core/inactivity_suspend_test.go
@@ -70,6 +70,26 @@ func TestSuspendInactiveUsers_InvalidDays(t *testing.T) {
 	}
 }
 
+// TestSuspendInactiveUsers_ExceedsMaxDays is the #G44 regression: before the fix,
+// InactiveDays had no upper bound, so time.Duration(cfg.InactiveDays)*24*time.Hour
+// could overflow int64 nanoseconds and wrap to a NEGATIVE duration — landing the
+// suspension threshold in the FUTURE and making every user in the deployment
+// appear inactive. A value comfortably past MaxInactiveDays must be rejected
+// before that arithmetic ever runs, and MockStorage has no ListInactiveUsers
+// expectation configured — if the rejection happened AFTER computing the
+// threshold, the mock call would panic instead of returning a clean error.
+func TestSuspendInactiveUsers_ExceedsMaxDays(t *testing.T) {
+	store := new(MockStorage)
+	c := newInactivityCore(store)
+	ctx := context.Background()
+
+	for _, days := range []int{MaxInactiveDays + 1, 1 << 30, 1 << 62} {
+		_, err := c.SuspendInactiveUsers(ctx, InactivitySuspendConfig{InactiveDays: days})
+		require.Error(t, err, "days=%d should be rejected", days)
+		assert.Contains(t, err.Error(), "exceeds the maximum")
+	}
+}
+
 // TestSuspendInactiveUsers_EmptyList ensures an empty inactive-user list returns a zero result.
 func TestSuspendInactiveUsers_EmptyList(t *testing.T) {
 	store := new(MockStorage)

--- a/internal/core/permission_baseline.go
+++ b/internal/core/permission_baseline.go
@@ -139,6 +139,14 @@ func (b *permBaselineBuilder) groupGrantRowsForUser(ctx context.Context, u *mode
 // tuple becomes one PermissionBaselineRow. Expired grants are included (snapshot
 // of all grants, including time-bound ones) so the auditor sees the full history;
 // callers that need only live grants should filter by expiry themselves.
+//
+// #G44: groupGrantRowsForUser below runs one GetUserGroups + one GetGroupRoles
+// call PER USER — a genuine N+1 whose cost scales with the deployment's own user
+// count, not with any caller-controlled input. Unlike this group's other members,
+// there's no bound to add here that wouldn't just silently drop users from a
+// compliance/audit report; the real fix is restructuring to batch-load every
+// user's group/role memberships in one or two queries up front. Left unfixed —
+// see REMEDIATION-STATUS.md G44.
 func (k *KeyorixCore) GetPermissionBaseline(ctx context.Context) (*PermissionBaseline, error) {
 	// 1. Load all users (no filter — we want every principal).
 	users, _, err := k.storage.ListUsers(ctx, &storage.UserFilter{PageSize: 100000})

--- a/internal/core/secret_bulk_rename.go
+++ b/internal/core/secret_bulk_rename.go
@@ -29,6 +29,12 @@ type SecretRename struct {
 	NewName string `json:"new_name"`
 }
 
+// maxBulkRenameBatchSize bounds the renames list — each entry does several per-item
+// storage round trips, so an unbounded list is a per-request resource-exhaustion
+// vector (#G44), the same class of bug as maxBulkAccessRequestBatchSize
+// (bulk_access_requests.go).
+const maxBulkRenameBatchSize = 500
+
 // SecretRenameOutcome reports what happened (or, in dry-run, would happen) for one
 // requested rename. Skipped outcomes carry the reason.
 type SecretRenameOutcome struct {
@@ -63,6 +69,9 @@ func (c *KeyorixCore) BulkRenameSecrets(ctx context.Context, projectID uint, ren
 	}
 	if len(renames) == 0 {
 		return nil, fmt.Errorf("at least one rename is required")
+	}
+	if len(renames) > maxBulkRenameBatchSize {
+		return nil, fmt.Errorf("renames exceeds the maximum batch size of %d", maxBulkRenameBatchSize)
 	}
 
 	report := &BulkRenameReport{DryRun: dryRun, Outcomes: make([]SecretRenameOutcome, 0, len(renames))}
@@ -108,6 +117,14 @@ func (c *KeyorixCore) BulkRenameSecrets(ctx context.Context, projectID uint, ren
 		}
 		if secret.Name == newName {
 			skip(rn.ID, secret.Name, newName, "name unchanged")
+			continue
+		}
+		// The mandatory length cap applies regardless of whether a naming policy is
+		// configured — validateSecretName below only enforces a length cap when a
+		// policy is enabled, so this call is the only thing standing between an
+		// unbounded new_name and storage when no policy is set (#G44).
+		if verr := validateNameLength("secret name", newName); verr != nil {
+			skip(rn.ID, secret.Name, newName, verr.Error())
 			continue
 		}
 		// Rename toward conformance only — refuse a new name that itself violates the

--- a/internal/core/secret_schedule.go
+++ b/internal/core/secret_schedule.go
@@ -117,6 +117,13 @@ func validateScheduleParams(days string, startHour, endHour int, timezone string
 		return fmt.Errorf("invalid timezone %q: %w", timezone, err)
 	}
 	if days != "*" {
+		// #G44: bound the string before splitting — 7 distinct days ("1,2,3,4,5,6,7")
+		// need at most 13 characters; an unbounded caller-supplied string otherwise
+		// drives an unbounded number of strconv.Atoi calls below.
+		const maxAllowedDaysLen = 64
+		if len(days) > maxAllowedDaysLen {
+			return fmt.Errorf("days exceeds the maximum length of %d characters", maxAllowedDaysLen)
+		}
 		for _, part := range strings.Split(days, ",") {
 			d, err := strconv.Atoi(strings.TrimSpace(part))
 			if err != nil || d < 1 || d > 7 {

--- a/internal/core/secret_templates.go
+++ b/internal/core/secret_templates.go
@@ -58,8 +58,14 @@ func (c *KeyorixCore) CreateSecretTemplate(ctx context.Context, req *CreateSecre
 	if strings.TrimSpace(req.Name) == "" {
 		return nil, fmt.Errorf("template name is required")
 	}
+	if err := validateNameLength("template name", req.Name); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
 	if err := validateTemplateClassification(req.DefaultClassification); err != nil {
 		return nil, err
+	}
+	if err := validateDescription(req.Description); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
 	if len(req.DescriptionPattern) > maxSecretDescriptionLen {
 		return nil, fmt.Errorf("%s: DescriptionPattern exceeds maximum length of %d", i18n.T("ErrorValidation", nil), maxSecretDescriptionLen)
@@ -124,8 +130,14 @@ func (c *KeyorixCore) UpdateSecretTemplate(ctx context.Context, id uint, req *Up
 	if strings.TrimSpace(req.Name) == "" {
 		return nil, fmt.Errorf("template name is required")
 	}
+	if err := validateNameLength("template name", req.Name); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
 	if err := validateTemplateClassification(req.DefaultClassification); err != nil {
 		return nil, err
+	}
+	if err := validateDescription(req.Description); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
 	if len(req.DescriptionPattern) > maxSecretDescriptionLen {
 		return nil, fmt.Errorf("%s: DescriptionPattern exceeds maximum length of %d", i18n.T("ErrorValidation", nil), maxSecretDescriptionLen)

--- a/internal/core/usage_analytics.go
+++ b/internal/core/usage_analytics.go
@@ -11,6 +11,10 @@ const (
 	defaultUsageWindowDays   = 30
 	defaultMostAccessedLimit = 10
 	maxMostAccessedLimit     = 100
+	// maxUsageWindowDays bounds the caller-supplied lookback window (#G44) — an
+	// unbounded value passed to AddDate can produce a pathological cutoff time
+	// and, more importantly, no longer matches "recent usage analytics" intent.
+	maxUsageWindowDays = 3650 // 10 years
 )
 
 // MostAccessedSecrets returns the most-read secrets (optionally scoped to a
@@ -19,6 +23,9 @@ const (
 func (c *KeyorixCore) MostAccessedSecrets(ctx context.Context, projectID *uint, days, limit int) ([]storage.SecretUsageStat, error) {
 	if days <= 0 {
 		days = defaultUsageWindowDays
+	}
+	if days > maxUsageWindowDays {
+		days = maxUsageWindowDays
 	}
 	if limit <= 0 {
 		limit = defaultMostAccessedLimit
@@ -40,6 +47,9 @@ func (c *KeyorixCore) MostAccessedSecrets(ctx context.Context, projectID *uint, 
 func (c *KeyorixCore) UnusedSecrets(ctx context.Context, projectID *uint, days int) ([]storage.UnusedSecretStat, error) {
 	if days <= 0 {
 		days = defaultUsageWindowDays
+	}
+	if days > maxUsageWindowDays {
+		days = maxUsageWindowDays
 	}
 	cutoff := c.now().AddDate(0, 0, -days)
 	stats, err := c.storage.UnusedSecrets(ctx, projectID, cutoff)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -47,6 +47,14 @@ type Server struct {
 	maxReads int64
 	// readCount is incremented atomically per successful keyorix_get_secret call.
 	readCount atomic.Int64
+	// maxListCalls, when > 0, caps the number of keyorix_list_secrets calls this
+	// server process will serve for its whole stdio session (#G44) — the same
+	// per-process resource-exhaustion reasoning as maxReads above: a manipulated
+	// agent can be driven to call a read-only listing tool an unbounded number of
+	// times just as easily as a value-reading one. 0 = unlimited. Set via SetMaxListCalls.
+	maxListCalls int64
+	// listCallCount is incremented atomically per successful keyorix_list_secrets call.
+	listCallCount atomic.Int64
 	// maxMessageBytes caps a single inbound JSON-RPC message (see maxMessageReader).
 	// 0 (the default, i.e. never set by NewServer) means "use defaultMaxMessageBytes" —
 	// tests may override this field directly to exercise the cap without transferring
@@ -74,6 +82,15 @@ func (s *Server) SetAllowedRefs(patterns []string) {
 func (s *Server) SetMaxReads(n int) {
 	if n > 0 {
 		s.maxReads = int64(n)
+	}
+}
+
+// SetMaxListCalls caps the number of keyorix_list_secrets calls this process will
+// serve for its whole session. A non-positive value means unlimited (the default)
+// — see maxListCalls.
+func (s *Server) SetMaxListCalls(n int) {
+	if n > 0 {
+		s.maxListCalls = int64(n)
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -122,6 +122,14 @@ func (s *Server) toolGetSecret(ctx context.Context, args json.RawMessage) map[st
 }
 
 func (s *Server) toolListSecrets(ctx context.Context, args json.RawMessage) map[string]interface{} {
+	// #G44: a per-process cap on how many keyorix_list_secrets calls this session
+	// serves, mirroring keyorix_get_secret's maxReads cap above for the same reason
+	// — a manipulated agent can be driven to repeat a read-only listing call just as
+	// easily as a value-reading one.
+	if s.maxListCalls > 0 && s.listCallCount.Load() >= s.maxListCalls {
+		log.Printf("keyorix_list_secrets: per-process call cap (%d) reached; refusing further listings this session", s.maxListCalls)
+		return errorResult(genericListError)
+	}
 	var a struct {
 		Environment string `json:"environment"`
 	}

--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -72,11 +72,17 @@ import (
 const maxStoragePageSize = 10000
 
 // clampPageSize bounds a caller-supplied page size to (0, maxStoragePageSize].
-// A non-positive size is passed through unchanged — several callers rely on
-// their own default/zero-value handling before this clamp runs.
+// A non-positive size is passed through as 0 rather than negative — several
+// callers rely on 0 meaning "use my own default" before this clamp runs, but
+// a negative value must never reach GORM's Limit(): Limit(-1) (or any
+// negative) removes the LIMIT clause entirely, turning a caller-controlled
+// negative page size into an unbounded query (#G44).
 func clampPageSize(pageSize int) int {
 	if pageSize > maxStoragePageSize {
 		return maxStoragePageSize
+	}
+	if pageSize < 0 {
+		return 0
 	}
 	return pageSize
 }
@@ -88,6 +94,14 @@ func clampPageSize(pageSize int) int {
 // 10000 pages × up to 100 rows/page = 1 million rows, far above any real
 // audit log a single deployment would accumulate.
 const maxStoragePage = 10_000
+
+// maxUnboundedListRows caps LocalStorage list queries that have no caller-
+// supplied pagination at all (no Page/PageSize/limit param in their
+// signature) — a defense-in-depth ceiling so a table that grows without
+// bound in production (rotation policies, SoD policies, dynamic leases,
+// access-review campaigns, etc.) can't turn a routine list call into an
+// unbounded full-table scan (#G44).
+const maxUnboundedListRows = 10000
 
 // clampPage bounds a caller-supplied page number to [1, maxStoragePage].
 func clampPage(page int) int {

--- a/internal/storage/store/local_access_activity.go
+++ b/internal/storage/store/local_access_activity.go
@@ -90,6 +90,18 @@ var secretsDeletionActivityEventTypes = []string{"secret.deleted"}
 // row seen per user (rather than SQL MAX(), whose result is an untyped string that
 // SQLite can't scan into time.Time). No row cap — a user's only activity could be
 // old, and capping would mis-report them as never-active (a silent-truncation bug).
+//
+// #G44: flagged for "no row cap" — a naive LIMIT is intentionally NOT applied here.
+// Because rows are ordered newest-first and results are deduped per-user in Go,
+// a LIMIT returns the N most recent events ACROSS ALL USERS, not the most recent
+// event PER USER — a project with more than N recent events from a few active
+// users would silently drop every dormant user from the result entirely (the
+// exact bug this function's own comment above already guards against). A correct
+// bound here needs either a per-user-windowed query (ROW_NUMBER() OVER PARTITION
+// BY user_id, unused elsewhere in this codebase and untested against both SQLite
+// and Postgres dialects) or a domain decision on how far back "last activity"
+// needs to look before a user is presumed dormant regardless. Left unfixed
+// pending that decision — see REMEDIATION-STATUS.md G44.
 func (ls *LocalStorage) lastUserActivityByEventTypes(ctx context.Context, projectID uint, eventTypes []string) (map[uint]time.Time, error) {
 	type row struct {
 		UserID    uint

--- a/internal/storage/store/local_access_review_campaigns.go
+++ b/internal/storage/store/local_access_review_campaigns.go
@@ -35,6 +35,7 @@ func (ls *LocalStorage) ListAccessReviewCampaigns(ctx context.Context, projectID
 	err := ls.db.WithContext(ctx).
 		Where("project_id = ?", projectID).
 		Order(sqlOrderCreatedAtDesc).
+		Limit(maxUnboundedListRows).
 		Find(&rows).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -128,6 +129,7 @@ func (ls *LocalStorage) ListAccessReviewItems(ctx context.Context, campaignID ui
 	err := ls.db.WithContext(ctx).
 		Where("campaign_id = ?", campaignID).
 		Order("id ASC").
+		Limit(maxUnboundedListRows).
 		Find(&rows).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -189,6 +189,7 @@ func (ls *LocalStorage) MostAccessedSecrets(ctx context.Context, projectID *uint
 	if limit <= 0 {
 		limit = 10
 	}
+	limit = clampPageSize(limit)
 	q := ls.db.WithContext(ctx).
 		Table("secret_access_logs AS l").
 		Select("l.secret_node_id AS secret_id, s.name AS secret_name, s.environment_id AS environment_id, COUNT(*) AS read_count, MAX(l.access_time) AS last_read").
@@ -237,7 +238,8 @@ func (ls *LocalStorage) UnusedSecrets(ctx context.Context, projectID *uint, notR
 		Where("s.deleted_at IS NULL").
 		Group("s.id, s.name, s.environment_id").
 		Having("MAX(l.access_time) IS NULL OR MAX(l.access_time) < ?", notReadSince).
-		Order("(MAX(l.access_time) IS NULL) DESC, last_read ASC")
+		Order("(MAX(l.access_time) IS NULL) DESC, last_read ASC").
+		Limit(maxUnboundedListRows)
 	if projectID != nil {
 		q = q.Where("s.project_id = ?", *projectID)
 	}
@@ -452,7 +454,7 @@ func (ls *LocalStorage) GetSecretReadCounts(ctx context.Context, secretID uint, 
 		Where("ae.secret_node_id = ? AND ae.event_type = ? AND ae.event_time >= ? AND ae.event_time < ?", secretID, "secret.read", since, until).
 		Group("ae.user_id").
 		Order("read_count DESC").
-		Limit(limit).
+		Limit(clampPageSize(limit)).
 		Scan(&rows).Error
 	if err != nil {
 		return nil, fmt.Errorf("GetSecretReadCounts: %w", err)

--- a/internal/storage/store/local_billing.go
+++ b/internal/storage/store/local_billing.go
@@ -8,10 +8,16 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 )
+
+// maxBillingReportProjectIDs bounds the caller-supplied project_id filter list —
+// without a cap, a large externally-supplied list is interpolated directly into
+// a SQL "project_id IN (...)" clause on every aggregation query in this file (#G44).
+const maxBillingReportProjectIDs = 1000
 
 // selectProjectCount is the shared "GROUP BY project_id" count projection
 // used by every per-project aggregation query below.
@@ -34,6 +40,9 @@ type billingCounts struct {
 // activity in the window. Projects with no secrets and no activity are omitted
 // to keep the report concise.
 func (ls *LocalStorage) GetBillingReport(ctx context.Context, from, to time.Time, projectIDs []uint) (*storage.BillingReport, error) {
+	if len(projectIDs) > maxBillingReportProjectIDs {
+		return nil, fmt.Errorf("project_id filter accepts at most %d ids, got %d", maxBillingReportProjectIDs, len(projectIDs))
+	}
 	if len(projectIDs) == 0 {
 		var err error
 		if projectIDs, err = ls.allProjectIDs(ctx); err != nil {

--- a/internal/storage/store/local_compliance_snapshot.go
+++ b/internal/storage/store/local_compliance_snapshot.go
@@ -33,6 +33,7 @@ func (ls *LocalStorage) ListCompliancePostureSnapshots(ctx context.Context, limi
 	if limit <= 0 {
 		limit = defaultSnapshotLimit
 	}
+	limit = clampPageSize(limit)
 	var snaps []*models.CompliancePostureSnapshot
 	if err := ls.db.WithContext(ctx).
 		Order("snapshot_date DESC").

--- a/internal/storage/store/local_dynamic.go
+++ b/internal/storage/store/local_dynamic.go
@@ -93,7 +93,7 @@ func (ls *LocalStorage) GetDynamicSecretLease(ctx context.Context, leaseID strin
 
 func (ls *LocalStorage) ListDynamicSecretLeases(ctx context.Context, configID uint) ([]*models.DynamicSecretLease, error) {
 	var ls2 []*models.DynamicSecretLease
-	if err := ls.db.WithContext(ctx).Where("config_id = ?", configID).Order("issued_at desc").Find(&ls2).Error; err != nil {
+	if err := ls.db.WithContext(ctx).Where("config_id = ?", configID).Order("issued_at desc").Limit(maxUnboundedListRows).Find(&ls2).Error; err != nil {
 		return nil, err
 	}
 	return ls2, nil
@@ -126,7 +126,7 @@ func (ls *LocalStorage) ListExpiredActiveLeases(ctx context.Context, before time
 	var leases []*models.DynamicSecretLease
 	if err := ls.db.WithContext(ctx).
 		Where("status IN ? AND expires_at < ?", []string{"active", "revoke_failed"}, before).
-		Order("id").Find(&leases).Error; err != nil {
+		Order("id").Limit(maxUnboundedListRows).Find(&leases).Error; err != nil {
 		return nil, err
 	}
 	return leases, nil

--- a/internal/storage/store/local_memberships.go
+++ b/internal/storage/store/local_memberships.go
@@ -88,6 +88,7 @@ func (ls *LocalStorage) ListStaleInvitedMemberships(ctx context.Context, before 
 	err := ls.db.WithContext(ctx).
 		Where("state = ? AND invited_at < ?", "invited", before).
 		Order("invited_at ASC").
+		Limit(maxUnboundedListRows).
 		Find(&rows).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/internal/storage/store/local_risk_exceptions.go
+++ b/internal/storage/store/local_risk_exceptions.go
@@ -28,7 +28,7 @@ func (ls *LocalStorage) ListRiskExceptions(ctx context.Context, activeOnly bool)
 	if activeOnly {
 		q = q.Where("revoked = ?", false)
 	}
-	if err := q.Find(&rows).Error; err != nil {
+	if err := q.Limit(maxUnboundedListRows).Find(&rows).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return rows, nil

--- a/internal/storage/store/local_rotation_policies.go
+++ b/internal/storage/store/local_rotation_policies.go
@@ -42,7 +42,7 @@ func (ls *LocalStorage) ListRotationPolicies(ctx context.Context, projectID *uin
 		query = query.Where("environment_id = ?", *environmentID)
 	}
 	var policies []*models.RotationPolicy
-	if err := query.Find(&policies).Error; err != nil {
+	if err := query.Limit(maxUnboundedListRows).Find(&policies).Error; err != nil {
 		return nil, fmt.Errorf("failed to list rotation policies: %w", err)
 	}
 	return policies, nil

--- a/internal/storage/store/local_secret_templates.go
+++ b/internal/storage/store/local_secret_templates.go
@@ -44,7 +44,7 @@ func (ls *LocalStorage) GetSecretTemplateByName(ctx context.Context, name string
 
 func (ls *LocalStorage) ListSecretTemplates(ctx context.Context) ([]*models.SecretTemplate, error) {
 	var templates []*models.SecretTemplate
-	if err := ls.db.WithContext(ctx).Order("name").Find(&templates).Error; err != nil {
+	if err := ls.db.WithContext(ctx).Order("name").Limit(maxUnboundedListRows).Find(&templates).Error; err != nil {
 		return nil, fmt.Errorf("failed to list secret templates: %w", err)
 	}
 	return templates, nil

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -684,7 +684,8 @@ func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretF
 	}
 
 	pageSize := clampPageSize(filter.PageSize)
-	offset := (filter.Page - 1) * pageSize
+	page := clampPage(filter.Page)
+	offset := (page - 1) * pageSize
 	query = query.Offset(offset).Limit(pageSize)
 
 	var secrets []*models.SecretNode
@@ -707,6 +708,7 @@ func (ls *LocalStorage) ListOrphanedSecrets(ctx context.Context, projectID uint)
 		Where("secret_nodes.project_id = ?", projectID).
 		Where("users.id IS NULL").
 		Order("secret_nodes.name ASC").
+		Limit(maxUnboundedListRows).
 		Find(&secrets).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -188,7 +188,7 @@ func (ls *LocalStorage) ListSharesBySecret(ctx context.Context, secretID uint) (
 	if err := ls.db.Where(
 		"secret_id = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
 		secretID, time.Now(),
-	).Find(&shares).Error; err != nil {
+	).Limit(maxUnboundedListRows).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return shares, nil
@@ -219,7 +219,7 @@ func (ls *LocalStorage) ListSharesByUser(ctx context.Context, userID uint) ([]*m
 	if err := ls.db.Where(
 		"recipient_id = ? AND is_group = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
 		userID, false, time.Now(),
-	).Find(&shares).Error; err != nil {
+	).Limit(maxUnboundedListRows).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return shares, nil
@@ -234,7 +234,7 @@ func (ls *LocalStorage) ListSharesByOwner(ctx context.Context, ownerID uint) ([]
 	if err := ls.db.Where(
 		"owner_id = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
 		ownerID, time.Now(),
-	).Find(&shares).Error; err != nil {
+	).Limit(maxUnboundedListRows).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return shares, nil
@@ -247,7 +247,7 @@ func (ls *LocalStorage) ListSharesByGroup(ctx context.Context, groupID uint) ([]
 	if err := ls.db.Where(
 		"recipient_id = ? AND is_group = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
 		groupID, true, time.Now(),
-	).Find(&shares).Error; err != nil {
+	).Limit(maxUnboundedListRows).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 	return shares, nil
@@ -259,19 +259,20 @@ func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*
 	// Expired (time-bound) shares no longer authorize, so they must not surface in
 	// the "shared with me" listing either — filter them the same way the auth queries do.
 	now := time.Now()
-	directQuery := `
+	directQuery := fmt.Sprintf(`
 		SELECT s.* FROM secret_nodes s
 		JOIN share_records sr ON s.id = sr.secret_id
 		WHERE sr.recipient_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL AND s.deleted_at IS NULL
 		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
-	`
+		LIMIT %d
+	`, maxUnboundedListRows)
 	if err := ls.db.Raw(directQuery, userID, false, now).Scan(&secrets).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
 
 	// JOIN groups … deleted_at IS NULL: a soft-deleted group's shares grant nothing,
 	// even though the share/membership rows are kept for restore.
-	groupQuery := `
+	groupQuery := fmt.Sprintf(`
 		SELECT s.* FROM secret_nodes s
 		JOIN share_records sr ON s.id = sr.secret_id
 		JOIN user_groups ug ON sr.recipient_id = ug.group_id
@@ -279,7 +280,8 @@ func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*
 		JOIN users u ON u.id = ug.user_id AND u.deleted_at IS NULL
 		WHERE ug.user_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL AND s.deleted_at IS NULL
 		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
-	`
+		LIMIT %d
+	`, maxUnboundedListRows)
 	var groupSecrets []*models.SecretNode
 	if err := ls.db.Raw(groupQuery, userID, true, now).Scan(&groupSecrets).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)

--- a/internal/storage/store/local_sod.go
+++ b/internal/storage/store/local_sod.go
@@ -27,7 +27,7 @@ func (ls *LocalStorage) GetSoDPolicy(ctx context.Context, id uint) (*models.SoDP
 
 func (ls *LocalStorage) ListSoDPolicies(ctx context.Context) ([]*models.SoDPolicy, error) {
 	var rows []*models.SoDPolicy
-	if err := ls.db.WithContext(ctx).Order("id ASC").Find(&rows).Error; err != nil {
+	if err := ls.db.WithContext(ctx).Order("id ASC").Limit(maxUnboundedListRows).Find(&rows).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return rows, nil

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -292,6 +292,7 @@ func (ls *LocalStorage) ListUsersInStateBefore(ctx context.Context, state string
 	err := ls.db.WithContext(ctx).
 		Where("account_state = ? AND created_at < ?", state, before).
 		Order("created_at ASC").
+		Limit(maxUnboundedListRows).
 		Find(&users).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -307,6 +308,7 @@ func (ls *LocalStorage) ListInactiveUsers(ctx context.Context, threshold time.Ti
 	err := ls.db.WithContext(ctx).
 		Where("(last_login_at IS NULL AND created_at < ?) OR last_login_at < ?", threshold, threshold).
 		Order("id ASC").
+		Limit(maxUnboundedListRows).
 		Find(&users).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -371,7 +373,8 @@ func (ls *LocalStorage) ListUsers(ctx context.Context, filter *storage.UserFilte
 	}
 
 	pageSize := clampPageSize(filter.PageSize)
-	offset := (filter.Page - 1) * pageSize
+	page := clampPage(filter.Page)
+	offset := (page - 1) * pageSize
 	if filter.Offset > 0 {
 		offset = filter.Offset
 	}

--- a/internal/storage/store/pagination_clamp_test.go
+++ b/internal/storage/store/pagination_clamp_test.go
@@ -27,13 +27,44 @@ func TestClampPageSize(t *testing.T) {
 		{"one over the ceiling clamped down", maxStoragePageSize + 1, maxStoragePageSize},
 		{"wildly oversized clamped down", 1 << 30, maxStoragePageSize},
 		{"zero passed through (caller's own default applies)", 0, 0},
-		{"negative passed through (caller's own default applies)", -1, -1},
+		// #G44: a negative size must NEVER reach GORM's Limit() — Limit(-1) (or any
+		// negative) removes the LIMIT clause entirely, turning a caller-controlled
+		// negative page size into an unbounded query. Clamped to 0, not passed through.
+		{"negative clamped to zero, not passed through", -1, 0},
+		{"large negative clamped to zero", -1 << 30, 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, clampPageSize(tc.in))
 		})
 	}
+}
+
+// TestClampPageSize_NegativeNeverReachesGORMLimit is the #G44 regression: before the
+// fix, a negative pageSize passed straight through clampPageSize into GORM's
+// Limit(), which treats any negative value as "no limit" — turning a caller-
+// controlled negative page size into an unbounded query. This proves the actual
+// query result is bounded, not just the clamp helper's return value.
+func TestClampPageSize_NegativeNeverReachesGORMLimit(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "dev"}).Error)
+	for i := 0; i < 5; i++ {
+		require.NoError(t, db.Create(&models.SecretNode{
+			ProjectID: 1, EnvironmentID: 1, Name: fmt.Sprintf("secret-%d", i),
+			IsSecret: true, Type: "api_key", Status: "active",
+		}).Error)
+	}
+
+	secrets, _, err := ls.ListSecrets(ctx, &storage.SecretFilter{
+		Page: 1, PageSize: -1, // a caller supplying a hostile negative page size
+	})
+	require.NoError(t, err)
+	assert.Empty(t, secrets, "a negative page size must return zero rows, never every row")
 }
 
 // TestClampPage pins the ceiling on caller-supplied page numbers to prevent

--- a/server/http/handlers/dashboard.go
+++ b/server/http/handlers/dashboard.go
@@ -137,7 +137,10 @@ func (h *DashboardHandler) GetActivity(w http.ResponseWriter, r *http.Request) {
 	pageSize := 10
 
 	if pageStr := r.URL.Query().Get("page"); pageStr != "" {
-		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
+		// #G44: an unbounded page number forces an equally unbounded SQL OFFSET
+		// downstream (deep-pagination DoS), the same class of bug the storage
+		// layer's own maxStoragePage ceiling exists to prevent.
+		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 && p <= 10000 {
 			page = p
 		}
 	}

--- a/server/http/handlers/groups_proxy.go
+++ b/server/http/handlers/groups_proxy.go
@@ -38,6 +38,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -47,6 +48,13 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// maxGroupsPageLimit bounds ListGroupsPageProxy's caller-supplied limit (#G44).
+const maxGroupsPageLimit = 1000
+
+// maxGroupMembersByIDsCount bounds ListGroupMembersByIDsProxy's comma-separated
+// ids query parameter (#G44) — each ID drives further per-group work downstream.
+const maxGroupMembersByIDsCount = 1000
 
 // groupProxyWire mirrors models.Group's fields exactly (snake_case) — the wire
 // shape internal/storage/store/remote_users.go's groupWire sends/expects. See
@@ -224,13 +232,15 @@ func (h *GroupHandler) ListGroupsProxy(w http.ResponseWriter, r *http.Request) {
 // ListGroupsPageProxy handles GET /api/v1/system/groups/page?offset=&limit=.
 func (h *GroupHandler) ListGroupsPageProxy(w http.ResponseWriter, r *http.Request) {
 	offset, err := strconv.Atoi(r.URL.Query().Get("offset"))
-	if err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "offset must be a valid integer")
+	if err != nil || offset < 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "offset must be a non-negative integer")
 		return
 	}
 	limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "limit must be a valid integer")
+	// #G44: a negative limit reaches GORM's Limit() unclamped, which removes the
+	// LIMIT clause entirely (Limit(-1) semantics) rather than restricting the page.
+	if err != nil || limit <= 0 || limit > maxGroupsPageLimit {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", fmt.Sprintf("limit must be a positive integer up to %d", maxGroupsPageLimit))
 		return
 	}
 	groups, total, err := h.coreService.Storage().ListGroupsPage(r.Context(), offset, limit)
@@ -346,6 +356,10 @@ func (h *GroupHandler) ListGroupMembersByIDsProxy(w http.ResponseWriter, r *http
 		return
 	}
 	parts := strings.Split(idsParam, ",")
+	if len(parts) > maxGroupMembersByIDsCount {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", fmt.Sprintf("ids exceeds the maximum of %d", maxGroupMembersByIDsCount))
+		return
+	}
 	groupIDs := make([]uint, 0, len(parts))
 	for _, p := range parts {
 		id, err := strconv.ParseUint(strings.TrimSpace(p), 10, 32)

--- a/server/http/handlers/handlers_s13_proxy_test.go
+++ b/server/http/handlers/handlers_s13_proxy_test.go
@@ -569,6 +569,25 @@ func TestPurgeDeletedSecretsBeforeProxy_HappyPath_S13(t *testing.T) {
 	assert.True(t, resp.Success)
 }
 
+// TestPurgeDeletedSecretsBeforeProxy_FutureBefore_S13 is the #G44 regression: every
+// route in retention_proxy.go is a "purge/strip everything older than before" sweep.
+// A small future skew (up to maxRetentionCutoffSkew) is legitimate padding — this
+// test uses a WILDLY distant cutoff, the actual attack shape the review flagged:
+// before the fix, a caller holding the same system.write credential any
+// RemoteStorage node already needs could set `before` decades out and instantly
+// purge every soft-deleted row.
+func TestPurgeDeletedSecretsBeforeProxy_FutureBefore_S13(t *testing.T) {
+	h := freshSecretHandlerForProxyS13(t)
+	body := proxyJSON(map[string]interface{}{"before": time.Now().AddDate(10, 0, 0)})
+	req := httptest.NewRequest(http.MethodPost, "/system/retention/secrets/purge", body)
+	w := httptest.NewRecorder()
+	h.PurgeDeletedSecretsBeforeProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+	assert.Contains(t, resp.Error.Message, "future")
+}
+
 // TestDeleteAnomalyAlertsBeforeProxy_BadBody_S13 — malformed JSON → 400.
 func TestDeleteAnomalyAlertsBeforeProxy_BadBody_S13(t *testing.T) {
 	h := freshAuditHandlerS13(t)
@@ -593,6 +612,21 @@ func TestDeleteAnomalyAlertsBeforeProxy_HappyPath_S13(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	resp := decodeRemoteResp(t, w)
 	assert.True(t, resp.Success)
+}
+
+// TestDeleteAnomalyAlertsBeforeProxy_FutureAckBefore_S13 — #G44 regression, same as
+// the secrets-purge sibling above: a wildly distant future ack_before must be rejected.
+func TestDeleteAnomalyAlertsBeforeProxy_FutureAckBefore_S13(t *testing.T) {
+	h := freshAuditHandlerS13(t)
+	body := proxyJSON(map[string]interface{}{
+		"ack_before": time.Now().AddDate(10, 0, 0),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/system/retention/anomaly-alerts/purge", body)
+	w := httptest.NewRecorder()
+	h.DeleteAnomalyAlertsBeforeProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
 }
 
 // TestDeleteClosedAccessReviewsBeforeProxy_BadBody_S13 — bad JSON → 400.

--- a/server/http/handlers/inactivity_suspend.go
+++ b/server/http/handlers/inactivity_suspend.go
@@ -6,6 +6,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -39,6 +40,10 @@ func (h *AdminJobsHandler) SuspendInactiveUsers(w http.ResponseWriter, r *http.R
 
 	if req.InactiveDays <= 0 {
 		sendError(w, "Bad Request", "inactive_days must be greater than 0", http.StatusBadRequest, nil)
+		return
+	}
+	if req.InactiveDays > core.MaxInactiveDays {
+		sendError(w, "Bad Request", fmt.Sprintf("inactive_days exceeds the maximum of %d", core.MaxInactiveDays), http.StatusBadRequest, nil)
 		return
 	}
 

--- a/server/http/handlers/retention_proxy.go
+++ b/server/http/handlers/retention_proxy.go
@@ -76,6 +76,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -92,6 +93,28 @@ type retentionBeforeBody struct {
 	Before time.Time `json:"before"`
 }
 
+// maxRetentionCutoffSkew bounds how far into the future a caller-supplied `before`
+// cutoff may sit relative to this server's own clock (#G44). Every route in this
+// file is a retention/expiry SWEEP — "purge/strip everything already older than
+// before" — so without SOME bound, a caller (holding the same system.read/
+// system.write credential any RemoteStorage node already needs) could set `before`
+// far in the future (e.g. decades out) and instantly purge every soft-deleted row,
+// or strip role grants/shares that have not actually expired yet, system-wide. A
+// generous 24h allowance is kept for legitimate near-future padding — every proxy
+// handler's own test suite already exercises a +1h cutoff as valid input (a caller
+// pre-emptively sweeping things that will have expired shortly) — while still
+// rejecting the actual attack shape (a wildly distant cutoff).
+const maxRetentionCutoffSkew = 24 * time.Hour
+
+// validateRetentionCutoff rejects a `before` timestamp that sits more than
+// maxRetentionCutoffSkew in the future relative to this server's clock.
+func validateRetentionCutoff(before time.Time) error {
+	if before.After(time.Now().Add(maxRetentionCutoffSkew)) {
+		return fmt.Errorf("before must not be in the future")
+	}
+	return nil
+}
+
 func decodeRetentionBeforeBody(w http.ResponseWriter, r *http.Request) (time.Time, bool) {
 	var body retentionBeforeBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -100,6 +123,10 @@ func decodeRetentionBeforeBody(w http.ResponseWriter, r *http.Request) (time.Tim
 	}
 	if body.Before.IsZero() {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "before is required")
+		return time.Time{}, false
+	}
+	if err := validateRetentionCutoff(body.Before); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
 		return time.Time{}, false
 	}
 	// See the package doc's timezone note: re-express in this server's own process
@@ -143,6 +170,20 @@ func (h *AuditHandler) DeleteAnomalyAlertsBeforeProxy(w http.ResponseWriter, r *
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
+	}
+	// A zero value disables the corresponding clause (see the type doc) — only a
+	// genuinely-set field needs the future-cutoff bound.
+	if !body.AckBefore.IsZero() {
+		if err := validateRetentionCutoff(body.AckBefore); err != nil {
+			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "ack_before: "+err.Error())
+			return
+		}
+	}
+	if !body.UnackCeiling.IsZero() {
+		if err := validateRetentionCutoff(body.UnackCeiling); err != nil {
+			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "unack_ceiling: "+err.Error())
+			return
+		}
 	}
 	// See the package doc's timezone note. .Local() on an already-zero time.Time
 	// leaves it zero (IsZero() depends only on the represented instant, not the
@@ -395,6 +436,10 @@ func (h *UserHandler) ListUsersInStateBeforeProxy(w http.ResponseWriter, r *http
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "before must be an RFC3339 timestamp")
 		return
 	}
+	// Unlike every other route in this file, a future `before` here is legitimate:
+	// this is a READ (stale-account WARNING report), not a purge, and "list users
+	// who will still be in this state as of tomorrow" is valid usage — no
+	// "not in the future" bound applies (see TestListUsersInStateBeforeProxy_WithUsers_S11).
 	// See the package doc's timezone note.
 	rows, err := h.coreService.Storage().ListUsersInStateBefore(r.Context(), state, before.Local())
 	if err != nil {

--- a/server/http/handlers/scheduler_lock_proxy.go
+++ b/server/http/handlers/scheduler_lock_proxy.go
@@ -51,6 +51,14 @@ type schedulerLockAcquireBody struct {
 	TTLMillis int64  `json:"ttl_millis"`
 }
 
+// maxSchedulerLockTTLMillis bounds the caller-supplied lease TTL (#G44) — without
+// a ceiling, a caller can acquire a named scheduler lock with an effectively
+// unbounded TTL, starving every other replica's (or every future tick's) attempt
+// to acquire that SAME lock indefinitely. 1 hour comfortably exceeds every real
+// scheduler tick interval in this codebase (retention purge, auto-rotation,
+// recertification, etc. all tick far more often than hourly).
+const maxSchedulerLockTTLMillis = int64(time.Hour / time.Millisecond)
+
 // AcquireSchedulerLockProxy handles POST /api/v1/system/scheduler-lock/acquire.
 // It calls storage.TryAcquireSchedulerLock directly, so it performs the SAME
 // atomic acquire-or-renew-or-reclaim decision local_scheduler_lock_lease.go's
@@ -68,6 +76,10 @@ func (h *AuthHandler) AcquireSchedulerLockProxy(w http.ResponseWriter, r *http.R
 	}
 	if body.TTLMillis <= 0 {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "ttl_millis must be positive")
+		return
+	}
+	if body.TTLMillis > maxSchedulerLockTTLMillis {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "ttl_millis exceeds the maximum allowed lease duration")
 		return
 	}
 	acquired, err := h.coreService.Storage().TryAcquireSchedulerLock(r.Context(), body.Key, body.Holder, time.Duration(body.TTLMillis)*time.Millisecond)

--- a/server/http/handlers/secrets_bulk_delete.go
+++ b/server/http/handlers/secrets_bulk_delete.go
@@ -42,7 +42,7 @@ func (h *SecretHandler) BulkDeleteSecrets(w http.ResponseWriter, r *http.Request
 	result, err := h.coreService.BulkDeleteSecrets(r.Context(), req, uint(projectID), userCtx.Username, userCtx.UserID, ip, ua)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "required") {
+		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "exceeds the maximum batch size") {
 			status = http.StatusBadRequest
 		}
 		h.sendError(w, "Error", err.Error(), status, nil)

--- a/server/http/handlers/secrets_bulk_rename.go
+++ b/server/http/handlers/secrets_bulk_rename.go
@@ -43,7 +43,7 @@ func (h *SecretHandler) BulkRenameSecrets(w http.ResponseWriter, r *http.Request
 	report, err := h.coreService.BulkRenameSecrets(r.Context(), uint(id), reqBody.Renames, reqBody.DryRun, userCtx.Username, userCtx.UserID, ip, ua)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "required") {
+		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "exceeds the maximum batch size") {
 			status = http.StatusBadRequest
 		}
 		h.sendError(w, "Error", err.Error(), status, nil)

--- a/server/http/handlers/secrets_bulk_rotate.go
+++ b/server/http/handlers/secrets_bulk_rotate.go
@@ -59,7 +59,7 @@ func (h *SecretHandler) BulkRotateSecrets(w http.ResponseWriter, r *http.Request
 	result, err := h.coreService.BulkRotateSecrets(r.Context(), req)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "required") {
+		if strings.Contains(err.Error(), "required") || strings.Contains(err.Error(), "exceeds the maximum batch size") {
 			status = http.StatusBadRequest
 		}
 		h.sendError(w, "Error", err.Error(), status, nil)


### PR DESCRIPTION
## Summary
Caller-controlled collection sizes, string lengths, and time-window parameters had no upper bound in ~32 independent places across the codebase, because there was no shared, enforced bounding/pagination convention — each caller had to remember its own cap, and many didn't even when a sibling field in the exact same struct/file did.

- **Foundational fix**: `clampPageSize` used to pass a negative page size straight through unchanged. GORM's `Limit(-1)` (or any negative) removes the LIMIT clause entirely, so a caller-controlled negative page size silently became an unbounded query. Negative input is now clamped to 0. `ListSecrets`/`ListUsers` were also missing the existing `clampPage` ceiling on the page NUMBER (deep-pagination DoS via a huge OFFSET), matching the audit-log listing's own established pattern.
- **Storage layer**: added a defense-in-depth `maxUnboundedListRows` ceiling to every `List*` method with no caller-supplied pagination at all. `GetBillingReport`'s caller-supplied `project_id` filter list is now capped before it's interpolated into a SQL IN-list.
- **Core layer**: `BulkDeleteSecrets`/`BulkRotateSecrets`/`BulkRenameSecrets` now reject an oversized ID/rename list before doing per-item storage work, matching the existing `maxBulkAccessRequestBatchSize` convention. `BulkRenameSecrets`' `new_name` now gets the mandatory 255-char cap that already applies at secret-create time. `UpdateAnomalyConfig` now bounds the ML/lookback knobs that directly drive per-scan detector cost. `MostAccessedSecrets`/`UnusedSecrets` now cap the lookback window. `GetBlastRadius`'s BFS was depth-bounded but not breadth-bounded — now capped, with truncation surfaced on the response rather than silently dropped.
- **Highest-severity member**: `SuspendInactiveUsers`'s `InactiveDays` had no upper bound — a large enough value overflows the int64 nanosecond Duration computed from it, wrapping to a NEGATIVE duration that lands the suspension threshold in the FUTURE, suspending every user in the deployment in one call. Now bounded at both the handler and core layer.
- **Handler layer**: the retention/purge/sweep proxies accepted an unbounded `before` cutoff — a caller could set it decades in the future and instantly purge every soft-deleted row or strip not-yet-expired grants system-wide. Bounded to a 24h future skew (generous enough for the existing test suite's own +1h "pre-emptive sweep" convention). Also bounded: scheduler-lock TTL, dashboard activity page number, groups page/id-list params.
- **MCP layer**: `keyorix_list_secrets` had no per-process call cap, unlike `keyorix_get_secret`'s existing `maxReads` — added an analogous `maxListCalls`/`KEYORIX_MCP_MAX_LIST_CALLS` cap (on by default).
- **CLI layer**: `keyorix run` injected ALL of a project's secrets as child-process env vars with no cap, risking exhausted CLI memory or an OS ARG_MAX overrun; now capped with a clear error.

Two members are deliberately left unfixed, each with a doc comment explaining why:
- `local_access_activity.go`'s `lastUserActivityByEventTypes` — a naive row cap would silently mis-report genuinely-dormant users as never-active, the exact bug its own existing comment already guards against.
- `permission_baseline.go`'s `GetPermissionBaseline` — a true N+1 whose cost scales with deployment size, not caller input; needs a batch-load restructuring, not a bound.

## Test plan
- [x] New/updated regression tests: `TestClampPageSize` (updated for the negative-input fix), `TestClampPageSize_NegativeNeverReachesGORMLimit`, `TestSuspendInactiveUsers_ExceedsMaxDays`, `TestBulkDeleteSecrets_ExceedsMaxBatchSize`, `TestPurgeDeletedSecretsBeforeProxy_FutureBefore_S13`, `TestDeleteAnomalyAlertsBeforeProxy_FutureAckBefore_S13`
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/core/... ./internal/storage/... ./internal/mcp/... ./internal/cli/run/... ./cmd/keyorix-mcp/... ./server/http/...` clean
- [x] `gosec -severity medium -exclude-generated ./...` clean on touched packages
- [x] `golangci-lint run` clean on touched packages