### PR TITLE
fix(security): close Wave 6 medium-severity batch 3 (8 findings)

### DIFF
--- a/internal/cli/project/env.go
+++ b/internal/cli/project/env.go
@@ -138,6 +138,25 @@ func runEnvDelete(cmd *cobra.Command, args []string) error {
 
 	ctx := context.Background()
 
+	// `env delete` has always accepted --project (registered in init() above,
+	// same as list/create) but never actually checked it: an operator who
+	// named the wrong project for a given bare environment ID would silently
+	// delete an environment belonging to a DIFFERENT project than the one
+	// they believed they were targeting. When --project is explicitly given,
+	// verify the id actually belongs to that project before deleting it. When
+	// it's omitted we keep prior (pre-existing) delete-by-bare-id behavior
+	// rather than newly forcing every invocation to resolve an active project
+	// that wasn't previously required for this command.
+	if envProjectFlag != "" {
+		_, projectID, err := resolveProjectContext(envProjectFlag)
+		if err != nil {
+			return err
+		}
+		if err := verifyEnvironmentBelongsToProject(ctx, projectID, uint(id)); err != nil {
+			return err
+		}
+	}
+
 	if rc, ok := common.NewRemoteClient(); ok {
 		path := fmt.Sprintf("/api/v1/environments/%d", id)
 		if err := rc.Delete(ctx, path); err != nil {
@@ -159,6 +178,39 @@ func runEnvDelete(cmd *cobra.Command, args []string) error {
 }
 
 // --- helpers ---
+
+// verifyEnvironmentBelongsToProject confirms environment id actually belongs
+// to projectID before a project-scoped operation (currently: `env delete
+// --project ...`) proceeds — the CLI-side counterpart to
+// core.KeyorixCore.GetEnvironmentInProject, so an operator who names a
+// project for a bare environment ID gets that belief cross-checked instead
+// of silently mutating a different project's environment.
+func verifyEnvironmentBelongsToProject(ctx context.Context, projectID, id uint) error {
+	if rc, ok := common.NewRemoteClient(); ok {
+		var resp struct {
+			Environments []*models.Environment `json:"environments"`
+		}
+		path := fmt.Sprintf("/api/v1/projects/%d/environments", projectID)
+		if err := rc.Get(ctx, path, &resp); err != nil {
+			return fmt.Errorf("failed to verify environment %d belongs to project %d: %w", id, projectID, err)
+		}
+		for _, e := range resp.Environments {
+			if e.ID == id {
+				return nil
+			}
+		}
+		return fmt.Errorf("environment %d does not belong to project %d", id, projectID)
+	}
+
+	svc, err := common.InitializeCoreService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize service: %w", err)
+	}
+	if _, err := svc.GetEnvironmentInProject(ctx, projectID, id); err != nil {
+		return fmt.Errorf("environment %d does not belong to project %d", id, projectID)
+	}
+	return nil
+}
 
 // resolveProjectContext looks up the project by name (from flag or active context)
 // and returns the name and numeric ID.

--- a/internal/cli/project/env_delete_test.go
+++ b/internal/cli/project/env_delete_test.go
@@ -69,3 +69,88 @@ func TestRunEnvDelete_InvalidID(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid environment ID")
 }
+
+// TestRunEnvDelete_ProjectMismatch_RefusedWithoutAPICall is the required
+// regression case at the CLI layer: `env delete --project <name>` declares a
+// project the operator believes environment 10 belongs to. Environment 10
+// actually belongs to a DIFFERENT project (id 77) than the one the mock
+// server returns for the named project's own environment list (which only
+// contains id 20). The bare id alone can't reveal this mismatch, so the fix
+// under test must look up the named project's environments and cross-check
+// before ever issuing the DELETE — must be refused, and the DELETE endpoint
+// must never be hit.
+func TestRunEnvDelete_ProjectMismatch_RefusedWithoutAPICall(t *testing.T) {
+	deleteCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":42,"name":"other-project"}]}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/42/environments":
+			// project 42's real environments do NOT include id 10 — the
+			// operator's belief that env 10 belongs to "other-project" is wrong.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":20,"name":"prod","project_id":42}]}}`))
+		case r.Method == http.MethodDelete:
+			deleteCalled = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origConfirm := envDeleteConfirm
+	origProject := envProjectFlag
+	t.Cleanup(func() {
+		envDeleteConfirm = origConfirm
+		envProjectFlag = origProject
+	})
+	envDeleteConfirm = true
+	envProjectFlag = "other-project"
+
+	err := runEnvDelete(envDeleteCmd, []string{"10"})
+	require.Error(t, err, "deleting an env id that doesn't belong to the named --project must be refused")
+	assert.Contains(t, err.Error(), "does not belong to project")
+	assert.False(t, deleteCalled, "DELETE must never be issued once the project cross-check fails")
+}
+
+// TestRunEnvDelete_ProjectMatch_CallsAPI is the positive counterpart: when
+// --project correctly names the environment's actual owning project, the
+// cross-check passes and the delete proceeds as before.
+func TestRunEnvDelete_ProjectMatch_CallsAPI(t *testing.T) {
+	deleteCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":42,"name":"other-project"}]}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/42/environments":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":10,"name":"prod","project_id":42}]}}`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/environments/10":
+			deleteCalled = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origConfirm := envDeleteConfirm
+	origProject := envProjectFlag
+	t.Cleanup(func() {
+		envDeleteConfirm = origConfirm
+		envProjectFlag = origProject
+	})
+	envDeleteConfirm = true
+	envProjectFlag = "other-project"
+
+	err := runEnvDelete(envDeleteCmd, []string{"10"})
+	require.NoError(t, err)
+	assert.True(t, deleteCalled, "DELETE must be issued once the project cross-check passes")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1707,11 +1707,24 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("failed to read config file %q: %w", path, err)
 	}
 
-	data = expandEnvVars(data)
-
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+
+	// server.http.domain/allowed_origins are the only fields documented (in
+	// server/config/production.yaml) as supporting ${VAR}/${VAR:-default} interpolation.
+	// Expansion is applied here, per-field, AFTER unmarshaling — not as a raw-bytes
+	// preprocessing pass over the whole file before yaml.Unmarshal — because
+	// storage.remote.api_key also legitimately contains a literal "${VAR}"-shaped string
+	// (see remote.Config.GetAPIKeyFromEnv, TestEnvironmentVariableSupport): that field is
+	// deliberately left as the unexpanded template by Load() and resolved lazily, only
+	// when the API key is actually used. A whole-file preprocessing pass can't tell that
+	// field's literal template apart from server.http's real interpolation points and
+	// would silently expand both.
+	cfg.Server.HTTP.Domain = expandEnvVars(cfg.Server.HTTP.Domain)
+	for i, origin := range cfg.Server.HTTP.AllowedOrigins {
+		cfg.Server.HTTP.AllowedOrigins[i] = expandEnvVars(origin)
 	}
 
 	return &cfg, nil
@@ -1724,37 +1737,34 @@ func Load(path string) (*Config, error) {
 // match) untouched.
 var envVarPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)(:-([^}]*))?\}`)
 
-// expandEnvVars resolves ${VAR} / ${VAR:-default} references in raw config bytes against
-// the process environment before YAML parsing. Go's os.ExpandEnv doesn't support the
-// `:-default` bash fallback form, so this is a small, scoped preprocessing step run only
-// from Load(), over the raw file bytes, before yaml.Unmarshal — not a general templating
-// engine.
+// expandEnvVars resolves ${VAR} / ${VAR:-default} references in a single already-parsed
+// config string value against the process environment. Go's os.ExpandEnv doesn't support
+// the `:-default` bash fallback form, so this is a small, scoped helper applied only to
+// the specific server.http.domain/allowed_origins fields Load() documents as supporting
+// it — not a general templating engine, and not run over the raw file bytes (see Load's
+// comment for why: storage.remote.api_key uses the identical "${VAR}" syntax for its own,
+// separately-deferred expansion and must not be touched here).
 //
 // Semantics match bash's ${VAR:-default}: the default is used when VAR is unset OR set to
 // the empty string. A reference with no default whose variable is unset is left
 // UNRESOLVED (not silently replaced with ""), so a misconfigured/missing env var fails
 // loudly downstream (e.g. as an invalid domain or empty allowed_origins entry) instead of
 // silently shipping a blank value.
-//
-// Caveat: this is a plain text substitution done before YAML parsing, so a substituted
-// value containing a literal `"` or newline could change the surrounding YAML's
-// structure — the same caveat that applies to any envsubst-style preprocessor. Values
-// like hostnames (the only documented use here) don't hit this.
-func expandEnvVars(data []byte) []byte {
-	return envVarPattern.ReplaceAllFunc(data, func(match []byte) []byte {
-		sub := envVarPattern.FindSubmatch(match)
-		name := string(sub[1])
+func expandEnvVars(s string) string {
+	return envVarPattern.ReplaceAllStringFunc(s, func(match string) string {
+		sub := envVarPattern.FindStringSubmatch(match)
+		name := sub[1]
 		hasDefault := len(sub[2]) > 0
 		v, set := os.LookupEnv(name)
 		if set && v != "" {
-			return []byte(v)
+			return v
 		}
 		if hasDefault {
-			return []byte(sub[3])
+			return sub[3]
 		}
 		if set {
 			// Explicitly set to "" with no default — honor the explicit empty value.
-			return []byte(v)
+			return v
 		}
 		return match
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -1706,12 +1707,57 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("failed to read config file %q: %w", path, err)
 	}
 
+	data = expandEnvVars(data)
+
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
 	return &cfg, nil
+}
+
+// envVarPattern matches shell-style ${VAR} and ${VAR:-default} references — the
+// interpolation syntax documented (and used) in server/config/production.yaml for
+// server.http.domain/allowed_origins. This is intentionally narrow: it recognizes only
+// this one pattern and leaves any other "${" text (including a literal one that doesn't
+// match) untouched.
+var envVarPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)(:-([^}]*))?\}`)
+
+// expandEnvVars resolves ${VAR} / ${VAR:-default} references in raw config bytes against
+// the process environment before YAML parsing. Go's os.ExpandEnv doesn't support the
+// `:-default` bash fallback form, so this is a small, scoped preprocessing step run only
+// from Load(), over the raw file bytes, before yaml.Unmarshal — not a general templating
+// engine.
+//
+// Semantics match bash's ${VAR:-default}: the default is used when VAR is unset OR set to
+// the empty string. A reference with no default whose variable is unset is left
+// UNRESOLVED (not silently replaced with ""), so a misconfigured/missing env var fails
+// loudly downstream (e.g. as an invalid domain or empty allowed_origins entry) instead of
+// silently shipping a blank value.
+//
+// Caveat: this is a plain text substitution done before YAML parsing, so a substituted
+// value containing a literal `"` or newline could change the surrounding YAML's
+// structure — the same caveat that applies to any envsubst-style preprocessor. Values
+// like hostnames (the only documented use here) don't hit this.
+func expandEnvVars(data []byte) []byte {
+	return envVarPattern.ReplaceAllFunc(data, func(match []byte) []byte {
+		sub := envVarPattern.FindSubmatch(match)
+		name := string(sub[1])
+		hasDefault := len(sub[2]) > 0
+		v, set := os.LookupEnv(name)
+		if set && v != "" {
+			return []byte(v)
+		}
+		if hasDefault {
+			return []byte(sub[3])
+		}
+		if set {
+			// Explicitly set to "" with no default — honor the explicit empty value.
+			return []byte(v)
+		}
+		return match
+	})
 }
 
 // LoadConfig loads configuration using the default path.

--- a/internal/config/config_env_expand_test.go
+++ b/internal/config/config_env_expand_test.go
@@ -42,7 +42,6 @@ func TestLoadExpandsEnvVarFallsBackToDefaultWhenUnset(t *testing.T) {
 	), 0600))
 
 	t.Setenv("KEYORIX_DOMAIN", "") // ensure not set from the outer environment
