### PR TITLE
fix(security): close Wave 6 medium-severity batch 1 (8 findings)

### DIFF
--- a/deploy/helm/keyorix/templates/_helpers.tpl
+++ b/deploy/helm/keyorix/templates/_helpers.tpl
@@ -48,3 +48,25 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- printf "%s:%s" .Values.web.image.repository (default .Chart.AppVersion .Values.web.image.tag) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+nginx's add_header does NOT merge/inherit across nesting levels: if a location
+block defines even one add_header of its own, every add_header inherited from
+the enclosing http/server block is silently dropped for that location, not
+just individually overridden. web-config.yaml's http{} block sets these as
+baseline security headers, but several location blocks also set their own
+add_header (CORS, Cache-Control, health-check Content-Type) for other
+purposes, which would otherwise strip all of these from those responses. This
+template is the single source of truth; every location block that defines its
+own add_header must also include this so the headers still apply there.
+*/}}
+{{- define "keyorix.web.securityHeaders" -}}
+add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "no-referrer" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; form-action 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none';" always;
+add_header Cross-Origin-Resource-Policy "same-origin" always;
+add_header Cross-Origin-Embedder-Policy "require-corp" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;
+{{- end -}}

--- a/deploy/helm/keyorix/templates/web-config.yaml
+++ b/deploy/helm/keyorix/templates/web-config.yaml
@@ -41,14 +41,12 @@ data:
         {{- end }}
       }
 
-      add_header X-Frame-Options "DENY" always;
-      add_header X-Content-Type-Options "nosniff" always;
-      add_header X-XSS-Protection "1; mode=block" always;
-      add_header Referrer-Policy "no-referrer" always;
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; form-action 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none';" always;
-      add_header Cross-Origin-Resource-Policy "same-origin" always;
-      add_header Cross-Origin-Embedder-Policy "require-corp" always;
-      add_header Cross-Origin-Opener-Policy "same-origin" always;
+      # Baseline security headers. NOTE: nginx's add_header does not inherit into
+      # any location block that defines its own add_header (see the comment on
+      # keyorix.web.securityHeaders in _helpers.tpl) — every location below that
+      # sets its own add_header re-includes this same template so the headers
+      # still apply there instead of silently disappearing.
+      {{- include "keyorix.web.securityHeaders" . | nindent 6 }}
 
       server {
         listen 80;
@@ -58,6 +56,7 @@ data:
 
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
           expires 1y;
+          {{- include "keyorix.web.securityHeaders" . | nindent 10 }}
           add_header Cache-Control "public, immutable";
           try_files $uri =404;
         }
@@ -70,6 +69,7 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- include "keyorix.web.securityHeaders" . | nindent 10 }}
           add_header Access-Control-Allow-Origin $cors_allowed_origin always;
           add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" always;
           add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept" always;
@@ -82,6 +82,7 @@ data:
         location /health {
           access_log off;
           return 200 "healthy\n";
+          {{- include "keyorix.web.securityHeaders" . | nindent 10 }}
           add_header Content-Type text/plain;
         }
 

