### PR TITLE
fix(security): surface truncation instead of reporting a capped result as complete (G24)

### DIFF
--- a/internal/core/blast_radius.go
+++ b/internal/core/blast_radius.go
@@ -37,6 +37,12 @@ type BlastRadiusReport struct {
 	Dependents       []BlastRadiusNode `json:"dependents"`
 	TotalImpact      int               `json:"total_impact"` // == len(Dependents)
 	MaxDepth         int               `json:"max_depth"`
+	// Truncated is true when the BFS hit its depth ceiling (maxDepth in blastBFS)
+	// while dependents still existed beyond it — TotalImpact/Dependents then
+	// reflect only the reachable-within-depth subset, not the true full impact
+	// (#G24: previously dropped entirely, so a capped result was indistinguishable
+	// from a genuinely complete one).
+	Truncated bool `json:"truncated"`
 }
 
 // blastBFSNode is an internal BFS traversal node.
@@ -47,11 +53,16 @@ type blastBFSNode struct {
 
 // blastBFS performs a bounded BFS over the dependents adjacency map starting
 // from rootID, returning nodes ordered by (depth, id). Max depth is 10.
-func blastBFS(rootID uint, adj map[uint][]uint) []blastBFSNode {
+// truncated is true when any node reached maxDepth — the BFS stops expanding a
+// node once it hits the ceiling, so a node's own further dependents (if any)
+// are never discovered; reaching the ceiling at all means the true tree MAY
+// extend further than what's returned (#G24 — conservative: flagged even if
+// that specific node turns out to have no further children, since "possibly
+// truncated" must never be silently reported as complete).
+func blastBFS(rootID uint, adj map[uint][]uint) (ordered []blastBFSNode, truncated bool) {
 	const maxDepth = 10
 	visited := map[uint]bool{rootID: true}
 	queue := []blastBFSNode{{id: rootID, depth: 0}}
-	var ordered []blastBFSNode
 
 	for len(queue) > 0 {
 		cur := queue[0]
@@ -65,6 +76,8 @@ func blastBFS(rootID uint, adj map[uint][]uint) []blastBFSNode {
 			ordered = append(ordered, next)
 			if next.depth < maxDepth {
 				queue = append(queue, next)
+			} else {
+				truncated = true
 			}
 		}
 	}
@@ -75,7 +88,7 @@ func blastBFS(rootID uint, adj map[uint][]uint) []blastBFSNode {
 		}
 		return ordered[i].id < ordered[j].id
 	})
-	return ordered
+	return ordered, truncated
 }
 
 // GetBlastRadius returns the full dependency tree downstream of secretID,
@@ -98,7 +111,7 @@ func (k *KeyorixCore) GetBlastRadius(ctx context.Context, secretID uint) (*Blast
 	edges = edgesWithinEnvironment(edges, info, source.EnvironmentID)
 
 	adj := dependentsAdjacency(edges)
-	ordered := blastBFS(secretID, adj)
+	ordered, truncated := blastBFS(secretID, adj)
 
 	maxDepthSeen := 0
 	nodes := make([]BlastRadiusNode, 0, len(ordered))
@@ -129,6 +142,7 @@ func (k *KeyorixCore) GetBlastRadius(ctx context.Context, secretID uint) (*Blast
 		Dependents:       nodes,
 		TotalImpact:      len(nodes),
 		MaxDepth:         maxDepthSeen,
+		Truncated:        truncated,
 	}, nil
 }
 

