### PR TITLE
fix(security): sanitize terminal-escape injection in CLI table renderers (G69)

### DIFF
--- a/internal/cli/accessreview/accessreview.go
+++ b/internal/cli/accessreview/accessreview.go
@@ -49,9 +49,13 @@ at the project scope.`,
 		fmt.Printf("Access review — project %d (%d grant(s)):\n\n", flagProject, len(out.Entries))
 		fmt.Printf("%-13s %-6s %-24s %-7s %-11s %s\n", "SOURCE", "TYPE", "PRINCIPAL", "ACCESS", "LAST-USED", "DETAIL")
 		for _, e := range out.Entries {
-			principal := e.PrincipalName
+			// #G69: principal name/email/role name/secret name are all
+			// attacker-controlled free text — a reviewed user must not be
+			// able to hide or spoof their own recertification row via a
+			// terminal escape sequence embedded in any of them.
+			principal := common.SanitizeForTerminal(e.PrincipalName)
 			if e.PrincipalType == "user" && e.Email != "" {
-				principal = fmt.Sprintf("%s <%s>", e.PrincipalName, e.Email)
+				principal = fmt.Sprintf("%s <%s>", principal, common.SanitizeForTerminal(e.Email))
 			}
 			detail := ""
 			switch e.Source {
@@ -60,9 +64,9 @@ at the project scope.`,
 				if e.EnvironmentID > 0 {
 					scope = fmt.Sprintf("env=%d", e.EnvironmentID)
 				}
-				detail = fmt.Sprintf("role=%s (%s)", e.RoleName, scope)
+				detail = fmt.Sprintf("role=%s (%s)", common.SanitizeForTerminal(e.RoleName), scope)
 			default: // owner / direct_share / group_share
-				detail = "secret=" + e.SecretName
+				detail = "secret=" + common.SanitizeForTerminal(e.SecretName)
 			}
 			fmt.Printf("%-13s %-6s %-24s %-7s %-11s %s\n", e.Source, e.PrincipalType, truncate(principal, 24), e.AccessLevel, lastUsedLabel(e.PrincipalType, e.LastUsedAt), detail)
 		}

--- a/internal/cli/accessreview/terminal_injection_test.go
+++ b/internal/cli/accessreview/terminal_injection_test.go
@@ -1,0 +1,61 @@
+// terminal_injection_test.go — #G69: the access-review table printed
+// attacker-controlled principal name/email/secret name/role name straight
+// through fmt.Printf with no sanitization, letting the reviewed principal
+// hide or spoof their own recertification row.
+package accessreview
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fnErr := fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out), fnErr
+}
+
+func TestAccessReview_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := struct {
+			Entries []entryView `json:"entries"`
+			Count   int         `json:"count"`
+		}{
+			Entries: []entryView{{
+				PrincipalType: "user", PrincipalName: malicious, Email: malicious,
+				Source: "owner", SecretName: malicious, AccessLevel: "read",
+			}},
+			Count: 1,
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": body})
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	origProject := flagProject
+	t.Cleanup(func() { flagProject = origProject })
+	flagProject = 1
+
+	out, err := captureStdout(t, func() error { return AccessReviewCmd.RunE(AccessReviewCmd, nil) })
+	require.NoError(t, err)
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/anomalies/anomalies.go
+++ b/internal/cli/anomalies/anomalies.go
@@ -82,8 +82,12 @@ func runListRemote(rc *common.RemoteClient) error {
 			ack = " [ACK]"
 		}
 		fmt.Printf("[%d] %s | %s | %s%s\n", a.ID, a.Severity, a.AlertType, a.DetectedAt[:min(16, len(a.DetectedAt))], ack)
-		fmt.Printf("    Secret: %s | User: %s | IP: %s\n", a.SecretName, a.AccessedBy, a.IPAddress)
-		fmt.Printf("    %s\n\n", a.Description)
+		// #G69: secret name/accessed-by/description are all attacker-controlled
+		// free text (the actor who triggered the alert influences all three) —
+		// they must not be able to hide or spoof their own alert row.
+		fmt.Printf("    Secret: %s | User: %s | IP: %s\n",
+			common.SanitizeForTerminal(a.SecretName), common.SanitizeForTerminal(a.AccessedBy), common.SanitizeForTerminal(a.IPAddress))
+		fmt.Printf("    %s\n\n", common.SanitizeForTerminal(a.Description))
 	}
 	return nil
 }

