### PR TITLE
fix(security): move validation guards into core layer + fix GORM/SQLite timezone bug recurrence (G38, G81)

### DIFF
--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -26,8 +27,32 @@ const (
 	maxEnvironmentNameLen = 200
 )
 
+// identifierRegex is the anti-homograph/anti-spoofing charset guard (G38):
+// letters, digits, spaces, hyphens, and underscores only — no zero-width
+// characters, no mixed-script confusables, no control characters. Ported
+// verbatim from server/validation/validator.go's identical `identifier` rule.
+// Before this fix, this charset check was enforced ONLY by the HTTP JSON
+// decoder's `validate:"identifier"` struct tag on the request body — the
+// gRPC service layer and CLI embedded-mode path, which construct a Project
+// directly without ever routing through that HTTP-specific validator, could
+// create a project whose name silently smuggled a confusable/spoofed
+// character sequence past every UI and audit log that assumes the HTTP path
+// already sanitized it. Duplicated here (not imported from server/validation)
+// to keep internal/core independent of the server/* packages that depend on
+// it, matching this file's existing validateProjectName/validateEnvironmentName
+// convention.
+var identifierRegex = regexp.MustCompile(`^[a-zA-Z0-9 _-]+$`)
+
+func validateIdentifier(name string) error {
+	if !identifierRegex.MatchString(name) {
+		return fmt.Errorf("%s: must contain only letters, digits, spaces, - or _", i18n.T("ErrorValidation", nil))
+	}
+	return nil
+}
+
 // validateProjectName bounds Project.Name (#383): required, and capped so an
