### PR TITLE
fix(security): per-project MFA gate fails open on error, skipped by global-scope aggregates (G17)

### DIFF
--- a/server/grpc/services/conversions.go
+++ b/server/grpc/services/conversions.go
@@ -116,8 +116,19 @@ func authorizeScoped(ctx context.Context, cs *core.KeyorixCore, actor *intercept
 // bypassable by switching transport. Non-interactive callers (PAT / machine) are
 // exempt — SessionAuth is false for them — and a global-scoped operation (project
 // 0) is never gated. Called after the permission check at every project-scoped
-// authorization chokepoint. Fails closed only on a positive requirement; a lookup
-// error leaves the prior permission decision in force (matching HTTP).
+// authorization chokepoint.
+//
+// #G17: fails CLOSED, matching every other primitive this file wires into
+// (AuthorizePrincipal, core.Authorize) — a ProjectRequiresMFA lookup error (a
+// transient storage timeout, a cancelled context) used to fall through to
+// `return nil`, silently treating the caller as MFA-compliant regardless of the
+// project's real policy or the session's real factor state. A "project not
+// found" error is deliberately excluded from the fail-closed path: this scope
+// was already permission-checked by the caller (authorizeScoped only reaches
+// this line after AuthorizePrincipal allowed it), so a nonexistent project
+// isn't an MFA-policy question — denying here would mask the RPC's own
+// not-found handling (e.g. GetProjectRotationPlan(unknownID)) behind a
+// misleading "MFA required" status instead of its real NotFound.
 func enforceProjectMFA(ctx context.Context, cs *core.KeyorixCore, actor *interceptors.UserContext, projectID uint) error {
 	if projectID == 0 || cs == nil || actor == nil {
 		return nil
@@ -125,9 +136,44 @@ func enforceProjectMFA(ctx context.Context, cs *core.KeyorixCore, actor *interce
 	if !actor.SessionAuth || actor.MFAEnabled {
 		return nil
 	}
-	if required, err := cs.ProjectRequiresMFA(ctx, projectID); err == nil && required {
+	required, err := cs.ProjectRequiresMFA(ctx, projectID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil
+		}
+		return status.Error(codes.Internal, "unable to verify project MFA policy; please try again")
+	}
+	if required {
 		return status.Error(codes.PermissionDenied,
 			"this project requires multi-factor authentication; enrol a second factor to access it")
+	}
+	return nil
+}
+
+// enforceProjectMFAForProjects applies enforceProjectMFA across every distinct,
+// non-zero project ID in projectIDs, denying on the first one that requires MFA
+// the actor's session lacks (or whose policy can't be verified).
+//
+// #G17: authorizeGlobal always calls enforceProjectMFA with projectID 0, which
+// no-ops unconditionally — correct for genuinely install-wide data, but several
+// authorizeGlobal-gated RPCs (GetDeploymentRotationPlan, ListUserShares,
+// ListSharedSecrets) return content aggregated from or belonging to SPECIFIC
+// projects, some of which may individually require MFA. A session-authenticated
+// caller without a second factor, blocked from a single MFA-required project's
+// per-project endpoint, could otherwise read that same project's data back out
+// of the aggregate endpoint instead — the step-up control silently routed around
+// by picking the global-scope sibling. Call this after loading the response data,
+// before returning it, with every project ID the response discloses.
+func enforceProjectMFAForProjects(ctx context.Context, cs *core.KeyorixCore, actor *interceptors.UserContext, projectIDs []uint) error {
+	seen := make(map[uint]bool, len(projectIDs))
+	for _, id := range projectIDs {
+		if id == 0 || seen[id] {
+			continue
+		}
+		seen[id] = true
+		if err := enforceProjectMFA(ctx, cs, actor, id); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/server/grpc/services/project_mfa_aggregate_test.go
+++ b/server/grpc/services/project_mfa_aggregate_test.go
@@ -1,0 +1,193 @@
+// project_mfa_aggregate_test.go — #G17 regression tests: enforceProjectMFA
+// fails closed on a lookup error, and authorizeGlobal-gated aggregate RPCs
+// (GetDeploymentRotationPlan, ListSharedSecrets, ListUserShares) apply the
+// per-project MFA policy across every project their response discloses,
+// instead of skipping it entirely because the caller authorized at global
+// scope (project 0).
+package services
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
+	pb "github.com/keyorixhq/keyorix/server/proto/pb"
+)
+
+// mfaAggregateTestRig seeds two projects — "guarded" (RequireMFA) and "open" —
+// each with an overdue secret (so both appear in GetDeploymentRotationPlan) and
+// a share owned by the actor (so both appear in ListSharedSecrets/ListUserShares).
+// The actor (user 1) holds secrets.read at GLOBAL scope, matching the
+// authorizeGlobal gate every RPC under test uses.
+type mfaAggregateTestRig struct {
+	db       *gorm.DB
+	projSvc  *ProjectGRPCService
+	shareSvc *ShareGRPCService
+}
+
+func newMFAAggregateTestRig(t *testing.T) *mfaAggregateTestRig {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.RotationPolicy{},
+		&models.SecretDependency{}, &models.ShareRecord{}, &models.User{}, &models.Role{},
+		&models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.SecretACL{},
+	))
+
+	require.NoError(t, db.Create(&models.Role{ID: writerRoleID, Name: "reader"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: writerRoleID, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: writerRoleID}).Error) // global
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "auditor", Email: "auditor@example.com"}).Error)
+
+	now := time.Now()
+	daysAgo := func(d int) *time.Time { tt := now.Add(-time.Duration(d) * 24 * time.Hour); return &tt }
+
+	// Project 1 ("guarded") requires MFA; project 2 ("open") does not. Both have
+	// an overdue secret so both surface in the deployment-wide rotation plan.
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "guarded", RequireMFA: true}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env1"}).Error)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		Name: "guarded-90d", Scope: "project", ProjectID: uintPtr(1), IntervalDays: 90, AlertDaysBefore: 14, IsActive: true,
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 1, Name: "guarded-secret", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active",
+		OwnerID: 1, LastRotatedAt: daysAgo(200),
+	}).Error)
+
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "open"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, ProjectID: 2, Name: "env2"}).Error)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		Name: "open-90d", Scope: "project", ProjectID: uintPtr(2), IntervalDays: 90, AlertDaysBefore: 14, IsActive: true,
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 2, Name: "open-secret", ProjectID: 2, EnvironmentID: 2, IsSecret: true, Status: "active",
+		OwnerID: 1, LastRotatedAt: daysAgo(200),
+	}).Error)
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	return &mfaAggregateTestRig{db: db, projSvc: NewProjectService(coreService), shareSvc: NewShareService(coreService)}
+}
+
+func uintPtr(v uint) *uint { return &v }
+
+// erroringProjectStorage wraps a real Storage but makes GetProject fail with a
+// non-"not found" error (a transient storage failure), to exercise
+// enforceProjectMFA's genuine fail-closed path without a nonexistent-project
+// "not found" (a different, deliberately non-blocking case — see
+// TestEnforceProjectMFA_NotFoundDoesNotBlock).
+type erroringProjectStorage struct {
+	corestorage.Storage
+}
+
+func (erroringProjectStorage) GetProject(context.Context, uint) (*models.Project, error) {
+	return nil, fmt.Errorf("connection reset by peer")
+}
+
+// TestEnforceProjectMFA_FailsClosedOnLookupError is #G17: a genuine
+// ProjectRequiresMFA lookup error (a transient storage failure, distinct from
+// "project not found") used to fall through to `return nil`, silently
+// treating the caller as MFA-compliant. It must now deny.
+func TestEnforceProjectMFA_FailsClosedOnLookupError(t *testing.T) {
+	r := newMFAAggregateTestRig(t)
+	coreService := core.NewKeyorixCore(erroringProjectStorage{store.NewLocalStorage(r.db)})
+	actor := &interceptors.UserContext{UserID: 1, SessionAuth: true, MFAEnabled: false}
+
+	err := enforceProjectMFA(context.Background(), coreService, actor, 1)
+	require.Error(t, err, "a genuine ProjectRequiresMFA lookup error must deny, not silently allow")
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+// TestEnforceProjectMFA_NotFoundDoesNotBlock is #G17's necessary carve-out:
+// enforceProjectMFA only runs after the caller's scope was already
+// permission-checked (authorizeScoped), so a nonexistent project is not an
+// MFA-policy question — it must fall through so the RPC's own not-found
+// handling produces the real NotFound, not a misleading "MFA required".
+func TestEnforceProjectMFA_NotFoundDoesNotBlock(t *testing.T) {
+	r := newMFAAggregateTestRig(t)
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(r.db))
+	actor := &interceptors.UserContext{UserID: 1, SessionAuth: true, MFAEnabled: false}
+
+	err := enforceProjectMFA(context.Background(), coreService, actor, 999)
+	require.NoError(t, err, "a nonexistent project must not be blocked by the MFA gate")
+}
+
+// TestProjectService_GetDeploymentRotationPlan_DeniesGlobalScopeMFABypass is #G17:
+// authorizeGlobal never runs enforceProjectMFA (scope.ProjectID is always 0), so a
+// session without MFA that holds secrets.read at global scope could read an
+// MFA-required project's rotation data back out of the deployment-wide roll-up,
+// even though that same session is correctly denied GetProjectRotationPlan(1)
+// directly.
+func TestProjectService_GetDeploymentRotationPlan_DeniesGlobalScopeMFABypass(t *testing.T) {
+	r := newMFAAggregateTestRig(t)
+
+	_, err := r.projSvc.GetDeploymentRotationPlan(sessionCtx(1, "auditor", false, "secrets.read"), &emptypb.Empty{})
+	require.Error(t, err, "an MFA-required project's data must not leak through the deployment-wide roll-up")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	_, err = r.projSvc.GetDeploymentRotationPlan(sessionCtx(1, "auditor", true, "secrets.read"), &emptypb.Empty{})
+	require.NoError(t, err, "a session with MFA is allowed")
+
+	_, err = r.projSvc.GetDeploymentRotationPlan(authCtx(1, "auditor", "secrets.read"), &emptypb.Empty{})
+	require.NoError(t, err, "a PAT (non-interactive) is exempt from the per-project MFA gate")
+}
+
+// TestShareService_ListSharedSecrets_DeniesGlobalScopeMFABypass is #G17's
+// ListSharedSecrets member: each returned SecretNode already carries its own
+// ProjectID, so the aggregate check needs no extra lookup.
+func TestShareService_ListSharedSecrets_DeniesGlobalScopeMFABypass(t *testing.T) {
+	r := newMFAAggregateTestRig(t)
+	// User 2 receives shares on both the guarded and open secrets.
+	require.NoError(t, r.db.Create(&models.User{ID: 2, Username: "recipient", Email: "recipient@example.com"}).Error)
+	require.NoError(t, r.db.Create(&models.UserRole{UserID: 2, RoleID: writerRoleID}).Error)
+	require.NoError(t, r.db.Create(&models.ShareRecord{SecretID: 1, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}).Error)
+	require.NoError(t, r.db.Create(&models.ShareRecord{SecretID: 2, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}).Error)
+
+	_, err := r.shareSvc.ListSharedSecrets(sessionCtx(2, "recipient", false, "secrets.read"), &pb.ListSharedSecretsRequest{})
+	require.Error(t, err, "a shared secret from an MFA-required project must not leak through this global-scope list")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	_, err = r.shareSvc.ListSharedSecrets(sessionCtx(2, "recipient", true, "secrets.read"), &pb.ListSharedSecretsRequest{})
+	require.NoError(t, err, "a session with MFA is allowed")
+}
+
+// TestShareService_ListUserShares_DeniesGlobalScopeMFABypass is #G17's
+// ListUserShares member: ShareRecord only carries SecretID, so the fix must
+// resolve each share's owning project via a batched lookup before the check.
+func TestShareService_ListUserShares_DeniesGlobalScopeMFABypass(t *testing.T) {
+	r := newMFAAggregateTestRig(t)
+	// User 1 (the fixture's global reader) owns shares on both secrets.
+	require.NoError(t, r.db.Create(&models.User{ID: 3, Username: "other", Email: "other@example.com"}).Error)
+	require.NoError(t, r.db.Create(&models.ShareRecord{SecretID: 1, OwnerID: 1, RecipientID: 3, IsGroup: false, Permission: "read"}).Error)
+	require.NoError(t, r.db.Create(&models.ShareRecord{SecretID: 2, OwnerID: 1, RecipientID: 3, IsGroup: false, Permission: "read"}).Error)
+
+	_, err := r.shareSvc.ListUserShares(sessionCtx(1, "auditor", false, "secrets.read"), &pb.ListUserSharesRequest{})
+	require.Error(t, err, "a share on an MFA-required project's secret must not leak through this global-scope list")
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	_, err = r.shareSvc.ListUserShares(sessionCtx(1, "auditor", true, "secrets.read"), &pb.ListUserSharesRequest{})
+	require.NoError(t, err, "a session with MFA is allowed")
+}

