### PR TITLE
fix(ci): fix codeql[] suppression placement so it actually suppresses

### DIFF
--- a/internal/connect/vault.go
+++ b/internal/connect/vault.go
@@ -165,15 +165,20 @@ func (c *VaultConnector) GetSecret(ctx context.Context, ref string) (string, err
 		return "", err
 	}
 	reqURL := c.address + "/v1/" + safeRef
-	// codeql[go/keyorix-ssrf-unvalidated-outbound-request]: the query traces this
-	// sink's taint back to server/http/handlers/connect.go's r.URL.Query().Get("ref")
-	// (an incoming-request field that happens to match the query's url/host/dsn/
-	// webhook/callback field-name heuristic) via this function's ref parameter --
-	// but ref only ever contributes a PATH SEGMENT appended after c.address (itself
-	// validated above by validateConnectorURL), never the request's host/scheme, and
-	// sanitizeVaultRef above rejects traversal/control characters and percent-escapes
-	// the rest, so it cannot reinterpret the URL's structure either. Not a real
-	// unvalidated destination -- a coincidental name match on net/http.Request.URL.
+	// The query traces this sink's taint back to server/http/handlers/connect.go's
+	// r.URL.Query().Get("ref") (an incoming-request field that happens to match
+	// the query's url/host/dsn/webhook/callback field-name heuristic) via this
+	// function's ref parameter -- but ref only ever contributes a PATH SEGMENT
+	// appended after c.address (itself validated above by validateConnectorURL),
+	// never the request's host/scheme, and sanitizeVaultRef above rejects
+	// traversal/control characters and percent-escapes the rest, so it cannot
+	// reinterpret the URL's structure either. Not a real unvalidated destination --
+	// a coincidental name match on net/http.Request.URL. The codeql[...] tag MUST
+	// be the single comment line directly above the sink (CodeQL's
+	// AlertSuppression.qll requires the comment's own end line == alert line - 1);
+	// splitting the justification above and keeping this line alone is
+	// deliberate, not style.
+	// codeql[go/keyorix-ssrf-unvalidated-outbound-request]
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("vault: new request: %w", err)

--- a/internal/storage/remote/client.go
+++ b/internal/storage/remote/client.go
@@ -233,15 +233,18 @@ func (c *HTTPClient) makeRequest(ctx context.Context, method, path string, body 
 	// a cross-host redirect, and config.BaseURL is scheme/host validated by
 	// Config.Validate's validateBaseURL(c.BaseURL) call (a direct field read,
 	// rejecting non-https except for a loopback host) before this client is
-	// ever constructed.
-	// codeql[go/keyorix-ssrf-unvalidated-outbound-request]: the query traces this
-	// sink's taint back to callers that build `path` from an incoming HTTP request's
-	// r.URL.Query() values (e.g. server/http/handlers/audit.go's filter params) --
-	// an incoming-request field that happens to match the query's url/host/dsn/
-	// webhook/callback field-name heuristic. Those values only ever contribute a
-	// query-string suffix appended to the already-validated c.baseURL above, never
-	// the request's own host/scheme. Not a real unvalidated destination -- a
-	// coincidental name match on net/http.Request.URL.
+	// ever constructed. The query traces this sink's taint back to callers that
+	// build `path` from an incoming HTTP request's r.URL.Query() values (e.g.
+	// server/http/handlers/audit.go's filter params) -- an incoming-request field
+	// that happens to match the query's url/host/dsn/webhook/callback field-name
+	// heuristic. Those values only ever contribute a query-string suffix appended
+	// to the already-validated c.baseURL above, never the request's own
+	// host/scheme. Not a real unvalidated destination -- a coincidental name
+	// match on net/http.Request.URL. The codeql[...] tag MUST be the single
+	// comment line directly above the sink (CodeQL's AlertSuppression.qll
+	// requires the comment's own end line == alert line - 1); splitting the
+	// justification above and keeping this line alone is deliberate, not style.
+	// codeql[go/keyorix-ssrf-unvalidated-outbound-request]
 	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)


### PR DESCRIPTION
## Summary
Two SSRF code-scanning alerts (#788 `internal/storage/remote/client.go`, #781 `internal/connect/vault.go`) stayed open on GitHub despite a merged `// codeql[go/keyorix-ssrf-unvalidated-outbound-request]: <reason>` comment justifying each as a false positive at the exact sink line.

Root-caused by reading CodeQL's actual `AlertSuppression.qll` matching predicate (bundled in the `codeql/go-queries` pack): the `codeql[...]` tag must be the entire, only content of a single comment line whose own end line is exactly `alert_line - 1` (`covers()` requires `this.hasLocationInfo(filepath, _, _, startline - 1, _)`). Each `//`-prefixed line is a **separate comment token** to CodeQL — putting the tag on the first line of a multi-line justification paragraph (9 lines above the sink in both cases) never lines up with that predicate, so the tag was never actually being read as a suppression.

Confirmed empirically two ways:
- Downloaded the actual SARIF GitHub has on file for the current `main` HEAD (`gh api -H "Accept: application/sarif+json" .../code-scanning/analyses/<id>`) — zero `suppressions` entries for either finding.
- Built a from-scratch local CodeQL database and ran the custom query alongside `codeql/go-queries`'s own `AlertSuppression.ql` in the same `codeql database analyze` invocation (this is what correlates a suppression comment to a finding) — same result, zero suppressions, on the unpatched source.

## Fix
Moved the bare `// codeql[go/keyorix-ssrf-unvalidated-outbound-request]` tag to its own dedicated line directly above the sink in both files, keeping the full justification on the lines above that.

## Test plan
- [x] Rebuilt the CodeQL database from this exact fix and re-ran the same `database analyze` invocation — both findings now carry `suppressions: [{"kind": "inSource"}]` in the resulting SARIF, confirmed via a before/after diff.
- [x] `go build ./...`, `go vet`, `gofmt -l` all clean
- [ ] After merge, confirm alerts #788/#781 actually transition to `dismissed`/`fixed` on the next CodeQL run on `main` (GitHub's own auto-dismissal for CodeQL-sourced `suppressions`, distinct from the Semgrep case where this doesn't happen — see project memory `nosemgrep-suppression-doesnt-close-github-alert.md`)