--- a/internal/cli/share/share_s25_test.go
+++ b/internal/cli/share/share_s25_test.go
@@ -72,12 +72,17 @@ func TestRunCreate_WithExpires_GroupShare(t *testing.T) {
 	t.Setenv("KEYORIX_TOKEN", "")
 
 	svc := openShareCore(t)
-	ownerID, secretID, _ := seedShareData(t, svc)
+	ownerID, secretID, projID := seedShareData(t, svc)
 	t.Setenv("KEYORIX_CLI_ACTOR", fmt.Sprintf("%d", ownerID)) // #G67: runCreate now asserts SharedBy from this
 
 	ctx := context.Background()
 	grp, err := svc.CreateGroup(ctx, 0, &core.CreateGroupRequest{Name: "expires-grp"})
 	require.NoError(t, err)
+
+	// ShareSecretWithGroup verifies the group is scoped to the secret's project.
+	role, err := svc.Storage().GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	require.NoError(t, svc.AssignRoleToGroup(ctx, ownerID, grp.ID, role.ID, core.Scope{ProjectID: projID}))
 
 	origSecretID, origRecipientID, origPerm, origIsGroup, origExpires :=
 		createSecretID, createRecipientID, createPermission, createIsGroup, createExpires

--- a/internal/cli/share/share_s3_test.go
+++ b/internal/cli/share/share_s3_test.go
@@ -86,6 +86,12 @@ func seedShareData(t *testing.T, svc *core.KeyorixCore) (ownerID, secretID, proj
 	require.NoError(t, err)
 	projID = proj.ID
 
+	// ShareSecret/UpdateSharePermission/RevokeShare gate the owner on live project
+	// membership (RBAC-001, requireLiveOwnerAuthority) — CreateProject alone
+	// doesn't grant the creator a project-scoped role, so add it explicitly,
+	// matching real onboarding (a project creator adds themselves as a member).
+	require.NoError(t, svc.AddProjectMember(ctx, ownerID, proj.ID, ownerID, "project_admin"))
+
 	// CreateProject seeds default environments; fetch the first one.
 	envs, err := svc.Storage().ListEnvironmentsByProject(ctx, proj.ID)
 	require.NoError(t, err)

--- a/internal/cli/share/share_s3_test.go
+++ b/internal/cli/share/share_s3_test.go
@@ -158,12 +158,17 @@ func TestRunCreate_GroupShare_Success(t *testing.T) {
 	t.Setenv("KEYORIX_TOKEN", "")
 
 	svc := openShareCore(t)
-	ownerID, secretID, _ := seedShareData(t, svc)
+	ownerID, secretID, projID := seedShareData(t, svc)
 	t.Setenv("KEYORIX_CLI_ACTOR", fmt.Sprintf("%d", ownerID)) // #G67: runCreate now asserts SharedBy from this
 
 	ctx := context.Background()
 	grp, err := svc.CreateGroup(ctx, 0, &core.CreateGroupRequest{Name: "teamalpha"})
 	require.NoError(t, err)
+
+	// ShareSecretWithGroup verifies the group is scoped to the secret's project.
+	role, err := svc.Storage().GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	require.NoError(t, svc.AssignRoleToGroup(ctx, ownerID, grp.ID, role.ID, core.Scope{ProjectID: projID}))
 
 	origSecretID, origRecipientID, origPerm, origIsGroup :=
 		createSecretID, createRecipientID, createPermission, createIsGroup
@@ -329,11 +334,16 @@ func TestRunGroupShares_PrintsTable(t *testing.T) {
 	t.Setenv("KEYORIX_TOKEN", "")
 
 	svc := openShareCore(t)
-	ownerID, secretID, _ := seedShareData(t, svc)
+	ownerID, secretID, projID := seedShareData(t, svc)
 
 	ctx := context.Background()
 	grp, err := svc.CreateGroup(ctx, 0, &core.CreateGroupRequest{Name: "devteam"})
 	require.NoError(t, err)
+
+	// ShareSecretWithGroup verifies the group is scoped to the secret's project.
+	role, err := svc.Storage().GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	require.NoError(t, svc.AssignRoleToGroup(ctx, ownerID, grp.ID, role.ID, core.Scope{ProjectID: projID}))
 
 	_, err = svc.ShareSecretWithGroup(ctx, &core.GroupShareSecretRequest{
 		SecretID:   secretID,

--- a/internal/core/group_sharing.go
+++ b/internal/core/group_sharing.go
@@ -33,8 +33,13 @@ func (c *KeyorixCore) ShareSecretWithGroup(ctx context.Context, req *GroupShareS
 	}
 	// Only the owner may share a secret — mirror the direct (non-group) path.
 	// Without this, any caller with secrets.write could group-share a secret they
-	// do not own, granting their group read/write access to it.
-	if !secretOwnedBy(secret.OwnerID, req.SharedBy) {
+	// do not own, granting their group read/write access to it. Owner authority also
+	// requires live project membership — see ShareSecret / CheckSecretPermission
+	// (RBAC-001): an owner removed from the project keeps their OwnerID tag until
+	// ClearProjectSecretOwnership runs.
+	if isLiveOwner, err := c.requireLiveOwnerAuthority(ctx, secret, req.SharedBy); err != nil {
+		return nil, err
+	} else if !isLiveOwner {
 		return nil, fmt.Errorf("not authorized to share this secret")
 	}
 

--- a/internal/core/group_sharing.go
+++ b/internal/core/group_sharing.go
@@ -43,6 +43,20 @@ func (c *KeyorixCore) ShareSecretWithGroup(ctx context.Context, req *GroupShareS
 		return nil, fmt.Errorf("not authorized to share this secret")
 	}
 
+	// Reject cross-project grants: the target group must itself be scoped to the
+	// secret's project (i.e. hold a live role grant at that project), mirroring
+	// the cross-project rejection ShareSecret's direct-user path performs for
+	// individual recipients. Without this, sharing with a group pulls in every
+	// current and future member of that group — including members with no tie
+	// to this project at all — into standing access to the secret; see
+	// CheckGroupPermissions, which enforces group membership but never the
+	// accessing user's project affiliation, so nothing downstream catches this.
+	if isScoped, serr := c.storage.IsGroupProjectScoped(ctx, req.GroupID, secret.ProjectID); serr != nil {
+		return nil, fmt.Errorf("failed to verify group project scope: %w", serr)
+	} else if !isScoped {
+		return nil, fmt.Errorf("%s", i18n.T("ErrorPermissionDenied", nil))
+	}
+
 	// A time-bound share must expire in the future (see ShareSecret).
 	if req.ExpiresAt != nil && !req.ExpiresAt.After(c.now()) {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "share expiry must be in the future")

--- a/internal/core/group_sharing_test.go
+++ b/internal/core/group_sharing_test.go
@@ -314,6 +314,8 @@ func TestShareSecretWithGroup_DepartedOwnerDenied(t *testing.T) {
 		shareRecord := &models.ShareRecord{ID: 1, SecretID: 1, OwnerID: 1, RecipientID: 2, IsGroup: true, Permission: "read"}
 		ms.On("GetSecret", ctx, uint(1)).Return(secret, nil)
 		ms.On("IsProjectMember", ctx, uint(1), uint(5)).Return(true, nil)
+		// ShareSecretWithGroup also verifies the group is scoped to the secret's project.
+		ms.On("IsGroupProjectScoped", ctx, uint(2), uint(5)).Return(true, nil)
 		ms.On("CreateShareRecord", ctx, mock.AnythingOfType("*models.ShareRecord")).Return(shareRecord, nil)
 		ms.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
 
@@ -377,6 +379,14 @@ func TestShareSecretWithGroup_CrossProjectRefused(t *testing.T) {
 		CreatedAt: now, UpdatedAt: now,
 	})
 	require.NoError(t, err)
+
+	// ShareSecretWithGroup also gates the owner on live project membership
+	// (RBAC-001, requireLiveOwnerAuthority) — give user 1 a project-scoped role,
+	// or every call below fails before ever reaching the group-scope check this
+	// test exercises. models.Role isn't migrated in this fixture (RoleID is an
+	// unenforced FK here, matching the GroupRole grants below), so no Role row
+	// is needed.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	// Group G belongs to a COMPLETELY DIFFERENT project (B, 2) — the exact
 	// exploit scenario from the finding: G has no relationship to project A.

--- a/internal/core/group_sharing_test.go
+++ b/internal/core/group_sharing_test.go
@@ -9,9 +9,12 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	sqlite "github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestKeyorixCore_ShareSecretWithGroup(t *testing.T) {
@@ -61,6 +64,8 @@ func TestKeyorixCore_ShareSecretWithGroup(t *testing.T) {
 	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
 	// ShareSecretWithGroup verifies the owner is still a live project member (RBAC-001).
 	mockStorage.On("IsProjectMember", ctx, uint(1), uint(0)).Return(true, nil)
+	// ShareSecretWithGroup verifies the group is scoped to the secret's project.
+	mockStorage.On("IsGroupProjectScoped", ctx, uint(2), uint(0)).Return(true, nil)
 	mockStorage.On("CreateShareRecord", ctx, mock.AnythingOfType("*models.ShareRecord")).Return(shareRecord, nil)
 	mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
 
@@ -335,4 +340,73 @@ func TestShareSecretWithGroup_NonOwnerDenied(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not authorized")
 	ms.AssertNotCalled(t, "CreateShareRecord", mock.Anything, mock.Anything)
+}
+
+// TestShareSecretWithGroup_CrossProjectRefused is the regression test for
+// findings-core/core-sharing.json#2: ShareSecretWithGroup used to grant
+// standing access to an arbitrary GroupID with no check tying that group to
+// the secret's project — unlike ShareSecret's direct-user path, which already
+// rejects cross-project recipients. The exploit: a secret owner shares with a
+// group that belongs to a completely different project, permanently exposing
+// the secret to every current and future member of that unrelated group, with
+// no project boundary enforced anywhere downstream (CheckGroupPermissions
+// checks group membership only, never project affiliation). Uses the real
+// sqlite-backed LocalStorage (no mocks) so the assertions exercise the actual
+// group-role-scope query, not a hand-rolled double.
+func TestShareSecretWithGroup_CrossProjectRefused(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
+		&models.Group{}, &models.UserGroup{}, &models.UserRole{}, &models.GroupRole{},
+	))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@t.com"}).Error)
+
+	now := time.Now()
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	ctx := context.Background()
+
+	// Secret S lives in project A (1).
+	secret, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "s", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: now, UpdatedAt: now,
+	})
+	require.NoError(t, err)
+
+	// Group G belongs to a COMPLETELY DIFFERENT project (B, 2) — the exact
+	// exploit scenario from the finding: G has no relationship to project A.
+	require.NoError(t, db.Create(&models.Group{ID: 20, Name: "other-project-group"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 20, RoleID: 1, ProjectID: 2}).Error)
+
+	_, err = c.ShareSecretWithGroup(ctx, &GroupShareSecretRequest{
+		SecretID: secret.ID, GroupID: 20, Permission: "read", SharedBy: 1,
+	})
+	require.Error(t, err, "sharing a secret with a group from an unrelated project must be refused")
+
+	shares, lerr := c.storage.ListSharesBySecret(ctx, secret.ID)
+	require.NoError(t, lerr)
+	assert.Empty(t, shares, "the refused cross-project group share must not have been persisted")
+
+	// A group with NO project scope at all must be refused too — there is no
+	// legitimate tie to project A to fall back on.
+	require.NoError(t, db.Create(&models.Group{ID: 21, Name: "unscoped-group"}).Error)
+	_, err = c.ShareSecretWithGroup(ctx, &GroupShareSecretRequest{
+		SecretID: secret.ID, GroupID: 21, Permission: "read", SharedBy: 1,
+	})
+	require.Error(t, err, "a group with no project scope at all must be refused")
+
+	// Sharing with a group that IS scoped to the secret's own project (A, 1)
+	// must still work.
+	require.NoError(t, db.Create(&models.Group{ID: 22, Name: "same-project-group"}).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 22, RoleID: 1, ProjectID: 1}).Error)
+	rec, err := c.ShareSecretWithGroup(ctx, &GroupShareSecretRequest{
+		SecretID: secret.ID, GroupID: 22, Permission: "read", SharedBy: 1,
+	})
+	require.NoError(t, err, "sharing with a group scoped to the secret's own project must succeed")
+	assert.Equal(t, uint(22), rec.RecipientID)
 }

--- a/internal/core/group_sharing_test.go
+++ b/internal/core/group_sharing_test.go
@@ -59,6 +59,8 @@ func TestKeyorixCore_ShareSecretWithGroup(t *testing.T) {
 
 	// Mock expectations
 	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+	// ShareSecretWithGroup verifies the owner is still a live project member (RBAC-001).
+	mockStorage.On("IsProjectMember", ctx, uint(1), uint(0)).Return(true, nil)
 	mockStorage.On("CreateShareRecord", ctx, mock.AnythingOfType("*models.ShareRecord")).Return(shareRecord, nil)
 	mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
 
@@ -271,6 +273,49 @@ func TestKeyorixCore_ListGroupSharedSecrets_ValidationError(t *testing.T) {
 	c := &KeyorixCore{storage: new(MockStorage), now: time.Now}
 	_, err := c.ListGroupSharedSecrets(context.Background(), ActorTypeUser, 1, 0)
 	assert.Error(t, err)
+}
+
+// TestShareSecretWithGroup_DepartedOwnerDenied is the RBAC-001 regression test for
+// ShareSecretWithGroup (adversarial-review finding core-sharing.json#1): an owner
+// who created a secret then left the secret's project (removed from membership;
+// OwnerID on the secret row is untouched) must no longer be able to group-share it
+// — mirrors CheckSecretPermission's owner branch. A still-live owner is unaffected.
+func TestShareSecretWithGroup_DepartedOwnerDenied(t *testing.T) {
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	secret := &models.SecretNode{ID: 1, Name: "test-secret", OwnerID: 1, ProjectID: 5}
+	req := &GroupShareSecretRequest{SecretID: 1, GroupID: 2, Permission: "read", SharedBy: 1}
+
+	t.Run("departed owner is denied", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := &KeyorixCore{storage: ms, now: time.Now}
+		ctx := context.Background()
+		ms.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+		// The owner no longer holds a live role grant in the secret's project.
+		ms.On("IsProjectMember", ctx, uint(1), uint(5)).Return(false, nil)
+
+		_, err := c.ShareSecretWithGroup(ctx, req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not authorized")
+		ms.AssertNotCalled(t, "CreateShareRecord", mock.Anything, mock.Anything)
+	})
+
+	t.Run("live owner still succeeds", func(t *testing.T) {
+		ms := new(MockStorage)
+		mockTime := time.Date(2025, 7, 1, 12, 0, 0, 0, time.UTC)
+		c := &KeyorixCore{storage: ms, now: func() time.Time { return mockTime }}
+		ctx := context.Background()
+		shareRecord := &models.ShareRecord{ID: 1, SecretID: 1, OwnerID: 1, RecipientID: 2, IsGroup: true, Permission: "read"}
+		ms.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+		ms.On("IsProjectMember", ctx, uint(1), uint(5)).Return(true, nil)
+		ms.On("CreateShareRecord", ctx, mock.AnythingOfType("*models.ShareRecord")).Return(shareRecord, nil)
+		ms.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
+
+		result, err := c.ShareSecretWithGroup(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, shareRecord, result)
+	})
 }
 
 // Regression (security review): a non-owner must not be able to group-share a

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -182,9 +182,50 @@ func (c *KeyorixCore) validateGroupJoinRoles(ctx context.Context, actorID, userI
 	return c.requireGroupJoinNoSoDViolation(ctx, userID, grants)
 }
 
+// domainAllowedForGroupJoin applies domainAllowedForUser's onboarding-domain
+// restriction to AddUserToGroup. A group membership only needs the check when
+// the join would actually confer a live role grant — a purely organizational
+// group with no role grants isn't an onboarding path and isn't gated, mirroring
+// the direct-grant paths (which only ever fire once a role is being assigned).
+//
+// Scope matching mirrors GetUserGroupRoleIDsAt (local_rbac.go): a project-scoped
+// membership (projectID != 0) is reached by the group's global (ProjectID==0)
+// grants and by grants scoped exactly to projectID; a global membership
+// (projectID == 0) is reached by EVERY grant the group holds — each at its own
+// matching project — so it is, if anything, the more dangerous case, not one to
+// skip.
+func (c *KeyorixCore) domainAllowedForGroupJoin(ctx context.Context, userID, groupID, projectID uint) error {
+	if len(c.membershipDomainAllowlist) == 0 {
+		return nil
+	}
+	grants, err := c.storage.ListGroupRoleAssignments(ctx, groupID)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	for _, g := range grants {
+		if projectID == 0 || g.ProjectID == 0 || g.ProjectID == projectID {
+			return c.domainAllowedForUser(ctx, userID)
+		}
+	}
+	return nil
+}
+
 func (c *KeyorixCore) AddUserToGroup(ctx context.Context, actorID, userID, groupID, projectID uint) error {
 	if userID == 0 || groupID == 0 {
 		return fmt.Errorf("%s: user ID and group ID are required", i18n.T("ErrorValidation", nil))
+	}
+	// #PM-006: a group membership confers every role the group holds at the
+	// matching scope (see this function's doc comment above), which is exactly
+	// the "grants a project-scope role directly by user ID" case
+	// domainAllowedForUser's doc comment (membership_lifecycle.go) says every
+	// onboarding path must cover — otherwise an install's membership domain
+	// allowlist (SetMembershipDomainAllowlist) can be bypassed entirely by
+	// routing a disallowed-domain user through group membership instead of
+	// InviteMember/AddProjectMember. Runs unconditionally, with no actorID==0
+	// exemption, matching AddProjectMember/InviteMember (this is an onboarding
+	// restriction, not an escalation-by-proxy authority ceiling).
+	if err := c.domainAllowedForGroupJoin(ctx, userID, groupID, projectID); err != nil {
+		return err
 	}
 	// #G04: validateGroupJoinRoles' set-based requireGroupJoinNoSoDViolation check
 	// and the membership write below must be treated as one step — see

--- a/internal/core/groups_domain_allowlist_test.go
+++ b/internal/core/groups_domain_allowlist_test.go
@@ -1,0 +1,147 @@
+// groups_domain_allowlist_test.go — findings-core/core-project-members.json#5
+// (PM-006): AddUserToGroup did not enforce the install's membership domain
+// allowlist (SetMembershipDomainAllowlist / domainAllowedForUser,
+// membership_lifecycle.go), even though a group membership confers every role
+// the group holds at the matching scope — identical in effect to a direct
+// AddProjectMember/InviteMember grant. That let an attacker with
+// group-management rights bypass a "only @company.com may be onboarded into
+// projects" allowlist entirely by routing the same access grant through group
+// membership instead of a direct role/invite. Fixed by
+// domainAllowedForGroupJoin (groups.go), called unconditionally from
+// AddUserToGroup before the membership row is written.
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestUserWithEmail creates a user with an explicit email, unlike
+// h.CreateTestUser which always mints "<username>@test.com" — these tests need
+// to control the domain to exercise the allowlist.
+func createTestUserWithEmail(t *testing.T, h *testhelper.RBACTestHelper, username, email string, userID uint) *models.User {
+	t.Helper()
+	user := &models.User{ID: userID, Username: username, Email: email}
+	require.NoError(t, h.DB.Create(user).Error)
+	return user
+}
+
+// TestAddUserToGroup_RejectsDisallowedDomain_ProjectScopedGrant is the core
+// regression: a group holding a role grant scoped to the SAME project as the
+// membership confers project access exactly like AddProjectMember, so a
+// disallowed-domain user must be refused, matching
+// TestAddProjectMember_RejectsDisallowedDomain's assertions for the direct path.
+func TestAddUserToGroup_RejectsDisallowedDomain_ProjectScopedGrant(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	const proj = uint(7)
+	h.CreateTestRole(t, "domain_gate_role", "", 80)
+	h.CreateTestGroup(t, "eng-project-group", "", 60)
+	projID := proj
+	h.AssignGroupRole(t, 60, 80, &projID) // project-scoped grant at proj 7
+
+	mallory := createTestUserWithEmail(t, h, "mallory", "mallory@evil.com", 90)
+
+	h.CoreService.SetMembershipDomainAllowlist([]string{"allowed.com"})
+
+	// actorID 99 is arbitrary/unprivileged: domain_gate_role is not an
+	// admin-tier role name, so requireAuthorityForRole imposes no ceiling here
+	// — only the domain-allowlist gate under test is exercised.
+	err := h.CoreService.AddUserToGroup(ctx, 99, mallory.ID, 60, proj)
+	require.Error(t, err, "adding a disallowed-domain user to a group that confers project access must be refused")
+	assert.Contains(t, err.Error(), "not on the allowlist")
+
+	groups, gerr := h.Storage.GetUserGroups(ctx, mallory.ID)
+	require.NoError(t, gerr)
+	assert.Empty(t, groups, "the blocked membership must not have been persisted")
+}
+
+// TestAddUserToGroup_RejectsDisallowedDomain_GlobalMembershipReachesProjectGrant
+// covers the case the naive "gate only when projectID != 0" fix would have
+// missed: a GLOBAL membership (projectID == 0) still reaches every
+// project-scoped grant the group holds (each at its own matching project, per
+// GetUserGroupRoleIDsAt's scope semantics) — so it must be gated too, and is
+// if anything the MORE dangerous route since it reaches every project the
+// group has a grant in, not just one.
+func TestAddUserToGroup_RejectsDisallowedDomain_GlobalMembershipReachesProjectGrant(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	const proj = uint(7)
+	h.CreateTestRole(t, "domain_gate_role_2", "", 81)
+	h.CreateTestGroup(t, "eng-project-group-2", "", 61)
+	projID := proj
+	h.AssignGroupRole(t, 61, 81, &projID) // project-scoped grant, group joined globally below
+
+	trent := createTestUserWithEmail(t, h, "trent", "trent@evil.com", 91)
+
+	h.CoreService.SetMembershipDomainAllowlist([]string{"allowed.com"})
+
+	// projectID 0 == a GLOBAL membership, not a project-scoped one.
+	err := h.CoreService.AddUserToGroup(ctx, 99, trent.ID, 61, 0)
+	require.Error(t, err, "a global group join that reaches a project-scoped grant must still be refused")
+	assert.Contains(t, err.Error(), "not on the allowlist")
+}
+
+// TestAddUserToGroup_AllowsAllowedDomain is the negative control: an
+// allowed-domain user can still be added to a group that confers project
+// access normally once the allowlist passes.
+func TestAddUserToGroup_AllowsAllowedDomain(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	const proj = uint(7)
+	h.CreateTestRole(t, "domain_gate_role_3", "", 82)
+	h.CreateTestGroup(t, "eng-project-group-3", "", 62)
+	projID := proj
+	h.AssignGroupRole(t, 62, 82, &projID)
+
+	peggy := createTestUserWithEmail(t, h, "peggy", "peggy@allowed.com", 92)
+
+	h.CoreService.SetMembershipDomainAllowlist([]string{"allowed.com"})
+
+	err := h.CoreService.AddUserToGroup(ctx, 99, peggy.ID, 62, proj)
+	require.NoError(t, err, "an allowed-domain user must still be able to join a project-conferring group")
+
+	groups, gerr := h.Storage.GetUserGroups(ctx, peggy.ID)
+	require.NoError(t, gerr)
+	var found bool
+	for _, g := range groups {
+		if g.ID == 62 {
+			found = true
+		}
+	}
+	assert.True(t, found, "the allowed membership must have been persisted")
+}
+
+// TestAddUserToGroup_NoRoleGrant_NotGatedByDomainAllowlist verifies the fix is
+// scoped correctly: a group holding NO role grants at all confers no access,
+// so joining it is not an onboarding path and must not be gated by the
+// allowlist — mirroring the direct-grant paths, which only ever fire once a
+// role is actually being assigned.
+func TestAddUserToGroup_NoRoleGrant_NotGatedByDomainAllowlist(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.CreateTestGroup(t, "org-chart-only-group", "", 63)
+	oscar := createTestUserWithEmail(t, h, "oscar", "oscar@evil.com", 93)
+
+	h.CoreService.SetMembershipDomainAllowlist([]string{"allowed.com"})
+
+	err := h.CoreService.AddUserToGroup(ctx, 99, oscar.ID, 63, 0)
+	require.NoError(t, err, "joining a group with no role grants confers no access and must not be gated")
+}

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -438,15 +438,36 @@ func (c *KeyorixCore) auditMFAFailed(ctx context.Context, userID uint, phase str
 }
 
 // requireReauth is the shared self-service re-authentication gate (#372) for
-// account-security-factor changes: it verifies codeOrPassword against a CURRENT,
-// already-active TOTP secret (only when user.MFAEnabled — never against an
-// in-flight, not-yet-activated enrolment secret, which an attacker who just called
-// BeginMFAEnrollment/BeginWebAuthnRegistration themselves would already know) or
-// the account password. Every caller (DisableMFA, RegenerateMFARecoveryCodes,
-// ActivateMFA, FinishWebAuthnRegistration, DeleteWebAuthnCredential) is reachable
+// account-security-factor changes. Every caller (DisableMFA,
+// RegenerateMFARecoveryCodes, ActivateMFA, FinishWebAuthnRegistration,
+// DeleteWebAuthnCredential, UpdateOwnProfile's email-change path) is reachable
 // with nothing but a bearer token — a stolen session OR a narrowly-scoped PAT,
 // which ADR-042 exempts from MFA policy entirely — so this check is the only thing
 // standing between a leaked bearer and a full account-security-factor takeover.
+//
+// Once a second factor is enrolled (user.MFAEnabled or user.WebAuthnEnabled), the
+// account password ALONE is no longer sufficient proof — accepting it would let a
+// bearer-token thief satisfy "step-up" re-auth with nothing but a password,
+// defeating the entire point of requiring a SECOND factor. In that case the
+// caller must additionally prove they still hold the second factor, via one of:
+//
+//  1. codeOrPassword is itself a CURRENT, currently-valid TOTP code, checked
+//     directly against the already-active secret (only possible when
+//     user.MFAEnabled — never against an in-flight, not-yet-activated
+//     enrolment secret, which an attacker who just called
+//     BeginMFAEnrollment/BeginWebAuthnRegistration themselves would already
+//     know). Anti-replay via MarkTOTPStepUsed, same as VerifyMFACredentials.
+//  2. codeOrPassword is the correct account password AND the user separately
+//     holds an active MFA step-up grant (HasActiveMFAStepUp) — an
+//     independent, time-limited proof that they recently re-verified their
+//     second factor (VerifyMFAStepUp for TOTP/recovery codes; a WebAuthn
+//     login also mints one, see FinishWebAuthnLogin/
+//     FinishWebAuthnPasswordlessLogin — a passkey assertion has no typable
+//     "code" to hand this function directly, so login itself is the proof).
+//
+// With no second factor enrolled at all, the account password alone remains
+// sufficient re-auth — unchanged from before this check existed.
+//
 // Feeds the same per-account lockout the second login factor (VerifyMFALogin)
 // uses, keyed by user (not IP, since this is an authenticated-session endpoint):
 // without it, this check would be the only throttle on guessing. phase labels the
@@ -455,6 +476,7 @@ func (c *KeyorixCore) requireReauth(ctx context.Context, user *models.User, code
 	if c.loginLocked(user) {
 		return fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
 	}
+	secondFactorEnrolled := user.MFAEnabled || user.WebAuthnEnabled
 	ok := false
 	if user.MFAEnabled {
 		if secret, err := c.loadTOTPSecret(ctx, user.ID); err == nil {
@@ -469,7 +491,15 @@ func (c *KeyorixCore) requireReauth(ctx context.Context, user *models.User, code
 		}
 	}
 	if !ok && codeOrPassword != "" && bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(codeOrPassword)) == nil {
-		ok = true
+		if !secondFactorEnrolled {
+			ok = true
+		} else if hasGrant, gerr := c.HasActiveMFAStepUp(ctx, user.ID); gerr == nil && hasGrant {
+			// The password is correct AND the caller independently proved they
+			// still hold the enrolled second factor recently — password alone
+			// would not be enough on its own, but password + a fresh, genuine
+			// step-up grant is equivalent proof to supplying the code directly.
+			ok = true
+		}
 	}
 	if !ok {
 		c.auditMFAFailed(ctx, user.ID, phase)

--- a/internal/core/mfa_atomicity_test.go
+++ b/internal/core/mfa_atomicity_test.go
@@ -112,6 +112,12 @@ func TestDisableMFA_AtomicOnDeleteFailure(t *testing.T) {
 	ctx := context.Background()
 	activateMFAForTest(t, c, fixed)
 
+	// MFA is enrolled, so password alone no longer satisfies requireReauth's
+	// second-factor requirement (#372-follow-up); seed an active step-up grant so
+	// re-auth succeeds and the test actually reaches (and exercises) the injected
+	// storage failure below, rather than failing earlier at re-auth.
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
+
 	c.storage = &failingStorage{Storage: c.storage, failMethod: "DeleteMFAForUser"}
 	err := c.DisableMFA(ctx, 1, mfaTestPassword)
 	require.Error(t, err)
@@ -135,6 +141,12 @@ func TestRegenerateMFARecoveryCodes_AtomicOnCreateFailure(t *testing.T) {
 	ctx := context.Background()
 	_, original := activateMFAForTest(t, c, fixed)
 	require.Len(t, original, mfaRecoveryCodeCount)
+
+	// MFA is enrolled, so password alone no longer satisfies requireReauth's
+	// second-factor requirement (#372-follow-up); seed an active step-up grant so
+	// re-auth succeeds and the test actually reaches (and exercises) the injected
+	// storage failure below, rather than failing earlier at re-auth.
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
 
 	c.storage = &failingStorage{Storage: c.storage, failMethod: "CreateMFARecoveryCodes"}
 	_, err := c.RegenerateMFARecoveryCodes(ctx, 1, mfaTestPassword)

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -187,6 +187,10 @@ func TestMFA_FullFlow(t *testing.T) {
 	require.Error(t, err, "recovery code is single-use")
 
 	// ── Disable via password → MFA off, secret cleared ──
+	// MFA is enrolled, so password alone no longer satisfies requireReauth's
+	// second-factor requirement (#372-follow-up): the caller must also hold an
+	// active step-up grant, proving they recently re-verified the second factor.
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
 	require.NoError(t, c.DisableMFA(ctx, 1, mfaTestPassword))
 	require.NoError(t, db.First(&user, 1).Error)
 	assert.False(t, user.MFAEnabled)
@@ -305,11 +309,15 @@ func TestMFA_RecoveryCodesRemaining(t *testing.T) {
 }
 
 func TestMFA_RegenerateRecoveryCodes(t *testing.T) {
-	c, _, fixed := newMFATestCore(t)
+	c, db, fixed := newMFATestCore(t)
 	ctx := context.Background()
 	secret, original := activateMFAForTest(t, c, fixed)
 
 	// Regenerate with the password → a fresh distinct set; the old codes stop working.
+	// MFA is enrolled, so password alone no longer satisfies requireReauth's
+	// second-factor requirement (#372-follow-up): also seed an active step-up
+	// grant, proving the caller recently re-verified the second factor.
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
 	fresh, err := c.RegenerateMFARecoveryCodes(ctx, 1, mfaTestPassword)
 	require.NoError(t, err)
 	require.Len(t, fresh, 10)
@@ -568,7 +576,11 @@ func TestDisableMFA_SuccessClearsLoginFailures(t *testing.T) {
 	require.NoError(t, db.First(&mid, 1).Error)
 	assert.Equal(t, 2, mid.FailedLoginAttempts)
 
-	// A correct password succeeds and resets the accrued failures.
+	// A correct password succeeds and resets the accrued failures. MFA is
+	// enrolled, so password alone no longer satisfies requireReauth's
+	// second-factor requirement (#372-follow-up): also seed an active step-up
+	// grant, proving the caller recently re-verified the second factor.
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
 	require.NoError(t, c.DisableMFA(ctx, 1, mfaTestPassword))
 	var after models.User
 	require.NoError(t, db.First(&after, 1).Error)
@@ -673,6 +685,79 @@ func TestRequireReauth_TOTPCodeNotReplayable(t *testing.T) {
 	err = c.requireReauth(ctx, user, code, "test_phase")
 	require.Error(t, err, "replaying the same TOTP code must be rejected by requireReauth")
 	assert.Contains(t, err.Error(), "invalid", "replay must surface as an invalid-code error, not a lock error")
+}
+
+// #372-follow-up: requireReauth's shared second-factor requirement — password
+// alone must no longer satisfy "step-up" re-auth once MFA is enabled. A stolen
+// session or a narrowly-scoped PAT (ADR-042 exempts PATs from MFA policy
+// entirely) already carries the password-equivalent trust a bearer token
+// implies; before this fix, requireReauth still fell through to a bare bcrypt
+// password check even when user.MFAEnabled was true, letting a bearer-token
+// thief who merely knows the password fully disable/downgrade the account's
+// second factor. Exercised via UpdateOwnProfile's email-change path — the exact
+// call site the underlying finding named, and the most direct test surface one
+// layer above requireReauth itself.
+func TestUpdateOwnProfile_EmailChange_PasswordAloneRefusedWhenMFAEnabled(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	activateMFAForTest(t, c, fixed)
+
+	_, err := c.UpdateOwnProfile(ctx, 1, "", "alice-new@b.com", mfaTestPassword)
+	require.Error(t, err, "the CORRECT password alone must not satisfy re-auth once MFA is enabled")
+
+	u, gerr := c.storage.GetUser(ctx, 1)
+	require.NoError(t, gerr)
+	assert.Equal(t, "a@b.com", u.Email, "a refused re-auth must not change the email")
+}
+
+// Companion positive case #1: a directly-supplied, currently-valid TOTP code
+// satisfies re-auth on its own (unchanged behavior) — the code itself IS the
+// second-factor proof, no step-up grant needed.
+func TestUpdateOwnProfile_EmailChange_ValidTOTPCodeSucceeds(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	secret, _ := activateMFAForTest(t, c, fixed)
+
+	code, err := totp.GenerateCode(secret, fixed)
+	require.NoError(t, err)
+
+	u, err := c.UpdateOwnProfile(ctx, 1, "", "alice-new@b.com", code)
+	require.NoError(t, err, "a valid current TOTP code must satisfy re-auth directly")
+	assert.Equal(t, "alice-new@b.com", u.Email)
+}
+
+// Companion positive case #2: the correct password PLUS an active, independent
+// MFA step-up grant (proof the caller recently re-verified the second factor,
+// e.g. via VerifyMFAStepUp or a WebAuthn login) DOES satisfy re-auth — password
+// alone is insufficient, but password + a genuine step-up grant is equivalent
+// proof to supplying the code directly.
+func TestUpdateOwnProfile_EmailChange_PasswordPlusActiveStepUpGrantSucceeds(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	activateMFAForTest(t, c, fixed)
+
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
+
+	u, err := c.UpdateOwnProfile(ctx, 1, "", "alice-new@b.com", mfaTestPassword)
+	require.NoError(t, err, "password + an active step-up grant must satisfy re-auth")
+	assert.Equal(t, "alice-new@b.com", u.Email)
+}
+
+// The fix closes the gap at the SHARED requireReauth helper, not just the
+// UpdateOwnProfile call site the finding named — confirm a second, independent
+// caller (DisableMFA) also now refuses password-only re-auth once MFA is
+// enabled.
+func TestDisableMFA_PasswordAloneRefusedWhenMFAEnabled(t *testing.T) {
+	c, _, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	activateMFAForTest(t, c, fixed)
+
+	err := c.DisableMFA(ctx, 1, mfaTestPassword)
+	require.Error(t, err, "the CORRECT password alone must not satisfy DisableMFA's re-auth once MFA is enabled")
+
+	u, gerr := c.storage.GetUser(ctx, 1)
+	require.NoError(t, gerr)
+	assert.True(t, u.MFAEnabled, "a refused re-auth must not disable MFA")
 }
 
 // VerifyMFALogin must record a MFA step-up token when the classification gate

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1196,6 +1196,11 @@ func (m *MockStorage) IsProjectMember(ctx context.Context, userID, projectID uin
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *MockStorage) IsGroupProjectScoped(ctx context.Context, groupID, projectID uint) (bool, error) {
+	args := m.Called(ctx, groupID, projectID)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *MockStorage) GetUserGroupRoleIDsAt(ctx context.Context, userID uint, scope storage.Scope) ([]uint, error) {
 	a := m.Called(ctx, userID, scope)
 	v, _ := a.Get(0).([]uint)

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -40,6 +40,25 @@ func secretOwnedBy(ownerID, actorID uint) bool {
 	return ownerID != 0 && ownerID == actorID
 }
 
+// requireLiveOwnerAuthority reports whether actorID holds owner-level authority over
+// secret: they must be the secret's OwnerID AND still be a LIVE member of the
+// secret's project. An owner who is removed from the project keeps their OwnerID tag
+// on the secret row until ClearProjectSecretOwnership runs, so a bare secretOwnedBy
+// check alone would let a departed owner retain full authority over the secret
+// forever (RBAC-001). Every owner-gated operation — CheckSecretPermission's owner
+// branch, and the sharing.go/group_sharing.go mutation paths — must call this instead
+// of secretOwnedBy directly.
+func (c *KeyorixCore) requireLiveOwnerAuthority(ctx context.Context, secret *models.SecretNode, actorID uint) (bool, error) {
+	if !secretOwnedBy(secret.OwnerID, actorID) {
+		return false, nil
+	}
+	member, err := c.storage.IsProjectMember(ctx, actorID, secret.ProjectID)
+	if err != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return member, nil
+}
+
 // PermissionLevel represents the level of access a user has to a secret.
 type PermissionLevel string
 
@@ -77,19 +96,15 @@ func (c *KeyorixCore) CheckSecretPermission(ctx context.Context, secretID, userI
 	// project. A user removed from the project retains their OwnerID tag until
 	// ClearProjectSecretOwnership runs (RBAC-002), so we gate owner access on live
 	// project membership to prevent post-offboarding access (RBAC-001).
-	if secretOwnedBy(secret.OwnerID, userID) {
-		member, err := c.storage.IsProjectMember(ctx, userID, secret.ProjectID)
-		if err != nil {
-			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
-		}
-		if member {
-			return &PermissionContext{
-				SecretID:   secretID,
-				UserID:     userID,
-				Permission: PermissionOwner,
-				Source:     "owner",
-			}, nil
-		}
+	if isLiveOwner, err := c.requireLiveOwnerAuthority(ctx, secret, userID); err != nil {
+		return nil, err
+	} else if isLiveOwner {
+		return &PermissionContext{
+			SecretID:   secretID,
+			UserID:     userID,
+			Permission: PermissionOwner,
+			Source:     "owner",
+		}, nil
 	}
 
 	shares, err := c.storage.ListSharesBySecret(ctx, secretID)

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -672,9 +672,22 @@ func (c *KeyorixCore) SetSecretAutoRotate(ctx context.Context, id uint, spec Aut
 	// their own readable secret (or reset an unrelated target's password) — the same
 	// escalation-by-proxy shape #93/#107 closed for role grants, applied here to
 	// credential-minting backends (#90).
-	if spec.Backend != "" {
+	//
+	// The same authority is required to CLEAR an existing binding: an admin decided this
+	// secret should auto-rotate against an upstream backend, and undoing that decision is
+	// just as security-relevant as making it — otherwise a plain secrets.write caller
+	// could silently strip an admin-configured rotation binding they were never allowed
+	// to set up in the first place. `secret` here still holds the PRE-update value (it
+	// was fetched above, before spec is applied below), so secret.RotationBackend is the
+	// backend that was bound before this call — non-empty only when there is something to
+	// unbind. An unbind-when-nothing-was-bound (both empty) stays a no-op and isn't gated.
+	if spec.Backend != "" || secret.RotationBackend != "" {
 		if err := c.requireAdminAuthorityAt(ctx, actorID, secret.ProjectID); err != nil {
-			return fmt.Errorf("binding a rotation backend requires admin authority on this project: %w", err)
+			action := "binding"
+			if spec.Backend == "" {
+				action = "unbinding"
+			}
+			return fmt.Errorf("%s a rotation backend requires admin authority on this project: %w", action, err)
 		}
 	}
 	secret.AutoRotate = spec.Enabled

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -423,6 +423,61 @@ func TestSetSecretAutoRotate_InKeyorixRotationNoAdminRequired(t *testing.T) {
 		"enabling in-Keyorix rotation (no backend) needs no elevated authority")
 }
 
+// TestSetSecretAutoRotate_UnbindingBackendRequiresAdminAuthority pins the unbind side of
+// #90: an admin decided this secret should auto-rotate against an upstream backend, and
+// clearing that binding is just as security-relevant as creating it. Before this fix, the
+// admin-authority guard fired only when spec.Backend != "" — a plain secrets.write caller
+// (no admin authority) could pass Backend: "" against an already-bound secret and silently
+// strip an admin-configured rotation binding they were never allowed to set up in the
+// first place.
+func TestSetSecretAutoRotate_UnbindingBackendRequiresAdminAuthority(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-24*time.Hour))
+	ctx := context.Background()
+	// actor 9 has secrets.write on the secret (enforced by the transport layer, out of
+	// scope here) but NO role at all — the realistic "project editor" persona.
+
+	err := c.SetSecretAutoRotate(ctx, 1, AutoRotateSpec{Enabled: true}, 9)
+	require.Error(t, err, "a non-admin actor must not be able to unbind an existing rotation backend")
+	assert.Contains(t, err.Error(), "admin authority")
+
+	var s models.SecretNode
+	require.NoError(t, db.First(&s, 1).Error)
+	assert.Equal(t, "pg", s.RotationBackend, "the existing binding must survive a refused unbind attempt")
+	assert.Equal(t, "app_svc", s.RotationRef)
+}
+
+// TestSetSecretAutoRotate_AdminCanUnbindBackend is the positive control: an actor who DOES
+// hold admin authority can still clear an existing rotation-backend binding.
+func TestSetSecretAutoRotate_AdminCanUnbindBackend(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	seedBackendSecret(t, db, 1, "pg", "app_svc", fixed.Add(-24*time.Hour))
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "project_admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 9, RoleID: 1, ProjectID: 1}).Error)
+
+	require.NoError(t, c.SetSecretAutoRotate(ctx, 1, AutoRotateSpec{Enabled: true}, 9),
+		"an admin caller can clear an existing rotation-backend binding")
+
+	var s models.SecretNode
+	require.NoError(t, db.First(&s, 1).Error)
+	assert.Empty(t, s.RotationBackend, "binding cleared")
+	assert.Empty(t, s.RotationRef, "ref cleared")
+}
+
+// TestSetSecretAutoRotate_UnboundSecretNoAdminRequired confirms the guard stays scoped to
+// an actual unbind: a secret with no backend ever bound, updated with Backend: "" again,
+// is a no-op and needs no elevated authority (mirrors the in-Keyorix-rotation control
+// above, but explicit about the "nothing to unbind" case).
+func TestSetSecretAutoRotate_UnboundSecretNoAdminRequired(t *testing.T) {
+	c, db, fixed := rotationExecCore(t)
+	seedRotatableSecret(t, db, 1, "key", false, fixed.Add(-24*time.Hour))
+	ctx := context.Background()
+
+	require.NoError(t, c.SetSecretAutoRotate(ctx, 1, AutoRotateSpec{Enabled: false}, 9),
+		"clearing a backend that was never bound is a no-op and needs no elevated authority")
+}
+
 // TestSetSecretAutoRotate_RejectsDangerousRefChars pins the earliest, shared layer of
 // defense against a malicious rotation_ref: SetSecretAutoRotate is the single
 // core-layer choke point every transport (HTTP/gRPC/CLI) goes through to set a

--- a/internal/core/secret_access_list_test.go
+++ b/internal/core/secret_access_list_test.go
@@ -25,7 +25,7 @@ func TestListSecretAccessors(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
-		&models.Group{}, &models.UserGroup{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.UserRole{}, &models.GroupRole{},
 	))
 	// Users: 1 owner, 2 direct recipient, 3 & 4 group members, 5 expired-share recipient.
 	for _, u := range []models.User{
@@ -43,6 +43,8 @@ func TestListSecretAccessors(t *testing.T) {
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "platform"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 3, GroupID: 10}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 4, GroupID: 10}).Error)
+	// ShareSecretWithGroup verifies the group is scoped to the secret's project (1).
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 10, RoleID: 1, ProjectID: 1}).Error)
 
 	now := time.Now()
 	st := store.NewLocalStorage(db)
@@ -95,7 +97,7 @@ func TestListSecretAccessors_StrongestGrantWins(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
-		&models.Group{}, &models.UserGroup{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.UserRole{}, &models.GroupRole{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "alice", Email: "a@t.com"}).Error)
@@ -103,6 +105,8 @@ func TestListSecretAccessors_StrongestGrantWins(t *testing.T) {
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "g"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 10}).Error)
+	// ShareSecretWithGroup verifies the group is scoped to the secret's project (1).
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 10, RoleID: 1, ProjectID: 1}).Error)
 
 	now := time.Now()
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
@@ -148,13 +152,15 @@ func TestListSecretAccessors_DegradedOnGroupMembersError(t *testing.T) {
 	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.User{}, &models.ShareRecord{},
-		&models.Group{}, &models.UserGroup{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.UserRole{}, &models.GroupRole{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", Email: "b@t.com"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "platform"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 2, GroupID: 10}).Error)
+	// ShareSecretWithGroup verifies the group is scoped to the secret's project (1).
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 10, RoleID: 1, ProjectID: 1}).Error)
 
 	now := time.Now()
 	base := store.NewLocalStorage(db)

--- a/internal/core/shares_expiry_test.go
+++ b/internal/core/shares_expiry_test.go
@@ -41,7 +41,10 @@ func newSharesExpiryFixture(t *testing.T) (*KeyorixCore, uint, time.Time, *gorm.
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "recip2", Email: "recip2@test.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 3, Username: "recip3", Email: "recip3@test.com"}).Error)
 	// ShareSecret checks IsProjectMember before creating the share record; seed
-	// project membership for both recipients so that check passes.
+	// project membership for both recipients so that check passes. The owner (1)
+	// also needs live project membership — requireLiveOwnerAuthority now re-checks
+	// it on every owner-gated sharing call (RBAC-001), mirroring CheckSecretPermission.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 1, ProjectID: 1}).Error)
 

--- a/internal/core/shares_expiry_test.go
+++ b/internal/core/shares_expiry_test.go
@@ -35,7 +35,7 @@ func newSharesExpiryFixture(t *testing.T) (*KeyorixCore, uint, time.Time, *gorm.
 	require.NoError(t, db.AutoMigrate(
 		&models.SecretNode{}, &models.SecretVersion{}, &models.ShareRecord{},
 		&models.AuditEvent{}, &models.User{}, &models.Group{}, &models.UserGroup{},
-		&models.UserRole{},
+		&models.UserRole{}, &models.GroupRole{},
 	))
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "owner@test.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "recip2", Email: "recip2@test.com"}).Error)
@@ -256,6 +256,9 @@ func TestReShareTightensExpiry(t *testing.T) {
 	t.Run("group share: re-sharing a permanent grant with an expiry persists it", func(t *testing.T) {
 		c, secretID, now, db := newSharesExpiryFixture(t)
 		require.NoError(t, db.Create(&models.Group{ID: 10, Name: "eng"}).Error)
+		// ShareSecretWithGroup verifies the group is scoped to the secret's project
+		// (project 1, per newSharesExpiryFixture); seed that grant so the share succeeds.
+		require.NoError(t, db.Create(&models.GroupRole{GroupID: 10, RoleID: 1, ProjectID: 1}).Error)
 
 		rec, err := c.ShareSecretWithGroup(ctx, &GroupShareSecretRequest{
 			SecretID: secretID, GroupID: 10, Permission: "read", SharedBy: 1,

--- a/internal/core/sharing.go
+++ b/internal/core/sharing.go
@@ -61,8 +61,12 @@ func (c *KeyorixCore) ShareSecret(ctx context.Context, req *ShareSecretRequest) 
 	}
 
 	// For user shares, reject cross-project grants: the recipient must be a member of
-	// the secret's project. Group shares are not gated here because group membership
-	// is enforced separately at the point of access.
+	// the secret's project. Group shares are not gated here — every group-share
+	// caller (HTTP, gRPC) routes to ShareSecretWithGroup (group_sharing.go) instead
+	// of here, and that function performs its own analogous cross-project check
+	// (IsGroupProjectScoped) against the group recipient. This is NOT compensated
+	// for at access time: CheckGroupPermissions (permissions.go) checks only group
+	// membership, never the accessing user's project affiliation.
 	if !req.IsGroup {
 		if isMember, merr := c.storage.IsProjectMember(ctx, req.RecipientID, secret.ProjectID); merr != nil {
 			return nil, fmt.Errorf("failed to verify project membership: %w", merr)

--- a/internal/core/sharing.go
+++ b/internal/core/sharing.go
@@ -50,8 +50,13 @@ func (c *KeyorixCore) ShareSecret(ctx context.Context, req *ShareSecretRequest) 
 	}
 
 	// Only the secret owner may share it (an ownerless / machine-created secret —
-	// OwnerID 0 — is owned by nobody and cannot be shared via the owner gate).
-	if !secretOwnedBy(secret.OwnerID, req.SharedBy) {
+	// OwnerID 0 — is owned by nobody and cannot be shared via the owner gate), and
+	// only while still a live member of the secret's project — mirrors
+	// CheckSecretPermission's owner branch (RBAC-001): an owner removed from the
+	// project keeps their OwnerID tag until ClearProjectSecretOwnership runs.
+	if isLiveOwner, err := c.requireLiveOwnerAuthority(ctx, secret, req.SharedBy); err != nil {
+		return nil, err
+	} else if !isLiveOwner {
 		return nil, fmt.Errorf("%s", i18n.T("ErrorPermissionDenied", nil))
 	}
 
@@ -120,7 +125,10 @@ func (c *KeyorixCore) UpdateSharePermission(ctx context.Context, req *UpdateShar
 	if err != nil {
 		return nil, err
 	}
-	if !secretOwnedBy(secret.OwnerID, req.UpdatedBy) {
+	// Owner authority also requires live project membership — see ShareSecret.
+	if isLiveOwner, err := c.requireLiveOwnerAuthority(ctx, secret, req.UpdatedBy); err != nil {
+		return nil, err
+	} else if !isLiveOwner {
 		return nil, fmt.Errorf("%s", i18n.T("ErrorPermissionDenied", nil))
 	}
 
@@ -176,7 +184,10 @@ func (c *KeyorixCore) RevokeShare(ctx context.Context, shareID uint, revokedBy u
 	if err != nil {
 		return err
 	}
-	if !secretOwnedBy(secret.OwnerID, revokedBy) {
+	// Owner authority also requires live project membership — see ShareSecret.
+	if isLiveOwner, err := c.requireLiveOwnerAuthority(ctx, secret, revokedBy); err != nil {
+		return err
+	} else if !isLiveOwner {
 		return fmt.Errorf("%s", i18n.T("ErrorPermissionDenied", nil))
 	}
 

--- a/internal/core/sharing_integration_simple_test.go
+++ b/internal/core/sharing_integration_simple_test.go
@@ -69,6 +69,8 @@ func TestSharingIntegrationSimple(t *testing.T) {
 		require.NoError(t, db.Create(&models.UserRole{UserID: uint(i), RoleID: 1, ProjectID: 1}).Error)
 	}
 	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "test-group"}).Error)
+	// ShareSecretWithGroup verifies the group is scoped to the secret's project (1).
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	// Initialize storage
 	storage := store.NewLocalStorage(db)

--- a/internal/core/sharing_test.go
+++ b/internal/core/sharing_test.go
@@ -57,7 +57,9 @@ func TestKeyorixCore_ShareSecret(t *testing.T) {
 
 	// Mock expectations
 	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
-	// ShareSecret verifies the recipient is a member of the secret's project.
+	// ShareSecret verifies the owner is still a live project member (RBAC-001) as
+	// well as that the recipient is a member of the secret's project.
+	mockStorage.On("IsProjectMember", ctx, uint(1), uint(0)).Return(true, nil)
 	mockStorage.On("IsProjectMember", ctx, uint(2), uint(0)).Return(true, nil)
 	mockStorage.On("CreateShareRecord", ctx, mock.AnythingOfType("*models.ShareRecord")).Return(shareRecord, nil)
 	mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
@@ -212,6 +214,7 @@ func TestKeyorixCore_ShareSecret_RejectsSelfShare(t *testing.T) {
 	groupSecret := &models.SecretNode{ID: 1, Name: "s", OwnerID: 1}
 	groupShareRecord := &models.ShareRecord{ID: 2, SecretID: 1, OwnerID: 1, RecipientID: 1, IsGroup: true, Permission: "read"}
 	mockStorage.On("GetSecret", ctx, uint(1)).Return(groupSecret, nil)
+	mockStorage.On("IsProjectMember", ctx, uint(1), uint(0)).Return(true, nil)
 	mockStorage.On("CreateShareRecord", ctx, mock.MatchedBy(func(s *models.ShareRecord) bool {
 		return s.SecretID == 1 && s.IsGroup
 	})).Return(groupShareRecord, nil)
@@ -291,6 +294,8 @@ func TestKeyorixCore_UpdateSharePermission(t *testing.T) {
 	// Mock expectations
 	mockStorage.On("GetShareRecord", ctx, uint(1)).Return(shareRecord, nil)
 	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+	// UpdateSharePermission verifies the owner is still a live project member (RBAC-001).
+	mockStorage.On("IsProjectMember", ctx, uint(1), uint(0)).Return(true, nil)
 	mockStorage.On("UpdateShareRecord", ctx, mock.AnythingOfType("*models.ShareRecord")).Return(updatedShareRecord, nil)
 	mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
 
@@ -333,6 +338,8 @@ func TestKeyorixCore_RevokeShare(t *testing.T) {
 	// Mock expectations
 	mockStorage.On("GetShareRecord", ctx, uint(1)).Return(shareRecord, nil)
 	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+	// RevokeShare verifies the owner is still a live project member (RBAC-001).
+	mockStorage.On("IsProjectMember", ctx, uint(1), uint(0)).Return(true, nil)
 	mockStorage.On("DeleteShareRecord", ctx, uint(1)).Return(nil)
 	mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
 	// Revoking a direct share notifies the recipient (best-effort).
@@ -374,6 +381,8 @@ func TestKeyorixCore_RevokeShare_NoPhantomAuditOnDeleteFailure(t *testing.T) {
 
 	mockStorage.On("GetShareRecord", ctx, uint(1)).Return(shareRecord, nil)
 	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+	// RevokeShare verifies the owner is still a live project member (RBAC-001).
+	mockStorage.On("IsProjectMember", ctx, uint(1), uint(0)).Return(true, nil)
 	mockStorage.On("DeleteShareRecord", ctx, uint(1)).Return(errors.New("storage unavailable"))
 
 	err := core.RevokeShare(ctx, 1, 1)
@@ -494,6 +503,126 @@ func TestKeyorixCore_ListSharesByUser(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, shares, result)
 	mockStorage.AssertExpectations(t)
+}
+
+// TestKeyorixCore_ShareSecret_DepartedOwnerDenied is the regression test for the
+// RBAC-001 gap in sharing.go (adversarial-review finding core-sharing.json#1): an
+// owner who created a secret then left the secret's project (removed from
+// membership; OwnerID on the secret row is untouched) must no longer be able to
+// share it — mirrors CheckSecretPermission's owner branch. A still-live owner must
+// be unaffected.
+func TestKeyorixCore_ShareSecret_DepartedOwnerDenied(t *testing.T) {
+	mockTime := time.Date(2025, 7, 1, 12, 0, 0, 0, time.UTC)
+	secret := &models.SecretNode{ID: 1, Name: "test-secret", OwnerID: 1, ProjectID: 5}
+	req := &ShareSecretRequest{SecretID: 1, RecipientID: 2, Permission: "read", SharedBy: 1}
+
+	t.Run("departed owner is denied", func(t *testing.T) {
+		mockStorage := new(MockStorage)
+		core := &KeyorixCore{storage: mockStorage, now: func() time.Time { return mockTime }}
+		ctx := context.Background()
+		mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+		// The owner no longer holds a live role grant in the secret's project.
+		mockStorage.On("IsProjectMember", ctx, uint(1), uint(5)).Return(false, nil)
+
+		_, err := core.ShareSecret(ctx, req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), i18n.T("ErrorPermissionDenied", nil))
+		mockStorage.AssertNotCalled(t, "CreateShareRecord", mock.Anything, mock.Anything)
+	})
+
+	t.Run("live owner still succeeds", func(t *testing.T) {
+		mockStorage := new(MockStorage)
+		core := &KeyorixCore{storage: mockStorage, now: func() time.Time { return mockTime }}
+		ctx := context.Background()
+		shareRecord := &models.ShareRecord{ID: 1, SecretID: 1, OwnerID: 1, RecipientID: 2, Permission: "read"}
+		mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+		mockStorage.On("IsProjectMember", ctx, uint(1), uint(5)).Return(true, nil)
+		mockStorage.On("IsProjectMember", ctx, uint(2), uint(5)).Return(true, nil)
+		mockStorage.On("CreateShareRecord", ctx, mock.AnythingOfType("*models.ShareRecord")).Return(shareRecord, nil)
+		mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
+		mockStorage.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).Return(&models.Notification{}, nil)
+
+		result, err := core.ShareSecret(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, shareRecord, result)
+	})
+}
+
+// TestKeyorixCore_UpdateSharePermission_DepartedOwnerDenied is the RBAC-001
+// regression test for UpdateSharePermission — see
+// TestKeyorixCore_ShareSecret_DepartedOwnerDenied.
+func TestKeyorixCore_UpdateSharePermission_DepartedOwnerDenied(t *testing.T) {
+	mockTime := time.Date(2025, 7, 1, 12, 0, 0, 0, time.UTC)
+	secret := &models.SecretNode{ID: 1, Name: "test-secret", OwnerID: 1, ProjectID: 5}
+	shareRecord := &models.ShareRecord{ID: 1, SecretID: 1, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}
+	req := &UpdateShareRequest{ShareID: 1, Permission: "write", UpdatedBy: 1}
+
+	t.Run("departed owner is denied", func(t *testing.T) {
+		mockStorage := new(MockStorage)
+		core := &KeyorixCore{storage: mockStorage, now: func() time.Time { return mockTime }}
+		ctx := context.Background()
+		mockStorage.On("GetShareRecord", ctx, uint(1)).Return(shareRecord, nil)
+		mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+		mockStorage.On("IsProjectMember", ctx, uint(1), uint(5)).Return(false, nil)
+
+		_, err := core.UpdateSharePermission(ctx, req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), i18n.T("ErrorPermissionDenied", nil))
+		mockStorage.AssertNotCalled(t, "UpdateShareRecord", mock.Anything, mock.Anything)
+	})
+
+	t.Run("live owner still succeeds", func(t *testing.T) {
+		mockStorage := new(MockStorage)
+		core := &KeyorixCore{storage: mockStorage, now: func() time.Time { return mockTime }}
+		ctx := context.Background()
+		updatedShareRecord := &models.ShareRecord{ID: 1, SecretID: 1, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "write"}
+		mockStorage.On("GetShareRecord", ctx, uint(1)).Return(shareRecord, nil)
+		mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+		mockStorage.On("IsProjectMember", ctx, uint(1), uint(5)).Return(true, nil)
+		mockStorage.On("UpdateShareRecord", ctx, mock.AnythingOfType("*models.ShareRecord")).Return(updatedShareRecord, nil)
+		mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
+
+		result, err := core.UpdateSharePermission(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, updatedShareRecord, result)
+	})
+}
+
+// TestKeyorixCore_RevokeShare_DepartedOwnerDenied is the RBAC-001 regression test
+// for RevokeShare — see TestKeyorixCore_ShareSecret_DepartedOwnerDenied.
+func TestKeyorixCore_RevokeShare_DepartedOwnerDenied(t *testing.T) {
+	mockTime := time.Date(2025, 7, 1, 12, 0, 0, 0, time.UTC)
+	secret := &models.SecretNode{ID: 1, Name: "test-secret", OwnerID: 1, ProjectID: 5}
+	shareRecord := &models.ShareRecord{ID: 1, SecretID: 1, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}
+
+	t.Run("departed owner is denied", func(t *testing.T) {
+		mockStorage := new(MockStorage)
+		core := &KeyorixCore{storage: mockStorage, now: func() time.Time { return mockTime }}
+		ctx := context.Background()
+		mockStorage.On("GetShareRecord", ctx, uint(1)).Return(shareRecord, nil)
+		mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+		mockStorage.On("IsProjectMember", ctx, uint(1), uint(5)).Return(false, nil)
+
+		err := core.RevokeShare(ctx, 1, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), i18n.T("ErrorPermissionDenied", nil))
+		mockStorage.AssertNotCalled(t, "DeleteShareRecord", mock.Anything, mock.Anything)
+	})
+
+	t.Run("live owner still succeeds", func(t *testing.T) {
+		mockStorage := new(MockStorage)
+		core := &KeyorixCore{storage: mockStorage, now: func() time.Time { return mockTime }}
+		ctx := context.Background()
+		mockStorage.On("GetShareRecord", ctx, uint(1)).Return(shareRecord, nil)
+		mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+		mockStorage.On("IsProjectMember", ctx, uint(1), uint(5)).Return(true, nil)
+		mockStorage.On("DeleteShareRecord", ctx, uint(1)).Return(nil)
+		mockStorage.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
+		mockStorage.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).Return(&models.Notification{}, nil)
+
+		err := core.RevokeShare(ctx, 1, 1)
+		require.NoError(t, err)
+	})
 }
 
 func TestKeyorixCore_CheckSharePermission(t *testing.T) {

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -421,8 +421,13 @@ func ssoBoundToOtherProvider(externalID, provider string) bool {
 // a scoped identity owned by a DIFFERENT provider (see ssoBoundToOtherProvider);
 // otherwise a second IdP asserting the same email could take over an account owned by
 // the first. A never-federated (native or SCIM-by-email) account is claimed for THIS
-// provider+subject on first link, so a later provider can't re-link it by asserting the
-// same address.
+// provider on first link (scoped even when the assertion carries no subject — e.g. a
+// SAML IdP that omits the Subject and relies solely on TrustAssertedEmail; see
+// CompleteSAML), so a later provider can't re-link it by asserting the same address.
+// The subject-less claim only marks provider ownership; it doesn't enable the
+// fast-path externalID lookup above, so a later assertion from the SAME provider that
+// does carry a subject still falls through to this email path and re-resolves here —
+// that's fine, since ssoBoundToOtherProvider still passes for the owning provider.
 func (c *KeyorixCore) resolveSSOUser(ctx context.Context, provider, sub, email string, emailVerified bool) (*models.User, error) {
 	if sub != "" {
 		if u, err := c.storage.GetUserByExternalID(ctx, ssoExternalID(provider, sub)); err == nil {
@@ -444,10 +449,14 @@ func (c *KeyorixCore) resolveSSOUser(ctx context.Context, provider, sub, email s
 	if ssoBoundToOtherProvider(u.ExternalID, provider) {
 		return nil, fmt.Errorf("the email %q is already linked to a different SSO provider", email)
 	}
-	if u.ExternalID == "" && sub != "" {
-		// Claim this never-federated account for the verifying provider+subject so a
-		// later provider can't re-link it by asserting the same email. Best-effort: a
-		// failed update just means we re-link on the next login.
+	if u.ExternalID == "" {
+		// Claim this never-federated account for the verifying provider (scoped by
+		// subject when the assertion carries one; ssoExternalID(provider, "") when it
+		// doesn't — e.g. a SAML assertion with no Subject) so a later provider can't
+		// re-link it by asserting the same email. A subject-less claim still fully
+		// closes the cross-provider vector: ssoBoundToOtherProvider only cares which
+		// provider owns the scoped id, not whether a subject is present. Best-effort:
+		// a failed update just means we re-link on the next login.
 		u.ExternalID = ssoExternalID(provider, sub)
 		if updated, uerr := c.storage.UpdateUser(ctx, u); uerr == nil {
 			u = updated
@@ -811,13 +820,14 @@ func (b *ssoBool) UnmarshalJSON(data []byte) error {
 }
 
 // verifyIDToken validates the id_token's signature (asymmetric only), issuer,
-// audience (= the provider's client_id), expiry, and the nonce, returning the
-// subject, email, (best-effort) name, and whether the email was EXPLICITLY verified.
-// The email is dropped only when the IdP explicitly marks it unverified
-// (email_verified: false). An absent email_verified claim is treated as trusted for
-// JIT-provisioning — it is OPTIONAL in OIDC and common enterprise IdPs (e.g. Entra ID)
-// omit it — but emailVerified is reported true only when the claim is present and true,
-// so resolveSSOUser can refuse to MATCH AN EXISTING account on a merely-asserted email.
+// audience (= the provider's client_id), azp (when the token names more than one
+// audience), expiry, and the nonce, returning the subject, email, (best-effort)
+// name, and whether the email was EXPLICITLY verified. The email is dropped only
+// when the IdP explicitly marks it unverified (email_verified: false). An absent
+// email_verified claim is treated as trusted for JIT-provisioning — it is OPTIONAL
+// in OIDC and common enterprise IdPs (e.g. Entra ID) omit it — but emailVerified is
+// reported true only when the claim is present and true, so resolveSSOUser can
+// refuse to MATCH AN EXISTING account on a merely-asserted email.
 func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expectedNonce, raw string) (sub, email, name string, emailVerified bool, err error) { // NOSONAR -- cognitive complexity 16, suppress go:S3776
 	var claims struct {
 		jwt.RegisteredClaims
@@ -825,6 +835,7 @@ func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expecte
 		EmailVerified *ssoBool `json:"email_verified"`
 		Name          string   `json:"name"`
 		Nonce         string   `json:"nonce"`
+		Azp           string   `json:"azp,omitempty"`
 	}
 	parser := jwt.NewParser(
 		jwt.WithValidMethods([]string{"RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"}),
@@ -855,6 +866,21 @@ func (c *KeyorixCore) verifyIDToken(ctx context.Context, p *SSOProvider, expecte
 	}
 	if !audOK {
 		return "", "", "", false, fmt.Errorf("id_token audience does not match the client id")
+	}
+	// A token naming MORE THAN ONE audience is, per OIDC, ambiguous about which
+	// party it was actually issued to — any one of the audiences matching our
+	// client_id isn't enough, since a multi-tenant IdP could mint a token shared
+	// across several relying parties and an attacker holding a copy issued to a
+	// DIFFERENT (also-trusted) party could replay it here. azp (authorized party)
+	// disambiguates the true recipient and must equal this provider's client_id.
+	// Mirrors OIDCVerifier.Verify in oidc.go (the machine-federation path).
+	if len(claims.Audience) > 1 {
+		if claims.Azp == "" {
+			return "", "", "", false, fmt.Errorf("id_token has multiple audiences but no azp claim")
+		}
+		if claims.Azp != p.ClientID {
+			return "", "", "", false, fmt.Errorf("id_token azp does not match the client id")
+		}
 	}
 	if expectedNonce == "" || claims.Nonce != expectedNonce {
 		return "", "", "", false, fmt.Errorf("id_token nonce mismatch")

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -138,6 +138,53 @@ func TestVerifyIDToken_EmailVerified(t *testing.T) {
 	assert.Equal(t, "ada@x.io", email)
 }
 
+// TestVerifyIDToken_Azp covers the multi-audience azp (authorized party) check that
+// mirrors OIDCVerifier.Verify in oidc.go: a single-audience token needs no azp, but a
+// multi-audience token MUST carry an azp equal to this provider's client_id, or a token
+// legitimately issued to a different (also-trusted) party could be replayed here.
+func TestVerifyIDToken_Azp(t *testing.T) {
+	c, _, key, p := ssoTestCore(t)
+	ctx := context.Background()
+	base := func() jwt.MapClaims {
+		return jwt.MapClaims{
+			"iss": "https://idp.test", "aud": []string{"client-1"}, "sub": "okta|123",
+			"email": "ada@x.io", "nonce": "N1", "exp": time.Now().Add(time.Hour).Unix(),
+		}
+	}
+
+	t.Run("single audience, no azp: accepted", func(t *testing.T) {
+		sub, _, _, _, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", base()))
+		require.NoError(t, err)
+		assert.Equal(t, "okta|123", sub)
+	})
+
+	t.Run("multiple audiences, no azp: rejected", func(t *testing.T) {
+		claims := base()
+		claims["aud"] = []string{"client-1", "some-other-trusted-client"}
+		_, _, _, _, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", claims))
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "azp")
+	})
+
+	t.Run("multiple audiences, azp for a different client: rejected", func(t *testing.T) {
+		claims := base()
+		claims["aud"] = []string{"client-1", "some-other-trusted-client"}
+		claims["azp"] = "some-other-trusted-client" // matches an audience, but not this provider's client_id
+		_, _, _, _, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", claims))
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "azp")
+	})
+
+	t.Run("multiple audiences, azp matches this client: accepted", func(t *testing.T) {
+		claims := base()
+		claims["aud"] = []string{"client-1", "some-other-trusted-client"}
+		claims["azp"] = "client-1"
+		sub, _, _, _, err := c.verifyIDToken(ctx, p, "N1", signToken(t, key, "kid-1", claims))
+		require.NoError(t, err)
+		assert.Equal(t, "okta|123", sub)
+	})
+}
+
 func TestResolveSSOUser(t *testing.T) {
 	// Mirrors the real storage "not found" error (wrapping the typed
 	// storage.ErrUserNotFound sentinel, #504), so the mock matches the real path.
@@ -210,6 +257,38 @@ func TestResolveSSOUser(t *testing.T) {
 		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return((*models.User)(nil), notFound())
 		u, err := c.resolveSSOUser(context.Background(), "okta", "okta|123", "ada@x.io", true)
 		require.NoError(t, err)
+		assert.Nil(t, u)
+	})
+
+	// No-subject regression: a SAML assertion can carry an email with no Subject (see
+	// CompleteSAML). The claim protection must still bind the account to THIS provider
+	// so a later, different provider can't take it over by asserting the same email —
+	// silently skipping the claim step just because sub=="" would defeat it.
+	t.Run("verified email with NO subject still claims the account for this provider", func(t *testing.T) {
+		c, store, _, _ := ssoTestCore(t)
+		// sub=="" so the externalId fast-path lookup must not even run.
+		store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, ExternalID: ""}, nil)
+		store.On("UpdateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
+			return u.ID == 9 && u.ExternalID == "sso:okta:"
+		})).Return(&models.User{ID: 9, ExternalID: "sso:okta:"}, nil)
+		u, err := c.resolveSSOUser(context.Background(), "okta", "", "ada@x.io", true)
+		require.NoError(t, err)
+		require.NotNil(t, u)
+		assert.Equal(t, uint(9), u.ID)
+		store.AssertCalled(t, "UpdateUser", mock.Anything, mock.Anything)
+		store.AssertNotCalled(t, "GetUserByExternalID", mock.Anything, mock.Anything)
+	})
+
+	// Once claimed via a no-subject assertion, a DIFFERENT provider asserting the same
+	// email must still be refused — that is the whole point of the claim.
+	t.Run("account claimed via a no-subject assertion still blocks a different provider", func(t *testing.T) {
+		c, store, _, _ := ssoTestCore(t)
+		store.On("GetUserByExternalID", mock.Anything, "sso:azure:azure|1").Return((*models.User)(nil), notFound())
+		store.On("GetUserByEmail", mock.Anything, "ada@x.io").
+			Return(&models.User{ID: 9, ExternalID: "sso:okta:"}, nil)
+		u, err := c.resolveSSOUser(context.Background(), "azure", "azure|1", "ada@x.io", true)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "different SSO provider")
 		assert.Nil(t, u)
 	})
 }

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -972,6 +972,13 @@ type Storage interface {
 	// project itself (project_id = projectID), directly or via a group — i.e. real
 	// membership. A global/install-wide role (project_id = 0) does NOT count.
 	IsProjectMember(ctx context.Context, userID, projectID uint) (bool, error)
+	// IsGroupProjectScoped reports whether groupID itself holds a LIVE role grant
+	// scoped to the project (group_roles.project_id = projectID) — the group-share
+	// counterpart to IsProjectMember, used to reject group shares whose recipient
+	// group has no legitimate tie to the secret's project. A global/install-wide
+	// group role grant (project_id = 0) does NOT count, matching IsProjectMember's
+	// own global exclusion.
+	IsGroupProjectScoped(ctx context.Context, groupID, projectID uint) (bool, error)
 	GetUserGroupRoleIDsAt(ctx context.Context, userID uint, scope Scope) ([]uint, error)
 	// GetUserRoleScopes returns the distinct (project, environment) scopes at which
 	// userID holds ANY role, directly or via a live (non-deleted) group. It is the

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -376,6 +376,15 @@ func (c *KeyorixCore) FinishWebAuthnLogin(ctx context.Context, challenge, sessio
 	if c.classificationRestrictedRequiresMFAStepUp {
 		_ = c.storage.UpsertMFAStepupToken(ctx, ch.UserID, c.now().Add(c.mfaStepUpWindow()))
 	}
+	// Also mint a genuine MFAStepUpGrant, unconditionally (not gated behind
+	// classificationRestrictedRequiresMFAStepUp): a WebAuthn login is itself proof
+	// of possessing the second factor, but — unlike TOTP, which requireReauth can
+	// verify directly against a freshly-typed code — a passkey assertion has no
+	// typable "code" to hand a later self-service re-auth call. Without this,
+	// requireReauth's second-factor requirement (#372-follow-up) would have no
+	// path at all for a WebAuthn-only account. Best-effort: a write failure does
+	// not block the login.
+	_ = c.storage.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: ch.UserID, ExpiresAt: c.now().Add(c.mfaStepUpWindow())})
 	uid := ch.UserID
 	c.writeAuditEventFull(ctx, "webauthn.login_verified", &uid, nil, nil, ip,
 		fmt.Sprintf("user %s passed WebAuthn", wu.user.Username))
@@ -469,6 +478,12 @@ func (c *KeyorixCore) FinishWebAuthnPasswordlessLogin(ctx context.Context, sessi
 	if c.classificationRestrictedRequiresMFAStepUp {
 		_ = c.storage.UpsertMFAStepupToken(ctx, resolved.ID, c.now().Add(c.mfaStepUpWindow()))
 	}
+	// Also mint a genuine MFAStepUpGrant, unconditionally — see the identical
+	// comment in FinishWebAuthnLogin: this is the only way a WebAuthn-only
+	// account can ever satisfy requireReauth's second-factor requirement, since a
+	// passkey assertion has no typable "code" equivalent to a TOTP code.
+	// Best-effort: a write failure does not block the login.
+	_ = c.storage.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: resolved.ID, ExpiresAt: c.now().Add(c.mfaStepUpWindow())})
 	uid := resolved.ID
 	c.writeAuditEventFull(ctx, "webauthn.passwordless_login", &uid, nil, nil, ip,
 		fmt.Sprintf("user %s logged in passwordlessly via WebAuthn", resolved.Username))

--- a/internal/core/webauthn_test.go
+++ b/internal/core/webauthn_test.go
@@ -27,7 +27,8 @@ func newWebAuthnTestCore(t *testing.T, withRP bool) (*KeyorixCore, *gorm.DB) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{},
-		&models.MFAChallenge{}, &models.WebAuthnCredential{}, &models.WebAuthnSession{}, &models.Notification{}))
+		&models.MFAChallenge{}, &models.WebAuthnCredential{}, &models.WebAuthnSession{}, &models.Notification{},
+		&models.MFAStepupToken{}, &models.MFAStepUpGrant{}))
 	hash, _ := bcrypt.GenerateFromPassword([]byte(webauthnTestPassword), bcrypt.DefaultCost)
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@b.com",
 		PasswordHash: string(hash), AccountState: "active"}).Error)
@@ -52,6 +53,17 @@ func seedCredential(t *testing.T, c *KeyorixCore, db *gorm.DB, userID uint, cred
 		UserID: userID, CredentialID: []byte(credID), Name: "test key", CredentialBlob: blob,
 	}).Error)
 	require.NoError(t, c.storage.SetUserWebAuthnEnabled(context.Background(), userID, true))
+}
+
+// seedStepUpGrant inserts an active MFAStepUpGrant for userID, mirroring what a
+// recent VerifyMFAStepUp call (TOTP) or WebAuthn login (FinishWebAuthnLogin/
+// FinishWebAuthnPasswordlessLogin) would produce. Since a WebAuthn-only account
+// has no typable "code" to hand requireReauth directly, this is the only way
+// such an account can satisfy requireReauth's password-plus-second-factor-proof
+// requirement in a unit test that doesn't drive a full login ceremony.
+func seedStepUpGrant(t *testing.T, db *gorm.DB, userID uint, now time.Time) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: userID, ExpiresAt: now.Add(15 * time.Minute)}).Error)
 }
 
 func TestWebAuthn_LoginGateRequiresSecondFactor(t *testing.T) {
@@ -135,17 +147,26 @@ func TestWebAuthn_DeleteClearsFlagOnLastAndIsUserScoped(t *testing.T) {
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", AccountState: "active"}).Error)
 	require.Error(t, c.DeleteWebAuthnCredential(ctx, 2, cred.ID, webauthnTestPassword))
 
-	// The owner deletes their last passkey → WebAuthn disabled.
+	// The owner deletes their last passkey → WebAuthn disabled. WebAuthn is now
+	// enrolled (seedCredential above), so password alone is no longer sufficient
+	// re-auth (#372-follow-up) — a WebAuthn-only account proves it still holds the
+	// second factor via an active step-up grant (see seedStepUpGrant's doc comment).
+	seedStepUpGrant(t, db, 1, c.now())
 	require.NoError(t, c.DeleteWebAuthnCredential(ctx, 1, cred.ID, webauthnTestPassword))
 	var user models.User
 	require.NoError(t, db.First(&user, 1).Error)
 	assert.False(t, user.WebAuthnEnabled, "removing the last passkey disables WebAuthn")
 }
 
-// #372: DeleteWebAuthnCredential must reject the deletion without a valid current
-// TOTP code or the account password — otherwise a stolen session/PAT alone can
+// #372 / #372-follow-up: DeleteWebAuthnCredential must reject the deletion
+// without valid re-authentication — otherwise a stolen session/PAT alone can
 // wipe every passkey (and, once the last one is gone, silently disable WebAuthn
-// account-wide). Mirrors TestMFA_RegenerateRequiresReauth's structure.
+// account-wide). Since WebAuthn enrollment is active, the account password
+// ALONE is no longer sufficient (requireReauth's second-factor requirement): the
+// caller must also hold an active MFA step-up grant, proving they recently
+// re-verified the second factor (a WebAuthn login mints one automatically, since
+// a passkey assertion has no typable "code" to hand this check directly).
+// Mirrors TestMFA_RegenerateRequiresReauth's structure.
 func TestWebAuthn_DeleteRequiresReauth(t *testing.T) {
 	c, db := newWebAuthnTestCore(t, true)
 	ctx := context.Background()
@@ -166,7 +187,18 @@ func TestWebAuthn_DeleteRequiresReauth(t *testing.T) {
 	require.NoError(t, db.First(&user, 1).Error)
 	assert.True(t, user.WebAuthnEnabled, "a failed re-auth must not touch the WebAuthnEnabled flag")
 
-	// Correct password → succeeds.
+	// The CORRECT password alone is still refused — WebAuthn is enrolled, so
+	// password-only re-auth must not satisfy the second-factor requirement.
+	err = c.DeleteWebAuthnCredential(ctx, 1, cred.ID, webauthnTestPassword)
+	require.Error(t, err, "correct password alone must not satisfy re-auth once a second factor (WebAuthn) is enrolled")
+
+	var stillThere2 models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ? AND id = ?", 1, cred.ID).First(&stillThere2).Error,
+		"password-only re-auth must not remove the credential once a second factor is enrolled")
+
+	// Correct password PLUS an active step-up grant (the caller separately proved
+	// they still hold the second factor) → succeeds.
+	seedStepUpGrant(t, db, 1, c.now())
 	require.NoError(t, c.DeleteWebAuthnCredential(ctx, 1, cred.ID, webauthnTestPassword))
 }
 

--- a/internal/dynamic/awssts.go
+++ b/internal/dynamic/awssts.go
@@ -63,11 +63,15 @@ func (e *AWSSTSEngine) SupportsNativeExpiry() bool { return true } // AWS enforc
 func (e *AWSSTSEngine) IsEphemeralBackend() bool   { return true }
 
 type awsSTSConfig struct {
-	RoleARN          string `json:"role_arn"`
-	Region           string `json:"region,omitempty"`
-	ExternalID       string `json:"external_id,omitempty"`
-	DurationSeconds  int32  `json:"duration_seconds,omitempty"`
-	AllowedAccountID string `json:"allowed_account_id,omitempty"` // when set, RoleARN must belong to this AWS account ID
+	RoleARN         string `json:"role_arn"`
+	Region          string `json:"region,omitempty"`
+	ExternalID      string `json:"external_id,omitempty"`
+	DurationSeconds int32  `json:"duration_seconds,omitempty"`
+	// AllowedAccountID, when non-empty, pins RoleARN to this AWS account ID
+	// (DYN-003) — any role_arn whose embedded account ID doesn't match is
+	// refused. If empty, account-ID pinning is not configured and any
+	// syntactically-valid role_arn is accepted (no restriction).
+	AllowedAccountID string `json:"allowed_account_id,omitempty"`
 }
 
 func (e *AWSSTSEngine) client(ctx context.Context, region string) (stsRoleAssumer, error) {
@@ -89,19 +93,17 @@ func validateAWSSTSCfg(cfg awsSTSConfig) error {
 	if strings.TrimSpace(cfg.RoleARN) == "" {
 		return fmt.Errorf("aws-sts: role_arn is required")
 	}
-	// Always enforce account-ID pinning: derive from the ARN when not set explicitly
-	// so a config without allowed_account_id still rejects cross-account role ARNs
-	// that may be injected through a config update (DYN-003).
-	if cfg.AllowedAccountID == "" {
-		derived := arnAccountID(cfg.RoleARN)
-		if derived == "" {
-			return fmt.Errorf("aws-sts: role_arn %q does not contain a recognisable AWS account ID; set allowed_account_id explicitly", cfg.RoleARN)
+	// Account-ID pinning (DYN-003) is opt-in: only enforced when the operator
+	// explicitly sets allowed_account_id. Deriving the "expected" account ID
+	// from role_arn itself — the same value being validated — would make this
+	// a tautology that can never fail, so an unset allowed_account_id simply
+	// skips the check (no restriction), matching this package's other opt-in
+	// allow-list fields (e.g. AllowedNamespaces in kubernetes.go).
+	if cfg.AllowedAccountID != "" {
+		if got := arnAccountID(cfg.RoleARN); got != cfg.AllowedAccountID {
+			return fmt.Errorf("aws-sts: role ARN account ID %q does not match allowed_account_id %q",
+				got, cfg.AllowedAccountID)
 		}
-		cfg.AllowedAccountID = derived
-	}
-	if arnAccountID(cfg.RoleARN) != cfg.AllowedAccountID {
-		return fmt.Errorf("aws-sts: role ARN account ID %q does not match allowed_account_id %q",
-			arnAccountID(cfg.RoleARN), cfg.AllowedAccountID)
 	}
 	return nil
 }

--- a/internal/dynamic/awssts_test.go
+++ b/internal/dynamic/awssts_test.go
@@ -83,3 +83,54 @@ func TestAWSSTSEngine_ConfigValidation(t *testing.T) {
 	_, _, err = eng.Issue(context.Background(), `{"region":"eu-west-1"}`, "", time.Hour)
 	require.Error(t, err)
 }
+
+// TestValidateAWSSTSCfg_AccountIDPinning is a regression test for a bug where
+// validateAWSSTSCfg, when allowed_account_id was left unset, derived the
+// "expected" account ID from role_arn itself and then compared role_arn's
+// account ID against that self-derived value — a tautology that can never
+// fail. That made account-ID pinning a silent no-op even though its intent
+// (and doc comment) was to reject a role_arn belonging to an unexpected AWS
+// account. The fix makes allowed_account_id an explicit opt-in: unset means
+// pinning is not configured (any account accepted, documented as such);
+// set means the comparison must be against the *operator-supplied* value,
+// never a value derived from the input under test.
+func TestValidateAWSSTSCfg_AccountIDPinning(t *testing.T) {
+	const accountX = "111111111111"
+	const accountY = "222222222222"
+	roleInAccountX := "arn:aws:iam::" + accountX + ":role/keyorix-dyn"
+
+	t.Run("explicit allowed_account_id rejects a role_arn from a different account", func(t *testing.T) {
+		cfg := awsSTSConfig{RoleARN: roleInAccountX, AllowedAccountID: accountY}
+		err := validateAWSSTSCfg(cfg)
+		require.Error(t, err, "role_arn account %q must be refused against allowed_account_id %q", accountX, accountY)
+		assert.Contains(t, err.Error(), "does not match allowed_account_id")
+	})
+
+	t.Run("explicit allowed_account_id accepts a matching role_arn", func(t *testing.T) {
+		cfg := awsSTSConfig{RoleARN: roleInAccountX, AllowedAccountID: accountX}
+		require.NoError(t, validateAWSSTSCfg(cfg))
+	})
+
+	t.Run("unset allowed_account_id skips pinning (no restriction, not a tautology)", func(t *testing.T) {
+		// Before the fix, this path derived AllowedAccountID from RoleARN itself
+		// and then compared RoleARN's account ID against that derived value,
+		// so it could never fail for any syntactically-valid role_arn. The
+		// correct behavior is an honest no-op: pinning simply isn't configured.
+		cfg := awsSTSConfig{RoleARN: roleInAccountX}
+		require.NoError(t, validateAWSSTSCfg(cfg))
+	})
+
+	// This is the case that actually distinguishes pre-fix from post-fix
+	// behavior (the two subtests above pass under both): the tautological
+	// "derive from role_arn, then compare against the derived value" path
+	// required role_arn to contain a *parseable* account ID even when
+	// pinning was never requested, purely as a side effect of doing the
+	// self-comparison. A role_arn with no discoverable account ID plus an
+	// unset allowed_account_id must now be accepted outright — the check is
+	// skipped entirely, not silently satisfied by comparing role_arn to
+	// itself.
+	t.Run("unset allowed_account_id accepts a role_arn with no parseable account ID", func(t *testing.T) {
+		cfg := awsSTSConfig{RoleARN: "not-an-arn"}
+		require.NoError(t, validateAWSSTSCfg(cfg))
+	})
+}

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -492,6 +492,27 @@ func (ls *LocalStorage) IsProjectMember(ctx context.Context, userID, projectID u
 	return viaGroup > 0, nil
 }
 
+// IsGroupProjectScoped reports whether groupID holds a LIVE role grant scoped to
+// the project itself (group_roles.project_id = projectID) — the group-share
+// counterpart to IsProjectMember above. A global/install-wide group role grant
+// (project_id = 0) does NOT count, matching IsProjectMember's own global
+// exclusion, and a soft-deleted group never counts (sqlJoinGroups filters it).
+func (ls *LocalStorage) IsGroupProjectScoped(ctx context.Context, groupID, projectID uint) (bool, error) {
+	if projectID == 0 {
+		return false, nil
+	}
+	now := time.Now().UTC()
+	var count int64
+	if err := ls.db.WithContext(ctx).Table("group_roles").
+		Joins(sqlJoinGroups).
+		Where("group_roles.group_id = ? AND group_roles.project_id = ?", groupID, projectID).
+		Where(sqlWhereGRNotExpired, now).
+		Count(&count).Error; err != nil {
+		return false, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return count > 0, nil
+}
+
 // ListProjectMembers returns the users holding a LIVE role at the project's scope
 // (project_id = projectID, environment_id = 0 — project-level membership per ADR-021).
 // Soft-deleted users AND expired time-bound grants are excluded — the same expires_at

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -693,6 +693,10 @@ func (rs *RemoteStorage) IsProjectMember(_ context.Context, _ uint, _ uint) (boo
 	return false, fmt.Errorf("not supported in remote storage")
 }
 
+func (rs *RemoteStorage) IsGroupProjectScoped(_ context.Context, _ uint, _ uint) (bool, error) {
+	return false, fmt.Errorf("not supported in remote storage")
+}
+
 // GetUserGroupRoleIDsAt is a server-internal authorization primitive.
 func (rs *RemoteStorage) GetUserGroupRoleIDsAt(_ context.Context, _ uint, _ storage.Scope) ([]uint, error) {
 	return nil, fmt.Errorf("not supported in remote storage")

--- a/server/grpc/services/share_service_test.go
+++ b/server/grpc/services/share_service_test.go
@@ -65,6 +65,7 @@ func newShareTestRig(t *testing.T) *shareTestRig {
 	require.NoError(t, db.Create(&models.RolePermission{RoleID: writerRoleID, PermissionID: 2}).Error)
 	require.NoError(t, db.Create(&models.RolePermission{RoleID: writerRoleID, PermissionID: 3}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: writerRoleID}).Error)               // global
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: writerRoleID, ProjectID: 1}).Error) // owner must also be a live project member (RBAC-001, requireLiveOwnerAuthority)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: writerRoleID, ProjectID: 1}).Error) // project member for recipient
 
 	// Give recipient (user 2) a project-scoped role with NO permissions so that

--- a/server/http/handlers/mfa_test.go
+++ b/server/http/handlers/mfa_test.go
@@ -125,11 +125,16 @@ func TestDisableMFA_DBErrorSanitized(t *testing.T) {
 
 	require.NoError(t, db.Migrator().DropTable(&models.MFASecret{}))
 
+	// MFA is enrolled, so a password alone no longer satisfies requireReauth's
+	// second-factor requirement (#372-follow-up) — even here, where the TOTP
+	// secret read fails silently because mfa_secrets is gone. Seed an active
+	// step-up grant (the same proof VerifyMFAStepUp/a WebAuthn login would
+	// produce) so password re-auth succeeds and the failure below genuinely
+	// comes from DeleteMFAForUser, not re-auth.
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: time.Now().Add(15 * time.Minute)}).Error)
+
 	logBuf := captureLogBuf(t)
 
-	// Password-only re-auth: requireReauth's TOTP-secret read fails silently
-	// (mfa_secrets is gone) and falls back to the bcrypt password check, which
-	// succeeds — so the failure below comes from DeleteMFAForUser, not re-auth.
 	body, _ := json.Marshal(map[string]string{"password": reauthTestPassword})
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/auth/mfa/disable", bytes.NewReader(body))
 	r = withUserContext(r, 1)
@@ -154,6 +159,12 @@ func TestRegenerateRecoveryCodes_DBErrorSanitized(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, db.Migrator().DropTable(&models.MFARecoveryCode{}))
+
+	// MFA is enrolled, so a password alone no longer satisfies requireReauth's
+	// second-factor requirement (#372-follow-up). Seed an active step-up grant so
+	// password re-auth succeeds and the failure below genuinely comes from
+	// DeleteMFARecoveryCodes, not re-auth.
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: time.Now().Add(15 * time.Minute)}).Error)
 
 	logBuf := captureLogBuf(t)
 

