### PR TITLE
fix(security): bundle tar bounds, session/DEK/RBAC hygiene, SCIM/re-parent scoping, CLI hardening (G41, G57, G60, G62, G65, G68, G70-72, G74, G77, G78, G84-86)

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -46,6 +46,27 @@ const (
 // can't exhaust memory before the signature is even checked. A real manifest is a few KiB.
 const maxManifestBytes = 4 << 20 // 4 MiB
 
+// maxComponentBytes caps a single component tar entry's declared size, checked immediately
+// after its header is parsed and BEFORE streamComponent ever calls io.Copy — so a corrupt or
+// malicious entry can't force wasted decompression/read work merely by lying in its header
+// (G57 #1). Real components are container images, Helm charts, CRDs, binaries, and DB
+// migrations; 2 GiB is an order of magnitude above the largest other in-repo transfer cap
+// (maxResponseBytes at 64 MiB, internal/storage/remote/client.go) yet comfortably covers any
+// single legitimate release artifact, while still being a hard, finite ceiling rather than
+// "whatever the archive claims."
+const maxComponentBytes = 2 << 30 // 2 GiB
+
+// maxComponentEntries caps the number of tar entries streamBundleComponents will iterate —
+// matched, unlisted, or non-regular — before refusing the archive outright (G57 #2). A
+// boolean "seen" map alone does not bound total work: nothing stops a crafted archive from
+// repeating one legitimately-signed component entry thousands of times, forcing thousands of
+// redundant hash/copy passes over otherwise-valid content, or padding the archive with large
+// numbers of cheap-to-parse-but-still-iterated non-regular entries. A real bundle's entry
+// count is 2 (manifest+sig) plus the pinned component count from its own size-bounded
+// manifest — realistically dozens; 1000 is a generous ceiling comfortably above any
+// legitimate release while bounding a pathological archive's total iteration cost.
+const maxComponentEntries = 1000
+
 var (
 	// ErrNoManifest means the archive did not begin with manifest.json + manifest.sig.
 	ErrNoManifest = errors.New("bundle: manifest.json/manifest.sig missing or out of order")
@@ -59,6 +80,12 @@ var (
 	ErrNotUpgrade = errors.New("bundle: version is not an upgrade over the installed version")
 	// ErrUpgradeSkipped means the installed version is older than the bundle's min_upgrade_from.
 	ErrUpgradeSkipped = errors.New("bundle: installed version is below the bundle's minimum upgrade-from")
+	// ErrEntryTooLarge means a tar entry declared a size exceeding the configured cap.
+	ErrEntryTooLarge = errors.New("bundle: tar entry declares a size exceeding the maximum allowed")
+	// ErrTooManyEntries means the archive contained more tar entries than the configured cap.
+	ErrTooManyEntries = errors.New("bundle: archive contains more tar entries than allowed")
+	// ErrDuplicateComponent means a component entry appeared more than once in the archive.
+	ErrDuplicateComponent = errors.New("bundle: duplicate component entry")
 )
 
 // Component pins one file in the bundle by its digest and size. Path is a clean,
@@ -365,6 +392,7 @@ func resolveIdempotentInstall(opts *extractOpts, m *Manifest) (installed string,
 // component was seen. Fails closed on any mismatch or missing component.
 func streamBundleComponents(tr *tar.Reader, pinned map[string]Component, dest string) error {
 	seen := make(map[string]bool, len(pinned))
+	entries := 0
 	for {
 		hdr, err := tr.Next()
 		if errors.Is(err, io.EOF) {
@@ -373,8 +401,22 @@ func streamBundleComponents(tr *tar.Reader, pinned map[string]Component, dest st
 		if err != nil {
 			return fmt.Errorf("bundle: read archive: %w", err)
 		}
+		// Count every entry iterated — matched, unlisted, or non-regular — and cap it as
+		// early as possible, before any other work on this entry. A boolean "seen" map alone
+		// does not bound total loop iterations; this is the general backstop (the duplicate
+		// check below is the specific, cheaper one for repeats of an already-matched name).
+		entries++
+		if entries > maxComponentEntries {
+			return fmt.Errorf("%w: more than %d entries", ErrTooManyEntries, maxComponentEntries)
+		}
 		if hdr.Typeflag != tar.TypeReg {
 			continue
+		}
+		// Reject an oversized declared size before ever reading (let alone decompressing)
+		// this entry's content — do this before the pinned-component lookup too, so an
+		// oversized entry can't hide behind a not-yet-checked name.
+		if hdr.Size > maxComponentBytes {
+			return fmt.Errorf("%w: %s declares %d bytes (max %d)", ErrEntryTooLarge, hdr.Name, hdr.Size, maxComponentBytes)
 		}
 		name, err := cleanComponentPath(hdr.Name)
 		if err != nil {
@@ -383,6 +425,20 @@ func streamBundleComponents(tr *tar.Reader, pinned map[string]Component, dest st
 		comp, ok := pinned[name]
 		if !ok {
 			return fmt.Errorf("%w: %s", ErrUnlistedComponent, name)
+		}
+		// A boolean "seen" map alone would silently allow reprocessing an already-verified
+		// component entry an unbounded number of times — a crafted archive repeating one
+		// legitimately-signed, digest-matching entry thousands of times would otherwise be
+		// re-hashed and re-staged that many times before ever reaching maxComponentEntries.
+		// Reject the repeat outright instead of doing that redundant work.
+		if seen[name] {
+			return fmt.Errorf("%w: %s", ErrDuplicateComponent, name)
+		}
+		// The tar header's declared size must match the pinned (signature-verified)
+		// manifest size before we trust it enough to stream — belt-and-suspenders atop the
+		// comp.Size-bounded read in streamComponent below.
+		if hdr.Size != comp.Size {
+			return fmt.Errorf("%w: %s (header size %d, manifest size %d)", ErrDigestMismatch, name, hdr.Size, comp.Size)
 		}
 		if err := streamComponent(tr, comp, dest); err != nil {
 			return err
@@ -652,6 +708,13 @@ func readNamedEntry(tr *tar.Reader, want string) ([]byte, error) {
 	}
 	if hdr.Name != want || hdr.Typeflag != tar.TypeReg {
 		return nil, fmt.Errorf("%w: got %q, want %q", ErrNoManifest, hdr.Name, want)
+	}
+	// Reject a header that declares more than the cap BEFORE ever reading (and thereby
+	// decompressing) its content — an explicit, promptly-returned error rather than relying
+	// solely on io.LimitReader's silent truncation below, which this manifest/sig path runs
+	// entirely before the signature is checked.
+	if hdr.Size > maxManifestBytes {
+		return nil, fmt.Errorf("%w: %s declares %d bytes (max %d)", ErrEntryTooLarge, want, hdr.Size, maxManifestBytes)
 	}
 	b, err := io.ReadAll(io.LimitReader(tr, maxManifestBytes))
 	if err != nil {

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -93,6 +93,44 @@ func writeRawBundle(t *testing.T, manifest, sig []byte, files [][2]string) []byt
 	return buf.Bytes()
 }
 
+// writeRawBundleOversizedEntry crafts a tar entry whose header declares declaredSize while
+// writing NO body bytes at all — a header lying about a size no real WriteBundle output would
+// ever contain. Used to prove the per-entry size cap rejects based on the declared header
+// alone, before ever attempting to read (let alone decompress) that many bytes: a correct
+// reader must never depend on the body actually being present in order to reject.
+func writeRawBundleOversizedEntry(t *testing.T, manifest, sig []byte, name string, declaredSize int64) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	put := func(n string, b []byte) {
+		if err := tw.WriteHeader(&tar.Header{Name: n, Mode: 0o644, Size: int64(len(b)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatalf("hdr %s: %v", n, err)
+		}
+		if _, err := tw.Write(b); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+	if manifest != nil {
+		put(manifestName, manifest)
+	}
+	if sig != nil {
+		put(sigName, sig)
+	}
+	// The malicious entry: only a header claiming declaredSize bytes, with no body written at
+	// all. tw.Close() is deliberately never called (a well-behaved tar.Writer would refuse
+	// this incomplete entry there) — the point of the test is that a correct reader must
+	// reject based on the declared header Size alone, so an absent/short body must never
+	// matter for that rejection to happen.
+	if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: declaredSize, Typeflag: tar.TypeReg}); err != nil {
+		t.Fatalf("hdr %s: %v", name, err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz close: %v", err)
+	}
+	return buf.Bytes()
+}
+
 // --- tests ---
 
 func TestVerify_RoundTrip(t *testing.T) {
@@ -228,6 +266,84 @@ func TestVerify_NoManifest(t *testing.T) {
 	raw := writeRawBundle(t, nil, nil, [][2]string{{"a", "x"}})
 	if _, err := Verify(bytes.NewReader(raw), reg); !errors.Is(err, ErrNoManifest) {
 		t.Fatalf("want ErrNoManifest, got %v", err)
+	}
+}
+
+// TestVerify_RejectsOversizedComponentDeclaredSize proves the G57 #1 fix: a tar header that
+// declares a size bigger than maxComponentBytes must be rejected immediately, based on the
+// header alone — before streamComponent ever calls io.Copy to read (and thereby decompress)
+// that many bytes. Without this cap, a crafted archive could force unbounded decompression
+// work by simply lying in one entry's header, regardless of what its pinned manifest size
+// says.
+func TestVerify_RejectsOversizedComponentDeclaredSize(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	dir := srcDirWith(t, map[string]string{"images/a.tar": "AAAA"})
+	m, err := BuildManifest(dir, "v1.0.0", "update-2026", "", time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, _ := Sign(m, priv)
+	manifestBytes, _ := m.MarshalCanonical()
+
+	// Declares far more than the cap, but writes no body — a decompression-bomb-shaped
+	// header a legitimate WriteBundle would never produce.
+	raw := writeRawBundleOversizedEntry(t, manifestBytes, sig, "images/a.tar", maxComponentBytes+1)
+
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeUpdate, "update-2026", pub)
+	if _, err := Verify(bytes.NewReader(raw), reg); !errors.Is(err, ErrEntryTooLarge) {
+		t.Fatalf("want ErrEntryTooLarge, got %v", err)
+	}
+}
+
+// TestVerify_RejectsOversizedManifestDeclaredSize proves the same cap applies to the very
+// first entry read, manifest.json itself (G57 #1, bundle.go:648): an oversized declared size
+// must be rejected before any signature check even runs, since the manifest hasn't been
+// parsed or verified yet at that point.
+func TestVerify_RejectsOversizedManifestDeclaredSize(t *testing.T) {
+	raw := writeRawBundleOversizedEntry(t, nil, nil, manifestName, maxManifestBytes+1)
+	reg := trust.NewRegistry()
+	pub, _, _ := ed25519.GenerateKey(nil)
+	_ = reg.Add(trust.PurposeUpdate, "update-2026", pub)
+	if _, err := Verify(bytes.NewReader(raw), reg); !errors.Is(err, ErrEntryTooLarge) {
+		t.Fatalf("want ErrEntryTooLarge, got %v", err)
+	}
+}
+
+// TestVerify_RejectsThousandsOfRepeatedValidEntries proves the G57 #2 fix: a boolean "seen"
+// map alone does not bound total processing — a crafted archive that repeats ONE
+// legitimately-signed, digest-matching component entry thousands of times must be rejected
+// well before all entries are processed. Pre-fix, this archive is NOT rejected at all: every
+// repeat individually matches its pinned digest, so the loop happily reprocesses all of them
+// and Verify succeeds once every pinned component has been "seen" — the vulnerability is
+// exactly that unbounded, wasted reprocessing, not an eventual failure.
+func TestVerify_RejectsThousandsOfRepeatedValidEntries(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	dir := srcDirWith(t, map[string]string{"images/a.tar": "x"})
+	m, err := BuildManifest(dir, "v1.0.0", "update-2026", "", time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, _ := Sign(m, priv)
+	manifestBytes, _ := m.MarshalCanonical()
+
+	// Well beyond maxComponentEntries, all of them individually valid (correct name,
+	// correct digest-matching content) — only the repeat-processing cap can catch this.
+	const repeats = maxComponentEntries + 500
+	files := make([][2]string, repeats)
+	for i := range files {
+		files[i] = [2]string{"images/a.tar", "x"}
+	}
+	raw := writeRawBundle(t, manifestBytes, sig, files)
+
+	reg := trust.NewRegistry()
+	_ = reg.Add(trust.PurposeUpdate, "update-2026", pub)
+	_, err = Verify(bytes.NewReader(raw), reg)
+	if err == nil {
+		t.Fatalf("want an error rejecting the repeated entries, got nil (unbounded reprocessing)")
+	}
+	if !errors.Is(err, ErrDuplicateComponent) && !errors.Is(err, ErrTooManyEntries) {
+		t.Fatalf("want ErrDuplicateComponent or ErrTooManyEntries, got %v", err)
 	}
 }
 

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -101,6 +101,11 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("server URL is required")
 	}
 
+	// #G74: about to persist a real API key against this server URL — warn
+	// before it's written if the URL isn't HTTPS (and not a loopback target),
+	// since the token will be sent in cleartext on every subsequent request.
+	common.WarnIfInsecureEndpoint(server)
+
 	// Update configuration
 	cfg.Storage.Type = "remote"
 	if cfg.Storage.Remote == nil {

--- a/internal/cli/auth/cleartext_warning_test.go
+++ b/internal/cli/auth/cleartext_warning_test.go
@@ -1,0 +1,51 @@
+// cleartext_warning_test.go — #G74: 'auth login' persists a real API key
+// against a user-supplied server URL with no cleartext-transmission warning
+// when that URL isn't HTTPS. Verifies the warning fires before the config is
+// saved for a plaintext http:// server, and stays silent for https://.
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetLoginFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = loginCmd.Flags().Set("api-key", "")
+		_ = loginCmd.Flags().Set("server", "")
+		loginCmd.Flags().Lookup("api-key").Changed = false
+		loginCmd.Flags().Lookup("server").Changed = false
+	})
+}
+
+func TestRunLogin_WarnsOnPlaintextHTTPServer(t *testing.T) {
+	t.Chdir(t.TempDir()) // runLogin writes keyorix.yaml relative to cwd
+	resetLoginFlags(t)
+
+	require.NoError(t, loginCmd.Flags().Set("api-key", "kx_api_secret"))
+	require.NoError(t, loginCmd.Flags().Set("server", "http://keyorix.example.com"))
+
+	out := captureStderr(t, func() {
+		require.NoError(t, runLogin(loginCmd, nil))
+	})
+	assert.Contains(t, out, "not HTTPS")
+	assert.Contains(t, out, "cleartext")
+	assert.Contains(t, out, "MITM-capturable")
+}
+
+func TestRunLogin_NoWarningOnHTTPSServer(t *testing.T) {
+	t.Chdir(t.TempDir())
+	resetLoginFlags(t)
+
+	require.NoError(t, loginCmd.Flags().Set("api-key", "kx_api_secret"))
+	require.NoError(t, loginCmd.Flags().Set("server", "https://keyorix.example.com"))
+
+	out := captureStderr(t, func() {
+		require.NoError(t, runLogin(loginCmd, nil))
+	})
+	assert.NotContains(t, out, "not HTTPS")
+	assert.NotContains(t, out, "MITM-capturable")
+}

--- a/internal/cli/common/common_s3_test.go
+++ b/internal/cli/common/common_s3_test.go
@@ -94,6 +94,26 @@ func TestRemoteClient_Get_EmptyDataEnvelope(t *testing.T) {
 	assert.Contains(t, err.Error(), "empty data")
 }
 
+// TestRemoteClient_Get_UnmarshalError tests the path where the "data" field is
+// present and valid JSON but cannot be unmarshalled into the caller's target type
+// (distinct from TestRemoteClient_Get_DecodeError, which covers the envelope
+// itself being malformed). Ported from internal/cli/run's now-removed
+// TestApiClientGet_UnmarshalError when that package's homegrown apiClient was
+// replaced by RemoteClient under #G71.
+func TestRemoteClient_Get_UnmarshalError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// data is a JSON string, but out expects an object.
+		_, _ = w.Write([]byte(`{"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	var out struct {
+		Projects []struct{ ID uint } `json:"projects"`
+	}
+	err := newTestClient(srv).Get(context.Background(), "/api/v1/projects", &out)
+	require.Error(t, err)
+}
+
 // ── Post ──────────────────────────────────────────────────────────────────────
 
 func TestRemoteClient_Post_Success(t *testing.T) {

--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -180,6 +180,25 @@ func NewRemoteClient() (*RemoteClient, bool) {
 	if !ok {
 		return nil, false
 	}
+	return newHardenedRemoteClient(endpoint, token)
+}
+
+// NewRemoteClientWithCredentials builds a RemoteClient for an explicit
+// endpoint/token pair rather than the one ResolveRemote resolves from
+// env/config — for the rare caller that needs to override just the token
+// (e.g. 'keyorix run --token', which still wants the endpoint resolved via
+// the normal ResolveRemote chain but a token supplied on the command line).
+// Carries the exact same hardened http.Client (request timeout + anti-SSRF
+// redirect refusal) as NewRemoteClient so callers don't have to reimplement
+// it. Returns (nil, false) when endpoint fails validation.
+func NewRemoteClientWithCredentials(endpoint, token string) (*RemoteClient, bool) {
+	return newHardenedRemoteClient(endpoint, token)
+}
+
+// newHardenedRemoteClient builds a RemoteClient with the http.Client hardening
+// every remote-mode CLI request needs, shared by NewRemoteClient and
+// NewRemoteClientWithCredentials so there is exactly one place this is set up.
+func newHardenedRemoteClient(endpoint, token string) (*RemoteClient, bool) {
 	rc := &RemoteClient{
 		Endpoint: endpoint,
 		Token:    token,

--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -100,12 +100,28 @@ func ResolveRemote() (endpoint, token string, ok bool) { // NOSONAR -- cognitive
 
 	// A non-HTTPS endpoint sends the bearer token in cleartext — warn loudly (a loopback
 	// target for local testing is fine).
-	if endpoint != "" && !endpointIsSecure(endpoint) {
-		fmt.Fprintf(os.Stderr, "⚠️  Remote endpoint %q is not HTTPS — the access token is sent in cleartext and is MITM-capturable.\n", endpoint)
-	}
+	WarnIfInsecureEndpoint(endpoint)
 
 	ok = endpoint != "" && token != ""
 	return
+}
+
+// WarnIfInsecureEndpoint prints the same cleartext-transmission warning that
+// ResolveRemote emits when a security-relevant remote endpoint is not HTTPS
+// (and not a loopback target used for local testing). ResolveRemote's own
+// check only fires when a *previously persisted* remote config is later read
+// back — it can't protect a credential that is about to be written or sent
+// for the first time. #G74: callers that persist an API key against a
+// user-supplied server URL (e.g. 'auth login', 'config set-remote') or that
+// transmit real credentials directly (e.g. 'system init --server' bootstrap)
+// must call this before committing to that URL, not rely on ResolveRemote
+// catching it afterwards. Returns true if a warning was printed.
+func WarnIfInsecureEndpoint(endpoint string) bool {
+	if endpoint == "" || endpointIsSecure(endpoint) {
+		return false
+	}
+	fmt.Fprintf(os.Stderr, "⚠️  Remote endpoint %q is not HTTPS — the access token is sent in cleartext and is MITM-capturable.\n", endpoint)
+	return true
 }
 
 // ValidateRemoteEndpointURL checks that a configured remote server endpoint is a

--- a/internal/cli/common/warn_endpoint_test.go
+++ b/internal/cli/common/warn_endpoint_test.go
@@ -1,0 +1,49 @@
+// warn_endpoint_test.go — #G74: verifies WarnIfInsecureEndpoint prints the
+// established cleartext-transmission warning for a non-HTTPS, non-loopback
+// server URL, and stays silent for https:// (and loopback) endpoints. This is
+// the shared helper that 'auth login', 'config set-remote', and 'system init
+// --server' must all call before persisting or transmitting a real credential
+// against a user-supplied server URL.
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWarnIfInsecureEndpoint(t *testing.T) {
+	t.Run("warns for a plaintext HTTP endpoint", func(t *testing.T) {
+		out := captureStderr(t, func() {
+			warned := WarnIfInsecureEndpoint("http://keyorix.example.com")
+			assert.True(t, warned)
+		})
+		assert.Contains(t, out, "not HTTPS")
+		assert.Contains(t, out, "cleartext")
+		assert.Contains(t, out, "MITM-capturable")
+	})
+
+	t.Run("stays silent for an https endpoint", func(t *testing.T) {
+		out := captureStderr(t, func() {
+			warned := WarnIfInsecureEndpoint("https://keyorix.example.com")
+			assert.False(t, warned)
+		})
+		assert.Empty(t, out)
+	})
+
+	t.Run("stays silent for a loopback HTTP endpoint (local testing)", func(t *testing.T) {
+		out := captureStderr(t, func() {
+			warned := WarnIfInsecureEndpoint("http://127.0.0.1:8080")
+			assert.False(t, warned)
+		})
+		assert.Empty(t, out)
+	})
+
+	t.Run("stays silent for an empty endpoint", func(t *testing.T) {
+		out := captureStderr(t, func() {
+			warned := WarnIfInsecureEndpoint("")
+			assert.False(t, warned)
+		})
+		assert.Empty(t, out)
+	})
+}

--- a/internal/cli/config/cleartext_warning_test.go
+++ b/internal/cli/config/cleartext_warning_test.go
@@ -1,0 +1,52 @@
+// cleartext_warning_test.go — #G74: 'config set-remote' persists a real API
+// key against a user-supplied server URL with no cleartext-transmission
+// warning when that URL isn't HTTPS. Verifies the warning fires before the
+// config is saved for a plaintext http:// server, and stays silent for
+// https://.
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetSetRemoteFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = setRemoteCmd.Flags().Set("url", "")
+		_ = setRemoteCmd.Flags().Set("api-key", "")
+		setRemoteCmd.Flags().Lookup("url").Changed = false
+		setRemoteCmd.Flags().Lookup("api-key").Changed = false
+	})
+}
+
+func TestRunSetRemote_WarnsOnPlaintextHTTPServer(t *testing.T) {
+	t.Chdir(t.TempDir()) // runSetRemote writes keyorix.yaml relative to cwd
+	resetSetRemoteFlags(t)
+
+	require.NoError(t, setRemoteCmd.Flags().Set("url", "http://keyorix.example.com"))
+	require.NoError(t, setRemoteCmd.Flags().Set("api-key", "kx_api_secret"))
+
+	out := captureStderr(t, func() {
+		require.NoError(t, runSetRemote(setRemoteCmd, nil))
+	})
+	assert.Contains(t, out, "not HTTPS")
+	assert.Contains(t, out, "cleartext")
+	assert.Contains(t, out, "MITM-capturable")
+}
+
+func TestRunSetRemote_NoWarningOnHTTPSServer(t *testing.T) {
+	t.Chdir(t.TempDir())
+	resetSetRemoteFlags(t)
+
+	require.NoError(t, setRemoteCmd.Flags().Set("url", "https://keyorix.example.com"))
+	require.NoError(t, setRemoteCmd.Flags().Set("api-key", "kx_api_secret"))
+
+	out := captureStderr(t, func() {
+		require.NoError(t, runSetRemote(setRemoteCmd, nil))
+	})
+	assert.NotContains(t, out, "not HTTPS")
+	assert.NotContains(t, out, "MITM-capturable")
+}

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -3,8 +3,11 @@ package config
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -96,9 +99,39 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// warnIfInsecureRemoteURL prints the same cleartext-transmission warning as
+// internal/cli/common.WarnIfInsecureEndpoint when a server URL that a real API
+// key is about to be persisted against is not HTTPS (and not a loopback
+// target used for local testing). Duplicated here (not imported) rather than
+// calling common.WarnIfInsecureEndpoint: internal/cli/common already imports
+// this package (internal/cli/config) for the CLI-connect config, so importing
+// it back here would cycle. Keep this message in sync with that one. #G74
+func warnIfInsecureRemoteURL(raw string) {
+	if raw == "" {
+		return
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "https" {
+		return
+	}
+	host := u.Hostname()
+	if host == "localhost" || strings.HasPrefix(host, "127.") || host == "::1" {
+		return
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "⚠️  Remote endpoint %q is not HTTPS — the access token is sent in cleartext and is MITM-capturable.\n", raw)
+}
+
 func runSetRemote(cmd *cobra.Command, args []string) error {
-	url, _ := cmd.Flags().GetString("url")
+	remoteURL, _ := cmd.Flags().GetString("url")
 	timeout, _ := cmd.Flags().GetInt("timeout")
+
+	// #G74: about to persist a real API key against this server URL — warn
+	// before it's written if the URL isn't HTTPS (and not a loopback target),
+	// since the token will be sent in cleartext on every subsequent request.
+	warnIfInsecureRemoteURL(remoteURL)
 
 	// Resolve the API key without ever requiring it on the command line: the
 	// (insecure, warned) --api-key flag if set, else KEYORIX_API_KEY. The key is
@@ -116,7 +149,7 @@ func runSetRemote(cmd *cobra.Command, args []string) error {
 	if cfg.Storage.Remote == nil {
 		cfg.Storage.Remote = &config.RemoteConfig{}
 	}
-	cfg.Storage.Remote.BaseURL = url
+	cfg.Storage.Remote.BaseURL = remoteURL
 	cfg.Storage.Remote.APIKey = apiKey
 	cfg.Storage.Remote.TimeoutSeconds = timeout
 	cfg.Storage.Remote.TLSVerify = config.BoolPtr(true)
@@ -126,7 +159,7 @@ func runSetRemote(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("✅ Configuration updated successfully!\n")
-	fmt.Printf("🌐 CLI now uses remote server: %s\n", url)
+	fmt.Printf("🌐 CLI now uses remote server: %s\n", remoteURL)
 	if apiKey == "" {
 		fmt.Printf("💡 Tip: set the KEYORIX_API_KEY environment variable if the server requires authentication (preferred over --api-key, which leaks via ps/history)\n")
 	}

--- a/internal/cli/dynamic/dynamic.go
+++ b/internal/cli/dynamic/dynamic.go
@@ -8,6 +8,7 @@ package dynamic
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sort"
 	"strconv"
 
@@ -257,7 +258,7 @@ var renewCmd = &cobra.Command{
 			ExpiresAt string `json:"expires_at"`
 		}
 		body := map[string]int{"ttl_seconds": flagTTL}
-		if err := c.Post(context.Background(), fmt.Sprintf("/api/v1/dynamic-secrets/leases/%s/renew", args[0]), body, &out); err != nil {
+		if err := c.Post(context.Background(), fmt.Sprintf("/api/v1/dynamic-secrets/leases/%s/renew", url.PathEscape(args[0])), body, &out); err != nil {
 			return err
 		}
 		fmt.Printf("Lease %s renewed — new expiry %s\n", out.LeaseID, out.ExpiresAt)
@@ -278,7 +279,7 @@ var revokeCmd = &cobra.Command{
 			LeaseID string `json:"lease_id"`
 			Status  string `json:"status"`
 		}
-		if err := c.Post(context.Background(), fmt.Sprintf("/api/v1/dynamic-secrets/leases/%s/revoke", args[0]), map[string]any{}, &out); err != nil {
+		if err := c.Post(context.Background(), fmt.Sprintf("/api/v1/dynamic-secrets/leases/%s/revoke", url.PathEscape(args[0])), map[string]any{}, &out); err != nil {
 			return err
 		}
 		fmt.Printf("Lease %s %s.\n", out.LeaseID, out.Status)

--- a/internal/cli/dynamic/dynamic_stub_test.go
+++ b/internal/cli/dynamic/dynamic_stub_test.go
@@ -3,6 +3,7 @@ package dynamic
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -246,4 +247,68 @@ func TestClassifyInvalidID(t *testing.T) {
 	err := classifyCmd.RunE(classifyCmd, []string{"not-a-number"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid config id")
+}
+
+// ── G70: lease-id must be path-escaped before interpolation ─────────────────
+//
+// Regression coverage for G70 member 2 (internal/cli/dynamic/dynamic.go:260):
+// renew/revoke used to interpolate the caller-supplied lease-id straight into
+// the request path, so a lease-id containing "/" could add extra path
+// segments and target a different resource than intended. We assert on
+// r.RequestURI (the exact bytes sent on the wire) because r.URL.Path decodes
+// "%2F" back to "/", which would hide the bug.
+
+// TestRenewAgainstMockServer_LeaseIDWithSlash proves that a lease-id
+// containing "/" is sent as a single, correctly-escaped path segment and
+// cannot redirect the request to a different resource.
+func TestRenewAgainstMockServer_LeaseIDWithSlash(t *testing.T) {
+	maliciousLeaseID := "abc/../../other-config/leases/xyz"
+
+	var gotRequestURI, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRequestURI = r.RequestURI
+		gotMethod = r.Method
+		_, _ = w.Write([]byte(`{"data":{"lease_id":"abc","expires_at":"2026-07-01T12:00:00Z"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	flagTTL = 3600
+
+	require.NoError(t, renewCmd.RunE(renewCmd, []string{maliciousLeaseID}))
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	wantEscaped := "/api/v1/dynamic-secrets/leases/" + url.PathEscape(maliciousLeaseID) + "/renew"
+	assert.Equal(t, wantEscaped, gotRequestURI,
+		"the raw request-target must contain the escaped lease-id as one segment, not literal '/'s")
+	// The literal "/" from the lease-id must never appear unescaped in the
+	// request line — it must show up as "%2F" so the server sees one segment.
+	assert.NotContains(t, gotRequestURI, "leases/abc/../..",
+		"unescaped slashes would let the lease-id smuggle extra path segments")
+}
+
+// TestRevokeAgainstMockServer_LeaseIDWithSlash mirrors the renew case for revoke.
+func TestRevokeAgainstMockServer_LeaseIDWithSlash(t *testing.T) {
+	maliciousLeaseID := "abc/../../revoke-all"
+
+	var gotRequestURI, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRequestURI = r.RequestURI
+		gotMethod = r.Method
+		_, _ = w.Write([]byte(`{"data":{"lease_id":"abc","status":"revoked"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	require.NoError(t, revokeCmd.RunE(revokeCmd, []string{maliciousLeaseID}))
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	wantEscaped := "/api/v1/dynamic-secrets/leases/" + url.PathEscape(maliciousLeaseID) + "/revoke"
+	assert.Equal(t, wantEscaped, gotRequestURI,
+		"the raw request-target must contain the escaped lease-id as one segment, not literal '/'s")
+	assert.NotContains(t, gotRequestURI, "leases/abc/../..",
+		"unescaped slashes would let the lease-id smuggle extra path segments")
 }

--- a/internal/cli/encryption/auth_encryption.go
+++ b/internal/cli/encryption/auth_encryption.go
@@ -79,6 +79,14 @@ func runAuthEncryptionStatus(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
+	return authStatusWithConfig(cfg)
+}
+
+// authStatusWithConfig is the testable core of runAuthEncryptionStatus: no flag
+// parsing, no config.Load — callers pass an explicit cfg, matching the
+// *WithConfig convention the DEK-focused commands in encryption.go already use
+// (rotateWithConfig, validateWithConfig, ...).
+func authStatusWithConfig(cfg *config.Config) error {
 	db, err := openDatabase(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to open database: %w", err)
@@ -88,6 +96,14 @@ func runAuthEncryptionStatus(cmd *cobra.Command, args []string) error {
 	if err := authEnc.Initialize(passphrase); err != nil {
 		return fmt.Errorf("failed to initialize auth encryption: %w", err)
 	}
+	// #292/G62: take the same cross-process shared DEK lock the sibling DEK
+	// commands (status/validate/fix-perms/upgrade-aad) already require, so this
+	// fails fast instead of racing a concurrent migrate-provider/rotate.
+	if err := authEnc.AcquireSharedKeyLock(); err != nil {
+		authEnc.Shutdown()
+		return fmt.Errorf("%w — a live server or an in-progress rotation/migrate-provider is using this key directory; stop it or wait for it to finish, then retry", err)
+	}
+	defer authEnc.Shutdown()
 	status := authEnc.GetAuthEncryptionStatus()
 
 	fmt.Println("🔐 Authentication Encryption Status")
@@ -117,6 +133,12 @@ func runEnableAuthEncryption(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
+	return enableAuthEncryptionWithConfig(cfg, force)
+}
+
+// enableAuthEncryptionWithConfig is the testable core of runEnableAuthEncryption:
+// no flag parsing, no config.Load — callers pass an explicit cfg and force bool.
+func enableAuthEncryptionWithConfig(cfg *config.Config, force bool) error {
 	if !cfg.Storage.Encryption.Enabled && !force {
 		return fmt.Errorf("encryption is disabled in configuration. Enable it in config or use --force flag")
 	}
@@ -134,6 +156,14 @@ func runEnableAuthEncryption(cmd *cobra.Command, args []string) error {
 	if err := authEnc.Initialize(passphrase); err != nil {
 		return fmt.Errorf("failed to initialize auth encryption: %w", err)
 	}
+	// #292/G62: take the same cross-process shared DEK lock the sibling DEK
+	// commands (status/validate/fix-perms/upgrade-aad) already require, so this
+	// fails fast instead of racing a concurrent migrate-provider/rotate.
+	if err := authEnc.AcquireSharedKeyLock(); err != nil {
+		authEnc.Shutdown()
+		return fmt.Errorf("%w — a live server or an in-progress rotation/migrate-provider is using this key directory; stop it or wait for it to finish, then retry", err)
+	}
+	defer authEnc.Shutdown()
 	fmt.Println("✅ Authentication encryption enabled successfully")
 	fmt.Println("🔑 New authentication tokens will be encrypted")
 	fmt.Println("💡 Use 'migrate' command to encrypt existing plaintext data")

--- a/internal/cli/encryption/auth_encryption_migrate.go
+++ b/internal/cli/encryption/auth_encryption_migrate.go
@@ -20,6 +20,12 @@ func runMigrateAuthData(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
+	return migrateAuthDataWithConfig(cfg, dryRun)
+}
+
+// migrateAuthDataWithConfig is the testable core of runMigrateAuthData: no flag
+// parsing, no config.Load — callers pass an explicit cfg and dryRun bool.
+func migrateAuthDataWithConfig(cfg *config.Config, dryRun bool) error {
 	db, err := openDatabase(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to open database: %w", err)
@@ -29,6 +35,15 @@ func runMigrateAuthData(cmd *cobra.Command, args []string) error {
 	if err := authEnc.Initialize(passphrase); err != nil {
 		return fmt.Errorf("failed to initialize auth encryption: %w", err)
 	}
+	// #292/G62: take the same cross-process shared DEK lock the sibling DEK
+	// commands (status/validate/fix-perms/upgrade-aad) already require — migrate
+	// writes under the current DEK without rotating it, exactly like upgrade-aad,
+	// so this fails fast instead of racing a concurrent migrate-provider/rotate.
+	if err := authEnc.AcquireSharedKeyLock(); err != nil {
+		authEnc.Shutdown()
+		return fmt.Errorf("%w — a live server or an in-progress rotation/migrate-provider is using this key directory; stop it or wait for it to finish, then retry", err)
+	}
+	defer authEnc.Shutdown()
 
 	if dryRun {
 		fmt.Println("🔍 DRY RUN: Analyzing authentication data for migration...")

--- a/internal/cli/encryption/auth_encryption_validate.go
+++ b/internal/cli/encryption/auth_encryption_validate.go
@@ -22,6 +22,12 @@ func runValidateAuthEncryption(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
+	return validateAuthEncryptionWithConfig(cfg, verbose)
+}
+
+// validateAuthEncryptionWithConfig is the testable core of runValidateAuthEncryption:
+// no flag parsing, no config.Load — callers pass an explicit cfg and verbose bool.
+func validateAuthEncryptionWithConfig(cfg *config.Config, verbose bool) error {
 	db, err := openDatabase(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to open database: %w", err)
@@ -31,6 +37,14 @@ func runValidateAuthEncryption(cmd *cobra.Command, args []string) error {
 	if err := authEnc.Initialize(passphrase); err != nil {
 		return fmt.Errorf("failed to initialize auth encryption: %w", err)
 	}
+	// #292/G62: take the same cross-process shared DEK lock the sibling DEK
+	// commands (status/validate/fix-perms/upgrade-aad) already require, so this
+	// fails fast instead of racing a concurrent migrate-provider/rotate.
+	if err := authEnc.AcquireSharedKeyLock(); err != nil {
+		authEnc.Shutdown()
+		return fmt.Errorf("%w — a live server or an in-progress rotation/migrate-provider is using this key directory; stop it or wait for it to finish, then retry", err)
+	}
+	defer authEnc.Shutdown()
 
 	fmt.Println("🔍 Validating authentication encryption...")
 

--- a/internal/cli/encryption/encryption.go
+++ b/internal/cli/encryption/encryption.go
@@ -11,6 +11,17 @@ import (
 	"gorm.io/gorm"
 )
 
+// wipeBytes overwrites a byte slice with zeros. Mirrors
+// internal/encryption's own unexported wipeBytes (not accessible from this
+// package) for the few places this CLI package handles raw key material
+// directly (rotate-kek's discarded evidence/audit-checkpoint key copies,
+// shamir-split's generated KEK) rather than only through Service/AuthEncryption.
+func wipeBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
 // masterPassphrase reads the master passphrase from KEYORIX_MASTER_PASSWORD. It is
 // required only for the default "password" key provider; with the file/env
 // providers (ADR-038) the KEK comes from key material elsewhere, so it returns ""

--- a/internal/cli/encryption/g62_auth_encryption_lock_test.go
+++ b/internal/cli/encryption/g62_auth_encryption_lock_test.go
@@ -1,0 +1,233 @@
+package encryption
+
+// g62_auth_encryption_lock_test.go — regression tests for G62 member 3:
+// auth-encryption status/enable/migrate/validate never took the cross-process
+// key-lock the sibling DEK commands (status/validate/fix-perms/upgrade-aad,
+// see local_key_lock_test.go) and the sibling encryption commands
+// (migrate-provider, rotate) were deliberately built to require — letting a
+// concurrent migrate-provider/rotate race them. `auth-encryption rotate` is
+// deliberately NOT covered here: it delegates straight to
+// Service.RotateDEKWithSweep, which already acquires the exclusive lock itself.
+//
+// Follows the exact structure of TestValidateWithConfig_RefusedWhileServerHoldsLock
+// / TestValidateWithConfig_SucceedsWithNoServerOrRotationRunning in
+// local_key_lock_test.go: a "server" Service acquires the exclusive dek.lock
+// first, and the *WithConfig testable core under test must be refused while it
+// holds it, then succeed once released.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	enc "github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+const authLockTestPassphrase = "auth-encryption-lock-test-passphrase-123"
+
+// newAuthLockTestConfig builds a cfg pointing at workDir for both the key
+// directory (AuthEncryption's baseDir is "." — the CLI always resolves it from
+// cwd, so callers must t.Chdir(workDir) first) and a local sqlite database
+// file, and sets KEYORIX_MASTER_PASSWORD so masterPassphrase() succeeds.
+func newAuthLockTestConfig(t *testing.T, workDir string) *config.Config {
+	t.Helper()
+	t.Setenv("KEYORIX_MASTER_PASSWORD", authLockTestPassphrase)
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Database.Path = filepath.Join(workDir, "secrets.db")
+	cfg.Storage.Encryption = config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "kek.salt",
+	}
+	return cfg
+}
+
+// provisionAuthLockTestDB creates the sqlite file at cfg's configured path and
+// migrates the tables migrate/validate query, mirroring an already-initialized
+// production database. Opened and closed independently of the *WithConfig call
+// under test, which opens its own connection via openDatabase(cfg).
+func provisionAuthLockTestDB(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	db, err := storage.OpenGormDB(cfg)
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.APIClient{}, &models.Session{}, &models.APIToken{}, &models.PasswordReset{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	if sqlDB, err := db.DB(); err == nil {
+		_ = sqlDB.Close()
+	}
+}
+
+// provisionAuthLockTestKeys generates the key material up front (mirrors
+// `keyorix encryption init`/a prior `auth-encryption enable` run having
+// already happened against this directory).
+func provisionAuthLockTestKeys(t *testing.T, cfg *config.Config, workDir string) {
+	t.Helper()
+	setup := enc.NewService(&cfg.Storage.Encryption, workDir)
+	if err := setup.Initialize(authLockTestPassphrase); err != nil {
+		t.Fatalf("failed to provision key material: %v", err)
+	}
+	setup.Shutdown()
+}
+
+// acquireSimulatedServerLock starts a Service against workDir and has it take
+// the exclusive dek.lock, simulating a live server (or an in-progress
+// rotation/migrate-provider — all three hold the identical lock). Callers must
+// defer the returned Service's Shutdown() to release it.
+func acquireSimulatedServerLock(t *testing.T, cfg *config.Config, workDir string) *enc.Service {
+	t.Helper()
+	serverSvc := enc.NewService(&cfg.Storage.Encryption, workDir)
+	if err := serverSvc.Initialize(authLockTestPassphrase); err != nil {
+		t.Fatalf("failed to initialize simulated server: %v", err)
+	}
+	if err := serverSvc.AcquireExclusiveKeyLock(); err != nil {
+		t.Fatalf("simulated server failed to acquire the exclusive key lock: %v", err)
+	}
+	return serverSvc
+}
+
+// ─── migrate ───────────────────────────────────────────────────────────────
+
+// TestMigrateAuthDataWithConfig_RefusedWhileServerHoldsLock is the direct
+// regression test for G62 member 3's detection idea: `auth-encryption migrate`
+// must be refused, not silently proceed, while a live server (or an
+// in-progress rotation/migrate-provider) holds the exclusive key lock.
+func TestMigrateAuthDataWithConfig_RefusedWhileServerHoldsLock(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	cfg := newAuthLockTestConfig(t, workDir)
+	provisionAuthLockTestDB(t, cfg)
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	serverSvc := acquireSimulatedServerLock(t, cfg, workDir)
+	defer serverSvc.Shutdown()
+
+	err := migrateAuthDataWithConfig(cfg, false)
+	if err == nil {
+		t.Fatal("expected auth-encryption migrate to be refused while a live server holds the exclusive key lock")
+	}
+	if !strings.Contains(err.Error(), "exclusively") {
+		t.Errorf("expected a clear, actionable error mentioning the exclusive holder, got: %v", err)
+	}
+}
+
+// TestMigrateAuthDataWithConfig_SucceedsWithNoServerOrRotationRunning is the
+// non-regression control: ordinary, single-invocation `auth-encryption
+// migrate` usage (no server running, no rotation in progress) must not be
+// broken by requiring a lock that's never actually contended in that case.
+func TestMigrateAuthDataWithConfig_SucceedsWithNoServerOrRotationRunning(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	cfg := newAuthLockTestConfig(t, workDir)
+	provisionAuthLockTestDB(t, cfg)
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	if err := migrateAuthDataWithConfig(cfg, false); err != nil {
+		t.Fatalf("expected auth-encryption migrate to succeed with no server/rotation running, got: %v", err)
+	}
+}
+
+// ─── validate ──────────────────────────────────────────────────────────────
+
+func TestValidateAuthEncryptionWithConfig_RefusedWhileServerHoldsLock(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	cfg := newAuthLockTestConfig(t, workDir)
+	provisionAuthLockTestDB(t, cfg)
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	serverSvc := acquireSimulatedServerLock(t, cfg, workDir)
+	defer serverSvc.Shutdown()
+
+	err := validateAuthEncryptionWithConfig(cfg, false)
+	if err == nil {
+		t.Fatal("expected auth-encryption validate to be refused while a live server holds the exclusive key lock")
+	}
+	if !strings.Contains(err.Error(), "exclusively") {
+		t.Errorf("expected a clear, actionable error mentioning the exclusive holder, got: %v", err)
+	}
+}
+
+func TestValidateAuthEncryptionWithConfig_SucceedsWithNoServerOrRotationRunning(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	cfg := newAuthLockTestConfig(t, workDir)
+	provisionAuthLockTestDB(t, cfg)
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	if err := validateAuthEncryptionWithConfig(cfg, false); err != nil {
+		t.Fatalf("expected auth-encryption validate to succeed with no server/rotation running, got: %v", err)
+	}
+}
+
+// ─── status ────────────────────────────────────────────────────────────────
+
+func TestAuthStatusWithConfig_RefusedWhileServerHoldsLock(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	cfg := newAuthLockTestConfig(t, workDir)
+	provisionAuthLockTestDB(t, cfg)
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	serverSvc := acquireSimulatedServerLock(t, cfg, workDir)
+	defer serverSvc.Shutdown()
+
+	err := authStatusWithConfig(cfg)
+	if err == nil {
+		t.Fatal("expected auth-encryption status to be refused while a live server holds the exclusive key lock")
+	}
+	if !strings.Contains(err.Error(), "exclusively") {
+		t.Errorf("expected a clear, actionable error mentioning the exclusive holder, got: %v", err)
+	}
+}
+
+func TestAuthStatusWithConfig_SucceedsWithNoServerOrRotationRunning(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	cfg := newAuthLockTestConfig(t, workDir)
+	provisionAuthLockTestDB(t, cfg)
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	if err := authStatusWithConfig(cfg); err != nil {
+		t.Fatalf("expected auth-encryption status to succeed with no server/rotation running, got: %v", err)
+	}
+}
+
+// ─── enable ────────────────────────────────────────────────────────────────
+
+func TestEnableAuthEncryptionWithConfig_RefusedWhileServerHoldsLock(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	cfg := newAuthLockTestConfig(t, workDir)
+	provisionAuthLockTestDB(t, cfg)
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	serverSvc := acquireSimulatedServerLock(t, cfg, workDir)
+	defer serverSvc.Shutdown()
+
+	err := enableAuthEncryptionWithConfig(cfg, false)
+	if err == nil {
+		t.Fatal("expected auth-encryption enable to be refused while a live server holds the exclusive key lock")
+	}
+	if !strings.Contains(err.Error(), "exclusively") {
+		t.Errorf("expected a clear, actionable error mentioning the exclusive holder, got: %v", err)
+	}
+}
+
+func TestEnableAuthEncryptionWithConfig_SucceedsWithNoServerOrRotationRunning(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	cfg := newAuthLockTestConfig(t, workDir)
+	provisionAuthLockTestDB(t, cfg)
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	if err := enableAuthEncryptionWithConfig(cfg, false); err != nil {
+		t.Fatalf("expected auth-encryption enable to succeed with no server/rotation running, got: %v", err)
+	}
+}

--- a/internal/cli/encryption/migrate_provider.go
+++ b/internal/cli/encryption/migrate_provider.go
@@ -434,6 +434,17 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
+	// O_TRUNC keeps a pre-existing destination's mode untouched — the 0600 passed to
+	// OpenFile above only applies when the file is freshly created. Without this
+	// explicit Chmod, re-running migrate-provider (or restoreBackup) against a dst
+	// that already existed with a looser mode (e.g. a DEK/backup path left
+	// world-readable by an older build, or created under a permissive umask) would
+	// silently keep serving that looser mode to the re-wrapped/restored key material
+	// (G68). Mirrors securefiles.SecureWriteFile/SecureWriteFileSync.
+	if cerr := f.Chmod(0600); cerr != nil {
+		_ = f.Close()
+		return cerr
+	}
 	if _, werr := f.Write(data); werr != nil {
 		_ = f.Close()
 		return werr

--- a/internal/cli/encryption/migrate_provider_test.go
+++ b/internal/cli/encryption/migrate_provider_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -51,6 +52,74 @@ func TestCopyFile_RefusesSymlinkDestination(t *testing.T) {
 	}
 	if string(got) != sentinelContent {
 		t.Fatalf("sentinel file was clobbered through the symlink: got %q, want %q", got, sentinelContent)
+	}
+}
+
+// TestCopyFile_NewDestinationRestrictiveModeRegardlessOfUmask — regression test for
+// G68: copyFile writes DEK/key material (the pre-migration wrapped-DEK backup, and
+// the restoreBackup path), so a freshly-created destination must end up at mode 0600
+// even under a permissive process umask (0022), not whatever OpenFile's perm
+// argument would otherwise be masked down to.
+func TestCopyFile_NewDestinationRestrictiveModeRegardlessOfUmask(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.key")
+	if err := os.WriteFile(src, []byte("wrapped-dek-bytes"), 0600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	dst := filepath.Join(dir, "dst.key")
+
+	oldUmask := syscall.Umask(0o022)
+	defer syscall.Umask(oldUmask)
+
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("expected new destination mode 0600 regardless of umask, got %o", perm)
+	}
+}
+
+// TestCopyFile_EnforcesModeOnPreexistingDestination — the finding (G68) specifically
+// calls out that copyFile's os.OpenFile mode argument only applies when the
+// destination is freshly created; O_TRUNC leaves an EXISTING file's mode untouched.
+// A stale world-readable destination (e.g. a leftover DEK/backup path from an older
+// build, or one created under a permissive umask before this fix) must be tightened
+// to 0600 when copyFile writes new key material over it, not left as-is.
+func TestCopyFile_EnforcesModeOnPreexistingDestination(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.key")
+	if err := os.WriteFile(src, []byte("new-wrapped-dek-bytes"), 0600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	dst := filepath.Join(dir, "dst.key")
+	// Pre-create the destination with a world-readable mode.
+	if err := os.WriteFile(dst, []byte("stale-content"), 0o644); err != nil {
+		t.Fatalf("write pre-existing dst: %v", err)
+	}
+
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("expected pre-existing destination mode to be tightened to 0600, got %o", perm)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != "new-wrapped-dek-bytes" {
+		t.Fatalf("expected copy to overwrite content, got %q", got)
 	}
 }
 

--- a/internal/cli/encryption/rotate_kek.go
+++ b/internal/cli/encryption/rotate_kek.go
@@ -106,14 +106,20 @@ func rotateKEKWithConfig(cfg *config.Config, confirm bool) error {
 		return fmt.Errorf("KEK rotation failed: %w", err)
 	}
 
-	_, eskID, ok := service.EvidenceSignKey()
+	// EvidenceSignKey/AuditCheckpointKey return fresh copies of the raw 32-byte
+	// HMAC key material (KeyManager.GetEvidenceSignKey/GetAuditCheckpointKey) —
+	// only the fingerprint is needed here, so wipe each copy immediately rather
+	// than letting it sit unwiped in memory until the GC gets to it.
+	eskKey, eskID, ok := service.EvidenceSignKey()
 	if !ok {
 		eskID = "(unavailable)"
 	}
-	_, ackID, ok := service.AuditCheckpointKey()
+	wipeBytes(eskKey)
+	ackKey, ackID, ok := service.AuditCheckpointKey()
 	if !ok {
 		ackID = "(unavailable)"
 	}
+	wipeBytes(ackKey)
 
 	fmt.Println("KEK rotation complete.")
 	fmt.Println()

--- a/internal/cli/encryption/shamir_split.go
+++ b/internal/cli/encryption/shamir_split.go
@@ -56,6 +56,10 @@ unrecoverable. Store shares separately and back them up.`,
 		if _, err := cryptorand.Read(kek); err != nil {
 			return fmt.Errorf("generate KEK: %w", err)
 		}
+		// The KEK is genuine, maximally sensitive key material — this command's own
+		// doc comment promises it is "NEVER printed or stored". Wipe it from memory
+		// once split/committed below, rather than leaving it for the GC.
+		defer wipeBytes(kek)
 		shares, err := crypto.SplitKEK(kek, ssShares, ssThreshold)
 		if err != nil {
 			return err

--- a/internal/cli/invite/resend.go
+++ b/internal/cli/invite/resend.go
@@ -42,6 +42,9 @@ var resendCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("invitation %d not found", resendID)
 		}
+		if err := requireInviteAuthority(ctx, service, actorID, inv.ProjectID); err != nil {
+			return err
+		}
 		prov, err := service.ResendInvitationLink(ctx, inv.ProjectID, resendID, actorID)
 		if err != nil {
 			return fmt.Errorf("failed to resend invitation link: %w", err)

--- a/internal/cli/invite/revoke.go
+++ b/internal/cli/invite/revoke.go
@@ -47,6 +47,9 @@ func runRevoke(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("invitation %d not found", revokeID)
 	}
+	if err := requireInviteAuthority(ctx, service, actorID, inv.ProjectID); err != nil {
+		return err
+	}
 	if err := service.RevokeInvitation(ctx, inv.ProjectID, revokeID, actorID); err != nil {
 		return fmt.Errorf("failed to revoke invitation: %w", err)
 	}

--- a/internal/cli/machine/machine.go
+++ b/internal/cli/machine/machine.go
@@ -17,6 +17,7 @@ package machine
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -102,13 +103,31 @@ func fetchMachineIdentities(ctx context.Context, projectID uint) ([]*models.Mach
 }
 
 // findMachineByRef finds a machine identity in a project by numeric ID or name.
+//
+// A ref that parses as a valid numeric ID is ALWAYS resolved as an ID lookup —
+// it never falls through to a Name match, even if no identity has that ID. The
+// server enforces no uniqueness between the Name and ID spaces (a purely
+// numeric Name like "5" is accepted), so an attacker-planted decoy identity
+// named after a real target's numeric ID could otherwise shadow the intended
+// machine and get resolved instead — silently redirecting destructive
+// operations (revoke/suspend) and defeating their typed-name confirmation
+// step, since the confirmation prompt echoes back the (decoy) match's own
+// Name, which trivially equals what the operator already typed (G78).
 func findMachineByRef(ctx context.Context, projectID uint, ref string) (*models.MachineIdentity, error) {
 	identities, err := fetchMachineIdentities(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list machine identities: %w", err)
 	}
+	if id, err := strconv.ParseUint(ref, 10, 64); err == nil {
+		for _, m := range identities {
+			if uint64(m.ID) == id {
+				return m, nil
+			}
+		}
+		return nil, fmt.Errorf("machine identity %q not found in project", ref)
+	}
 	for _, m := range identities {
-		if m.Name == ref || fmt.Sprintf("%d", m.ID) == ref {
+		if m.Name == ref {
 			return m, nil
 		}
 	}

--- a/internal/cli/machine/machine_s22_test.go
+++ b/internal/cli/machine/machine_s22_test.go
@@ -155,6 +155,61 @@ func TestFindMachineByRef_S22_ByNumericID(t *testing.T) {
 	assert.Equal(t, "ci-bot", m.Name)
 }
 
+// TestFindMachineByRef_S22_NumericRefNeverShadowedByDecoyName regression-tests
+// G78: the server enforces no uniqueness tying a machine identity's Name to
+// the ID space, so a purely-numeric Name like "5" is legal. Before the fix,
+// findMachineByRef scanned for the first entry where Name == ref OR
+// string(ID) == ref, so an attacker-planted decoy identity named "5" could
+// shadow the real machine whose numeric ID is 5 — silently redirecting
+// destructive operations (revoke/suspend) that reference it by ID, and
+// defeating their typed-name confirmation step (the prompt would echo back
+// the decoy's own Name, which trivially matches what the operator typed).
+// The decoy is listed FIRST so a naive first-match scan would pick it.
+func TestFindMachineByRef_S22_NumericRefNeverShadowedByDecoyName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects/9/machine-identities":
+			_, _ = w.Write([]byte(`{"data":{"machine_identities":[` +
+				`{"id":99,"name":"5","identity_type":"ci","state":"active"},` +
+				`{"id":5,"name":"real-target","identity_type":"service","state":"active"}` +
+				`]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	m, err := findMachineByRef(context.Background(), 9, "5")
+	require.NoError(t, err)
+	assert.Equal(t, uint(5), m.ID, "a numeric ref must resolve to the matching numeric ID, never a decoy Name match")
+	assert.Equal(t, "real-target", m.Name)
+}
+
+// TestFindMachineByRef_S22_NonNumericRefStillMatchesByName confirms the fix
+// does not break the legitimate Name-lookup case: a ref that does NOT parse
+// as a numeric ID must still resolve by exact Name match.
+func TestFindMachineByRef_S22_NonNumericRefStillMatchesByName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects/9/machine-identities":
+			_, _ = w.Write([]byte(`{"data":{"machine_identities":[` +
+				`{"id":5,"name":"ci-runner","identity_type":"ci","state":"active"}` +
+				`]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	m, err := findMachineByRef(context.Background(), 9, "ci-runner")
+	require.NoError(t, err)
+	assert.Equal(t, uint(5), m.ID)
+}
+
 // ── runList — empty project ───────────────────────────────────────────────────
 
 // TestRunList_S22_EmptyProject exercises printMachineTable's "no identities"

--- a/internal/cli/rbac/export_matrix.go
+++ b/internal/cli/rbac/export_matrix.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 	"text/tabwriter"
 	"time"
 
@@ -64,12 +65,34 @@ type remoteMatrixRow struct {
 	ExpiresAt       *time.Time `json:"expires_at"`
 }
 
+// openSecureOutputFile opens path for the --output file. The permission
+// matrix is deployment-wide access-control data (usernames, emails, every
+// user/role/permission/scope tuple) — sensitive enough that it must never
+// land on disk world/group-readable, regardless of the process umask (G68).
+// O_TRUNC alone keeps a pre-existing file's mode untouched, so the perm
+// argument to OpenFile only takes effect when the file is freshly created;
+// the explicit Chmod below enforces 0600 even when --output points at an
+// already-existing (possibly world-readable) path. O_NOFOLLOW refuses to
+// write through a final-component symlink. Mirrors
+// securefiles.SecureWriteFile/SecureWriteFileSync.
+func openSecureOutputFile(path string) (*os.File, error) {
+	f, err := os.OpenFile(filepath.Clean(path), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0o600) // #nosec G304 -- operator-supplied CLI output path, not attacker input
+	if err != nil {
+		return nil, err
+	}
+	if cerr := f.Chmod(0o600); cerr != nil {
+		_ = f.Close()
+		return nil, cerr
+	}
+	return f, nil
+}
+
 func runExportMatrix(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	out := io.Writer(os.Stdout)
 	if exportMatrixOutput != "" {
-		f, err := os.Create(filepath.Clean(exportMatrixOutput))
+		f, err := openSecureOutputFile(exportMatrixOutput)
 		if err != nil {
 			return fmt.Errorf("failed to open output file: %w", err)
 		}

--- a/internal/cli/rbac/export_matrix_test.go
+++ b/internal/cli/rbac/export_matrix_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -724,6 +725,65 @@ func TestExportMatrix_EmbeddedInitStorageError(t *testing.T) {
 	err := runExportMatrix(exportMatrixCmd, nil)
 	// The error may come from config.Load or factory.CreateStorage.
 	require.Error(t, err, "missing config must cause InitializeStorage error")
+}
+
+// TestExportMatrix_OutputFileRestrictiveModeRegardlessOfUmask — regression test for
+// G68: `rbac export-matrix --output` must write its file at mode 0600 even when the
+// process umask would otherwise leave it group/world-readable (a permissive 0022
+// umask, common on many systems, previously produced a 0644 file via the old bare
+// os.Create call). The matrix carries every user/role/permission/scope tuple
+// (usernames, emails) in the deployment, so a readable-by-default export is a real
+// disclosure risk.
+func TestExportMatrix_OutputFileRestrictiveModeRegardlessOfUmask(t *testing.T) {
+	setupEmbeddedMode(t)
+
+	dir := t.TempDir()
+	outPath := dir + "/matrix-perm-check.json"
+
+	prevFormat := exportMatrixFormat
+	prevProject := exportMatrixProject
+	prevOutput := exportMatrixOutput
+	t.Cleanup(func() {
+		exportMatrixFormat = prevFormat
+		exportMatrixProject = prevProject
+		exportMatrixOutput = prevOutput
+	})
+
+	exportMatrixFormat = "json"
+	exportMatrixProject = ""
+	exportMatrixOutput = outPath
+
+	oldUmask := syscall.Umask(0o022)
+	t.Cleanup(func() { syscall.Umask(oldUmask) })
+
+	err := runExportMatrix(exportMatrixCmd, nil)
+	require.NoError(t, err)
+
+	info, err := os.Stat(outPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+		"export-matrix --output file must be mode 0600 regardless of process umask")
+}
+
+// TestOpenSecureOutputFile_EnforcesModeOnPreexistingDestination — if --output points
+// at an already-existing, world-readable file (e.g. an old export from before this
+// fix, or one created by another tool under a permissive umask), openSecureOutputFile
+// must tighten its mode to 0600 rather than leaving it as-is: O_TRUNC alone keeps a
+// pre-existing file's mode untouched, so the 0600 passed to OpenFile only takes
+// effect at creation time.
+func TestOpenSecureOutputFile_EnforcesModeOnPreexistingDestination(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/existing.json"
+	require.NoError(t, os.WriteFile(path, []byte("stale"), 0o644))
+
+	f, err := openSecureOutputFile(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+		"pre-existing destination mode must be tightened to 0600")
 }
 
 // TestExportMatrix_EmbeddedProjectFound — project filter resolves successfully when

--- a/internal/cli/rbac/group_role.go
+++ b/internal/cli/rbac/group_role.go
@@ -272,7 +272,7 @@ func runAssignRoleToGroupRemote(ctx context.Context, rc *common.RemoteClient, gr
 		}
 		body["project_id"] = projectID
 		if env != "" {
-			envID, err := resolveEnvironmentIDByName(ctx, rc, env)
+			envID, err := resolveEnvironmentIDByName(ctx, rc, projectID, env)
 			if err != nil {
 				return err
 			}
@@ -313,7 +313,7 @@ func runRemoveRoleFromGroupRemote(ctx context.Context, rc *common.RemoteClient, 
 		}
 		params = append(params, fmt.Sprintf("project_id=%d", projectID))
 		if env != "" {
-			envID, err := resolveEnvironmentIDByName(ctx, rc, env)
+			envID, err := resolveEnvironmentIDByName(ctx, rc, projectID, env)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/rbac/rbac_scope_cov_test.go
+++ b/internal/cli/rbac/rbac_scope_cov_test.go
@@ -525,7 +525,7 @@ func TestResolveProjectIDByName_NotFound(t *testing.T) {
 // TestResolveEnvironmentIDByName_GETError verifies rc.Get error propagation.
 func TestResolveEnvironmentIDByName_GETError(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/projects/1/environments", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(`{"error":"down"}`))
 	})
@@ -533,7 +533,7 @@ func TestResolveEnvironmentIDByName_GETError(t *testing.T) {
 	t.Cleanup(srv.Close)
 	rc := remoteClientFor(t, srv)
 
-	_, err := resolveEnvironmentIDByName(context.Background(), rc, "any")
+	_, err := resolveEnvironmentIDByName(context.Background(), rc, 1, "any")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list environments")
 }
@@ -541,16 +541,50 @@ func TestResolveEnvironmentIDByName_GETError(t *testing.T) {
 // TestResolveEnvironmentIDByName_NotFound verifies not-found error.
 func TestResolveEnvironmentIDByName_NotFound(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/projects/1/environments", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"staging"}]}}`))
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	rc := remoteClientFor(t, srv)
 
-	_, err := resolveEnvironmentIDByName(context.Background(), rc, "production")
+	_, err := resolveEnvironmentIDByName(context.Background(), rc, 1, "production")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `"production" not found`)
+}
+
+// TestResolveEnvironmentIDByName_ScopedToProject verifies the resolver only
+// matches environments within the requested project's scope, never falling
+// back to a deployment-wide match — regression test for G78 (cross-project
+// scope confusion via resolveEnvironmentIDByName's former unscoped
+// GET /api/v1/environments listing).
+func TestResolveEnvironmentIDByName_ScopedToProject(t *testing.T) {
+	mux := http.NewServeMux()
+	// Two projects, each with an environment literally named "prod" but a
+	// different environment ID — the classic decoy-name-collision setup.
+	mux.HandleFunc("/api/v1/projects/1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":101,"name":"prod"}]}}`))
+	})
+	mux.HandleFunc("/api/v1/projects/2/environments", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":202,"name":"prod"}]}}`))
+	})
+	// The deployment-wide listing must never be consulted by the fixed
+	// resolver; if it is, resolving project A's "prod" here would wrongly
+	// pick up project B's environment ID.
+	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":202,"name":"prod"},{"id":101,"name":"prod"}]}}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	rc := remoteClientFor(t, srv)
+
+	envID, err := resolveEnvironmentIDByName(context.Background(), rc, 1, "prod")
+	require.NoError(t, err)
+	assert.Equal(t, uint(101), envID, "must resolve project A's own \"prod\" environment, never project B's")
+
+	envID, err = resolveEnvironmentIDByName(context.Background(), rc, 2, "prod")
+	require.NoError(t, err)
+	assert.Equal(t, uint(202), envID, "must resolve project B's own \"prod\" environment, never project A's")
 }
 
 // ── runRemoveRoleRemote project+env path ──────────────────────────────────────
@@ -568,7 +602,7 @@ func TestRunRemoveRoleRemote_WithProjectAndEnv(t *testing.T) {
 	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":3,"name":"myproject"}]}}`))
 	})
-	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/projects/3/environments", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":7,"name":"production"}]}}`))
 	})
 	mux.HandleFunc("/api/v1/user-roles", func(w http.ResponseWriter, r *http.Request) {
@@ -620,7 +654,7 @@ func TestRunAssignRoleRemote_EnvError(t *testing.T) {
 	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":3,"name":"myproject"}]}}`))
 	})
