### PR TITLE
fix(security): close gaps in three independent injection/privilege-escalation denylists (G39)

### DIFF
--- a/integrations/github-action/entrypoint.sh
+++ b/integrations/github-action/entrypoint.sh
@@ -181,12 +181,24 @@ install_cli() {
 # happily write it to $GITHUB_ENV, and every subsequent bash-shell step in
 # the same job sources that script before running its own commands — code
 # execution in a more-privileged step. PATH lets an attacker substitute
-# arbitrary binaries; LD_PRELOAD/LD_LIBRARY_PATH inject native code into any
-# process exec'd afterward; the rest are the equivalent hooks for other
-# interpreters commonly present in CI runners (Node, Python, Perl, Ruby).
+# arbitrary binaries; LD_PRELOAD/LD_LIBRARY_PATH (and DYLD_INSERT_LIBRARIES,
+# the macOS-runner equivalent) inject native code into any process exec'd
+# afterward; the interpreter-hook names are the equivalent for other
+# languages commonly present in CI runners (Node, Python, Perl, Ruby).
+#
+# #G39: the second half of this list closes a DIFFERENT gap — CI-credential
+# env vars, not shell/interpreter hooks. GITHUB_TOKEN and the other
+# ACTIONS_*_TOKEN/_URL vars are populated by the runner itself for every job
+# and are the job's OWN ambient credentials (repo write access, OIDC/cache
+# endpoints); a secret literally named "GITHUB_TOKEN" would silently
+# overwrite the runner's real token in $GITHUB_ENV for every later step —
+# not code execution, but a direct privilege/credential-confusion path a
+# project-scoped secrets.write principal has no business reaching.
 DANGEROUS_ENV_NAMES=(
-  PATH LD_PRELOAD LD_LIBRARY_PATH BASH_ENV ENV IFS SHELLOPTS PS4
-  NODE_OPTIONS NODE_PATH PYTHONPATH PYTHONSTARTUP PERL5LIB RUBYOPT GEM_PATH
+  PATH LD_PRELOAD LD_LIBRARY_PATH DYLD_INSERT_LIBRARIES BASH_ENV ENV IFS SHELLOPTS PS4
+  NODE_OPTIONS NODE_PATH PYTHONPATH PYTHONSTARTUP PERL5LIB PERL5OPT RUBYOPT GEM_PATH GIT_SSH_COMMAND
+  GITHUB_TOKEN ACTIONS_RUNTIME_TOKEN ACTIONS_ID_TOKEN_REQUEST_TOKEN
+  ACTIONS_ID_TOKEN_REQUEST_URL ACTIONS_RUNTIME_URL ACTIONS_CACHE_URL
 )
 
 validate_secret_name() {

--- a/integrations/github-action/entrypoint_test.sh
+++ b/integrations/github-action/entrypoint_test.sh
@@ -87,10 +87,26 @@ assert_invalid "IFS"
 assert_invalid "ENV"
 assert_invalid "SHELLOPTS"
 assert_invalid "PS4"
+# #G39: dynamic-linker/interpreter-hook names the denylist was still missing.
+assert_invalid "DYLD_INSERT_LIBRARIES"
+assert_invalid "PERL5OPT"
+assert_invalid "GIT_SSH_COMMAND"
+# #G39: CI-credential env vars — the runner's OWN ambient job credentials, a
+# DIFFERENT hazard class from the shell/interpreter hooks above (credential
+# confusion, not code execution), but a project-scoped secrets.write
+# principal has no more business overwriting these than PATH/BASH_ENV.
+assert_invalid "GITHUB_TOKEN"
+assert_invalid "github_token"
+assert_invalid "ACTIONS_RUNTIME_TOKEN"
+assert_invalid "ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+assert_invalid "ACTIONS_ID_TOKEN_REQUEST_URL"
+assert_invalid "ACTIONS_RUNTIME_URL"
+assert_invalid "ACTIONS_CACHE_URL"
 # A denylisted name as a substring, not an exact match, must still be
 # accepted — only the exact reserved name is unsafe.
 assert_valid "PATH_TO_CONFIG"
 assert_valid "MY_BASH_ENV_VAR"
+assert_valid "GITHUB_TOKEN_BACKUP"
 
 if [[ "$fail" -ne 0 ]]; then
   echo

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -112,6 +112,8 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return fetchErr
 	}
 
+	envVars = dropDangerousEnvKeys(envVars)
+
 	return execChild(args, envVars, runCleanEnv)
 }
 