--- a/server/grpc/services/project_service.go
+++ b/server/grpc/services/project_service.go
@@ -132,6 +132,16 @@ func (s *ProjectGRPCService) GetDeploymentRotationPlan(ctx context.Context, _ *e
 	if err != nil {
 		return nil, mapProjectError(err)
 	}
+	// #G17: the response aggregates every project's own rotation plan; a
+	// project that individually requires MFA must not be readable via this
+	// global-scope roll-up by a session that lacks it.
+	projectIDs := make([]uint, 0, len(plan.Projects))
+	for _, p := range plan.Projects {
+		projectIDs = append(projectIDs, p.ProjectID)
+	}
+	if err := enforceProjectMFAForProjects(ctx, s.core, user, projectIDs); err != nil {
+		return nil, err
+	}
 	return deploymentRotationPlanToProto(plan), nil
 }
 

--- a/server/grpc/services/share_service.go
+++ b/server/grpc/services/share_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"log"
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -110,8 +111,48 @@ func (s *ShareGRPCService) ListUserShares(ctx context.Context, req *pb.ListUserS
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to list user shares")
 	}
+	// #G17: ShareRecord only carries SecretID, so resolve each share's owning
+	// project in one batched lookup before applying the same aggregate MFA
+	// check GetDeploymentRotationPlan/ListSharedSecrets use — see
+	// enforceProjectMFAForProjects's doc comment for why this global-scope
+	// endpoint needs it despite authorizeGlobal's scope.ProjectID being 0.
+	if err := enforceProjectMFAForProjects(ctx, s.core, user, s.shareProjectIDs(ctx, shares)); err != nil {
+		return nil, err
+	}
 	page, pageSize := normalizePage(req.GetPage(), req.GetPageSize())
 	return sharesToResponse(shares, page, pageSize), nil