--- a/internal/core/blast_radius_test.go
+++ b/internal/core/blast_radius_test.go
@@ -212,6 +212,25 @@ func TestGetBlastRadius_MaxDepthRespected(t *testing.T) {
 	require.NoError(t, err)
 	assert.LessOrEqual(t, report.MaxDepth, 10,
 		"BFS must not exceed maxDepth=10, got %d", report.MaxDepth)
+	// #G24: hitting the depth ceiling with dependents still beyond it must be
+	// flagged — a capped result must never be silently reported as complete.
+	assert.True(t, report.Truncated, "depth-capped report must set Truncated")
+}
+
+// TestGetBlastRadius_NotTruncatedWhenWithinDepth is the #G24 counterpart: a
+// chain shorter than maxDepth must NOT be flagged as truncated.
+func TestGetBlastRadius_NotTruncatedWhenWithinDepth(t *testing.T) {
+	c, db := newBlastRadiusCore(t)
+	prev := mkBlastSecret(t, db, "root")
+	for i := 0; i < 3; i++ {
+		next := mkBlastSecret(t, db, "link")
+		mkBlastDep(t, db, next, prev)
+		prev = next
+	}
+
+	report, err := c.GetBlastRadius(context.Background(), 1)
+	require.NoError(t, err)
+	assert.False(t, report.Truncated)
 }
 
 func TestGetBlastRadius_RiskLevelCritical(t *testing.T) {

--- a/internal/core/permission_change_audit.go
+++ b/internal/core/permission_change_audit.go
@@ -51,6 +51,11 @@ type PermissionChangeReport struct {
 	Until   time.Time               `json:"until"`
 	Changes []PermissionChangeEvent `json:"changes"`
 	Total   int                     `json:"total"`
+	// Truncated is true when more matching events exist than the bounded limit
+	// returned — Changes/len(Changes) then reflect only the first page, not the
+	// true total (#G24: previously Total silently reported len(Changes), the
+	// truncated sample size, as if it were the real total).
+	Truncated bool `json:"truncated"`
 }
 
 // normPermChangeWindow normalises the since/until/limit parameters, filling in defaults.
@@ -146,7 +151,7 @@ func (k *KeyorixCore) GetPermissionChangeAudit(ctx context.Context, since, until
 		Page:      1,
 	}
 
-	events, _, err := k.storage.GetAuditLogs(ctx, filter)
+	events, total, err := k.storage.GetAuditLogs(ctx, filter)
 	if err != nil {
 		return nil, fmt.Errorf("permission_change_audit: query failed: %w", err)
 	}
@@ -157,9 +162,10 @@ func (k *KeyorixCore) GetPermissionChangeAudit(ctx context.Context, since, until
 	}
 
 	return &PermissionChangeReport{
-		Since:   since,
-		Until:   until,
-		Changes: changes,
-		Total:   len(changes),
+		Since:     since,
+		Until:     until,
+		Changes:   changes,
+		Total:     int(total),
+		Truncated: int64(len(changes)) < total,
 	}, nil
 }

--- a/internal/core/permission_change_audit_test.go
+++ b/internal/core/permission_change_audit_test.go
@@ -212,7 +212,12 @@ func TestGetPermissionChangeAudit_LimitApplied(t *testing.T) {
 
 	report, err := c.GetPermissionChangeAudit(ctx, now.Add(-time.Minute), now.Add(time.Minute), 3)
 	require.NoError(t, err)
-	assert.LessOrEqual(t, report.Total, 3)
+	// #G24: Total now reports the TRUE matching count (5), not the returned page
+	// size — Changes is what's capped at the requested limit, and Truncated
+	// signals the gap between them.
+	assert.LessOrEqual(t, len(report.Changes), 3)
+	assert.Equal(t, 5, report.Total)
+	assert.True(t, report.Truncated)
 }
 
 // TestGetPermissionChangeAudit_LimitExceedsMax — limit > 1000 is capped at 1000.