-	os.Unsetenv("KEYORIX_DOMAIN")
 	cfg, err := Load(p)
 	require.NoError(t, err)
 	assert.Equal(t, "localhost", cfg.Server.HTTP.Domain)
@@ -73,7 +72,7 @@ func TestLoadLeavesUnresolvedEnvVarWithNoDefaultIntact(t *testing.T) {
 		"server:\n  http:\n    domain: \"${KEYORIX_REQUIRED_DOMAIN}\"\n",
 	), 0600))
 
-	os.Unsetenv("KEYORIX_REQUIRED_DOMAIN")
+	require.NoError(t, os.Unsetenv("KEYORIX_REQUIRED_DOMAIN"))
 	cfg, err := Load(p)
 	require.NoError(t, err)
 	assert.Equal(t, "${KEYORIX_REQUIRED_DOMAIN}", cfg.Server.HTTP.Domain)

--- a/internal/config/config_env_expand_test.go
+++ b/internal/config/config_env_expand_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// server/config/production.yaml documents ${VAR:-default} shell-style interpolation for
+// server.http.domain/allowed_origins, but the loader used to do a plain yaml.Unmarshal
+// with no expansion step — the documented syntax silently became the literal string
+// "${KEYORIX_DOMAIN:-localhost}" instead of resolving. These tests exercise Load()'s
+// expandEnvVars preprocessing end to end, covering the var-set and var-unset/default
+// cases the documented syntax relies on.
+
+// When the referenced environment variable is set (and non-empty), its value is used —
+// the default is ignored, matching bash's ${VAR:-default} semantics.
+func TestLoadExpandsEnvVarWhenSet(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(
+		"server:\n  http:\n    domain: \"${KEYORIX_DOMAIN:-localhost}\"\n    allowed_origins:\n      - \"https://${KEYORIX_DOMAIN:-localhost}\"\n",
+	), 0600))
+
+	t.Setenv("KEYORIX_DOMAIN", "secrets.example.com")
+	cfg, err := Load(p)
+	require.NoError(t, err)
+	assert.Equal(t, "secrets.example.com", cfg.Server.HTTP.Domain)
+	assert.Equal(t, []string{"https://secrets.example.com"}, cfg.Server.HTTP.AllowedOrigins)
+}
+
+// When the referenced environment variable is unset, the ":-default" fallback is used —
+// the documented "sane default for local/dev" behavior.
+func TestLoadExpandsEnvVarFallsBackToDefaultWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(
+		"server:\n  http:\n    domain: \"${KEYORIX_DOMAIN:-localhost}\"\n",
+	), 0600))
+
+	t.Setenv("KEYORIX_DOMAIN", "") // ensure not set from the outer environment
+	os.Unsetenv("KEYORIX_DOMAIN")
+	cfg, err := Load(p)
+	require.NoError(t, err)
+	assert.Equal(t, "localhost", cfg.Server.HTTP.Domain)
+}
+
+// bash ${VAR:-default} semantics: an explicitly-empty variable also falls back to the
+// default, not to an empty string.
+func TestLoadExpandsEnvVarFallsBackToDefaultWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(
+		"server:\n  http:\n    domain: \"${KEYORIX_DOMAIN:-localhost}\"\n",
+	), 0600))
+
+	t.Setenv("KEYORIX_DOMAIN", "")
+	cfg, err := Load(p)
+	require.NoError(t, err)
+	assert.Equal(t, "localhost", cfg.Server.HTTP.Domain)
+}
+
+// A reference with no default whose variable is unset is left unresolved rather than
+// silently collapsed to "" — a missing required value should fail loudly downstream
+// (e.g. as an obviously-wrong domain), not disappear.
+func TestLoadLeavesUnresolvedEnvVarWithNoDefaultIntact(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(
+		"server:\n  http:\n    domain: \"${KEYORIX_REQUIRED_DOMAIN}\"\n",
+	), 0600))
+
+	os.Unsetenv("KEYORIX_REQUIRED_DOMAIN")
+	cfg, err := Load(p)
+	require.NoError(t, err)
+	assert.Equal(t, "${KEYORIX_REQUIRED_DOMAIN}", cfg.Server.HTTP.Domain)
+}
+
+// production.yaml itself must still load cleanly and resolve its documented
+// KEYORIX_DOMAIN interpolation end to end.
+func TestLoadProductionYAMLExpandsDomain(t *testing.T) {
+	repoRoot, err := filepath.Abs("../..")
+	require.NoError(t, err)
+	p := filepath.Join(repoRoot, "server", "config", "production.yaml")
+	if _, statErr := os.Stat(p); statErr != nil {
+		t.Skipf("production.yaml not found at %s: %v", p, statErr)
+	}
+
+	t.Setenv("KEYORIX_DOMAIN", "vault.example.com")
+	cfg, err := Load(p)
+	require.NoError(t, err)
+	assert.Equal(t, "vault.example.com", cfg.Server.HTTP.Domain)
+	assert.Contains(t, cfg.Server.HTTP.AllowedOrigins, "https://vault.example.com")
+	assert.Contains(t, cfg.Server.HTTP.AllowedOrigins, "https://www.vault.example.com")
+	assert.NotEmpty(t, cfg.Server.HTTP.TrustedProxies, "production.yaml should document a trusted_proxies example")
+}

--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -348,8 +348,44 @@ func (c *KeyorixCore) ListEnvironmentsByProjectIncludingDeleted(ctx context.Cont
 }
 
 // GetEnvironment returns a single environment by ID.