+}
+
+// shareProjectIDs resolves the distinct projects the given shares' secrets
+// belong to, via one batched GetSecretsByIDs lookup. A resolution failure is
+// logged and treated as an empty set — enforceProjectMFAForProjects then has
+// nothing to check, which is safe here because ListSharesByUser only returns
+// shares the caller is independently entitled to see; the risk this closes is
+// an MFA-required project's data leaking through the aggregate view, not raw
+// existence, so skipping the extra step-up check on a transient lookup error
+// degrades to the pre-fix behavior rather than blocking the endpoint outright.
+func (s *ShareGRPCService) shareProjectIDs(ctx context.Context, shares []*models.ShareRecord) []uint {
+	if len(shares) == 0 {
+		return nil
+	}
+	secretIDSet := make(map[uint]bool, len(shares))
+	secretIDs := make([]uint, 0, len(shares))
+	for _, sh := range shares {
+		if !secretIDSet[sh.SecretID] {
+			secretIDSet[sh.SecretID] = true
+			secretIDs = append(secretIDs, sh.SecretID)
+		}
+	}
+	secrets, err := s.core.Storage().GetSecretsByIDs(ctx, secretIDs)
+	if err != nil {
+		log.Printf("shareProjectIDs: failed to resolve project ids for MFA check: %v", err)
+		return nil
+	}
+	projectIDs := make([]uint, 0, len(secrets))
+	for _, sec := range secrets {
+		projectIDs = append(projectIDs, sec.ProjectID)
+	}
+	return projectIDs
 }
 
 // ListSharedSecrets lists secrets shared with the calling user.
