### PR TITLE
fix(security): make Recovery/Logger/Metrics handle a mid-response panic consistently (G55)

### DIFF
--- a/server/middleware/logger.go
+++ b/server/middleware/logger.go
@@ -104,7 +104,21 @@ func Logger() func(next http.Handler) http.Handler {
 
 			t1 := time.Now()
 			defer func() {
-				entry.Write(ww.Status(), ww.BytesWritten(), ww.Header(), time.Since(t1), nil)
+				// #G55: without recover() here, a panicking handler still reaches this
+				// defer (defers always run), but ww.Status() reads 0 at this point in the
+				// unwind (Recovery's write happens later, further up the stack) — logging
+				// a misleading status 0 instead of the 500 the client actually receives.
+				// Recover, log the TRUE eventual status, then re-panic so Recovery (outer)
+				// still gets to handle it.
+				panicVal := recover()
+				status := ww.Status()
+				if panicVal != nil {
+					status = http.StatusInternalServerError
+				}
+				entry.Write(status, ww.BytesWritten(), ww.Header(), time.Since(t1), nil)
+				if panicVal != nil {
+					panic(panicVal)
+				}
 			}()
 
 			next.ServeHTTP(ww, middleware.WithLogEntry(r, entry))

--- a/server/middleware/metrics.go
+++ b/server/middleware/metrics.go
@@ -43,22 +43,44 @@ func PrometheusMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		ww := chimw.NewWrapResponseWriter(w, r.ProtoMajor)
-		next.ServeHTTP(ww, r)
 
-		// RoutePattern is populated once chi has matched the route, so it is read
-		// after the handler runs. Unmatched requests (404s) share one label to
-		// avoid unbounded cardinality from arbitrary paths.
-		route := chi.RouteContext(r.Context()).RoutePattern()
-		if route == "" {
-			route = "unmatched"
-		}
-		status := ww.Status()
-		if status == 0 {
-			status = http.StatusOK // handler returned without an explicit WriteHeader
-		}
-		method := normalizeMethod(r.Method)
-		httpRequestsTotal.WithLabelValues(method, route, strconv.Itoa(status)).Inc()
-		httpRequestDuration.WithLabelValues(method, route).Observe(time.Since(start).Seconds())
+		// #G55: previously the metric-recording logic below ran only on normal
+		// return — a panicking handler skipped straight past it (this function's own
+		// stack frame unwinds without ever reaching the code after next.ServeHTTP),
+		// making panicking requests invisible in metrics entirely. A defer runs
+		// regardless of panic vs. normal return; recover()+re-panic here records the
+		// request (as the 500 Recovery, further up the chain, will produce) without
+		// swallowing the panic — Recovery still needs to see it to respond.
+		defer func() {
+			// RoutePattern is populated once chi has matched the route, so it is read
+			// after the handler runs. Unmatched requests (404s) share one label to
+			// avoid unbounded cardinality from arbitrary paths.
+			route := chi.RouteContext(r.Context()).RoutePattern()
+			if route == "" {
+				route = "unmatched"
+			}
+			panicVal := recover()
+			var status int
+			switch {
+			case panicVal != nil:
+				// ww.Status() is still 0 here — nothing has been written through ww at
+				// this point in the panic unwind (Recovery's own write happens later,
+				// further up the stack). Record the status Recovery will actually send.
+				status = http.StatusInternalServerError
+			case ww.Status() == 0:
+				status = http.StatusOK // handler returned without an explicit WriteHeader
+			default:
+				status = ww.Status()
+			}
+			method := normalizeMethod(r.Method)
+			httpRequestsTotal.WithLabelValues(method, route, strconv.Itoa(status)).Inc()
+			httpRequestDuration.WithLabelValues(method, route).Observe(time.Since(start).Seconds())
+			if panicVal != nil {
+				panic(panicVal)
+			}
+		}()
+
+		next.ServeHTTP(ww, r)
 	})
 }
 

