### PR TITLE
fix(security): close Wave 6 medium-severity batch 2 (8 findings)

### DIFF
--- a/internal/cli/migrate/migrate_s3_test.go
+++ b/internal/cli/migrate/migrate_s3_test.go
@@ -182,8 +182,11 @@ func TestResolveProjectID_ViaEnvVar(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestRequireMigrationAuthority_AuthorizeErrorFirstCall exercises the error
-// return from the first svc.Authorize call by using a canceled context so the
-// storage layer returns a context error.
+// return from the FIRST DB-backed check requireMigrationAuthority performs —
+// which, since the Wave 6 account-liveness gate was added
+// (findings-gaps/cli-project.json#1), is AccountStillUsable, not
+// svc.Authorize — by using a canceled context so the storage layer returns a
+// context error.
 func TestRequireMigrationAuthority_AuthorizeErrorFirstCall(t *testing.T) {
 	c, _ := newBootstrappedCore(t)
 
@@ -191,9 +194,10 @@ func TestRequireMigrationAuthority_AuthorizeErrorFirstCall(t *testing.T) {
 	cancel() // cancel immediately so DB calls fail
 
 	err := requireMigrationAuthority(ctx, c, 1, 1)
-	// A canceled-context error from the DB appears as a failed-to-verify-authority error.
+	// A canceled-context error from the DB appears as a failed-to-verify
+	// account-state error (the first check performed).
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to verify --by authority")
+	assert.Contains(t, err.Error(), "failed to verify --by account state")
 }
 
 // TestRequireMigrationAuthority_AuthorizeErrorSecondCall exercises the error

--- a/internal/cli/migrate/user_to_machine.go
+++ b/internal/cli/migrate/user_to_machine.go
@@ -97,7 +97,25 @@ func runUserToMachine(cmd *cobra.Command, args []string) error {
 // assumes the caller already authorized — the HTTP handler's job is done by
 // router middleware), so this must be verified here, at the CLI entrypoint,
 // before the resolved actor is credited with the action.
+//
+// Role/permission possession alone is not enough: a suspended or deactivated
+// admin's role assignments remain in the database (suspension flips
+// IsActive/AccountState, it does not revoke grants), so Authorize would still
+// return true for them. Without an explicit liveness check here, a suspended
+// admin reachable through some other still-valid credential (an unrevoked
+// session or PAT) could attribute a privileged migration to themselves. This
+// mirrors the account-state gate the real login/session-validation path
+// enforces (AccountStillUsable, used by ValidateSessionToken's cache-hit
+// re-check per ADR-025) rather than inventing a new one.
 func requireMigrationAuthority(ctx context.Context, svc *core.KeyorixCore, actorID, projectID uint) error {
+	usable, err := svc.AccountStillUsable(ctx, actorID)
+	if err != nil {
+		return fmt.Errorf("failed to verify --by account state: %w", err)
+	}
+	if !usable {
+		return fmt.Errorf("--by actor's account is suspended or deactivated; refusing to attribute this migration to them")
+	}
+
 	ok, err := svc.Authorize(ctx, actorID, "roles.assign", core.Scope{ProjectID: projectID})
 	if err != nil {
 		return fmt.Errorf("failed to verify --by authority: %w", err)

--- a/internal/cli/migrate/user_to_machine_authority_test.go
+++ b/internal/cli/migrate/user_to_machine_authority_test.go
@@ -112,3 +112,57 @@ func TestRequireMigrationAuthority_BootstrapAdminAllowed(t *testing.T) {
 
 	require.NoError(t, requireMigrationAuthority(ctx, c, bootstrapAdmin.ID, 1))
 }
+
+// Wave 6 (findings-gaps/cli-project.json#1): an actor holding every permission
+// grant the operation requires (roles.assign + users.write, exactly the
+// AuthorizedActorAllowed fixture below) but whose ACCOUNT has since been
+// suspended must still be refused. Suspension flips account_state, it does not
+// revoke the actor's role assignments — Authorize alone would happily return
+// true for a suspended admin. requireMigrationAuthority must additionally gate
+// on account liveness (AccountStillUsable), the same check the real
+// login/session path enforces, so a suspended admin reachable via some other
+// still-valid credential (an unrevoked session or PAT) cannot attribute a
+// privileged migration to themselves.
+func TestRequireMigrationAuthority_SuspendedActorRejected(t *testing.T) {
+	c, st := newTestMigrateCore(t)
+	ctx := context.Background()
+
+	bootstrapAdmin, err := st.GetUserByEmail(ctx, "admin@example.com")
+	require.NoError(t, err)
+
+	actor := seedUserWithRole(t, st, "u2m-suspended-admin", "admin", core.Scope{})
+
+	// Sanity: before suspension, the fully-privileged actor is allowed — proves
+	// the subsequent rejection is caused by account state, not by the role
+	// fixture being wrong.
+	require.NoError(t, requireMigrationAuthority(ctx, c, actor, 1))
+
+	// Suspend the actor (another admin remains active, so this isn't blocked by
+	// the last-admin guard). Role/permission grants are untouched by suspension.
+	require.NoError(t, c.SuspendUser(ctx, bootstrapAdmin.ID, actor))
+
+	err = requireMigrationAuthority(ctx, c, actor, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "suspended")
+}
+
+// Wave 6 positive control: a deactivated (IsActive=false) actor — the other
+// half of AccountStillUsable's gate, distinct from account_state suspension —
+// must also be refused even though it still holds every required grant.
+func TestRequireMigrationAuthority_DeactivatedActorRejected(t *testing.T) {
+	c, st := newTestMigrateCore(t)
+	ctx := context.Background()
+
+	actor := seedUserWithRole(t, st, "u2m-deactivated-admin", "admin", core.Scope{})
+	require.NoError(t, requireMigrationAuthority(ctx, c, actor, 1))
+
+	u, err := st.GetUser(ctx, actor)
+	require.NoError(t, err)
+	u.IsActive = false
+	_, err = st.UpdateUser(ctx, u)
+	require.NoError(t, err)
+
+	err = requireMigrationAuthority(ctx, c, actor, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "suspended or deactivated")
+}

--- a/internal/cli/user/by_authority_test.go
+++ b/internal/cli/user/by_authority_test.go
@@ -1,0 +1,200 @@
+// by_authority_test.go — regression coverage for the impersonation-ceiling
+// finding (adversarial-review findings-unreviewed/internal-cli.json#4,
+// tracked as fix-wave5-g05): resolveAdminID resolved --by to a user ID with
+// ZERO authority check, so any local operator could attribute a destructive
+// account-lifecycle action (suspend/delete/etc.) to an arbitrary admin's
+// identity purely by naming their email on --by, poisoning the audit trail.
+//
+// Sibling of internal/cli/invite/send_authority_test.go and
+// internal/cli/request/review_authority_test.go (#264/#491): the fix adds
+// requireUserAuthority, verified here both directly and through the
+// user-facing commands that call it (suspend/delete), confirming an
+// unprivileged --by actor is now refused rather than silently credited.
+package user
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// newByAuthorityTestCore spins up an in-memory store, runs the production
+// BootstrapSystem (seeding the real RBAC role/permission catalog), and returns
+// the core + storage for authority assertions — mirrors
+// invite.newTestInviteCore / request's equivalent helper.
+func newByAuthorityTestCore(t *testing.T) (*core.KeyorixCore, *store.LocalStorage) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Discard})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SystemMetadata{},
+		&models.MachineIdentity{}, &models.MachineIdentityRole{},
+		&models.PersonalAccessToken{}, &models.Session{}, &models.AuditEvent{},
+		&models.PasswordHistory{},
+	))
+	st := store.NewLocalStorage(db)
+	c := core.NewKeyorixCore(st)
+	c.SetBootstrapToken("by-authority-test-token")
+	_, err = c.BootstrapSystem(context.Background(), &core.BootstrapRequest{
+		Username: "admin", Email: "admin@example.com", Password: "S3cur3!P@ssw0rd#2026",
+		DisplayName: "Admin", Token: "by-authority-test-token",
+	})
+	require.NoError(t, err)
+	return c, st
+}
+
+// seedByAuthorityUserWithRole creates a user and assigns roleName at scope,
+// returning the new user's ID.
+func seedByAuthorityUserWithRole(t *testing.T, st *store.LocalStorage, username, roleName string, scope core.Scope) uint {
+	t.Helper()
+	ctx := context.Background()
+	u, err := st.CreateUser(ctx, &models.User{Username: username, Email: username + "@example.com", IsActive: true})
+	require.NoError(t, err)
+	role, err := st.GetRoleByName(ctx, roleName)
+	require.NoErrorf(t, err, "role %s must be seeded", roleName)
+	require.NoError(t, st.AssignRole(ctx, u.ID, role.ID, scope))
+	return u.ID
+}
+
+// ──────────────────────── requireUserAuthority: direct unit coverage ────────
+
+// An actor holding only "viewer" (users.read, not users.write/users.delete)
+// must be refused for both permissions the account-lifecycle commands need —
+// the CLI must not let --by attribute the action to an unprivileged account.
+func TestRequireUserAuthority_UnprivilegedActorRejected(t *testing.T) {
+	c, st := newByAuthorityTestCore(t)
+	ctx := context.Background()
+	actor := seedByAuthorityUserWithRole(t, st, "user-viewer", "viewer", core.Scope{})
+
+	err := requireUserAuthority(ctx, c, actor, permUsersWrite)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "users.write")
+	assert.Contains(t, err.Error(), "refusing to attribute")
+
+	err = requireUserAuthority(ctx, c, actor, permUsersDelete)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "users.delete")
+}
+
+// An actor with NO role at all (zero role IDs resolved) must also be
+// refused, not silently treated as authorized.
+func TestRequireUserAuthority_NoRoleActorRejected(t *testing.T) {
+	c, st := newByAuthorityTestCore(t)
+	ctx := context.Background()
+	u, err := st.CreateUser(ctx, &models.User{Username: "roleless", Email: "roleless@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	err = requireUserAuthority(ctx, c, u.ID, permUsersWrite)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not hold users.write")
+}
+
+// The bootstrap admin (the realistic legitimate --by actor for these
+// commands) must be allowed through for both permissions.
+func TestRequireUserAuthority_BootstrapAdminAllowed(t *testing.T) {
+	c, st := newByAuthorityTestCore(t)
+	ctx := context.Background()
+	admin, err := st.GetUserByEmail(ctx, "admin@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, requireUserAuthority(ctx, c, admin.ID, permUsersWrite))
+	require.NoError(t, requireUserAuthority(ctx, c, admin.ID, permUsersDelete))
+}
+
+// ──────────── end-to-end: the exploit scenario is now refused ──────────────
+
+// TestRunLifecycle_UnprivilegedByRejected reproduces the exact exploit: a
+// local operator invokes `keyorix user suspend --by <victim-admin-email>`
+// where victim-admin holds no users.write permission. Pre-fix, resolveAdminID
+// would happily resolve the email and SuspendUser would be credited to them
+// with zero verification. Post-fix, the operation must be refused before
+// SuspendUser is ever called.
+func TestRunLifecycle_UnprivilegedByRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, targetID := seedUserDB(t)
+
+	// Seed a second, unprivileged user directly against the same file-backed
+	// DB that seedUserDB/InitializeCoreService just created, so --by resolves
+	// to a REAL user record that simply lacks users.write.
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	ctx := context.Background()
+	victim, err := svc.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "victim-admin", Email: "victim-admin@example.com",
+		DisplayName: "Victim Admin", Password: "V1ct1m!P@ssw0rd#2026",
+	})
+	require.NoError(t, err)
+
+	err = runLifecycle(targetID, "victim-admin@example.com", "suspended",
+		func(s *core.KeyorixCore, c context.Context, adminID, userID uint) error {
+			return s.SuspendUser(c, adminID, userID)
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "users.write")
+	assert.Contains(t, err.Error(), "refusing to attribute")
+
+	// Confirm the target user was NOT actually suspended — the rejection
+	// happened before SuspendUser was reached.
+	u, err := svc.GetUser(ctx, targetID)
+	require.NoError(t, err)
+	assert.True(t, u.IsActive, "target must remain active: the unauthorized --by suspend must not have applied")
+	_ = victim.ID
+}
+
+// TestRunDelete_UnprivilegedByRejected is the delete-path sibling: --by
+// naming an unprivileged user must be refused (users.delete), not silently
+// credited as the deleting actor.
+func TestRunDelete_UnprivilegedByRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, targetID := seedUserDB(t)
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	ctx := context.Background()
+	_, err = svc.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "victim-admin2", Email: "victim-admin2@example.com",
+		DisplayName: "Victim Admin 2", Password: "V1ct1m!P@ssw0rd#2026",
+	})
+	require.NoError(t, err)
+
+	origID, origBy, origForce := deleteUserID, deleteBy, deleteForce
+	defer func() { deleteUserID = origID; deleteBy = origBy; deleteForce = origForce }()
+	deleteUserID = targetID
+	deleteBy = "victim-admin2@example.com"
+	deleteForce = true
+
+	err = runDelete(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "users.delete")
+	assert.Contains(t, err.Error(), "refusing to attribute")
+
+	// Confirm the target user was NOT actually deleted.
+	u, err := svc.GetUser(ctx, targetID)
+	require.NoError(t, err)
+	require.NotNil(t, u)
+}

