### PR TITLE
fix(grpc): preserve context.Canceled through StreamAuditLogs drain errors

### DIFF
--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -370,6 +370,9 @@ func (s *AuditGRPCService) StreamAuditLogs(req *pb.StreamAuditLogsRequest, strea
 				ProjectID: optUint(req.ProjectId),
 			})
 			if err != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
 				return status.Error(codes.Internal, "failed to read audit logs")
 			}
 			if len(events) == 0 {

--- a/server/grpc/services/audit_stream_test.go
+++ b/server/grpc/services/audit_stream_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -203,6 +204,7 @@ func TestAuditService_StreamAuditLogs_MaxConcurrentPerPrincipal(t *testing.T) {
 		}
 	})
 
+	streamKey := fmt.Sprintf("%s:%d", core.ActorTypeUser, 1)
 	for i := 0; i < auditStreamMaxPerPrincipal; i++ {
 		ctx, cancel := context.WithCancel(authCtx(1, "admin", "audit.read"))
 		cancels = append(cancels, cancel)
@@ -210,9 +212,17 @@ func TestAuditService_StreamAuditLogs_MaxConcurrentPerPrincipal(t *testing.T) {
 		done := make(chan error, 1)
 		dones = append(dones, done)
 		go func() { done <- svc.StreamAuditLogs(&pb.StreamAuditLogsRequest{}, stream) }()
-		// Give StreamAuditLogs time to reach acquireStreamSlot and register before the
-		// next iteration opens another one.
-		time.Sleep(10 * time.Millisecond)
+		// Wait for this iteration's stream to actually register its slot in
+		// acquireStreamSlot before opening the next one — a fixed sleep here is
+		// racy under CI load (if the goroutine hasn't reached acquireStreamSlot
+		// yet, the cap check below can undercount and let an over-cap stream
+		// through, which then blocks forever with nothing left to cancel it).
+		wantCount := i + 1
+		require.Eventually(t, func() bool {
+			svc.streamCountsMu.Lock()
+			defer svc.streamCountsMu.Unlock()
+			return svc.streamCounts[streamKey] >= wantCount
+		}, time.Second, time.Millisecond, "stream %d did not register its slot in time", i)
 	}
 
 	// One more, over the cap, must be refused immediately.


### PR DESCRIPTION
## Summary
- `drain()` inside `StreamAuditLogs` always converted a `GetAuditLogs` error into a generic `status.Error(codes.Internal, "failed to read audit logs")`, discarding the underlying error.
- When client-context cancellation raced with an in-flight `drain()` call (triggered by the fallback/wake tickers), the DB layer surfaces a `context canceled` error, but it got swallowed into the opaque Internal status instead of propagating as `context.Canceled`.
- This is the root cause of the intermittent CI failures in `TestAuditService_StreamAuditLogs_TailsNewEvents` (`Target error should be in err chain: expected "context canceled", in chain: "rpc error: code = Internal desc = failed to read audit logs"`), which has been hitting unrelated PRs (#1394, #1402, #1395) since it's a pre-existing bug on `main`.
- Fix: check `ctx.Err()` first and propagate it directly when set, falling back to the generic Internal status only for genuine read failures.

## Test plan
- [x] `go test ./server/grpc/services/... -run TestAuditService_StreamAuditLogs -v` — all pass
- [x] `go test ./server/grpc/services/... -race -run TestAuditService_StreamAuditLogs` — clean
- [x] `go build ./server/grpc/services/...`, `go vet ./server/grpc/services/...`, `gofmt -l` — clean