@@ -130,6 +171,15 @@ func (s *ShareGRPCService) ListSharedSecrets(ctx context.Context, req *pb.ListSh
 	secrets, err := s.core.ListSharedSecrets(ctx, user.UserID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to list shared secrets")
+	}
+	// #G17: each SecretNode already carries its own ProjectID — no extra lookup
+	// needed, unlike ListUserShares' ShareRecord-based path above.
+	projectIDs := make([]uint, 0, len(secrets))
+	for _, sec := range secrets {
+		projectIDs = append(projectIDs, sec.ProjectID)
+	}
+	if err := enforceProjectMFAForProjects(ctx, s.core, user, projectIDs); err != nil {
+		return nil, err
 	}
 	page, pageSize := normalizePage(req.GetPage(), req.GetPageSize())
 	out := make([]*pb.Secret, 0, len(secrets))

--- a/server/http/handlers/project_mfa_aggregate_test.go
+++ b/server/http/handlers/project_mfa_aggregate_test.go
@@ -1,0 +1,136 @@
+// project_mfa_aggregate_test.go — #G17 regression tests (HTTP side): the
+// GET /rotation-plan, GET /shares, and GET /shared-secrets handlers are gated
+// only by a global RequirePermission check, which never applies the
+// per-project MFA policy (ADR-037) regardless of which specific projects the
+// response discloses. Mirrors server/grpc/services/project_mfa_aggregate_test.go.
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// httpMFAAggregateTestRig mirrors mfaAggregateTestRig (gRPC side): two
+// projects — "guarded" (RequireMFA) and "open" — each with an overdue secret
+// (so both appear in the deployment rotation plan) and a share (so both
+// appear in the shares/shared-secrets listings).
+type httpMFAAggregateTestRig struct {
+	secretH *SecretHandler
+	shareH  *ShareHandler
+}
+
+func newHTTPMFAAggregateTestRig(t *testing.T) *httpMFAAggregateTestRig {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.RotationPolicy{},
+		&models.SecretDependency{}, &models.ShareRecord{}, &models.User{},
+		&models.Group{}, &models.UserGroup{},
+	))
+
+	now := time.Now()
+	daysAgo := func(d int) *time.Time { tt := now.Add(-time.Duration(d) * 24 * time.Hour); return &tt }
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "guarded", RequireMFA: true}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "env1"}).Error)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		Name: "guarded-90d", Scope: "project", ProjectID: uintPtr(1), IntervalDays: 90, AlertDaysBefore: 14, IsActive: true,
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 1, Name: "guarded-secret", ProjectID: 1, EnvironmentID: 1, IsSecret: true, Status: "active",
+		OwnerID: 1, LastRotatedAt: daysAgo(200),
+	}).Error)
+
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "open"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, ProjectID: 2, Name: "env2"}).Error)
+	require.NoError(t, db.Create(&models.RotationPolicy{
+		Name: "open-90d", Scope: "project", ProjectID: uintPtr(2), IntervalDays: 90, AlertDaysBefore: 14, IsActive: true,
+	}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 2, Name: "open-secret", ProjectID: 2, EnvironmentID: 2, IsSecret: true, Status: "active",
+		OwnerID: 1, LastRotatedAt: daysAgo(200),
+	}).Error)
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "auditor", Email: "auditor@example.com"}).Error)
+	require.NoError(t, db.Create(&models.ShareRecord{SecretID: 1, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}).Error)
+	require.NoError(t, db.Create(&models.ShareRecord{SecretID: 2, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}).Error)
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	secretH, err := NewSecretHandler(coreService)
+	require.NoError(t, err)
+	shareH, err := NewShareHandler(coreService)
+	require.NoError(t, err)
+	return &httpMFAAggregateTestRig{secretH: secretH, shareH: shareH}
+}
+
+func uintPtr(v uint) *uint { return &v }
+
+// sessionReq builds a GET request carrying an interactive session UserContext,
+// as the auth middleware would populate it after validating a session token.
+func sessionReq(userID uint, mfaEnabled bool) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	uc := &middleware.UserContext{UserID: userID, Username: "auditor", SessionAuth: true, MFAEnabled: mfaEnabled}
+	return r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), uc))
+}
+
+// TestGetDeploymentRotationPlan_DeniesGlobalScopeMFABypass is #G17: the route
+// is gated only by global secrets.read (RequirePermission), which never
+// applies ProjectMFABlocked — a project-scoped call to the same underlying
+// data (GetProjectRotationPlan) would deny a no-MFA session, but the
+// deployment-wide roll-up did not.
+func TestGetDeploymentRotationPlan_DeniesGlobalScopeMFABypass(t *testing.T) {
+	r := newHTTPMFAAggregateTestRig(t)
+
+	w := httptest.NewRecorder()
+	r.secretH.GetDeploymentRotationPlan(w, sessionReq(1, false))
+	require.Equal(t, http.StatusForbidden, w.Code, "an MFA-required project's data must not leak through the deployment-wide roll-up")
+
+	w2 := httptest.NewRecorder()
+	r.secretH.GetDeploymentRotationPlan(w2, sessionReq(1, true))
+	require.Equal(t, http.StatusOK, w2.Code, "a session with MFA is allowed")
+}
+
+// TestListSharedSecrets_DeniesGlobalScopeMFABypass is #G17's ListSharedSecrets
+// HTTP member.
+func TestListSharedSecrets_DeniesGlobalScopeMFABypass(t *testing.T) {
+	r := newHTTPMFAAggregateTestRig(t)
+
+	w := httptest.NewRecorder()
+	r.shareH.ListSharedSecrets(w, sessionReq(2, false))
+	require.Equal(t, http.StatusForbidden, w.Code, "a shared secret from an MFA-required project must not leak through this global-scope list")
+
+	w2 := httptest.NewRecorder()
+	r.shareH.ListSharedSecrets(w2, sessionReq(2, true))
+	require.Equal(t, http.StatusOK, w2.Code, "a session with MFA is allowed")
+}
+
+// TestListShares_DeniesGlobalScopeMFABypass is #G17's ListShares (ListUserShares
+// gRPC equivalent) HTTP member — ShareView only carries SecretID, so the fix
+// must resolve each share's owning project via a batched lookup.
+func TestListShares_DeniesGlobalScopeMFABypass(t *testing.T) {
+	r := newHTTPMFAAggregateTestRig(t)
+
+	w := httptest.NewRecorder()
+	r.shareH.ListShares(w, sessionReq(1, false))
+	require.Equal(t, http.StatusForbidden, w.Code, "a share on an MFA-required project's secret must not leak through this global-scope list")
+
+	w2 := httptest.NewRecorder()
+	r.shareH.ListShares(w2, sessionReq(1, true))
+	require.Equal(t, http.StatusOK, w2.Code, "a session with MFA is allowed")
+}

