### PR TITLE
fix(ci): cut Actions-minute waste — cancel superseded runs, group routine dep bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,26 +24,52 @@ updates:
           - "github/codeql-action/*"
   # #478: without a gomod entry, Go dependency/toolchain-minimum drift (e.g. #477)
   # has no automated forcing function and depends on someone noticing manually.
+  #
+  # go-patch-minor groups every patch/minor bump into one PR: each PR (regardless
+  # of diff size) pays the same fixed CI cost -- CodeQL/SonarCloud/the full
+  # test-suite scale with the codebase, not the diff -- so N ungrouped routine
+  # bumps cost roughly N times what one grouped PR costs for the same updates.
+  # Patch/minor bumps essentially never conflict with each other and rarely need
+  # individual review. Majors are deliberately left ungrouped/individual: they
+  # can be breaking and deserve their own review/testing pass, not a bundle that
+  # blocks on the slowest one.
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      go-patch-minor:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: gomod
     directory: /operator
     schedule:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      go-patch-minor:
+        update-types:
+          - "minor"
+          - "patch"
   # ADR-070: web/ (the dashboard, ex-keyorix-web) is now a subtree here.
   # web/.github/dependabot.yml — the pnpm-ecosystem entry that covered it as
   # a standalone repo — is deleted along with the rest of web/.github/ in the
   # same commit; without this entry Dependabot would silently stop updating
   # the frontend's dependency tree entirely.
+  #
+  # npm-patch-minor groups routine bumps the same way as go-patch-minor above.
   - package-ecosystem: npm
     directory: /web
     schedule:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      npm-patch-minor:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,15 @@ on:
 # flags a blanket workflow-level grant even when it's already read-only.
 permissions: {}
 
+# Cancel superseded runs on the same ref (matches web-ci.yml's own convention):
+# a later push/merge on the same branch makes an in-flight run's result moot
+# before it even finishes, and this is by far the most expensive workflow here
+# (8 parallel test-suite shards among ~20 jobs) -- letting a superseded run
+# burn its full runtime is pure wasted Actions-minute spend.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Pinned security tooling (SSDLC Phase 1, June 2026). Do not use @latest:
   # the tools that gate our security checks are themselves a supply-chain

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,15 @@ on:
 permissions:
   contents: read # NOSONAR githubactions:S8264 -- workflow-level read is intentional; job-level permissions further restrict (security-events:write only for the upload step)
 
+# Cancel superseded runs on the same ref (matches web-ci.yml's own convention):
+# a later push/merge on the same branch makes an in-flight run's result moot
+# before it even finishes. Also covers the weekly schedule trigger -- if it
+# happens to overlap a push-triggered run, that push-run already scans the
+# current code, making the concurrent scheduled one redundant.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GO_VERSION: '1.26.6'
 

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -12,6 +12,13 @@ on:
 
 permissions: {}
 
+# Cancel superseded runs on the same ref (matches web-ci.yml's own convention):
+# a later push/merge on the same branch makes an in-flight run's result moot
+# before it even finishes.
+concurrency:
+  group: hadolint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   hadolint:
     runs-on: ubuntu-latest

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -12,6 +12,13 @@ on:
 
 permissions: {}
 
+# Cancel superseded runs on the same ref (matches web-ci.yml's own convention):
+# a later push/merge on the same branch makes an in-flight run's result moot
+# before it even finishes.
+concurrency:
+  group: osv-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan:
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@f4cfcc01edc9c8b756a9b873b7a623ca674da51e" # v1.9.1

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,6 +12,13 @@ on:
 
 permissions: {}
 
+# Cancel superseded runs on the same ref (matches web-ci.yml's own convention):
+# a later push/merge on the same branch makes an in-flight run's result moot
+# before it even finishes.
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,6 +10,13 @@ on:
 
 permissions: {}
 
+# Cancel superseded runs on the same ref (matches web-ci.yml's own convention):
+# a later push/merge on the same branch makes an in-flight run's result moot
+# before it even finishes.
+concurrency:
+  group: sonarcloud-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Sonar's "New Code Coverage" gate only evaluates lines this PR actually
   # changed (ADR-070's blended-percentage tradeoff is about the overall

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -12,6 +12,13 @@ on:
 
 permissions: {}
 
+# Cancel superseded runs on the same ref (matches web-ci.yml's own convention):
+# a later push/merge on the same branch makes an in-flight run's result moot
+# before it even finishes.
+concurrency:
+  group: trivy-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Hit the GitHub Actions monthly minute limit (2,000/2,000) for the first time in months on 2026-08-14. Root cause: ~16-20 PRs open simultaneously (a batch of security-hardening PRs plus 13 individually-opened dependabot PRs), several pushed to multiple times (rebases, fix commits), each push re-triggering the full required-check suite (CodeQL, Semgrep, SonarCloud, Trivy, Hadolint, OSV-Scanner, DCO, and CI's ~20 jobs including 8 parallel test-suite shards). That fixed cost is paid per push, not per line changed — CodeQL/SonarCloud/the test suite scale with the codebase, not the diff.

Two independent, additive fixes:

- **`concurrency: cancel-in-progress` groups** (scoped to `github.ref`) added to `ci.yml`, `codeql.yml`, `semgrep.yml`, `sonarcloud.yml`, `trivy.yml`, `hadolint.yml`, `osv-scanner.yml` — only `web-ci.yml` had this already. A later push/merge on the same branch makes an in-flight run's result moot before it even finishes; without cancellation, a superseded run keeps burning its full runtime for nothing.
- **`.github/dependabot.yml`**: added a `go-patch-minor` group to both `gomod` entries (root + operator) and an `npm-patch-minor` group to the web `npm` entry, bundling routine patch/minor bumps into one PR each instead of one PR per dependency. Only `codeql-action` was grouped before (for a real correctness reason unrelated to this: mismatched init/analyze/upload-sarif versions break CodeQL outright). Majors are deliberately left ungrouped — they can be breaking and deserve individual review, not a bundle blocked on the slowest one. Today's spike included 7 separate `go_modules` PRs and 6 separate `npm` PRs for routine version bumps that this would have collapsed into ~2.

## Test plan
- [x] `actionlint` on all 7 modified workflow files — clean
- [x] Ruby YAML parse on all 8 modified files (workflows + dependabot.yml) — clean
- [x] Manual review: every concurrency group is additive only (no trigger/job logic changed); dependabot groups only add `update-types` filters, no existing entries removed or restructured