+//
+// storage.Storage's GetEnvironment/DeleteEnvironment take a bare, unscoped id
+// (unlike RestoreEnvironment, which is deliberately project-scoped) because
+// some legitimate callers don't yet know which project an id belongs to and
+// use this to find out (e.g. server/middleware.ScopeFromEnvParam resolving an
+// authorization scope from a URL id, or the read-only display-name cache in
+// permission_matrix.go). Callers that already believe an environment belongs
+// to a specific project — and would silently operate on the wrong tenant's
+// environment if that belief were wrong — must use GetEnvironmentInProject
+// below instead of calling this (or storage.GetEnvironment) directly.
 func (c *KeyorixCore) GetEnvironment(ctx context.Context, id uint) (*models.Environment, error) {
 	return c.storage.GetEnvironment(ctx, id)
+}
+
+// GetEnvironmentInProject returns an environment by id, but only if it
+// actually belongs to projectID — the project-scoped counterpart to the bare
+// GetEnvironment above, mirroring the scoping storage.Storage.RestoreEnvironment
+// already gets from its signature. Use this (not GetEnvironment) whenever a
+// caller already has a projectID in hand (from a nested URL path, a request
+// body field, an active CLI project context, etc.) and is about to look up or
+// act on an environment it BELIEVES belongs to that project — so a bare-id
+// mismatch (the environment actually belongs to a different project) is
+// refused instead of silently operating cross-tenant.
+//
+// Returns a generic "environment not found" error (not a distinct "wrong
+// project" error) on mismatch, matching storage.GetEnvironment's own
+// not-found error and RestoreEnvironment's WHERE-clause behavior, so a caller
+// without access to project B can't use this to probe whether a given
+// environment id exists there.
+func (c *KeyorixCore) GetEnvironmentInProject(ctx context.Context, projectID, id uint) (*models.Environment, error) {
+	env, err := c.storage.GetEnvironment(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if env.ProjectID != projectID {
+		return nil, fmt.Errorf("environment not found")
+	}
+	return env, nil
 }
 
 // CreateEnvironment creates a single environment under an existing project,

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -741,12 +741,20 @@ func (c *KeyorixCore) RevokeLeasesForConfig(ctx context.Context, configID, userI
 // deleted_at predicate. Shared by IssueLease and RenewLease (#369): a project's
 // soft-delete does not, on its own, revoke the role grants scoped to it, so
 // issuance/renewal need their own explicit liveness gate independent of RBAC.
+//
+// Uses GetEnvironmentInProject (not the bare GetEnvironment) so this also
+// refuses when environmentID exists but belongs to a DIFFERENT project than
+// projectID — both callers (IssueLease/RenewLease) already have both IDs
+// available (from the config/lease row), so there's no reason to accept a
+// mismatch here even though today's callers happen to pass coupled fields
+// from the same row; this closes the gap defensively rather than relying on
+// that coupling holding forever.
 func (c *KeyorixCore) requireLiveProjectAndEnvironment(ctx context.Context, projectID, environmentID uint) error {
 	if _, err := c.storage.GetProject(ctx, projectID); err != nil {
 		return fmt.Errorf("cannot issue lease: project not found or deleted")
 	}
 	if environmentID != 0 {
-		if _, err := c.storage.GetEnvironment(ctx, environmentID); err != nil {
+		if _, err := c.GetEnvironmentInProject(ctx, projectID, environmentID); err != nil {
 			return fmt.Errorf("cannot issue lease: environment not found or deleted")
 		}
 	}

--- a/internal/core/environment_scope_test.go
+++ b/internal/core/environment_scope_test.go
@@ -1,0 +1,120 @@
+// environment_scope_test.go — regression coverage for GetEnvironmentInProject
+// and its use in requireLiveProjectAndEnvironment: storage.Storage's
+// GetEnvironment/DeleteEnvironment take a bare, unscoped id (unlike
+// RestoreEnvironment, which is project-scoped by signature), so any core
+// caller that already believes an environment belongs to a specific project
+// must cross-check that belief explicitly instead of trusting the bare id —
+// otherwise a caller authorized for project A could reference an environment
+// that actually belongs to project B and operate on it by mistake (or via a
+// crafted request that supplies a mismatched id).
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// newEnvScopeTestCore builds a minimal KeyorixCore over an isolated in-memory
+// SQLite DB, keyed by test name to avoid cross-test collisions.
+func newEnvScopeTestCore(t *testing.T) *KeyorixCore {
+	t.Helper()
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=private", t.Name())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{},
+		&models.Environment{},
+	))
+	return &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+}
+
+// TestGetEnvironmentInProject_CrossProjectReferenceRefused is the required
+// regression case: an environment belonging to project A, a caller operating
+// in the context of project B, references that environment's bare id — the
+// project-scoped lookup must refuse it rather than silently returning A's
+// environment as if it belonged to B.
+func TestGetEnvironmentInProject_CrossProjectReferenceRefused(t *testing.T) {
+	c := newEnvScopeTestCore(t)
+	ctx := context.Background()
+
+	projectA, err := c.storage.CreateProject(ctx, &models.Project{Name: "project-a"})
+	require.NoError(t, err)
+	projectB, err := c.storage.CreateProject(ctx, &models.Project{Name: "project-b"})
+	require.NoError(t, err)
+
+	envInA, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: projectA.ID})
+	require.NoError(t, err)
+
+	// Caller operating in the context of project B, referencing A's environment
+	// by its bare id, must be refused.
+	got, err := c.GetEnvironmentInProject(ctx, projectB.ID, envInA.ID)
+	require.Error(t, err, "environment belonging to a different project must be refused, not returned")
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "not found", "mismatch must surface as a generic not-found error, not leak that the id exists under a different project")
+
+	// Sanity: the SAME lookup scoped to the environment's real, owning project
+	// (A) succeeds, proving the refusal above is specifically about project
+	// scoping and not some other bug in the lookup.
+	got, err = c.GetEnvironmentInProject(ctx, projectA.ID, envInA.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, envInA.ID, got.ID)
+}
+
+// TestGetEnvironmentInProject_NonexistentEnvironmentRefused confirms the
+// helper still behaves like a normal not-found lookup when the id simply
+// doesn't exist at all (not just when it exists under a different project).
+func TestGetEnvironmentInProject_NonexistentEnvironmentRefused(t *testing.T) {
+	c := newEnvScopeTestCore(t)
+	ctx := context.Background()
+
+	project, err := c.storage.CreateProject(ctx, &models.Project{Name: "solo-project"})
+	require.NoError(t, err)
+
+	_, err = c.GetEnvironmentInProject(ctx, project.ID, 999999)
+	require.Error(t, err)
+}
+
+// TestRequireLiveProjectAndEnvironment_CrossProjectMismatchRefused exercises
+// the dynamic-secrets liveness gate (shared by IssueLease/RenewLease)
+// directly: even though today's only callers pass coupled projectID/
+// environmentID fields from the same config/lease row, the gate itself must
+// independently refuse a mismatch rather than relying on that coupling to
+// always hold.
+func TestRequireLiveProjectAndEnvironment_CrossProjectMismatchRefused(t *testing.T) {
+	c := newEnvScopeTestCore(t)
+	ctx := context.Background()
+
+	projectA, err := c.storage.CreateProject(ctx, &models.Project{Name: "dyn-project-a"})
+	require.NoError(t, err)
+	projectB, err := c.storage.CreateProject(ctx, &models.Project{Name: "dyn-project-b"})
+	require.NoError(t, err)
+
+	envInB, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: projectB.ID})
+	require.NoError(t, err)
+
+	// projectID names a live project (A), but environmentID actually belongs
+	// to a different project (B) — must be refused.
+	err = c.requireLiveProjectAndEnvironment(ctx, projectA.ID, envInB.ID)
+	require.Error(t, err, "a projectID/environmentID pair spanning two different projects must be refused")
+
+	// Sanity: the correctly-paired (A, A's own environment) case still passes.
+	envInA, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "prod", ProjectID: projectA.ID})
+	require.NoError(t, err)
+	require.NoError(t, c.requireLiveProjectAndEnvironment(ctx, projectA.ID, envInA.ID))
+
+	// Sanity: environmentID == 0 (no environment scoping requested) still passes.
+	require.NoError(t, c.requireLiveProjectAndEnvironment(ctx, projectA.ID, 0))
+}

--- a/internal/core/risk_exceptions.go
+++ b/internal/core/risk_exceptions.go
@@ -53,6 +53,36 @@ func exceptionStatus(e *models.RiskException, now time.Time) string {
 // exception must sunset and be re-reviewed, not become a permanent waiver.
 const maxRiskExceptionDuration = 365 * 24 * time.Hour
 
+// validateSoDReferenceIsLiveViolation enforces that a "sod"-category risk
+// exception's reference actually names a CURRENTLY-DETECTED SoD violation
+// (Wave 6 core-sod finding #3, ISO 27001 A.5.8/A.5.3): without this, two
+// system.write holders could create-and-approve an exception for a
+// (policy, principal) pair that has never violated anything yet — or no
+// longer does — pre-emptively suppressing a violation before it's ever real
+// (or rubber-stamping one that was resolved between creation and approval).
+// That defeats dual control's whole point, which is governed acceptance of a
+// KNOWN, currently-real gap, not a blanket bypass for a future one. Applies
+// only to category "sod"; every other category's reference is free text (a
+// user, a secret, ...) with no live report to check it against. Fails closed:
+// a reference that doesn't appear in DetectSoDViolations' current output —
+// including because the scan couldn't fully evaluate the referenced
+// principal (report.Degraded) — is refused, not assumed valid.
+func (c *KeyorixCore) validateSoDReferenceIsLiveViolation(ctx context.Context, category, reference string) error {
+	if category != "sod" {
+		return nil
+	}
+	report, err := c.DetectSoDViolations(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to validate SoD violation reference: %w", err)
+	}
+	for _, v := range report.Violations {
+		if v.Reference == reference {
+			return nil
+		}
+	}
+	return fmt.Errorf("reference %q does not match any currently-detected SoD violation (see GET /sod/violations for a valid reference)", reference)
+}
+
 // CreateRiskException records a governed, time-bound acceptance of a control gap.
 // actorID is the accepting owner; expiresAt must be in the future. The exception
 // does NOT suppress anything yet: it must be separately approved by a DIFFERENT
@@ -75,6 +105,9 @@ func (c *KeyorixCore) CreateRiskException(ctx context.Context, actorID uint, tit
 	// forever (e.g. year 9999), defeating the "accepted with a sunset" governance intent.
 	if expiresAt.After(c.now().Add(maxRiskExceptionDuration)) {
 		return nil, fmt.Errorf("expires_at must be within %d days (exceptions must sunset and be re-reviewed)", int(maxRiskExceptionDuration/(24*time.Hour)))
+	}
+	if err := c.validateSoDReferenceIsLiveViolation(ctx, category, reference); err != nil {
+		return nil, err
 	}
 	created, err := c.storage.CreateRiskException(ctx, &models.RiskException{
 		Title: title, Category: category, Reference: reference, Justification: justification,
@@ -202,6 +235,16 @@ func (c *KeyorixCore) ApproveRiskException(ctx context.Context, actorID, id uint
 		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), "",
 			fmt.Sprintf("risk exception %d approval DENIED: creator %d cannot self-approve", id, actorID))
 		return fmt.Errorf("the exception's creator cannot approve it (dual control); a different system.write holder must approve")
+	}
+	// Re-validate against a FRESH DetectSoDViolations scan, not just at creation
+	// time: the referenced violation may have been resolved (or, if creation-time
+	// validation were ever bypassed, may never have existed) by the time a
+	// different approver reviews it — a stale or bogus reference must not be
+	// rubber-stamped either.
+	if err := c.validateSoDReferenceIsLiveViolation(ctx, e.Category, e.Reference); err != nil {
+		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), "",
+			fmt.Sprintf("risk exception %d approval DENIED: %v", id, err))
+		return err
 	}
 	now := c.now()
 	e.Approved = true

--- a/internal/core/risk_exceptions_live_violation_external_test.go
+++ b/internal/core/risk_exceptions_live_violation_external_test.go
@@ -1,0 +1,107 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Wave 6 core-sod finding #3: a "sod"-category risk exception's reference must
+// name a violation DetectSoDViolations is CURRENTLY reporting — otherwise two
+// system.write holders could create-and-approve an exception for a
+// (policy, principal) pair that has never violated anything (pre-emptively
+// suppressing a future violation before it exists) or that has already been
+// resolved, defeating dual control's whole point of governing acceptance of a
+// KNOWN, currently-real gap.
+
+// A reference that does not correspond to any currently-detected SoD
+// violation must be refused at creation time.
+func TestCreateRiskException_RejectsNonExistentSoDReference(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}, &models.RiskException{}))
+
+	ctx := context.Background()
+	// A policy exists, but NOBODY currently violates it — no user/machine holds
+	// both sides. The reference format is fully guessable/deterministic
+	// (sod:policy:<id>:<principalType>:<principalID>) from public policy/user
+	// IDs, which is exactly the exploit: a bogus or future-looking reference
+	// naming a (policy, principal) pair that has no live violation yet.
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
+	require.NoError(t, err)
+
+	sod, err := h.CoreService.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+	require.Empty(t, sod.Violations, "no one holds both sides yet")
+
+	bogusRef := "sod:policy:1:user:9999" // matches the reference format, but no such violation exists
+	_, err = h.CoreService.CreateRiskException(ctx, 1, "pre-authorize future SoD gap", "sod", bogusRef, "just in case", time.Now().Add(30*24*time.Hour))
+	require.Error(t, err, "a reference that names no live SoD violation must be refused")
+	assert.Contains(t, err.Error(), "does not match any currently-detected SoD violation")
+}
+
+// A reference naming a violation that IS currently live must still succeed —
+// the fix must not break the legitimate flow.
+func TestCreateRiskException_AcceptsLiveSoDReference(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}, &models.RiskException{}))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, nil) // editor → secrets.write + users.read
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
+	require.NoError(t, err)
+
+	sod, err := h.CoreService.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, sod.Violations)
+	ref := sod.Violations[0].Reference
+
+	exc, err := h.CoreService.CreateRiskException(ctx, 1, "accept for Q3 migration", "sod", ref, "temporary", time.Now().Add(30*24*time.Hour))
+	require.NoError(t, err, "a reference matching a live violation must be accepted")
+	assert.Equal(t, ref, exc.Reference)
+}
+
+// Re-validation at approval time: if the violation the exception referenced
+// gets resolved (the principal's offending role is revoked) between creation
+// and approval, approval must be refused too — a stale reference cannot be
+// rubber-stamped just because it was live at creation time.
+func TestApproveRiskException_RejectsSoDReferenceThatWentStale(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}, &models.RiskException{}))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, nil) // editor → secrets.write + users.read
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
+	require.NoError(t, err)
+
+	sod, err := h.CoreService.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, sod.Violations)
+	ref := sod.Violations[0].Reference
+
+	exc, err := h.CoreService.CreateRiskException(ctx, 1, "accept for Q3 migration", "sod", ref, "temporary", time.Now().Add(30*24*time.Hour))
+	require.NoError(t, err)
+
+	// The violation resolves before anyone approves the exception (e.g. alice's
+	// editor role is revoked) — deleted directly via storage, mirroring how
+	// AssignUserRole above seeded it, so this exercises only the SoD
+	// re-validation under test rather than any unrelated RBAC authority check.
+	require.NoError(t, h.DB.Where("user_id = ? AND role_id = ?", 10, 3).Delete(&models.UserRole{}).Error)
+
+	sodAfter, err := h.CoreService.DetectSoDViolations(ctx)
+	require.NoError(t, err)
+	require.Empty(t, sodAfter.Violations, "the violation must be gone")
+
+	err = h.CoreService.ApproveRiskException(ctx, 2, exc.ID)
+	require.Error(t, err, "approval must re-validate against a fresh scan and refuse a now-stale reference")
+	assert.Contains(t, err.Error(), "does not match any currently-detected SoD violation")
+}

