### PR TITLE
fix(security): Wave 5 batch — impersonation, restriction, core-singleton, and SecretACL fixes (G05, G07, G12, G13)

### DIFF
--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -463,20 +463,17 @@ func (c *KeyorixCore) ValidateSessionToken(ctx context.Context, token string) (*
 	// or deactivating the admin would not stop their in-flight impersonation, since the
 	// session is keyed to the target's user_id and the gate above only checks the
 	// target. Self-checking backstop alongside the session purge on state change.
+	// MT-007/#G05: re-verify both the admin's active state and the ceiling (not
+	// just the target's, checked above) so neither an elevation of the target's
+	// roles NOR a demotion/suspension of the impersonating admin after
+	// impersonation started silently persists for the rest of the session.
+	// Cached (IMP-001) to avoid repeated DB queries on every session validation;
+	// cache TTL is 2× the auth-cache window. See ReauthorizeImpersonation's doc
+	// comment (impersonation.go) — StreamAuditLogs' dedicated re-auth ticker
+	// (#108) runs the identical check for long-lived gRPC streams.
 	if session.ImpersonatedBy != nil && *session.ImpersonatedBy != 0 {
-		admin, err := c.storage.GetUser(ctx, *session.ImpersonatedBy)
-		if err != nil {
-			return nil, nil, fmt.Errorf("impersonating account not found")
-		}
-		if !admin.IsActive || AccountLoginBlocked(admin.AccountState) {
-			return nil, nil, fmt.Errorf("impersonating account is not active")
-		}
-		// MT-007: re-check the impersonation ceiling so an elevation of the target's
-		// roles AFTER impersonation started does not silently extend the impersonator's
-		// reach beyond their current authority. Cached (IMP-001) to avoid repeated DB
-		// queries on every session validation; cache TTL is 2× the auth-cache window.
-		if err := c.cachedImpersonationCeiling(ctx, *session.ImpersonatedBy, session.UserID); err != nil {
-			return nil, nil, fmt.Errorf("impersonation ceiling exceeded — target's authority now exceeds impersonator's: %w", err)
+		if err := c.ReauthorizeImpersonation(ctx, *session.ImpersonatedBy, session.UserID); err != nil {
+			return nil, nil, err
 		}
 	}
 	// Best-effort, throttled last-seen stamp for the My Account sessions view.

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -369,7 +369,7 @@ type ceilingCacheEntry struct {
 
 const ceilingCacheTTL = 60 * time.Second
 
-// cachedImpersonationCeiling wraps requireEqualOrGreaterAdminAuthority with a
+// cachedImpersonationCeiling wraps requireStillAuthorizedToImpersonate with a
 // short-lived cache (ceilingCacheTTL) so the expensive DB reads it issues are
 // not repeated on every ValidateSessionToken call (IMP-001). The cache TTL is
 // intentionally 2× the auth-cache window so a cache miss here never triggers
@@ -381,9 +381,31 @@ func (c *KeyorixCore) cachedImpersonationCeiling(ctx context.Context, actorID, t
 			return entry.err
 		}
 	}
-	err := c.requireEqualOrGreaterAdminAuthority(ctx, actorID, targetID, "impersonate")
+	err := c.requireStillAuthorizedToImpersonate(ctx, actorID, targetID)
 	c.impersonationCeilingCache.Store(key, ceilingCacheEntry{err: err, expiresAt: c.now().Add(ceilingCacheTTL)})
 	return err
+}
+
+// requireStillAuthorizedToImpersonate combines the two conditions that must
+// continue to hold for the DURATION of an active impersonation session, not
+// just at StartImpersonation's issuance-time check (#G05's detection_idea):
+// the admin must still be independently granted users.impersonate — revoking
+// it mid-session must end the session within one re-auth cycle, the same as
+// revoking any other permission does for an ordinary session, not just block
+// a NEW StartImpersonation call — and must still hold equal-or-greater
+// authority than the target (the pre-existing MT-007 ceiling re-check).
+// permUsersImpersonate is checked at global scope: impersonation authority is
+// deployment-wide by design (StartImpersonation's target lookup is unscoped),
+// mirroring the router's own RequirePermission("users.impersonate") gate.
+func (c *KeyorixCore) requireStillAuthorizedToImpersonate(ctx context.Context, actorID, targetID uint) error {
+	ok, err := c.Authorize(ctx, actorID, "users.impersonate", Scope{})
+	if err != nil {
+		return fmt.Errorf("failed to resolve actor authority: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("impersonation authority has been revoked")
+	}
+	return c.requireEqualOrGreaterAdminAuthority(ctx, actorID, targetID, "impersonate")
 }
 
 // requireMachinePrivilegeCeiling refuses to issue a token for machineID when the
@@ -413,14 +435,26 @@ func (c *KeyorixCore) requireMachinePrivilegeCeiling(ctx context.Context, actorI
 	return nil
 }
 
-// requireEqualOrGreaterAdminAuthority refuses when targetID holds an admin-tier
-// role — global OR project-scoped, direct OR group-inherited — at any scope where
-// actorID does not ALSO hold admin-tier authority. Unlike the single-scope
+// requireEqualOrGreaterAdminAuthority refuses when targetID holds, at any scope
+// (global OR project-scoped, direct OR group-inherited), a permission actorID
+// does not ALSO effectively hold at that same scope. Unlike the single-scope
 // IsGlobalAdmin check, this discovers and checks EVERY scope the target actually
 // holds a grant at (via GetUserRoleScopes), so a target who is a project-scoped
 // project_admin — never itself flagged "global admin" — is still compared
-// correctly. Used by impersonation's admin-rank-ceiling check (#165): the action
-// string only customizes the error message (e.g. "impersonate").
+// correctly. Used by impersonation's admin-rank-ceiling check (#165/#G05): the
+// action string only customizes the error message (e.g. "impersonate").
+//
+// #G05: this compares the target's actual bundled PERMISSIONS against what the
+// actor can actually exercise (via c.Authorize, which resolves the admin-role-
+// name bypass and broader-scope grants exactly like every other authorization
+// decision) — not role-NAME membership in the fixed adminRoleNames list. The old
+// role-name check silently no-op'd for any target whose admin-tier role was
+// defined under a different name (a custom "SecOps" role bundling roles.assign +
+// system.write, say): roleSetContainsAdmin(target) would return false, skipping
+// the ceiling entirely, letting a lower-privileged actor impersonate a de-facto
+// admin uncontested. Comparing actual permissions closes that regardless of what
+// the role bundling them is named. This mirrors requireGranterHoldsRolePermissions'
+// established pattern (the role-GRANT ceiling) applied here to impersonation.
 func (c *KeyorixCore) requireEqualOrGreaterAdminAuthority(ctx context.Context, actorID, targetID uint, action string) error {
 	scopes, err := c.storage.GetUserRoleScopes(ctx, targetID)
 	if err != nil {
@@ -431,15 +465,24 @@ func (c *KeyorixCore) requireEqualOrGreaterAdminAuthority(ctx context.Context, a
 		if err != nil {
 			return fmt.Errorf("failed to resolve target authority: %w", err)
 		}
-		if !c.roleSetContainsAdmin(ctx, targetRoleIDs) {
-			continue
+		targetPerms := make(map[string]bool)
+		for _, roleID := range targetRoleIDs {
+			perms, err := c.rolePermissionNameSet(ctx, roleID)
+			if err != nil {
+				return fmt.Errorf("failed to resolve target authority: %w", err)
+			}
+			for p := range perms {
+				targetPerms[p] = true
+			}
 		}
-		actorRoleIDs, err := c.scopedRoleIDs(ctx, actorID, scope)
-		if err != nil {
-			return fmt.Errorf("failed to resolve actor authority: %w", err)
-		}
-		if !c.roleSetContainsAdmin(ctx, actorRoleIDs) {
-			return fmt.Errorf("cannot %s a user holding administrative authority you do not also hold", action)
+		for permName := range targetPerms {
+			ok, aerr := c.Authorize(ctx, actorID, permName, scope)
+			if aerr != nil {
+				return fmt.Errorf("failed to resolve actor authority: %w", aerr)
+			}
+			if !ok {
+				return fmt.Errorf("cannot %s a user holding permission %q, which you do not also hold", action, permName)
+			}
 		}
 	}
 	return nil

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -129,6 +129,34 @@ func patRestrictionFromContext(ctx context.Context) *PATRestriction {
 	return r
 }
 
+// sessionAuthCtxKey is the unexported context key carrying whether the request
+// authenticated via a genuine interactive session token.
+type sessionAuthCtxKey struct{}
+
+// WithSessionAuth tags ctx with whether the request authenticated via a real
+// interactive session token — true only for a session; false for a PAT
+// (restricted or not) or a machine token, which are non-interactive
+// credentials. #G07: StartImpersonation reads this back, because
+// patRestrictionFromContext alone can't distinguish "no restriction" from "no
+// PAT at all" — an UNRESTRICTED PAT carries a nil restriction identical to a
+// session's, so a check gated only on PATRestriction != nil misses it.
+func WithSessionAuth(ctx context.Context, sessionAuth bool) context.Context {
+	return context.WithValue(ctx, sessionAuthCtxKey{}, sessionAuth)
+}
+
+// sessionAuthFromContext reports whether ctx was tagged as a genuine
+// interactive session. Defaults to true when untagged (e.g. a test or an
+// internal/CLI call with no HTTP/gRPC auth layer in front of it) so this
+// check only ever narrows a request the auth layer explicitly marked
+// non-interactive, never a caller the auth layer never touched.
+func sessionAuthFromContext(ctx context.Context) bool {
+	v, ok := ctx.Value(sessionAuthCtxKey{}).(bool)
+	if !ok {
+		return true
+	}
+	return v
+}
+
 // Scope identifies the project/environment an authorization check or a role
 // assignment applies to. It aliases storage.Scope so the same 0 = global
 // sentinel flows from the HTTP layer through to the queries unchanged.

--- a/internal/core/impersonation.go
+++ b/internal/core/impersonation.go
@@ -75,12 +75,13 @@ func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID 
 	if err := c.requireEqualOrGreaterAdminAuthority(ctx, adminID, targetID, "impersonate"); err != nil {
 		return nil, nil, err
 	}
-	// The ceiling check above runs once at impersonation start. If the target
-	// user's roles are elevated above the impersonator's DURING an active
-	// impersonation session (up to 1h TTL), the impersonator retains the
-	// already-issued session — the check is not re-evaluated per-request.
-	// The auth cache TTL (30s) bounds the propagation delay for role changes,
-	// but the ceiling is not continuously enforced.
+	// The ceiling check above runs once here at start, but is NOT only a
+	// point-in-time check (MT-007): ValidateSessionToken re-runs
+	// ReauthorizeImpersonation on every request against this session, and
+	// StreamAuditLogs' dedicated re-auth ticker (#108, audit_service.go) does
+	// the same for long-lived gRPC streams — both catch either side's authority
+	// changing (the target elevated, or the admin demoted/suspended) DURING an
+	// active session, cached at ceilingCacheTTL (60s) to bound the added cost.
 	token, err := generateSecureToken()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate session token: %w", err)
@@ -135,6 +136,31 @@ func (c *KeyorixCore) EndImpersonation(ctx context.Context, token string) error 
 	c.writeImpersonationEvent(ctx, EventImpersonationEnd, adminID, targetID, session.IPAddress, desc, diff)
 
 	return c.storage.DeleteSession(ctx, session.ID)
+}
+
+// ReauthorizeImpersonation re-verifies an ACTIVE impersonation session's admin
+// side: that adminID's account is still active, and that adminID still holds
+// equal-or-greater authority than targetID (MT-007/#G05) — the same ceiling
+// StartImpersonation checked at issuance, re-run for a long-lived credential
+// that authenticates once and is not re-validated by the ordinary per-request
+// path. ValidateSessionToken calls this on every request against an
+// impersonation session; StreamAuditLogs' dedicated re-auth ticker
+// (server/grpc/services/audit_service.go, #108) calls it too, since a gRPC
+// stream's own auth happens once at open. Cached via cachedImpersonationCeiling
+// (IMP-001, 60s) so neither caller repeats the underlying DB reads on every
+// invocation.
+func (c *KeyorixCore) ReauthorizeImpersonation(ctx context.Context, adminID, targetID uint) error {
+	admin, err := c.storage.GetUser(ctx, adminID)
+	if err != nil {
+		return fmt.Errorf("impersonating account not found")
+	}
+	if !admin.IsActive || AccountLoginBlocked(admin.AccountState) {
+		return fmt.Errorf("impersonating account is not active")
+	}
+	if err := c.cachedImpersonationCeiling(ctx, adminID, targetID); err != nil {
+		return fmt.Errorf("impersonation ceiling exceeded — target's authority now exceeds impersonator's: %w", err)
+	}
+	return nil
 }
 
 // SessionImpersonator returns the initiating admin ID if token belongs to an

--- a/internal/core/impersonation.go
+++ b/internal/core/impersonation.go
@@ -45,6 +45,15 @@ func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID 
 	if patRestrictionFromContext(ctx) != nil {
 		return nil, nil, fmt.Errorf("a restricted access token may not start impersonation")
 	}
+	// #G07: the check above only catches a RESTRICTED PAT — patRestrictionFromContext
+	// returns nil for BOTH a session and an UNRESTRICTED PAT (or a machine token),
+	// which look identical from that helper's perspective (see its own doc comment:
+	// "or nil for sessions / unrestricted PATs"). Impersonation is an interactive
+	// admin action, not something an API credential should ever be able to trigger,
+	// restricted or not — sessionAuthFromContext distinguishes the two.
+	if !sessionAuthFromContext(ctx) {
+		return nil, nil, fmt.Errorf("impersonation requires an interactive session, not an API credential")
+	}
 	admin, err := c.storage.GetUser(ctx, adminID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("admin not found")

--- a/internal/core/impersonation_test.go
+++ b/internal/core/impersonation_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -97,8 +98,11 @@ func TestStartImpersonation_RejectsAdminTargetForNonAdminCaller(t *testing.T) {
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(2), mock.Anything).Return([]uint{}, nil)
 	store.On("GetUserRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{}, nil)
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{}, nil)
+	// #G05: the ceiling now compares the target's ACTUAL bundled permissions
+	// (not the "admin" role name itself) against what the caller can exercise.
+	store.On("GetRolePermissions", ctx, uint(7)).Return([]*models.Permission{{Name: "system.write"}}, nil)
 	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
-	if err == nil || !strings.Contains(err.Error(), "administrative authority") {
+	if err == nil || !strings.Contains(err.Error(), "which you do not also hold") {
 		t.Fatalf("expected an admin-target rejection, got %v", err)
 	}
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
@@ -121,8 +125,9 @@ func TestStartImpersonation_RejectsProjectScopedAdminTargetForNonAdminCaller(t *
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(2), projScope).Return([]uint{}, nil)
 	store.On("GetUserRoleIDsAt", ctx, uint(1), projScope).Return([]uint{}, nil)
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), projScope).Return([]uint{}, nil)
+	store.On("GetRolePermissions", ctx, uint(8)).Return([]*models.Permission{{Name: "roles.assign"}}, nil)
 	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
-	if err == nil || !strings.Contains(err.Error(), "administrative authority") {
+	if err == nil || !strings.Contains(err.Error(), "which you do not also hold") {
 		t.Fatalf("expected a project-scoped admin-target rejection, got %v", err)
 	}
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
@@ -145,6 +150,7 @@ func TestStartImpersonation_AllowsProjectScopedAdminTargetForSameScopeAdminCalle
 	// Caller also holds project_admin at the SAME project scope.
 	store.On("GetUserRoleIDsAt", ctx, uint(1), projScope).Return([]uint{8}, nil)
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), projScope).Return([]uint{}, nil)
+	store.On("GetRolePermissions", ctx, uint(8)).Return([]*models.Permission{{Name: "roles.assign"}}, nil)
 	store.On("CreateSession", ctx, mock.MatchedBy(func(s *models.Session) bool {
 		return s.UserID == 2 && s.ImpersonatedBy != nil && *s.ImpersonatedBy == 1
 	})).Return(&models.Session{ID: 100, UserID: 2, SessionToken: "tok2"}, nil)
@@ -154,6 +160,90 @@ func TestStartImpersonation_AllowsProjectScopedAdminTargetForSameScopeAdminCalle
 	require.NoError(t, err)
 	require.Equal(t, "tok2", session.SessionToken)
 	require.Equal(t, "proj-admin", target.Username)
+}
+
+// A non-admin caller cannot impersonate a target whose admin-tier authority
+// comes from a CUSTOM role (not one of the fixed adminRoleNames) that bundles
+// an admin-tier permission — #G05's exact regression for the old role-NAME
+// check, which silently skipped the ceiling entirely for any role it didn't
+// recognize by name, no matter how privileged its actual permission bundle.
+func TestStartImpersonation_RejectsCustomAdminTierRoleTargetForNonAdminCaller(t *testing.T) {
+	store := new(MockStorage)
+	c := newImpersonationCore(store)
+	ctx := context.Background()
+	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "helpdesk"}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "secops", IsActive: true}, nil)
+	// Target (id 2) holds a custom "secops" role (id 9) at global scope, bundling
+	// system.write — never named in adminRoleNames, so roleSetContainsAdmin(target)
+	// would have returned false and the old check would have skipped this scope.
+	store.On("GetRoleByName", ctx, mock.Anything).Return((*models.Role)(nil), fmt.Errorf("not found"))
+	store.On("GetUserRoleScopes", ctx, uint(2)).Return([]Scope{{}}, nil)
+	store.On("GetUserRoleIDsAt", ctx, uint(2), mock.Anything).Return([]uint{9}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(2), mock.Anything).Return([]uint{}, nil)
+	store.On("GetUserRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{}, nil)
+	store.On("GetRolePermissions", ctx, uint(9)).Return([]*models.Permission{{Name: "system.write"}}, nil)
+	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
+	if err == nil || !strings.Contains(err.Error(), "which you do not also hold") {
+		t.Fatalf("expected a custom-admin-tier-role rejection, got %v", err)
+	}
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
+// #G05 detection_idea: revoke the impersonator's users.impersonate mid-session
+// (the admin keeps every OTHER permission — this is deliberately NOT a rank
+// demotion, to isolate the missing check) — ReauthorizeImpersonation (the
+// function ValidateSessionToken calls on every request against an active
+// impersonation session, and StreamAuditLogs' re-auth ticker calls for gRPC)
+// must now refuse, so the session is terminated within one re-auth cycle
+// rather than remaining valid for the rest of its TTL.
+func TestReauthorizeImpersonation_RevokedImpersonatePermission(t *testing.T) {
+	store := new(MockStorage)
+	c := newImpersonationCore(store)
+	ctx := context.Background()
+	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin", IsActive: true}, nil)
+	// Admin (1) no longer holds users.impersonate: RoleSetHasPermission returns
+	// false for it, but the admin otherwise still outranks the target (2, no
+	// roles at all) — isolates the missing per-permission re-check from the
+	// pre-existing rank-ceiling re-check.
+	store.On("GetUserRoleIDsAt", ctx, uint(1), Scope{}).Return([]uint{5}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), Scope{}).Return([]uint{}, nil)
+	store.On("GetRoleByName", ctx, mock.Anything).Return((*models.Role)(nil), fmt.Errorf("not found"))
+	store.On("RoleSetHasPermission", ctx, []uint{5}, "users.impersonate").Return(false, nil)
+	err := c.ReauthorizeImpersonation(ctx, 1, 2)
+	if err == nil || !strings.Contains(err.Error(), "impersonation authority has been revoked") {
+		t.Fatalf("expected a revoked-impersonate-permission rejection, got %v", err)
+	}
+}
+
+// The companion positive case: an admin who still holds users.impersonate and
+// still outranks the target passes re-authorization.
+func TestReauthorizeImpersonation_StillAuthorized(t *testing.T) {
+	store := new(MockStorage)
+	c := newImpersonationCore(store)
+	ctx := context.Background()
+	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin", IsActive: true}, nil)
+	store.On("GetUserRoleIDsAt", ctx, uint(1), Scope{}).Return([]uint{5}, nil)
+	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), Scope{}).Return([]uint{}, nil)
+	store.On("GetRoleByName", ctx, mock.Anything).Return((*models.Role)(nil), fmt.Errorf("not found"))
+	store.On("RoleSetHasPermission", ctx, []uint{5}, "users.impersonate").Return(true, nil)
+	store.On("GetUserRoleScopes", ctx, uint(2)).Return([]Scope{}, nil)
+	err := c.ReauthorizeImpersonation(ctx, 1, 2)
+	require.NoError(t, err)
+}
+
+// A suspended/deactivated admin fails re-authorization even if their role
+// grants are otherwise untouched (the pre-existing account-state half of
+// MT-007, still exercised through the shared ReauthorizeImpersonation path).
+func TestReauthorizeImpersonation_SuspendedAdmin(t *testing.T) {
+	store := new(MockStorage)
+	c := newImpersonationCore(store)
+	ctx := context.Background()
+	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin", IsActive: false}, nil)
+	err := c.ReauthorizeImpersonation(ctx, 1, 2)
+	if err == nil || !strings.Contains(err.Error(), "not active") {
+		t.Fatalf("expected a suspended-admin rejection, got %v", err)
+	}
 }
 
 func TestEndImpersonation_LogsDurationAndActionCount(t *testing.T) {

--- a/internal/core/impersonation_test.go
+++ b/internal/core/impersonation_test.go
@@ -69,6 +69,36 @@ func TestStartImpersonation_RejectsRestrictedPAT(t *testing.T) {
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
 }
 
+// #G07: an UNRESTRICTED PAT (or any other non-interactive credential) must not
+// be able to start impersonation either — patRestrictionFromContext alone
+// can't tell an unrestricted PAT apart from a session (both carry nil), so
+// the restricted-PAT check above misses this case entirely.
+func TestStartImpersonation_RejectsNonSessionAuth(t *testing.T) {
+	store := new(MockStorage)
+	c := newImpersonationCore(store)
+	ctx := WithSessionAuth(context.Background(), false)
+	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
+	if err == nil || !strings.Contains(err.Error(), "interactive session") {
+		t.Fatalf("expected a non-session-auth rejection, got %v", err)
+	}
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
+// A genuine interactive session (the untagged/default case, and the explicit
+// true case) is unaffected by the #G07 check.
+func TestStartImpersonation_AllowsSessionAuth(t *testing.T) {
+	store := new(MockStorage)
+	c := newImpersonationCore(store)
+	ctx := WithSessionAuth(context.Background(), true)
+	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin"}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "alice", IsActive: true}, nil)
+	store.On("GetUserRoleScopes", ctx, uint(2)).Return([]Scope{}, nil)
+	store.On("CreateSession", ctx, mock.Anything).Return(&models.Session{ID: 1, UserID: 2, SessionToken: "tok"}, nil)
+	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
+	require.NoError(t, err)
+}
+
 // A suspended/inactive target cannot be impersonated (the session would be dead on
 // arrival and only emit a misleading audit event).
 func TestStartImpersonation_RejectsInactiveTarget(t *testing.T) {

--- a/internal/core/permission_enforcement_test.go
+++ b/internal/core/permission_enforcement_test.go
@@ -729,6 +729,9 @@ func TestCheckSecretPermission_ACLFallback_GrantsAccess(t *testing.T) {
 	mockStorage.On("GetSecretACL", mock.Anything, uint(1), uint(8)).Return(&models.SecretACL{
 		SecretID: 1, UserID: 8, Permissions: `["secrets.read"]`,
 	}, nil)
+	// #G13: aclGrantsPermission now re-verifies the grantee is still a member
+	// of the secret's project before honoring the grant.
+	mockStorage.On("IsProjectMember", mock.Anything, uint(8), uint(5)).Return(true, nil)
 
 	c := NewKeyorixCore(mockStorage)
 

--- a/internal/core/secret_acl.go
+++ b/internal/core/secret_acl.go
@@ -195,17 +195,50 @@ func (c *KeyorixCore) HasSecretACL(ctx context.Context, userID, secretID uint, p
 	return false, nil
 }
 
-// aclGrantsPermission checks if userID has an ACL grant on nodeID covering perm.
+// aclGrantsPermission checks if userID has an ACL grant on nodeID covering
+// perm, AND that userID is still a live member of the grant's project.
 func (c *KeyorixCore) aclGrantsPermission(ctx context.Context, nodeID, userID uint, perm string) (bool, error) {
 	acl, err := c.storage.GetSecretACL(ctx, nodeID, userID)
 	if err != nil {
 		if isNotFound(err) {
 			return false, nil
 		}
+		// #G13: a backend that doesn't support SecretACL at all (RemoteStorage,
+		// before this fix only DeleteSecretACLsByUserAndProject was proxied)
+		// must not turn EVERY secret-access check into a hard failure — mirrors
+		// HasSecretACL's own handling of GetSecretAncestors returning the same
+		// sentinel: "this backend doesn't support the feature" degrades to "no
+		// grant", falling through to project-scope RBAC, not a fail-closed error.
+		if errors.Is(err, storage.ErrUnsupportedByBackend) {
+			return false, nil
+		}
 		return false, err
 	}
 	perms := DecodeSecretACLPerms(acl.Permissions)
-	return slices.Contains(perms, perm), nil
+	if !slices.Contains(perms, perm) {
+		return false, nil
+	}
+	// #G13: an ACL grant only remains valid while its grantee is still a member
+	// of the secret's project. Without this, a user removed from the project
+	// (offboarded) retains per-secret access indefinitely via this row alone —
+	// AuthorizeSecret checks ACL grants before the project-scope RBAC fallback
+	// and short-circuits on the first match, so the project-level removal
+	// provides no protection by itself. RemoveProjectMember's
+	// DeleteSecretACLsByUserAndProject call proactively deletes these rows on
+	// removal, but that's cleanup-on-write; this is the corresponding
+	// authorization-time guard, so a gap in that cleanup path (a backend that
+	// doesn't support it, a code path that bypasses RemoveProjectMember, a
+	// TOCTOU window) can't leave a stale grant silently exploitable in the
+	// meantime. Fails closed: a lookup error denies the grant.
+	node, err := c.storage.GetSecret(ctx, nodeID)
+	if err != nil {
+		return false, err
+	}
+	isMember, err := c.storage.IsProjectMember(ctx, userID, node.ProjectID)
+	if err != nil {
+		return false, err
+	}
+	return isMember, nil
 }
 
 // isNotFound reports whether err looks like a "not found" storage error.

--- a/internal/core/secret_acl_folder_test.go
+++ b/internal/core/secret_acl_folder_test.go
@@ -30,7 +30,16 @@ func mockNoACL(ms *MockStorage, secretID, userID uint) {
 		Return((*models.SecretACL)(nil), fmt.Errorf("not found"))
 }
 
-// mockAllowACL registers a GetSecretACL expectation that returns an ACL with the given perms.
+// mockAllowLiveMember is the fixed project ID mockAllowACL stubs GetSecret /
+// IsProjectMember with — its value is arbitrary, these tests don't exercise
+// project-scoping itself, only that a live member's grant is honored.
+const mockAllowLiveMember = uint(1)
+
+// mockAllowACL registers a GetSecretACL expectation that returns an ACL with
+// the given perms, plus the #G13 live-membership-recheck stubs
+// (GetSecret/IsProjectMember, both returning "still a member") every
+// authorized-grant test needs now that aclGrantsPermission re-verifies
+// project membership before honoring a grant.
 func mockAllowACL(ms *MockStorage, secretID, userID uint, perms ...string) {
 	encoded, _ := EncodeSecretACLPerms(perms)
 	ms.On("GetSecretACL", mock.Anything, secretID, userID).
@@ -39,6 +48,10 @@ func mockAllowACL(ms *MockStorage, secretID, userID uint, perms ...string) {
 			UserID:      userID,
 			Permissions: encoded,
 		}, nil)
+	ms.On("GetSecret", mock.Anything, secretID).
+		Return(&models.SecretNode{ID: secretID, ProjectID: mockAllowLiveMember}, nil).Maybe()
+	ms.On("IsProjectMember", mock.Anything, userID, mockAllowLiveMember).
+		Return(true, nil).Maybe()
 }
 
 // --- HasSecretACL tests ---

--- a/internal/core/secret_acl_test.go
+++ b/internal/core/secret_acl_test.go
@@ -10,9 +10,22 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
+
+// unsupportedACLStorage wraps a real storage.Storage but forces GetSecretACL
+// to return storage.ErrUnsupportedByBackend, simulating a backend (like
+// RemoteStorage's still-unproxied ACL read path) that doesn't support
+// SecretACL at all.
+type unsupportedACLStorage struct {
+	corestorage.Storage
+}
+
+func (unsupportedACLStorage) GetSecretACL(context.Context, uint, uint) (*models.SecretACL, error) {
+	return nil, corestorage.ErrUnsupportedByBackend
+}
 
 // newACLCore returns a KeyorixCore backed by an in-memory SQLite DB with all
 // tables needed for the ACL tests already migrated.
@@ -252,6 +265,76 @@ func TestAuthorizeSecretPrincipal_MachineGetSecretError(t *testing.T) {
 	ok, err := c.AuthorizeSecretPrincipal(ctx, ActorTypeMachine, 1, 999999, "secrets.read")
 	require.Error(t, err)
 	assert.False(t, ok, "an unresolvable secret must never authorize a machine principal")
+}
+
+// TestHasSecretACL_DeniesStaleGrantAfterMembershipRemoved is the #G13
+// regression implementing the review's own detection_idea: remove a project
+// member who holds a SecretACL grant, assert subsequent reads using that
+// grant fail. The UserRole row is deleted directly (bypassing
+// RemoveProjectMember's own DeleteSecretACLsByUserAndProject cleanup call)
+// to isolate the NEW authorization-time guard in aclGrantsPermission from the
+// pre-existing cleanup-on-removal path — proving the grant is denied even
+// when cleanup didn't run (a gap in that path, a backend that doesn't
+// support it, a TOCTOU window), not only when it did.
+func TestHasSecretACL_DeniesStaleGrantAfterMembershipRemoved(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "offboarding-secret")
+
+	require.NoError(t, c.GrantSecretACL(ctx, 1, sid, 42, []string{"secrets.read"}))
+	got, err := c.HasSecretACL(ctx, 42, sid, "secrets.read")
+	require.NoError(t, err)
+	require.True(t, got, "sanity: the grant must be honored while the grantee is still a project member")
+
+	// Remove user 42's project membership WITHOUT touching the SecretACL row —
+	// the stale-grant scenario this check exists to close.
+	require.NoError(t, db.Where("user_id = ? AND project_id = ?", 42, 1).Delete(&models.UserRole{}).Error)
+
+	got2, err := c.HasSecretACL(ctx, 42, sid, "secrets.read")
+	require.NoError(t, err)
+	assert.False(t, got2, "a SecretACL grant must not authorize a user who is no longer a member of the secret's project")
+}
+
+// TestAuthorizeSecret_DeniesStaleGrantAfterMembershipRemoved is the
+// AuthorizeSecret-level counterpart: a departed member's stale ACL grant
+// must not fall through to authorize a read, and — since AuthorizeSecret is
+// what backs the transfer-ownership route's permission gate
+// (RequireScopedSecretPermission -> AuthorizeSecretPrincipal ->
+// AuthorizeSecret) — this is also what closes the "transferOwnership
+// satisfied by that same stale grant" half of the detection_idea: a departed
+// member can no longer even reach TransferSecretOwnership via that route,
+// since AuthorizeSecret(..., "secrets.write") now denies them too.
+func TestAuthorizeSecret_DeniesStaleGrantAfterMembershipRemoved(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "offboarding-secret-2")
+
+	require.NoError(t, c.GrantSecretACL(ctx, 1, sid, 55, []string{"secrets.read", "secrets.write"}))
+	ok, err := c.AuthorizeSecret(ctx, 55, sid, "secrets.write")
+	require.NoError(t, err)
+	require.True(t, ok, "sanity: the grant must authorize secrets.write while the grantee is still a project member")
+
+	require.NoError(t, db.Where("user_id = ? AND project_id = ?", 55, 1).Delete(&models.UserRole{}).Error)
+
+	ok2, err := c.AuthorizeSecret(ctx, 55, sid, "secrets.write")
+	require.NoError(t, err)
+	assert.False(t, ok2, "a departed member's stale ACL grant must not authorize secrets.write — this is the same check gating TransferSecretOwnership's HTTP route")
+}
+
+// TestHasSecretACL_UnsupportedBackendDegradesToNoGrant verifies that a
+// backend returning storage.ErrUnsupportedByBackend for GetSecretACL (e.g.
+// RemoteStorage's still-unproxied read path) degrades to "no grant" rather
+// than failing every secret-access check closed — mirroring HasSecretACL's
+// existing GetSecretAncestors handling for the same sentinel.
+func TestHasSecretACL_UnsupportedBackendDegradesToNoGrant(t *testing.T) {
+	ctx := context.Background()
+	c, db := newACLCore(t)
+	sid := mkACLSecret(t, db, "unsupported-backend-secret")
+	c.storage = unsupportedACLStorage{c.storage}
+
+	got, err := c.HasSecretACL(ctx, 42, sid, "secrets.read")
+	require.NoError(t, err, "an unsupported-backend error from GetSecretACL must not propagate as a hard failure")
+	assert.False(t, got)
 }
 
 // TestGrantSecretACL_Upsert verifies that a second grant on the same (secret, user)

--- a/internal/storage/store/concurrency_purge_restore_race_test.go
+++ b/internal/storage/store/concurrency_purge_restore_race_test.go
@@ -45,7 +45,7 @@ func TestConcurrency_PurgeDeletedSecretsBefore_RestoreWinsRace(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{},
-		&models.SecretNode{}, &models.SecretVersion{}, &models.SecretDependency{}))
+		&models.SecretNode{}, &models.SecretVersion{}, &models.SecretDependency{}, &models.SecretACL{}))
 	ls := NewLocalStorage(db)
 	ctx := context.Background()
 