-	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/projects/3/environments", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 	srv := httptest.NewServer(mux)
@@ -937,7 +971,7 @@ func TestRunAssignRoleToGroupRemote_EnvError(t *testing.T) {
 	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"production"}]}}`))
 	})
-	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/projects/5/environments", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 	srv := httptest.NewServer(mux)
@@ -1015,7 +1049,7 @@ func TestRunRemoveRoleFromGroupRemote_EnvError(t *testing.T) {
 	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"production"}]}}`))
 	})
-	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/projects/5/environments", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 	srv := httptest.NewServer(mux)
@@ -1071,7 +1105,7 @@ func TestRunRemoveRoleRemote_EnvError(t *testing.T) {
 	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":3,"name":"myproject"}]}}`))
 	})
-	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/projects/3/environments", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 	srv := httptest.NewServer(mux)
@@ -1429,7 +1463,7 @@ func TestRunRemoveRoleFromGroupRemote_WithEnv(t *testing.T) {
 	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"production"}]}}`))
 	})
-	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/projects/5/environments", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":9,"name":"prod"}]}}`))
 	})
 	mux.HandleFunc("/api/v1/groups/7/roles/2", func(w http.ResponseWriter, r *http.Request) {
@@ -1498,7 +1532,7 @@ func TestRunAssignRoleToGroupRemote_WithProjectAndEnv(t *testing.T) {
 	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"production"}]}}`))
 	})
-	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/projects/5/environments", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":9,"name":"prod"}]}}`))
 	})
 	mux.HandleFunc("/api/v1/groups/7/roles", func(w http.ResponseWriter, r *http.Request) {
@@ -1570,7 +1604,7 @@ func TestRunRemoveRoleFromGroupRemote_WithEnvSuccess(t *testing.T) {
 	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":5,"name":"prod"}]}}`))
 	})
-	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/projects/5/environments", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":9,"name":"staging"}]}}`))
 	})
 	mux.HandleFunc("/api/v1/groups/7/roles/2", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cli/rbac/rbac_scope_test.go
+++ b/internal/cli/rbac/rbac_scope_test.go
@@ -207,7 +207,7 @@ func TestRunAssignRoleRemote_WithProjectAndEnv(t *testing.T) {
 	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"projects":[{"id":3,"name":"staging"}]}}`))
 	})