--- a/server/http/handlers/secret_dependencies.go
+++ b/server/http/handlers/secret_dependencies.go
@@ -215,5 +215,17 @@ func (h *SecretHandler) GetDeploymentRotationPlan(w http.ResponseWriter, r *http
 		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
 		return
 	}
+	// #G17: the response aggregates every project's own rotation plan; a
+	// project that individually requires MFA must not be readable via this
+	// global-scope roll-up by a session that lacks it — mirrors the gRPC-side
+	// enforceProjectMFAForProjects fix in the same finding.
+	projectIDs := make([]uint, 0, len(plan.Projects))
+	for _, p := range plan.Projects {
+		projectIDs = append(projectIDs, p.ProjectID)
+	}
+	if middleware.ProjectsMFABlocked(r, h.coreService, projectIDs) {
+		middleware.WriteProjectMFARequired(w)
+		return
+	}
 	h.sendSuccess(w, plan, "")
 }

--- a/server/http/handlers/shares_query.go
+++ b/server/http/handlers/shares_query.go
@@ -6,6 +6,7 @@
 package handlers
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"strconv"
@@ -72,6 +73,13 @@ func (h *ShareHandler) ListShares(w http.ResponseWriter, r *http.Request) {
 		h.sendError(w, "InternalError", "Failed to list shares", http.StatusInternalServerError, nil)
 		return
 	}