--- a/internal/cli/anomalies/terminal_injection_test.go
+++ b/internal/cli/anomalies/terminal_injection_test.go
@@ -1,0 +1,58 @@
+// terminal_injection_test.go — #G69: the anomalies list printed attacker-
+// controlled secret name/accessed-by/description straight through fmt.Printf
+// with no sanitization, letting the actor who triggered the alert hide or
+// spoof it.
+package anomalies
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fnErr := fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out), fnErr
+}
+
+func TestRunListRemote_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := anomalyListResponse{
+			Alerts: []anomalyAlert{{
+				ID: 1, SecretName: malicious, AlertType: "new_ip", Severity: "high",
+				Description: malicious, AccessedBy: malicious, IPAddress: malicious,
+				DetectedAt: "2026-08-13T00:00:00Z",
+			}},
+			Total: 1,
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": resp})
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	out, err := captureStdout(t, func() error { return runListRemote(rc) })
+	require.NoError(t, err)
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -438,8 +438,13 @@ func printAuditLogTable(logs []logEntry, total int64) {
 		if e.Impersonation && e.ImpersonatedBy != "" {
 			actor = e.ImpersonatedBy + "→" + e.Actor
 		}
+		// #G69: actor and description are attacker-controlled free text (a
+		// username, or a description built from user-supplied metadata) — a
+		// reviewing operator must not have their terminal spoofed/hidden by
+		// the very row they're trying to audit.
 		fmt.Printf("%-6d %-20s %-16s %-9s %-22s %s\n",
-			e.ID, shortTime(e.Timestamp), truncate(actor, 16), e.ActorType, truncate(e.EventType, 22), e.Description)
+			e.ID, shortTime(e.Timestamp), truncate(common.SanitizeForTerminal(actor), 16), e.ActorType,
+			truncate(e.EventType, 22), common.SanitizeForTerminal(e.Description))
 	}
 	fmt.Printf("\nShowing %d of %d total event(s).\n", len(logs), total)
 }
@@ -583,9 +588,11 @@ func buildAuditSearchQuery() (url.Values, error) {
 func printAuditSearchTable(events []searchEvent, total int64) {
 	fmt.Printf("%-6s %-20s %-9s %-22s %-15s %s\n", "ID", "TIME", "KIND", "EVENT", "IP", "DESCRIPTION")
 	for _, e := range events {
+		// #G69: description is attacker-controlled free text — see
+		// printAuditLogTable's identical guard above.
 		fmt.Printf("%-6d %-20s %-9s %-22s %-15s %s\n",
 			e.ID, shortTime(e.EventTime), truncate(e.ActorType, 9),
-			truncate(e.EventType, 22), truncate(e.IPAddress, 15), e.Description)
+			truncate(e.EventType, 22), truncate(e.IPAddress, 15), common.SanitizeForTerminal(e.Description))
 	}
 	fmt.Printf("\nShowing %d of %d total event(s).\n", len(events), total)
 }