-	mux.HandleFunc("/api/v1/environments", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/projects/3/environments", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"environments":[{"id":2,"name":"dev"}]}}`))
 	})
 	mux.HandleFunc("/api/v1/user-roles", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cli/rbac/remote.go
+++ b/internal/cli/rbac/remote.go
@@ -42,15 +42,26 @@ func resolveProjectIDByName(ctx context.Context, rc *common.RemoteClient, name s
 	return 0, fmt.Errorf("project %q not found — run 'keyorix project list' to see available projects", name)
 }
 
-// resolveEnvironmentIDByName finds an environment's ID by name via GET /api/v1/environments.
-func resolveEnvironmentIDByName(ctx context.Context, rc *common.RemoteClient, name string) (uint, error) {
+// resolveEnvironmentIDByName finds an environment's ID by name WITHIN a
+// specific project, via the project-scoped GET /api/v1/projects/{id}/environments.
+//
+// This must NOT fall back to the deployment-wide GET /api/v1/environments
+// listing: that endpoint returns every environment across every project, and
+// picking the first case-insensitive name match against it resolves cross-
+// project — e.g. an "assign-role --project A --environment prod" grant could
+// silently resolve to project B's "prod" environment if it happened to sort
+// first, granting/removing access in the wrong project's scope (G78). A name
+// that doesn't exist within the target project's scope is refused, never
+// silently widened to a deployment-wide match.
+func resolveEnvironmentIDByName(ctx context.Context, rc *common.RemoteClient, projectID uint, name string) (uint, error) {
 	var resp struct {
 		Environments []struct {
 			ID   uint   `json:"id"`
 			Name string `json:"name"`
 		} `json:"environments"`
 	}
-	if err := rc.Get(ctx, "/api/v1/environments", &resp); err != nil {
+	path := fmt.Sprintf("/api/v1/projects/%d/environments", projectID)
+	if err := rc.Get(ctx, path, &resp); err != nil {
 		return 0, fmt.Errorf("failed to list environments: %w", err)
 	}
 	for _, e := range resp.Environments {
@@ -58,7 +69,7 @@ func resolveEnvironmentIDByName(ctx context.Context, rc *common.RemoteClient, na
 			return e.ID, nil
 		}
 	}
-	return 0, fmt.Errorf("environment %q not found", name)
+	return 0, fmt.Errorf("environment %q not found in project", name)
 }
 
 // resolveUserIDByEmail finds a user's ID by email via GET /api/v1/users.
@@ -254,7 +265,7 @@ func runAssignRoleRemote(ctx context.Context, rc *common.RemoteClient, email, ro
 		}
 		body["project_id"] = projectID
 		if env != "" {
-			envID, err := resolveEnvironmentIDByName(ctx, rc, env)
+			envID, err := resolveEnvironmentIDByName(ctx, rc, projectID, env)
 			if err != nil {
 				return err
 			}
@@ -291,7 +302,7 @@ func runRemoveRoleRemote(ctx context.Context, rc *common.RemoteClient, email, ro
 		}
 		body["project_id"] = projectID
 		if env != "" {
-			envID, err := resolveEnvironmentIDByName(ctx, rc, env)
+			envID, err := resolveEnvironmentIDByName(ctx, rc, projectID, env)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/request/bulk.go
+++ b/internal/cli/request/bulk.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/spf13/cobra"
 )
 
@@ -139,9 +140,11 @@ var rejectionTemplatesCmd = &cobra.Command{
 }
 
 var (
-	tmplName   string
-	tmplReason string
-	tmplBy     string
+	tmplName     string
+	tmplReason   string
+	tmplBy       string
+	tmplListBy   string
+	tmplDeleteBy string
 )
 
 var tmplListCmd = &cobra.Command{
@@ -171,6 +174,12 @@ func init() {
 	_ = tmplAddCmd.MarkFlagRequired("reason")
 	_ = tmplAddCmd.MarkFlagRequired("by")
 
+	tmplListCmd.Flags().StringVar(&tmplListBy, "by", "", "Acting admin email address (required, for authorization)")
+	_ = tmplListCmd.MarkFlagRequired("by")
+
+	tmplDeleteCmd.Flags().StringVar(&tmplDeleteBy, "by", "", "Acting admin email address (required, for authorization and audit)")
+	_ = tmplDeleteCmd.MarkFlagRequired("by")
+
 	rejectionTemplatesCmd.AddCommand(tmplListCmd)
 	rejectionTemplatesCmd.AddCommand(tmplAddCmd)
 	rejectionTemplatesCmd.AddCommand(tmplDeleteCmd)
@@ -182,6 +191,14 @@ func runTmplList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	ctx := context.Background()
+
+	viewerID, err := resolveUserID(ctx, service, tmplListBy)
+	if err != nil {
+		return err
+	}
+	if err := requireTemplateAuthority(ctx, service, viewerID); err != nil {
+		return err
+	}
 
 	templates, err := service.ListRejectionReasonTemplates(ctx)
 	if err != nil {
@@ -208,6 +225,9 @@ func runTmplAdd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if err := requireTemplateAuthority(ctx, service, creatorID); err != nil {
+		return err
+	}
 
 	t, err := service.CreateRejectionReasonTemplate(ctx, creatorID, tmplName, tmplReason)
 	if err != nil {
@@ -228,10 +248,43 @@ func runTmplDelete(cmd *cobra.Command, args []string) error {
 	}
 	ctx := context.Background()
 
-	if err := service.DeleteRejectionReasonTemplate(ctx, uint(id)); err != nil {
+	deleterID, err := resolveUserID(ctx, service, tmplDeleteBy)
+	if err != nil {
+		return err
+	}
+	if err := requireTemplateAuthority(ctx, service, deleterID); err != nil {
+		return err
+	}
+
+	if err := service.DeleteRejectionReasonTemplate(ctx, deleterID, uint(id)); err != nil {
 		return fmt.Errorf("failed to delete template: %w", err)
 	}
 	fmt.Printf("Template %d deleted.\n", id)
+	return nil
+}
+
+// requireTemplateAuthority verifies that actorID — the user resolved from
+// --by — actually holds the authority the equivalent HTTP routes require for
+// rejection-reason-template management: POST/GET/DELETE
+// /rejection-reason-templates are all gated on a global roles.assign (see
+// router.go; unlike access-request review, templates are not project-scoped,
+// so the check here uses the global Scope{}). The local CLI has no
+// session/middleware to enforce this, so --by resolving ANY email — with zero
+// authority check — would let an operator add, list, or delete rejection
+// reason templates by naming an arbitrary or unprivileged account.
+// CreateRejectionReasonTemplate/ListRejectionReasonTemplates/
+// DeleteRejectionReasonTemplate themselves do not check permissions (the HTTP
+// handler's job is done by router middleware), so this must be verified here,
+// at the CLI entrypoint, before the resolved actor is credited with the
+// action. Sibling of requireReviewAuthority/requireInviteAuthority (#264/#491).
+func requireTemplateAuthority(ctx context.Context, svc *core.KeyorixCore, actorID uint) error {
+	ok, err := svc.Authorize(ctx, actorID, "roles.assign", core.Scope{})
+	if err != nil {
+		return fmt.Errorf("failed to verify --by authority: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("--by actor does not hold roles.assign; refusing to attribute this action to them")
+	}
 	return nil
 }
 

--- a/internal/cli/request/bulk_s1_test.go
+++ b/internal/cli/request/bulk_s1_test.go
@@ -152,6 +152,12 @@ func TestRunTmplList_EmptySuccess(t *testing.T) {
 	_, _, svc := seedBulkApproveDB(t)
 	_ = svc // DB is seeded; RejectionReasonTemplate table exists
 
+	// #G72: runTmplList now requires --by and verifies roles.assign; the
+	// bootstrap admin seeded by seedBulkApproveDB is authorized.
+	origBy := tmplListBy
+	defer func() { tmplListBy = origBy }()
+	tmplListBy = "admin@example.com"
+
 	require.NoError(t, runTmplList(nil, nil))
 }
 
@@ -167,6 +173,12 @@ func TestRunTmplList_WithData(t *testing.T) {
 		Name: "not-qualified", Reason: "Does not meet requirements.",
 	})
 	require.NoError(t, err)
+
+	// #G72: runTmplList now requires --by and verifies roles.assign; the
+	// bootstrap admin seeded by seedBulkApproveDB is authorized.
+	origBy := tmplListBy
+	defer func() { tmplListBy = origBy }()
+	tmplListBy = "admin@example.com"
 
 	require.NoError(t, runTmplList(nil, nil))
 }
@@ -202,6 +214,12 @@ func TestRunTmplDelete_SuccessPath(t *testing.T) {
 	tmpl := &models.RejectionReasonTemplate{Name: "to-del", Reason: "gone"}
 	err := svc.Storage().CreateRejectionReasonTemplate(ctx, tmpl)
 	require.NoError(t, err)
+
+	// #G72: runTmplDelete now requires --by and verifies roles.assign; the
+	// bootstrap admin seeded by seedBulkApproveDB is authorized.
+	origBy := tmplDeleteBy
+	defer func() { tmplDeleteBy = origBy }()
+	tmplDeleteBy = "admin@example.com"
 
 	err = runTmplDelete(nil, []string{strconv.FormatUint(uint64(tmpl.ID), 10)})
 	require.NoError(t, err)

--- a/internal/cli/request/bulk_test.go
+++ b/internal/cli/request/bulk_test.go
@@ -36,28 +36,6 @@ func withFailingInitService(t *testing.T) {
 // bulkBrokenCounter avoids DSN collisions across parallel tests.
 var bulkBrokenCounter int
 
-// withBrokenDBService replaces bulkInitService with one that returns a
-// KeyorixCore backed by a closed SQLite connection (all storage calls fail).
-func withBrokenDBService(t *testing.T) {
-	t.Helper()
-	require.NoError(t, i18n.InitializeForTesting())
-	bulkBrokenCounter++
-	dsn := fmt.Sprintf("file:bulk_broken_%d?mode=memory&cache=shared", bulkBrokenCounter)
-	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
-	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(
-		&models.AccessRequest{},
-		&models.RejectionReasonTemplate{},
-	))
-	sqlDB, err := db.DB()
-	require.NoError(t, err)
-	require.NoError(t, sqlDB.Close())
-	svc := core.NewKeyorixCore(store.NewLocalStorage(db))
-	orig := bulkInitService
-	bulkInitService = func() (*core.KeyorixCore, error) { return svc, nil }
-	t.Cleanup(func() { bulkInitService = orig })
-}
-
 // withUserSeededPartialService returns a KeyorixCore backed by a SQLite DB
 // that has ONLY the users table migrated (not access_requests / templates),
 // with an admin user seeded. GetUserByEmail succeeds; bulk-access / template
@@ -391,7 +369,21 @@ func TestRunBulkReject_BulkRejectError(t *testing.T) {
 }
 
 func TestRunTmplList_ListError(t *testing.T) {
-	withBrokenDBService(t)
+	// #G72: runTmplList now verifies the --by actor holds roles.assign before
+	// calling ListRejectionReasonTemplates. withBrokenDBService's connection is
+	// closed for every query (including the new authority check itself), so it
+	// can no longer isolate a ListRejectionReasonTemplates-specific failure.
+	// Use the full RBAC-catalog fixture (bootstrap admin authorized) instead —
+	// it has no rejection_reason_templates table, so the call still fails at
+	// the intended step, preserving this test's original assertion.
+	origBy := tmplListBy
+	defer func() { tmplListBy = origBy }()
+	tmplListBy = "admin@example.com"
+	svc, _ := newTestRequestCore(t)
+	origInit := bulkInitService
+	bulkInitService = func() (*core.KeyorixCore, error) { return svc, nil }
+	t.Cleanup(func() { bulkInitService = origInit })
+
 	err := runTmplList(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list templates")
@@ -402,11 +394,22 @@ func TestRunTmplAdd_CreateError(t *testing.T) {
 	defer func() { tmplName = origName; tmplReason = origReason; tmplBy = origBy }()
 	tmplName = "x"
 	tmplReason = "y"
-	tmplBy = "partial@example.com"
-	// Service has only the users table — GetUserByEmail succeeds (user is seeded)
-	// but CreateRejectionReasonTemplate fails (no rejection_reason_templates table),
-	// triggering the error branch at lines 207-209.
-	withUserSeededPartialService(t, "partial@example.com")
+	// #G72: runTmplAdd now verifies the --by actor holds roles.assign before
+	// calling CreateRejectionReasonTemplate, so this needs a service with the
+	// full RBAC catalog seeded (newTestRequestCore's bootstrap admin), NOT the
+	// users-only withUserSeededPartialService fixture — that fixture has no
+	// role/permission tables at all, so the new authority check would fail
+	// closed on a missing-table error before ever reaching the create call.
+	// The bootstrap admin (global admin bypass) is authorized, so the flow
+	// still reaches CreateRejectionReasonTemplate, which fails (no
+	// rejection_reason_templates table), preserving this test's original
+	// intent: exercising the error branch at lines 207-209.
+	tmplBy = "admin@example.com"
+	svc, _ := newTestRequestCore(t)
+	origInit := bulkInitService
+	bulkInitService = func() (*core.KeyorixCore, error) { return svc, nil }
+	t.Cleanup(func() { bulkInitService = origInit })
+
 	err := runTmplAdd(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create template")

--- a/internal/cli/request/list.go
+++ b/internal/cli/request/list.go
@@ -5,10 +5,14 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/spf13/cobra"
 )
 
-var listProject string
+var (
+	listProject string
+	listBy      string
+)
 
 var listCmd = &cobra.Command{
 	Use:   "list",
@@ -19,6 +23,8 @@ var listCmd = &cobra.Command{
 
 func init() {
 	listCmd.Flags().StringVar(&listProject, "project", "", "Project name (or use KEYORIX_PROJECT / active project)")
+	listCmd.Flags().StringVar(&listBy, "by", "", "Acting admin email address (required, for authorization)")
+	_ = listCmd.MarkFlagRequired("by")
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -34,6 +40,14 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 	projectID, err := common.LookupProjectIDByName(ctx, service.Storage(), projectName)
 	if err != nil {
+		return err
+	}
+
+	viewerID, err := resolveUserID(ctx, service, listBy)
+	if err != nil {
+		return err
+	}
+	if err := requireListAuthority(ctx, service, viewerID, projectID); err != nil {
 		return err
 	}
 
@@ -55,6 +69,27 @@ func runList(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%-6d %-24s %-14s %-14s %-11s %-10s %s\n",
 			req.ID, userLabel(ctx, service, req.UserID), dashIfEmpty(req.SuggestedRole),
 			dashIfEmpty(req.GrantedRole), req.State, secretCol, dashIfEmpty(req.Reason))
+	}
+	return nil
+}
+
+// requireListAuthority verifies that actorID — the user resolved from --by —
+// actually holds the authority the equivalent HTTP route requires for this
+// exact operation: GET .../projects/{id}/access-requests is gated on
+// roles.assign scoped to the project (see router.go). The local CLI has no
+// session/middleware to enforce this, so --by resolving ANY email — with zero
+// authority check — would let an operator read a project's access-request
+// list (which surfaces who requested what, and why) purely by naming an
+// arbitrary or unprivileged account. ListAccessRequests itself does not check
+// permissions (the HTTP handler's job is done by router middleware), so this
+// must be verified here, at the CLI entrypoint, before the list is returned.
+func requireListAuthority(ctx context.Context, svc *core.KeyorixCore, actorID, projectID uint) error {
+	ok, err := svc.Authorize(ctx, actorID, "roles.assign", core.Scope{ProjectID: projectID})
+	if err != nil {
+		return fmt.Errorf("failed to verify --by authority: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("--by actor does not hold roles.assign at project %d; refusing to list access requests on their behalf", projectID)
 	}
 	return nil
 }

--- a/internal/cli/request/list_template_authority_test.go
+++ b/internal/cli/request/list_template_authority_test.go
@@ -1,0 +1,99 @@
+// list_template_authority_test.go — regression coverage for #G72: the --by
+// actor for `keyorix request list` and the rejection-reason-template
+// add/list/delete commands must actually hold the authority the equivalent
+// HTTP route requires (roles.assign), not merely resolve to SOME user
+// record. Mirrors review_authority_test.go's TestRequireReviewAuthority_*
+// shape, reusing this package's existing newTestRequestCore/seedUserWithRole
+// helpers.
+package request
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+// #G72: an actor holding only a read-only project role (no roles.assign)
+// must be refused — the CLI must not let --by attribute a project's
+// access-request list read to an unprivileged account.
+func TestRequireListAuthority_UnprivilegedActorRejected(t *testing.T) {
+	c, st := newTestRequestCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "list-viewer", "project_viewer", core.Scope{ProjectID: 1})
+
+	err := requireListAuthority(ctx, c, actor, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "roles.assign")
+}
+
+// #G72 positive control: an actor holding roles.assign at the project (the
+// equivalent HTTP route's requirement) must be allowed through.
+func TestRequireListAuthority_AuthorizedActorAllowed(t *testing.T) {
+	c, st := newTestRequestCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "list-admin", "project_admin", core.Scope{ProjectID: 1})
+
+	require.NoError(t, requireListAuthority(ctx, c, actor, 1))
+}
+
+// #G72 positive control: the bootstrap admin created by BootstrapSystem
+// itself (the realistic legitimate --by actor for this command) must pass
+// too.
+func TestRequireListAuthority_BootstrapAdminAllowed(t *testing.T) {
+	c, st := newTestRequestCore(t)
+	ctx := context.Background()
+	bootstrapAdmin, err := st.GetUserByEmail(ctx, "admin@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, requireListAuthority(ctx, c, bootstrapAdmin.ID, 1))
+}
+
+// #G72: rejection-reason templates are not project-scoped (unlike the review/
+// list checks above), so an actor holding roles.assign at a PROJECT scope —
+// not globally — must still be refused: the equivalent HTTP routes gate on a
+// global roles.assign.
+func TestRequireTemplateAuthority_ProjectScopedActorRejected(t *testing.T) {
+	c, st := newTestRequestCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "tmpl-project-admin", "project_admin", core.Scope{ProjectID: 1})
+
+	err := requireTemplateAuthority(ctx, c, actor)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "roles.assign")
+}
+
+// #G72: an actor holding only a read-only role must also be refused.
+func TestRequireTemplateAuthority_UnprivilegedActorRejected(t *testing.T) {
+	c, st := newTestRequestCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "tmpl-viewer", "project_viewer", core.Scope{ProjectID: 1})
+
+	err := requireTemplateAuthority(ctx, c, actor)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "roles.assign")
+}
+
+// #G72 positive control: an actor holding roles.assign at global scope (the
+// equivalent HTTP routes' requirement) must be allowed through.
+func TestRequireTemplateAuthority_GlobalActorAllowed(t *testing.T) {
+	c, st := newTestRequestCore(t)
+	ctx := context.Background()
+	actor := seedUserWithRole(t, st, "tmpl-admin", "system_admin", core.Scope{})
+
+	require.NoError(t, requireTemplateAuthority(ctx, c, actor))
+}
+
+// #G72 positive control: the bootstrap admin created by BootstrapSystem
+// itself must pass too.
+func TestRequireTemplateAuthority_BootstrapAdminAllowed(t *testing.T) {
+	c, st := newTestRequestCore(t)
+	ctx := context.Background()
+	bootstrapAdmin, err := st.GetUserByEmail(ctx, "admin@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, requireTemplateAuthority(ctx, c, bootstrapAdmin.ID))
+}

--- a/internal/cli/request/request_s24_test.go
+++ b/internal/cli/request/request_s24_test.go
@@ -34,6 +34,12 @@ func TestRunList_EmptyProject(t *testing.T) {
 	defer func() { listProject = orig }()
 	listProject = "testproj"
 
+	// #G72: runList now requires --by and verifies roles.assign before listing;
+	// the bootstrap admin seeded by seedRequestDB is authorized.
+	origBy := listBy
+	defer func() { listBy = origBy }()
+	listBy = "admin@example.com"
+
 	// Project exists, zero requests → must print "No access requests found."
 	// and return nil (not an error).
 	require.NoError(t, runList(nil, nil))

--- a/internal/cli/request/request_s3_test.go
+++ b/internal/cli/request/request_s3_test.go
@@ -128,6 +128,12 @@ func TestRunList_PrintsTable(t *testing.T) {
 	defer func() { listProject = orig }()
 	listProject = "testproj"
 
+	// #G72: runList now requires --by and verifies roles.assign before listing;
+	// the bootstrap admin seeded by seedRequestDB is authorized.
+	origBy := listBy
+	defer func() { listBy = origBy }()
+	listBy = "admin@example.com"
+
 	require.NoError(t, runList(nil, nil))
 }
 
@@ -155,6 +161,12 @@ func TestRunList_PrintsTableWithSecretID(t *testing.T) {
 	orig := listProject
 	defer func() { listProject = orig }()
 	listProject = "testproj"
+
+	// #G72: runList now requires --by and verifies roles.assign before listing;
+	// the bootstrap admin seeded by seedRequestDB is authorized.
+	origBy := listBy
+	defer func() { listBy = origBy }()
+	listBy = "admin@example.com"
 
 	require.NoError(t, runList(nil, nil))
 }

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -2,30 +2,17 @@ package run
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/spf13/cobra"
 )
-
-// maxAPIResponseBytes caps how much of a Keyorix server response body this
-// client will read into memory before decoding — the response here is a
-// project's secrets envelope, potentially a large list, so a generous cap is
-// used (matching the same 10MB idiom used elsewhere for Keyorix server
-// response decodes, e.g. internal/cli/common/remote_client.go). This bounds a
-// malicious or misbehaving server response from exhausting client memory via
-// an unbounded json.Decode of resp.Body.
-const maxAPIResponseBytes = 10 << 20 // 10MB
 
 var (
 	runEnv      string
@@ -80,6 +67,17 @@ func init() {
 }
 
 func runRun(cmd *cobra.Command, args []string) error {
+	// context.Background() with NO deadline attached: matches the other 100+
+	// common.RemoteClient call sites across this CLI (secret/rbac/machine/rotation/
+	// project/dynamic, etc — see NewRemoteClient's own comment). The hang protection
+	// against a stalled/malicious KEYORIX_SERVER comes from common.RemoteClient's
+	// per-request http.Client.Timeout (fetchSecretsRemote below), not a context
+	// deadline: fetchSecretsRemote pages through and fetches every secret in the
+	// project/environment (up to maxRunInjectedSecrets) as a sequence of individual
+	// requests, so a single fixed *total* deadline here would risk aborting a
+	// legitimately large — but healthy — fetch partway through. The child process
+	// execChild launches afterwards is unaffected either way: it takes no context and
+	// is free to run indefinitely, matching 'keyorix run's interactive/streaming design.
 	ctx := context.Background()
 
 	// Resolve project via ADR-016 chain: --project → KEYORIX_PROJECT → cli.yaml → "default"
@@ -190,72 +188,24 @@ func fetchSecretsEmbedded(ctx context.Context, project, env string) (map[string]
 
 // ── Remote / client mode ──────────────────────────────────────────────────────
 
-// apiClient makes authenticated requests to the Keyorix HTTP API.
-type apiClient struct {
-	endpoint string
-	token    string
-	http     *http.Client
-}
-
-// refuseRedirect stops apiClient from following any redirect: without this, a
-// 3xx response from the configured server could bounce the bearer-token-bearing
-// request to an internal host (e.g. cloud IMDS) at request time (CWE-918).
-func refuseRedirect(req *http.Request, _ []*http.Request) error {
-	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
-}
-
-// get performs a GET, strips the {"data":…} wrapper, and unmarshals into out.
-func (c *apiClient) get(ctx context.Context, path string, out interface{}) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+path, nil)
-	if err != nil {
-		return fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return fmt.Errorf("request: %w", err)
-	}
-	defer resp.Body.Close() //nolint:errcheck
-
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
-	}
-
-	var envelope struct {
-		Data json.RawMessage `json:"data"`
-	}
-	if err := json.NewDecoder(io.LimitReader(resp.Body, maxAPIResponseBytes)).Decode(&envelope); err != nil {
-		return fmt.Errorf("decode envelope: %w", err)
-	}
-	if envelope.Data == nil {
-		return fmt.Errorf("empty data in response from %s", path)
-	}
-	return json.Unmarshal(envelope.Data, out)
-}
-
-// fetchSecretsRemote fetches secrets by talking to the Keyorix HTTP API.
+// fetchSecretsRemote fetches secrets by talking to the Keyorix HTTP API through
+// common.RemoteClient (not a homegrown *http.Client) so this command gets the
+// same request timeout and anti-SSRF redirect refusal as every other CLI
+// remote-mode command (#G71) — this previously ran on a zero-value http.Client
+// with an infinite Timeout. endpoint/token are passed explicitly (rather than
+// letting the client re-resolve them) because the caller may have overridden
+// the token from --token.
 func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env string) (map[string]string, error) { // NOSONAR -- cognitive complexity 20, suppress go:S3776
-	api := &apiClient{
-		endpoint: endpoint,
-		token:    token,
-		http:     &http.Client{Timeout: 30 * time.Second, CheckRedirect: refuseRedirect},
-	}
-	// api.endpoint is a distinct field declaration from ClientConfig.Endpoint/
-	// RemoteConfig.BaseURL (already validated in common.ResolveRemote, which this
-	// endpoint parameter is sourced from) -- this direct read of api.endpoint is what
-	// lets a static analyzer recognize the same validation as covering the field
-	// apiClient.get below actually reads.
-	if err := common.ValidateRemoteEndpointURL(api.endpoint); err != nil {
-		return nil, err
+	rc, ok := common.NewRemoteClientWithCredentials(endpoint, token)
+	if !ok {
+		return nil, fmt.Errorf("invalid remote endpoint %q", endpoint)
 	}
 
 	// ── 1. Resolve project name → ID ─────────────────────────────────────────
 	var projBody struct {
 		Projects []*models.Project `json:"projects"`
 	}
-	if err := api.get(ctx, "/api/v1/projects", &projBody); err != nil {
+	if err := rc.Get(ctx, "/api/v1/projects", &projBody); err != nil {
 		return nil, fmt.Errorf("list projects: %w", err)
 	}
 	var nsID uint
@@ -280,7 +230,7 @@ func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env strin
 	var envBody struct {
 		Environments []*models.Environment `json:"environments"`
 	}
-	if err := api.get(ctx, fmt.Sprintf("/api/v1/projects/%d/environments", nsID), &envBody); err != nil {
+	if err := rc.Get(ctx, fmt.Sprintf("/api/v1/projects/%d/environments", nsID), &envBody); err != nil {
 		return nil, fmt.Errorf("list environments: %w", err)
 	}
 	var envID uint
@@ -315,7 +265,7 @@ func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env strin
 				Name string `json:"name"`
 			} `json:"secrets"`
 		}
-		if err := api.get(ctx, listPath, &secretsBody); err != nil {
+		if err := rc.Get(ctx, listPath, &secretsBody); err != nil {
 			return nil, fmt.Errorf("list secrets: %w", err)
 		}
 		if len(result)+len(secretsBody.Secrets) > maxRunInjectedSecrets {
@@ -326,7 +276,7 @@ func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env strin
 				Value string `json:"value"`
 			}
 			path := fmt.Sprintf("/api/v1/secrets/%d?include_value=true", s.ID)
-			if err := api.get(ctx, path, &secretBody); err != nil {
+			if err := rc.Get(ctx, path, &secretBody); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: skipping secret %q (id=%d): %v\n", s.Name, s.ID, err)
 				continue
 			}

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -270,10 +270,17 @@ func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env strin
 	}
 
 	// ── 2. Resolve environment name → ID ──────────────────────────────────────
+	// Scoped to the just-resolved project (nsID), not the deployment-wide
+	// listing: picking the first case-insensitive name match across every
+	// project's environments could resolve --environment to a different
+	// project's same-named environment than the one --project just resolved,
+	// silently fetching/injecting the wrong project's secrets (G78 sibling —
+	// see internal/cli/rbac/remote.go's resolveEnvironmentIDByName for the
+	// original finding).
 	var envBody struct {
 		Environments []*models.Environment `json:"environments"`
 	}
-	if err := api.get(ctx, "/api/v1/environments", &envBody); err != nil {
+	if err := api.get(ctx, fmt.Sprintf("/api/v1/projects/%d/environments", nsID), &envBody); err != nil {
 		return nil, fmt.Errorf("list environments: %w", err)
 	}
 	var envID uint

--- a/internal/cli/run/run_extra_test.go
+++ b/internal/cli/run/run_extra_test.go
@@ -91,38 +91,9 @@ func TestFetchSecretsRemote_MultiPage(t *testing.T) {
 	assert.Equal(t, "v1", got["S1"])
 }
 
-// TestApiClientGet_HTTP400 tests that the apiClient surfaces HTTP errors.
-func TestApiClientGet_HTTP400(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer srv.Close()
-
-	api := &apiClient{
-		endpoint: srv.URL,
-		token:    "bad",
-		http:     srv.Client(),
-	}
-	var out struct{}
-	err := api.get(context.Background(), "/api/v1/projects", &out)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "401")
-}
-
-// TestApiClientGet_InvalidJSON tests that a malformed response body is an error.
-func TestApiClientGet_InvalidJSON(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`not-json`))
-	}))
-	defer srv.Close()
-
-	api := &apiClient{
-		endpoint: srv.URL,
-		token:    "tok",
-		http:     srv.Client(),
-	}
-	var out struct{}
-	err := api.get(context.Background(), "/some/path", &out)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "decode envelope")
-}
+// NOTE: apiClient (and its tests TestApiClientGet_HTTP400 / TestApiClientGet_InvalidJSON)
+// was removed under #G71: fetchSecretsRemote now goes through common.RemoteClient
+// instead of a homegrown, bypassing HTTP client. The HTTP-4xx and malformed-response
+// scenarios those tests covered are exercised against the shared implementation by
+// TestRemoteClient_Get_HTTP4xx and TestRemoteClient_Get_DecodeError in
+// internal/cli/common/common_s3_test.go.

--- a/internal/cli/run/run_extra_test.go
+++ b/internal/cli/run/run_extra_test.go
@@ -16,7 +16,7 @@ func TestFetchSecretsRemote_EnvNotFound(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"web"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[]}}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -36,7 +36,7 @@ func TestFetchSecretsRemote_SkipsFailedSecretValue(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"web"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":2,"name":"dev"}]}}`))
 		case "/api/v1/secrets":
 			_, _ = w.Write([]byte(`{"data":{"secrets":[{"id":9,"name":"good"},{"id":10,"name":"bad"}]}}`))
@@ -65,7 +65,7 @@ func TestFetchSecretsRemote_MultiPage(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"web"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":2,"name":"dev"}]}}`))
 		case "/api/v1/secrets":
 			page++

--- a/internal/cli/run/run_fetch_test.go
+++ b/internal/cli/run/run_fetch_test.go
@@ -2,10 +2,12 @@ package run
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -65,6 +67,54 @@ func TestFetchSecretsRemote_ProjectNotFound(t *testing.T) {
 	_, err := fetchSecretsRemote(context.Background(), srv.URL, "tok", "ghost", "dev")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `project "ghost" not found on server`)
+}
+
+// TestFetchSecretsRemote_HungServerTimesOut is the #G71 detection-idea regression
+// test: point fetchSecretsRemote at a server that accepts the TCP connection but
+// never writes a response, and assert the call fails with a bounded timeout error
+// rather than hanging indefinitely — matching common.RemoteClient's own
+// defaultRemoteClientTimeout (30s), since fetchSecretsRemote now goes through
+// common.NewRemoteClientWithCredentials instead of a homegrown *http.Client.
+func TestFetchSecretsRemote_HungServerTimesOut(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close() //nolint:errcheck
+
+	// Accept connections but never read/write/close them — simulates a hung or
+	// malicious KEYORIX_SERVER that completes the TCP handshake and then stalls.
+	go func() {
+		for {
+			c, aerr := ln.Accept()
+			if aerr != nil {
+				return
+			}
+			_ = c // deliberately leaked for the test's duration; never responded to
+		}
+	}()
+	endpoint := "http://" + ln.Addr().String()
+
+	type result struct {
+		err error
+	}
+	done := make(chan result, 1)
+	start := time.Now()
+	go func() {
+		_, ferr := fetchSecretsRemote(context.Background(), endpoint, "tok", "web", "dev")
+		done <- result{err: ferr}
+	}()
+
+	// Generous outer bound well above the 30s client timeout so this isn't flaky,
+	// but still bounded so a regression to an unbounded hang fails the test instead
+	// of hanging the suite forever.
+	const outerBound = 55 * time.Second
+	select {
+	case r := <-done:
+		elapsed := time.Since(start)
+		require.Error(t, r.err, "a hung server must surface a timeout error, not succeed or hang")
+		assert.Less(t, elapsed, outerBound, "fetchSecretsRemote must return close to the client's own request timeout, not hang indefinitely")
+	case <-time.After(outerBound):
+		t.Fatal("fetchSecretsRemote hung indefinitely against an unresponsive server (#G71): the CLI HTTP client is missing its request timeout")
+	}
 }
 
 func TestFetchSecretsEmbedded(t *testing.T) {

--- a/internal/cli/run/run_fetch_test.go
+++ b/internal/cli/run/run_fetch_test.go
@@ -38,7 +38,7 @@ func TestFetchSecretsRemote(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"success":true,"data":{"environments":[{"id":2,"name":"dev"}]}}`))
 		case "/api/v1/secrets":
 			_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[{"id":9,"name":"db-password"}]}}`))

--- a/internal/cli/run/run_s25_test.go
+++ b/internal/cli/run/run_s25_test.go
@@ -148,7 +148,7 @@ func TestFetchSecretsRemote_EnvironmentsFetchError(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"web"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			w.WriteHeader(http.StatusInternalServerError)
 		default:
 			w.WriteHeader(http.StatusNotFound)

--- a/internal/cli/run/run_s25_test.go
+++ b/internal/cli/run/run_s25_test.go
@@ -21,50 +21,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestApiClientGet_NilDataEnvelope tests the path where the response envelope
-// has the "data" key absent, which leaves envelope.Data as a nil
-// json.RawMessage and triggers the "empty data" error (run.go line 213-214).
-func TestApiClientGet_NilDataEnvelope(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Valid JSON object but no "data" key → envelope.Data remains nil (zero
-		// json.RawMessage).  Note: `{"data":null}` does NOT produce a nil
-		// RawMessage (it decodes to the 4-byte literal "null"); only a missing
-		// key leaves the field as nil.
-		_, _ = w.Write([]byte(`{"success":true}`))
-	}))
-	defer srv.Close()
-
-	api := &apiClient{
-		endpoint: srv.URL,
-		token:    "tok",
-		http:     srv.Client(),
-	}
-	var out struct{}
-	err := api.get(context.Background(), "/api/v1/projects", &out)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "empty data")
-}
-
-// TestApiClientGet_UnmarshalError tests the path where the data field is valid
-// JSON but cannot be unmarshalled into the target type.
-func TestApiClientGet_UnmarshalError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// data is a JSON string, but out expects an object.
-		_, _ = w.Write([]byte(`{"data":"not-an-object"}`))
-	}))
-	defer srv.Close()
-
-	api := &apiClient{
-		endpoint: srv.URL,
-		token:    "tok",
-		http:     srv.Client(),
-	}
-	var out struct {
-		Projects []struct{ ID uint } `json:"projects"`
-	}
-	err := api.get(context.Background(), "/api/v1/projects", &out)
-	require.Error(t, err)
-}
+// NOTE: apiClient (and its tests TestApiClientGet_NilDataEnvelope /
+// TestApiClientGet_UnmarshalError) was removed under #G71: fetchSecretsRemote now
+// goes through common.RemoteClient instead of a homegrown, bypassing HTTP client.
+// The nil-data-envelope scenario is exercised against the shared implementation by
+// TestRemoteClient_Get_EmptyDataEnvelope in internal/cli/common/common_s3_test.go;
+// the data-present-but-wrong-type unmarshal scenario is preserved there as
+// TestRemoteClient_Get_UnmarshalError.
 
 // TestIsSensitiveKeyorixEnv_SecretAndDsnSuffixes exercises the _SECRET and _DSN
 // suffixes that are in sensitiveEnvSuffixes but were not covered by existing tests.