-// unbounded text column can't be used to bloat storage/index size.
+// unbounded text column can't be used to bloat storage/index size. Also
+// enforces the anti-homograph identifier charset (G38) — see validateIdentifier.
 func validateProjectName(name string) error {
 	if name == "" {
 		return fmt.Errorf("%s: project name is required", i18n.T("ErrorValidation", nil))
@@ -35,7 +60,7 @@ func validateProjectName(name string) error {
 	if len(name) > maxProjectNameLen {
 		return fmt.Errorf("%s: project name exceeds %d characters", i18n.T("ErrorValidation", nil), maxProjectNameLen)
 	}
-	return nil
+	return validateIdentifier(name)
 }
 
 // validateEnvironmentName bounds Environment.Name (#383), mirroring validateProjectName.
@@ -332,9 +357,22 @@ func (c *KeyorixCore) GetEnvironment(ctx context.Context, id uint) (*models.Envi
 // CreateProjectWithEnvs's fan-out create; callers (the HTTP
 // POST /projects/{id}/environments handler, the `keyorix project env create`
 // CLI) previously wrote straight to storage, bypassing any name-length guard.
+//
+// G38: also confirms projectID names a LIVE (non-soft-deleted) project before
+// creating anything under it. The HTTP handler's own scope middleware resolves
+// projectID from the URL without verifying the project still exists, so
+// without this check here, a caller who still held write authority on a
+// since-soft-deleted project (RBAC grants aren't retroactively revoked by a
+// project delete) could re-establish a usable environment/scope under it —
+// storage.GetProject excludes soft-deleted projects, so this fails closed the
+// same way the HTTP handler's own defense-in-depth check already does, but
+// now for every transport (gRPC, CLI embedded mode) instead of only HTTP.
 func (c *KeyorixCore) CreateEnvironment(ctx context.Context, projectID uint, name string) (*models.Environment, error) {
 	if err := validateEnvironmentName(name); err != nil {
 		return nil, err
+	}
+	if _, err := c.storage.GetProject(ctx, projectID); err != nil {
+		return nil, fmt.Errorf("%s: project not found", i18n.T("ErrorNotFound", nil))
 	}
 	return c.storage.CreateEnvironment(ctx, &models.Environment{ProjectID: projectID, Name: name})
 }

--- a/internal/core/g38_transport_agnostic_validation_test.go
+++ b/internal/core/g38_transport_agnostic_validation_test.go
@@ -1,0 +1,165 @@
+// g38_transport_agnostic_validation_test.go — regression coverage for G38:
+// several input-validation and business-rule guards were previously enforced
+// only in the HTTP JSON-decoding layer (server/validation's `validate:"..."`
+// struct tags), so the gRPC service layer and CLI embedded-mode path — which
+// construct a request directly and never route through that HTTP-specific
+// validator — silently accepted input the HTTP path would reject. These
+// tests call the CORE layer directly (the single choke point every
+// transport, including gRPC and CLI embedded mode, ultimately funnels
+// through), proving the guard now applies regardless of transport.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+func newG38TestCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{}, &models.Group{}, &models.AuditEvent{},
+		&models.User{},
+	))
+	return NewKeyorixCore(store.NewLocalStorage(db)), db
+}
+
+// TestCreateProject_RejectsHomographCharset pins member 1+2 (identifier
+// guard / project-name anti-spoofing charset): a project name containing a
+// character outside [a-zA-Z0-9 _-] — the exact charset the HTTP validator's
+// `identifier` rule enforces — must be refused at the core layer, not just
+// when a caller happens to route through the HTTP JSON decoder.
+func TestCreateProject_RejectsHomographCharset(t *testing.T) {
+	c, _ := newG38TestCore(t)
+	ctx := context.Background()
+
+	for _, name := range []string{
+		"аdmin",    // Cyrillic "а" (U+0430) homograph of Latin "a"
+		"proj™",    // trademark symbol
+		"a/b",      // path separator
+		"a\u200bb", // zero-width space
+	} {
+		_, err := c.CreateProject(ctx, name, "")
+		require.Errorf(t, err, "name %q should have been rejected", name)
+		assert.Contains(t, err.Error(), "letters, digits, spaces, - or _")
+	}
+
+	// A legitimate name (letters, digits, spaces, hyphen, underscore) is accepted.
+	_, err := c.CreateProject(ctx, "my-project_2", "")
+	require.NoError(t, err)
+}
+
+// TestUpdateProject_RejectsHomographCharset: same guard, update path.
+func TestUpdateProject_RejectsHomographCharset(t *testing.T) {
+	c, _ := newG38TestCore(t)
+	ctx := context.Background()
+
+	p, err := c.CreateProject(ctx, "legit", "")
+	require.NoError(t, err)
+
+	_, err = c.UpdateProject(ctx, p.ID, "аdmin", "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "letters, digits, spaces, - or _")
+}
+
+// TestCreateProjectWithEnvs_RejectsHomographCharset: same guard, the
+// --envs-overriding create path.
+func TestCreateProjectWithEnvs_RejectsHomographCharset(t *testing.T) {
+	c, _ := newG38TestCore(t)
+	ctx := context.Background()
+
+	_, err := c.CreateProjectWithEnvs(ctx, "proj™", "", []string{"dev"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "letters, digits, spaces, - or _")
+}
+
+// TestCreateEnvironment_RefusesDeadParentProject pins member 3 ("parent
+// project must be live"): CreateEnvironment must refuse to create an
+// environment under a soft-deleted project. Before this fix, only the HTTP
+// handler's own defense-in-depth check enforced this — a caller reaching
+// core.CreateEnvironment directly (gRPC, CLI embedded mode) had no such
+// check at all.
+func TestCreateEnvironment_RefusesDeadParentProject(t *testing.T) {
+	c, db := newG38TestCore(t)
+	ctx := context.Background()
+
+	p, err := c.CreateProject(ctx, "to-delete", "")
+	require.NoError(t, err)
+	require.NoError(t, db.Delete(&models.Project{}, p.ID).Error) // soft-delete (gorm.DeletedAt)
+
+	_, err = c.CreateEnvironment(ctx, p.ID, "orphan-env")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	// A live project still works normally.
+	live, err := c.CreateProject(ctx, "still-live", "")
+	require.NoError(t, err)
+	_, err = c.CreateEnvironment(ctx, live.ID, "real-env")
+	require.NoError(t, err)
+}
+
+// TestCreateUser_RejectsMalformedEmail pins member 4/5 (CreateUser skips
+// HTTP-enforced format validation / CreateUserRequest's dead validate tags):
+// a malformed email must be refused at the core layer, matching the HTTP
+// path's `validate:"required,email"` rule — not merely documented by a
+// struct tag nothing reads.
+func TestCreateUser_RejectsMalformedEmail(t *testing.T) {
+	c, _ := newG38TestCore(t)
+	ctx := context.Background()
+
+	_, err := c.CreateUser(ctx, &CreateUserRequest{
+		Username: "gooduser", Email: "not-an-email", DisplayName: "Good User", Password: "StrongPassw0rd!2026x",
+	})
+	require.Error(t, err)
+
+	// A well-formed request is accepted.
+	_, err = c.CreateUser(ctx, &CreateUserRequest{
+		Username: "gooduser", Email: "good@example.com", DisplayName: "Good User", Password: "StrongPassw0rd!2026x",
+	})
+	require.NoError(t, err)
+}
+
+// TestCreateUser_RejectsShortUsername pins the username length half of the
+// same gap (HTTP: `validate:"required,min=3,max=50"`).
+func TestCreateUser_RejectsShortUsername(t *testing.T) {
+	c, _ := newG38TestCore(t)
+	ctx := context.Background()
+
+	_, err := c.CreateUser(ctx, &CreateUserRequest{
+		Username: "ab", Email: "ab@example.com", DisplayName: "Ab", Password: "StrongPassw0rd!2026x",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "username")
+}
+
+// TestUpdateUser_RejectsMalformedEmail: same guard, update path — an empty
+// Email means "leave unchanged" (partial update), so only a NON-empty,
+// malformed value should be refused.
+func TestUpdateUser_RejectsMalformedEmail(t *testing.T) {
+	c, _ := newG38TestCore(t)
+	ctx := context.Background()
+
+	u, err := c.CreateUser(ctx, &CreateUserRequest{
+		Username: "target", Email: "target@example.com", DisplayName: "Target", Password: "StrongPassw0rd!2026x",
+	})
+	require.NoError(t, err)
+
+	_, err = c.UpdateUser(ctx, &UpdateUserRequest{ID: u.ID, Email: "not-an-email"})
+	require.Error(t, err)
+
+	// Leaving Email blank (no change) still works.
+	active := true
+	_, err = c.UpdateUser(ctx, &UpdateUserRequest{ID: u.ID, IsActive: &active})
+	require.NoError(t, err)
+}

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -8,12 +8,55 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"golang.org/x/crypto/bcrypt"
 )
+
+// emailRegex/usernameMinLen/usernameMaxLen/displayNameMinLen/displayNameMaxLen
+// mirror the exact format rules server/http/handlers' request-body `validate`
+// struct tags enforce for username/email/display_name (users_handler.go,
+// users_crud.go) — NOT internal/core/users_types.go's CreateUserRequest.validate
+// tags, which are unread dead documentation (no validator library in this
+// codebase resolves them) and, for Username, actually claim a stricter
+// `alphanum` rule the live HTTP path never enforces. Duplicated here rather
+// than imported from server/validation (which internal/core does not, and per
+// this repo's layering should not, depend on) so gRPC and CLI embedded-mode —
+// which construct a CreateUserRequest/UpdateUserRequest directly and never
+// route through the HTTP JSON decoder's validator — get the identical format
+// guarantee the HTTP path already has (G38).
+var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+
+const (
+	usernameMinLen    = 3
+	usernameMaxLen    = 50
+	displayNameMinLen = 1
+	displayNameMaxLen = 100
+)
+
+func validateUsernameFormat(username string) error {
+	if len(username) < usernameMinLen || len(username) > usernameMaxLen {
+		return fmt.Errorf("%s: username must be between %d and %d characters", i18n.T("ErrorValidation", nil), usernameMinLen, usernameMaxLen)
+	}
+	return nil
+}
+
+func validateEmailFormat(email string) error {
+	if !emailRegex.MatchString(email) {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), i18n.T("LabelEmail", nil))
+	}
+	return nil
+}
+
+func validateDisplayNameFormat(displayName string) error {
+	if len(displayName) < displayNameMinLen || len(displayName) > displayNameMaxLen {
+		return fmt.Errorf("%s: display name must be between %d and %d characters", i18n.T("ErrorValidation", nil), displayNameMinLen, displayNameMaxLen)
+	}
+	return nil
+}
 
 // ProjectAssignment grants Role to the new user at a project's scope, applied
 // atomically with the user create (ADR-028).