--- a/server/http/handlers/mfa_webauthn_reauth_test.go
+++ b/server/http/handlers/mfa_webauthn_reauth_test.go
@@ -44,7 +44,8 @@ func setupMFAReauthTest(t *testing.T) (*AuthHandler, *core.KeyorixCore, *gorm.DB
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.MFASecret{}, &models.MFARecoveryCode{},
 		&models.MFAChallenge{}, &models.Session{}, &models.AuditEvent{},
-		&models.WebAuthnCredential{}, &models.WebAuthnSession{}))
+		&models.WebAuthnCredential{}, &models.WebAuthnSession{},
+		&models.MFAStepupToken{}, &models.MFAStepUpGrant{}))
 	hash, err := bcrypt.GenerateFromPassword([]byte(reauthTestPassword), bcrypt.MinCost)
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@b.com",

--- a/server/http/handlers/shares_s13_test.go
+++ b/server/http/handlers/shares_s13_test.go
@@ -148,6 +148,9 @@ func TestShareSecret_ExpiryInPast_S13(t *testing.T) {
 	// Seed a project, put the recipient (ID=2) in it, and assign the secret that project.
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "default"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
+	// Wave 6: ShareSecret now also gates the owner on live project membership
+	// (RBAC-001, requireLiveOwnerAuthority) — user 1 (owner) must be a member too.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 	// Seed a secret owned by user 1.
 	require.NoError(t, db.Create(&models.SecretNode{ID: 101, Name: "expiry-test", IsSecret: true, OwnerID: 1, ProjectID: 1}).Error)
 
@@ -252,7 +255,11 @@ func TestUpdateSharePermission_NotFound_S13(t *testing.T) {
 // TestUpdateSharePermission_ExpiryInPast_S13 — expiry error branch → 400.
 func TestUpdateSharePermission_ExpiryInPast_S13(t *testing.T) {
 	cs, db := freshCoreS12WithAdmin(t)
-	require.NoError(t, db.Create(&models.SecretNode{ID: 102, Name: "upd-expiry", IsSecret: true, OwnerID: 1}).Error)
+	// Wave 6: UpdateSharePermission now also gates the owner on live project
+	// membership (RBAC-001, requireLiveOwnerAuthority) — needs a real project.
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "default"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 102, Name: "upd-expiry", IsSecret: true, OwnerID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.ShareRecord{ID: 50, SecretID: 102, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}).Error)
 
 	h, err := NewShareHandler(cs)
@@ -738,7 +745,11 @@ func TestShareHandler_SendError_WithDetails_S13(t *testing.T) {
 // TestRevokeShare_Success_S13 seeds a share owned by user 1 and revokes it → 204.
 func TestRevokeShare_Success_S13(t *testing.T) {
 	cs, db := freshCoreS12WithAdmin(t)
-	require.NoError(t, db.Create(&models.SecretNode{ID: 200, Name: "revoke-me", IsSecret: true, OwnerID: 1}).Error)
+	// Wave 6: RevokeShare now also gates the owner on live project membership
+	// (RBAC-001, requireLiveOwnerAuthority) — needs a real project.
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "default"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 200, Name: "revoke-me", IsSecret: true, OwnerID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.ShareRecord{ID: 60, SecretID: 200, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}).Error)
 
 	h, err := NewShareHandler(cs)
@@ -767,6 +778,9 @@ func TestShareSecret_Success_S13(t *testing.T) {
 	// User ID=1 is already seeded by freshCoreS12WithAdmin. Add recipient.
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "recip-share-s13", Email: "recip-share-s13@x.com", AccountState: "active"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
+	// Wave 6: ShareSecret now also gates the owner on live project membership
+	// (RBAC-001, requireLiveOwnerAuthority) — user 1 (owner) must be a member too.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 	require.NoError(t, db.Create(&models.SecretNode{ID: 300, Name: "my-secret-s13", IsSecret: true, OwnerID: 1, ProjectID: 1}).Error)
 
 	h, err := NewShareHandler(cs)

--- a/server/http/sharing_integration_test.go
+++ b/server/http/sharing_integration_test.go
@@ -99,12 +99,22 @@ func newSharingTestCore(t *testing.T) *core.KeyorixCore {
 	adminRole := &models.Role{ID: 1, Name: "admin", Description: "Administrator"}
 	require.NoError(t, db.Create(adminRole).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)
+	// ShareSecret/UpdateSharePermission/RevokeShare also gate the OWNER on live
+	// project membership (RBAC-001, requireLiveOwnerAuthority) — the global grant
+	// above doesn't count (IsProjectMember only counts a project-scoped grant),
+	// so give user 1 one too. Without this, every "Share Secret" step below fails
+	// with "not authorized to share this secret".
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 1}).Error)
 
 	// Seed a viewer role (secrets.read) for user 2 (recipient) so it can read.
 	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
 	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "viewer", Description: "Reader"}).Error)
 	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2}).Error)