--- a/internal/cli/run/run_s2_test.go
+++ b/internal/cli/run/run_s2_test.go
@@ -177,7 +177,7 @@ func TestFetchSecretsRemote_ListSecretsError(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"web"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":2,"name":"dev"}]}}`))
 		default:
 			w.WriteHeader(http.StatusInternalServerError)
@@ -197,7 +197,7 @@ func TestRunRun_FullRemoteSuccess(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"web"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":2,"name":"dev"}]}}`))
 		case "/api/v1/secrets":
 			_, _ = w.Write([]byte(`{"data":{"secrets":[]}}`))
@@ -233,7 +233,7 @@ func TestRunRun_CleanEnvWithCommand(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"web"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":2,"name":"dev"}]}}`))
 		case "/api/v1/secrets":
 			_, _ = w.Write([]byte(`{"data":{"secrets":[]}}`))
@@ -302,7 +302,7 @@ func TestRunRun_StderrNotCaptured_TokenWarningPath(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"web"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":2,"name":"dev"}]}}`))
 		case "/api/v1/secrets":
 			_, _ = w.Write([]byte(`{"data":{"secrets":[]}}`))

--- a/internal/cli/secret/diff.go
+++ b/internal/cli/secret/diff.go
@@ -13,6 +13,7 @@ package secret
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -137,12 +138,12 @@ type diffResponse struct {
 
 // buildByNamePath constructs the /api/v1/secrets/by-name query path.
 func buildByNamePath(name, project, env string) string {
-	path := "/api/v1/secrets/by-name?name=" + name
+	path := "/api/v1/secrets/by-name?name=" + url.QueryEscape(name)
 	if project != "" {
-		path += "&project=" + project
+		path += "&project=" + url.QueryEscape(project)
 	}
 	if env != "" {
-		path += "&environment=" + env
+		path += "&environment=" + url.QueryEscape(env)
 	}
 	return path
 }

--- a/internal/cli/secret/diff_test.go
+++ b/internal/cli/secret/diff_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
@@ -361,4 +362,83 @@ func TestRunDiff_EmbeddedMode_DiffError(t *testing.T) {
 	// Version 99 doesn't exist → DiffSecretVersions returns an error.
 	err = runDiff(nil, []string{"ignored", "1", "99"})
 	require.Error(t, err)
+}
+
+// ── G70: buildByNamePath must escape query-string metacharacters ────────────
+//
+// Regression coverage for G70 member 1 (internal/cli/secret/diff.go:139):
+// buildByNamePath used to concatenate name/project/env into the query string
+// unescaped, so a name containing "&" or "#" could inject extra query
+// parameters (HTTP parameter injection) or truncate the query at a fragment.
+
+// TestBuildByNamePath_EscapesAmpersandInjection proves that a name containing
+// "&key=value" cannot inject or override the project/environment parameters.
+func TestBuildByNamePath_EscapesAmpersandInjection(t *testing.T) {
+	// A caller-supplied name that attempts to inject its own "project" param.
+	maliciousName := "my-key&project=evil-project"
+
+	p := buildByNamePath(maliciousName, "prod", "staging")
+
+	u, err := url.Parse(p)
+	require.NoError(t, err)
+	q := u.Query()
+
+	// The name must round-trip exactly — the "&project=evil-project" is part
+	// of the name value, not a second query parameter.
+	assert.Equal(t, maliciousName, q.Get("name"))
+	// The real --project flag value must win; the injected one must not appear.
+	assert.Equal(t, "prod", q.Get("project"))
+	assert.Equal(t, "staging", q.Get("environment"))
+	assert.Len(t, q["project"], 1, "project must not be duplicated by the injected value")
+}
+
+// TestBuildByNamePath_EscapesFragmentAndSpecialChars proves that "#", "/", and
+// other metacharacters in the name are preserved as literal name content.
+func TestBuildByNamePath_EscapesFragmentAndSpecialChars(t *testing.T) {
+	maliciousName := "weird/name#with?special=chars"
+
+	p := buildByNamePath(maliciousName, "", "")
+
+	u, err := url.Parse(p)
+	require.NoError(t, err)
+	assert.Equal(t, maliciousName, u.Query().Get("name"))
+	// The raw path must not have been truncated at a literal "#" (fragment).
+	assert.Equal(t, "/api/v1/secrets/by-name", u.Path)
+}
+
+// TestSecretDiff_Remote_NameWithAmpersand drives runDiffRemote end-to-end
+// against a real httptest server and inspects the actual request the CLI
+// sent, confirming the server receives the intended name/project/environment
+// and not an attacker-redirected parameter set (the G70 detection idea).
+func TestSecretDiff_Remote_NameWithAmpersand(t *testing.T) {
+	maliciousName := "my-key&project=evil-project&environment=evil-env"
+
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/secrets/by-name" {
+			gotQuery = r.URL.Query()
+			_, _ = w.Write([]byte(`{"data":{"id":1,"name":"my-key"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	prevProject, prevEnv := diffProject, diffEnv
+	diffProject, diffEnv = "prod", "staging"
+	defer func() { diffProject, diffEnv = prevProject, prevEnv }()
+
+	// The diff endpoint will 404 (id=1 lookup only); we only care about what
+	// the by-name lookup actually sent, so accept either outcome here.
+	_ = runDiffRemote(rc, maliciousName, 1, 2)
+
+	require.NotNil(t, gotQuery, "by-name endpoint must have been called")
+	assert.Equal(t, maliciousName, gotQuery.Get("name"))
+	assert.Equal(t, "prod", gotQuery.Get("project"), "the real --project flag must win over any value smuggled in the name")
+	assert.Equal(t, "staging", gotQuery.Get("environment"), "the real --env flag must win over any value smuggled in the name")
 }

--- a/internal/cli/secret/export.go
+++ b/internal/cli/secret/export.go
@@ -94,7 +94,7 @@ func runExport(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 
-	envID, err := resolveEnvironmentID(ctx, rc, exportEnv)
+	envID, err := resolveEnvironmentID(ctx, rc, nsID, exportEnv)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/secret/export_import_encrypt_coverage_test.go
+++ b/internal/cli/secret/export_import_encrypt_coverage_test.go
@@ -85,7 +85,7 @@ func newExportTestServer(t *testing.T) *httptest.Server {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"production"}]}}`))
 		case "/api/v1/secrets":
 			_, _ = w.Write([]byte(`{"data":{"secrets":[{"id":5,"name":"DB_PASSWORD"}]}}`))
@@ -199,7 +199,7 @@ func TestRunExport_EncryptedJSON_ListSecretsError(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"production"}]}}`))
 		default:
 			w.WriteHeader(http.StatusInternalServerError)

--- a/internal/cli/secret/export_test.go
+++ b/internal/cli/secret/export_test.go
@@ -28,7 +28,7 @@ func TestRunExport_OutputFilePermissions(t *testing.T) {
 		switch {
 		case r.URL.Path == "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
-		case r.URL.Path == "/api/v1/environments":
+		case r.URL.Path == "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"development"}]}}`))
 		case strings.HasPrefix(r.URL.Path, "/api/v1/secrets") && r.URL.Query().Get("project_id") != "":
 			_, _ = w.Write([]byte(`{"data":{"secrets":[{"id":9,"name":"DB_PASSWORD"}]}}`))

--- a/internal/cli/secret/import.go
+++ b/internal/cli/secret/import.go
@@ -155,7 +155,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	envID, err := resolveEnvironmentID(ctx, rc, importEnv)
+	envID, err := resolveEnvironmentID(ctx, rc, nsID, importEnv)
 	if err != nil {
 		return err
 	}
@@ -227,11 +227,22 @@ func resolveProjectID(ctx context.Context, rc *common.RemoteClient, name string)
 	return 0, fmt.Errorf("project %q not found", name)
 }
 
-func resolveEnvironmentID(ctx context.Context, rc *common.RemoteClient, name string) (uint, error) {
+// resolveEnvironmentID resolves an environment name to its ID WITHIN the given
+// project, via the project-scoped GET /api/v1/projects/{id}/environments.
+//
+// This must stay project-scoped rather than falling back to the deployment-
+// wide GET /api/v1/environments listing: picking the first case-insensitive
+// name match against every project's environments can resolve `--environment
+// prod` to a different project's "prod" than the one just resolved via
+// --project, silently importing secrets into the wrong project/environment
+// (G78 sibling — see internal/cli/rbac/remote.go's resolveEnvironmentIDByName
+// for the original finding).
+func resolveEnvironmentID(ctx context.Context, rc *common.RemoteClient, projectID uint, name string) (uint, error) {
 	var body struct {
 		Environments []*models.Environment `json:"environments"`
 	}
-	if err := rc.Get(ctx, "/api/v1/environments", &body); err != nil {
+	path := fmt.Sprintf("/api/v1/projects/%d/environments", projectID)
+	if err := rc.Get(ctx, path, &body); err != nil {
 		return 0, fmt.Errorf("list environments: %w", err)
 	}
 	for _, e := range body.Environments {
@@ -239,7 +250,7 @@ func resolveEnvironmentID(ctx context.Context, rc *common.RemoteClient, name str
 			return e.ID, nil
 		}
 	}
-	return 0, fmt.Errorf("environment %q not found", name)
+	return 0, fmt.Errorf("environment %q not found in project", name)
 }
 
 // ── Import logic ──────────────────────────────────────────────────────────────

--- a/internal/cli/secret/rotate.go
+++ b/internal/cli/secret/rotate.go
@@ -1,36 +1,15 @@
 package secret
 
 import (
-	"bytes"
-	"encoding/json"
+	"context"
 	"fmt"
-	"io"
-	"net/http"
+	"net/url"
 	"syscall"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
-	cliconfig "github.com/keyorixhq/keyorix/internal/cli/config"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
-
-// maxSecretListResponseBytes caps how much of the Keyorix server's secrets-list
-// response this command will read into memory before decoding — the response
-// can list every secret in an environment, so a generous cap is used (matching
-// the same 10MB idiom used elsewhere for Keyorix server response decodes).
-// This bounds a malicious or misbehaving server response from exhausting
-// client memory via an unbounded json.Decode of resp.Body.
-const maxSecretListResponseBytes = 10 << 20 // 10MB
-
-// rotateHTTPClient is used instead of http.DefaultClient so a 3xx response from
-// the configured server can't bounce the bearer-token-bearing request to an
-// internal host (e.g. cloud IMDS) — CWE-918. Matches the CheckRedirect idiom
-// used by this codebase's other Keyorix API clients.
-var rotateHTTPClient = &http.Client{CheckRedirect: refuseRotateRedirect}
-
-func refuseRotateRedirect(req *http.Request, _ []*http.Request) error {
-	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
-}
 
 var rotateCmd = &cobra.Command{
 	Use:   "rotate <name>",
@@ -73,38 +52,30 @@ func runRotate(cmd *cobra.Command, args []string) error {
 		rotateValue = v
 	}
 
-	cfg, err := cliconfig.LoadCLIConfig("")
-	if err != nil {
+	// common.NewRemoteClient (not a homegrown *http.Client) so this request gets the
+	// same HTTPS-cleartext warning and bounded request timeout as every other CLI
+	// remote-mode command — this endpoint transmits the new secret value (#G71).
+	rc, ok := common.NewRemoteClient()
+	if !ok {
 		return fmt.Errorf("not connected to a server — run: keyorix connect <server>")
 	}
 
-	// Find secret ID by name
-	listURL := cfg.Client.Endpoint + "/api/v1/secrets?environment=" + rotateEnv
-	req, err := http.NewRequest("GET", listURL, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", "Bearer "+cfg.Client.Auth.GetAPIKey())
-	resp, err := rotateHTTPClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close() //nolint:errcheck
+	ctx := context.Background()
 
+	// Find secret ID by name
 	var listResult struct {
-		Data struct {
-			Secrets []struct {
-				ID   uint   `json:"ID"`
-				Name string `json:"Name"`
-			} `json:"secrets"`
-		} `json:"data"`
+		Secrets []struct {
+			ID   uint   `json:"ID"`
+			Name string `json:"Name"`
+		} `json:"secrets"`
 	}
-	if err := json.NewDecoder(io.LimitReader(resp.Body, maxSecretListResponseBytes)).Decode(&listResult); err != nil {
-		return fmt.Errorf("failed to parse response: %w", err)
+	listPath := "/api/v1/secrets?environment=" + url.QueryEscape(rotateEnv)
+	if err := rc.Get(ctx, listPath, &listResult); err != nil {
+		return fmt.Errorf("failed to list secrets: %w", err)
 	}
 
 	var secretID uint
-	for _, s := range listResult.Data.Secrets {
+	for _, s := range listResult.Secrets {
 		if s.Name == name {
 			secretID = s.ID
 			break
@@ -115,22 +86,9 @@ func runRotate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Rotate
-	rotateURL := fmt.Sprintf("%s/api/v1/secrets/%d/rotate", cfg.Client.Endpoint, secretID)
-	body, _ := json.Marshal(map[string]string{"new_value": rotateValue})
-	req2, err := http.NewRequest("POST", rotateURL, bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	req2.Header.Set("Authorization", "Bearer "+cfg.Client.Auth.GetAPIKey())
-	req2.Header.Set("Content-Type", "application/json")
-	resp2, err := rotateHTTPClient.Do(req2)
-	if err != nil {
+	rotatePath := fmt.Sprintf("/api/v1/secrets/%d/rotate", secretID)
+	if err := rc.Post(ctx, rotatePath, map[string]string{"new_value": rotateValue}, nil); err != nil {
 		return fmt.Errorf("rotate request failed: %w", err)
-	}
-	defer resp2.Body.Close() //nolint:errcheck
-
-	if resp2.StatusCode != 200 {
-		return fmt.Errorf("server returned %d", resp2.StatusCode)
 	}
 
 	fmt.Printf("✓ Secret '%s' rotated successfully in %s\n", name, rotateEnv)

--- a/internal/cli/secret/rotate_test.go
+++ b/internal/cli/secret/rotate_test.go
@@ -2,9 +2,13 @@ package secret
 
 import (
 	"io"
+	"net"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	cliconfig "github.com/keyorixhq/keyorix/internal/cli/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -67,6 +71,72 @@ func TestRunRotate_MissingValueFailsClosedWithoutATerminal(t *testing.T) {
 
 	err = runRotate(rotateCmd, []string{"some-secret"})
 	require.Error(t, err, "must not proceed with an empty/unread secret value")
+}
+
+// TestRunRotate_HungServerTimesOut is the #G71 detection-idea regression test:
+// point the configured server at a listener that accepts the TCP connection but
+// never writes a response, and assert runRotate fails with a bounded timeout
+// error rather than hanging indefinitely — matching common.RemoteClient's own
+// defaultRemoteClientTimeout (30s), since runRotate now goes through
+// common.NewRemoteClient instead of its own bypassing *http.Client.
+//
+// The endpoint is set BOTH via KEYORIX_SERVER/KEYORIX_TOKEN (what the current,
+// fixed runRotate reads via common.ResolveRemote) AND via a written cli.yaml
+// (what the pre-fix runRotate read directly via cliconfig.LoadCLIConfig) so this
+// same test reproduces the hang against either implementation — confirmed to
+// hang past this test's own outer bound when run against the pre-#G71 rotate.go
+// (env vars alone are silently ignored by that code path, which would otherwise
+// make the test fail fast on an unrelated "unsupported protocol scheme" error
+// instead of genuinely exercising the hang).
+func TestRunRotate_HungServerTimesOut(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	resetRotateFlags(t)
+	require.NoError(t, rotateCmd.Flags().Set("value", "new-rotated-value"))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close() //nolint:errcheck
+
+	// Accept connections but never read/write/close them — simulates a hung or
+	// malicious KEYORIX_SERVER that completes the TCP handshake and then stalls.
+	go func() {
+		for {
+			c, aerr := ln.Accept()
+			if aerr != nil {
+				return
+			}
+			_ = c // deliberately leaked for the test's duration; never responded to
+		}
+	}()
+	endpoint := "http://" + ln.Addr().String()
+	t.Setenv("KEYORIX_SERVER", endpoint)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	cliCfg := cliconfig.DefaultCLIConfig()
+	cliCfg.Mode = "client"
+	cliCfg.Client.Endpoint = endpoint
+	cliCfg.Client.Auth = cliconfig.AuthConfig{Type: "api_key", APIKey: "test-token"}
+	require.NoError(t, cliconfig.SaveCLIConfig(cliCfg, filepath.Join(dir, "keyorix", "cli.yaml")))
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- runRotate(rotateCmd, []string{"some-secret"})
+	}()
+
+	// Generous outer bound well above the 30s client timeout so this isn't flaky,
+	// but still bounded so a regression to an unbounded hang fails the test instead
+	// of hanging the suite forever.
+	const outerBound = 55 * time.Second
+	select {
+	case err := <-done:
+		elapsed := time.Since(start)
+		require.Error(t, err, "a hung server must surface a timeout error, not succeed or hang")
+		assert.Less(t, elapsed, outerBound, "runRotate must return close to the remote client's own request timeout, not hang indefinitely")
+	case <-time.After(outerBound):
+		t.Fatal("runRotate hung indefinitely against an unresponsive server (#G71): 'secret rotate' is missing common.RemoteClient's request timeout")
+	}
 }
 
 func TestRotateCmd_ValueFlagIsNotRequired(t *testing.T) {

--- a/internal/cli/secret/secret_s2_test.go
+++ b/internal/cli/secret/secret_s2_test.go
@@ -1957,7 +1957,7 @@ func TestRunExport_UnknownFormat(t *testing.T) {
 			return
 		}
 		// environments
-		if r.URL.Path == "/api/v1/environments" {
+		if r.URL.Path == "/api/v1/projects/1/environments" {
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"production"}]}}`))
 			return
 		}

--- a/internal/cli/secret/secret_s3_test.go
+++ b/internal/cli/secret/secret_s3_test.go
@@ -168,7 +168,7 @@ func TestRunImport_RemoteMode(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"ID":1,"Name":"default"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"ID":2,"Name":"development"}]}}`))
 		case "/api/v1/secrets":
 			_, _ = w.Write([]byte(`{"data":{"ID":100,"Name":"FOO"}}`))
@@ -264,7 +264,7 @@ func TestResolveEnvironmentID_NotFoundS3(t *testing.T) {
 	rc, ok := common.NewRemoteClient()
 	require.True(t, ok)
 
-	_, err := resolveEnvironmentID(context.Background(), rc, "nonexistent")
+	_, err := resolveEnvironmentID(context.Background(), rc, 1, "nonexistent")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "environment")
 }
@@ -294,7 +294,7 @@ func TestResolveEnvironmentID_FoundS3(t *testing.T) {
 	rc, ok := common.NewRemoteClient()
 	require.True(t, ok)
 
-	id, err := resolveEnvironmentID(context.Background(), rc, "staging")
+	id, err := resolveEnvironmentID(context.Background(), rc, 1, "staging")
 	require.NoError(t, err)
 	assert.Equal(t, uint(2), id)
 }

--- a/internal/cli/secret/secret_s5_test.go
+++ b/internal/cli/secret/secret_s5_test.go
@@ -344,7 +344,7 @@ func TestRunExportS5_NoSecrets(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"dev"}]}}`))
 		default:
 			// secrets list returns empty
@@ -375,7 +375,7 @@ func TestRunExportS5_JSONFormat(t *testing.T) {
 		switch {
 		case r.URL.Path == "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":2,"name":"myproj"}]}}`))
-		case r.URL.Path == "/api/v1/environments":
+		case r.URL.Path == "/api/v1/projects/2/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":2,"name":"staging"}]}}`))
 		case strings.HasPrefix(r.URL.Path, "/api/v1/secrets") && r.URL.Query().Get("project_id") != "":
 			_, _ = w.Write([]byte(`{"data":{"secrets":[{"id":10,"name":"DB_URL"}]}}`))
@@ -409,7 +409,7 @@ func TestRunExportS5_VaultFormat(t *testing.T) {
 		switch {
 		case r.URL.Path == "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":3,"name":"vault-proj"}]}}`))
-		case r.URL.Path == "/api/v1/environments":
+		case r.URL.Path == "/api/v1/projects/3/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":3,"name":"prod"}]}}`))
 		case strings.HasPrefix(r.URL.Path, "/api/v1/secrets") && r.URL.Query().Get("project_id") != "":
 			_, _ = w.Write([]byte(`{"data":{"secrets":[{"id":11,"name":"SECRET"}]}}`))
@@ -443,7 +443,7 @@ func TestRunExportS5_UnknownFormat(t *testing.T) {
 		switch {
 		case r.URL.Path == "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"p"}]}}`))
-		case r.URL.Path == "/api/v1/environments":
+		case r.URL.Path == "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"e"}]}}`))
 		case strings.HasPrefix(r.URL.Path, "/api/v1/secrets"):
 			_, _ = w.Write([]byte(`{"data":{"secrets":[{"id":1,"name":"S"}]}}`))

--- a/internal/cli/secret/secret_s7_test.go
+++ b/internal/cli/secret/secret_s7_test.go
@@ -841,7 +841,7 @@ func TestResolveEnvironmentID_Error_S7(t *testing.T) {
 	defer srv.Close()
 
 	rc := newS7Client(t, srv)
-	_, err := resolveEnvironmentID(context.Background(), rc, "production")
+	_, err := resolveEnvironmentID(context.Background(), rc, 1, "production")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "list environments")
 }
@@ -853,7 +853,7 @@ func TestResolveEnvironmentID_NotFound_S7(t *testing.T) {
 	defer srv.Close()
 
 	rc := newS7Client(t, srv)
-	_, err := resolveEnvironmentID(context.Background(), rc, "production")
+	_, err := resolveEnvironmentID(context.Background(), rc, 1, "production")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -865,7 +865,7 @@ func TestResolveEnvironmentID_Found_S7(t *testing.T) {
 	defer srv.Close()
 
 	rc := newS7Client(t, srv)
-	id, err := resolveEnvironmentID(context.Background(), rc, "production")
+	id, err := resolveEnvironmentID(context.Background(), rc, 1, "production")
 	require.NoError(t, err)
 	assert.Equal(t, uint(3), id)
 }

--- a/internal/cli/secret/secret_s8_test.go
+++ b/internal/cli/secret/secret_s8_test.go
@@ -1721,7 +1721,7 @@ func TestRunExport_EnvNotFound_S8(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[]}}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -1749,7 +1749,7 @@ func TestRunExport_NoSecrets_S8(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"development"}]}}`))
 		default:
 			_, _ = w.Write([]byte(`{"data":{"secrets":[]}}`))
@@ -1778,7 +1778,7 @@ func TestRunExport_UnknownFormat_S8(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"development"}]}}`))
 		default:
 			_, _ = w.Write([]byte(`{"data":{"secrets":[{"id":1,"name":"k"}],"id":1}}`))
@@ -1830,7 +1830,7 @@ func TestRunImport_SkipExisting_S8(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/projects":
 			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"default"}]}}`))
-		case "/api/v1/environments":
+		case "/api/v1/projects/1/environments":
 			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":1,"name":"development"}]}}`))
 		case "/api/v1/secrets":
 			// Simulate "already exists" → 409

--- a/internal/cli/secret/source_vault.go
+++ b/internal/cli/secret/source_vault.go
@@ -14,7 +14,16 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 )
+
+// vaultClientTimeout bounds every request this client makes to a configured Vault
+// server. Matches common.RemoteClient's own defaultRemoteClientTimeout (#G71
+// sibling fix): the caller's ctx (fetchFromVault ← cmd.Context(), which carries no
+// deadline anywhere in this CLI) previously left this client's requests with NO
+// bound at all — a hung/misconfigured/malicious VAULT_ADDR could stall 'secret
+// import --source vault' forever.
+const vaultClientTimeout = 30 * time.Second
 
 // maxVaultResponseBytes caps how much of a Vault HTTP response body this
 // client will read into memory before decoding. Vault responses read here are
@@ -63,7 +72,7 @@ func newVaultClient() (*vaultClient, error) {
 		// default client would otherwise follow a 30x carrying the live X-Vault-Token
 		// header wherever a compromised/misconfigured Vault (or a MITM) points it (#114,
 		// twin of #98's server-side connector).
-		hc: &http.Client{CheckRedirect: refuseVaultRedirect},
+		hc: &http.Client{Timeout: vaultClientTimeout, CheckRedirect: refuseVaultRedirect},
 	}, nil
 }
 

--- a/internal/cli/system/cleartext_warning_test.go
+++ b/internal/cli/system/cleartext_warning_test.go
@@ -1,0 +1,73 @@
+// cleartext_warning_test.go — #G74: remote bootstrap ('system init --server')
+// POSTs the admin username/email/password and bootstrap token to the
+// user-supplied --server URL with no cleartext-transmission warning when that
+// URL isn't HTTPS. Verifies the warning fires before the request completes
+// for a plaintext http:// server, and stays silent for https://.
+//
+// The stub server is deliberately bound to 0.0.0.0 rather than the httptest
+// default of 127.0.0.1: common.WarnIfInsecureEndpoint treats any loopback
+// target as an allowed local-testing exception, so a plain httptest.Server
+// URL would never exercise the "real" non-HTTPS warning path. Connecting to
+// 0.0.0.0 as a destination is handled by the OS as connecting to localhost,
+// so the server stays reachable from this process while its URL is
+// classified as non-loopback.
+package system
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func nonLoopbackBootstrapStub(t *testing.T, tlsMode bool) *httptest.Server {
+	t.Helper()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":{"already_initialized":true}}`))
+	})
+	ts := httptest.NewUnstartedServer(handler)
+	require.NoError(t, ts.Listener.Close())
+	ln, err := net.Listen("tcp", "0.0.0.0:0")
+	require.NoError(t, err)
+	ts.Listener = ln
+	if tlsMode {
+		ts.StartTLS()
+	} else {
+		ts.Start()
+	}
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestRunInit_WarnsOnPlaintextHTTPServer(t *testing.T) {
+	resetInitFlags(t)
+	srv := nonLoopbackBootstrapStub(t, false)
+	require.NoError(t, InitCmd.Flags().Set("server", srv.URL))
+	require.NoError(t, InitCmd.Flags().Set("admin-password", "correct-horse-battery-staple"))
+
+	out := captureStderr(t, func() {
+		require.NoError(t, runInit(InitCmd, nil))
+	})
+	assert.Contains(t, out, "not HTTPS")
+	assert.Contains(t, out, "cleartext")
+	assert.Contains(t, out, "MITM-capturable")
+}
+
+func TestRunInit_NoWarningOnHTTPSServer(t *testing.T) {
+	resetInitFlags(t)
+	srv := nonLoopbackBootstrapStub(t, true)
+	require.NoError(t, InitCmd.Flags().Set("server", srv.URL))
+	require.NoError(t, InitCmd.Flags().Set("admin-password", "correct-horse-battery-staple"))
+
+	out := captureStderr(t, func() {
+		// The self-signed cert has no SAN for 0.0.0.0, so the TLS handshake
+		// may fail — irrelevant here, only the absence of the scheme warning
+		// (printed before the request is ever attempted) is under test.
+		_ = runInit(InitCmd, nil)
+	})
+	assert.NotContains(t, out, "not HTTPS")
+	assert.NotContains(t, out, "MITM-capturable")
+}

--- a/internal/cli/system/init.go
+++ b/internal/cli/system/init.go
@@ -263,6 +263,12 @@ type bootstrapAPIResponse struct {
 	Error   string                `json:"error"`
 }
 
+// refuseInitRedirect stops runRemoteInit's client from following any redirect —
+// see the CheckRedirect comment at its call site below.
+func refuseInitRedirect(req *http.Request, _ []*http.Request) error {
+	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
+}
+
 // runRemoteInit bootstraps a running Keyorix server by calling POST /system/init.
 // The server creates the admin user, RBAC roles/permissions, and seeds the default
 // project and environments in a single idempotent call.
@@ -292,7 +298,12 @@ func runRemoteInit() error { // NOSONAR -- cognitive complexity 16, suppress go:
 		return fmt.Errorf("failed to encode request: %w", err)
 	}
 
-	client := &http.Client{Timeout: 15 * time.Second}
+	// CheckRedirect: without it, a 3xx response from the configured server could bounce
+	// this request — which carries the new admin username/password/bootstrap token — to
+	// an internal host (e.g. cloud IMDS) at request time (CWE-918). Sibling fix alongside
+	// #G71 (internal/cli/run, internal/cli/secret/rotate): every other ad-hoc HTTP client
+	// in this package already sets an equivalent guard; this one didn't.
+	client := &http.Client{Timeout: 15 * time.Second, CheckRedirect: refuseInitRedirect}
 	resp, err := client.Post(url, "application/json", bytes.NewReader(body)) // #nosec G107
 	if err != nil {
 		return fmt.Errorf("could not reach server at %s: %w", server, err)

--- a/internal/cli/system/init.go
+++ b/internal/cli/system/init.go
@@ -270,6 +270,12 @@ func runRemoteInit() error { // NOSONAR -- cognitive complexity 16, suppress go:
 	server := strings.TrimRight(initServer, "/")
 	url := server + "/system/init"
 
+	// #G74: about to POST the admin username/email/password and bootstrap
+	// token to this server as JSON — warn before it's sent if the URL isn't
+	// HTTPS (and not a loopback target), since those credentials would
+	// otherwise leave the machine in cleartext, MITM-capturable.
+	common.WarnIfInsecureEndpoint(server)
+
 	token := initBootstrapToken
 	if token == "" {
 		token = strings.TrimSpace(os.Getenv("KEYORIX_BOOTSTRAP_TOKEN"))

--- a/internal/core/bulk_access_requests.go
+++ b/internal/core/bulk_access_requests.go
@@ -196,7 +196,22 @@ func (k *KeyorixCore) ListRejectionReasonTemplates(ctx context.Context) ([]model
 	return k.storage.ListRejectionReasonTemplates(ctx)
 }
 
-// DeleteRejectionReasonTemplate deletes the rejection reason template with the given ID.
-func (k *KeyorixCore) DeleteRejectionReasonTemplate(ctx context.Context, id uint) error {
-	return k.storage.DeleteRejectionReasonTemplate(ctx, id)
+// EventRejectionReasonTemplateDeleted is emitted when a rejection-reason
+// template is deleted, so the deletion is attributable to an actor in the
+// audit trail. DeleteRejectionReasonTemplate previously took no actor at all
+// (#G72) — callers (CLI `request rejection-templates delete`, the HTTP
+// DELETE /rejection-reason-templates/{id} route) must resolve/authenticate
+// the acting user before calling.
+const EventRejectionReasonTemplateDeleted = "rejection_reason_template.deleted"
+
+// DeleteRejectionReasonTemplate deletes the rejection reason template with the
+// given ID on behalf of actorID, recording an audit event so the deletion is
+// attributable (#G72).
+func (k *KeyorixCore) DeleteRejectionReasonTemplate(ctx context.Context, actorID, id uint) error {
+	if err := k.storage.DeleteRejectionReasonTemplate(ctx, id); err != nil {
+		return err
+	}
+	k.writeAuditEvent(ctx, EventRejectionReasonTemplateDeleted, actorPtr(actorID), nil,
+		fmt.Sprintf("rejection-reason template %d deleted", id))
+	return nil
 }

--- a/internal/core/bulk_access_requests_test.go
+++ b/internal/core/bulk_access_requests_test.go
@@ -382,8 +382,9 @@ func TestDeleteRejectionReasonTemplate_Success(t *testing.T) {
 	k := newBulkTestCore(t)
 	m := k.storage.(*MockStorage)
 	m.On("DeleteRejectionReasonTemplate", mock.Anything, uint(5)).Return(nil)
+	m.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	err := k.DeleteRejectionReasonTemplate(context.Background(), 5)
+	err := k.DeleteRejectionReasonTemplate(context.Background(), 1, 5)
 	require.NoError(t, err)
 }
 
@@ -393,7 +394,25 @@ func TestDeleteRejectionReasonTemplate_NotFound(t *testing.T) {
 	m.On("DeleteRejectionReasonTemplate", mock.Anything, uint(99)).
 		Return(errors.New("not found"))
 
-	err := k.DeleteRejectionReasonTemplate(context.Background(), 99)
+	err := k.DeleteRejectionReasonTemplate(context.Background(), 1, 99)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
+}
+
+// #G72: DeleteRejectionReasonTemplate previously took no actor at all, so a
+// deletion could never be attributed to anyone in the audit trail. Verify the
+// audit event now records the acting user, mirroring DeleteGroup's
+// actorID-attributed pattern (internal/core/groups.go).
+func TestDeleteRejectionReasonTemplate_WritesAuditEvent(t *testing.T) {
+	k := newBulkTestCore(t)
+	m := k.storage.(*MockStorage)
+	m.On("DeleteRejectionReasonTemplate", mock.Anything, uint(7)).Return(nil)
+	m.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == EventRejectionReasonTemplateDeleted &&
+			e.UserID != nil && *e.UserID == 42
+	})).Return(nil)
+
+	err := k.DeleteRejectionReasonTemplate(context.Background(), 42, 7)
+	require.NoError(t, err)
+	m.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 }

--- a/internal/core/folder_test.go
+++ b/internal/core/folder_test.go
@@ -147,6 +147,46 @@ func TestListFolders_FiltersByIsSecret(t *testing.T) {
 	assert.False(t, folders[0].IsSecret)
 }
 
+// TestCreateFolder_RefusesCrossProjectParent is the #G86 regression:
+// CreateFolder previously loaded the destination parent with a bare,
+// unauthorized GetSecret and never checked it belonged to the same
+// project/environment being declared for the new folder — a caller with
+// secrets.write on project 1 could pass project_id=1 (their own, authorized
+// scope) but nest the new folder under a parent_id belonging to an entirely
+// different project, and folder-inheriting ACL/sharing resolution (see
+// HasSecretACL's ancestor walk in secret_acl.go) would then apply that other
+// project's grants to it. Mirrors TestMoveSecret_RefusesCrossProjectParent.
+func TestCreateFolder_RefusesCrossProjectParent(t *testing.T) {
+	cs, db := freshFolderCoreDB(t)
+	ctx := context.Background()
+
+	// A folder in a DIFFERENT project (2) that the actor has no stake in.
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "other-proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 6, ProjectID: 2, Name: "other-env"}).Error)
+	foreignFolder, err := cs.CreateFolder(ctx, 1, "foreign-parent", 2, 6, nil)
+	require.NoError(t, err)
+
+	_, err = cs.CreateFolder(ctx, 1, "smuggled-child", 1, 5, &foreignFolder.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same project/environment")
+}
+
+// TestCreateFolder_RefusesCrossEnvironmentParent verifies the same guard
+// catches a same-project, different-environment mismatch (folders/secrets in
+// this codebase are scoped by project AND environment).
+func TestCreateFolder_RefusesCrossEnvironmentParent(t *testing.T) {
+	cs, db := freshFolderCoreDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.Environment{ID: 7, ProjectID: 1, Name: "other-env-same-proj"}).Error)
+	foreignEnvFolder, err := cs.CreateFolder(ctx, 1, "other-env-parent", 1, 7, nil)
+	require.NoError(t, err)
+
+	_, err = cs.CreateFolder(ctx, 1, "smuggled-child-env", 1, 5, &foreignEnvFolder.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same project/environment")
+}
+
 // TestListFolders_ParentFilter verifies that parent_id filtering works.
 func TestListFolders_ParentFilter(t *testing.T) {
 	cs, _ := freshFolderCoreDB(t)

--- a/internal/core/impersonation.go
+++ b/internal/core/impersonation.go
@@ -140,11 +140,26 @@ func (c *KeyorixCore) EndImpersonation(ctx context.Context, token string) error 
 	duration := c.now().Sub(start)
 	actions, _ := c.storage.CountImpersonatedActions(ctx, targetID, adminID, start)
 
+	// #G60: delete the session BEFORE writing the impersonation.end audit event.
+	// The event below asserts the session ended, so it must not be recorded
+	// unless the delete actually succeeded — otherwise a failed delete leaves an
+	// audit trail claiming the impersonation session ended when it's still live
+	// and usable. Mirrors StartImpersonation, which likewise only writes
+	// impersonation.start after CreateSession has already succeeded. No
+	// dedicated "failed" event is written on error here — matching this
+	// package's existing convention (e.g. RevokeMachineToken, RevokeUserSessions)
+	// of a plain error return when a state-changing storage call fails
+	// mid-operation, reserving the explicit failed-audit-event helper for
+	// pre-mutation authorization denials instead.
+	if err := c.storage.DeleteSession(ctx, session.ID); err != nil {
+		return fmt.Errorf("failed to end impersonation session: %w", err)
+	}
+
 	diff := fmt.Sprintf(`{"duration_seconds":%d,"action_count":%d}`, int64(duration.Seconds()), actions)
 	desc := fmt.Sprintf("impersonation ended after %s (%d action(s))", duration.Round(time.Second), actions)
 	c.writeImpersonationEvent(ctx, EventImpersonationEnd, adminID, targetID, session.IPAddress, desc, diff)
 
-	return c.storage.DeleteSession(ctx, session.ID)
+	return nil
 }
 
 // ReauthorizeImpersonation re-verifies an ACTIVE impersonation session's admin

--- a/internal/core/impersonation_test.go
+++ b/internal/core/impersonation_test.go
@@ -310,3 +310,33 @@ func TestEndImpersonation_RejectsNonImpersonationSession(t *testing.T) {
 		t.Fatal("expected an error for a non-impersonation session")
 	}
 }