@@ -107,7 +107,7 @@ func TestConcurrency_PurgeDeletedUsersBefore_RestoreWinsRace(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.UserRole{}, &models.UserGroup{},
-		&models.ShareRecord{}, &models.PersonalAccessToken{}, &models.Session{}))
+		&models.ShareRecord{}, &models.PersonalAccessToken{}, &models.Session{}, &models.SecretACL{}))
 	ls := NewLocalStorage(db)
 	ctx := context.Background()
 

--- a/internal/storage/store/local_coverage_test.go
+++ b/internal/storage/store/local_coverage_test.go
@@ -406,6 +406,7 @@ func TestPurgeDeletedUsersBefore_Cov_PurgesWithImpersonation(t *testing.T) {
 		&models.ShareRecord{},
 		&models.PersonalAccessToken{},
 		&models.Session{},
+		&models.SecretACL{},
 	)
 	ctx := context.Background()
 	now := time.Now()

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -83,6 +83,12 @@ func (ls *LocalStorage) PurgeDeletedUsersBefore(ctx context.Context, before time
 		if e := tx.Where(sqlWhereUserIDIn, stillEligible()).Delete(&models.PersonalAccessToken{}).Error; e != nil {
 			return e
 		}
+		// #G13: SecretACL (the grantee side, user_id) has no deleted_at of its own
+		// and no FK/cascade — a plain purge of just the users row left these grants
+		// permanently orphaned, referencing a user ID nothing else destroys.
+		if e := tx.Where(sqlWhereUserIDIn, stillEligible()).Delete(&models.SecretACL{}).Error; e != nil {
+			return e
+		}
 		if e := tx.Where("user_id IN (?) OR impersonated_by IN (?)", stillEligible(), stillEligible()).Delete(&models.Session{}).Error; e != nil {
 			return e
 		}
@@ -254,6 +260,13 @@ func (ls *LocalStorage) PurgeDeletedSecretsBefore(ctx context.Context, before ti
 		}
 		if e := tx.Where("dependent_secret_id IN (?) OR depends_on_secret_id IN (?)", stillEligible(), stillEligible()).
 			Delete(&models.SecretDependency{}).Error; e != nil {
+			return e
+		}
+		// #G13: SecretACL grants ON the purged secret have no deleted_at/FK of
+		// their own either — the same orphaning gap PurgeDeletedUsersBefore's
+		// SecretACL cleanup closes for the grantee side, mirrored here for the
+		// secret side.
+		if e := tx.Where("secret_id IN (?)", stillEligible()).Delete(&models.SecretACL{}).Error; e != nil {
 			return e
 		}
 		rn := tx.Unscoped().

--- a/internal/storage/store/local_purge_test.go
+++ b/internal/storage/store/local_purge_test.go
@@ -19,7 +19,7 @@ func newPurgeTestStore(t *testing.T) *LocalStorage {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Project{}, &models.Environment{},
 		&models.UserRole{}, &models.GroupRole{}, &models.Group{}, &models.UserGroup{}, &models.ShareRecord{},
-		&models.PersonalAccessToken{}, &models.Session{}))
+		&models.PersonalAccessToken{}, &models.Session{}, &models.SecretACL{}))
 	return NewLocalStorage(db)
 }
 