--- a/server/middleware/panic_chain_test.go
+++ b/server/middleware/panic_chain_test.go
@@ -1,0 +1,106 @@
+// panic_chain_test.go — #G55 detection_idea: a handler that writes a PARTIAL
+// response then panics, run through the REAL middleware chain order (Recovery
+// outermost, then Logger, then PrometheusMiddleware innermost — see router.go's
+// r.Use registration order). Asserts all three of the group's own acceptance
+// criteria at once: the client sees a clean abort (not corrupted/duplicated
+// output), the Prometheus counter for that request still increments, and the
+// access log records status 500 (not a misleading 0).
+package middleware
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// chainedRecoveryLoggerMetrics reproduces router.go's real registration order:
+// Recovery(Logger(PrometheusMiddleware(next))).
+func chainedRecoveryLoggerMetrics(next http.Handler) http.Handler {
+	return Recovery()(Logger()(PrometheusMiddleware(next)))
+}
+
+func TestPanicChain_PartialWriteThenPanic(t *testing.T) {
+	const partialBody = "partial-body-before-panic"
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(partialBody))
+		panic("boom mid-response")
+	})
+
+	var logBuf bytes.Buffer
+	origOut := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(origOut)
+
+	before := testutil.ToFloat64(httpRequestsTotal.WithLabelValues(http.MethodGet, "unmatched", "500"))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/panics-midway", nil)
+
+	// Recovery's own defer re-panics with http.ErrAbortHandler once it sees a
+	// response was already started (ww.Status() != 0) — the client-facing
+	// consequence of a genuinely mid-response panic is an aborted connection, which
+	// httptest.ResponseRecorder can't simulate directly, so the test observes it as
+	// this panic propagating out of ServeHTTP (matching what a real net/http.Server
+	// does: abort the connection, no further write, no stack-trace log for this
+	// specific sentinel).
+	func() {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r, "a mid-response panic must propagate out as http.ErrAbortHandler, not be silently swallowed")
+			assert.Equal(t, http.ErrAbortHandler, r)
+		}()
+		chainedRecoveryLoggerMetrics(handler).ServeHTTP(rec, req)
+	}()
+
+	// Client sees exactly what the handler itself wrote — no corrupted/duplicated
+	// JSON-500 payload appended after the partial body.
+	assert.Equal(t, http.StatusOK, rec.Code, "the status the handler already sent must be untouched")
+	assert.Equal(t, partialBody, rec.Body.String(), "no additional content may be appended after a mid-response panic")
+
+	// The Prometheus counter for this (method, route, 500) combination still
+	// incremented — a panicking request is not invisible in metrics, even though
+	// the client-visible status code was never actually 500 in this exact edge case
+	// (the handler already committed 200) — 500 is what Recovery WOULD have sent had
+	// the response not already started, and is what the request's outcome was.
+	after := testutil.ToFloat64(httpRequestsTotal.WithLabelValues(http.MethodGet, "unmatched", "500"))
+	assert.Equal(t, before+1, after, "the panicking request must still be recorded in metrics")
+
+	// The access log recorded status 500, not a misleading 0.
+	assert.Contains(t, logBuf.String(), " 500 ", "the access log must record the eventual 500, not a misleading 0")
+}
+
+// TestPanicChain_PanicBeforeAnyWrite is the more common case: the handler panics
+// before writing anything. Recovery can (and must) still produce a clean JSON 500,
+// and metrics/logging must record it accurately — this is the sibling case to the
+// partial-write one above, confirming the fix didn't regress the common path.
+func TestPanicChain_PanicBeforeAnyWrite(t *testing.T) {
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom before any write")
+	})
+
+	var logBuf bytes.Buffer
+	origOut := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(origOut)
+
+	before := testutil.ToFloat64(httpRequestsTotal.WithLabelValues(http.MethodGet, "unmatched", "500"))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/panics-immediately", nil)
+	chainedRecoveryLoggerMetrics(handler).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	after := testutil.ToFloat64(httpRequestsTotal.WithLabelValues(http.MethodGet, "unmatched", "500"))
+	assert.Equal(t, before+1, after, "the panicking request must be recorded in metrics")
+
+	assert.Contains(t, logBuf.String(), " 500 ", "the access log must record status 500")
+}

--- a/server/middleware/recovery.go
+++ b/server/middleware/recovery.go
@@ -7,6 +7,8 @@ import (
 	"runtime/debug"
 	"strings"
 	"unicode"
+
+	chimw "github.com/go-chi/chi/v5/middleware"
 )
 
 // stripControl removes control characters (CR/LF, ANSI/C1 escapes, NUL, etc.) from a