+
+// #G60 regression: EndImpersonation must not write the impersonation.end audit
+// event before the session row is actually deleted. This fault-injects a
+// DeleteSession failure and asserts the function (a) surfaces the error and
+// (b) never wrote the misleading "ended" audit event — before the fix, the
+// audit write ran first unconditionally, so a failed delete still left an
+// audit trail claiming the session had ended.
+func TestEndImpersonation_DeleteSessionFails_NoMisleadingAuditEvent(t *testing.T) {
+	store := new(MockStorage)
+	c := newImpersonationCore(store)
+	ctx := context.Background()
+
+	started := c.now().Add(-2 * time.Minute)
+	admin := uint(1)
+	store.On("GetSession", ctx, "tok").Return(&models.Session{
+		ID: 99, UserID: 2, ImpersonatedBy: &admin, ImpersonationStartedAt: &started,
+	}, nil)
+	store.On("CountImpersonatedActions", uint(2), uint(1), started).Return(int64(1), nil)
+	store.On("DeleteSession", ctx, uint(99)).Return(fmt.Errorf("db unavailable"))
+
+	err := c.EndImpersonation(ctx, "tok")
+	if err == nil {
+		t.Fatal("expected an error when the session delete fails")
+	}
+	// The impersonation.end event must never have been written: it asserts the
+	// session ended, which is false here — the delete failed and the session is
+	// still live.
+	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+	store.AssertExpectations(t)
+}

--- a/internal/core/machine_ip_allowlist_test.go
+++ b/internal/core/machine_ip_allowlist_test.go
@@ -94,7 +94,7 @@ func TestValidateMachineToken_ReturnsCIDRRestriction(t *testing.T) {
 	c := NewKeyorixCore(store)
 	c.now = func() time.Time { return fixed }
 
-	_, _, restriction, err := c.ValidateMachineToken(context.Background(), raw)
+	_, _, restriction, _, err := c.ValidateMachineToken(context.Background(), raw)
 	require.NoError(t, err)
 	require.NotNil(t, restriction)
 	assert.Equal(t, []string{"10.0.0.0/8", "192.168.1.0/24"}, restriction.AllowedCIDRs)

--- a/internal/core/machine_token.go
+++ b/internal/core/machine_token.go
@@ -237,43 +237,61 @@ func (c *KeyorixCore) ClassifyMachineToken(ctx context.Context, projectID, machi
 }
 
 // ValidateMachineToken resolves a raw machine token to its identity, granted
-// role names, and network restriction. It rejects revoked/expired credentials
-// and any machine not in the active state, and best-effort throttled-updates
-// last_used_at. The middleware gates on the machineTokenPrefix before calling this.
-func (c *KeyorixCore) ValidateMachineToken(ctx context.Context, raw string) (*models.MachineIdentity, []string, *MachineTokenRestriction, error) {
+// role names, network restriction, and the credential's row id. It rejects
+// revoked/expired credentials and any machine not in the active state. The
+// middleware gates on the machineTokenPrefix before calling this.
+//
+// #G60: this deliberately does NOT touch last_used_at itself (sibling of the
+// same fix in ValidatePATToken). The credential's network allowlist is
+// evaluated by the CALLER (server/middleware, server/grpc/interceptors),
+// strictly after this function returns — stamping last_used_at in here would
+// record the credential as "used" even for a request the caller is about to
+// reject outright for arriving from a disallowed network. The returned
+// credential id lets the caller invoke TouchMachineTokenLastUsed itself, once
+// its own restriction check has actually passed.
+func (c *KeyorixCore) ValidateMachineToken(ctx context.Context, raw string) (*models.MachineIdentity, []string, *MachineTokenRestriction, uint, error) {
 	if !strings.HasPrefix(raw, machineTokenPrefix) {
-		return nil, nil, nil, fmt.Errorf("not a machine token")
+		return nil, nil, nil, 0, fmt.Errorf("not a machine token")
 	}
 	cred, err := c.storage.GetMachineIdentityCredentialByHash(ctx, sha256Hex(raw))
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("invalid token")
+		return nil, nil, nil, 0, fmt.Errorf("invalid token")
 	}
 	if cred.Revoked {
-		return nil, nil, nil, ErrMachineTokenRevoked
+		return nil, nil, nil, 0, ErrMachineTokenRevoked
 	}
 	if cred.ExpiresAt != nil && c.now().After(*cred.ExpiresAt) {
-		return nil, nil, nil, ErrMachineTokenExpired
+		return nil, nil, nil, 0, ErrMachineTokenExpired
 	}
 	m, err := c.storage.GetMachineIdentity(ctx, cred.MachineIdentityID)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("machine identity not found")
+		return nil, nil, nil, 0, fmt.Errorf("machine identity not found")
 	}
 	if m.State != MachineActive {
-		return nil, nil, nil, fmt.Errorf("machine identity is %s", m.State)
+		return nil, nil, nil, 0, fmt.Errorf("machine identity is %s", m.State)
 	}
-
-	// Best-effort, throttled last-used stamp — never fails the request.
-	_ = c.storage.TouchMachineIdentityCredential(ctx, cred.ID, c.now(), machineTouchInterval)
 
 	roles, err := c.storage.GetMachineRoles(ctx, m.ID)
 	if err != nil {
-		return m, []string{}, machineRestrictionFrom(cred), nil
+		return m, []string{}, machineRestrictionFrom(cred), cred.ID, nil
 	}
 	roleNames := make([]string, len(roles))
 	for i, r := range roles {
 		roleNames[i] = r.Name
 	}
-	return m, roleNames, machineRestrictionFrom(cred), nil
+	return m, roleNames, machineRestrictionFrom(cred), cred.ID, nil
+}
+
+// TouchMachineTokenLastUsed records that machine credential credID was just
+// used, subject to the same machineTouchInterval throttle the inline stamp
+// always used. Split out of ValidateMachineToken (#G60) so the caller only
+// stamps last_used_at AFTER its own network-restriction (CIDR allowlist)
+// check has passed. Best-effort: never fails the caller's request.
+func (c *KeyorixCore) TouchMachineTokenLastUsed(ctx context.Context, credID uint) {
+	if credID == 0 {
+		return
+	}
+	_ = c.storage.TouchMachineIdentityCredential(ctx, credID, c.now(), machineTouchInterval)
 }
 
 // CurrentMachineTokenRestriction re-fetches a machine token's network restriction

--- a/internal/core/machine_token_test.go
+++ b/internal/core/machine_token_test.go
@@ -81,11 +81,12 @@ func TestValidateMachineToken(t *testing.T) {
 		c := NewKeyorixCore(store)
 		c.now = func() time.Time { return fixed }
 
-		m, roles, restriction, err := c.ValidateMachineToken(context.Background(), raw)
+		m, roles, restriction, credID, err := c.ValidateMachineToken(context.Background(), raw)
 		require.NoError(t, err)
 		require.Equal(t, uint(1), m.ID)
 		require.Equal(t, []string{"project_viewer"}, roles)
 		require.Nil(t, restriction)
+		require.Equal(t, uint(5), credID, "the credential's row id is surfaced so the caller can touch last_used_at itself")
 	})
 
 	t.Run("revoked credential rejected", func(t *testing.T) {
@@ -93,7 +94,7 @@ func TestValidateMachineToken(t *testing.T) {
 		store.On("GetMachineIdentityCredentialByHash", mock.Anything, hash).Return(&models.MachineIdentityCredential{ID: 5, MachineIdentityID: 1, Revoked: true}, nil)
 		c := NewKeyorixCore(store)
 		c.now = func() time.Time { return fixed }
-		_, _, _, err := c.ValidateMachineToken(context.Background(), raw)
+		_, _, _, _, err := c.ValidateMachineToken(context.Background(), raw)
 		require.ErrorContains(t, err, "revoked")
 	})
 
@@ -103,7 +104,7 @@ func TestValidateMachineToken(t *testing.T) {
 		store.On("GetMachineIdentityCredentialByHash", mock.Anything, hash).Return(&models.MachineIdentityCredential{ID: 5, MachineIdentityID: 1, ExpiresAt: &past}, nil)
 		c := NewKeyorixCore(store)
 		c.now = func() time.Time { return fixed }
-		_, _, _, err := c.ValidateMachineToken(context.Background(), raw)
+		_, _, _, _, err := c.ValidateMachineToken(context.Background(), raw)
 		require.ErrorContains(t, err, "expired")
 	})
 
@@ -113,7 +114,7 @@ func TestValidateMachineToken(t *testing.T) {
 		store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, State: MachineSuspended}, nil)
 		c := NewKeyorixCore(store)
 		c.now = func() time.Time { return fixed }
-		_, _, _, err := c.ValidateMachineToken(context.Background(), raw)
+		_, _, _, _, err := c.ValidateMachineToken(context.Background(), raw)
 		require.ErrorContains(t, err, "suspended")
 	})
 }

--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -116,33 +116,43 @@ func (c *KeyorixCore) RevokeOwnPAT(ctx context.Context, userID, tokenID uint) (t
 	return pat.TokenHash, nil
 }
 
-// ValidatePATToken resolves a raw PAT to its owning user, role names, and any
+// ValidatePATToken resolves a raw PAT to its owning user, role names, any
 // least-privilege restriction (ADR-042; nil when the token is unrestricted),
-// mirroring the shape of ValidateSessionToken so the auth middleware can use
-// either. It rejects revoked/expired tokens and inactive users, and best-effort
-// throttled-updates last_used_at. The caller (middleware) is expected to gate on
-// the patPrefix.
-func (c *KeyorixCore) ValidatePATToken(ctx context.Context, raw string) (*models.User, []string, *PATRestriction, error) {
+// and the PAT's row id, mirroring the shape of ValidateSessionToken so the
+// auth middleware can use either. It rejects revoked/expired tokens and
+// inactive users. The caller (middleware) is expected to gate on the
+// patPrefix.
+//
+// #G60: this deliberately does NOT touch last_used_at itself. A PAT's network
+// allowlist (the restriction's AllowedCIDRs) is evaluated by the CALLER
+// (server/middleware, server/grpc/interceptors), strictly after this function
+// returns — stamping last_used_at in here would record the token as "used"
+// even for a request the caller is about to reject outright for arriving
+// from a disallowed network, making the timestamp lie about whether the
+// token actually succeeded from that request's source. The returned PAT id
+// lets the caller invoke TouchPATLastUsed itself, once its own restriction
+// check has actually passed.
+func (c *KeyorixCore) ValidatePATToken(ctx context.Context, raw string) (*models.User, []string, *PATRestriction, uint, error) {
 	if !strings.HasPrefix(raw, patPrefix) {
-		return nil, nil, nil, fmt.Errorf("not a personal access token")
+		return nil, nil, nil, 0, fmt.Errorf("not a personal access token")
 	}
 	pat, err := c.storage.GetPersonalAccessTokenByHash(ctx, sha256Hex(raw))
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("invalid token")
+		return nil, nil, nil, 0, fmt.Errorf("invalid token")
 	}
 	if pat.Revoked {
-		return nil, nil, nil, ErrPATRevoked
+		return nil, nil, nil, 0, ErrPATRevoked
 	}
 	if IsPATExpired(pat, c.now()) {
 		c.emitPATExpiredNotification(ctx, pat)
-		return nil, nil, nil, ErrPATExpired
+		return nil, nil, nil, 0, ErrPATExpired
 	}
 	user, err := c.storage.GetUser(ctx, pat.UserID)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("user not found")
+		return nil, nil, nil, 0, fmt.Errorf("user not found")
 	}
 	if !user.IsActive {
-		return nil, nil, nil, fmt.Errorf("user inactive")
+		return nil, nil, nil, 0, fmt.Errorf("user inactive")
 	}
 	// A suspended/blocked account must not authenticate via a PAT either. SuspendUser sets
 	// account_state but deliberately leaves is_active untouched (and kills sessions), so
@@ -150,23 +160,33 @@ func (c *KeyorixCore) ValidatePATToken(ctx context.Context, raw string) (*models
 	// personal access tokens fully working. Mirror ValidateSessionToken's account-state
 	// gate so suspension is immediately effective on every credential type.
 	if AccountLoginBlocked(user.AccountState) {
-		return nil, nil, nil, fmt.Errorf("account is not active")
+		return nil, nil, nil, 0, fmt.Errorf("account is not active")
 	}
-
-	// Best-effort, throttled last-used stamp — never fails the request.
-	_ = c.storage.TouchPersonalAccessToken(ctx, pat.ID, c.now(), patTouchInterval)
 
 	restriction := patRestrictionFrom(pat)
 
 	roles, err := c.storage.GetUserRoles(ctx, user.ID)
 	if err != nil {
-		return user, []string{}, restriction, nil
+		return user, []string{}, restriction, pat.ID, nil
 	}
 	roleNames := make([]string, len(roles))
 	for i, r := range roles {
 		roleNames[i] = r.Name
 	}
-	return user, roleNames, restriction, nil
+	return user, roleNames, restriction, pat.ID, nil
+}
+
+// TouchPATLastUsed records that PAT patID was just used, subject to the same
+// patTouchInterval throttle the inline stamp always used. Split out of
+// ValidatePATToken (#G60) so the caller only stamps last_used_at AFTER its
+// own network-restriction (CIDR allowlist) check has passed — see
+// ValidatePATToken's doc comment for why touching unconditionally during
+// validation was misleading. Best-effort: never fails the caller's request.
+func (c *KeyorixCore) TouchPATLastUsed(ctx context.Context, patID uint) {
+	if patID == 0 {
+		return
+	}
+	_ = c.storage.TouchPersonalAccessToken(ctx, patID, c.now(), patTouchInterval)
 }
 
 // encodePATScopes normalises and JSON-encodes a permission allowlist for storage.

--- a/internal/core/pat_expiry_enforce_test.go
+++ b/internal/core/pat_expiry_enforce_test.go
@@ -112,7 +112,7 @@ func TestValidatePATToken_ExpiredPAT_ReturnsErrPATExpired(t *testing.T) {
 	ms.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).
 		Return(&models.Notification{ID: 99}, nil)
 
-	_, _, _, err := c.ValidatePATToken(ctx, raw)
+	_, _, _, _, err := c.ValidatePATToken(ctx, raw)
 
 	require.ErrorIs(t, err, ErrPATExpired)
 	ms.AssertCalled(t, "CreateNotification", ctx, mock.AnythingOfType("*models.Notification"))
@@ -131,12 +131,10 @@ func TestValidatePATToken_ValidNonExpiredPAT_Succeeds(t *testing.T) {
 		Return(&models.PersonalAccessToken{ID: 7, UserID: 2, ExpiresAt: &future}, nil)
 	ms.On("GetUser", ctx, uint(2)).
 		Return(&models.User{ID: 2, Username: "alice", IsActive: true}, nil)
-	ms.On("TouchPersonalAccessToken", ctx, uint(7), mock.AnythingOfType("time.Time"), patTouchInterval).
-		Return(nil)
 	ms.On("GetUserRoles", ctx, uint(2)).
 		Return([]*models.Role{{Name: "project_viewer"}}, nil)
 
-	user, roles, _, err := c.ValidatePATToken(ctx, raw)
+	user, roles, _, _, err := c.ValidatePATToken(ctx, raw)
 
 	require.NoError(t, err)
 	assert.Equal(t, uint(2), user.ID)

--- a/internal/core/pat_scoping_e2e_test.go
+++ b/internal/core/pat_scoping_e2e_test.go
@@ -62,7 +62,7 @@ func TestPATScoping_EndToEnd_RealRBAC(t *testing.T) {
 		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-read", nil, []string{"secrets.read"}, 0, 0, nil)
 		require.NoError(t, err)
 
-		user, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
+		user, _, restriction, _, err := c.ValidatePATToken(ctx, res.PlainToken)
 		require.NoError(t, err)
 		require.Equal(t, admin.ID, user.ID)
 		require.NotNil(t, restriction)
@@ -80,7 +80,7 @@ func TestPATScoping_EndToEnd_RealRBAC(t *testing.T) {
 	t.Run("project-scoped PAT is confined to its project", func(t *testing.T) {
 		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-proj3", nil, nil, 3, 0, nil)
 		require.NoError(t, err)
-		_, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
+		_, _, restriction, _, err := c.ValidatePATToken(ctx, res.PlainToken)
 		require.NoError(t, err)
 		require.NotNil(t, restriction)
 		rctx := WithPATRestriction(ctx, restriction)
@@ -101,7 +101,7 @@ func TestPATScoping_EndToEnd_RealRBAC(t *testing.T) {
 	t.Run("environment-scoped PAT is confined to its environment", func(t *testing.T) {
 		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-env7", nil, nil, 0, 7, nil) // env 7 only
 		require.NoError(t, err)
-		_, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
+		_, _, restriction, _, err := c.ValidatePATToken(ctx, res.PlainToken)
 		require.NoError(t, err)
 		require.NotNil(t, restriction)
 		require.Equal(t, uint(7), restriction.EnvironmentID)
@@ -123,7 +123,7 @@ func TestPATScoping_EndToEnd_RealRBAC(t *testing.T) {
 	t.Run("unrestricted PAT resolves to no restriction and keeps full inheritance", func(t *testing.T) {
 		res, err := c.CreateOwnPAT(ctx, admin.ID, "ci-full", nil, nil, 0, 0, nil)
 		require.NoError(t, err)
-		_, _, restriction, err := c.ValidatePATToken(ctx, res.PlainToken)
+		_, _, restriction, _, err := c.ValidatePATToken(ctx, res.PlainToken)
 		require.NoError(t, err)
 		assert.Nil(t, restriction, "no scopes + no project = unrestricted (back-compat)")
 	})

--- a/internal/core/pat_suspend_test.go
+++ b/internal/core/pat_suspend_test.go
@@ -42,7 +42,7 @@ func TestValidatePATToken_SuspendRevokesTokenAccess(t *testing.T) {
 	}).Error)
 
 	// Precondition: the PAT validates while the account is active.
-	u, _, _, err := c.ValidatePATToken(ctx, raw)
+	u, _, _, _, err := c.ValidatePATToken(ctx, raw)
 	require.NoError(t, err)
 	require.Equal(t, uint(1), u.ID)
 
@@ -51,7 +51,7 @@ func TestValidatePATToken_SuspendRevokesTokenAccess(t *testing.T) {
 
 	// The PAT must now be rejected — suspension actively revokes the user's PATs (not just
 	// blocking them via account state), so the token is reported revoked.
-	_, _, _, err = c.ValidatePATToken(ctx, raw)
+	_, _, _, _, err = c.ValidatePATToken(ctx, raw)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "revoked")
 

--- a/internal/core/pat_test.go
+++ b/internal/core/pat_test.go
@@ -74,15 +74,15 @@ func TestValidatePATToken(t *testing.T) {
 		c := NewKeyorixCore(ms)
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{ID: 9, UserID: 1}, nil)
 		ms.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: acctTestUser, IsActive: true}, nil)
-		ms.On("TouchPersonalAccessToken", ctx, uint(9), mock.AnythingOfType("time.Time"), patTouchInterval).Return(nil)
 		role := "system_viewer"
 		ms.On("GetUserRoles", ctx, uint(1)).Return([]*models.Role{{Name: role}}, nil)
 
-		user, roles, restriction, err := c.ValidatePATToken(ctx, raw)
+		user, roles, restriction, patID, err := c.ValidatePATToken(ctx, raw)
 		require.NoError(t, err)
 		assert.Equal(t, uint(1), user.ID)
 		assert.Equal(t, []string{role}, roles)
 		assert.Nil(t, restriction, "an unscoped token resolves to no restriction (full inheritance)")
+		assert.Equal(t, uint(9), patID, "the PAT's row id is surfaced so the caller can touch last_used_at itself")
 	})
 
 	t.Run("surfaces the least-privilege restriction for a scoped token (ADR-042)", func(t *testing.T) {
@@ -92,10 +92,9 @@ func TestValidatePATToken(t *testing.T) {
 			ID: 9, UserID: 1, Scopes: `["secrets.read"]`, ProjectScope: 4,
 		}, nil)
 		ms.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: acctTestUser, IsActive: true}, nil)
-		ms.On("TouchPersonalAccessToken", ctx, uint(9), mock.AnythingOfType("time.Time"), patTouchInterval).Return(nil)
 		ms.On("GetUserRoles", ctx, uint(1)).Return([]*models.Role{{Name: "system_viewer"}}, nil)
 
-		_, _, restriction, err := c.ValidatePATToken(ctx, raw)
+		_, _, restriction, _, err := c.ValidatePATToken(ctx, raw)
 		require.NoError(t, err)
 		require.NotNil(t, restriction)
 		assert.Equal(t, []string{"secrets.read"}, restriction.Permissions)
@@ -106,7 +105,7 @@ func TestValidatePATToken(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{ID: 9, UserID: 1, Revoked: true}, nil)
-		_, _, _, err := c.ValidatePATToken(ctx, raw)
+		_, _, _, _, err := c.ValidatePATToken(ctx, raw)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "revoked")
 	})
@@ -118,7 +117,7 @@ func TestValidatePATToken(t *testing.T) {
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{ID: 9, UserID: 1, Name: "old-ci", ExpiresAt: &past}, nil)
 		// emitPATExpiredNotification is called best-effort before the error is returned.
 		ms.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).Return(&models.Notification{ID: 1}, nil)
-		_, _, _, err := c.ValidatePATToken(ctx, raw)
+		_, _, _, _, err := c.ValidatePATToken(ctx, raw)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expired")
 	})
@@ -128,7 +127,7 @@ func TestValidatePATToken(t *testing.T) {
 		c := NewKeyorixCore(ms)
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{ID: 9, UserID: 1}, nil)
 		ms.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, IsActive: false}, nil)
-		_, _, _, err := c.ValidatePATToken(ctx, raw)
+		_, _, _, _, err := c.ValidatePATToken(ctx, raw)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "inactive")
 	})
@@ -141,7 +140,7 @@ func TestValidatePATToken(t *testing.T) {
 		c := NewKeyorixCore(ms)
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{ID: 9, UserID: 1}, nil)
 		ms.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, IsActive: true, AccountState: AccountSuspended}, nil)
-		_, _, _, err := c.ValidatePATToken(ctx, raw)
+		_, _, _, _, err := c.ValidatePATToken(ctx, raw)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not active")
 		// Must reject before stamping last-used — a blocked token is not "used".
@@ -152,14 +151,14 @@ func TestValidatePATToken(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(nil, assert.AnError)
-		_, _, _, err := c.ValidatePATToken(ctx, raw)
+		_, _, _, _, err := c.ValidatePATToken(ctx, raw)
 		require.Error(t, err)
 	})
 
 	t.Run("rejects a non-PAT token before any storage lookup", func(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
-		_, _, _, err := c.ValidatePATToken(ctx, "some-session-token")
+		_, _, _, _, err := c.ValidatePATToken(ctx, "some-session-token")
 		require.Error(t, err)
 		ms.AssertNotCalled(t, "GetPersonalAccessTokenByHash", mock.Anything, mock.Anything)
 	})

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -506,15 +506,55 @@ func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint)
 	return nil
 }
 
+// GetSCIMUser retrieves a user by ID for a SCIM GET, refusing (as the not-found
+// sentinel) a target that isn't SCIM-managed (scimManaged) — closing the read-path
+// half of the boundary UpdateSCIMUser/DeprovisionSCIMUser already enforce on write
+// (#120). Before this, GET /scim/v2/Users/{id} called the generic core.GetUser (also
+// used by the admin console and self-profile lookups) with no scimManaged check at
+// all, so a valid SCIM bearer token could disclose ANY native (non-SCIM-managed)
+// account's userName/email/displayName just by guessing/enumerating numeric ids
+// (#G85). The handler maps this error to a generic SCIM 404 either way — same as a
+// truly nonexistent id — so the response never confirms whether an out-of-scope id
+// exists at all, matching SCIM convention for a resource outside the client's scope.
+func (c *KeyorixCore) GetSCIMUser(ctx context.Context, id uint) (*models.User, error) {
+	user, err := c.storage.GetUser(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
+	}
+	if !scimManaged(user) {
+		return nil, fmt.Errorf("%s: not a SCIM-managed account", i18n.T("ErrorUserNotFound", nil))
+	}
+	return user, nil
+}
+
 // SCIMMaxPageSize bounds how many resources a single SCIM list page returns — the
 // value advertised in ServiceProviderConfig (filter.maxResults). A larger requested
 // count is clamped to it so an unfiltered list can't drain the whole directory into one
 // response (memory + DB amplification).
 const SCIMMaxPageSize = 200
 