@@ -587,8 +630,23 @@ func (c *KeyorixCore) validateCreateUserRequest(req *CreateUserRequest) error {
 	if req.Username == "" {
 		return fmt.Errorf("%s", i18n.T("LabelUsername", nil))
 	}
+	if err := validateUsernameFormat(req.Username); err != nil {
+		return err
+	}
 	if req.Email == "" {
 		return fmt.Errorf("%s", i18n.T("LabelEmail", nil))
+	}
+	if err := validateEmailFormat(req.Email); err != nil {
+		return err
+	}
+	// DisplayName is optional at this layer (buildUserForCreate defaults it to
+	// Username when blank) — only format-check it when the caller actually
+	// supplied one, matching the HTTP path's required-at-the-request-body-level
+	// semantics without re-imposing that requirement here.
+	if req.DisplayName != "" {
+		if err := validateDisplayNameFormat(req.DisplayName); err != nil {
+			return err
+		}
 	}
 	if req.Password == "" {
 		return fmt.Errorf("%s", i18n.T("LabelPassword", nil))
@@ -599,6 +657,28 @@ func (c *KeyorixCore) validateCreateUserRequest(req *CreateUserRequest) error {
 func (c *KeyorixCore) validateUpdateUserRequest(req *UpdateUserRequest) error {
 	if req.ID == 0 {
 		return fmt.Errorf("user ID is required")
+	}
+	// Username/Email/DisplayName are partial-update fields (UpdateUser only
+	// applies a non-empty value; see the req.Username != "" / req.Email != "" /
+	// req.DisplayName != "" guards below in UpdateUser) — an empty string means
+	// "leave unchanged," not "clear the field," so only format-check a value
+	// the caller actually supplied (G38: gRPC/CLI-embedded previously skipped
+	// this check entirely, unlike the HTTP path's `omitempty,...` request-body
+	// validate tags).
+	if req.Username != "" {
+		if err := validateUsernameFormat(req.Username); err != nil {
+			return err
+		}
+	}
+	if req.Email != "" {
+		if err := validateEmailFormat(req.Email); err != nil {
+			return err
+		}
+	}
+	if req.DisplayName != "" {
+		if err := validateDisplayNameFormat(req.DisplayName); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/core/users_types.go
+++ b/internal/core/users_types.go
@@ -2,8 +2,19 @@
 package core
 
 // CreateUserRequest represents a request to create a new user.
+//
+// G38: the `validate:"..."` tags below are documentation only — no validator
+// library in this codebase resolves struct tags on this type (that reflection
+// convention exists only in server/validation, and is never invoked here); the
+// actual enforcement is validateCreateUserRequest (users.go), called from every
+// creation path (CreateUser, CreateUserWithSetupLink, CreateUserWithOneTimePassword,
+// CreateUserWithAssignments) via the shared buildUserForCreate. Username's tag
+// previously claimed `alphanum`, a rule the live HTTP handlers never actually
+// enforce (server/http/handlers/users_handler.go, users_crud.go: `min=3,max=50`
+// only) — corrected here to match what's genuinely enforced, not what the tag
+// merely aspired to.
 type CreateUserRequest struct {
-	Username    string `json:"username" validate:"required,min=3,max=50,alphanum"`
+	Username    string `json:"username" validate:"required,min=3,max=50"`
 	Email       string `json:"email" validate:"required,email"`
 	DisplayName string `json:"display_name" validate:"required,min=1,max=100"`
 	Password    string `json:"password" validate:"required,min=8"`

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -403,6 +403,19 @@ type MFAStepupToken struct {
 	CreatedAt time.Time
 }
 
+// BeforeSave normalises ExpiresAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 —
+// mirrors MFAStepUpGrant's identical hook below; this sibling model was never
+// given one when it was added, reopening the same bug class). Note this hook
+// only fires on a plain Create/Save — UpsertMFAStepupToken's ON CONFLICT
+// DoUpdates path writes expires_at from a raw map on the UPDATE branch,
+// bypassing model hooks entirely, so that call site normalises explicitly too
+// (see local_mfa_stepup.go).
+func (t *MFAStepupToken) BeforeSave(_ *gorm.DB) error {
+	t.ExpiresAt = t.ExpiresAt.UTC()
+	return nil
+}
+
 // MFAStepUpGrant records that a user explicitly re-verified their second factor
 // (via VerifyMFAStepUp) to gain a time-limited window for reading
 // restricted-classified secrets. Unlike MFAStepupToken (which is upserted on
@@ -838,6 +851,20 @@ type DynamicSecretLease struct {
 	IssuedAt       time.Time
 	ExpiresAt      time.Time `gorm:"index:idx_lease_status_expiry"`
 	RevokedAt      *time.Time
+}
+
+// BeforeSave normalises ExpiresAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81). Before
+// this hook, a lease issued while the server ran in a non-UTC local timezone
+// stored expires_at in that local time, but ListExpiredActiveLeases' sweep
+// query compares it against a caller-supplied `before` cutoff — if that
+// cutoff isn't consistently normalised the same way, SQLite's string-based
+// time comparison can silently misjudge which leases are actually past
+// expiry, letting the auto-revoke sweep skip a genuinely-expired credential
+// (or revoke one prematurely) depending on the sign of the offset from UTC.
+func (l *DynamicSecretLease) BeforeSave(_ *gorm.DB) error {
+	l.ExpiresAt = l.ExpiresAt.UTC()
+	return nil
 }
 
 type SecretAccessLog struct {

--- a/internal/storage/store/g81_dynamic_lease_timezone_test.go
+++ b/internal/storage/store/g81_dynamic_lease_timezone_test.go
@@ -1,0 +1,101 @@
+// g81_dynamic_lease_timezone_test.go — regression coverage for G81's
+// DynamicSecretLease member: this codebase previously fixed a GORM/SQLite
+// timezone-comparison bug (mixed UTC/local time.Time values break SQLite's
+// string-based time comparisons) by adding UTC-normalizing BeforeSave hooks
+// to the affected models, but DynamicSecretLease was never given one — and
+// its ExpiresAt is the field the auto-revoke sweep's whole purpose depends
+// on comparing correctly.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func newG81LeaseStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.DynamicSecretLease{}))
+	return NewLocalStorage(db)
+}
+
+// TestCreateDynamicSecretLease_NonUTCExpiryStoredAsUTC pins the write half of
+// G81: a lease created with an ExpiresAt constructed in a non-UTC local
+// timezone (e.g. a server running with TZ set) must be persisted as UTC.
+func TestCreateDynamicSecretLease_NonUTCExpiryStoredAsUTC(t *testing.T) {
+	ls := newG81LeaseStore(t)
+	ctx := context.Background()
+	nonUTC := time.FixedZone("UTC-7", -7*60*60)
+	exp := time.Date(2026, 8, 20, 12, 0, 0, 0, nonUTC)
+
+	created, err := ls.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
+		ConfigID: 1, LeaseID: "lease-1", Status: "active",
+		IssuedAt: time.Now(), ExpiresAt: exp,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, time.UTC, created.ExpiresAt.Location(), "expires_at must be stored in UTC")
+	assert.True(t, created.ExpiresAt.Equal(exp), "the instant must be preserved even though the zone changed")
+
+	var reloaded models.DynamicSecretLease
+	require.NoError(t, ls.db.First(&reloaded, created.ID).Error)
+	assert.Equal(t, time.UTC, reloaded.ExpiresAt.Location())
+}
+
+// TestListExpiredActiveLeases_RecognizesNonUTCExpiryAsExpired is G81's own
+// detection_idea for the DynamicSecretLease member, run directly: set a
+// lease's expiry in a non-UTC local time that has genuinely already passed,
+// persist it, and confirm the sweep query (ListExpiredActiveLeases) still
+// recognizes it as expired — the exact scenario a mixed UTC/local ExpiresAt
+// could silently break, letting a genuinely-expired lease's target
+// credential stay live past its TTL undetected.
+func TestListExpiredActiveLeases_RecognizesNonUTCExpiryAsExpired(t *testing.T) {
+	ls := newG81LeaseStore(t)
+	ctx := context.Background()
+	nonUTC := time.FixedZone("UTC+9", 9*60*60)
+	pastExpiry := time.Now().In(nonUTC).Add(-1 * time.Minute)
+
+	_, err := ls.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
+		ConfigID: 1, LeaseID: "lease-expired", Status: "active",
+		IssuedAt: time.Now(), ExpiresAt: pastExpiry,
+	})
+	require.NoError(t, err)
+
+	// The sweep cutoff itself is also constructed in a non-UTC zone here,
+	// matching server/main.go's real call site (time.Now(), local system
+	// time) — ListExpiredActiveLeases must normalize it internally rather
+	// than relying on the caller to remember to pass UTC.
+	cutoff := time.Now().In(time.FixedZone("UTC+2", 2*60*60))
+	expired, err := ls.ListExpiredActiveLeases(ctx, cutoff)
+	require.NoError(t, err)
+	require.Len(t, expired, 1, "the genuinely-expired non-UTC lease must be found by the sweep")
+	assert.Equal(t, "lease-expired", expired[0].LeaseID)
+}
+
+// TestListExpiredActiveLeases_DoesNotFlagNotYetExpiredLease is the negative
+// control for the same fix: a lease whose non-UTC expiry has NOT actually
+// passed yet must not be swept.
+func TestListExpiredActiveLeases_DoesNotFlagNotYetExpiredLease(t *testing.T) {
+	ls := newG81LeaseStore(t)
+	ctx := context.Background()
+	nonUTC := time.FixedZone("UTC+9", 9*60*60)
+	futureExpiry := time.Now().In(nonUTC).Add(1 * time.Hour)
+
+	_, err := ls.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
+		ConfigID: 1, LeaseID: "lease-still-live", Status: "active",
+		IssuedAt: time.Now(), ExpiresAt: futureExpiry,
+	})
+	require.NoError(t, err)
+
+	expired, err := ls.ListExpiredActiveLeases(ctx, time.Now())
+	require.NoError(t, err)
+	assert.Empty(t, expired, "a lease that has not actually expired yet must not be swept")
+}

--- a/internal/storage/store/local_dynamic.go
+++ b/internal/storage/store/local_dynamic.go
@@ -128,10 +128,20 @@ func (ls *LocalStorage) CountActiveLeases(ctx context.Context, configID uint) (i
 // revoke failed, so their credential is still live). Ordered by id (stable) for the sweep.
 // Without the revoke_failed inclusion such a credential would stay live past TTL forever,
 // excluded from both the sweep and a manual retry.
+//
+// before is normalised to UTC here (G81), not left to the caller: DynamicSecretLease's
+// BeforeSave hook already stores expires_at as UTC, but the caller-supplied cutoff
+// (server/main.go's sweep passes time.Now(), local system time) previously wasn't —
+// SQLite compares time.Time values as strings, so a local-time cutoff compared against
+// a UTC-normalised expires_at column could silently misjudge which leases are actually
+// past expiry, letting the auto-revoke sweep skip a genuinely-expired credential (or
+// revoke one prematurely) depending on the sign of the local/UTC offset. Normalising
+// here — the single place this comparison happens — means every caller gets a correct
+// comparison regardless of whether it remembers to pass UTC itself.
 func (ls *LocalStorage) ListExpiredActiveLeases(ctx context.Context, before time.Time) ([]*models.DynamicSecretLease, error) {
 	var leases []*models.DynamicSecretLease
 	if err := ls.db.WithContext(ctx).
-		Where("status IN ? AND expires_at < ?", []string{"active", "revoke_failed"}, before).
+		Where("status IN ? AND expires_at < ?", []string{"active", "revoke_failed"}, before.UTC()).
 		Order("id").Limit(maxUnboundedListRows).Find(&leases).Error; err != nil {
 		return nil, err
 	}

--- a/internal/storage/store/local_mfa_stepup.go
+++ b/internal/storage/store/local_mfa_stepup.go
@@ -19,7 +19,15 @@ const sqlWhereUserIDAndNotExpired = "user_id = ? AND expires_at > ?"
 // UpsertMFAStepupToken inserts or replaces the step-up record for userID,
 // setting its expiry to expiresAt. A second MFA verification within the window
 // extends the window cleanly (ON CONFLICT updates expires_at in place).
+//
+// expiresAt is normalised to UTC explicitly here (G81), not left to the
+// model's BeforeSave hook alone: the ON CONFLICT DoUpdates clause below
+// writes expires_at from its own raw map on the UPDATE branch of the upsert,
+// which bypasses GORM model hooks entirely — only the INSERT branch (via
+// Create) would ever see BeforeSave run. Normalising once here up front
+// keeps both branches consistent regardless of which one actually fires.
 func (ls *LocalStorage) UpsertMFAStepupToken(ctx context.Context, userID uint, expiresAt time.Time) error {
+	expiresAt = expiresAt.UTC()
 	tok := &models.MFAStepupToken{UserID: userID, ExpiresAt: expiresAt}
 	return ls.db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "user_id"}},
@@ -32,8 +40,13 @@ func (ls *LocalStorage) UpsertMFAStepupToken(ctx context.Context, userID uint, e
 // Returns (false, nil) when no record exists or the record has expired.
 func (ls *LocalStorage) HasActiveMFAStepup(ctx context.Context, userID uint) (bool, error) {
 	var tok models.MFAStepupToken
+	// now is normalised to UTC (G81) to match expires_at's own UTC-normalised
+	// storage (UpsertMFAStepupToken above) — mirrors the identical
+	// now.UTC() call MFAStepUpGrant's HasActiveMFAStepupGrant already makes
+	// for the exact same reason: SQLite compares time.Time values as strings,
+	// so both sides of the comparison must use the same timezone convention.
 	err := ls.db.WithContext(ctx).
-		Where(sqlWhereUserIDAndNotExpired, userID, time.Now()).
+		Where(sqlWhereUserIDAndNotExpired, userID, time.Now().UTC()).
 		First(&tok).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return false, nil

--- a/internal/storage/store/local_mfa_stepup_test.go
+++ b/internal/storage/store/local_mfa_stepup_test.go
@@ -84,3 +84,55 @@ func TestHasActiveMFAStepup_FalseWhenNoRecord(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok)
 }
+
+// TestUpsertMFAStepupToken_NonUTCExpiryStoredAsUTC pins G81: MFAStepupToken
+// previously had no UTC-normalizing BeforeSave hook (unlike its sibling
+// MFAStepUpGrant), and its upsert's ON CONFLICT DoUpdates path bypasses model
+// hooks entirely even once one exists — so an expiry constructed in a
+// non-UTC local timezone (e.g. a server running with TZ set) could be
+// persisted as-is. SQLite compares time.Time values as strings, so a mixed
+// UTC/local ExpiresAt breaks comparisons. Sets the expiry in a fixed
+// non-UTC zone and asserts the persisted value round-trips as UTC — both via
+// a fresh INSERT and via the ON CONFLICT UPDATE branch (a second upsert for
+// the same user), since the two branches take genuinely different code
+// paths in UpsertMFAStepupToken.
+func TestUpsertMFAStepupToken_NonUTCExpiryStoredAsUTC(t *testing.T) {
+	s := newStepupStore(t)
+	ctx := context.Background()
+	nonUTC := time.FixedZone("UTC-7", -7*60*60)
+	exp := time.Date(2026, 8, 20, 12, 0, 0, 0, nonUTC)
+
+	// INSERT branch.
+	require.NoError(t, s.UpsertMFAStepupToken(ctx, 5, exp))
+	var tok models.MFAStepupToken
+	require.NoError(t, s.db.Where("user_id = ?", 5).First(&tok).Error)
+	assert.Equal(t, time.UTC, tok.ExpiresAt.Location(), "expires_at must be stored in UTC after INSERT")
+	assert.True(t, tok.ExpiresAt.Equal(exp), "the instant must be preserved even though the zone changed")
+
+	// ON CONFLICT UPDATE branch — a second upsert for the same user.
+	exp2 := time.Date(2026, 8, 20, 13, 0, 0, 0, nonUTC)
+	require.NoError(t, s.UpsertMFAStepupToken(ctx, 5, exp2))
+	require.NoError(t, s.db.Where("user_id = ?", 5).First(&tok).Error)
+	assert.Equal(t, time.UTC, tok.ExpiresAt.Location(), "expires_at must be stored in UTC after the ON CONFLICT UPDATE branch")
+	assert.True(t, tok.ExpiresAt.Equal(exp2))
+}
+
+// TestHasActiveMFAStepup_RecognizesNonUTCExpiryAsExpired is the detection_idea
+// for G81's MFAStepupToken member directly: set an expiry in a non-UTC local
+// time that has genuinely already passed, persist it, and confirm the read
+// path still recognises it as expired — the exact scenario a mixed UTC/local
+// ExpiresAt could silently break (SQLite's string comparison misjudging an
+// expired local-time value as still-active, or vice versa, depending on the
+// sign of the zone offset).
+func TestHasActiveMFAStepup_RecognizesNonUTCExpiryAsExpired(t *testing.T) {
+	s := newStepupStore(t)
+	ctx := context.Background()
+	nonUTC := time.FixedZone("UTC+9", 9*60*60)
+	pastExpiry := time.Now().In(nonUTC).Add(-1 * time.Minute)
+
+	require.NoError(t, s.UpsertMFAStepupToken(ctx, 6, pastExpiry))
+
+	ok, err := s.HasActiveMFAStepup(ctx, 6)
+	require.NoError(t, err)
+	assert.False(t, ok, "a non-UTC expiry that has genuinely passed must still be recognized as expired")
+}


### PR DESCRIPTION
## Summary

**G38 — Input-validation/business-rule guard lives only in the HTTP handler layer** (high, 5 members)

Several input-validation and business-rule guards were implemented only in the HTTP JSON-decoding/handler layer (`server/validation`'s reflection-driven `validate:"..."` struct tags, or a one-off check inside a specific HTTP handler) — so the gRPC service layer and CLI embedded-mode path, which construct a request/call core directly and never route through that HTTP-specific validator, silently accepted input the HTTP path would reject.

- `internal/core/catalog.go`: new `validateIdentifier` (the anti-homograph/anti-spoofing charset guard — letters, digits, spaces, hyphens, underscores only — ported verbatim from `server/validation/validator.go`'s identical `identifier` rule) is now called from `validateProjectName`, so `CreateProject`/`UpdateProject`/`CreateProjectWithEnvs` enforce it regardless of transport.
- `internal/core/catalog.go`: `CreateEnvironment` now confirms `projectID` names a live (non-soft-deleted) project before creating anything under it — previously only the HTTP handler's own defense-in-depth check enforced this.
- `internal/core/users.go`: `validateCreateUserRequest`/`validateUpdateUserRequest` now enforce the same username-length (3-50), email-format, and display-name-length (1-100) rules the HTTP request-body validate tags already enforce, closing the gap for `CreateUser` (and its `CreateUserWithSetupLink`/`CreateUserWithOneTimePassword`/`CreateUserWithAssignments` siblings, which all funnel through the same `buildUserForCreate`/`validateCreateUserRequest` choke point) and `UpdateUser` reached via gRPC or CLI embedded mode.
- `internal/core/users_types.go`: `CreateUserRequest`'s `validate:"..."` struct tags were dead documentation — no validator library resolves them on this type. Username's tag also claimed a stricter `alphanum` rule the live HTTP handlers never actually enforce — corrected to match what's genuinely enforced.

The new checks are duplicated locally in `internal/core` rather than importing `server/validation`: the two packages have no existing import relationship, and `internal/core` importing a `server/*` package would invert this codebase's established dependency direction. This matches the precedent `internal/core/secret_description.go`'s `validateNameLength` already established for the identical HTTP/gRPC parity problem (backlog #190).

**G81 — Sibling model missing the UTC-normalizing BeforeSave hook (GORM/SQLite timezone bug recurrence)** (high, 2 members)

This codebase previously fixed a GORM/SQLite timezone-comparison bug (mixed UTC/local `time.Time` values break SQLite's string-based time comparisons) by adding UTC-normalizing `BeforeSave` hooks to the affected models (e.g. `MFAStepUpGrant`). Two sibling models storing security-relevant expiry timestamps were never given the same hook when they were added, reopening the identical bug class.

- `MFAStepupToken.ExpiresAt`: added the same `BeforeSave` hook `MFAStepUpGrant` already has — but that alone isn't sufficient, since `UpsertMFAStepupToken`'s `ON CONFLICT DoUpdates` clause writes `expires_at` from its own raw map on the UPDATE branch of the upsert, bypassing GORM model hooks entirely. Normalizes `expiresAt.UTC()` explicitly at the top of `UpsertMFAStepupToken` so both the INSERT and UPDATE branches stay consistent. `HasActiveMFAStepup`'s read query also switched from `time.Now()` to `time.Now().UTC()`, mirroring the identical call `MFAStepUpGrant`'s own read path already makes.
- `DynamicSecretLease.ExpiresAt`: added a `BeforeSave` hook (this model's write path uses a plain `Create`, so the hook alone is sufficient on the write side). `ListExpiredActiveLeases` — the auto-revoke sweep's query — now normalizes its caller-supplied `before` cutoff to UTC internally rather than trusting every caller to pass UTC itself; the real production call site (`server/main.go`) passes `time.Now()`, local system time, so without this the sweep could silently skip a genuinely-expired lease (or revoke one prematurely) depending on the sign of the server's local/UTC offset — the highest-severity member of this group, since a skipped lease means a short-lived database credential stays live well past its intended TTL.

## Test plan

- [x] G38: new regression tests (`internal/core/g38_transport_agnostic_validation_test.go`) call the core layer directly — the single choke point every transport (HTTP, gRPC, CLI embedded mode) ultimately funnels through — with inputs the HTTP validator would reject (homograph/confusable characters, a soft-deleted parent project, a malformed email, an under-length username), matching the finding's own detection_idea. All 7 confirmed to fail against the pre-fix code (temporarily reverted the three production files via a scoped `git stash`, confirmed all 7 fail, restored) before being trusted.
- [x] G81: new regression tests set an expiry using a genuinely non-UTC `time.FixedZone`, persist it, and confirm both the write path (stored as UTC) and the read/sweep path (a genuinely-past non-UTC expiry is still recognized as expired) behave correctly. 4 of 5 confirmed to fail against the pre-fix code (the 5th is a negative control, not expected to fail) via the same scoped `git stash` approach.
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated` clean
- [x] `golangci-lint run` clean (caught and fixed one real finding during G38 development: a literal zero-width-space character embedded directly in test source, replaced with an explicit unicode escape)
- [x] Full `internal/core`, `internal/storage`, `server/http/handlers`, `server/grpc/services`, `internal/cli/project`, `internal/cli/user` suites green

Opened as a new PR (rather than added to #1446) because #1446 merged while G38 was in progress — cut fresh off the post-merge `origin/main`. G81 was small enough to batch onto this same still-open PR rather than opening another one. Both were worked as dedicated, single-threaded passes (not parallelized) — G38 given its architectural, cross-cutting nature (matching the standing plan's decision to defer it from the earlier parallel batches), G81 given its small, well-scoped nature made a dedicated pass just as fast as dispatching an agent.