+	// ShareSecretWithGroup rejects a group with no live role grant at the secret's
+	// project (group_sharing.go's IsGroupProjectScoped gate) — give test-group
+	// (ID 1) one, or every "Share Secret (group)" step below fails.
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: 1, RoleID: 2, ProjectID: 1}).Error)
 	// Also grant it scoped to project 1: ShareSecret rejects a non-group share to a
 	// recipient who isn't a member of the secret's project (sharing.go's
 	// IsProjectMember gate), and IsProjectMember only counts a project-scoped role


### PR DESCRIPTION
## Summary

First batch (of 6) of the 50 medium-severity Wave 6 singleton findings — all re-verified against current `main` before fixing (none were stale this time, unlike the earlier critical/high pass).

1. **Departed/removed owner retains sharing authority forever** — `ShareSecret`, `UpdateSharePermission`, `RevokeShare` (`internal/core/sharing.go`) and `ShareSecretWithGroup` (`internal/core/group_sharing.go`) authorized the acting owner via a bare `secretOwnedBy` check, never re-validating live project membership — unlike `CheckSecretPermission`'s owner branch, which already enforces this (RBAC-001). An owner removed from a project keeps their `OwnerID` tag until a separate cleanup job runs, so they retained full sharing authority indefinitely. Extracted a shared `requireLiveOwnerAuthority` helper and wired it into all four mutation paths plus `CheckSecretPermission` itself.
2. **Group shares had no project-tie check** — `ShareSecretWithGroup` granted standing access to an arbitrary `GroupID` with no check tying that group to the secret's project (unlike the direct-user path, which explicitly rejects cross-project recipients). Added `IsGroupProjectScoped`, mirroring `IsProjectMember`.
3. **`AddUserToGroup` bypassed the membership domain allowlist** — the direct-membership paths (`InviteMember`/`AddProjectMember`) enforce an install-level email-domain allowlist; adding the same user via a group sidestepped it entirely. Added the equivalent check, correctly scoped so a *global* group join is checked against every project-scoped grant the group holds (not just direct project joins).
4. **MFA/WebAuthn step-up re-auth accepted password alone** — `requireReauth` (shared re-auth gate for `DisableMFA`, `RegenerateMFARecoveryCodes`, `ActivateMFA`, `FinishWebAuthnRegistration`, `DeleteWebAuthnCredential`, and `UpdateOwnProfile`'s email-change path) fell through to a bare password check even when a second factor was enrolled — letting a stolen session or an MFA-policy-exempt PAT downgrade/disable 2FA with nothing but the password. Now requires a second factor too, either a direct TOTP code or an active MFA step-up grant; wired `FinishWebAuthnLogin`/`FinishWebAuthnPasswordlessLogin` to mint a step-up grant so WebAuthn-only accounts have a path through the stronger check.
5. **SSO account-claim/token-audience gaps** — `resolveSSOUser` never claimed an account when the assertion carried no subject (defeating cross-provider account-claim protection for that case); `verifyIDToken` (human SSO) had no `azp` check for multi-audience `id_token`s, unlike the machine-federation verifier.
6. **nginx silently dropped 8 security headers** on `/api`, `/auth`, `/system`, static-asset, and `/health` locations — `add_header` doesn't inherit once a location sets its own, and those locations each set unrelated headers of their own. Moved the header set into a shared Helm template included at every affected location.
7. **AWS STS account-ID pinning was a tautology** — when `allowed_account_id` was unset, the guard derived its "expected" value from the same `role_arn` it then compared against, always trivially passing. Made it an honest opt-in.
8. **Rotation-backend unbind skipped the admin check** — `SetSecretAutoRotate` required admin authority to bind a rotation backend but not to clear an existing one, letting a plain `secrets.write` caller silently strip an admin-configured binding.

One follow-up commit fixes fixture gaps that only surfaced once findings #1 and #2 compose in the same batch (both now run in `ShareSecretWithGroup`'s call path) — see its message for detail.

## Test plan

- [x] Each fix has a dedicated regression test confirmed to fail pre-fix (scoped `git stash` of production files) and pass post-fix.
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean across the full repo.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues across 789 files.
- [x] Full `go test ./...` green except pre-existing, machine-local/unrelated failures already confirmed identical on unmodified `main` (CLI dual-mode 30s-timeout tests from a stale local connect config, and a handful of `RealServer`/`SecretDependencies` tests).
- [x] Every branch independently re-verified from a fresh worktree off `origin/main` before integration; the two sharing-related fixes' interaction was specifically re-tested together after merging, since each was authored and tested in isolation.