@@ -25,6 +27,13 @@ func stripControl(s string) string {
 func Recovery() func(next http.Handler) http.Handler { // NOSONAR -- cognitive complexity 20, suppress go:S3776
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// #G55: wrapping here (the outermost middleware) means every inner
+			// middleware's own writer (Logger, PrometheusMiddleware) chains ON TOP of
+			// this one — any write from the handler cascades back down through every
+			// layer to ww, so ww.Status() reliably reflects "did the handler write
+			// anything before it panicked", regardless of how many middlewares sit
+			// between here and the handler.
+			ww := chimw.NewWrapResponseWriter(w, r.ProtoMajor)
 			defer func() {
 				if err := recover(); err != nil {
 					// Log the panic with stack trace
@@ -57,14 +66,29 @@ func Recovery() func(next http.Handler) http.Handler { // NOSONAR -- cognitive c
 					log.Printf("PANIC CONTEXT: RequestID=%s, User=%s, Method=%s, Path=%s, RemoteAddr=%s",
 						requestID, userInfo, r.Method, logSafeRequestURI(r), r.RemoteAddr)
 
+					// #G55: if the handler already sent a status/wrote part of the body
+					// before panicking, our own WriteHeader below would be a silent no-op
+					// (net/http only honors the FIRST WriteHeader call) and our JSON body
+					// would land AFTER whatever partial content the handler already wrote —
+					// corrupting the response into something that looks complete but isn't,
+					// worse than no response at all. Nothing can cleanly recover a
+					// mid-response panic at this layer; abort the connection instead so the
+					// client sees a reset/truncated response, an unambiguous failure signal,
+					// rather than a silently-corrupted 200. http.ErrAbortHandler is net/http's
+					// own sentinel for exactly this — the server closes the connection without
+					// logging a stack trace for it (already logged in full above).
+					if ww.Status() != 0 {
+						panic(http.ErrAbortHandler)
+					}
+
 					// Send a generic error response. We deliberately NEVER return the
 					// panic value, stack trace, or other internals to the client — this
 					// is a secrets manager, and a panic value can carry sensitive data;
 					// leaking internals (even gated behind a "dev mode" flag) is a foot-
 					// gun one config toggle away from production. Operators get the full
 					// panic + stack from the logs above; clients get only an opaque 500.
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusInternalServerError)
+					ww.Header().Set("Content-Type", "application/json")
+					ww.WriteHeader(http.StatusInternalServerError)
 
 					response := map[string]interface{}{
 						"error":   "InternalServerError",
@@ -72,14 +96,14 @@ func Recovery() func(next http.Handler) http.Handler { // NOSONAR -- cognitive c
 						"code":    http.StatusInternalServerError,
 					}
 
-					if encodeErr := json.NewEncoder(w).Encode(response); encodeErr != nil {
+					if encodeErr := json.NewEncoder(ww).Encode(response); encodeErr != nil {
 						log.Printf("Failed to encode panic response: %v", encodeErr)
-						http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+						http.Error(ww, "Internal Server Error", http.StatusInternalServerError)
 					}
 				}
 			}()
 
-			next.ServeHTTP(w, r)
+			next.ServeHTTP(ww, r)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`Recovery`, `PrometheusMiddleware`, and `Logger` each assumed a request completes normally through the full middleware chain:

- `Recovery` unconditionally called `WriteHeader(500)` + wrote a JSON body on every panic, even if the handler had already written part of the response — `net/http` only honors the FIRST `WriteHeader` call, so this was a silent no-op for the status, and the JSON body landed AFTER whatever partial content the handler already sent, corrupting the response into something that looks complete but isn't. It now wraps the response in chi's `WrapResponseWriter` and checks whether anything was already written before attempting its own response; if so, it aborts the connection (`panic(http.ErrAbortHandler)`, net/http's own sentinel for exactly this) instead of writing corrupted content.
- `PrometheusMiddleware` had **no defer/recover at all** — its metric-recording code ran only on normal return, so a panicking handler's stack unwound straight past it, making panicking requests invisible in metrics entirely. It now records the request in a defer/recover, then re-panics so `Recovery` still gets to handle it.
- `Logger`'s deferred write already ran on both normal return and panic, but read `ww.Status()` at that point in the unwind — still 0, since `Recovery`'s own write happens later, further up the stack — logging a misleading status 0 instead of the 500 the client actually receives. It now recovers, logs the true eventual status, and re-panics.

`Recovery` is outermost in the real chain (router.go's `r.Use` order), so wrapping there means every inner middleware's writer chains on top of it — any write from the handler cascades back down through every layer, so each middleware's own `Status()` reliably reflects "did the handler write anything yet."

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `gosec -severity medium -exclude-generated` clean
- [x] `golangci-lint run` clean
- [x] Full `server/middleware` suite green
- [x] New regression tests (`panic_chain_test.go`) implement the detection_idea directly, run through the REAL chain order (`Recovery(Logger(PrometheusMiddleware(handler)))`): a handler that writes a partial response then panics — asserting no corrupted/duplicated output (an aborted connection), the Prometheus counter still increments, and the access log records status 500. A sibling test confirms the common "panics before any write" case still works.