+	// #G17: ShareView only carries SecretID, so resolve each share's owning
+	// project in one batched lookup before applying the aggregate MFA check —
+	// mirrors the gRPC-side ListUserShares fix in the same finding.
+	if middleware.ProjectsMFABlocked(r, h.coreService, h.shareViewProjectIDs(r.Context(), views)) {
+		middleware.WriteProjectMFARequired(w)
+		return
+	}
 
 	// Optional server-side filters.
 	if v := r.URL.Query().Get("secretId"); v != "" {
@@ -116,6 +124,35 @@ func (h *ShareHandler) ListShares(w http.ResponseWriter, r *http.Request) {
 	}, "")
 }
 
+// shareViewProjectIDs resolves the distinct projects the given share views'
+// secrets belong to, via one batched GetSecretsByIDs lookup. A resolution
+// failure is logged and treated as an empty set — see the gRPC-side
+// shareProjectIDs (share_service.go) for why this degrades safely rather than
+// blocking the endpoint outright.
+func (h *ShareHandler) shareViewProjectIDs(ctx context.Context, views []core.ShareView) []uint {
+	if len(views) == 0 {
+		return nil
+	}
+	secretIDSet := make(map[uint]bool, len(views))
+	secretIDs := make([]uint, 0, len(views))
+	for _, v := range views {
+		if !secretIDSet[v.SecretID] {
+			secretIDSet[v.SecretID] = true
+			secretIDs = append(secretIDs, v.SecretID)
+		}
+	}
+	secrets, err := h.coreService.Storage().GetSecretsByIDs(ctx, secretIDs)
+	if err != nil {
+		log.Printf("shareViewProjectIDs: failed to resolve project ids for MFA check: %v", err)
+		return nil
+	}
+	projectIDs := make([]uint, 0, len(secrets))
+	for _, sec := range secrets {
+		projectIDs = append(projectIDs, sec.ProjectID)
+	}
+	return projectIDs
+}
+
 // filterShareViews returns the views satisfying keep.
 func filterShareViews(views []core.ShareView, keep func(core.ShareView) bool) []core.ShareView {
 	out := views[:0:0]
@@ -151,6 +188,16 @@ func (h *ShareHandler) ListSharedSecrets(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		log.Printf("Error listing shared secrets: %v", err)
 		h.sendError(w, "InternalError", "Failed to list shared secrets", http.StatusInternalServerError, nil)
+		return
+	}
+	// #G17: each SecretNode already carries its own ProjectID — no extra lookup
+	// needed. Mirrors the gRPC-side ListSharedSecrets fix in the same finding.
+	projectIDs := make([]uint, 0, len(secrets))
+	for _, sec := range secrets {
+		projectIDs = append(projectIDs, sec.ProjectID)
+	}
+	if middleware.ProjectsMFABlocked(r, h.coreService, projectIDs) {
+		middleware.WriteProjectMFARequired(w)
 		return
 	}
 	if secrets == nil {

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -1099,6 +1099,20 @@ func forbiddenResponse(w http.ResponseWriter, message string) {
 // cost and stay exempt — consistent with EnforceMFAEnrollment. Handlers that
 // authorize in-handler (not via RequireScopedPermission) call this too, so the
 // policy is enforced uniformly across every project-scoped path.
+//
+// #G17: fails CLOSED (blocks) on a genuine ProjectRequiresMFA lookup error —
+// matching the gRPC-side enforceProjectMFA fix. A lookup error used to fall
+// through to "not blocked", silently treating the caller as MFA-compliant;
+// left unfixed here while gRPC failed closed, a caller could deliberately
+// trigger the same lookup error and pick whichever transport still failed
+// open, reopening exactly the transport-divergence bypass class this
+// function's own doc comment says it exists to prevent. A "project not
+// found" error is deliberately excluded from the fail-closed path: this
+// scope was already permission-checked by the caller (finishScopedPermissionRequest
+// only reaches here on allowed==true), so a nonexistent project is not an
+// MFA-policy question — blocking it here would mask the handler's own
+// existence check (e.g. a project-health probe for an unknown ID) behind a
+// misleading "MFA required" response instead of its real 404/403.
 func ProjectMFABlocked(r *http.Request, cs *core.KeyorixCore, projectID uint) bool {
 	if projectID == 0 || cs == nil {
 		return false
@@ -1108,7 +1122,35 @@ func ProjectMFABlocked(r *http.Request, cs *core.KeyorixCore, projectID uint) bo
 		return false
 	}
 	req, err := cs.ProjectRequiresMFA(r.Context(), projectID)
-	return err == nil && req
+	if err != nil {
+		return !strings.Contains(err.Error(), "not found")
+	}
+	return req
+}
+
+// ProjectsMFABlocked generalizes ProjectMFABlocked across a set of project IDs
+// disclosed by an aggregate/global-scope response — true if ANY project in the
+// set requires MFA the caller's session lacks (or whose policy can't be
+// verified). See ProjectMFABlocked's doc comment for the exemption rules.
+//
+// #G17: an aggregate endpoint (e.g. GET /rotation-plan, GET /shares,
+// GET /shared-secrets) is gated only by a global RequirePermission check, which
+// never scopes to any one project — so ProjectMFABlocked's own per-project gate
+// is never reached for these routes regardless of which specific projects' data
+// the response actually discloses. Call this with every project ID the response
+// discloses before writing it out.
+func ProjectsMFABlocked(r *http.Request, cs *core.KeyorixCore, projectIDs []uint) bool {
+	seen := make(map[uint]bool, len(projectIDs))
+	for _, id := range projectIDs {
+		if id == 0 || seen[id] {
+			continue
+		}
+		seen[id] = true
+		if ProjectMFABlocked(r, cs, id) {
+			return true
+		}
+	}
+	return false
 }
 
 // WriteProjectMFARequired writes the 403 ProjectMFARequired response (exported so

--- a/server/middleware/project_mfa_test.go
+++ b/server/middleware/project_mfa_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
@@ -64,5 +66,75 @@ func TestProjectMFABlocked(t *testing.T) {
 
 	t.Run("global scope (projectID 0): not subject to any project policy", func(t *testing.T) {
 		assert.False(t, ProjectMFABlocked(reqWithUser(sessionNoMFA), cs, 0))
+	})
+}
+
+// erroringProjectStorage wraps a real Storage but makes GetProject fail with a
+// non-"not found" error (a transient storage failure), to exercise the
+// genuine fail-closed path without a nonexistent-project "not found" (a
+// different, deliberately non-blocking case — see
+// TestProjectMFABlocked_NotFoundDoesNotBlock).
+type erroringProjectStorage struct {
+	corestorage.Storage
+}
+
+func (erroringProjectStorage) GetProject(context.Context, uint) (*models.Project, error) {
+	return nil, fmt.Errorf("connection reset by peer")
+}
+
+// TestProjectMFABlocked_FailsClosedOnLookupError is #G17: a genuine
+// ProjectRequiresMFA lookup error (a transient storage failure, distinct from
+// "project not found") used to fall through to "not blocked" (`err == nil &&
+// req` is false on any error), silently treating an interactive session
+// without a second factor as MFA-compliant regardless of the project's real
+// policy. It must now deny.
+func TestProjectMFABlocked_FailsClosedOnLookupError(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}))
+	cs := core.NewKeyorixCore(erroringProjectStorage{store.NewLocalStorage(db)})
+	sessionNoMFA := &UserContext{UserID: 1, ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: false}
+
+	assert.True(t, ProjectMFABlocked(reqWithUser(sessionNoMFA), cs, 1),
+		"a genuine ProjectRequiresMFA lookup error must deny, not silently allow")
+}
+
+// TestProjectMFABlocked_NotFoundDoesNotBlock is #G17's necessary carve-out:
+// ProjectMFABlocked only runs after the caller's scope was already
+// permission-checked (finishScopedPermissionRequest only reaches here on
+// allowed==true), so a nonexistent project is not an MFA-policy question — it
+// must not block, so the handler's own existence check produces the real
+// 404/403 instead of a misleading "MFA required" response.
+func TestProjectMFABlocked_NotFoundDoesNotBlock(t *testing.T) {
+	cs := newProjectMFACore(t)
+	sessionNoMFA := &UserContext{UserID: 1, ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: false}
+
+	assert.False(t, ProjectMFABlocked(reqWithUser(sessionNoMFA), cs, 999),
+		"a nonexistent project must not be blocked by the MFA gate")
+}
+
+// TestProjectsMFABlocked is #G17: an aggregate endpoint whose response spans
+// several projects must be blocked if ANY of them requires MFA the caller's
+// session lacks, even though every individual project ID is passed to the same
+// underlying ProjectMFABlocked check that a single-project endpoint uses.
+func TestProjectsMFABlocked(t *testing.T) {
+	cs := newProjectMFACore(t)
+	sessionNoMFA := &UserContext{UserID: 1, ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: false}
+
+	t.Run("one of several projects requires MFA: BLOCKED", func(t *testing.T) {
+		assert.True(t, ProjectsMFABlocked(reqWithUser(sessionNoMFA), cs, []uint{2, 1}))
+	})
+
+	t.Run("none of the projects require MFA: allowed", func(t *testing.T) {
+		assert.False(t, ProjectsMFABlocked(reqWithUser(sessionNoMFA), cs, []uint{2}))
+	})
+
+	t.Run("empty set: allowed", func(t *testing.T) {
+		assert.False(t, ProjectsMFABlocked(reqWithUser(sessionNoMFA), cs, nil))
+	})
+
+	t.Run("session WITH MFA: allowed even when a project requires it", func(t *testing.T) {
+		withMFA := &UserContext{UserID: 1, ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: true}
+		assert.False(t, ProjectsMFABlocked(reqWithUser(withMFA), cs, []uint{1, 2}))
 	})
 }