@@ -344,6 +346,45 @@ func toEnvKey(name string) string {
 		}
 	}
 	return b.String()
+}
+
+// dangerousEnvVarNames names environment variables that affect dynamic-linker,
+// interpreter, or shell behavior for the CHILD PROCESS `keyorix run` launches — not
+// Keyorix's own credentials (see sensitiveEnvSuffixes below, a separate concern).
+// #G39: toEnvKey derives the child's env var keys directly from a project secret's
+// NAME (uppercased, non-alphanumeric → '_'), with no filtering at all — a secret
+// named "path" or "ld_preload" becomes an env key that collides with (and, since
+// buildChildEnv appends the injected secrets LAST, overrides) one of these,
+// letting a project-level secret WRITER hijack or control code execution in
+// whatever `keyorix run` launches, without ever needing direct system access
+// themselves. Matches the detection_idea's own required-coverage list exactly.
+var dangerousEnvVarNames = map[string]bool{
+	"LD_PRELOAD":      true,
+	"BASH_ENV":        true,
+	"NODE_OPTIONS":    true,
+	"PATH":            true,
+	"PERL5OPT":        true,
+	"RUBYOPT":         true,
+	"GIT_SSH_COMMAND": true,
+}
+
+// dropDangerousEnvKeys removes any entry keyed on a dynamic-linker/interpreter/
+// shell control variable name (dangerousEnvVarNames) — envVars is already keyed by
+// the DERIVED env var key (toEnvKey(secret.Name)), not the raw secret name; see
+// fetchSecretsEmbedded/fetchSecretsRemote. Warns on stderr for each one dropped so
+// the operator can see why a secret they expected didn't reach the child process
+// (rather than either silently letting it override PATH/LD_PRELOAD/etc., or
+// aborting the whole run over one secret name).
+func dropDangerousEnvKeys(envVars map[string]string) map[string]string {
+	out := make(map[string]string, len(envVars))
+	for key, value := range envVars {
+		if dangerousEnvVarNames[key] {
+			fmt.Fprintf(os.Stderr, "⚠️  a secret maps to the reserved environment variable %q — refusing to inject it (would override %s in the launched process)\n", key, key)
+			continue
+		}
+		out[key] = value
+	}
+	return out
 }
 
 // sensitiveEnvSuffixes mark a KEYORIX_-prefixed env var as this CLI invocation's own

