### PR TITLE
fix(security): deref pointer fields in required/identifier validation rules (G47)

### DIFF
--- a/server/validation/validator.go
+++ b/server/validation/validator.go
@@ -149,7 +149,16 @@ func (v *Validator) validateField(errs map[string][]string, fieldName string, fi
 func (v *Validator) applyRule(fieldName string, field reflect.Value, ruleName, param string) error {
 	switch ruleName {
 	case "required":
-		if v.isEmpty(field) {
+		// A nil pointer/interface has nothing to check (ok=false) and is
+		// itself "not provided", so it fails required just like isEmpty's
+		// own Pointer/Interface case does. A non-nil pointer is dereferenced
+		// so it's judged by the SAME emptiness rule as its non-pointer
+		// equivalent (e.g. a non-nil *string pointing at "" or a non-nil
+		// *int pointing at 0 must fail required exactly as a plain ""/0
+		// field would) instead of unconditionally passing just because the
+		// pointer itself is non-nil.
+		resolved, ok := derefForRule(field)
+		if !ok || v.isEmpty(resolved) {
 			return fmt.Errorf("%s", i18n.T("ErrorValidation", nil))
 		}
 	case "min":
@@ -445,6 +454,11 @@ var identifierRegex = regexp.MustCompile(`^[a-zA-Z0-9 _-]+$`)
 // applied globally, since some fields (e.g. free-form secret names) intentionally allow
 // a broader charset.
 func (v *Validator) validateIdentifier(field reflect.Value) error {
+	resolved, ok := derefForRule(field)
+	if !ok {
+		return nil
+	}
+	field = resolved
 	if field.Kind() != reflect.String {
 		return nil
 	}

--- a/server/validation/validator_test.go
+++ b/server/validation/validator_test.go
@@ -352,6 +352,108 @@ func TestValidate_PointerAndNonPointer_IdenticalRuleOutcome(t *testing.T) {
 	}
 }
 
+// --- G47: `required` and `identifier` must dereference a pointer field ---
+//
+// Every rule in applyRule/validateXxx is supposed to call derefForRule so a
+// pointer-typed field is judged against its pointed-to value, exactly like
+// its non-pointer equivalent. `required` and `validateIdentifier` were the
+// two rules that skipped this: `required` inspected isEmpty(field) directly,
+// so a non-nil pointer was NEVER considered empty (isEmpty's Pointer case
+// only checks IsNil) and `required` silently passed a non-nil pointer to a
+// blank string. `validateIdentifier` checked field.Kind() != reflect.String
+// directly, so a *string field's Kind() is Pointer, never String, and the
+// charset check was silently skipped entirely for any pointer-typed field.
+
+func TestValidate_Required_NonNilPointerToBlankString_Fails(t *testing.T) {
+	type payload struct {
+		Name *string `json:"name" validate:"required"`
+	}
+	v := NewValidator()
+
+	// Non-pointer equivalent: an explicit blank string must fail required.
+	type payloadNonPtr struct {
+		Name string `json:"name" validate:"required"`
+	}
+	require.Error(t, v.Validate(payloadNonPtr{Name: ""}), "non-pointer equivalent must fail required")
+
+	// A non-nil pointer to a blank string must fail required the same way,
+	// not silently pass just because the pointer itself is non-nil.
+	require.Error(t, v.Validate(payload{Name: strPtr("")}), "non-nil pointer to empty string must fail required")
+	require.Error(t, v.Validate(payload{Name: strPtr("   ")}), "non-nil pointer to whitespace-only string must fail required")
+}
+
+func TestValidate_Required_NonNilPointerToNonBlankString_Passes(t *testing.T) {
+	type payload struct {
+		Name *string `json:"name" validate:"required"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{Name: strPtr("present")}))
+}
+
+func TestValidate_Required_NilPointer_Fails(t *testing.T) {
+	// A nil pointer means "not provided", which must still fail a bare
+	// `required` tag (no `omitempty` present to short-circuit it first) —
+	// this must keep working exactly as before the derefForRule fix.
+	type payload struct {
+		Name *string `json:"name" validate:"required"`
+	}
+	v := NewValidator()
+
+	require.Error(t, v.Validate(payload{Name: nil}), "nil pointer must fail required")
+}
+
+func TestValidate_Required_NonNilPointerToZeroInt_Fails(t *testing.T) {
+	// Same principle for a non-string kind: a non-nil *int pointing at 0
+	// must fail required exactly as a plain int field set to 0 would.
+	type payload struct {
+		Count *int `json:"count" validate:"required"`
+	}
+	v := NewValidator()
+
+	require.Error(t, v.Validate(payload{Count: intPtr(0)}), "non-nil pointer to zero int must fail required")
+	require.NoError(t, v.Validate(payload{Count: intPtr(5)}))
+}
+
+func TestValidate_Identifier_NonNilPointerToInvalidCharset_Fails(t *testing.T) {
+	type payload struct {
+		Name *string `json:"name" validate:"omitempty,identifier"`
+	}
+	v := NewValidator()
+
+	// Non-pointer equivalent: disallowed characters must fail identifier.
+	type payloadNonPtr struct {
+		Name string `json:"name" validate:"omitempty,identifier"`
+	}
+	require.Error(t, v.Validate(payloadNonPtr{Name: "path/traversal"}), "non-pointer equivalent must fail identifier")
+
+	// A non-nil pointer to the same invalid value must fail identically,
+	// not be silently skipped because Kind() is Pointer rather than String.
+	require.Error(t, v.Validate(payload{Name: strPtr("path/traversal")}), "non-nil pointer with disallowed charset must fail identifier")
+	require.Error(t, v.Validate(payload{Name: strPtr("<script>")}), "non-nil pointer with disallowed charset must fail identifier")
+}
+
+func TestValidate_Identifier_NonNilPointerToValidCharset_Passes(t *testing.T) {
+	type payload struct {
+		Name *string `json:"name" validate:"omitempty,identifier"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{Name: strPtr("prod-db_01")}))
+}
+
+func TestValidate_Identifier_NilPointer_Passes(t *testing.T) {
+	// A nil pointer has nothing to validate against the charset rule and
+	// must pass, matching every other charset rule's nil-pointer handling
+	// (validateEmail, validateURL, validateAlpha, etc via derefForRule).
+	type payload struct {
+		Name *string `json:"name" validate:"omitempty,identifier"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{Name: nil}))
+}
+
 func TestValidate_UsesJSONNameForErrorField(t *testing.T) {
 	type payload struct {
 		UserName string `json:"user_name" validate:"required"`


### PR DESCRIPTION
## Summary
Two rule functions in the shared struct validator (`server/validation/validator.go`) inspected a field's `Kind()`/value directly instead of calling `derefForRule` first, unlike every other rule (validateMin, validateMax, validateEmail, validateURL, validateAlpha, validateAlphaNum, validateNumeric, validateOneOf), which already deref a non-nil pointer before applying the rule.

- `required`: called `v.isEmpty(field)` directly. `isEmpty`'s Pointer/Interface case only checks `IsNil()`, so a non-nil pointer was never considered empty regardless of what it pointed at — a non-nil `*string` pointing at `""` (or a non-nil `*int` pointing at `0`) silently satisfied `required`.
- `validateIdentifier`: checked `field.Kind() != reflect.String` before ever dereferencing, so a `*string` field's `Kind()` is `Pointer`, never `String` — the identifier charset check was silently skipped entirely for any pointer-typed field tagged `validate:"identifier"`.

Fixed by calling `derefForRule` first in both, matching the established convention. `required` needed slightly different handling since (unlike the other rules) a nil pointer must still fail `required` — `!ok || v.isEmpty(resolved)`.

Checked every other rule function end-to-end; all 8 already call `derefForRule` correctly, so these were the only two sibling instances. No current caller declares a pointer-typed field with a `required`/`identifier` validate tag (grepped `server/`), so this doesn't newly reject any input production code accepts today — it only corrects the rule's behavior for pointer fields using these tags going forward.

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt -l` clean
- [x] New regression tests for both rules against a non-nil pointer to an empty/invalid value (asserting the same failure as the non-pointer equivalent) and a nil pointer (asserting the established nil-handling convention) — `go test ./server/validation/...` all pass