--- a/internal/core/project_health.go
+++ b/internal/core/project_health.go
@@ -20,6 +20,12 @@ type ProjectHealthSummary struct {
 	MediumRiskCount int                `json:"medium_risk_count"`
 	LowRiskCount    int                `json:"low_risk_count"`
 	TopRiskSecrets  []*SecretRiskScore `json:"secrets"`
+	// Truncated is true when the project has more secrets than the bounded
+	// PageSize below fetched — TotalSecrets and the risk-band counts then
+	// reflect only the fetched sample, not the project's true secret count
+	// (#G24: previously TotalSecrets silently reported the truncated sample
+	// size as if it were the real total).
+	Truncated bool `json:"truncated"`
 }
 
 const (
@@ -37,7 +43,7 @@ func (c *KeyorixCore) GetProjectHealthSummary(ctx context.Context, projectID uin
 
 	// Fetch ALL secrets for the project (no paging — admin function).
 	trueVal := true
-	secrets, _, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+	secrets, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
 		ProjectID: &projectID,
 		IsSecret:  &trueVal,
 		PageSize:  maxHealthLimit * 10, // generous upper bound; health is a bounded admin view
@@ -46,6 +52,7 @@ func (c *KeyorixCore) GetProjectHealthSummary(ctx context.Context, projectID uin
 	if err != nil {
 		return nil, fmt.Errorf("list secrets: %w", err)
 	}
+	truncated := int64(len(secrets)) < total
 
 	// Collect all IDs in one pass.
 	ids := make([]uint, 0, len(secrets))
@@ -90,10 +97,11 @@ func (c *KeyorixCore) GetProjectHealthSummary(ctx context.Context, projectID uin
 
 	return &ProjectHealthSummary{
 		ProjectID:       projectID,
-		TotalSecrets:    len(secrets),
+		TotalSecrets:    int(total),
 		HighRiskCount:   highN,
 		MediumRiskCount: medN,
 		LowRiskCount:    lowN,
 		TopRiskSecrets:  top,
+		Truncated:       truncated,
 	}, nil
 }

--- a/internal/core/project_health_test.go
+++ b/internal/core/project_health_test.go
@@ -239,6 +239,31 @@ func TestGetProjectHealthSummary_LimitClamping(t *testing.T) {
 	assert.LessOrEqual(t, len(summary.TopRiskSecrets), 20, "limit=200 should clamp to defaultHealthLimit=20")
 }
 
+// TestGetProjectHealthSummary_Truncated is the #G24 regression: before the fix,
+// TotalSecrets silently reported len(secrets) (the fetched, possibly-capped
+// sample) as if it were the project's true secret count. ListSecrets' own real
+// total (its second return value) was discarded. Uses MockStorage to simulate a
+// project with more secrets (1500) than the fetch returns (0, so
+// ComputeSecretRiskScoresBatch short-circuits on empty input) — TotalSecrets
+// must reflect the TRUE total and Truncated must be set.
+func TestGetProjectHealthSummary_Truncated(t *testing.T) {
+	const proj = uint(9)
+	ctx := context.Background()
+
+	ms := &MockStorage{}
+	ms.On("ListSecrets", ctx, mock.MatchedBy(func(f *storage.SecretFilter) bool {
+		return f.ProjectID != nil && *f.ProjectID == proj
+	})).Return([]*models.SecretNode{}, int64(1500), nil)
+
+	c := &KeyorixCore{storage: ms, now: time.Now}
+	summary, err := c.GetProjectHealthSummary(ctx, proj, 20)
+	require.NoError(t, err)
+	assert.Equal(t, 1500, summary.TotalSecrets, "TotalSecrets must be the real total, not the fetched sample size")
+	assert.True(t, summary.Truncated)
+
+	ms.AssertExpectations(t)
+}
+
 // TestGetProjectHealthSummary_ListSecretsError verifies that a storage failure
 // on ListSecrets propagates as an error rather than producing a partial result.
 func TestGetProjectHealthSummary_ListSecretsError(t *testing.T) {

--- a/internal/core/project_stats.go
+++ b/internal/core/project_stats.go
@@ -42,6 +42,12 @@ type ProjectStats struct {
 	ClassificationCounts map[string]int `json:"classification_counts"`
 
 	ComputedAt time.Time `json:"computed_at"`
+
+	// Truncated is true when the project has more live secrets than the 50 000-row
+	// cap ListLiveSecretNamesByProject applied — TotalSecrets/ClassificationCounts
+	// then reflect only the fetched sample, not the project's true secret count
+	// (#G24: previously the storage layer's own truncation flag was discarded).
+	Truncated bool `json:"truncated"`
 }
 
 // GetProjectStats computes statistics for a project by querying existing storage
@@ -69,11 +75,12 @@ func (c *KeyorixCore) GetProjectStats(ctx context.Context, projectID uint) (*Pro
 	// ListLiveSecretNamesByProject returns one row per live secret with enough
 	// metadata for classification bucketing and ID cross-referencing (anomaly
 	// lookup). Cap at 50 000 to bound memory on very large projects.
-	nameRows, _, err := c.storage.ListLiveSecretNamesByProject(ctx, []uint{projectID}, 50_000)
+	nameRows, truncated, err := c.storage.ListLiveSecretNamesByProject(ctx, []uint{projectID}, 50_000)
 	if err != nil {
 		return nil, fmt.Errorf("list project secret names: %w", err)
 	}
 	out.TotalSecrets = len(nameRows)
+	out.Truncated = truncated
 	classCounts, secretIDs := buildClassificationCounts(nameRows)
 	out.ClassificationCounts = classCounts
 

--- a/internal/core/secret_expiring.go
+++ b/internal/core/secret_expiring.go
@@ -24,9 +24,13 @@ const (
 // ListExpiringSecrets returns the project's secrets whose expiration falls before
 // now+window (already-expired included), soonest-first. `withinDays` is clamped to
 // [1, maxExpiringWindowDays]; non-positive falls back to the default. Metadata only.
-func (c *KeyorixCore) ListExpiringSecrets(ctx context.Context, projectID uint, withinDays int) ([]*models.SecretNode, error) {
+// truncated is true when more matching secrets exist than expiringScanPageSize —
+// the storage layer orders by expiration ascending before applying the cap (#G24),
+// so a truncated result is still correctly prioritized (the N soonest-expiring,
+// not an arbitrary N), but callers must still know it isn't the complete set.
+func (c *KeyorixCore) ListExpiringSecrets(ctx context.Context, projectID uint, withinDays int) (secrets []*models.SecretNode, truncated bool, err error) {
 	if projectID == 0 {
-		return nil, fmt.Errorf("project ID is required")
+		return nil, false, fmt.Errorf("project ID is required")
 	}
 	if withinDays <= 0 {
 		withinDays = defaultExpiringWindowDays
@@ -36,22 +40,24 @@ func (c *KeyorixCore) ListExpiringSecrets(ctx context.Context, projectID uint, w
 	}
 	cutoff := c.now().Add(time.Duration(withinDays) * 24 * time.Hour)
 
-	secrets, _, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+	secrets, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
 		ProjectID:     &projectID,
 		ExpiresBefore: &cutoff,
 		Page:          1,
 		PageSize:      expiringScanPageSize,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return nil, false, fmt.Errorf("%w", err)
 	}
-	// Soonest expiration first (already-expired lead). A returned row always has a
-	// non-nil Expiration (the filter requires it), but guard defensively.
+	// Soonest expiration first (already-expired lead). Storage now orders by
+	// expiration ASC too, so this is a stable re-affirmation, not the sole
+	// ordering guarantee. A returned row always has a non-nil Expiration (the
+	// filter requires it), but guard defensively.
 	sort.SliceStable(secrets, func(i, j int) bool {
 		if secrets[i].Expiration == nil || secrets[j].Expiration == nil {
 			return secrets[j].Expiration != nil
 		}
 		return secrets[i].Expiration.Before(*secrets[j].Expiration)
 	})
-	return secrets, nil
+	return secrets, int64(len(secrets)) < total, nil
 }

--- a/internal/core/secret_expiring_test.go
+++ b/internal/core/secret_expiring_test.go
@@ -55,27 +55,30 @@ func TestListExpiringSecrets(t *testing.T) {
 	_ = mk("other", p2.ID, e2.ID, &soon) // different project
 
 	t.Run("lists expiring/expired within the window, soonest-first, project-scoped", func(t *testing.T) {
-		got, err := c.ListExpiringSecrets(ctx, p.ID, 30)
+		got, truncated, err := c.ListExpiringSecrets(ctx, p.ID, 30)
 		require.NoError(t, err)
 		require.Len(t, got, 2, "expired + soon; far/never/other-project excluded")
 		assert.Equal(t, expiredID, got[0].ID, "already-expired leads")
 		assert.Equal(t, soonID, got[1].ID)
+		assert.False(t, truncated)
 	})
 
 	t.Run("a wider window includes the far one", func(t *testing.T) {
-		got, err := c.ListExpiringSecrets(ctx, p.ID, 200)
+		got, truncated, err := c.ListExpiringSecrets(ctx, p.ID, 200)
 		require.NoError(t, err)
 		assert.Len(t, got, 3)
+		assert.False(t, truncated)
 	})
 
 	t.Run("a project ID of zero is rejected", func(t *testing.T) {
-		_, err := c.ListExpiringSecrets(ctx, 0, 30)
+		_, _, err := c.ListExpiringSecrets(ctx, 0, 30)
 		require.Error(t, err)
 	})
 
 	t.Run("non-positive window falls back to the default (30d)", func(t *testing.T) {
-		got, err := c.ListExpiringSecrets(ctx, p.ID, 0)
+		got, truncated, err := c.ListExpiringSecrets(ctx, p.ID, 0)
 		require.NoError(t, err)
 		assert.Len(t, got, 2)
+		assert.False(t, truncated)
 	})
 }

--- a/internal/core/secret_extend_expiring.go
+++ b/internal/core/secret_extend_expiring.go
@@ -19,10 +19,13 @@ const defaultExtendWindowDays = 90
 // number extended. A secret whose current expiration is already later than the new one
 // is left untouched (this only ever pushes expiry out, never pulls it in). Best-effort:
 // a per-secret update failure is skipped so one bad row doesn't abort the rest. Each
-// renewal is audited as secret.updated.
-func (c *KeyorixCore) ExtendExpiringSecrets(ctx context.Context, projectID uint, withinDays, newWindowDays int, actor string, actorID uint) (int, error) {
+// renewal is audited as secret.updated. truncated is true when more secrets matched
+// the window than ListExpiringSecrets returned (#G24) — the sweep still renews the
+// soonest-expiring ones first (storage orders by expiration ascending), but a caller
+// with more matching secrets than the scan cap must know not every one was renewed.
+func (c *KeyorixCore) ExtendExpiringSecrets(ctx context.Context, projectID uint, withinDays, newWindowDays int, actor string, actorID uint) (extended int, truncated bool, err error) {
 	if projectID == 0 || actorID == 0 {
-		return 0, fmt.Errorf("project ID and actor ID are required")
+		return 0, false, fmt.Errorf("project ID and actor ID are required")
 	}
 	if newWindowDays <= 0 {
 		newWindowDays = defaultExtendWindowDays
@@ -32,12 +35,11 @@ func (c *KeyorixCore) ExtendExpiringSecrets(ctx context.Context, projectID uint,
 	}
 	newExpiry := c.now().Add(time.Duration(newWindowDays) * 24 * time.Hour)
 
-	secrets, err := c.ListExpiringSecrets(ctx, projectID, withinDays)
+	secrets, truncated, err := c.ListExpiringSecrets(ctx, projectID, withinDays)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 
-	extended := 0
 	for _, s := range secrets {
 		// Re-check per-secret write authorization (owner/share). The project-wide
 		// secrets.write route gate is not sufficient on its own — the single-secret PUT
@@ -57,5 +59,5 @@ func (c *KeyorixCore) ExtendExpiringSecrets(ctx context.Context, projectID uint,
 		c.LogSecretUpdatedWithProject(ctx, actorID, s.ID, projectID, actor, s.Name, "", "")
 		extended++
 	}
-	return extended, nil
+	return extended, truncated, nil
 }

--- a/internal/core/secret_extend_expiring_test.go
+++ b/internal/core/secret_extend_expiring_test.go
@@ -54,9 +54,10 @@ func TestExtendExpiringSecrets(t *testing.T) {
 	neverID := mk("never", nil) // no expiry — untouched
 
 	t.Run("renews expiring/expired secrets to now+window, leaves others", func(t *testing.T) {
-		n, err := c.ExtendExpiringSecrets(ctx, p.ID, 30, 90, "admin", 1)
+		n, truncated, err := c.ExtendExpiringSecrets(ctx, p.ID, 30, 90, "admin", 1)
 		require.NoError(t, err)
 		assert.Equal(t, 2, n, "expired + soon renewed; far + never untouched")
+		assert.False(t, truncated)
 
 		want := now.Add(90 * 24 * time.Hour)
 		get := func(id uint) *models.SecretNode {
@@ -73,9 +74,9 @@ func TestExtendExpiringSecrets(t *testing.T) {
 	})
 
 	t.Run("a project ID or actor ID of zero is rejected", func(t *testing.T) {
-		_, err := c.ExtendExpiringSecrets(ctx, 0, 30, 90, "admin", 1)
+		_, _, err := c.ExtendExpiringSecrets(ctx, 0, 30, 90, "admin", 1)
 		require.Error(t, err)
-		_, err = c.ExtendExpiringSecrets(ctx, p.ID, 30, 90, "admin", 0)
+		_, _, err = c.ExtendExpiringSecrets(ctx, p.ID, 30, 90, "admin", 0)
 		require.Error(t, err)
 	})
 }

--- a/internal/core/secret_name_conformance.go
+++ b/internal/core/secret_name_conformance.go
@@ -33,6 +33,11 @@ type SecretNameConformanceReport struct {
 	MaxLength     int                   `json:"max_length,omitempty"`
 	TotalSecrets  int                   `json:"total_secrets"`
 	Violations    []SecretNameViolation `json:"violations"`
+	// Truncated reports whether secretInventoryMaxRows was hit, i.e. the project
+	// has more secrets than were scanned — TotalSecrets/Violations then reflect
+	// only the scanned sample (#G24: matches the deployment-wide sibling's own
+	// Truncated field, which this per-project report previously lacked).
+	Truncated bool `json:"truncated,omitempty"`
 }
 
 // SecretNameConformance scans every live secret in the project (folders excluded) and
@@ -56,12 +61,13 @@ func (c *KeyorixCore) SecretNameConformance(ctx context.Context, projectID uint)
 		return report, nil
 	}
 
-	secrets, _, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
+	secrets, total, err := c.storage.ListSecrets(ctx, &storage.SecretFilter{
 		ProjectID: &projectID, Page: 1, PageSize: secretInventoryMaxRows,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list secrets: %w", err)
 	}
+	report.Truncated = int64(len(secrets)) < total
 
 	for _, s := range secrets {
 		if !s.IsSecret {

--- a/internal/core/secret_name_conformance_test.go
+++ b/internal/core/secret_name_conformance_test.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -96,4 +98,31 @@ func TestSecretNameConformance(t *testing.T) {
 		_, err := c.SecretNameConformance(ctx, 0)
 		require.Error(t, err)
 	})
+}
+
+// TestSecretNameConformance_Truncated is the #G24 regression: before the fix,
+// the per-project report discarded ListSecrets' real total (its second return
+// value), unlike its deployment-wide sibling (secret_name_conformance_deployment.go)
+// which already surfaces a Truncated flag. Uses MockStorage to simulate a
+// project with more secrets (5000) than the scan cap returned (0).
+func TestSecretNameConformance_Truncated(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	const proj = uint(9)
+	ctx := context.Background()
+
+	ms := &MockStorage{}
+	ms.On("ListSecrets", ctx, mock.MatchedBy(func(f *storage.SecretFilter) bool {
+		return f.ProjectID != nil && *f.ProjectID == proj
+	})).Return([]*models.SecretNode{}, int64(5000), nil)
+
+	c := &KeyorixCore{storage: ms, now: time.Now}
+	require.NoError(t, c.SetSecretNamePolicy(SecretNamePolicy{
+		Enabled: true, Pattern: "^[A-Z][A-Z0-9_]*$", MaxLength: 64,
+	}))
+
+	rep, err := c.SecretNameConformance(ctx, proj)
+	require.NoError(t, err)
+	assert.True(t, rep.Truncated)
+
+	ms.AssertExpectations(t)
 }

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -649,6 +649,13 @@ func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretF
 	}
 	if filter.ExpiresBefore != nil {
 		query = query.Where("secret_nodes.expiration IS NOT NULL AND secret_nodes.expiration < ?", *filter.ExpiresBefore)
+		// #G24: order soonest-expiring first so a capped PageSize returns the
+		// TRUE most-urgent rows, not an arbitrary unordered slice truncated to
+		// whatever page happened to be returned — callers filtering by expiry
+		// (ListExpiringSecrets) need the returned page to be exactly "the N
+		// secrets closest to expiring", not "N secrets that happen to expire
+		// before the cutoff" in no particular order.
+		query = query.Order("secret_nodes.expiration ASC")
 	}
 	if filter.Classification != nil {
 		if *filter.Classification == "unclassified" {

--- a/server/http/handlers/permission_change_audit_test.go
+++ b/server/http/handlers/permission_change_audit_test.go
@@ -186,7 +186,7 @@ func TestGetPermissionChangeAudit_LimitParam(t *testing.T) {
 		Data struct {
 			Total     int                      `json:"total"`
 			Changes   []map[string]interface{} `json:"changes"`
-			Truncated bool                      `json:"truncated"`
+			Truncated bool                     `json:"truncated"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))

--- a/server/http/handlers/permission_change_audit_test.go
+++ b/server/http/handlers/permission_change_audit_test.go
@@ -184,11 +184,17 @@ func TestGetPermissionChangeAudit_LimitParam(t *testing.T) {
 
 	var resp struct {
 		Data struct {
-			Total int `json:"total"`
+			Total     int                      `json:"total"`
+			Changes   []map[string]interface{} `json:"changes"`
+			Truncated bool                      `json:"truncated"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-	assert.LessOrEqual(t, resp.Data.Total, 2)
+	// #G24: total now reports the TRUE matching count (5), not the returned page
+	// size — changes is what's capped at the requested limit.
+	assert.LessOrEqual(t, len(resp.Data.Changes), 2)
+	assert.Equal(t, 5, resp.Data.Total)
+	assert.True(t, resp.Data.Truncated)
 }
 
 // TestGetPermissionChangeAudit_StorageError_500 — storage failure → 500.

--- a/server/http/handlers/secrets_expiring.go
+++ b/server/http/handlers/secrets_expiring.go
@@ -41,7 +41,7 @@ func (h *SecretHandler) ExpiringSecrets(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	secrets, err := h.coreService.ListExpiringSecrets(r.Context(), uint(id), days)
+	secrets, truncated, err := h.coreService.ListExpiringSecrets(r.Context(), uint(id), days)
 	if err != nil {
 		h.sendError(w, "InternalError", "Failed to list expiring secrets", http.StatusInternalServerError, nil)
 		return
@@ -59,5 +59,9 @@ func (h *SecretHandler) ExpiringSecrets(w http.ResponseWriter, r *http.Request) 
 		}
 		entries = append(entries, e)
 	}
-	h.sendSuccess(w, map[string]interface{}{"expiring": entries, "total": len(entries)}, "")
+	// #G24: "total" reflects the returned sample size, not necessarily the true
+	// count of matching secrets — "truncated" tells the caller/UI whether more
+	// exist beyond expiringScanPageSize (soonest-expiring are still guaranteed
+	// to be included, since storage orders by expiration ascending).
+	h.sendSuccess(w, map[string]interface{}{"expiring": entries, "total": len(entries), "truncated": truncated}, "")
 }

--- a/server/http/handlers/secrets_extend_expiring.go
+++ b/server/http/handlers/secrets_extend_expiring.go
@@ -40,7 +40,7 @@ func (h *SecretHandler) ExtendExpiringSecrets(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	n, err := h.coreService.ExtendExpiringSecrets(r.Context(), uint(id), reqBody.WithinDays, reqBody.NewWindowDays, userCtx.Username, userCtx.UserID)
+	n, truncated, err := h.coreService.ExtendExpiringSecrets(r.Context(), uint(id), reqBody.WithinDays, reqBody.NewWindowDays, userCtx.Username, userCtx.UserID)
 	if err != nil {
 		status := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "required") {
@@ -49,5 +49,8 @@ func (h *SecretHandler) ExtendExpiringSecrets(w http.ResponseWriter, r *http.Req
 		h.sendError(w, "Error", err.Error(), status, nil)
 		return
 	}
-	h.sendSuccess(w, map[string]interface{}{"extended": n}, "")
+	// #G24: "truncated" tells the caller more secrets matched the window than the
+	// scan cap covered — the soonest-expiring ones were still renewed first
+	// (storage orders by expiration ascending), but not every matching secret was.
+	h.sendSuccess(w, map[string]interface{}{"extended": n, "truncated": truncated}, "")
 }


### PR DESCRIPTION
## Summary
Multiple reporting/listing functions silently capped result size and either dropped the truncation flag their own data source already provided, or reported the truncated sample size AS the true total — so downstream dashboards, compliance exports, and prioritization logic couldn't distinguish a capped result from a complete one.

- `GetProjectHealthSummary`: `TotalSecrets` reported `len(secrets)` (the fetched, possibly-capped sample) instead of `ListSecrets`' own real total (its second return value, previously discarded). Now uses the real total and adds a `Truncated` field.
- `GetPermissionChangeAudit`: `Total` fabricated `len(changes)` the same way, discarding `GetAuditLogs`' real total. Same fix.
- `GetProjectStats`: `ListLiveSecretNamesByProject` already returns an explicit `truncated` bool — it was discarded entirely. Now captured into a new `ProjectStats.Truncated` field.
- `ListExpiringSecrets`: capped at 500 rows with no ordering at the SQL level, so a truncated result wasn't even guaranteed to be the N soonest-expiring secrets — an operator with >500 matching secrets could see arbitrary rows while the genuinely most-urgent ones were silently dropped. `storage.ListSecrets` now orders by expiration ascending whenever `ExpiresBefore` is set (safe for every other caller of that filter — none currently depends on a different order), and `ListExpiringSecrets`/`ExtendExpiringSecrets`/their two HTTP handler siblings (`secrets_expiring.go`, `secrets_extend_expiring.go`) all now return/surface a truncated flag.
- `SecretNameConformance` (per-project): silently truncated at `secretInventoryMaxRows`, unlike its deployment-wide sibling (`secret_name_conformance_deployment.go`) which already has a `Truncated` field. Brought in line with the same convention.
- `GetBlastRadius`: the BFS hard-caps at depth 10 with no signal that dependents may exist beyond it. `blastBFS` now reports whether the depth ceiling was ever reached, surfaced as `BlastRadiusReport.Truncated`.

Two existing tests encoded the old buggy semantics (asserting `Total <= limit`, which only held because `Total` was fabricated as the capped sample size) — updated to assert the real total plus the new `Truncated` flag instead.

**Note**: this PR and #1404 (G44) both touch `internal/core/blast_radius.go` and `internal/storage/store/local_secrets.go` — expect a straightforward merge conflict resolution whichever merges second (G44 adds a breadth cap + `Truncated` for that; this PR adds depth-cap truncation detection — the two `Truncated` computations combine with an `||`).

## Test plan
- [x] New/updated regression tests: `TestGetBlastRadius_MaxDepthRespected` (now asserts `Truncated`), `TestGetBlastRadius_NotTruncatedWhenWithinDepth`, `TestGetProjectHealthSummary_Truncated`, `TestSecretNameConformance_Truncated`, `TestGetPermissionChangeAudit_LimitApplied`/`TestGetPermissionChangeAudit_LimitParam` (updated to assert the real total + truncated flag)
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/core/... ./internal/storage/... ./server/http/...` clean
- [x] `gosec -severity medium -exclude-generated ./...` clean on touched packages
- [x] `golangci-lint run` clean on touched packages