### PR TITLE
fix(security): evict impersonation sessions from auth cache on revocation (G06)

### DIFF
--- a/internal/core/account_sessions.go
+++ b/internal/core/account_sessions.go
@@ -26,11 +26,19 @@ func (c *KeyorixCore) RevokeUserSessions(ctx context.Context, adminID, userID ui
 		return 0, fmt.Errorf("user not found: %w", err)
 	}
 
-	sessions, err := c.storage.ListSessionsByUser(ctx, userID)
+	// #G06: the eviction list must be built from the SAME (user_id=? OR
+	// impersonated_by=?) predicate DeleteSessionsForUserExcept below actually
+	// deletes with — ListSessionsByUser only matches user_id, so a session this
+	// user STARTED as an impersonator (impersonated_by = userID) was deleted from
+	// the DB but never evicted from the auth cache, leaving it live until the
+	// positive-cache TTL expired. ListSessionTokenHashesForUser already unions
+	// both predicates (it backs the same eviction need on other state-change
+	// paths) and returns the exact session_token hashes invalidateTokenCache needs.
+	tokens, err := c.storage.ListSessionTokenHashesForUser(ctx, userID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to list sessions: %w", err)
 	}
-	n := len(sessions)
+	n := len(tokens)
 	// exceptID 0 matches no session, so this drops them all.
 	if err := c.storage.DeleteSessionsForUserExcept(ctx, userID, 0); err != nil {
 		return 0, fmt.Errorf("failed to revoke sessions: %w", err)
@@ -39,9 +47,7 @@ func (c *KeyorixCore) RevokeUserSessions(ctx context.Context, adminID, userID ui
 	// authenticating on the NEXT request instead of lingering for the positive-cache TTL
 	// — this is the incident-response control, so the residual window matters. The stored
 	// session_token IS the SHA-256 cache key.
-	for _, s := range sessions {
-		c.invalidateTokenCache(s.SessionToken)
-	}
+	c.invalidateTokenCache(tokens...)
 
 	aid := adminID
 	c.writeAuditEventFull(ctx, EventUserSessionsRevoked, &aid, nil, nil, "",

--- a/internal/core/account_sessions_test.go
+++ b/internal/core/account_sessions_test.go
@@ -88,3 +88,50 @@ func TestRevokeUserSessions(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// TestRevokeUserSessions_EvictsImpersonationSessionsStarted is the #G06
+// regression: RevokeUserSessions used to build its auth-cache eviction list
+// from ListSessionsByUser (user_id = ? only), while the actual DB deletion
+// (DeleteSessionsForUserExcept) also removes sessions the user STARTED as an
+// impersonator (impersonated_by = ?). A revoked admin's own impersonation
+// session was deleted from the DB but never evicted from the cache, leaving
+// it live — authenticating on the fast path — until the positive-cache TTL
+// expired.
+func TestRevokeUserSessions_EvictsImpersonationSessionsStarted(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "a@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "target", Email: "t@t.com"}).Error)
+
+	adminID := uint(1)
+	// The admin's own session.
+	require.NoError(t, db.Create(&models.Session{ID: 20, UserID: 1, SessionToken: "admin-own", CreatedAt: time.Now()}).Error)
+	// A session issued FOR the target user, STARTED by the admin impersonating them —
+	// UserID is the target's, ImpersonatedBy is the admin's.
+	require.NoError(t, db.Create(&models.Session{
+		ID: 21, UserID: 2, SessionToken: "admin-impersonating-target",
+		ImpersonatedBy: &adminID, CreatedAt: time.Now(),
+	}).Error)
+
+	var evicted []string
+	c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+	n, err := c.RevokeUserSessions(ctx, 1, 1) // revoke the admin's own sessions
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "both the admin's own session and the impersonation session it started")
+
+	assert.ElementsMatch(t, []string{"admin-own", "admin-impersonating-target"}, evicted,
+		"the impersonation session must be evicted from the auth cache, not just deleted from the DB")
+
+	// Both rows are actually gone from the DB too.
+	var remaining int64
+	require.NoError(t, db.Model(&models.Session{}).Where("id IN ?", []uint{20, 21}).Count(&remaining).Error)
+	assert.Equal(t, int64(0), remaining)
+}


### PR DESCRIPTION
## Summary
`RevokeUserSessions` built its HTTP auth-cache eviction list from `ListSessionsByUser` (`user_id = ?` only), while the actual DB deletion (`DeleteSessionsForUserExcept`) also removes sessions the target user STARTED as an impersonator (`impersonated_by = ?`) — the eviction list and the deletion list were built from two different queries the author assumed were equivalent. A revoked admin's own impersonation session was deleted from the database but never evicted from the cache, leaving it live — authenticating on the fast path — until the positive-cache TTL expired.

Switched the eviction list to `ListSessionTokenHashesForUser`, which already unions `(user_id = ? OR impersonated_by = ?)` for exactly this purpose (it already backs auth-cache eviction on other state-change paths) and returns the session_token hashes directly, matching `invalidateTokenCache`'s variadic signature. The revoked-session count now reflects both sets too, fixing a related under-count when impersonation sessions existed.

`ListSessionsByUser` itself is left unchanged — its one other caller, `ListOwnSessions` ("list my active sessions"), correctly wants only sessions belonging to the user, not sessions they started while impersonating someone else.

## Test plan
- [x] New regression test `TestRevokeUserSessions_EvictsImpersonationSessionsStarted` — revokes an admin's sessions, seeds an impersonation session they started, asserts both the DB deletion AND the cache eviction cover it
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/core/... ./internal/storage/... ./server/...` clean
- [x] `gosec -severity medium -exclude-generated ./...` clean
- [x] `golangci-lint run` clean