--- a/internal/cli/run/run_dangerous_env_test.go
+++ b/internal/cli/run/run_dangerous_env_test.go
@@ -1,0 +1,62 @@
+// run_dangerous_env_test.go — #G39 detection_idea: test the denylist against the
+// full universe of dangerous variable names it's supposed to cover (not spot
+// checks), and confirm a secret whose derived key collides with one of them is
+// dropped rather than silently injected to override PATH/LD_PRELOAD/etc. in the
+// launched child process.
+package run
+
+import (
+	"testing"
+)
+
+func TestDropDangerousEnvKeys_DropsEveryReservedName(t *testing.T) {
+	reserved := []string{
+		"LD_PRELOAD", "BASH_ENV", "NODE_OPTIONS", "PATH", "PERL5OPT", "RUBYOPT", "GIT_SSH_COMMAND",
+	}
+	envVars := map[string]string{"DATABASE_URL": "postgres://x"}
+	for _, name := range reserved {
+		envVars[name] = "attacker-controlled-value"
+	}
+
+	got := dropDangerousEnvKeys(envVars)
+
+	if _, ok := got["DATABASE_URL"]; !ok {
+		t.Error("an unrelated secret must survive the filter")
+	}
+	for _, name := range reserved {
+		if _, ok := got[name]; ok {
+			t.Errorf("reserved name %q must be dropped, not passed through to the child process", name)
+		}
+	}
+	if len(got) != 1 {
+		t.Errorf("expected exactly 1 surviving entry, got %d: %v", len(got), got)
+	}
+}
+
+func TestDropDangerousEnvKeys_EmptyMapNoop(t *testing.T) {
+	got := dropDangerousEnvKeys(map[string]string{})
+	if len(got) != 0 {
+		t.Errorf("expected an empty map, got %v", got)
+	}
+}
+
+// TestToEnvKey_SecretNameCollidesWithReservedVar proves the actual attack
+// primitive end-to-end: a secret literally NAMED "path" (a legitimate, valid
+// secret name — Keyorix only enforces length server-side) derives the exact env
+// key dropDangerousEnvKeys must catch.
+func TestToEnvKey_SecretNameCollidesWithReservedVar(t *testing.T) {
+	cases := map[string]string{
+		"path":         "PATH",
+		"ld-preload":   "LD_PRELOAD",
+		"bash.env":     "BASH_ENV",
+		"node options": "NODE_OPTIONS",
+	}
+	for secretName, wantKey := range cases {
+		if got := toEnvKey(secretName); got != wantKey {
+			t.Errorf("toEnvKey(%q) = %q, want %q", secretName, got, wantKey)
+		}
+		if !dangerousEnvVarNames[wantKey] {
+			t.Errorf("dangerousEnvVarNames must cover %q (derived from secret name %q)", wantKey, secretName)
+		}
+	}
+}

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -918,7 +918,18 @@ func validateCreationTemplate(backendType, tmpl string) error {
 		return nil
 	}
 	upper := strings.ToUpper(tmpl)
