### PR TITLE
fix: close 4 remaining Wave 3 findings (G29, G32, G26, G46)

### DIFF
--- a/internal/cli/connect/connect.go
+++ b/internal/cli/connect/connect.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"syscall"
 	"time"
 
@@ -160,9 +159,11 @@ func isLoopbackHost(host string) bool {
 	if host == "localhost" {
 		return true
 	}
-	if strings.HasPrefix(host, "127.") || host == "::1" {
-		return true
-	}
+	// #G46: a raw strings.HasPrefix(host, "127.") also matched an attacker-controlled DNS
+	// name like "127.evil.com" — silently classifying a remote host as loopback and
+	// skipping the cleartext-credential warning entirely. net.ParseIP only succeeds on an
+	// actual IP literal, never a hostname, so it and IsLoopback() below are sufficient on
+	// their own for every real loopback address (127.0.0.0/8, ::1) without that gap.
 	if ip := net.ParseIP(host); ip != nil {
 		return ip.IsLoopback()
 	}

--- a/internal/cli/connect/connect_extra_test.go
+++ b/internal/cli/connect/connect_extra_test.go
@@ -22,6 +22,17 @@ func TestIsLoopbackHost(t *testing.T) {
 	}
 }
 
+// TestIsLoopbackHost_RejectsDNSNamePrefixedWith127 is #G46: an attacker-controlled DNS
+// name like "127.evil.com" must never be classified as loopback — a raw
+// strings.HasPrefix(host, "127.") used to match it, silently skipping the
+// cleartext-credential warning `keyorix connect` prints for every non-loopback host.
+func TestIsLoopbackHost_RejectsDNSNamePrefixedWith127(t *testing.T) {
+	adversarial := []string{"127.evil.com", "127.0.0.1.attacker.com", "127.attacker.net"}
+	for _, h := range adversarial {
+		assert.False(t, isLoopbackHost(h), "%s must NOT be classified as loopback", h)
+	}
+}
+
 func cmdWithFlags() *cobra.Command {
 	c := &cobra.Command{}
 	c.Flags().String("api-key", "", "")

--- a/internal/cli/secret/export.go
+++ b/internal/cli/secret/export.go
@@ -25,15 +25,17 @@ var (
 	exportEncryptFor string
 )
 
-// createExportFile opens path for a fresh plaintext-secrets export. O_EXCL
-// refuses to write through a pre-existing path — including a symlink an
-// attacker (with write access to a shared directory, e.g. /tmp) planted at the
-// target ahead of time, which os.Create's default O_TRUNC would silently
-// follow, writing plaintext secrets to wherever the symlink points. O_NOFOLLOW
-// is a second layer against a dangling symlink placed in the instant between
-// the check and the open. 0600 keeps the export from being world/group-
-// readable on disk (#114).
-func createExportFile(path string) (*os.File, error) {
+// createSecureOutputFile opens path for a fresh output file (export, render
+// --output, scan --report). O_EXCL refuses to write through a pre-existing
+// path — including a symlink an attacker (with write access to a shared
+// directory, e.g. /tmp) planted at the target ahead of time, which
+// os.Create's/os.WriteFile's default O_TRUNC would silently follow, writing
+// plaintext secrets to wherever the symlink points. O_NOFOLLOW is a second
+// layer against a dangling symlink placed in the instant between the check
+// and the open. 0600 keeps the output from being world/group-readable on
+// disk (#114). #G26: this pattern was originally export-only; every
+// --output/--report-style file write in this package now goes through it.
+func createSecureOutputFile(path string) (*os.File, error) {
 	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL|syscall.O_NOFOLLOW, 0o600) // #nosec G304 -- operator-supplied CLI output path, not attacker input
 }
 
@@ -118,7 +120,7 @@ func runExport(cmd *cobra.Command, args []string) (retErr error) {
 
 	var out io.Writer = os.Stdout
 	if exportOutput != "" {
-		f, err := createExportFile(exportOutput)
+		f, err := createSecureOutputFile(exportOutput)
 		if err != nil {
 			return fmt.Errorf("cannot create output file %q (it may already exist — remove it or choose a different path): %w", exportOutput, err)
 		}

--- a/internal/cli/secret/export_file_test.go
+++ b/internal/cli/secret/export_file_test.go
@@ -12,14 +12,14 @@ import (
 
 // TestCreateExportFile_ModeAndSymlinkSafety pins #114: an exported-secrets file
 // was created with os.Create (0644, world-readable) and would silently write
-// through a pre-planted symlink. createExportFile must produce a 0600 file and
+// through a pre-planted symlink. createSecureOutputFile must produce a 0600 file and
 // refuse a symlinked or already-existing target.
 func TestCreateExportFile_ModeAndSymlinkSafety(t *testing.T) {
 	dir := t.TempDir()
 
 	t.Run("creates a 0600 file", func(t *testing.T) {
 		target := filepath.Join(dir, "out.env")
-		f, err := createExportFile(target)
+		f, err := createSecureOutputFile(target)
 		require.NoError(t, err)
 		defer f.Close() //nolint:errcheck
 
@@ -33,7 +33,7 @@ func TestCreateExportFile_ModeAndSymlinkSafety(t *testing.T) {
 	t.Run("refuses an already-existing path", func(t *testing.T) {
 		target := filepath.Join(dir, "exists.env")
 		require.NoError(t, os.WriteFile(target, []byte("old"), 0o600))
-		_, err := createExportFile(target)
+		_, err := createSecureOutputFile(target)
 		require.Error(t, err, "O_EXCL must refuse to overwrite/write-through a pre-existing path")
 	})
 
@@ -44,7 +44,7 @@ func TestCreateExportFile_ModeAndSymlinkSafety(t *testing.T) {
 		evilTarget := filepath.Join(dir, "attacker-owned.txt")
 		link := filepath.Join(dir, "planted-link.env")
 		require.NoError(t, os.Symlink(evilTarget, link))
-		_, err := createExportFile(link)
+		_, err := createSecureOutputFile(link)
 		require.Error(t, err, "a symlinked target must be refused, not followed")
 		_, statErr := os.Stat(evilTarget)
 		assert.True(t, os.IsNotExist(statErr), "the symlink target must never have been created/written")

--- a/internal/cli/secret/fix.go
+++ b/internal/cli/secret/fix.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 
 	"github.com/spf13/cobra"
 )
@@ -195,5 +196,20 @@ func applyFix(basePath string, plan fixPlan) error {
 		return fmt.Errorf("line %d out of range", plan.Line)
 	}
 	lines[plan.Line-1] = plan.NewLine
-	return os.WriteFile(fullPath, []byte(strings.Join(lines, "\n")), 0600) // #nosec G703 -- fullPath is basePath (operator-supplied --path) joined with a relative path from filepath.Walk rooted at that same basePath; path traversal not a realistic threat for this local CLI tool
+	// #G26: os.WriteFile follows a symlink at fullPath and writes through it — a scanned
+	// directory can contain attacker-planted content, so a symlink swapped in at a
+	// discovered path (between the scan and this apply) would let `secret fix` overwrite
+	// an arbitrary file the process can write to. O_NOFOLLOW refuses that; no O_CREATE/
+	// O_EXCL since the fix always targets a file findAndPlanFix already read via this
+	// same fullPath, so it must already exist.
+	f, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_TRUNC|syscall.O_NOFOLLOW, 0600) // #nosec G304 -- fullPath is basePath (operator-supplied --path) joined with a relative path from filepath.Walk rooted at that same basePath
+	if err != nil {
+		return err
+	}
+	_, werr := f.Write([]byte(strings.Join(lines, "\n")))
+	cerr := f.Close()
+	if werr != nil {
+		return werr
+	}
+	return cerr
 }

--- a/internal/cli/secret/fix_symlink_test.go
+++ b/internal/cli/secret/fix_symlink_test.go
@@ -1,0 +1,60 @@
+package secret
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyFix_RefusesSymlinkTarget is #G26: applyFix used os.WriteFile, which follows
+// a symlink at the resolved path and writes through it. A scanned directory can contain
+// attacker-planted content, so a symlink swapped in at a discovered finding's path
+// (between the scan and the apply) would let `secret fix` overwrite an arbitrary file
+// the process can write to. O_NOFOLLOW must refuse it instead.
+func TestApplyFix_RefusesSymlinkTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	basePath := t.TempDir()
+	evilTarget := filepath.Join(basePath, "attacker-owned.txt")
+	require.NoError(t, os.WriteFile(evilTarget, []byte("do-not-touch"), 0o600))
+	link := filepath.Join(basePath, "config.py")
+	require.NoError(t, os.Symlink(evilTarget, link))
+
+	plan := fixPlan{
+		File:         "config.py",
+		Line:         1,
+		OriginalLine: `API_KEY = "sk-realvalue"`,
+		NewLine:      `API_KEY = os.getenv("API_KEY")`,
+	}
+	err := applyFix(basePath, plan)
+	require.Error(t, err, "a symlinked finding path must be refused, not followed")
+
+	content, rerr := os.ReadFile(evilTarget)
+	require.NoError(t, rerr)
+	assert.Equal(t, "do-not-touch", string(content), "the symlink target must never be overwritten")
+}
+
+// TestApplyFix_WritesRegularFile confirms the O_NOFOLLOW fix didn't break the ordinary
+// (non-symlink) apply path.
+func TestApplyFix_WritesRegularFile(t *testing.T) {
+	basePath := t.TempDir()
+	target := filepath.Join(basePath, "config.py")
+	require.NoError(t, os.WriteFile(target, []byte(`API_KEY = "sk-realvalue"`), 0o600))
+
+	plan := fixPlan{
+		File:         "config.py",
+		Line:         1,
+		OriginalLine: `API_KEY = "sk-realvalue"`,
+		NewLine:      `API_KEY = os.getenv("API_KEY")`,
+	}
+	require.NoError(t, applyFix(basePath, plan))
+
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, `API_KEY = os.getenv("API_KEY")`, string(content))
+}

--- a/internal/cli/secret/render.go
+++ b/internal/cli/secret/render.go
@@ -64,9 +64,19 @@ func runRender(_ *cobra.Command, args []string) error {
 	}
 
 	if renderOutput != "" {
-		// #nosec G703 -- renderOutput is the operator's own --output flag (trusted CLI input).
-		if err := os.WriteFile(renderOutput, []byte(out), 0o600); err != nil {
+		// #G26: os.WriteFile follows a symlink at renderOutput and truncates whatever it
+		// points to — createSecureOutputFile (export.go) refuses that (O_EXCL+O_NOFOLLOW).
+		f, err := createSecureOutputFile(renderOutput)
+		if err != nil {
 			return fmt.Errorf("write output: %w", err)
+		}
+		_, werr := f.Write([]byte(out))
+		cerr := f.Close()
+		if werr != nil {
+			return fmt.Errorf("write output: %w", werr)
+		}
+		if cerr != nil {
+			return fmt.Errorf("write output: %w", cerr)
 		}
 		fmt.Printf("✓ Rendered to %s\n", renderOutput)
 		return nil

--- a/internal/cli/secret/scan.go
+++ b/internal/cli/secret/scan.go
@@ -254,8 +254,19 @@ func runScan(cmd *cobra.Command, args []string) error { // NOSONAR -- cognitive 
 		if err != nil {
 			return fmt.Errorf("failed to marshal report: %w", err)
 		}
-		if err := os.WriteFile(scanReport, data, 0600); err != nil {
+		// #G26: os.WriteFile follows a symlink at scanReport and truncates whatever it
+		// points to — createSecureOutputFile (export.go) refuses that (O_EXCL+O_NOFOLLOW).
+		rf, err := createSecureOutputFile(scanReport)
+		if err != nil {
 			return fmt.Errorf("failed to save report: %w", err)
+		}
+		_, werr := rf.Write(data)
+		cerr := rf.Close()
+		if werr != nil {
+			return fmt.Errorf("failed to save report: %w", werr)
+		}
+		if cerr != nil {
+			return fmt.Errorf("failed to save report: %w", cerr)
 		}
 		fmt.Printf("\n📄 Report saved to %s\n", scanReport)
 	}

--- a/internal/core/blast_radius.go
+++ b/internal/core/blast_radius.go
@@ -108,7 +108,13 @@ func blastBFS(rootID uint, adj map[uint][]uint) (ordered []blastBFSNode, truncat
 // GetBlastRadius returns the full dependency tree downstream of secretID,
 // up to a maximum depth of 10 to prevent cycles causing infinite loops.
 // Each node carries OwnerID, ProjectID, and a RiskLevel assessment.
-func (k *KeyorixCore) GetBlastRadius(ctx context.Context, secretID uint) (*BlastRadiusReport, error) {
+//
+// #G32: the BFS traverses the full graph (a hop through a peer the caller isn't
+// independently authorized on still surfaces further, independently-authorized
+// dependents), but a node the caller has no grant of their own on is never disclosed
+// in the returned report — same-environment membership alone is not sufficient, since
+// a per-secret ACL grant on secretID does not extend to a peer.
+func (k *KeyorixCore) GetBlastRadius(ctx context.Context, actorKind string, actorID, secretID uint) (*BlastRadiusReport, error) {
 	source, err := k.requireSecret(ctx, secretID)
 	if err != nil {
 		return nil, err
@@ -130,6 +136,9 @@ func (k *KeyorixCore) GetBlastRadius(ctx context.Context, secretID uint) (*Blast
 	maxDepthSeen := 0
 	nodes := make([]BlastRadiusNode, 0, len(ordered))
 	for _, o := range ordered {
+		if !k.canReadSecret(ctx, actorKind, actorID, o.id) {
+			continue // #G32: don't disclose a peer the caller isn't independently authorized to see
+		}
 		dep, depErr := k.storage.GetSecret(ctx, o.id)
 		if depErr != nil {
 			// Dependent no longer exists (soft-deleted); skip it gracefully.

--- a/internal/core/blast_radius_test.go
+++ b/internal/core/blast_radius_test.go
@@ -60,6 +60,16 @@ func TestBlastRiskLevel_AllBranches(t *testing.T) {
 
 // ── GetBlastRadius integration tests using real SQLite ────────────────────────
 
+// blastRadiusTestActor is the caller identity used by every real-SQLite test in this
+// file (see newBlastRadiusCore's grantGlobalAdmin call). #G32: GetBlastRadius now
+// independently authorizes each peer secret it discloses, so a caller with no RBAC
+// grant at all would see every Dependents entry filtered out — these tests are about
+// the BFS/risk-level shape, not authorization, so the fixture actor is granted global
+// admin to keep that orthogonal (peer-authorization-gap regression tests live in
+// TestGetBlastRadius_DoesNotDiscloseUnauthorizedPeer below, with a deliberately
+// unprivileged actor).
+const blastRadiusTestActor = uint(999)
+
 // newBlastRadiusCore creates an isolated in-memory core for blast-radius tests.
 func newBlastRadiusCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
@@ -68,13 +78,22 @@ func newBlastRadiusCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{},
 		&models.SecretDependency{},
+		&models.SecretACL{},
 		&models.AuditEvent{},
 		&models.Project{},
 		&models.Environment{},
 		&models.ShareRecord{},
+		&models.User{}, &models.Role{}, &models.UserRole{},
+		&models.Permission{}, &models.RolePermission{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.MachineIdentityRole{},
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env1"}).Error)
+	// Global admin bypass for blastRadiusTestActor (see its doc comment above).
+	role := &models.Role{Name: "admin"}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: blastRadiusTestActor, RoleID: role.ID, ProjectID: 0, EnvironmentID: 0}).Error)
 	now := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
 	return c, db
@@ -117,7 +136,7 @@ func mkBlastDep(t *testing.T, db *gorm.DB, dependent, dependsOn uint) {
 
 func TestGetBlastRadius_SourceNotFound(t *testing.T) {
 	c, _ := newBlastRadiusCore(t)
-	_, err := c.GetBlastRadius(context.Background(), 99999)
+	_, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, 99999)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -125,7 +144,7 @@ func TestGetBlastRadius_SourceNotFound(t *testing.T) {
 func TestGetBlastRadius_NoDependents(t *testing.T) {
 	c, db := newBlastRadiusCore(t)
 	srcID := mkBlastSecret(t, db, "standalone")
-	report, err := c.GetBlastRadius(context.Background(), srcID)
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, srcID)
 	require.NoError(t, err)
 	assert.Equal(t, srcID, report.SourceSecretID)
 	assert.Equal(t, "standalone", report.SourceSecretName)
@@ -140,7 +159,7 @@ func TestGetBlastRadius_OneDirectDependent(t *testing.T) {
 	depID := mkBlastSecret(t, db, "app-token", withOwner(20))
 	mkBlastDep(t, db, depID, srcID) // app-token depends on db-password
 
-	report, err := c.GetBlastRadius(context.Background(), srcID)
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, srcID)
 	require.NoError(t, err)
 	assert.Equal(t, 1, report.TotalImpact)
 	assert.Equal(t, 1, report.MaxDepth)
@@ -162,7 +181,7 @@ func TestGetBlastRadius_TransitiveDependents(t *testing.T) {
 	mkBlastDep(t, db, b, a)  // B depends on A
 	mkBlastDep(t, db, cc, b) // C depends on B
 
-	report, err := c.GetBlastRadius(context.Background(), a)
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, a)
 	require.NoError(t, err)
 	assert.Equal(t, 2, report.TotalImpact)
 	assert.Equal(t, 2, report.MaxDepth)
@@ -192,7 +211,7 @@ func TestGetBlastRadius_CycleDetection(t *testing.T) {
 
 	// Starting from A: B is a direct dependent (depth=1).
 	// From B, A is a dependent, but A is already visited → stop.
-	report, err := c.GetBlastRadius(context.Background(), a)
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, a)
 	require.NoError(t, err)
 	assert.Equal(t, 1, report.TotalImpact) // only B, not A again
 	assert.Equal(t, b, report.Dependents[0].SecretID)
@@ -208,7 +227,7 @@ func TestGetBlastRadius_MaxDepthRespected(t *testing.T) {
 		prev = next
 	}
 
-	report, err := c.GetBlastRadius(context.Background(), 1)
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, 1)
 	require.NoError(t, err)
 	assert.LessOrEqual(t, report.MaxDepth, 10,
 		"BFS must not exceed maxDepth=10, got %d", report.MaxDepth)
@@ -228,7 +247,7 @@ func TestGetBlastRadius_NotTruncatedWhenWithinDepth(t *testing.T) {
 		prev = next
 	}
 
-	report, err := c.GetBlastRadius(context.Background(), 1)
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, 1)
 	require.NoError(t, err)
 	assert.False(t, report.Truncated)
 }
@@ -240,7 +259,7 @@ func TestGetBlastRadius_RiskLevelCritical(t *testing.T) {
 	depID := mkBlastSecret(t, db, "dep-secret")
 	mkBlastDep(t, db, depID, srcID)
 
-	report, err := c.GetBlastRadius(context.Background(), srcID)
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, srcID)
 	require.NoError(t, err)
 	require.Len(t, report.Dependents, 1)
 	assert.Equal(t, "critical", report.Dependents[0].RiskLevel)
@@ -253,7 +272,7 @@ func TestGetBlastRadius_RiskLevelDepClassification(t *testing.T) {
 	depID := mkBlastSecret(t, db, "restricted-dep", withClassification("restricted"))
 	mkBlastDep(t, db, depID, srcID)
 
-	report, err := c.GetBlastRadius(context.Background(), srcID)
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, srcID)
 	require.NoError(t, err)
 	require.Len(t, report.Dependents, 1)
 	assert.Equal(t, "critical", report.Dependents[0].RiskLevel)
@@ -269,7 +288,7 @@ func TestGetBlastRadius_RiskLevelHighFromDeepConfidential(t *testing.T) {
 	mkBlastDep(t, db, midID, srcID)  // depth=1
 	mkBlastDep(t, db, leafID, midID) // depth=2
 
-	report, err := c.GetBlastRadius(context.Background(), srcID)
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, srcID)
 	require.NoError(t, err)
 	require.Len(t, report.Dependents, 2)
 	// depth=1 node → high (from depth=1 rule, not critical since src is confidential not restricted)
@@ -289,7 +308,7 @@ func TestGetBlastRadius_RiskLevelLow(t *testing.T) {
 	mkBlastDep(t, db, cc, b)
 	mkBlastDep(t, db, d, cc)
 
-	report, err := c.GetBlastRadius(context.Background(), a)
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, a)
 	require.NoError(t, err)
 	require.Len(t, report.Dependents, 3)
 	assert.Equal(t, "low", report.Dependents[2].RiskLevel) // depth=3
@@ -306,7 +325,7 @@ func TestGetBlastRadius_SameDeptSortedByID(t *testing.T) {
 	mkBlastDep(t, db, bID, aID) // B depends on A (depth=1)
 	mkBlastDep(t, db, cID, aID) // C depends on A (depth=1)
 
-	report, err := c.GetBlastRadius(context.Background(), aID)
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, aID)
 	require.NoError(t, err)
 	assert.Equal(t, 2, report.TotalImpact)
 	assert.Equal(t, 1, report.MaxDepth)
@@ -331,7 +350,7 @@ func TestGetBlastRadius_StorageErrorOnListDependencies(t *testing.T) {
 	ms.On("ListSecretDependenciesForProject", mock.Anything, uint(1)).
 		Return(nil, errors.New("db error"))
 
-	_, err := c.GetBlastRadius(context.Background(), 1)
+	_, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, 1)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "db error")
 }
@@ -341,7 +360,7 @@ func TestGetBlastRadius_SourceIsFolder_Rejected(t *testing.T) {
 	folder := &models.SecretNode{ID: 5, ProjectID: 1, EnvironmentID: 1, Name: "folder", IsSecret: false}
 	ms.On("GetSecret", mock.Anything, uint(5)).Return(folder, nil)
 
-	_, err := c.GetBlastRadius(context.Background(), 5)
+	_, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, 5)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a secret")
 }
@@ -365,7 +384,7 @@ func TestGetBlastRadius_SkipsSoftDeletedDependent(t *testing.T) {
 	// Then during the BFS result phase, GetSecret is called again and returns not-found
 	ms.On("GetSecret", mock.Anything, uint(2)).Return(nil, errors.New("not found"))
 
-	report, err := c.GetBlastRadius(context.Background(), 1)
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, blastRadiusTestActor, 1)
 	require.NoError(t, err)
 	assert.Empty(t, report.Dependents)
 	assert.Equal(t, 0, report.TotalImpact)

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -82,15 +82,24 @@ func (c *KeyorixCore) SetMembershipDomainAllowlist(domains []string) {
 // domainAllowed reports whether email's domain passes the configured
 // allowlist. An empty allowlist means no restriction (default, backward
 // compatible).
+//
+// #G46: this used to extract the domain via strings.LastIndex(email, "@"),
+// which silently accepts a malformed multi-'@' address like
+// "attacker@evil.com@allowed.com" and reports its trailing segment as the
+// domain — a parser-differential risk if any downstream mail/identity
+// consumer of the same raw email string parses '@' differently (e.g. takes
+// the FIRST '@' as the local-part boundary). Requiring exactly one '@' closes
+// that gap: a malformed address is rejected outright instead of having its
+// domain guessed.
 func (c *KeyorixCore) domainAllowed(email string) bool {
 	if len(c.membershipDomainAllowlist) == 0 {
 		return true
 	}
-	at := strings.LastIndex(email, "@")
-	if at < 0 {
+	local, domain, ok := strings.Cut(email, "@")
+	if !ok || local == "" || domain == "" || strings.Contains(domain, "@") {
 		return false
 	}
-	domain := strings.ToLower(email[at+1:])
+	domain = strings.ToLower(domain)
 	for _, d := range c.membershipDomainAllowlist {
 		if strings.ToLower(d) == domain {
 			return true

--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -109,6 +109,30 @@ func TestInviteMember_RejectsDisallowedDomain(t *testing.T) {
 	store.AssertNotCalled(t, "CreateProjectMembership", mock.Anything, mock.Anything)
 }
 
+// TestDomainAllowed_RejectsMalformedMultiAtEmail is #G46: domainAllowed used to extract
+// the domain via strings.LastIndex(email, "@"), which silently accepts a malformed
+// multi-'@' address like "attacker@evil.com@allowed.com" and reports "allowed.com" (its
+// trailing segment) as the domain — a parser-differential risk if any downstream mail/
+// identity consumer of the same raw string parses '@' differently. A well-formed email
+// has exactly one '@'; anything else must be rejected outright, not domain-guessed.
+func TestDomainAllowed_RejectsMalformedMultiAtEmail(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	c.membershipDomainAllowlist = []string{"allowed.com"}
+
+	adversarial := []string{
+		"attacker@evil.com@allowed.com",
+		"attacker@allowed.com@evil.com",
+		"@allowed.com",
+		"user@",
+		"nodomainatall",
+	}
+	for _, email := range adversarial {
+		assert.False(t, c.domainAllowed(email), "%q must be rejected as malformed, not domain-guessed", email)
+	}
+	assert.True(t, c.domainAllowed("user@allowed.com"), "a well-formed single-'@' email on the allowlist must still pass")
+}
+
 func TestInviteMember_RejectsDuplicate(t *testing.T) {
 	store := new(MockStorage)
 	c := newMembershipCore(store)

--- a/internal/core/rotation_planner_test.go
+++ b/internal/core/rotation_planner_test.go
@@ -75,6 +75,11 @@ func TestRotationWavesDetectsCycle(t *testing.T) {
 
 // --- integration against a real in-memory store ---
 
+// plannerTestActor is granted global admin below so #G32's independent peer-secret
+// authorization check doesn't interfere with these tests, which are about rotation-plan
+// waving/ordering, not authorization.
+const plannerTestActor = uint(1)
+
 func newPlannerCore(t *testing.T, now time.Time) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -82,7 +87,12 @@ func newPlannerCore(t *testing.T, now time.Time) (*KeyorixCore, *gorm.DB) {
 	require.NoError(t, db.AutoMigrate(
 		&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.RotationPolicy{},
 		&models.SecretDependency{}, &models.ShareRecord{}, &models.SecretAccessLog{}, &models.AuditEvent{},
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{}, &models.RolePermission{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.MachineIdentityRole{}, &models.SecretACL{},
 	))
+	role := &models.Role{Name: "admin"}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: plannerTestActor, RoleID: role.ID, ProjectID: 0, EnvironmentID: 0}).Error)
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
 	return c, db
 }
@@ -112,7 +122,7 @@ func TestGenerateRotationPlan(t *testing.T) {
 	mk(4, "healthy-key", daysAgo(5))   // ok → excluded from the plan
 
 	// overdue-app depends on overdue-db → it must rotate in a later wave.
-	_, err := c.AddSecretDependency(ctx, 1, 1, 2, "app token derives from db password")
+	_, err := c.AddSecretDependency(ctx, ActorTypeUser, plannerTestActor, 1, 2, "app token derives from db password")
 	require.NoError(t, err)
 
 	plan, err := c.GenerateRotationPlan(ctx, projectID)

--- a/internal/core/secret_dependencies.go
+++ b/internal/core/secret_dependencies.go
@@ -6,7 +6,11 @@
 // rotate a project's secrets so each is rotated before anything that depends on it).
 // The graph is kept acyclic: self-edges, duplicates, and cycles are rejected at add.
 // Metadata only — secret values are never read. Authz is enforced at the HTTP layer
-// (secrets.read to view, secrets.write to mutate), scoped to the secret's project.
+// (secrets.read to view, secrets.write to mutate) for the FOCAL (path) secret; every
+// function below additionally checks each PEER secret's authorization independently
+// (see canReadSecret) before disclosing or acting on it — same project+environment
+// membership is not sufficient on its own, since a per-secret ACL grant on the focal
+// secret does not extend to a peer merely because they share an environment (#G32).
 package core
 
 import (
@@ -89,7 +93,7 @@ type RotationOrder struct {
 // row, on RemoteStorage) is what now also serializes across replicas/processes — the
 // same two-layer pattern login_lockout.go's recordFailedLogin and RemoveUserRole's
 // guardLastGlobalAdmin use.
-func (c *KeyorixCore) AddSecretDependency(ctx context.Context, actorID, dependentID, dependsOnID uint, note string) (*models.SecretDependency, error) {
+func (c *KeyorixCore) AddSecretDependency(ctx context.Context, actorKind string, actorID, dependentID, dependsOnID uint, note string) (*models.SecretDependency, error) {
 	if dependentID == dependsOnID {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a secret cannot depend on itself")
 	}
@@ -101,12 +105,19 @@ func (c *KeyorixCore) AddSecretDependency(ctx context.Context, actorID, dependen
 	// "in another project or environment" — the caller is only authorized on the path
 	// (dependent) secret's scope, so a differentiated error here is a cross-scope
 	// existence-and-type oracle (probe arbitrary IDs by 404-vs-400). Collapse them into a
-	// single opaque error. Confining the edge to the same project AND environment is also
-	// what makes the path-secret authorization cover the dependency secret (authorization
-	// is environment-granular and the HTTP layer authorizes only the path secret's env).
+	// single opaque error.
 	dependsOn, derr := c.requireSecret(ctx, dependsOnID)
 	if derr != nil || dependsOn.ProjectID != dependent.ProjectID || dependsOn.EnvironmentID != dependent.EnvironmentID {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "the dependency target must be a secret in the same project and environment")
+	}
+	// #G32: same project+environment is NOT the same as "the caller is authorized on
+	// it" — a per-secret ACL grant on the dependent (path) secret does not extend to
+	// dependsOn. Require the caller to be independently authorized to write the
+	// dependency target too, before linking it into the graph.
+	if allowed, aerr := c.AuthorizeSecretPrincipal(ctx, actorKind, actorID, dependsOnID, permSecretsWrite); aerr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), aerr)
+	} else if !allowed {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "not authorized on the dependency target")
 	}
 
 	c.secretDependencyMu.Lock()
@@ -161,7 +172,11 @@ func (c *KeyorixCore) LockedCreateSecretDependencyExclusive(ctx context.Context,
 // the edge. Matching on project alone would be too coarse — authorization is
 // environment-granular, and a caller could otherwise delete an edge between two secrets
 // in another environment of the same project. actorID is the acting principal.
-func (c *KeyorixCore) RemoveSecretDependency(ctx context.Context, actorID, focalSecretID, edgeID uint) error {
+//
+// #G32: focalSecretID is only ONE endpoint of the edge — the other endpoint (the peer)
+// gets independently authorized below before the edge can be removed, since a per-secret
+// ACL grant on focalSecretID does not extend to it.
+func (c *KeyorixCore) RemoveSecretDependency(ctx context.Context, actorKind string, actorID, focalSecretID, edgeID uint) error {
 	if _, err := c.requireSecret(ctx, focalSecretID); err != nil {
 		return err
 	}
@@ -171,6 +186,15 @@ func (c *KeyorixCore) RemoveSecretDependency(ctx context.Context, actorID, focal
 	}
 	if edge.DependentSecretID != focalSecretID && edge.DependsOnSecretID != focalSecretID {
 		return fmt.Errorf("%s: dependency %d does not reference secret %d", i18n.T("ErrorNotFound", nil), edgeID, focalSecretID)
+	}
+	peerID := edge.DependentSecretID
+	if peerID == focalSecretID {
+		peerID = edge.DependsOnSecretID
+	}
+	if allowed, aerr := c.AuthorizeSecretPrincipal(ctx, actorKind, actorID, peerID, permSecretsWrite); aerr != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), aerr)
+	} else if !allowed {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "not authorized on the dependency target")
 	}
 	if err := c.storage.DeleteSecretDependency(ctx, edgeID); err != nil {
 		return err
@@ -183,7 +207,7 @@ func (c *KeyorixCore) RemoveSecretDependency(ctx context.Context, actorID, focal
 
 // ListSecretDependencies returns a secret's direct dependencies and dependents, with
 // names resolved.
-func (c *KeyorixCore) ListSecretDependencies(ctx context.Context, secretID uint) (*SecretDependencies, error) {
+func (c *KeyorixCore) ListSecretDependencies(ctx context.Context, actorKind string, actorID, secretID uint) (*SecretDependencies, error) {
 	secret, err := c.requireSecret(ctx, secretID)
 	if err != nil {
 		return nil, err
@@ -202,8 +226,16 @@ func (c *KeyorixCore) ListSecretDependencies(ctx context.Context, secretID uint)
 	for _, e := range edges {
 		switch secretID {
 		case e.DependentSecretID:
+			// #G32: same environment is not the same as "independently authorized" —
+			// don't disclose a peer the caller has no grant on of their own.
+			if !c.canReadSecret(ctx, actorKind, actorID, e.DependsOnSecretID) {
+				continue
+			}
 			out.DependsOn = append(out.DependsOn, DependencyEdge{ID: e.ID, SecretID: e.DependsOnSecretID, SecretName: info[e.DependsOnSecretID].name, Note: e.Note})
 		case e.DependsOnSecretID:
+			if !c.canReadSecret(ctx, actorKind, actorID, e.DependentSecretID) {
+				continue
+			}
 			out.Dependents = append(out.Dependents, DependencyEdge{ID: e.ID, SecretID: e.DependentSecretID, SecretName: info[e.DependentSecretID].name, Note: e.Note})
 		}
 	}
@@ -212,7 +244,7 @@ func (c *KeyorixCore) ListSecretDependencies(ctx context.Context, secretID uint)
 
 // GetSecretImpact returns the blast radius of rotating/changing a secret: every
 // secret that transitively depends on it, with hop-distance, in breadth-first order.
-func (c *KeyorixCore) GetSecretImpact(ctx context.Context, secretID uint) (*SecretImpact, error) {
+func (c *KeyorixCore) GetSecretImpact(ctx context.Context, actorKind string, actorID, secretID uint) (*SecretImpact, error) {
 	secret, err := c.requireSecret(ctx, secretID)
 	if err != nil {
 		return nil, err
@@ -226,9 +258,29 @@ func (c *KeyorixCore) GetSecretImpact(ctx context.Context, secretID uint) (*Secr
 	affected := transitiveDependents(edges, secretID)
 	out := &SecretImpact{SecretID: secretID, SecretName: secret.Name, Affected: make([]ImpactedSecret, 0, len(affected))}
 	for _, a := range affected {
+		// #G32: the BFS traverses the full graph so a hop through an unauthorized peer
+		// still surfaces further, independently-authorized dependents — but a peer the
+		// caller has no grant of their own on is never disclosed in the output.
+		if !c.canReadSecret(ctx, actorKind, actorID, a.id) {
+			continue
+		}
 		out.Affected = append(out.Affected, ImpactedSecret{SecretID: a.id, SecretName: info[a.id].name, Depth: a.depth})
 	}
 	return out, nil
+}
+
+// canReadSecret reports whether actor is independently authorized to read secretID —
+// used to decide whether a peer secret's name/id may be disclosed to the caller in a
+// dependency/impact/blast-radius view. #G32: dependency edges are confined to the focal
+// secret's own project+environment, but authorization is per-secret (a SecretACL grant
+// on the focal secret does not extend to a peer merely because they share an
+// environment), so same-environment membership alone is not sufficient to disclose a
+// peer's identity — this calls the same actor-aware, ACL-inclusive primitive
+// server/middleware/auth.go's RequireScopedSecretPermission uses to authorize the path
+// secret at the HTTP layer.
+func (c *KeyorixCore) canReadSecret(ctx context.Context, actorKind string, actorID, secretID uint) bool {
+	allowed, err := c.AuthorizeSecretPrincipal(ctx, actorKind, actorID, secretID, permSecretsRead)
+	return err == nil && allowed
 }
 
 // GetProjectRotationOrder returns a safe rotation sequence for a project's dependency

--- a/internal/core/secret_dependencies_authz_test.go
+++ b/internal/core/secret_dependencies_authz_test.go
@@ -1,0 +1,209 @@
+// secret_dependencies_authz_test.go — #G32 regression tests: secret-relationship
+// functions (secret_dependencies.go, blast_radius.go, secret_impact_preview.go) used
+// to authorize only the FOCAL (path) secret and disclose/act on a PEER secret with no
+// independent check, reasoning that "same project+environment" was equivalent to "the
+// caller is authorized." It is not: this codebase's authorization model includes
+// per-secret ACL grants (GrantSecretACL / AuthorizeSecretPrincipal → HasSecretACL) that
+// do NOT extend to a peer secret merely because it shares the focal secret's project and
+// environment. These tests reproduce the group's own detection_idea: grant a caller an
+// ACL on the focal secret only (no project-wide role, so it has no ambient visibility
+// into any other secret), link a peer the caller has no grant on, and assert the peer's
+// name/ID never leaks — and that a mutation touching the peer is rejected.
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// authzTestActor is the low-privilege caller used throughout this file: an ACL grant
+// on specific secrets only, no project-wide role — so it has no ambient authorization
+// on any secret it wasn't explicitly granted.
+const authzTestActor = uint(50)
+
+// newDepAuthzCore builds an isolated in-memory core with the RBAC/ACL tables migrated.
+func newDepAuthzCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretDependency{}, &models.SecretACL{}, &models.AuditEvent{},
+		&models.Project{}, &models.Environment{}, &models.ShareRecord{},
+		&models.User{}, &models.Role{}, &models.UserRole{},
+		&models.Permission{}, &models.RolePermission{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.MachineIdentityRole{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env1"}).Error)
+	// Placeholder project membership: GrantSecretACL requires the grantee to already be
+	// a project member (mirrors secret_acl_test.go's newACLCore). RoleID 999 is a
+	// placeholder — membership is checked on user_id+project_id, not the role itself.
+	require.NoError(t, db.Create(&models.UserRole{UserID: authzTestActor, RoleID: 999, ProjectID: 1}).Error)
+	// The granting actor (0) needs no setup: writeAuditEvent tolerates actor 0, and
+	// GrantSecretACL below is called directly by the test as a fixture step, not through
+	// an authorization path of its own.
+	now := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	return c, db
+}
+
+// mkAuthzSecret inserts a secret into project 1 / environment 1.
+func mkAuthzSecret(t *testing.T, db *gorm.DB, name string) uint {
+	t.Helper()
+	s := &models.SecretNode{ProjectID: 1, EnvironmentID: 1, Name: name, IsSecret: true, Status: "active"}
+	require.NoError(t, db.Create(s).Error)
+	return s.ID
+}
+
+// grantDepACL gives authzTestActor secrets.read+secrets.write on secretID, via a
+// per-secret ACL grant — NOT a project/environment role, so it confers no visibility
+// into any other secret.
+func grantDepACL(t *testing.T, c *KeyorixCore, secretID uint) {
+	t.Helper()
+	require.NoError(t, c.GrantSecretACL(context.Background(), 1, secretID, authzTestActor, []string{"secrets.read", "secrets.write"}))
+}
+
+// TestListSecretDependencies_DoesNotDiscloseUnauthorizedPeer is the read-path
+// regression: authzTestActor has an ACL grant on the focal secret and on one of its two
+// peers, but not the other. Same project+environment membership must not stand in for
+// authorization on the unauthorized peer.
+func TestListSecretDependencies_DoesNotDiscloseUnauthorizedPeer(t *testing.T) {
+	c, db := newDepAuthzCore(t)
+	focal := mkAuthzSecret(t, db, "focal")
+	seen := mkAuthzSecret(t, db, "peer-authorized")
+	hidden := mkAuthzSecret(t, db, "peer-hidden")
+	grantDepACL(t, c, focal)
+	grantDepACL(t, c, seen)
+	// No grant on `hidden` at all.
+
+	require.NoError(t, db.Create(&models.SecretDependency{ProjectID: 1, DependentSecretID: focal, DependsOnSecretID: seen}).Error)
+	require.NoError(t, db.Create(&models.SecretDependency{ProjectID: 1, DependentSecretID: focal, DependsOnSecretID: hidden}).Error)
+
+	deps, err := c.ListSecretDependencies(context.Background(), ActorTypeUser, authzTestActor, focal)
+	require.NoError(t, err)
+	ids := make([]uint, 0, len(deps.DependsOn))
+	for _, e := range deps.DependsOn {
+		ids = append(ids, e.SecretID)
+	}
+	assert.Contains(t, ids, seen, "an authorized peer must still be disclosed")
+	assert.NotContains(t, ids, hidden, "a peer the caller has no independent grant on must never be disclosed")
+}
+
+// TestGetSecretImpact_DoesNotDiscloseUnauthorizedPeer covers the transitive-impact view:
+// the BFS must still traverse through an unauthorized peer to find further,
+// independently-authorized dependents, but must never disclose the unauthorized peer
+// itself.
+func TestGetSecretImpact_DoesNotDiscloseUnauthorizedPeer(t *testing.T) {
+	c, db := newDepAuthzCore(t)
+	focal := mkAuthzSecret(t, db, "focal")
+	hidden := mkAuthzSecret(t, db, "hidden-mid")
+	beyond := mkAuthzSecret(t, db, "beyond-hidden")
+	grantDepACL(t, c, focal)
+	grantDepACL(t, c, beyond) // authorized on the far node, NOT on the hidden hop between them
+	// hidden depends on focal (depth 1); beyond depends on hidden (depth 2).
+	require.NoError(t, db.Create(&models.SecretDependency{ProjectID: 1, DependentSecretID: hidden, DependsOnSecretID: focal}).Error)
+	require.NoError(t, db.Create(&models.SecretDependency{ProjectID: 1, DependentSecretID: beyond, DependsOnSecretID: hidden}).Error)
+
+	impact, err := c.GetSecretImpact(context.Background(), ActorTypeUser, authzTestActor, focal)
+	require.NoError(t, err)
+	ids := make([]uint, 0, len(impact.Affected))
+	for _, a := range impact.Affected {
+		ids = append(ids, a.SecretID)
+	}
+	assert.NotContains(t, ids, hidden, "the unauthorized hop must not be disclosed")
+	assert.Contains(t, ids, beyond, "a hop through an unauthorized peer must still surface a further, independently-authorized dependent")
+}
+
+// TestGetBlastRadius_DoesNotDiscloseUnauthorizedPeer mirrors the GetSecretImpact
+// regression for the richer blast-radius report.
+func TestGetBlastRadius_DoesNotDiscloseUnauthorizedPeer(t *testing.T) {
+	c, db := newDepAuthzCore(t)
+	focal := mkAuthzSecret(t, db, "focal")
+	hidden := mkAuthzSecret(t, db, "hidden-mid")
+	beyond := mkAuthzSecret(t, db, "beyond-hidden")
+	grantDepACL(t, c, focal)
+	grantDepACL(t, c, beyond)
+	require.NoError(t, db.Create(&models.SecretDependency{ProjectID: 1, DependentSecretID: hidden, DependsOnSecretID: focal}).Error)
+	require.NoError(t, db.Create(&models.SecretDependency{ProjectID: 1, DependentSecretID: beyond, DependsOnSecretID: hidden}).Error)
+
+	report, err := c.GetBlastRadius(context.Background(), ActorTypeUser, authzTestActor, focal)
+	require.NoError(t, err)
+	ids := make([]uint, 0, len(report.Dependents))
+	for _, n := range report.Dependents {
+		ids = append(ids, n.SecretID)
+	}
+	assert.NotContains(t, ids, hidden, "the unauthorized hop must not be disclosed")
+	assert.Contains(t, ids, beyond, "a hop through an unauthorized peer must still surface a further, independently-authorized dependent")
+}
+
+// TestGetSecretImpactPreview_CountsFullButIDsFiltered: the cascade-delete preview's
+// counts reflect the TRUE full impact (an operator needs the real size to decide
+// whether to delete), but the identifying AffectedSecretIDs list is filtered to only
+// the peers the caller is independently authorized to read.
+func TestGetSecretImpactPreview_CountsFullButIDsFiltered(t *testing.T) {
+	c, db := newDepAuthzCore(t)
+	focal := mkAuthzSecret(t, db, "focal")
+	seen := mkAuthzSecret(t, db, "peer-authorized")
+	hidden := mkAuthzSecret(t, db, "peer-hidden")
+	grantDepACL(t, c, focal)
+	grantDepACL(t, c, seen)
+	require.NoError(t, db.Create(&models.SecretDependency{ProjectID: 1, DependentSecretID: seen, DependsOnSecretID: focal}).Error)
+	require.NoError(t, db.Create(&models.SecretDependency{ProjectID: 1, DependentSecretID: hidden, DependsOnSecretID: focal}).Error)
+
+	preview, err := c.GetSecretImpactPreview(context.Background(), ActorTypeUser, authzTestActor, focal)
+	require.NoError(t, err)
+	assert.Equal(t, 2, preview.DirectDependents, "the true cascade count is disclosed even though one peer's identity is not")
+	assert.Equal(t, 2, preview.TransitiveDependents)
+	assert.Contains(t, preview.AffectedSecretIDs, seen)
+	assert.NotContains(t, preview.AffectedSecretIDs, hidden, "an unauthorized peer's ID must not appear in the identifying list")
+}
+
+// TestAddSecretDependency_RejectsUnauthorizedPeer is the write-path regression: the
+// caller is authorized (secrets.write) on the focal secret but has no grant at all on
+// the dependency target — same project+environment must not substitute for an
+// independent authorization check on the target.
+func TestAddSecretDependency_RejectsUnauthorizedPeer(t *testing.T) {
+	c, db := newDepAuthzCore(t)
+	focal := mkAuthzSecret(t, db, "focal")
+	target := mkAuthzSecret(t, db, "unauthorized-target")
+	grantDepACL(t, c, focal)
+	// No grant on `target`.
+
+	_, err := c.AddSecretDependency(context.Background(), ActorTypeUser, authzTestActor, focal, target, "")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "unauthorized-target", "must not leak the target's name in the error")
+
+	var count int64
+	require.NoError(t, db.Model(&models.SecretDependency{}).Count(&count).Error)
+	assert.Zero(t, count, "no edge must be persisted when the target is unauthorized")
+}
+
+// TestRemoveSecretDependency_RejectsUnauthorizedPeer: the caller is authorized on the
+// focal (path) secret but not on the edge's other endpoint — removal must be rejected,
+// not silently allowed because both endpoints share a project+environment.
+func TestRemoveSecretDependency_RejectsUnauthorizedPeer(t *testing.T) {
+	c, db := newDepAuthzCore(t)
+	focal := mkAuthzSecret(t, db, "focal")
+	target := mkAuthzSecret(t, db, "unauthorized-target")
+	grantDepACL(t, c, focal)
+	// No grant on `target`.
+	edge := &models.SecretDependency{ProjectID: 1, DependentSecretID: focal, DependsOnSecretID: target}
+	require.NoError(t, db.Create(edge).Error)
+
+	err := c.RemoveSecretDependency(context.Background(), ActorTypeUser, authzTestActor, focal, edge.ID)
+	require.Error(t, err)
+
+	var count int64
+	require.NoError(t, db.Model(&models.SecretDependency{}).Where("id = ?", edge.ID).Count(&count).Error)
+	assert.Equal(t, int64(1), count, "the edge must not be removed when the caller lacks authorization on the peer")
+}

--- a/internal/core/secret_dependencies_cascade_test.go
+++ b/internal/core/secret_dependencies_cascade_test.go
@@ -34,9 +34,9 @@ func TestGetProjectRotationOrder_CascadesSoftDeleteAndRestore(t *testing.T) {
 	appTok := mkSecret(t, db, 1, "app-token")
 	cacheKey := mkSecret(t, db, 1, "cache-key")
 	// app-token and cache-key both depend on db-password.
-	_, err := c.AddSecretDependency(ctx, 10, appTok, dbPass, "")
+	_, err := c.AddSecretDependency(ctx, ActorTypeUser, 10, appTok, dbPass, "")
 	require.NoError(t, err)
-	_, err = c.AddSecretDependency(ctx, 10, cacheKey, dbPass, "")
+	_, err = c.AddSecretDependency(ctx, ActorTypeUser, 10, cacheKey, dbPass, "")
 	require.NoError(t, err)
 
 	// Baseline: dependency first, then its two dependents (sorted by id).
@@ -61,13 +61,13 @@ func TestGetSecretImpact_CascadesSoftDeleteAndRestore(t *testing.T) {
 	dbPass := mkSecret(t, db, 1, "db-password")
 	appTok := mkSecret(t, db, 1, "app-token")
 	cacheKey := mkSecret(t, db, 1, "cache-key")
-	_, err := c.AddSecretDependency(ctx, 10, appTok, dbPass, "")
+	_, err := c.AddSecretDependency(ctx, ActorTypeUser, 10, appTok, dbPass, "")
 	require.NoError(t, err)
-	_, err = c.AddSecretDependency(ctx, 10, cacheKey, dbPass, "")
+	_, err = c.AddSecretDependency(ctx, ActorTypeUser, 10, cacheKey, dbPass, "")
 	require.NoError(t, err)
 
 	impactNames := func() []string {
-		si, err := c.GetSecretImpact(ctx, dbPass)
+		si, err := c.GetSecretImpact(ctx, ActorTypeUser, 10, dbPass)
 		require.NoError(t, err)
 		names := make([]string, len(si.Affected))
 		for i, a := range si.Affected {
@@ -96,9 +96,9 @@ func TestDeleteSecret_EmitsDependencyInvalidatedAuditEvents(t *testing.T) {
 	appTok := mkSecret(t, db, 1, "app-token")
 	cacheKey := mkSecret(t, db, 1, "cache-key")
 	// appTok and cacheKey both depend on dbPass.
-	_, err := c.AddSecretDependency(ctx, 10, appTok, dbPass, "")
+	_, err := c.AddSecretDependency(ctx, ActorTypeUser, 10, appTok, dbPass, "")
 	require.NoError(t, err)
-	_, err = c.AddSecretDependency(ctx, 10, cacheKey, dbPass, "")
+	_, err = c.AddSecretDependency(ctx, ActorTypeUser, 10, cacheKey, dbPass, "")
 	require.NoError(t, err)
 
 	// Soft-delete the dependency target (dbPass). Both edges become invalid.
@@ -128,9 +128,9 @@ func TestRestoreSecret_EmitsDependencyRestoredAuditEvents(t *testing.T) {
 	dbPass := mkSecret(t, db, 1, "db-password")
 	appTok := mkSecret(t, db, 1, "app-token")
 	cacheKey := mkSecret(t, db, 1, "cache-key")
-	_, err := c.AddSecretDependency(ctx, 10, appTok, dbPass, "")
+	_, err := c.AddSecretDependency(ctx, ActorTypeUser, 10, appTok, dbPass, "")
 	require.NoError(t, err)
-	_, err = c.AddSecretDependency(ctx, 10, cacheKey, dbPass, "")
+	_, err = c.AddSecretDependency(ctx, ActorTypeUser, 10, cacheKey, dbPass, "")
 	require.NoError(t, err)
 
 	require.NoError(t, c.DeleteSecret(ctx, dbPass))
@@ -163,7 +163,7 @@ func TestDeleteSecret_EmitsEventWhenDeletedSecretIsDependent(t *testing.T) {
 	upstream := mkSecret(t, db, 1, "upstream")
 	downstream := mkSecret(t, db, 1, "downstream")
 	// downstream depends on upstream.
-	_, err := c.AddSecretDependency(ctx, 10, downstream, upstream, "")
+	_, err := c.AddSecretDependency(ctx, ActorTypeUser, 10, downstream, upstream, "")
 	require.NoError(t, err)
 
 	// Delete the dependent (downstream). The edge is incident to it, so one event

--- a/internal/core/secret_dependencies_test.go
+++ b/internal/core/secret_dependencies_test.go
@@ -70,6 +70,16 @@ func TestTopologicalRotationOrderDetectsCycle(t *testing.T) {
 
 // --- integration tests against a real in-memory store ---
 
+// depTestActors are the caller identities used throughout this file's real-SQLite
+// tests; newDepCore grants each one global admin. #G32: every G32 member now
+// independently authorizes each peer secret it discloses/mutates, so a caller with no
+// RBAC grant at all would fail on any two-secret operation — these tests are about the
+// dependency-graph shape (cycles, environment scoping, soft-delete cascade), not
+// authorization, so the fixture actors are granted global admin to keep that
+// orthogonal. The peer-authorization-gap regression tests live in
+// secret_dependencies_authz_test.go, with a deliberately unprivileged actor.
+var depTestActors = []uint{1, 10}
+
 func newDepCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -78,12 +88,20 @@ func newDepCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	// secret's own soft-delete, so ShareRecord must be migrated even though these
 	// tests never create a share directly.
 	// SecretACL is included because DeleteSecret also revokes ACL rows in the same tx.
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretDependency{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.ShareRecord{}, &models.SecretACL{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretDependency{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}, &models.ShareRecord{}, &models.SecretACL{},
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{}, &models.RolePermission{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.MachineIdentityRole{},
+	))
 	// Live parent projects (1, 2) + environment (1): RestoreSecret refuses to restore a
 	// secret into a soft-deleted parent, so the dependency-cascade tests need them present.
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
 	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "p2"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env1"}).Error)
+	role := &models.Role{Name: "admin"}
+	require.NoError(t, db.Create(role).Error)
+	for _, actor := range depTestActors {
+		require.NoError(t, db.Create(&models.UserRole{UserID: actor, RoleID: role.ID, ProjectID: 0, EnvironmentID: 0}).Error)
+	}
 	now := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC)
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
 	return c, db
@@ -110,7 +128,7 @@ func TestAddSecretDependency_Validation(t *testing.T) {
 	otherProj := mkSecret(t, db, 2, "other-secret")
 
 	t.Run("happy path", func(t *testing.T) {
-		got, err := c.AddSecretDependency(ctx, 10, appTok, dbPass, "app token derives from db password")
+		got, err := c.AddSecretDependency(ctx, ActorTypeUser, 10, appTok, dbPass, "app token derives from db password")
 		require.NoError(t, err)
 		assert.Equal(t, appTok, got.DependentSecretID)
 		assert.Equal(t, dbPass, got.DependsOnSecretID)
@@ -118,32 +136,32 @@ func TestAddSecretDependency_Validation(t *testing.T) {
 	})
 
 	t.Run("self-dependency rejected", func(t *testing.T) {
-		_, err := c.AddSecretDependency(ctx, 10, dbPass, dbPass, "")
+		_, err := c.AddSecretDependency(ctx, ActorTypeUser, 10, dbPass, dbPass, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "itself")
 	})
 
 	t.Run("cross-project rejected", func(t *testing.T) {
-		_, err := c.AddSecretDependency(ctx, 10, appTok, otherProj, "")
+		_, err := c.AddSecretDependency(ctx, ActorTypeUser, 10, appTok, otherProj, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "same project")
 	})
 
 	t.Run("duplicate rejected", func(t *testing.T) {
-		_, err := c.AddSecretDependency(ctx, 10, appTok, dbPass, "")
+		_, err := c.AddSecretDependency(ctx, ActorTypeUser, 10, appTok, dbPass, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "already exists")
 	})
 
 	t.Run("cycle rejected", func(t *testing.T) {
 		// appTok already depends on dbPass; making dbPass depend on appTok is a cycle.
-		_, err := c.AddSecretDependency(ctx, 10, dbPass, appTok, "")
+		_, err := c.AddSecretDependency(ctx, ActorTypeUser, 10, dbPass, appTok, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cycle")
 	})
 
 	t.Run("missing dependency target rejected with an opaque error (no existence oracle)", func(t *testing.T) {
-		_, err := c.AddSecretDependency(ctx, 10, appTok, 9999, "")
+		_, err := c.AddSecretDependency(ctx, ActorTypeUser, 10, appTok, 9999, "")
 		require.Error(t, err)
 		// Must NOT reveal whether 9999 exists / what it is — same message as a cross-scope
 		// target, so the caller can't enumerate secret IDs across scopes.
@@ -160,7 +178,7 @@ func TestAddSecretDependency_CrossEnvironmentRejected(t *testing.T) {
 	c, db := newDepCore(t)
 	staging := mkSecretEnv(t, db, 1, 1, "app-token")     // project 1, env 1
 	prod := mkSecretEnv(t, db, 1, 2, "prod-db-password") // project 1, env 2
-	_, err := c.AddSecretDependency(ctx, 10, staging, prod, "")
+	_, err := c.AddSecretDependency(ctx, ActorTypeUser, 10, staging, prod, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "environment")
 }
@@ -173,16 +191,16 @@ func TestRemoveSecretDependency_RequiresFocalReference(t *testing.T) {
 	a := mkSecret(t, db, 1, "a")
 	b := mkSecret(t, db, 1, "b")
 	other := mkSecret(t, db, 1, "other")
-	e, err := c.AddSecretDependency(ctx, 1, a, b, "")
+	e, err := c.AddSecretDependency(ctx, ActorTypeUser, 1, a, b, "")
 	require.NoError(t, err)
 
 	// 'other' is not part of edge a→b → removal scoped to 'other' is rejected.
-	err = c.RemoveSecretDependency(ctx, 1, other, e.ID)
+	err = c.RemoveSecretDependency(ctx, ActorTypeUser, 1, other, e.ID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not reference")
 
 	// Scoped to the dependent secret 'a' → allowed.
-	require.NoError(t, c.RemoveSecretDependency(ctx, 1, a, e.ID))
+	require.NoError(t, c.RemoveSecretDependency(ctx, ActorTypeUser, 1, a, e.ID))
 }
 
 // Defence-in-depth: even if a cross-environment edge is somehow present (here inserted
@@ -199,11 +217,11 @@ func TestSecretDependencyReadsFilterByEnvironment(t *testing.T) {
 		ProjectID: 1, DependentSecretID: envA, DependsOnSecretID: envB,
 	}).Error)
 
-	deps, err := c.ListSecretDependencies(ctx, envA)
+	deps, err := c.ListSecretDependencies(ctx, ActorTypeUser, 1, envA)
 	require.NoError(t, err)
 	assert.Empty(t, deps.DependsOn, "a cross-environment edge must not appear in env-A's view")
 
-	impact, err := c.GetSecretImpact(ctx, envB)
+	impact, err := c.GetSecretImpact(ctx, ActorTypeUser, 1, envB)
 	require.NoError(t, err)
 	assert.Empty(t, impact.Affected, "impact from env-B must not cross into env-A via a forged edge")
 }
@@ -216,13 +234,13 @@ func TestSecretDependencyImpactAndOrderAndRemove(t *testing.T) {
 	leaf := mkSecret(t, db, 1, "service-cert")
 
 	// service-cert depends on intermediate depends on root-ca.
-	_, err := c.AddSecretDependency(ctx, 1, mid, root, "")
+	_, err := c.AddSecretDependency(ctx, ActorTypeUser, 1, mid, root, "")
 	require.NoError(t, err)
-	e2, err := c.AddSecretDependency(ctx, 1, leaf, mid, "")
+	e2, err := c.AddSecretDependency(ctx, ActorTypeUser, 1, leaf, mid, "")
 	require.NoError(t, err)
 
 	// Impact of rotating root-ca: intermediate (depth1) then service-cert (depth2).
-	impact, err := c.GetSecretImpact(ctx, root)
+	impact, err := c.GetSecretImpact(ctx, ActorTypeUser, 1, root)
 	require.NoError(t, err)
 	require.Len(t, impact.Affected, 2)
 	assert.Equal(t, "intermediate", impact.Affected[0].SecretName)
@@ -238,7 +256,7 @@ func TestSecretDependencyImpactAndOrderAndRemove(t *testing.T) {
 		[]string{order.Order[0].SecretName, order.Order[1].SecretName, order.Order[2].SecretName})
 
 	// List from the middle secret: depends on root, depended on by leaf.
-	view, err := c.ListSecretDependencies(ctx, mid)
+	view, err := c.ListSecretDependencies(ctx, ActorTypeUser, 1, mid)
 	require.NoError(t, err)
 	require.Len(t, view.DependsOn, 1)
 	assert.Equal(t, "root-ca", view.DependsOn[0].SecretName)
@@ -246,8 +264,8 @@ func TestSecretDependencyImpactAndOrderAndRemove(t *testing.T) {
 	assert.Equal(t, "service-cert", view.Dependents[0].SecretName)
 
 	// Remove the leaf→mid edge; impact of root shrinks to just intermediate.
-	require.NoError(t, c.RemoveSecretDependency(ctx, 1, leaf, e2.ID))
-	impact, err = c.GetSecretImpact(ctx, root)
+	require.NoError(t, c.RemoveSecretDependency(ctx, ActorTypeUser, 1, leaf, e2.ID))
+	impact, err = c.GetSecretImpact(ctx, ActorTypeUser, 1, root)
 	require.NoError(t, err)
 	require.Len(t, impact.Affected, 1)
 	assert.Equal(t, "intermediate", impact.Affected[0].SecretName)
@@ -283,12 +301,12 @@ func TestAddSecretDependency_ConcurrentRaceCannotPersistACycle(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			_, results[0] = c.AddSecretDependency(ctx, 1, a, b, "")
+			_, results[0] = c.AddSecretDependency(ctx, ActorTypeUser, 1, a, b, "")
 		}()
 		go func() {
 			defer wg.Done()
 			<-start
-			_, results[1] = c.AddSecretDependency(ctx, 1, b, a, "")
+			_, results[1] = c.AddSecretDependency(ctx, ActorTypeUser, 1, b, a, "")
 		}()
 		close(start)
 		wg.Wait()

--- a/internal/core/secret_impact_preview.go
+++ b/internal/core/secret_impact_preview.go
@@ -28,7 +28,15 @@ type ImpactPreviewResult struct {
 //
 // The result is a flat count/summary, not the annotated node graph that
 // GetSecretImpact returns.
-func (c *KeyorixCore) GetSecretImpactPreview(ctx context.Context, secretID uint) (*ImpactPreviewResult, error) {
+//
+// #G32: DirectDependents/TransitiveDependents/MaxDepth are computed over the FULL
+// graph — an operator deciding whether to delete secretID needs the true cascade size,
+// even if some affected secrets are outside their own visibility, and a bare count
+// discloses no peer identity. AffectedSecretIDs is the identifying part, though, so it
+// is filtered to only the peers the caller is independently authorized to read (same
+// reasoning as ListSecretDependencies/GetSecretImpact: same-environment membership
+// alone does not prove authorization on a peer).
+func (c *KeyorixCore) GetSecretImpactPreview(ctx context.Context, actorKind string, actorID, secretID uint) (*ImpactPreviewResult, error) {
 	secret, err := c.requireSecret(ctx, secretID)
 	if err != nil {
 		return nil, err
@@ -55,13 +63,15 @@ func (c *KeyorixCore) GetSecretImpactPreview(ctx context.Context, secretID uint)
 	}
 
 	for _, a := range affected {
-		result.AffectedSecretIDs = append(result.AffectedSecretIDs, a.id)
 		result.TransitiveDependents++
 		if a.depth == 1 {
 			result.DirectDependents++
 		}
 		if a.depth > result.MaxDepth {
 			result.MaxDepth = a.depth
+		}
+		if c.canReadSecret(ctx, actorKind, actorID, a.id) {
+			result.AffectedSecretIDs = append(result.AffectedSecretIDs, a.id)
 		}
 	}
 

--- a/internal/core/secret_impact_preview_test.go
+++ b/internal/core/secret_impact_preview_test.go
@@ -19,6 +19,11 @@ import (
 // newImpactPreviewCore builds a minimal in-memory core for impact-preview tests.
 // Each call gets a fresh in-memory DB via ":memory:" — no DSN collision because
 // each gorm.Open(":memory:") allocates its own SQLite database.
+// impactPreviewTestActor is granted global admin below so #G32's independent
+// peer-secret authorization check doesn't interfere with these tests, which are about
+// the cascade-impact count/shape, not authorization.
+const impactPreviewTestActor = uint(1)
+
 func newImpactPreviewCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -30,9 +35,14 @@ func newImpactPreviewCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 		&models.Project{},
 		&models.Environment{},
 		&models.ShareRecord{},
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{}, &models.RolePermission{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.MachineIdentityRole{}, &models.SecretACL{},
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p-impact"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env-impact"}).Error)
+	role := &models.Role{Name: "admin"}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: impactPreviewTestActor, RoleID: role.ID, ProjectID: 0, EnvironmentID: 0}).Error)
 	now := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
 	return c, db
@@ -52,7 +62,7 @@ func TestGetSecretImpactPreview_NoDependents(t *testing.T) {
 	c, db := newImpactPreviewCore(t)
 	aID := mkIPSecret(t, db, "standalone")
 
-	got, err := c.GetSecretImpactPreview(context.Background(), aID)
+	got, err := c.GetSecretImpactPreview(context.Background(), ActorTypeUser, impactPreviewTestActor, aID)
 	require.NoError(t, err)
 	assert.Equal(t, aID, got.SecretID)
 	assert.Equal(t, 0, got.DirectDependents)
@@ -71,7 +81,7 @@ func TestGetSecretImpactPreview_TwoDirectDependents(t *testing.T) {
 	addImpactEdge(t, db, depA, rootID)
 	addImpactEdge(t, db, depB, rootID)
 
-	got, err := c.GetSecretImpactPreview(context.Background(), rootID)
+	got, err := c.GetSecretImpactPreview(context.Background(), ActorTypeUser, impactPreviewTestActor, rootID)
 	require.NoError(t, err)
 	assert.Equal(t, 2, got.DirectDependents)
 	assert.Equal(t, 2, got.TransitiveDependents)
@@ -90,7 +100,7 @@ func TestGetSecretImpactPreview_TransitiveChain(t *testing.T) {
 	addImpactEdge(t, db, bID, aID)
 	addImpactEdge(t, db, cID, bID)
 
-	got, err := c.GetSecretImpactPreview(context.Background(), aID)
+	got, err := c.GetSecretImpactPreview(context.Background(), ActorTypeUser, impactPreviewTestActor, aID)
 	require.NoError(t, err)
 	assert.Equal(t, 1, got.DirectDependents, "only B directly depends on A")
 	assert.Equal(t, 2, got.TransitiveDependents, "B and C are both affected")
@@ -109,7 +119,7 @@ func TestGetSecretImpactPreview_CycleDetection(t *testing.T) {
 	addImpactEdge(t, db, bID, aID)
 
 	// Must not hang or panic; returns safely.
-	got, err := c.GetSecretImpactPreview(context.Background(), aID)
+	got, err := c.GetSecretImpactPreview(context.Background(), ActorTypeUser, impactPreviewTestActor, aID)
 	require.NoError(t, err)
 	// B is a direct dependent of A (depth 1); A is already in the visited set so
 	// the back-edge is cut — transitive total is 1.
@@ -124,7 +134,7 @@ func TestGetSecretImpactPreview_CycleDetection(t *testing.T) {
 func TestGetSecretImpactPreview_SecretNotFound(t *testing.T) {
 	c, db := newImpactPreviewCore(t)
 	_ = db
-	_, err := c.GetSecretImpactPreview(context.Background(), 999999)
+	_, err := c.GetSecretImpactPreview(context.Background(), ActorTypeUser, impactPreviewTestActor, 999999)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -144,7 +154,7 @@ func TestGetSecretImpactPreview_StorageError(t *testing.T) {
 	now := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
 	c := &KeyorixCore{storage: ms, now: func() time.Time { return now }}
 
-	_, err := c.GetSecretImpactPreview(context.Background(), 1)
+	_, err := c.GetSecretImpactPreview(context.Background(), ActorTypeUser, impactPreviewTestActor, 1)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, storageErr)
 

--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -84,15 +84,40 @@ func (m *Manager) Names() []string {
 	return names
 }
 
+// isAlnumByte reports whether b is an ASCII letter or digit. Anything else — '_', '-',
+// '.', '/', ':', a quote, a space — counts as an explicit boundary between identifier
+// segments for prefixAllowed below.
+func isAlnumByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
 // prefixAllowed reports whether ref is permitted by an allowed-refs prefix allowlist: an
-// empty list places no restriction; otherwise ref must begin with one of the prefixes.
-// A guardrail on top of the backend admin identity's own privileges.
+// empty list places no restriction; otherwise ref must equal one of the entries, or
+// extend one at an explicit segment boundary — never merely share a prefix with one. A
+// guardrail on top of the backend admin identity's own privileges.
+//
+// #G46: a raw strings.HasPrefix let an allowed_refs entry of "myapp" also admit
+// "myapp2"/"myappadmin" — an unintended superset an operator who configured "myapp"
+// (without a trailing delimiter) would not expect. The match must now land on an
+// explicit boundary: either the configured prefix's own last character is already
+// non-alphanumeric (the pre-existing convention of e.g. "app_" already relies on this —
+// the operator's own choice already delimits it), or ref's very next character after the
+// prefix is.
 func prefixAllowed(allowed []string, ref string) bool {
 	if len(allowed) == 0 {
 		return true
 	}
 	for _, p := range allowed {
-		if p != "" && strings.HasPrefix(ref, p) {
+		if p == "" {
+			continue
+		}
+		if ref == p {
+			return true
+		}
+		if !strings.HasPrefix(ref, p) {
+			continue
+		}
+		if !isAlnumByte(p[len(p)-1]) || !isAlnumByte(ref[len(p)]) {
 			return true
 		}
 	}

--- a/internal/rotation/rotation_test.go
+++ b/internal/rotation/rotation_test.go
@@ -30,3 +30,17 @@ func TestPrefixAllowed(t *testing.T) {
 	assert.False(t, prefixAllowed([]string{"app_"}, "root"))   // no match
 	assert.False(t, prefixAllowed([]string{""}, "x"))          // empty prefix never matches
 }
+
+// TestPrefixAllowed_RequiresBoundary is #G46: a raw strings.HasPrefix let an
+// allowed_refs entry of "myapp" also admit "myapp2"/"myappadmin" — an unintended
+// superset an operator who configured "myapp" (without a trailing delimiter) would not
+// expect. An exact match, or a match landing on an explicit segment boundary, must still
+// be required.
+func TestPrefixAllowed_RequiresBoundary(t *testing.T) {
+	allowed := []string{"myapp"}
+	assert.True(t, prefixAllowed(allowed, "myapp"), "exact match must still be allowed")
+	assert.True(t, prefixAllowed(allowed, "myapp-prod"), "a delimited child must still be allowed")
+	assert.True(t, prefixAllowed(allowed, "myapp/db"), "a delimited child must still be allowed")
+	assert.False(t, prefixAllowed(allowed, "myapp2"), "a bare numeric suffix must not be admitted")
+	assert.False(t, prefixAllowed(allowed, "myappadmin"), "a bare alpha suffix must not be admitted")
+}

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -197,7 +197,15 @@ func SecureDeleteFile(path string) error {
 	}
 	size := info.Size()
 
-	f, err := os.OpenFile(path, os.O_WRONLY, 0) // #nosec G304 -- caller-controlled key-backup path, not network input
+	// #G26: every other write primitive in this file (SecureWriteFile,
+	// SecureWriteFileSync, FixFilePerms) opens with O_NOFOLLOW; this one didn't — a
+	// symlink at path (planted after the Stat above, or simply never checked for) would
+	// have this shred-then-unlink through it to the symlink's target, overwriting an
+	// arbitrary file the process can write to with random-then-zero bytes. os.Remove
+	// below still only unlinks the symlink itself, never touching the shredded target —
+	// so without O_NOFOLLOW this destroys arbitrary file content while leaving no trace
+	// at the expected path.
+	f, err := os.OpenFile(path, os.O_WRONLY|syscall.O_NOFOLLOW, 0) // #nosec G304 -- caller-controlled key-backup path, not network input
 	if err != nil {
 		return err
 	}

--- a/internal/securefiles/securefiles_test.go
+++ b/internal/securefiles/securefiles_test.go
@@ -3,6 +3,7 @@ package securefiles
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -334,4 +335,29 @@ func TestSecureDeleteFile_OverwritesAndRemoves(t *testing.T) {
 
 func TestSecureDeleteFile_MissingFileIsNotAnError(t *testing.T) {
 	require.NoError(t, SecureDeleteFile(filepath.Join(t.TempDir(), "does-not-exist")))
+}
+
+// TestSecureDeleteFile_RefusesSymlinkTarget is #G26: unlike every other write
+// primitive in this file, SecureDeleteFile's open had no O_NOFOLLOW — a symlink at
+// path would have the shred pass (random-then-zero overwrite) write through it to the
+// target, destroying arbitrary file content the process can write to. The final
+// os.Remove only unlinks the symlink itself, so without O_NOFOLLOW the corrupted
+// target would be left with no trace at the expected path.
+func TestSecureDeleteFile_RefusesSymlinkTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	dir := t.TempDir()
+	evilTarget := filepath.Join(dir, "attacker-owned.txt")
+	original := []byte("do-not-shred-me")
+	require.NoError(t, os.WriteFile(evilTarget, original, 0600))
+	link := filepath.Join(dir, "dek.key.migrate-backup.456")
+	require.NoError(t, os.Symlink(evilTarget, link))
+
+	err := SecureDeleteFile(link)
+	require.Error(t, err, "a symlinked backup path must be refused, not followed")
+
+	content, rerr := os.ReadFile(evilTarget)
+	require.NoError(t, rerr)
+	assert.Equal(t, original, content, "the symlink target must never be shredded")
 }

--- a/internal/storage/sqlitedialect/migrator.go
+++ b/internal/storage/sqlitedialect/migrator.go
@@ -207,6 +207,15 @@ func (m Migrator) DropConstraint(value interface{}, name string) error {
 	})
 }
 
+// likeEscaper escapes SQLite LIKE's own wildcard characters ('%', '_') plus the escape
+// character itself, so a value spliced into a LIKE pattern is matched literally. #G46: a
+// constraint name containing '_' (extremely common — GORM's own default FK-name
+// convention is "fk_<table>_<column>") was previously spliced unescaped, where '_'
+// matches ANY single character in a LIKE pattern — silently over-matching a similarly-
+// shaped but different constraint and corrupting HasConstraint's existence check (a false
+// positive here makes a migration skip creating a genuinely-missing constraint).
+var likeEscaper = strings.NewReplacer("\\", "\\\\", "%", "\\%", "_", "\\_")
+
 func (m Migrator) HasConstraint(value interface{}, name string) bool {
 	var count int64
 	_ = m.RunWithValue(value, func(stmt *gorm.Statement) error {
@@ -214,10 +223,11 @@ func (m Migrator) HasConstraint(value interface{}, name string) bool {
 		if constraint != nil {
 			name = constraint.GetName()
 		}
+		escaped := likeEscaper.Replace(name)
 
 		_ = m.DB.Raw(
-			"SELECT count(*) FROM sqlite_master WHERE type = ? AND tbl_name = ? AND (sql LIKE ? OR sql LIKE ? OR sql LIKE ? OR sql LIKE ? OR sql LIKE ?)",
-			"table", table, `%CONSTRAINT "`+name+`" %`, `%CONSTRAINT `+name+` %`, "%CONSTRAINT `"+name+"`%", "%CONSTRAINT ["+name+"]%", "%CONSTRAINT \t"+name+"\t%",
+			"SELECT count(*) FROM sqlite_master WHERE type = ? AND tbl_name = ? AND (sql LIKE ? ESCAPE '\\' OR sql LIKE ? ESCAPE '\\' OR sql LIKE ? ESCAPE '\\' OR sql LIKE ? ESCAPE '\\' OR sql LIKE ? ESCAPE '\\')",
+			"table", table, `%CONSTRAINT "`+escaped+`" %`, `%CONSTRAINT `+escaped+` %`, "%CONSTRAINT `"+escaped+"`%", "%CONSTRAINT ["+escaped+"]%", "%CONSTRAINT \t"+escaped+"\t%",
 		).Row().Scan(&count)
 
 		return nil

--- a/internal/storage/sqlitedialect/migrator_test.go
+++ b/internal/storage/sqlitedialect/migrator_test.go
@@ -20,6 +20,15 @@ type constraintTestModel struct {
 	Slug string `gorm:"unique"`
 }
 
+// likeEscapeTestModel's constraint name deliberately contains no '_' — the adversarial
+// query in TestMigrator_HasConstraint_EscapesLikeWildcards below supplies '_' characters
+// instead, in the exact positions this model's real 'X's sit, to prove they're no longer
+// treated as SQL LIKE wildcards.
+type likeEscapeTestModel struct {
+	ID    uint `gorm:"primaryKey"`
+	Score int  `gorm:"check:chkXaXscore,score >= 0"`
+}
+
 func TestMigrator_HasTable(t *testing.T) {
 	db := openTestDB(t)
 	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
@@ -82,6 +91,23 @@ func TestMigrator_HasConstraint(t *testing.T) {
 
 	require.NoError(t, m.CreateConstraint(&migratorTestModel{}, "chk_migrator_score"))
 	assert.True(t, m.HasConstraint(&migratorTestModel{}, "chk_migrator_score"))
+}
+
+// TestMigrator_HasConstraint_EscapesLikeWildcards is #G46: HasConstraint spliced the
+// queried constraint name unescaped into a SQL LIKE pattern, so '_' (which is EXTREMELY
+// common in real constraint names — GORM's own default FK-naming convention is
+// "fk_<table>_<column>") was interpreted as a single-character wildcard instead of a
+// literal underscore. A query for "chk_a_score" must not incorrectly match a
+// differently-named constraint like "chkXaXscore" just because '_' happens to wildcard
+// onto 'X' in that position.
+func TestMigrator_HasConstraint_EscapesLikeWildcards(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&likeEscapeTestModel{}))
+	m := db.Migrator()
+
+	assert.True(t, m.HasConstraint(&likeEscapeTestModel{}, "chkXaXscore"), "the real constraint name must still match itself")
+	assert.False(t, m.HasConstraint(&likeEscapeTestModel{}, "chk_a_score"),
+		"a queried name containing '_' must be matched literally, not as a LIKE wildcard — chk_a_score must not incorrectly match chkXaXscore")
 }
 
 func TestMigrator_ConstraintLifecycle(t *testing.T) {

--- a/server/grpc/services/rotation_plan_service_test.go
+++ b/server/grpc/services/rotation_plan_service_test.go
@@ -41,7 +41,7 @@ func newRotationPlanRig(t *testing.T) *ProjectGRPCService {
 
 	svc := core.NewKeyorixCore(store.NewLocalStorage(db))
 	// app-token depends on db-password → it must rotate in a later wave.
-	_, err := svc.AddSecretDependency(t.Context(), 1, 11, 10, "")
+	_, err := svc.AddSecretDependency(t.Context(), core.ActorTypeUser, 1, 11, 10, "")
 	require.NoError(t, err)
 	return NewProjectService(svc)
 }

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -111,7 +111,7 @@ func (s *SecretGRPCService) ListSecretDependencies(ctx context.Context, req *pb.
 	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetId()), permSecretsRead); err != nil {
 		return nil, err
 	}
-	deps, err := s.core.ListSecretDependencies(ctx, uint(req.GetId()))
+	deps, err := s.core.ListSecretDependencies(ctx, user.ActorKind(), user.PrincipalID(), uint(req.GetId()))
 	if err != nil {
 		return nil, mapSecretError(err)
 	}
@@ -128,7 +128,7 @@ func (s *SecretGRPCService) GetSecretImpact(ctx context.Context, req *pb.GetSecr
 	if err := authorizeSecretScoped(ctx, s.core, user, uint(req.GetId()), permSecretsRead); err != nil {
 		return nil, err
 	}
-	impact, err := s.core.GetSecretImpact(ctx, uint(req.GetId()))
+	impact, err := s.core.GetSecretImpact(ctx, user.ActorKind(), user.PrincipalID(), uint(req.GetId()))
 	if err != nil {
 		return nil, mapSecretError(err)
 	}

--- a/server/http/handlers/blast_radius.go
+++ b/server/http/handlers/blast_radius.go
@@ -15,7 +15,8 @@ import (
 
 // GetBlastRadius handles GET /api/v1/secrets/{id}/blast-radius
 func (h *SecretHandler) GetBlastRadius(w http.ResponseWriter, r *http.Request) {
-	if middleware.GetUserFromContext(r.Context()) == nil {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
 		h.sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
 		return
 	}
@@ -24,7 +25,7 @@ func (h *SecretHandler) GetBlastRadius(w http.ResponseWriter, r *http.Request) {
 		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
 		return
 	}
-	report, err := h.coreService.GetBlastRadius(r.Context(), uint(id))
+	report, err := h.coreService.GetBlastRadius(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), uint(id))
 	if err != nil {
 		status := dependencyErrorStatus(err.Error())
 		msg := err.Error()

--- a/server/http/handlers/secret_dep_coverage_test.go
+++ b/server/http/handlers/secret_dep_coverage_test.go
@@ -52,6 +52,13 @@ func freshDepCovCore(t *testing.T) (*core.KeyorixCore, *gorm.DB) {
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(models.AllTestModels()...))
+	// withUserCtx's UserID 1 is granted global admin: #G32's independent peer-secret
+	// authorization check would otherwise reject every Add/RemoveSecretDependency call
+	// here (this file tests the handler's glue logic — param parsing, error-status
+	// mapping — not authorization, which is the router middleware's job).
+	role := &models.Role{Name: "admin"}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: role.ID, ProjectID: 0, EnvironmentID: 0}).Error)
 	return core.NewKeyorixCore(store.NewLocalStorage(db)), db
 }
 

--- a/server/http/handlers/secret_dependencies.go
+++ b/server/http/handlers/secret_dependencies.go
@@ -44,7 +44,8 @@ func dependencyErrorStatus(msg string) int {
 
 // ListSecretDependencies handles GET /api/v1/secrets/{id}/dependencies
 func (h *SecretHandler) ListSecretDependencies(w http.ResponseWriter, r *http.Request) {
-	if middleware.GetUserFromContext(r.Context()) == nil {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
 		h.sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
 		return
 	}
@@ -53,7 +54,7 @@ func (h *SecretHandler) ListSecretDependencies(w http.ResponseWriter, r *http.Re
 		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
 		return
 	}
-	deps, err := h.coreService.ListSecretDependencies(r.Context(), uint(id))
+	deps, err := h.coreService.ListSecretDependencies(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), uint(id))
 	if err != nil {
 		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
 		return
@@ -85,7 +86,7 @@ func (h *SecretHandler) AddSecretDependency(w http.ResponseWriter, r *http.Reque
 		h.sendError(w, "InvalidParameter", "depends_on_id is required", http.StatusBadRequest, nil)
 		return
 	}
-	dep, err := h.coreService.AddSecretDependency(r.Context(), userCtx.UserID, uint(id), reqBody.DependsOnID, reqBody.Note)
+	dep, err := h.coreService.AddSecretDependency(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), uint(id), reqBody.DependsOnID, reqBody.Note)
 	if err != nil {
 		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
 		return
@@ -110,7 +111,7 @@ func (h *SecretHandler) RemoveSecretDependency(w http.ResponseWriter, r *http.Re
 		h.sendError(w, "InvalidParameter", "Invalid dependency ID", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.RemoveSecretDependency(r.Context(), userCtx.UserID, uint(id), uint(depID)); err != nil {
+	if err := h.coreService.RemoveSecretDependency(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), uint(id), uint(depID)); err != nil {
 		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
 		return
 	}
@@ -119,7 +120,8 @@ func (h *SecretHandler) RemoveSecretDependency(w http.ResponseWriter, r *http.Re
 
 // GetSecretImpact handles GET /api/v1/secrets/{id}/impact
 func (h *SecretHandler) GetSecretImpact(w http.ResponseWriter, r *http.Request) {
-	if middleware.GetUserFromContext(r.Context()) == nil {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
 		h.sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
 		return
 	}
@@ -128,7 +130,7 @@ func (h *SecretHandler) GetSecretImpact(w http.ResponseWriter, r *http.Request) 
 		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
 		return
 	}
-	impact, err := h.coreService.GetSecretImpact(r.Context(), uint(id))
+	impact, err := h.coreService.GetSecretImpact(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), uint(id))
 	if err != nil {
 		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
 		return
@@ -141,7 +143,8 @@ func (h *SecretHandler) GetSecretImpact(w http.ResponseWriter, r *http.Request) 
 // if the given secret were soft-deleted: direct dependent count, total transitive
 // count, all affected IDs, and the maximum dependency chain depth reached.
 func (h *SecretHandler) GetSecretImpactPreview(w http.ResponseWriter, r *http.Request) {
-	if middleware.GetUserFromContext(r.Context()) == nil {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
 		h.sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
 		return
 	}
@@ -150,7 +153,7 @@ func (h *SecretHandler) GetSecretImpactPreview(w http.ResponseWriter, r *http.Re
 		h.sendError(w, "InvalidParameter", errInvalidSecretID, http.StatusBadRequest, nil)
 		return
 	}
-	preview, err := h.coreService.GetSecretImpactPreview(r.Context(), uint(id))
+	preview, err := h.coreService.GetSecretImpactPreview(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), uint(id))
 	if err != nil {
 		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
 		return

--- a/server/middleware/logger.go
+++ b/server/middleware/logger.go
@@ -26,7 +26,13 @@ var sensitiveURIPattern = regexp.MustCompile(`(?i)^(/(?:api/v1/)?auth/(?:setup|i
 // query param that is the secret reference or name. Logging these verbatim would
 // write secret names/references to the access log (container logs, log-aggregation
 // SaaS, on-call terminal), leaking the secret catalogue to log readers.
-var sensitiveQueryPattern = regexp.MustCompile(`(?i)/secrets/(?:value|by-name)\b`)
+//
+// #G29: the OAuth/OIDC SSO callback (GET .../auth/sso/{provider}/callback) was
+// never added here — its ?code=&state= query carries a single-use OAuth
+// authorization code (redeemable for a session on its own) and a CSRF state
+// nonce, so every SSO login used to write the authorization code to the log
+// stream in plaintext.
+var sensitiveQueryPattern = regexp.MustCompile(`(?i)/secrets/(?:value|by-name)\b|/auth/sso/[^/?]+/callback\b`)
 
 // redactSensitiveURI replaces the credential segment of a known-sensitive path
 // with a fixed placeholder, and strips the entire query string for paths that
@@ -44,6 +50,29 @@ func redactSensitiveURI(uri string) string {
 	return uri
 }
 
+// decodedRequestURI reconstructs r.URL.Path + its query string as a single
+// string, built from the already-percent-decoded .Path — NOT the raw
+// r.RequestURI wire form redactSensitiveURI used to be applied to directly.
+// #G29: a percent-encoded route character (e.g. %2F standing in for a literal
+// '/') still routes to the same handler via chi's decoded-path matching, but
+// left RequestURI's raw, still-encoded form unmatched by sensitiveURIPattern —
+// a redaction bypass. Matching against the decoded path closes it.
+func decodedRequestURI(r *http.Request) string {
+	if r.URL.RawQuery == "" {
+		return r.URL.Path
+	}
+	return r.URL.Path + "?" + r.URL.RawQuery
+}
+
+// logSafeRequestURI is the single canonicalizing function fix_shape (#G29)
+// asks for: redact known-sensitive path/query content, then strip control
+// characters (CR/LF, ANSI/C1 escapes, NUL) from whatever remains — applied
+// uniformly here (the access log) and in recovery.go's panic-context log, so
+// neither can independently drift out of sync with the other's coverage.
+func logSafeRequestURI(r *http.Request) string {
+	return stripControl(redactSensitiveURI(decodedRequestURI(r)))
+}
+
 // Logger returns a middleware that logs HTTP requests. It behaves like chi's
 // middleware.RequestLogger(DefaultLogFormatter), except the request handed to the
 // formatter has any known-sensitive path segment redacted first (see
@@ -55,13 +84,17 @@ func redactSensitiveURI(uri string) string {
 // use it for account takeover.
 func Logger() func(next http.Handler) http.Handler {
 	formatter := &middleware.DefaultLogFormatter{
-		Logger:  log.Default(),
-		NoColor: false,
+		Logger: log.Default(),
+		// #G29: server access logs are captured non-interactively (container
+		// logs, a log-aggregation SaaS) where ANSI color codes are noise at
+		// best and an unnecessary terminal-control byte stream at worst if
+		// ever viewed raw — never emit them here.
+		NoColor: true,
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			logReq := r
-			if redacted := redactSensitiveURI(r.RequestURI); redacted != r.RequestURI {
+			if redacted := logSafeRequestURI(r); redacted != r.RequestURI {
 				clone := r.Clone(r.Context())
 				clone.RequestURI = redacted
 				logReq = clone

--- a/server/middleware/logger_test.go
+++ b/server/middleware/logger_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestLogger_RedactsSetupToken is the security invariant for #291: the setup/
@@ -122,4 +123,71 @@ func TestRedactSensitiveURI(t *testing.T) {
 			assert.Equal(t, tc.want, redactSensitiveURI(tc.in))
 		})
 	}
+}
+
+// TestLogger_RedactsSSOCallbackQuery is #G29 (high): the OAuth/OIDC SSO
+// callback route was never added to sensitiveQueryPattern, so every SSO login
+// wrote its single-use authorization code (redeemable for a session on its
+// own) and CSRF state nonce to the access log in plaintext.
+func TestLogger_RedactsSSOCallbackQuery(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	const code = "aVeryLongOAuthAuthorizationCodeDoNotLeak123"
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/sso/okta/callback?code="+code+"&state=xyz", nil)
+	rec := httptest.NewRecorder()
+	Logger()(ok).ServeHTTP(rec, req)
+
+	logged := buf.String()
+	assert.NotContains(t, logged, code, "the OAuth authorization code must never be written to the log stream")
+	assert.Contains(t, logged, "[redacted]")
+}
+
+// TestLogger_RedactsPercentEncodedSetupToken is #G29 (medium): a percent-
+// encoded route character (here %2F standing in for the literal '/' before
+// "setup") still routes to the same handler via the decoded path, but the old
+// implementation matched sensitiveURIPattern against the RAW, still-encoded
+// r.RequestURI — so this exact request bypassed redaction while chi routed it
+// correctly.
+func TestLogger_RedactsPercentEncodedSetupToken(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	const token = "percentEncodedBypassMustNotLeakThisToken789"
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth%2Fsetup/"+token, nil)
+	require.Equal(t, "/auth/setup/"+token, req.URL.Path, "sanity: net/url decodes %2F into the Path field")
+	rec := httptest.NewRecorder()
+	Logger()(ok).ServeHTTP(rec, req)
+
+	logged := buf.String()
+	assert.NotContains(t, logged, token, "a percent-encoded route character must not bypass redaction")
+	assert.Contains(t, logged, "[REDACTED]")
+}
+
+// TestLogger_NoColor pins #G29 (low): server access logs are captured non-
+// interactively — chi's formatter must never emit ANSI color escape bytes.
+func TestLogger_NoColor(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	Logger()(ok).ServeHTTP(rec, req)
+
+	assert.NotContains(t, buf.String(), "\x1b[", "the access log must not contain ANSI color escape sequences")
 }

--- a/server/middleware/recovery.go
+++ b/server/middleware/recovery.go
@@ -47,8 +47,15 @@ func Recovery() func(next http.Handler) http.Handler { // NOSONAR -- cognitive c
 						userInfo = "anonymous"
 					}
 
+					// #G29: this used to log r.URL.Path raw, bypassing redaction
+					// entirely — a panic mid-request to e.g. GET /auth/setup/{token}
+					// or the SSO callback (?code=...) would write that credential
+					// straight to the panic log. logSafeRequestURI (logger.go) is
+					// the SAME canonicalizing redact+strip-control function the
+					// access log uses, so this can't independently drift out of
+					// sync with it.
 					log.Printf("PANIC CONTEXT: RequestID=%s, User=%s, Method=%s, Path=%s, RemoteAddr=%s",
-						requestID, userInfo, r.Method, r.URL.Path, r.RemoteAddr)
+						requestID, userInfo, r.Method, logSafeRequestURI(r), r.RemoteAddr)
 
 					// Send a generic error response. We deliberately NEVER return the
 					// panic value, stack trace, or other internals to the client — this

--- a/server/middleware/recovery_test.go
+++ b/server/middleware/recovery_test.go
@@ -1,7 +1,9 @@
 package middleware
 
 import (
+	"bytes"
 	"encoding/json"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -49,4 +51,45 @@ func TestRecovery_PassesThroughNonPanic(t *testing.T) {
 	Recovery()(ok).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 	require.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "ok", strings.TrimSpace(rec.Body.String()))
+}
+
+// TestRecovery_RedactsSetupTokenInPanicContextLog is #G29 (high + low): the
+// PANIC CONTEXT log line used to write r.URL.Path raw, bypassing logger.go's
+// redaction entirely — a panic mid-request to GET /auth/setup/{token} would
+// write that single-use bearer credential straight to the panic log.
+func TestRecovery_RedactsSetupTokenInPanicContextLog(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	const token = "panicPathMustNotLeakThisSetupToken456"
+	panicking := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { panic("boom") })
+
+	rec := httptest.NewRecorder()
+	Recovery()(panicking).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/auth/setup/"+token, nil))
+
+	logged := buf.String()
+	assert.NotContains(t, logged, token, "the setup token must never reach the panic-context log")
+	assert.Contains(t, logged, "[REDACTED]")
+}
+
+// TestRecovery_RedactsSSOCallbackQueryInPanicContextLog covers the same gap
+// for the OAuth/OIDC SSO callback's authorization code.
+func TestRecovery_RedactsSSOCallbackQueryInPanicContextLog(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	const code = "panicPathMustNotLeakThisOAuthCode789"
+	panicking := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { panic("boom") })
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/sso/okta/callback?code="+code+"&state=xyz", nil)
+	Recovery()(panicking).ServeHTTP(rec, req)
+
+	logged := buf.String()
+	assert.NotContains(t, logged, code, "the OAuth authorization code must never reach the panic-context log")
+	assert.Contains(t, logged, "[redacted]")
 }

--- a/web/src/components/layout/RequirePasswordChange.tsx
+++ b/web/src/components/layout/RequirePasswordChange.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Navigate, useLocation } from 'react-router';
 import { useAuth } from '../../features/auth';
 import { ROUTES } from '../../constants';
+import { matchesRoutePrefix } from '../../utils/routing';
 
 interface RequirePasswordChangeProps {
     children: React.ReactNode;
@@ -19,7 +20,7 @@ export const RequirePasswordChange: React.FC<RequirePasswordChangeProps> = ({ ch
     const { user } = useAuth();
     const location = useLocation();
 
-    if (user?.passwordChangeRequired && !location.pathname.startsWith(ROUTES.PROFILE)) {
+    if (user?.passwordChangeRequired && !matchesRoutePrefix(location.pathname, ROUTES.PROFILE)) {
         return <Navigate to={ROUTES.PROFILE} replace />;
     }
 

--- a/web/src/components/layout/__tests__/RequirePasswordChange.test.tsx
+++ b/web/src/components/layout/__tests__/RequirePasswordChange.test.tsx
@@ -64,4 +64,21 @@ describe('RequirePasswordChange', () => {
         renderAt('/dashboard');
         expect(screen.getByText('App Content')).toBeInTheDocument();
     });
+
+    // #G46: a raw `location.pathname.startsWith(ROUTES.PROFILE)` would also match an
+    // unrelated sibling route that merely shares the '/profile' prefix (e.g.
+    // '/profile-settings') — this must still redirect a restricted user, not treat it
+    // as if it were the profile page.
+    it('redirects a restricted user away from a route that only shares the /profile prefix', () => {
+        mockUser = { id: 1, passwordChangeRequired: true };
+        renderAt('/profile-settings');
+        expect(screen.getByText('Profile Page')).toBeInTheDocument();
+        expect(screen.queryByText('App Content')).not.toBeInTheDocument();
+    });
+
+    it('lets a restricted user reach a true sub-route of /profile', () => {
+        mockUser = { id: 1, passwordChangeRequired: true };
+        renderAt('/profile/security');
+        expect(screen.getByText('App Content')).toBeInTheDocument();
+    });
 });

--- a/web/src/utils/routing.ts
+++ b/web/src/utils/routing.ts
@@ -74,7 +74,8 @@ export const getPostLoginRedirect = (defaultPath: string = ROUTES.DASHBOARD): st
  * unrelated sibling paths that merely share a prefix (e.g. `/login-help`
  * against `/login`), so callers should use this instead.
  */
-const matchesRoutePrefix = (path: string, route: string): boolean => path === route || path.startsWith(`${route}/`);
+export const matchesRoutePrefix = (path: string, route: string): boolean =>
+    path === route || path.startsWith(`${route}/`);
 
 /**
  * Checks if a route requires authentication


### PR DESCRIPTION
## Summary

Fourth and final Wave 3 batch — completes the adversarial-review remediation plan's Wave 3 (all 23 groups now fixed). Continuation of #1407/#1410/#1411.

- **G29** — access-log/panic-log redaction coverage gaps (5 members, high). Panic-context logging bypassed redaction entirely; the OAuth/OIDC SSO callback route was never added to the sensitive-query pattern; a percent-encoded route character bypassed the regex; `stripControl` wasn't applied uniformly; ANSI color codes leaked into non-interactive logs. Consolidated into one canonicalizing `logSafeRequestURI` used by both the access log and the panic-context log.

- **G32** — secret-relationship functions authorize the focal secret, disclose the peer (5 members, high). `AddSecretDependency`/`RemoveSecretDependency`/`ListSecretDependencies`/`GetSecretImpact`/`GetBlastRadius`/`GetSecretImpactPreview` authorized only the focal (path) secret and relied on "same project+environment" as a stand-in for peer authorization — unsound, since this codebase's authorization model includes per-secret ACL grants that don't extend to a peer merely because it shares an environment. Mutating paths now independently authorize the peer; read paths filter out any peer the caller isn't independently authorized to see (while still traversing the full graph internally, so a hop through an unauthorized peer doesn't hide a further authorized dependent).

- **G26** — symlink-unsafe file op missing O_NOFOLLOW/O_EXCL a sibling already has (5 members, high). `export.go`'s hardened O_EXCL+O_NOFOLLOW pattern (renamed `createSecureOutputFile`) was never propagated to `secret render --output`, `secret scan --report`, `secret fix`'s file-editing apply step, or `securefiles.SecureDeleteFile` — each now refuses to write through a pre-planted symlink.

- **G46** — string/route matching lacks boundary anchoring (5 members, high). Five independent naive substring/prefix matchers (an email-domain allowlist, a rotation-ref prefix allowlist, a SQL LIKE-pattern constraint matcher, a React route-prefix exemption, and a CLI loopback-host check) each anchored on an explicit boundary or escaped wildcards instead. The loopback-host check is the group's highest-severity member: `strings.HasPrefix(host, "127.")` matched an attacker-controlled DNS name like `127.evil.com`, silently skipping `keyorix connect`'s only cleartext-credential-transmission warning.

Each group has regression tests reproducing its `detection_idea` from the review's `ROOT-CAUSE-GROUPS.md`.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean repo-wide
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues (788 files)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./internal/core/... ./internal/rotation/... ./internal/storage/sqlitedialect/... ./internal/cli/connect/... ./internal/cli/secret/... ./internal/securefiles/... ./server/http/handlers/... ./server/grpc/services/... ./server/middleware/...` all green
- [x] web: `pnpm type-check` / `pnpm lint` / `pnpm format:check` / `pnpm build` clean; `pnpm test --run` green (175 files / 2967 tests)