### PR TITLE
fix(security): encode SCIM error body via encoding/json, not raw Fprintf (G798)

### DIFF
--- a/server/middleware/scim.go
+++ b/server/middleware/scim.go
@@ -6,8 +6,9 @@ package middleware
 
 import (
 	"crypto/subtle"
-	"fmt"
+	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -37,12 +38,21 @@ func SCIMToken(token string) func(http.Handler) http.Handler {
 	}
 }
 
-// scimError writes a SCIM-format (RFC 7644 §3.12) error response.
+// scimError writes a SCIM-format (RFC 7644 §3.12) error response. Both current
+// callers pass a fixed string literal, but detail is encoded via encoding/json
+// (matching the sibling scimError in server/http/handlers/scim.go) rather than
+// spliced into a hand-built JSON string with %s -- a future caller passing
+// anything containing a `"` or control character would otherwise corrupt the
+// response's JSON structure (semgrep: no-fprintf-to-responsewriter, #G798).
 func scimError(w http.ResponseWriter, status int, detail string) {
 	w.Header().Set("Content-Type", "application/scim+json")
 	if status == http.StatusTooManyRequests {
 		w.Header().Set("Retry-After", "60")
 	}
 	w.WriteHeader(status)
-	_, _ = fmt.Fprintf(w, `{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"status":"%d","detail":"%s"}`, status, detail)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:Error"},
+		"status":  strconv.Itoa(status),
+		"detail":  detail,
+	})
 }

--- a/server/middleware/scim_test.go
+++ b/server/middleware/scim_test.go
@@ -1,11 +1,13 @@
 package middleware
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSCIMToken(t *testing.T) {
@@ -70,4 +72,25 @@ func TestSCIMToken_ThrottlesRepeatedFailures(t *testing.T) {
 	// The next attempt from the same IP must be throttled, not re-evaluated as
 	// just another failed comparison.
 	assert.Equal(t, http.StatusTooManyRequests, call(), "attempt exceeding the failure budget must be throttled")
+}
+
+// G798: scimError previously hand-built its JSON body via fmt.Fprintf with a raw
+// %s substitution for detail, so a detail string containing a `"` would corrupt
+// the response's JSON structure instead of round-tripping as a properly-escaped
+// value. This asserts the response is well-formed JSON with the exact SCIM error
+// shape (RFC 7644 §3.12: schemas array, string status, detail), not just a status
+// code -- proving the fix actually goes through encoding/json now, not just that
+// Fprintf happened to still produce parseable output for today's fixed-string callers.
+func TestSCIMError_ProducesWellFormedJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	scimError(w, http.StatusUnauthorized, `detail with a "quote" and a backslash \`)
+
+	assert.Equal(t, "application/scim+json", w.Header().Get("Content-Type"))
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body), "response body must be valid JSON")
+
+	assert.Equal(t, []any{"urn:ietf:params:scim:api:messages:2.0:Error"}, body["schemas"])
+	assert.Equal(t, "401", body["status"])
+	assert.Equal(t, `detail with a "quote" and a backslash \`, body["detail"])
 }


### PR DESCRIPTION
## Summary
`scimError` (`server/middleware/scim.go`) hand-built its JSON error response via `fmt.Fprintf` with a raw `%s` substitution for `detail` — flagged by Semgrep's `go.lang.security.audit.xss.no-fprintf-to-responsewriter` rule (alert #798).

Both current callers pass a fixed string literal, so today this isn't exploitable, but the pattern is inherently fragile: any future caller passing a `detail` string containing a `"` or control character would corrupt the response's JSON structure (break out of the string field, potentially injecting adjacent keys) rather than round-tripping safely — and the sibling `scimError` in `server/http/handlers/scim.go` already does this correctly via `json.Encoder.Encode`.

## Fix
Build the response as a map and encode it with `encoding/json`, matching the established sibling pattern — eliminates the injection class entirely regardless of what future callers pass.

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt -l` clean
- [x] New regression test asserts the response is well-formed, correctly-shaped JSON (schemas array, string status, detail) for a detail string containing a quote and a backslash — confirmed it fails with `invalid character 'q' after object key:value pair` against the pre-fix Fprintf version, and passes against the fix
- [x] `semgrep scan --config=r/go.lang.security.audit.xss.no-fprintf-to-responsewriter` — 0 findings after the fix