--- a/internal/core/risk_exceptions_test.go
+++ b/internal/core/risk_exceptions_test.go
@@ -15,12 +15,17 @@ func riskCore(store *MockStorage, now time.Time) *KeyorixCore {
 	return &KeyorixCore{storage: store, now: func() time.Time { return now }}
 }
 
+// Category "mfa" (unlike "sod") has no live-violation report to validate
+// reference against, so this exercises plain create+audit behavior without
+// needing to stand up a DetectSoDViolations fixture. See
+// risk_exceptions_external_test.go for the "sod" category's live-reference
+// enforcement (Wave 6 core-sod finding #3).
 func TestCreateRiskException_ValidatesAndAudits(t *testing.T) {
 	now := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
 	store := new(MockStorage)
 	store.On("CreateRiskException", mock.Anything, mock.MatchedBy(func(e *models.RiskException) bool {
-		return e.Title == "accept SoD for migration" && e.Category == "sod" && e.CreatedBy == 9
-	})).Return(&models.RiskException{ID: 1, Title: "accept SoD for migration"}, nil)
+		return e.Title == "accept dormant access for migration" && e.Category == "mfa" && e.CreatedBy == 9
+	})).Return(&models.RiskException{ID: 1, Title: "accept dormant access for migration"}, nil)
 	var audited string
 	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(ev *models.AuditEvent) bool {
 		if ev.EventType == EventRiskExceptionCreated {
@@ -31,7 +36,7 @@ func TestCreateRiskException_ValidatesAndAudits(t *testing.T) {
 	})).Return(nil)
 
 	c := riskCore(store, now)
-	_, err := c.CreateRiskException(context.Background(), 9, "accept SoD for migration", "sod", "alice+roles.assign/secrets.delete", "temporary during cutover", now.AddDate(0, 0, 30))
+	_, err := c.CreateRiskException(context.Background(), 9, "accept dormant access for migration", "mfa", "alice@example.com", "temporary during cutover", now.AddDate(0, 0, 30))
 	require.NoError(t, err)
 	assert.Equal(t, EventRiskExceptionCreated, audited)
 }