--- a/internal/cli/user/create.go
+++ b/internal/cli/user/create.go
@@ -112,6 +112,9 @@ func runCreate(cmd *cobra.Command, args []string) error { // NOSONAR -- cognitiv
 			if createdBy, err = resolveAdminID(ctx, service, createBy); err != nil {
 				return err
 			}
+			if err := requireUserAuthority(ctx, service, createdBy, permUsersWrite); err != nil {
+				return err
+			}
 		}
 		u, prov, err := service.CreateUserWithSetupLink(ctx, req, createdBy)
 		if err != nil {
@@ -126,6 +129,9 @@ func runCreate(cmd *cobra.Command, args []string) error { // NOSONAR -- cognitiv
 		var createdBy uint
 		if createBy != "" {
 			if createdBy, err = resolveAdminID(ctx, service, createBy); err != nil {
+				return err
+			}
+			if err := requireUserAuthority(ctx, service, createdBy, permUsersWrite); err != nil {
 				return err
 			}
 		}

--- a/internal/cli/user/delete.go
+++ b/internal/cli/user/delete.go
@@ -50,6 +50,9 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if err := requireUserAuthority(ctx, service, adminID, permUsersDelete); err != nil {
+		return err
+	}
 
 	// Deleting a user is irreversible, so require an explicit confirmation unless
 	// the caller opted out with --force (e.g. for scripted/CI use).

--- a/internal/cli/user/lifecycle.go
+++ b/internal/cli/user/lifecycle.go
@@ -95,6 +95,9 @@ var revokeSessionsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if err := requireUserAuthority(ctx, service, adminID, permUsersWrite); err != nil {
+			return err
+		}
 		n, err := service.RevokeUserSessions(ctx, adminID, revokeSessionsUserID)
 		if err != nil {
 			return fmt.Errorf("failed: %w", err)
@@ -145,6 +148,9 @@ func runLifecycle(userID uint, by, pastTense string, apply func(*core.KeyorixCor
 
 	adminID, err := resolveAdminID(ctx, service, by)
 	if err != nil {
+		return err
+	}
+	if err := requireUserAuthority(ctx, service, adminID, permUsersWrite); err != nil {
 		return err
 	}
 

--- a/internal/cli/user/setup_link.go
+++ b/internal/cli/user/setup_link.go
@@ -42,6 +42,9 @@ var resendSetupLinkCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if err := requireUserAuthority(ctx, service, adminID, permUsersWrite); err != nil {
+			return err
+		}
 		prov, err := service.ResendAccountSetupLink(ctx, resendSetupLinkUserID, adminID)
 		if err != nil {
 			return fmt.Errorf("failed to resend setup link: %w", err)

--- a/internal/cli/user/user.go
+++ b/internal/cli/user/user.go
@@ -31,7 +31,10 @@ func init() {
 
 // resolveAdminID resolves an admin email to a user ID for audit attribution.
 // The local CLI has no session, so account-lifecycle commands take the acting
-// admin's email via --by (mirrors the invite/request CLI).
+// admin's email via --by (mirrors the invite/request CLI). This ONLY resolves
+// the email to an ID — it proves nothing about the caller's authority to act
+// as that user. Every call site must follow up with requireUserAuthority
+// before crediting the resolved actor with the operation.
 func resolveAdminID(ctx context.Context, service *core.KeyorixCore, email string) (uint, error) {
 	u, err := service.GetUserByEmail(ctx, email)
 	if err != nil {
@@ -39,3 +42,37 @@ func resolveAdminID(ctx context.Context, service *core.KeyorixCore, email string
 	}
 	return u.ID, nil
 }
+
+// requireUserAuthority verifies that actorID — the user resolved from --by —
+// actually holds the permission the equivalent HTTP route requires for this
+// exact account-lifecycle operation (see router.go: "users.delete" gates
+// DELETE /users/{id}; "users.write" gates suspend/reactivate/
+// require-password-reset/revoke-sessions/resend-setup-link/create). The local
+// CLI has no session/middleware to enforce this, so --by resolving ANY email —
+// with zero authority check — would let a local operator attribute an
+// arbitrary destructive account-lifecycle action (suspending/deleting a user)
+// to any other admin's identity purely for what appears in the audit trail.
+// None of the KeyorixCore methods these commands call (SuspendUser,
+// ReactivateUser, DeleteUser, etc.) check permissions themselves (the HTTP
+// handler's job is done by router middleware), so this must be verified here,
+// at the CLI entrypoint, before the resolved actor is credited with the
+// action. Sibling of requireInviteAuthority/requireReviewAuthority/
+// requireTemplateAuthority (#264/#491).
+func requireUserAuthority(ctx context.Context, svc *core.KeyorixCore, actorID uint, permission string) error {
+	ok, err := svc.Authorize(ctx, actorID, permission, core.Scope{})
+	if err != nil {
+		return fmt.Errorf("failed to verify --by authority: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("--by actor does not hold %s; refusing to attribute this action to them", permission)
+	}
+	return nil
+}
+
+// Permission strings mirroring the equivalent HTTP routes in
+// server/http/router.go (permUsersWrite / "users.delete"), used by
+// requireUserAuthority.
+const (
+	permUsersWrite  = "users.write"
+	permUsersDelete = "users.delete"
+)

--- a/internal/core/impersonation.go
+++ b/internal/core/impersonation.go
@@ -25,9 +25,15 @@ import (
 const impersonationSessionTTL = 1 * time.Hour
 
 // EventImpersonationStart / EventImpersonationEnd are the discrete bracket events.
+// EventImpersonationStartFailed is the failure counterpart of
+// EventImpersonationStart, following this codebase's `<domain>.<action>_failed`
+// convention for auditing a refused/blocked attempt alongside its success event
+// (e.g. auth.login_failed alongside auth.login, secret.rotate_failed alongside
+// secret.rotated) — see writeImpersonationDeniedEvent.
 const (
-	EventImpersonationStart = "impersonation.start"
-	EventImpersonationEnd   = "impersonation.end"
+	EventImpersonationStart       = "impersonation.start"
+	EventImpersonationEnd         = "impersonation.end"
+	EventImpersonationStartFailed = "impersonation.start_failed"
 )
 
 // StartImpersonation issues an impersonation session for targetID initiated by
@@ -35,6 +41,8 @@ const (
 // token the caller should hand back to the admin's client) and the target user.
 func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID uint, ip string) (*models.Session, *models.User, error) {
 	if adminID == targetID {
+		c.writeImpersonationDeniedEvent(ctx, adminID, &targetID, ip,
+			fmt.Sprintf("user %d attempted to impersonate themselves", adminID))
 		return nil, nil, fmt.Errorf("cannot impersonate yourself")
 	}
 	// A request authenticated with a least-privilege PAT (ADR-042) must not LAUNDER that
@@ -43,6 +51,8 @@ func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID 
 	// permissions — escaping the bound the PAT deliberately imposed. Refuse, mirroring
 	// IsGlobalAdmin's fail-closed convention for the PAT restriction.
 	if patRestrictionFromContext(ctx) != nil {
+		c.writeImpersonationDeniedEvent(ctx, adminID, &targetID, ip,
+			fmt.Sprintf("user %d attempted to impersonate user %d using a restricted access token", adminID, targetID))
 		return nil, nil, fmt.Errorf("a restricted access token may not start impersonation")
 	}
 	// #G07: the check above only catches a RESTRICTED PAT — patRestrictionFromContext
@@ -52,20 +62,28 @@ func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID 
 	// admin action, not something an API credential should ever be able to trigger,
 	// restricted or not — sessionAuthFromContext distinguishes the two.
 	if !sessionAuthFromContext(ctx) {
+		c.writeImpersonationDeniedEvent(ctx, adminID, &targetID, ip,
+			fmt.Sprintf("user %d attempted to impersonate user %d using a non-interactive credential", adminID, targetID))
 		return nil, nil, fmt.Errorf("impersonation requires an interactive session, not an API credential")
 	}
 	admin, err := c.storage.GetUser(ctx, adminID)
 	if err != nil {
+		c.writeImpersonationDeniedEvent(ctx, adminID, &targetID, ip,
+			fmt.Sprintf("impersonation attempt refused: acting admin user %d not found", adminID))
 		return nil, nil, fmt.Errorf("admin not found")
 	}
 	target, err := c.storage.GetUser(ctx, targetID)
 	if err != nil {
+		c.writeImpersonationDeniedEvent(ctx, adminID, &targetID, ip,
+			fmt.Sprintf("%s attempted to impersonate user %d, but the target was not found", admin.Username, targetID))
 		return nil, nil, fmt.Errorf("target user not found")
 	}
 	// Don't mint a session for a target who cannot log in: it would be dead on arrival
 	// (ValidateSessionToken rejects blocked/inactive accounts on every request) and would
 	// only produce a misleading impersonation.start audit event.
 	if !target.IsActive || AccountLoginBlocked(target.AccountState) {
+		c.writeImpersonationDeniedEvent(ctx, adminID, &targetID, ip,
+			fmt.Sprintf("%s attempted to impersonate %s, but the target is suspended or inactive", admin.Username, target.Username))
 		return nil, nil, fmt.Errorf("cannot impersonate a suspended or inactive user")
 	}
 	// Admin-rank-ceiling check (#165): the impersonator must already hold authority
@@ -82,6 +100,8 @@ func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID 
 	// is ever delegated to a lower-privileged (sub-admin) role, or if the target is
 	// merely a project-scoped project_admin the older global-only check never saw.
 	if err := c.requireEqualOrGreaterAdminAuthority(ctx, adminID, targetID, "impersonate"); err != nil {
+		c.writeImpersonationDeniedEvent(ctx, adminID, &targetID, ip,
+			fmt.Sprintf("%s attempted to impersonate %s but was refused by the admin-rank ceiling: %v", admin.Username, target.Username, err))
 		return nil, nil, err
 	}
 	// The ceiling check above runs once here at start, but is NOT only a
@@ -213,6 +233,35 @@ func (c *KeyorixCore) writeImpersonationEvent(ctx context.Context, eventType str
 		Diff:           diff,
 		ImpersonatedBy: &ab,
 		ActingAs:       &ta,
+		Impersonation:  true,
+	}
+	c.emitAudit(ctx, event)
+}
+
+// writeImpersonationDeniedEvent records a REFUSED impersonation attempt
+// (Success=false) — the failure counterpart of writeImpersonationEvent,
+// following this codebase's dedicated `<domain>.<action>_failed` convention
+// for auditing failures alongside successes (auth.login_failed alongside
+// auth.login, secret.rotate_failed alongside secret.rotated). Without this,
+// StartImpersonation's error returns (self-impersonation, a restricted-PAT
+// or non-interactive caller, a suspended target, or — critically — the
+// admin-rank-ceiling denial from #165/#G05) are invisible to security
+// monitoring: a defender investigating suspicious activity would see only
+// successful impersonations, never a blocked privilege-escalation attempt.
+// targetID is still recorded even when the target account itself could not
+// be resolved, so a probe against a non-existent user ID is not lost either.
+func (c *KeyorixCore) writeImpersonationDeniedEvent(ctx context.Context, adminID uint, targetID *uint, ip, description string) {
+	f := false
+	ab := adminID
+	event := &models.AuditEvent{
+		EventType:      EventImpersonationStartFailed,
+		UserID:         &ab,
+		IPAddress:      ip,
+		Description:    description,
+		Success:        &f,
+		EventTime:      time.Now(),
+		ImpersonatedBy: &ab,
+		ActingAs:       targetID,
 		Impersonation:  true,
 	}
 	c.emitAudit(ctx, event)

--- a/internal/core/impersonation_test.go
+++ b/internal/core/impersonation_test.go
@@ -17,6 +17,22 @@ func newImpersonationCore(store *MockStorage) *KeyorixCore {
 	return &KeyorixCore{storage: store, now: func() time.Time { return fixed }}
 }
 
+// deniedEventMatcher builds a mock.MatchedBy predicate asserting that a
+// refused StartImpersonation attempt was audited as a distinct
+// impersonation.start_failed event (Success=false), attributed to both the
+// admin who attempted it (ImpersonatedBy) and the target they tried to reach
+// (ActingAs), with descSubstr present in the human-readable reason.
+func deniedEventMatcher(adminID, targetID uint, descSubstr string) func(*models.AuditEvent) bool {
+	return func(e *models.AuditEvent) bool {
+		return e.EventType == EventImpersonationStartFailed &&
+			e.Success != nil && !*e.Success &&
+			e.Impersonation &&
+			e.ImpersonatedBy != nil && *e.ImpersonatedBy == adminID &&
+			e.ActingAs != nil && *e.ActingAs == targetID &&
+			strings.Contains(e.Description, descSubstr)
+	}
+}
+
 func TestStartImpersonation_Success(t *testing.T) {
 	store := new(MockStorage)
 	c := newImpersonationCore(store)
@@ -50,9 +66,21 @@ func TestStartImpersonation_Success(t *testing.T) {
 func TestStartImpersonation_RejectsSelf(t *testing.T) {
 	store := new(MockStorage)
 	c := newImpersonationCore(store)
-	if _, _, err := c.StartImpersonation(context.Background(), 5, 5, ""); err == nil {
+	ctx := context.Background()
+	// A refused attempt must still be audited (Success=false) — otherwise a
+	// blocked privilege-escalation attempt (or repeated probing) is invisible
+	// to security monitoring, which only ever sees successful impersonations.
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == EventImpersonationStartFailed &&
+			e.Success != nil && !*e.Success &&
+			e.Impersonation &&
+			e.ImpersonatedBy != nil && *e.ImpersonatedBy == 5 &&
+			e.ActingAs != nil && *e.ActingAs == 5
+	})).Return(nil)
+	if _, _, err := c.StartImpersonation(ctx, 5, 5, ""); err == nil {
 		t.Fatal("expected an error impersonating yourself")
 	}
+	store.AssertExpectations(t)
 }
 
 // A request carrying a least-privilege PAT restriction may not start impersonation —
@@ -62,11 +90,18 @@ func TestStartImpersonation_RejectsRestrictedPAT(t *testing.T) {
 	store := new(MockStorage)
 	c := newImpersonationCore(store)
 	ctx := WithPATRestriction(context.Background(), &PATRestriction{Permissions: []string{"users.*"}})
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == EventImpersonationStartFailed &&
+			e.Success != nil && !*e.Success &&
+			e.ImpersonatedBy != nil && *e.ImpersonatedBy == 1 &&
+			e.ActingAs != nil && *e.ActingAs == 2
+	})).Return(nil)
 	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
 	if err == nil || !strings.Contains(err.Error(), "restricted access token") {
 		t.Fatalf("expected a restricted-token rejection, got %v", err)
 	}
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+	store.AssertExpectations(t)
 }
 
 // #G07: an UNRESTRICTED PAT (or any other non-interactive credential) must not
@@ -77,11 +112,18 @@ func TestStartImpersonation_RejectsNonSessionAuth(t *testing.T) {
 	store := new(MockStorage)
 	c := newImpersonationCore(store)
 	ctx := WithSessionAuth(context.Background(), false)
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == EventImpersonationStartFailed &&
+			e.Success != nil && !*e.Success &&
+			e.ImpersonatedBy != nil && *e.ImpersonatedBy == 1 &&
+			e.ActingAs != nil && *e.ActingAs == 2
+	})).Return(nil)
 	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
 	if err == nil || !strings.Contains(err.Error(), "interactive session") {
 		t.Fatalf("expected a non-session-auth rejection, got %v", err)
 	}
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+	store.AssertExpectations(t)
 }
 
 // A genuine interactive session (the untagged/default case, and the explicit
@@ -107,11 +149,22 @@ func TestStartImpersonation_RejectsInactiveTarget(t *testing.T) {
 	ctx := context.Background()
 	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin"}, nil)
 	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "alice", IsActive: false}, nil)
+	// The refusal must be audited too — an attempt against a suspended/inactive
+	// account is exactly the kind of probing a defender needs visibility into.
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.EventType == EventImpersonationStartFailed &&
+			e.Success != nil && !*e.Success &&
+			e.Impersonation &&
+			e.ImpersonatedBy != nil && *e.ImpersonatedBy == 1 &&
+			e.ActingAs != nil && *e.ActingAs == 2 &&
+			strings.Contains(e.Description, "suspended or inactive")
+	})).Return(nil)
 	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
 	if err == nil || !strings.Contains(err.Error(), "suspended or inactive") {
 		t.Fatalf("expected an inactive-target rejection, got %v", err)
 	}
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+	store.AssertExpectations(t)
 }
 
 // A non-admin caller cannot impersonate a global admin (privilege escalation guard).