--- a/internal/cli/audit/terminal_injection_test.go
+++ b/internal/cli/audit/terminal_injection_test.go
@@ -1,0 +1,51 @@
+// terminal_injection_test.go — #G69: printAuditLogTable/printAuditSearchTable
+// printed attacker-controlled actor/description text straight through
+// fmt.Printf with no sanitization, letting a crafted value embed terminal
+// escape sequences that overwrite, hide, or spoof rows in a reviewing
+// operator's terminal.
+package audit
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func TestPrintAuditLogTable_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row\n"
+	logs := []logEntry{{
+		ID: 1, EventType: "secret.read", Actor: malicious, ActorType: "user",
+		Description: malicious, Timestamp: "2026-08-13T00:00:00Z",
+	}}
+	out := captureStdout(t, func() { printAuditLogTable(logs, 1) })
+	assert.NotContains(t, out, "\x1b")
+}
+
+func TestPrintAuditSearchTable_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row\n"
+	events := []searchEvent{{
+		ID: 1, EventType: "secret.read", Description: malicious,
+		EventTime: "2026-08-13T00:00:00Z", ActorType: "user",
+	}}
+	out := captureStdout(t, func() { printAuditSearchTable(events, 1) })
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/billing/billing.go
+++ b/internal/cli/billing/billing.go
@@ -140,7 +140,8 @@ func printBillingReport(report *storage.BillingReport) error {
 		return err
 	}
 	for _, p := range report.Projects {
-		name := p.ProjectName
+		// #G69: ProjectName is attacker-controlled free text.
+		name := common.SanitizeForTerminal(p.ProjectName)
 		if name == "" {
 			name = fmt.Sprintf("(project %d)", p.ProjectID)
 		}

--- a/internal/cli/billing/terminal_injection_test.go
+++ b/internal/cli/billing/terminal_injection_test.go
@@ -1,0 +1,43 @@
+// terminal_injection_test.go — #G69: printBillingReport printed the attacker-
+// controlled ProjectName straight through fmt.Fprintf with no sanitization,
+// letting a crafted project name embed terminal escape sequences that
+// overwrite, hide, or spoof rows in a reviewing operator's terminal.
+package billing
+
+import (
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fnErr := fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out), fnErr
+}
+
+func TestPrintBillingReport_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row"
+	report := &storage.BillingReport{
+		From: time.Now(), To: time.Now(), GeneratedAt: time.Now(),
+		Projects: []storage.BillingProjectStat{{ProjectID: 1, ProjectName: malicious}},
+	}
+	out, err := captureStdout(t, func() error { return printBillingReport(report) })
+	require.NoError(t, err)
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -14,6 +15,30 @@ import (
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage"
 )
+
+// SanitizeForTerminal strips control characters (CR/LF, ANSI/C1 escapes, NUL,
+// etc.) from untrusted text before it's echoed to the operator's terminal in a
+// table/report row. #G69: a crafted username/secret name/description/etc.
+// could otherwise embed terminal escape sequences that overwrite, hide, or
+// spoof rows in a reviewing operator's terminal — undermining the "read this
+// table and trust what it says" use case these commands exist for (audit
+// review, access-review recertification, anomaly triage, compliance
+// evidence, billing/hygiene reports, machine-identity review). Originally
+// local to internal/cli/secret/import.go (the first caller to need it);
+// promoted here so every CLI table/report renderer can share one
+// implementation instead of re-deriving it ad hoc or omitting it entirely. A
+// tab is normalized to a space; other controls are dropped.
+func SanitizeForTerminal(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1 // drop
+		}
+		return r
+	}, s)
+}
 
 // cliActorEnvVar lets an operator self-assert their own Keyorix user ID for local
 // CLI mutations (#150). Local mode has no authenticated session — every core