--- a/internal/core/secret_move.go
+++ b/internal/core/secret_move.go
@@ -8,8 +8,10 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -62,6 +64,25 @@ func (c *KeyorixCore) MoveSecret(ctx context.Context, actorID, secretID uint, ne
 		// apply that other project's grants to it.
 		if parent.ProjectID != secret.ProjectID || parent.EnvironmentID != secret.EnvironmentID {
 			return nil, fmt.Errorf("%s: target parent %d does not belong to the same project/environment", i18n.T("ErrorValidation", nil), *newParentID)
+		}
+		// Reject moves that would introduce a cycle: the direct self-parent
+		// check above only catches *newParentID == secretID, but a folder can
+		// also be moved underneath one of its OWN descendants (e.g. A -> B ->
+		// C, then move A under C), which corrupts the tree just as badly and
+		// would send any parent-chain walk (breadcrumbs, ACL inheritance in
+		// HasSecretACL) into an infinite loop. Walk the proposed new parent's
+		// ancestor chain — reusing the same bounded, cycle-safe walk
+		// GetSecretAncestors already provides for ACL folder inheritance — and
+		// refuse the move if secretID appears in it, meaning newParentID is a
+		// descendant of the node being moved.
+		ancestors, err := c.storage.GetSecretAncestors(ctx, *newParentID)
+		if err != nil && !errors.Is(err, storage.ErrUnsupportedByBackend) {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		for _, ancestorID := range ancestors {
+			if ancestorID == secretID {
+				return nil, fmt.Errorf("%s: cannot move a node into its own descendant", i18n.T("ErrorValidation", nil))
+			}
 		}
 		secret.ParentID = newParentID
 	} else {

--- a/internal/core/secret_move_test.go
+++ b/internal/core/secret_move_test.go
@@ -244,6 +244,74 @@ func TestMoveSecret_ZeroSecretID(t *testing.T) {
 	assert.Contains(t, err.Error(), "required")
 }
 
+// createFolder is a small helper for the descendant-cycle tests below: it
+// creates a folder node (IsSecret=false) in project/env 1, optionally under
+// parentID.
+func createFolder(t *testing.T, c *KeyorixCore, name string, parentID *uint) uint {
+	t.Helper()
+	ctx := context.Background()
+	f, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: name, ProjectID: 1, EnvironmentID: 1,
+		Type: "folder", OwnerID: 1, IsSecret: false, Status: "active",
+		ParentID: parentID, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	return f.ID
+}
+
+// TestMoveSecret_RefusesDescendantCycle builds A -> B -> C (A is B's parent,
+// B is C's parent) and asserts that moving A to become a child of its own
+// grandchild C is refused: the direct self-parent guard (*newParentID ==
+// secretID) does not catch this, since A != C — only walking C's ancestor
+// chain (C -> B -> A) reveals that A is being moved under its own descendant.
+func TestMoveSecret_RefusesDescendantCycle(t *testing.T) {
+	c, _, _, _ := newMoveFixture(t)
+	ctx := context.Background()
+
+	a := createFolder(t, c, "A", nil)
+	b := createFolder(t, c, "B", &a)
+	cc := createFolder(t, c, "C", &b)
+
+	_, err := c.MoveSecret(ctx, 1, a, &cc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "descendant")
+}
+
+// TestMoveSecret_RefusesDescendantCycle_Deeper is the same scenario one level
+// deeper: A -> B -> C -> D, move A under D (A's great-grandchild). Confirms
+// the ancestor walk isn't accidentally limited to a single hop.
+func TestMoveSecret_RefusesDescendantCycle_Deeper(t *testing.T) {
+	c, _, _, _ := newMoveFixture(t)
+	ctx := context.Background()
+
+	a := createFolder(t, c, "A", nil)
+	b := createFolder(t, c, "B", &a)
+	cc := createFolder(t, c, "C", &b)
+	d := createFolder(t, c, "D", &cc)
+
+	_, err := c.MoveSecret(ctx, 1, a, &d)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "descendant")
+}
+
+// TestMoveSecret_AllowsNonDescendantMove is the legitimate counterpart to the
+// two cycle tests above: given the same A -> B -> C chain plus an unrelated
+// folder E, moving C under E (not a descendant of C) must still succeed.
+func TestMoveSecret_AllowsNonDescendantMove(t *testing.T) {
+	c, _, _, _ := newMoveFixture(t)
+	ctx := context.Background()
+
+	a := createFolder(t, c, "A", nil)
+	b := createFolder(t, c, "B", &a)
+	cc := createFolder(t, c, "C", &b)
+	e := createFolder(t, c, "E", nil)
+
+	updated, err := c.MoveSecret(ctx, 1, cc, &e)
+	require.NoError(t, err)
+	require.NotNil(t, updated.ParentID)
+	assert.Equal(t, e, *updated.ParentID)
+}
+
 // TestMoveFolder_ToAnotherFolder moves a folder node into a sibling folder.
 func TestMoveFolder_ToAnotherFolder(t *testing.T) {
 	c, _, folderID, db := newMoveFixture(t)

--- a/internal/core/secret_render.go
+++ b/internal/core/secret_render.go
@@ -12,6 +12,22 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/secrettemplate"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// timingCanaryID stands in for a real environment/secret ID when equalizing
+// resolution timing (see equalizeReferenceResolutionCost): auto-increment IDs
+// start at 1, so this can never collide with a real row, and every lookup
+// against it is a guaranteed, harmless miss.
+const timingCanaryID = ^uint(0)
+
+// timingCanaryPlaintext/timingCanaryAAD are fixed, non-secret inputs used only
+// to exercise the secret-value encryptor's real cost (KMS wrap + AES-256-GCM)
+// when a render reference must NOT trigger a real decrypt — see
+// equalizeReferenceResolutionCost. Never persisted; the result is discarded.
+var (
+	timingCanaryPlaintext = []byte("keyorix-render-timing-equalizer")     // NOSONAR -- not a credential; timing-equalization sentinel
+	timingCanaryAAD       = []byte("keyorix-render-timing-equalizer-aad") // NOSONAR -- not a credential; timing-equalization sentinel
 )
 
 // RenderSecretTemplate expands ${secret:<environment>/<name>} references in template
@@ -58,46 +74,175 @@ func (c *KeyorixCore) RenderSecretTemplate(ctx context.Context, template string,
 		envByName[e.Name] = e.ID
 	}
 
-	return secrettemplate.Render(template, func(ref string) (string, error) {
-		envName, secretName, err := splitRenderRef(ref)
-		if err != nil {
-			return "", err
-		}
-		envID, ok := envByName[envName]
-		if !ok {
-			// TMPL-002: use the same sentinel as "secret not found" to avoid leaking
-			// the environment name in the HTTP response via sendRenderTemplateError.
-			return "", ErrSecretRefNotFound
-		}
-		secret, err := c.storage.GetSecretByName(ctx, secretName, projectID, envID)
-		if err != nil || secret == nil {
-			// A reference to a name that doesn't exist. Deliberately the SAME sentinel
-			// (same error, same eventual HTTP status/message) as "exists but you can't
-			// read it" below — see the permission check for why (#181).
-			return "", ErrSecretRefNotFound
-		}
-		// Run the permission check BEFORE anything that could distinguish this from the
-		// "doesn't exist" branch above. GetSecretByName has no ACL of its own, so if we
-		// let a permission failure surface its own distinct error/status here, a
-		// `viewer`-role project member with no access to this secret could enumerate
-		// candidate names via ${secret:<env>/<guess>} and learn existence per guess from
-		// 404-vs-403 alone — info never surfaced by their normal scoped listing. Folding
-		// both outcomes into the identical ErrSecretRefNotFound closes that oracle (#181).
-		if _, err := c.ValidateSecretAccess(ctx, secret.ID, userID); err != nil {
-			return "", ErrSecretRefNotFound
-		}
-		val, err := c.getSecretValueForUser(ctx, secret.ID, userID)
-		if err != nil {
-			return "", err
-		}
-		// Record the read like the single-secret read path does, so a bulk render is
-		// auditable and visible to the anomaly detector (detached so it survives the
-		// request and never blocks the render).
-		goSafe(func() {
-			c.LogSecretReadWithProject(DetachedAuditContext(ctx), userID, secret.ID, projectID, username, secretName, ip, ua)
-		}) // #nosec G118
-		return string(val), nil
+	// staged accumulates every reference successfully resolved while checking the
+	// template, in first-seen order (secrettemplate.Render resolves distinct
+	// references in exactly that order via stageRenderRef below). Its max-reads
+	// budget consumption and secret.read audit emission are deferred to the commit
+	// loop below and applied ONLY once the ENTIRE template is confirmed to render
+	// successfully. Without this, a template naming N references where a LATER one
+	// fails would leave the earlier, successfully-decrypted-but-ultimately-discarded
+	// ones "half charged": budget consumed and an audit trail generated for values
+	// that were never delivered to anyone, and a large template with one
+	// deliberately-failing reference could be used to probe/burn another read's
+	// budget or flood the audit trail with reads that produced no output. This
+	// extends the function's existing "fails the whole render, no partial output"
+	// contract to its side effects, not just its return value.
+	var staged []*stagedSecretRead
+
+	output, err := secrettemplate.Render(template, func(ref string) (string, error) {
+		return c.stageRenderRef(ctx, ref, projectID, userID, envByName, &staged)
 	})
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range staged {
+		if err := c.commitStagedSecretRead(ctx, s, projectID, userID, username, ip, ua); err != nil {
+			return "", err
+		}
+	}
+	return output, nil
+}
+
+// stagedSecretRead holds a reference successfully resolved during
+// RenderSecretTemplate's staging pass (stageRenderRef): the permission check
+// passed and the value decrypted cleanly, but the max-reads budget consumption
+// and secret.read audit emission for it have NOT been committed yet — see
+// RenderSecretTemplate's commit loop.
+type stagedSecretRead struct {
+	secret     *models.SecretNode
+	version    *models.SecretVersion
+	secretName string
+}
+
+// stageRenderRef resolves one secret reference for RenderSecretTemplate: it runs
+// the permission check and decrypts the value, but does NOT consume max-reads
+// budget or emit a secret.read audit event — those are staged into *staged and
+// committed by the caller only once the WHOLE template is confirmed to render
+// successfully.
+//
+// It also performs the SAME SHAPE of DB lookup and decrypt-cost work regardless
+// of whether the reference turns out to be unknown, forbidden, or readable — see
+// equalizeReferenceResolutionCost — so response timing can't be used to tell the
+// three cases apart, defeating this function's own anti-enumeration design (#181).
+func (c *KeyorixCore) stageRenderRef(ctx context.Context, ref string, projectID, userID uint, envByName map[string]uint, staged *[]*stagedSecretRead) (string, error) {
+	envName, secretName, err := splitRenderRef(ref)
+	if err != nil {
+		return "", err
+	}
+	envID, ok := envByName[envName]
+	if !ok {
+		// TMPL-002: fall through to the SAME GetSecretByName call a known
+		// environment would make, against a canary ID that can never match a real
+		// row, instead of returning immediately — an unknown environment must not
+		// resolve FASTER than a known one, or timing alone reveals which case
+		// occurred (also avoids leaking the environment name in the HTTP response
+		// via sendRenderTemplateError).
+		envID = timingCanaryID
+	}
+	secret, err := c.storage.GetSecretByName(ctx, secretName, projectID, envID)
+	if err != nil || secret == nil {
+		// A reference to a name that doesn't exist. Deliberately the SAME sentinel
+		// (same error, same eventual HTTP status/message) as "exists but you can't
+		// read it" below — see the permission check for why (#181).
+		c.equalizeReferenceResolutionCost(ctx, userID, nil)
+		return "", ErrSecretRefNotFound
+	}
+	// Run the permission check BEFORE anything that could distinguish this from the
+	// "doesn't exist" branch above. GetSecretByName has no ACL of its own, so if we
+	// let a permission failure surface its own distinct error/status here, a
+	// `viewer`-role project member with no access to this secret could enumerate
+	// candidate names via ${secret:<env>/<guess>} and learn existence per guess from
+	// 404-vs-403 alone — info never surfaced by their normal scoped listing. Folding
+	// both outcomes into the identical ErrSecretRefNotFound closes that oracle (#181).
+	if _, err := c.ValidateSecretAccess(ctx, secret.ID, userID); err != nil {
+		c.equalizeReferenceResolutionCost(ctx, userID, secret)
+		return "", ErrSecretRefNotFound
+	}
+	// From here on this mirrors getSecretValueForUser's body exactly, minus the
+	// max-reads increment (deferred to commitStagedSecretRead).
+	if err := c.enforceSecretReadGuards(ctx, secret, userID); err != nil {
+		return "", err
+	}
+	version, err := c.storage.GetLatestSecretVersion(ctx, secret.ID)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", i18n.T("ErrorVersionNotFound", nil), err)
+	}
+	val, err := c.decryptVersionValue(secret, version)
+	if err != nil {
+		return "", err
+	}
+	*staged = append(*staged, &stagedSecretRead{secret: secret, version: version, secretName: secretName})
+	return string(val), nil
+}
+
+// equalizeReferenceResolutionCost performs the same SHAPE of DB lookup and
+// decrypt-cost work that a successful reference resolution performs, so a
+// caller cannot use response timing to tell "reference doesn't exist" (secret
+// == nil) apart from "reference exists but userID may not read it" (secret !=
+// nil) apart from "reference exists and is readable". Mirrors the
+// dummy-bcrypt-hash technique VerifyPasswordCredentials uses for unknown-user
+// logins (bcrypt_cost.go): run the SAME real, expensive primitive on a fixed
+// canary input rather than skipping it.
+//
+// Scope: this closes the dominant, easily-measurable gap — a not-found
+// reference costing zero DB round trips and no decrypt versus a readable one
+// costing several DB round trips plus a real decrypt. It does NOT attempt to
+// make CheckSecretPermission's OWN internal cost constant across every one of
+// its (owner/share/group/ACL/RBAC) branches — that variability is
+// architectural and already a documented residual gap (see the #G10 comment
+// above), not something a per-reference timing equalizer here can close.
+func (c *KeyorixCore) equalizeReferenceResolutionCost(ctx context.Context, userID uint, secret *models.SecretNode) {
+	if secret == nil {
+		// No real secret to check; ValidateSecretAccess still walks its normal
+		// first step (a GetSecret lookup) against a canary ID that can never
+		// exist before failing, giving this branch the same representative
+		// DB-call shape a genuine permission check pays.
+		_, _ = c.ValidateSecretAccess(ctx, timingCanaryID, userID)
+		_, _ = c.storage.GetLatestSecretVersion(ctx, timingCanaryID)
+	} else {
+		// The permission check already ran for real (and denied) by the time this
+		// is called; pad with the SAME read-guard + version-lookup shape the
+		// readable path pays next, using the real (existing) secret — read-only,
+		// so this is harmless even though the caller isn't authorized to read its
+		// value.
+		_ = c.enforceSecretReadGuards(ctx, secret, userID)
+		_, _ = c.storage.GetLatestSecretVersion(ctx, secret.ID)
+	}
+	if c.secretValueEncryptor != nil {
+		// Real crypto cost (KMS wrap + AES-256-GCM) — the same primitive the
+		// readable path's decrypt pays — on fixed, non-secret canary input.
+		_, _, _ = c.secretValueEncryptor.EncryptSecretWithAAD(timingCanaryPlaintext, timingCanaryAAD)
+	}
+}
+
+// commitStagedSecretRead applies the max-reads budget consumption and emits the
+// secret.read audit event (+ access log) for one staged reference — the
+// deferred side effects of a reference RenderSecretTemplate has already
+// confirmed is part of a successful render. Mirrors readVersionValue's
+// max-reads enforcement (versions.go); the value itself was already decrypted
+// during staging, so there's nothing left to decrypt here.
+func (c *KeyorixCore) commitStagedSecretRead(ctx context.Context, s *stagedSecretRead, projectID, userID uint, username, ip, ua string) error {
+	if s.secret.MaxReads != nil && *s.secret.MaxReads > 0 {
+		ok, err := c.storage.TryIncrementSecretNodeReadCount(ctx, s.secret.ID, *s.secret.MaxReads)
+		if err != nil {
+			return fmt.Errorf("max-reads enforcement failed: %w", err)
+		}
+		if !ok {
+			return fmt.Errorf("%s", i18n.T("ErrorMaxReadsExceeded", nil))
+		}
+		// Best-effort per-version read_count (CLI/gRPC display only, not the
+		// enforcement mechanism above): a failure here must not block an
+		// already-authorized read.
+		_, _ = c.storage.TryIncrementSecretReadCount(ctx, s.version.ID, *s.secret.MaxReads)
+	}
+	// Record the read like the single-secret read path does, so a bulk render is
+	// auditable and visible to the anomaly detector (detached so it survives the
+	// request and never blocks the render).
+	goSafe(func() {
+		c.LogSecretReadWithProject(DetachedAuditContext(ctx), userID, s.secret.ID, projectID, username, s.secretName, ip, ua)
+	}) // #nosec G118
+	return nil
 }
 
 // splitRenderRef splits "<environment>/<name>"; the name may contain further slashes.

--- a/internal/core/secret_render_test.go
+++ b/internal/core/secret_render_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -295,4 +296,165 @@ func TestRenderSecretTemplate_RejectsTooManyDistinctReferences(t *testing.T) {
 	var n int64
 	require.NoError(t, db.Model(&models.SecretAccessLog{}).Count(&n).Error)
 	assert.Zero(t, n, "an over-cap template must be rejected before resolving/reading any secret")
+}
+
+// callRecordingStorage wraps a real *store.LocalStorage and records the sequence
+// of GetSecret / GetSecretByName / GetLatestSecretVersion calls made through it,
+// delegating every other method (and the real behavior of these three) to the
+// embedded implementation. Used by
+// TestRenderSecretTemplate_EqualizesResolutionCostShape to assert the SAME SET
+// of storage calls happens whether a reference doesn't exist, exists but is
+// forbidden, or exists and is readable — the timing side-channel closed by
+// equalizeReferenceResolutionCost in secret_render.go.
+type callRecordingStorage struct {
+	*store.LocalStorage
+	mu    sync.Mutex
+	calls []string
+}
+
+func (s *callRecordingStorage) record(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, name)
+}
+
+func (s *callRecordingStorage) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = nil
+}
+
+func (s *callRecordingStorage) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+func (s *callRecordingStorage) GetSecret(ctx context.Context, id uint) (*models.SecretNode, error) {
+	s.record("GetSecret")
+	return s.LocalStorage.GetSecret(ctx, id)
+}
+
+func (s *callRecordingStorage) GetSecretByName(ctx context.Context, name string, projectID, environmentID uint) (*models.SecretNode, error) {
+	s.record("GetSecretByName")
+	return s.LocalStorage.GetSecretByName(ctx, name, projectID, environmentID)
+}
+
+func (s *callRecordingStorage) GetLatestSecretVersion(ctx context.Context, secretID uint) (*models.SecretVersion, error) {
+	s.record("GetLatestSecretVersion")
+	return s.LocalStorage.GetLatestSecretVersion(ctx, secretID)
+}
+
+// #<timing finding>: RenderSecretTemplate's per-reference resolution must perform
+// the SAME SHAPE of DB lookup work — GetSecretByName, GetSecret, and
+// GetLatestSecretVersion all invoked — whether the reference doesn't exist,
+// exists but is forbidden, or exists and is readable. Before the fix, a
+// nonexistent reference returned after GetSecretByName alone (skipping GetSecret
+// and GetLatestSecretVersion entirely) and a forbidden reference returned after
+// GetSecretByName + GetSecret (skipping GetLatestSecretVersion) — cheaper, and
+// therefore measurably faster, than the readable case. A caller who can submit
+// templates with guessed references and measure response time could use that
+// gap to tell "doesn't exist" apart from "exists but forbidden" apart from
+// "exists and readable", defeating this function's own anti-enumeration design
+// (#181). This is a structural stand-in for a true timing measurement (flaky in
+// a unit test): it asserts the call SET is now uniform, which is what makes the
+// three cases' cost uniform.
+func TestRenderSecretTemplate_EqualizesResolutionCostShape(t *testing.T) {
+	ctx := context.Background()
+	c, _, projectID, _ := newRenderFixture(t)
+
+	realStorage, ok := c.storage.(*store.LocalStorage)
+	require.True(t, ok, "fixture must back RenderSecretTemplate with *store.LocalStorage")
+	spy := &callRecordingStorage{LocalStorage: realStorage}
+	c.storage = spy
+
+	wantCalls := []string{"GetSecretByName", "GetSecret", "GetLatestSecretVersion"}
+
+	spy.reset()
+	_, err := c.RenderSecretTemplate(ctx, "${secret:production/does-not-exist}", projectID, 1, "owner", "10.0.0.1", "ua")
+	require.Error(t, err)
+	notFoundCalls := spy.snapshot()
+
+	spy.reset()
+	// User 2 owns nothing and has no share on db-password, which DOES exist.
+	_, err = c.RenderSecretTemplate(ctx, "${secret:production/db-password}", projectID, 2, "viewer", "10.0.0.1", "ua")
+	require.Error(t, err)
+	forbiddenCalls := spy.snapshot()
+
+	spy.reset()
+	_, err = c.RenderSecretTemplate(ctx, "${secret:production/db-password}", projectID, 1, "owner", "10.0.0.1", "ua")
+	require.NoError(t, err)
+	readableCalls := spy.snapshot()
+
+	cases := map[string][]string{
+		"not-found": notFoundCalls,
+		"forbidden": forbiddenCalls,
+		"readable":  readableCalls,
+	}
+	for label, calls := range cases {
+		got := make(map[string]bool, len(calls))
+		for _, c := range calls {
+			got[c] = true
+		}
+		for _, want := range wantCalls {
+			assert.True(t, got[want], "%s case: expected a %s call among %v", label, want, calls)
+		}
+	}
+}
+
+// #<rollback finding>: a template naming N references where a LATER one fails
+// must not leave the earlier, successfully-resolved-but-ultimately-discarded
+// references "half charged" — no secret.read audit event, no access-log row,
+// and no max-reads budget consumed for any of them, since the overall render
+// produced no output. Extends the documented "fails the whole render, no
+// partial output" contract to RenderSecretTemplate's side effects, not just its
+// return value — otherwise a caller could submit a large template naming many
+// real references plus one deliberately-failing one to burn through a read
+// budget and flood the audit trail with reads that delivered nothing.
+func TestRenderSecretTemplate_NoSideEffectsWhenLaterReferenceFails(t *testing.T) {
+	ctx := context.Background()
+	c, db, projectID, dbSecretID := newRenderFixture(t)
+
+	envs, err := c.storage.ListEnvironmentsByProject(ctx, projectID)
+	require.NoError(t, err)
+	require.Len(t, envs, 1)
+
+	maxReads := 5
+	apiKey, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+		Name: "api-key", ProjectID: projectID, EnvironmentID: envs[0].ID, Type: "password",
+		OwnerID: 1, IsSecret: true, MaxReads: &maxReads, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	_, err = c.storage.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: apiKey.ID, VersionNumber: 1, EncryptedValue: []byte("a-p-i"),
+	})
+	require.NoError(t, err)
+
+	// The first two references resolve cleanly; the third names a secret that
+	// doesn't exist, so the whole render fails.
+	tmpl := "${secret:production/db-password}${secret:production/api-key}${secret:production/does-not-exist}"
+	_, err = c.RenderSecretTemplate(ctx, tmpl, projectID, 1, "owner", "10.0.0.1", "ua")
+	require.Error(t, err)
+
+	// Give any (incorrect) stray audit/access-log writes a moment to land before
+	// asserting they never happened.
+	time.Sleep(30 * time.Millisecond)
+
+	var accessLogs int64
+	require.NoError(t, db.Model(&models.SecretAccessLog{}).Count(&accessLogs).Error)
+	assert.Zero(t, accessLogs, "no secret_access_logs row for any reference in a template whose render ultimately failed")
+
+	var auditEvents int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "secret.read").Count(&auditEvents).Error)
+	assert.Zero(t, auditEvents, "no secret.read audit event for any reference in a template whose render ultimately failed")
+
+	reloadedAPIKey, err := c.storage.GetSecret(ctx, apiKey.ID)
+	require.NoError(t, err)
+	assert.Zero(t, reloadedAPIKey.ReadCount, "max-reads budget must not be consumed for a reference in a template whose render ultimately failed")
+
+	reloadedDB, err := c.storage.GetSecret(ctx, dbSecretID)
+	require.NoError(t, err)
+	assert.Zero(t, reloadedDB.ReadCount)
 }