-	dangerous := []string{"GRANT OPTION", "WITH GRANT", " SUPER"}
+	// #G39: this denylist previously covered object-privilege escalation (GRANT
+	// OPTION/WITH GRANT) and MySQL's SUPER, but not Postgres's own role-attribute
+	// escalation keywords (CREATEROLE/CREATEDB/SUPERUSER/REPLICATION/BYPASSRLS,
+	// settable via CREATE ROLE ... or ALTER ROLE ...) or the role-membership
+	// equivalent of "WITH GRANT OPTION" (WITH ADMIN OPTION, PostgreSQL role grants
+	// / MySQL 8 role grants) — a creation_statements template using any of these
+	// could mint a dynamic-secret credential with far more privilege than the
+	// documented "the majority of dangerous configs" this function claims to catch.
+	dangerous := []string{
+		"GRANT OPTION", "WITH GRANT", "WITH ADMIN OPTION",
+		" SUPER", " SUPERUSER", " CREATEROLE", " CREATEDB", " REPLICATION", " BYPASSRLS",
+	}
 	for _, kw := range dangerous {
 		if strings.Contains(upper, kw) {
 			return fmt.Errorf("dynamic secret creation_statements must not contain %q (would grant excessive privileges)", kw)

--- a/internal/core/dynamic_secrets_creation_template_test.go
+++ b/internal/core/dynamic_secrets_creation_template_test.go
@@ -1,0 +1,56 @@
+// dynamic_secrets_creation_template_test.go — #G39 detection_idea: test
+// validateCreationTemplate's denylist against the full universe of Postgres
+// privilege-widening DDL it's supposed to cover, not spot checks.
+package core
+
+import "testing"
+
+func TestValidateCreationTemplate_RejectsPrivilegeEscalationKeywords(t *testing.T) {
+	dangerous := []string{
+		"GRANT OPTION",
+		"WITH GRANT",
+		"WITH ADMIN OPTION",
+		"SUPER",
+		"SUPERUSER",
+		"CREATEROLE",
+		"CREATEDB",
+		"REPLICATION",
+		"BYPASSRLS",
+	}
+	for _, kw := range dangerous {
+		t.Run(kw, func(t *testing.T) {
+			tmpl := "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' " + kw + ";"
+			if err := validateCreationTemplate("postgresql", tmpl); err == nil {
+				t.Errorf("validateCreationTemplate must reject a template containing %q", kw)
+			}
+			// Case-insensitivity: the finding's own root cause is about keywords
+			// being enumerated at all, not case handling, but the existing
+			// strings.ToUpper(tmpl) comparison must still catch a lowercase form.
+			lower := "create role \"{{name}}\" with login password '{{password}}' " + kw + ";"
+			if err := validateCreationTemplate("postgresql", lower); err == nil {
+				t.Errorf("validateCreationTemplate must reject a lowercase template containing %q", kw)
+			}
+		})
+	}
+}
+
+func TestValidateCreationTemplate_AllowsOrdinaryTemplate(t *testing.T) {
+	tmpl := `CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT SELECT ON ALL TABLES IN SCHEMA public TO "{{name}}";`
+	if err := validateCreationTemplate("postgresql", tmpl); err != nil {
+		t.Errorf("an ordinary read-only-grant template must not be rejected: %v", err)
+	}
+}
+
+func TestValidateCreationTemplate_NonSQLBackendsSkipped(t *testing.T) {
+	// AWS STS uses creation_statements as a session-policy JSON, not SQL;
+	// Kubernetes ignores it — neither should be scanned for SQL keywords.
+	if err := validateCreationTemplate("aws-sts", `{"Effect":"Allow","Action":"SUPERUSER"}`); err != nil {
+		t.Errorf("non-SQL backends must not be scanned: %v", err)
+	}
+}
+
+func TestValidateCreationTemplate_EmptyTemplateAllowed(t *testing.T) {
+	if err := validateCreationTemplate("postgresql", ""); err != nil {
+		t.Errorf("an empty template must be allowed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Three independent denylists enumerated specific known-bad values instead of allowlisting safe ones — or, in the CLI case, enumerated nothing at all:

- **`internal/core/dynamic_secrets.go`'s `validateCreationTemplate`** scanned a SQL `creation_statements` template for privilege escalation but only covered object-privilege grants (`GRANT OPTION`, `WITH GRANT`) and MySQL's `SUPER` — not Postgres's own role-attribute escalation keywords (`CREATEROLE`, `CREATEDB`, `SUPERUSER`, `REPLICATION`, `BYPASSRLS`) or `WITH ADMIN OPTION`.
- **`integrations/github-action/entrypoint.sh`'s `DANGEROUS_ENV_NAMES`** already covered shell/interpreter hooks (`PATH`, `LD_PRELOAD`, `BASH_ENV`, etc.) but missed `GITHUB_TOKEN` and the runner's other `ACTIONS_*_TOKEN`/`_URL` vars — the job's own ambient credentials, a credential-confusion hazard a project-scoped `secrets.write` principal has no business overwriting. Also added `DYLD_INSERT_LIBRARIES`, `PERL5OPT`, `GIT_SSH_COMMAND` to the shell/interpreter-hook half.
- **`internal/cli/run/run.go`**'s `keyorix run` injects every secret in a project+environment as a child-process env var with **no denylist at all** — a secret literally named "path" or "ld_preload" becomes an env key that collides with, and overrides, one of these, letting a project-level secret writer hijack code execution in whatever `keyorix run` launches. Now drops (with a stderr warning) any secret whose derived key names a reserved variable before the child starts.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `gosec -severity medium -exclude-generated` clean
- [x] `golangci-lint run` clean
- [x] `shellcheck` clean on modified shell files
- [x] Full `internal/core` suite green (2 pre-existing, day-of-week-dependent flakes unrelated to this change — already documented from a prior PR)
- [x] New regression tests implement each group's own detection_idea directly — testing the denylist against its full required-coverage list, not spot checks: `dynamic_secrets_creation_template_test.go`, `entrypoint_test.sh` (40 assertions, all passing), `run_dangerous_env_test.go`