@@ -131,11 +184,20 @@ func TestStartImpersonation_RejectsAdminTargetForNonAdminCaller(t *testing.T) {
 	// #G05: the ceiling now compares the target's ACTUAL bundled permissions
 	// (not the "admin" role name itself) against what the caller can exercise.
 	store.On("GetRolePermissions", ctx, uint(7)).Return([]*models.Permission{{Name: "system.write"}}, nil)
+	// The admin-rank-ceiling denial (#165/#G05) is the most security-critical
+	// refusal of all — a blocked privilege-escalation attempt against a
+	// higher-authority target must be audited, not silently swallowed.
+	deniedMatcher := deniedEventMatcher(1, 2, "rank ceiling")
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(deniedMatcher)).Return(nil)
 	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
 	if err == nil || !strings.Contains(err.Error(), "which you do not also hold") {
 		t.Fatalf("expected an admin-target rejection, got %v", err)
 	}
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+	// GetRoleByName is set up speculatively by this test but the current ceiling
+	// implementation doesn't always exercise it, so assert the specific audit
+	// call was made rather than the full (and unrelated to this fix) mock set.
+	store.AssertCalled(t, "LogAuditEvent", ctx, mock.MatchedBy(deniedMatcher))
 }
 
 // A non-admin caller cannot impersonate a target who holds an admin-tier role