@@ -87,6 +87,35 @@ func TestPurgeDeletedUsersBefore_CascadesDependentRows(t *testing.T) {
 	assert.Zero(t, count, "PersonalAccessToken must be purged with the user")
 	require.NoError(t, ls.db.Model(&models.Session{}).Where("user_id = ?", 1).Count(&count).Error)
 	assert.Zero(t, count, "Session must be purged with the user")
+}
+
+// TestPurgeDeletedUsersBefore_CascadesSecretACL pins #G13: SecretACL has no
+// deleted_at/FK of its own, so purging a user who was still the grantee of a
+// per-secret ACL left that row permanently orphaned, referencing a user ID
+// nothing else ever destroys. A grant belonging to a DIFFERENT, live user
+// must survive.
+func TestPurgeDeletedUsersBefore_CascadesSecretACL(t *testing.T) {
+	ls := newPurgeTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	old := now.AddDate(0, 0, -40)
+	cutoff := now.AddDate(0, 0, -30)
+
+	require.NoError(t, ls.db.Create(&models.User{ID: 1, Username: "ghost", Email: "g@x"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 2, Username: "live", Email: "l@x"}).Error)
+	require.NoError(t, ls.db.Create(&models.SecretACL{SecretID: 1, UserID: 1, Permissions: `["secrets.read"]`, GrantedBy: 2}).Error)
+	require.NoError(t, ls.db.Create(&models.SecretACL{SecretID: 1, UserID: 2, Permissions: `["secrets.read"]`, GrantedBy: 2}).Error)
+	require.NoError(t, ls.db.Unscoped().Model(&models.User{}).Where("id = ?", 1).Update("deleted_at", old).Error)
+
+	n, err := ls.PurgeDeletedUsersBefore(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	var count int64
+	require.NoError(t, ls.db.Model(&models.SecretACL{}).Where("user_id = ?", 1).Count(&count).Error)
+	assert.Zero(t, count, "SecretACL grant held by the purged user must be purged with them")
+	require.NoError(t, ls.db.Model(&models.SecretACL{}).Where("user_id = ?", 2).Count(&count).Error)
+	assert.Equal(t, int64(1), count, "a live user's SecretACL grant must survive")
 }
 
 func TestPurgeDeletedProjectsAndEnvironments(t *testing.T) {
@@ -157,7 +186,7 @@ func TestPurgeDeletedUsersBefore_NothingToPurge(t *testing.T) {
 func TestPurgeDeletedSecretsBefore_DestroysVersions(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.SecretDependency{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.SecretDependency{}, &models.SecretACL{}))
 	ls := NewLocalStorage(db)
 	ctx := context.Background()
 	now := time.Now()
@@ -189,6 +218,37 @@ func TestPurgeDeletedSecretsBefore_DestroysVersions(t *testing.T) {
 	assert.Equal(t, int64(1), liveVersions)
 }
 
+// TestPurgeDeletedSecretsBefore_CascadesSecretACL pins #G13's other half:
+// SecretACL grants ON a purged secret have no deleted_at/FK of their own
+// either, mirroring the orphaning gap closed for the grantee side by
+// TestPurgeDeletedUsersBefore_CascadesSecretACL. A grant on a different,
+// still-live secret must survive.
+func TestPurgeDeletedSecretsBefore_CascadesSecretACL(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.SecretDependency{}, &models.SecretACL{}))
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	now := time.Now()
+
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "old"}).Error)
+	require.NoError(t, db.Create(&models.SecretACL{SecretID: 1, UserID: 1, Permissions: `["secrets.read"]`, GrantedBy: 2}).Error)
+	require.NoError(t, db.Unscoped().Model(&models.SecretNode{}).Where("id = ?", 1).Update("deleted_at", now.AddDate(0, 0, -40)).Error)
+
+	require.NoError(t, db.Create(&models.SecretNode{ID: 2, Name: "live"}).Error)
+	require.NoError(t, db.Create(&models.SecretACL{SecretID: 2, UserID: 1, Permissions: `["secrets.read"]`, GrantedBy: 2}).Error)
+
+	n, err := ls.PurgeDeletedSecretsBefore(ctx, now.AddDate(0, 0, -30))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	var count int64
+	require.NoError(t, db.Model(&models.SecretACL{}).Where("secret_id = ?", 1).Count(&count).Error)
+	assert.Zero(t, count, "SecretACL grant on the purged secret must be purged with it")
+	require.NoError(t, db.Model(&models.SecretACL{}).Where("secret_id = ?", 2).Count(&count).Error)
+	assert.Equal(t, int64(1), count, "a grant on a live secret must survive")
+}
+
 // TestPurgeDeletedSecretsBefore_RespectsRetentionOverride is #G43:
 // SetSecretRetentionOverride's per-secret window was never actually consulted
 // by the purge sweep — every secret purged strictly on the deployment-wide
@@ -199,7 +259,7 @@ func TestPurgeDeletedSecretsBefore_DestroysVersions(t *testing.T) {
 func TestPurgeDeletedSecretsBefore_RespectsRetentionOverride(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.SecretDependency{}))
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.SecretDependency{}, &models.SecretACL{}))
 	ls := NewLocalStorage(db)
 	ctx := context.Background()
 	now := time.Now()

--- a/internal/storage/store/remote_secret_acl.go
+++ b/internal/storage/store/remote_secret_acl.go
@@ -1,14 +1,24 @@
 // remote_secret_acl.go — SecretACL stubs for RemoteStorage (RBAC Phase 3).
-// These operations are currently not proxied over HTTP; they return ErrRemoteUnsupported.
-// A future PR may add proxy routes under /api/v1/system/secret-acls.
+// Most of these operations are not proxied over HTTP; they return
+// ErrRemoteUnsupported (core.aclGrantsPermission treats this the same as
+// "no grant" — it does not fail secret authorization closed). A future PR
+// may add proxy routes for the rest under /api/v1/system/secret-acls.
 //
 // GetSecretAncestors returns ErrUnsupportedByBackend so the core ancestor walk
 // in HasSecretACL skips folder-inheritance checks on remote callers — the server
 // already enforces them locally before returning a response to the CLI.
+//
+// #G13: DeleteSecretACLsByUserAndProject IS proxied — unlike the others, this
+// one is a security-relevant CLEANUP call (RemoveProjectMember uses it to
+// revoke stale per-secret grants when a member is removed, CWE-284) rather
+// than an ordinary CRUD passthrough, so leaving it unsupported under
+// storage.type: remote silently reintroduced the exact stale-grant exposure
+// the call exists to close.
 package store
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -33,8 +43,20 @@ func (rs *RemoteStorage) DeleteSecretACL(_ context.Context, _ uint) error {
 	return remoteUnsupported("DeleteSecretACL")
 }
 
