### PR TITLE
fix(security): make MFA state changes atomic (G08)

### DIFF
--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/pquerna/otp"
@@ -105,24 +106,33 @@ func (c *KeyorixCore) ActivateMFA(ctx context.Context, userID uint, code, passwo
 		c.auditMFAFailed(ctx, userID, "activate")
 		return nil, fmt.Errorf("invalid code")
 	}
-	if err := c.storage.ActivateMFASecret(ctx, userID); err != nil {
-		return nil, fmt.Errorf("failed to activate MFA: %w", err)
+	codes, hashes, err := generateRecoveryCodes(mfaRecoveryCodeCount)
+	if err != nil {
+		return nil, err
 	}
-	if err := c.storage.SetUserMFAEnabled(ctx, userID, true); err != nil {
-		return nil, fmt.Errorf("failed to enable MFA: %w", err)
+	// #G08: activating the secret, flipping MFAEnabled, and creating recovery codes must
+	// move together — a storage failure between any two of these previously left the
+	// account in an inconsistent state (e.g. MFAEnabled=true with no recovery codes ever
+	// issued, locking the user out with no fallback the moment their device is lost).
+	if err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		if err := tx.ActivateMFASecret(ctx, userID); err != nil {
+			return fmt.Errorf("failed to activate MFA: %w", err)
+		}
+		if err := tx.SetUserMFAEnabled(ctx, userID, true); err != nil {
+			return fmt.Errorf("failed to enable MFA: %w", err)
+		}
+		if err := tx.CreateMFARecoveryCodes(ctx, userID, hashes); err != nil {
+			return fmt.Errorf("failed to store recovery codes: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	// Invalidate any sessions minted before MFA was enabled (and evict them from the auth
 	// cache), so a pre-enrolment session cannot outlive the security upgrade — even for
 	// the cache TTL (same hygiene as password change / suspend). Best-effort: enrolment
 	// must not fail on a session-cleanup error.
 	_ = c.deleteSessionsForUserAndEvict(ctx, userID, 0, "")
-	codes, hashes, err := generateRecoveryCodes(mfaRecoveryCodeCount)
-	if err != nil {
-		return nil, err
-	}
-	if err := c.storage.CreateMFARecoveryCodes(ctx, userID, hashes); err != nil {
-		return nil, fmt.Errorf("failed to store recovery codes: %w", err)
-	}
 	uid := userID
 	c.writeAuditEventFull(ctx, "mfa.activated", &uid, nil, nil, "", fmt.Sprintf("user %s activated MFA", user.Username))
 	return codes, nil
@@ -141,10 +151,16 @@ func (c *KeyorixCore) DisableMFA(ctx context.Context, userID uint, codeOrPasswor
 	if err := c.requireReauth(ctx, user, codeOrPassword, "disable"); err != nil {
 		return err
 	}
-	if err := c.storage.SetUserMFAEnabled(ctx, userID, false); err != nil {
-		return err
-	}
-	if err := c.storage.DeleteMFAForUser(ctx, userID); err != nil {
+	// #G08: flipping MFAEnabled and clearing the secret/recovery codes must move
+	// together — a storage failure between the two previously could leave MFAEnabled
+	// false while stale credential material survived (or vice versa), an inconsistent
+	// state the API nonetheless reported as a clean failure.
+	if err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		if err := tx.SetUserMFAEnabled(ctx, userID, false); err != nil {
+			return err
+		}
+		return tx.DeleteMFAForUser(ctx, userID)
+	}); err != nil {
 		return err
 	}
 	// Purge all sessions now that MFA is disabled — the security downgrade must not
@@ -177,10 +193,16 @@ func (c *KeyorixCore) RegenerateMFARecoveryCodes(ctx context.Context, userID uin
 	if err != nil {
 		return nil, err
 	}
-	if err := c.storage.DeleteMFARecoveryCodes(ctx, userID); err != nil {
-		return nil, fmt.Errorf("failed to clear old recovery codes: %w", err)
-	}
-	if err := c.storage.CreateMFARecoveryCodes(ctx, userID, hashes); err != nil {
+	// #G08: deleting the old codes and inserting the new set must move together — a
+	// storage failure between the two previously could leave the account with ZERO
+	// recovery codes (old set gone, new set never landed), an unsafe state the API
+	// nonetheless reported as a clean failure.
+	if err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		if err := tx.DeleteMFARecoveryCodes(ctx, userID); err != nil {
+			return fmt.Errorf("failed to clear old recovery codes: %w", err)
+		}
+		return tx.CreateMFARecoveryCodes(ctx, userID, hashes)
+	}); err != nil {
 		return nil, fmt.Errorf("failed to store recovery codes: %w", err)
 	}
 	uid := userID

--- a/internal/core/mfa_atomicity_test.go
+++ b/internal/core/mfa_atomicity_test.go
@@ -1,0 +1,147 @@
+// mfa_atomicity_test.go — #G08 detection_idea: force a storage failure between the
+// two (or three) writes each of DisableMFA/RegenerateMFARecoveryCodes/ActivateMFA
+// makes, and assert — by reading the raw DB directly, not just checking the
+// returned error — that NO state exists where the enforcement flag and the
+// credential material disagree. Each test wraps a real SQLite-backed
+// storage.Storage with failingStorage, which forwards every call to the real
+// implementation except one method (the SECOND write in the pair/triple), which it
+// fails outright — proving the fix's WithTransaction wrapping causes a genuine
+// rollback of the FIRST write too, not just an early return.
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failingStorage wraps a real storage.Storage and fails every call to the named
+// method with errInjectedFailure — every other method (including WithTransaction,
+// which re-wraps the transactional storage.Storage handed to the callback so the
+// injected failure applies INSIDE the transaction, not just at the outer layer)
+// passes through untouched.
+type failingStorage struct {
+	storage.Storage
+	failMethod string
+}
+
+var errInjectedFailure = errors.New("injected storage failure")
+
+func (f *failingStorage) WithTransaction(ctx context.Context, fn func(storage.Storage) error) error {
+	return f.Storage.WithTransaction(ctx, func(tx storage.Storage) error {
+		return fn(&failingStorage{Storage: tx, failMethod: f.failMethod})
+	})
+}
+
+func (f *failingStorage) ActivateMFASecret(ctx context.Context, userID uint) error {
+	if f.failMethod == "ActivateMFASecret" {
+		return errInjectedFailure
+	}
+	return f.Storage.ActivateMFASecret(ctx, userID)
+}
+
+func (f *failingStorage) SetUserMFAEnabled(ctx context.Context, userID uint, enabled bool) error {
+	if f.failMethod == "SetUserMFAEnabled" {
+		return errInjectedFailure
+	}
+	return f.Storage.SetUserMFAEnabled(ctx, userID, enabled)
+}
+
+func (f *failingStorage) CreateMFARecoveryCodes(ctx context.Context, userID uint, hashes []string) error {
+	if f.failMethod == "CreateMFARecoveryCodes" {
+		return errInjectedFailure
+	}
+	return f.Storage.CreateMFARecoveryCodes(ctx, userID, hashes)
+}
+
+func (f *failingStorage) DeleteMFAForUser(ctx context.Context, userID uint) error {
+	if f.failMethod == "DeleteMFAForUser" {
+		return errInjectedFailure
+	}
+	return f.Storage.DeleteMFAForUser(ctx, userID)
+}
+
+func (f *failingStorage) DeleteMFARecoveryCodes(ctx context.Context, userID uint) error {
+	if f.failMethod == "DeleteMFARecoveryCodes" {
+		return errInjectedFailure
+	}
+	return f.Storage.DeleteMFARecoveryCodes(ctx, userID)
+}
+
+// TestActivateMFA_AtomicOnRecoveryCodesFailure: CreateMFARecoveryCodes (the LAST of
+// the three writes) fails — ActivateMFASecret and SetUserMFAEnabled must both roll
+// back too, or the account would end up MFA-enabled with zero recovery codes and no
+// fallback if the device is ever lost.
+func TestActivateMFA_AtomicOnRecoveryCodesFailure(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	code, err := totp.GenerateCode(secret, fixed.Add(-30*time.Second))
+	require.NoError(t, err)
+
+	c.storage = &failingStorage{Storage: c.storage, failMethod: "CreateMFARecoveryCodes"}
+	_, err = c.ActivateMFA(ctx, 1, code, mfaTestPassword)
+	require.Error(t, err)
+
+	var user models.User
+	require.NoError(t, db.First(&user, 1).Error)
+	assert.False(t, user.MFAEnabled, "MFAEnabled must roll back to false when recovery-code creation fails")
+
+	var secretRow models.MFASecret
+	require.NoError(t, db.Where("user_id = ?", 1).First(&secretRow).Error)
+	assert.False(t, secretRow.Activated, "the MFA secret must roll back to NOT activated")
+
+	var codeCount int64
+	require.NoError(t, db.Model(&models.MFARecoveryCode{}).Where("user_id = ?", 1).Count(&codeCount).Error)
+	assert.Zero(t, codeCount, "no recovery codes may exist after a failed activation")
+}
+
+// TestDisableMFA_AtomicOnDeleteFailure: DeleteMFAForUser (the second write) fails —
+// SetUserMFAEnabled's flip to false must roll back too, or the account would report
+// MFA disabled while the TOTP secret and recovery codes are still live in storage.
+func TestDisableMFA_AtomicOnDeleteFailure(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	activateMFAForTest(t, c, fixed)
+
+	c.storage = &failingStorage{Storage: c.storage, failMethod: "DeleteMFAForUser"}
+	err := c.DisableMFA(ctx, 1, mfaTestPassword)
+	require.Error(t, err)
+
+	var user models.User
+	require.NoError(t, db.First(&user, 1).Error)
+	assert.True(t, user.MFAEnabled, "MFAEnabled must roll back to true when clearing credential material fails")
+
+	var secretCount int64
+	require.NoError(t, db.Model(&models.MFASecret{}).Where("user_id = ?", 1).Count(&secretCount).Error)
+	assert.Equal(t, int64(1), secretCount, "the TOTP secret must still exist — DeleteMFAForUser's failure must not have partially cleared it while MFAEnabled reports true")
+}
+
+// TestRegenerateMFARecoveryCodes_AtomicOnCreateFailure: CreateMFARecoveryCodes (the
+// second write) fails — the prior DeleteMFARecoveryCodes must roll back too, or the
+// account would be left with ZERO recovery codes: no old set (deleted) and no new
+// set (creation failed), an unsafe state the API nonetheless reports as a clean
+// failure to the caller.
+func TestRegenerateMFARecoveryCodes_AtomicOnCreateFailure(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	_, original := activateMFAForTest(t, c, fixed)
+	require.Len(t, original, mfaRecoveryCodeCount)
+
+	c.storage = &failingStorage{Storage: c.storage, failMethod: "CreateMFARecoveryCodes"}
+	_, err := c.RegenerateMFARecoveryCodes(ctx, 1, mfaTestPassword)
+	require.Error(t, err)
+
+	var codeCount int64
+	require.NoError(t, db.Model(&models.MFARecoveryCode{}).Where("user_id = ?", 1).Count(&codeCount).Error)
+	assert.Equal(t, int64(mfaRecoveryCodeCount), codeCount,
+		"the ORIGINAL recovery codes must still be present — deleting them must roll back when creating the replacement set fails")
+}


### PR DESCRIPTION
## Summary

`DisableMFA`, `RegenerateMFARecoveryCodes`, and `ActivateMFA` each performed a state-changing sequence as two or three separate, non-transactional writes (flip the enforcement flag, then touch credential rows, or vice versa). A storage failure between the writes left the account in an inconsistent, unsafe state — e.g. `MFAEnabled=true` with zero recovery codes ever created (locked out with no fallback), or `MFAEnabled=false` with the TOTP secret/recovery codes still live — while the API reported a clean failure.

All three now wrap their writes in a single `storage.WithTransaction` call:
- `ActivateMFA`: `ActivateMFASecret` + `SetUserMFAEnabled(true)` + `CreateMFARecoveryCodes`
- `DisableMFA`: `SetUserMFAEnabled(false)` + `DeleteMFAForUser`
- `RegenerateMFARecoveryCodes`: `DeleteMFARecoveryCodes` + `CreateMFARecoveryCodes`

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `gosec -severity medium -exclude-generated` clean
- [x] `golangci-lint run` clean
- [x] Full `internal/core` suite green
- [x] New regression tests (`mfa_atomicity_test.go`) implement the group's own detection_idea directly: a `failingStorage` wrapper forces a genuine failure on the LAST write of each sequence (inside the transaction), then reads the raw DB — not just the returned error — to confirm the earlier write(s) rolled back too, proving true atomicity