@@ -156,11 +218,14 @@ func TestStartImpersonation_RejectsProjectScopedAdminTargetForNonAdminCaller(t *
 	store.On("GetUserRoleIDsAt", ctx, uint(1), projScope).Return([]uint{}, nil)
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), projScope).Return([]uint{}, nil)
 	store.On("GetRolePermissions", ctx, uint(8)).Return([]*models.Permission{{Name: "roles.assign"}}, nil)
+	deniedMatcher := deniedEventMatcher(1, 2, "rank ceiling")
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(deniedMatcher)).Return(nil)
 	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
 	if err == nil || !strings.Contains(err.Error(), "which you do not also hold") {
 		t.Fatalf("expected a project-scoped admin-target rejection, got %v", err)
 	}
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+	store.AssertCalled(t, "LogAuditEvent", ctx, mock.MatchedBy(deniedMatcher))
 }
 
 // A caller who ALSO holds project_admin at the target's exact project scope may
@@ -213,11 +278,14 @@ func TestStartImpersonation_RejectsCustomAdminTierRoleTargetForNonAdminCaller(t 
 	store.On("GetUserRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{}, nil)
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), mock.Anything).Return([]uint{}, nil)
 	store.On("GetRolePermissions", ctx, uint(9)).Return([]*models.Permission{{Name: "system.write"}}, nil)
+	deniedMatcher := deniedEventMatcher(1, 2, "rank ceiling")
+	store.On("LogAuditEvent", ctx, mock.MatchedBy(deniedMatcher)).Return(nil)
 	_, _, err := c.StartImpersonation(ctx, 1, 2, "")
 	if err == nil || !strings.Contains(err.Error(), "which you do not also hold") {
 		t.Fatalf("expected a custom-admin-tier-role rejection, got %v", err)
 	}
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+	store.AssertCalled(t, "LogAuditEvent", ctx, mock.MatchedBy(deniedMatcher))
 }
 
 // #G05 detection_idea: revoke the impersonator's users.impersonate mid-session