-func (rs *RemoteStorage) DeleteSecretACLsByUserAndProject(_ context.Context, _, _ uint) error {
-	return remoteUnsupported("DeleteSecretACLsByUserAndProject")
+// DeleteSecretACLsByUserAndProject proxies to POST
+// /api/v1/system/rbac/delete-secret-acls-by-user-and-project, mirroring
+// ClearProjectSecretOwnership's identical passthrough pattern immediately
+// above it at RemoveProjectMember's call site.
+func (rs *RemoteStorage) DeleteSecretACLsByUserAndProject(ctx context.Context, userID, projectID uint) error {
+	payload := map[string]uint{"user_id": userID, "project_id": projectID}
+	resp, err := rs.client.Post(ctx, "/api/v1/system/rbac/delete-secret-acls-by-user-and-project", payload)
+	if err != nil {
+		return fmt.Errorf("failed to delete secret ACLs by user and project: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete secret ACLs by user and project failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
 // GetSecretAncestors is the folder-ACL inheritance walk helper. Folder-ACL

--- a/internal/storage/store/remote_unsupported_registry_test.go
+++ b/internal/storage/store/remote_unsupported_registry_test.go
@@ -42,14 +42,13 @@ func init() {
 			"round 119 audit: sole caller is VerifyMFACredentials, same bypassed-branch reasoning as MarkTOTPStepUsed — recovery codes are only ever consumed at login, never during enrollment/management"},
 
 		// Secret ACL (RBAC Phase 3)
-		"ListAllUserRoleGrants":            {statusIntentional, "permission matrix is server-aggregated via GET /api/v1/rbac/permission-matrix; direct grant enumeration runs server-side"},
-		"CreateOrUpdateSecretACL":          {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
-		"ListSecretACLs":                   {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
-		"ListSecretACLsByUser":             {statusIntentional, "RBAC Phase 3 — listing ACL-granted secrets for a user runs server-side in ListSecretsWithSharingInfo; the core function calls LocalStorage on the server, not RemoteStorage"},
-		"GetSecretACL":                     {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
-		"DeleteSecretACL":                  {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
-		"DeleteSecretACLsByUserAndProject": {statusIntentional, "RBAC Phase 3 — project member removal runs server-side; RemoveProjectMember is never called from a remote-storage CLI context"},
-		"GetSecretAncestors":               {statusIntentional, "RBAC Phase 3 — folder-ACL inheritance walk runs server-side; HasSecretACL uses ErrUnsupportedByBackend to skip the ancestor walk on remote callers"},
+		"ListAllUserRoleGrants":   {statusIntentional, "permission matrix is server-aggregated via GET /api/v1/rbac/permission-matrix; direct grant enumeration runs server-side"},
+		"CreateOrUpdateSecretACL": {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
+		"ListSecretACLs":          {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
+		"ListSecretACLsByUser":    {statusIntentional, "RBAC Phase 3 — listing ACL-granted secrets for a user runs server-side in ListSecretsWithSharingInfo; the core function calls LocalStorage on the server, not RemoteStorage"},
+		"GetSecretACL":            {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
+		"DeleteSecretACL":         {statusIntentional, "RBAC Phase 3 — no proxy route yet; ACL management is always server-side"},
+		"GetSecretAncestors":      {statusIntentional, "RBAC Phase 3 — folder-ACL inheritance walk runs server-side; HasSecretACL uses ErrUnsupportedByBackend to skip the ancestor walk on remote callers"},
 
 		"GetProjectUsageStats": {statusIntentional, "usage report queries run server-side; a future PR may add a /api/v1/system/usage proxy route"},
 

--- a/internal/storage/store/store_s27b_test.go
+++ b/internal/storage/store/store_s27b_test.go
@@ -128,7 +128,7 @@ func TestPurgeDeletedUsersBefore_S27b_ZeroUsersNoOp(t *testing.T) {
 func TestPurgeDeletedUsersBefore_S27b_PurgesUser(t *testing.T) {
 	ls := newS27bStore(t,
 		&models.User{}, &models.UserRole{}, &models.UserGroup{},
-		&models.ShareRecord{}, &models.PersonalAccessToken{}, &models.Session{},
+		&models.ShareRecord{}, &models.PersonalAccessToken{}, &models.Session{}, &models.SecretACL{},
 	)
 	ctx := context.Background()
 	past := time.Now().Add(-24 * time.Hour)

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -108,6 +108,10 @@ func AuthInterceptor(coreService *core.KeyorixCore, requireMFA bool) grpc.UnaryS
 		if restriction != nil {
 			newCtx = core.WithPATRestriction(newCtx, restriction)
 		}
+		// #G07: tag whether this is a genuine interactive session — see the HTTP
+		// buildRequestContext's identical tag for why PATRestriction alone can't
+		// distinguish an unrestricted PAT from a session.
+		newCtx = core.WithSessionAuth(newCtx, userCtx.SessionAuth)
 		return handler(newCtx, req)
 	}
 }
@@ -138,6 +142,8 @@ func StreamAuthInterceptor(coreService *core.KeyorixCore, requireMFA bool) grpc.
 		if restriction != nil {
 			streamCtx = core.WithPATRestriction(streamCtx, restriction)
 		}
+		// #G07: see AuthInterceptor's identical tag.
+		streamCtx = core.WithSessionAuth(streamCtx, userCtx.SessionAuth)
 		wrappedStream := &wrappedServerStream{
 			ServerStream: stream,
 			ctx:          streamCtx,
@@ -154,6 +160,13 @@ func StreamAuthInterceptor(coreService *core.KeyorixCore, requireMFA bool) grpc.
 // BlockWhenImpersonating. (Service-account token issuance has no gRPC surface today.)
 var credentialMintingMethods = map[string]bool{
 	pb.MachineIdentityService_IssueMachineToken_FullMethodName: true,
+	// #G07: ActivateBreakGlass mints a durable, time-bound role grant
+	// attributed to the impersonated TARGET that outlives the bounded,
+	// audited impersonation session — the same class of credential-minting
+	// action IssueMachineToken is blocked for; the HTTP route
+	// (POST /projects/{id}/break-glass) gets the identical BlockWhenImpersonating
+	// guard.
+	pb.BreakGlassService_ActivateBreakGlass_FullMethodName: true,
 }
 
 // blockedUnderImpersonation reports whether fullMethod mints a durable credential that

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -69,6 +69,11 @@ func TestAuthInterceptor_BlocksMachineTokenIssuanceWhileImpersonating(t *testing
 	target := uint(7001)
 	h.CreateTestUser(t, "imp-admin", admin)
 	h.CreateTestUser(t, "imp-target", target)
+	// #G05: ValidateSessionToken now re-verifies the impersonation ceiling
+	// (users.impersonate + equal-or-greater authority than the target) on
+	// every request against an active impersonation session — a real admin
+	// holds this via the super_admin name-bypass, so grant it here too.
+	h.AssignUserRole(t, admin, 1, nil) // super_admin
 	expiry := time.Now().Add(time.Hour)
 	_, err := h.Storage.CreateSession(context.Background(), &models.Session{
 		UserID: target, SessionToken: "imp-token", ExpiresAt: &expiry, ImpersonatedBy: &admin,
@@ -461,10 +466,13 @@ func TestAuthInterceptor_ImpersonationSessionStampsAdminInAudit(t *testing.T) {
 
 	const adminID, targetID uint = 7001, 7002
 	h.CreateTestUser(t, "imp-target", targetID)
-	// The impersonating admin must exist and be active: ValidateSessionToken now
-	// re-checks the impersonator's account state on every impersonation-session request
-	// (so suspending the admin ends their impersonation immediately).
+	// The impersonating admin must exist, be active, and still hold the
+	// impersonation ceiling: ValidateSessionToken now re-checks BOTH the
+	// impersonator's account state AND the ceiling (#G05) on every
+	// impersonation-session request (so suspending or demoting the admin
+	// ends their impersonation immediately).
 	h.CreateTestUser(t, "imp-admin", adminID)
+	h.AssignUserRole(t, adminID, 1, nil) // super_admin
 	exp := time.Now().Add(time.Hour)
 	admin := adminID
 	_, err := h.Storage.CreateSession(context.Background(), &models.Session{

--- a/server/grpc/interceptors/credential_minting_parity_test.go
+++ b/server/grpc/interceptors/credential_minting_parity_test.go
@@ -67,6 +67,18 @@ func TestCredentialMintingMethods_CoversNamingConvention(t *testing.T) {
 	assert.Contains(t, found, pb.MachineIdentityService_IssueMachineToken_FullMethodName)
 }
 
+// TestCredentialMintingMethods_IncludesActivateBreakGlass is the #G07 direct
+// regression: ActivateBreakGlass mints a durable, time-bound role grant
+// attributed to whoever the session currently acts as, but its method name
+// ("ActivateBreakGlass") doesn't match credentialMintingNamePattern (it
+// doesn't end in "Token"), so the naming-convention test above can't catch
+// this specific gap — it was missing from credentialMintingMethods despite
+// IssueMachineToken (the same class of action) already being blocked.
+func TestCredentialMintingMethods_IncludesActivateBreakGlass(t *testing.T) {
+	assert.True(t, credentialMintingMethods[pb.BreakGlassService_ActivateBreakGlass_FullMethodName],
+		"ActivateBreakGlass mints a durable role grant and must be blocked while impersonating, the same as IssueMachineToken")
+}
+
 // TestCredentialMintingMethods_NoUnknownEntries is the converse check: every entry
 // in credentialMintingMethods must correspond to an RPC that actually exists across
 // the registered services, so a stale/typo'd entry (e.g. after a method rename)

--- a/server/grpc/interceptors/interceptors_s22_test.go
+++ b/server/grpc/interceptors/interceptors_s22_test.go
@@ -385,6 +385,7 @@ func TestStreamAuthInterceptor_S22_BlocksImpersonatedCredentialMinting(t *testin
 	target := uint(8101)
 	h.CreateTestUser(t, "stream-imp-admin", admin)
 	h.CreateTestUser(t, "stream-imp-target", target)
+	h.AssignUserRole(t, admin, 1, nil) // super_admin — #G05 ceiling re-check
 	expiry := time.Now().Add(time.Hour)
 	_, err := h.Storage.CreateSession(context.Background(), &models.Session{
 		UserID: target, SessionToken: "stream-imp-token", ExpiresAt: &expiry, ImpersonatedBy: &admin,
@@ -412,6 +413,7 @@ func TestStreamAuthInterceptor_S22_NonCredentialMintingMethodAllowedWhileImperso
 	target := uint(8201)
 	h.CreateTestUser(t, "stream-imp-admin2", admin)
 	h.CreateTestUser(t, "stream-imp-target2", target)
+	h.AssignUserRole(t, admin, 1, nil) // super_admin — #G05 ceiling re-check
 	expiry := time.Now().Add(time.Hour)
 	_, err := h.Storage.CreateSession(context.Background(), &models.Session{
 		UserID: target, SessionToken: "stream-imp-ok-token", ExpiresAt: &expiry, ImpersonatedBy: &admin,

--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -128,7 +128,12 @@ func (s *AuditGRPCService) reauthorizeAuditStream(ctx context.Context, actor *in
 	}
 	if actor.ImpersonatedBy != nil {
 		if err := s.core.ReauthorizeImpersonation(ctx, *actor.ImpersonatedBy, actor.UserID); err != nil {
-			return status.Error(codes.PermissionDenied, err.Error())
+			// Fixed safe string, not err.Error(): matches this function's own
+			// convention two lines above. ReauthorizeImpersonation's errors are
+			// themselves fixed strings today, but one wraps cachedImpersonationCeiling's
+			// error with %w — a raw passthrough here would let that wrapped detail
+			// change out from under this boundary without anyone noticing.
+			return status.Error(codes.PermissionDenied, "impersonation session no longer authorized")
 		}
 	}
 	return nil

--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -63,7 +63,18 @@ func NewAuditService(coreService *core.KeyorixCore) *AuditGRPCService {
 // concurrent StreamAuditLogs slots, refusing a new stream once the cap is reached.
 // The returned release func MUST be deferred by the caller to free the slot.
 func (s *AuditGRPCService) acquireStreamSlot(actor *interceptors.UserContext) (func(), error) {
-	key := fmt.Sprintf("%s:%d", actor.ActorKind(), actor.PrincipalID())
+	// #G05: during impersonation, actor.PrincipalID() resolves to the TARGET
+	// (the session this stream authenticated with), not the admin actually
+	// driving the client. Keying on the target lets an admin bypass their own
+	// per-principal cap by impersonating N different targets for 3 streams
+	// each, and cross-contaminates the cap with whatever streams the target
+	// separately holds open under their own, unrelated session. Key on the
+	// admin's own id instead so the cap bounds the real acting principal.
+	principalID := actor.PrincipalID()
+	if actor.ImpersonatedBy != nil {
+		principalID = *actor.ImpersonatedBy
+	}
+	key := fmt.Sprintf("%s:%d", actor.ActorKind(), principalID)
 	s.streamCountsMu.Lock()
 	defer s.streamCountsMu.Unlock()
 	if s.streamCounts[key] >= auditStreamMaxPerPrincipal {
@@ -91,6 +102,15 @@ func (s *AuditGRPCService) acquireStreamSlot(actor *interceptors.UserContext) (f
 // context does not retain — the account- and role-level checks close the practical
 // admin-action revocation paths (suspend, deprovision, delete, remove role) #108
 // describes.
+//
+// #G05: the checks above run against actor.UserID, which during impersonation is
+// the TARGET (the id the stream authenticated with) — never the initiating admin.
+// Without an explicit admin-side check here, MT-007's ceiling re-verification
+// (ValidateSessionToken, the ordinary per-request path) is never reached for a
+// gRPC stream's own dedicated re-auth cadence, so an admin demoted/suspended, or
+// whose authority drops below the target's, mid-stream keeps receiving the live
+// audit feed until the stream's natural end. ReauthorizeImpersonation runs the
+// identical MT-007 check this ticker's HTTP counterpart already applies.
 func (s *AuditGRPCService) reauthorizeAuditStream(ctx context.Context, actor *interceptors.UserContext) error {
 	if err := authorizeGlobal(ctx, s.core, actor, permAuditRead); err != nil {
 		return err
@@ -105,6 +125,11 @@ func (s *AuditGRPCService) reauthorizeAuditStream(ctx context.Context, actor *in
 	u, err := s.core.Storage().GetUser(ctx, actor.UserID)
 	if err != nil || !u.IsActive || core.AccountLoginBlocked(u.AccountState) {
 		return status.Error(codes.PermissionDenied, "account is no longer active")
+	}
+	if actor.ImpersonatedBy != nil {
+		if err := s.core.ReauthorizeImpersonation(ctx, *actor.ImpersonatedBy, actor.UserID); err != nil {
+			return status.Error(codes.PermissionDenied, err.Error())
+		}
 	}
 	return nil
 }

--- a/server/grpc/services/coverage_s21_test.go
+++ b/server/grpc/services/coverage_s21_test.go
@@ -114,3 +114,57 @@ func TestReauthorizeAuditStream_MachineGetError_S21(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }
+
+// TestReauthorizeAuditStream_ImpersonatingAdminLosesAuthority_S21 is the #G05
+// regression for the gRPC half of MT-007: the pre-existing checks above all
+// validate the TARGET (actor.UserID, the identity the stream authenticated
+// with) and never the initiating admin, so an admin whose authority drops
+// below the target's mid-stream previously kept receiving the live audit feed
+// for the rest of the stream's life. The target here holds super_admin
+// (audit.read + the full admin-tier bundle) so every pre-existing check
+// passes; the impersonating admin holds no roles at all, so only the NEW
+// ReauthorizeImpersonation call added to reauthorizeAuditStream can catch it.
+func TestReauthorizeAuditStream_ImpersonatingAdminLosesAuthority_S21(t *testing.T) {
+	svc, h := newAuditServiceWithMachineUser(t)
+
+	require.NoError(t, h.DB.Create(&models.User{
+		ID: 5, Username: "victim-target", Email: "target@example.com", IsActive: true,
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.UserRole{UserID: 5, RoleID: 1}).Error) // super_admin
+
+	require.NoError(t, h.DB.Create(&models.User{
+		ID: 6, Username: "weak-admin", Email: "weak@example.com", IsActive: true,
+	}).Error) // no roles at all
+
+	weakAdmin := uint(6)
+	actor := &interceptors.UserContext{
+		UserID: 5, Username: "victim-target", Permissions: []string{"audit.read"},
+		ImpersonatedBy: &weakAdmin,
+	}
+	ctx := context.WithValue(context.Background(), interceptors.GetUserContextKey(), actor)
+	err := svc.reauthorizeAuditStream(ctx, actor)
+	require.Error(t, err, "an impersonating admin who no longer outranks the target must be refused")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// TestReauthorizeAuditStream_ImpersonatingAdminStillAuthorized_S21 is the
+// companion positive case: an admin whose OWN authority still meets the
+// ceiling is not spuriously refused.
+func TestReauthorizeAuditStream_ImpersonatingAdminStillAuthorized_S21(t *testing.T) {
+	svc, h := newAuditServiceWithMachineUser(t)
+
+	require.NoError(t, h.DB.Create(&models.User{
+		ID: 5, Username: "victim-target", Email: "target@example.com", IsActive: true,
+	}).Error)
+	require.NoError(t, h.DB.Create(&models.UserRole{UserID: 5, RoleID: 1}).Error) // super_admin
+
+	// User 1 (from newAuditServiceWithMachineUser) already holds super_admin.
+	realAdmin := uint(1)
+	actor := &interceptors.UserContext{
+		UserID: 5, Username: "victim-target", Permissions: []string{"audit.read"},
+		ImpersonatedBy: &realAdmin,
+	}
+	ctx := context.WithValue(context.Background(), interceptors.GetUserContextKey(), actor)
+	err := svc.reauthorizeAuditStream(ctx, actor)
+	require.NoError(t, err, "an impersonating admin who still outranks the target must not be refused")
+}

--- a/server/grpc/services/coverage_s21b_test.go
+++ b/server/grpc/services/coverage_s21b_test.go
@@ -64,6 +64,45 @@ func TestAcquireStreamSlot_ResourceExhausted_S21b(t *testing.T) {
 	}
 }
 
+// TestAcquireStreamSlot_ImpersonationCapsPerAdmin_S21b is the #G05 regression
+// (detection_idea: "concurrent impersonation of N different targets by one
+// admin is capped like N single-identity sessions"): an admin impersonating
+// auditStreamMaxPerPrincipal DIFFERENT targets must hit the SAME cap as if
+// they held all those streams under their own identity — the slot key must
+// resolve to the ADMIN's id, not each target's, during impersonation.
+func TestAcquireStreamSlot_ImpersonationCapsPerAdmin_S21b(t *testing.T) {
+	svc := newAuditService(t)
+	admin := uint(1)
+
+	var releases []func()
+	for i := 0; i < auditStreamMaxPerPrincipal; i++ {
+		target := uint(100 + i) // a DIFFERENT target each time
+		actor := &interceptors.UserContext{UserID: target, ImpersonatedBy: &admin}
+		release, err := svc.acquireStreamSlot(actor)
+		require.NoError(t, err, "slot %d (impersonating target %d) should be acquirable", i+1, target)
+		releases = append(releases, release)
+	}
+
+	// A (max+1)th target, still impersonated by the SAME admin, must be refused —
+	// proving the cap is keyed on the admin, not on each distinct target's id
+	// (which would never collide and so never trip the cap at all).
+	oneMoreTarget := uint(999)
+	actor := &interceptors.UserContext{UserID: oneMoreTarget, ImpersonatedBy: &admin}
+	_, err := svc.acquireStreamSlot(actor)
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+
+	// The admin's own, non-impersonated identity shares the same key — also capped.
+	ownActor := &interceptors.UserContext{UserID: admin}
+	_, err = svc.acquireStreamSlot(ownActor)
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+
+	for _, r := range releases {
+		r()
+	}
+}
+
 // TestAcquireStreamSlot_ReleasedSlotReacquirable_S21b confirms that after
 // releasing a slot the counter drops back and the next acquire succeeds.
 func TestAcquireStreamSlot_ReleasedSlotReacquirable_S21b(t *testing.T) {

--- a/server/http/handlers/rbac_role_grants_proxy.go
+++ b/server/http/handlers/rbac_role_grants_proxy.go
@@ -188,6 +188,33 @@ func (h *RBACHandler) ClearProjectSecretOwnershipProxy(w http.ResponseWriter, r 
 	writeRemoteAPISuccess(w, map[string]bool{"cleared": true})
 }
 
+// deleteSecretACLsByUserAndProjectWire is the request body for
+// DeleteSecretACLsByUserAndProjectProxy.
+type deleteSecretACLsByUserAndProjectWire struct {
+	UserID    uint `json:"user_id"`
+	ProjectID uint `json:"project_id"`
+}
+
+// DeleteSecretACLsByUserAndProjectProxy handles POST
+// /api/v1/system/rbac/delete-secret-acls-by-user-and-project (#G13/CWE-284).
+func (h *RBACHandler) DeleteSecretACLsByUserAndProjectProxy(w http.ResponseWriter, r *http.Request) {
+	var body deleteSecretACLsByUserAndProjectWire
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
+		return
+	}
+	if body.UserID == 0 || body.ProjectID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id and project_id are required")
+		return
+	}
+	if err := h.coreService.Storage().DeleteSecretACLsByUserAndProject(r.Context(), body.UserID, body.ProjectID); err != nil {
+		log.Printf("rbac proxy: delete secret ACLs by user and project failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}
+
 // ListGroupRoleAssignmentsProxy handles GET
 // /api/v1/system/rbac/groups/{groupID}/role-assignments.
 func (h *RBACHandler) ListGroupRoleAssignmentsProxy(w http.ResponseWriter, r *http.Request) {

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -1261,3 +1261,67 @@ func TestImpersonationRoundTrip_CookieSwapAndRestore(t *testing.T) {
 	assert.Equal(t, originalAdminCookie, restoredCookie, "must restore the SAME original session, not a fresh one")
 	assert.Equal(t, "testadmin", getProfileUsername(), "admin's own identity and permissions are back with no re-login")
 }
+
+// TestImpersonation_BreakGlassBlocked is the #G07 regression for the HTTP half
+// of the ActivateBreakGlass gap: activation mints a durable, time-bound role
+// grant attributed to whoever the session currently acts as — during
+// impersonation that's the TARGET, not the admin — so it must be blocked the
+// same way IssueMachineToken already is (POST /projects/{id}/machine-identities/{id}/tokens).
+// Before this fix the route carried no BlockWhenImpersonating guard at all.
+func TestImpersonation_BreakGlassBlocked(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "8080"}}}
+	testCore := newTestCore(t)
+	_ = createTestToken(t, testCore) // seeds testadmin (admin role) /TestPassword123!
+
+	ctx := context.Background()
+	targetUser, err := testCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "bg-target", Email: "bg-target@example.com", Password: "CorrectHorseBattery9!",
+	})
+	require.NoError(t, err)
+	project, err := testCore.CreateProject(ctx, "bg-project", "")
+	require.NoError(t, err)
+
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	client := newCookieClient(t)
+	loginResp := loginViaHTTP(t, client, server.URL, "testadmin", "TestPassword123!")
+	_ = loginResp.Body.Close()
+	require.Equal(t, http.StatusOK, loginResp.StatusCode)
+
+	startBody, _ := json.Marshal(map[string]uint{"user_id": targetUser.ID})
+	startReq, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/admin/impersonate", bytes.NewReader(startBody))
+	require.NoError(t, err)
+	startReq.Header.Set("Content-Type", "application/json")
+	startReq.Header.Set("X-CSRF-Token", csrfCookieValue(t, client, server.URL))
+	startResp, err := client.Do(startReq)
+	require.NoError(t, err)
+	defer func() { _ = startResp.Body.Close() }()
+	require.Equal(t, http.StatusOK, startResp.StatusCode)
+
+	bgBody, _ := json.Marshal(map[string]string{"justification": "incident response"})
+	bgReq, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("%s/api/v1/projects/%d/break-glass", server.URL, project.ID), bytes.NewReader(bgBody))
+	require.NoError(t, err)
+	bgReq.Header.Set("Content-Type", "application/json")
+	bgReq.Header.Set("X-CSRF-Token", csrfCookieValue(t, client, server.URL))
+	bgResp, err := client.Do(bgReq)
+	require.NoError(t, err)
+	defer func() { _ = bgResp.Body.Close() }()
+	require.Equal(t, http.StatusForbidden, bgResp.StatusCode,
+		"break-glass activation must be refused while impersonating, minting no grant attributed to the target")
+	// Break-glass is disabled by default in this test's config too, which ALSO
+	// returns 403 (a permission-denied from ActivateBreakGlass itself) — assert
+	// on the specific message so this test can't pass for that unrelated reason
+	// instead of the BlockWhenImpersonating guard actually under test.
+	var bgErrBody struct {
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.NewDecoder(bgResp.Body).Decode(&bgErrBody))
+	assert.Contains(t, bgErrBody.Message, "not permitted while impersonating")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1849,6 +1849,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Post("/rbac/assign-role-to-group-with-expiry", rbacHandler.AssignRoleToGroupWithExpiryProxy)
 			r.Post("/rbac/remove-all-project-role-grants", rbacHandler.RemoveAllProjectRoleGrantsProxy)
 			r.Post("/rbac/clear-project-secret-ownership", rbacHandler.ClearProjectSecretOwnershipProxy)
+			r.Post("/rbac/delete-secret-acls-by-user-and-project", rbacHandler.DeleteSecretACLsByUserAndProjectProxy)
 			r.Post("/rbac/global-admin-role/remove-guarded", rbacHandler.RemoveGlobalAdminRoleGuardedProxy)
 
 			// MFA enrolment/management storage-primitive proxy (finding #524). Lets a

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -501,7 +501,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// Break-glass emergency access: activation is self-service (un-gated — the
 		// point is access the caller lacks; controlled by config + justification +
 		// audit + auto-expiry). Listing/revoking are review actions (roles.read/assign).
-		r.Post("/projects/{id}/break-glass", catalogHandler.ActivateBreakGlass)
+		// #G07: blocked while impersonating, same as IssueMachineToken below — it
+		// mints a durable, time-bound role grant attributed to the impersonated
+		// TARGET that outlives the bounded, audited impersonation session.
+		r.With(customMiddleware.BlockWhenImpersonating).Post("/projects/{id}/break-glass", catalogHandler.ActivateBreakGlass)
 		r.With(customMiddleware.RequireScopedPermission(permRolesRead, projectScope)).Get("/projects/{id}/break-glass", catalogHandler.ListBreakGlassActivations)
 		r.With(customMiddleware.RequireScopedPermission(permRolesAssign, projectScope)).Post("/projects/{id}/break-glass/{activationId}/revoke", catalogHandler.RevokeBreakGlass)
 		// Machine identities (ADR-023): non-human members, segmented from humans.

--- a/server/main.go
+++ b/server/main.go
@@ -122,6 +122,38 @@ func main() { // NOSONAR -- cognitive complexity 22, suppress go:S3776
 		log.Fatalf("key file security: %v", err)
 	}
 
+	// #G12: construct the core service (and its owned singletons — encryption
+	// Service + exclusive DEK flock, SIEM Forwarder + spool, dynamic-secrets-sweep
+	// flag) exactly ONCE for the whole process, shared by both the HTTP and gRPC
+	// servers. Previously startHTTPServer and startGRPCServer each called
+	// initializeCoreService independently: two exclusive DEK flock acquisitions
+	// raced (only one could actually win it), the gRPC server's own
+	// *encryption.Service was discarded and never Shutdown() (the KEK was never
+	// wiped from memory on that path), and two SIEM Forwarder instances
+	// independently wrote the same on-disk spool file with no cross-instance
+	// coordination.
+	coreService, encSvc, err := initializeCoreService(cfg)
+	if err != nil {
+		log.Fatalf("failed to initialize core service: %v", err)
+	}
+	// Ensure KEK is wiped from memory on shutdown.
+	if encSvc != nil {
+		defer encSvc.Shutdown()
+	}
+	// #G56: flush/close the SIEM audit forwarder (if configured) on shutdown — it
+	// queues events in memory (worker.go's Deliver is non-blocking, async), and
+	// nothing would otherwise call Close() to drain that queue before the process
+	// exits, silently losing whatever was in flight at SIGTERM.
+	defer closeAuditForwarder(coreService)
+
+	// Record the evaluated license state once at startup (ADR-065), so the
+	// entitlement (and any degrade reason) is on the audit record.
+	coreService.AuditLicenseState(ctx)
+
+	// Start every background scheduler exactly once, regardless of which of
+	// HTTP/gRPC is enabled (#G12) — see startSchedulers' doc comment.
+	startSchedulers(ctx, cfg, coreService)
+
 	var wg sync.WaitGroup
 
 	// Start HTTP server
@@ -129,7 +161,7 @@ func main() { // NOSONAR -- cognitive complexity 22, suppress go:S3776
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := startHTTPServer(ctx, cfg); err != nil {
+			if err := startHTTPServer(ctx, cfg, coreService); err != nil {
 				log.Printf("HTTP server error: %v", err)
 			}
 		}()
@@ -140,7 +172,7 @@ func main() { // NOSONAR -- cognitive complexity 22, suppress go:S3776
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := startGRPCServer(ctx, cfg); err != nil {
+			if err := startGRPCServer(ctx, cfg, coreService); err != nil {
 				log.Printf("gRPC server error: %v", err)
 			}
 		}()
@@ -858,34 +890,17 @@ func closeAuditForwarder(coreService *core.KeyorixCore) {
 	}
 }
 
-func startHTTPServer(ctx context.Context, cfg *config.Config) error { // NOSONAR -- cognitive complexity 188, suppress go:S3776
-	// Initialize core service (and encryption if enabled)
-	coreService, encSvc, err := initializeCoreService(cfg)
-	if err != nil {
-		return fmt.Errorf("failed to initialize core service: %w", err)
-	}
-
-	// Ensure KEK is wiped from memory on shutdown
-	if encSvc != nil {
-		defer encSvc.Shutdown()
-	}
-
-	// #G56: flush/close the SIEM audit forwarder (if configured) on shutdown — it
-	// queues events in memory (worker.go's Deliver is non-blocking, async), and
-	// nothing previously called Close() to drain that queue before the process
-	// exited, silently losing whatever was in flight at SIGTERM.
-	defer closeAuditForwarder(coreService)
-
-	// Record the evaluated license state once at startup (ADR-065), so the entitlement
-	// (and any degrade reason) is on the audit record.
-	coreService.AuditLicenseState(ctx)
-
-	// Create HTTP router
-	router, err := httpServer.NewRouter(cfg, coreService)
-	if err != nil {
-		return fmt.Errorf("failed to create HTTP router: %w", err)
-	}
-
+// startSchedulers starts every opt-in/default background scheduler exactly
+// once for the process (#G12). Previously this whole block lived inside
+// startHTTPServer, so a gRPC-only deployment (HTTP disabled) never ran ANY of
+// these — most visibly, SetDynamicSweepEnabled(cfg.DynamicSecrets.SweepEnabled)
+// (set unconditionally from static config in initializeCoreService) told the
+// dynamic-secrets engine a sweeper was active when, for that deployment shape,
+// no process actually ran one. Each job is already single-replica-gated via a
+// Postgres advisory lock (ADR-039), so starting the loop in every process
+// (regardless of which transport it serves) is the existing, intended
+// coordination model — not a new behavior.
+func startSchedulers(ctx context.Context, cfg *config.Config, coreService *core.KeyorixCore) { // NOSONAR -- cognitive complexity 188, suppress go:S3776
 	// Start anomaly detection scheduler. Single-replica-gated (ADR-039) so N
 	// replicas don't emit N copies of each alert. When anomaly_alerts is enabled,
 	// each detection pass is followed by an alerting pass that pushes newly detected
@@ -1356,6 +1371,14 @@ func startHTTPServer(ctx context.Context, cfg *config.Config) error { // NOSONAR
 			})
 		})
 	}
+}
+
+func startHTTPServer(ctx context.Context, cfg *config.Config, coreService *core.KeyorixCore) error { // NOSONAR -- cognitive complexity 188, suppress go:S3776
+	// Create HTTP router
+	router, err := httpServer.NewRouter(cfg, coreService)
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP router: %w", err)
+	}
 
 	// Create HTTP server
 	server := &http.Server{
@@ -1604,18 +1627,7 @@ func enforceKeyFilePermissions(cfg *config.Config) error { // NOSONAR -- cogniti
 	return nil
 }
 
-func startGRPCServer(ctx context.Context, cfg *config.Config) error {
-	// Initialize the core service so the gRPC auth interceptor can validate
-	// session tokens (mirrors the HTTP server's own core initialization).
-	coreService, _, err := initializeCoreService(cfg)
-	if err != nil {
-		return fmt.Errorf("failed to initialize core service: %w", err)
-	}
-	// #G56: this is a SEPARATE core.KeyorixCore (and therefore a separate SIEM
-	// forwarder instance) from startHTTPServer's — each running server owns and
-	// must flush its own.
-	defer closeAuditForwarder(coreService)
-
+func startGRPCServer(ctx context.Context, cfg *config.Config, coreService *core.KeyorixCore) error {
 	// Create gRPC server
 	grpcServer, err := grpc.NewServer(cfg, coreService)
 	if err != nil {

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -832,6 +832,12 @@ func buildRequestContext(parent context.Context, userCtx *UserContext, coreServi
 	if userCtx != nil && userCtx.PATRestriction != nil {
 		ctx = core.WithPATRestriction(ctx, userCtx.PATRestriction)
 	}
+	// #G07: tag whether this is a genuine interactive session — StartImpersonation
+	// needs this distinction directly, since an unrestricted PAT is indistinguishable
+	// from a session by PATRestriction alone (both carry nil).
+	if userCtx != nil {
+		ctx = core.WithSessionAuth(ctx, userCtx.SessionAuth)
+	}
 	return ctx
 }
 

--- a/server/server_s27_test.go
+++ b/server/server_s27_test.go
@@ -3,11 +3,9 @@
 // startup_validation_test.go, transport_tls_test.go, and verify_encryption_wiring_test.go.
 //
 // Covered here:
-//   - startHTTPServer: initializeCoreService failure (bad WebAuthn config) returns error
 //   - startHTTPServer: TLS-enabled path with bad cert → createTLSConfig error
 //   - startHTTPServer: HTTP listener bind failure (port already in use)
-//   - startHTTPServer: anomaly off-hours with OffHoursStart/OffHoursEnd != 0 (but Timezone empty)
-//   - startGRPCServer: initializeCoreService failure (bad config) returns error
+//   - startSchedulers: anomaly off-hours with OffHoursStart/OffHoursEnd != 0 (but Timezone empty)
 //   - startGRPCServer: NewServer failure with invalid gRPC TLS config
 //   - startGRPCServer: net.Listen failure (invalid port string)
 //   - initializeCoreService: login lockout disabled (warning log path)
@@ -19,6 +17,13 @@
 //   - buildSSOProviders: JWKS resolver error (invalid jwks_uri after successful discovery)
 //   - runStartupValidation: enabled path with warnings (errors collection logs)
 //   - resolveOutboundIP: fallback path (127.0.0.1) is exercised indirectly via conn failure
+//
+// #G12: startHTTPServer/startGRPCServer no longer call initializeCoreService
+// themselves (that now happens once in main(), shared by both) — every test
+// below that needs a live server now constructs its own coreService via
+// mustInitCoreService first and passes it in, and coverage for the background
+// schedulers (moved out of startHTTPServer into startSchedulers) is exercised
+// by calling startSchedulers directly instead.
 package main
 
 import (
@@ -36,43 +41,91 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
 	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-// ── startHTTPServer: initializeCoreService failure returns error ──────────────
+// mustInitCoreService constructs a coreService for a test that needs one to
+// pass to startHTTPServer/startGRPCServer/startSchedulers directly (#G12
+// moved that construction out of those functions and into main(), shared).
+// Fails the test immediately if cfg itself doesn't produce a valid core
+// service — callers testing an initializeCoreService failure path should call
+// initializeCoreService directly instead (see server_s4_test.go /
+// server_s22_test.go / server_s23_test.go for that convention).
+func mustInitCoreService(t *testing.T, cfg *config.Config) *core.KeyorixCore {
+	t.Helper()
+	coreService, _, err := initializeCoreService(cfg)
+	if err != nil {
+		t.Fatalf("initializeCoreService: %v", err)
+	}
+	return coreService
+}
 
-// TestStartHTTPServer_S27_CoreServiceInitFailure verifies that
-// startHTTPServer propagates an initializeCoreService error without
-// hanging. We use a WebAuthn config with an empty RPID (which fails
-// initializeCoreService) to trigger the error path.
-func TestStartHTTPServer_S27_CoreServiceInitFailure(t *testing.T) {
+// TestInitializeCoreService_DualConstruction_RacesExclusiveDEKLock is the #G12
+// regression implementing the review's own detection_idea: two independent
+// initializeCoreService calls for the SAME encrypted deployment must not both
+// succeed — proving why main() now constructs the core service exactly once
+// and shares it between startHTTPServer/startGRPCServer, instead of each
+// calling initializeCoreService (and therefore AcquireExclusiveKeyLock)
+// independently the way the pre-fix code did.
+//
+// encryption.Service.AcquireExclusiveKeyLock is a non-blocking OS advisory
+// flock (internal/encryption/service_rotation.go) held for "the server's
+// whole lifetime" — so a second, independent construction against the same
+// DEK path fails immediately with a lock-acquisition error rather than
+// blocking, which is exactly what let this bug through: whichever of
+// startHTTPServer/startGRPCServer's goroutine ran initializeCoreService
+// second would non-deterministically fail to start at all.
+func TestInitializeCoreService_DualConstruction_RacesExclusiveDEKLock(t *testing.T) {
 	initI18n(t)
 	dir := t.TempDir()
 	t.Chdir(dir)
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "test-g12-dual-construction")
 
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
-			Database: config.DatabaseConfig{Path: "httptest_s27_fail.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    "0",
+			Database: config.DatabaseConfig{Path: "g12_dual.db"},
+			Encryption: config.EncryptionConfig{
+				Enabled:  true,
+				DEKPath:  "dek_g12.json",
+				SaltPath: "salt_g12.bin",
 			},
-		},
-		// WebAuthn with empty RPID causes initializeCoreService to return an error.
-		WebAuthn: config.WebAuthnConfig{
-			Enabled: true,
-			RPID:    "", // invalid — fails initializeCoreService
 		},
 	}
 
-	ctx := context.Background()
-	err := startHTTPServer(ctx, cfg)
+	// First construction (what main() now does exactly once) succeeds and
+	// holds the exclusive DEK lock for its lifetime.
+	_, encSvc1, err := initializeCoreService(cfg)
+	if err != nil {
+		t.Fatalf("first initializeCoreService: %v", err)
+	}
+	if encSvc1 == nil {
+		t.Fatal("expected a non-nil encryption.Service for an encrypted deployment")
+	}
+
+	// A second, independent construction against the SAME DEK path — exactly
+	// what the pre-#G12 startGRPCServer did in parallel with startHTTPServer's
+	// own call — must fail: the lock is already held and exclusive.
+	_, encSvc2, err := initializeCoreService(cfg)
 	if err == nil {
-		t.Fatal("startHTTPServer must return an error when initializeCoreService fails")
+		if encSvc2 != nil {
+			encSvc2.Shutdown()
+		}
+		t.Fatal("a second independent initializeCoreService call for the same encrypted deployment must fail to acquire the exclusive DEK lock while the first is still held")
+	}
+
+	// Releasing the first frees the lock for a subsequent (not concurrent)
+	// construction — confirming the failure above was specifically the lock
+	// contention, not some other config problem.
+	encSvc1.Shutdown()
+	_, encSvc3, err := initializeCoreService(cfg)
+	if err != nil {
+		t.Fatalf("initializeCoreService after the first Shutdown() must succeed (lock released): %v", err)
+	}
+	if encSvc3 != nil {
+		encSvc3.Shutdown()
 	}
 }
 
@@ -105,10 +158,12 @@ func TestStartHTTPServer_S27_TLSBadCert(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel to avoid hanging on success
 
-	err := startHTTPServer(ctx, cfg)
+	err := startHTTPServer(ctx, cfg, coreService)
 	if err == nil {
 		t.Fatal("startHTTPServer must return an error for missing TLS cert/key files")
 	}
@@ -137,41 +192,33 @@ func TestStartHTTPServer_S27_ListenerBindFailure(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
+
 	// Do NOT cancel ctx — startHTTPServer must fail at bind before reaching <-ctx.Done().
 	ctx := context.Background()
-	err := startHTTPServer(ctx, cfg)
+	err := startHTTPServer(ctx, cfg, coreService)
 	if err == nil {
 		t.Fatal("startHTTPServer must return an error when the port is invalid/out-of-range")
 	}
 }
 
-// ── startHTTPServer: anomaly off-hours with non-zero start/end ───────────────
+// ── startSchedulers: anomaly off-hours with non-zero start/end ───────────────
 
-// TestStartHTTPServer_S27_AnomalyOffHoursNumeric exercises the anomaly
+// TestStartSchedulers_S27_AnomalyOffHoursNumeric exercises the anomaly
 // off-hours branch where OffHoursStart != 0 but Timezone is empty. The empty
-// timezone triggers the tzLabel = "UTC" fallback before calling SetBusinessHours.
-func TestStartHTTPServer_S27_AnomalyOffHoursNumeric(t *testing.T) {
+// timezone triggers the tzLabel = "UTC" fallback before calling
+// SetBusinessHours. #G12: this branch lives in startSchedulers now (moved out
+// of startHTTPServer), so it's exercised directly rather than via an HTTP
+// listener.
+func TestStartSchedulers_S27_AnomalyOffHoursNumeric(t *testing.T) {
 	initI18n(t)
 	dir := t.TempDir()
 	t.Chdir(dir)
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
 
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_s27_hours.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		AnomalyAlerts: config.AnomalyAlertsConfig{
 			BusinessHours: config.AnomalyBusinessHoursConfig{
@@ -181,53 +228,15 @@ func TestStartHTTPServer_S27_AnomalyOffHoursNumeric(t *testing.T) {
 			},
 		},
 	}
+	coreService := mustInitCoreService(t, cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() { done <- startHTTPServer(ctx, cfg) }()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with numeric off-hours did not return")
-	}
-}
-
-// ── startGRPCServer: initializeCoreService failure ───────────────────────────
-
-// TestStartGRPCServer_S27_CoreServiceInitFailure verifies that
-// startGRPCServer propagates an initializeCoreService error.
-func TestStartGRPCServer_S27_CoreServiceInitFailure(t *testing.T) {
-	initI18n(t)
-	dir := t.TempDir()
-	t.Chdir(dir)
-
-	cfg := &config.Config{
-		Storage: config.StorageConfig{
-			Type:     "local",
-			Database: config.DatabaseConfig{Path: "grpctest_s27_fail.db"},
-		},
-		Server: config.ServerConfig{
-			GRPC: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    "0",
-			},
-		},
-		// WebAuthn with empty RPID causes initializeCoreService to return an error.
-		WebAuthn: config.WebAuthnConfig{
-			Enabled: true,
-			RPID:    "",
-		},
-	}
-
-	ctx := context.Background()
-	err := startGRPCServer(ctx, cfg)
-	if err == nil {
-		t.Fatal("startGRPCServer must return an error when initializeCoreService fails")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	// startSchedulers only wires up the scheduler goroutines and returns
+	// immediately; give the anomaly detector's first (immediate) tick a moment
+	// to run so the off-hours branch actually executes before the test exits.
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── startGRPCServer: invalid port string → net.Listen failure ────────────────
@@ -253,10 +262,12 @@ func TestStartGRPCServer_S27_InvalidPort(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := startGRPCServer(ctx, cfg)
+	err := startGRPCServer(ctx, cfg, coreService)
 	if err == nil {
 		t.Fatal("startGRPCServer must return an error for an invalid port")
 	}
@@ -289,10 +300,12 @@ func TestStartGRPCServer_S27_TLSBadCert(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := startGRPCServer(ctx, cfg)
+	err := startGRPCServer(ctx, cfg, coreService)
 	if err == nil {
 		t.Fatal("startGRPCServer must return an error when gRPC TLS cert/key files are missing")
 	}
@@ -559,33 +572,21 @@ func TestInitializeCoreService_S27_SIEMInitError(t *testing.T) {
 	_ = err
 }
 
-// ── startHTTPServer: anomaly business hours with OffHoursEnd != 0 ─────────────
+// ── startSchedulers: anomaly business hours with OffHoursEnd != 0 ─────────────
 
-// TestStartHTTPServer_S27_AnomalyOffHoursEndOnly exercises the anomaly
+// TestStartSchedulers_S27_AnomalyOffHoursEndOnly exercises the anomaly
 // off-hours branch triggered when OffHoursEnd != 0 (but OffHoursStart == 0).
 // This covers the condition `bh.OffHoursEnd != 0` part of the composite check.
-func TestStartHTTPServer_S27_AnomalyOffHoursEndOnly(t *testing.T) {
+// #G12: this branch lives in startSchedulers now.
+func TestStartSchedulers_S27_AnomalyOffHoursEndOnly(t *testing.T) {
 	initI18n(t)
 	dir := t.TempDir()
 	t.Chdir(dir)
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
 
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_s27_offhours.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		AnomalyAlerts: config.AnomalyAlertsConfig{
 			BusinessHours: config.AnomalyBusinessHoursConfig{
@@ -595,19 +596,12 @@ func TestStartHTTPServer_S27_AnomalyOffHoursEndOnly(t *testing.T) {
 			},
 		},
 	}
+	coreService := mustInitCoreService(t, cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() { done <- startHTTPServer(ctx, cfg) }()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with OffHoursEnd set did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── initializeCoreService: evidence multi-target (switch default case) ────────
@@ -765,11 +759,13 @@ func TestStartHTTPServer_S27_AutoCertTLS(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel so the server exits immediately after <-ctx.Done()
 
 	done := make(chan error, 1)
-	go func() { done <- startHTTPServer(ctx, cfg) }()
+	go func() { done <- startHTTPServer(ctx, cfg, coreService) }()
 
 	select {
 	case err := <-done:
@@ -951,21 +947,19 @@ func TestDiscoverOIDC_S27_InvalidJSON(t *testing.T) {
 	}
 }
 
-// ── startHTTPServer: encryption enabled — defer encSvc.Shutdown + audit checkpoint ──
+// ── startSchedulers: encryption enabled — audit checkpoint scheduler ─────────
 
-// TestStartHTTPServer_S27_WithEncryption runs startHTTPServer with storage
-// encryption enabled. This covers two uncovered branches:
-//   - line 837: `if encSvc != nil { defer encSvc.Shutdown() }` — the defer
-//     is registered and fires when startHTTPServer returns.
-//   - lines 1194–1209: the audit-checkpoint switch `default:` case — when
-//     encryption is active, AuditCheckpointsAvailable() returns true and
-//     the audit-checkpoint scheduler is started. The goroutine fires
-//     immediately (runScheduler calls tick() once before the first tick),
-//     covering the WriteAuditCheckpoint callback body.
-//
-// A context timer (300 ms) gives the scheduler goroutine time to run its
-// first tick before the server shuts down.
-func TestStartHTTPServer_S27_WithEncryption(t *testing.T) {
+// TestStartSchedulers_S27_WithEncryption runs startSchedulers with storage
+// encryption enabled, covering the audit-checkpoint switch `default:` case:
+// when encryption is active, AuditCheckpointsAvailable() returns true and the
+// audit-checkpoint scheduler is started. The goroutine fires immediately
+// (runScheduler calls tick() once before the first tick), covering the
+// WriteAuditCheckpoint callback body. #G12: both the audit-checkpoint
+// scheduler AND encSvc's lifecycle moved out of startHTTPServer (into
+// startSchedulers and main() respectively) — encSvc.Shutdown() itself is
+// exercised directly here rather than via startHTTPServer's now-removed
+// defer.
+func TestStartSchedulers_S27_WithEncryption(t *testing.T) {
 	initI18n(t)
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -981,21 +975,22 @@ func TestStartHTTPServer_S27_WithEncryption(t *testing.T) {
 				SaltPath: "salt_s27.bin",
 			},
 		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    "0", // OS picks a free port
-			},
-		},
+	}
+
+	coreService, encSvc, err := initializeCoreService(cfg)
+	if err != nil {
+		t.Fatalf("initializeCoreService: %v", err)
+	}
+	if encSvc != nil {
+		defer encSvc.Shutdown()
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	time.AfterFunc(300*time.Millisecond, cancel)
-
-	// startHTTPServer blocks until ctx is cancelled (300 ms).
-	// During that window the audit-checkpoint goroutine runs once.
-	// When startHTTPServer returns, defer encSvc.Shutdown() fires.
-	_ = startHTTPServer(ctx, cfg)
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	// The audit-checkpoint goroutine's first (immediate) tick needs a moment
+	// to run before the test exits.
+	time.Sleep(300 * time.Millisecond)
 }
 
 // ── startHTTPServer: SCIM enabled with weak token → NewRouter error ──────────
@@ -1026,8 +1021,10 @@ func TestStartHTTPServer_S27_SCIMWeakToken(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
+
 	// startHTTPServer must return an error because NewRouter rejects the weak SCIM token.
-	err := startHTTPServer(context.Background(), cfg)
+	err := startHTTPServer(context.Background(), cfg, coreService)
 	if err == nil {
 		t.Fatal("expected startHTTPServer to return an error for a weak SCIM token")
 	}
@@ -1064,9 +1061,11 @@ func TestStartHTTPServer_S27_AutoCertBadCipher(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	time.AfterFunc(200*time.Millisecond, cancel)
-	_ = startHTTPServer(ctx, cfg)
+	_ = startHTTPServer(ctx, cfg, coreService)
 }
 
 // ── startHTTPServer: non-AutoCert TLS with valid cert → ServeTLS path ────────
@@ -1102,9 +1101,11 @@ func TestStartHTTPServer_S27_TLSNonAutoCert(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	time.AfterFunc(200*time.Millisecond, cancel)
-	_ = startHTTPServer(ctx, cfg)
+	_ = startHTTPServer(ctx, cfg, coreService)
 }
 
 // ── buildSSOProviders: SAML provider where ssoCompleteURL rejects ACSURL ─────
@@ -1162,19 +1163,19 @@ func TestBuildSSOProviders_S27_SAMLInvalidACSURL(t *testing.T) {
 	}
 }
 
-// ── startHTTPServer: active legal hold blocks the retention-purge scheduler ──
+// ── startSchedulers: active legal hold blocks the retention-purge scheduler ──
 
-// TestStartHTTPServer_S27_LegalHoldBlocksPurge exercises the legalHoldBlocks
-// closure's "active hold" branch (lines 915-918) inside startHTTPServer. A
-// legal hold is inserted directly into the storage layer (bypassing the RBAC
-// check in PlaceLegalHold) by calling initializeCoreService once to set up the
-// DB schema and insert the hold, then running startHTTPServer against the same
-// DB with the retention-purge scheduler enabled.
+// TestStartSchedulers_S27_LegalHoldBlocksPurge exercises the legalHoldBlocks
+// closure's "active hold" branch inside startSchedulers. A legal hold is
+// inserted directly into the storage layer (bypassing the RBAC check in
+// PlaceLegalHold), then startSchedulers runs against the same DB with the
+// retention-purge scheduler enabled.
 //
 // On its first tick (immediate, per runScheduler) the purge scheduler calls
 // legalHoldBlocks, which finds an active hold and returns true, logging the
-// "skipped: a legal hold is active" message — covering lines 915.13,918.4.
-func TestStartHTTPServer_S27_LegalHoldBlocksPurge(t *testing.T) {
+// "skipped: a legal hold is active" message. #G12: this scheduler moved out
+// of startHTTPServer into startSchedulers.
+func TestStartSchedulers_S27_LegalHoldBlocksPurge(t *testing.T) {
 	initI18n(t)
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -1185,25 +1186,19 @@ func TestStartHTTPServer_S27_LegalHoldBlocksPurge(t *testing.T) {
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: dbPath},
 		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    "0",
-			},
-		},
 		Purge: config.PurgeConfig{
 			Enabled:  true,
 			Schedule: "1ms",
 		},
 	}
 
-	// Phase 1: initialise the DB schema and insert a legal hold via direct storage access.
-	coreService1, _, err := initializeCoreService(cfg)
+	// Initialise the DB schema and insert a legal hold via direct storage access.
+	coreService, _, err := initializeCoreService(cfg)
 	if err != nil {
-		t.Fatalf("initializeCoreService (phase 1): %v", err)
+		t.Fatalf("initializeCoreService: %v", err)
 	}
 	ctx1 := context.Background()
-	_, err = coreService1.Storage().CreateLegalHold(ctx1, &models.LegalHold{
+	_, err = coreService.Storage().CreateLegalHold(ctx1, &models.LegalHold{
 		Reason:   "s27-test-hold",
 		PlacedAt: time.Now(),
 		Released: false,
@@ -1212,24 +1207,24 @@ func TestStartHTTPServer_S27_LegalHoldBlocksPurge(t *testing.T) {
 		t.Fatalf("CreateLegalHold: %v", err)
 	}
 
-	// Phase 2: run the HTTP server against the same DB. The purge scheduler fires
-	// immediately (interval=1ms), finds the active legal hold, and logs the skip message,
-	// covering lines 915-918.
+	// Run the schedulers against the same DB. The purge scheduler fires
+	// immediately (interval=1ms), finds the active legal hold, and logs the
+	// skip message.
 	ctx2, cancel := context.WithCancel(context.Background())
-	time.AfterFunc(200*time.Millisecond, cancel)
-	_ = startHTTPServer(ctx2, cfg)
+	defer cancel()
+	startSchedulers(ctx2, cfg, coreService)
+	time.Sleep(200 * time.Millisecond)
 }
 
-// ── startHTTPServer: JIT access-expiry sweep removes expired role grants ─────
+// ── startSchedulers: JIT access-expiry sweep removes expired role grants ─────
 
-// TestStartHTTPServer_S27_JITExpiredGrantSwept exercises the JIT expiry
-// scheduler's "n > 0" log branch (lines 1233-1235) by pre-populating the DB
-// with an expired role grant. initializeCoreService sets up the schema; then a
-// role and a user are inserted directly and the role is assigned to the user
-// with a past expiry time. When startHTTPServer runs with
-// JITAccessExpiry.Enabled, the sweeper fires immediately (interval=1ms) and
-// RemoveExpiredRoleGrants returns n=1, triggering the log.Printf call.
-func TestStartHTTPServer_S27_JITExpiredGrantSwept(t *testing.T) {
+// TestStartSchedulers_S27_JITExpiredGrantSwept exercises the JIT expiry
+// scheduler's "n > 0" log branch by pre-populating the DB with an expired
+// role grant, then running startSchedulers with JITAccessExpiry.Enabled: the
+// sweeper fires immediately (interval=1ms) and RemoveExpiredRoleGrants
+// returns n=1, triggering the log.Printf call. #G12: this scheduler moved out
+// of startHTTPServer into startSchedulers.
+func TestStartSchedulers_S27_JITExpiredGrantSwept(t *testing.T) {
 	initI18n(t)
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -1240,25 +1235,19 @@ func TestStartHTTPServer_S27_JITExpiredGrantSwept(t *testing.T) {
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: dbPath},
 		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    "0",
-			},
-		},
 		JITAccessExpiry: config.JITAccessExpiryConfig{
 			Enabled:  true,
 			Schedule: "1ms",
 		},
 	}
 
-	// Phase 1: initialise DB schema and pre-populate an expired role grant.
-	coreService1, _, err := initializeCoreService(cfg)
+	// Initialise DB schema and pre-populate an expired role grant.
+	coreService, _, err := initializeCoreService(cfg)
 	if err != nil {
-		t.Fatalf("initializeCoreService (phase 1): %v", err)
+		t.Fatalf("initializeCoreService: %v", err)
 	}
 	ctx1 := context.Background()
-	store := coreService1.Storage()
+	store := coreService.Storage()
 
 	role, err := store.CreateRole(ctx1, &models.Role{Name: "s27-jit-role"})
 	if err != nil {
@@ -1279,10 +1268,11 @@ func TestStartHTTPServer_S27_JITExpiredGrantSwept(t *testing.T) {
 		t.Fatalf("AssignRoleWithExpiry: %v", err)
 	}
 
-	// Phase 2: run the server. The JIT expiry sweeper fires at once (interval=1ms),
-	// calls RemoveExpiredRoleGrants, finds n=1, and logs the "removed N expired grant(s)"
-	// message — covering lines 1233.14,1235.6.
+	// Run the schedulers. The JIT expiry sweeper fires at once (interval=1ms),
+	// calls RemoveExpiredRoleGrants, finds n=1, and logs the "removed N
+	// expired grant(s)" message.
 	ctx2, cancel := context.WithCancel(context.Background())
-	time.AfterFunc(300*time.Millisecond, cancel)
-	_ = startHTTPServer(ctx2, cfg)
+	defer cancel()
+	startSchedulers(ctx2, cfg, coreService)
+	time.Sleep(300 * time.Millisecond)
 }

--- a/server/server_s4_test.go
+++ b/server/server_s4_test.go
@@ -919,13 +919,15 @@ func TestStartHTTPServer_CancelledContext(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // already cancelled
 
 	// startHTTPServer blocks on <-ctx.Done() which returns immediately.
 	done := make(chan error, 1)
 	go func() {
-		done <- startHTTPServer(ctx, cfg)
+		done <- startHTTPServer(ctx, cfg, coreService)
 	}()
 
 	select {
@@ -992,12 +994,14 @@ func TestStartGRPCServer_CancelledContext(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // already cancelled
 
 	done := make(chan error, 1)
 	go func() {
-		done <- startGRPCServer(ctx, cfg)
+		done <- startGRPCServer(ctx, cfg, coreService)
 	}()
 
 	select {
@@ -1008,31 +1012,21 @@ func TestStartGRPCServer_CancelledContext(t *testing.T) {
 	}
 }
 
-// ── startHTTPServer — with optional scheduler features ───────────────────────
+// ── startSchedulers — with optional scheduler features ───────────────────────
 
-func TestStartHTTPServer_WithSchedulers(t *testing.T) {
+// #G12: this used to run through startHTTPServer with a pre-cancelled context
+// (the schedulers wired up synchronously before the HTTP listener even bound);
+// scheduler wiring moved to startSchedulers, so it's exercised directly.
+func TestStartSchedulers_WithSchedulers(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest2.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		AnomalyAlerts: config.AnomalyAlertsConfig{
 			Enabled: true,
@@ -1093,47 +1087,26 @@ func TestStartHTTPServer_WithSchedulers(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with schedulers did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── startHTTPServer — anomaly BusinessHours bad timezone ─────────────────────
 
-func TestStartHTTPServer_AnomalyBadTimezone(t *testing.T) {
+// #G12: moved to startSchedulers.
+func TestStartSchedulers_AnomalyBadTimezone(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest3.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		AnomalyAlerts: config.AnomalyAlertsConfig{
 			BusinessHours: config.AnomalyBusinessHoursConfig{
@@ -1142,47 +1115,26 @@ func TestStartHTTPServer_AnomalyBadTimezone(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with bad timezone did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── startHTTPServer — license expiry scheduler ────────────────────────────────
 
-func TestStartHTTPServer_LicenseExpiryScheduler(t *testing.T) {
+// #G12: moved to startSchedulers.
+func TestStartSchedulers_LicenseExpiryScheduler(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest4.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		LicenseExpiry: config.LicenseExpiryConfig{
 			Enabled:  true,
@@ -1191,20 +1143,11 @@ func TestStartHTTPServer_LicenseExpiryScheduler(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with LicenseExpiry did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── initializeCoreService — SIEM audit forwarding ─────────────────────────────
@@ -1428,30 +1371,18 @@ func TestBuildSSOProviders_SAMLOnly(t *testing.T) {
 
 // ── startHTTPServer — data-retention enabled but unconfigured ─────────────────
 
-func TestStartHTTPServer_DataRetention_Unconfigured(t *testing.T) {
+// #G12: moved to startSchedulers.
+func TestStartSchedulers_DataRetention_Unconfigured(t *testing.T) {
 	// DataRetention.Enabled with no windows → logs a warning, no scheduler started.
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_dr.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		DataRetention: config.DataRetentionConfig{
 			Enabled: true,
@@ -1459,48 +1390,27 @@ func TestStartHTTPServer_DataRetention_Unconfigured(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with unconfigured DataRetention did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── startHTTPServer — evidence delivery (no target) ───────────────────────────
 
-func TestStartHTTPServer_EvidenceDelivery_NoTarget(t *testing.T) {
+// #G12: moved to startSchedulers.
+func TestStartSchedulers_EvidenceDelivery_NoTarget(t *testing.T) {
 	// EvidenceDelivery.Enabled but no target → logs a warning, no scheduler started.
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_ev.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		EvidenceDelivery: config.EvidenceDeliveryConfig{
 			Enabled: true,
@@ -1508,141 +1418,78 @@ func TestStartHTTPServer_EvidenceDelivery_NoTarget(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with EvidenceDelivery no-target did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── startHTTPServer — audit checkpoints disabled ──────────────────────────────
 
-func TestStartHTTPServer_AuditCheckpointsDisabled(t *testing.T) {
+// #G12: moved to startSchedulers.
+func TestStartSchedulers_AuditCheckpointsDisabled(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
 
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_ckpt.db"},
 		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
-		},
 		AuditCheckpoints: config.AuditCheckpointsConfig{
 			Disabled: true,
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with AuditCheckpoints.Disabled did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── startHTTPServer — anomaly alerts enabled ──────────────────────────────────
 
-func TestStartHTTPServer_AnomalyAlertsEnabled(t *testing.T) {
+// #G12: moved to startSchedulers.
+func TestStartSchedulers_AnomalyAlertsEnabled(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
 
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_anom.db"},
 		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
-		},
 		AnomalyAlerts: config.AnomalyAlertsConfig{
 			Enabled: true, // enables the alerting branch
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with AnomalyAlerts.Enabled did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── startHTTPServer — purge scheduler enabled ─────────────────────────────────
 
-func TestStartHTTPServer_PurgeScheduler(t *testing.T) {
+// #G12: moved to startSchedulers.
+func TestStartSchedulers_PurgeScheduler(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_purge.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		Purge: config.PurgeConfig{
 			Enabled:  true,
@@ -1650,47 +1497,26 @@ func TestStartHTTPServer_PurgeScheduler(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with Purge scheduler did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── startHTTPServer — data-retention configured scheduler ────────────────────
 
-func TestStartHTTPServer_DataRetention_Configured(t *testing.T) {
+// #G12: moved to startSchedulers.
+func TestStartSchedulers_DataRetention_Configured(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_dr2.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		DataRetention: config.DataRetentionConfig{
 			Enabled:           true,
@@ -1698,47 +1524,26 @@ func TestStartHTTPServer_DataRetention_Configured(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with configured DataRetention did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── startHTTPServer — JIT access expiry + dynamic secrets enabled ─────────────
 
-func TestStartHTTPServer_JITAndDynamicSecrets(t *testing.T) {
+// #G12: moved to startSchedulers.
+func TestStartSchedulers_JITAndDynamicSecrets(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_jit.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		JITAccessExpiry: config.JITAccessExpiryConfig{
 			Enabled:  true,
@@ -1749,20 +1554,11 @@ func TestStartHTTPServer_JITAndDynamicSecrets(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with JIT+DynamicSecrets did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── initializeCoreService — auto rotation enabled ─────────────────────────────
@@ -1783,29 +1579,17 @@ func TestInitializeCoreService_AutoRotation_Enabled(t *testing.T) {
 
 // ── startHTTPServer — auto rotation + recertification ────────────────────────
 
-func TestStartHTTPServer_AutoRotationAndRecertification(t *testing.T) {
+// #G12: moved to startSchedulers.
+func TestStartSchedulers_AutoRotationAndRecertification(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_rot.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		AutoRotation: config.AutoRotationConfig{
 			Enabled:  true,
@@ -1823,20 +1607,11 @@ func TestStartHTTPServer_AutoRotationAndRecertification(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with AutoRotation+Recertification did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── initializeCoreService — rotation backends no-allowed-refs for all types ──
@@ -2056,7 +1831,8 @@ func testSelfSignedCACert(t *testing.T) []byte {
 // schedule and execute their first closure invocation. This covers the closure
 // bodies inside the scheduler callbacks (anomaly detection, retention purge,
 // rotation reminders, etc.) that require the scheduler goroutine to actually run.
-func TestStartHTTPServer_ShortLive(t *testing.T) {
+// #G12: moved to startSchedulers.
+func TestStartSchedulers_ShortLive(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping live server test in short mode")
 	}
@@ -2066,31 +1842,18 @@ func TestStartHTTPServer_ShortLive(t *testing.T) {
 	t.Chdir(dir)
 
 	// The evidence-delivery scheduler fires at 1ms and may write a new file
-	// after startHTTPServer returns but before t.TempDir() cleanup runs,
-	// causing "directory not empty". Use a separate dir with ignored cleanup.
+	// after the test returns but before t.TempDir() cleanup runs, causing
+	// "directory not empty". Use a separate dir with ignored cleanup.
 	evidenceDir, errMkdir := os.MkdirTemp("", "kx-evidence-test-*")
 	if errMkdir != nil {
 		t.Fatalf("MkdirTemp: %v", errMkdir)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(evidenceDir) })
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_live.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		// Enable all schedulers so their closure bodies execute on the first tick.
 		AnomalyAlerts: config.AnomalyAlertsConfig{
@@ -2154,26 +1917,20 @@ func TestStartHTTPServer_ShortLive(t *testing.T) {
 		},
 	}
 
-	// Use a short timeout so goroutines execute and the server shuts down on its own.
+	coreService := mustInitCoreService(t, cfg)
+
+	// Use a short timeout so the scheduler goroutines' own <-ctx.Done() exits fire.
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
+	startSchedulers(ctx, cfg, coreService)
 
 	// 11 schedulers all fire on this 200ms window; under a loaded CI runner
-	// running the rest of the suite in parallel, waiting for all of them to
-	// settle and the server to shut down can take longer than a tight ceiling
-	// allows (observed flake: keyorixhq/keyorix#1257, #1258, #1263) even
-	// though the goroutine itself completes in well under 1s locally.
-	select {
-	case err := <-done:
-		_ = err
-	case <-time.After(10 * time.Second):
-		t.Fatal("startHTTPServer did not return within 10s")
-	}
+	// running the rest of the suite in parallel, their first ticks (each
+	// wrapped in a WithSchedulerLock DB round-trip) can take longer than a
+	// tight ceiling allows (observed flake: keyorixhq/keyorix#1257, #1258,
+	// #1263) even though each tick completes in well under 1s locally — give
+	// them a generous window to settle before the test (and its DB) tears down.
+	time.Sleep(2 * time.Second)
 }
 
 // ── loadCertPool — success path ───────────────────────────────────────────────
@@ -2270,29 +2027,17 @@ func TestEnforceKeyFilePermissions_GRPCTLSKey(t *testing.T) {
 // TestStartHTTPServer_CertExpiryAndRotationReminder covers the cert-expiry
 // (lines 1036–1053) and rotation-reminder (lines 993–1009) scheduler branches
 // within startHTTPServer.
-func TestStartHTTPServer_CertExpiryAndRotationReminder(t *testing.T) {
+// #G12: moved to startSchedulers.
+func TestStartSchedulers_CertExpiryAndRotationReminder(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_certrr.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		CertificateExpiry: config.CertificateExpiryConfig{
 			Enabled:  true,
@@ -2310,49 +2055,27 @@ func TestStartHTTPServer_CertExpiryAndRotationReminder(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with CertExpiry+RotationReminder did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── startHTTPServer — anomaly ML config enabled ───────────────────────────────
 
-// TestStartHTTPServer_AnomalyML covers the ML-config path inside the anomaly
-// scheduler block (lines 869–877) within startHTTPServer.
-func TestStartHTTPServer_AnomalyML(t *testing.T) {
+// TestStartSchedulers_AnomalyML covers the ML-config path inside the anomaly
+// scheduler block. #G12: moved to startSchedulers.
+func TestStartSchedulers_AnomalyML(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_aml.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		AnomalyAlerts: config.AnomalyAlertsConfig{
 			Enabled:  true,
@@ -2367,49 +2090,28 @@ func TestStartHTTPServer_AnomalyML(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with AnomalyML did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── startHTTPServer — evidence delivery with configured target ────────────────
 
-// TestStartHTTPServer_EvidenceDelivery_WithTarget covers the evidence-delivery
-// scheduler branch when a valid webhook target is configured (lines 1153–1180).
-func TestStartHTTPServer_EvidenceDelivery_WithTarget(t *testing.T) {
+// TestStartSchedulers_EvidenceDelivery_WithTarget covers the evidence-delivery
+// scheduler branch when a valid webhook target is configured. #G12: moved to
+// startSchedulers.
+func TestStartSchedulers_EvidenceDelivery_WithTarget(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_evtgt.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		EvidenceDelivery: config.EvidenceDeliveryConfig{
 			Enabled:  true,
@@ -2422,51 +2124,28 @@ func TestStartHTTPServer_EvidenceDelivery_WithTarget(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with EvidenceDelivery+target did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // ── startHTTPServer — read-quota alert scheduler ──────────────────────────────
 
-// TestStartHTTPServer_ReadQuotaAlerts verifies that startHTTPServer wires the
+// TestStartSchedulers_ReadQuotaAlerts verifies that startSchedulers wires the
 // read-quota alert background scheduler when ReadQuotaAlerts.Enabled is true.
-// A pre-cancelled context makes the function return immediately after
-// registering the scheduler, keeping the test instant.
-func TestStartHTTPServer_ReadQuotaAlerts(t *testing.T) {
+// #G12: moved out of startHTTPServer.
+func TestStartSchedulers_ReadQuotaAlerts(t *testing.T) {
 	initI18n(t)
 
 	dir := t.TempDir()
 	t.Chdir(dir)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("get free port: %v", err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
 			Type:     "local",
 			Database: config.DatabaseConfig{Path: "httptest_rqa.db"},
-		},
-		Server: config.ServerConfig{
-			HTTP: config.ServerInstanceConfig{
-				Enabled: true,
-				Port:    itoa(port),
-			},
 		},
 		ReadQuotaAlerts: config.ReadQuotaAlertsConfig{
 			Enabled:  true,
@@ -2474,18 +2153,9 @@ func TestStartHTTPServer_ReadQuotaAlerts(t *testing.T) {
 		},
 	}
 
+	coreService := mustInitCoreService(t, cfg)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- startHTTPServer(ctx, cfg)
-	}()
-
-	select {
-	case err := <-done:
-		_ = err
-	case <-context.Background().Done():
-		t.Fatal("startHTTPServer with ReadQuotaAlerts did not return")
-	}
+	defer cancel()
+	startSchedulers(ctx, cfg, coreService)
+	time.Sleep(50 * time.Millisecond)
 }


### PR DESCRIPTION
## Summary

Batched Wave 5 fixes (matching the #1410 wave3-batch pattern: one commit per finding, one PR per batch). Each commit below has its own detailed rationale.

**G05 — impersonation ceiling/re-auth checks the wrong identity or a name allowlist** (high, 4 members)
- `requireEqualOrGreaterAdminAuthority` rewritten from role-NAME allowlist matching to actual bundled-permission comparison via `c.Authorize`, closing the gap where a custom-named admin-tier role skipped the ceiling entirely.
- The "ceiling only checked once at start" member was already fixed in a prior PR (MT-007); only the narrower "admin must still hold `users.impersonate` itself" sub-case was open — closed via `requireStillAuthorizedToImpersonate`.
- `StreamAuditLogs`' re-auth ticker validated only the target's state, never the admin's — added `core.ReauthorizeImpersonation`, shared by `ValidateSessionToken` and the ticker.
- `acquireStreamSlot`'s concurrency cap keyed on the target during impersonation, not the admin — now keys on the admin.
- Follow-up hardening: `reauthorizeAuditStream`'s `ImpersonatedBy` branch forwarded `ReauthorizeImpersonation`'s raw `err.Error()` to the gRPC client — the one line in this function not already using a fixed safe string. One of that function's errors wraps `cachedImpersonationCeiling`'s error with `%w`, so a raw passthrough would leak that wrapped internal detail the moment the wrapping changes. Now uses a fixed string, matching the function's own convention.

**G07 — impersonation restriction/blocklist misses a case its sibling covers** (medium, 2 members)
- `StartImpersonation`'s PAT-restriction gate caught a restricted PAT but not an unrestricted one (both look identical via `patRestrictionFromContext`) — added a `WithSessionAuth` context tag so the check is "is this a genuine session" instead.
- `ActivateBreakGlass` mints a durable role grant but was missing from the gRPC impersonation blocklist (the literal finding) and, on closer check, **also** missing the `BlockWhenImpersonating` HTTP middleware entirely on its route — a broader version of the same gap. Fixed both.

**G12 — main.go double-constructs core singletons for HTTP and gRPC independently** (high, 4 members)
- `startGRPCServer` discarded its own `*encryption.Service` entirely, so it was never `Shutdown()` (KEK never wiped from memory on that path).
- Both `startHTTPServer`/`startGRPCServer` goroutines' `initializeCoreService` calls raced for the same exclusive, non-blocking DEK flock — whichever ran second would fail outright, non-deterministically breaking one of the two servers on an encrypted deployment.
- The 16-job background scheduler block lived entirely inside `startHTTPServer`, so a gRPC-only deployment never ran any of them — most visibly, the dynamic-secrets-sweep flag was set from static config regardless of whether a sweeper actually ran.
- Two independently-constructed SIEM Forwarder instances wrote the same on-disk spool file with no cross-instance coordination.
- Fixed per the review's `fix_shape`: `initializeCoreService` now runs exactly once in `main()`, and the shared `*core.KeyorixCore` is passed to both servers; the scheduler block was extracted into a new `startSchedulers`, called once regardless of which transport is enabled.

**G13 — SecretACL grant honored with no live re-check of project membership** (CWE-284)
- `SecretACL` rows are additive per-secret grants, checked independently of project-scope RBAC. `aclGrantsPermission` (and thus `HasSecretACL`/`AuthorizeSecret`) trusted a grant row's mere existence with no re-check that the grantee is still a member of the secret's project — a removed/offboarded member retained indefinite per-secret access via a forgotten ACL grant, gating routes like `TransferSecretOwnership` through `RequireScopedSecretPermission`'s ACL-aware authorization path.
- `aclGrantsPermission` now calls `GetSecret` + `IsProjectMember` after decoding the grant's permissions, denying if the grantee is no longer a project member. A backend that doesn't support `SecretACL` at all (`ErrUnsupportedByBackend`) degrades to "no grant" rather than a hard failure, mirroring `HasSecretACL`'s existing handling of `GetSecretAncestors`.
- `RemoveProjectMember` already had a proactive cleanup call (`DeleteSecretACLsByUserAndProject`) with an explicit CWE-284 doc comment, but it was a no-op stub under `RemoteStorage` — implemented via a new `/api/v1/system/rbac/delete-secret-acls-by-user-and-project` proxy route, matching the existing `rbac_role_grants_proxy.go` convention.
- `PurgeDeletedUsersBefore`/`PurgeDeletedSecretsBefore` now also delete `SecretACL` rows for the purged user/secret — `SecretACL` has no `deleted_at`/FK of its own, so these grants were previously orphaned forever once their owning user or secret was hard-deleted by retention purge.

## Test plan

- [x] New/updated regression tests implement each group's own `detection_idea` directly (see individual commit messages for the full list).
- [x] Every new test verified to fail against the pre-fix code before being trusted — including G05's custom-role test (panics on the pre-fix logic, proving a live vulnerability), G07's HTTP break-glass test (initially passed vacuously for an unrelated reason and was tightened), G12's `TestInitializeCoreService_DualConstruction_RacesExclusiveDEKLock` (proves the exact exclusive-lock race the pre-fix code hit), and G13's `TestHasSecretACL_DeniesStaleGrantAfterMembershipRemoved`/`TestAuthorizeSecret_DeniesStaleGrantAfterMembershipRemoved`.
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated` clean on all touched packages
- [x] `golangci-lint run` clean on all touched packages
- [x] Full `internal/core`, `internal/storage/store`, `server`, `server/grpc/services`, `server/grpc/interceptors`, `server/middleware` suites green (2 pre-existing day-of-week-dependent flakes in `internal/core`, unrelated)
- [x] `server/http`: pre-existing `_RealServer` test failures confirmed identical against the pre-fix baseline, unrelated to this PR (documented in commit history)
