### PR TITLE
fix(security): CLI local-mode commands use the operator-asserted actor, not a hardcoded placeholder (G67)

### DIFF
--- a/internal/cli/common/actor_test.go
+++ b/internal/cli/common/actor_test.go
@@ -29,3 +29,30 @@ func TestResolveActorID(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveActorLabel is the #G67 detection_idea for the string-typed
+// attribution fields (core.CreateSecretRequest.CreatedBy/UpdatedBy) that
+// previously hardcoded the literal "cli-user" regardless of KEYORIX_CLI_ACTOR:
+// setting the env var to a specific ID must be reflected in the resolved label,
+// and the existing "cli-user" default must survive when it's unset/invalid —
+// exactly the fallback ResolveActorID() itself already uses for 0.
+func TestResolveActorLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"unset", "", "cli-user"},
+		{"valid", "42", "42"},
+		{"zero explicit", "0", "cli-user"},
+		{"non-numeric", "not-a-number", "cli-user"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv(cliActorEnvVar, c.env)
+			if got := ResolveActorLabel(); got != c.want {
+				t.Errorf("ResolveActorLabel() with %s=%q = %q, want %q", cliActorEnvVar, c.env, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -67,6 +67,21 @@ func ResolveActorID() uint {
 	return uint(id)
 }
 
+// ResolveActorLabel is ResolveActorID's counterpart for the (older, string-typed)
+// audit-attribution fields some CLI request structs still use (e.g.
+// core.CreateSecretRequest.CreatedBy, which the HTTP path populates with
+// userCtx.Username — a human-readable label, not a raw ID). #G67: those fields
+// previously hardcoded the literal "cli-user" regardless of who ran the command;
+// this still falls back to "cli-user" when KEYORIX_CLI_ACTOR is unset (preserving
+// the existing default label for operators who haven't opted in to self-assertion)
+// but otherwise reflects the actually-asserted actor ID.
+func ResolveActorLabel() string {
+	if id := ResolveActorID(); id != 0 {
+		return strconv.FormatUint(uint64(id), 10)
+	}
+	return "cli-user"
+}
+
 // InitializeCoreService creates a core service instance using the storage factory
 // This function should be used by all CLI commands instead of directly creating storage
 func InitializeCoreService() (*core.KeyorixCore, error) {

--- a/internal/cli/machine/create.go
+++ b/internal/cli/machine/create.go
@@ -64,8 +64,8 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
-	// Local mode has no authenticated user; record a system (0) creator.
-	m, err := svc.CreateMachineIdentity(ctx, projectID, createName, createType, createDescription, createClassification, 0)
+	// #G67: operator-asserted actor (KEYORIX_CLI_ACTOR), not a hardcoded placeholder.
+	m, err := svc.CreateMachineIdentity(ctx, projectID, createName, createType, createDescription, createClassification, common.ResolveActorID())
 	if err != nil {
 		return fmt.Errorf("failed to create machine identity: %w", err)
 	}

--- a/internal/cli/machine/lifecycle.go
+++ b/internal/cli/machine/lifecycle.go
@@ -107,7 +107,8 @@ func transitionMachine(ctx context.Context, projectID uint, m *models.MachineIde
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
-	if _, err := svc.TransitionMachineIdentity(ctx, m.ProjectID, m.ID, targetState, 0); err != nil {
+	// #G67: operator-asserted actor (KEYORIX_CLI_ACTOR), not a hardcoded placeholder.
+	if _, err := svc.TransitionMachineIdentity(ctx, m.ProjectID, m.ID, targetState, common.ResolveActorID()); err != nil {
 		return fmt.Errorf("failed to %s machine identity: %w", action, err)
 	}
 	fmt.Printf("Machine identity %q → %s\n", m.Name, targetState)

--- a/internal/cli/machine/token.go
+++ b/internal/cli/machine/token.go
@@ -92,7 +92,8 @@ func runTokenIssue(cmd *cobra.Command, args []string) error {
 		t := time.Now().AddDate(0, 0, tokenIssueExpiryDays)
 		expiresAt = &t
 	}
-	result, err := svc.IssueMachineToken(ctx, projectID, m.ID, 0, core.IssueMachineTokenParams{
+	// #G67: operator-asserted actor (KEYORIX_CLI_ACTOR), not a hardcoded placeholder.
+	result, err := svc.IssueMachineToken(ctx, projectID, m.ID, common.ResolveActorID(), core.IssueMachineTokenParams{
 		Name:           tokenIssueName,
 		ExpiresAt:      expiresAt,
 		Classification: tokenIssueClass,
@@ -268,7 +269,8 @@ func runTokenRevoke(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
-	if _, err := svc.RevokeMachineToken(ctx, projectID, m.ID, uint(tokenID), 0); err != nil {
+	// #G67: operator-asserted actor (KEYORIX_CLI_ACTOR), not a hardcoded placeholder.
+	if _, err := svc.RevokeMachineToken(ctx, projectID, m.ID, uint(tokenID), common.ResolveActorID()); err != nil {
 		return fmt.Errorf("failed to revoke machine token: %w", err)
 	}
 	fmt.Println("Machine token revoked.")

--- a/internal/cli/secret/create.go
+++ b/internal/cli/secret/create.go
@@ -170,7 +170,7 @@ func buildCreateRequest() (*core.CreateSecretRequest, error) { // NOSONAR -- cog
 		ProjectID:     createProjectID,
 		EnvironmentID: createEnvironmentID,
 		Description:   createDescription,
-		CreatedBy:     "cli-user",
+		CreatedBy:     common.ResolveActorLabel(), // #G67: operator-asserted actor, not a hardcoded placeholder
 	}
 
 	if createMaxReads > 0 {
@@ -249,7 +249,7 @@ func interactiveCreate() (*core.CreateSecretRequest, error) { // NOSONAR -- cogn
 		ProjectID:     projectID,
 		EnvironmentID: environmentID,
 		Value:         valueBytes,
-		CreatedBy:     "cli-user",
+		CreatedBy:     common.ResolveActorLabel(), // #G67: operator-asserted actor, not a hardcoded placeholder
 	}
 
 	maxReadsStr := ask("Max reads (0 for unlimited)", "0")

--- a/internal/cli/secret/update.go
+++ b/internal/cli/secret/update.go
@@ -194,7 +194,7 @@ func runUpdateRemote(rc *common.RemoteClient) error {
 func buildUpdateRequest() (*core.UpdateSecretRequest, error) { // NOSONAR -- cognitive complexity 16, suppress go:S3776
 	req := &core.UpdateSecretRequest{
 		ID:        updateID,
-		UpdatedBy: "cli-user",
+		UpdatedBy: common.ResolveActorLabel(), // #G67: operator-asserted actor, not a hardcoded placeholder
 	}
 
 	if updateFromFile != "" {
@@ -272,7 +272,7 @@ func interactiveUpdate(current *models.SecretNode) (*core.UpdateSecretRequest, e
 
 	req := &core.UpdateSecretRequest{
 		ID:        updateID,
-		UpdatedBy: "cli-user",
+		UpdatedBy: common.ResolveActorLabel(), // #G67: operator-asserted actor, not a hardcoded placeholder
 	}
 
 	if askBool("Update secret value?") {

--- a/internal/cli/share/create.go
+++ b/internal/cli/share/create.go
@@ -72,7 +72,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			SecretID:   createSecretID,
 			GroupID:    createRecipientID,
 			Permission: createPermission,
-			SharedBy:   1, // CLI user ID
+			SharedBy:   common.ResolveActorID(), // #G67: operator-asserted actor, not a hardcoded placeholder
 			ExpiresAt:  expiresAt,
 		}
 
@@ -88,7 +88,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			RecipientID: createRecipientID,
 			IsGroup:     false,
 			Permission:  createPermission,
-			SharedBy:    1, // CLI user ID
+			SharedBy:    common.ResolveActorID(), // #G67: operator-asserted actor, not a hardcoded placeholder
 			ExpiresAt:   expiresAt,
 		}
 

--- a/internal/cli/share/revoke.go
+++ b/internal/cli/share/revoke.go
@@ -38,7 +38,7 @@ func runRevoke(cmd *cobra.Command, args []string) error {
 
 	// Call service
 	ctx := context.Background()
-	err = service.RevokeShare(ctx, revokeShareID, 1) // CLI user ID
+	err = service.RevokeShare(ctx, revokeShareID, common.ResolveActorID()) // #G67: operator-asserted actor, not a hardcoded placeholder
 	if err != nil {
 		return fmt.Errorf("failed to revoke share: %w", err)
 	}

--- a/internal/cli/share/share_s25_test.go
+++ b/internal/cli/share/share_s25_test.go
@@ -11,6 +11,7 @@ package share
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -34,6 +35,7 @@ func TestRunCreate_WithExpires_UserShare(t *testing.T) {
 
 	svc := openShareCore(t)
 	ownerID, secretID, projID := seedShareData(t, svc)
+	t.Setenv("KEYORIX_CLI_ACTOR", fmt.Sprintf("%d", ownerID)) // #G67: runCreate now asserts SharedBy from this
 
 	ctx := context.Background()
 	recipient, err := svc.Storage().CreateUser(ctx, &models.User{
@@ -70,7 +72,8 @@ func TestRunCreate_WithExpires_GroupShare(t *testing.T) {
 	t.Setenv("KEYORIX_TOKEN", "")
 
 	svc := openShareCore(t)
-	_, secretID, _ := seedShareData(t, svc)
+	ownerID, secretID, _ := seedShareData(t, svc)
+	t.Setenv("KEYORIX_CLI_ACTOR", fmt.Sprintf("%d", ownerID)) // #G67: runCreate now asserts SharedBy from this
 
 	ctx := context.Background()
 	grp, err := svc.CreateGroup(ctx, 0, &core.CreateGroupRequest{Name: "expires-grp"})

--- a/internal/cli/share/share_s3_test.go
+++ b/internal/cli/share/share_s3_test.go
@@ -118,6 +118,7 @@ func TestRunCreate_UserShare_Success(t *testing.T) {
 
 	svc := openShareCore(t)
 	ownerID, secretID, projID := seedShareData(t, svc)
+	t.Setenv("KEYORIX_CLI_ACTOR", fmt.Sprintf("%d", ownerID)) // #G67: runCreate now asserts SharedBy from this
 
 	ctx := context.Background()
 	recipient, err := svc.Storage().CreateUser(ctx, &models.User{
@@ -151,7 +152,8 @@ func TestRunCreate_GroupShare_Success(t *testing.T) {
 	t.Setenv("KEYORIX_TOKEN", "")
 
 	svc := openShareCore(t)
-	_, secretID, _ := seedShareData(t, svc)
+	ownerID, secretID, _ := seedShareData(t, svc)
+	t.Setenv("KEYORIX_CLI_ACTOR", fmt.Sprintf("%d", ownerID)) // #G67: runCreate now asserts SharedBy from this
 
 	ctx := context.Background()
 	grp, err := svc.CreateGroup(ctx, 0, &core.CreateGroupRequest{Name: "teamalpha"})
@@ -183,6 +185,7 @@ func TestRunCreate_WithTTL_Success(t *testing.T) {
 
 	svc := openShareCore(t)
 	ownerID, secretID, projID := seedShareData(t, svc)
+	t.Setenv("KEYORIX_CLI_ACTOR", fmt.Sprintf("%d", ownerID)) // #G67: runCreate now asserts SharedBy from this
 
 	ctx := context.Background()
 	recipient, err := svc.Storage().CreateUser(ctx, &models.User{
@@ -286,6 +289,7 @@ func TestRunRevoke_Success(t *testing.T) {
 
 	svc := openShareCore(t)
 	ownerID, secretID, projID := seedShareData(t, svc)
+	t.Setenv("KEYORIX_CLI_ACTOR", fmt.Sprintf("%d", ownerID)) // #G67: runRevoke now asserts revokedBy from this
 
 	ctx := context.Background()
 	recipient, err := svc.Storage().CreateUser(ctx, &models.User{
@@ -390,6 +394,7 @@ func TestRunUpdate_Success(t *testing.T) {
 
 	svc := openShareCore(t)
 	ownerID, secretID, projID := seedShareData(t, svc)
+	t.Setenv("KEYORIX_CLI_ACTOR", fmt.Sprintf("%d", ownerID)) // #G67: runUpdate now asserts updatedBy from this
 
 	ctx := context.Background()
 	recipient, err := svc.Storage().CreateUser(ctx, &models.User{
@@ -427,6 +432,7 @@ func TestRunUpdate_WithTTL_Success(t *testing.T) {
 
 	svc := openShareCore(t)
 	ownerID, secretID, projID := seedShareData(t, svc)
+	t.Setenv("KEYORIX_CLI_ACTOR", fmt.Sprintf("%d", ownerID)) // #G67: runUpdate now asserts updatedBy from this
 
 	ctx := context.Background()
 	recipient, err := svc.Storage().CreateUser(ctx, &models.User{
@@ -464,6 +470,7 @@ func TestRunUpdate_ClearExpiry_Success(t *testing.T) {
 
 	svc := openShareCore(t)
 	ownerID, secretID, projID := seedShareData(t, svc)
+	t.Setenv("KEYORIX_CLI_ACTOR", fmt.Sprintf("%d", ownerID)) // #G67: runUpdate now asserts updatedBy from this
 
 	ctx := context.Background()
 	recipient, err := svc.Storage().CreateUser(ctx, &models.User{

--- a/internal/cli/share/update.go
+++ b/internal/cli/share/update.go
@@ -65,7 +65,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	req := &core.UpdateShareRequest{
 		ShareID:     updateShareID,
 		Permission:  updatePermission,
-		UpdatedBy:   1, // CLI user ID
+		UpdatedBy:   common.ResolveActorID(), // #G67: operator-asserted actor, not a hardcoded placeholder
 		ExpiresAt:   expiresAt,
 		ClearExpiry: updateClearExpiry,
 	}


### PR DESCRIPTION
## Summary

`common.ResolveActorID()` (backed by `KEYORIX_CLI_ACTOR`, #150) exists specifically so embedded/local-mode CLI mutations — which have no authenticated HTTP session — can let an operator self-assert their own Keyorix user ID for audit-attribution and ownership-check purposes. Three independent command families never called it, each hardcoding a different placeholder:

- **`share create`/`update`/`revoke`** hardcoded the literal user ID `1` as the acting user. Worse than the other two members: `internal/core/sharing.go`'s `secretOwnedBy(secret.OwnerID, ...)` is a REAL authorization check a hardcoded actor trivially defeats, not just an attribution/audit-quality issue.
- **`machine create`/`suspend`/`reactivate`/`revoke`** and **token issue/revoke** hardcoded `actorID=0`, bypassing the operator-attribution mechanism already wired into this same package's OIDC bindings.
- **`secret create`/`update`** hardcoded the audit actor to the literal string `"cli-user"`.

The first two are now `common.ResolveActorID()` directly. The third needed a new helper — `CreatedBy`/`UpdatedBy` are string fields (the HTTP path populates them with `userCtx.Username`, a label, not a raw ID) — so `common.ResolveActorLabel()` formats the resolved actor ID as a decimal string, falling back to the existing `"cli-user"` default when `KEYORIX_CLI_ACTOR` is unset.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `gosec -severity medium -exclude-generated` clean
- [x] `golangci-lint run` clean
- [x] New regression test (`actor_test.go`) implements the detection_idea directly: set `KEYORIX_CLI_ACTOR` and assert the resolved label reflects it
- [x] Note: could not run the existing `share`/`machine`/`secret` CLI package test suites locally — they hit a pre-existing, machine-specific hang (a leftover local `~/.keyorix/cli.yaml` remote config causes `common.NewRemoteClient()` to attempt a real network dial regardless of test intent); confirmed via isolated runs that this reproduces identically on unrelated local-mode tests, unrelated to this change