--- a/internal/cli/common/sanitize_terminal_test.go
+++ b/internal/cli/common/sanitize_terminal_test.go
@@ -1,0 +1,42 @@
+// sanitize_terminal_test.go — #G69: SanitizeForTerminal was promoted here from
+// internal/cli/secret/import.go's package-local sanitizeForTerminal (kept there
+// as a thin alias, still covered by that package's own extensive test suite) so
+// every CLI table/report renderer across the codebase can share one
+// implementation instead of re-deriving it ad hoc or omitting it entirely.
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeForTerminal_StripsControlAndANSI(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "hello", "hello"},
+		{"ansi_escape", "\x1b[2Khidden\x1b[0m", "[2Khidden[0m"},
+		{"cr_lf", "line1\r\nline2", "line1line2"},
+		{"nul", "a\x00b", "ab"},
+		{"tab_normalized", "a\tb", "a b"},
+		{"bell", "a\x07b", "ab"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, SanitizeForTerminal(tc.in))
+		})
+	}
+}
+
+// TestSanitizeForTerminal_NeutralizesCursorHidingSequence pins the exact attack
+// this exists to close: a table/report row containing an attacker-controlled
+// free-text field (username, project name, description, ...) that tries to move
+// the cursor up and overwrite a prior row a reviewing operator is looking at.
+func TestSanitizeForTerminal_NeutralizesCursorHidingSequence(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  spoofed row pretending to be legitimate\n"
+	out := SanitizeForTerminal(malicious)
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/compliance/permission_changes.go
+++ b/internal/cli/compliance/permission_changes.go
@@ -96,13 +96,15 @@ Requires audit.read.`,
 			"----------------------", "----------------", "----------------",
 			"----------------", "--------------------", "------")
 		for _, e := range report.Changes {
+			// #G69: actor/target/role names are attacker-controlled free text
+			// in this auditor-facing evidence output.
 			fmt.Printf("%-22s  %-16s  %-16s  %-16s  %-20s  %s\n",
 				e.ChangedAt.UTC().Format(permChangeTimeFormat),
-				truncate(e.ActorName, 16),
+				truncate(common.SanitizeForTerminal(e.ActorName), 16),
 				truncate(e.Action, 16),
-				truncate(e.TargetUser, 16),
-				truncate(e.RoleName, 20),
-				e.Scope,
+				truncate(common.SanitizeForTerminal(e.TargetUser), 16),
+				truncate(common.SanitizeForTerminal(e.RoleName), 20),
+				common.SanitizeForTerminal(e.Scope),
 			)
 		}
 		return nil

--- a/internal/cli/compliance/terminal_injection_test.go
+++ b/internal/cli/compliance/terminal_injection_test.go
@@ -1,0 +1,35 @@
+// terminal_injection_test.go — #G69: the permission-change audit table printed
+// attacker-controlled actor/target/role text straight through fmt.Printf with
+// no sanitization in this auditor-facing evidence output.
+package compliance
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermissionChanges_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		report := permChangeReport{
+			Since: time.Now(), Until: time.Now(), Total: 1,
+			Changes: []permChangeEvent{{
+				EventID: 1, Action: "role.assigned", ActorName: malicious, TargetUser: malicious,
+				RoleName: malicious, Scope: malicious, ChangedAt: time.Now(),
+			}},
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": report})
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	out := captureStdout(t, func() { require.NoError(t, permissionChangesCmd.RunE(permissionChangesCmd, nil)) })
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/machine/describe.go
+++ b/internal/cli/machine/describe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
 )
 
@@ -30,13 +31,14 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	// #G69: Name/Description are attacker-controlled free text.
 	fmt.Printf("ID:          %d\n", m.ID)
-	fmt.Printf("Name:        %s\n", m.Name)
+	fmt.Printf("Name:        %s\n", common.SanitizeForTerminal(m.Name))
 	fmt.Printf("Type:        %s\n", m.IdentityType)
 	fmt.Printf("State:       %s\n", m.State)
 	fmt.Printf("Project ID:  %d\n", m.ProjectID)
 	if m.Description != "" {
-		fmt.Printf("Description: %s\n", m.Description)
+		fmt.Printf("Description: %s\n", common.SanitizeForTerminal(m.Description))
 	}
 	if m.LastSeenAt != nil {
 		fmt.Printf("Last seen:   %s\n", m.LastSeenAt.Format("2006-01-02 15:04:05 MST"))

--- a/internal/cli/machine/describe_terminal_injection_test.go
+++ b/internal/cli/machine/describe_terminal_injection_test.go
@@ -1,0 +1,42 @@
+// describe_terminal_injection_test.go — #G69: runDescribe printed attacker-
+// controlled Name/Description straight through fmt.Printf with no
+// sanitization.
+package machine
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunDescribe_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{
+				"projects": []map[string]any{{"id": 1, "name": "proj"}},
+			}})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{
+				"machine_identities": []map[string]any{{
+					"id": 1, "name": malicious, "identity_type": "ci", "state": "active", "description": malicious,
+				}},
+			}})
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	origProject := describeProjectName
+	t.Cleanup(func() { describeProjectName = origProject })
+	describeProjectName = "proj"
+
+	out := captureStdout(t, func() { require.NoError(t, runDescribe(describeCmd, []string{"1"})) })
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/machine/list.go
+++ b/internal/cli/machine/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/spf13/cobra"
 )
@@ -46,6 +47,7 @@ func printMachineTable(identities []*models.MachineIdentity, projectName string)
 		if len(desc) > 40 {
 			desc = desc[:37] + "..."
 		}
-		fmt.Printf("%-5d %-24s %-12s %-10s %s\n", m.ID, m.Name, m.IdentityType, m.State, desc)
+		// #G69: Name/Description are attacker-controlled free text.
+		fmt.Printf("%-5d %-24s %-12s %-10s %s\n", m.ID, common.SanitizeForTerminal(m.Name), m.IdentityType, m.State, common.SanitizeForTerminal(desc))
 	}
 }

--- a/internal/cli/machine/terminal_injection_test.go
+++ b/internal/cli/machine/terminal_injection_test.go
@@ -1,0 +1,22 @@
+// terminal_injection_test.go — #G69: printMachineTable/runDescribe/token-hygiene
+// table printed attacker-controlled Name/Description text straight through
+// fmt.Printf with no sanitization, letting a crafted value embed terminal
+// escape sequences that overwrite, hide, or spoof rows in a reviewing
+// operator's terminal.
+package machine
+
+import (
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintMachineTable_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row\n"
+	identities := []*models.MachineIdentity{{
+		ID: 1, Name: malicious, IdentityType: "ci", State: "active", Description: malicious,
+	}}
+	out := captureStdout(t, func() { printMachineTable(identities, "proj") })
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/machine/token_hygiene.go
+++ b/internal/cli/machine/token_hygiene.go
@@ -48,7 +48,9 @@ window (non-human token sprawl). Requires global system.read. Never prints a sec
 			if last == "" {
 				last = "never"
 			}
-			fmt.Printf("%-5d %-22s %-16s %-8d %-8s %s\n", r.ID, r.Name, r.TokenPrefix+"…", r.MachineIdentityID, machineFlagLabel(r), last)
+			// #G69: Name is attacker-controlled free text (this report is
+			// admin-only and cross-tenant, so the risk spans every tenant).
+			fmt.Printf("%-5d %-22s %-16s %-8d %-8s %s\n", r.ID, common.SanitizeForTerminal(r.Name), r.TokenPrefix+"…", r.MachineIdentityID, machineFlagLabel(r), last)
 		}
 		return nil
 	},

--- a/internal/cli/machine/token_hygiene_terminal_injection_test.go
+++ b/internal/cli/machine/token_hygiene_terminal_injection_test.go
@@ -1,0 +1,33 @@
+// token_hygiene_terminal_injection_test.go — #G69: the token-hygiene report
+// printed attacker-controlled Name text straight through fmt.Printf with no
+// sanitization — admin-only and cross-tenant, so the blast radius spans every
+// tenant.
+package machine
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenHygiene_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{
+			"tokens": []map[string]any{{
+				"id": 1, "machine_identity_id": 1, "name": malicious,
+				"token_prefix": "kx_mach_ab", "last_used_at": "", "expired": true, "stale": false,
+			}},
+		}})
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	out := captureStdout(t, func() { require.NoError(t, tokenHygieneCmd.RunE(tokenHygieneCmd, nil)) })
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/risk/risk.go
+++ b/internal/cli/risk/risk.go
@@ -66,8 +66,13 @@ var listCmd = &cobra.Command{
 			if e.Approved {
 				approval = "approved"
 			}
-			fmt.Printf("[%s, %s] #%d %s (category=%s, ref=%q)\n", e.Status, approval, e.ID, e.Title, e.Category, e.Reference)
-			fmt.Printf("        expires %s — %s\n", e.ExpiresAt, e.Justification)
+			// #G69: Title/Category/Justification are attacker-controlled free
+			// text — Reference alone being %q-quoted (which does escape
+			// control characters) left the other three as an inconsistent,
+			// unsanitized terminal-escape-injection path.
+			fmt.Printf("[%s, %s] #%d %s (category=%s, ref=%q)\n", e.Status, approval, e.ID,
+				common.SanitizeForTerminal(e.Title), common.SanitizeForTerminal(e.Category), e.Reference)
+			fmt.Printf("        expires %s — %s\n", e.ExpiresAt, common.SanitizeForTerminal(e.Justification))
 		}
 		return nil
 	},

--- a/internal/cli/risk/terminal_injection_test.go
+++ b/internal/cli/risk/terminal_injection_test.go
@@ -1,0 +1,35 @@
+// terminal_injection_test.go — #G69: risk list rendered exception Title/
+// Category/Justification unescaped while only Reference was quoted (%q) —
+// an inconsistent terminal-escape neutralization.
+package risk
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRiskList_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := struct {
+			Exceptions []exceptionView `json:"exceptions"`
+		}{
+			Exceptions: []exceptionView{{
+				ID: 1, Title: malicious, Category: malicious, Reference: "REF-1",
+				Justification: malicious, Status: "pending", ExpiresAt: "2026-12-01",
+			}},
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": body})
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	out := captureStdout(t, func() { require.NoError(t, listCmd.RunE(listCmd, nil)) })
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/secret/import.go
+++ b/internal/cli/secret/import.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"unicode"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -109,16 +108,12 @@ type secretEntry struct {
 // embed terminal escape sequences that overwrite or hide the CLI's own status
 // lines during the same run. This only affects what's printed — the value
 // actually stored in the vault is left untouched.
+//
+// #G69: promoted to common.SanitizeForTerminal so every CLI table/report
+// renderer shares one implementation; kept as a local alias here rather than
+// rewriting every call site in this file/package's own extensive test suite.
 func sanitizeForTerminal(s string) string {
-	return strings.Map(func(r rune) rune {
-		if r == '\t' {
-			return ' '
-		}
-		if unicode.IsControl(r) {
-			return -1 // drop
-		}
-		return r
-	}, s)
+	return common.SanitizeForTerminal(s)
 }
 
 func runImport(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

- `internal/cli/secret/import.go` already defines a `sanitizeForTerminal` helper (strips CR/LF/ANSI/C1/NUL control characters) specifically because a crafted import file could embed terminal escape sequences that overwrite or hide the CLI's own status lines — but at least seven other table/report renderers across six CLI subpackages printed attacker-controlled free text (usernames, secret/project/role names, descriptions, IP-derived/audit fields) straight through `fmt.Printf`/`Fprintf` with no equivalent sanitization.
- This let the actor who set that text — who may be lower-privileged than, or even be the SUBJECT of, the report — inject ANSI/C1 escape sequences that overwrite, hide, or spoof rows in a reviewing operator's terminal, undermining the "read this table and trust what it says" use case these commands exist for (audit review, access-review recertification, anomaly triage, compliance evidence, billing/hygiene reports, machine-identity review).
- Promoted `sanitizeForTerminal` to `common.SanitizeForTerminal` (kept as a local alias in `import.go`, still covered by that package's own extensive test suite) and applied it at all 7 member sites:
  - `internal/cli/audit/audit.go` — logs/search tables (actor, description)
  - `internal/cli/accessreview/accessreview.go` — recertification rows (principal name/email, secret name, role name)
  - `internal/cli/anomalies/anomalies.go` — alert listings (secret name, accessed-by, IP, description)
  - `internal/cli/risk/risk.go` — exception listings (title, category, justification — Reference alone was already `%q`-quoted, an inconsistent partial mitigation)
  - `internal/cli/machine/{list,describe,token_hygiene}.go` — machine-identity name/description (token-hygiene is admin-only and cross-tenant)
  - `internal/cli/billing/billing.go` — project names in billing/usage reports
  - `internal/cli/compliance/permission_changes.go` — permission-change audit trail (actor, target, role, scope)

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] Full-repo `gosec -severity medium -exclude-generated ./...`: 0 issues (787 files)
- [x] Full-repo `golangci-lint run ./...`: 0 issues
- [x] New regression test at every one of the 7 member sites, plus a dedicated test for the promoted `common.SanitizeForTerminal` helper, asserting the injected ANSI escape byte never survives into the printed output
- [x] Known pre-existing, unrelated local-only flakes confirmed (leftover `~/.keyorix/cli.yaml` connect config causing `_NotConnected`/`_Local`/`_NoClient`-named test timeouts) — not touched by this change