--- a/internal/core/secret_ownership.go
+++ b/internal/core/secret_ownership.go
@@ -8,6 +8,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -17,6 +18,20 @@ import (
 
 // EventSecretOwnerTransferred is audited when a secret's ownership changes hands.
 const EventSecretOwnerTransferred = "secret.owner_transferred"
+
+// ownershipTransferDetail is the structured payload stored in a
+// secret.owner_transferred event's Diff field, carrying the from/to user IDs
+// out-of-band from the free-text Description. The Description also embeds the
+// secret's NAME (e.g. `transferred ownership of secret "NAME" from user X to
+// user Y`), and the name is attacker-controllable via rename — a secret named
+// something like `evil" from user 1 to user 999 fake` would let a regex over the
+// Description forge the reported from/to owners. GetSecretOwnershipHistory reads
+// FromUserID/ToUserID from this structured field instead, so the untrusted name
+// can never be mistaken for the security-relevant IDs.
+type ownershipTransferDetail struct {
+	FromUserID uint `json:"from_user_id"`
+	ToUserID   uint `json:"to_user_id"`
+}
 
 // TransferSecretOwnership sets secretID's owner to newOwnerID. The caller (transport)
 // must have enforced scoped secrets.write. Authorization here: the actor must be the
@@ -78,8 +93,10 @@ func (c *KeyorixCore) transferOwnership(ctx context.Context, secretID, newOwnerI
 
 	uid := actorID
 	sid := secretID
-	c.writeAuditEvent(ctx, EventSecretOwnerTransferred, &uid, &sid,
-		fmt.Sprintf("transferred ownership of secret %q from user %d to user %d", updated.Name, oldOwner, newOwnerID))
+	detail, _ := json.Marshal(ownershipTransferDetail{FromUserID: oldOwner, ToUserID: newOwnerID})
+	c.writeAuditEventDiff(ctx, EventSecretOwnerTransferred, &uid, &sid, nil, "",
+		fmt.Sprintf("transferred ownership of secret %q from user %d to user %d", updated.Name, oldOwner, newOwnerID),
+		string(detail))
 	return updated, nil
 }
 

--- a/internal/core/secret_ownership_history.go
+++ b/internal/core/secret_ownership_history.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -26,9 +27,20 @@ type OwnershipRecord struct {
 	Description string `json:"description"`
 }
 
-// ownershipDescRe parses the description written by transferOwnership:
+// ownershipDescRe is a LEGACY fallback for secret.owner_transferred rows written
+// before this file started reading the structured ownershipTransferDetail out of
+// the event's Diff field (see secret_ownership.go). Those older rows have no Diff
+// and only carry the human-readable description:
 //
 //	transferred ownership of secret "NAME" from user OLD_ID to user NEW_ID
+//
+// Do NOT rely on this for new events: the secret NAME is attacker-controllable
+// (rename) and is interpolated into that same string ahead of the numeric IDs, so
+// a maliciously-named secret can forge what a leftmost regex match reports as the
+// from/to owner. transferOwnership now writes FromUserID/ToUserID as structured
+// JSON in Diff specifically so parsing never has to trust free text again; this
+// regex only exists to keep pre-fix historical rows from silently losing their
+// parsed IDs.
 var ownershipDescRe = regexp.MustCompile(`from user (\d+) to user (\d+)`)
 
 // GetSecretOwnershipHistory returns the chain of ownership transfers for secretID
@@ -63,8 +75,14 @@ func (c *KeyorixCore) GetSecretOwnershipHistory(ctx context.Context, secretID, a
 		if e.UserID != nil {
 			rec.ChangedBy = *e.UserID
 		}
-		// Parse "from user X to user Y" from the description.
-		if m := ownershipDescRe.FindStringSubmatch(e.Description); len(m) == 3 {
+		// Prefer the structured from/to IDs written to Diff (see
+		// ownershipTransferDetail) — never derived from attacker-controllable text.
+		var d ownershipTransferDetail
+		if e.Diff != "" && json.Unmarshal([]byte(e.Diff), &d) == nil {
+			rec.FromID = d.FromUserID
+			rec.ToID = d.ToUserID
+		} else if m := ownershipDescRe.FindStringSubmatch(e.Description); len(m) == 3 {
+			// LEGACY fallback for rows written before Diff carried structured IDs.
 			fromID, err1 := strconv.ParseUint(m[1], 10, 32)
 			toID, err2 := strconv.ParseUint(m[2], 10, 32)
 			if err1 == nil && err2 == nil {

--- a/internal/core/secret_ownership_history_test.go
+++ b/internal/core/secret_ownership_history_test.go
@@ -7,10 +7,14 @@ import (
 	"time"
 
 	stg "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func newOwnershipCore(store *MockStorage) *KeyorixCore {
@@ -151,6 +155,86 @@ func TestGetSecretOwnershipHistory_AuditLogsError(t *testing.T) {
 
 	_, err := c.GetSecretOwnershipHistory(ctx, 100, 42)
 	require.Error(t, err)
+}
+
+// newOwnershipHistoryFixture builds a real in-memory-SQLite-backed core (not a
+// mock) with users 1 (owner) and 2 (eligible new owner), and a secret owned by
+// user 1 — the same shape as newOwnershipFixture (secret_ownership_test.go) but
+// additionally migrating models.AuditEvent, since this fixture exercises the real
+// TransferSecretOwnership -> writeAuditEventDiff -> GetSecretOwnershipHistory
+// round trip instead of mocking storage.
+func newOwnershipHistoryFixture(t *testing.T) (*KeyorixCore, uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.User{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.AuditEvent{}))
+	for _, u := range []models.User{
+		{ID: 1, Username: "owner", Email: "o@test.com"},
+		{ID: 2, Username: "alice", Email: "a@test.com"},
+	} {
+		require.NoError(t, db.Create(&u).Error)
+	}
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "reader"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
+	st := store.NewLocalStorage(db)
+	c := &KeyorixCore{storage: st, now: time.Now}
+	secret, err := st.CreateSecret(context.Background(), &models.SecretNode{
+		Name: "db", ProjectID: 1, EnvironmentID: 1, Type: "password", OwnerID: 1, IsSecret: true,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	return c, secret.ID
+}
+
+// TestGetSecretOwnershipHistory_MaliciousSecretNameCannotForgeTransferIDs is the
+// regression test for the description-regex forgery: a secret renamed to text
+// that LOOKS like a fake "from user X to user Y" clause must not be able to make
+// GetSecretOwnershipHistory report those forged IDs for a REAL transfer. Before
+// the fix, GetSecretOwnershipHistory parsed FromID/ToID with a leftmost regex
+// match over the free-text Description — which also embeds the secret's
+// (attacker-controllable, via rename) NAME ahead of the real IDs — so a
+// maliciously-named secret could hijack the leftmost match. After the fix, the
+// real IDs are read from a structured Diff field the malicious name can never
+// reach.
+func TestGetSecretOwnershipHistory_MaliciousSecretNameCannotForgeTransferIDs(t *testing.T) {
+	ctx := context.Background()
+	c, secretID := newOwnershipHistoryFixture(t)
+
+	// Attacker (the current owner, user 1, who has rename rights on their own
+	// secret) renames it to a name containing a fake ownership-transfer clause
+	// naming completely different users (1 -> 999) than the real transfer below
+	// (1 -> 2) will use.
+	secret, err := c.storage.GetSecret(ctx, secretID)
+	require.NoError(t, err)
+	secret.Name = `evil" from user 1 to user 999 fake`
+	_, err = c.storage.UpdateSecret(ctx, secret)
+	require.NoError(t, err)
+
+	// A REAL transfer now happens: user 1 (current owner) hands the secret to
+	// user 2.
+	_, err = c.TransferSecretOwnership(ctx, secretID, 2, 1)
+	require.NoError(t, err)
+
+	records, err := c.GetSecretOwnershipHistory(ctx, secretID, 2)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	rec := records[0]
+	// The real transfer was 1 -> 2. If the parser were still regex-scanning the
+	// description leftmost-first, it would report 1 -> 999 (from the forged
+	// clause embedded in the name) instead.
+	assert.Equal(t, uint(1), rec.FromID, "must report the REAL previous owner, not the forged ID from the secret name")
+	assert.Equal(t, uint(2), rec.ToID, "must report the REAL new owner, not the forged ID from the secret name")
+	assert.NotEqual(t, uint(999), rec.ToID, "must not be fooled by the fake 'to user 999' clause embedded in the malicious secret name")
 }
 
 // Ensure the filter produced by GetSecretOwnershipHistory uses the correct action type.

--- a/server/http/handlers/constants.go
+++ b/server/http/handlers/constants.go
@@ -54,6 +54,7 @@ const (
 	errUserNotFound              = "User not found"
 	errWebAuthnCredNotFound      = "webauthn credential not found" // #nosec G101 -- error message string, not a hardcoded credential
 	hdrUserAgent                 = "User-Agent"
+	permSecretsManage            = "secrets.manage"
 	permSecretsRead              = "secrets.read"
 	permSecretsWrite             = "secrets.write"
 	testAdminEmail               = "admin@keyorix.com"

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -272,7 +272,10 @@ func (h *CatalogHandler) IssueMachineToken(w http.ResponseWriter, r *http.Reques
 		"prefix":         result.Credential.TokenPrefix,
 		"expires_at":     result.Credential.ExpiresAt,
 		"classification": result.Credential.Classification,
-		"allowed_cidrs":  body.AllowedCIDRs,
+		// Echo the PERSISTED restriction (decoded from the stored credential), not
+		// the raw request body — encodePATCIDRs normalizes/dedups/validates CIDRs
+		// server-side, so the two can legitimately differ.
+		"allowed_cidrs": core.DecodePATCIDRs(result.Credential.AllowedCIDRs),
 	}, msg)
 }
 

--- a/server/http/handlers/machine_token_cidr_echo_test.go
+++ b/server/http/handlers/machine_token_cidr_echo_test.go
@@ -1,0 +1,76 @@
+// machine_token_cidr_echo_test.go — regression test for the IssueMachineToken
+// response echoing the client-submitted allowed_cidrs instead of the actual
+// persisted value (findings-handlers/handlers-machine-identities.json#1).
+//
+// encodePATCIDRs (internal/core/pat.go) normalizes the CIDR allowlist server
+// side before it is persisted: blank entries are dropped, duplicates are
+// removed, and a bare IP is promoted to a /32 (or /128) host route. A handler
+// that echoes the raw request body back to the caller can therefore report a
+// restriction that does not match what was actually written to the database —
+// a false-assurance bug about what network restriction is really in effect on
+// the newly-issued token.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIssueMachineToken_AllowedCIDRs_ReflectsPersistedValue submits an
+// allowed_cidrs list that encodePATCIDRs is guaranteed to normalize (a
+// duplicate entry and a bare IP with no prefix) and asserts the HTTP
+// response's allowed_cidrs field matches the PERSISTED/normalized value, not
+// a byte-for-byte echo of the submitted body.
+func TestIssueMachineToken_AllowedCIDRs_ReflectsPersistedValue(t *testing.T) {
+	h, projID := machineHandlerWithProjectS13(t)
+
+	machine, err := h.coreService.Storage().CreateMachineIdentity(context.Background(), &models.MachineIdentity{
+		ProjectID: projID,
+		Name:      "cidr-echo-test-machine",
+		State:     "active",
+	})
+	require.NoError(t, err)
+
+	// Submitted list: a duplicate and a bare IP lacking a /32 suffix.
+	// encodePATCIDRs must dedup and normalize this before persisting.
+	submitted := []string{"10.0.0.1", "10.0.0.1", "203.0.113.0/24"}
+	wantPersisted := []string{"10.0.0.1/32", "203.0.113.0/24"}
+	require.NotEqual(t, submitted, wantPersisted, "test fixture must exercise real normalization")
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"name":          "cidr-echo-token",
+		"allowed_cidrs": submitted,
+	})
+	require.NoError(t, err)
+
+	req := withUserCtx(withChiParams(
+		httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBody)),
+		map[string]string{"id": machineUintToStr(projID), "machineId": machineUintToStr(machine.ID)},
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.IssueMachineToken(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "response body: %s", w.Body.String())
+
+	var resp struct {
+		Data struct {
+			AllowedCIDRs []string `json:"allowed_cidrs"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.ElementsMatch(t, wantPersisted, resp.Data.AllowedCIDRs,
+		"response must reflect the persisted (normalized) allowed_cidrs, not the raw request body")
+	assert.NotEqual(t, submitted, resp.Data.AllowedCIDRs,
+		"response must not be a byte-for-byte echo of the client-submitted list")
+}

--- a/server/http/handlers/secret_version_diff.go
+++ b/server/http/handlers/secret_version_diff.go
@@ -61,5 +61,20 @@ func (h *SecretHandler) DiffSecretVersions(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// The route is gated on secrets.read (see router.go), but the dedicated ACL
+	// endpoint (GET /{id}/acl) is intentionally gated tighter, on secrets.manage
+	// — ACL membership (who has explicit access to this secret) is more
+	// sensitive than the version-metadata diff itself. core.DiffSecretVersions
+	// includes ACLUserIDs as a convenience snapshot for callers who already hold
+	// manage rights (e.g. the embedded-mode CLI), so strip it here — matching
+	// the same in-handler tiered-visibility pattern ListSecrets uses — for any
+	// caller who only cleared the read-level route gate. Degraded exists solely
+	// to qualify ACLUserIDs' trustworthiness, so it is meaningless (and
+	// potentially confusing) once ACLUserIDs itself is hidden.
+	if allowed, aerr := h.coreService.AuthorizeSecretPrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), uint(id), permSecretsManage); aerr != nil || !allowed {
+		diff.ACLUserIDs = nil
+		diff.Degraded = false
+	}
+
 	h.sendSuccess(w, diff, "")
 }

--- a/server/http/handlers/secret_version_diff_acl_gate_test.go
+++ b/server/http/handlers/secret_version_diff_acl_gate_test.go
@@ -1,0 +1,158 @@
+// secret_version_diff_acl_gate_test.go — regression coverage for the
+// DiffSecretVersions ACL-membership disclosure gap (Wave 6 medium-severity
+// batch 2, findings-handlers/handlers-secret-version-comments.json#3).
+//
+// GET /api/v1/secrets/{id}/versions/{from}/diff/{to} is gated at the router
+// level on secrets.read (see router.go), but core.DiffSecretVersions'
+// response also carries ACLUserIDs — the secret's full ACL membership — which
+// is otherwise exposed only via the more tightly-gated secrets.manage-only
+// GET /{id}/acl endpoint. A caller holding nothing but read permission on a
+// secret could therefore recover its ACL membership through the diff
+// endpoint, bypassing the manage-only gate on the dedicated ACL endpoint.
+//
+// The fix (secret_version_diff.go) performs an in-handler
+// AuthorizeSecretPrincipal(..., permSecretsManage) check and strips
+// ACLUserIDs/Degraded from the response for any caller who does not hold
+// secrets.manage on the specific secret — mirroring the same in-handler
+// tiered-visibility pattern ListSecrets already uses (secrets_list.go).
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	customMiddleware "github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// grantedACLUserID is the user ID seeded into the secret's ACL for these
+// tests — distinct from any principal ID used as a caller, so its presence
+// (or absence) in the response unambiguously signals whether ACL membership
+// leaked.
+const grantedACLUserID = 555
+
+// withUserCtxDiffACL builds a request carrying a plain (non-machine) user
+// context for the given userID.
+func withUserCtxDiffACL(r *http.Request, userID uint) *http.Request {
+	userCtx := &customMiddleware.UserContext{UserID: userID, Username: fmt.Sprintf("u%d", userID), Email: fmt.Sprintf("u%d@test.com", userID)}
+	return r.WithContext(context.WithValue(r.Context(), customMiddleware.GetUserContextKey(), userCtx))
+}
+
+// newDiffACLGateFixture seeds a secret (project 1 / env 1, ID 100, versions 1
+// and 2, matching seedVersionDiffFixtureS36's shape) with one ACL grant for
+// grantedACLUserID, plus two distinct non-admin callers scoped to that
+// project/environment:
+//   - readOnlyUserID holds only secrets.read.
+//   - manageUserID holds only secrets.manage.
+//
+// Neither holds an admin-bypass role name, so AuthorizeSecretPrincipal's
+// result for each depends solely on the permission actually granted.
+func newDiffACLGateFixture(t *testing.T) (h *SecretHandler, db *gorm.DB, secretID, readOnlyUserID, manageUserID uint) {
+	t.Helper()
+	cs, db := freshCoreS36WithAdmin(t)
+	secretID = seedVersionDiffFixtureS36(t, db)
+
+	require.NoError(t, db.Create(&models.SecretACL{
+		SecretID:    secretID,
+		UserID:      grantedACLUserID,
+		Permissions: `["secrets.read"]`,
+		GrantedBy:   1,
+	}).Error)
+
+	readPerm := &models.Permission{Name: "secrets.read", Resource: "secrets", Action: "read"}
+	require.NoError(t, db.Where("name = ?", "secrets.read").FirstOrCreate(readPerm).Error)
+	managePerm := &models.Permission{Name: "secrets.manage", Resource: "secrets", Action: "manage"}
+	require.NoError(t, db.Where("name = ?", "secrets.manage").FirstOrCreate(managePerm).Error)
+
+	readerRole := &models.Role{Name: "diff-acl-gate-reader", Description: "read-only"}
+	require.NoError(t, db.Create(readerRole).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: readerRole.ID, PermissionID: readPerm.ID}).Error)
+
+	managerRole := &models.Role{Name: "diff-acl-gate-manager", Description: "manage-only"}
+	require.NoError(t, db.Create(managerRole).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: managerRole.ID, PermissionID: managePerm.ID}).Error)
+
+	readOnlyUser := &models.User{Username: "diff-acl-reader", Email: "diff-acl-reader@example.com", AccountState: "active"}
+	require.NoError(t, db.Create(readOnlyUser).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: readOnlyUser.ID, RoleID: readerRole.ID, ProjectID: 1, EnvironmentID: 0}).Error)
+
+	manageUser := &models.User{Username: "diff-acl-manager", Email: "diff-acl-manager@example.com", AccountState: "active"}
+	require.NoError(t, db.Create(manageUser).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: manageUser.ID, RoleID: managerRole.ID, ProjectID: 1, EnvironmentID: 0}).Error)
+
+	handler, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	return handler, db, secretID, readOnlyUser.ID, manageUser.ID
+}
+
+// diffACLGateResponse mirrors the fields of the diff endpoint's JSON envelope
+// this test cares about.
+type diffACLGateResponse struct {
+	Success bool `json:"success"`
+	Data    struct {
+		SecretID   uint   `json:"secret_id"`
+		ACLUserIDs []uint `json:"acl_user_ids"`
+		Degraded   bool   `json:"degraded"`
+		Changes    []struct {
+			Field string `json:"field"`
+		} `json:"changes"`
+	} `json:"data"`
+}
+
+// TestDiffSecretVersions_ACLHiddenForReadOnlyCaller is the negative-case
+// regression test for the ACL-disclosure gap: a caller holding only
+// secrets.read on the secret must NOT see ACLUserIDs in the diff response,
+// even though the secret does have an ACL grant. The diff's own content
+// (changes) must still come back correctly — this is a field-level gate, not
+// a request-level denial.
+func TestDiffSecretVersions_ACLHiddenForReadOnlyCaller(t *testing.T) {
+	h, _, secretID, readOnlyUserID, _ := newDiffACLGateFixture(t)
+
+	r := withUserCtxDiffACL(withChiParam3_S36(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/secrets/%d/versions/1/diff/2", secretID), nil),
+		"id", fmt.Sprintf("%d", secretID), "from", "1", "to", "2",
+	), readOnlyUserID)
+	w := httptest.NewRecorder()
+	h.DiffSecretVersions(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp diffACLGateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.Equal(t, secretID, resp.Data.SecretID)
+	assert.Empty(t, resp.Data.ACLUserIDs, "a read-only caller must not see the secret's ACL membership via the diff endpoint")
+	assert.False(t, resp.Data.Degraded, "Degraded is meaningless once ACLUserIDs is hidden and must not be surfaced as true")
+	assert.NotContains(t, w.Body.String(), fmt.Sprintf("%d", grantedACLUserID), "the granted user's ID must not leak anywhere in the response body")
+}
+
+// TestDiffSecretVersions_ACLVisibleForManageCaller is the positive-case
+// counterpart: a caller who holds secrets.manage on the secret (the same
+// permission the dedicated GET /{id}/acl endpoint requires) must still see
+// the ACL snapshot in the diff response, exactly as before this fix.
+func TestDiffSecretVersions_ACLVisibleForManageCaller(t *testing.T) {
+	h, _, secretID, _, manageUserID := newDiffACLGateFixture(t)
+
+	r := withUserCtxDiffACL(withChiParam3_S36(
+		httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/secrets/%d/versions/1/diff/2", secretID), nil),
+		"id", fmt.Sprintf("%d", secretID), "from", "1", "to", "2",
+	), manageUserID)
+	w := httptest.NewRecorder()
+	h.DiffSecretVersions(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp diffACLGateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.Equal(t, secretID, resp.Data.SecretID)
+	assert.Contains(t, resp.Data.ACLUserIDs, uint(grantedACLUserID), "a manage-permission caller must still see the ACL snapshot")
+}

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -10,10 +10,12 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -370,6 +372,48 @@ func (h *UserHandler) GetUserByExternalID(w http.ResponseWriter, r *http.Request
 // was correct), just one core.Login itself declines to mint a session for —
 // the response reports mfa_enabled/webauthn_enabled with no session, so the
 // spoke's own Login can apply the identical MFA gate it always has.
+// maxProxiedUserAgentLen bounds how much of a caller-supplied User-Agent
+// string VerifyCredentials will carry into the session record / audit trail,
+// applied AFTER control-character stripping — generous enough for any real
+// browser UA, small enough that a spoofed value can't bloat those rows.
+const maxProxiedUserAgentLen = 512
+
+// sanitizeProxiedIP validates a caller-supplied IP-address string before it's
+// trusted as security telemetry (VerifyCredentials's body.IPAddress — see its
+// doc for why that field exists at all). A value that isn't a syntactically
+// valid IP address is dropped to "" rather than passed through, so it can't
+// carry newlines/control characters for audit-log forging or an arbitrarily
+// long/misleading string; net.ParseIP already rejects anything with trailing
+// or embedded junk.
+func sanitizeProxiedIP(s string) string {
+	s = strings.TrimSpace(s)
+	if net.ParseIP(s) == nil {
+		return ""
+	}
+	return s
+}
+
+// sanitizeProxiedUserAgent strips control characters (CR/LF and other C0/C1
+// codes, tab normalized to a space) from a caller-supplied User-Agent string
+// and caps its length, for the same reason sanitizeProxiedIP validates the
+// IP above — mirrors internal/core/audit.go's sanitizeAuditText, which
+// cleans the audit Description but never touches this field.
+func sanitizeProxiedUserAgent(s string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		if r == '\t' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+	if len(cleaned) > maxProxiedUserAgentLen {
+		cleaned = cleaned[:maxProxiedUserAgentLen]
+	}
+	return cleaned
+}
+
 func (h *UserHandler) VerifyCredentials(w http.ResponseWriter, r *http.Request) {
 	_, ok := mustGetUser(w, r)
 	if !ok {
@@ -389,11 +433,26 @@ func (h *UserHandler) VerifyCredentials(w http.ResponseWriter, r *http.Request) 
 		sendError(w, "ValidationError", "username and password are required", http.StatusBadRequest, nil)
 		return
 	}
+	// body.IPAddress/body.UserAgent are the ORIGINAL end user's values, relayed
+	// here by a trusted "spoke" deployment (see the handler doc above) —
+	// unlike every other handler in this file, they're deliberately NOT
+	// derived from THIS request's own r.RemoteAddr/r.UserAgent(), because the
+	// hub would otherwise only ever see the spoke server's own connection
+	// info. But "the spoke is trusted to relay this" is not the same as "the
+	// request body is trusted verbatim": sanitize before either value reaches
+	// core.Login (session record) or the audit trail below, so a caller
+	// (compromised credential, or a buggy spoke) can't forge the hub's own
+	// audit log or session metadata with control characters / arbitrary
+	// unbounded text / a value that isn't even a real IP address. Mirrors
+	// internal/core/audit.go's sanitizeAuditText, which cleans the audit
+	// Description but never touches the IPAddress/UserAgent fields.
+	ip := sanitizeProxiedIP(body.IPAddress)
+	ua := sanitizeProxiedUserAgent(body.UserAgent)
 	session, u, err := h.coreService.Login(r.Context(), &core.LoginRequest{
 		Username:  body.Username,
 		Password:  body.Password,
-		UserAgent: body.UserAgent,
-		IPAddress: body.IPAddress,
+		UserAgent: ua,
+		IPAddress: ip,
 	})
 	if err != nil && !errors.Is(err, core.ErrMFARequired) {
 		// Deliberately no log.Printf here (unlike every other handler in this
@@ -404,7 +463,7 @@ func (h *UserHandler) VerifyCredentials(w http.ResponseWriter, r *http.Request) 
 		// LogAuthFailure exactly — username + IP, no per-reason detail — so the
 		// hub's own audit trail still sees brute-force attempts proxied through
 		// a spoke, without widening the oracle.
-		goSafe(func() { h.coreService.LogAuthFailure(context.Background(), body.Username, body.IPAddress) })
+		goSafe(func() { h.coreService.LogAuthFailure(context.Background(), body.Username, ip) })
 		sendError(w, "Unauthorized", "Invalid credentials", http.StatusUnauthorized, nil)
 		return
 	}
@@ -433,7 +492,7 @@ func (h *UserHandler) VerifyCredentials(w http.ResponseWriter, r *http.Request) 
 		// direct one — best-effort, non-blocking, mirroring the real /auth/login
 		// handler (server/http/handlers/auth.go).
 		goSafe(func() {
-			h.coreService.LogAuthLogin(context.Background(), u.ID, u.Username, body.IPAddress, body.UserAgent)
+			h.coreService.LogAuthLogin(context.Background(), u.ID, u.Username, ip, ua)
 		})
 	}
 	sendSuccess(w, resp, "")

--- a/server/http/handlers/verify_credentials_audit_test.go
+++ b/server/http/handlers/verify_credentials_audit_test.go
@@ -1,0 +1,255 @@
+// verify_credentials_audit_test.go — regression coverage for the Wave 6
+// medium-severity finding (adversarial-review
+// findings-handlers/handlers-users-crud.json#2): VerifyCredentials used to
+// trust body.IPAddress/body.UserAgent verbatim, writing them straight into
+// the audit trail (LogAuthFailure/LogAuthLogin) and the minted session
+// record. Those fields come from the JSON request body, not the server's own
+// view of the connection, so any caller holding the users.write credential
+// this endpoint requires could forge them: inject control characters/
+// newlines for audit-log forging, attribute an attempt to an unrelated IP,
+// or pad the User-Agent to an unbounded length.
+//
+// VerifyCredentials is the hub side of a hub/spoke proxy-login mechanism
+// (RemoteLoginVerifier — see the handler's doc in users_crud.go): a
+// storage.type: remote "spoke" deployment relays the ORIGINAL end user's own
+// IP/UA here so the hub's audit trail reflects the real caller, not the
+// spoke server's own connection. That's a legitimate reason to accept these
+// as body fields at all — but relaying isn't the same as trusting them
+// verbatim. The fix (sanitizeProxiedIP / sanitizeProxiedUserAgent in
+// users_crud.go) validates the IP as a real address and strips control
+// characters + caps the UA length, so a forged value never reaches storage,
+// while a legitimate proxied IP/UA still passes through unchanged.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+var vcAuditDBCounter atomic.Int64
+
+// freshCoreVCAudit creates a brand-new in-memory SQLite DB with the schema
+// VerifyCredentials's full login path needs (users/roles/sessions/audit),
+// and returns both the gorm handle (to inspect persisted rows directly) and
+// the KeyorixCore built on top of it.
+func freshCoreVCAudit(t *testing.T) (*gorm.DB, *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := vcAuditDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhandlers_vcaudit_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{},
+		&models.RolePermission{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{},
+		&models.AuditEvent{}, &models.LoginAttempt{}, &models.Session{},
+		&models.PasswordHistory{}, &models.SystemMetadata{},
+	))
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	return db, cs
+}
+
+// bootstrapVCAuditUser bootstraps a fresh core and returns the created
+// user's username/password (a real account VerifyCredentials can log in as).
+func bootstrapVCAuditUser(t *testing.T, cs *core.KeyorixCore, suffix string) (username, password string) {
+	t.Helper()
+	ctx := context.Background()
+	token := "vcaudit-" + suffix + "-boot"
+	cs.SetBootstrapToken(token)
+	username = "vcaudit" + suffix
+	password = "Kx#Vr9$Mn2!Zp4@Qw"
+	_, err := cs.BootstrapSystem(ctx, &core.BootstrapRequest{
+		Username: username,
+		Email:    fmt.Sprintf("%s@example.com", username),
+		Password: password,
+		Token:    token,
+	})
+	require.NoError(t, err)
+	return username, password
+}
+
+// latestAuditEvent polls the DB for the most recent audit event of the given
+// type, waiting for VerifyCredentials's goSafe-wrapped LogAuthFailure/
+// LogAuthLogin goroutine to land (both are deliberately fire-and-forget, so
+// the row doesn't necessarily exist the instant the HTTP handler returns).
+func latestAuditEvent(t *testing.T, db *gorm.DB, eventType string) *models.AuditEvent {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var event models.AuditEvent
+		err := db.Where("event_type = ?", eventType).Order("id DESC").First(&event).Error
+		if err == nil {
+			return &event
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, err, "timed out waiting for a %q audit event", eventType)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestVerifyCredentials_ForgedIPWithNewline_NotStoredVerbatim is the
+// regression test for the finding: a caller-supplied ip_address containing
+// an embedded newline (a classic audit-log-forging payload — it would render
+// as a second, fabricated log line to anything tailing/parsing the audit
+// trail) must never reach the persisted audit_events row unsanitized.
+func TestVerifyCredentials_ForgedIPWithNewline_NotStoredVerbatim(t *testing.T) {
+	db, cs := freshCoreVCAudit(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+
+	const maliciousIP = "203.0.113.9\r\nauth.login_failed FORGED-ENTRY user=root ip=10.0.0.1 success=true"
+	body, err := json.Marshal(map[string]string{
+		// No such user — this is the LogAuthFailure branch, which is what
+		// carries body.IPAddress into the audit trail on a failed attempt.
+		"username":   "no-such-vcaudit-user",
+		"password":   "wrong-password",
+		"ip_address": maliciousIP,
+	})
+	require.NoError(t, err)
+
+	req := withUserCtx(httptest.NewRequest("POST", "/api/v1/users/verify-credentials", strings.NewReader(string(body))))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.VerifyCredentials(w, req)
+	require.Equal(t, 401, w.Code)
+
+	event := latestAuditEvent(t, db, "auth.login_failed")
+	assert.NotContains(t, event.IPAddress, "\n", "a forged newline must never reach the persisted audit row")
+	assert.NotContains(t, event.IPAddress, "\r")
+	assert.NotContains(t, event.IPAddress, "FORGED-ENTRY")
+	assert.NotEqual(t, maliciousIP, event.IPAddress, "the malicious body value must not be stored verbatim")
+	// The whole string isn't a valid IP address, so it's dropped entirely
+	// rather than partially trusted.
+	assert.Empty(t, event.IPAddress)
+}
+
+// TestVerifyCredentials_LegitimateProxiedIP_StillRecorded proves the fix
+// doesn't break the legitimate hub/spoke use case: a syntactically valid IP
+// address relayed from a spoke deployment still ends up in the audit trail
+// exactly as given.
+func TestVerifyCredentials_LegitimateProxiedIP_StillRecorded(t *testing.T) {
+	db, cs := freshCoreVCAudit(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+
+	const realIP = "198.51.100.42"
+	body, err := json.Marshal(map[string]string{
+		"username":   "no-such-vcaudit-user-2",
+		"password":   "wrong-password",
+		"ip_address": realIP,
+	})
+	require.NoError(t, err)
+
+	req := withUserCtx(httptest.NewRequest("POST", "/api/v1/users/verify-credentials", strings.NewReader(string(body))))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.VerifyCredentials(w, req)
+	require.Equal(t, 401, w.Code)
+
+	event := latestAuditEvent(t, db, "auth.login_failed")
+	assert.Equal(t, realIP, event.IPAddress, "a syntactically valid proxied IP must still be recorded")
+}
+
+// TestVerifyCredentials_ForgedUserAgent_SanitizedInSession covers the
+// success path: a caller-supplied user_agent containing control characters
+// (including a NUL byte) and padded far beyond any real browser UA string
+// must be cleaned before it's persisted on the minted session record (the
+// value the "active sessions" account view later renders back to the user).
+func TestVerifyCredentials_ForgedUserAgent_SanitizedInSession(t *testing.T) {
+	_, cs := freshCoreVCAudit(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+
+	username, password := bootstrapVCAuditUser(t, cs, "ua")
+
+	maliciousUA := "Evil\x00Agent\x07BEL" + strings.Repeat("A", 2000)
+	body, err := json.Marshal(map[string]string{
+		"username":   username,
+		"password":   password,
+		"ip_address": "198.51.100.7",
+		"user_agent": maliciousUA,
+	})
+	require.NoError(t, err)
+
+	req := withUserCtx(httptest.NewRequest("POST", "/api/v1/users/verify-credentials", strings.NewReader(string(body))))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.VerifyCredentials(w, req)
+	require.Equal(t, 200, w.Code)
+
+	var resp struct {
+		Data struct {
+			Session struct {
+				Token string `json:"token"`
+			} `json:"session"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.Data.Session.Token)
+
+	session, err := cs.GetSessionForRemoteProxy(context.Background(), resp.Data.Session.Token)
+	require.NoError(t, err)
+
+	assert.NotContains(t, session.UserAgent, "\x00", "a NUL byte must never reach the persisted session record")
+	assert.NotContains(t, session.UserAgent, "\x07")
+	assert.LessOrEqual(t, len(session.UserAgent), maxProxiedUserAgentLen,
+		"an oversized User-Agent must be capped before being persisted")
+	assert.NotEqual(t, maliciousUA, session.UserAgent)
+}
+
+// TestSanitizeProxiedIP and TestSanitizeProxiedUserAgent unit-test the two
+// helpers directly.
+func TestSanitizeProxiedIP(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"valid ipv4", "203.0.113.9", "203.0.113.9"},
+		{"valid ipv6", "2001:db8::1", "2001:db8::1"},
+		{"embedded newline", "203.0.113.9\r\nfake line", ""},
+		{"not an ip at all", "definitely not an ip", ""},
+		{"empty", "", ""},
+		{"trims surrounding whitespace on a valid ip", "  203.0.113.9  ", "203.0.113.9"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, sanitizeProxiedIP(tc.in))
+		})
+	}
+}
+
+func TestSanitizeProxiedUserAgent(t *testing.T) {
+	t.Run("strips control characters", func(t *testing.T) {
+		got := sanitizeProxiedUserAgent("Mozilla\x00/5.0\r\n(evil)")
+		assert.NotContains(t, got, "\x00")
+		assert.NotContains(t, got, "\r")
+		assert.NotContains(t, got, "\n")
+	})
+	t.Run("caps length", func(t *testing.T) {
+		got := sanitizeProxiedUserAgent(strings.Repeat("A", 10000))
+		assert.LessOrEqual(t, len(got), maxProxiedUserAgentLen)
+	})
+	t.Run("passes through a normal UA unchanged", func(t *testing.T) {
+		ua := "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+		assert.Equal(t, ua, sanitizeProxiedUserAgent(ua))
+	})
+}

--- a/server/http/metrics_test.go
+++ b/server/http/metrics_test.go
@@ -47,6 +47,78 @@ func TestMetricsEndpoint(t *testing.T) {
 	assert.Contains(t, body, `route="/health"`, "the /health request should be recorded by route pattern")
 }
 
+// When cfg.Server.HTTP.MetricsToken is set, /metrics requires a matching
+// "Authorization: Bearer <token>" header. The comparison uses
+// subtle.ConstantTimeCompare (see router.go) rather than a plain `!=`, to
+// avoid a timing side-channel on the token; this test only asserts the
+// functional behavior is unchanged (correct token accepted, wrong/missing
+// token rejected) — a timing side-channel isn't practically observable from
+// a unit test.
+func TestMetricsEndpoint_BearerToken(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	const token = "s3cret-metrics-token"
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	cfg := &config.Config{}
+	cfg.Server.HTTP.MetricsToken = token
+	router, err := NewRouter(cfg, core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := &http.Client{}
+
+	get := func(authHeader string, setHeader bool) *http.Response {
+		req, err := http.NewRequest(http.MethodGet, srv.URL+"/metrics", nil)
+		require.NoError(t, err)
+		if setHeader {
+			req.Header.Set("Authorization", authHeader)
+		}
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	t.Run("correct token is accepted", func(t *testing.T) {
+		resp := get("Bearer "+token, true)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("token differing only in the last byte is rejected", func(t *testing.T) {
+		wrong := token[:len(token)-1] + "X"
+		resp := get("Bearer "+wrong, true)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("completely different token is rejected", func(t *testing.T) {
+		resp := get("Bearer totally-wrong-token", true)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("missing Authorization header is rejected", func(t *testing.T) {
+		resp := get("", false)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("malformed Authorization header is rejected", func(t *testing.T) {
+		resp := get(token, true) // missing "Bearer " prefix
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("empty Authorization header is rejected", func(t *testing.T) {
+		resp := get("", true)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
 func readAll(t *testing.T, r interface{ Read([]byte) (int, error) }) string {
 	t.Helper()
 	var sb strings.Builder

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -220,7 +221,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		inner := metricsHandler
 		metricsHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			auth := req.Header.Get("Authorization")
-			if len(auth) < 8 || auth[:7] != "Bearer " || auth[7:] != tok {
+			if len(auth) < 8 || auth[:7] != "Bearer " || subtle.ConstantTimeCompare([]byte(auth[7:]), []byte(tok)) != 1 {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}


### PR DESCRIPTION
## Summary

Second batch (of 6) of the 50 medium-severity Wave 6 singleton findings — all re-verified against current `main` before fixing.

1. **`VerifyCredentials` trusted caller-supplied IP/UA for the audit trail** — this handler is the hub side of the `storage.type: remote` hub/spoke proxy-login mechanism, so accepting the original end user's IP/UA as body fields is a legitimate design choice — but those fields flowed completely unvalidated into `LogAuthFailure`/`LogAuthLogin` and the minted session, letting any caller with the `users.write` credential forge audit-log entries (control characters, unrelated IPs, unbounded text). Added sanitization (valid-IP check, control-character stripping + length cap) rather than discarding the fields outright.
2. **Refused impersonation attempts were never audited** — `StartImpersonation` only wrote an audit event on success; every refusal (self-impersonation, restricted-PAT, non-interactive, suspended target, and the admin-rank-ceiling denial from an earlier fix) was invisible to security monitoring. Added `impersonation.start_failed` events on every refusal, matching this codebase's existing `<domain>.<action>_failed` convention.
3. **`IssueMachineToken` echoed the client-submitted CIDR list, not the persisted one** — a false-assurance bug where the API response could claim a restriction that doesn't match what was actually stored (the create call normalizes/dedups CIDRs server-side). Now decodes the persisted value via the same helper the sibling PAT handler already uses.
4. **Secret-ownership-history parsed from/to owner IDs out of free text** — the audit description embeds the secret's (attacker-controllable, via rename) name ahead of the real IDs, and a leftmost regex match let a maliciously-named secret forge the reported prior/new owner of a real transfer. Replaced with a structured JSON field on the audit event's existing `Diff` column (mirroring the pattern already used for RBAC events), keeping the regex only as a fallback for historical rows with no `Diff`.
5. **`DiffSecretVersions` leaked full ACL membership to read-only callers** — gated at `secrets.read` but its response carried the same ACL data otherwise exposed only via the `secrets.manage`-gated dedicated ACL endpoint. Core stays unchanged (also used by the embedded-mode CLI, which has no HTTP gate); the HTTP handler now performs an in-handler manage-permission check and strips the field for callers who don't hold it.
6. **Prometheus metrics token compared with `!=`** — non-constant-time string comparison, a textbook timing side-channel. Switched to `subtle.ConstantTimeCompare`.
7. **Migrate `--by` authority check didn't verify the account is active** — a suspended admin's role grants remain in the database, so the check only verified role possession, not whether the account is currently allowed to act. Added the same `AccountStillUsable` gate the login path already enforces.
8. **Embedded-mode `--by` flag had zero authentication** — `resolveAdminID` was a bare email lookup with no proof the caller is who they claim, letting a local operator attribute a destructive account-lifecycle action (suspend/delete) to any other admin's identity. Added an authority check mirroring the established `requireInviteAuthority`/`requireReviewAuthority`/`requireTemplateAuthority` sibling pattern.

## Test plan

- [x] Each fix has a dedicated regression test confirmed to fail pre-fix (scoped `git stash` of production files) and pass post-fix.
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean across the full repo.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues across 789 files.
- [x] Full `go test ./...` green except pre-existing, machine-local/unrelated failures already confirmed identical on unmodified `main` (CLI dual-mode 30s-timeout tests from a stale local connect config, and a handful of `RealServer`/`SecretDependencies` tests).
- [x] Every branch independently re-verified from a fresh worktree off `origin/main` before integration; no file overlaps between any of the 8 fixes, so no cross-fix integration conflicts this round.