-// ListSCIMUsersPage returns one page of users for a SCIM list and the total count.
-// startIndex is 1-based (SCIM convention); count is clamped to [0, SCIMMaxPageSize]
-// (count==0 returns no resources, just the total).
+// ListSCIMUsersPage returns one page of SCIM-managed users for a SCIM list, and the
+// SCIM-managed total (not the full directory size). startIndex is 1-based (SCIM
+// convention); count is clamped to [0, SCIMMaxPageSize] (count==0 returns no
+// resources, just the total).
+//
+// Filtered to scimManaged (#G85): GET /scim/v2/Users previously enumerated the
+// ENTIRE user directory — native, non-SCIM-managed accounts included — because
+// storage.ListUsers/UserFilter has no externalId-presence filter and this method
+// never applied one of its own, unlike UpdateSCIMUser/DeprovisionSCIMUser which
+// already refuse a non-SCIM-managed target (#120). A leaked totalResults count was
+// itself a smaller instance of the same disclosure, so it's fixed here too.
+//
+// Rather than add a filter to storage.UserFilter — which would need wiring through
+// BOTH LocalStorage's query AND RemoteStorage's wire protocol plus whatever
+// server-side route it proxies to (the server can run against either backend via
+// the storage factory; the SCIM handler doesn't know or care which) — this loads
+// the already storage-agnostic full user list via ListSCIMUsers and filters/pages
+// it in Go. That's the same "load once, filter/slice in memory" shape
+// ListGroups' filtered path already uses for groups (scim_groups.go), and it
+// guarantees the scimManaged boundary holds no matter which storage backend is
+// configured, at the cost of an O(directory size) scan per page instead of a
+// DB-level LIMIT/OFFSET.
 func (c *KeyorixCore) ListSCIMUsersPage(ctx context.Context, startIndex, count int) ([]*models.User, int, error) {
 	if startIndex < 1 {
 		startIndex = 1
@@ -525,20 +565,27 @@ func (c *KeyorixCore) ListSCIMUsersPage(ctx context.Context, startIndex, count i
 	if count > SCIMMaxPageSize {
 		count = SCIMMaxPageSize
 	}
-	if count == 0 {
-		// SCIM count=0 → return totalResults only. Use PageSize=1 to get an accurate
-		// total without a separate count API; the single fetched row is discarded.
-		_, total, err := c.storage.ListUsers(ctx, &storage.UserFilter{Page: 1, PageSize: 1})
-		if err != nil {
-			return nil, 0, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
-		}
-		return []*models.User{}, int(total), nil
-	}
-	users, total, err := c.storage.ListUsers(ctx, &storage.UserFilter{Offset: startIndex - 1, PageSize: count})
+	allUsers, err := c.ListSCIMUsers(ctx)
 	if err != nil {
-		return nil, 0, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		return nil, 0, err
 	}
-	return users, int(total), nil
+	managed := make([]*models.User, 0, len(allUsers))
+	for _, u := range allUsers {
+		if scimManaged(u) {
+			managed = append(managed, u)
+		}
+	}
+	total := len(managed)
+	if count == 0 || startIndex > total {
+		// SCIM count=0 (or a startIndex past the end) → return totalResults only.
+		return []*models.User{}, total, nil
+	}
+	lo := startIndex - 1
+	hi := lo + count
+	if hi > total {
+		hi = total
+	}
+	return managed[lo:hi], total, nil
 }
 
 // ListSCIMUsers returns users for a SCIM list, paging through all of them.

--- a/internal/core/scim_deprovision_test.go
+++ b/internal/core/scim_deprovision_test.go
@@ -43,7 +43,7 @@ func TestDeprovisionSCIMUser_RevokesSessionAndPAT(t *testing.T) {
 	su, _, err := c.ValidateSessionToken(ctx, "sess-tok")
 	require.NoError(t, err)
 	require.Equal(t, uint(1), su.ID)
-	pu, _, _, err := c.ValidatePATToken(ctx, raw)
+	pu, _, _, _, err := c.ValidatePATToken(ctx, raw)
 	require.NoError(t, err)
 	require.Equal(t, uint(1), pu.ID)
 
@@ -53,7 +53,7 @@ func TestDeprovisionSCIMUser_RevokesSessionAndPAT(t *testing.T) {
 	// Neither credential may authenticate the deprovisioned user any longer.
 	_, _, err = c.ValidateSessionToken(ctx, "sess-tok")
 	require.Error(t, err, "a deprovisioned user's session must not validate")
-	_, _, _, err = c.ValidatePATToken(ctx, raw)
+	_, _, _, _, err = c.ValidatePATToken(ctx, raw)
 	require.Error(t, err, "a deprovisioned user's PAT must not validate")
 
 	// And the user is soft-deleted — no longer resolvable.

--- a/internal/core/scim_paging_test.go
+++ b/internal/core/scim_paging_test.go
@@ -26,9 +26,15 @@ func TestListSCIMUsersPage(t *testing.T) {
 	c := NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
 
+	// #G85: ListSCIMUsersPage now filters to scimManaged (ExternalID != "") users
+	// only, matching the boundary UpdateSCIMUser/DeprovisionSCIMUser already
+	// enforce — see TestListSCIMUsersPage_ExcludesNonSCIMManaged below for that
+	// filtering behavior itself. This fixture sets a stored externalId on every
+	// seeded user so it continues to exercise pagination/windowing mechanics
+	// (this test's actual concern) against a realistic, SCIM-managed directory.
 	const n = 25
 	for i := 1; i <= n; i++ {
-		require.NoError(t, db.Create(&models.User{ID: uint(i), Username: fmt.Sprintf("u%02d", i), Email: fmt.Sprintf("u%02d@x.io", i)}).Error)
+		require.NoError(t, db.Create(&models.User{ID: uint(i), Username: fmt.Sprintf("u%02d", i), Email: fmt.Sprintf("u%02d@x.io", i), ExternalID: fmt.Sprintf("ext-%02d", i)}).Error)
 	}
 
 	t.Run("count is clamped to the max page size", func(t *testing.T) {
@@ -53,4 +59,35 @@ func TestListSCIMUsersPage(t *testing.T) {
 		assert.Equal(t, n, total)
 		assert.Empty(t, users)
 	})
+}
+
+// TestListSCIMUsersPage_ExcludesNonSCIMManaged pins #G85: ListSCIMUsersPage
+// previously queried storage.ListUsers with no scimManaged filter at all, so an
+// unfiltered SCIM directory listing enumerated EVERY user account — native
+// (non-SCIM-managed) accounts included — not just the ones actually under SCIM
+// control, unlike UpdateSCIMUser/DeprovisionSCIMUser which already refuse a
+// non-SCIM-managed target (#120). Seeds a mix of SCIM-managed (stored externalId)
+// and native (no externalId) users and asserts both the returned page AND the
+// total/count reflect only the SCIM-managed subset.
+func TestListSCIMUsersPage_ExcludesNonSCIMManaged(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+	c := NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "managed1", Email: "managed1@x.io", ExternalID: "okta-1"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "managed2", Email: "managed2@x.io", ExternalID: "okta-2"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 3, Username: "native1", Email: "native1@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 4, Username: "native2", Email: "native2@x.io"}).Error)
+
+	users, total, err := c.ListSCIMUsersPage(ctx, 1, 200)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total, "totalResults must count only the SCIM-managed users, not the full 4-user directory")
+	require.Len(t, users, 2, "only the SCIM-managed users may be returned")
+	for _, u := range users {
+		assert.NotEmpty(t, u.ExternalID, "every returned user must be SCIM-managed")
+		assert.NotContains(t, []string{"native1", "native2"}, u.Username, "a native account must never appear in a SCIM listing")
+	}
 }

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -541,6 +541,20 @@ func (c *KeyorixCore) CreateFolder(
 		if parent.IsSecret {
 			return nil, fmt.Errorf("%s: parent node %d is a secret, not a folder", i18n.T("ErrorValidation", nil), *parentID)
 		}
+		// The destination parent was loaded with a bare, unauthorized GetSecret:
+		// the caller's write authorization was only ever checked against
+		// (projectID, envID) — the NEW folder's own claimed scope — and says
+		// nothing about the target parent's actual scope. Mirror CreateSecret's
+		// own parent-folder validation (above in this file) and MoveSecret's
+		// (secret_move.go): require the destination to live in the SAME
+		// project/environment the caller was authorized for, otherwise a caller
+		// could nest a folder under a parent in a project/environment they have
+		// no access to, and folder-inheriting ACL/sharing resolution (see
+		// HasSecretACL's ancestor walk in secret_acl.go) would then apply that
+		// other project's grants to it.
+		if parent.ProjectID != projectID || parent.EnvironmentID != envID {
+			return nil, fmt.Errorf("%s: parent folder %d does not belong to the same project/environment", i18n.T("ErrorValidation", nil), *parentID)
+		}
 	}
 
 	node := &models.SecretNode{

--- a/internal/crypto/azurekms/azurekms.go
+++ b/internal/crypto/azurekms/azurekms.go
@@ -15,16 +15,21 @@
 // (at first run) and a later Decrypt call (at every subsequent restart) — the new
 // version cannot unwrap ciphertext produced by the old one. To make this immune
 // to rotation, Encrypt captures the exact key version Azure actually used (from
-// the response KID, which is always fully versioned) and embeds it in the
-// returned blob behind a magic prefix; Decrypt recognizes that prefix and targets
-// the pinned version instead of "current". Ciphertext wrapped before this change
-// (no prefix) still decrypts via the old "current"/configured-version resolution
-// — see decodeEnvelope.
+// the response KID, which is always fully versioned, and which Encrypt checks
+// names the configured key before trusting it) and embeds it in the returned
+// blob behind a magic prefix, alongside a MAC binding that version to the
+// unwrapped plaintext (see envelope's doc comment) so the version can't be
+// rewritten independently of the ciphertext it travels with. Decrypt recognizes
+// that prefix and targets the pinned version instead of "current". Ciphertext
+// wrapped before this change (no prefix) still decrypts via the old
+// "current"/configured-version resolution — see decodeEnvelope.
 package azurekms
 
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -52,14 +57,41 @@ const envelopeMagic = "keyorix-azkms-v1:"
 
 // envelope carries the exact key version a KEK was wrapped under, alongside the
 // wrap result, so Decrypt can always target that version rather than "current".
+//
+// MAC binds Version to the plaintext that Ciphertext actually unwraps to: it is
+// HMAC-SHA256(key=plaintext KEK, message=Version), computed once at Encrypt time
+// while the plaintext is available and re-checked at Decrypt time against the
+// plaintext Key Vault just returned. Version alone is otherwise unauthenticated
+// metadata — nothing ties it to the ciphertext it travels with in the same
+// on-disk blob, so anyone able to modify the blob could rewrite Version
+// independently of Ciphertext. A plain (unkeyed) checksum wouldn't help: an
+// attacker with write access to the blob can already read Ciphertext from that
+// same blob and recompute a checksum to match any Version they choose. Keying
+// the MAC on the recovered plaintext instead works because that plaintext is
+// never persisted anywhere — it exists only in Key Vault and briefly in this
+// process's memory — so a storage-only attacker (or a rogue component sitting
+// in front of Key Vault fabricating an UnwrapKey response) cannot compute a
+// matching MAC without already knowing it. MAC is empty for envelopes written
+// before this field existed (see decodeEnvelope); Decrypt only enforces it when
+// present, so already-encrypted-and-stored DEKs keep decrypting unchanged.
 type envelope struct {
 	Version    string `json:"version"`
 	Ciphertext []byte `json:"ciphertext"`
+	MAC        []byte `json:"mac,omitempty"`
 }
 
-// encodeEnvelope prepends the magic prefix to a JSON-encoded envelope.
-func encodeEnvelope(version string, ciphertext []byte) ([]byte, error) {
-	body, err := json.Marshal(envelope{Version: version, Ciphertext: ciphertext})
+// versionMAC computes the HMAC binding an envelope's Version to the plaintext
+// its Ciphertext unwraps to (see envelope's doc comment).
+func versionMAC(plaintext []byte, version string) []byte {
+	h := hmac.New(sha256.New, plaintext)
+	h.Write([]byte(version))
+	return h.Sum(nil)
+}
+
+// encodeEnvelope prepends the magic prefix to a JSON-encoded envelope. plaintext
+// is the KEK material ciphertext wraps — used only to derive MAC, never stored.
+func encodeEnvelope(version string, ciphertext, plaintext []byte) ([]byte, error) {
+	body, err := json.Marshal(envelope{Version: version, Ciphertext: ciphertext, MAC: versionMAC(plaintext, version)})
 	if err != nil {
 		return nil, fmt.Errorf("azure-kms: encode envelope: %w", err)
 	}
@@ -217,16 +249,33 @@ func (c *client) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) 
 	// when the request (c.keyVersion) was unversioned/"current". Pin it into the
 	// returned blob so a later Decrypt targets this exact version and is immune
 	// to the key being rotated to a new "current" version in the meantime.
+	//
+	// res.KID is untrusted key-selection metadata, not just a version hint: it
+	// names both a key and a version. Before trusting either, confirm the KID
+	// actually names the key we asked Key Vault to wrap under (c.keyName) —
+	// reusing parseKeyID, the same defensive URL parser already used for the
+	// user-supplied kms_key_id. A KID naming a different key (an SDK bug, a
+	// Key Vault misconfiguration, or an untrusted component sitting in front
+	// of Key Vault) must never be silently pinned as if it were ours: that
+	// would record the KEK as wrapped under the wrong key and point every
+	// future Decrypt at it.
 	var version string
 	if res.KID != nil {
-		version = res.KID.Version()
+		_, kidName, kidVersion, perr := parseKeyID(string(*res.KID))
+		if perr != nil {
+			return nil, fmt.Errorf("azure-kms: wrap response KID %q is not a valid key identifier: %w", string(*res.KID), perr)
+		}
+		if kidName != c.keyName {
+			return nil, fmt.Errorf("azure-kms: wrap response KID names key %q, configured key is %q — refusing to pin a version for a different key", kidName, c.keyName)
+		}
+		version = kidVersion
 	}
 	if version == "" {
 		// Unexpected (Key Vault always returns a versioned KID), but fail safe by
 		// falling back to the legacy, unpinned blob rather than erroring out.
 		return res.Result, nil
 	}
-	return encodeEnvelope(version, res.Result)
+	return encodeEnvelope(version, res.Result, plaintext)
 }
 
 func (c *client) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
@@ -246,6 +295,14 @@ func (c *client) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error)
 	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("azure-kms: unwrap key: %w", err)
+	}
+	// Envelopes written before the MAC field existed carry none (env.MAC is
+	// nil) — only enforce the check when a MAC is actually present, so those
+	// already-encrypted-and-stored DEKs keep decrypting exactly as before.
+	if pinned && len(env.MAC) > 0 {
+		if !hmac.Equal(versionMAC(res.Result, env.Version), env.MAC) {
+			return nil, fmt.Errorf("azure-kms: version-pinned envelope failed integrity check: Version does not match the recovered key material — the envelope may have been tampered with")
+		}
 	}
 	return res.Result, nil
 }

--- a/internal/crypto/azurekms/azurekms_extra_test.go
+++ b/internal/crypto/azurekms/azurekms_extra_test.go
@@ -12,7 +12,8 @@ import (
 // TestEncodeDecodeEnvelope_RoundTrip verifies the envelope encodes and decodes symmetrically.
 func TestEncodeDecodeEnvelope_RoundTrip(t *testing.T) {
 	ct := []byte("fake-ciphertext")
-	blob, err := encodeEnvelope("v1", ct)
+	pt := []byte("fake-plaintext")
+	blob, err := encodeEnvelope("v1", ct, pt)
 	if err != nil {
 		t.Fatalf("encodeEnvelope: %v", err)
 	}
@@ -28,6 +29,9 @@ func TestEncodeDecodeEnvelope_RoundTrip(t *testing.T) {
 	}
 	if string(env.Ciphertext) != string(ct) {
 		t.Errorf("ciphertext: got %q, want %q", env.Ciphertext, ct)
+	}
+	if string(env.MAC) != string(versionMAC(pt, "v1")) {
+		t.Errorf("mac: got %x, want %x", env.MAC, versionMAC(pt, "v1"))
 	}
 }
 

--- a/internal/crypto/azurekms/azurekms_s2_test.go
+++ b/internal/crypto/azurekms/azurekms_s2_test.go
@@ -127,7 +127,7 @@ func TestDecrypt_UnwrapKeyError_IsPrefixed(t *testing.T) {
 // for a version-pinned (magic-prefix) envelope blob.
 func TestDecrypt_UnwrapKeyError_PinnedEnvelope(t *testing.T) {
 	// Produce a valid envelope blob first.
-	blob, err := encodeEnvelope("v1", []byte("ciphertext"))
+	blob, err := encodeEnvelope("v1", []byte("ciphertext"), []byte("plaintext"))
 	require.NoError(t, err)
 
 	c := &client{

--- a/internal/crypto/azurekms/azurekms_test.go
+++ b/internal/crypto/azurekms/azurekms_test.go
@@ -268,6 +268,85 @@ func TestNew_RejectsNonKeyVaultHost(t *testing.T) {
 	assert.Contains(t, err.Error(), "not a recognized Azure Key Vault")
 }
 
+// fakePermissiveKeys always returns the same plaintext from UnwrapKey
+// regardless of the version requested — modeling a rogue/misbehaving
+// component sitting between this client and Key Vault (or an SDK bug) that
+// does not itself enforce that the requested version matches what the
+// ciphertext was actually wrapped under. Used to prove that the envelope's
+// own MAC — not just Key Vault's/the fake's version-consistency enforcement
+// — is what refuses a Version field tampered independently of the
+// ciphertext (G77 member 1).
+type fakePermissiveKeys struct {
+	plaintext []byte
+}
+
+func (f fakePermissiveKeys) WrapKey(_ context.Context, _ string, _ string, _ azkeys.KeyOperationParameters, _ *azkeys.WrapKeyOptions) (azkeys.WrapKeyResponse, error) {
+	return azkeys.WrapKeyResponse{}, fmt.Errorf("fakePermissiveKeys: WrapKey not implemented")
+}
+
+func (f fakePermissiveKeys) UnwrapKey(_ context.Context, _ string, _ string, _ azkeys.KeyOperationParameters, _ *azkeys.UnwrapKeyOptions) (azkeys.UnwrapKeyResponse, error) {
+	return azkeys.UnwrapKeyResponse{KeyOperationResult: azkeys.KeyOperationResult{Result: f.plaintext}}, nil
+}
+
+// TestAzureKMS_DecryptRefusesTamperedVersion is the G77 member-1 regression:
+// the version-pinning envelope's Version field must be bound to the
+// ciphertext it travels with, so tampering it independently is detected
+// rather than silently trusted as key-selection metadata.
+func TestAzureKMS_DecryptRefusesTamperedVersion(t *testing.T) {
+	secret := []byte("real-secret-kek-material")
+	blob, err := encodeEnvelope("v1", []byte("original-ciphertext"), secret)
+	require.NoError(t, err)
+
+	// Tamper Version independently of Ciphertext — exactly the finding's
+	// scenario: someone able to modify the on-disk blob rewrites the version
+	// tag. They cannot recompute a matching MAC because it's keyed on secret,
+	// which is never persisted anywhere (it only ever exists in Key Vault and
+	// transiently in process memory).
+	env, ok, err := decodeEnvelope(blob)
+	require.NoError(t, err)
+	require.True(t, ok)
+	env.Version = "v2-attacker-chosen"
+	tamperedBody, err := json.Marshal(env)
+	require.NoError(t, err)
+	tamperedBlob := append([]byte(envelopeMagic), tamperedBody...)
+
+	// Even in the worst case — UnwrapKey with the tampered version still
+	// "succeeds" (a rogue component in front of Key Vault, or a permissive
+	// SDK/mock that doesn't itself enforce the version/ciphertext binding)
+	// and returns the true plaintext — Decrypt must still refuse: the MAC was
+	// computed over the ORIGINAL version and won't match one recomputed over
+	// the tampered version.
+	c := &client{keys: fakePermissiveKeys{plaintext: secret}, keyName: "kek", keyVersion: ""}
+	_, err = c.Decrypt(context.Background(), tamperedBlob)
+	require.Error(t, err, "Decrypt must refuse an envelope whose Version was tampered independently of the ciphertext/MAC")
+	assert.Contains(t, err.Error(), "integrity check")
+}
+
+// fakeKeysWrongKID returns a WrapKey response whose KID names a DIFFERENT key
+// than the one requested — modeling an SDK bug, a Key Vault misconfiguration,
+// or an untrusted component sitting in front of Key Vault.
+type fakeKeysWrongKID struct{}
+
+func (f fakeKeysWrongKID) WrapKey(_ context.Context, _ string, _ string, params azkeys.KeyOperationParameters, _ *azkeys.WrapKeyOptions) (azkeys.WrapKeyResponse, error) {
+	kid := azkeys.ID("https://vault.vault.azure.net/keys/some-other-key/v1")
+	return azkeys.WrapKeyResponse{KeyOperationResult: azkeys.KeyOperationResult{KID: &kid, Result: params.Value}}, nil
+}
+
+func (f fakeKeysWrongKID) UnwrapKey(_ context.Context, _ string, _ string, _ azkeys.KeyOperationParameters, _ *azkeys.UnwrapKeyOptions) (azkeys.UnwrapKeyResponse, error) {
+	return azkeys.UnwrapKeyResponse{}, fmt.Errorf("fakeKeysWrongKID: UnwrapKey not implemented")
+}
+
+// TestAzureKMS_EncryptRefusesMismatchedKID is the G77 member-2 regression:
+// Encrypt must not trust the wrap response's KID without checking it names
+// the configured key — a mismatch must be refused, not silently pinned.
+func TestAzureKMS_EncryptRefusesMismatchedKID(t *testing.T) {
+	c := &client{keys: fakeKeysWrongKID{}, keyName: "kek", keyVersion: ""}
+	_, err := c.Encrypt(context.Background(), []byte("kek-material"))
+	require.Error(t, err, "Encrypt must refuse a wrap response whose KID names a different key than configured")
+	assert.Contains(t, err.Error(), "some-other-key")
+	assert.Contains(t, err.Error(), "kek")
+}
+
 func TestParseKeyID(t *testing.T) {
 	tests := []struct {
 		name                             string

--- a/internal/encryption/auth_encryption.go
+++ b/internal/encryption/auth_encryption.go
@@ -42,6 +42,31 @@ func (ae *AuthEncryption) Initialize(passphrase string) error {
 	return ae.service.Initialize(passphrase)
 }
 
+// AcquireSharedKeyLock takes the same cross-process shared DEK lock
+// (Service.AcquireSharedKeyLock, #196) the DEK-focused local CLI commands
+// (status/validate/fix-perms/upgrade-aad) already require, for the sibling
+// auth-encryption commands (status/enable/migrate/validate) that read (or, for
+// migrate, write under) the CURRENT DEK without themselves rotating it. Refused
+// while a live server or an in-progress rotation/migrate-provider holds the lock
+// exclusively, so those commands fail fast instead of racing a DEK that's
+// concurrently being replaced. A no-op when encryption is disabled, matching
+// Initialize's own no-op in that case (there is no DEK to guard).
+func (ae *AuthEncryption) AcquireSharedKeyLock() error {
+	if !ae.service.IsEnabled() {
+		return nil
+	}
+	return ae.service.AcquireSharedKeyLock()
+}
+
+// Shutdown releases resources held by the underlying encryption Service —
+// wiping the DEK from memory and releasing the key lock if AcquireSharedKeyLock
+// (or Initialize's own exclusive-lock paths, e.g. via RotateAuthEncryption) took
+// one. Safe to call even if encryption is disabled or Initialize was never
+// called.
+func (ae *AuthEncryption) Shutdown() {
+	ae.service.Shutdown()
+}
+
 // GetAuthEncryptionStatus returns the current authentication encryption status.
 func (ae *AuthEncryption) GetAuthEncryptionStatus() map[string]interface{} {
 	status := map[string]interface{}{

--- a/internal/encryption/g62_dek_safety_test.go
+++ b/internal/encryption/g62_dek_safety_test.go
@@ -1,0 +1,194 @@
+package encryption
+
+// g62_dek_safety_test.go — regression tests for G62: newer encryption-package
+// code skipping the package's own established DEK-safety conventions.
+//
+//   - RewrapDEKWithProvider (the `migrate-provider` command's core function)
+//     never acquired the cross-process exclusive key lock RotateDEKWithSweep/
+//     RotateKEKPassphrase already require, so a concurrent migrate-provider run
+//     could race a live server (or an in-progress rotation) on the same key
+//     file. TestRewrapDEKWithProvider_RefusesWhileServerHoldsLock and its
+//     positive-control sibling pin the fix.
+//
+//   - EncryptionService.dek (and the pre-rotation EncryptionService that
+//     RotateDEKWithSweep discards once it's superseded) was never wiped via
+//     wipeBytes on shutdown/replacement, unlike every other DEK-bearing
+//     variable in this package. TestServiceShutdown_WipesEncryptionServiceDEK
+//     and TestRotateDEKWithSweep_WipesSupersededEncryptionServiceDEK are
+//     memory-scan-style tests proving no DEK bytes remain afterward.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/crypto"
+)
+
+// allZeroBytes reports whether every byte in b is 0 — the wipeBytes
+// post-condition. An empty/nil slice is trivially "all zero" (nothing left to
+// leak), which is also what a slice looks like after being set to nil.
+func allZeroBytes(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// ─── member 1: RewrapDEKWithProvider must take the cross-process exclusive lock ───
+
+// TestRewrapDEKWithProvider_RefusesWhileServerHoldsLock is the direct
+// regression test for G62 member 1: migrate-provider (RewrapDEKWithProvider)
+// must refuse to run while a live server (or an in-progress rotation — both
+// hold the same exclusive dek.lock via AcquireExclusiveKeyLock) already holds
+// the key directory, exactly like RotateDEKWithSweep already does
+// (TestRotateDEKWithSweep_RefusesWhileServerHoldsLock in exclusive_lock_test.go).
+func TestRewrapDEKWithProvider_RefusesWhileServerHoldsLock(t *testing.T) {
+	serverSvc, dir := newTestService(t, lockTestPassphrase)
+	if err := serverSvc.AcquireExclusiveKeyLock(); err != nil {
+		t.Fatalf("server failed to acquire its own key lock: %v", err)
+	}
+	defer serverSvc.Shutdown()
+
+	migrateSvc := newTestServiceAtDir(t, dir, lockTestPassphrase)
+	defer migrateSvc.Shutdown()
+
+	newKEKPath := filepath.Join(dir, "new.kek")
+	writeHexKEK(t, newKEKPath)
+	newProvider := crypto.NewFileKeyProvider(newKEKPath)
+
+	err := migrateSvc.RewrapDEKWithProvider(newProvider)
+	if err == nil {
+		t.Fatal("expected RewrapDEKWithProvider to be refused while the server holds the key lock")
+	}
+	if !strings.Contains(err.Error(), "refusing to re-wrap") {
+		t.Fatalf("expected a 'refusing to re-wrap' error, got: %v", err)
+	}
+}
+
+// TestRewrapDEKWithProvider_SucceedsAfterServerLockReleased is the positive
+// control: once the "server" shuts down (releasing the exclusive lock),
+// RewrapDEKWithProvider proceeds normally — ordinary, single-process
+// migrate-provider usage must not be broken by the new lock requirement.
+func TestRewrapDEKWithProvider_SucceedsAfterServerLockReleased(t *testing.T) {
+	serverSvc, dir := newTestService(t, lockTestPassphrase)
+	if err := serverSvc.AcquireExclusiveKeyLock(); err != nil {
+		t.Fatalf("server failed to acquire its own key lock: %v", err)
+	}
+	serverSvc.Shutdown() // releases the lock
+
+	migrateSvc := newTestServiceAtDir(t, dir, lockTestPassphrase)
+	defer migrateSvc.Shutdown()
+
+	newKEKPath := filepath.Join(dir, "new.kek")
+	writeHexKEK(t, newKEKPath)
+	newProvider := crypto.NewFileKeyProvider(newKEKPath)
+
+	if err := migrateSvc.RewrapDEKWithProvider(newProvider); err != nil {
+		t.Fatalf("RewrapDEKWithProvider should succeed once the server's lock is released: %v", err)
+	}
+}
+
+// TestRewrapDEKWithProvider_RefusedDuringConcurrentRotationSweep mirrors
+// TestAcquireSharedKeyLock_RefusedWhileRotationSweepInProgress: an in-progress
+// RotateDEKWithSweep holds the exact same exclusive dek.lock for the duration
+// of its sweep, so a concurrent migrate-provider must be refused too, not just
+// while a long-lived server is up.
+func TestRewrapDEKWithProvider_RefusedDuringConcurrentRotationSweep(t *testing.T) {
+	rotatingSvc, dir := newTestService(t, lockTestPassphrase)
+	if err := rotatingSvc.AcquireExclusiveKeyLock(); err != nil {
+		t.Fatalf("rotation failed to acquire the exclusive key lock: %v", err)
+	}
+	defer rotatingSvc.Shutdown()
+
+	migrateSvc := newTestServiceAtDir(t, dir, lockTestPassphrase)
+	defer migrateSvc.Shutdown()
+
+	newKEKPath := filepath.Join(dir, "new.kek")
+	writeHexKEK(t, newKEKPath)
+	newProvider := crypto.NewFileKeyProvider(newKEKPath)
+
+	err := migrateSvc.RewrapDEKWithProvider(newProvider)
+	if err == nil {
+		t.Fatal("expected RewrapDEKWithProvider to be refused while a rotation sweep holds the exclusive key lock")
+	}
+}
+
+// ─── member 2: EncryptionService.dek must be wiped, not leaked in memory ───
+
+// TestServiceShutdown_WipesEncryptionServiceDEK is the memory-scan-style
+// regression test for G62 member 2: Service.Shutdown() called
+// s.keyManager.Wipe() (which only zeroes km.currentDEK) but never wiped
+// s.encryptionService.dek — a SEPARATE copy of the DEK bytes made via
+// s.keyManager.GetDEK() in Initialize — leaving a live copy of the DEK in
+// process memory after "shutdown". This captures a reference to the DEK
+// backing array before Shutdown and asserts every byte is zero afterward.
+func TestServiceShutdown_WipesEncryptionServiceDEK(t *testing.T) {
+	svc, _ := newTestService(t, lockTestPassphrase)
+
+	svc.mu.RLock()
+	if svc.encryptionService == nil {
+		svc.mu.RUnlock()
+		t.Fatal("test setup bug: expected an initialized encryptionService before Shutdown")
+	}
+	dekRef := svc.encryptionService.dek // same backing array wipeBytes must zero in place
+	svc.mu.RUnlock()
+
+	if allZeroBytes(dekRef) {
+		t.Fatal("test setup bug: DEK was already all-zero before Shutdown")
+	}
+
+	svc.Shutdown()
+
+	if !allZeroBytes(dekRef) {
+		t.Fatal("EncryptionService.dek was not wiped by Shutdown — DEK bytes remain live in process memory")
+	}
+
+	svc.mu.RLock()
+	stillReferenced := svc.encryptionService != nil
+	svc.mu.RUnlock()
+	if stillReferenced {
+		t.Error("expected Service.encryptionService to be cleared (nil) after Shutdown")
+	}
+}
+
+// TestRotateDEKWithSweep_WipesSupersededEncryptionServiceDEK is the
+// memory-scan-style regression test for the other half of G62 member 2: when
+// RotateDEKWithSweep replaces s.encryptionService with a new one bound to the
+// freshly-rotated DEK, the OLD EncryptionService (bound to the now-superseded
+// DEK) becomes unreachable through s but its DEK-bytes copy was never wiped —
+// unlike km.currentDEK, which the key-manager layer does wipe on the same
+// rotation. This captures the pre-rotation DEK backing array and asserts it is
+// zeroed once the rotation completes and the old EncryptionService is
+// discarded.
+func TestRotateDEKWithSweep_WipesSupersededEncryptionServiceDEK(t *testing.T) {
+	svc, _ := newTestService(t, lockTestPassphrase)
+	defer svc.Shutdown()
+
+	svc.mu.RLock()
+	oldDEKRef := svc.encryptionService.dek
+	svc.mu.RUnlock()
+	if allZeroBytes(oldDEKRef) {
+		t.Fatal("test setup bug: DEK was already all-zero before rotation")
+	}
+
+	db := newTestDB(t)
+	if _, err := svc.RotateDEKWithSweep(lockTestPassphrase, db); err != nil {
+		t.Fatalf("RotateDEKWithSweep failed: %v", err)
+	}
+
+	if !allZeroBytes(oldDEKRef) {
+		t.Fatal("the pre-rotation EncryptionService's DEK copy was not wiped after being superseded by RotateDEKWithSweep")
+	}
+
+	// Non-regression: the NEW encryption service (the one actually in use after
+	// rotation) must still work — this fix must not have wiped the wrong slice.
+	svc.mu.RLock()
+	newDEKRef := svc.encryptionService.dek
+	svc.mu.RUnlock()
+	if allZeroBytes(newDEKRef) {
+		t.Fatal("the post-rotation (live) EncryptionService's DEK was wiped too — encryption would now be broken")
+	}
+}

--- a/internal/encryption/keymanager_lifecycle.go
+++ b/internal/encryption/keymanager_lifecycle.go
@@ -224,6 +224,10 @@ func (km *KeyManager) Initialize(passphrase string) error {
 	// unchanged (#268).
 	esk, eskID, err := deriveEvidenceSignKey(kek)
 	if err != nil {
+		// dek was already unwrapped above and would otherwise leak, unwiped, on
+		// this error path — matching how RotateKEKPassphrase wipes its own
+		// same-shaped intermediate on the identical derivation-failure branch.
+		wipeBytes(dek)
 		return fmt.Errorf("failed to derive evidence-signing key: %w", err)
 	}
 
@@ -232,6 +236,8 @@ func (km *KeyManager) Initialize(passphrase string) error {
 	// verifiable after one.
 	ack, ackID, err := deriveAuditCheckpointKey(kek)
 	if err != nil {
+		wipeBytes(dek)
+		wipeBytes(esk)
 		return fmt.Errorf("failed to derive audit-checkpoint key: %w", err)
 	}
 

--- a/internal/encryption/keymanager_lock_test.go
+++ b/internal/encryption/keymanager_lock_test.go
@@ -15,9 +15,20 @@ package encryption
 // database, and asserts the security property that matters — whichever one
 // "wins" the race, the DEK left on disk once both finish is the one the
 // database was actually re-encrypted under, never a stale, superseded one.
+//
+// G62: RewrapDEKWithProvider now also self-enforces the exclusive,
+// non-blocking Service-level dek.lock RotateDEKWithSweep already took (the
+// #92 server-vs-CLI lock, distinct from this file's #195 KeyManager-level
+// dek.key.lock). Before that fix only rotate took it, so rewrap could run
+// concurrently and rely purely on RewrapDEK's staleness check to detect and
+// abort a lost race after the fact. Now the two are mutually exclusive at the
+// Service layer too: whichever acquires the lock first runs to completion,
+// and the other is refused immediately, before it ever touches the DEK file —
+// so exactly one of the two must succeed, not both racing to the finish line.
 
 import (
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -131,40 +142,57 @@ func TestRewrapAndRotate_ConcurrentRace_FinalDEKMatchesDB(t *testing.T) {
 	}()
 	wg.Wait()
 
-	// Rotate must always succeed — a concurrent rewrap attempt must never be
-	// able to block or corrupt it.
-	if rotateErr != nil {
-		t.Fatalf("RotateDEKWithSweep failed under concurrent rewrap: %v", rotateErr)
+	// G62: RewrapDEKWithProvider now self-enforces the same exclusive
+	// Service-level dek.lock RotateDEKWithSweep takes, so the two can no
+	// longer both proceed concurrently — whichever acquires it first runs to
+	// completion, and the other is refused immediately with a DEK-lock error,
+	// before touching the DEK file at all. Exactly one of the two must
+	// succeed.
+	if (rotateErr == nil) == (rewrapErr == nil) {
+		t.Fatalf("expected exactly one of RotateDEKWithSweep/RewrapDEKWithProvider to succeed under the Service-level exclusive lock; rotateErr=%v rewrapErr=%v", rotateErr, rewrapErr)
 	}
-	// Rewrap either wins cleanly, or correctly detects that the DEK it holds
-	// went stale under it and aborts rather than clobbering the rotated one.
-	// Both are safe outcomes; the invariant checked below is what matters.
-	t.Logf("concurrent RewrapDEKWithProvider result: %v", rewrapErr)
 
-	// Fetch the row rotate's sweep re-encrypted and confirm svcA (which now
-	// holds the freshly-rotated DEK) can still decrypt it — the DB and svcA's
-	// in-memory DEK must agree.
 	var v models.SecretVersion
 	if err := db.First(&v, versionID).Error; err != nil {
 		t.Fatalf("failed to fetch SecretVersion: %v", err)
 	}
 	aad := SecretAAD(nodeID, projectID, 1)
-	plaintext, err := svcA.DecryptSecretWithAAD(v.EncryptedValue, aad)
+
+	var winner *Service
+	if rotateErr == nil {
+		// Rotate won: the DB was fully re-encrypted under the new DEK —
+		// confirm svcA (which now holds it) can still decrypt the row, and
+		// that the loser was refused via the DEK lock, not some other error.
+		winner = svcA
+		if !strings.Contains(rewrapErr.Error(), "DEK lock") {
+			t.Errorf("expected the refused rewrap to report the DEK lock, got: %v", rewrapErr)
+		}
+	} else {
+		// Rewrap won instead: the DEK VALUE is unchanged (only its wrapping
+		// changed), so the pre-existing row must still decrypt under svcB
+		// (now holding that same DEK, wrapped under newProvider).
+		winner = svcB
+		if !strings.Contains(rotateErr.Error(), "DEK lock") {
+			t.Errorf("expected the refused rotate to report the DEK lock, got: %v", rotateErr)
+		}
+	}
+	plaintext, err := winner.DecryptSecretWithAAD(v.EncryptedValue, aad)
 	if err != nil {
-		t.Fatalf("decrypt post-rotation row with svcA: %v", err)
+		t.Fatalf("decrypt row with the winning service: %v", err)
 	}
 	if string(plaintext) != "top-secret-race-value" {
-		t.Fatalf("unexpected plaintext after rotation: %q", plaintext)
+		t.Fatalf("unexpected plaintext after the race: %q", plaintext)
 	}
 
 	// Now resolve whichever DEK is ACTUALLY on disk right now, independently
 	// of which candidate provider wrapped it, and confirm it is byte-
-	// identical to svcA's post-rotation in-memory DEK — i.e. the file left
-	// behind is never the stale pre-rotation value.
+	// identical to the winner's own in-memory DEK — i.e. the file left behind
+	// always matches the operation that actually ran, never a stale or
+	// corrupted value from the race.
 	finalDEK := resolveFinalDEK(t, dir, cfg, "test-passphrase", newProvider)
-	postRotateDEK := captureCurrentDEK(t, svcA)
-	if string(finalDEK) != string(postRotateDEK) {
-		t.Fatalf("on-disk DEK after the race does not match the DEK the database was re-encrypted under — ciphertext orphaned")
+	winnerDEK := captureCurrentDEK(t, winner)
+	if string(finalDEK) != string(winnerDEK) {
+		t.Fatalf("on-disk DEK after the race does not match the winning operation's in-memory DEK — ciphertext orphaned")
 	}
 }
 

--- a/internal/encryption/service_rotation.go
+++ b/internal/encryption/service_rotation.go
@@ -86,6 +86,13 @@ func (s *Service) RotateDEKWithSweep(passphrase string, db *gorm.DB) (*SweepResu
 	if err != nil {
 		return nil, fmt.Errorf("failed to recreate encryption service after rotation: %w", err)
 	}
+	// The old encryption service wraps the now-superseded DEK (a distinct copy from
+	// s.keyManager.GetDEK(), not the km.currentDEK slice the key manager itself
+	// already wipes) and is about to be discarded — wipe its DEK copy from memory
+	// here, like every other DEK-bearing variable in this package.
+	if s.encryptionService != nil {
+		wipeBytes(s.encryptionService.dek)
+	}
 	s.encryptionService = encSvc
 	return sweepResult, nil
 }
@@ -208,11 +215,23 @@ func (s *Service) UpgradeAuthAAD(db *gorm.DB) (*SweepResult, error) {
 // file is modified. The server must be stopped (exclusive key lock must not
 // be held by another process) before running this command.
 func (s *Service) RotateKEKPassphrase(oldPassphrase, newPassphrase string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
 	if !s.initialized {
+		s.mu.RUnlock()
 		return fmt.Errorf("encryption service not initialized")
 	}
+	s.mu.RUnlock()
+
+	// Self-enforce the same exclusive server-vs-CLI lock RotateDEKWithSweep and
+	// RewrapDEKWithProvider already take internally, rather than relying solely on
+	// the CLI caller (rotate-kek) to acquire it first, as defense in depth.
+	// Idempotent — a no-op if this Service (or its caller) already holds it.
+	if err := s.AcquireExclusiveKeyLock(); err != nil {
+		return fmt.Errorf("refusing to rotate KEK: %w — stop the running server before rotating", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.keyManager.RotateKEKPassphrase(oldPassphrase, newPassphrase)
 }
 
@@ -224,11 +243,24 @@ func (s *Service) RotateKEKPassphrase(oldPassphrase, newPassphrase string) error
 // then verify the new provider unwraps the DEK before discarding the previous
 // wrapped-DEK backup.
 func (s *Service) RewrapDEKWithProvider(newProvider crypto.KeyProvider) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
 	if !s.initialized {
+		s.mu.RUnlock()
 		return fmt.Errorf("encryption service not initialized")
 	}
+	s.mu.RUnlock()
+
+	// Refuse to re-wrap against a live server (#92, mirroring RotateDEKWithSweep):
+	// without this, a concurrent `migrate-provider` run and a live server (or a
+	// concurrent rotation) could race on the same dek.key.pending → dek.key path.
+	// AcquireExclusiveKeyLock is released by the deferred Shutdown() the CLI
+	// already calls after this function returns.
+	if err := s.AcquireExclusiveKeyLock(); err != nil {
+		return fmt.Errorf("refusing to re-wrap DEK: %w — stop the running server before migrating the KEK provider", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.keyManager.RewrapDEK(newProvider)
 }
 
@@ -318,6 +350,13 @@ func (s *Service) Shutdown() {
 	defer s.mu.Unlock()
 	if s.keyManager != nil {
 		s.keyManager.Wipe()
+	}
+	// s.keyManager.Wipe() only zeroes km.currentDEK — s.encryptionService.dek is a
+	// separate copy (made via s.keyManager.GetDEK() in Initialize/RotateDEKWithSweep)
+	// and was never wiped, unlike every other DEK-bearing variable in this package.
+	if s.encryptionService != nil {
+		wipeBytes(s.encryptionService.dek)
+		s.encryptionService = nil
 	}
 	releaseKeyLock(s.serverLock)
 	s.serverLock = nil

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -284,11 +284,12 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore, req
 	var (
 		user        *models.User
 		restriction *core.PATRestriction
+		patID       uint
 		err         error
 	)
 	viaPAT := strings.HasPrefix(token, patTokenPrefix)
 	if viaPAT {
-		user, _, restriction, err = coreService.ValidatePATToken(ctx, token)
+		user, _, restriction, patID, err = coreService.ValidatePATToken(ctx, token)
 	} else {
 		user, _, err = coreService.ValidateSessionToken(ctx, token)
 	}
@@ -340,6 +341,17 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore, req
 		return nil, nil, err
 	}
 
+	// #G60: stamp last_used_at only now that the PAT's network restriction (and
+	// the rest of enforceGRPCAccessPolicy) has actually been evaluated and
+	// passed — touching earlier (formerly done unconditionally inside
+	// ValidatePATToken) would mark a PAT as "used" even for a request just
+	// rejected above for arriving from a disallowed network. No-op for a
+	// non-PAT principal (patID is 0). gRPC has no auth cache, so every request
+	// re-validates and this always runs on the success path.
+	if viaPAT {
+		coreService.TouchPATLastUsed(ctx, patID)
+	}
+
 	// Resolve roles + permissions for downstream per-method authorization.
 	identity, err := coreService.GetUserIdentity(ctx, user.ID)
 	if err != nil {
@@ -365,7 +377,7 @@ func authenticateRequest(ctx context.Context, coreService *core.KeyorixCore, req
 }
 
 func validateGRPCMachineToken(ctx context.Context, coreService *core.KeyorixCore, token string) (*UserContext, *core.PATRestriction, error) {
-	machine, roles, restriction, err := coreService.ValidateMachineToken(ctx, token)
+	machine, roles, restriction, credID, err := coreService.ValidateMachineToken(ctx, token)
 	if err != nil {
 		return nil, nil, grpcAuthFailure(ctx)
 	}
@@ -384,6 +396,10 @@ func validateGRPCMachineToken(ctx context.Context, coreService *core.KeyorixCore
 			return nil, nil, status.Errorf(codes.PermissionDenied, "token not permitted from this network")
 		}
 	}
+	// #G60: stamp last_used_at only now that the network restriction has been
+	// evaluated and passed (sibling of the same fix for the PAT path below).
+	// gRPC has no auth cache, so this always runs on the success path.
+	coreService.TouchMachineTokenLastUsed(ctx, credID)
 	return uc, nil, nil
 }
 

--- a/server/http/handlers/bulk_access_requests.go
+++ b/server/http/handlers/bulk_access_requests.go
@@ -121,12 +121,16 @@ func (h *CatalogHandler) ListRejectionReasonTemplates(w http.ResponseWriter, r *
 // DeleteRejectionReasonTemplate handles
 // DELETE /api/v1/rejection-reason-templates/{id}
 func (h *CatalogHandler) DeleteRejectionReasonTemplate(w http.ResponseWriter, r *http.Request) {
+	actor, ok := mustGetUser(w, r)
+	if !ok {
+		return
+	}
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
 		sendError(w, "InvalidParameter", "Invalid template ID", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.DeleteRejectionReasonTemplate(r.Context(), uint(id)); err != nil {
+	if err := h.coreService.DeleteRejectionReasonTemplate(r.Context(), actor.UserID, uint(id)); err != nil {
 		msg := err.Error()
 		status := http.StatusInternalServerError
 		if strings.Contains(msg, errNotFound) {

--- a/server/http/handlers/bulk_access_requests_test.go
+++ b/server/http/handlers/bulk_access_requests_test.go
@@ -224,7 +224,7 @@ func TestListRejectionTemplates_WithData(t *testing.T) {
 
 func TestDeleteRejectionTemplate_InvalidID(t *testing.T) {
 	h := newBulkAccessTestHandler(t)
-	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "abc")
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodDelete, "/", nil)), "id", "abc")
 	w := httptest.NewRecorder()
 	h.DeleteRejectionReasonTemplate(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -232,7 +232,7 @@ func TestDeleteRejectionTemplate_InvalidID(t *testing.T) {
 
 func TestDeleteRejectionTemplate_NotFound(t *testing.T) {
 	h := newBulkAccessTestHandler(t)
-	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "999")
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodDelete, "/", nil)), "id", "999")
 	w := httptest.NewRecorder()
 	h.DeleteRejectionReasonTemplate(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -245,7 +245,7 @@ func TestDeleteRejectionTemplate_Success(t *testing.T) {
 		bytes.NewBufferString(`{"name":"del-me","reason":"to delete"}`))))
 	require.Equal(t, http.StatusCreated, cw.Code)
 
-	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "1")
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodDelete, "/", nil)), "id", "1")
 	w := httptest.NewRecorder()
 	h.DeleteRejectionReasonTemplate(w, req)
 	assert.Equal(t, http.StatusNoContent, w.Code)
@@ -300,7 +300,7 @@ func TestDeleteRejectionTemplate_DBError_Returns500(t *testing.T) {
 	h := newBulkAccessBrokenHandler(t)
 	// DB is closed: DeleteRejectionReasonTemplate returns a generic error (not
 	// "not found") which routes to the 500 else-branch.
-	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "1")
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodDelete, "/", nil)), "id", "1")
 	w := httptest.NewRecorder()
 	h.DeleteRejectionReasonTemplate(w, req)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)

--- a/server/http/handlers/folders_handler.go
+++ b/server/http/handlers/folders_handler.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -104,7 +105,23 @@ func (h *FolderHandler) CreateFolder(w http.ResponseWriter, r *http.Request) {
 	folder, err := h.coreService.CreateFolder(r.Context(), userCtx.UserID, reqBody.Name, reqBody.ProjectID, reqBody.EnvironmentID, reqBody.ParentID)
 	if err != nil {
 		log.Printf("Error creating folder: %v", err)
-		h.sendError(w, "InternalError", "Failed to create folder", http.StatusInternalServerError, nil)
+		msg := err.Error()
+		status := http.StatusInternalServerError
+		errType := "InternalError"
+		respMsg := "Failed to create folder"
+		switch {
+		case strings.Contains(msg, "not found"):
+			status = http.StatusNotFound
+			errType = "NotFound"
+			respMsg = "Parent folder not found"
+		case strings.Contains(msg, "validation") ||
+			strings.Contains(msg, "not a folder") ||
+			strings.Contains(msg, "does not belong to the same project"):
+			status = http.StatusBadRequest
+			errType = "ValidationError"
+			respMsg = msg
+		}
+		h.sendError(w, errType, respMsg, status, nil)
 		return
 	}
 

--- a/server/http/handlers/folders_handler_test.go
+++ b/server/http/handlers/folders_handler_test.go
@@ -147,6 +147,104 @@ func TestCreateFolder_NoUserContext_401(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
+// withScopedWriterCtx injects a UserContext for a non-admin user with only
+// secrets.write on a single project (no admin bypass) — the "caller
+// authorized only on project A" persona used by the #G86 regression tests.
+func withScopedWriterCtx(r *http.Request, userID uint, username string) *http.Request {
+	uc := &middleware.UserContext{
+		UserID: userID, Username: username,
+		ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: true,
+	}
+	return r.WithContext(context.WithValue(r.Context(), middleware.GetUserContextKey(), uc))
+}
+
+// seedScopedWriter creates user userID with a non-admin role granting
+// secrets.write scoped ONLY to projectID (EnvironmentID: 0 = any environment
+// within that project, per the established RBAC scoping convention — see
+// TestListSecrets_ScopedUser_SingleProject in secrets_list_scoped_test.go).
+func seedScopedWriter(t *testing.T, db *gorm.DB, userID uint, username string, projectID uint) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.User{ID: userID, Username: username, AccountState: "active"}).Error)
+	role := mustCreateRole(t, db, username+"-writer")
+	perm := mustCreatePermission(t, db, "secrets.write", "secrets", "write")
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: role.ID, PermissionID: perm.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{
+		UserID: userID, RoleID: role.ID, ProjectID: projectID, EnvironmentID: 0,
+	}).Error)
+}
+
+// TestCreateFolder_RefusesCrossProjectParent_HTTP is the #G86 regression: a
+// caller authorized ONLY on project 1 (secrets.write, not admin) declares
+// project_id=1 (their own, authorized scope) but points parent_id at a
+// folder that actually lives in project 2 — a project they have no access
+// to. Before the fix, CreateFolder happily nested the new project-1 folder
+// under the foreign project-2 parent; folder-inheriting ACL/sharing
+// resolution would then apply project 2's grants to it. Must be refused.
+func TestCreateFolder_RefusesCrossProjectParent_HTTP(t *testing.T) {
+	h, _, db := freshFolderFixture(t)
+
+	// A second project the scoped writer has no access to, with a folder in it.
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "proj-foreign"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 20, ProjectID: 2, Name: "env-foreign"}).Error)
+	foreignFolder := &models.SecretNode{
+		Name: "foreign-parent", ProjectID: 2, EnvironmentID: 20,
+		IsSecret: false, Type: "folder", Status: "active",
+		CreatedBy: "attacker", OwnerID: 99,
+	}
+	require.NoError(t, db.Create(foreignFolder).Error)
+
+	seedScopedWriter(t, db, 2, "attacker", 1) // write access to project 1 ONLY
+
+	body, _ := json.Marshal(map[string]any{
+		"name":           "smuggled",
+		"project_id":     1,
+		"environment_id": 10,
+		"parent_id":      foreignFolder.ID,
+	})
+	r := withScopedWriterCtx(
+		httptest.NewRequest(http.MethodPost, "/api/v1/folders", bytes.NewReader(body)),
+		2, "attacker",
+	)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateFolder(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "same project")
+}
+
+// TestCreateFolder_ScopedWriter_SameProjectParent_Succeeds_HTTP is the
+// legitimate-case companion to the above: the SAME scoped-to-project-1
+// writer nests a new folder under a parent that also lives in project 1 —
+// this must keep working after the #G86 fix.
+func TestCreateFolder_ScopedWriter_SameProjectParent_Succeeds_HTTP(t *testing.T) {
+	h, cs, db := freshFolderFixture(t)
+
+	parent, err := cs.CreateFolder(context.Background(), 1, "legit-parent", 1, 10, nil)
+	require.NoError(t, err)
+
+	seedScopedWriter(t, db, 2, "legit-user", 1)
+
+	body, _ := json.Marshal(map[string]any{
+		"name":           "legit-child",
+		"project_id":     1,
+		"environment_id": 10,
+		"parent_id":      parent.ID,
+	})
+	r := withScopedWriterCtx(
+		httptest.NewRequest(http.MethodPost, "/api/v1/folders", bytes.NewReader(body)),
+		2, "legit-user",
+	)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateFolder(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+	var resp SuccessResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+}
+
 // ── ListFolders ──────────────────────────────────────────────────────────────
 
 func TestListFolders_HappyPath(t *testing.T) {

--- a/server/http/handlers/handlers_s13_rbac_test.go
+++ b/server/http/handlers/handlers_s13_rbac_test.go
@@ -834,8 +834,13 @@ func TestGetUserPermissionsForUser_BadParam_S13(t *testing.T) {
 // TestGetUserPermissionsForUser_NonExistent_S13 confirms that a request for a
 // non-existent user returns 200 with an empty permissions list (storage returns
 // nil/nil for unknown users — the handler succeeds with empty data).
+// G84: reading a DIFFERENT user's (even a nonexistent one's) permission set
+// requires the caller to be self, an admin, or a roles.read holder — a bare
+// authenticated context is no longer enough. Use the admin-seeded core so this
+// still exercises the "nonexistent target" data path the test is named for.
 func TestGetUserPermissionsForUser_NonExistent_S13(t *testing.T) {
-	h := newUsersRolesHandlerS13(t)
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewUsersRolesHandler(cs)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/9999/permissions", nil)
 	req = withUserCtx(withChiParam(req, "id", "9999"))
 	w := httptest.NewRecorder()

--- a/server/http/handlers/handlers_s6_test.go
+++ b/server/http/handlers/handlers_s6_test.go
@@ -521,8 +521,13 @@ func TestGetUserMembershipsForUser_BadID_S6(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// G84: reading a DIFFERENT user's memberships now requires self, admin, or
+// roles.read — use an admin-seeded core (isolated from the shared S4 core, which
+// has no RBAC tables seeded for UserID 1) so the "happy path" for an admin
+// inspecting another user's memberships is what's actually exercised here.
 func TestGetUserMembershipsForUser_HappyPath_S6(t *testing.T) {
-	h := newUsersRolesHandlerS6(t)
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewUsersRolesHandler(cs)
 	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "9999"))
 	w := httptest.NewRecorder()
 	h.GetUserMembershipsForUser(w, req)

--- a/server/http/handlers/rbac_real_test.go
+++ b/server/http/handlers/rbac_real_test.go
@@ -429,6 +429,211 @@ func TestRBACReal_GetUserPermissionsForUser(t *testing.T) {
 	assert.NotContains(t, names, "secrets.write", "an expired time-bound grant confers no permissions")
 }
 
+// --- G84: GetUserPermissionsForUser/GetUserMembershipsForUser must not disclose an
+// arbitrary OTHER user's RBAC state to a caller holding only the group-wide
+// users.read permission (held by nearly every seeded role). Require self, OR
+// roles.read — the same admin-tier gate GetUserRolesForUser already requires for
+// the sibling roles-list view (#141). ---
+
+// A caller holding ONLY users.read (no roles.read, not an admin role) must be
+// refused when requesting a DIFFERENT user's effective permission set.
+func TestRBACReal_GetUserPermissionsForUser_NonAdminCannotReadOtherUser(t *testing.T) {
+	db := openTestDB(t)
+	handler := NewUsersRolesHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	target := &models.User{Username: "g84-perm-target", Email: "g84-perm-target@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(target).Error)
+	actor := &models.User{Username: "g84-perm-actor", Email: "g84-perm-actor@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(actor).Error)
+
+	readOnlyRole := mustCreateRole(t, db, "g84-perm-users-read-only")
+	usersReadPerm := mustCreatePermission(t, db, "users.read", "users", "read")
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: readOnlyRole.ID, PermissionID: usersReadPerm.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: actor.ID, RoleID: readOnlyRole.ID}).Error)
+
+	req := withUserCtxID(
+		withChiParam(httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%d/permissions", target.ID), nil),
+			"id", fmt.Sprintf("%d", target.ID)),
+		actor.ID, "g84-perm-actor")
+	w := httptest.NewRecorder()
+
+	handler.GetUserPermissionsForUser(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "users.read alone must not disclose another user's permission set")
+}
+
+// The SAME shape of actor (users.read only, not admin) reading THEIR OWN
+// permissions must still succeed — the legitimate self-read case must not regress.
+func TestRBACReal_GetUserPermissionsForUser_SelfReadAllowed(t *testing.T) {
+	db := openTestDB(t)
+	handler := NewUsersRolesHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	actor := &models.User{Username: "g84-perm-self", Email: "g84-perm-self@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(actor).Error)
+	readOnlyRole := mustCreateRole(t, db, "g84-perm-users-read-only-self")
+	usersReadPerm := mustCreatePermission(t, db, "users.read", "users", "read")
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: readOnlyRole.ID, PermissionID: usersReadPerm.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: actor.ID, RoleID: readOnlyRole.ID}).Error)
+
+	req := withUserCtxID(
+		withChiParam(httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%d/permissions", actor.ID), nil),
+			"id", fmt.Sprintf("%d", actor.ID)),
+		actor.ID, "g84-perm-self")
+	w := httptest.NewRecorder()
+
+	handler.GetUserPermissionsForUser(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "a user must still be able to read their own effective permissions")
+}
+
+// An actor holding roles.read (granted via an explicit role, NOT the global-admin
+// bypass) — the same tier GetUserRolesForUser requires (#141) — may read another
+// user's permission set. Exercises the permission-grant path distinctly from the
+// admin-role bypass covered below.
+func TestRBACReal_GetUserPermissionsForUser_RolesReadHolderCanReadOtherUser(t *testing.T) {
+	db := openTestDB(t)
+	handler := NewUsersRolesHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	target := &models.User{Username: "g84-perm-target2", Email: "g84-perm-target2@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(target).Error)
+	actor := &models.User{Username: "g84-perm-auditor", Email: "g84-perm-auditor@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(actor).Error)
+
+	auditorRole := mustCreateRole(t, db, "g84-perm-roles-read")
+	rolesReadPerm := mustCreatePermission(t, db, "roles.read", "roles", "read")
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: auditorRole.ID, PermissionID: rolesReadPerm.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: actor.ID, RoleID: auditorRole.ID}).Error)
+
+	req := withUserCtxID(
+		withChiParam(httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%d/permissions", target.ID), nil),
+			"id", fmt.Sprintf("%d", target.ID)),
+		actor.ID, "g84-perm-auditor")
+	w := httptest.NewRecorder()
+
+	handler.GetUserPermissionsForUser(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "a roles.read holder must still be able to inspect another user's effective permissions")
+}
+
+// A global admin (adminRoleNames bypass, same actor shape as openTestDB's seeded
+// UserID 1) may still read another user's permission set — the legitimate
+// admin-read case must not regress.
+func TestRBACReal_GetUserPermissionsForUser_GlobalAdminCanReadOtherUser(t *testing.T) {
+	db := openTestDB(t)
+	handler := NewUsersRolesHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	target := &models.User{Username: "g84-perm-target3", Email: "g84-perm-target3@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(target).Error)
+
+	req := withUserCtx( // UserID 1, seeded as system_admin by openTestDB
+		withChiParam(httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%d/permissions", target.ID), nil),
+			"id", fmt.Sprintf("%d", target.ID)))
+	w := httptest.NewRecorder()
+
+	handler.GetUserPermissionsForUser(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "a global admin must still be able to read another user's effective permissions")
+}
+
+// A caller holding ONLY users.read must be refused when requesting a DIFFERENT
+// user's project memberships (same disclosure class as permissions above).
+func TestRBACReal_GetUserMembershipsForUser_NonAdminCannotReadOtherUser(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&models.ProjectMembership{}))
+	handler := NewUsersRolesHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	target := &models.User{Username: "g84-mem-target", Email: "g84-mem-target@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(target).Error)
+	actor := &models.User{Username: "g84-mem-actor", Email: "g84-mem-actor@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(actor).Error)
+
+	readOnlyRole := mustCreateRole(t, db, "g84-mem-users-read-only")
+	usersReadPerm := mustCreatePermission(t, db, "users.read", "users", "read")
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: readOnlyRole.ID, PermissionID: usersReadPerm.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: actor.ID, RoleID: readOnlyRole.ID}).Error)
+
+	req := withUserCtxID(
+		withChiParam(httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%d/memberships", target.ID), nil),
+			"id", fmt.Sprintf("%d", target.ID)),
+		actor.ID, "g84-mem-actor")
+	w := httptest.NewRecorder()
+
+	handler.GetUserMembershipsForUser(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "users.read alone must not disclose another user's project memberships")
+}
+
+// The SAME shape of actor reading THEIR OWN memberships must still succeed.
+func TestRBACReal_GetUserMembershipsForUser_SelfReadAllowed(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&models.ProjectMembership{}))
+	handler := NewUsersRolesHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	actor := &models.User{Username: "g84-mem-self", Email: "g84-mem-self@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(actor).Error)
+	readOnlyRole := mustCreateRole(t, db, "g84-mem-users-read-only-self")
+	usersReadPerm := mustCreatePermission(t, db, "users.read", "users", "read")
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: readOnlyRole.ID, PermissionID: usersReadPerm.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: actor.ID, RoleID: readOnlyRole.ID}).Error)
+
+	req := withUserCtxID(
+		withChiParam(httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%d/memberships", actor.ID), nil),
+			"id", fmt.Sprintf("%d", actor.ID)),
+		actor.ID, "g84-mem-self")
+	w := httptest.NewRecorder()
+
+	handler.GetUserMembershipsForUser(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "a user must still be able to read their own project memberships")
+}
+
+// An actor holding roles.read (explicit grant, not the admin-role bypass) may read
+// another user's project memberships.
+func TestRBACReal_GetUserMembershipsForUser_RolesReadHolderCanReadOtherUser(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&models.ProjectMembership{}))
+	handler := NewUsersRolesHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	target := &models.User{Username: "g84-mem-target2", Email: "g84-mem-target2@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(target).Error)
+	actor := &models.User{Username: "g84-mem-auditor", Email: "g84-mem-auditor@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(actor).Error)
+
+	auditorRole := mustCreateRole(t, db, "g84-mem-roles-read")
+	rolesReadPerm := mustCreatePermission(t, db, "roles.read", "roles", "read")
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: auditorRole.ID, PermissionID: rolesReadPerm.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: actor.ID, RoleID: auditorRole.ID}).Error)
+
+	req := withUserCtxID(
+		withChiParam(httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%d/memberships", target.ID), nil),
+			"id", fmt.Sprintf("%d", target.ID)),
+		actor.ID, "g84-mem-auditor")
+	w := httptest.NewRecorder()
+
+	handler.GetUserMembershipsForUser(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "a roles.read holder must still be able to inspect another user's project memberships")
+}
+
+// A global admin may still read another user's project memberships.
+func TestRBACReal_GetUserMembershipsForUser_GlobalAdminCanReadOtherUser(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&models.ProjectMembership{}))
+	handler := NewUsersRolesHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	target := &models.User{Username: "g84-mem-target3", Email: "g84-mem-target3@example.com", PasswordHash: "x"}
+	require.NoError(t, db.Create(target).Error)
+
+	req := withUserCtx( // UserID 1, seeded as system_admin by openTestDB
+		withChiParam(httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/users/%d/memberships", target.ID), nil),
+			"id", fmt.Sprintf("%d", target.ID)))
+	w := httptest.NewRecorder()
+
+	handler.GetUserMembershipsForUser(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "a global admin must still be able to read another user's project memberships")
+}
+
 func TestRBACReal_Unauthorized(t *testing.T) {
 	handler, _, _ := setupRBACTestWithDB(t)
 

--- a/server/http/handlers/scim.go
+++ b/server/http/handlers/scim.go
@@ -208,13 +208,17 @@ func listResponsePaged(resources []map[string]interface{}, total, startIndex int
 	}
 }
 