### PR DESCRIPTION
## Summary

`enforceProjectMFA` (gRPC) and `ProjectMFABlocked` (HTTP) are the single shared primitive gating ADR-037's per-project MFA step-up: an interactive session without a second factor must be denied access to a project that requires MFA. Both had two independent gaps (G17, medium, 3 members):

- **Fail-open on a `ProjectRequiresMFA` lookup error**: `err == nil && required` silently fell through to "not blocked" on any error (a transient storage timeout, a cancelled context), regardless of the project's real policy or the session's real factor state — the one place in this authorization stack that didn't fail closed like every other primitive it wires into (`AuthorizePrincipal`, `core.Authorize`). Now fails closed, with a deliberate carve-out: a "project not found" error does NOT block, since the scope was already permission-checked by the caller and a nonexistent project isn't an MFA-policy question — blocking it would mask the caller's own not-found handling behind a misleading "MFA required" response.
- **`authorizeGlobal` always calls `enforceProjectMFA` with projectID 0**, which no-ops unconditionally. Correct for genuinely install-wide data, but `GetDeploymentRotationPlan`, `ListUserShares`, and `ListSharedSecrets` (plus their HTTP equivalents: `GET /rotation-plan`, `GET /shares`, `GET /shared-secrets`) all return content aggregated from or belonging to SPECIFIC projects, some of which may individually require MFA — a caller correctly denied a single MFA-required project's per-project endpoint could read that project's data back out of the aggregate endpoint instead, the step-up control silently routed around by picking the global-scope sibling. New `enforceProjectMFAForProjects` (gRPC) / `ProjectsMFABlocked` (HTTP) apply the per-project check across every project ID the aggregate response discloses, denying if any of them requires MFA the caller's session lacks.

## Test plan

- [x] New regression tests across `server/grpc/services`, `server/http/handlers`, and `server/middleware` implement the group's `detection_idea` directly: force `ProjectRequiresMFA` to error and assert denial (with a genuine-error-vs-not-found distinction, both proven correct), and seed one MFA-required and one open project so the aggregate response spans both, asserting a no-MFA session is denied while a session with MFA passes.
- [x] Every new test verified to fail against the pre-fix code before being trusted.
- [x] The fail-closed fix's initial version (deny on ANY `ProjectRequiresMFA` error, including not-found) broke 3 pre-existing tests whose fixtures legitimately probe a nonexistent project ID through the scoped-permission middleware — surfaced by the full `server/http` suite, fixed before push (see the not-found carve-out above).
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated` clean on all touched packages
- [x] `golangci-lint run` clean on all touched packages
- [x] Full `server/grpc`, `server/middleware`, `server/http/handlers` suites green
- [x] `server/http`'s remaining failures are the pre-existing `_RealServer` flake class (documented in prior PRs), confirmed identical against the pre-fix baseline in the same worktree — unrelated to this change

Opened as a new PR (rather than added to #1436) because #1436 merged while this fix was in progress — a natural batch boundary per the standing PR-batching convention.