--- a/internal/storage/store/local_audit_chain.go
+++ b/internal/storage/store/local_audit_chain.go
@@ -13,6 +13,7 @@ package store
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"strconv"
 	"time"
@@ -34,15 +35,53 @@ const auditAdvisoryLockKey = 0x4B455941_55444954 // "KEYAUDIT"
 const auditChainVerifyBatch = 1000
 
 // computeAuditEntryHash hashes an event's semantically meaningful fields plus
-// prevHash, in a fixed order with null separators (so field boundaries are
-// unambiguous). The DB-assigned id is excluded — it is unknown before insert and
-// chain linkage already pins position. event_time is encoded as Unix
-// microseconds to round-trip identically on Postgres (µs precision) and SQLite.
+// prevHash, in a fixed order, each field preceded by its own big-endian
+// uint64 byte length ("length-prefixed" / TLV-style encoding). The DB-assigned
+// id is excluded — it is unknown before insert and chain linkage already pins
+// position. event_time is encoded as Unix microseconds to round-trip
+// identically on Postgres (µs precision) and SQLite.
+//
+// Length-prefixing (not a delimiter byte) is required for the encoding to be
+// injective: several of these fields are free-form strings that can
+// legitimately (or, via IngestAuditEventProxy's raw passthrough on
+// SQLite-backed deployments — Postgres TEXT columns reject embedded NUL
+// outright, so this was only ever live there) contain ANY byte value,
+// including a delimiter byte. A single NUL-separated write() (the prior
+// scheme) is then non-injective: "a\x00" + "bc" and "a" + "\x00bc" concatenate
+// to the identical byte stream and therefore hash identically, even though
+// the field values differ — defeating the tamper-evidence guarantee this hash
+// chain exists to provide. A length prefix carried out-of-band (as a fixed-
+// width binary integer, never as characters that could themselves be part of
+// the content) removes that ambiguity regardless of what bytes a field
+// contains.
+//
+// BREAKING CHANGE / no backward compatibility with pre-fix hashes: this
+// encoding is NOT the same byte stream the old NUL-delimited scheme produced,
+// even for a field that never contained a NUL byte — so the change is a hash-
+// format break, not a content-preserving refactor. VerifyAuditChain re-derives
+// every row's entry_hash from this same function (see verifyBatchEvents), so
+// on any deployment that already has chained audit_events rows written before
+// this fix, re-verifying those rows post-upgrade WILL recompute a different
+// hash than what is stored and report the chain broken at the first pre-
+// upgrade row — indistinguishable, from VerifyAuditChain's callers' point of
+// view, from real tampering. There is no per-row encoding-version marker in
+// the schema to let verification pick the right algorithm per row (adding one
+// is a real schema migration, out of scope here), and the existing retention
+// re-anchor mechanism (audit_retention_anchor.go) does not help either — it
+// only substitutes the genesis-prevHash requirement for the anchored row, it
+// does not skip re-deriving that row's own entry_hash. Coordinating a fix for
+// deployments with pre-existing audit history (e.g. a one-time migration that
+// re-derives entry_hash/prev_hash for every existing row under this new
+// encoding, in ascending id order, before the upgrade takes live traffic) is
+// left to the integrating release process; this change intentionally does not
+// attempt that migration itself, per this change's own review discussion.
 func computeAuditEntryHash(e *models.AuditEvent, prevHash string) string {
 	h := sha256.New()
+	var lenBuf [8]byte
 	write := func(s string) {
+		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(s)))
+		h.Write(lenBuf[:])
 		h.Write([]byte(s))