-// GetUser handles GET /scim/v2/Users/{id}.
+// GetUser handles GET /scim/v2/Users/{id}. Routed through GetSCIMUser (not the
+// generic core.GetUser also used by the admin console/self-profile lookups) so a
+// non-SCIM-managed (native) account's id is refused the same way ReplaceUser/
+// PatchUser/DeleteUser already refuse one (#120) — a generic 404 either way, so the
+// response never confirms whether an out-of-scope id exists at all (#G85).
 func (h *SCIMHandler) GetUser(w http.ResponseWriter, r *http.Request) {
 	id, ok := scimID(w, r)
 	if !ok {
 		return
 	}
-	user, err := h.coreService.GetUser(r.Context(), id)
+	user, err := h.coreService.GetSCIMUser(r.Context(), id)
 	if err != nil {
 		scimError(w, http.StatusNotFound, "user not found")
 		return

--- a/server/http/handlers/scim_test.go
+++ b/server/http/handlers/scim_test.go
@@ -206,6 +206,63 @@ func TestSCIM_ListFilterDoesNotLeakNativeAccount(t *testing.T) {
 	assert.Empty(t, resources, "a filter match against a native (non-SCIM-managed) account must not be returned")
 }
 
+// TestSCIM_ListUsersOnlyReturnsSCIMManaged pins the "GET /scim/v2/Users" half of
+// #G85: ListSCIMUsersPage previously queried storage.ListUsers with no scimManaged
+// filter at all, so the unfiltered SCIM directory listing enumerated EVERY user
+// account — native, non-SCIM-managed accounts included, not just the ones actually
+// under SCIM control. Seeds one SCIM-managed user (via the normal CreateUser flow)
+// and one native account (created directly, no externalId — same shape as the
+// classic bootstrap admin), then asserts the unfiltered list surfaces only the
+// SCIM-managed one, and that totalResults/itemsPerPage reflect that filtered count,
+// not the full 2-user directory.
+func TestSCIM_ListUsersOnlyReturnsSCIMManaged(t *testing.T) {
+	h, db := setupSCIMTest(t)
+	managedID := provisionUser(t, h, "managed@corp.com")
+	require.NoError(t, db.Create(&models.User{
+		ID: 999, Username: "native", Email: "native@corp.com", DisplayName: "Native Admin",
+		IsActive: true, AccountState: core.AccountActive,
+	}).Error)
+
+	w := httptest.NewRecorder()
+	h.ListUsers(w, httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := decodeSCIM(t, w)
+
+	assert.Equal(t, float64(1), resp["totalResults"], "totalResults must reflect only the SCIM-managed user, not the full 2-user directory")
+	assert.Equal(t, float64(1), resp["itemsPerPage"])
+
+	resources, _ := resp["Resources"].([]interface{})
+	require.Len(t, resources, 1, "only the SCIM-managed account may be listed")
+	only, _ := resources[0].(map[string]interface{})
+	assert.Equal(t, managedID, only["id"], "the returned resource must be the SCIM-managed user, not the native one")
+	assert.NotEqual(t, "native@corp.com", only["userName"], "a native (non-SCIM-managed) account must never appear in a SCIM listing")
+}
+
+// TestSCIM_GetUserRefusesNativeAccount pins the "GET /scim/v2/Users/{id}" half of
+// #G85: GetUser previously called the generic core.GetUser with no scimManaged
+// check at all, so any valid numeric id — including a NATIVE admin account SCIM
+// never provisioned — would be disclosed. A native id must now come back as a
+// generic SCIM 404, the same response a genuinely nonexistent id gets, so the
+// response never confirms whether an out-of-scope resource exists, and must not
+// leak any of the native account's fields along the way.
+func TestSCIM_GetUserRefusesNativeAccount(t *testing.T) {
+	h, db := setupSCIMTest(t)
+	require.NoError(t, db.Create(&models.User{
+		ID: 42, Username: "native", Email: "native@corp.com", DisplayName: "Native Admin",
+		IsActive: true, AccountState: core.AccountActive,
+	}).Error)
+
+	w := httptest.NewRecorder()
+	h.GetUser(w, withID(httptest.NewRequest(http.MethodGet, "/scim/v2/Users/42", nil), "42"))
+	assert.Equal(t, http.StatusNotFound, w.Code, "GET on a non-SCIM-managed id must be refused, not disclosed")
+
+	resp := decodeSCIM(t, w)
+	assert.Equal(t, "user not found", resp["detail"], "the refusal must be the same generic message a nonexistent id gets")
+	body := w.Body.String()
+	assert.NotContains(t, body, "native@corp.com", "the native account's email must not leak in the refusal response")
+	assert.NotContains(t, body, "Native Admin", "the native account's display name must not leak in the refusal response")
+}
+
 func TestSCIM_ServiceProviderConfig(t *testing.T) {
 	h, _ := setupSCIMTest(t)
 	w := httptest.NewRecorder()

--- a/server/http/handlers/secrets_move.go
+++ b/server/http/handlers/secrets_move.go
@@ -47,7 +47,8 @@ func (h *SecretHandler) MoveSecret(w http.ResponseWriter, r *http.Request) {
 			status = http.StatusNotFound
 		case strings.Contains(msg, "validation") ||
 			strings.Contains(msg, "not a folder") ||
-			strings.Contains(msg, "cannot move"):
+			strings.Contains(msg, "cannot move") ||
+			strings.Contains(msg, "does not belong to the same project"):
 			status = http.StatusBadRequest
 		case strings.Contains(msg, "permission") || strings.Contains(msg, "not authorized"):
 			status = http.StatusForbidden

--- a/server/http/handlers/secrets_move_test.go
+++ b/server/http/handlers/secrets_move_test.go
@@ -30,6 +30,11 @@ type moveFixtureResult struct {
 	handler  *SecretHandler
 	secretID uint
 	folderID uint
+	// db and projectID are exposed (in addition to the pre-seeded IDs above)
+	// so #G86 regression tests can seed a SECOND, foreign project/folder to
+	// verify cross-project moves are refused.
+	db        *gorm.DB
+	projectID uint
 }
 
 // freshMoveFixture opens a unique in-memory SQLite DB with all required models,
@@ -113,7 +118,27 @@ func freshMoveFixture(t *testing.T) moveFixtureResult {
 
 	handler, err := NewSecretHandler(cs)
 	require.NoError(t, err)
-	return moveFixtureResult{handler: handler, secretID: secret.ID, folderID: folder.ID}
+	return moveFixtureResult{
+		handler: handler, secretID: secret.ID, folderID: folder.ID,
+		db: db, projectID: proj.ID,
+	}
+}
+
+// seedForeignMoveFolder creates a SECOND project (that fx's owner has no
+// stake in) with its own folder, and returns the foreign folder's ID.
+func seedForeignMoveFolder(t *testing.T, fx moveFixtureResult) uint {
+	t.Helper()
+	foreignProj := &models.Project{Name: "proj-move-foreign"}
+	require.NoError(t, fx.db.Create(foreignProj).Error)
+	foreignEnv := &models.Environment{Name: "env-move-foreign", ProjectID: foreignProj.ID}
+	require.NoError(t, fx.db.Create(foreignEnv).Error)
+	foreignFolder := &models.SecretNode{
+		Name: "foreign-folder-move", ProjectID: foreignProj.ID, EnvironmentID: foreignEnv.ID,
+		Type: "folder", OwnerID: 99, IsSecret: false, Status: "active",
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	require.NoError(t, fx.db.Create(foreignFolder).Error)
+	return foreignFolder.ID
 }
 
 // withMoveUserCtx injects user 1 into the request context.
@@ -228,6 +253,38 @@ func TestMoveSecret_InvalidJSON_HTTP(t *testing.T) {
 	fx.handler.MoveSecret(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestMoveSecret_RefusesCrossProjectParent_HTTP is the HTTP-layer companion
+// to core's TestMoveSecret_RefusesCrossProjectParent (#G86): the caller owns
+// (and has write access to) the secret in their own project, but the
+// parent_id they supply belongs to a DIFFERENT project. core.MoveSecret
+// already refuses this (fixed by #1396), but the HTTP status-code
+// classification in MoveSecret's error switch never matched the resulting
+// "does not belong to the same project/environment" message (it only tested
+// for a lowercase "validation" substring, which never matches the
+// capitalized, i18n-translated "Validation error:" prefix) — so the refusal
+// fell through to a bare 500 instead of a proper 400. This test locks in
+// both: the move must still be refused, AND it must surface as 400.
+func TestMoveSecret_RefusesCrossProjectParent_HTTP(t *testing.T) {
+	fx := freshMoveFixture(t)
+
+	// A folder in a DIFFERENT project that the actor has no stake in.
+	foreignFolderID := seedForeignMoveFolder(t, fx)
+
+	body, _ := json.Marshal(map[string]uint{"parent_id": foreignFolderID})
+	req := withChiParamS14(
+		httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)),
+		"id", strconv.Itoa(int(fx.secretID)),
+	)
+	req = withMoveUserCtx(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	fx.handler.MoveSecret(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "same project")
 }
 
 // TestMoveSecret_NoUserCtx_HTTP verifies a 401 when no user context is present.

--- a/server/http/handlers/users_enhancement_test.go
+++ b/server/http/handlers/users_enhancement_test.go
@@ -105,7 +105,12 @@ func TestGetUserMembershipsHandler(t *testing.T) {
 	require.NoError(t, db.Where("name = ?", "payments").First(&proj).Error)
 	require.NoError(t, db.Create(&models.ProjectMembership{ProjectID: proj.ID, UserID: 42, Role: "project_developer", State: "active"}).Error)
 
-	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodGet, "/api/v1/users/42/memberships", nil)), "id", "42")
+	// G84: reading a DIFFERENT user's memberships now requires self, admin, or
+	// roles.read; this DB has no RBAC tables migrated (setupUserEnhancementTest
+	// only migrates User/ProjectMembership/Project), so exercise the self-read
+	// path — the caller IS user 42 — which is the case this test's data setup
+	// actually models (a user's own memberships, resolved with the project name).
+	req := withChiParam(withUserCtxID(httptest.NewRequest(http.MethodGet, "/api/v1/users/42/memberships", nil), 42, "g84-self-42"), "id", "42")
 	w := httptest.NewRecorder()
 	rh.GetUserMembershipsForUser(w, req)
 

--- a/server/http/handlers/users_roles.go
+++ b/server/http/handlers/users_roles.go
@@ -69,6 +69,24 @@ func (h *UsersRolesHandler) GetUserRolesForUser(w http.ResponseWriter, r *http.R
 	sendSuccess(w, map[string]interface{}{"roles": apiRoles}, "")
 }
 
+// canReadRBACStateFor reports whether actor may view TARGET user's RBAC state
+// (effective permissions or project memberships): either the actor IS the target
+// (own-profile read), or the actor holds roles.read (global scope) — the same
+// admin-tier gate GetUserRolesForUser already requires for a user's role list
+// (#141), and the tier this codebase treats as "may manage/inspect access" rather
+// than the much broader, nearly-universally-held users.read. G84.
+func (h *UsersRolesHandler) canReadRBACStateFor(r *http.Request, actor *middleware.UserContext, targetUserID uint) bool {
+	if actor.UserID == targetUserID {
+		return true
+	}
+	allowed, err := h.coreService.AuthorizePrincipal(r.Context(), actor.ActorKind(), actor.PrincipalID(), "roles.read", core.Scope{})
+	if err != nil {
+		log.Printf("Error checking roles.read for RBAC-state read (actor=%d target=%d): %v", actor.UserID, targetUserID, err)
+		return false
+	}
+	return allowed
+}
+
 // apiPermission is one entry in a user's effective-permission view.
 type apiPermission struct {
 	Name        string `json:"name"`
@@ -80,14 +98,28 @@ type apiPermission struct {
 // GetUserPermissionsForUser handles GET /api/v1/users/{id}/permissions — the user's
 // effective permission set (the de-duplicated union across all assigned roles). The
 // "what can this user do" view for the dashboard and access reviews.
+//
+// This discloses a TARGET user's full effective RBAC state, which is a much bigger
+// disclosure than the route's group-level users.read gate implies (users.read is held
+// by nearly every seeded role, so it lets any project member reconnoiter an arbitrary
+// other user's complete permission set — privilege-escalation targeting material).
+// Require self OR roles.read: the same roles.read tier GetUserRolesForUser already
+// requires for the sibling roles-list view (#141), which restricts this data to the
+// personas that actually manage access (system_admin/system_auditor/project_admin).
 func (h *UsersRolesHandler) GetUserPermissionsForUser(w http.ResponseWriter, r *http.Request) {
-	if middleware.GetUserFromContext(r.Context()) == nil {
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
 		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
 		return
 	}
 
 	userID, ok := parseUintParam(w, r, "id")
 	if !ok {
+		return
+	}
+
+	if !h.canReadRBACStateFor(r, actor, userID) {
+		sendError(w, "Forbidden", "You may not view another user's permissions", http.StatusForbidden, nil)
 		return
 	}
 
@@ -120,14 +152,24 @@ type apiUserMembership struct {
 // GetUserMembershipsForUser handles GET /api/v1/users/{id}/memberships (ADR-025) —
 // the user's project memberships with project name, role, and lifecycle state,
 // powering the per-user assignments table on the detail page.
+//
+// Same disclosure class as GetUserPermissionsForUser above (G84): the group-wide
+// users.read gate lets any project member enumerate an arbitrary other user's full
+// project-membership/role footprint. Same fix — self OR roles.read.
 func (h *UsersRolesHandler) GetUserMembershipsForUser(w http.ResponseWriter, r *http.Request) {
-	if middleware.GetUserFromContext(r.Context()) == nil {
+	actor := middleware.GetUserFromContext(r.Context())
+	if actor == nil {
 		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
 		return
 	}
 
 	userID, ok := parseUintParam(w, r, "id")
 	if !ok {
+		return
+	}
+
+	if !h.canReadRBACStateFor(r, actor, userID) {
+		sendError(w, "Forbidden", "You may not view another user's memberships", http.StatusForbidden, nil)
 		return
 	}
 

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -38,8 +38,8 @@ const (
 // downstream per-scope authorization work unchanged.
 type sessionValidator interface {
 	ValidateSessionToken(ctx context.Context, token string) (*models.User, []string, error)
-	ValidatePATToken(ctx context.Context, token string) (*models.User, []string, *core.PATRestriction, error)
-	ValidateMachineToken(ctx context.Context, token string) (*models.MachineIdentity, []string, *core.MachineTokenRestriction, error)
+	ValidatePATToken(ctx context.Context, token string) (*models.User, []string, *core.PATRestriction, uint, error)
+	ValidateMachineToken(ctx context.Context, token string) (*models.MachineIdentity, []string, *core.MachineTokenRestriction, uint, error)
 	ValidateOIDCToken(ctx context.Context, token string) (*models.MachineIdentity, []string, error)
 	OIDCEnabled() bool
 }
@@ -89,6 +89,16 @@ type UserContext struct {
 	// MachineTokenRestriction carries the network-level IP allowlist for a machine
 	// token credential, or nil when none is set. Enforced at the auth boundary.
 	MachineTokenRestriction *core.MachineTokenRestriction `json:"-"`
+	// patID is the validated PAT's row id (0 for a non-PAT principal). #G60: kept
+	// unexported/uncached-in-JSON, used only by handleAuthRequest to stamp
+	// last_used_at via TouchPATLastUsed AFTER tokenNetworkAllowed has passed for
+	// this specific request — never touched on a cache hit (serveAuthCacheHit
+	// deliberately never re-stamps, matching pre-existing behavior).
+	patID uint `json:"-"`
+	// machineCredID is the validated machine credential's row id (0 for a
+	// non-machine principal) — the machine-token sibling of patID, same #G60
+	// rationale and same handleAuthRequest post-check touch.
+	machineCredID uint `json:"-"`
 }
 
 // cloneUserContextWithRestriction returns a shallow copy of base with
@@ -296,6 +306,16 @@ func handleAuthRequest(next http.Handler, w http.ResponseWriter, r *http.Request
 	if !tokenNetworkAllowed(r, userCtx) {
 		forbiddenResponse(w, "token not permitted from this network")
 		return
+	}
+	// #G60: stamp last_used_at only now that the token's network restriction has
+	// actually been evaluated and passed — touching earlier (formerly done
+	// unconditionally inside ValidatePATToken/ValidateMachineToken) would mark a
+	// credential as "used" even for a request just rejected above for arriving
+	// from a disallowed network. Each Touch* is a no-op when its id is 0 (i.e.
+	// the principal is not that credential kind).
+	if coreService != nil {
+		coreService.TouchPATLastUsed(r.Context(), userCtx.patID)
+		coreService.TouchMachineTokenLastUsed(r.Context(), userCtx.machineCredID)
 	}
 	next.ServeHTTP(w, r.WithContext(buildRequestContext(r.Context(), userCtx, coreService)))
 }
@@ -905,7 +925,7 @@ func GetUserFromContext(ctx context.Context) *UserContext {
 // machine id, and ActorType machine_identity so RBAC and audit are identical.
 // restriction is nil for OIDC tokens (no per-credential allowlist) and for
 // opaque tokens that carry no AllowedCIDRs.
-func machineUserContext(m *models.MachineIdentity, roleNames []string, restriction *core.MachineTokenRestriction) *UserContext {
+func machineUserContext(m *models.MachineIdentity, roleNames []string, restriction *core.MachineTokenRestriction, credID uint) *UserContext {
 	mid := m.ID
 	return &UserContext{
 		UserID:                  0,
@@ -916,6 +936,7 @@ func machineUserContext(m *models.MachineIdentity, roleNames []string, restricti
 		Roles:                   roleNames,
 		AccountState:            core.AccountActive,
 		MachineTokenRestriction: restriction,
+		machineCredID:           credID,
 	}
 }
 
@@ -994,11 +1015,11 @@ func validateToken(ctx context.Context, validator sessionValidator, token string
 	}
 	// Machine tokens (ADR-030) authenticate AS a machine identity, not a user.
 	if strings.HasPrefix(token, machineTokenPrefix) {
-		m, roleNames, restriction, err := validator.ValidateMachineToken(ctx, token)
+		m, roleNames, restriction, credID, err := validator.ValidateMachineToken(ctx, token)
 		if err != nil {
 			return nil, err
 		}
-		return machineUserContext(m, roleNames, restriction), nil
+		return machineUserContext(m, roleNames, restriction, credID), nil
 	}
 
 	// Federated OIDC / Kubernetes-JWT tokens (ADR-031) also authenticate AS a
@@ -1036,7 +1057,7 @@ func validateToken(ctx context.Context, validator sessionValidator, token string
 				boundedForLog(issuer), boundedForLog(kid), boundedForLog(err.Error()))
 			return nil, err
 		}
-		return machineUserContext(m, roleNames, nil), nil
+		return machineUserContext(m, roleNames, nil, 0), nil
 	}
 
 	// Route by prefix: PATs authenticate AS their owning user, resolving to the same
@@ -1045,11 +1066,12 @@ func validateToken(ctx context.Context, validator sessionValidator, token string
 		user        *models.User
 		roleNames   []string
 		restriction *core.PATRestriction
+		patID       uint
 		err         error
 		viaSession  bool
 	)
 	if strings.HasPrefix(token, patTokenPrefix) {
-		user, roleNames, restriction, err = validator.ValidatePATToken(ctx, token)
+		user, roleNames, restriction, patID, err = validator.ValidatePATToken(ctx, token)
 	} else {
 		user, roleNames, err = validator.ValidateSessionToken(ctx, token)
 		viaSession = true
@@ -1068,6 +1090,7 @@ func validateToken(ctx context.Context, validator sessionValidator, token string
 		MFAEnabled:     user.MFAEnabled || user.WebAuthnEnabled,
 		SessionAuth:    viaSession,
 		PATRestriction: restriction,
+		patID:          patID,
 	}, nil
 }
 

--- a/server/middleware/auth_s24_test.go
+++ b/server/middleware/auth_s24_test.go
@@ -75,11 +75,11 @@ type oidcDisabledFakeValidator struct{}
 func (oidcDisabledFakeValidator) ValidateSessionToken(_ context.Context, _ string) (*models.User, []string, error) {
 	return nil, nil, http.ErrNotSupported
 }
-func (oidcDisabledFakeValidator) ValidatePATToken(_ context.Context, _ string) (*models.User, []string, *core.PATRestriction, error) {
-	return nil, nil, nil, http.ErrNotSupported
+func (oidcDisabledFakeValidator) ValidatePATToken(_ context.Context, _ string) (*models.User, []string, *core.PATRestriction, uint, error) {
+	return nil, nil, nil, 0, http.ErrNotSupported
 }
-func (oidcDisabledFakeValidator) ValidateMachineToken(_ context.Context, _ string) (*models.MachineIdentity, []string, *core.MachineTokenRestriction, error) {
-	return nil, nil, nil, http.ErrNotSupported
+func (oidcDisabledFakeValidator) ValidateMachineToken(_ context.Context, _ string) (*models.MachineIdentity, []string, *core.MachineTokenRestriction, uint, error) {
+	return nil, nil, nil, 0, http.ErrNotSupported
 }
 func (oidcDisabledFakeValidator) ValidateOIDCToken(_ context.Context, _ string) (*models.MachineIdentity, []string, error) {
 	return nil, nil, http.ErrNotSupported

--- a/server/middleware/auth_test.go
+++ b/server/middleware/auth_test.go
@@ -22,6 +22,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
@@ -60,40 +61,44 @@ func (fakeValidator) ValidateSessionToken(_ context.Context, token string) (*mod
 // ValidatePATToken accepts a single fixed PAT and resolves it to a user, mirroring
 // the shape of ValidateSessionToken so the prefix-routing in validateToken can be
 // exercised. Anything else is rejected.
-func (fakeValidator) ValidatePATToken(_ context.Context, token string) (*models.User, []string, *core.PATRestriction, error) {
+func (fakeValidator) ValidatePATToken(_ context.Context, token string) (*models.User, []string, *core.PATRestriction, uint, error) {
 	if token == "kx_pat_validtoken" {
 		return &models.User{
 			ID:       3,
 			Username: "patuser",
 			Email:    "pat@example.com",
-		}, []string{"system_viewer"}, nil, nil
+		}, []string{"system_viewer"}, nil, 0, nil
 	}
 	if token == "kx_pat_scopedtoken" {
 		// A least-privilege token confined to secrets.read in project 5 (ADR-042).
 		return &models.User{ID: 3, Username: "patuser", Email: "pat@example.com"},
 			[]string{"system_viewer"},
 			&core.PATRestriction{Permissions: []string{"secrets.read"}, ProjectID: 5},
+			0,
 			nil
 	}
 	if token == "kx_pat_cidrtoken" {
-		// A token restricted to the 10.0.0.0/8 network.
+		// A token restricted to the 10.0.0.0/8 network. patID is 0 (fake, not a real
+		// storage-backed PAT), so handleAuthRequest's post-check TouchPATLastUsed is a
+		// harmless no-op in tests exercising this fake.
 		return &models.User{ID: 3, Username: "patuser", Email: "pat@example.com"},
 			[]string{"system_viewer"},
 			&core.PATRestriction{AllowedCIDRs: []string{"10.0.0.0/8"}},
+			0,
 			nil
 	}
-	return nil, nil, nil, fmt.Errorf("invalid token")
+	return nil, nil, nil, 0, fmt.Errorf("invalid token")
 }
 
-func (fakeValidator) ValidateMachineToken(_ context.Context, token string) (*models.MachineIdentity, []string, *core.MachineTokenRestriction, error) {
+func (fakeValidator) ValidateMachineToken(_ context.Context, token string) (*models.MachineIdentity, []string, *core.MachineTokenRestriction, uint, error) {
 	if token == "kx_machine_validtoken" {
 		return &models.MachineIdentity{
 			ID:    9,
 			Name:  "ci-bot",
 			State: "active",
-		}, []string{"project_viewer"}, nil, nil
+		}, []string{"project_viewer"}, nil, 0, nil
 	}
-	return nil, nil, nil, fmt.Errorf("invalid token")
+	return nil, nil, nil, 0, fmt.Errorf("invalid token")
 }
 
 func (fakeValidator) OIDCEnabled() bool { return true }
@@ -371,6 +376,7 @@ func TestRequireRole_DeniesMachinePrincipal(t *testing.T) {
 		&models.MachineIdentity{ID: machineID, Name: "ci-deployer"},
 		[]string{"deployer"}, // GetMachineRoles' unscoped flattening of a project-A-only grant
 		nil,
+		0,
 	)
 	require.NotNil(t, userCtx.MachineIdentityID)
 	require.Equal(t, machineID, *userCtx.MachineIdentityID)
@@ -758,6 +764,70 @@ func TestAuthentication_PATNetworkAllowlist_RefreshesOnCacheHit(t *testing.T) {
 		"a narrowed allowlist must take effect on the very next request, not after the cache TTL")
 	// And the newly-allowed network is now honored, also on a cache hit.
 	assert.Equal(t, http.StatusOK, serve("192.0.2.7:5555"))
+}
+
+// #G60 regression: a CIDR-restricted PAT presented from a disallowed source IP
+// must be rejected WITHOUT stamping last_used_at — the touch must only fire
+// once the network-restriction check has actually passed, not merely because
+// the token itself resolved. This exercises the real core.KeyorixCore (not
+// fakeValidator) as the sessionValidator so ValidatePATToken's real PAT-id
+// plumbing and handleAuthRequest's post-check TouchPATLastUsed both run.
+func TestAuthentication_PATNetworkAllowlist_DeniedRequestDoesNotTouchLastUsed(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	// Role/UserRole are needed by ValidatePATToken's GetUserRoles call on the real
+	// (non-fake) storage path this test exercises.
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.PersonalAccessToken{}, &models.Role{}, &models.UserRole{}))
+	require.NoError(t, db.Create(&models.User{ID: 4, Username: "cidruser", Email: "cidr@example.com", IsActive: true}).Error)
+
+	hashOf := func(raw string) string {
+		sum := sha256.Sum256([]byte(raw))
+		return hex.EncodeToString(sum[:])
+	}
+
+	// Two DISTINCT tokens, each used exactly once, so neither request can be
+	// served from the auth cache (a cache HIT deliberately never re-touches
+	// last_used_at at all — see TestAuthentication_PATNetworkAllowlist_RefreshesOnCacheHit
+	// above — which would make the second assertion below vacuously true if
+	// this test instead reused the SAME token for both calls).
+	const deniedRaw = "kx_pat_touchcidr_denied"
+	deniedPAT := &models.PersonalAccessToken{ID: 1, UserID: 4, Name: "ci-denied", TokenHash: hashOf(deniedRaw), AllowedCIDRs: `["10.0.0.0/8"]`}
+	require.NoError(t, db.Create(deniedPAT).Error)
+
+	const allowedRaw = "kx_pat_touchcidr_allowed"
+	allowedPAT := &models.PersonalAccessToken{ID: 2, UserID: 4, Name: "ci-allowed", TokenHash: hashOf(allowedRaw), AllowedCIDRs: `["10.0.0.0/8"]`}
+	require.NoError(t, db.Create(allowedPAT).Error)
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	mw := Authentication(coreService)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	serve := func(raw, remoteAddr string) int {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+raw)
+		req.RemoteAddr = remoteAddr
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// A PAT presented from a disallowed network is rejected...
+	require.Equal(t, http.StatusForbidden, serve(deniedRaw, "203.0.113.9:5555"))
+
+	var reloadedDenied models.PersonalAccessToken
+	require.NoError(t, db.First(&reloadedDenied, 1).Error)
+	assert.Nil(t, reloadedDenied.LastUsedAt, "a request rejected for its source network must not stamp last_used_at")
+
+	// ...but a different token, from an allowed network, succeeds and DOES stamp
+	// it — confirming the assertion above isn't just "never touched at all".
+	require.Equal(t, http.StatusOK, serve(allowedRaw, "10.1.2.3:5555"))
+
+	var reloadedAllowed models.PersonalAccessToken
+	require.NoError(t, db.First(&reloadedAllowed, 2).Error)
+	assert.NotNil(t, reloadedAllowed.LastUsedAt, "a request accepted from an allowed network stamps last_used_at")
 }
 
 // A token revoked WHILE a slow-path validation was in flight must not be resurrected by

--- a/web/src/pages/auth/LoginPage.tsx
+++ b/web/src/pages/auth/LoginPage.tsx
@@ -17,6 +17,12 @@ export const LoginPage: React.FC = () => {
     const [resetError, setResetError] = useState<string | null>(null);
     const [ssoProviders, setSsoProviders] = useState<string[]>([]);
     const ssoError = new URLSearchParams(location.search).get('sso_error');
+    // G65: authStore.logout() redirects here via window.location.href (a hard
+    // navigation, so no in-memory error state survives it) when the
+    // server-side session invalidation call itself failed. The client still
+    // clears its own local state as a fail-safe, but the user needs to know
+    // the server may still consider the old session valid.
+    const logoutError = new URLSearchParams(location.search).get('logout_error');
 
     useEffect(() => {
         let active = true;
@@ -99,6 +105,15 @@ export const LoginPage: React.FC = () => {
                 >
                     {mode === 'login' && (
                         <>
+                            {logoutError && (
+                                <div
+                                    className="mb-4 rounded-lg px-3 py-2 text-sm"
+                                    style={{ backgroundColor: 'var(--error-subtle)', color: 'var(--error)' }}
+                                >
+                                    Sign-out could not be confirmed with the server. Your previous session may still be
+                                    active — for safety on a shared device, consider changing your password.
+                                </div>
+                            )}
                             {ssoError && (
                                 <div
                                     className="mb-4 rounded-lg px-3 py-2 text-sm"

--- a/web/src/pages/auth/__tests__/LoginPage.test.tsx
+++ b/web/src/pages/auth/__tests__/LoginPage.test.tsx
@@ -162,6 +162,19 @@ describe('LoginPage', () => {
         expect(screen.queryByText(/SSO sign-in failed/)).not.toBeInTheDocument();
     });
 
+    it('shows a logout-failure banner from the logout_error query param (G65: surfaced instead of a silent redirect)', () => {
+        window.history.pushState({}, '', '/login?logout_error=1');
+        render(<LoginPage />);
+
+        expect(screen.getByText(/Sign-out could not be confirmed with the server/)).toBeInTheDocument();
+    });
+
+    it('does not show a logout-failure banner when there is no logout_error param (e.g. a clean logout)', () => {
+        render(<LoginPage />);
+
+        expect(screen.queryByText(/Sign-out could not be confirmed/)).not.toBeInTheDocument();
+    });
+
     it('renders SSO provider links once they load, targeting the default dashboard return_to', async () => {
         getSSOProvidersMock.mockResolvedValue(['google', 'okta']);
         render(<LoginPage />);

--- a/web/src/services/__tests__/auth.test.ts
+++ b/web/src/services/__tests__/auth.test.ts
@@ -120,9 +120,14 @@ describe('authService.logout', () => {
         await expect(authService.logout()).resolves.toBeUndefined();
     });
 
-    it('swallows server errors (never throws)', async () => {
-        mockPost.mockRejectedValueOnce(new Error('network error'));
-        await expect(authService.logout()).resolves.toBeUndefined();
+    it('rethrows on server error (G65: no longer silently swallowed — the caller must know a server-side logout failed)', async () => {
+        mockPost.mockRejectedValueOnce(axiosErr(500, { error: 'Session store unavailable' }));
+        await expect(authService.logout()).rejects.toThrow('Session store unavailable');
+    });
+
+    it('throws a generic message when the server sends no error text', async () => {
+        mockPost.mockRejectedValueOnce(axiosErr(500, {}));
+        await expect(authService.logout()).rejects.toThrow('Logout failed');
     });
 });
 

--- a/web/src/services/auth.ts
+++ b/web/src/services/auth.ts
@@ -65,11 +65,22 @@ export const authService = {
     },
 
     async logout(): Promise<void> {
+        // Deliberately does NOT swallow a failed server-side session
+        // invalidation (G65) — the caller (authStore.logout()) still clears
+        // all local client-side state as a fail-safe regardless of the
+        // outcome here, but it needs the rejection to know the server-side
+        // session may still be valid and surface that to the user, instead
+        // of silently reporting a clean logout. Mirrors the
+        // catch-and-rethrow-with-message shape used by login()/refreshToken()
+        // above.
         try {
             await authApi.post(API_ENDPOINTS.AUTH.LOGOUT);
         } catch (error) {
-            // Even if logout fails on server, we clear local state.
-            console.warn('Logout request failed:', error);
+            if (axios.isAxiosError(error)) {
+                const message = error.response?.data?.error || error.response?.data?.message || 'Logout failed';
+                throw new Error(message, { cause: error });
+            }
+            throw error;
         }
     },
 

--- a/web/src/store/__tests__/authStore.test.ts
+++ b/web/src/store/__tests__/authStore.test.ts
@@ -253,7 +253,7 @@ describe('authStore', () => {
             expect(window.location.href).toBe('/login');
         });
 
-        it('still clears local state and redirects even when the server logout call fails', async () => {
+        it('still clears local state and redirects even when the server logout call fails, but surfaces the failure via a logout_error query param instead of silently succeeding (G65)', async () => {
             useAuthStore.setState({ user: makeUser(), isAuthenticated: true });
             vi.mocked(authService.logout).mockRejectedValueOnce(new Error('network blip'));
             const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -265,9 +265,89 @@ describe('authStore', () => {
             expect(state.user).toBeNull();
             expect(state.isAuthenticated).toBe(false);
             expect(authUtils.clearPersistedAuthData).toHaveBeenCalledOnce();
-            expect(window.location.href).toBe('/login');
+            // G65: pre-fix this asserted plain '/login' — the exact same URL as
+            // the success path — meaning a failed server-side logout was
+            // indistinguishable from a clean one. LoginPage reads this param
+            // (mirroring the existing sso_error pattern) and shows a banner.
+            expect(window.location.href).toBe('/login?logout_error=1');
 
             warnSpy.mockRestore();
+        });
+
+        it('does NOT append logout_error when the server logout call succeeds (only a genuine failure is surfaced)', async () => {
+            useAuthStore.setState({ user: makeUser(), isAuthenticated: true });
+            vi.mocked(authService.logout).mockResolvedValueOnce(undefined);
+
+            await useAuthStore.getState().logout();
+
+            expect(window.location.href).toBe('/login');
+        });
+    });
+
+    describe('persisted snapshot never carries permissions (G65)', () => {
+        // Regression coverage for the two G65 gaps together: (1) logout()
+        // clearing the whole 'auth-storage' key on every session-ending path
+        // that runs through it, and (2) the persist middleware's own
+        // partialize() never writing `permissions` to localStorage in the
+        // first place — so even a session-ending path that DOESN'T run any
+        // client-side code at all (tab crash, forced browser close) can't
+        // leave a stale permissions snapshot behind, because nothing
+        // sensitive was ever written to disk to begin with.
+        function withLocalStorageBacking() {
+            const backing = new Map<string, string>();
+            vi.mocked(localStorage.getItem).mockImplementation((key: string) => backing.get(key) ?? null);
+            vi.mocked(localStorage.setItem).mockImplementation((key: string, value: string) => {
+                backing.set(key, value);
+            });
+            vi.mocked(localStorage.removeItem).mockImplementation((key: string) => {
+                backing.delete(key);
+            });
+            return backing;
+        }
+
+        it('never writes permissions to the auth-storage entry, even while the session is active', () => {
+            withLocalStorageBacking();
+
+            useAuthStore.setState({
+                user: makeUser({ permissions: ['secrets:read', 'secrets:write', 'admin:users'] }),
+                isAuthenticated: true,
+            });
+
+            const raw = localStorage.getItem('auth-storage');
+            expect(raw).not.toBeNull();
+            const parsed = JSON.parse(raw as string);
+            expect(parsed.state.user.permissions).toEqual([]);
+            // Sanity check: the in-memory store still has the real permissions
+            // (only the on-disk copy is scrubbed) — checkAuth()/login() still
+            // populate the real value for hasPermission()/route guards to use.
+            expect(useAuthStore.getState().user?.permissions).toEqual(['secrets:read', 'secrets:write', 'admin:users']);
+        });
+
+        it('leaves no stale permissions in localStorage after a non-logout session-ending path (checkAuth detecting a server-side revocation)', async () => {
+            const backing = withLocalStorageBacking();
+
+            // Start from an authenticated session whose on-disk snapshot
+            // already exists (permissions scrubbed per the above, but present).
+            useAuthStore.setState({
+                user: makeUser({ permissions: ['secrets:read'] }),
+                isAuthenticated: true,
+            });
+            expect(backing.has('auth-storage')).toBe(true);
+
+            // Simulate the session ending some way OTHER than the user
+            // clicking "log out" — e.g. the server revoked the session and
+            // the next checkAuth() (inactivity-timeout re-check, tab focus,
+            // multi-tab sync, etc.) discovers it via a 401. This is the same
+            // clearPersistedAuthData() call the inactivity-timeout and
+            // 401-forced-logout paths ultimately reach via logout(); checkAuth
+            // reaches it directly on its own failure branch.
+            vi.mocked(authService.getProfile).mockRejectedValueOnce(new Error('unauthorized'));
+            await useAuthStore.getState().checkAuth();
+
+            expect(authUtils.clearPersistedAuthData).toHaveBeenCalled();
+            const state = useAuthStore.getState();
+            expect(state.user).toBeNull();
+            expect(state.isAuthenticated).toBe(false);
         });
     });
 

--- a/web/src/store/authStore.ts
+++ b/web/src/store/authStore.ts
@@ -174,12 +174,21 @@ export const useAuthStore = create<AuthStore>()(
             logout: async () => {
                 set({ isLoading: true });
 
+                // G65: track whether the server-side session invalidation
+                // itself failed, so it can be surfaced below instead of
+                // silently reported as a clean logout. authService.logout()
+                // rethrows on failure (it no longer swallows the error
+                // itself); this is the only place that catches it.
+                let serverLogoutFailed = false;
                 try {
                     await authService.logout();
                 } catch (error) {
+                    serverLogoutFailed = true;
                     console.warn('Logout request failed:', error);
                 } finally {
-                    // Always clear local state regardless of server response
+                    // Always clear local state regardless of server response —
+                    // a failed server-side logout must not trap the user in a
+                    // "logged in" UI state.
                     set({
                         user: null,
                         isAuthenticated: false,
@@ -190,8 +199,15 @@ export const useAuthStore = create<AuthStore>()(
 
                     // Clear stored data
                     clearPersistedAuthData();
-                    // Redirect to login
-                    window.location.href = '/login';
+                    // Redirect to login. This is a hard navigation
+                    // (window.location.href), so no in-memory React/store
+                    // state survives it — a server-side logout failure is
+                    // surfaced via a query param instead, mirroring the
+                    // sso_error pattern LoginPage already reads. The user
+                    // needs to know their session may still be valid
+                    // server-side (e.g. on a shared machine) even though the
+                    // client has cleared its own local state.
+                    window.location.href = serverLogoutFailed ? '/login?logout_error=1' : '/login';
                 }
             },
 
@@ -324,8 +340,23 @@ export const useAuthStore = create<AuthStore>()(
         }),
         {
             name: 'auth-storage',
+            // G65: never write `permissions` (or other authorization-shaping
+            // fields, should this list grow) to localStorage. The persisted
+            // snapshot is purely optimistic pre-paint bookkeeping — merge()
+            // below forces hasCheckedAuth: false on every rehydrate, and
+            // every route guard (ProtectedRoute/AdminRoute) gates its render
+            // on hasCheckedAuth, so a rehydrated user is never actually used
+            // for an authorization decision before checkAuth() re-validates
+            // and repopulates the real permissions into (non-persisted)
+            // in-memory state. Scrubbing it here means there is no sensitive
+            // permission snapshot left on disk to go stale in the first
+            // place — closing the gap for every session-ending path,
+            // including ones no client-side code can react to at all (tab
+            // crash, forced browser close, server-side revocation before the
+            // next request), not just the two functions (logout/checkAuth)
+            // that proactively clear the whole `auth-storage` key today.
             partialize: (state) => ({
-                user: state.user,
+                user: state.user ? { ...state.user, permissions: [] } : state.user,
                 isAuthenticated: state.isAuthenticated,
             }),
             // Prevent synchronous localStorage hydration on store creation.


### PR DESCRIPTION
## Summary

**G57 — Bundle tar processing has no bound on entry size or repeat count** (medium, 2 members)

`internal/bundle/bundle.go`'s tar-entry processing loop trusted the tar header's declared size and a boolean "seen" map with no cap on total entries. New `maxComponentBytes` (2 GiB) and `maxComponentEntries` (1000) reject oversized/excessive entries before any decompress work; a duplicate component name is rejected outright; the header's declared size is cross-checked against the pinned manifest size. Same cap applied to the manifest.json/manifest.sig reads, which run before the signature is checked.

**G65 — authStore.ts has two independent client-side session-hygiene gaps** (medium, 2 members)

`logout()` swallowed the server-side session-invalidation failure twice and always reported local success — now surfaced via a `logout_error` query param, mirroring the existing `sso_error` pattern. The Zustand `persist` middleware wrote the full user object including `permissions[]` to `localStorage` with no proactive clear — `partialize()` now strips `permissions` from what's ever persisted; route guards gate on `hasCheckedAuth` (forced `false` on every rehydrate), so the persisted snapshot was never load-bearing for an authorization decision.

**G84 — A `users.read`-tier holder can enumerate an arbitrary other user's full RBAC state** (high, 2 members)

`GetUserPermissionsForUser`/`GetUserMembershipsForUser` were gated only on the broad `users.read` permission, letting any authenticated caller enumerate an arbitrary other user's full RBAC footprint. Now requires self OR `roles.read` at global scope, the deferred sibling of an earlier fix that tightened the analogous `GetUserRolesForUser`.

**G85 — SCIM user-listing endpoints disclose non-SCIM-managed accounts** (high, 2 members)

Both SCIM read endpoints queried/returned every user account regardless of `scimManaged`, unlike the write paths which already enforce the boundary. New `GetSCIMUser` and a filtered `ListSCIMUsersPage` close both gaps, including the `totalResults` count leak.

**G86 — Secret/folder re-parent operation never validates the target parent's project/environment scope** (high, 2 members)

`CreateFolder` accepted a caller-supplied `parent_id` with no check that the target parent's scope matched. Fixed by requiring the resolved parent to live in the same project/environment. The finding's other member, `MoveSecret`, was investigated and found **already fixed** at the core layer — documented rather than silently re-fixed; only its HTTP status-code mapping needed a small correction.

**G41 — gRPC interceptor chain built unary-only; stream RPC exempt from rate-limit/timeout** (medium, 3 members) — landed directly on #1442 before it merged.

**G60 — Side-effect recorded before a dependent check completes** (medium, 2 members)

`EndImpersonation` wrote its audit event before deleting the session row; a failed delete left a misleading audit trail. `ValidatePATToken`/`ValidateMachineToken` stamped `last_used_at` before the caller evaluated the token's CIDR restriction, recording a network-rejected request as "used" anyway. Both reordered: the side effect only happens once the dependent step actually succeeded, via new `TouchPATLastUsed`/`TouchMachineTokenLastUsed` called by the HTTP/gRPC callers after their own restriction check passes.

**G62 — New encryption-package code skips the package's own DEK-safety conventions** (medium, 3 members + 4 siblings)

`RewrapDEKWithProvider` never took the exclusive server-vs-CLI key lock its siblings require; `EncryptionService.dek` was never wiped on shutdown/rotation; the `auth-encryption` CLI subcommands never took the cross-process key-lock their siblings were built to require. Sibling sweep found 4 more instances of the same two gaps (`KeyManager.Initialize` leaking an unwiped DEK on a later failure, `rotate-kek` discarding unwiped key copies, `shamir-split` never wiping its generated KEK, `RotateKEKPassphrase` not self-enforcing its lock) — fixed alongside.

**G68 — CLI-written sensitive output/key-material files use default, unenforced permissions** (medium, 2 members)

`rbac export-matrix --output` and `migrate-provider`'s `copyFile` both wrote at whatever mode the process umask allowed. Both now enforce 0600 explicitly — including tightening a pre-existing, looser-mode destination file, since `O_TRUNC` alone doesn't change an existing file's mode.

**G70 — CLI request URL built via unescaped interpolation** (medium, 2 members)

`secret diff`'s by-name query and `dynamic lease renew/revoke`'s path both interpolated caller-supplied values unescaped, unlike every sibling builder in their packages. Both now escape via `url.QueryEscape`/`url.PathEscape`.

**G71 — CLI HTTP call path bypasses common.RemoteClient's established timeout/cleartext-warning protections** (medium, 2 members + 2 siblings)

`run.go` built its own homegrown `apiClient` with a zero-value (infinite-timeout) `http.Client`; `secret rotate` bypassed `common.RemoteClient` entirely. Both now route through the shared, hardened client (new `common.NewRemoteClientWithCredentials` for `run.go`'s token-override case). Sibling sweep found `source_vault.go`'s Vault client had no request timeout and `system init --server`'s bootstrap POST had no anti-redirect guard — fixed alongside.

**G72 — CLI command omits an authorization check its HTTP route or CLI sibling enforces** (medium, 4 members)

`request list`, the rejection-reason-template commands, and `invite resend`/`revoke` each reached core functionality with no equivalent authorization check to the one enforced elsewhere for the same action. Added the missing `requireListAuthority`/`requireTemplateAuthority`/`requireInviteAuthority` calls at each site, mirroring the sibling/HTTP-route pattern already established. Template deletion also gained actor attribution (a new audit event) it previously had none of.

**G74 — CLI persists/transmits credentials over plaintext HTTP with no cleartext-transmission warning** (medium, 2 members)

`auth login`/`config set-remote` and `system init --server` all resolved a server URL and persisted/transmitted a real credential with no HTTPS check. New `common.WarnIfInsecureEndpoint` (extracted from the existing `ResolveRemote` check) is called at all three sites before the credential leaves the machine.

**G77 — azurekms trusts unauthenticated key-selection metadata without cross-checking the configured key** (low, 2 members)

`Encrypt` pinned the wrap response's KID version without checking its key-name segment matched the configured key. The version-pinning envelope's `Version` field had no integrity check tying it to the ciphertext. Fixed via a KID key-name check on `Encrypt`, and a new envelope `MAC` field — `HMAC-SHA256(key=plaintext KEK, message=Version)` — computed at encrypt time and re-verified at decrypt time; additive and backward-compatible with already-stored envelopes.

**G78 — CLI name-based target resolution lacks disambiguation/scoping** (high, 2 members + 2 siblings)

`findMachineByRef` picked the first entry matching either Name or ID with no ID-preference, letting an attacker-planted decoy (e.g. a machine named "5") shadow a real numeric-ID target and defeat destructive-operation confirmation. Now a numeric ref resolves exclusively via ID. `resolveEnvironmentIDByName` queried the deployment-wide environment listing instead of the already-resolved project's scope, letting `--environment` silently cross-resolve into a different project. Sibling sweep found the identical pattern in `secret import/export` and `keyorix run` — fixed alongside.

## Test plan

- [x] All 15 groups: new regression tests confirmed to fail pre-fix (build failure, explicit revert, or neutralized-check re-run) and pass post-fix.
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated` clean on all touched Go packages
- [x] `golangci-lint run` clean on all touched Go packages (including one real dead-code finding caught and fixed during integration — see notes below)
- [x] Full suites green for every touched package, including `-race` where concurrency changed (`internal/encryption`, `server/grpc/interceptors`)
- [x] Full web green gate for G65 (3016 tests)

**14 of these 15 groups were built in parallel by independent background agents**, each in an isolated git worktree, across two dispatches. Every branch was independently re-verified by the orchestrating session from scratch (full build/vet/gofmt/gosec/lint/test re-run, diffs read and spot-checked line-by-line for the security-sensitive ones, commit messages/DCO/attribution checked) before cherry-picking — never trusting an agent's self-report alone.

Notable integration findings from this batch:
- **G60/G41 both modify `server/grpc/interceptors/auth.go`**: cherry-picked cleanly, no conflict.
- **G71/G78 both modify `internal/cli/run/run.go`'s environment-lookup call site**: a real conflict (G78's project-scoping fix vs. G71's `apiClient`→`common.RemoteClient` rewrite of the same line), resolved by hand — combining both fixes — before G71 was even committed, then verified byte-identical against G78's already-integrated version for every file G71 also touched incidentally.
- **G72's golangci-lint caught a genuine dead-code leftover** (`withBrokenDBService`, an unused test helper orphaned by the agent's own test rewrite) — removed during integration.
- **G72's pre-existing HTTP handler tests broke** from the new `mustGetUser` requirement on `DeleteRejectionReasonTemplate` (4 tests didn't wrap their request with the test harness's user-context helper, unlike sibling tests in the same file) — fixed during integration by adding the missing wrapper, matching the established pattern.
- **G72 also had no dedicated refusal-case tests** for its two new authority-check helpers (only production code + happy-path fixture updates) — added 7 tests directly exercising `requireListAuthority`/`requireTemplateAuthority` (unauthorized actor refused, authorized actor allowed, bootstrap admin allowed) during integration, mirroring this package's existing `requireReviewAuthority` test shape, and confirmed each refusal case fails when its check is temporarily neutralized.
- **G71 and G72's background agents both hit their session's API usage limit** mid-task before their final commit; their uncommitted worktree diffs were reviewed with the same rigor as a completed agent's output before being finished, verified, and committed/pushed by the orchestrating session on their behalf.
- **G86's `MoveSecret` member was a stale finding** (already fixed at the core layer, confirmed by reverting and re-running its existing test directly against unmodified `origin/main`) — documented rather than silently re-fixed or dropped.
- **G83** (a related finding — `clientIP()` mangles IPv6) was found already resolved as a side effect of G20 (in #1442) and required no new work; recorded in the tracking doc so it isn't re-investigated later.
