### PR TITLE
fix(security): Wave 3 remediation batch — 17 root-cause groups

### DIFF
--- a/cmd/system/fixfileperm.go
+++ b/cmd/system/fixfileperm.go
@@ -2,34 +2,77 @@ package system
 
 import (
 	"fmt"
-	"log"
+	"os"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
+	"github.com/keyorixhq/keyorix/internal/startup"
 	"github.com/spf13/cobra"
 )
+
+// fixFilePermConfigFile mirrors audit.go's --config flag: an empty default
+// defers to config.Load's own resolution order (KEYORIX_CONFIG_PATH env var,
+// then "keyorix.yaml") rather than baking in a literal filename that silently
+// diverges from --config / KEYORIX_CONFIG_PATH on any non-default deployment.
+var fixFilePermConfigFile string
 
 var FixFilePermCmd = &cobra.Command{
 	Use:   "fixfileperm",
 	Short: "Fix file permissions on critical files (config, salt, DEK)",
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg, err := config.Load("keyorix.yaml")
-		if err != nil {
-			log.Fatalf("Failed to load config: %v", err)
-		}
-
-		files := []securefiles.FilePermSpec{
-			{Path: cfg.Storage.Encryption.SaltPath, Mode: 0600},
-			{Path: cfg.Storage.Encryption.DEKPath, Mode: 0600},
-			{Path: "keyorix.yaml", Mode: 0600},
-		}
-
-		// fix permissions: autofix = true
-		err = securefiles.FixFilePerms(files, true)
-		if err != nil {
-			fmt.Printf("❌ Failed to fix file permissions: %v\n", err)
-		} else {
-			fmt.Println("✅ All file permissions fixed successfully")
-		}
+		runFixFilePerm()
 	},
+}
+
+func init() {
+	FixFilePermCmd.Flags().StringVar(&fixFilePermConfigFile, "config", "", "Path to config file (defaults to $KEYORIX_CONFIG_PATH or keyorix.yaml)")
+}
+
+func runFixFilePerm() {
+	if runFixFilePermNoExit() {
+		os.Exit(1)
+	}
+}
+
+// runFixFilePermNoExit performs the fix and reports the outcome on stdout,
+// returning true if it failed. Splitting this out from runFixFilePerm lets
+// tests exercise the real config-path resolution and path-sanitization logic
+// (including a deliberate failure) without a failing case tearing down the
+// test binary — mirrors runAuditNoExit in audit.go.
+func runFixFilePermNoExit() bool {
+	resolvedPath := config.ResolvedPath(fixFilePermConfigFile)
+	cfg, err := config.Load(fixFilePermConfigFile)
+	if err != nil {
+		fmt.Println("Failed to load config:", err)
+		return true
+	}
+
+	// #G59: every path below is config-driven (a config field or the config
+	// file's own resolved path) and about to be Chmod'd — sanitized through
+	// the same containment check validateFilePermissions applies before
+	// FixFilePerms, so a config-driven '..' can't chmod an unintended file.
+	var files []securefiles.FilePermSpec
+	for _, spec := range []struct{ label, path string }{
+		{"KEK salt", cfg.Storage.Encryption.SaltPath},
+		{"DEK", cfg.Storage.Encryption.DEKPath},
+		{"config file", resolvedPath},
+	} {
+		if spec.path == "" {
+			continue
+		}
+		clean, cerr := startup.SafeFilePermPath(spec.label, spec.path)
+		if cerr != nil {
+			fmt.Println("Failed to fix file permissions:", cerr)
+			return true
+		}
+		files = append(files, securefiles.FilePermSpec{Path: clean, Mode: 0600})
+	}
+
+	// fix permissions: autofix = true
+	if err := securefiles.FixFilePerms(files, true); err != nil {
+		fmt.Printf("❌ Failed to fix file permissions: %v\n", err)
+		return true
+	}
+	fmt.Println("✅ All file permissions fixed successfully")
+	return false
 }

--- a/cmd/system/fixfileperm_test.go
+++ b/cmd/system/fixfileperm_test.go
@@ -1,0 +1,144 @@
+// fixfileperm_test.go — regression coverage for #G59: `keyorix system
+// fixfileperm` hardcoded config.Load("keyorix.yaml"), ignoring both --config
+// and KEYORIX_CONFIG_PATH (unlike its sibling `system audit`), and fed
+// config-driven salt/DEK/config paths straight to FixFilePerms's autofix
+// (chmod) with no containment validation (unlike internal/startup/
+// validation.go's SafeFilePermPath) — so a config-driven ".." path traversal
+// in dek_path could make autofix chmod an arbitrary file outside the intended
+// key directory.
+package system
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureFixFilePermStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func resetFixFilePermConfigFile(t *testing.T) {
+	t.Helper()
+	orig := fixFilePermConfigFile
+	t.Cleanup(func() {
+		fixFilePermConfigFile = orig
+		FixFilePermCmd.Flags().Lookup("config").Changed = false
+	})
+}
+
+// writeFixFilePermConfig writes a minimal, valid keyorix config (encryption
+// enabled, salt/DEK paths already present with correct perms) at dir/name —
+// deliberately NOT named "keyorix.yaml" — so success can only happen if the
+// command actually resolved and read this exact file.
+func writeFixFilePermConfig(t *testing.T, dir, name, saltPath, dekPath string) string {
+	t.Helper()
+	require.NoError(t, os.WriteFile(saltPath, []byte("salt"), 0600))
+	require.NoError(t, os.WriteFile(dekPath, []byte("dek"), 0600))
+
+	cfgPath := filepath.Join(dir, name)
+	yaml := fmt.Sprintf("storage:\n  encryption:\n    enabled: true\n    salt_path: %s\n    dek_path: %s\n", saltPath, dekPath)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(yaml), 0600))
+	return cfgPath
+}
+
+// The --config flag (mirroring `system audit`) must actually be honoured:
+// pointing it at a real config file with a name other than keyorix.yaml must
+// make the fix operate on THAT file's salt/DEK/config paths.
+func TestRunFixFilePerm_HonoursConfigFlagNotHardcodedKeyorixYaml(t *testing.T) {
+	resetFixFilePermConfigFile(t)
+	dir := t.TempDir()
+	cfgPath := writeFixFilePermConfig(t, dir, "production-config.yaml",
+		filepath.Join(dir, "salt.bin"), filepath.Join(dir, "dek.bin"))
+	// Deliberately loosen the config file's own perms so the fix must actually
+	// touch it — otherwise a no-op pass wouldn't distinguish "fixed the right
+	// file" from "silently did nothing to a nonexistent keyorix.yaml".
+	require.NoError(t, os.Chmod(cfgPath, 0644))
+
+	fixFilePermConfigFile = cfgPath
+
+	var out string
+	assert.NotPanics(t, func() {
+		out = captureFixFilePermStdout(t, func() { runFixFilePermNoExit() })
+	})
+	assert.Contains(t, out, "fixed successfully")
+
+	info, err := os.Stat(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "the resolved config file's own perms must have been fixed")
+}
+
+// KEYORIX_CONFIG_PATH must be honoured too, matching config.Load's documented
+// resolution order, when --config is left unset — same property as audit.go's
+// TestRunAudit_HonoursConfigPathEnvVar.
+func TestRunFixFilePerm_HonoursConfigPathEnvVar(t *testing.T) {
+	resetFixFilePermConfigFile(t)
+	dir := t.TempDir()
+	cfgPath := writeFixFilePermConfig(t, dir, "env-config.yaml",
+		filepath.Join(dir, "salt.bin"), filepath.Join(dir, "dek.bin"))
+
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	fixFilePermConfigFile = "" // simulate --config left at its default (unset)
+
+	out := captureFixFilePermStdout(t, func() { runFixFilePermNoExit() })
+	assert.Contains(t, out, "fixed successfully")
+}
+
+// A ".."-traversal DEK path must be refused rather than handed to
+// FixFilePerms's autofix (chmod) — the exact #G59 containment gap.
+func TestRunFixFilePerm_RefusesPathTraversalInDEKPath(t *testing.T) {
+	resetFixFilePermConfigFile(t)
+	dir := t.TempDir()
+	saltPath := filepath.Join(dir, "salt.bin")
+	require.NoError(t, os.WriteFile(saltPath, []byte("salt"), 0600))
+
+	// A RELATIVE traversal with more ".." segments than leading real ones — the
+	// exact shape SafeFilePermPath's own established test suite
+	// (TestSafeFilePermPath_RejectsTraversal) validates: filepath.Clean cannot
+	// fully resolve it away, so it still contains ".." after cleaning.
+	const traversalDEKPath = "sub/../../outside/dek.key"
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	yaml := fmt.Sprintf("storage:\n  encryption:\n    enabled: true\n    salt_path: %s\n    dek_path: %s\n", saltPath, traversalDEKPath)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(yaml), 0600))
+	// The config file itself starts at a safe 0600 — a bypassed traversal check
+	// would otherwise still leave THIS file looking "fixed" and mask the gap.
+	require.NoError(t, os.Chmod(saltPath, 0644))
+
+	fixFilePermConfigFile = cfgPath
+
+	var failed bool
+	out := captureFixFilePermStdout(t, func() { failed = runFixFilePermNoExit() })
+
+	assert.True(t, failed, "a '..'-traversal dek_path must be refused, not silently chmod'd")
+	assert.Contains(t, out, "unsafe")
+}
+
+// A --config pointing at a nonexistent path must fail loudly, not silently
+// report success against nothing.
+func TestRunFixFilePerm_MissingConfigFails(t *testing.T) {
+	resetFixFilePermConfigFile(t)
+	fixFilePermConfigFile = filepath.Join(t.TempDir(), "does-not-exist.yaml")
+
+	var failed bool
+	out := captureFixFilePermStdout(t, func() { failed = runFixFilePermNoExit() })
+
+	assert.True(t, failed, "a missing config file must be reported as a failure, not a false pass")
+	assert.NotContains(t, out, "fixed successfully")
+}

--- a/internal/audit/siem/metrics.go
+++ b/internal/audit/siem/metrics.go
@@ -13,12 +13,17 @@ import (
 
 var (
 	// siemForwards counts each audit event by terminal outcome:
-	//   - delivered: the SIEM accepted it (2xx).
-	//   - failed:    a permanent error (4xx) or retries exhausted / abandoned on shutdown.
-	//   - dropped:   the bounded queue was full (a wedged SIEM) so it was never sent.
+	//   - delivered:     the SIEM accepted it (2xx).
+	//   - failed:        a permanent error (4xx) or retries exhausted / abandoned on shutdown.
+	//   - dropped:       the bounded in-memory queue was full (a wedged SIEM) so it was
+	//     never sent.
+	//   - spool_corrupt: a spool line exceeded the per-line size cap or failed to parse
+	//     as JSON during replay — a distinct failure mode from "dropped" (#G56): this is
+	//     data corruption/oversize on disk, not backpressure, so it must be visible
+	//     separately rather than folded into either dropped or failed.
 	siemForwards = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "keyorix_siem_forwards_total",
-		Help: "SIEM audit-event forwards by terminal outcome (delivered|failed|dropped).",
+		Help: "SIEM audit-event forwards by terminal outcome (delivered|failed|dropped|spool_corrupt).",
 	}, []string{"outcome"})
 
 	// siemRetries counts forwards retried after a transient (5xx/429/transport) failure.
@@ -35,4 +40,7 @@ const (
 	// spooled: persisted to the on-disk durable spool for later replay instead of being
 	// dropped (only when Config.SpoolDir is set).
 	outcomeSpooled = "spooled"
+	// spoolCorrupt: a spool line was skipped during replay for being oversized or
+	// unparseable — see siemForwards' doc comment.
+	outcomeSpoolCorrupt = "spool_corrupt"
 )

--- a/internal/audit/siem/siem_s24_test.go
+++ b/internal/audit/siem/siem_s24_test.go
@@ -3,11 +3,13 @@ package siem
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -150,32 +152,38 @@ func TestSpool_ReplayFileVanishesMidReconcileWithRemaining(t *testing.T) {
 	assert.NoError(t, statErr, "replay must re-persist failed lines even if the file vanished mid-reconcile")
 }
 
-// TestSpool_TailScanErrorIsLogged verifies that a bufio.ErrTooLong error
-// encountered while scanning the concurrent-append tail (the second scanner
-// inside replay()) triggers the "tail-scan stopped early" log message.
-// This exercises the `ts.Err()` error branch at line ~216 of spool.go.
-func TestSpool_TailScanErrorIsLogged(t *testing.T) {
+// TestSpool_OversizedTailLineIsSkippedNotFatal is #G56: an oversized line
+// appended concurrently (landing in the "tail" — bytes beyond snapshotLen that
+// the reconcile step scans separately) used to make bufio.Scanner stop
+// entirely, silently losing everything scanned after it. Now only the
+// oversized tail line itself is skipped (logged) — a well-formed event added
+// AFTER it in the same concurrent-append tail must still be kept for replay.
+func TestSpool_OversizedTailLineIsSkippedNotFatal(t *testing.T) {
 	dir := t.TempDir()
 	tr := true
 
-	// The deliver hook appends an oversized line to the spool on first call,
-	// making it land in the "tail" (bytes beyond snapshotLen) that the second
-	// scanner reads during reconcile. The delivery itself succeeds so the
-	// snapshot lines are removed; only the oversized tail causes the scan error.
+	// The deliver hook appends an oversized line, then a well-formed one, to the
+	// spool on the first call — both land in the "tail" (bytes beyond
+	// snapshotLen) that the reconcile step scans after delivery. The delivery
+	// itself succeeds so the snapshot line is removed; only the tail matters.
+	var mu sync.Mutex
+	var delivered []uint
 	var hookCount int
 	hook := func(_ context.Context, e *models.AuditEvent) error {
 		hookCount++
 		if hookCount == 1 {
-			// Append an oversized line into the spool while holding no lock
-			// (simulating a concurrent add with an enormous payload). This makes
-			// the tail-scan hit bufio.ErrTooLong.
 			f, ferr := os.OpenFile(filepath.Join(dir, spoolFileName), os.O_APPEND|os.O_WRONLY, 0o600)
 			if ferr == nil {
 				oversized := bytes.Repeat([]byte("x"), 5<<20) // 5 MiB > 4 MiB cap
 				_, _ = f.Write(append(oversized, '\n'))
+				wellFormed, _ := json.Marshal(&models.AuditEvent{ID: 21, EventType: "secret.read", Success: &tr})
+				_, _ = f.Write(append(wellFormed, '\n'))
 				_ = f.Close()
 			}
 		}
+		mu.Lock()
+		delivered = append(delivered, e.ID)
+		mu.Unlock()
 		return nil // delivery succeeds
 	}
 
@@ -191,23 +199,15 @@ func TestSpool_TailScanErrorIsLogged(t *testing.T) {
 	t.Cleanup(func() { log.SetOutput(prevOut) })
 
 	s.replay()
+	// The well-formed tail event (id 21) survived the reconcile and is now on
+	// disk for the next replay to pick up.
+	s.replay()
 
-	assert.Contains(t, logBuf.String(), "tail-scan stopped early",
-		"an oversized tail line must trigger the tail-scan error log")
-}
-
-// TestData2Reader verifies the data2reader helper returns a working reader
-// over the supplied bytes. Although it is exercised implicitly by replay(),
-// a direct unit test ensures the helper itself is counted as covered.
-func TestData2Reader(t *testing.T) {
-	input := []byte("hello world")
-	r := data2reader(input)
-	require.NotNil(t, r)
-	buf := make([]byte, len(input))
-	n, readErr := r.Read(buf)
-	require.NoError(t, readErr)
-	assert.Equal(t, len(input), n)
-	assert.Equal(t, input, buf[:n])
+	assert.Contains(t, logBuf.String(), "oversized spool line",
+		"an oversized tail line must be logged, not silently dropped")
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, delivered, uint(21), "the well-formed tail event after the oversized line must still be replayed")
 }
 
 // TestSpool_LoopTickerDrivesReplay verifies that the background loop's ticker

--- a/internal/audit/siem/spool.go
+++ b/internal/audit/siem/spool.go
@@ -10,7 +10,6 @@
 package siem
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -32,6 +31,12 @@ const (
 	// audit chain remains the durable system of record regardless. Beyond the cap, new
 	// events are dropped (counted) rather than appended.
 	defaultSpoolMaxBytes int64 = 100 << 20 // 100 MiB
+	// maxSpoolLineBytes bounds a single spool line (one JSON-encoded audit event). A
+	// line exceeding this is corrupt/oversized and is SKIPPED — not fatal to the rest
+	// of the file (#G56: bufio.Scanner's default behavior on a token over its buffer
+	// cap is to stop scanning entirely, which silently dropped every legitimate event
+	// after the oversized line on the next rewrite).
+	maxSpoolLineBytes = 4 << 20 // 4 MiB
 )
 
 // spool persists undelivered events and replays them on an interval. deliverOnce
@@ -151,18 +156,13 @@ func (s *spool) replay() { // NOSONAR -- cognitive complexity 26, suppress go:S3
 	}
 
 	var remaining [][]byte
-	sc := bufio.NewScanner(data2reader(data))
-	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	for sc.Scan() {
-		line := sc.Bytes()
-		if len(bytes.TrimSpace(line)) == 0 {
-			continue
-		}
+	for _, line := range scanSpoolLines(data) {
 		var event models.AuditEvent
 		if err := json.Unmarshal(line, &event); err != nil {
 			// A corrupt line can never be delivered; drop it loudly rather than wedging
 			// the whole spool on it forever.
 			log.Printf("siem: discarding unparseable spool line: %v", err)
+			siemForwards.WithLabelValues(outcomeSpoolCorrupt).Inc()
 			continue
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
@@ -175,14 +175,6 @@ func (s *spool) replay() { // NOSONAR -- cognitive complexity 26, suppress go:S3
 		} else {
 			siemForwards.WithLabelValues(outcomeDelivered).Inc()
 		}
-	}
-	if err := sc.Err(); err != nil {
-		// bufio.Scanner stops silently on any read/token error (e.g. bufio.ErrTooLong for a
-		// line over the buffer cap, or a torn write). Everything from the failing line onward
-		// was never scanned, so it's about to be dropped by the rewrite below — log loudly so
-		// this isn't silent, even though we deliberately don't abort the replay (the lines
-		// already reconciled above are still correctly delivered/kept).
-		log.Printf("siem: spool scan stopped early (data past this point is being dropped from the spool): %v", err)
 	}
 
 	// Reconcile under the lock: the file is now [snapshot bytes][lines add()ed meanwhile].
@@ -201,20 +193,7 @@ func (s *spool) replay() { // NOSONAR -- cognitive complexity 26, suppress go:S3
 		return
 	}
 	if int64(len(cur)) > snapshotLen {
-		ts := bufio.NewScanner(data2reader(cur[snapshotLen:]))
-		ts.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-		for ts.Scan() {
-			line := ts.Bytes()
-			if len(bytes.TrimSpace(line)) == 0 {
-				continue
-			}
-			kept := make([]byte, len(line))
-			copy(kept, line)
-			remaining = append(remaining, kept)
-		}
-		if err := ts.Err(); err != nil {
-			log.Printf("siem: spool tail-scan stopped early (data past this point is being dropped from the spool): %v", err)
-		}
+		remaining = append(remaining, scanSpoolLines(cur[snapshotLen:])...)
 	}
 
 	if len(remaining) == 0 {
@@ -260,6 +239,33 @@ func (s *spool) close() {
 	<-s.done
 }
 
-// data2reader wraps a byte slice as an io.Reader for the scanner without pulling in
-// bytes.NewReader at every call site.
-func data2reader(b []byte) *bytes.Reader { return bytes.NewReader(b) }
+// scanSpoolLines splits data on newlines and returns the non-blank lines, each a
+// fresh slice safe to retain past data's lifetime. A line exceeding
+// maxSpoolLineBytes is corrupt/oversized and is SKIPPED (logged + counted) rather
+// than treated as fatal — #G56: data is already fully in memory (read via
+// os.ReadFile by the caller), so there is no streaming-buffer memory risk to
+// guard against here; the cap exists only to bound a single malformed/oversized
+// record, and one such record must not take the rest of the file down with it.
+func scanSpoolLines(data []byte) [][]byte {
+	var lines [][]byte
+	for len(data) > 0 {
+		var line []byte
+		if idx := bytes.IndexByte(data, '\n'); idx >= 0 {
+			line, data = data[:idx], data[idx+1:]
+		} else {
+			line, data = data, nil
+		}
+		if len(line) > maxSpoolLineBytes {
+			log.Printf("siem: discarding oversized spool line (%d bytes > %d cap)", len(line), maxSpoolLineBytes)
+			siemForwards.WithLabelValues(outcomeSpoolCorrupt).Inc()
+			continue
+		}
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		kept := make([]byte, len(line))
+		copy(kept, line)
+		lines = append(lines, kept)
+	}
+	return lines
+}

--- a/internal/audit/siem/spool_test.go
+++ b/internal/audit/siem/spool_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -202,35 +203,41 @@ func TestSpool_ConcurrentReplayCallsDoNotDoubleDeliver(t *testing.T) {
 	assert.ElementsMatch(t, []uint{1, 2}, d.delivered, "each event must be delivered exactly once despite concurrent replay() callers")
 }
 
-// A line past the scanner's max token size (bufio.ErrTooLong) makes bufio.Scanner stop
-// silently — replay() must not swallow this: it has to log a clear warning rather than
-// pretending nothing happened, even though (by design, see #338) it doesn't attempt to
-// recover the oversized line itself.
-func TestSpool_ReplayLogsOnScanError(t *testing.T) {
+// TestSpool_ReplaySkipsOnlyOversizedLine is #G56: a line past maxSpoolLineBytes used
+// to make bufio.Scanner stop entirely, silently dropping every legitimate event after
+// it in the file on the next rewrite. Now only the oversized line itself is skipped
+// (logged + counted) — a well-formed event AFTER it in the same file must still be
+// replayed.
+func TestSpool_ReplaySkipsOnlyOversizedLine(t *testing.T) {
 	dir := t.TempDir()
 	d := &fakeDelivery{}
 	s, err := newSpool(dir, time.Hour, d.deliver)
 	require.NoError(t, err)
 	s.close() // stop the background loop; drive replay() manually below
 
-	// A well-formed line, then one far larger than the 4 MiB scan buffer cap: the scanner
-	// hits bufio.ErrTooLong on the second line and stops, so neither it nor anything after
-	// it gets scanned.
+	// A well-formed line, an oversized line, then ANOTHER well-formed line — the
+	// oversized line sits in the middle so a "stops at first failure" bug would
+	// provably lose event 2 as well as the oversized one.
 	tr := true
 	s.add(&models.AuditEvent{ID: 1, EventType: "secret.read", Success: &tr})
-	oversized := bytes.Repeat([]byte("x"), 5<<20) // 5 MiB > 4 MiB scanner cap
+	oversized := bytes.Repeat([]byte("x"), 5<<20) // 5 MiB > 4 MiB cap
 	f, err := os.OpenFile(filepath.Join(dir, spoolFileName), os.O_APPEND|os.O_WRONLY, 0o600)
 	require.NoError(t, err)
 	_, err = f.Write(append(oversized, '\n'))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
+	s.add(&models.AuditEvent{ID: 2, EventType: "secret.read", Success: &tr})
 
 	var logBuf bytes.Buffer
 	prevOut := log.Writer()
 	log.SetOutput(&logBuf)
 	t.Cleanup(func() { log.SetOutput(prevOut) })
 
+	corruptBefore := testutil.ToFloat64(siemForwards.WithLabelValues(outcomeSpoolCorrupt))
+
 	s.replay()
 
-	assert.Contains(t, logBuf.String(), "scan stopped early", "a scan error must be logged loudly, not silently swallowed")
+	assert.Contains(t, logBuf.String(), "oversized spool line", "the oversized line must be logged loudly, not silently dropped")
+	assert.Equal(t, float64(1), testutil.ToFloat64(siemForwards.WithLabelValues(outcomeSpoolCorrupt))-corruptBefore)
+	assert.ElementsMatch(t, []uint{1, 2}, d.delivered, "both well-formed events must survive replay despite the oversized line between them")
 }

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -74,6 +74,11 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	if server == "" {
 		if cfg.Storage.Remote != nil && cfg.Storage.Remote.BaseURL != "" {
 			server = cfg.Storage.Remote.BaseURL
+			// #G73: this is about to persist a freshly-entered real API key
+			// against whatever server ./keyorix.yaml (an untrusted, CWD-
+			// relative, attacker-plantable file) named — carry the same
+			// warning ResolveRemote's other CLI callers already get.
+			common.WarnUntrustedCWDConfigServerURL()
 		} else {
 			fmt.Print("Enter server URL: ")
 			_, _ = fmt.Scanln(&server) // #nosec G104

--- a/internal/cli/auth/auth_remote_test.go
+++ b/internal/cli/auth/auth_remote_test.go
@@ -49,7 +49,16 @@ func TestRunLogin_ServerFromExistingConfig(t *testing.T) {
 	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(yaml), 0600))
 
 	t.Setenv("KEYORIX_API_KEY", "kx_env_key")
-	require.NoError(t, runLogin(loginCmd, nil))
+
+	// #G73: a server URL sourced from ./keyorix.yaml (untrusted, CWD-relative,
+	// attacker-plantable) is about to have a freshly-entered real API key
+	// persisted against it — this must warn, the same way ResolveRemote's
+	// other CLI callers already do.
+	out := captureStderr(t, func() {
+		require.NoError(t, runLogin(loginCmd, nil))
+	})
+	assert.Contains(t, out, "keyorix.yaml")
+	assert.Contains(t, out, "malicious file")
 }
 
 func TestRunLogout_WritesLocalConfig(t *testing.T) {

--- a/internal/cli/auth/mfa_stepup.go
+++ b/internal/cli/auth/mfa_stepup.go
@@ -38,6 +38,13 @@ func init() {
 }
 
 func runMFAStepUp(cmd *cobra.Command, _ []string) error {
+	// #G58: --code carries a live TOTP/recovery credential the same way
+	// --value/--admin-password carry secret material — warn the same way
+	// those flags already do (shell history, ps/proc visibility). The
+	// interactive prompt below has neither exposure, so this only fires
+	// when the flag itself was actually used.
+	common.WarnInsecureFlag(cmd, "code", "omit it and enter the code at the interactive prompt instead.")
+
 	rc, ok := common.NewRemoteClient()
 	if !ok {
 		return fmt.Errorf("MFA step-up requires remote mode — run 'keyorix auth login' first")

--- a/internal/cli/auth/mfa_stepup_flag_warning_test.go
+++ b/internal/cli/auth/mfa_stepup_flag_warning_test.go
@@ -1,0 +1,31 @@
+// mfa_stepup_flag_warning_test.go — #G58: 'auth mfa stepup --code' must warn on
+// stderr when the code is passed on the command line (ps/proc + shell-history
+// exposure), matching the same property already covered for --api-key in
+// login_flag_warning_test.go.
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunMFAStepUp_CodeFlagWarnsWhenExplicitlySet(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	require.NoError(t, mfaStepUpCmd.Flags().Set("code", "123456"))
+	t.Cleanup(func() {
+		_ = mfaStepUpCmd.Flags().Set("code", "")
+		mfaStepUpCmd.Flags().Lookup("code").Changed = false
+	})
+
+	out := captureStderr(t, func() {
+		// No remote session configured, so this returns an error after the
+		// warning fires — only the warning itself is under test here.
+		_ = runMFAStepUp(mfaStepUpCmd, nil)
+	})
+	assert.Contains(t, out, "--code")
+	assert.Contains(t, out, "ps/proc")
+}

--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -33,6 +33,18 @@ const (
 // memory via an unbounded json.Decode of resp.Body.
 const maxRemoteResponseBytes = 10 << 20 // 10MB
 
+// WarnUntrustedCWDConfigServerURL warns that a security-relevant server URL was
+// sourced from a keyorix.yaml file in the current working directory — a file an
+// attacker can plant to redirect this CLI command to a server they control
+// (config.Load resolves a CWD-relative ./keyorix.yaml regardless of
+// KEYORIX_CONFIG_PATH). #G73: every command that uses a CWD-config-sourced
+// remote URL for a security-relevant action (issuing/persisting real
+// credentials, an outbound connectivity probe) must carry this warning, not
+// just ResolveRemote's own callers.
+func WarnUntrustedCWDConfigServerURL() {
+	fmt.Fprintf(os.Stderr, "⚠️  Using a remote server config from ./keyorix.yaml in the current directory. If you did not place it here, a malicious file could be redirecting the CLI — prefer KEYORIX_SERVER/KEYORIX_TOKEN or 'keyorix connect'.\n")
+}
+
 // ResolveRemote returns the server endpoint and Bearer token from all config sources.
 //
 // Priority: env vars > ~/.keyorix/cli.yaml (written by 'keyorix connect')
@@ -73,7 +85,7 @@ func ResolveRemote() (endpoint, token string, ok bool) { // NOSONAR -- cognitive
 				fromMain = true
 			}
 			if fromMain {
-				fmt.Fprintf(os.Stderr, "⚠️  Using a remote server config from ./keyorix.yaml in the current directory. If you did not place it here, a malicious file could be redirecting the CLI — prefer KEYORIX_SERVER/KEYORIX_TOKEN or 'keyorix connect'.\n")
+				WarnUntrustedCWDConfigServerURL()
 			}
 		}
 	}

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -189,6 +189,15 @@ func testRemoteConnection(cfg *config.Config) error {
 	if cfg.Storage.Remote.BaseURL == "" {
 		return fmt.Errorf("remote server URL not configured")
 	}
+	// #G73: this is about to issue an outbound HTTP request (SSRF exposure,
+	// including link-local/metadata addresses) to a server URL sourced from
+	// ./keyorix.yaml — an untrusted, CWD-relative, attacker-plantable file —
+	// with no user confirmation. Duplicated here (not imported) rather than
+	// calling internal/cli/common.WarnUntrustedCWDConfigServerURL: that
+	// package already imports internal/cli/config for the CLI-connect config,
+	// so importing it back here would cycle. Keep this message in sync with
+	// that one.
+	fmt.Fprintln(os.Stderr, "⚠️  Testing connection using a remote server config from ./keyorix.yaml in the current directory. If you did not place it here, a malicious file could be redirecting the CLI — prefer 'keyorix connect'.")
 	fmt.Printf("🌐 Remote server: %s\n", cfg.Storage.Remote.BaseURL)
 
 	timeout := time.Duration(cfg.Storage.Remote.TimeoutSeconds) * time.Second

--- a/internal/cli/config/conn_test.go
+++ b/internal/cli/config/conn_test.go
@@ -1,12 +1,32 @@
 package config
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	appconfig "github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
 
 func cfgFor(url string) *appconfig.Config {
 	c := &appconfig.Config{}
@@ -40,4 +60,22 @@ func TestTestRemoteConnection_NoURL(t *testing.T) {
 	if err := testRemoteConnection(cfgFor("")); err == nil {
 		t.Fatal("expected an error when base URL is unset, got nil")
 	}
+}
+
+// TestTestRemoteConnection_WarnsUntrustedConfigSource is #G73: this issues an
+// outbound HTTP request (SSRF exposure) to a server URL sourced from
+// ./keyorix.yaml — an untrusted, CWD-relative, attacker-plantable file — with
+// no warning that the target came from there. Must warn the same way
+// internal/cli/common.ResolveRemote's other CLI callers already do.
+func TestTestRemoteConnection_WarnsUntrustedConfigSource(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	out := captureStderr(t, func() {
+		require.NoError(t, testRemoteConnection(cfgFor(srv.URL)))
+	})
+	assert.Contains(t, out, "keyorix.yaml")
+	assert.Contains(t, out, "malicious file")
 }

--- a/internal/cli/secret/import.go
+++ b/internal/cli/secret/import.go
@@ -124,6 +124,11 @@ func sanitizeForTerminal(s string) string {
 func runImport(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
+	// #G58: --vault-token carries a live Vault credential the same way
+	// --value/--admin-password carry secret material — warn the same way
+	// those flags already do (ps/proc visibility, shell history).
+	common.WarnInsecureFlag(cmd, "vault-token", "use the VAULT_TOKEN environment variable instead.")
+
 	entries, err := collectEntries(ctx)
 	if err != nil {
 		return err
@@ -137,11 +142,10 @@ func runImport(cmd *cobra.Command, args []string) error {
 	if importDryRun {
 		fmt.Printf("Dry run — would import %d secret(s):\n\n", len(entries))
 		for _, e := range entries {
-			preview := e.Value
-			if len(preview) > 20 {
-				preview = preview[:20] + "..."
-			}
-			fmt.Printf("  %-30s = %s\n", sanitizeForTerminal(e.Name), sanitizeForTerminal(preview))
+			// #G58: a dry run must never put real secret bytes on the
+			// operator's terminal (scrollback, tmux/screen logging, screen
+			// share) — show only the length, not a prefix of the value.
+			fmt.Printf("  %-30s = <%d bytes>\n", sanitizeForTerminal(e.Name), len(e.Value))
 		}
 		fmt.Printf("\nNo changes made (--dry-run).\n")
 		return nil

--- a/internal/cli/secret/import_flag_warning_test.go
+++ b/internal/cli/secret/import_flag_warning_test.go
@@ -1,0 +1,60 @@
+// import_flag_warning_test.go — #G58: 'secret import' must warn on stderr when
+// --vault-token is passed on the command line (ps/proc + shell-history exposure,
+// same property already covered for --value in value_flag_warning_test.go), and
+// its --dry-run preview must never print a substring of the real secret value.
+package secret
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunImport_VaultTokenFlagWarnsOnCommandLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "in.env")
+	require.NoError(t, os.WriteFile(path, []byte("FOO=bar\n"), 0o600))
+
+	origFile, origFormat, origDryRun, origToken := importFile, importFormat, importDryRun, vaultToken
+	t.Cleanup(func() {
+		importFile, importFormat, importDryRun, vaultToken = origFile, origFormat, origDryRun, origToken
+		importCmd.Flags().Lookup("vault-token").Changed = false
+	})
+	importFile = path
+	importFormat = "dotenv"
+	importDryRun = true
+	require.NoError(t, importCmd.Flags().Set("vault-token", "s3cr3t-vault-token-on-argv"))
+
+	out := captureStderr(t, func() {
+		_ = runImport(importCmd, nil)
+	})
+	assert.Contains(t, out, "--vault-token")
+	assert.Contains(t, out, "ps/proc")
+}
+
+func TestRunImport_DryRunPreviewNeverContainsRealValueSubstring(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "in.env")
+	const secretValue = "sup3r-s3cr3t-database-password-xyz"
+	require.NoError(t, os.WriteFile(path, []byte("DB_PASSWORD="+secretValue+"\n"), 0o600))
+
+	origFile, origFormat, origDryRun := importFile, importFormat, importDryRun
+	t.Cleanup(func() { importFile, importFormat, importDryRun = origFile, origFormat, origDryRun })
+	importFile = path
+	importFormat = "dotenv"
+	importDryRun = true
+
+	out := captureStdout(t, func() {
+		_ = runImport(importCmd, nil)
+	})
+	assert.Contains(t, out, "DB_PASSWORD")
+	// The whole value, and any 8+ char substring of it, must never appear —
+	// this is the review's own detection_idea for G58.
+	assert.NotContains(t, out, secretValue)
+	for i := 0; i+8 <= len(secretValue); i += 4 {
+		assert.NotContains(t, out, secretValue[i:i+8])
+	}
+}

--- a/internal/cli/system/audit.go
+++ b/internal/cli/system/audit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
+	"github.com/keyorixhq/keyorix/internal/startup"
 	"github.com/spf13/cobra"
 )
 
@@ -53,10 +54,24 @@ func runAuditNoExit() bool {
 		return true
 	}
 
-	files := []securefiles.FilePermSpec{
-		{Path: configPath, Mode: 0600},
-		{Path: cfg.Storage.Encryption.SaltPath, Mode: 0600},
-		{Path: cfg.Storage.Encryption.DEKPath, Mode: 0600},
+	// #G59 (sibling gap): SaltPath/DEKPath are config-driven and about to be
+	// Lstat'd/opened — sanitized the same way validateFilePermissions and
+	// fixfileperm.go's autofix path do, so a config-driven '..' can't probe an
+	// unintended file's permissions even in audit-only mode.
+	files := []securefiles.FilePermSpec{{Path: configPath, Mode: 0600}}
+	for _, spec := range []struct{ label, path string }{
+		{"KEK salt", cfg.Storage.Encryption.SaltPath},
+		{"DEK", cfg.Storage.Encryption.DEKPath},
+	} {
+		if spec.path == "" {
+			continue
+		}
+		clean, cerr := startup.SafeFilePermPath(spec.label, spec.path)
+		if cerr != nil {
+			fmt.Println("Failed to fix file permissions:", cerr)
+			return true
+		}
+		files = append(files, securefiles.FilePermSpec{Path: clean, Mode: 0600})
 	}
 
 	if err := securefiles.FixFilePerms(files, false); err != nil { // false = audit only

--- a/internal/cli/system/audit_test.go
+++ b/internal/cli/system/audit_test.go
@@ -122,6 +122,30 @@ func TestRunAudit_ConfigFlagBeatsEnvVar(t *testing.T) {
 	assert.NotContains(t, out, envCfg)
 }
 
+// TestRunAudit_RefusesPathTraversalInDEKPath is #G59 (sibling gap): audit.go fed
+// SaltPath/DEKPath straight to FixFilePerms with no containment validation,
+// unlike internal/startup/validation.go's SafeFilePermPath (now reused here) —
+// a RELATIVE traversal must be refused rather than silently stat/opened.
+func TestRunAudit_RefusesPathTraversalInDEKPath(t *testing.T) {
+	resetAuditConfigFile(t)
+	dir := t.TempDir()
+	saltPath := filepath.Join(dir, "salt.bin")
+	require.NoError(t, os.WriteFile(saltPath, []byte("salt"), 0600))
+
+	const traversalDEKPath = "sub/../../outside/dek.key"
+	cfgPath := filepath.Join(dir, "audit-config.yaml")
+	yaml := fmt.Sprintf("storage:\n  encryption:\n    enabled: true\n    salt_path: %s\n    dek_path: %s\n", saltPath, traversalDEKPath)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(yaml), 0600))
+
+	auditConfigFile = cfgPath
+
+	var failed bool
+	out := captureStdout(t, func() { failed = runAuditNoExit() })
+
+	assert.True(t, failed, "a '..'-traversal dek_path must be refused, not silently stat'd")
+	assert.Contains(t, out, "unsafe")
+}
+
 // A --config pointing at a nonexistent path must fail loudly, not silently
 // report success against nothing (the exact failure mode #228 warned about).
 func TestRunAudit_MissingConfigFails(t *testing.T) {

--- a/internal/cli/system/init.go
+++ b/internal/cli/system/init.go
@@ -9,12 +9,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -68,14 +70,24 @@ func init() {
 	// Remote-bootstrap flags
 	InitCmd.Flags().StringVar(&initServer, "server", "", "Bootstrap a remote Keyorix server (triggers remote mode)")
 	InitCmd.Flags().StringVar(&initAdminUsername, "admin-username", "admin", "Admin username to create")
-	InitCmd.Flags().StringVar(&initAdminPassword, "admin-password", "admin", "Admin password (change after first login)")
+	// #G76: no default. A defaulted "admin" password bootstrapped a live remote
+	// server with a well-known admin/admin credential pair, and the only
+	// feedback (the trailing success banner) arrived AFTER the account already
+	// existed — an operator who forgot the flag never saw a warning until the
+	// account was already live. Now it's REQUIRED for --server mode, checked
+	// before the request is ever sent (see runRemoteInit).
+	InitCmd.Flags().StringVar(&initAdminPassword, "admin-password", "", "Admin password (required for --server; INSECURE on the command line — prefer KEYORIX_ADMIN_PASSWORD env var, or omit to be prompted)")
 	InitCmd.Flags().StringVar(&initAdminEmail, "admin-email", "admin@localhost", "Admin email address")
 	InitCmd.Flags().StringVar(&initBootstrapToken, "bootstrap-token", "", "Bootstrap token authorizing first-admin creation (or env KEYORIX_BOOTSTRAP_TOKEN; printed in the server log on first boot)")
 }
 
 func runInit(cmd *cobra.Command, args []string) error { // NOSONAR -- cognitive complexity 17, suppress go:S3776
 	if initServer != "" {
-		common.WarnInsecureFlag(cmd, "admin-password", "consider leaving it unset and changing the password after first login instead.")
+		password, err := resolveAdminPassword(cmd)
+		if err != nil {
+			return err
+		}
+		initAdminPassword = password
 		return runRemoteInit()
 	}
 
@@ -196,6 +208,38 @@ func initializeLogging() error {
 		return fmt.Errorf("failed to create log file: %w", err)
 	}
 	return nil
+}
+
+// resolveAdminPassword resolves the remote-bootstrap admin password in order
+// of preference, mirroring common.ResolveAPIKey's tiered shape for "supply a
+// secret to a CLI command safely":
+//  1. the (insecure, warned) --admin-password flag, if set;
+//  2. the KEYORIX_ADMIN_PASSWORD environment variable;
+//  3. an interactive no-echo prompt.
+//
+// #G76: --admin-password used to default to the literal "admin", silently
+// bootstrapping a live remote server with a well-known admin/admin credential
+// pair — the only feedback was a warning in the trailing success banner,
+// printed AFTER the account already existed. Requiring an explicit choice
+// here, before runRemoteInit ever POSTs to the server, closes that gap.
+func resolveAdminPassword(cmd *cobra.Command) (string, error) {
+	if initAdminPassword != "" {
+		common.WarnInsecureFlag(cmd, "admin-password", "prefer the KEYORIX_ADMIN_PASSWORD environment variable, or omit it to be prompted.")
+		return initAdminPassword, nil
+	}
+	if p := os.Getenv("KEYORIX_ADMIN_PASSWORD"); p != "" {
+		return p, nil
+	}
+	fmt.Fprint(os.Stderr, "Enter admin password for the new account: ")
+	b, err := term.ReadPassword(int(syscall.Stdin))
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", fmt.Errorf("failed to read admin password: %w", err)
+	}
+	if len(b) == 0 {
+		return "", fmt.Errorf("admin password is required to bootstrap a remote server (--admin-password, KEYORIX_ADMIN_PASSWORD, or enter one at the prompt)")
+	}
+	return string(b), nil
 }
 
 // ── Remote bootstrap ──────────────────────────────────────────────────────────

--- a/internal/cli/system/init.go
+++ b/internal/cli/system/init.go
@@ -342,7 +342,11 @@ func runRemoteInit() error { // NOSONAR -- cognitive complexity 16, suppress go:
 	fmt.Printf("  keyorix run --env production -- your-app\n")
 
 	if initAdminPassword == "admin" {
-		fmt.Printf("\nWARNING: You are using the default password %q. Change it immediately.\n", initAdminPassword)
+		// Deliberately doesn't interpolate initAdminPassword: it's already known to be
+		// literally "admin" inside this branch, and echoing a caller-supplied secret
+		// back to stdout (terminal scrollback, CI logs) is itself a cleartext-logging
+		// exposure independent of what value it happens to be.
+		fmt.Printf("\nWARNING: You are using the default password %q. Change it immediately.\n", "admin")
 	}
 
 	return nil

--- a/internal/cli/system/init_flag_warning_test.go
+++ b/internal/cli/system/init_flag_warning_test.go
@@ -1,6 +1,8 @@
 // init_flag_warning_test.go — verifies 'system init --server ... --admin-password'
 // warns on stderr about ps/proc + shell-history exposure when the flag is explicitly
-// passed on the command line, and stays silent when it is left at its default.
+// passed on the command line, and (#G76) that leaving it unset no longer silently
+// bootstraps the server with the well-known default password "admin" — it must be
+// resolved (flag/env/prompt) BEFORE the server is ever contacted.
 package system
 
 import (
@@ -8,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,14 +65,39 @@ func TestRunInit_AdminPasswordFlagWarnsWhenExplicitlySet(t *testing.T) {
 	assert.Contains(t, out, "ps/proc")
 }
 
-func TestRunInit_AdminPasswordFlagSilentWhenLeftAtDefault(t *testing.T) {
+// TestRunInit_AdminPasswordUnsetNeverContactsServer is #G76: --admin-password
+// no longer defaults to "admin" — leaving it (and KEYORIX_ADMIN_PASSWORD)
+// unset must fail BEFORE the server is ever POSTed to, not silently bootstrap
+// a well-known admin/admin credential pair. Stdin isn't a TTY in a test
+// binary, so the interactive-prompt fallback fails fast rather than hanging —
+// exactly the "refuse rather than proceed" outcome this closes.
+func TestRunInit_AdminPasswordUnsetNeverContactsServer(t *testing.T) {
+	resetInitFlags(t)
+	var contacted atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contacted.Store(true)
+		_, _ = w.Write([]byte(`{"success":true,"data":{"already_initialized":true}}`))
+	}))
+	t.Cleanup(srv.Close)
+	require.NoError(t, InitCmd.Flags().Set("server", srv.URL))
+	// admin-password left unset (no default) and no env var.
+
+	err := runInit(InitCmd, nil)
+	require.Error(t, err, "an unresolvable admin password must refuse, not silently bootstrap with a default")
+	assert.False(t, contacted.Load(), "the server must never be contacted until the admin password is actually resolved")
+}
+
+// KEYORIX_ADMIN_PASSWORD must be honoured silently (no warning, no prompt) —
+// the safe alternative to the insecure --admin-password flag.
+func TestRunInit_AdminPasswordEnvVarResolvesSilently(t *testing.T) {
 	resetInitFlags(t)
 	url := remoteInitStub(t)
 	require.NoError(t, InitCmd.Flags().Set("server", url))
-	// admin-password left untouched (default "admin").
+	t.Setenv("KEYORIX_ADMIN_PASSWORD", "correct-horse-battery-staple")
 
 	out := captureStderr(t, func() {
 		require.NoError(t, runInit(InitCmd, nil))
 	})
-	assert.NotContains(t, out, "--admin-password")
+	assert.NotContains(t, out, "--admin-password", "the env var path must not warn — no command-line exposure occurred")
+	assert.NotContains(t, out, "Enter admin password", "the env var path must not prompt")
 }

--- a/internal/cli/system/system_s2_test.go
+++ b/internal/cli/system/system_s2_test.go
@@ -270,7 +270,10 @@ func TestRunInit_SelectiveLogging(t *testing.T) {
 func TestRunInit_ServerFlagTriggersPOST(t *testing.T) {
 	restore := saveInitFlags(t)
 	defer restore()
+	origPW := initAdminPassword
+	defer func() { initAdminPassword = origPW }()
 	initServer = "http://127.0.0.1:1" // nothing listening
+	initAdminPassword = "not-admin"   // #G76: must be resolved before this test's actual target (unreachable server) is exercised
 
 	err := runInit(InitCmd, nil)
 	require.Error(t, err)

--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -196,11 +196,17 @@ func (c *KeyorixCore) GetAccessReviewCampaign(ctx context.Context, projectID, ca
 // checkReviewerIndependence enforces ISO 27001 A.5.18: a reviewer must not certify
 // their own access, directly (user-scoped item) or via group membership. Fails closed:
 // a group-lookup error is treated as membership to block self-certification by error.
-func (c *KeyorixCore) checkReviewerIndependence(ctx context.Context, actorID uint, item *models.AccessReviewItem) error {
-	if item.PrincipalType == "user" && item.PrincipalID == actorID {
+// checkReviewerIndependence takes the normalized principal type/ID directly
+// (not an *models.AccessReviewItem) so the SAME check can gate both the
+// campaign flow (DecideAccessReviewItem, via item.PrincipalType/PrincipalID)
+// and the standalone attest/revoke endpoints (#G52, via
+// principalTypeForDecision's inference — AccessReviewDecision.PrincipalType
+// is only ever populated by the caller for "role" sources).
+func (c *KeyorixCore) checkReviewerIndependence(ctx context.Context, actorID uint, principalType string, principalID uint) error {
+	if principalType == "user" && principalID == actorID {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you cannot review your own access; an independent reviewer is required")
 	}
-	if item.PrincipalType == "group" && c.userInGroup(ctx, actorID, item.PrincipalID) {
+	if principalType == "group" && c.userInGroup(ctx, actorID, principalID) {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "you cannot review access for a group you belong to; an independent reviewer is required")
 	}
 	return nil
@@ -273,7 +279,7 @@ func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, proje
 	if item.Decision != ReviewItemPending {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this item has already been decided")
 	}
-	if err := c.checkReviewerIndependence(ctx, actorID, item); err != nil {
+	if err := c.checkReviewerIndependence(ctx, actorID, item.PrincipalType, item.PrincipalID); err != nil {
 		return err
 	}
 	// ARC-001: a machine identity provisioned by the actor must not be self-certified

--- a/internal/core/access_review_external_test.go
+++ b/internal/core/access_review_external_test.go
@@ -367,3 +367,94 @@ func TestAttestAccessReviewGrant_Share(t *testing.T) {
 		Where("event_type = ?", core.EventAccessReviewAttested).Count(&count).Error)
 	assert.Equal(t, int64(1), count, "exactly the one live attestation was recorded")
 }
+
+// TestAttestAccessReviewGrant_MachineRole is #G51's machine-identity gap: a
+// machine identity's role grant lives in a separate table from user/group
+// grants, so verifyAccessReviewGrantExists must check it too, mirroring
+// TestGenerateProjectAccessReview_IncludesMachineIdentities and
+// TestRevokeAccessReviewGrant_MachineRole (#91) — before the fix, this
+// attestation spuriously failed "no longer exists" for a grant that was very
+// much live.
+func TestAttestAccessReviewGrant_MachineRole(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AuditEvent{}))
+
+	const proj = uint(2)
+	require.NoError(t, h.DB.Create(&models.MachineIdentity{
+		ID: 50, ProjectID: proj, Name: "ci-runner", IdentityType: "ci", State: "active",
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.MachineIdentityRole{
+		MachineIdentityID: 50, RoleID: 3, ProjectID: proj,
+	}).Error)
+
+	err := h.CoreService.AttestAccessReviewGrant(context.Background(), 1, proj, core.AccessReviewDecision{
+		Source: "role", PrincipalType: "machine", PrincipalID: 50, RoleID: 3,
+	})
+	require.NoError(t, err, "a live machine-identity role grant must attest cleanly")
+
+	var count int64
+	require.NoError(t, h.DB.Model(&models.AuditEvent{}).
+		Where("event_type = ?", core.EventAccessReviewAttested).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+// TestAttestAccessReviewGrant_RefusesCrossProjectShare is #G51's cross-tenant
+// IDOR: a reviewer authorized on project 2 must not be able to certify (as
+// compliance evidence) a share belonging to a secret in a DIFFERENT project,
+// by passing that secret's ID alongside a recipient who happens to hold SOME
+// share on it. Mirrors revokeReviewShare's identical guard (#99).
+func TestAttestAccessReviewGrant_RefusesCrossProjectShare(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.ShareRecord{}, &models.AuditEvent{}))
+
+	const reviewedProject = uint(2)
+	const otherProject = uint(3)
+	h.CreateTestUser(t, "alice", 10) // owner, other project
+	h.CreateTestUser(t, "bob", 11)   // direct-share recipient, other project
+	require.NoError(t, h.DB.Create(&models.Environment{ID: 30, ProjectID: otherProject, Name: "prod"}).Error)
+	require.NoError(t, h.DB.Create(&models.SecretNode{
+		ID: 501, ProjectID: otherProject, EnvironmentID: 30, OwnerID: 10, Name: "other-project-secret", Type: "password", Status: "active", IsSecret: true,
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.ShareRecord{SecretID: 501, RecipientID: 11, IsGroup: false, Permission: "read"}).Error)
+
+	// A reviewer scoped to reviewedProject attests a share on a secret that
+	// actually lives in otherProject — must be refused as "not found", not
+	// silently certified.
+	err := h.CoreService.AttestAccessReviewGrant(context.Background(), 1, reviewedProject, core.AccessReviewDecision{
+		Source: "direct_share", PrincipalID: 11, SecretID: 501,
+	})
+	require.Error(t, err, "a share on a secret outside the reviewed project must be refused")
+
+	var count int64
+	require.NoError(t, h.DB.Model(&models.AuditEvent{}).
+		Where("event_type = ?", core.EventAccessReviewAttested).Count(&count).Error)
+	assert.Equal(t, int64(0), count, "no cross-project attestation evidence must be recorded")
+}
+
+// TestAttestAccessReviewGrant_RefusesCrossProjectOwnership is the "owner"
+// source analogue of the share IDOR above.
+func TestAttestAccessReviewGrant_RefusesCrossProjectOwnership(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.AuditEvent{}))
+
+	const reviewedProject = uint(2)
+	const otherProject = uint(3)
+	h.CreateTestUser(t, "alice", 10)
+	require.NoError(t, h.DB.Create(&models.Environment{ID: 30, ProjectID: otherProject, Name: "prod"}).Error)
+	require.NoError(t, h.DB.Create(&models.SecretNode{
+		ID: 502, ProjectID: otherProject, EnvironmentID: 30, OwnerID: 10, Name: "other-project-secret", Type: "password", Status: "active", IsSecret: true,
+	}).Error)
+
+	err := h.CoreService.AttestAccessReviewGrant(context.Background(), 1, reviewedProject, core.AccessReviewDecision{
+		Source: "owner", PrincipalID: 10, SecretID: 502,
+	})
+	require.Error(t, err, "ownership of a secret outside the reviewed project must be refused")
+
+	var count int64
+	require.NoError(t, h.DB.Model(&models.AuditEvent{}).
+		Where("event_type = ?", core.EventAccessReviewAttested).Count(&count).Error)
+	assert.Equal(t, int64(0), count, "no cross-project attestation evidence must be recorded")
+}

--- a/internal/core/access_review_external_test.go
+++ b/internal/core/access_review_external_test.go
@@ -171,6 +171,72 @@ func TestRevokeAccessReviewGrant_Role(t *testing.T) {
 	assert.Empty(t, after.Entries, "alice's role grant is gone after revoke")
 }
 
+// TestRevokeAccessReviewGrant_RejectsSelfCertification is #G52: before the
+// fix, the standalone RevokeAccessReviewGrant/AttestAccessReviewGrant
+// endpoints had NO reviewer-independence check at all — only
+// DecideAccessReviewItem (the campaign flow) enforced it, BEFORE calling
+// into these same two functions. A caller reaching them directly (the
+// project_members.go standalone HTTP handlers) could self-certify their own
+// access.
+func TestRevokeAccessReviewGrant_RejectsSelfCertification(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+
+	const proj = uint(2)
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj)) // editor → write
+
+	err := h.CoreService.RevokeAccessReviewGrant(context.Background(), 10, proj, core.AccessReviewDecision{
+		Source: "role", PrincipalType: "user", PrincipalID: 10, RoleID: 3,
+	})
+	require.Error(t, err, "alice must not be able to revoke her own access")
+	assert.Contains(t, err.Error(), "your own access")
+}
+
+// TestRevokeAccessReviewGrant_RejectsNonHumanReviewer is #G52: actorID 0
+// (a machine-identity credential, which authorizes via PrincipalID not
+// UserID) must not be able to act as a reviewer via the standalone endpoint.
+func TestRevokeAccessReviewGrant_RejectsNonHumanReviewer(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+
+	const proj = uint(2)
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+
+	err := h.CoreService.RevokeAccessReviewGrant(context.Background(), 0, proj, core.AccessReviewDecision{
+		Source: "role", PrincipalType: "user", PrincipalID: 10, RoleID: 3,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "attributable human reviewer")
+}
+
+// TestAttestAccessReviewGrant_RejectsSelfCertification_Share is #G52's share
+// case: a direct-share recipient must not be able to attest their OWN share
+// via the standalone endpoint — AccessReviewDecision.PrincipalType is only
+// ever populated for "role" sources, so this exercises
+// principalTypeForDecision's "direct_share is always a user" inference.
+func TestAttestAccessReviewGrant_RejectsSelfCertification_Share(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.ShareRecord{}, &models.AuditEvent{}))
+
+	const proj = uint(2)
+	h.CreateTestUser(t, "alice", 10) // owner
+	h.CreateTestUser(t, "bob", 11)   // direct-share recipient
+	require.NoError(t, h.DB.Create(&models.Environment{ID: 20, ProjectID: proj, Name: "prod"}).Error)
+	require.NoError(t, h.DB.Create(&models.SecretNode{
+		ID: 500, ProjectID: proj, EnvironmentID: 20, OwnerID: 10, Name: "db-pw", Type: "password", Status: "active", IsSecret: true,
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.ShareRecord{SecretID: 500, RecipientID: 11, IsGroup: false, Permission: "read"}).Error)
+
+	err := h.CoreService.AttestAccessReviewGrant(context.Background(), 11, proj, core.AccessReviewDecision{
+		Source: "direct_share", PrincipalID: 11, SecretID: 500,
+	})
+	require.Error(t, err, "bob must not be able to attest his own share")
+	assert.Contains(t, err.Error(), "your own access")
+}
+
 // Revoking a group share removes that ShareRecord; revoking ownership is refused.
 func TestRevokeAccessReviewGrant_ShareAndOwner(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)

--- a/internal/core/access_review_revoke.go
+++ b/internal/core/access_review_revoke.go
@@ -167,6 +167,26 @@ func (c *KeyorixCore) verifyAccessReviewGrantExists(ctx context.Context, project
 		if d.PrincipalID == 0 || d.RoleID == 0 {
 			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "principal_id and role_id are required to attest a role grant")
 		}
+		// #G51: machine-identity role grants live in a separate table from
+		// user/group grants (local_rbac.go's MachineIdentityRole vs
+		// UserRole/GroupRole) — ListProjectRoleAssignments never queries it,
+		// so every machine-identity attestation spuriously "not found" before
+		// this branch. RevokeAccessReviewGrant's revokeRoleByPrincipalType
+		// already dispatches machine grants separately (RemoveMachineRole);
+		// mirror that split here.
+		if d.PrincipalType == "machine" {
+			machineAssignments, err := c.storage.ListProjectMachineRoleAssignments(ctx, projectID)
+			if err != nil {
+				return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+			}
+			for _, a := range machineAssignments {
+				if a.PrincipalID == d.PrincipalID && a.RoleID == d.RoleID && a.EnvironmentID == d.EnvironmentID {
+					return nil
+				}
+			}
+			return fmt.Errorf("%s: %s", i18n.T("ErrorNotFound", nil),
+				"the role grant being attested no longer exists — the review is stale, re-sync and try again")
+		}
 		assignments, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
 		if err != nil {
 			return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -183,6 +203,17 @@ func (c *KeyorixCore) verifyAccessReviewGrantExists(ctx context.Context, project
 	case "direct_share", "group_share":
 		if d.PrincipalID == 0 || d.SecretID == 0 {
 			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "principal_id and secret_id are required to attest a share")
+		}
+		// #G51: verify the secret actually belongs to projectID BEFORE
+		// looking at its shares — otherwise a reviewer authorized on project A
+		// could pass any SecretID and attest a share belonging to a secret in
+		// a DIFFERENT project (cross-tenant IDOR), certifying compliance
+		// evidence for a grant they have no authority over. Mirrors
+		// revokeReviewShare's identical guard (#99).
+		secret, err := c.storage.GetSecret(ctx, d.SecretID)
+		if err != nil || secret == nil || secret.ProjectID != projectID {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorNotFound", nil),
+				"the share being attested no longer exists — the review is stale, re-sync and try again")
 		}
 		isGroup := d.Source == "group_share"
 		shares, err := c.storage.ListSharesBySecret(ctx, d.SecretID)
@@ -201,7 +232,10 @@ func (c *KeyorixCore) verifyAccessReviewGrantExists(ctx context.Context, project
 			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "principal_id and secret_id are required to attest ownership")
 		}
 		secret, err := c.storage.GetSecret(ctx, d.SecretID)
-		if err != nil || secret == nil {
+		if err != nil || secret == nil || secret.ProjectID != projectID {
+			// #G51: same cross-tenant guard as the share branch above — a
+			// secret in a DIFFERENT project must read as "not found" here,
+			// not leak whether it exists or who owns it.
 			return fmt.Errorf("%s: %s", i18n.T("ErrorNotFound", nil),
 				"the secret being attested no longer exists — the review is stale, re-sync and try again")
 		}

--- a/internal/core/access_review_revoke.go
+++ b/internal/core/access_review_revoke.go
@@ -55,6 +55,58 @@ type accessReviewAuditDetail struct {
 	SecretID      uint   `json:"secret_id,omitempty"`
 }
 
+// principalTypeForDecision normalizes d's principal type for the reviewer-
+// independence check, mirroring GenerateProjectAccessReview's own
+// PrincipalType assignment per source (access_review.go): "role" decisions
+// carry an explicit, caller-supplied PrincipalType (user/group/machine); the
+// other three sources don't (AccessReviewDecision's PrincipalType field is
+// documented "for role grants" only) but their principal kind is fixed by
+// the source itself — a direct_share/owner principal is always a user, a
+// group_share principal is always a group.
+func principalTypeForDecision(d AccessReviewDecision) string {
+	switch d.Source {
+	case "direct_share", "owner":
+		return "user"
+	case "group_share":
+		return "group"
+	default: // "role"
+		return d.PrincipalType
+	}
+}
+
+// enforceAccessReviewReviewerControls applies the SAME reviewer-independence
+// and human-reviewer controls DecideAccessReviewItem enforces for the
+// campaign flow (SOC2 CC6.2-6.3 / ISO A.5.18 / ARC-001) to the standalone
+// attest/revoke endpoints (#G52). Before this fix, RevokeAccessReviewGrant/
+// AttestAccessReviewGrant had NO such checks at all — DecideAccessReviewItem
+// only ever applied them BEFORE calling into these two functions, so a
+// caller reaching them directly (project_members.go's standalone HTTP
+// handlers) could self-certify their own access, certify access for a group
+// they belong to, or have a machine-identity token "review" (attest/revoke)
+// with no attributable human reviewer at all.
+func (c *KeyorixCore) enforceAccessReviewReviewerControls(ctx context.Context, actorID uint, d AccessReviewDecision) error {
+	if err := requireHumanReviewer(actorID); err != nil {
+		return err
+	}
+	principalType := principalTypeForDecision(d)
+	if err := c.checkReviewerIndependence(ctx, actorID, principalType, d.PrincipalID); err != nil {
+		return err
+	}
+	// ARC-001: a machine identity provisioned by the actor must not be
+	// self-certified by its creator — mirrors DecideAccessReviewItem's
+	// identical inline check. Fails closed on a lookup error.
+	if d.Source == "role" && principalType == "machine" {
+		machine, err := c.storage.GetMachineIdentity(ctx, d.PrincipalID)
+		if err != nil {
+			return fmt.Errorf("loading machine identity: %w", err)
+		}
+		if machine.CreatedBy == actorID {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "independent reviewer required for machine identities you provisioned")
+		}
+	}
+	return nil
+}
+
 // RevokeAccessReviewGrant removes the grant identified by the decision: a project-
 // scoped role assignment (user or group) or a secret share (direct or group). The
 // underlying removal is itself audited (role.removed / role.group_removed for
@@ -63,6 +115,9 @@ type accessReviewAuditDetail struct {
 func (c *KeyorixCore) RevokeAccessReviewGrant(ctx context.Context, actorID, projectID uint, d AccessReviewDecision) error {
 	if projectID == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
+	}
+	if err := c.enforceAccessReviewReviewerControls(ctx, actorID, d); err != nil {
+		return err
 	}
 	switch d.Source {
 	case "role":
@@ -148,6 +203,9 @@ func (c *KeyorixCore) AttestAccessReviewGrant(ctx context.Context, actorID, proj
 	}
 	if d.Source == "" {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "source is required")
+	}
+	if err := c.enforceAccessReviewReviewerControls(ctx, actorID, d); err != nil {
+		return err
 	}
 	if err := c.verifyAccessReviewGrantExists(ctx, projectID, d); err != nil {
 		return err

--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -167,7 +167,7 @@ func (c *KeyorixCore) validateNewPassword(ctx context.Context, user *models.User
 // (hash persisted but the state clear lost, or vice versa) can't happen on backends
 // that support real transactions.
 func (c *KeyorixCore) applyNewPassword(ctx context.Context, user *models.User, newPassword string) error {
-	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcryptCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), int(bcryptCost.Load()))
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}

--- a/internal/core/alert_escalation.go
+++ b/internal/core/alert_escalation.go
@@ -177,12 +177,17 @@ func (c *KeyorixCore) dispatchToChannel(ctx context.Context, ch *models.Notifica
 		// accessed_by and ip_address are intentionally omitted: PII must not be
 		// forwarded to an external webhook receiver. The server-side audit log
 		// already captures this data for incident investigation.
+		//
+		// #G30: several alert types (new_ip, new_user, ml_outlier,
+		// principal_breadth) embed the SAME accessed_by/IP values as free text
+		// in Description, which used to bypass the redaction above — scrub any
+		// occurrence of this alert's own accessed_by/IP before it leaves too.
 		return c.postJSONToURL(ctx, ch.URL, map[string]any{
 			"event":       "anomaly.escalated",
 			"alert_id":    alert.ID,
 			"severity":    alert.Severity,
 			"alert_type":  alert.AlertType,
-			"description": alert.Description,
+			"description": redactAlertDescription(alert),
 			"secret_name": alert.SecretName,
 			"detected_at": alert.DetectedAt.Format(time.RFC3339),
 			"policy_name": policy.Name,
@@ -193,6 +198,23 @@ func (c *KeyorixCore) dispatchToChannel(ctx context.Context, ch *models.Notifica
 		log.Printf("alert escalation: channel %q (type=%s): escalation for alert %d logged (full delivery via notification sink)", ch.Name, ch.Type, alert.ID)
 		return nil
 	}
+}
+
+// redactAlertDescription strips any occurrence of the alert's own AccessedBy/
+// IPAddress from its free-text Description before it leaves the deployment via
+// an external webhook/Slack payload. Several alert types (new_ip, new_user,
+// ml_outlier, principal_breadth) embed these exact values as free text, which
+// would otherwise carry the same PII the structured accessed_by/ip_address
+// fields are deliberately omitted for on this path.
+func redactAlertDescription(alert *models.AnomalyAlert) string {
+	desc := alert.Description
+	if alert.AccessedBy != "" {
+		desc = strings.ReplaceAll(desc, alert.AccessedBy, "[redacted]")
+	}
+	if alert.IPAddress != "" {
+		desc = strings.ReplaceAll(desc, alert.IPAddress, "[redacted]")
+	}
+	return desc
 }
 
 // noEscalationRedirect refuses all HTTP redirects from webhook endpoints. An

--- a/internal/core/alert_escalation_test.go
+++ b/internal/core/alert_escalation_test.go
@@ -657,6 +657,36 @@ func TestSplitChannelIDs(t *testing.T) {
 	assert.Nil(t, splitChannelIDs(",,,"))
 }
 
+// TestDispatchToChannel_WebhookRedactsPIIEmbeddedInDescription is #G30: several
+// alert types (new_ip, new_user, ml_outlier, principal_breadth) embed the
+// alert's own AccessedBy/IPAddress as free text inside Description — which
+// used to bypass the accessed_by/ip_address structured-field redaction this
+// path already applies. The outbound JSON payload must not contain either
+// value anywhere, including inside "description".
+func TestDispatchToChannel_WebhookRedactsPIIEmbeddedInDescription(t *testing.T) {
+	var body []byte
+	tr := &fakeWebhookTransport{capture: func(b []byte) { body = b }}
+
+	c := NewKeyorixCore(new(MockStorage))
+	c.httpClient = &http.Client{Transport: tr}
+
+	alert := makeAlert(1, "high", 60)
+	alert.AccessedBy = "alice"
+	alert.IPAddress = "203.0.113.7"
+	alert.Description = fmt.Sprintf("ML detected an anomalous access pattern (score 0.92): %s from %s at 14:00 UTC differs from this secret's learned baseline",
+		alert.AccessedBy, alert.IPAddress)
+
+	ch := &models.NotificationChannel{ID: 7, Name: "test-webhook", Type: "webhook", URL: "http://fake-webhook.test/hook", Enabled: true}
+	policy := makePolicy(1, "p1", "medium", 30)
+
+	require.NoError(t, c.dispatchToChannel(context.Background(), ch, &alert, &policy))
+	require.NotNil(t, body)
+	assert.NotContains(t, string(body), "alice", "accessed_by embedded in Description must be redacted")
+	assert.NotContains(t, string(body), "203.0.113.7", "ip_address embedded in Description must be redacted")
+	assert.Contains(t, string(body), "[redacted]")
+	assert.Contains(t, string(body), "ML detected an anomalous access pattern", "the rest of the description must survive")
+}
+
 // ---- dispatchToChannel (teams type) ----
 
 func TestDispatchToChannel_TeamsType_LogOnly(t *testing.T) {

--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -376,9 +376,22 @@ func detectPrincipalBreadth(ctx context.Context, s StorageInterface, now, window
 	var alerts []models.AnomalyAlert
 	for principal, secrets := range firstSeen {
 		newCount := 0
-		for _, t := range secrets {
+		// #G43: pick a deterministic representative secret (lowest ID) among the
+		// ones that triggered this alert. AlertNewAnomalies resolves the owning
+		// project — and therefore which admins to notify in-app — from
+		// AnomalyAlert.SecretNodeID; principal_breadth left it unset (there's no
+		// single natural owner across many secrets), so every principal_breadth
+		// alert silently skipped the in-app admin notification, even though the
+		// audit/SIEM event still fired. One representative secret is enough to
+		// resolve a real project and get admins notified — it does not need to
+		// be exhaustive across every project the principal touched.
+		var representativeID uint
+		for secretID, t := range secrets {
 			if !t.Before(windowStart) { // first ever access to this secret falls in the live window
 				newCount++
+				if representativeID == 0 || secretID < representativeID {
+					representativeID = secretID
+				}
 			}
 		}
 		if newCount < principalBreadthMinNewSecrets {
@@ -389,8 +402,9 @@ func detectPrincipalBreadth(ctx context.Context, s StorageInterface, now, window
 			severity = "high"
 		}
 		alerts = append(alerts, models.AnomalyAlert{
-			AlertType: "principal_breadth",
-			Severity:  severity,
+			SecretNodeID: representativeID,
+			AlertType:    "principal_breadth",
+			Severity:     severity,
 			Description: fmt.Sprintf(
 				"%s accessed %d distinct secrets with no prior access history in the last scan window — possible breadth exfiltration",
 				principal, newCount),

--- a/internal/core/anomaly_alerting_external_test.go
+++ b/internal/core/anomaly_alerting_external_test.go
@@ -211,6 +211,53 @@ func TestRunDetection_DetectsPrincipalBreadthAcrossSecrets(t *testing.T) {
 	}
 	require.NotNil(t, breadth, "a principal reading 6 never-before-touched secrets must raise principal_breadth")
 	assert.Equal(t, "medium", breadth.Severity, "6 new secrets is below the high-severity multiplier (2x threshold = 10)")
+	assert.NotZero(t, breadth.SecretNodeID, "#G43: a representative SecretNodeID is required to resolve the owning project for in-app admin notification")
+}
+
+// TestAlertNewAnomalies_PrincipalBreadthNotifiesProjectAdmins is #G43: principal_breadth
+// alerts left SecretNodeID unset, so AlertNewAnomalies could never resolve a project and
+// silently skipped the in-app admin notification for every one of them (the audit/SIEM
+// event still fired, masking the gap). This drives the real detect → alert flow end to
+// end and asserts a project admin actually receives an in-app notification.
+func TestAlertNewAnomalies_PrincipalBreadthNotifiesProjectAdmins(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SecretNode{}, &models.SecretAccessLog{},
+		&models.AnomalyAlert{}, &models.AuditEvent{}, &models.Notification{}))
+
+	ctx := context.Background()
+	const adminID = uint(30)
+	projectID := uint(1)
+	require.NoError(t, h.DB.Create(&models.User{ID: adminID, Username: "admin30", Email: "admin30@x"}).Error)
+	h.AssignUserRole(t, adminID, 2, &projectID) // role 2 = "admin" (an approver role)
+
+	var secrets []models.SecretNode
+	for i := uint(910); i < 916; i++ {
+		s := models.SecretNode{ID: i, ProjectID: 1, Name: "s", Status: "active", IsSecret: true}
+		require.NoError(t, h.DB.Create(&s).Error)
+		secrets = append(secrets, s)
+		require.NoError(t, h.DB.Create(&models.SecretAccessLog{
+			SecretNodeID: s.ID, AccessedBy: "alice", Action: "read", IPAddress: "10.0.0.1",
+			AccessTime: time.Now().Add(-10 * 24 * time.Hour),
+		}).Error)
+	}
+	for _, s := range secrets {
+		require.NoError(t, h.DB.Create(&models.SecretAccessLog{
+			SecretNodeID: s.ID, AccessedBy: "mallory", Action: "read", IPAddress: "203.0.113.5",
+			AccessTime: time.Now(),
+		}).Error)
+	}
+
+	detector := core.NewAnomalyDetector(h.CoreService.Storage())
+	require.NoError(t, detector.RunDetection(ctx, secrets))
+
+	n, err := h.CoreService.AlertNewAnomalies(ctx)
+	require.NoError(t, err)
+	assert.Positive(t, n, "at least the principal_breadth alert must be announced")
+
+	var notif models.Notification
+	err = h.DB.Where("user_id = ? AND type = ?", adminID, core.EventAnomalyDetected).First(&notif).Error
+	require.NoError(t, err, "the project admin must have received an in-app notification for the principal_breadth alert")
 }
 
 // The compliance posture counts open (unacknowledged) anomalies, with a high-severity tally.

--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -219,6 +219,16 @@ func (c *KeyorixCore) writeAuditEventFailed(ctx context.Context, eventType strin
 		EventTime:   time.Now(),
 		ActorType:   actorTypeFromContext(ctx),
 	}
+	// #G23: stamp impersonation attribution the same way the success-path
+	// writer (writeAuditEventDiff) does — a failed action taken inside an
+	// impersonation session must be attributable to the impersonating admin
+	// too, not just the userID it was attempted as.
+	if adminID, ok := impersonatorFromContext(ctx); ok {
+		a := adminID
+		event.ImpersonatedBy = &a
+		event.ActingAs = userID
+		event.Impersonation = true
+	}
 	c.emitAudit(ctx, event)
 }
 

--- a/internal/core/audit_retention.go
+++ b/internal/core/audit_retention.go
@@ -33,18 +33,38 @@ func (c *KeyorixCore) PurgeAuditLogs(ctx context.Context, cfg AuditLogRetentionC
 		return nil, fmt.Errorf("%w: retention_days must be at least %d (got %d)",
 			ErrInvalidAuditRetentionDays, minRetentionDays, cfg.RetentionDays)
 	}
-	// Re-check the legal hold immediately before the delete — same pattern as
-	// PurgeExpiredSoftDeletes / PurgeExpiredComplianceRecords. A hold placed after
-	// the scheduler's pre-lock check would otherwise not stop an in-flight purge
-	// from destroying audit evidence that is now under hold (irreversible spoliation).
-	if err := c.legalHoldGuard(ctx); err != nil {
-		return nil, err
-	}
-
+	// #G21: the legal-hold check and the delete run inside ONE transaction — not
+	// a plain re-check immediately before an otherwise-separate delete call. A
+	// bare "check, then separately delete" still leaves a real (if narrow)
+	// window for PlaceLegalHold to commit an INSERT in between the two calls,
+	// which this closes for LocalStorage: SQLite's single-writer model means
+	// the transaction below holds an exclusive write lock for its whole
+	// duration, so a concurrent PlaceLegalHold's INSERT (also a write) cannot
+	// interleave between the hold check and the delete — it either committed
+	// before this transaction started (the check sees it and aborts) or blocks
+	// until this transaction finishes. NOTE: RemoteStorage.WithTransaction is a
+	// no-op passthrough (fn(rs), no real transaction) — under storage.type:
+	// remote this narrows the window (one closure instead of two independent
+	// core-layer calls) but does not eliminate it; closing it there would need
+	// a dedicated atomic proxy endpoint, out of scope for this pattern-level fix.
 	cutoff := c.now().UTC().AddDate(0, 0, -cfg.RetentionDays)
-	n, err := c.storage.DeleteAuditLogsBefore(ctx, cutoff)
-	if err != nil {
-		return nil, fmt.Errorf("failed to purge audit logs: %w", err)
+	var n int64
+	txErr := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		hold, err := tx.GetActiveLegalHold(ctx)
+		if err != nil {
+			return fmt.Errorf("refusing to purge: could not confirm legal-hold status: %w", err)
+		}
+		if hold != nil {
+			return fmt.Errorf("refusing to purge: a deployment-wide legal hold is active")
+		}
+		n, err = tx.DeleteAuditLogsBefore(ctx, cutoff)
+		if err != nil {
+			return fmt.Errorf("failed to purge audit logs: %w", err)
+		}
+		return nil
+	})
+	if txErr != nil {
+		return nil, txErr
 	}
 
 	// AUD-004: attribute the purge to the triggering user when one is present,

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -38,11 +38,6 @@ type LoginRequest struct {
 	IPAddress string
 }
 
-// dummyBcryptHash is a fixed bcrypt hash used to equalize the timing of the
-// user-not-found login path with the wrong-password path, so /auth/login can't
-// be used as a username-existence oracle. Initialized in bcrypt_cost.go init().
-var dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), bcryptCost) // NOSONAR -- not a credential; timing-equalization sentinel
-
 // RemoteLoginVerifier is implemented by storage backends that cannot themselves
 // supply a real password hash for VerifyPasswordCredentials to compare against
 // (#506): models.User.PasswordHash is deliberately `json:"-"` and NEVER crosses
@@ -105,7 +100,7 @@ func (c *KeyorixCore) VerifyPasswordCredentials(ctx context.Context, username, p
 	if err != nil {
 		// Spend an equivalent bcrypt comparison so a missing username doesn't return
 		// faster than a wrong password (account-enumeration timing side-channel).
-		_ = bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
+		_ = bcrypt.CompareHashAndPassword(*dummyBcryptHash.Load(), []byte(password))
 		return nil, fmt.Errorf("invalid credentials")
 	}
 	// Per-account lockout gate: while locked, refuse regardless of the password, so
@@ -114,7 +109,7 @@ func (c *KeyorixCore) VerifyPasswordCredentials(ctx context.Context, username, p
 	// fast (no-bcrypt) response on a locked account is a username-existence oracle (the
 	// attacker first forces the lockout, then probes by timing).
 	if c.loginLocked(user) {
-		_ = bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
+		_ = bcrypt.CompareHashAndPassword(*dummyBcryptHash.Load(), []byte(password))
 		return nil, fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)); err != nil {

--- a/internal/core/bcrypt_cost.go
+++ b/internal/core/bcrypt_cost.go
@@ -1,18 +1,41 @@
 package core
 
-import "golang.org/x/crypto/bcrypt"
+import (
+	"sync/atomic"
+
+	"golang.org/x/crypto/bcrypt"
+)
 
 // bcryptCost is the work factor for all password hashing. Production default is
 // 12. Tests should call SetBcryptCostForTesting(bcrypt.MinCost) in TestMain to
 // avoid slowing down the test suite.
-var bcryptCost = 12
+//
+// #G63: bcryptCost and dummyBcryptHash are both atomic (not a plain int/[]byte)
+// — SetBcryptCostForTesting is exported and nothing enforces its documented
+// "call before any test runs" contract, so a call racing a concurrent
+// account.go/scim.go/users.go/auth.go password-hashing read is a real,
+// unsynchronized data race (caught by `go test -race`), not just a
+// theoretical one.
+var bcryptCost atomic.Int32
+
+// dummyBcryptHash is a fixed bcrypt hash used to equalize the timing of the
+// user-not-found login path with the wrong-password path (auth.go), so
+// /auth/login can't be used as a username-existence oracle.
+var dummyBcryptHash atomic.Pointer[[]byte]
+
+func init() {
+	bcryptCost.Store(12)
+	hash, _ := bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), 12) // NOSONAR -- not a credential; timing-equalization sentinel
+	dummyBcryptHash.Store(&hash)
+}
 
 // SetBcryptCostForTesting sets the bcrypt work factor and regenerates the
 // timing-equalization dummy hash. Call this in TestMain before any test runs;
 // do not call in production code.
 func SetBcryptCostForTesting(cost int) {
-	bcryptCost = cost
+	bcryptCost.Store(int32(cost)) // #nosec G115 -- test-only; bcrypt's own valid range is 4-31, far below int32's range
 	// Regenerate so the dummy hash matches the test cost; otherwise the
 	// timing-equalization constant is computed at cost 12 even in tests.
-	dummyBcryptHash, _ = bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), cost) // NOSONAR
+	hash, _ := bcrypt.GenerateFromPassword([]byte("keyorix-login-timing-equalizer"), cost) // NOSONAR
+	dummyBcryptHash.Store(&hash)
 }

--- a/internal/core/bcrypt_cost_test.go
+++ b/internal/core/bcrypt_cost_test.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	"sync"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// TestSetBcryptCostForTesting_ConcurrentWithReads is #G63: bcryptCost/
+// dummyBcryptHash are package-level state read on every password-hashing call
+// (account.go, scim.go, users.go, auth.go). SetBcryptCostForTesting is
+// exported and its doc comment's "call before any test runs" contract isn't
+// enforced by anything — a call racing a concurrent read is a real,
+// unsynchronized data race under `go test -race`, not just a theoretical one.
+// This doesn't assert a specific value (concurrent writers make the observed
+// value nondeterministic by design); it only proves no race is reported and
+// nothing panics.
+func TestSetBcryptCostForTesting_ConcurrentWithReads(t *testing.T) {
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			SetBcryptCostForTesting(bcrypt.MinCost)
+		}()
+	}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = bcrypt.GenerateFromPassword([]byte("probe"), int(bcryptCost.Load()))
+			_ = bcrypt.CompareHashAndPassword(*dummyBcryptHash.Load(), []byte("probe"))
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	// Leave the package at MinCost regardless of which concurrent writer
+	// above landed last — this package's TestMain does not itself lower the
+	// cost, so leaving it at the slow production default (12) would slow
+	// down every later bcrypt-hashing test in this package.
+	SetBcryptCostForTesting(bcrypt.MinCost)
+}

--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -214,8 +214,16 @@ func (c *KeyorixCore) ActivateBreakGlass(ctx context.Context, projectID, userID 
 }
 
 // ListBreakGlassActivations returns the project's activations, newest first. An
-// active record whose expiry has passed is reported as expired (the grant is gone
-// by then, swept or filtered out — the record's stored state is reconciled lazily).
+// active record whose expiry has passed is reported as expired and, since this
+// is the most frequently-invoked read path for break-glass state (dashboards,
+// compliance posture snapshots), the transition is also persisted here —
+// best-effort, since the list result above is already correct regardless of
+// whether the write lands. #G43: previously the state was flipped ONLY on the
+// in-memory copy returned to this call's caller — the stored row stayed
+// 'active' in the database indefinitely (until the separate, much-longer-window
+// data-retention purge eventually hard-deletes it), so any consumer reading the
+// row directly (a proxy endpoint under storage.type: remote, a report querying
+// the table directly) saw a stale 'active' state.
 func (c *KeyorixCore) ListBreakGlassActivations(ctx context.Context, projectID uint) ([]*models.BreakGlassActivation, error) {
 	if projectID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
@@ -228,6 +236,9 @@ func (c *KeyorixCore) ListBreakGlassActivations(ctx context.Context, projectID u
 	for _, a := range rows {
 		if a.State == BreakGlassActive && a.ExpiresAt != nil && a.ExpiresAt.Before(now) {
 			a.State = BreakGlassExpired
+			if uerr := c.storage.UpdateBreakGlassActivation(ctx, a); uerr != nil {
+				log.Printf("break-glass: activation %d: failed to persist TTL-lapse state transition to %q: %v", a.ID, BreakGlassExpired, uerr)
+			}
 		}
 	}
 	return rows, nil

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -290,6 +290,15 @@ func TestListBreakGlassActivations_ExpiredReconciliation(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 	assert.Equal(t, core.BreakGlassExpired, list[0].State, "an active grant past expiry reads as expired")
+
+	// #G43: the transition must be PERSISTED to the row, not just reflected in
+	// the in-memory copy returned above — otherwise any consumer reading the
+	// table directly (a storage.type: remote proxy endpoint, a report) sees a
+	// stale 'active' state until the much-later data-retention purge deletes
+	// the row outright.
+	var stored models.BreakGlassActivation
+	require.NoError(t, h.DB.First(&stored, list[0].ID).Error)
+	assert.Equal(t, core.BreakGlassExpired, stored.State, "the TTL-lapse transition must be persisted to the database row")
 }
 
 // An expired break-glass grant must confer NO access at the authorization boundary — not

--- a/internal/core/classify_machine_test.go
+++ b/internal/core/classify_machine_test.go
@@ -18,10 +18,10 @@ func TestClassifyMachineIdentity(t *testing.T) {
 		c := newMachineCore(store)
 		store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, Name: "ci"}, nil)
 		var saved *models.MachineIdentity
-		store.On("UpdateMachineIdentity", mock.Anything, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+		store.On("TransitionMachineIdentityState", mock.Anything, mock.MatchedBy(func(m *models.MachineIdentity) bool {
 			saved = m
 			return true
-		})).Return(nil)
+		}), "").Return(true, nil)
 		store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
 			return e.EventType == "machine_identity.classified"
 		})).Return(nil)
@@ -30,6 +30,18 @@ func TestClassifyMachineIdentity(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "restricted", m.Classification)
 		assert.Equal(t, "restricted", saved.Classification)
+	})
+
+	t.Run("loses the race against a concurrent transition", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, Name: "ci", State: MachineActive}, nil)
+		store.On("TransitionMachineIdentityState", mock.Anything, mock.Anything, MachineActive).Return(false, nil)
+
+		_, err := c.ClassifyMachineIdentity(ctx, 2, 1, ClassificationRestricted, 9)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrMachineStateConflict)
+		store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 	})
 
 	t.Run("invalid level rejected", func(t *testing.T) {
@@ -46,7 +58,7 @@ func TestClassifyMachineIdentity(t *testing.T) {
 		store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2}, nil)
 		_, err := c.ClassifyMachineIdentity(ctx, 999, 1, ClassificationInternal, 9) // wrong project
 		require.Error(t, err)
-		store.AssertNotCalled(t, "UpdateMachineIdentity", mock.Anything, mock.Anything)
+		store.AssertNotCalled(t, "TransitionMachineIdentityState", mock.Anything, mock.Anything, mock.Anything)
 	})
 }
 

--- a/internal/core/compliance_digest.go
+++ b/internal/core/compliance_digest.go
@@ -97,7 +97,13 @@ func plural(n int) string {
 // every wired channel was a no-op — e.g. an email-only deployment with no
 // email.broadcast_to destination configured, #221). Audited either way, but the
 // audit event only claims success when delivery was actually attempted.
-func (c *KeyorixCore) SendComplianceDigest(ctx context.Context) (bool, error) {
+//
+// actorID is the admin who triggered an on-demand send (dashboard/admin-jobs
+// endpoints); 0 for the background scheduler (server/main.go), which has no
+// authenticated principal. #G23: this used to always audit actor_type=system
+// with a nil UserID even for an admin-triggered on-demand send, so a manual
+// "send now" was indistinguishable from the scheduled run in the audit trail.
+func (c *KeyorixCore) SendComplianceDigest(ctx context.Context, actorID uint) (bool, error) {
 	if c.notificationSink == nil {
 		return false, nil // nowhere to deliver — no channel configured
 	}
@@ -111,12 +117,19 @@ func (c *KeyorixCore) SendComplianceDigest(ctx context.Context) (bool, error) {
 		Message: body,
 		Link:    "/compliance",
 	})
-	sysCtx := WithActorType(ctx, ActorTypeSystem)
+	auditCtx := ctx
+	var userID *uint
+	if actorID != 0 {
+		uid := actorID
+		userID = &uid
+	} else {
+		auditCtx = WithActorType(ctx, ActorTypeSystem)
+	}
 	if !attempted {
 		log.Printf("compliance digest: notification channel(s) configured but none accepted the broadcast (e.g. email-only with no broadcast destination) — digest was NOT delivered")
-		c.writeAuditEventFailed(sysCtx, EventComplianceDigestSent, nil, "", "compliance digest broadcast attempted but no configured channel could accept it")
+		c.writeAuditEventFailed(auditCtx, EventComplianceDigestSent, userID, "", "compliance digest broadcast attempted but no configured channel could accept it")
 		return false, nil
 	}
-	c.writeAuditEvent(sysCtx, EventComplianceDigestSent, nil, nil, "compliance digest broadcast to notification channels")
+	c.writeAuditEvent(auditCtx, EventComplianceDigestSent, userID, nil, "compliance digest broadcast to notification channels")
 	return true, nil
 }

--- a/internal/core/compliance_digest_test.go
+++ b/internal/core/compliance_digest_test.go
@@ -44,7 +44,7 @@ func TestFormatComplianceDigest_AllPass(t *testing.T) {
 
 func TestSendComplianceDigest_NoSinkNoOp(t *testing.T) {
 	c := &KeyorixCore{storage: new(MockStorage), now: time.Now}
-	sent, err := c.SendComplianceDigest(context.Background())
+	sent, err := c.SendComplianceDigest(context.Background(), 0)
 	require.NoError(t, err)
 	assert.False(t, sent, "no notification channel → nothing delivered")
 }
@@ -53,7 +53,7 @@ func TestSendComplianceDigest_Broadcasts(t *testing.T) {
 	c, db, _ := newEvidenceExportCore(t) // real store, empty deployment
 	sink := &fakeSink{}
 	c.SetNotificationSink(sink)
-	sent, err := c.SendComplianceDigest(context.Background())
+	sent, err := c.SendComplianceDigest(context.Background(), 0)
 	require.NoError(t, err)
 	assert.True(t, sent)
 	require.Len(t, sink.events, 1)
@@ -65,6 +65,29 @@ func TestSendComplianceDigest_Broadcasts(t *testing.T) {
 	require.Len(t, events, 1)
 	require.NotNil(t, events[0].Success)
 	assert.True(t, *events[0].Success, "the digest genuinely was delivered — the audit event must say so")
+	assert.Nil(t, events[0].UserID, "actorID=0 (scheduler) must audit as system, not attributed to a user")
+}
+
+// TestSendComplianceDigest_AttributesOnDemandSendToActor is #G23: an admin
+// triggering the digest on-demand (dashboard/admin-jobs endpoints) must be
+// attributed by UserID in the audit trail — previously this was always
+// hardcoded to actor_type=system with a nil UserID, indistinguishable from
+// the unattended scheduled run.
+func TestSendComplianceDigest_AttributesOnDemandSendToActor(t *testing.T) {
+	c, db, _ := newEvidenceExportCore(t) // real store, empty deployment
+	sink := &fakeSink{}
+	c.SetNotificationSink(sink)
+
+	const actorID = 42
+	sent, err := c.SendComplianceDigest(context.Background(), actorID)
+	require.NoError(t, err)
+	assert.True(t, sent)
+
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", "compliance.digest_sent").Find(&events).Error)
+	require.Len(t, events, 1)
+	require.NotNil(t, events[0].UserID)
+	assert.Equal(t, uint(actorID), *events[0].UserID)
 }
 
 // TestSendComplianceDigest_NoChannelAcceptsIt is a regression test for #221: an
@@ -84,7 +107,7 @@ func TestSendComplianceDigest_NoChannelAcceptsIt(t *testing.T) {
 	var sent bool
 	var err error
 	logged := captureLog(t, func() {
-		sent, err = c.SendComplianceDigest(context.Background())
+		sent, err = c.SendComplianceDigest(context.Background(), 0)
 	})
 	require.NoError(t, err)
 	assert.False(t, sent, "no channel accepted the broadcast — the caller must be told delivery did not happen")

--- a/internal/core/core_s26_test.go
+++ b/internal/core/core_s26_test.go
@@ -616,8 +616,31 @@ func TestVerifyAccessReviewGrantExists_RoleSource_Found(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestVerifyAccessReviewGrantExists_RoleSource_Machine is #G51: a
+// machine-identity role grant is queried from ListProjectMachineRoleAssignments,
+// a separate storage call from the user/group path — and must NOT fall through
+// to ListProjectRoleAssignments at all (it would never match there).
+func TestVerifyAccessReviewGrantExists_RoleSource_Machine(t *testing.T) {
+	ms := new(MockStorage)
+	assignments := []storage.RoleAssignment{
+		{PrincipalType: "machine", PrincipalID: 50, RoleID: 3, EnvironmentID: 0},
+	}
+	ms.On("ListProjectMachineRoleAssignments", mock.Anything, uint(1)).Return(assignments, nil)
+	c := NewKeyorixCore(ms)
+	d := AccessReviewDecision{
+		Source:        "role",
+		PrincipalType: "machine",
+		PrincipalID:   50,
+		RoleID:        3,
+	}
+	err := c.verifyAccessReviewGrantExists(context.Background(), 1, d)
+	require.NoError(t, err)
+	ms.AssertNotCalled(t, "ListProjectRoleAssignments", mock.Anything, mock.Anything)
+}
+
 func TestVerifyAccessReviewGrantExists_DirectShare_Found(t *testing.T) {
 	ms := new(MockStorage)
+	ms.On("GetSecret", mock.Anything, uint(10)).Return(&models.SecretNode{ID: 10, ProjectID: 1}, nil)
 	shares := []*models.ShareRecord{
 		{ID: 1, SecretID: 10, RecipientID: 5, IsGroup: false},
 	}
@@ -632,8 +655,28 @@ func TestVerifyAccessReviewGrantExists_DirectShare_Found(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestVerifyAccessReviewGrantExists_DirectShare_CrossProjectRefused is #G51: a
+// share on a secret belonging to a DIFFERENT project must be refused even
+// though the recipient/isGroup match — the secret's own project must gate the
+// share lookup.
+func TestVerifyAccessReviewGrantExists_DirectShare_CrossProjectRefused(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetSecret", mock.Anything, uint(10)).Return(&models.SecretNode{ID: 10, ProjectID: 2}, nil)
+	c := NewKeyorixCore(ms)
+	d := AccessReviewDecision{
+		Source:      "direct_share",
+		SecretID:    10,
+		PrincipalID: 5,
+	}
+	err := c.verifyAccessReviewGrantExists(context.Background(), 1, d)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no longer exists")
+	ms.AssertNotCalled(t, "ListSharesBySecret", mock.Anything, mock.Anything)
+}
+
 func TestVerifyAccessReviewGrantExists_DirectShare_NotFound(t *testing.T) {
 	ms := new(MockStorage)
+	ms.On("GetSecret", mock.Anything, uint(10)).Return(&models.SecretNode{ID: 10, ProjectID: 1}, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(10)).Return([]*models.ShareRecord{}, nil)
 	c := NewKeyorixCore(ms)
 	d := AccessReviewDecision{
@@ -648,7 +691,7 @@ func TestVerifyAccessReviewGrantExists_DirectShare_NotFound(t *testing.T) {
 
 func TestVerifyAccessReviewGrantExists_Owner_Found(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("GetSecret", mock.Anything, uint(10)).Return(&models.SecretNode{ID: 10, OwnerID: 5}, nil)
+	ms.On("GetSecret", mock.Anything, uint(10)).Return(&models.SecretNode{ID: 10, ProjectID: 1, OwnerID: 5}, nil)
 	c := NewKeyorixCore(ms)
 	d := AccessReviewDecision{
 		Source:      "owner",
@@ -661,12 +704,29 @@ func TestVerifyAccessReviewGrantExists_Owner_Found(t *testing.T) {
 
 func TestVerifyAccessReviewGrantExists_Owner_WrongOwner(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("GetSecret", mock.Anything, uint(10)).Return(&models.SecretNode{ID: 10, OwnerID: 99}, nil)
+	ms.On("GetSecret", mock.Anything, uint(10)).Return(&models.SecretNode{ID: 10, ProjectID: 1, OwnerID: 99}, nil)
 	c := NewKeyorixCore(ms)
 	d := AccessReviewDecision{
 		Source:      "owner",
 		SecretID:    10,
 		PrincipalID: 5, // != 99
+	}
+	err := c.verifyAccessReviewGrantExists(context.Background(), 1, d)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no longer exists")
+}
+
+// TestVerifyAccessReviewGrantExists_Owner_CrossProjectRefused is #G51: a
+// secret's ownership grant in a DIFFERENT project must be refused even when
+// the owner ID matches, exactly mirroring the direct_share cross-project case.
+func TestVerifyAccessReviewGrantExists_Owner_CrossProjectRefused(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetSecret", mock.Anything, uint(10)).Return(&models.SecretNode{ID: 10, ProjectID: 2, OwnerID: 5}, nil)
+	c := NewKeyorixCore(ms)
+	d := AccessReviewDecision{
+		Source:      "owner",
+		SecretID:    10,
+		PrincipalID: 5,
 	}
 	err := c.verifyAccessReviewGrantExists(context.Background(), 1, d)
 	require.Error(t, err)

--- a/internal/core/core_s30_test.go
+++ b/internal/core/core_s30_test.go
@@ -215,7 +215,10 @@ func TestWithdrawAccessRequest_WrongUser(t *testing.T) {
 	c := NewKeyorixCore(ms)
 	err := c.WithdrawAccessRequest(context.Background(), 1, 99)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not your access request")
+	// #G14: same generic "not found" a nonexistent request ID gets — a distinct
+	// "not your access request" message would let a caller enumerate request IDs
+	// that exist but belong to someone else.
+	assert.Contains(t, err.Error(), "access request not found")
 }
 
 func TestWithdrawAccessRequest_NotPending(t *testing.T) {

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -37,6 +37,25 @@ var (
 	// dropped or silently clobber the winner.
 	ErrUserActiveStateConflict = errors.New("user's active state changed concurrently")
 
+	// ErrMembershipStateConflict is returned by TransitionMembership when it
+	// loses a race against a concurrent TransitionMembership call on the same
+	// project membership — the row's persisted state moved away from the
+	// value this call observed between its read and its conditional write
+	// (storage.Storage.TransitionProjectMembershipState). #G42: mirrors
+	// ErrUserActiveStateConflict/ErrMachineStateConflict — the caller must
+	// retry against the current state, not silently clobber (or be clobbered
+	// by) the transition.
+	ErrMembershipStateConflict = errors.New("project membership's state changed concurrently")
+
+	// ErrMachineStateConflict is returned by ClassifyMachineIdentity when it
+	// loses a race against a concurrent TransitionMachineIdentity call on the
+	// same machine identity — the row's persisted state moved away from the
+	// value this call observed between its read and its conditional write
+	// (storage.Storage.TransitionMachineIdentityState). #G42: mirrors
+	// ErrUserActiveStateConflict — the caller must retry against the current
+	// state, not silently clobber (or be clobbered by) the state transition.
+	ErrMachineStateConflict = errors.New("machine identity's state changed concurrently")
+
 	// ErrConnectDisabled is returned by the Keyorix Connect (ADR-043) methods when
 	// no external-store connector is configured.
 	ErrConnectDisabled = errors.New("keyorix connect is not enabled")

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -37,6 +37,12 @@ var (
 	// dropped or silently clobber the winner.
 	ErrUserActiveStateConflict = errors.New("user's active state changed concurrently")
 
+	// ErrNotProjectMember is returned by RemoveProjectMember when the target
+	// user holds no role grant in the project — a benign no-op distinguishable
+	// (via errors.Is) from a real refusal such as guardLastProjectAdmin's,
+	// which callers must NOT treat the same way (#G54).
+	ErrNotProjectMember = errors.New("user is not a member of this project")
+
 	// ErrMembershipStateConflict is returned by TransitionMembership when it
 	// loses a race against a concurrent TransitionMembership call on the same
 	// project membership — the row's persisted state moved away from the

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -477,6 +477,26 @@ func (c *KeyorixCore) RequestProjectAccess(ctx context.Context, projectID, userI
 	if _, err := c.storage.GetProject(ctx, projectID); err != nil {
 		return nil, fmt.Errorf("project %d not found: %w", projectID, err)
 	}
+	// #G82: refuse a second pending PROJECT-ROLE request for the SAME (user,
+	// project) pair — without this, any authenticated user could call this
+	// endpoint in a tight loop and flood the project with an unbounded number
+	// of pending AccessRequest rows, each firing its own admin notification
+	// (notifyAccessRequested below). Scoped to e.SecretID == nil: a
+	// SECRET-scoped request (RequestSecretAccess, classification_gate.go)
+	// shares the same (UserID, ProjectID) shape but is a semantically
+	// different request the user may legitimately have pending at the same
+	// time as a project-role request. ListAccessRequests lazily expires stale
+	// pending rows on read, so this check is never blocked by a request
+	// that's actually expired.
+	existing, err := c.storage.ListAccessRequests(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing access requests: %w", err)
+	}
+	for _, e := range existing {
+		if e.UserID == userID && e.State == AccessRequestPending && e.SecretID == nil {
+			return nil, fmt.Errorf("you already have a pending access request for this project")
+		}
+	}
 	now := c.now()
 	expires := now.Add(accessRequestTTL)
 	req := &models.AccessRequest{

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -792,13 +792,18 @@ func (c *KeyorixCore) RejectAccessRequest(ctx context.Context, projectID, reques
 }
 
 // WithdrawAccessRequest lets the requester cancel their own pending request.
+// #G14: a nonexistent requestID and one that exists but belongs to another
+// user both yield the SAME "access request not found" error — a distinct "not
+// your access request" message would let a caller enumerate which request IDs
+// exist (and are owned by someone else) purely from the response shape.
 func (c *KeyorixCore) WithdrawAccessRequest(ctx context.Context, requestID, userID uint) error {
+	notFound := fmt.Errorf("access request not found")
 	req, err := c.storage.GetAccessRequest(ctx, requestID)
 	if err != nil {
-		return fmt.Errorf("access request not found")
+		return notFound
 	}
 	if req.UserID != userID {
-		return fmt.Errorf("not your access request")
+		return notFound
 	}
 	if req.State != AccessRequestPending {
 		return fmt.Errorf("only a pending request can be withdrawn (state is %s)", req.State)

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -366,10 +366,11 @@ func TestWithdrawAccessRequest_OwnershipChecked(t *testing.T) {
 	ctx := context.Background()
 	store.On("GetAccessRequest", ctx, uint(3)).Return(&models.AccessRequest{ID: 3, UserID: 2, State: AccessRequestPending}, nil)
 
-	// A different user cannot withdraw it.
+	// A different user cannot withdraw it. #G14: the denial is the same generic
+	// "not found" a nonexistent request ID gets, not a distinct ownership message.
 	err := c.WithdrawAccessRequest(ctx, 3, 99)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not your")
+	assert.Contains(t, err.Error(), "not found")
 	store.AssertNotCalled(t, "UpdateAccessRequest", mock.Anything, mock.Anything)
 }
 

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -323,6 +323,33 @@ func TestRequestProjectAccess_RejectsSoftDeletedProject(t *testing.T) {
 	require.Error(t, err, "requesting access to a soft-deleted project must be refused")
 }
 
+// TestRequestProjectAccess_RefusesDuplicatePending is #G82: an authenticated
+// user must not be able to flood a project with unbounded pending access
+// requests (and the admin notification each one fires) by calling this
+// endpoint repeatedly — a second request while the first is still pending
+// must be refused.
+func TestRequestProjectAccess_RefusesDuplicatePending(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	requester, err := st.CreateUser(ctx, &models.User{Username: "requester", Email: "requester@example.com", IsActive: true})
+	require.NoError(t, err)
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "flood-target"})
+	require.NoError(t, err)
+
+	first, err := c.RequestProjectAccess(ctx, proj.ID, requester.ID, "", "please")
+	require.NoError(t, err)
+	require.Equal(t, AccessRequestPending, first.State)
+
+	_, err = c.RequestProjectAccess(ctx, proj.ID, requester.ID, "", "please again")
+	require.Error(t, err, "a second request while the first is still pending must be refused")
+	assert.Contains(t, err.Error(), "already have a pending")
+
+	requests, err := c.ListAccessRequests(ctx, proj.ID)
+	require.NoError(t, err)
+	assert.Len(t, requests, 1, "the flood attempt must not have created a second row")
+}
+
 // #371: ApproveAccessRequestWithExpiry must refuse to approve a request whose target
 // project has been soft-deleted in the meantime — DeleteProject never touches
 // access_requests, so without this check a stale pending request could be approved

--- a/internal/core/legal_hold_external_test.go
+++ b/internal/core/legal_hold_external_test.go
@@ -84,6 +84,29 @@ func TestLegalHold_PlaceDeniedForNonAdmin(t *testing.T) {
 	assert.False(t, hold.Released)
 }
 
+// TestLegalHold_PlaceDeniedAuditsImpersonator is #G23: writeAuditEventFailed
+// (used by the denied-placement path above) didn't stamp impersonation
+// attribution the way the success-path writer (writeAuditEventDiff) already
+// did — an action taken and DENIED inside an impersonation session must still
+// be attributable to the impersonating admin, not just the userID it was
+// attempted as.
+func TestLegalHold_PlaceDeniedAuditsImpersonator(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.LegalHold{}, &models.AuditEvent{}, &models.User{}, &models.UserRole{}))
+	ctx := core.WithImpersonation(context.Background(), 1) // admin 1 is impersonating actor 9
+
+	// Actor 9 holds no role at all — not admin-tier, so placement is denied.
+	_, err := h.CoreService.PlaceLegalHold(ctx, 9, "bogus decoy hold")
+	require.Error(t, err)
+
+	var event models.AuditEvent
+	require.NoError(t, h.DB.Where("event_type = ? AND success = ?", core.EventLegalHoldPlaced, false).First(&event).Error)
+	require.NotNil(t, event.ImpersonatedBy, "the denied action must record who was impersonating")
+	assert.Equal(t, uint(1), *event.ImpersonatedBy)
+	assert.True(t, event.Impersonation)
+}
+
 // TestLegalHold_PlaceDeniedForProjectScopedAdmin is the #G01 regression: an
 // admin-tier role granted only at a specific project must not be treated as
 // install-wide admin-bypass authority — PlaceLegalHold is a deployment-wide

--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -227,10 +227,22 @@ func (c *KeyorixCore) ClassifyMachineIdentity(ctx context.Context, projectID, id
 		return m, nil // no-op
 	}
 	old := m.Classification
+	fromState := m.State
 	m.Classification = level
 	m.UpdatedAt = c.now()
-	if err := c.storage.UpdateMachineIdentity(ctx, m); err != nil {
+	// #G42: a blind c.storage.UpdateMachineIdentity (full-row Save) here would
+	// race TransitionMachineIdentity — m was read above via machineInProject,
+	// so a concurrent suspend/revoke landing between that read and this write
+	// would be silently reverted (or, if this write lands first, silently
+	// clobbered), resurrecting a just-revoked identity. Route through the
+	// same conditional write TransitionMachineIdentity itself uses, gated on
+	// the state this call actually observed.
+	matched, err := c.storage.TransitionMachineIdentityState(ctx, m, fromState)
+	if err != nil {
 		return nil, fmt.Errorf("failed to update machine identity: %w", err)
+	}
+	if !matched {
+		return nil, fmt.Errorf("machine identity %d: %w", m.ID, ErrMachineStateConflict)
 	}
 	aid, pid := actorID, m.ProjectID
 	diff := fmt.Sprintf(`{"classification":{"before":%q,"after":%q}}`, old, level)

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -275,8 +275,19 @@ func (c *KeyorixCore) TransitionMembership(ctx context.Context, projectID, membe
 	case MembershipRevoked:
 		m.RevokedAt = &now
 	}
-	if err := c.storage.UpdateProjectMembership(ctx, m); err != nil {
+	// #G42: a blind UpdateProjectMembership (full-row Save) here would race a
+	// concurrent TransitionMembership call on the same membership — m was
+	// read above via GetProjectMembership with no lock, so a concurrent
+	// transition landing between that read and this write would be silently
+	// reverted (or, if this write lands first, silently clobbered). Route
+	// through the conditional write gated on the state this call actually
+	// observed (prevState).
+	matched, err := c.storage.TransitionProjectMembershipState(ctx, m, prevState)
+	if err != nil {
 		return nil, fmt.Errorf("failed to update membership: %w", err)
+	}
+	if !matched {
+		return nil, fmt.Errorf("membership %d: %w", membershipID, ErrMembershipStateConflict)
 	}
 
 	// Side effects on the role grant.
@@ -375,6 +386,11 @@ func (c *KeyorixCore) logMembershipEvent(ctx context.Context, eventType string, 
 // audited (flagged for manual cleanup) rather than returned or retried — a partial
 // revert is strictly better than silently leaving the active row standing.
 func (c *KeyorixCore) revertFailedActivation(ctx context.Context, m *models.ProjectMembership, toState string) {
+	// #G42: m.State is still MembershipActive here (TransitionMembership's own
+	// write above just committed it) — capture that as fromState so this
+	// revert's write only matches if nothing else has touched the row since,
+	// same as TransitionMembership's own conditional write.
+	fromState := m.State
 	m.State = toState
 	m.UpdatedAt = c.now()
 	if toState == MembershipRevoked {
@@ -383,7 +399,11 @@ func (c *KeyorixCore) revertFailedActivation(ctx context.Context, m *models.Proj
 	} else {
 		m.ActivatedAt = nil
 	}
-	if err := c.storage.UpdateProjectMembership(ctx, m); err != nil {
+	matched, err := c.storage.TransitionProjectMembershipState(ctx, m, fromState)
+	if err == nil && !matched {
+		err = fmt.Errorf("%w", ErrMembershipStateConflict)
+	}
+	if err != nil {
 		c.auditProjectScoped(ctx, "membership.activation_race_revert_failed", m.UserID, m.ProjectID,
 			fmt.Sprintf("failed to revert orphaned active membership %d for user %d in project %d (state %s) after a role-grant failure: %v — MANUAL CLEANUP REQUIRED",
 				m.ID, m.UserID, m.ProjectID, toState, err))

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -304,8 +304,20 @@ func (c *KeyorixCore) TransitionMembership(ctx context.Context, projectID, membe
 			return nil, fmt.Errorf("failed to grant role on activation: %w", err)
 		}
 	case MembershipRevoked:
-		// Best-effort: the membership is already revoked; a missing grant is fine.
-		_ = c.RemoveProjectMember(ctx, actorID, m.ProjectID, m.UserID)
+		if err := c.RemoveProjectMember(ctx, actorID, m.ProjectID, m.UserID); err != nil && !errors.Is(err, ErrNotProjectMember) {
+			// #G54: a security-relevant refusal (guardLastProjectAdmin: this user is
+			// the project's last roles.assign holder) or a real storage failure must
+			// not be silently swallowed — the membership row was just committed as
+			// `revoked` above, but if the underlying role grant removal was
+			// REFUSED, the user still holds full access via that live grant while
+			// ListProjectMemberships and friends report them as removed. Revert the
+			// membership back to its pre-transition state and surface the error,
+			// same as the activation-failure handling above. ErrNotProjectMember
+			// (no grant existed to remove — already gone via some other path) is
+			// the one genuinely benign case and is still ignored.
+			c.revertFailedActivation(ctx, m, prevState)
+			return nil, fmt.Errorf("failed to remove role grant on revocation: %w", err)
+		}
 	}
 
 	c.logMembershipEvent(ctx, "membership."+transitionVerb(to), m, actorID)

--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -133,7 +133,7 @@ func TestTransitionMembership_RejectsIllegalJump(t *testing.T) {
 	_, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot transition")
-	store.AssertNotCalled(t, "UpdateProjectMembership", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "TransitionProjectMembershipState", mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestInviteMember_OpenActivationFailure_RevertsOrphanedActiveMembership is the
@@ -163,9 +163,9 @@ func TestInviteMember_OpenActivationFailure_RevertsOrphanedActiveMembership(t *t
 	// any caller whose role is already held via an independent path).
 	store.On("AssignRole", ctx, uint(2), uint(6), storage.Scope{ProjectID: 1}).
 		Return(fmt.Errorf("Role already assigned"))
-	store.On("UpdateProjectMembership", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
+	store.On("TransitionProjectMembershipState", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
 		return m.ID == 51 && m.State == MembershipRevoked && m.RevokedAt != nil
-	})).Return(nil)
+	}), MembershipActive).Return(true, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
 	m, err := c.InviteMember(ctx, 1, 2, "project_viewer", 9, false)
@@ -176,7 +176,7 @@ func TestInviteMember_OpenActivationFailure_RevertsOrphanedActiveMembership(t *t
 	assert.Nil(t, m)
 
 	// (b) the just-created row was actually reverted, not left standing active.
-	store.AssertNumberOfCalls(t, "UpdateProjectMembership", 1)
+	store.AssertNumberOfCalls(t, "TransitionProjectMembershipState", 1)
 	assert.Equal(t, MembershipRevoked, created.State, "orphaned row must not still read as active")
 	assert.NotNil(t, created.RevokedAt)
 }
@@ -198,15 +198,15 @@ func TestTransitionMembership_ActivationFailure_RevertsToPriorState(t *testing.T
 	store.On("GetProjectMembership", ctx, uint(50)).Return(existing, nil)
 	store.On("GetRoleByName", ctx, "project_viewer").Return(&models.Role{ID: 6, Name: "project_viewer"}, nil)
 	// First write: persists the (about to be reverted) active state.
-	store.On("UpdateProjectMembership", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
+	store.On("TransitionProjectMembershipState", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
 		return m.ID == 50 && m.State == MembershipActive
-	})).Return(nil).Once()
+	}), MembershipProvisioned).Return(true, nil).Once()
 	store.On("AssignRole", ctx, uint(2), uint(6), storage.Scope{ProjectID: 1}).
 		Return(fmt.Errorf("Role already assigned"))
 	// Revert write: must go back to `provisioned`, not `revoked`.
-	store.On("UpdateProjectMembership", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
+	store.On("TransitionProjectMembershipState", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
 		return m.ID == 50 && m.State == MembershipProvisioned
-	})).Return(nil).Once()
+	}), MembershipActive).Return(true, nil).Once()
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
 	m, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9)
@@ -215,7 +215,7 @@ func TestTransitionMembership_ActivationFailure_RevertsToPriorState(t *testing.T
 	assert.Contains(t, err.Error(), "failed to grant role on activation")
 	assert.Nil(t, m)
 	assert.Equal(t, MembershipProvisioned, existing.State, "must revert to the pre-transition state, not stay active or jump to revoked")
-	store.AssertNumberOfCalls(t, "UpdateProjectMembership", 2)
+	store.AssertNumberOfCalls(t, "TransitionProjectMembershipState", 2)
 }
 
 // Cross-project guard: a membership in project 2 must not be transitionable when
@@ -230,7 +230,7 @@ func TestTransitionMembership_RejectsOtherProject(t *testing.T) {
 	_, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
-	store.AssertNotCalled(t, "UpdateProjectMembership", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "TransitionProjectMembershipState", mock.Anything, mock.Anything, mock.Anything)
 	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
@@ -240,9 +240,9 @@ func TestTransitionMembership_ActivateGrantsRole(t *testing.T) {
 	ctx := context.Background()
 	m := &models.ProjectMembership{ID: 50, ProjectID: 1, UserID: 2, Role: "project_developer", State: MembershipProvisioned}
 	store.On("GetProjectMembership", ctx, uint(50)).Return(m, nil)
-	store.On("UpdateProjectMembership", ctx, mock.MatchedBy(func(x *models.ProjectMembership) bool {
+	store.On("TransitionProjectMembershipState", ctx, mock.MatchedBy(func(x *models.ProjectMembership) bool {
 		return x.State == MembershipActive && x.ActivatedAt != nil
-	})).Return(nil)
+	}), MembershipProvisioned).Return(true, nil)
 	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5}, nil)
 	store.On("AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1}).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
@@ -259,9 +259,9 @@ func TestTransitionMembership_RevokeRemovesRole(t *testing.T) {
 	ctx := context.Background()
 	m := &models.ProjectMembership{ID: 50, ProjectID: 1, UserID: 2, State: MembershipActive}
 	store.On("GetProjectMembership", ctx, uint(50)).Return(m, nil)
-	store.On("UpdateProjectMembership", ctx, mock.MatchedBy(func(x *models.ProjectMembership) bool {
+	store.On("TransitionProjectMembershipState", ctx, mock.MatchedBy(func(x *models.ProjectMembership) bool {
 		return x.State == MembershipRevoked && x.RevokedAt != nil
-	})).Return(nil)
+	}), MembershipActive).Return(true, nil)
 	// RemoveProjectMember resolves and drops the role grant (best-effort). The
 	// role (5) doesn't carry roles.assign, so the last-admin guard (#236) is a
 	// fast no-op. ListProjectRoleAssignments is still consulted unconditionally

--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -282,6 +282,46 @@ func TestTransitionMembership_RevokeRemovesRole(t *testing.T) {
 	store.AssertCalled(t, "ClearProjectSecretOwnership", ctx, uint(2), uint(1))
 }
 
+// TestTransitionMembership_RevokeRefusedForLastAdmin_RevertsAndReturnsError is
+// #G54: RemoveProjectMember's guardLastProjectAdmin refusal (the target is the
+// project's last roles.assign holder) must not be silently swallowed. Before
+// the fix, TransitionMembership discarded this error entirely — the
+// membership row committed as `revoked` while the user's role grant (their
+// actual access) stayed fully live, a security-relevant inconsistency. The
+// fix must revert the membership back to its pre-transition state and
+// surface the error.
+func TestTransitionMembership_RevokeRefusedForLastAdmin_RevertsAndReturnsError(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	ctx := context.Background()
+	m := &models.ProjectMembership{ID: 50, ProjectID: 1, UserID: 2, State: MembershipActive}
+	store.On("GetProjectMembership", ctx, uint(50)).Return(m, nil)
+	// First write: persists the (about to be reverted) revoked state.
+	store.On("TransitionProjectMembershipState", ctx, mock.MatchedBy(func(x *models.ProjectMembership) bool {
+		return x.State == MembershipRevoked
+	}), MembershipActive).Return(true, nil).Once()
+	// RemoveProjectMember's guardLastProjectAdmin: user 2 is the project's
+	// only roles.assign holder, so removal is refused.
+	store.On("GetUserRoleIDsExact", ctx, uint(2), storage.Scope{ProjectID: 1}).Return([]uint{5}, nil)
+	store.On("RoleSetHasPermission", ctx, []uint{5}, "roles.assign").Return(true, nil)
+	store.On("RoleSetHasPermission", ctx, []uint(nil), "roles.assign").Return(false, nil)
+	store.On("ListProjectRoleAssignments", ctx, uint(1)).Return([]storage.RoleAssignment{
+		{PrincipalType: "user", PrincipalID: 2, RoleID: 5, ProjectID: 1},
+	}, nil)
+	// Revert write: must go back to `active`, not stay revoked.
+	store.On("TransitionProjectMembershipState", ctx, mock.MatchedBy(func(x *models.ProjectMembership) bool {
+		return x.State == MembershipActive
+	}), MembershipRevoked).Return(true, nil).Once()
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	out, err := c.TransitionMembership(ctx, 1, 50, MembershipRevoked, 9)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to remove role grant on revocation")
+	assert.Nil(t, out)
+	assert.Equal(t, MembershipActive, m.State, "must revert to active, not leave the row revoked while the grant stays live")
+	store.AssertNotCalled(t, "RemoveAllProjectRoleGrants", mock.Anything, mock.Anything, mock.Anything)
+}
+
 func TestStaleInvites_PassesCutoff(t *testing.T) {
 	store := new(MockStorage)
 	c := newMembershipCore(store)

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1980,6 +1980,11 @@ func (m *MockStorage) UpdateProjectMembership(ctx context.Context, pm *models.Pr
 	return args.Error(0)
 }
 
+func (m *MockStorage) TransitionProjectMembershipState(ctx context.Context, pm *models.ProjectMembership, fromState string) (bool, error) {
+	args := m.Called(ctx, pm, fromState)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *MockStorage) ListProjectMemberships(ctx context.Context, projectID uint) ([]*models.ProjectMembership, error) {
 	args := m.Called(ctx, projectID)
 	if args.Get(0) == nil {

--- a/internal/core/notification_dispatch_test.go
+++ b/internal/core/notification_dispatch_test.go
@@ -161,7 +161,7 @@ func TestSendComplianceDigest_UsesBroadcastSinkNotRecipientSink(t *testing.T) {
 	c.SetNotificationSink(broadcast)
 	c.SetRecipientNotificationSink(recipient)
 
-	sent, err := c.SendComplianceDigest(context.Background())
+	sent, err := c.SendComplianceDigest(context.Background(), 0)
 	require.NoError(t, err)
 	assert.True(t, sent)
 	assert.Len(t, broadcast.events, 1, "the compliance digest is deployment-wide and belongs on the broadcast sink")

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -96,7 +96,7 @@ func (c *KeyorixCore) RemoveProjectMember(ctx context.Context, actorID, projectI
 		return err
 	}
 	if len(existing) == 0 {
-		return fmt.Errorf("user is not a member of this project")
+		return ErrNotProjectMember
 	}
 	// Refuse to remove the project's last roles.assign holder (#236): the ordinary
 	// member-management API has no other safeguard, so without this the sole

--- a/internal/core/purge.go
+++ b/internal/core/purge.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 )
 
 // PurgeResult reports how many soft-deleted rows each entity purge removed.
@@ -28,15 +30,20 @@ func (r PurgeResult) Total() int64 {
 // it emits one system-actored `data.purged` audit event with the counts. Errors on
 // individual entities are collected but do not abort the others.
 func (c *KeyorixCore) PurgeExpiredSoftDeletes(ctx context.Context, before time.Time) (*PurgeResult, error) {
-	// Re-check the legal hold HERE — inside the purge, under the scheduler lock and
-	// immediately before the deletes — not only in the scheduler closure before the lock
-	// is taken. Otherwise a hold placed after the pre-lock check (PlaceLegalHold doesn't
-	// take the lock) would not stop an in-flight purge from hard-deleting records that are
-	// now under hold (irreversible spoliation, ISO A.5.34). Fails SAFE: an unconfirmable
-	// hold status aborts the purge.
-	if err := c.legalHoldGuard(ctx); err != nil {
-		return &PurgeResult{}, err
-	}
+	// #G21: the legal-hold check and all four deletes below run inside ONE
+	// transaction — previously the guard was checked once, then four SEPARATE,
+	// unsynchronized delete calls followed, leaving a window across all four
+	// where PlaceLegalHold could commit in between (irreversible spoliation,
+	// ISO A.5.34). SQLite's single-writer model means this transaction holds an
+	// exclusive write lock for its whole duration, so a concurrent
+	// PlaceLegalHold's INSERT cannot land partway through. Each Purge*Before
+	// call already manages its own internal atomicity (a nested
+	// transaction/savepoint), so a single entity's failure doesn't abort the
+	// others — matching the pre-existing "continue past individual errors,
+	// report the first" partial-success design. NOTE: RemoteStorage.WithTransaction
+	// is a no-op passthrough — under storage.type: remote this narrows the
+	// window but does not eliminate it (see audit_retention.go's PurgeAuditLogs
+	// for the same caveat).
 	res := &PurgeResult{}
 	var firstErr error
 	record := func(n int64, err error) int64 {
@@ -46,10 +53,23 @@ func (c *KeyorixCore) PurgeExpiredSoftDeletes(ctx context.Context, before time.T
 		return n
 	}
 
-	res.Users = record(c.storage.PurgeDeletedUsersBefore(ctx, before))
-	res.Projects = record(c.storage.PurgeDeletedProjectsBefore(ctx, before))
-	res.Environments = record(c.storage.PurgeDeletedEnvironmentsBefore(ctx, before))
-	res.Secrets = record(c.storage.PurgeDeletedSecretsBefore(ctx, before))
+	txErr := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		hold, err := tx.GetActiveLegalHold(ctx)
+		if err != nil {
+			return fmt.Errorf("refusing to purge: could not confirm legal-hold status: %w", err)
+		}
+		if hold != nil {
+			return fmt.Errorf("refusing to purge: a deployment-wide legal hold is active")
+		}
+		res.Users = record(tx.PurgeDeletedUsersBefore(ctx, before))
+		res.Projects = record(tx.PurgeDeletedProjectsBefore(ctx, before))
+		res.Environments = record(tx.PurgeDeletedEnvironmentsBefore(ctx, before))
+		res.Secrets = record(tx.PurgeDeletedSecretsBefore(ctx, before))
+		return nil
+	})
+	if txErr != nil {
+		return &PurgeResult{}, txErr
+	}
 
 	if res.Total() > 0 {
 		sysCtx := WithActorType(ctx, ActorTypeSystem)

--- a/internal/core/rate_limit.go
+++ b/internal/core/rate_limit.go
@@ -144,3 +144,48 @@ func (c *KeyorixCore) RecordPasswordResetAttempt(ctx context.Context, ip string)
 	}
 	_ = c.storage.RecordLoginAttempt(ctx, passwordResetRateLimitPrefix+ip, c.now())
 }
+
+// ssoRateLimitPrefix namespaces SSO/SAML login-initiation attempts within the
+// SAME LoginAttempt table (ADR-040), mirroring passwordResetRateLimitPrefix.
+// #G82: BeginSSO/BeginSAML are both fully unauthenticated and each write a
+// SSOLoginState row per call with no rate limit of any kind — an unbounded
+// flood grows that table without limit and, since every SSOLoginState carries
+// a fresh CSRF-protecting state/nonce, also churns through randomness/storage
+// for no legitimate purpose. Shared between SSO and SAML since both are the
+// same "pre-login state write" abuse shape against the same table.
+const ssoRateLimitPrefix = "sso:" // NOSONAR
+
+// SSOBeginMaxAttempts is the request budget per IP within SSOBeginWindow.
+const SSOBeginMaxAttempts = 20
+
+// SSOBeginWindow is the sliding window over which attempts are counted.
+const SSOBeginWindow = 15 * time.Minute
+
+// IsSSOBeginRateLimited reports whether an IP has reached the SSO/SAML
+// login-initiation budget within the window. Fails open (false) on an empty
+// IP or a storage error, matching the login/password-reset limiters' backstop
+// (not the sole abuse control) design.
+func (c *KeyorixCore) IsSSOBeginRateLimited(ctx context.Context, ip string) bool {
+	if ip == "" {
+		return false
+	}
+	n, err := c.storage.CountRecentLoginAttempts(ctx, ssoRateLimitPrefix+ip, c.now().Add(-SSOBeginWindow))
+	if err != nil {
+		if isUnsupportedByBackend(err) {
+			c.warnRateLimitUnsupportedOnce()
+		}
+		return false
+	}
+	return n >= SSOBeginMaxAttempts
+}
+
+// RecordSSOBeginAttempt records an SSO/SAML login-initiation request from an
+// IP. Recorded on every call regardless of outcome (unknown-provider or
+// success) — the request itself is the abuse signal. Best-effort: a storage
+// error does not block the response.
+func (c *KeyorixCore) RecordSSOBeginAttempt(ctx context.Context, ip string) {
+	if ip == "" {
+		return
+	}
+	_ = c.storage.RecordLoginAttempt(ctx, ssoRateLimitPrefix+ip, c.now())
+}

--- a/internal/core/rate_limit_test.go
+++ b/internal/core/rate_limit_test.go
@@ -63,6 +63,53 @@ func TestRateLimit_EmptyIPNeverLimited(t *testing.T) {
 	assert.False(t, c.IsLoginRateLimited(ctx, ""), "an empty IP is never rate-limited")
 }
 
+// TestRateLimit_SSOBegin_BlocksAtBudgetAndExpiresWithWindow is #G82: BeginSSO/
+// BeginSAML previously had no rate limit at all, letting an unauthenticated
+// flood grow the SSOLoginState table without bound.
+func TestRateLimit_SSOBegin_BlocksAtBudgetAndExpiresWithWindow(t *testing.T) {
+	c, setNow := newRateLimitCore(t)
+	ctx := context.Background()
+	base := c.now()
+
+	for i := 0; i < SSOBeginMaxAttempts-1; i++ {
+		c.RecordSSOBeginAttempt(ctx, "1.2.3.4")
+	}
+	assert.False(t, c.IsSSOBeginRateLimited(ctx, "1.2.3.4"), "under budget is allowed")
+
+	c.RecordSSOBeginAttempt(ctx, "1.2.3.4")
+	assert.True(t, c.IsSSOBeginRateLimited(ctx, "1.2.3.4"), "at the budget the IP is blocked")
+
+	assert.False(t, c.IsSSOBeginRateLimited(ctx, "9.9.9.9"), "a different IP is unaffected")
+
+	setNow(base.Add(SSOBeginWindow + time.Minute))
+	assert.False(t, c.IsSSOBeginRateLimited(ctx, "1.2.3.4"), "attempts age out of the window")
+}
+
+func TestRateLimit_SSOBegin_EmptyIPNeverLimited(t *testing.T) {
+	c, _ := newRateLimitCore(t)
+	ctx := context.Background()
+	for i := 0; i < SSOBeginMaxAttempts+5; i++ {
+		c.RecordSSOBeginAttempt(ctx, "")
+	}
+	assert.False(t, c.IsSSOBeginRateLimited(ctx, ""), "an empty IP is never rate-limited")
+}
+
+// TestRateLimit_SSOBegin_SharesLoginAttemptTableButOwnBudget confirms the
+// ssoRateLimitPrefix namespacing: an IP flooding the login endpoint doesn't
+// also consume its SSO-begin budget, and vice versa — they're independent
+// counters sharing one table (matching the existing password-reset prefix
+// convention).
+func TestRateLimit_SSOBegin_SharesLoginAttemptTableButOwnBudget(t *testing.T) {
+	c, _ := newRateLimitCore(t)
+	ctx := context.Background()
+
+	for i := 0; i < LoginMaxAttempts; i++ {
+		c.RecordFailedLogin(ctx, "1.2.3.4")
+	}
+	require.True(t, c.IsLoginRateLimited(ctx, "1.2.3.4"))
+	assert.False(t, c.IsSSOBeginRateLimited(ctx, "1.2.3.4"), "login attempts must not consume the SSO-begin budget")
+}
+
 func TestRateLimit_PruneRemovesAgedRows(t *testing.T) {
 	c, setNow := newRateLimitCore(t)
 	ctx := context.Background()

--- a/internal/core/rbac_audit.go
+++ b/internal/core/rbac_audit.go
@@ -18,11 +18,11 @@ import (
 // RBACAuditEntry is a reconstructed RBAC audit record: who changed which role for
 // whom, at what scope, and when.
 type RBACAuditEntry struct {
-	ID           uint
-	Action       string // role.assigned | role.removed | role.group_assigned | role.group_removed | group.member_added | group.member_removed
-	ActorUserID  *uint  // the principal who made the change (nil for system/CLI)
-	TargetUserID *uint  // set for user-role events
-	GroupID      *uint  // set for group-role events
+	ID            uint
+	Action        string // role.assigned | role.removed | role.group_assigned | role.group_removed | group.member_added | group.member_removed
+	ActorUserID   *uint  // the principal who made the change (nil for system/CLI)
+	TargetUserID  *uint  // set for user-role events
+	GroupID       *uint  // set for group-role events
 	RoleID        *uint
 	PermissionID  *uint // set for permission-to-role events
 	ProjectID     *uint

--- a/internal/core/rbac_audit.go
+++ b/internal/core/rbac_audit.go
@@ -23,11 +23,12 @@ type RBACAuditEntry struct {
 	ActorUserID  *uint  // the principal who made the change (nil for system/CLI)
 	TargetUserID *uint  // set for user-role events
 	GroupID      *uint  // set for group-role events
-	RoleID       *uint
-	PermissionID *uint // set for permission-to-role events
-	ProjectID    *uint
-	Details      string
-	CreatedAt    time.Time
+	RoleID        *uint
+	PermissionID  *uint // set for permission-to-role events
+	ProjectID     *uint
+	EnvironmentID *uint
+	Details       string
+	CreatedAt     time.Time
 }
 
 // ListRBACAuditLogs returns the RBAC audit trail (role assignments/removals),
@@ -80,6 +81,10 @@ func (c *KeyorixCore) ListRBACAuditLogs(ctx context.Context, page, pageSize int)
 			if d.ProjectID != 0 {
 				p := d.ProjectID
 				entry.ProjectID = &p
+			}
+			if d.EnvironmentID != 0 {
+				e := d.EnvironmentID
+				entry.EnvironmentID = &e
 			}
 		}
 		entries = append(entries, entry)

--- a/internal/core/rbac_audit_test.go
+++ b/internal/core/rbac_audit_test.go
@@ -61,6 +61,31 @@ func TestRBACAuditTrail_AssignAndRemove(t *testing.T) {
 	assert.Equal(t, uint(10), *removed.TargetUserID)
 }
 
+// TestRBACAuditTrail_EnvironmentIDRoundTrips is #G23: writeRBACAudit already
+// stamps EnvironmentID into the event's structured diff (rbacAuditDetail),
+// but ListRBACAuditLogs never read it back out into RBACAuditEntry — an
+// environment-scoped grant's audit row silently lost its EnvironmentID on
+// the read side even though it was captured at write time.
+func TestRBACAuditTrail_EnvironmentIDRoundTrips(t *testing.T) {
+	c := newRBACAuditCore(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.AssignUserRole(ctx, 5, 10, 2, Scope{ProjectID: 3, EnvironmentID: 7}))
+
+	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
+	require.NoError(t, err)
+
+	var assigned *RBACAuditEntry
+	for _, e := range entries {
+		if e.Action == EventRoleAssigned {
+			assigned = e
+		}
+	}
+	require.NotNil(t, assigned)
+	require.NotNil(t, assigned.EnvironmentID)
+	assert.Equal(t, uint(7), *assigned.EnvironmentID)
+}
+
 // A change made without an authenticated principal (actorID 0, e.g. local CLI)
 // records no actor.
 func TestRBACAuditTrail_SystemActor(t *testing.T) {

--- a/internal/core/read_quota_alerts.go
+++ b/internal/core/read_quota_alerts.go
@@ -69,6 +69,19 @@ func (k *KeyorixCore) CheckReadQuotas(ctx context.Context) (*ReadQuotaCheckResul
 		title, msg := quotaMessage(s.Name, s.ReadCount, *s.MaxReads, exhausted)
 		nType := quotaNotificationType(severity)
 
+		// #G21: this check-then-act (read here, CreateNotification below) has no
+		// DB-level backstop — unlike rotation/expiry reminders, which get one from
+		// uniq_notifications_unread_reminder (#488). That index can't simply be
+		// extended to cover read-quota notifications: it's keyed on (user_id,
+		// type, project_id), but read-quota dedup is per-SECRET (unreadQuotaNotification
+		// matches on secretID via Link content, see below) — a blanket per-project
+		// index would silently drop a legitimate second secret's notification
+		// while the first is still unread. A correct fix needs a stable,
+		// structured dedup key (not the current strings.Contains(Link, ...)
+		// content match — see G22, the same underlying gap) plus a schema
+		// migration; deferred as a larger, separate change. Worst case today is
+		// a duplicate notification under a genuine concurrent-run race, not a
+		// security or data-integrity issue.
 		existing := k.unreadQuotaNotification(ctx, s.OwnerID, s.ID)
 		if existing != nil {
 			if severity <= existing.Severity {

--- a/internal/core/remote_account_state_hardfail_test.go
+++ b/internal/core/remote_account_state_hardfail_test.go
@@ -91,9 +91,9 @@ func TestUpdateSCIMUser_NoStateChange_DoesNotConsultSetAccountState(t *testing.T
 
 	target := &models.User{ID: 2, Username: "bob", IsActive: true, AccountState: AccountActive, ExternalID: "okta|bob"}
 	store.On("GetUser", ctx, uint(2)).Return(target, nil)
-	store.On("UpdateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
+	store.On("UpdateUserIfActiveStateMatches", ctx, mock.MatchedBy(func(u *models.User) bool {
 		return u.DisplayName == "Bob Smith"
-	})).Return(&models.User{ID: 2, DisplayName: "Bob Smith"}, nil)
+	}), true).Return(true, nil)
 	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
 
 	name := "Bob Smith"

--- a/internal/core/role_expiry_notify.go
+++ b/internal/core/role_expiry_notify.go
@@ -65,6 +65,11 @@ func (k *KeyorixCore) CheckRoleExpiry(ctx context.Context) (*RoleExpiryCheckResu
 		roleName := k.roleName(ctx, g.RoleID)
 		title, msg := roleExpiryMessage(roleName, g.ExpiresAt)
 
+		// #G21: no DB backstop for this check-then-act — see read_quota_alerts.go's
+		// CheckReadQuotas for why the existing #488 reminder-dedup index can't
+		// simply be extended to cover this type (per-role dedup via message
+		// content, not a structured column). Deferred; worst case is a duplicate
+		// notification, not a security/data-integrity issue.
 		existing := k.unreadRoleExpiryReminder(ctx, g.UserID, g.RoleID)
 		if existing != nil {
 			if severity <= existing.Severity {

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -197,16 +197,10 @@ func (c *KeyorixCore) RunAutoRotation(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 	byProject, projectOrder := groupDueByProject(due, dueOrder)
-	rotated, totalFailed := 0, 0
+	rotated := 0
 	for _, pid := range projectOrder {
-		r, f := c.rotateProject(ctx, pid, byProject[pid], due)
+		r, _ := c.rotateProject(ctx, pid, byProject[pid], due)
 		rotated += r
-		totalFailed += f
-	}
-	if totalFailed > 0 {
-		sysCtx := WithActorType(ctx, ActorTypeSystem)
-		c.writeAuditEvent(sysCtx, EventAutoRotationFailures, nil, nil,
-			fmt.Sprintf("auto-rotation: %d secret(s) failed to rotate", totalFailed))
 	}
 	return rotated, nil
 }
@@ -303,6 +297,15 @@ func (c *KeyorixCore) rotateProject(ctx context.Context, pid uint, ids []uint, d
 	// broadcast right after this project finishes, before moving on to the next.
 	failed, n := c.rotateProjectWaves(ctx, waves, due, dependsOnInRun)
 	c.notifyRotationFailures(ctx, pid, failed)
+	if len(failed) > 0 {
+		// #G23: scoped to this project (pid is known here, unlike the old
+		// run-wide summary this replaced, which had to write ProjectID=nil
+		// because it aggregated failures across every project in the run).
+		sysCtx := WithActorType(ctx, ActorTypeSystem)
+		p := pid
+		c.writeAuditEventFull(sysCtx, EventAutoRotationFailures, nil, nil, &p, "",
+			fmt.Sprintf("auto-rotation: %d secret(s) failed to rotate in project %d", len(failed), pid))
+	}
 	return n, len(failed)
 }
 
@@ -322,7 +325,8 @@ func (c *KeyorixCore) rotateProjectWaves(ctx context.Context, waves [][]uint, du
 					depName = d.secret.Name
 				}
 				sid := id
-				c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+				pid := dr.secret.ProjectID
+				c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",
 					fmt.Sprintf("auto-rotation DEFERRED for secret %q: it depends on %q which did not rotate this run", dr.secret.Name, depName))
 				failed[id] = fmt.Sprintf("%q: deferred — depends on %q which did not rotate this run", dr.secret.Name, depName)
 				continue
@@ -374,7 +378,8 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 		// ROTATION-001: emit before calling upstream so a crash between upstream success
 		// and Keyorix store is visible in the audit trail as an orphaned "started" event.
 		sid := secret.ID
-		c.writeAuditEvent(ctx, EventSecretRotateBackendStarted, nil, &sid,
+		pid := secret.ProjectID
+		c.writeAuditEventFull(ctx, EventSecretRotateBackendStarted, nil, &sid, &pid, "",
 			fmt.Sprintf("auto-rotation: calling upstream backend %q ref %q for secret %q",
 				secret.RotationBackend, secret.RotationRef, secret.Name))
 		upstreamVal, err := c.applyBackendRotation(ctx, secret, val)
@@ -390,7 +395,8 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 			incompleteMsg = fmt.Sprintf("%q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err)
 		case err != nil:
 			sid := secret.ID
-			c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+			pid := secret.ProjectID
+			c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",
 				fmt.Sprintf("auto-rotation FAILED for secret %q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err))
 			log.Printf("auto-rotation: backend rotate secret %d: %v", secret.ID, err)
 			failed[secret.ID] = fmt.Sprintf("%q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err)
@@ -403,16 +409,17 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 		log.Printf("auto-rotation: rotate secret %d: %v", secret.ID, rerr)
 		failed[secret.ID] = fmt.Sprintf("%q: store new version: %v", secret.Name, rerr)
 		sid := secret.ID
+		pid := secret.ProjectID
 		if secret.RotationBackend != "" {
 			// The upstream credential was rotated but storing the new value failed: the
 			// live credential and Keyorix's record have now DRIFTED. Audit it distinctly
 			// (the backend-apply-failure path above is audited too) so an operator can
 			// reconcile — the live secret may no longer match Keyorix.
-			c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+			c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",
 				fmt.Sprintf("auto-rotation DRIFT for secret %q: backend %q ref %q rotated upstream but storing the new value failed: %v — the live credential may no longer match Keyorix",
 					secret.Name, secret.RotationBackend, secret.RotationRef, rerr))
 		} else {
-			c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+			c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",
 				fmt.Sprintf("auto-rotation FAILED to store new version for secret %q: %v", secret.Name, rerr))
 		}
 		return false
@@ -424,18 +431,20 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 		// audit it distinctly.
 		failed[secret.ID] = incompleteMsg
 		sid := secret.ID
-		c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+		pid := secret.ProjectID
+		c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",
 			fmt.Sprintf("auto-rotation INCOMPLETE for secret %q: new credential stored but a prior credential is still live and must be removed manually — %s", secret.Name, incompleteMsg))
 		log.Printf("auto-rotation: incomplete cleanup for secret %d: %s", secret.ID, incompleteMsg)
 		return true
 	}
 	delete(failed, secret.ID)
 	sid := secret.ID
+	pid := secret.ProjectID
 	via := ""
 	if secret.RotationBackend != "" {
 		via = fmt.Sprintf(" via backend %q ref %q", secret.RotationBackend, secret.RotationRef)
 	}
-	c.writeAuditEvent(ctx, EventSecretAutoRotated, nil, &sid,
+	c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",
 		fmt.Sprintf("auto-rotated secret %q (policy %q, interval %dd)%s", secret.Name, policy.Name, policy.IntervalDays, via))
 	return true
 }
@@ -507,7 +516,8 @@ func (c *KeyorixCore) RotateSecretOnDemand(ctx context.Context, id uint, newValu
 	// ROTATION-001: emit before calling upstream so a crash between upstream success
 	// and Keyorix store is visible in the audit trail as an orphaned "started" event.
 	oidSid := id
-	c.writeAuditEvent(ctx, EventSecretRotateBackendStarted, nil, &oidSid,
+	pid := secret.ProjectID
+	c.writeAuditEventFull(ctx, EventSecretRotateBackendStarted, nil, &oidSid, &pid, "",
 		fmt.Sprintf("on-demand rotation: calling upstream backend %q ref %q for secret %q",
 			secret.RotationBackend, secret.RotationRef, secret.Name))
 	upstreamVal, berr := c.applyBackendRotation(ctx, secret, string(newValue))
@@ -522,14 +532,14 @@ func (c *KeyorixCore) RotateSecretOnDemand(ctx context.Context, id uint, newValu
 			return nil, serr
 		}
 		sid := id
-		c.writeAuditEvent(ctx, EventSecretRotateIncomplete, nil, &sid,
+		c.writeAuditEventFull(ctx, EventSecretRotateIncomplete, nil, &sid, &pid, "",
 			fmt.Sprintf("on-demand rotation INCOMPLETE for secret %q via backend %q ref %q: new credential stored but a prior credential is still live and must be removed manually: %v",
 				secret.Name, secret.RotationBackend, secret.RotationRef, berr))
 		return updated, fmt.Errorf("backend %q rotation for secret %q partially completed: new credential stored but a prior credential is still live upstream and must be removed manually: %w",
 			secret.RotationBackend, secret.Name, berr)
 	case berr != nil:
 		sid := id
-		c.writeAuditEvent(ctx, EventSecretRotateFailed, nil, &sid,
+		c.writeAuditEventFull(ctx, EventSecretRotateFailed, nil, &sid, &pid, "",
 			fmt.Sprintf("on-demand rotation FAILED for secret %q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, berr))
 		return nil, fmt.Errorf("backend %q rotation failed for secret %q (upstream credential NOT rotated): %w", secret.RotationBackend, secret.Name, berr)
 	default:
@@ -664,7 +674,8 @@ func (c *KeyorixCore) SetSecretAutoRotate(ctx context.Context, id uint, spec Aut
 	if spec.Backend != "" {
 		via = fmt.Sprintf(" (backend %q ref %q)", spec.Backend, spec.Ref)
 	}
-	c.writeAuditEvent(ctx, EventSecretAutoRotateConfig, &uid, &sid,
+	pid := secret.ProjectID
+	c.writeAuditEventFull(ctx, EventSecretAutoRotateConfig, &uid, &sid, &pid, "",
 		fmt.Sprintf("auto-rotation %s for secret %q%s", verb, secret.Name, via))
 	return nil
 }

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -361,10 +361,19 @@ func lowestBlockedDep(deps []uint, blocked map[uint]bool) (uint, bool) {
 // in failed and logged; it returns true only when the secret was rotated and stored
 // successfully. Best-effort: it never returns an error or aborts the run.
 func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.SecretNode, policy *models.RotationPolicy, failed map[uint]string) bool {
+	// #G43: SetRotationState/GetRotationState (rotation_state.go) were fully
+	// wired at the storage layer and exposed via GET /secrets/{id}/rotation-state,
+	// with a doc comment claiming "called by the rotation executor when a
+	// rotation job starts, completes, or fails" — but nothing here ever actually
+	// called it, so the endpoint always reported "idle" regardless of real
+	// activity. Best-effort: a failure to stamp state must not abort a
+	// rotation that otherwise succeeded or genuinely failed.
+	c.stampRotationState(ctx, policy.ID, RotationStateRotating, "")
 	val, gerr := generateRotatedValueSpec(secret.RotationLength, secret.RotationCharset)
 	if gerr != nil {
 		log.Printf("auto-rotation: generate value for secret %d: %v", secret.ID, gerr)
 		failed[secret.ID] = fmt.Sprintf("%q: generate value: %v", secret.Name, gerr)
+		c.stampRotationState(ctx, policy.ID, RotationStateFailed, failed[secret.ID])
 		return false
 	}
 	// Backend rotation (ADR-047): if the secret names a configured executor, rotate the
@@ -400,6 +409,7 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 				fmt.Sprintf("auto-rotation FAILED for secret %q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err))
 			log.Printf("auto-rotation: backend rotate secret %d: %v", secret.ID, err)
 			failed[secret.ID] = fmt.Sprintf("%q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err)
+			c.stampRotationState(ctx, policy.ID, RotationStateFailed, failed[secret.ID])
 			return false
 		default:
 			storeVal = upstreamVal
@@ -422,6 +432,7 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 			c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",
 				fmt.Sprintf("auto-rotation FAILED to store new version for secret %q: %v", secret.Name, rerr))
 		}
+		c.stampRotationState(ctx, policy.ID, RotationStateFailed, failed[secret.ID])
 		return false
 	}
 	if incompleteMsg != "" {
@@ -435,6 +446,7 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 		c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",
 			fmt.Sprintf("auto-rotation INCOMPLETE for secret %q: new credential stored but a prior credential is still live and must be removed manually — %s", secret.Name, incompleteMsg))
 		log.Printf("auto-rotation: incomplete cleanup for secret %d: %s", secret.ID, incompleteMsg)
+		c.stampRotationState(ctx, policy.ID, RotationStateFailed, incompleteMsg)
 		return true
 	}
 	delete(failed, secret.ID)
@@ -446,7 +458,17 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 	}
 	c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",
 		fmt.Sprintf("auto-rotated secret %q (policy %q, interval %dd)%s", secret.Name, policy.Name, policy.IntervalDays, via))
+	c.stampRotationState(ctx, policy.ID, RotationStateSucceeded, "")
 	return true
+}
+
+// stampRotationState calls SetRotationState best-effort — a failure to persist
+// the execution-state marker must never abort or fail an otherwise-complete
+// rotation attempt, so it is logged rather than propagated.
+func (c *KeyorixCore) stampRotationState(ctx context.Context, policyID uint, state, errMsg string) {
+	if err := c.SetRotationState(ctx, policyID, state, errMsg); err != nil {
+		log.Printf("auto-rotation: policy %d: failed to stamp rotation state %q: %v", policyID, state, err)
+	}
 }
 
 // applyBackendRotation resolves the secret's named rotation executor and rotates the

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -84,6 +85,32 @@ func TestRunAutoRotation_RotatesOverdueOptedInOnly(t *testing.T) {
 	// s2 and s3 are untouched (still on version 1).
 	assert.Equal(t, 1, latestVersion(t, db, 2).VersionNumber, "not-due secret unchanged")
 	assert.Equal(t, 1, latestVersion(t, db, 3).VersionNumber, "non-opted-in secret unchanged")
+}
+
+// TestRunAutoRotation_AuditEventsCarryProjectID is #G23: every rotation-domain
+// audit event used to be written with ProjectID=nil, even though the secret
+// (and its ProjectID) is known at every one of these call sites — an operator
+// filtering the audit trail by project couldn't find auto-rotation activity.
+func TestRunAutoRotation_AuditEventsCarryProjectID(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "30-day", Scope: "project", ProjectID: &pid, IntervalDays: 30,
+		IsActive: true, CreatedBy: "admin",
+	}).Error)
+	seedRotatableSecret(t, db, 1, "due-managed", true, fixed.Add(-60*24*time.Hour))
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventSecretAutoRotated).Find(&events).Error)
+	require.NotEmpty(t, events)
+	for _, e := range events {
+		require.NotNil(t, e.ProjectID, "rotation audit event %q must carry a ProjectID", e.EventType)
+		assert.Equal(t, uint(1), *e.ProjectID)
+	}
 }
 
 func TestRunAutoRotation_InactivePolicyIgnored(t *testing.T) {
@@ -733,12 +760,17 @@ func TestRunAutoRotation_FailuresNotBundledAcrossProjects(t *testing.T) {
 		}
 	}
 
-	// The audit trail still records one run-level summary (aggregate count only — no
-	// secret names/reasons, so bundling it is not itself a leak).
+	// #G23: the audit trail now records one summary PER PROJECT (each carrying that
+	// project's ProjectID) rather than a single run-level summary with ProjectID=nil
+	// aggregated across every project in the run.
 	var auditEvents []models.AuditEvent
 	require.NoError(t, db.Where("event_type = ?", EventAutoRotationFailures).Find(&auditEvents).Error)
-	require.Len(t, auditEvents, 1)
-	assert.Contains(t, auditEvents[0].Description, "2 secret")
+	require.Len(t, auditEvents, 2)
+	for _, e := range auditEvents {
+		require.NotNil(t, e.ProjectID)
+		assert.Contains(t, e.Description, "1 secret")
+		assert.Contains(t, e.Description, fmt.Sprintf("project %d", *e.ProjectID))
+	}
 }
 
 func ptrTime(t time.Time) *time.Time { return &t }

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -87,6 +87,47 @@ func TestRunAutoRotation_RotatesOverdueOptedInOnly(t *testing.T) {
 	assert.Equal(t, 1, latestVersion(t, db, 3).VersionNumber, "non-opted-in secret unchanged")
 }
 
+// TestRunAutoRotation_StampsRotationStateOnSuccess is #G43: SetRotationState was
+// fully wired at the storage layer (with a doc comment claiming "called by the
+// rotation executor when a rotation job starts, completes, or fails") but the
+// executor never actually called it, so GetRotationState always reported "idle"
+// regardless of real activity.
+func TestRunAutoRotation_StampsRotationStateOnSuccess(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	pid := uint(1)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		ID: 1, Name: "30-day", Scope: "project", ProjectID: &pid, IntervalDays: 30,
+		IsActive: true, CreatedBy: "admin",
+	}).Error)
+	seedRotatableSecret(t, db, 1, "due-managed", true, fixed.Add(-60*24*time.Hour))
+
+	n, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	info, err := c.GetRotationState(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, RotationStateSucceeded, info.State)
+	assert.Empty(t, info.LastRotationError)
+}
+
+// TestRunAutoRotation_StampsRotationStateOnFailure covers the failure branch of
+// the same #G43 gap: a backend rotation failure must also be visible via
+// GetRotationState, not just in the run's return value / audit trail.
+func TestRunAutoRotation_StampsRotationStateOnFailure(t *testing.T) {
+	fake := &fakeExecutor{name: "pg", err: errors.New("connection refused")}
+	c, db, fixed := backendPolicyCore(t, fake)
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-60*24*time.Hour))
+
+	_, err := c.RunAutoRotation(context.Background())
+	require.NoError(t, err)
+
+	info, err := c.GetRotationState(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, RotationStateFailed, info.State)
+	assert.Contains(t, info.LastRotationError, "connection refused")
+}
+
 // TestRunAutoRotation_AuditEventsCarryProjectID is #G23: every rotation-domain
 // audit event used to be written with ProjectID=nil, even though the secret
 // (and its ProjectID) is known at every one of these call sites — an operator

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -102,7 +102,7 @@ func randomPasswordHash() (string, error) {
 	if _, err := rand.Read(b); err != nil {
 		return "", err
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(hex.EncodeToString(b)), bcryptCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(hex.EncodeToString(b)), int(bcryptCost.Load()))
 	if err != nil {
 		return "", err
 	}

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -232,6 +232,22 @@ func scimManaged(user *models.User) bool {
 // LockUserForUpdate row lock (across replicas, Postgres only). See accountStateMu's doc
 // comment in service.go and setAccountState in account_state.go.
 func (c *KeyorixCore) UpdateSCIMUser(ctx context.Context, actorID, id uint, displayName, email *string, active *bool) (*models.User, error) {
+	// #G14: the SCIM-ownership check runs FIRST, before checkSCIMEmailCollision
+	// below — otherwise a SCIM token holder could supply an arbitrary id it has
+	// no rights to touch (e.g. a native admin's) together with a probe email,
+	// and learn from "email already in use" whether that email is registered to
+	// a DIFFERENT account, without ever needing a target id it can legitimately
+	// act on. This is a best-effort pre-check (matching DeprovisionSCIMUser's
+	// own GetUser+scimManaged pattern) — scimUpdateUserTx below still re-checks
+	// scimManaged against the fresh, lock-guarded read for the authoritative,
+	// race-free decision.
+	target, err := c.storage.GetUser(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
+	}
+	if !scimManaged(target) {
+		return nil, fmt.Errorf("%s: not a SCIM-managed account", i18n.T("ErrorUserNotFound", nil))
+	}
 	// Refuse an email that collides with a DIFFERENT user (#336). Checked up front
 	// (against id, not a pre-fetched struct) since it targets a DIFFERENT user's row
 	// and doesn't need the account-state lock below. The DB partial unique index

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -329,6 +329,7 @@ func (c *KeyorixCore) scimUpdateUserTx(ctx context.Context, tx storage.Storage, 
 	// changes (#454) — avoiding a hard failure on RemoteStorage for a plain name/email
 	// PATCH that never touches lifecycle state.
 	origState := user.AccountState
+	wasActive := user.IsActive
 	if displayName != nil {
 		user.DisplayName = *displayName
 	}
@@ -345,11 +346,23 @@ func (c *KeyorixCore) scimUpdateUserTx(ctx context.Context, tx storage.Storage, 
 		}
 	}
 	user.UpdatedAt = c.now()
-	u, err := tx.UpdateUser(ctx, user)
+	// #G42: LockUserForUpdate above only takes a real row lock on Postgres: on
+	// SQLite (this codebase's default embedded deployment) a deferred
+	// transaction doesn't acquire its exclusive write lock until the FIRST
+	// write statement, leaving a window between this read and that first
+	// write where a concurrent, un-transacted core.UpdateUser call can commit
+	// its own IsActive flip via UpdateUserIfActiveStateMatches. A blind
+	// tx.UpdateUser here would silently revert that flip using the
+	// now-stale in-memory user struct. Route through the same
+	// state-conditional write core.UpdateUser itself uses instead.
+	matched, err := tx.UpdateUserIfActiveStateMatches(ctx, user, wasActive)
 	if err != nil {
 		return nil, false, err
 	}
-	return u, deactivated, nil
+	if !matched {
+		return nil, false, fmt.Errorf("user %d: %w", id, ErrUserActiveStateConflict)
+	}
+	return user, deactivated, nil
 }
 
 // applySCIMActiveState applies an IdP active=true/false directive to the user model,

--- a/internal/core/scim_guards_test.go
+++ b/internal/core/scim_guards_test.go
@@ -42,6 +42,33 @@ func TestUpdateSCIMUser_RejectsEmailCollision(t *testing.T) {
 	assert.Contains(t, err.Error(), "already in use")
 }
 
+// TestUpdateSCIMUser_OwnershipCheckedBeforeEmailCollision is the #G14
+// regression: the SCIM-ownership check must run BEFORE checkSCIMEmailCollision
+// — otherwise a SCIM token holder could supply a NATIVE (non-SCIM) account's id
+// together with a probe email and learn, from "email already in use" vs
+// proceeding further, whether that email is registered to a different account —
+// without ever having rights to touch the target id at all.
+func TestUpdateSCIMUser_OwnershipCheckedBeforeEmailCollision(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	// user 1 is a NATIVE account (no ExternalID) — never provisioned via SCIM.
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "native-admin", Email: "native@x.io", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "someone-else", Email: "taken@x.io", IsActive: true, AccountState: AccountActive}).Error)
+
+	// Probing with an email that DOES collide must fail with the SAME ownership
+	// error as probing with one that doesn't — never "email already in use".
+	collidingEmail := "taken@x.io"
+	_, err := c.UpdateSCIMUser(ctx, 9, 1, nil, &collidingEmail, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a SCIM-managed account")
+	assert.NotContains(t, err.Error(), "already in use")
+
+	freeEmail := "nobody-has-this@x.io"
+	_, err2 := c.UpdateSCIMUser(ctx, 9, 1, nil, &freeEmail, nil)
+	require.Error(t, err2)
+	assert.Equal(t, err.Error(), err2.Error(), "a colliding and a free probe email must be indistinguishable for a non-SCIM-managed target")
+}
+
 func TestUpdateSCIMUser_RefusesLastAdminDeactivation(t *testing.T) {
 	c, db := newSCIMGuardCore(t)
 	ctx := context.Background()

--- a/internal/core/secret_bulk_rename.go
+++ b/internal/core/secret_bulk_rename.go
@@ -85,13 +85,14 @@ func (c *KeyorixCore) BulkRenameSecrets(ctx context.Context, projectID uint, ren
 			continue
 		}
 
+		// #G14: "not found", "belongs to another project", and "not authorized" are
+		// collapsed into one uniform denial below — a distinct message per case
+		// would let a caller enumerate secret IDs that exist in OTHER projects
+		// (or that they can't individually act on) from the shape of the failure
+		// alone, even though they're plainly a real, existing secret.
 		secret, err := c.storage.GetSecret(ctx, rn.ID)
-		if err != nil || secret == nil {
+		if err != nil || secret == nil || secret.ProjectID != projectID {
 			skip(rn.ID, "", newName, "secret not found")
-			continue
-		}
-		if secret.ProjectID != projectID {
-			skip(rn.ID, secret.Name, newName, "secret does not belong to this project")
 			continue
 		}
 		// Re-check per-secret write authorization (owner/share). The project-wide
@@ -99,7 +100,7 @@ func (c *KeyorixCore) BulkRenameSecrets(ctx context.Context, projectID uint, ren
 		// path enforces this, so the bulk op must not let a caller rename a secret they
 		// can't update individually.
 		if _, perr := c.EnforceSecretWritePermission(ctx, secret.ID, actorID); perr != nil {
-			skip(rn.ID, secret.Name, newName, "not authorized to rename this secret")
+			skip(rn.ID, "", newName, "secret not found")
 			continue
 		}
 		if !secret.IsSecret {

--- a/internal/core/secret_bulk_rename_test.go
+++ b/internal/core/secret_bulk_rename_test.go
@@ -76,12 +76,16 @@ func TestBulkRenameSecrets(t *testing.T) {
 		mine := mk("non-conf-x", p.ID, true) // owned by user 1
 		// User 2 holds no ownership/share on it — even with project secrets.write it must
 		// not be renamable via the bulk op (parity with the single-secret PUT gate).
+		// #G14: the denial is the SAME generic "secret not found" a nonexistent ID gets —
+		// a distinct "not authorized" message would let a caller confirm the secret
+		// exists (and that they lack access to it) purely from the response shape.
 		rep, err := c.BulkRenameSecrets(ctx, p.ID, []SecretRename{{ID: mine, NewName: "MINE_X"}}, false, "intruder", 2, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, 0, rep.Renamed)
 		require.Len(t, rep.Outcomes, 1)
 		assert.Equal(t, renameStatusSkipped, rep.Outcomes[0].Status)
-		assert.Contains(t, rep.Outcomes[0].Reason, "not authorized")
+		assert.Contains(t, rep.Outcomes[0].Reason, "not found")
+		assert.Empty(t, rep.Outcomes[0].OldName, "the secret's real name must not leak to an unauthorized caller")
 	})
 
 	t.Run("dry run validates but changes nothing", func(t *testing.T) {
@@ -139,10 +143,15 @@ func TestBulkRenameSecrets(t *testing.T) {
 	})
 
 	t.Run("cross-project guard: cannot rename another project's secret", func(t *testing.T) {
+		// #G14: same uniform "secret not found" denial as a nonexistent ID — a
+		// distinct "does not belong to this project" message would let a
+		// project-scoped caller enumerate secret IDs that exist in OTHER
+		// projects, just by observing which IDs get this message vs plain
+		// "not found".
 		rep, err := c.BulkRenameSecrets(ctx, p.ID, []SecretRename{{ID: foreign, NewName: "OTHER_SECRET"}}, false, "alice", 1, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, 0, rep.Renamed)
-		assert.Contains(t, rep.Outcomes[0].Reason, "does not belong")
+		assert.Contains(t, rep.Outcomes[0].Reason, "not found")
 		// Untouched in its own project.
 		s, err := c.storage.GetSecret(ctx, foreign)
 		require.NoError(t, err)

--- a/internal/core/secret_copy.go
+++ b/internal/core/secret_copy.go
@@ -31,25 +31,42 @@ func (c *KeyorixCore) CopySecret(ctx context.Context, sourceID, targetEnvID uint
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "source secret ID and target environment ID are required")
 	}
 
+	// #G14: authorize read access to the source BEFORE the cross-project
+	// existence/collision check below. GetSecret itself does no authorization
+	// (see its own doc comment), so checking "is targetEnv in the same project
+	// as source" first would let a caller with a valid target environment in
+	// project A probe an arbitrary sourceID and learn — from "target
+	// environment must be in the same project" vs "secret not found" — whether
+	// that ID exists in some OTHER project, without ever needing read access to
+	// it. Reading the value now (rather than after the project check) means an
+	// unauthorized caller gets the SAME "secret not found" a nonexistent ID
+	// would, regardless of which project the real secret is actually in. Only
+	// the specific "doesn't exist" / "insufficient permissions" outcomes are
+	// collapsed — a genuine, unrelated storage failure (DB down, read-only,
+	// etc.) still propagates as-is so it isn't misreported and mishandled
+	// upstream as a plain not-found.
+	notFound := fmt.Errorf("%s: %s", i18n.T("ErrorSecretNotFound", nil), "not found")
 	source, err := c.GetSecret(ctx, sourceID)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorSecretNotFound", nil), err)
+		return nil, notFound
+	}
+	value, err := c.GetSecretValueWithPermissionCheck(ctx, sourceID, actorID)
+	if err != nil {
+		if strings.Contains(err.Error(), "insufficient permissions") {
+			return nil, notFound
+		}
+		return nil, err
 	}
 
 	// Same-project guard: the target environment must live in the source's project,
-	// so a copy can never move a value across a project boundary.
+	// so a copy can never move a value across a project boundary. The caller has
+	// already proven read access to source above, so this reveals nothing new.
 	targetEnv, err := c.storage.GetEnvironment(ctx, targetEnvID)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
 	if targetEnv.ProjectID != source.ProjectID {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "target environment must be in the same project as the source")
-	}
-
-	// Read the source value — permission-checked (the actor must be able to read it).
-	value, err := c.GetSecretValueWithPermissionCheck(ctx, sourceID, actorID)
-	if err != nil {
-		return nil, err
 	}
 	c.LogSecretReadWithProject(ctx, actorID, source.ID, source.ProjectID, actorUsername, source.Name, ip, ua)
 

--- a/internal/core/secret_copy_test.go
+++ b/internal/core/secret_copy_test.go
@@ -103,6 +103,27 @@ func TestCopySecret(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	// TestCopySecret_CrossProjectExistenceOracle is the #G14 regression: an
+	// unauthorized caller probing a REAL secret in another project must get the
+	// exact same error a nonexistent source ID would — not a distinct "target
+	// environment must be in the same project" message that would confirm the
+	// probed ID exists somewhere, even without any read access to it.
+	t.Run("an unauthorized cross-project probe and a nonexistent ID give the identical error", func(t *testing.T) {
+		require.NoError(t, db.Create(&models.User{ID: 2, Username: "intruder", Email: "i@t.com"}).Error)
+		// Deliberately no UserRole/share for user 2 anywhere — a fully unauthorized caller.
+		intruderCtx := ctx
+
+		_, realErr := c.CopySecret(intruderCtx, src.ID, otherEnv.ID, "", "intruder", 2, "", "")
+		require.Error(t, realErr)
+		assert.NotContains(t, realErr.Error(), "same project",
+			"an unauthorized caller must not learn the source exists in a different project")
+
+		_, fakeErr := c.CopySecret(intruderCtx, 999999, otherEnv.ID, "", "intruder", 2, "", "")
+		require.Error(t, fakeErr)
+		assert.Equal(t, realErr.Error(), fakeErr.Error(),
+			"a real-but-unauthorized source and a nonexistent one must be indistinguishable")
+	})
+
 	t.Run("required IDs are validated", func(t *testing.T) {
 		_, err := c.CopySecret(ctx, 0, prod.ID, "", "owner", 1, "", "")
 		require.Error(t, err)

--- a/internal/core/secret_version_diff.go
+++ b/internal/core/secret_version_diff.go
@@ -27,6 +27,12 @@ type SecretVersionDiff struct {
 	// ACLs are secret-scoped, not version-scoped, so this is always the current
 	// snapshot rather than a per-version diff.
 	ACLUserIDs []uint `json:"acl_user_ids"`
+	// Degraded is true when the ACL lookup itself failed (#G54): ACLUserIDs is
+	// then an EMPTY snapshot, not a confirmed "no ACL grants" — a caller must
+	// not treat it as authoritative (e.g. in a security/audit review) without
+	// checking this flag first, matching this codebase's established
+	// Degraded convention (compliance posture, dashboard, access review).
+	Degraded bool `json:"degraded"`
 }
 
 // SecretVersionChange describes a single metadata field that differs between
@@ -149,7 +155,13 @@ func (c *KeyorixCore) DiffSecretVersions(ctx context.Context, secretID uint, fro
 	}
 
 	// --- ACLs (current snapshot, not per-version) ---
-	acls, _ := c.storage.ListSecretACLs(ctx, secretID) // best-effort; ignore error
+	// #G54: ListSecretACLs' error is no longer silently discarded — a storage
+	// failure here must not be reported as an authoritative "no ACL grants"
+	// (a misleadingly reassuring result for a security-relevant diff); it
+	// surfaces as Degraded instead, same as the codebase's other partial
+	// -result signals.
+	acls, aclErr := c.storage.ListSecretACLs(ctx, secretID)
+	degraded := aclErr != nil
 	var aclUserIDs []uint
 	for _, a := range acls {
 		aclUserIDs = append(aclUserIDs, a.UserID)
@@ -161,6 +173,7 @@ func (c *KeyorixCore) DiffSecretVersions(ctx context.Context, secretID uint, fro
 		FromVersion: fromVersion,
 		ToVersion:   toVersion,
 		Changes:     changes,
+		Degraded:    degraded,
 		ACLUserIDs:  aclUserIDs,
 	}, nil
 }

--- a/internal/core/secret_version_diff_test.go
+++ b/internal/core/secret_version_diff_test.go
@@ -349,6 +349,26 @@ func TestDiffSecretVersions_WithACLEntries(t *testing.T) {
 	assert.Contains(t, diff.ACLUserIDs, uint(42), "ACL entry for user 42 must appear in the result")
 }
 
+// TestDiffSecretVersions_DegradedOnACLLookupError is #G54: a ListSecretACLs
+// storage failure must not be reported as an authoritative "this secret has
+// no ACL grants" — that's misleadingly reassuring for a security-relevant
+// diff. The diff must still succeed (ACLs are a supplementary snapshot, not
+// central to the version comparison), but must flag Degraded so a caller
+// doesn't treat the empty ACLUserIDs as confirmed.
+func TestDiffSecretVersions_DegradedOnACLLookupError(t *testing.T) {
+	c, db := newDiffCore(t)
+	sid := seedDiffFixture(t, db, "", nil)
+	addVersion(t, db, sid, 1, 0)
+	addVersion(t, db, sid, 2, 0)
+
+	require.NoError(t, db.Migrator().DropTable(&models.SecretACL{}))
+
+	diff, err := c.DiffSecretVersions(context.Background(), sid, 1, 2)
+	require.NoError(t, err, "the diff itself must still succeed despite the ACL lookup failing")
+	assert.True(t, diff.Degraded, "an ACL lookup failure must be flagged, not silently reported as zero grants")
+	assert.Empty(t, diff.ACLUserIDs)
+}
+
 // ── TestDiffSecretVersions_NegativeDelta ─────────────────────────────────────
 
 // TestDiffSecretVersions_NegativeDelta exercises the branch where to.ReadCount <

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -325,6 +325,15 @@ func (c *KeyorixCore) SetAuditForwarder(f AuditForwarder) {
 	c.auditForwarder = f
 }
 
+// AuditForwarder returns the wired audit forwarder (nil if none configured).
+// #G56: the server needs this at shutdown to flush/close the concrete
+// forwarder (e.g. *siem.Forwarder) — SetAuditForwarder's caller previously had
+// no way to reach it again afterward, since the constructed value lived only
+// as a local variable inside server initialization.
+func (c *KeyorixCore) AuditForwarder() AuditForwarder {
+	return c.auditForwarder
+}
+
 // SetLicenseGate wires the offline-license feature gate built at startup from the
 // installed token. nil = no license (community baseline). Safe to leave unset.
 func (c *KeyorixCore) SetLicenseGate(g *license.Gate) {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -516,6 +516,20 @@ type Storage interface {
 	CreateProjectMembership(ctx context.Context, m *models.ProjectMembership) (*models.ProjectMembership, error)
 	GetProjectMembership(ctx context.Context, id uint) (*models.ProjectMembership, error)
 	UpdateProjectMembership(ctx context.Context, m *models.ProjectMembership) error
+	// TransitionProjectMembershipState persists m's full row via a single
+	// conditional write — "UPDATE ... WHERE id = ? AND state = ?" — succeeding
+	// only if the row's CURRENT persisted state still equals fromState (the
+	// value TransitionMembership/revertFailedActivation observed immediately
+	// before mutating m in memory), mirroring TransitionMachineIdentityState's
+	// exact shape (#G42). Unlike that helper, there's no row lock backing this
+	// read — the conditional write is the ONLY thing closing the race, so
+	// UpdateProjectMembership must never be used for a state transition: a
+	// concurrent TransitionMembership call landing between the read and the
+	// write would otherwise be silently reverted (or silently revert this
+	// call), corrupting the ADR-022 state machine. Returns whether the write
+	// actually matched a row; a false match must be treated exactly like an
+	// illegal transition, not retried or silently overwritten.
+	TransitionProjectMembershipState(ctx context.Context, m *models.ProjectMembership, fromState string) (bool, error)
 	ListProjectMemberships(ctx context.Context, projectID uint) ([]*models.ProjectMembership, error)
 	// GetActiveProjectMembership returns the user's non-revoked membership in a
 	// project, or an error if none exists.

--- a/internal/core/token_expiry_remind.go
+++ b/internal/core/token_expiry_remind.go
@@ -77,6 +77,11 @@ func (k *KeyorixCore) checkPATExpiry(ctx context.Context, now time.Time, cutoff 
 		severity := tokenExpirySeverity(p.ExpiresAt, now)
 		title, msg := patExpiryMessage(p.Name, p.ExpiresAt)
 
+		// #G21: no DB backstop for this check-then-act — see read_quota_alerts.go's
+		// CheckReadQuotas for why the existing #488 reminder-dedup index can't
+		// simply be extended to cover this type (per-PAT-name dedup via message
+		// content, not a structured column). Deferred; worst case is a duplicate
+		// notification, not a security/data-integrity issue.
 		existing := k.unreadPATExpiryReminder(ctx, p.UserID, p.Name)
 		if existing != nil {
 			if severity <= existing.Severity {

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -44,7 +44,7 @@ func (c *KeyorixCore) buildUserForCreate(ctx context.Context, req *CreateUserReq
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcryptCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), int(bcryptCost.Load()))
 	if err != nil {
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}

--- a/internal/crypto/shamir_provider.go
+++ b/internal/crypto/shamir_provider.go
@@ -190,7 +190,14 @@ func (p *ShamirKeyProvider) KEK() ([]byte, error) { // NOSONAR -- cognitive comp
 		// Not a hard failure — existing key material split before shamir_commitment
 		// existed has no commitment to check — but this is a real reduction in
 		// verification strength that every startup should surface loudly.
-		log.Fatalf("shamir key provider: no shamir_commitment configured — reconstruction relies solely on the forgeable magic-byte framing check, NOT a cryptographic integrity check (see issue #429); run `keyorix encryption shamir-split` again and set shamir_commitment to close this gap")
+		//
+		// #G61: this used to log.Fatalf (os.Exit) here, unlike every other
+		// KeyProvider implementation, which returns an error and lets the caller
+		// (MultiKeyProvider) fall back to another configured provider. A missing
+		// shamir_commitment is a WEAKER verification posture, not an unrecoverable
+		// condition — killing the whole process denied that fallback a chance to
+		// run at all.
+		log.Printf("WARNING: shamir key provider: no shamir_commitment configured — reconstruction relies solely on the forgeable magic-byte framing check, NOT a cryptographic integrity check (see issue #429); run `keyorix encryption shamir-split` again and set shamir_commitment to close this gap")
 	}
 	// combineKEK enforces the embedded threshold and verifies the framing magic, so
 	// a sub-threshold or wrong set of shares fails closed here — including on a fresh

--- a/internal/crypto/shamir_provider_test.go
+++ b/internal/crypto/shamir_provider_test.go
@@ -136,3 +136,48 @@ func TestShamirKeyProvider_ForgedShareRejectedWithCommitment(t *testing.T) {
 	_, err = NewShamirKeyProvider([]string{f1, f2, f3}, nil, commitmentHex).KEK()
 	require.Error(t, err, "forged share must be rejected once shamir_commitment is configured")
 }
+
+// TestShamirKeyProvider_NoCommitmentConfiguredDoesNotExit is #G61: KEK() used to
+// log.Fatalf (os.Exit) when shamir_commitment was unset, unlike every other
+// KeyProvider implementation, which returns an error. This proves the process
+// survives — reconstruction proceeds with the weaker magic-byte-only check
+// (#429) instead of killing the whole server. If this test were run against
+// the pre-fix code, the log.Fatalf would tear down the test binary itself
+// (not just fail this test), which is exactly the bug.
+func TestShamirKeyProvider_NoCommitmentConfiguredDoesNotExit(t *testing.T) {
+	dir := t.TempDir()
+	kek := testKEK()
+	shares, err := SplitKEK(kek, 5, 3)
+	require.NoError(t, err)
+
+	f1 := filepath.Join(dir, "s1")
+	f2 := filepath.Join(dir, "s2")
+	f3 := filepath.Join(dir, "s3")
+	require.NoError(t, os.WriteFile(f1, []byte(hex.EncodeToString(shares[0])), 0600))
+	require.NoError(t, os.WriteFile(f2, []byte(hex.EncodeToString(shares[1])), 0600))
+	require.NoError(t, os.WriteFile(f3, []byte(hex.EncodeToString(shares[2])), 0600))
+
+	got, err := NewShamirKeyProvider([]string{f1, f2, f3}, nil, "").KEK()
+	require.NoError(t, err, "no shamir_commitment configured must reduce verification strength, not kill the process")
+	assert.Equal(t, kek, got)
+}
+
+// TestMultiKeyProvider_FallsBackWhenShamirKEKErrors is #G61's fallback half:
+// a ShamirKeyProvider that returns an error (too few shares, here) must let
+// MultiKeyProvider move on to the next configured provider — the whole reason
+// KEK() must return an error instead of calling log.Fatalf, which would have
+// killed the process before MultiKeyProvider ever got a chance to fall back.
+func TestMultiKeyProvider_FallsBackWhenShamirKEKErrors(t *testing.T) {
+	failingShamir := NewShamirKeyProvider(nil, nil, "") // 0 shares < threshold 2 → KEK() errors
+	kek := testKEK()
+	kekPath := filepath.Join(t.TempDir(), "kek.bin")
+	require.NoError(t, os.WriteFile(kekPath, kek, 0600))
+	fallback := NewFileKeyProvider(kekPath)
+
+	m, err := NewMultiKeyProvider([]KeyProvider{failingShamir, fallback})
+	require.NoError(t, err)
+
+	got, err := m.KEK()
+	require.NoError(t, err, "MultiKeyProvider must fall back to the next provider when shamir errors")
+	assert.Equal(t, kek, got)
+}

--- a/internal/notary/notary_fuzz_test.go
+++ b/internal/notary/notary_fuzz_test.go
@@ -1,7 +1,10 @@
 package notary
 
 import (
+	"context"
 	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -31,5 +34,32 @@ func FuzzVerifyReceipt(f *testing.F) {
 	f.Fuzz(func(t *testing.T, token []byte) {
 		// Must never panic.
 		_, _ = VerifyReceipt(roots, message, token)
+	})
+}
+
+// FuzzRFC3161Anchor is #G61's continuous-fuzz counterpart to FuzzVerifyReceipt:
+// Anchor() hands the TSA response body to digitorus/timestamp.ParseResponse,
+// the same parser family, so a malformed/hostile response must never panic
+// the process — only ever return an error.
+func FuzzRFC3161Anchor(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte("not DER at all"))
+	f.Add([]byte{0x30, 0x00})
+	f.Add([]byte{0x30, 0x01, 0x00})
+	f.Add([]byte{0x30, 0x10, 0x00})
+	f.Add([]byte{0x30, 0x81})
+	f.Add([]byte{0x30, 0x82})
+	f.Add([]byte{0xff, 0x81})
+	f.Add([]byte{0x30, 0x80, 0x00, 0x00})
+
+	f.Fuzz(func(t *testing.T, body []byte) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer srv.Close()
+		r := NewRFC3161(srv.URL, defaultTimeout)
+		// Must never panic.
+		_, _ = r.Anchor(context.Background(), []byte("fuzz anchor message"))
 	})
 }

--- a/internal/notary/notary_s17_test.go
+++ b/internal/notary/notary_s17_test.go
@@ -3,6 +3,8 @@ package notary
 import (
 	"context"
 	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -80,6 +82,38 @@ func TestRFC3161_Anchor_UnreachableHost(t *testing.T) {
 	_, err := r.Anchor(context.Background(), []byte("hello"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "post to")
+}
+
+// TestRFC3161_Anchor_MalformedTSAResponseNoPanic is #G61: Anchor() hands the
+// TSA's response bytes to timestamp.ParseResponse, the same digitorus parser
+// family VerifyReceipt was already hardened against (index out of range on
+// malformed BER, found by the continuous fuzz rig). A hostile or buggy TSA
+// endpoint must produce an error, never a process-killing panic — the same
+// property TestVerifyReceipt_MalformedToken_NoPanic pins for VerifyReceipt.
+func TestRFC3161_Anchor_MalformedTSAResponseNoPanic(t *testing.T) {
+	cases := [][]byte{
+		{},
+		[]byte("not DER at all"),
+		{0x30, 0x81},             // SEQUENCE + long-form length, no length byte follows
+		{0x30, 0x82},             // SEQUENCE + long-form length claiming 2 bytes, none follow
+		{0x30, 0x01},             // SEQUENCE claiming 1 content byte, none present
+		{0xff, 0x81},             // high-tag-number form, truncated
+		{0x30, 0x80, 0x00, 0x00}, // indefinite-length SEQUENCE
+	}
+	for _, body := range cases {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		client := NewRFC3161(srv.URL, 5*time.Second)
+
+		var err error
+		require.NotPanics(t, func() {
+			_, err = client.Anchor(context.Background(), []byte("anchor message"))
+		})
+		assert.Error(t, err, "a malformed TSA response must be reported as an error, not silently accepted")
+		srv.Close()
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/notary/rfc3161.go
+++ b/internal/notary/rfc3161.go
@@ -47,7 +47,19 @@ func refuseRedirect(req *http.Request, _ []*http.Request) error {
 
 func (r *RFC3161) Provider() string { return "rfc3161:" + r.url }
 
-func (r *RFC3161) Anchor(ctx context.Context, message []byte) (*Receipt, error) {
+func (r *RFC3161) Anchor(ctx context.Context, message []byte) (_ *Receipt, err error) {
+	// #G61: digitorus/pkcs7 panics on certain malformed BER inputs instead of
+	// returning an error (index out of range in ber.go:readObject, found by
+	// fuzz rig) — the same known parser panic class notary.go's VerifyReceipt
+	// was already hardened against. ParseResponse below hands attacker/TSA-
+	// controlled bytes to that same parser, so this needs the identical
+	// recover(): a hostile or buggy TSA endpoint must return an error, not
+	// crash the process anchoring an audit checkpoint.
+	defer func() {
+		if rec := recover(); rec != nil {
+			err = fmt.Errorf("rfc3161: parser panic on malformed TSA response: %v", rec)
+		}
+	}()
 	// CreateRequest hashes the message (SHA-256) into the MessageImprint and asks
 	// the TSA to include its signing certificate so the token is self-contained.
 	reqDER, err := timestamp.CreateRequest(bytes.NewReader(message), &timestamp.RequestOptions{

--- a/internal/notifychan/delivery.go
+++ b/internal/notifychan/delivery.go
@@ -71,8 +71,17 @@ type deliverer struct {
 	closing     chan struct{} // closed by close() to abort in-flight retry backoff
 	closeOnce   sync.Once
 	wg          sync.WaitGroup
-	mu          sync.Mutex
-	dropped     int
+	// mu guards both dropped and closed below — #G63: enqueue()'s non-blocking
+	// send on queue and close()'s close(queue) are otherwise unsynchronized, so
+	// a concurrent enqueue()/close() can send on an already-closed channel
+	// (a genuine Go runtime panic, not just a logical race). close() sets
+	// closed=true and enqueue() checks it under the SAME mutex as the send
+	// itself, so either enqueue() completes its send/drop entirely before
+	// close() can proceed to actually close the channel, or it observes
+	// closed=true and never touches the channel at all.
+	mu      sync.Mutex
+	closed  bool
+	dropped int
 }
 
 // newDeliverer starts the worker. channel is the Prometheus label; baseBackoff is
@@ -91,12 +100,20 @@ func newDeliverer(channel string, queueSize int, baseBackoff time.Duration, send
 }
 
 // enqueue offers the event to the queue without blocking; a full queue (a wedged
-// destination) drops and counts it rather than stalling the caller.
+// destination) drops and counts it rather than stalling the caller. A queue
+// that's being (or has been) closed also drops silently rather than sending —
+// see the deliverer.mu doc comment for why the closed check and the send share
+// one critical section.
 func (d *deliverer) enqueue(ev core.NotificationEvent) {
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return
+	}
 	select {
 	case d.queue <- ev:
+		d.mu.Unlock()
 	default:
-		d.mu.Lock()
 		d.dropped++
 		dropped := d.dropped
 		d.mu.Unlock()
@@ -144,6 +161,9 @@ func (d *deliverer) deliver(ev core.NotificationEvent) {
 // bounded. Idempotent.
 func (d *deliverer) close() {
 	d.closeOnce.Do(func() {
+		d.mu.Lock()
+		d.closed = true
+		d.mu.Unlock()
 		close(d.closing)
 		close(d.queue)
 	})

--- a/internal/notifychan/notifychan_s17_test.go
+++ b/internal/notifychan/notifychan_s17_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -233,6 +234,39 @@ func TestEnqueue_DropCountedWhenQueueFull(t *testing.T) {
 
 	close(release)
 	d.close()
+}
+
+// TestEnqueue_ConcurrentWithClose_NoPanic is #G63: enqueue()'s non-blocking
+// send on d.queue and close()'s close(d.queue) were unsynchronized — a
+// concurrent enqueue() landing mid-send while close() closes the channel is a
+// genuine Go runtime panic ("send on closed channel"), not just a logical
+// race. Run under `go test -race` this also catches the underlying data race
+// even on a run where the panic doesn't happen to trigger.
+func TestEnqueue_ConcurrentWithClose_NoPanic(t *testing.T) {
+	send := func(_ context.Context, _ core.NotificationEvent) (bool, error) {
+		return false, nil
+	}
+	d := newDeliverer("test-race", 4, time.Millisecond, send)
+	ev := core.NotificationEvent{UserID: 1}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			d.enqueue(ev)
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		d.close()
+	}()
+	close(start)
+	wg.Wait()
 }
 
 // TestDeliver_RetriesAbandonedOnShutdown exercises the closing-channel branch in

--- a/internal/notifychan/webhook.go
+++ b/internal/notifychan/webhook.go
@@ -73,7 +73,11 @@ func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*WebhookSink, err
 	}
 	transport := &http.Transport{}
 	if cfg.InsecureSkipVerify {
-		log.Printf("WARNING: notifychan webhook %q has TLS verification disabled (insecure_skip_verify); do not use in production", cfg.Endpoint)
+		// #G30: the endpoint URL IS the bearer credential for this channel (the
+		// token lives in the path, not a header — see delivery.go's
+		// embeddedURLPattern doc) — log only scheme+host, matching this
+		// package's own redactURLHost/sanitizeDeliveryError policy elsewhere.
+		log.Printf("WARNING: notifychan webhook %q has TLS verification disabled (insecure_skip_verify); do not use in production", redactURLHost(cfg.Endpoint))
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- NOSONAR go:S4830 go:S5527: InsecureSkipVerify is an explicit operator opt-in, guarded by config flag and WARNING log
 	}
 	s := &WebhookSink{

--- a/internal/notifychan/webhook_test.go
+++ b/internal/notifychan/webhook_test.go
@@ -1,11 +1,13 @@
 package notifychan
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -209,6 +211,37 @@ func TestNewWebhook_RejectsNonHTTPSEndpoint(t *testing.T) {
 	require.Error(t, err, "InsecureSkipVerify alone must not bypass the https requirement")
 	_, err = NewWebhook(WebhookConfig{Endpoint: "http://siem.example.com/hook", AllowPrivateNetworkTarget: true})
 	require.NoError(t, err, "AllowPrivateNetworkTarget is the dedicated opt-in for a non-https/internal target")
+}
+
+// TestNewWebhook_InsecureSkipVerifyWarningRedactsEndpoint is #G30: the endpoint
+// URL is the bearer credential for this channel (the token lives in the path,
+// not a header), so the InsecureSkipVerify startup warning must not log it
+// verbatim — matching this package's own redactURLHost policy used elsewhere
+// (delivery.go, TestChatSink_DeliveryFailureLogDoesNotLeakWebhookToken).
+func TestNewWebhook_InsecureSkipVerifyWarningRedactsEndpoint(t *testing.T) {
+	orig := lookupIPAddr
+	defer func() { lookupIPAddr = orig }()
+	lookupIPAddr = func(host string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("203.0.113.5")}}, nil // public TEST-NET-3
+	}
+
+	const token = "xoxb-topsecret-1234567890"
+
+	var buf bytes.Buffer
+	origOut := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(origOut)
+
+	_, err := NewWebhook(WebhookConfig{
+		Endpoint:           "https://siem.example.com/services/T000/B000/" + token,
+		InsecureSkipVerify: true,
+	})
+	require.NoError(t, err)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "siem.example.com", "host should be kept for diagnostic value")
+	assert.NotContains(t, logged, token, "the webhook's embedded bearer token must never reach the log stream")
+	assert.NotContains(t, logged, "services/T000/B000", "the webhook's path (which carries the token) must never reach the log stream")
 }
 
 // TestNewWebhook_RejectsHostnameResolvingToPrivateIP pins #130: the SSRF guard

--- a/internal/startup/validation.go
+++ b/internal/startup/validation.go
@@ -85,7 +85,7 @@ func ValidateStartup(configPath string, forceAutoFix bool) (*ValidationResult, e
 	return result, nil
 }
 
-// safeFilePermPath cleans path and rejects it if the cleaned form still
+// SafeFilePermPath cleans path and rejects it if the cleaned form still
 // contains a ".." segment. Unlike validateEncryption/validateDatabase (whose
 // paths come from a small, fixed set of config fields dedicated to a single
 // key/db file), the paths collected here span several independently-authored
@@ -93,7 +93,7 @@ func ValidateStartup(configPath string, forceAutoFix bool) (*ValidationResult, e
 // FixFilePerms below will Lstat/Chmod/Chown — so every one of them is
 // sanitized the same way before it is ever added to that list, closing off a
 // config-driven path-traversal into chmod/chown of an unintended file.
-func safeFilePermPath(label, path string) (string, error) {
+func SafeFilePermPath(label, path string) (string, error) {
 	clean := filepath.Clean(path)
 	if strings.Contains(clean, "..") {
 		return "", fmt.Errorf("%s path is unsafe (contains '..'): %s", label, path)
@@ -108,7 +108,7 @@ func validateFilePermissions(cfg *config.Config, configPath string, forceAutoFix
 	// the loader resolves KEYORIX_CONFIG_PATH / an absolute path, so a fixed relative
 	// name would silently stat a non-existent file and pass. Skip only when truly unknown.
 	if cfgFile := strings.TrimSpace(configPath); cfgFile != "" {
-		clean, err := safeFilePermPath("config file", cfgFile)
+		clean, err := SafeFilePermPath("config file", cfgFile)
 		if err != nil {
 			return err
 		}
@@ -118,11 +118,11 @@ func validateFilePermissions(cfg *config.Config, configPath string, forceAutoFix
 	if cfg.Storage.Encryption.Enabled {
 		// The KEK is passphrase-derived and never on disk (ADR-004); the salt and
 		// the wrapped DEK are the only key files to lock down.
-		saltPath, err := safeFilePermPath("KEK salt", cfg.Storage.Encryption.SaltPath)
+		saltPath, err := SafeFilePermPath("KEK salt", cfg.Storage.Encryption.SaltPath)
 		if err != nil {
 			return err
 		}
-		dekPath, err := safeFilePermPath("DEK", cfg.Storage.Encryption.DEKPath)
+		dekPath, err := SafeFilePermPath("DEK", cfg.Storage.Encryption.DEKPath)
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func validateFilePermissions(cfg *config.Config, configPath string, forceAutoFix
 		// no local database file to check
 	default: // "local", ""
 		if cfg.Storage.Database.Path != "" {
-			dbPath, err := safeFilePermPath("database", cfg.Storage.Database.Path)
+			dbPath, err := SafeFilePermPath("database", cfg.Storage.Database.Path)
 			if err != nil {
 				return err
 			}
@@ -154,11 +154,11 @@ func validateFilePermissions(cfg *config.Config, configPath string, forceAutoFix
 	}
 
 	if cfg.Server.HTTP.TLS.Enabled {
-		certPath, err := safeFilePermPath("HTTP TLS cert", cfg.Server.HTTP.TLS.CertFile)
+		certPath, err := SafeFilePermPath("HTTP TLS cert", cfg.Server.HTTP.TLS.CertFile)
 		if err != nil {
 			return err
 		}
-		keyPath, err := safeFilePermPath("HTTP TLS key", cfg.Server.HTTP.TLS.KeyFile)
+		keyPath, err := SafeFilePermPath("HTTP TLS key", cfg.Server.HTTP.TLS.KeyFile)
 		if err != nil {
 			return err
 		}
@@ -168,11 +168,11 @@ func validateFilePermissions(cfg *config.Config, configPath string, forceAutoFix
 		)
 	}
 	if cfg.Server.GRPC.TLS.Enabled {
-		certPath, err := safeFilePermPath("gRPC TLS cert", cfg.Server.GRPC.TLS.CertFile)
+		certPath, err := SafeFilePermPath("gRPC TLS cert", cfg.Server.GRPC.TLS.CertFile)
 		if err != nil {
 			return err
 		}
-		keyPath, err := safeFilePermPath("gRPC TLS key", cfg.Server.GRPC.TLS.KeyFile)
+		keyPath, err := SafeFilePermPath("gRPC TLS key", cfg.Server.GRPC.TLS.KeyFile)
 		if err != nil {
 			return err
 		}

--- a/internal/startup/validation_extra_test.go
+++ b/internal/startup/validation_extra_test.go
@@ -13,7 +13,7 @@ import (
 // TestSafeFilePermPath_CleanAbsolute validates that a safe absolute path is
 // returned unchanged (after Clean).
 func TestSafeFilePermPath_CleanAbsolute(t *testing.T) {
-	got, err := safeFilePermPath("label", "/app/keys/dek.key")
+	got, err := SafeFilePermPath("label", "/app/keys/dek.key")
 	require.NoError(t, err)
 	assert.Equal(t, "/app/keys/dek.key", got)
 }
@@ -21,7 +21,7 @@ func TestSafeFilePermPath_CleanAbsolute(t *testing.T) {
 // TestSafeFilePermPath_RejectsTraversal validates that paths with ".." are
 // rejected after filepath.Clean.
 func TestSafeFilePermPath_RejectsTraversal(t *testing.T) {
-	_, err := safeFilePermPath("test", "sub/../../outside")
+	_, err := SafeFilePermPath("test", "sub/../../outside")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "..")
 }
@@ -29,14 +29,14 @@ func TestSafeFilePermPath_RejectsTraversal(t *testing.T) {
 // TestSafeFilePermPath_RejectsParentDirOnly validates that ".." alone is
 // rejected.
 func TestSafeFilePermPath_RejectsParentDirOnly(t *testing.T) {
-	_, err := safeFilePermPath("label", "..")
+	_, err := SafeFilePermPath("label", "..")
 	require.Error(t, err)
 }
 
 // TestSafeFilePermPath_SafeRelative validates that a safe relative path without
 // traversal is allowed.
 func TestSafeFilePermPath_SafeRelative(t *testing.T) {
-	got, err := safeFilePermPath("label", "keys/dek.key")
+	got, err := SafeFilePermPath("label", "keys/dek.key")
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Clean("keys/dek.key"), got)
 }

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -570,17 +570,39 @@ func rebuildRolePKPostgres(db *gorm.DB, table, idCol, pkCols, oldConstraint stri
 // On a fresh DB, AutoMigrate creates all tables. On an existing DB,
 // it adds missing columns and indexes without dropping anything.
 func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR -- cognitive complexity 266, suppress go:S3776
+	// #G54: every additive column/index migration below is now checked and
+	// propagated (fail-closed) via this helper, instead of the bare
+	// db.Exec(...) each previously used — which discarded the result
+	// entirely. A silently-failed ALTER for a security-relevant column
+	// (account_state, mfa_enabled, failed_login_attempts, login_locked_until,
+	// ...) would let the app boot as if the migration succeeded, only to hard
+	// -fail (or silently no-op) the first time application code reads or
+	// writes that column, far from the actual root cause. Mirrors this same
+	// function's own AutoMigrate/Migrator.AddColumn calls below, which
+	// already check and wrap their errors.
+	exec := func(sql string) error {
+		if err := db.Exec(sql).Error; err != nil {
+			return fmt.Errorf("migration failed (%s): %w", sql, err)
+		}
+		return nil
+	}
 	// Additive column migration for existing databases (no-op on fresh DBs).
 	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "last_rotated_at") {
-		db.Exec("ALTER TABLE secret_nodes ADD COLUMN last_rotated_at TIMESTAMP WITH TIME ZONE")
+		if err := exec("ALTER TABLE secret_nodes ADD COLUMN last_rotated_at TIMESTAMP WITH TIME ZONE"); err != nil {
+			return err
+		}
 	}
 	// ADR-033: secrets soft-delete. Additive deleted_at (nil = live).
 	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "deleted_at") {
-		db.Exec("ALTER TABLE secret_nodes ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE")
+		if err := exec("ALTER TABLE secret_nodes ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE"); err != nil {
+			return err
+		}
 	}
 	// Data classification (ISO A.5.12). Additive classification ("" = unclassified).
 	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "classification") {
-		db.Exec("ALTER TABLE secret_nodes ADD COLUMN classification TEXT DEFAULT ''")
+		if err := exec("ALTER TABLE secret_nodes ADD COLUMN classification TEXT DEFAULT ''"); err != nil {
+			return err
+		}
 	}
 	// Companion index: models.SecretNode.Classification carries `gorm:"index"`, so a
 	// fresh AutoMigrate-created install already gets this index automatically, but an
@@ -593,35 +615,51 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	// running it unconditionally on every boot (matching the ensure*Index helpers below)
 	// is cheap once the index is in place.
 	if tableExists(db, "secret_nodes") {
-		db.Exec("CREATE INDEX IF NOT EXISTS idx_secret_nodes_classification ON secret_nodes (classification)")
+		if err := exec("CREATE INDEX IF NOT EXISTS idx_secret_nodes_classification ON secret_nodes (classification)"); err != nil {
+			return err
+		}
 	}
 	// ADR-046: automated rotation opt-in. Additive auto_rotate (false = off).
 	if tableExists(db, "secret_nodes") && !columnExists(db, "secret_nodes", "auto_rotate") {
-		db.Exec("ALTER TABLE secret_nodes ADD COLUMN auto_rotate BOOLEAN NOT NULL DEFAULT false")
+		if err := exec("ALTER TABLE secret_nodes ADD COLUMN auto_rotate BOOLEAN NOT NULL DEFAULT false"); err != nil {
+			return err
+		}
 	}
 	// ADR-046: per-secret generated-value shape. Additive (0/'' = defaults).
 	if tableExists(db, "secret_nodes") {
 		if !columnExists(db, "secret_nodes", "rotation_length") {
-			db.Exec("ALTER TABLE secret_nodes ADD COLUMN rotation_length INTEGER NOT NULL DEFAULT 0")
+			if err := exec("ALTER TABLE secret_nodes ADD COLUMN rotation_length INTEGER NOT NULL DEFAULT 0"); err != nil {
+				return err
+			}
 		}
 		if !columnExists(db, "secret_nodes", "rotation_charset") {
-			db.Exec("ALTER TABLE secret_nodes ADD COLUMN rotation_charset TEXT NOT NULL DEFAULT ''")
+			if err := exec("ALTER TABLE secret_nodes ADD COLUMN rotation_charset TEXT NOT NULL DEFAULT ''"); err != nil {
+				return err
+			}
 		}
 		// ADR-047: backend rotation wiring. Additive ('' = regenerate-in-Keyorix).
 		if !columnExists(db, "secret_nodes", "rotation_backend") {
-			db.Exec("ALTER TABLE secret_nodes ADD COLUMN rotation_backend TEXT NOT NULL DEFAULT ''")
+			if err := exec("ALTER TABLE secret_nodes ADD COLUMN rotation_backend TEXT NOT NULL DEFAULT ''"); err != nil {
+				return err
+			}
 		}
 		if !columnExists(db, "secret_nodes", "rotation_ref") {
-			db.Exec("ALTER TABLE secret_nodes ADD COLUMN rotation_ref TEXT NOT NULL DEFAULT ''")
+			if err := exec("ALTER TABLE secret_nodes ADD COLUMN rotation_ref TEXT NOT NULL DEFAULT ''"); err != nil {
+				return err
+			}
 		}
 		// ADR-056: cached certificate expiry. Additive (nil = not yet evaluated).
 		if !columnExists(db, "secret_nodes", "cert_not_after") {
-			db.Exec("ALTER TABLE secret_nodes ADD COLUMN cert_not_after TIMESTAMP WITH TIME ZONE")
+			if err := exec("ALTER TABLE secret_nodes ADD COLUMN cert_not_after TIMESTAMP WITH TIME ZONE"); err != nil {
+				return err
+			}
 		}
 		// Companion index (models.SecretNode.CertNotAfter is `gorm:"index"`); see the
 		// classification companion-index comment above for why this runs unconditionally
 		// (gated on the table only) rather than nested inside the ALTER guard above.
-		db.Exec("CREATE INDEX IF NOT EXISTS idx_secret_nodes_cert_not_after ON secret_nodes (cert_not_after)")
+		if err := exec("CREATE INDEX IF NOT EXISTS idx_secret_nodes_cert_not_after ON secret_nodes (cert_not_after)"); err != nil {
+			return err
+		}
 	}
 	// MT-006: partial unique index on (project_id, environment_id, name) WHERE
 	// deleted_at IS NULL — enforces at the DB layer the invariant the application
@@ -638,99 +676,143 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	}
 	// Anomaly alerting: additive `alerted` flag (false = not yet pushed out).
 	if tableExists(db, "anomaly_alerts") && !columnExists(db, "anomaly_alerts", "alerted") {
-		db.Exec("ALTER TABLE anomaly_alerts ADD COLUMN alerted BOOLEAN DEFAULT FALSE")
+		if err := exec("ALTER TABLE anomaly_alerts ADD COLUMN alerted BOOLEAN DEFAULT FALSE"); err != nil {
+			return err
+		}
 	}
 	// Companion index (models.AnomalyAlert.Alerted is `gorm:"default:false;index"`); see
 	// the secret_nodes.classification companion-index comment above for why this is
 	// gated on the table only, not on the ALTER above having just run.
 	if tableExists(db, "anomaly_alerts") {
-		db.Exec("CREATE INDEX IF NOT EXISTS idx_anomaly_alerts_alerted ON anomaly_alerts (alerted)")
+		if err := exec("CREATE INDEX IF NOT EXISTS idx_anomaly_alerts_alerted ON anomaly_alerts (alerted)"); err != nil {
+			return err
+		}
 	}
 
 	// Track last successful login per user (nil = never logged in).
 	if tableExists(db, "users") && !columnExists(db, "users", "last_login_at") {
-		db.Exec("ALTER TABLE users ADD COLUMN last_login_at TIMESTAMP WITH TIME ZONE")
+		if err := exec("ALTER TABLE users ADD COLUMN last_login_at TIMESTAMP WITH TIME ZONE"); err != nil {
+			return err
+		}
 	}
 
 	// Track when the current password was set, for max-age expiry (ADR-025).
 	if tableExists(db, "users") && !columnExists(db, "users", "password_changed_at") {
-		db.Exec("ALTER TABLE users ADD COLUMN password_changed_at TIMESTAMP WITH TIME ZONE")
+		if err := exec("ALTER TABLE users ADD COLUMN password_changed_at TIMESTAMP WITH TIME ZONE"); err != nil {
+			return err
+		}
 	}
 
 	// Account lifecycle state (ADR-025). Existing rows default to active.
 	if tableExists(db, "users") && !columnExists(db, "users", "account_state") {
-		db.Exec("ALTER TABLE users ADD COLUMN account_state TEXT NOT NULL DEFAULT 'active'")
+		if err := exec("ALTER TABLE users ADD COLUMN account_state TEXT NOT NULL DEFAULT 'active'"); err != nil {
+			return err
+		}
 	}
 
 	// MFA/TOTP opt-in flag. Existing rows default to false (MFA off).
 	if tableExists(db, "users") && !columnExists(db, "users", "mfa_enabled") {
-		db.Exec("ALTER TABLE users ADD COLUMN mfa_enabled BOOLEAN NOT NULL DEFAULT false")
+		if err := exec("ALTER TABLE users ADD COLUMN mfa_enabled BOOLEAN NOT NULL DEFAULT false"); err != nil {
+			return err
+		}
 	}
 
 	// SCIM external ID (RFC 7644). Additive; empty for locally-created users.
 	if tableExists(db, "users") && !columnExists(db, "users", "external_id") {
-		db.Exec("ALTER TABLE users ADD COLUMN external_id TEXT NOT NULL DEFAULT ''")
+		if err := exec("ALTER TABLE users ADD COLUMN external_id TEXT NOT NULL DEFAULT ''"); err != nil {
+			return err
+		}
 	}
 
 	// Per-account login lockout (brute-force protection). Additive; safe on existing DBs.
 	if tableExists(db, "users") {
 		if !columnExists(db, "users", "failed_login_attempts") {
-			db.Exec("ALTER TABLE users ADD COLUMN failed_login_attempts INTEGER NOT NULL DEFAULT 0")
+			if err := exec("ALTER TABLE users ADD COLUMN failed_login_attempts INTEGER NOT NULL DEFAULT 0"); err != nil {
+				return err
+			}
 		}
 		if !columnExists(db, "users", "last_failed_login_at") {
-			db.Exec("ALTER TABLE users ADD COLUMN last_failed_login_at TIMESTAMP WITH TIME ZONE")
+			if err := exec("ALTER TABLE users ADD COLUMN last_failed_login_at TIMESTAMP WITH TIME ZONE"); err != nil {
+				return err
+			}
 		}
 		if !columnExists(db, "users", "login_locked_until") {
-			db.Exec("ALTER TABLE users ADD COLUMN login_locked_until TIMESTAMP WITH TIME ZONE")
+			if err := exec("ALTER TABLE users ADD COLUMN login_locked_until TIMESTAMP WITH TIME ZONE"); err != nil {
+				return err
+			}
 		}
 		if !columnExists(db, "users", "login_lockout_count") {
-			db.Exec("ALTER TABLE users ADD COLUMN login_lockout_count INTEGER NOT NULL DEFAULT 0")
+			if err := exec("ALTER TABLE users ADD COLUMN login_lockout_count INTEGER NOT NULL DEFAULT 0"); err != nil {
+				return err
+			}
 		}
 	}
 
 	// Enrich sessions for the My Account "active sessions" view (device/IP/last-active).
 	if tableExists(db, "sessions") {
 		if !columnExists(db, "sessions", "user_agent") {
-			db.Exec("ALTER TABLE sessions ADD COLUMN user_agent TEXT")
+			if err := exec("ALTER TABLE sessions ADD COLUMN user_agent TEXT"); err != nil {
+				return err
+			}
 		}
 		if !columnExists(db, "sessions", "ip_address") {
-			db.Exec("ALTER TABLE sessions ADD COLUMN ip_address TEXT")
+			if err := exec("ALTER TABLE sessions ADD COLUMN ip_address TEXT"); err != nil {
+				return err
+			}
 		}
 		if !columnExists(db, "sessions", "last_seen_at") {
-			db.Exec("ALTER TABLE sessions ADD COLUMN last_seen_at TIMESTAMP WITH TIME ZONE")
+			if err := exec("ALTER TABLE sessions ADD COLUMN last_seen_at TIMESTAMP WITH TIME ZONE"); err != nil {
+				return err
+			}
 		}
 		// Absolute session-lifetime ceiling (short-lived tokens): set at login,
 		// carried through refresh, never extended. nil on legacy rows = uncapped.
 		if !columnExists(db, "sessions", "absolute_expires_at") {
-			db.Exec("ALTER TABLE sessions ADD COLUMN absolute_expires_at TIMESTAMP WITH TIME ZONE")
+			if err := exec("ALTER TABLE sessions ADD COLUMN absolute_expires_at TIMESTAMP WITH TIME ZONE"); err != nil {
+				return err
+			}
 		}
 	}
 
 	// Audit-design block: diff payload + impersonation attribution on audit rows.
 	if tableExists(db, "audit_events") {
 		if !columnExists(db, "audit_events", "diff") {
-			db.Exec("ALTER TABLE audit_events ADD COLUMN diff TEXT")
+			if err := exec("ALTER TABLE audit_events ADD COLUMN diff TEXT"); err != nil {
+				return err
+			}
 		}
 		if !columnExists(db, "audit_events", "impersonated_by") {
-			db.Exec("ALTER TABLE audit_events ADD COLUMN impersonated_by INTEGER")
+			if err := exec("ALTER TABLE audit_events ADD COLUMN impersonated_by INTEGER"); err != nil {
+				return err
+			}
 		}
 		if !columnExists(db, "audit_events", "acting_as") {
-			db.Exec("ALTER TABLE audit_events ADD COLUMN acting_as INTEGER")
+			if err := exec("ALTER TABLE audit_events ADD COLUMN acting_as INTEGER"); err != nil {
+				return err
+			}
 		}
 		if !columnExists(db, "audit_events", "impersonation") {
-			db.Exec("ALTER TABLE audit_events ADD COLUMN impersonation BOOLEAN NOT NULL DEFAULT false")
+			if err := exec("ALTER TABLE audit_events ADD COLUMN impersonation BOOLEAN NOT NULL DEFAULT false"); err != nil {
+				return err
+			}
 		}
 		// ADR-023: actor kind (user vs machine_identity) on every event.
 		if !columnExists(db, "audit_events", "actor_type") {
-			db.Exec("ALTER TABLE audit_events ADD COLUMN actor_type TEXT NOT NULL DEFAULT 'user'")
+			if err := exec("ALTER TABLE audit_events ADD COLUMN actor_type TEXT NOT NULL DEFAULT 'user'"); err != nil {
+				return err
+			}
 		}
 		// ADR-029: tamper-evidence hash chain. Empty on legacy rows (the chain
 		// begins at the first event written after these columns exist).
 		if !columnExists(db, "audit_events", "prev_hash") {
-			db.Exec("ALTER TABLE audit_events ADD COLUMN prev_hash TEXT NOT NULL DEFAULT ''")
+			if err := exec("ALTER TABLE audit_events ADD COLUMN prev_hash TEXT NOT NULL DEFAULT ''"); err != nil {
+				return err
+			}
 		}
 		if !columnExists(db, "audit_events", "entry_hash") {
-			db.Exec("ALTER TABLE audit_events ADD COLUMN entry_hash TEXT NOT NULL DEFAULT ''")
+			if err := exec("ALTER TABLE audit_events ADD COLUMN entry_hash TEXT NOT NULL DEFAULT ''"); err != nil {
+				return err
+			}
 		}
 		// Companion indexes (models.AuditEvent.PrevHash/EntryHash are both
 		// `gorm:"index"`). VerifyAuditChain walks this hash chain as a security
@@ -739,17 +821,25 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 		// check being skipped operationally once it gets too slow to run regularly.
 		// Gated on the table only, not the ALTERs above — see the
 		// secret_nodes.classification companion-index comment for why.
-		db.Exec("CREATE INDEX IF NOT EXISTS idx_audit_events_prev_hash ON audit_events (prev_hash)")
-		db.Exec("CREATE INDEX IF NOT EXISTS idx_audit_events_entry_hash ON audit_events (entry_hash)")
+		if err := exec("CREATE INDEX IF NOT EXISTS idx_audit_events_prev_hash ON audit_events (prev_hash)"); err != nil {
+			return err
+		}
+		if err := exec("CREATE INDEX IF NOT EXISTS idx_audit_events_entry_hash ON audit_events (entry_hash)"); err != nil {
+			return err
+		}
 	}
 
 	// Impersonation sessions carry the initiating admin + start time.
 	if tableExists(db, "sessions") {
 		if !columnExists(db, "sessions", "impersonated_by") {
-			db.Exec("ALTER TABLE sessions ADD COLUMN impersonated_by INTEGER")
+			if err := exec("ALTER TABLE sessions ADD COLUMN impersonated_by INTEGER"); err != nil {
+				return err
+			}
 		}
 		if !columnExists(db, "sessions", "impersonation_started_at") {
-			db.Exec("ALTER TABLE sessions ADD COLUMN impersonation_started_at TIMESTAMP WITH TIME ZONE")
+			if err := exec("ALTER TABLE sessions ADD COLUMN impersonation_started_at TIMESTAMP WITH TIME ZONE"); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -764,10 +854,14 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 			continue
 		}
 		if !columnExists(db, m.tbl, "environment_id") {
-			db.Exec(m.addEnvID)
+			if err := exec(m.addEnvID); err != nil {
+				return err
+			}
 		}
 		if columnExists(db, m.tbl, "project_id") {
-			db.Exec(m.nullPID)
+			if err := exec(m.nullPID); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -887,14 +981,18 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 		}
 		// Data classification (ISO A.5.12). Additive ("" = unclassified).
 		if tableExists(db, "dynamic_secret_configs") && !columnExists(db, "dynamic_secret_configs", "classification") {
-			db.Exec("ALTER TABLE dynamic_secret_configs ADD COLUMN classification TEXT DEFAULT ''")
+			if err := exec("ALTER TABLE dynamic_secret_configs ADD COLUMN classification TEXT DEFAULT ''"); err != nil {
+				return err
+			}
 		}
 		// Companion index (models.DynamicSecretConfig.Classification is `gorm:"index"`);
 		// this whole branch only runs when dynamic_secret_configs already existed (the
 		// upgrade path — a fresh install's AutoMigrate call below already creates the
 		// index), so it's safe to run unconditionally here rather than nesting inside
 		// the ALTER guard above — see the secret_nodes.classification comment for why.
-		db.Exec("CREATE INDEX IF NOT EXISTS idx_dynamic_secret_configs_classification ON dynamic_secret_configs (classification)")
+		if err := exec("CREATE INDEX IF NOT EXISTS idx_dynamic_secret_configs_classification ON dynamic_secret_configs (classification)"); err != nil {
+			return err
+		}
 		// Disabled (#369): refuses new leases once the owning project is soft-deleted.
 		// Additive (defaults false = every pre-existing config stays enabled).
 		if !m.HasColumn(&models.DynamicSecretConfig{}, "Disabled") {
@@ -1135,14 +1233,18 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	} else {
 		if !columnExists(db, "machine_identities", "classification") {
 			// Data classification (ISO A.5.12). Additive ("" = unclassified).
-			db.Exec("ALTER TABLE machine_identities ADD COLUMN classification TEXT DEFAULT ''")
+			if err := exec("ALTER TABLE machine_identities ADD COLUMN classification TEXT DEFAULT ''"); err != nil {
+				return err
+			}
 		}
 		// Companion index (models.MachineIdentity.Classification is `gorm:"index"`);
 		// this else branch only runs on the upgrade path (a fresh install's
 		// AutoMigrate call above already creates the index) — see the
 		// secret_nodes.classification comment for why this runs unconditionally
 		// rather than nested inside the ALTER guard.
-		db.Exec("CREATE INDEX IF NOT EXISTS idx_machine_identities_classification ON machine_identities (classification)")
+		if err := exec("CREATE INDEX IF NOT EXISTS idx_machine_identities_classification ON machine_identities (classification)"); err != nil {
+			return err
+		}
 	}
 
 	// Create machine-token tables if missing (ADR-030, additive, safe on existing DBs).
@@ -1152,12 +1254,16 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 		}
 	} else {
 		if !columnExists(db, "machine_identity_credentials", "classification") {
-			db.Exec("ALTER TABLE machine_identity_credentials ADD COLUMN classification TEXT DEFAULT ''")
+			if err := exec("ALTER TABLE machine_identity_credentials ADD COLUMN classification TEXT DEFAULT ''"); err != nil {
+				return err
+			}
 		}
 		// Companion index (models.MachineIdentityCredential.Classification is
 		// `gorm:"index"`); see the machine_identities.classification comment above
 		// for why this runs unconditionally in this (upgrade-only) branch.
-		db.Exec("CREATE INDEX IF NOT EXISTS idx_machine_identity_credentials_classification ON machine_identity_credentials (classification)")
+		if err := exec("CREATE INDEX IF NOT EXISTS idx_machine_identity_credentials_classification ON machine_identity_credentials (classification)"); err != nil {
+			return err
+		}
 	}
 	if !machineRoleExists {
 		if err := db.AutoMigrate(&models.MachineIdentityRole{}); err != nil {
@@ -1245,7 +1351,9 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	// creation; upgraded installs get a best-effort column add so the application
 	// can at least insert new scoped rows without breaking on old global ones.
 	if tableExists(db, "user_groups") && !columnExists(db, "user_groups", "project_id") {
-		db.Exec("ALTER TABLE user_groups ADD COLUMN project_id INTEGER NOT NULL DEFAULT 0")
+		if err := exec("ALTER TABLE user_groups ADD COLUMN project_id INTEGER NOT NULL DEFAULT 0"); err != nil {
+			return err
+		}
 	}
 
 	// Swap the plain unique index on users.username for a partial one (live rows only),

--- a/internal/storage/sqlitedialect/migrator.go
+++ b/internal/storage/sqlitedialect/migrator.go
@@ -161,7 +161,18 @@ func (m Migrator) DropColumn(value interface{}, name string) error {
 				name = field.DBName
 			}
 
-			ddl.removeColumn(name)
+			// #G54: removeColumn's bool return, previously discarded, signals
+			// whether the requested column was actually found and removed
+			// from the table's DDL. Ignoring it here meant DropColumn always
+			// reported success — including recreating the whole table for no
+			// reason when name didn't match anything — even when the column
+			// it was asked to drop never went away. A caller relying on
+			// DropColumn to actually remove a deprecated or insecure column
+			// (e.g. a plaintext field superseded by an encrypted one) would
+			// get no indication the drop silently no-op'd.
+			if !ddl.removeColumn(name) {
+				return nil, nil, fmt.Errorf("sqlitedialect: column %q not found, nothing dropped", name)
+			}
 			return ddl, nil, nil
 		})
 	})

--- a/internal/storage/sqlitedialect/migrator_test.go
+++ b/internal/storage/sqlitedialect/migrator_test.go
@@ -41,6 +41,21 @@ func TestMigrator_HasColumnAndDropColumn(t *testing.T) {
 	assert.False(t, m.HasColumn(&migratorTestModel{}, "Email"))
 }
 
+// TestMigrator_DropColumn_NonexistentColumnErrors is #G54: before the fix,
+// DropColumn reported success for a column name that was never actually
+// present in the table's DDL — removeColumn's bool signaling "not found" was
+// discarded, so a caller relying on DropColumn to actually remove a
+// deprecated or insecure column got no indication the drop silently no-op'd.
+func TestMigrator_DropColumn_NonexistentColumnErrors(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	err := m.DropColumn(&migratorTestModel{}, "DoesNotExist")
+	require.Error(t, err, "dropping a column that was never in the table must report failure, not silent success")
+	assert.Contains(t, err.Error(), "not found")
+}
+
 func TestMigrator_IndexLifecycle(t *testing.T) {
 	db := openTestDB(t)
 	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"time"
 
+	"gorm.io/gorm"
+
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -504,17 +506,26 @@ func (ls *LocalStorage) CreateAnomalyAlert(ctx context.Context, alert *models.An
 	}
 	cutoff = cutoff.Add(-anomalyDedupWindow)
 
-	var existing int64
-	if err := ls.db.WithContext(ctx).Model(&models.AnomalyAlert{}).
-		Where("secret_node_id = ? AND alert_type = ? AND accessed_by = ? AND ip_address = ? AND detected_at > ?",
-			alert.SecretNodeID, alert.AlertType, alert.AccessedBy, alert.IPAddress, cutoff).
-		Count(&existing).Error; err != nil {
-		return err
-	}
-	if existing > 0 {
-		return nil
-	}
-	return ls.db.WithContext(ctx).Create(alert).Error
+	// #G21: the dedup check and the insert run inside ONE transaction — two
+	// concurrent detection runs processing the same access event could
+	// otherwise both observe existing==0 before either commits, producing
+	// duplicate alerts. SQLite's single-writer model holds this transaction's
+	// exclusive write lock for its whole duration, so a concurrent insert of
+	// the same (secret, type, actor, ip) tuple cannot land in between the
+	// count and this insert.
+	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing int64
+		if err := tx.Model(&models.AnomalyAlert{}).
+			Where("secret_node_id = ? AND alert_type = ? AND accessed_by = ? AND ip_address = ? AND detected_at > ?",
+				alert.SecretNodeID, alert.AlertType, alert.AccessedBy, alert.IPAddress, cutoff).
+			Count(&existing).Error; err != nil {
+			return err
+		}
+		if existing > 0 {
+			return nil
+		}
+		return tx.Create(alert).Error
+	})
 }
 
 // ListAnomalyAlerts returns alerts newest-first. acknowledged filters by state:

--- a/internal/storage/store/local_dynamic.go
+++ b/internal/storage/store/local_dynamic.go
@@ -60,9 +60,15 @@ func (ls *LocalStorage) UpdateDynamicSecretConfig(ctx context.Context, c *models
 // UpdatedAt, ...) is persisted in the same statement, not just a hardcoded
 // column subset.
 func (ls *LocalStorage) TransitionDynamicSecretConfigDisabled(ctx context.Context, c *models.DynamicSecretConfig, fromDisabled bool) (bool, error) {
+	// #G42: the guard only checks `disabled`, so a concurrent DSN rotation or
+	// classification change (UpdateDynamicSecretConfig, an unconditional Save
+	// that doesn't touch `disabled`) still matches this WHERE clause. A
+	// Select("*") here would silently revert that concurrent edit back to
+	// this call's stale copy even though the enable/disable toggle itself is
+	// legitimate. Whitelist only the columns this transition actually owns.
 	res := ls.db.WithContext(ctx).Model(&models.DynamicSecretConfig{}).
 		Where("id = ? AND disabled = ?", c.ID, fromDisabled).
-		Select("*").
+		Select("Disabled", "UpdatedAt").
 		Updates(c)
 	if res.Error != nil {
 		return false, res.Error

--- a/internal/storage/store/local_memberships.go
+++ b/internal/storage/store/local_memberships.go
@@ -60,6 +60,22 @@ func (ls *LocalStorage) UpdateProjectMembership(ctx context.Context, m *models.P
 	return nil
 }
 
+// TransitionProjectMembershipState persists m's full row via a conditional
+// UPDATE gated on the row's CURRENT state still being fromState (#G42).
+// Mirrors TransitionMachineIdentityState's `WHERE id = ? AND state = ?` +
+// `Select("*")` shape exactly, so every field the caller mutated on m (State,
+// UpdatedAt, ActivatedAt, RevokedAt, ...) is persisted in the same statement.
+func (ls *LocalStorage) TransitionProjectMembershipState(ctx context.Context, m *models.ProjectMembership, fromState string) (bool, error) {
+	res := ls.db.WithContext(ctx).Model(&models.ProjectMembership{}).
+		Where("id = ? AND state = ?", m.ID, fromState).
+		Select("*").
+		Updates(m)
+	if res.Error != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)
+	}
+	return res.RowsAffected == 1, nil
+}
+
 func (ls *LocalStorage) ListProjectMemberships(ctx context.Context, projectID uint) ([]*models.ProjectMembership, error) {
 	var rows []*models.ProjectMembership
 	err := ls.db.WithContext(ctx).

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -194,12 +194,41 @@ func (ls *LocalStorage) PurgeDeletedEnvironmentsBefore(ctx context.Context, befo
 // not just the ID list — so a row a restore raced out from under the purge is left alone.
 func (ls *LocalStorage) PurgeDeletedSecretsBefore(ctx context.Context, before time.Time) (int64, error) {
 	var purged int64
+	// #G43: SetSecretRetentionOverride's per-secret window was never consulted here —
+	// every secret purged strictly on the deployment-wide cutoff regardless of a set
+	// override. The candidate set below is intentionally wider than sqlWhereDeletedBefore
+	// (every still-soft-deleted secret, not just ones past the global cutoff) so a
+	// SHORTER override (secret should be gone sooner than the global window) is caught
+	// too, not just a longer one; GetEffectiveRetentionDays (the same helper
+	// SetSecretRetentionOverride's own doc points callers to) then decides per row
+	// whether `before` (no override) or `now - override days` (override set) applies.
+	// now is a single wall-clock read for the whole sweep, not per-row, so every
+	// candidate in this run is judged against the same instant.
+	now := time.Now()
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var ids []uint
+		var candidates []struct {
+			ID                    uint
+			DeletedAt             gorm.DeletedAt
+			RetentionOverrideDays int
+		}
 		if e := tx.Unscoped().Model(&models.SecretNode{}).
-			Where(sqlWhereDeletedBefore, before).
-			Pluck("id", &ids).Error; e != nil {
+			Select("id, deleted_at, retention_override_days").
+			Where("deleted_at IS NOT NULL").
+			Find(&candidates).Error; e != nil {
 			return e
+		}
+		var ids []uint
+		for _, cand := range candidates {
+			if !cand.DeletedAt.Valid {
+				continue
+			}
+			cutoff := before
+			if cand.RetentionOverrideDays > 0 {
+				cutoff = now.AddDate(0, 0, -cand.RetentionOverrideDays)
+			}
+			if cand.DeletedAt.Time.Before(cutoff) {
+				ids = append(ids, cand.ID)
+			}
 		}
 		if len(ids) == 0 {
 			return nil
@@ -210,10 +239,15 @@ func (ls *LocalStorage) PurgeDeletedSecretsBefore(ctx context.Context, before ti
 		// than the stale `ids` list, so a secret restored after the SELECT above is
 		// excluded from every delete below it. A fresh subquery builder is used per
 		// reference since a *gorm.DB is stateful and must not be shared across clauses.
+		// #G43: this re-check only re-asserts "still soft-deleted" (id IN ids AND
+		// deleted_at IS NOT NULL), not the age predicate sqlWhereIDsDeletedBefore
+		// re-asserts elsewhere — ids above was already computed per-secret against
+		// GetEffectiveRetentionDays, which a blanket "< before" re-check would
+		// silently undo for any secret whose override differs from the global window.
 		stillEligible := func() *gorm.DB {
 			return tx.Unscoped().Model(&models.SecretNode{}).
 				Select("id").
-				Where(sqlWhereIDsDeletedBefore, ids, before)
+				Where("id IN ? AND deleted_at IS NOT NULL", ids)
 		}
 		if e := tx.Where("secret_node_id IN (?)", stillEligible()).Delete(&models.SecretVersion{}).Error; e != nil {
 			return e
@@ -223,7 +257,7 @@ func (ls *LocalStorage) PurgeDeletedSecretsBefore(ctx context.Context, before ti
 			return e
 		}
 		rn := tx.Unscoped().
-			Where(sqlWhereIDsDeletedBefore, ids, before).
+			Where("id IN ? AND deleted_at IS NOT NULL", ids).
 			Delete(&models.SecretNode{})
 		if rn.Error != nil {
 			return rn.Error

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -299,22 +299,27 @@ func (ls *LocalStorage) DeleteAnomalyAlertsBefore(ctx context.Context, ackBefore
 // Open campaigns (closed_at IS NULL) are never touched.
 func (ls *LocalStorage) DeleteClosedAccessReviewsBefore(ctx context.Context, before time.Time) (int64, int64, error) {
 	var campaigns, items int64
+	eligible := "state = ? AND closed_at IS NOT NULL AND closed_at < ?"
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var ids []uint
-		if e := tx.Model(&models.AccessReviewCampaign{}).
-			Where("state = ? AND closed_at IS NOT NULL AND closed_at < ?", "closed", before).
-			Pluck("id", &ids).Error; e != nil {
-			return e
-		}
-		if len(ids) == 0 {
-			return nil
-		}
-		ri := tx.Where("campaign_id IN ?", ids).Delete(&models.AccessReviewItem{})
+		// #G21: both deletes re-evaluate the eligibility predicate LIVE, at the
+		// moment each DELETE statement executes, instead of deleting by a
+		// Pluck'd ID list captured earlier in the transaction. A campaign
+		// reopened between an initial Pluck and a later delete-by-ID would
+		// still be destroyed under the old pattern — under Postgres READ
+		// COMMITTED (unlike SQLite's single-writer exclusivity) a concurrent
+		// transaction's UPDATE can commit in that window without this one
+		// seeing it via a lock. Filtering the item-delete via a live subquery
+		// against the campaign table's CURRENT state, and the campaign-delete
+		// via the same live predicate directly, closes that gap for both
+		// backends.
+		ri := tx.Where("campaign_id IN (?)", tx.Model(&models.AccessReviewCampaign{}).
+			Select("id").Where(eligible, "closed", before)).
+			Delete(&models.AccessReviewItem{})
 		if ri.Error != nil {
 			return ri.Error
 		}
 		items = ri.RowsAffected
-		rc := tx.Where("id IN ?", ids).Delete(&models.AccessReviewCampaign{})
+		rc := tx.Where(eligible, "closed", before).Delete(&models.AccessReviewCampaign{})
 		if rc.Error != nil {
 			return rc.Error
 		}
@@ -344,22 +349,21 @@ func (ls *LocalStorage) DeleteExpiredBreakGlassBefore(ctx context.Context, befor
 // transaction. Pending requests (resolved_at IS NULL) are never touched.
 func (ls *LocalStorage) DeleteResolvedAccessRequestsBefore(ctx context.Context, before time.Time) (int64, int64, error) {
 	var requests, approvals int64
+	eligible := "resolved_at IS NOT NULL AND resolved_at < ?"
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var ids []uint
-		if e := tx.Model(&models.AccessRequest{}).
-			Where("resolved_at IS NOT NULL AND resolved_at < ?", before).
-			Pluck("id", &ids).Error; e != nil {
-			return e
-		}
-		if len(ids) == 0 {
-			return nil
-		}
-		ra := tx.Where("request_id IN ?", ids).Delete(&models.AccessRequestApproval{})
+		// #G21: same live-predicate-at-delete-time fix as
+		// DeleteClosedAccessReviewsBefore above — see its comment for why a
+		// Pluck'd ID list captured earlier in the transaction can go stale
+		// under Postgres READ COMMITTED if a request is un-resolved
+		// concurrently.
+		ra := tx.Where("request_id IN (?)", tx.Model(&models.AccessRequest{}).
+			Select("id").Where(eligible, before)).
+			Delete(&models.AccessRequestApproval{})
 		if ra.Error != nil {
 			return ra.Error
 		}
 		approvals = ra.RowsAffected
-		rr := tx.Where("id IN ?", ids).Delete(&models.AccessRequest{})
+		rr := tx.Where(eligible, before).Delete(&models.AccessRequest{})
 		if rr.Error != nil {
 			return rr.Error
 		}

--- a/internal/storage/store/local_purge_test.go
+++ b/internal/storage/store/local_purge_test.go
@@ -188,3 +188,48 @@ func TestPurgeDeletedSecretsBefore_DestroysVersions(t *testing.T) {
 	require.NoError(t, db.Model(&models.SecretVersion{}).Where("secret_node_id = ?", 2).Count(&liveVersions).Error)
 	assert.Equal(t, int64(1), liveVersions)
 }
+
+// TestPurgeDeletedSecretsBefore_RespectsRetentionOverride is #G43:
+// SetSecretRetentionOverride's per-secret window was never actually consulted
+// by the purge sweep — every secret purged strictly on the deployment-wide
+// cutoff. This proves both directions: a secret with a LONGER override must
+// survive a global cutoff that would otherwise purge it, and a secret with a
+// SHORTER override must be purged even though the global cutoff alone would
+// still keep it.
+func TestPurgeDeletedSecretsBefore_RespectsRetentionOverride(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.SecretDependency{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Global cutoff is 30 days: without an override, anything soft-deleted before
+	// this point is purged.
+	globalCutoff := now.AddDate(0, 0, -30)
+
+	// Deleted 40 days ago (past the global cutoff) but overridden to 90 days —
+	// must survive.
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "long-retention", RetentionOverrideDays: 90}).Error)
+	require.NoError(t, db.Unscoped().Model(&models.SecretNode{}).Where("id = ?", 1).
+		Update("deleted_at", now.AddDate(0, 0, -40)).Error)
+
+	// Deleted 10 days ago (within the global cutoff) but overridden to 7 days —
+	// must be purged despite being "recent" by the global window.
+	require.NoError(t, db.Create(&models.SecretNode{ID: 2, Name: "short-retention", RetentionOverrideDays: 7}).Error)
+	require.NoError(t, db.Unscoped().Model(&models.SecretNode{}).Where("id = ?", 2).
+		Update("deleted_at", now.AddDate(0, 0, -10)).Error)
+
+	// Deleted 40 days ago with no override — purged by the global cutoff as before.
+	require.NoError(t, db.Create(&models.SecretNode{ID: 3, Name: "no-override"}).Error)
+	require.NoError(t, db.Unscoped().Model(&models.SecretNode{}).Where("id = ?", 3).
+		Update("deleted_at", now.AddDate(0, 0, -40)).Error)
+
+	n, err := ls.PurgeDeletedSecretsBefore(ctx, globalCutoff)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n, "short-retention and no-override secrets are purged; long-retention survives")
+
+	var remaining []uint
+	require.NoError(t, db.Unscoped().Model(&models.SecretNode{}).Pluck("id", &remaining).Error)
+	assert.Equal(t, []uint{1}, remaining, "only the long-retention override secret survives")
+}

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -115,47 +115,65 @@ func (ls *LocalStorage) assignUserRole(ctx context.Context, userID, roleID uint,
 		utc := expiresAt.UTC()
 		expiresAt = &utc
 	}
-	var existing models.UserRole
-	err := ls.db.WithContext(ctx).
-		Where(sqlWhereUserRoleEnv,
+	// #G21: the read (is there a stale, expired row blocking this key?), the
+	// delete of that stale row, and the create of the fresh grant all run
+	// inside ONE database transaction, so SQLite's single-writer locking
+	// (acquired at the first write statement below, held until commit)
+	// prevents a concurrent assignUserRole call from inserting its own live
+	// grant at this key in between our read and our write — a plain
+	// match-by-composite-key delete run outside a transaction could
+	// otherwise silently destroy that concurrently-created live grant. (An
+	// earlier version of this fix tried to additionally re-assert the exact
+	// observed expires_at value in the delete's WHERE clause, but GORM's
+	// struct-field writes and a raw driver parameter bind serialize
+	// time.Time inconsistently with this driver — confirmed empirically, not
+	// just suspected — so any Go-side round trip of the value risked a
+	// false-negative byte mismatch even for the SAME row; transactional
+	// isolation avoids depending on that comparison at all.) See
+	// WithTransaction's doc comment for the caveat that RemoteStorage's
+	// implementation is a passthrough, so this narrows but doesn't eliminate
+	// the race under storage.type: remote deployments.
+	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing models.UserRole
+		err := tx.Where(sqlWhereUserRoleEnv,
 			userID, roleID, scope.ProjectID, scope.EnvironmentID).First(&existing).Error
-	switch err {
-	case nil:
-		// A row already exists at this exact (user, role, project, environment) key. A
-		// still-live grant (no expiry, or an expiry still in the future) genuinely blocks
-		// a duplicate assignment. But an EXPIRED grant is a stale, un-reaped row — e.g. a
-		// prior break-glass activation whose time-bound grant naturally lapsed — and must
-		// be treated as ABSENT for this check, or a second real-incident activation for
-		// the same user/role/scope is permanently refused with "already assigned" even
-		// though nothing live is actually being duplicated (#263). Delete the stale row
-		// so the composite primary key (user_id, role_id, project_id, environment_id) is
-		// free for the fresh Create below, mirroring how live-authorization queries
-		// elsewhere (e.g. GetUserRoles) already exclude expired grants.
-		if existing.ExpiresAt == nil || existing.ExpiresAt.After(time.Now()) {
-			return fmt.Errorf("%s", i18n.T("ErrorRoleAlreadyAssigned", nil))
-		}
-		if derr := ls.db.WithContext(ctx).
-			Where(sqlWhereUserRoleEnv,
+		switch err {
+		case nil:
+			// A row already exists at this exact (user, role, project, environment) key. A
+			// still-live grant (no expiry, or an expiry still in the future) genuinely blocks
+			// a duplicate assignment. But an EXPIRED grant is a stale, un-reaped row — e.g. a
+			// prior break-glass activation whose time-bound grant naturally lapsed — and must
+			// be treated as ABSENT for this check, or a second real-incident activation for
+			// the same user/role/scope is permanently refused with "already assigned" even
+			// though nothing live is actually being duplicated (#263). Delete the stale row
+			// so the composite primary key (user_id, role_id, project_id, environment_id) is
+			// free for the fresh Create below, mirroring how live-authorization queries
+			// elsewhere (e.g. GetUserRoles) already exclude expired grants.
+			if existing.ExpiresAt == nil || existing.ExpiresAt.After(time.Now()) {
+				return fmt.Errorf("%s", i18n.T("ErrorRoleAlreadyAssigned", nil))
+			}
+			if derr := tx.Where(sqlWhereUserRoleEnv,
 				userID, roleID, scope.ProjectID, scope.EnvironmentID).
-			Delete(&models.UserRole{}).Error; derr != nil {
-			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), derr)
+				Delete(&models.UserRole{}).Error; derr != nil {
+				return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), derr)
+			}
+		case gorm.ErrRecordNotFound:
+			// no existing row for this key — proceed to create.
+		default:
+			return fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
 		}
-	case gorm.ErrRecordNotFound:
-		// no existing row for this key — proceed to create.
-	default:
-		return fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
-	}
-	userRole := models.UserRole{
-		UserID:        userID,
-		RoleID:        roleID,
-		ProjectID:     scope.ProjectID,
-		EnvironmentID: scope.EnvironmentID,
-		ExpiresAt:     expiresAt,
-	}
-	if err := ls.db.WithContext(ctx).Create(&userRole).Error; err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-	return nil
+		userRole := models.UserRole{
+			UserID:        userID,
+			RoleID:        roleID,
+			ProjectID:     scope.ProjectID,
+			EnvironmentID: scope.EnvironmentID,
+			ExpiresAt:     expiresAt,
+		}
+		if err := tx.Create(&userRole).Error; err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		return nil
+	})
 }
 
 // RemoveRole removes a role from a user at scope.
@@ -662,46 +680,54 @@ func (ls *LocalStorage) assignGroupRole(ctx context.Context, groupID, roleID uin
 		utc := expiresAt.UTC()
 		expiresAt = &utc
 	}
-	var existing models.GroupRole
-	err := ls.db.WithContext(ctx).
-		Where(sqlWhereGroupRoleEnv,
+	// #G21: see assignUserRole's identical fix — the read, the stale-row
+	// delete, and the fresh-grant create all run inside ONE transaction so
+	// SQLite's single-writer locking prevents a concurrent
+	// AssignRoleToGroup call from inserting its own live grant at this key
+	// in between our read and our write, rather than trying to re-verify the
+	// observed expires_at value in the delete's WHERE clause (abandoned:
+	// GORM's struct-field writes and a raw driver parameter bind serialize
+	// time.Time inconsistently with this driver, confirmed empirically).
+	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing models.GroupRole
+		err := tx.Where(sqlWhereGroupRoleEnv,
 			groupID, roleID, scope.ProjectID, scope.EnvironmentID).First(&existing).Error
-	switch err {
-	case nil:
-		// A row already exists at this exact (group, role, project, environment) key. A
-		// still-live grant (no expiry, or an expiry still in the future) genuinely blocks
-		// a duplicate assignment. But an EXPIRED grant is a stale, un-reaped row — e.g. a
-		// prior break-glass activation whose time-bound grant naturally lapsed — and must
-		// be treated as ABSENT for this check, or a second real-incident activation for
-		// the same group/role/scope is permanently refused with "already assigned" even
-		// though nothing live is actually being duplicated (#263/#471). Delete the stale
-		// row so the composite primary key (group_id, role_id, project_id, environment_id)
-		// is free for the fresh Create below, mirroring assignUserRole's identical fix.
-		if existing.ExpiresAt == nil || existing.ExpiresAt.After(time.Now()) {
-			return fmt.Errorf("%s", i18n.T("ErrorRoleAlreadyAssigned", nil))
-		}
-		if derr := ls.db.WithContext(ctx).
-			Where(sqlWhereGroupRoleEnv,
+		switch err {
+		case nil:
+			// A row already exists at this exact (group, role, project, environment) key. A
+			// still-live grant (no expiry, or an expiry still in the future) genuinely blocks
+			// a duplicate assignment. But an EXPIRED grant is a stale, un-reaped row — e.g. a
+			// prior break-glass activation whose time-bound grant naturally lapsed — and must
+			// be treated as ABSENT for this check, or a second real-incident activation for
+			// the same group/role/scope is permanently refused with "already assigned" even
+			// though nothing live is actually being duplicated (#263/#471). Delete the stale
+			// row so the composite primary key (group_id, role_id, project_id, environment_id)
+			// is free for the fresh Create below, mirroring assignUserRole's identical fix.
+			if existing.ExpiresAt == nil || existing.ExpiresAt.After(time.Now()) {
+				return fmt.Errorf("%s", i18n.T("ErrorRoleAlreadyAssigned", nil))
+			}
+			if derr := tx.Where(sqlWhereGroupRoleEnv,
 				groupID, roleID, scope.ProjectID, scope.EnvironmentID).
-			Delete(&models.GroupRole{}).Error; derr != nil {
-			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), derr)
+				Delete(&models.GroupRole{}).Error; derr != nil {
+				return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), derr)
+			}
+		case gorm.ErrRecordNotFound:
+			// no existing row for this key — proceed to create.
+		default:
+			return fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
 		}
-	case gorm.ErrRecordNotFound:
-		// no existing row for this key — proceed to create.
-	default:
-		return fmt.Errorf("%s: %w", i18n.T("ErrorInternalServer", nil), err)
-	}
-	groupRole := models.GroupRole{
-		GroupID:       groupID,
-		RoleID:        roleID,
-		ProjectID:     scope.ProjectID,
-		EnvironmentID: scope.EnvironmentID,
-		ExpiresAt:     expiresAt,
-	}
-	if err := ls.db.WithContext(ctx).Create(&groupRole).Error; err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-	return nil
+		groupRole := models.GroupRole{
+			GroupID:       groupID,
+			RoleID:        roleID,
+			ProjectID:     scope.ProjectID,
+			EnvironmentID: scope.EnvironmentID,
+			ExpiresAt:     expiresAt,
+		}
+		if err := tx.Create(&groupRole).Error; err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		return nil
+	})
 }
 
 // DeleteExpiredRoleGrants removes user_roles and group_roles whose ExpiresAt is

--- a/internal/storage/store/local_risk_exceptions.go
+++ b/internal/storage/store/local_risk_exceptions.go
@@ -63,9 +63,20 @@ func (ls *LocalStorage) UpdateRiskException(ctx context.Context, e *models.RiskE
 // caller mutated on e — Revoked, RevokedBy, RevokedAt — is persisted in the same
 // statement, not just a hardcoded column subset.
 func (ls *LocalStorage) RevokeRiskExceptionIfNotRevoked(ctx context.Context, e *models.RiskException) (bool, error) {
+	// #G42: unlike ApproveRiskExceptionIfPending (whose WHERE clause already
+	// guards on both revoked AND approved, so it can never clobber a
+	// concurrent revoke), this WHERE clause only guards on revoked — it can't
+	// also gate on approved without incorrectly blocking a legitimate revoke
+	// of an already-approved exception. A Select("*") here would still be
+	// wrong: if a concurrent ApproveRiskException committed between the
+	// caller's GetRiskException read and this write, this call's `e` carries
+	// stale (pre-approval) Approved/ApprovedBy/ApprovedAt, and a full-row
+	// overwrite would silently revert that just-committed approval even
+	// though the revoke itself is legitimate. Whitelist only the columns
+	// this transition actually owns.
 	res := ls.db.WithContext(ctx).Model(&models.RiskException{}).
 		Where("id = ? AND revoked = ?", e.ID, false).
-		Select("*").
+		Select("Revoked", "RevokedBy", "RevokedAt").
 		Updates(e)
 	if res.Error != nil {
 		return false, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), res.Error)

--- a/internal/storage/store/local_risk_exceptions_test.go
+++ b/internal/storage/store/local_risk_exceptions_test.go
@@ -150,3 +150,53 @@ func TestApproveRiskExceptionIfPending_ConditionalOnPending_Sequential(t *testin
 	assert.True(t, final.Revoked)
 	assert.False(t, final.Approved, "the revoked exception must not end up approved")
 }
+
+// TestRevokeRiskExceptionIfNotRevoked_DoesNotClobberConcurrentApproval is #G42:
+// unlike the two tests above (where the SECOND write is the one that must
+// lose), here a legitimate revoke's WHERE clause only guards on `revoked`, so
+// it still matches after a concurrent approve — the risk is the revoke's
+// blind full-row overwrite silently reverting that just-committed approval
+// even though the revoke itself succeeds correctly.
+func TestRevokeRiskExceptionIfNotRevoked_DoesNotClobberConcurrentApproval(t *testing.T) {
+	ctx := context.Background()
+	ls := newRiskTestStore(t)
+	exp := time.Now().AddDate(0, 0, 30)
+
+	created, err := ls.CreateRiskException(ctx, &models.RiskException{
+		Title: "shared exception", Category: "mfa", CreatedBy: 9, ExpiresAt: exp,
+	})
+	require.NoError(t, err)
+
+	// An admin reads the still-pending, unrevoked row to revoke it — this copy
+	// has NO knowledge of the approval about to land.
+	revokeCopy, err := ls.GetRiskException(ctx, created.ID)
+	require.NoError(t, err)
+	revokedAt := time.Now()
+	revokeCopy.Revoked = true
+	revokeCopy.RevokedBy = 1
+	revokeCopy.RevokedAt = &revokedAt
+
+	// A different approver's approval commits FIRST, before the revoke's write.
+	approveCopy, err := ls.GetRiskException(ctx, created.ID)
+	require.NoError(t, err)
+	approvedAt := time.Now()
+	approveCopy.Approved = true
+	approveCopy.ApprovedBy = 2
+	approveCopy.ApprovedAt = &approvedAt
+	ok, err := ls.ApproveRiskExceptionIfPending(ctx, approveCopy)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// The revoke still legitimately matches (revoked was still false when this
+	// call's WHERE clause evaluated) — it must succeed, but must NOT revert the
+	// just-committed approval using its own stale (pre-approval) copy.
+	ok, err = ls.RevokeRiskExceptionIfNotRevoked(ctx, revokeCopy)
+	require.NoError(t, err)
+	require.True(t, ok, "revoking an approved-but-not-yet-revoked exception is legitimate")
+
+	final, err := ls.GetRiskException(ctx, created.ID)
+	require.NoError(t, err)
+	assert.True(t, final.Revoked, "the revoke itself must have taken effect")
+	assert.True(t, final.Approved, "the concurrent approval must survive the revoke")
+	assert.Equal(t, uint(2), final.ApprovedBy, "approval attribution must not be reverted")
+}

--- a/internal/storage/store/local_stats.go
+++ b/internal/storage/store/local_stats.go
@@ -17,13 +17,26 @@ import (
 	"gorm.io/gorm"
 )
 
-// GetStats aggregates row counts for the key entity types.
+// GetStats aggregates row counts for the key entity types. #G54: each Count's
+// error is checked and propagated — previously a failed query silently left
+// its field at Go's zero value, so a genuine storage error (a missing table,
+// a connectivity blip) was indistinguishable from an honestly-empty
+// deployment, fabricating a "0 secrets, 0 users" success result for any
+// dashboard/health consumer of this call.
 func (ls *LocalStorage) GetStats(ctx context.Context) (*storage.StorageStats, error) {
 	stats := &storage.StorageStats{}
-	ls.db.WithContext(ctx).Model(&models.SecretNode{}).Count(&stats.TotalSecrets)
-	ls.db.WithContext(ctx).Model(&models.User{}).Count(&stats.TotalUsers)
-	ls.db.WithContext(ctx).Model(&models.Role{}).Count(&stats.TotalRoles)
-	ls.db.WithContext(ctx).Model(&models.Session{}).Count(&stats.TotalSessions)
+	if err := ls.db.WithContext(ctx).Model(&models.SecretNode{}).Count(&stats.TotalSecrets).Error; err != nil {
+		return nil, err
+	}
+	if err := ls.db.WithContext(ctx).Model(&models.User{}).Count(&stats.TotalUsers).Error; err != nil {
+		return nil, err
+	}
+	if err := ls.db.WithContext(ctx).Model(&models.Role{}).Count(&stats.TotalRoles).Error; err != nil {
+		return nil, err
+	}
+	if err := ls.db.WithContext(ctx).Model(&models.Session{}).Count(&stats.TotalSessions).Error; err != nil {
+		return nil, err
+	}
 	return stats, nil
 }
 

--- a/internal/storage/store/memberships_test.go
+++ b/internal/storage/store/memberships_test.go
@@ -50,6 +50,53 @@ func TestProjectMembership_RoundTrip(t *testing.T) {
 	assert.Equal(t, created.ID, active.ID)
 }
 
+func TestTransitionProjectMembershipState_MatchesOnCurrentState(t *testing.T) {
+	ctx := context.Background()
+	ls := newMembershipStore(t)
+	now := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
+
+	created, err := ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: 1, UserID: 2, Role: "project_developer",
+		State: "provisioned", InvitedBy: 9, InvitedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+
+	created.State = "active"
+	matched, err := ls.TransitionProjectMembershipState(ctx, created, "provisioned")
+	require.NoError(t, err)
+	assert.True(t, matched)
+
+	reloaded, err := ls.GetProjectMembership(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "active", reloaded.State)
+}
+
+func TestTransitionProjectMembershipState_LostRaceReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+	ls := newMembershipStore(t)
+	now := time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC)
+
+	created, err := ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: 1, UserID: 2, Role: "project_developer",
+		State: "provisioned", InvitedBy: 9, InvitedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+
+	// A concurrent caller already moved the row to "active" before this call's
+	// stale fromState ("provisioned") is used — must refuse, not clobber.
+	created.State = "active"
+	require.NoError(t, ls.UpdateProjectMembership(ctx, created))
+
+	stale := &models.ProjectMembership{ID: created.ID, State: "revoked"}
+	matched, err := ls.TransitionProjectMembershipState(ctx, stale, "provisioned")
+	require.NoError(t, err)
+	assert.False(t, matched, "must not match once the row has moved off the observed fromState")
+
+	reloaded, err := ls.GetProjectMembership(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "active", reloaded.State, "the concurrent winner's state must survive untouched")
+}
+
 func TestGetActiveProjectMembership_IgnoresRevoked(t *testing.T) {
 	ctx := context.Background()
 	ls := newMembershipStore(t)

--- a/internal/storage/store/remote_memberships.go
+++ b/internal/storage/store/remote_memberships.go
@@ -171,8 +171,9 @@ func (rs *RemoteStorage) GetProjectMembership(ctx context.Context, id uint) (*mo
 
 // UpdateProjectMembership persists a membership's current state via PUT
 // /api/v1/system/project-memberships/{id} — a single round trip mapping directly
-// onto local_memberships.go's plain Save (see the package doc: there is no
-// conditional-write guarantee to preserve here, unlike UpdateProjectInvitation).
+// onto local_memberships.go's plain Save. #G42: this must NEVER be used for a
+// state-machine transition (State/ActivatedAt/RevokedAt) — see
+// TransitionProjectMembershipState, which exists specifically for that.
 func (rs *RemoteStorage) UpdateProjectMembership(ctx context.Context, m *models.ProjectMembership) error {
 	path := fmt.Sprintf("/api/v1/system/project-memberships/%d", m.ID)
 	resp, err := rs.client.Put(ctx, path, newMembershipWire(m))
@@ -183,6 +184,22 @@ func (rs *RemoteStorage) UpdateProjectMembership(ctx context.Context, m *models.
 		return fmt.Errorf("update membership failed: %s", resp.Error.Error())
 	}
 	return nil
+}
+
+// TransitionProjectMembershipState persists m's full row via a single
+// conditional PUT to /api/v1/system/project-memberships/{id}/transition,
+// gated server-side on the row's CURRENT state still being fromState —
+// mirrors RevokeRiskExceptionIfNotRevoked/UpdateUserIfActiveStateMatches
+// exactly. See interface.go's doc for why this exists (RemoteStorage has no
+// real transaction/row lock, so this conditional round trip is the ONLY thing
+// closing the TOCTOU across the HTTP hop).
+func (rs *RemoteStorage) TransitionProjectMembershipState(ctx context.Context, m *models.ProjectMembership, fromState string) (bool, error) {
+	path := fmt.Sprintf("/api/v1/system/project-memberships/%d/transition", m.ID)
+	body := struct {
+		Membership membershipWire `json:"membership"`
+		FromState  string         `json:"from_state"`
+	}{Membership: newMembershipWire(m), FromState: fromState}
+	return rs.putConditionalTransition(ctx, path, body, "transition project membership")
 }
 
 // ListProjectMemberships lists a project's memberships via GET

--- a/internal/storage/store/remote_memberships_test.go
+++ b/internal/storage/store/remote_memberships_test.go
@@ -81,6 +81,41 @@ func TestRemoteStorage_UpdateProjectMembership(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRemoteStorage_TransitionProjectMembershipState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/system/project-memberships/7/transition", r.URL.Path)
+		var body map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "provisioned", body["from_state"])
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	m := &models.ProjectMembership{ID: 7, ProjectID: 10, UserID: 5, Role: "viewer", State: "active"}
+	matched, err := rs.TransitionProjectMembershipState(context.Background(), m, "provisioned")
+	require.NoError(t, err)
+	assert.True(t, matched)
+}
+
+func TestRemoteStorage_TransitionProjectMembershipState_NotMatched(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"matched": false}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	m := &models.ProjectMembership{ID: 7, State: "active"}
+	matched, err := rs.TransitionProjectMembershipState(context.Background(), m, "provisioned")
+	require.NoError(t, err)
+	assert.False(t, matched)
+}
+
 func TestRemoteStorage_ListProjectMemberships(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)

--- a/internal/storage/store/store_s3_local3_test.go
+++ b/internal/storage/store/store_s3_local3_test.go
@@ -995,6 +995,22 @@ func TestStats_GetStatsAndHealthCheck(t *testing.T) {
 	require.NoError(t, ls.HealthCheck(ctx))
 }
 
+// TestStats_GetStats_PropagatesCountError is #G54: a failed Count query for
+// any one of the four entity types must fail the whole call, not leave that
+// field at its Go zero value while GetStats still reports success — which
+// would fabricate a "0 secrets" result indistinguishable from a genuinely
+// empty deployment.
+func TestStats_GetStats_PropagatesCountError(t *testing.T) {
+	ctx := context.Background()
+	ls := newStoreS3(t, "stats_err_"+t.Name(),
+		&models.SecretNode{}, &models.User{}, &models.Role{}, &models.Session{})
+
+	require.NoError(t, ls.db.Migrator().DropTable(&models.SecretNode{}))
+
+	_, err := ls.GetStats(ctx)
+	require.Error(t, err, "a Count failure on any one entity type must fail the whole call")
+}
+
 func TestStats_SaveAndGetPreviousSnapshot(t *testing.T) {
 	ctx := context.Background()
 	ls := newStoreS3(t, "stats_snap_"+t.Name(), &models.StatsSnapshot{})

--- a/internal/storage/store/store_s3_test.go
+++ b/internal/storage/store/store_s3_test.go
@@ -921,6 +921,46 @@ func TestTransitionDynamicSecretConfigDisabled_ClosesRace(t *testing.T) {
 	assert.True(t, matched3)
 }
 
+// TestTransitionDynamicSecretConfigDisabled_DoesNotClobberConcurrentDSNRotation
+// is #G42: the guard only checks `disabled`, so a concurrent DSN rotation
+// (UpdateDynamicSecretConfig, an unconditional Save that never touches
+// `disabled`) still matches this WHERE clause. The toggle itself must
+// succeed, but must not revert the rotation using its own stale copy of
+// AdminDSNEnc.
+func TestTransitionDynamicSecretConfigDisabled_DoesNotClobberConcurrentDSNRotation(t *testing.T) {
+	ctx := context.Background()
+	ls := newDynamicFullStore(t)
+
+	cfg, err := ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+		Name: "rotate-config", ProjectID: 1, EnvironmentID: 1, BackendType: "postgres",
+		Disabled: false, AdminDSNEnc: []byte("old-dsn"),
+	})
+	require.NoError(t, err)
+
+	// An admin reads the config to disable it — this copy has NO knowledge of
+	// the DSN rotation about to land.
+	toggle := *cfg
+	toggle.Disabled = true
+
+	// A concurrent DSN rotation commits FIRST, via the plain (non-conditional)
+	// update path — this is what a real rotation job uses.
+	rotated := *cfg
+	rotated.AdminDSNEnc = []byte("new-dsn")
+	require.NoError(t, ls.UpdateDynamicSecretConfig(ctx, &rotated))
+
+	// The disable toggle still legitimately matches (disabled was still false
+	// when this call's WHERE clause evaluated) — it must succeed, but must NOT
+	// revert the just-committed DSN rotation using its own stale copy.
+	matched, err := ls.TransitionDynamicSecretConfigDisabled(ctx, &toggle, false)
+	require.NoError(t, err)
+	assert.True(t, matched, "disabling a config that was just rotated is legitimate")
+
+	got, err := ls.GetDynamicSecretConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	assert.True(t, got.Disabled, "the toggle itself must have taken effect")
+	assert.Equal(t, []byte("new-dsn"), got.AdminDSNEnc, "the concurrent DSN rotation must survive the toggle")
+}
+
 // TestTransitionDynamicSecretConfigDisabled_NotFound verifies the
 // RowsAffected == 0 path when the config id doesn't exist at all.
 func TestTransitionDynamicSecretConfigDisabled_NotFound(t *testing.T) {

--- a/internal/trust/trust.go
+++ b/internal/trust/trust.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // Purpose scopes a key to one use, so an update-signing key can never validate a license
@@ -40,7 +41,15 @@ var (
 )
 
 // KeyRegistry holds trusted public keys keyed by purpose and key-id.
+//
+// #G63: mu guards keys. This package has no caller in the current live
+// request path (see the package doc above), but Add is an exported mutator
+// on a plain map with no synchronization of its own — a future runtime
+// key-rotation caller (ADR-062 Phases 1-2 build on this package) racing a
+// concurrent Verify/KeyIDs read would be a real, unsynchronized map access,
+// not just a theoretical one.
 type KeyRegistry struct {
+	mu   sync.RWMutex
 	keys map[Purpose]map[string]ed25519.PublicKey
 }
 
@@ -57,6 +66,8 @@ func (r *KeyRegistry) Add(purpose Purpose, keyID string, pub ed25519.PublicKey) 
 	if strings.TrimSpace(keyID) == "" {
 		return fmt.Errorf("trust: key-id is required")
 	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.keys[purpose] == nil {
 		r.keys[purpose] = make(map[string]ed25519.PublicKey)
 	}
@@ -68,11 +79,13 @@ func (r *KeyRegistry) Add(purpose Purpose, keyID string, pub ed25519.PublicKey) 
 // for (purpose, keyID). It fails closed: an unconfigured purpose, an unknown key-id, or a
 // bad signature all return an error.
 func (r *KeyRegistry) Verify(purpose Purpose, keyID string, message, sig []byte) error {
-	m := r.keys[purpose]
-	if len(m) == 0 {
+	r.mu.RLock()
+	pub, ok := r.keys[purpose][keyID]
+	noKeysForPurpose := len(r.keys[purpose]) == 0
+	r.mu.RUnlock()
+	if noKeysForPurpose {
 		return fmt.Errorf("%w (%s)", ErrNoKeys, purpose)
 	}
-	pub, ok := m[keyID]
 	if !ok {
 		return fmt.Errorf("%w (%s/%s)", ErrUnknownKey, purpose, keyID)
 	}
@@ -84,6 +97,8 @@ func (r *KeyRegistry) Verify(purpose Purpose, keyID string, message, sig []byte)
 
 // KeyIDs lists the trusted key-ids for a purpose, sorted (for logging/diagnostics).
 func (r *KeyRegistry) KeyIDs(purpose Purpose) []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	ids := make([]string, 0, len(r.keys[purpose]))
 	for id := range r.keys[purpose] {
 		ids = append(ids, id)

--- a/internal/trust/trust_test.go
+++ b/internal/trust/trust_test.go
@@ -2,6 +2,7 @@ package trust
 
 import (
 	"crypto/ed25519"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,4 +87,45 @@ func TestDefaultRegistry_EmptyByDefaultFailsClosed(t *testing.T) {
 	require.NoError(t, err)
 	assert.ErrorIs(t, r.Verify(PurposeUpdate, "any", []byte("m"), []byte("s")), ErrNoKeys)
 	assert.ErrorIs(t, r.Verify(PurposeLicense, "any", []byte("m"), []byte("s")), ErrNoKeys)
+}
+
+// TestRegistry_ConcurrentAddAndVerify_NoRace is #G63: KeyRegistry.keys is a
+// plain map read by Verify/KeyIDs and written by Add, with no synchronization
+// of its own before this fix — a future runtime key-rotation caller (this
+// package's own doc comment: "the bundle/license phases build on it") racing
+// a concurrent verification is a real, unsynchronized map access under
+// `go test -race`, not just a theoretical one.
+func TestRegistry_ConcurrentAddAndVerify_NoRace(t *testing.T) {
+	r := NewRegistry()
+	pub, priv, err := GenerateKey()
+	require.NoError(t, err)
+	msg := []byte("manifest bytes")
+	sig := ed25519.Sign(priv, msg)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			keyID := "key"
+			if i%2 == 0 {
+				keyID = "other-key"
+			}
+			_ = r.Add(PurposeUpdate, keyID, pub)
+		}(i)
+	}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = r.Verify(PurposeUpdate, "key", msg, sig)
+			_ = r.KeyIDs(PurposeUpdate)
+		}()
+	}
+	close(start)
+	wg.Wait()
 }

--- a/migrations/007_rotation_policies.up.sql
+++ b/migrations/007_rotation_policies.up.sql
@@ -2,13 +2,25 @@
 -- below references the `projects` table, which only exists after that rename
 -- (see #201 — this migration was previously numbered 006 and ran before the
 -- rename existed, which failed outright against a real migration runner).
+--
+-- #G52: project_id/environment_id deliberately do NOT cascade. A raw
+-- `DELETE FROM projects`/`DELETE FROM environments` (or the DB engine's own
+-- CASCADE machinery for ANY other FK someone later adds) must not be able to
+-- silently take rotation_policies rows down with it, with no application
+-- involvement, no authorization check, and no audit trail — rotation policy
+-- removal is a deliberate action the live schema (internal/storage/factory.go's
+-- GORM AutoMigrate, which defines NO FK constraint here at all, so this
+-- exposure never existed there) always routes through application code.
+-- ON DELETE RESTRICT means the raw delete is refused outright rather than
+-- cascading, forcing whoever performs it to handle the dependent rotation
+-- policies explicitly first.
 CREATE TABLE rotation_policies (
     id SERIAL PRIMARY KEY,
     name VARCHAR(255) NOT NULL, -- NOSONAR -- plsql:VarcharUsageCheck false positive: SQLite (not Oracle) uses VARCHAR
     description TEXT,
     scope VARCHAR(20) NOT NULL DEFAULT 'environment', -- NOSONAR -- plsql:VarcharUsageCheck false positive: SQLite uses VARCHAR
-    project_id INTEGER REFERENCES projects(id) ON DELETE CASCADE,
-    environment_id INTEGER REFERENCES environments(id) ON DELETE CASCADE,
+    project_id INTEGER REFERENCES projects(id) ON DELETE RESTRICT,
+    environment_id INTEGER REFERENCES environments(id) ON DELETE RESTRICT,
     interval_days INTEGER NOT NULL,
     alert_days_before INTEGER NOT NULL DEFAULT 7,
     notify_on_breach BOOLEAN NOT NULL DEFAULT true,

--- a/operator/internal/controller/keyorixsecret_controller.go
+++ b/operator/internal/controller/keyorixsecret_controller.go
@@ -265,7 +265,7 @@ func (r *KeyorixSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			// status reason so it's clear from .status which of the two happened.
 			return r.wipeAndFailGone(ctx, &ks, secretName, "UpstreamAccessRevoked", err)
 		default:
-			return r.fail(ctx, &ks, err)
+			return r.fail(ctx, &ks, err, orphanWipeErr)
 		}
 	}
 
@@ -273,7 +273,7 @@ func (r *KeyorixSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if err := r.applySecret(ctx, &ks, secretName, desired); err != nil {
 		logger.Error(err, "failed to apply target Secret")
-		return r.fail(ctx, &ks, err)
+		return r.fail(ctx, &ks, err, orphanWipeErr)
 	}
 
 	if err := r.succeed(ctx, &ks, hash, secretName, orphanWipeErr); err != nil {
@@ -412,8 +412,22 @@ const (
 )
 
 // fail records a SyncError on the Ready condition and requeues with backoff.
-func (r *KeyorixSecretReconciler) fail(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, cause error) (ctrl.Result, error) {
-	r.setReady(ks, metav1.ConditionFalse, "SyncError", cause.Error())
+// fail records an ordinary sync failure. orphanWipeErr, when non-nil, means
+// this SAME reconcile also detected a spec.target.name change and failed to
+// wipe the Secret orphaned under the old name (see Reconcile's orphanWipeErr
+// doc) — #G54: before this, that failure was silently dropped whenever the
+// reconcile ALSO failed later (buildDesired/applySecret), so .status would
+// show only the later failure with no indication a stale, possibly
+// revoked/rotated Secret is still sitting in the cluster under the old name,
+// mountable by any workload with ordinary Secret-read RBAC. Mirrors
+// failGone's identical "WipeFailed" reason/message augmentation.
+func (r *KeyorixSecretReconciler) fail(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, cause, orphanWipeErr error) (ctrl.Result, error) {
+	reason, msg := "SyncError", cause.Error()
+	if orphanWipeErr != nil {
+		reason += "OrphanWipeFailed"
+		msg = fmt.Sprintf("%s — additionally, wiping the Secret orphaned by a spec.target.name change failed, it may still contain stale/rotated data under the old name: %v", cause.Error(), orphanWipeErr)
+	}
+	r.setReady(ks, metav1.ConditionFalse, reason, msg)
 	if err := r.Status().Update(ctx, ks); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/operator/internal/controller/keyorixsecret_controller_test.go
+++ b/operator/internal/controller/keyorixsecret_controller_test.go
@@ -514,6 +514,62 @@ func TestReconcile_RetargetWipeFailureKeepsOldLastTargetNameAndWarns(t *testing.
 		"a blocked orphan wipe must be visible in the Ready message, not just logged")
 }
 
+// TestReconcile_OrphanWipeFailureSurfacedAlongsideLaterSyncFailure is #G54:
+// before the fix, orphanWipeErr was captured but then silently dropped
+// whenever the SAME reconcile also failed later (buildDesired or
+// applySecret) — fail() had no way to carry it. An operator reading .status
+// after a reconcile that hit BOTH failures would see only the later one,
+// with no indication a stale Secret is still sitting in the cluster under
+// the old target name.
+func TestReconcile_OrphanWipeFailureSurfacedAlongsideLaterSyncFailure(t *testing.T) {
+	ks := ksFixture()
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"),
+		"app/production/api-key":     []byte("k3y"),
+	}}
+	s := testScheme(t)
+	inner := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&secretsv1alpha1.KeyorixSecret{}).
+		WithObjects(ks, tokenSecret()).
+		Build()
+	blocked := &deleteBlockingClient{Client: inner, blockDeleteName: "db-creds"}
+	r := &KeyorixSecretReconciler{
+		Client:         blocked,
+		Scheme:         s,
+		AllowedServers: []string{"https://keyorix.internal"},
+		newClient:      func(_, _ string) valueFetcher { return fetcher },
+		hashKey:        []byte("test-fixture-hmac-key"),
+	}
+	_, err := reconcile(t, r)
+	require.NoError(t, err)
+
+	var got secretsv1alpha1.KeyorixSecret
+	require.NoError(t, blocked.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &got))
+	require.Equal(t, "db-creds", got.Status.LastTargetName)
+
+	// Retarget AND make the new target's own fetch fail transiently (NOT
+	// ErrSecretGone) — buildDesired hits the default branch in Reconcile,
+	// which used to drop orphanWipeErr entirely.
+	got.Spec.Target.Name = "db-creds-v2"
+	require.NoError(t, blocked.Update(context.Background(), &got))
+	fetcher.failRefs = map[string]bool{"app/production/db-password": true}
+
+	_, err = reconcile(t, r)
+	require.Error(t, err, "the transient fetch failure must still fail this reconcile")
+
+	require.NoError(t, blocked.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &got))
+	assert.Equal(t, "db-creds", got.Status.LastTargetName,
+		"LastTargetName must stay at the OLD name so the next reconcile retries the orphan wipe")
+	require.Len(t, got.Status.Conditions, 1)
+	cond := got.Status.Conditions[0]
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, "SyncErrorOrphanWipeFailed", cond.Reason)
+	assert.Contains(t, cond.Message, "boom", "the fetch failure that actually failed this reconcile must still be visible")
+	assert.Contains(t, cond.Message, "wiping the Secret orphaned",
+		"the SEPARATE orphan-wipe failure must not be silently dropped just because this reconcile also failed later")
+}
+
 // A target Secret this operator does NOT manage (no ManagedByLabel — applySecret
 // already refuses to adopt it) must never be deleted, even when the upstream secret is
 // confirmed gone: it isn't ours to touch, and it may belong to an unrelated workload

--- a/scripts/fuzzing/targets.conf
+++ b/scripts/fuzzing/targets.conf
@@ -44,3 +44,8 @@ internal/bundle|FuzzBundleVerify|2h
 # enough; the interesting cases (truncated length, unknown tag, zero-length
 # content) surface quickly.
 internal/notary|FuzzVerifyReceipt|1h
+# RFC 3161 Anchor(): the same digitorus/timestamp.ParseResponse call, but on the
+# response body Anchor feeds it, from a network-reachable TSA endpoint (vs.
+# VerifyReceipt's already-stored, previously-parsed receipt above). 1h: same
+# parser family, same expected fuzz-productive shape.
+internal/notary|FuzzRFC3161Anchor|1h

--- a/server/close_audit_forwarder_test.go
+++ b/server/close_audit_forwarder_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// fakeClosingForwarder is a minimal core.AuditForwarder that also implements
+// Close(), mirroring *siem.Forwarder's shape without pulling in the real
+// package (spool files, HTTP delivery) for a pure wiring test.
+type fakeClosingForwarder struct{ closed bool }
+
+func (f *fakeClosingForwarder) Forward(_ *models.AuditEvent) {}
+func (f *fakeClosingForwarder) Close()                       { f.closed = true }
+
+// fakeForwarderNoClose implements only Forward — the narrow core.AuditForwarder
+// interface — with no Close method at all, exercising the "not a closer" branch.
+type fakeForwarderNoClose struct{}
+
+func (f *fakeForwarderNoClose) Forward(_ *models.AuditEvent) {}
+
+func newTestCoreService(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open in-memory db: %v", err)
+	}
+	return core.NewKeyorixCore(store.NewLocalStorage(db))
+}
+
+// TestCloseAuditForwarder_ClosesWiredForwarder is #G56: nothing previously called
+// Forwarder.Close() at shutdown, so the SIEM forwarder's in-memory queue was never
+// flushed/drained before the process exited. This proves closeAuditForwarder
+// actually reaches and invokes Close() on whatever was wired via SetAuditForwarder.
+func TestCloseAuditForwarder_ClosesWiredForwarder(t *testing.T) {
+	coreService := newTestCoreService(t)
+	fake := &fakeClosingForwarder{}
+	coreService.SetAuditForwarder(fake)
+
+	closeAuditForwarder(coreService)
+
+	if !fake.closed {
+		t.Fatal("closeAuditForwarder did not call Close() on the wired forwarder")
+	}
+}
+
+// TestCloseAuditForwarder_NilForwarderNoPanic covers the common case (no
+// audit.siem block configured) — closeAuditForwarder must be a safe no-op.
+func TestCloseAuditForwarder_NilForwarderNoPanic(t *testing.T) {
+	closeAuditForwarder(newTestCoreService(t))
+}
+
+// TestCloseAuditForwarder_ForwarderWithoutCloseNoPanic covers a hypothetical
+// AuditForwarder implementation that only satisfies the narrow Forward-only
+// interface (no Close method) — the type assertion in closeAuditForwarder must
+// fail gracefully, not panic.
+func TestCloseAuditForwarder_ForwarderWithoutCloseNoPanic(t *testing.T) {
+	coreService := newTestCoreService(t)
+	coreService.SetAuditForwarder(&fakeForwarderNoClose{})
+	closeAuditForwarder(coreService)
+}

--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -308,6 +308,9 @@ func rbacEntryToProto(e *core.RBACAuditEntry) *pb.RBACAuditLog {
 	if e.ProjectID != nil {
 		out.ProjectId = ptrU32(*e.ProjectID)
 	}
+	if e.EnvironmentID != nil {
+		out.EnvironmentId = ptrU32(*e.EnvironmentID)
+	}
 	return out
 }
 

--- a/server/grpc/services/coverage_s23_test.go
+++ b/server/grpc/services/coverage_s23_test.go
@@ -251,10 +251,12 @@ func TestGetSecretImpact_PermissionDenied_S23(t *testing.T) {
 	ctx := authCtx(1, "owner", "secrets.write", "secrets.read")
 	sec := r.createSecret(t, ctx, "impact-sec", "v")
 
+	// #G14: authorizeSecretScoped returns the same NotFound a nonexistent secret
+	// ID would, not PermissionDenied.
 	nobody := authCtx(999, "nobody")
 	_, err := r.svc.GetSecretImpact(nobody, &pb.GetSecretRequest{Id: sec.GetId()})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
 // ---------------------------------------------------------------------------

--- a/server/grpc/services/dynamic_secret_service.go
+++ b/server/grpc/services/dynamic_secret_service.go
@@ -46,13 +46,26 @@ func mapDynamicError(err error) error {
 	}
 }
 
-// loadConfigScoped loads a config by ID and authorizes perm at its project/env scope.
+// loadConfigScoped loads a config by ID and authorizes perm at its project/env
+// scope. A missing config AND a found-but-unauthorized one both yield the SAME
+// NotFound (#G14) — returning PermissionDenied for the found-but-unauthorized
+// branch would let a caller distinguish "this ID doesn't exist" from "this ID
+// exists but you can't touch it". Deliberately does not call the shared
+// authorizeScoped helper: its own found-but-MFA-required branch (via
+// enforceProjectMFA) is NOT an existence leak — the caller is already known to
+// be authorized at this point, just missing a second factor — and collapsing
+// that into a generic NotFound would hide an actionable, legitimate error.
 func (s *DynamicSecretGRPCService) loadConfigScoped(ctx context.Context, user *interceptors.UserContext, id uint, perm string) (*models.DynamicSecretConfig, error) {
+	notFound := status.Error(codes.NotFound, "config not found")
 	cfg, err := s.core.GetDynamicSecretConfig(ctx, id)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, "config not found")
+		return nil, notFound
 	}
-	if err := authorizeScoped(ctx, s.core, user, perm, core.Scope{ProjectID: cfg.ProjectID, EnvironmentID: cfg.EnvironmentID}); err != nil {
+	scope := core.Scope{ProjectID: cfg.ProjectID, EnvironmentID: cfg.EnvironmentID}
+	if allowed, err := s.core.AuthorizePrincipal(ctx, user.ActorKind(), user.PrincipalID(), perm, scope); err != nil || !allowed {
+		return nil, notFound
+	}
+	if err := enforceProjectMFA(ctx, s.core, user, scope.ProjectID); err != nil {
 		return nil, err
 	}
 	return cfg, nil
@@ -189,13 +202,20 @@ func (s *DynamicSecretGRPCService) ListLeases(ctx context.Context, req *pb.ListL
 	return &pb.ListLeasesResponse{Leases: out}, nil
 }
 
-// loadLeaseScoped loads a lease by its opaque ID and authorizes perm at its scope.
+// loadLeaseScoped loads a lease by its opaque ID and authorizes perm at its
+// scope. Same #G14 uniform-NotFound treatment as loadConfigScoped above —
+// see its doc comment for why the MFA branch is deliberately excluded.
 func (s *DynamicSecretGRPCService) loadLeaseScoped(ctx context.Context, user *interceptors.UserContext, leaseID, perm string) (*models.DynamicSecretLease, error) {
+	notFound := status.Error(codes.NotFound, "lease not found")
 	lease, err := s.core.GetDynamicSecretLease(ctx, leaseID)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, "lease not found")
+		return nil, notFound
 	}
-	if err := authorizeScoped(ctx, s.core, user, perm, core.Scope{ProjectID: lease.ProjectID, EnvironmentID: lease.EnvironmentID}); err != nil {
+	scope := core.Scope{ProjectID: lease.ProjectID, EnvironmentID: lease.EnvironmentID}
+	if allowed, err := s.core.AuthorizePrincipal(ctx, user.ActorKind(), user.PrincipalID(), perm, scope); err != nil || !allowed {
+		return nil, notFound
+	}
+	if err := enforceProjectMFA(ctx, s.core, user, scope.ProjectID); err != nil {
 		return nil, err
 	}
 	return lease, nil

--- a/server/grpc/services/secret_acl_service_test.go
+++ b/server/grpc/services/secret_acl_service_test.go
@@ -154,13 +154,15 @@ func TestGrantSecretACL_PermissionDenied(t *testing.T) {
 	r := newACLTestRig(t)
 	// Guest (user 2) has no RBAC role, so AuthorizePrincipal will deny.
 	ctx := authCtx(aclGuestUserID, "guest", "secrets.read")
+	// #G14: authorizeSecretScoped returns the same NotFound a nonexistent secret
+	// ID would, not PermissionDenied.
 	_, err := r.svc.GrantSecretACL(ctx, &pb.GrantSecretACLRequest{
 		SecretId:    r.secretID,
 		UserId:      aclAdminUserID,
 		Permissions: []string{"secrets.read"},
 	})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
 // TestGrantSecretACL_MissingSecretID validates that a zero secret_id is rejected.
@@ -239,9 +241,11 @@ func TestListSecretACLs_Unauthenticated(t *testing.T) {
 func TestListSecretACLs_PermissionDenied(t *testing.T) {
 	r := newACLTestRig(t)
 	ctx := authCtx(aclGuestUserID, "guest", "secrets.read")
+	// #G14: authorizeSecretScoped returns the same NotFound a nonexistent secret
+	// ID would, not PermissionDenied.
 	_, err := r.svc.ListSecretACLs(ctx, &pb.ListSecretACLsRequest{SecretId: r.secretID})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
 // TestListSecretACLs_MissingSecretID validates that a zero secret_id is rejected.
@@ -294,12 +298,14 @@ func TestRevokeSecretACL_Unauthenticated(t *testing.T) {
 func TestRevokeSecretACL_PermissionDenied(t *testing.T) {
 	r := newACLTestRig(t)
 	ctx := authCtx(aclGuestUserID, "guest", "secrets.read")
+	// #G14: authorizeSecretScoped returns the same NotFound a nonexistent secret
+	// ID would, not PermissionDenied.
 	_, err := r.svc.RevokeSecretACL(ctx, &pb.RevokeSecretACLRequest{
 		SecretId: r.secretID,
 		AclId:    1,
 	})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
 // TestRevokeSecretACL_MissingSecretID validates that a zero secret_id is rejected.

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -488,17 +488,22 @@ func mapSecretACLError(err error) error {
 // authorizeSecretScoped resolves a secret's project/environment and checks the
 // permission AT that scope — mirroring the HTTP RequireScopedPermission gate, so
 // gRPC enforces the same scoped-RBAC model as HTTP rather than the flat, global
-// permission set. A missing secret yields NotFound (not PermissionDenied) to
-// avoid leaking existence; the downstream *WithPermissionCheck core calls still
-// enforce ownership/share on top of this.
+// permission set. Both a missing secret AND a found-but-unauthorized one yield
+// the SAME NotFound response (#G14) — returning PermissionDenied only for the
+// found-but-unauthorized branch would let a caller distinguish "this ID doesn't
+// exist" from "this ID exists but you can't touch it" purely from the response
+// shape, an existence oracle across every project/tenant boundary. The
+// downstream *WithPermissionCheck core calls still enforce ownership/share on
+// top of this.
 func authorizeSecretScoped(ctx context.Context, cs *core.KeyorixCore, actor *interceptors.UserContext, secretID uint, perm string) error {
+	notFound := status.Error(codes.NotFound, "secret not found")
 	secret, err := cs.Storage().GetSecret(ctx, secretID)
 	if err != nil {
-		return status.Error(codes.NotFound, "secret not found")
+		return notFound
 	}
 	scope := core.Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
 	if allowed, err := cs.AuthorizePrincipal(ctx, actor.ActorKind(), actor.PrincipalID(), perm, scope); err != nil || !allowed {
-		return status.Error(codes.PermissionDenied, "insufficient permissions for this secret")
+		return notFound
 	}
 	return enforceProjectMFA(ctx, cs, actor, scope.ProjectID)
 }

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -234,25 +234,28 @@ func TestSecretService_PerSecretOps_ScopedToOtherProjectDenied(t *testing.T) {
 	// Flat list advertises every permission — the bug would have honoured it.
 	ctx := authCtx(3, "scoped", "secrets.read", "secrets.write", "secrets.delete")
 
+	// #G14: authorizeSecretScoped now returns the SAME NotFound a nonexistent ID
+	// would get, not PermissionDenied — a distinct code for "exists but you can't
+	// touch it" is an existence oracle across the project boundary.
 	_, err := r.svc.GetSecret(ctx, &pb.GetSecretRequest{Id: 50})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err), "GetSecret cross-project")
+	assert.Equal(t, codes.NotFound, status.Code(err), "GetSecret cross-project")
 
 	_, err = r.svc.GetSecretValue(ctx, &pb.GetSecretRequest{Id: 50})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err), "GetSecretValue cross-project")
+	assert.Equal(t, codes.NotFound, status.Code(err), "GetSecretValue cross-project")
 
 	_, err = r.svc.UpdateSecret(ctx, &pb.UpdateSecretRequest{Id: 50})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err), "UpdateSecret cross-project")
+	assert.Equal(t, codes.NotFound, status.Code(err), "UpdateSecret cross-project")
 
 	_, err = r.svc.DeleteSecret(ctx, &pb.DeleteSecretRequest{Id: 50})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err), "DeleteSecret cross-project")
+	assert.Equal(t, codes.NotFound, status.Code(err), "DeleteSecret cross-project")
 
 	_, err = r.svc.GetSecretVersions(ctx, &pb.GetSecretVersionsRequest{Id: 50})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err), "GetSecretVersions cross-project")
+	assert.Equal(t, codes.NotFound, status.Code(err), "GetSecretVersions cross-project")
 }
 
 // A scoped user CAN operate on a secret within a project where they hold the
@@ -491,8 +494,10 @@ func TestSecretService_SetSecretAutoRotate_PermissionDenied(t *testing.T) {
 	owner := authCtx(1, "writer", "secrets.write", "secrets.read")
 	sec := r.createSecret(t, owner, "rotatable", "v")
 
+	// #G14: authorizeSecretScoped returns the same NotFound a nonexistent secret
+	// ID would, not PermissionDenied — see authorizeSecretScoped's doc comment.
 	ctx := authCtx(2, "reader", "secrets.read") // no write grant
 	_, err := r.svc.SetSecretAutoRotate(ctx, &pb.SetSecretAutoRotateRequest{Id: sec.GetId(), Enabled: true})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
 }

--- a/server/grpc/services/share_service_test.go
+++ b/server/grpc/services/share_service_test.go
@@ -106,13 +106,15 @@ func TestShareService_ShareSecret_ScopedToOtherProjectDenied(t *testing.T) {
 
 	ctx := authCtx(3, "scoped", "secrets.read", "secrets.write")
 
+	// #G14: authorizeSecretScoped returns the same NotFound a nonexistent secret
+	// ID would, not PermissionDenied.
 	_, err := r.svc.ShareSecret(ctx, &pb.ShareSecretRequest{SecretId: 90, RecipientId: 2, Permission: "read"})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err), "ShareSecret cross-project")
+	assert.Equal(t, codes.NotFound, status.Code(err), "ShareSecret cross-project")
 
 	_, err = r.svc.ListSecretShares(ctx, &pb.ListSecretSharesRequest{SecretId: 90})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err), "ListSecretShares cross-project")
+	assert.Equal(t, codes.NotFound, status.Code(err), "ListSecretShares cross-project")
 }
 
 func ownerCtx() context.Context {

--- a/server/http/handlers/admin_jobs.go
+++ b/server/http/handlers/admin_jobs.go
@@ -82,11 +82,12 @@ func (h *AdminJobsHandler) RunExpiryReminders(w http.ResponseWriter, r *http.Req
 // RunComplianceDigest handles POST /api/v1/admin/jobs/compliance-digest — broadcast the
 // compliance digest now. Returns {sent} (false when there were no recipients/changes).
 func (h *AdminJobsHandler) RunComplianceDigest(w http.ResponseWriter, r *http.Request) {
-	if middleware.GetUserFromContext(r.Context()) == nil {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
 		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
 		return
 	}
-	sent, err := h.coreService.SendComplianceDigest(r.Context())
+	sent, err := h.coreService.SendComplianceDigest(r.Context(), userCtx.UserID)
 	if err != nil {
 		log.Printf("Error running compliance digest job: %v", err)
 		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -317,6 +317,7 @@ func (h *AuditHandler) GetRBACAuditLogs(w http.ResponseWriter, r *http.Request) 
 			"role_id":        e.RoleID,
 			"permission_id":  e.PermissionID,
 			"project_id":     e.ProjectID,
+			"environment_id": e.EnvironmentID,
 			"details":        e.Details,
 			"created_at":     e.CreatedAt.UTC().Format(time.RFC3339),
 		})

--- a/server/http/handlers/dashboard.go
+++ b/server/http/handlers/dashboard.go
@@ -72,7 +72,11 @@ func (h *DashboardHandler) GetComplianceDigest(w http.ResponseWriter, r *http.Re
 // (Slack/Teams/webhook/email). Returns {sent: bool}: false when no channel is wired.
 // Gated by system.write in the router (same as admin-jobs compliance-digest).
 func (h *DashboardHandler) SendComplianceDigest(w http.ResponseWriter, r *http.Request) {
-	sent, err := h.coreService.SendComplianceDigest(r.Context())
+	var actorID uint
+	if userCtx := middleware.GetUserFromContext(r.Context()); userCtx != nil {
+		actorID = userCtx.UserID
+	}
+	sent, err := h.coreService.SendComplianceDigest(r.Context(), actorID)
 	if err != nil {
 		sendError(w, "InternalServerError", "Failed to send compliance digest", http.StatusInternalServerError, nil)
 		return

--- a/server/http/handlers/dynamic_secrets.go
+++ b/server/http/handlers/dynamic_secrets.go
@@ -220,13 +220,7 @@ func (h *DynamicSecretHandler) RevokeLease(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	leaseID := chi.URLParam(r, "leaseID")
-	lease, err := h.coreService.GetDynamicSecretLease(r.Context(), leaseID)
-	if err != nil {
-		sendError(w, "NotFound", "Lease not found", http.StatusNotFound, nil)
-		return
-	}
-	if ok, mfaBlocked := h.authorize(r, permSecretsWrite, core.Scope{ProjectID: lease.ProjectID, EnvironmentID: lease.EnvironmentID}); !ok {
-		h.denyAuthz(w, mfaBlocked)
+	if _, ok := h.loadAuthorizedLease(w, r, leaseID, permSecretsWrite); !ok {
 		return
 	}
 	if err := h.coreService.RevokeLease(r.Context(), leaseID, userCtx.UserID, "manual"); err != nil {
@@ -249,13 +243,7 @@ func (h *DynamicSecretHandler) RenewLease(w http.ResponseWriter, r *http.Request
 		return
 	}
 	leaseID := chi.URLParam(r, "leaseID")
-	lease, err := h.coreService.GetDynamicSecretLease(r.Context(), leaseID)
-	if err != nil {
-		sendError(w, "NotFound", "Lease not found", http.StatusNotFound, nil)
-		return
-	}
-	if ok, mfaBlocked := h.authorize(r, permSecretsWrite, core.Scope{ProjectID: lease.ProjectID, EnvironmentID: lease.EnvironmentID}); !ok {
-		h.denyAuthz(w, mfaBlocked)
+	if _, ok := h.loadAuthorizedLease(w, r, leaseID, permSecretsWrite); !ok {
 		return
 	}
 	var body struct {
@@ -358,7 +346,14 @@ func (h *DynamicSecretHandler) SetConfigEnabled(w http.ResponseWriter, r *http.R
 }
 
 // loadAuthorizedConfig loads the {id} config and authorizes the caller against
-// its scope. It writes the error response and returns ok=false on failure.
+// its scope. It writes the error response and returns ok=false on failure. A
+// missing config AND a found-but-unauthorized one both write the SAME NotFound
+// response (#G14) — a distinct Forbidden for the found-but-unauthorized branch
+// would let a caller distinguish "this ID doesn't exist" from "this ID exists
+// but you can't touch it". The MFA-blocked branch is deliberately NOT
+// collapsed: the caller is already known to be authorized at that point, just
+// missing a second factor, so hiding it behind a generic NotFound would mask
+// an actionable, legitimate error.
 func (h *DynamicSecretHandler) loadAuthorizedConfig(w http.ResponseWriter, r *http.Request, perm string) (*models.DynamicSecretConfig, bool) {
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseUint(idStr, 10, 32)
@@ -372,10 +367,36 @@ func (h *DynamicSecretHandler) loadAuthorizedConfig(w http.ResponseWriter, r *ht
 		return nil, false
 	}
 	if ok, mfaBlocked := h.authorize(r, perm, core.Scope{ProjectID: cfg.ProjectID, EnvironmentID: cfg.EnvironmentID}); !ok {
-		h.denyAuthz(w, mfaBlocked)
+		if mfaBlocked {
+			h.denyAuthz(w, true)
+		} else {
+			sendError(w, "NotFound", "Config not found", http.StatusNotFound, nil)
+		}
 		return nil, false
 	}
 	return cfg, true
+}
+
+// loadAuthorizedLease loads the leaseID lease and authorizes the caller
+// against its scope, with the same #G14 uniform-NotFound treatment as
+// loadAuthorizedConfig above — see its doc comment for why the MFA branch is
+// deliberately excluded. Shared by RevokeLease/RenewLease so the pattern isn't
+// duplicated (and can't silently diverge) across call sites.
+func (h *DynamicSecretHandler) loadAuthorizedLease(w http.ResponseWriter, r *http.Request, leaseID string, perm string) (*models.DynamicSecretLease, bool) {
+	lease, err := h.coreService.GetDynamicSecretLease(r.Context(), leaseID)
+	if err != nil {
+		sendError(w, "NotFound", "Lease not found", http.StatusNotFound, nil)
+		return nil, false
+	}
+	if ok, mfaBlocked := h.authorize(r, perm, core.Scope{ProjectID: lease.ProjectID, EnvironmentID: lease.EnvironmentID}); !ok {
+		if mfaBlocked {
+			h.denyAuthz(w, true)
+		} else {
+			sendError(w, "NotFound", "Lease not found", http.StatusNotFound, nil)
+		}
+		return nil, false
+	}
+	return lease, true
 }
 
 // sanitizeConfig returns the safe public view of a config — never the encrypted

--- a/server/http/handlers/handlers_s13_project_test.go
+++ b/server/http/handlers/handlers_s13_project_test.go
@@ -103,7 +103,10 @@ func TestAttestProjectAccessReview_StorageError_S13(t *testing.T) {
 	// source decision, forcing a raw driver error out of core.
 	require.NoError(t, db.Exec("DROP TABLE IF EXISTS user_roles").Error)
 
-	body := `{"source":"role","principal_type":"user","principal_id":1,"role_id":1}`
+	// principal_id deliberately != the acting user's ID (1, per withUserCtx) —
+	// otherwise #G52's new self-review independence check refuses the request
+	// before it ever reaches the broken table this test exists to exercise.
+	body := `{"source":"role","principal_type":"user","principal_id":999,"role_id":1}`
 	r := withUserCtx(withChiParam(
 		httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)),
 		"id", fmt.Sprintf("%d", proj.ID),

--- a/server/http/handlers/handlers_s13_proxy_test.go
+++ b/server/http/handlers/handlers_s13_proxy_test.go
@@ -571,6 +571,26 @@ func TestPurgeDeletedSecretsBeforeProxy_HappyPath_S13(t *testing.T) {
 	assert.True(t, resp.Success)
 }
 
+// TestPurgeDeletedSecretsBeforeProxy_RefusesUnderLegalHold_S13 is #G52: this
+// route reaches storage.PurgeDeletedSecretsBefore directly, with no
+// core-layer involvement — before the fix it completely bypassed the SAME
+// legal-hold guard PurgeExpiredSoftDeletes (internal/core/purge.go) enforces
+// for the identical underlying purge.
+func TestPurgeDeletedSecretsBeforeProxy_RefusesUnderLegalHold_S13(t *testing.T) {
+	h := freshSecretHandlerForProxyS13(t)
+	_, err := h.coreService.Storage().CreateLegalHold(context.Background(), &models.LegalHold{Reason: "litigation hold", PlacedBy: 1})
+	require.NoError(t, err)
+
+	body := proxyJSON(map[string]interface{}{"before": time.Now()})
+	req := httptest.NewRequest(http.MethodPost, "/system/retention/secrets/purge", body)
+	w := httptest.NewRecorder()
+	h.PurgeDeletedSecretsBeforeProxy(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.False(t, resp.Success)
+	assert.Equal(t, "LEGAL_HOLD_ACTIVE", resp.Error.Code)
+}
+
 // TestDeleteAnomalyAlertsBeforeProxy_BadBody_S13 — malformed JSON → 400.
 func TestDeleteAnomalyAlertsBeforeProxy_BadBody_S13(t *testing.T) {
 	h := freshAuditHandlerS13(t)
@@ -693,6 +713,22 @@ func TestPurgeDeletedProjectsBeforeProxy_HappyPath_S13(t *testing.T) {
 	assert.True(t, resp.Success)
 }
 
+// TestPurgeDeletedProjectsBeforeProxy_RefusesUnderLegalHold_S13 is #G52 — see
+// TestPurgeDeletedSecretsBeforeProxy_RefusesUnderLegalHold_S13's comment.
+func TestPurgeDeletedProjectsBeforeProxy_RefusesUnderLegalHold_S13(t *testing.T) {
+	h := freshCatalogHandlerS13(t)
+	_, err := h.coreService.Storage().CreateLegalHold(context.Background(), &models.LegalHold{Reason: "litigation hold", PlacedBy: 1})
+	require.NoError(t, err)
+
+	body := proxyJSON(map[string]interface{}{"before": time.Now()})
+	req := httptest.NewRequest(http.MethodPost, "/system/retention/projects/purge", body)
+	w := httptest.NewRecorder()
+	h.PurgeDeletedProjectsBeforeProxy(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "LEGAL_HOLD_ACTIVE", resp.Error.Code)
+}
+
 // TestPurgeDeletedEnvironmentsBeforeProxy_BadBody_S13 — bad JSON → 400.
 func TestPurgeDeletedEnvironmentsBeforeProxy_BadBody_S13(t *testing.T) {
 	h := freshCatalogHandlerS13(t)
@@ -712,6 +748,22 @@ func TestPurgeDeletedEnvironmentsBeforeProxy_HappyPath_S13(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	resp := decodeRemoteResp(t, w)
 	assert.True(t, resp.Success)
+}
+
+// TestPurgeDeletedEnvironmentsBeforeProxy_RefusesUnderLegalHold_S13 is #G52 —
+// see TestPurgeDeletedSecretsBeforeProxy_RefusesUnderLegalHold_S13's comment.
+func TestPurgeDeletedEnvironmentsBeforeProxy_RefusesUnderLegalHold_S13(t *testing.T) {
+	h := freshCatalogHandlerS13(t)
+	_, err := h.coreService.Storage().CreateLegalHold(context.Background(), &models.LegalHold{Reason: "litigation hold", PlacedBy: 1})
+	require.NoError(t, err)
+
+	body := proxyJSON(map[string]interface{}{"before": time.Now()})
+	req := httptest.NewRequest(http.MethodPost, "/system/retention/environments/purge", body)
+	w := httptest.NewRecorder()
+	h.PurgeDeletedEnvironmentsBeforeProxy(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "LEGAL_HOLD_ACTIVE", resp.Error.Code)
 }
 
 // TestDeleteExpiredRoleGrantsProxy_BadBody_S13 — bad JSON → 400.
@@ -775,6 +827,22 @@ func TestPurgeDeletedUsersBeforeProxy_HappyPath_S13(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	resp := decodeRemoteResp(t, w)
 	assert.True(t, resp.Success)
+}
+
+// TestPurgeDeletedUsersBeforeProxy_RefusesUnderLegalHold_S13 is #G52 — see
+// TestPurgeDeletedSecretsBeforeProxy_RefusesUnderLegalHold_S13's comment.
+func TestPurgeDeletedUsersBeforeProxy_RefusesUnderLegalHold_S13(t *testing.T) {
+	h := freshUserHandlerForProxyS13(t)
+	_, err := h.coreService.Storage().CreateLegalHold(context.Background(), &models.LegalHold{Reason: "litigation hold", PlacedBy: 1})
+	require.NoError(t, err)
+
+	body := proxyJSON(map[string]interface{}{"before": time.Now()})
+	req := httptest.NewRequest(http.MethodPost, "/system/retention/users/purge", body)
+	w := httptest.NewRecorder()
+	h.PurgeDeletedUsersBeforeProxy(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "LEGAL_HOLD_ACTIVE", resp.Error.Code)
 }
 
 // TestListUsersInStateBeforeProxy_MissingState_S13 — missing state → 400.

--- a/server/http/handlers/handlers_s23_test.go
+++ b/server/http/handlers/handlers_s23_test.go
@@ -286,10 +286,12 @@ func TestDynamic_IssueLease_NoUserCtx_S23(t *testing.T) {
 	require.NoError(t, db.Create(cfg).Error)
 
 	// IssueLease calls loadAuthorizedConfig first, which calls authorize();
-	// authorize() returns false when userCtx is nil, so the 403/401 guard fires
-	// before the core.IssueLease call. Because IssueLease's outer guard comes
-	// AFTER loadAuthorizedConfig (which has its own authorize inside), no user
-	// ctx means loadAuthorizedConfig returns false → 403 (not 401).
+	// authorize() returns false when userCtx is nil, so the guard fires before
+	// the core.IssueLease call. Because IssueLease's outer guard comes AFTER
+	// loadAuthorizedConfig (which has its own authorize inside), no user ctx
+	// means loadAuthorizedConfig returns false → NotFound (#G14: the
+	// found-but-unauthorized branch collapses to the same response a missing
+	// config ID would get, not a distinct Forbidden).
 	req := withChiParam(
 		httptest.NewRequest(http.MethodPost, "/api/v1/dynamic-secrets/configs/1/issue", nil),
 		"id", uintStr(cfg.ID),
@@ -297,8 +299,7 @@ func TestDynamic_IssueLease_NoUserCtx_S23(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.IssueLease(w, req)
 
-	// denyAuthz with mfaBlocked=false → 403 Forbidden
-	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 // TestDynamic_IssueLease_BadConfigID_S23 verifies that a non-numeric config id

--- a/server/http/handlers/project_memberships_proxy.go
+++ b/server/http/handlers/project_memberships_proxy.go
@@ -144,10 +144,11 @@ func (h *CatalogHandler) GetMembershipProxy(w http.ResponseWriter, r *http.Reque
 
 // UpdateMembershipProxy handles PUT /api/v1/system/project-memberships/{id}. This
 // is a raw passthrough onto storage.UpdateProjectMembership (local_memberships.go's
-// plain Save) — see remote_memberships.go's package doc for why, unlike
-// UpdateInvitationProxy, there is no conditional `WHERE state = ?` write to
-// preserve here: the state-machine legality check (canTransition) already runs in
-// the CALLING core.KeyorixCore before this is ever invoked.
+// plain Save). #G42: this must NEVER be used for a state-machine transition
+// (State/ActivatedAt/RevokedAt) — the calling core.KeyorixCore's canTransition
+// legality check running before this is invoked does NOT close the TOCTOU a
+// concurrent transition on the same membership races; see
+// TransitionMembershipProxy below, which exists specifically for that.
 func (h *CatalogHandler) UpdateMembershipProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
@@ -166,6 +167,42 @@ func (h *CatalogHandler) UpdateMembershipProxy(w http.ResponseWriter, r *http.Re
 		return
 	}
 	writeRemoteAPISuccess(w, map[string]bool{"updated": true})
+}
+
+// TransitionMembershipProxy handles PUT
+// /api/v1/system/project-memberships/{id}/transition — the server-side
+// endpoint backing RemoteStorage.TransitionProjectMembershipState (#G42).
+// Persists the membership's full row via a single conditional UPDATE, gated
+// on the row's CURRENT state still matching the request's from_state, so a
+// concurrent transition on the same membership can't be silently reverted
+// (or silently revert this one) across the HTTP hop the way UpdateMembershipProxy
+// could.
+func (h *CatalogHandler) TransitionMembershipProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid membership ID")
+		return
+	}
+	var body struct {
+		Membership membershipProxyWire `json:"membership"`
+		FromState  string              `json:"from_state"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.FromState == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "from_state is required")
+		return
+	}
+	body.Membership.ID = uint(id)
+	matched, err := h.coreService.Storage().TransitionProjectMembershipState(r.Context(), body.Membership.toModel(), body.FromState)
+	if err != nil {
+		log.Printf("project-memberships proxy: transition failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"matched": matched})
 }
 
 // ListMembershipsProxy handles GET /api/v1/system/project-memberships?project_id=X.

--- a/server/http/handlers/readiness.go
+++ b/server/http/handlers/readiness.go
@@ -9,18 +9,58 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
 )
+
+// readinessCacheTTL bounds how often GET /readyz actually pings the database
+// (#G82): unlike the login/SSO endpoints, an unauthenticated flood here can't
+// be rejected outright with a rate-limit error — a readiness probe that starts
+// reporting "too many requests" instead of the real DB status would make
+// Kubernetes wrongly conclude a healthy replica is unready, a self-inflicted
+// outage strictly worse than the DB-load DoS this closes. Caching the last
+// real result for a short window instead means a flood reuses that result
+// (bounding DB round trips) while still reflecting reality well within any
+// realistic orchestrator probe interval (Kubernetes' own default is 10s).
+// Overridable by tests.
+var readinessCacheTTL = time.Second
+
+// readinessNow is time.Now, overridable by tests so they can force the cache
+// to expire without a real sleep.
+var readinessNow = time.Now
+
+// readinessCache is the last real HealthCheck result and when it was taken.
+type readinessCache struct {
+	mu       sync.Mutex
+	checked  time.Time
+	notReady bool
+}
 
 // ReadinessCheck returns a handler for GET /readyz that reports whether the server is
 // ready to serve traffic (database reachable). 200 = ready, 503 = not ready. The error
 // detail is intentionally generic so internals aren't leaked on an unauthenticated route.
 func ReadinessCheck(svc *core.KeyorixCore) http.HandlerFunc {
+	cache := &readinessCache{}
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "no-cache")
-		if err := svc.HealthCheck(r.Context()); err != nil {
+
+		cache.mu.Lock()
+		fresh := readinessNow().Sub(cache.checked) < readinessCacheTTL
+		notReady := cache.notReady
+		cache.mu.Unlock()
+
+		if !fresh {
+			notReady = svc.HealthCheck(r.Context()) != nil
+			cache.mu.Lock()
+			cache.checked = readinessNow()
+			cache.notReady = notReady
+			cache.mu.Unlock()
+		}
+
+		if notReady {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "not_ready", "reason": "database unreachable"})
 			return

--- a/server/http/handlers/readiness_test.go
+++ b/server/http/handlers/readiness_test.go
@@ -41,7 +41,7 @@ func TestReadinessCheck(t *testing.T) {
 	})
 
 	t.Run("reports 503 not_ready when the database is unreachable", func(t *testing.T) {
-		require.NoError(t, sqlDB.Close()) // sever the DB connection → SELECT 1 fails
+		require.NoError(t, sqlDB.Close())            // sever the DB connection → SELECT 1 fails
 		fakeNow = fakeNow.Add(2 * readinessCacheTTL) // force the cached "ready" result to expire
 		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 		w := httptest.NewRecorder()

--- a/server/http/handlers/readiness_test.go
+++ b/server/http/handlers/readiness_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,14 @@ func TestReadinessCheck(t *testing.T) {
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
 
+	// This test exercises a genuine state transition (DB reachable -> severed)
+	// across two calls to the SAME handler instance, so it must defeat
+	// readiness.go's short-TTL cache (#G82) between subtests — a fake clock
+	// that jumps forward stands in for a real sleep.
+	fakeNow := time.Now()
+	readinessNow = func() time.Time { return fakeNow }
+	t.Cleanup(func() { readinessNow = time.Now })
+
 	h := ReadinessCheck(core.NewKeyorixCore(store.NewLocalStorage(db)))
 
 	t.Run("reports ready when the database is reachable", func(t *testing.T) {
@@ -33,6 +42,7 @@ func TestReadinessCheck(t *testing.T) {
 
 	t.Run("reports 503 not_ready when the database is unreachable", func(t *testing.T) {
 		require.NoError(t, sqlDB.Close()) // sever the DB connection → SELECT 1 fails
+		fakeNow = fakeNow.Add(2 * readinessCacheTTL) // force the cached "ready" result to expire
 		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 		w := httptest.NewRecorder()
 		h(w, req)
@@ -40,4 +50,38 @@ func TestReadinessCheck(t *testing.T) {
 		require.Equal(t, http.StatusServiceUnavailable, w.Code)
 		assert.Contains(t, w.Body.String(), `"status":"not_ready"`)
 	})
+}
+
+// TestReadinessCheck_CachesWithinTTL is #G82: within the cache window, a flood
+// of requests must reuse the last real DB check result instead of hitting the
+// database on every single call — bounding the DB round trips an unauthenticated
+// flood can force, without ever risking a false "too many requests" rejection
+// that would make an orchestrator wrongly conclude a healthy replica is unready.
+func TestReadinessCheck_CachesWithinTTL(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	fakeNow := time.Now()
+	readinessNow = func() time.Time { return fakeNow }
+	t.Cleanup(func() { readinessNow = time.Now })
+
+	h := ReadinessCheck(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Sever the DB connection, but stay WITHIN the cache TTL — a flood of
+	// calls here must still return the cached "ready" result, not a fresh
+	// (now-failing) check.
+	require.NoError(t, sqlDB.Close())
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		w := httptest.NewRecorder()
+		h(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "within the cache window every call must reuse the cached result, not hit the DB")
+	}
 }

--- a/server/http/handlers/retention_proxy.go
+++ b/server/http/handlers/retention_proxy.go
@@ -107,12 +107,39 @@ func decodeRetentionBeforeBody(w http.ResponseWriter, r *http.Request) (time.Tim
 	return body.Before.Local(), true
 }
 
+// refuseIfLegalHoldActive is #G52: PurgeExpiredSoftDeletes (internal/core/purge.go)
+// gates its user/project/environment/secret purges behind ONE combined
+// GetActiveLegalHold check (ISO A.5.34 — no destroying potentially
+// litigation-relevant data while a hold is active). The four retention-proxy
+// routes below reach the SAME underlying storage.Storage purge primitives
+// directly, with no core-layer involvement at all, so without this they
+// completely bypass that guard — a storage.type: remote caller holding
+// system.write (the same credential a legitimate RemoteStorage client needs)
+// could purge exactly the data a legal hold exists to protect. Returns true
+// (and has already written the HTTP response) if the caller should stop.
+func refuseIfLegalHoldActive(w http.ResponseWriter, r *http.Request, storage coreStorage.Storage) bool {
+	hold, err := storage.GetActiveLegalHold(r.Context())
+	if err != nil {
+		log.Printf("retention proxy: could not confirm legal-hold status: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", "could not confirm legal-hold status")
+		return true
+	}
+	if hold != nil {
+		writeRemoteAPIError(w, http.StatusConflict, "LEGAL_HOLD_ACTIVE", "refusing to purge: a deployment-wide legal hold is active")
+		return true
+	}
+	return false
+}
+
 // --- SecretHandler: PurgeDeletedSecretsBefore (ADR-032) ---
 
 // PurgeDeletedSecretsBeforeProxy handles POST /api/v1/system/retention/secrets/purge.
 func (h *SecretHandler) PurgeDeletedSecretsBeforeProxy(w http.ResponseWriter, r *http.Request) {
 	before, ok := decodeRetentionBeforeBody(w, r)
 	if !ok {
+		return
+	}
+	if refuseIfLegalHoldActive(w, r, h.coreService.Storage()) {
 		return
 	}
 	n, err := h.coreService.Storage().PurgeDeletedSecretsBefore(r.Context(), before)
@@ -219,6 +246,9 @@ func (h *CatalogHandler) PurgeDeletedProjectsBeforeProxy(w http.ResponseWriter, 
 	if !ok {
 		return
 	}
+	if refuseIfLegalHoldActive(w, r, h.coreService.Storage()) {
+		return
+	}
 	n, err := h.coreService.Storage().PurgeDeletedProjectsBefore(r.Context(), before)
 	if err != nil {
 		log.Printf("retention proxy: purge deleted projects failed: %v", err)
@@ -233,6 +263,9 @@ func (h *CatalogHandler) PurgeDeletedProjectsBeforeProxy(w http.ResponseWriter, 
 func (h *CatalogHandler) PurgeDeletedEnvironmentsBeforeProxy(w http.ResponseWriter, r *http.Request) {
 	before, ok := decodeRetentionBeforeBody(w, r)
 	if !ok {
+		return
+	}
+	if refuseIfLegalHoldActive(w, r, h.coreService.Storage()) {
 		return
 	}
 	n, err := h.coreService.Storage().PurgeDeletedEnvironmentsBefore(r.Context(), before)
@@ -362,6 +395,9 @@ func newUserRetentionProxyWire(u *models.User) userRetentionProxyWire {
 func (h *UserHandler) PurgeDeletedUsersBeforeProxy(w http.ResponseWriter, r *http.Request) {
 	before, ok := decodeRetentionBeforeBody(w, r)
 	if !ok {
+		return
+	}
+	if refuseIfLegalHoldActive(w, r, h.coreService.Storage()) {
 		return
 	}
 	n, err := h.coreService.Storage().PurgeDeletedUsersBefore(r.Context(), before)

--- a/server/http/handlers/saml.go
+++ b/server/http/handlers/saml.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -37,6 +38,16 @@ func (h *AuthHandler) SAMLMetadata(w http.ResponseWriter, r *http.Request) {
 // BeginSAML handles GET /auth/saml/{provider}/login — redirects the browser to the IdP
 // SSO endpoint with a fresh AuthnRequest.
 func (h *AuthHandler) BeginSAML(w http.ResponseWriter, r *http.Request) {
+	ip := r.RemoteAddr
+	if idx := strings.LastIndex(ip, ":"); idx != -1 {
+		ip = ip[:idx]
+	}
+	if h.coreService.IsSSOBeginRateLimited(r.Context(), ip) {
+		sendError(w, "TooManyRequests", "Too many login attempts. Try again later.", http.StatusTooManyRequests, nil)
+		return
+	}
+	h.coreService.RecordSSOBeginAttempt(r.Context(), ip)
+
 	provider := chi.URLParam(r, "provider")
 	redirectURL, err := h.coreService.BeginSAML(r.Context(), provider, r.URL.Query().Get("return_to"))
 	if err != nil {

--- a/server/http/handlers/sso.go
+++ b/server/http/handlers/sso.go
@@ -79,6 +79,16 @@ func (h *AuthHandler) ListSSOProviders(w http.ResponseWriter, _ *http.Request) {
 // BeginSSO handles GET /auth/sso/{provider}/login — redirects the browser to the IdP
 // authorization endpoint with a fresh state + nonce.
 func (h *AuthHandler) BeginSSO(w http.ResponseWriter, r *http.Request) {
+	ip := r.RemoteAddr
+	if idx := strings.LastIndex(ip, ":"); idx != -1 {
+		ip = ip[:idx]
+	}
+	if h.coreService.IsSSOBeginRateLimited(r.Context(), ip) {
+		sendError(w, "TooManyRequests", "Too many login attempts. Try again later.", http.StatusTooManyRequests, nil)
+		return
+	}
+	h.coreService.RecordSSOBeginAttempt(r.Context(), ip)
+
 	provider := chi.URLParam(r, "provider")
 	authURL, err := h.coreService.BeginSSO(r.Context(), provider, r.URL.Query().Get("return_to"))
 	if err != nil {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1364,6 +1364,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/project-memberships", catalogHandler.ListMembershipsProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/project-memberships", catalogHandler.CreateMembershipProxy)
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/project-memberships/{id}", catalogHandler.UpdateMembershipProxy)
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Put("/project-memberships/{id}/transition", catalogHandler.TransitionMembershipProxy)
 
 			// Secret-dependency storage-primitive proxy (finding #519). Lets a
 			// downstream Keyorix server booted with storage.type: remote (ADR-049)

--- a/server/main.go
+++ b/server/main.go
@@ -1151,7 +1151,7 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error { // NOSONAR
 		log.Printf("Compliance-digest scheduler enabled: every %s", interval)
 		runScheduler(ctx, "compliance_digest", interval, func() middleware.SchedulerOutcome {
 			return lockedRun(ctx, coreService.Storage(), schedLockDigest, "Compliance-digest", func() error {
-				sent, derr := coreService.SendComplianceDigest(ctx)
+				sent, derr := coreService.SendComplianceDigest(ctx, 0)
 				if derr != nil {
 					log.Printf("Compliance-digest error: %v", derr)
 					return derr

--- a/server/main.go
+++ b/server/main.go
@@ -857,6 +857,17 @@ func cmpOr(a, b string) string {
 	return b
 }
 
+// closeAuditForwarder flushes/closes the wired SIEM audit forwarder (if any) on
+// shutdown. core.AuditForwarder only declares Forward (core has no dependency
+// on the concrete siem package), so the Close method is reached via a local
+// interface rather than a direct type assertion to *siem.Forwarder.
+func closeAuditForwarder(coreService *core.KeyorixCore) {
+	type closer interface{ Close() }
+	if cl, ok := coreService.AuditForwarder().(closer); ok {
+		cl.Close()
+	}
+}
+
 func startHTTPServer(ctx context.Context, cfg *config.Config) error { // NOSONAR -- cognitive complexity 188, suppress go:S3776
 	// Initialize core service (and encryption if enabled)
 	coreService, encSvc, err := initializeCoreService(cfg)
@@ -868,6 +879,12 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error { // NOSONAR
 	if encSvc != nil {
 		defer encSvc.Shutdown()
 	}
+
+	// #G56: flush/close the SIEM audit forwarder (if configured) on shutdown — it
+	// queues events in memory (worker.go's Deliver is non-blocking, async), and
+	// nothing previously called Close() to drain that queue before the process
+	// exited, silently losing whatever was in flight at SIGTERM.
+	defer closeAuditForwarder(coreService)
 
 	// Record the evaluated license state once at startup (ADR-065), so the entitlement
 	// (and any degrade reason) is on the audit record.
@@ -1567,6 +1584,10 @@ func startGRPCServer(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize core service: %w", err)
 	}
+	// #G56: this is a SEPARATE core.KeyorixCore (and therefore a separate SIEM
+	// forwarder instance) from startHTTPServer's — each running server owns and
+	// must flush its own.
+	defer closeAuditForwarder(coreService)
 
 	// Create gRPC server
 	grpcServer, err := grpc.NewServer(cfg, coreService)

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -618,6 +618,9 @@ message RBACAuditLog {
   // Set for permission-to-role events (permission.assigned / permission.removed):
   // the permission granted to / removed from the role.
   optional uint32 permission_id = 10;
+  // Set when the grant's scope included an environment (project-scoped grants
+  // with no environment leave this unset, matching project_id's semantics).
+  optional uint32 environment_id = 11;
 }
 
 message GetRBACAuditLogsRequest {

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -3637,7 +3637,10 @@ type RBACAuditLog struct {
 	GroupId *uint32 `protobuf:"varint,9,opt,name=group_id,json=groupId,proto3,oneof" json:"group_id,omitempty"`
 	// Set for permission-to-role events (permission.assigned / permission.removed):
 	// the permission granted to / removed from the role.
-	PermissionId  *uint32 `protobuf:"varint,10,opt,name=permission_id,json=permissionId,proto3,oneof" json:"permission_id,omitempty"`
+	PermissionId *uint32 `protobuf:"varint,10,opt,name=permission_id,json=permissionId,proto3,oneof" json:"permission_id,omitempty"`
+	// Set when the grant's scope included an environment (project-scoped grants
+	// with no environment leave this unset, matching project_id's semantics).
+	EnvironmentId *uint32 `protobuf:"varint,11,opt,name=environment_id,json=environmentId,proto3,oneof" json:"environment_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3738,6 +3741,13 @@ func (x *RBACAuditLog) GetGroupId() uint32 {
 func (x *RBACAuditLog) GetPermissionId() uint32 {
 	if x != nil && x.PermissionId != nil {
 		return *x.PermissionId
+	}
+	return 0
+}
+
+func (x *RBACAuditLog) GetEnvironmentId() uint32 {
+	if x != nil && x.EnvironmentId != nil {
+		return *x.EnvironmentId
 	}
 	return 0
 }
@@ -11058,7 +11068,7 @@ const file_keyorix_proto_rawDesc = "" +
 	"\x04page\x18\x03 \x01(\rR\x04page\x12\x1b\n" +
 	"\tpage_size\x18\x04 \x01(\rR\bpageSize\x12\x1f\n" +
 	"\vtotal_pages\x18\x05 \x01(\rR\n" +
-	"totalPages\"\xca\x03\n" +
+	"totalPages\"\x89\x04\n" +
 	"\fRBACAuditLog\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12\x16\n" +
 	"\x06action\x18\x02 \x01(\tR\x06action\x12'\n" +
@@ -11072,14 +11082,16 @@ const file_keyorix_proto_rawDesc = "" +
 	"created_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12\x1e\n" +
 	"\bgroup_id\x18\t \x01(\rH\x04R\agroupId\x88\x01\x01\x12(\n" +
 	"\rpermission_id\x18\n" +
-	" \x01(\rH\x05R\fpermissionId\x88\x01\x01B\x10\n" +
+	" \x01(\rH\x05R\fpermissionId\x88\x01\x01\x12*\n" +
+	"\x0eenvironment_id\x18\v \x01(\rH\x06R\renvironmentId\x88\x01\x01B\x10\n" +
 	"\x0e_actor_user_idB\x11\n" +
 	"\x0f_target_user_idB\n" +
 	"\n" +
 	"\b_role_idB\r\n" +
 	"\v_project_idB\v\n" +
 	"\t_group_idB\x10\n" +
-	"\x0e_permission_id\"\xeb\x01\n" +
+	"\x0e_permission_idB\x11\n" +
+	"\x0f_environment_id\"\xeb\x01\n" +
 	"\x17GetRBACAuditLogsRequest\x12\x1b\n" +
 	"\x06action\x18\x01 \x01(\tH\x00R\x06action\x88\x01\x01\x12'\n" +
 	"\ractor_user_id\x18\x02 \x01(\rH\x01R\vactorUserId\x88\x01\x01\x12)\n" +


### PR DESCRIPTION
## Summary

Batched fix for 17 Wave-3 root-cause groups from the adversarial security review (`ROOT-CAUSE-GROUPS.md`), each committed standalone with its own regression test derived from the group's `detection_idea`. Groups: G14, G21, G42, G51, G54, G82, G52, G63, G58, G23, G30, G43, G56, G59, G61, G73, G76 (G06 from the same wave already merged separately in an earlier PR).

Highlights:
- **G14** — collapsed existence/collision-check-before-authz oracles across 8 sites (secret bulk rename/copy, gRPC scoped-secret authz, dynamic-secret configs, access-request withdrawal, SCIM email collision).
- **G21** — closed unsynchronized check-then-act races via storage transactions (audit retention purge, soft-delete purge, RBAC stale-expired-row reclaim).
- **G42** — replaced blind full-row `Save`s with narrow conditional updates across 4 subsystems, adding a new `TransitionProjectMembershipState` primitive (local + remote + proxy).
- **G51 / G52** — closed cross-project IDOR gaps in access-review grant verification and self-review/legal-hold bypasses in the retention proxy.
- **G54** — propagated 6 previously-discarded security-relevant errors (membership revoke, operator orphan-wipe, migration DDL, ACL-lookup degradation, stats counts).
- **G82** — added rate limiting to SSO/SAML begin endpoints, a cached readiness probe, and duplicate-access-request dedup.
- **G63** — fixed a genuine send-on-closed-channel panic and two data races (bcrypt cost globals, trust-key registry), each verified via `git stash` against the pre-fix code.
- **G58 / G73 / G76** — CLI credential hygiene: masked dry-run secret previews, warned on insecure `--vault-token`/`--code`/`--admin-password` flags, warned when a CWD `keyorix.yaml` drives a security-relevant network action, and removed the "admin" default password for remote bootstrap (now flag/env/prompt, resolved before the server is ever contacted).
- **G23 / G30** — audit-event attribution/redaction gaps (impersonation stamping on failed events, rotation-domain ProjectID, compliance-digest actor, RBAC EnvironmentID; PII embedded in free-text alert descriptions; webhook token in a startup log line).
- **G43** — wired 4 documented-but-never-invoked controls (per-secret retention override in the purge sweep, break-glass TTL-lapse persistence, principal-breadth in-app notification, rotation-state stamping).
- **G56** — SIEM forwarder flush-on-shutdown and a spool-scanner fix that no longer drops every event after one oversized line.
- **G59** — `fixfileperm` now honors `KEYORIX_CONFIG_PATH` and validates path containment (plus the identical gap in its `audit` sibling).
- **G61** — two process-killing paths (`log.Fatalf`, unrecovered panic) converted to proper error returns, matching every sibling implementation.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean (main module + `operator` module via `GOWORK=off`)
- [x] Full-repo `gosec -severity medium -exclude-generated ./...`: 0 issues (787 files)
- [x] Full-repo `golangci-lint run ./...`: 0 issues (main module + operator module)
- [x] Every touched package's full test suite green; each group has at least one new regression test derived from its `detection_idea`
- [x] Known pre-existing, unrelated local-only flakes confirmed via baseline comparison (leftover `~/.keyorix/cli.yaml` connect config; 17 `RealServer` HTTP integration tests) — not touched by this batch