-		h.Write([]byte{0})
 	}
 	uptr := func(p *uint) string {
 		if p == nil {

--- a/internal/storage/store/local_audit_chain_test.go
+++ b/internal/storage/store/local_audit_chain_test.go
@@ -276,3 +276,53 @@ func TestComputeAuditEntryHash_Deterministic(t *testing.T) {
 		computeAuditEntryHash(e, "different-prev"),
 		"prev_hash is bound into the entry hash")
 }
+
+// TestComputeAuditEntryHash_FieldBoundaryCollisionRejected is the regression
+// test for the NUL-delimiter injectivity bug (findings-store/store-audit.json#1).
+//
+// IPAddress and Description are adjacent in computeAuditEntryHash's write
+// order. Under the OLD scheme (each field followed by a single 0x00
+// separator, no length prefix), these two field-value pairs concatenate to
+// the byte-identical stream even though the field values themselves differ:
+//
+//	e1: IPAddress="1.2.3.4\x00evil", Description="normal"
+//	    -> "1.2.3.4" 0x00 "evil" 0x00 "normal" 0x00
+//	e2: IPAddress="1.2.3.4",         Description="evil\x00normal"
+//	    -> "1.2.3.4" 0x00 "evil" 0x00 "normal" 0x00   (same bytes!)
+//
+// e2's Description simply contains the 0x00 delimiter byte itself plus the
+// bytes that used to be e1's next field content — the delimiter byte inside a
+// field's own value is indistinguishable from a real field boundary. A
+// SQLite-backed deployment accepts an embedded NUL in a TEXT column (unlike
+// Postgres), and IngestAuditEventProxy passes a caller-supplied
+// models.AuditEvent straight to LogAuditEvent without the control-character
+// stripping the normal emitAudit path applies — so a caller reaching that
+// proxy can supply exactly this kind of value.
+//
+// The length-prefixed encoding must NOT collide here: the byte length of each
+// field is carried out-of-band, so no field content — NUL or otherwise — can
+// be mistaken for a length prefix or shift a boundary.
+func TestComputeAuditEntryHash_FieldBoundaryCollisionRejected(t *testing.T) {
+	tr := true
+	at := time.Unix(1_700_000_000, 0).UTC()
+
+	base := models.AuditEvent{
+		EventType: "secret.read", Success: &tr, EventTime: at, ActorType: "user",
+	}
+
+	e1 := base
+	e1.IPAddress = "1.2.3.4\x00evil"
+	e1.Description = "normal"
+
+	e2 := base
+	e2.IPAddress = "1.2.3.4"
+	e2.Description = "evil\x00normal"
+
+	require.NotEqual(t, e1.IPAddress, e2.IPAddress, "sanity: the two events carry different IPAddress values")
+	require.NotEqual(t, e1.Description, e2.Description, "sanity: the two events carry different Description values")
+
+	h1 := computeAuditEntryHash(&e1, auditGenesisHash)
+	h2 := computeAuditEntryHash(&e2, auditGenesisHash)
+	assert.NotEqual(t, h1, h2,
+		"logically different field values must never hash to the same entry_hash, regardless of embedded delimiter-like bytes")
+}

--- a/internal/trust/trust.go
+++ b/internal/trust/trust.go
@@ -11,6 +11,7 @@
 package trust
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
@@ -22,7 +23,11 @@ import (
 )
 
 // Purpose scopes a key to one use, so an update-signing key can never validate a license
-// (independent blast radii).
+// (independent blast radii). This is enforced, not just a naming convention: Add refuses to
+// register the same raw public key under two different purposes (see Add below) — because an
+// ed25519 signature carries no purpose tag of its own, a key shared across purposes would
+// otherwise let a signature valid for one purpose (e.g. an update manifest) verify as valid
+// for the other (e.g. a license), defeating the independent-blast-radii guarantee entirely.
 type Purpose string
 
 const (
@@ -38,6 +43,9 @@ var (
 	ErrUnknownKey = errors.New("trust: no trusted key for key-id")
 	// ErrBadSignature means the signature did not verify against the trusted key.
 	ErrBadSignature = errors.New("trust: signature verification failed")
+	// ErrKeyReusedAcrossPurposes means Add was asked to register a public key that is
+	// already trusted under a different purpose. Refused: see the Purpose doc comment.
+	ErrKeyReusedAcrossPurposes = errors.New("trust: public key is already trusted for a different purpose")
 )
 
 // KeyRegistry holds trusted public keys keyed by purpose and key-id.
@@ -58,7 +66,20 @@ func NewRegistry() *KeyRegistry {
 	return &KeyRegistry{keys: make(map[Purpose]map[string]ed25519.PublicKey)}
 }
 
-// Add trusts pub for (purpose, keyID). It rejects a key of the wrong size.
+// Add trusts pub for (purpose, keyID). It rejects a key of the wrong size, and — this is the
+// enforcement point for the Purpose doc comment's "independent blast radii" guarantee — it
+// refuses to register a public key that is already trusted under a DIFFERENT purpose.
+//
+// Without this check, the purpose scoping is purely a naming/registration convention: an
+// ed25519 signature carries no domain/purpose tag of its own, so if the SAME key were ever
+// registered under both PurposeUpdate and PurposeLicense (by operator mistake, or a build
+// misconfiguration that embeds the same key material for both -X vars), a signature produced
+// for one purpose would trivially verify as valid for the other too. Catching the reuse here,
+// at registration time, means the mistake fails the whole registry construction (e.g.
+// DefaultRegistry() at process startup) instead of silently weakening trust at verify time.
+//
+// A re-Add of the SAME key under the SAME purpose (e.g. under a different key-id, for
+// rotation) is unaffected — only cross-purpose reuse is refused.
 func (r *KeyRegistry) Add(purpose Purpose, keyID string, pub ed25519.PublicKey) error {
 	if len(pub) != ed25519.PublicKeySize {
 		return fmt.Errorf("trust: bad public key size %d (want %d)", len(pub), ed25519.PublicKeySize)
@@ -68,6 +89,17 @@ func (r *KeyRegistry) Add(purpose Purpose, keyID string, pub ed25519.PublicKey) 
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	for otherPurpose, ids := range r.keys {
+		if otherPurpose == purpose {
+			continue
+		}
+		for otherKeyID, otherPub := range ids {
+			if bytes.Equal(otherPub, pub) {
+				return fmt.Errorf("%w: key-id %q (purpose %q) is the same public key already trusted as key-id %q for purpose %q",
+					ErrKeyReusedAcrossPurposes, keyID, purpose, otherKeyID, otherPurpose)
+			}
+		}
+	}
 	if r.keys[purpose] == nil {
 		r.keys[purpose] = make(map[string]ed25519.PublicKey)
 	}

--- a/internal/trust/trust_test.go
+++ b/internal/trust/trust_test.go
@@ -48,6 +48,64 @@ func TestRegistry_AddRejectsBadKey(t *testing.T) {
 	assert.Error(t, r.Add(PurposeUpdate, "", pub), "empty key-id is rejected")
 }
 
+// TestRegistry_AddRejectsKeyReuseAcrossPurposes is the regression test for the documented
+// "independent blast radii" guarantee (see the Purpose doc comment): registering the SAME
+// ed25519 public key under both PurposeUpdate and PurposeLicense must be refused, because
+// without this check a signature valid for one purpose would trivially verify as valid for
+// the other too (ed25519 signatures carry no purpose tag of their own).
+func TestRegistry_AddRejectsKeyReuseAcrossPurposes(t *testing.T) {
+	pub, priv, err := GenerateKey()
+	require.NoError(t, err)
+
+	r := NewRegistry()
+	require.NoError(t, r.Add(PurposeUpdate, "upd-1", pub))
+
+	// Registering the identical key under a different purpose must be refused.
+	err = r.Add(PurposeLicense, "lic-1", pub)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrKeyReusedAcrossPurposes)
+
+	// The registry must not have been mutated by the rejected Add: the license purpose
+	// still has no trusted keys at all.
+	assert.Empty(t, r.KeyIDs(PurposeLicense))
+
+	// And critically: a signature produced under the update purpose must still fail to
+	// verify against the license purpose, because the key was never actually registered
+	// there — the exploit this guards against (a cross-purpose signature verifying) never
+	// gets the chance to occur.
+	msg := []byte("update manifest bytes")
+	sig := ed25519.Sign(priv, msg)
+	require.NoError(t, r.Verify(PurposeUpdate, "upd-1", msg, sig))
+	assert.ErrorIs(t, r.Verify(PurposeLicense, "lic-1", msg, sig), ErrNoKeys)
+}
+
+// TestRegistry_AddAllowsSameKeySameePurposeDifferentKeyID confirms the reuse check is scoped
+// to cross-PURPOSE reuse only — re-registering the same key under the SAME purpose (e.g. for
+// key-id rotation bookkeeping) must still work.
+func TestRegistry_AddAllowsSameKeySamePurposeDifferentKeyID(t *testing.T) {
+	pub, _, err := GenerateKey()
+	require.NoError(t, err)
+
+	r := NewRegistry()
+	require.NoError(t, r.Add(PurposeUpdate, "upd-old", pub))
+	require.NoError(t, r.Add(PurposeUpdate, "upd-new", pub))
+	assert.ElementsMatch(t, []string{"upd-new", "upd-old"}, r.KeyIDs(PurposeUpdate))
+}
+
+// TestRegistry_AddLegitimateSinglePurposeUseStillWorks confirms the ordinary, non-reused case
+// — a key registered and used consistently for exactly ONE purpose — is unaffected.
+func TestRegistry_AddLegitimateSinglePurposeUseStillWorks(t *testing.T) {
+	pub, priv, err := GenerateKey()
+	require.NoError(t, err)
+
+	r := NewRegistry()
+	require.NoError(t, r.Add(PurposeLicense, "lic-2026", pub))
+
+	msg := []byte("license payload")
+	sig := ed25519.Sign(priv, msg)
+	assert.NoError(t, r.Verify(PurposeLicense, "lic-2026", msg, sig))
+}
+
 func TestRegistry_KeyIDsSorted(t *testing.T) {
 	pub, _, _ := GenerateKey()
 	r := NewRegistry()

--- a/server/config/production.yaml
+++ b/server/config/production.yaml
@@ -19,6 +19,15 @@ server:
     allowed_origins:
       - "https://${KEYORIX_DOMAIN:-localhost}"
       - "https://www.${KEYORIX_DOMAIN:-localhost}"
+    # trusted_proxies MUST be set to your actual reverse proxy's address (or its
+    # CIDR, e.g. the LB/ingress subnet) before deploying — the example CIDR below is
+    # the loopback-only default and will NOT match a real proxy on another host.
+    # This is required for the "TLS handled by reverse proxy" topology assumed by
+    # tls.enabled=false below: without it, X-Forwarded-For/X-Real-IP are ignored and
+    # every request's client IP resolves to the PROXY's address, not the real
+    # client's — silently breaking per-client rate limiting and audit logging.
+    trusted_proxies:
+      - "127.0.0.1/32"
     tls:
       enabled: false  # TLS handled by reverse proxy
       auto_cert: false

--- a/server/main.go
+++ b/server/main.go
@@ -1498,6 +1498,16 @@ func resolvePasswordPolicy(pp config.PasswordPolicyConfig) core.PasswordPolicy {
 // protocol_versions remains a separate, still-unwired tuning field (out of scope for
 // #333 — the TLS 1.2 floor stays fixed in code) — it still only warns, not fails, so an
 // operator isn't misled into thinking it took effect.
+//
+// For HTTP specifically, a cleartext listener commonly means "TLS is terminated by a
+// reverse proxy in front of this" (the topology production.yaml/web-enabled.yaml
+// document) — but server.http.trusted_proxies defaults to empty, which makes
+// middleware.ClientIP ignore X-Forwarded-For/X-Real-IP and use the raw TCP peer address
+// (the proxy's own IP, not the real client's) for every request. That silently breaks
+// per-client rate limiting and audit logging, with no error, so warn whenever both hold:
+// this is deliberately a warning, not a fail-closed check — an empty trusted_proxies is
+// also the correct, safe setting for a listener that has NO proxy in front of it, and
+// config alone can't tell the two cases apart.
 func checkTransportTLSPosture(cfg *config.Config) error {
 	require := cfg.Security.RequireTransportTLS
 	check := func(name string, inst config.ServerInstanceConfig) error {
@@ -1523,6 +1533,9 @@ func checkTransportTLSPosture(cfg *config.Config) error {
 			return fmt.Errorf("%s listener has no TLS but security.require_transport_tls is set: refusing to serve credentials/secrets in cleartext (enable tls or front it with a TLS-terminating proxy and unset the requirement)", name)
 		}
 		log.Printf("WARNING: %s listener is serving CLEARTEXT (no TLS) — bearer tokens and secret values are unencrypted. Front it with a TLS-terminating proxy, enable tls, or set security.require_transport_tls to fail closed.", name)
+		if name == "HTTP" && len(inst.TrustedProxies) == 0 {
+			log.Printf("WARNING: HTTP listener has TLS disabled and server.http.trusted_proxies is empty. If a reverse proxy terminates TLS in front of this listener (as the cleartext warning above implies), X-Forwarded-For/X-Real-IP are being IGNORED and every client IP resolves to the proxy's address — silently breaking per-client rate limiting and audit logging. Set trusted_proxies to your proxy's address/CIDR, or ignore this if the listener truly has no proxy in front of it.")
+		}
 		return nil
 	}
 	if err := check("HTTP", cfg.Server.HTTP); err != nil {

--- a/server/transport_tls_test.go
+++ b/server/transport_tls_test.go
@@ -185,6 +185,63 @@ func TestCheckTransportTLSPosture_ProtocolVersionsStillWarns(t *testing.T) {
 	}
 }
 
+// A cleartext HTTP listener with no trusted_proxies configured must warn — that
+// combination silently breaks per-client IP derivation (rate limiting, audit logging)
+// for the documented "TLS terminated by a reverse proxy in front" topology, since
+// middleware.ClientIP falls back to the raw TCP peer (the proxy's own address) when
+// trusted_proxies is empty.
+func TestCheckTransportTLSPosture_WarnsOnEmptyTrustedProxiesWithCleartextHTTP(t *testing.T) {
+	c := cfgWith(true, false, false, false, false)
+
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	if err := checkTransportTLSPosture(c); err != nil {
+		t.Fatalf("cleartext HTTP without require must not fail: %v", err)
+	}
+	if !strings.Contains(buf.String(), "trusted_proxies") {
+		t.Errorf("expected a warning mentioning trusted_proxies, got log output: %q", buf.String())
+	}
+}
+
+// The same listener with trusted_proxies set must NOT emit that warning.
+func TestCheckTransportTLSPosture_NoTrustedProxiesWarningWhenSet(t *testing.T) {
+	c := cfgWith(true, false, false, false, false)
+	c.Server.HTTP.TrustedProxies = []string{"10.0.0.0/8"}
+
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	if err := checkTransportTLSPosture(c); err != nil {
+		t.Fatalf("cleartext HTTP without require must not fail: %v", err)
+	}
+	if strings.Contains(buf.String(), "trusted_proxies") {
+		t.Errorf("did not expect a trusted_proxies warning once it's configured, got log output: %q", buf.String())
+	}
+}
+
+// A cleartext gRPC listener has no ClientIP middleware wired to it, so it must never
+// emit the trusted_proxies warning regardless of TrustedProxies being empty.
+func TestCheckTransportTLSPosture_NoTrustedProxiesWarningForGRPC(t *testing.T) {
+	c := cfgWith(false, false, true, false, false)
+
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	if err := checkTransportTLSPosture(c); err != nil {
+		t.Fatalf("cleartext gRPC without require must not fail: %v", err)
+	}
+	if strings.Contains(buf.String(), "trusted_proxies") {
+		t.Errorf("gRPC listener must not trigger the HTTP-only trusted_proxies warning, got log output: %q", buf.String())
+	}
+}
+
 // #172: AutoCert mode must not silently discard the hardened MinVersion/CipherSuites
 // — buildAutoCertTLSConfig (the AutoCert-mode config builder) must apply the same
 // hardening as the non-AutoCert path (createTLSConfig).


### PR DESCRIPTION
## Summary

Third batch (of 6) of the 50 medium-severity Wave 6 singleton findings — all re-verified against current `main` before fixing.

1. **⚠️ Audit hash-chain encoding was non-injective (NUL-delimited fields)** — `computeAuditEntryHash` joined fields with a single `0x00` delimiter; on SQLite (Postgres TEXT rejects embedded NUL outright), a caller-supplied audit event routed through `IngestAuditEventProxy` (which bypasses the normal control-character sanitization) could contain a `0x00` byte, making two different field-value pairs hash identically — defeating the tamper-evidence guarantee. Replaced with a length-prefixed (TLV) encoding, which is unambiguously injective regardless of field content. **This is a breaking hash-format change** for any deployment with pre-existing chained `audit_events` rows: re-verifying those rows after this ships will report the chain broken starting at the first pre-upgrade row (indistinguishable from tampering), since there's no per-row encoding-version marker. No live data migration is included in this PR — it's flagged in the code's doc comment and here for the release process to coordinate (e.g. a one-time job re-deriving `entry_hash`/`prev_hash` for existing rows in ascending order, which would fully restore chain self-consistency, but touches historical audit data and deserves its own review before shipping).
2. **Trust-key purpose separation was documentation-only** — `KeyRegistry` promised an update-signing key can never validate a license, but `Add()`/`Verify()` never enforced it. Chose the narrower, non-breaking fix (reject cross-purpose key reuse at `Add()`) over domain-separating the signed message, since no release has ever shipped real trust keys (`TRUST_UPDATE_KEYS`/`TRUST_LICENSE_KEYS` are unset in CI) and several call sites sign raw bytes directly, bypassing `KeyRegistry`.
3. **`MoveSecret` only rejected direct self-parenting** — moving a folder underneath its own descendant (A→B→C, move A under C) wasn't caught, risking a corrupted tree and infinite loops in any parent-chain walker. Reused the existing bounded, cycle-safe `GetSecretAncestors` helper (already used for ACL inheritance) rather than writing a new walk.
4. **Risk-exception dual control had no forward-reference check** — two `system.write` holders could create-and-approve an exception for an SoD violation that doesn't exist (yet), pre-authorizing a future gap. Now validated against a live `DetectSoDViolations` result at both creation and approval time, so a reference that goes stale between the two is also refused.
5. **`RenderSecretTemplate` had a timing side-channel and no rollback on partial failure** — not-found/forbidden/readable references did divergent amounts of DB/decrypt work (defeating the function's own documented anti-enumeration design), and an earlier-resolved reference in a template still consumed read-budget and emitted audit events even if a later reference failed the whole render. Fixed by equalizing the DB-call/decrypt-cost shape across all three cases (mirroring the existing dummy-bcrypt-hash technique) and splitting resolution into a staging pass (no side effects) + a commit pass (only runs once the whole template is confirmed to succeed).
6. **Documented `${VAR:-default}` config interpolation didn't actually work** — `production.yaml` documented shell-style interpolation for `server.http.domain`/`allowed_origins`, but the loader never expanded it. Implemented real expansion — scoped specifically to those two fields (not a whole-file preprocessing pass), since `storage.remote.api_key` uses the identical `${VAR}` syntax for its own, separately pre-existing deferred-expansion mechanism (resolved on demand when the key is used, not at load time) that a blanket pass would have silently broken. Caught this via the full test suite and fixed it in a follow-up commit before this PR was opened.
7. **`production.yaml` assumed a reverse proxy but never set `trusted_proxies`** — silently making `ClientIP` middleware ignore forwarding headers and use the proxy's own address for every request, breaking per-client rate limiting/audit logging. Set an example value with a comment telling the operator to replace it, plus a startup warning (not a hard failure, since empty `trusted_proxies` is also correct for a listener with no proxy in front).
8. **`GetEnvironment`/`DeleteEnvironment` had inconsistent tenant scoping** vs. the already-scoped `RestoreEnvironment`. Traced every call site before deciding scope: the main HTTP delete route turned out to already be safe (its middleware resolves auth against the environment's real owning project), so the storage-interface signature was deliberately left unchanged rather than risk breaking legitimate unscoped-lookup callers. Closed the two real gaps instead: CLI `env delete --project` silently ignored the flag, and `dynamic_secrets.go`'s liveness gate never cross-checked project/environment pairing. Also surfaced (not fixed here, out of scope) a separate bug found during investigation: `CreateDynamicSecretConfig` doesn't validate `EnvironmentID` belongs to `ProjectID` — tracked for a future pass.

## Test plan

- [x] Each fix has a dedicated regression test confirmed to fail pre-fix (scoped `git stash` of production files) and pass post-fix.
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean across the full repo.
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues across 789 files.
- [x] Full `go test ./...` green except pre-existing, machine-local/unrelated failures already confirmed identical on unmodified `main`. One real cross-fix regression was caught by this pass (the config env-var expansion breaking the pre-existing `api_key` deferred-expansion test) and fixed before opening this PR — see the follow-up commit.
- [x] Every branch independently re-verified from a fresh worktree off `origin/main` before integration.

**Please read finding #1's callout above before merging** — it's a real, intentional breaking change to the audit hash format for deployments with existing audit history, and needs a coordinated decision on migration timing, not a silent merge.