### PR TITLE
fix(security): close Wave 6 medium-severity batch 5 (8 findings)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.40.0
 	golang.org/x/time v0.15.0
@@ -147,7 +148,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect

--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -119,6 +119,12 @@ type verifyResult struct {
 	AnchorToken    string `json:"anchor_token,omitempty"`
 	AnchoredAt     string `json:"anchored_at,omitempty"`
 	AnchorProvider string `json:"anchor_provider,omitempty"`
+	// AnchorTrustRootConfigured is false when the server has no TSA trust root
+	// (ca_cert_path) configured — AnchorToken above was recorded (a real RFC 3161
+	// receipt exists) but never locally verified against any root of trust. Do not
+	// read a present AnchorToken alone as proof this anchor was cryptographically
+	// confirmed.
+	AnchorTrustRootConfigured bool `json:"anchor_trust_root_configured,omitempty"`
 }
 
 var verifyCmd = &cobra.Command{
@@ -168,6 +174,11 @@ var verifyCmd = &cobra.Command{
 				fmt.Printf("  anchored at:      %s\n", v.AnchoredAt)
 				fmt.Printf("  anchor:           %s\n", v.AnchorProvider)
 				fmt.Printf("  anchor token:     %s\n", v.AnchorToken)
+				if v.AnchorTrustRootConfigured {
+					fmt.Println("  anchor verified:  yes (checked locally against the configured TSA trust root)")
+				} else {
+					fmt.Println("  anchor verified:  NO — no TSA trust root (ca_cert_path) is configured; this token was recorded but never checked against any root of trust")
+				}
 			}
 		}
 
@@ -308,6 +319,9 @@ type checkpointResult struct {
 	// here, since checkpoints are normally written by the background scheduler and
 	// this on-demand write may be the only time an operator sees this response.
 	AnchorToken string `json:"anchor_token"`
+	// AnchorTrustRootConfigured is false when no TSA trust root (ca_cert_path) is
+	// configured — see verifyResult.AnchorTrustRootConfigured for what that means.
+	AnchorTrustRootConfigured bool `json:"anchor_trust_root_configured"`
 }
 
 var checkpointCmd = &cobra.Command{
@@ -341,6 +355,9 @@ verify (broken, or a prior signed checkpoint proves a truncation).`,
 			fmt.Printf("  anchored at:    %s\n", out.AnchoredAt)
 			fmt.Printf("  anchor:         %s\n", out.AnchorProvider)
 			fmt.Printf("  anchor token:   %s\n", out.AnchorToken)
+			if !out.AnchorTrustRootConfigured {
+				fmt.Println("  anchor verified: NO — no TSA trust root (ca_cert_path) is configured; this token was recorded but never checked against any root of trust")
+			}
 		}
 		return nil
 	},

--- a/internal/cli/audit/audit_s25_test.go
+++ b/internal/cli/audit/audit_s25_test.go
@@ -56,6 +56,21 @@ func TestVerify_ValidWithAnchor(t *testing.T) {
 	require.NoError(t, verifyCmd.RunE(verifyCmd, nil))
 }
 
+// TestVerify_ValidWithVerifiedAnchor exercises the "anchor verified: yes" branch
+// (anchor_trust_root_configured=true) — the counterpart to
+// TestVerify_ValidWithAnchor, which pins the false/unverified case
+// (#baseline/notary-findings.json#1).
+func TestVerify_ValidWithVerifiedAnchor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"valid":true,"chained_events":10,"unchained_events":0,"head_hash":"deadbeef","head_id":10,"anchor_token":"dG9rZW4=","anchored_at":"2026-07-01T00:00:00Z","anchor_provider":"RFC3161/example-tsa","anchor_trust_root_configured":true}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	flagJSON = false
+	require.NoError(t, verifyCmd.RunE(verifyCmd, nil))
+}
+
 // TestVerify_ServerError exercises the c.Get error path in verifyCmd.
 func TestVerify_ServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -644,6 +644,18 @@ type KeyProviderConfig struct {
 	TPMDevice string `yaml:"tpm_device"`
 	// Fallbacks is an ordered list of providers tried when the primary fails.
 	Fallbacks []KeyProviderConfig `yaml:"fallbacks,omitempty"`
+	// AllowWeakerFallback must be explicitly set to allow a Fallbacks chain that
+	// downgrades KEK-sourcing strength — e.g. a hardware/HSM/cloud-KMS-backed
+	// provider (tpm, aws-kms, gcp-kms, azure-kms) falling back to a software-
+	// derivable one (password, file, env, exec) or to shamir. Without it, a
+	// downgrading chain is a hard startup error (crypto.DetectFallbackDowngrade):
+	// silently accepting one would mean a transient failure of the strong primary
+	// (a momentary TPM glitch, a KMS network blip) quietly drops the deployment's
+	// actual security to "whatever a local password/file/env-var can be
+	// leaked/brute-forced", with only a log line marking the moment it happened. A
+	// fallback chain that stays flat or gets stronger (e.g. one KMS region falling
+	// back to another) is unaffected and never needs this flag.
+	AllowWeakerFallback bool `yaml:"allow_weaker_fallback"`
 }
 
 type SecretsConfig struct {

--- a/internal/core/anomaly.go
+++ b/internal/core/anomaly.go
@@ -37,6 +37,25 @@ type AnomalyDetector struct {
 	// cumulative_rate rule fires for low-traffic secrets (ANOMALY-06). Defaults to
 	// defaultCumulativeRateMax when zero.
 	cumulativeRateMax int
+	// lastAuditedOffHours is the off-hours band/timezone last written to the audit
+	// log by auditBusinessHoursConfig. ApplyAnomalyConfig re-applies the persisted
+	// config (including SetBusinessHours) on every scheduler tick — see
+	// server/main.go's "Hotload" comment — so without this, an unchanged persisted
+	// config would write a fresh anomaly.business_hours_configured audit event every
+	// tick, drowning out genuine changes. nil until the first successful
+	// SetBusinessHours call, which is always audited.
+	lastAuditedOffHours *auditedOffHours
+}
+
+// auditedOffHours is the comparable subset of a SetBusinessHours call's applied
+// state, used to detect whether the band/timezone actually changed since the last
+// audit write. tz is the canonical location name (offHoursPolicy.loc.String()), not
+// the raw caller-supplied string, so "" and "UTC" — which resolve to the same
+// location — are treated as the same config rather than a spurious change.
+type auditedOffHours struct {
+	tz    string
+	start int
+	end   int
 }
 
 // minDetectionLookback is the floor for the per-pass scan window.
@@ -188,7 +207,11 @@ const EventAnomalyBusinessHoursConfigured = "anomaly.business_hours_configured" 
 // equal, checked on the FINAL merged pair, not just the raw inputs) — a start==end
 // band matches no hour in isOffHours, which would silently disable the rule with no
 // validation error and no audit trail if allowed through. Any error leaves the prior
-// policy unchanged. On success the new band is recorded as an audit event.
+// policy unchanged. On success the new band is recorded as an audit event — but only
+// the first time it's applied, or when it actually differs from what was last
+// audited (see lastAuditedOffHours). ApplyAnomalyConfig calls this on every
+// scheduler tick to hot-load the persisted config (server/main.go); without this
+// change check, an unchanged config would write a duplicate audit event every tick.
 func (d *AnomalyDetector) SetBusinessHours(ctx context.Context, tz string, startHour, endHour int) error {
 	p := defaultOffHoursPolicy()
 	if tz != "" {
@@ -216,14 +239,22 @@ func (d *AnomalyDetector) SetBusinessHours(ctx context.Context, tz string, start
 		return fmt.Errorf("anomaly business_hours: start_hour and end_hour must differ (an equal start/end band is empty and would silently disable the off_hours rule; pass 0,0 to explicitly keep the default band)")
 	}
 	d.offHours = p
-	d.auditBusinessHoursConfig(ctx, tz, p)
+	current := auditedOffHours{tz: p.loc.String(), start: p.start, end: p.end}
+	if d.lastAuditedOffHours == nil || *d.lastAuditedOffHours != current {
+		d.auditBusinessHoursConfig(ctx, tz, p)
+		d.lastAuditedOffHours = &current
+	}
 	return nil
 }
 
 // auditBusinessHoursConfig records the newly-applied off-hours band/timezone as an
-// audit event. Best-effort: a storage failure here must not undo the in-memory
-// policy change SetBusinessHours already applied, but it is logged loudly (a missed
-// audit write for a detection-control config change is itself a small gap).
+// audit event. Called by SetBusinessHours only when the band/timezone actually
+// changed since the last audit write (see lastAuditedOffHours), so a caller that
+// re-applies the same persisted config on every scheduler tick doesn't spam the
+// audit log with identical no-op events. Best-effort: a storage failure here must
+// not undo the in-memory policy change SetBusinessHours already applied, but it is
+// logged loudly (a missed audit write for a detection-control config change is
+// itself a small gap).
 func (d *AnomalyDetector) auditBusinessHoursConfig(ctx context.Context, tz string, p offHoursPolicy) {
 	if d.storage == nil {
 		return

--- a/internal/core/anomaly_config_test.go
+++ b/internal/core/anomaly_config_test.go
@@ -198,6 +198,74 @@ func TestApplyAnomalyConfig_PropagatesBusinessHoursError(t *testing.T) {
 	assert.Equal(t, 0.75, detector.ml.Threshold)
 }
 
+// TestApplyAnomalyConfig_HotloadDoesNotDuplicateAuditOnUnchangedConfig is the
+// findings-core-2/core-anomaly.json#1 regression at the ApplyAnomalyConfig level:
+// server/main.go's scheduler calls ApplyAnomalyConfig on every tick to hot-load the
+// persisted config, and it previously called SetBusinessHours -> the audit write
+// unconditionally, so an unchanged persisted off-hours config produced a fresh
+// anomaly.business_hours_configured audit event every single tick. Calling
+// ApplyAnomalyConfig repeatedly with the SAME persisted config (simulating
+// consecutive scheduler ticks) must only audit once.
+func TestApplyAnomalyConfig_HotloadDoesNotDuplicateAuditOnUnchangedConfig(t *testing.T) {
+	store := new(MockStorage)
+	c := newAnomalyConfigCore(store)
+	ctx := context.Background()
+
+	cfg := &models.AnomalyConfigRecord{
+		OffHoursEnabled:  true,
+		OffHoursTimezone: "UTC",
+		OffHoursStart:    20,
+		OffHoursEnd:      7,
+	}
+	store.On("GetAnomalyConfig", ctx).Return(cfg, nil)
+	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+	detector := NewAnomalyDetector(store)
+
+	// Simulate five consecutive scheduler ticks hot-loading the same persisted
+	// config, as server/main.go's runScheduler loop does every scan interval.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, c.ApplyAnomalyConfig(ctx, detector))
+	}
+
+	store.AssertNumberOfCalls(t, "LogAuditEvent", 1)
+}
+
+// TestApplyAnomalyConfig_HotloadAuditsGenuineChange confirms the fix above doesn't
+// just suppress the audit event outright: a real operator change to the persisted
+// off-hours config must still produce a fresh audit event on the next hot-load
+// tick, and that new value must then stop re-auditing on subsequent unchanged ticks.
+func TestApplyAnomalyConfig_HotloadAuditsGenuineChange(t *testing.T) {
+	store := new(MockStorage)
+	c := newAnomalyConfigCore(store)
+	ctx := context.Background()
+
+	cfg := &models.AnomalyConfigRecord{
+		OffHoursEnabled:  true,
+		OffHoursTimezone: "UTC",
+		OffHoursStart:    20,
+		OffHoursEnd:      7,
+	}
+	store.On("GetAnomalyConfig", ctx).Return(cfg, nil)
+	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+	detector := NewAnomalyDetector(store)
+
+	require.NoError(t, c.ApplyAnomalyConfig(ctx, detector))
+	require.NoError(t, c.ApplyAnomalyConfig(ctx, detector))
+	store.AssertNumberOfCalls(t, "LogAuditEvent", 1)
+
+	// A genuine operator change to the persisted band...
+	cfg.OffHoursStart = 21
+	require.NoError(t, c.ApplyAnomalyConfig(ctx, detector))
+	store.AssertNumberOfCalls(t, "LogAuditEvent", 2)
+
+	// ...and re-applying that NEW value on subsequent ticks must not duplicate it
+	// again either.
+	require.NoError(t, c.ApplyAnomalyConfig(ctx, detector))
+	store.AssertNumberOfCalls(t, "LogAuditEvent", 2)
+}
+
 func TestApplyAnomalyConfig_PropagatesGetError(t *testing.T) {
 	store := new(MockStorage)
 	c := newAnomalyConfigCore(store)

--- a/internal/core/anomaly_test.go
+++ b/internal/core/anomaly_test.go
@@ -17,6 +17,7 @@ type captureStore struct {
 	sinces       []time.Time
 	createErr    error
 	createdCount int
+	auditCount   int
 }
 
 func (c *captureStore) ListSecretAccessLogs(_ context.Context, _ uint, since time.Time) ([]models.SecretAccessLog, error) {
@@ -39,7 +40,10 @@ func (c *captureStore) ListAnomalyAlerts(_ context.Context, _ *bool) ([]models.A
 func (c *captureStore) PrincipalSecretFirstSeen(_ context.Context, _ time.Time) (map[string]map[uint]time.Time, error) {
 	return nil, nil
 }
-func (c *captureStore) LogAuditEvent(_ context.Context, _ *models.AuditEvent) error { return nil }
+func (c *captureStore) LogAuditEvent(_ context.Context, _ *models.AuditEvent) error {
+	c.auditCount++
+	return nil
+}
 
 // The recent-access scan window must honor the configured lookback (so a longer scan
 // cadence scans a proportionally longer window), and be floored at one hour.
@@ -372,6 +376,47 @@ func TestSetBusinessHours_PartialUpdateCollision(t *testing.T) {
 		assert.Equal(t, 6, d.offHours.start)
 		assert.Equal(t, 18, d.offHours.end)
 	})
+}
+
+// TestSetBusinessHours_AuditsOnlyOnChange is the findings-core-2/core-anomaly.json#1
+// regression: ApplyAnomalyConfig re-applies the persisted off-hours config via
+// SetBusinessHours on every scheduler tick (server/main.go's "Hotload" comment), and
+// SetBusinessHours previously wrote an anomaly.business_hours_configured audit event
+// unconditionally on every successful call -- so an unchanged persisted config wrote
+// a fresh, identical audit event every tick, defeating the event's change-tracking
+// purpose and growing the audit table without bound. Repeated calls with the SAME
+// band/timezone must audit exactly once; a genuine change must still audit again.
+func TestSetBusinessHours_AuditsOnlyOnChange(t *testing.T) {
+	store := &captureStore{}
+	d := NewAnomalyDetector(store)
+	ctx := context.Background()
+
+	// The very first call has no prior known state and must be audited.
+	require.NoError(t, d.SetBusinessHours(ctx, "UTC", 20, 7))
+	assert.Equal(t, 1, store.auditCount)
+
+	// Repeated calls with the SAME config (simulating ApplyAnomalyConfig's
+	// per-scheduler-tick hotload) must NOT audit again.
+	for i := 0; i < 4; i++ {
+		require.NoError(t, d.SetBusinessHours(ctx, "UTC", 20, 7))
+	}
+	assert.Equal(t, 1, store.auditCount, "an unchanged band/timezone must not re-audit on every hotload tick")
+
+	// A genuine band change must audit again.
+	require.NoError(t, d.SetBusinessHours(ctx, "UTC", 21, 7))
+	assert.Equal(t, 2, store.auditCount)
+
+	// A timezone-only change (same hours) is also a genuine change.
+	require.NoError(t, d.SetBusinessHours(ctx, "America/New_York", 21, 7))
+	assert.Equal(t, 3, store.auditCount)
+
+	// "" and "UTC" resolve to the same canonical location and must NOT be treated
+	// as a change from one another.
+	d2 := NewAnomalyDetector(store)
+	require.NoError(t, d2.SetBusinessHours(ctx, "UTC", 0, 0))
+	assert.Equal(t, 4, store.auditCount)
+	require.NoError(t, d2.SetBusinessHours(ctx, "", 0, 0))
+	assert.Equal(t, 4, store.auditCount, "\"\" and \"UTC\" resolve to the same location and must not re-audit")
 }
 
 func TestVolumeSpike(t *testing.T) {

--- a/internal/core/audit_checkpoint.go
+++ b/internal/core/audit_checkpoint.go
@@ -100,6 +100,20 @@ func (c *KeyorixCore) SetCheckpointAnchorRoots(roots *x509.CertPool) {
 	c.checkpointAnchorRoots = roots
 }
 
+// CheckpointAnchorVerifiable reports whether a TSA trust root is configured
+// (SetCheckpointAnchorRoots) — i.e. whether this server is able to locally
+// re-verify an external-notary anchor, as opposed to merely having recorded
+// one. Anchoring (writing a checkpoint's RFC 3161 receipt) can be enabled
+// without a trust root configured (see CheckpointNotaryConfig.CACertPath's doc
+// comment) — that is a legitimate, intentional configuration, not a bug — but
+// callers reviewing checkpoint records must be able to tell the two states
+// apart rather than assuming every recorded AnchorToken was cryptographically
+// confirmed. See AuditChainVerification.AnchorTrustRootConfigured, which
+// surfaces this on every VerifyAuditChain read.
+func (c *KeyorixCore) CheckpointAnchorVerifiable() bool {
+	return c.checkpointAnchorRoots != nil
+}
+
 // anchorCheckpoint best-effort anchors a checkpoint's canonical bytes with the
 // configured notary and persists the receipt on the row. A notary/storage failure
 // is logged and swallowed: an unanchored checkpoint is still a valid checkpoint,
@@ -300,6 +314,11 @@ func (c *KeyorixCore) enforceAuditCheckpoint(ctx context.Context, v *storage.Aud
 		v.AnchorToken = cp.AnchorToken
 		v.AnchoredAt = cp.AnchoredAt
 		v.AnchorProvider = cp.AnchorProvider
+		// Surface whether THIS server can even locally re-verify that token (a trust
+		// root is configured) — without this, a recorded-but-never-checked anchor is
+		// indistinguishable from a cryptographically confirmed one to anything reading
+		// this verdict (#baseline/notary-findings.json#1).
+		v.AnchorTrustRootConfigured = c.CheckpointAnchorVerifiable()
 	}
 
 	if !c.checkpointSignatureValid(cp) {

--- a/internal/core/audit_checkpoint_test.go
+++ b/internal/core/audit_checkpoint_test.go
@@ -205,6 +205,58 @@ func TestAuditCheckpoint_AnchorIsBestEffort(t *testing.T) {
 	assert.Empty(t, row.AnchorToken, "an un-anchored checkpoint is still a valid checkpoint")
 }
 
+// TestAuditCheckpoint_AnchorTrustRootConfigured_NoRoots confirms that anchoring
+// without a configured trust root (SetCheckpointAnchorRoots never called) still
+// records the raw TSA receipt (a legitimate, intentional configuration — see
+// CheckpointNotaryConfig.CACertPath's doc comment) but surfaces
+// AnchorTrustRootConfigured=false on every read, so a caller/auditor can tell a
+// recorded-but-unverifiable anchor apart from one this server actually checked
+// against a root of trust (#baseline/notary-findings.json#1).
+func TestAuditCheckpoint_AnchorTrustRootConfigured_NoRoots(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newCheckpointCore(t)
+	logEvents(t, c, 3)
+	fn := &fakeNotary{token: []byte("opaque-tsa-token"), at: time.Date(2026, 6, 15, 9, 0, 0, 0, time.UTC)}
+	c.SetCheckpointNotary(fn)
+	// Deliberately no SetCheckpointAnchorRoots call.
+
+	_, written, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, written)
+
+	assert.False(t, c.CheckpointAnchorVerifiable())
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, v.AnchorToken, "the anchor was still recorded")
+	assert.False(t, v.AnchorTrustRootConfigured, "no trust root configured — must not read as verified")
+	assert.True(t, v.Valid, "recording without a trust root must not itself fail the checkpoint")
+}
+
+// TestAuditCheckpoint_AnchorTrustRootConfigured_WithRoots confirms
+// AnchorTrustRootConfigured flips true once a trust root is wired
+// (SetCheckpointAnchorRoots), independent of whether the specific stored token
+// actually verifies against it (checked separately by the tamper-detection path).
+func TestAuditCheckpoint_AnchorTrustRootConfigured_WithRoots(t *testing.T) {
+	ctx := context.Background()
+	c, _ := newCheckpointCore(t)
+	logEvents(t, c, 3)
+	fn := &fakeNotary{token: []byte("opaque-tsa-token"), at: time.Date(2026, 6, 15, 9, 0, 0, 0, time.UTC)}
+	c.SetCheckpointNotary(fn)
+	c.SetCheckpointAnchorRoots(x509.NewCertPool())
+
+	_, written, err := c.WriteAuditCheckpoint(ctx)
+	require.NoError(t, err)
+	require.True(t, written)
+
+	assert.True(t, c.CheckpointAnchorVerifiable())
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, v.AnchorToken)
+	assert.True(t, v.AnchorTrustRootConfigured, "a trust root is configured — server can locally re-verify")
+}
+
 func TestVerifyCheckpointAnchor_NoAnchor(t *testing.T) {
 	c, _ := newCheckpointCore(t)
 	at, ok, err := c.VerifyCheckpointAnchor(&models.AuditCheckpoint{ID: 1})

--- a/internal/core/pat_expiry_enforce.go
+++ b/internal/core/pat_expiry_enforce.go
@@ -35,7 +35,29 @@ func IsPATExpired(pat *models.PersonalAccessToken, now time.Time) bool {
 // emitPATExpiredNotification creates a best-effort in-app notification for the
 // PAT owner when an expired token is presented at the auth boundary.  Errors
 // are swallowed so a failed insert never blocks the auth rejection.
+//
+// Deduplicated the same way as every other standing reminder in this package
+// (see unreadPATExpiryReminder / unreadMachineCredExpiryReminder in
+// token_expiry_remind.go, unreadRoleExpiryReminder, unreadRotationReminder,
+// unreadExpiryReminder): skip creating a new notification while the owner
+// already has an unread one of this type for this exact token. Without this,
+// anyone who ever captured the raw token string — even long after it stopped
+// being valid for anything else — could keep presenting it at the auth
+// boundary and get a fresh notification (and any wired email/webhook
+// delivery) fired every single time, spamming the owner indefinitely. The
+// standing notification only clears, letting a fresh one fire, once the
+// owner reads/dismisses it — this codebase has no time-window/cooldown-based
+// dedup anywhere; every periodic-notification mechanism here dedups on
+// unread-notification presence instead, so this follows suit rather than
+// inventing a new mechanism.
 func (c *KeyorixCore) emitPATExpiredNotification(ctx context.Context, pat *models.PersonalAccessToken) {
+	if pat.UserID == 0 {
+		return
+	}
+	link := patExpiredUsedLink(pat.ID)
+	if c.unreadPATExpiredUsedReminder(ctx, pat.UserID, link) != nil {
+		return
+	}
 	c.notifyWithSeverity(
 		ctx,
 		pat.UserID,
@@ -43,9 +65,37 @@ func (c *KeyorixCore) emitPATExpiredNotification(ctx context.Context, pat *model
 		"Expired PAT presented",
 		fmt.Sprintf("Personal access token '%s' has expired and was rejected. Revoke or replace it.", pat.Name),
 		nil,
-		"/account/tokens",
+		link,
 		models.NotificationSeverityWarning,
 	)
+}
+
+// patExpiredUsedLink builds the stable per-token dedup key (and in-app
+// navigation target) for an "expired PAT presented" notification. Keyed on
+// the token's ID, not its display Name — two PATs owned by the same user are
+// not required to have distinct names, and matching on name would let one
+// token's standing reminder silently suppress a distinct token's reminder
+// (mirrors the #G22 rationale for patExpiryLink/machineCredExpiryLink in
+// token_expiry_remind.go).
+func patExpiredUsedLink(patID uint) string {
+	return fmt.Sprintf("/account/tokens?token=%d", patID)
+}
+
+// unreadPATExpiredUsedReminder returns an existing unread "expired PAT
+// presented" notification for the given user matching link (see
+// patExpiredUsedLink), or nil if none exists (including on a storage error —
+// best-effort, same fail-open behavior as unreadPATExpiryReminder).
+func (c *KeyorixCore) unreadPATExpiredUsedReminder(ctx context.Context, userID uint, link string) *models.Notification {
+	notes, err := c.storage.ListNotifications(ctx, userID, true, 200)
+	if err != nil {
+		return nil
+	}
+	for _, n := range notes {
+		if n.Type == NotificationPATExpiredUsed && n.Link == link {
+			return n
+		}
+	}
+	return nil
 }
 
 // ListExpiredOwnPATs returns the caller's own non-revoked PATs whose ExpiresAt

--- a/internal/core/pat_expiry_enforce_test.go
+++ b/internal/core/pat_expiry_enforce_test.go
@@ -69,6 +69,8 @@ func TestEmitPATExpiredNotification_CreatesWarningNotification(t *testing.T) {
 	pat := &models.PersonalAccessToken{ID: 42, UserID: 7, Name: "my-ci-token"}
 
 	var captured *models.Notification
+	ms.On("ListNotifications", ctx, uint(7), true, 200).
+		Return([]*models.Notification{}, nil)
 	ms.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).
 		Run(func(args mock.Arguments) { captured = args.Get(1).(*models.Notification) }).
 		Return(&models.Notification{ID: 1}, nil)
@@ -80,7 +82,60 @@ func TestEmitPATExpiredNotification_CreatesWarningNotification(t *testing.T) {
 	assert.Equal(t, uint(7), captured.UserID)
 	assert.Equal(t, NotificationPATExpiredUsed, captured.Type)
 	assert.Equal(t, models.NotificationSeverityWarning, captured.Severity)
+	assert.Equal(t, patExpiredUsedLink(42), captured.Link)
 	assert.Contains(t, captured.Message, "my-ci-token")
+}
+
+// TestEmitPATExpiredNotification_UnreadExisting_Skipped is the regression test
+// for the notification-spam finding: repeatedly presenting the same expired PAT
+// must not create a fresh notification while an unread one for that exact token
+// already stands. Before the fix, emitPATExpiredNotification unconditionally
+// called CreateNotification — this test's mock has no CreateNotification
+// expectation at all, so it would fail loudly (unexpected call) against
+// pre-fix code instead of silently passing.
+func TestEmitPATExpiredNotification_UnreadExisting_Skipped(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+
+	pat := &models.PersonalAccessToken{ID: 42, UserID: 7, Name: "my-ci-token"}
+
+	ms.On("ListNotifications", ctx, uint(7), true, 200).
+		Return([]*models.Notification{{
+			ID:   9,
+			Type: NotificationPATExpiredUsed,
+			Link: patExpiredUsedLink(42),
+		}}, nil)
+
+	c.emitPATExpiredNotification(ctx, pat)
+
+	ms.AssertExpectations(t)
+	ms.AssertNotCalled(t, "CreateNotification", mock.Anything, mock.Anything)
+}
+
+// TestEmitPATExpiredNotification_UnreadExisting_DifferentToken_StillFires
+// confirms dedup is keyed per-token (by ID, not by owner alone): an unread
+// standing reminder for a DIFFERENT token owned by the same user must not
+// suppress this token's notification (#G22-style token-identity concern).
+func TestEmitPATExpiredNotification_UnreadExisting_DifferentToken_StillFires(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+
+	pat := &models.PersonalAccessToken{ID: 42, UserID: 7, Name: "my-ci-token"}
+
+	ms.On("ListNotifications", ctx, uint(7), true, 200).
+		Return([]*models.Notification{{
+			ID:   9,
+			Type: NotificationPATExpiredUsed,
+			Link: patExpiredUsedLink(43), // a different token
+		}}, nil)
+	ms.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).
+		Return(&models.Notification{ID: 10}, nil)
+
+	c.emitPATExpiredNotification(ctx, pat)
+
+	ms.AssertExpectations(t)
 }
 
 func TestEmitPATExpiredNotification_ZeroUserID_NoOp(t *testing.T) {
@@ -109,6 +164,8 @@ func TestValidatePATToken_ExpiredPAT_ReturnsErrPATExpired(t *testing.T) {
 	past := time.Now().Add(-time.Hour)
 	ms.On("GetPersonalAccessTokenByHash", ctx, hash).
 		Return(&models.PersonalAccessToken{ID: 5, UserID: 3, Name: "old-token", ExpiresAt: &past}, nil)
+	ms.On("ListNotifications", ctx, uint(3), true, 200).
+		Return([]*models.Notification{}, nil)
 	ms.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).
 		Return(&models.Notification{ID: 99}, nil)
 
@@ -116,6 +173,66 @@ func TestValidatePATToken_ExpiredPAT_ReturnsErrPATExpired(t *testing.T) {
 
 	require.ErrorIs(t, err, ErrPATExpired)
 	ms.AssertCalled(t, "CreateNotification", ctx, mock.AnythingOfType("*models.Notification"))
+}
+
+// TestValidatePATToken_ExpiredPAT_RepeatedPresentation_OnlyFirstNotifies is the
+// end-to-end regression test for the notification-spam finding: an attacker (or
+// a stale client) who repeatedly presents the SAME already-expired PAT string at
+// the auth boundary must trigger at most one standing notification, not one per
+// attempt. Uses a real in-memory-SQLite-backed core (not the mock) so the dedup
+// check reads back what CreateNotification actually persisted, exactly as it
+// does in production.
+func TestValidatePATToken_ExpiredPAT_RepeatedPresentation_OnlyFirstNotifies(t *testing.T) {
+	db := newPATExpiryDB(t)
+	raw := patPrefix + "repeatedspam0test"
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-time.Hour)
+
+	require.NoError(t, db.Create(&models.PersonalAccessToken{
+		ID: 60, UserID: 40, Name: "spammed-token",
+		TokenHash: sha256Hex(raw), ExpiresAt: &past, Revoked: false,
+	}).Error)
+
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return now }}
+	ctx := context.Background()
+
+	// Five rapid-fire presentations of the same expired token, as an attacker
+	// replaying a captured (now-worthless-for-access, but still notification-
+	// triggering) token string would do.
+	for i := 0; i < 5; i++ {
+		_, _, _, _, err := c.ValidatePATToken(ctx, raw)
+		require.ErrorIs(t, err, ErrPATExpired)
+	}
+
+	notes, err := c.storage.ListNotifications(ctx, 40, false, 200)
+	require.NoError(t, err)
+	var patNotes []*models.Notification
+	for _, n := range notes {
+		if n.Type == NotificationPATExpiredUsed {
+			patNotes = append(patNotes, n)
+		}
+	}
+	require.Len(t, patNotes, 1, "5 rapid repeat presentations of the same expired PAT must yield exactly 1 notification, not 5")
+
+	// The owner reads (dismisses) the standing notification — the same signal
+	// every other reminder in this package uses to allow a fresh one later.
+	require.NoError(t, c.storage.MarkNotificationRead(ctx, patNotes[0].ID, 40))
+
+	// A further presentation after the standing notification was read must fire
+	// a new one: the owner has now seen (and presumably acted on, or chosen to
+	// ignore) the first warning, so a renewed attempt is worth re-surfacing.
+	_, _, _, _, err = c.ValidatePATToken(ctx, raw)
+	require.ErrorIs(t, err, ErrPATExpired)
+
+	notes, err = c.storage.ListNotifications(ctx, 40, false, 200)
+	require.NoError(t, err)
+	patNotes = nil
+	for _, n := range notes {
+		if n.Type == NotificationPATExpiredUsed {
+			patNotes = append(patNotes, n)
+		}
+	}
+	require.Len(t, patNotes, 2, "presenting again after the standing notification was read must fire a new one")
 }
 
 func TestValidatePATToken_ValidNonExpiredPAT_Succeeds(t *testing.T) {

--- a/internal/core/pat_test.go
+++ b/internal/core/pat_test.go
@@ -116,6 +116,8 @@ func TestValidatePATToken(t *testing.T) {
 		past := time.Now().Add(-time.Hour)
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{ID: 9, UserID: 1, Name: "old-ci", ExpiresAt: &past}, nil)
 		// emitPATExpiredNotification is called best-effort before the error is returned.
+		// It dedups against any existing unread notification for this token first.
+		ms.On("ListNotifications", ctx, uint(1), true, 200).Return([]*models.Notification{}, nil)
 		ms.On("CreateNotification", ctx, mock.AnythingOfType("*models.Notification")).Return(&models.Notification{ID: 1}, nil)
 		_, _, _, _, err := c.ValidatePATToken(ctx, raw)
 		require.Error(t, err)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1862,6 +1862,14 @@ type AuditChainVerification struct {
 	AnchorToken    []byte
 	AnchoredAt     *time.Time
 	AnchorProvider string
+	// AnchorTrustRootConfigured is true when a TSA trust root
+	// (audit.checkpoint_notary.ca_cert_path) is configured, i.e. this server is
+	// actually able to locally re-verify AnchorToken against a root of trust.
+	// Only meaningful when AnchorToken is non-empty. When false, AnchorToken was
+	// still merely RECORDED (a raw TSA receipt was obtained and stored) but this
+	// server has never checked it against any root of trust — callers must not
+	// treat a recorded-but-unverifiable anchor as equivalent to a verified one.
+	AnchorTrustRootConfigured bool
 }
 
 // AuditChainAnchor is an authenticated re-anchor point for VerifyAuditChain's

--- a/internal/crypto/multi_provider.go
+++ b/internal/crypto/multi_provider.go
@@ -10,8 +10,17 @@ import (
 // first that succeeds. If all fail it returns a wrapped error. An empty list
 // is a configuration error.
 type MultiKeyProvider struct {
-	providers []KeyProvider
+	providers   []KeyProvider
+	onDowngrade DowngradeHook
 }
+
+// DowngradeHook is called when KEK() actually falls back, at runtime, to a
+// provider whose tier is weaker than the strongest tier seen earlier in the chain
+// (see DetectFallbackDowngrade) — i.e. an ACTUAL downgrade occurrence for THIS KEK
+// derivation, not merely a configuration that permits one. Set via
+// SetDowngradeHook; nil (the default) means the event is only recorded via the
+// loud "SECURITY:" log line KEK() always emits on a downgrading fallback.
+type DowngradeHook func(d FallbackDowngrade)
 
 // NewMultiKeyProvider creates a MultiKeyProvider. Returns error if list is empty.
 func NewMultiKeyProvider(providers []KeyProvider) (*MultiKeyProvider, error) {
@@ -19,6 +28,15 @@ func NewMultiKeyProvider(providers []KeyProvider) (*MultiKeyProvider, error) {
 		return nil, fmt.Errorf("multi key provider: at least one provider is required")
 	}
 	return &MultiKeyProvider{providers: providers}, nil
+}
+
+// SetDowngradeHook wires an optional callback invoked whenever KEK() actually
+// falls back to a weaker-tier provider. The loud "SECURITY:" log line in KEK()
+// fires either way; a caller that has a queryable audit trail available (the
+// encryption.Service does, once storage is up) should wire one here so the
+// downgrade isn't only observable in logs.
+func (m *MultiKeyProvider) SetDowngradeHook(hook DowngradeHook) {
+	m.onDowngrade = hook
 }
 
 // Name returns "multi(p1,p2,...)" for logging/status output.
@@ -30,19 +48,37 @@ func (m *MultiKeyProvider) Name() string {
 	return "multi(" + strings.Join(names, ",") + ")"
 }
 
-// KEK tries each provider in order. The first successful result is returned.
+// KEK tries each provider in order. The first successful result is returned. If
+// the provider that succeeds is weaker (see ProviderTier) than the strongest tier
+// among the providers tried before it — e.g. a TPM/KMS-backed primary that failed
+// and fell through to a password fallback — that is a REAL, live downgrade of this
+// process's encryption strength, not just a permitted configuration shape. It is
+// always logged loudly, and reported to onDowngrade if one is wired (see
+// SetDowngradeHook), so a caller with a real audit trail available can record it
+// as more than a log line.
 func (m *MultiKeyProvider) KEK() ([]byte, error) {
 	var errs []string
-	for _, p := range m.providers {
+	maxTier := ProviderTierOf(m.providers[0].Name())
+	for i, p := range m.providers {
 		key, err := p.KEK()
 		if err == nil {
 			if len(m.providers) > 1 {
 				log.Printf("key provider: %s succeeded", p.Name())
 			}
+			if tier := ProviderTierOf(p.Name()); i > 0 && tier < maxTier {
+				d := FallbackDowngrade{Index: i, Provider: p.Name(), FromTier: maxTier, ToTier: tier}
+				log.Printf("SECURITY: key provider fallback downgraded KEK strength: now using %q (%s) after an earlier, %s provider in the configured chain failed", p.Name(), tier, maxTier)
+				if m.onDowngrade != nil {
+					m.onDowngrade(d)
+				}
+			}
 			return key, nil
 		}
 		log.Printf("key provider: %s failed (%v), trying next", p.Name(), err)
 		errs = append(errs, fmt.Sprintf("%s: %v", p.Name(), err))
+		if t := ProviderTierOf(p.Name()); t > maxTier {
+			maxTier = t
+		}
 	}
 	return nil, fmt.Errorf("all key providers failed: %s", strings.Join(errs, "; "))
 }

--- a/internal/crypto/multi_provider_test.go
+++ b/internal/crypto/multi_provider_test.go
@@ -73,3 +73,121 @@ func TestMultiKeyProvider_Name(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "multi(aws-kms,file)", m.Name())
 }
+
+// ── ProviderTierOf / DetectFallbackDowngrade ─────────────────────────────────
+
+func TestProviderTierOf_Ordering(t *testing.T) {
+	hardware := []string{"tpm", "aws-kms", "gcp-kms", "azure-kms"}
+	for _, name := range hardware {
+		assert.Equal(t, crypto.TierHardware, crypto.ProviderTierOf(name), name)
+	}
+	assert.Equal(t, crypto.TierDistributed, crypto.ProviderTierOf("shamir"))
+	software := []string{"password", "file", "env", "exec"}
+	for _, name := range software {
+		assert.Equal(t, crypto.TierSoftware, crypto.ProviderTierOf(name), name)
+	}
+	assert.Equal(t, crypto.TierUnknown, crypto.ProviderTierOf("some-future-provider-type"))
+
+	// Ordering must hold for the downgrade check to mean anything.
+	assert.Less(t, int(crypto.TierUnknown), int(crypto.TierSoftware))
+	assert.Less(t, int(crypto.TierSoftware), int(crypto.TierDistributed))
+	assert.Less(t, int(crypto.TierDistributed), int(crypto.TierHardware))
+}
+
+func TestDetectFallbackDowngrade_EmptyOrSingle(t *testing.T) {
+	_, ok := crypto.DetectFallbackDowngrade(nil)
+	assert.False(t, ok)
+	_, ok = crypto.DetectFallbackDowngrade([]crypto.KeyProvider{goodProvider("tpm")})
+	assert.False(t, ok)
+}
+
+func TestDetectFallbackDowngrade_KMSPrimary_PasswordFallback_Downgrades(t *testing.T) {
+	d, ok := crypto.DetectFallbackDowngrade([]crypto.KeyProvider{
+		goodProvider("aws-kms"), goodProvider("password"),
+	})
+	require.True(t, ok)
+	assert.Equal(t, 1, d.Index)
+	assert.Equal(t, "password", d.Provider)
+	assert.Equal(t, crypto.TierHardware, d.FromTier)
+	assert.Equal(t, crypto.TierSoftware, d.ToTier)
+}
+
+// TestDetectFallbackDowngrade_SameTier_NoDowngrade covers the legitimate,
+// non-downgrading multi-provider use case (e.g. KMS-in-a-different-region
+// fallback) that must keep working with no opt-in required.
+func TestDetectFallbackDowngrade_SameTier_NoDowngrade(t *testing.T) {
+	_, ok := crypto.DetectFallbackDowngrade([]crypto.KeyProvider{
+		goodProvider("aws-kms"), goodProvider("gcp-kms"),
+	})
+	assert.False(t, ok)
+}
+
+func TestDetectFallbackDowngrade_Upgrade_NoDowngrade(t *testing.T) {
+	_, ok := crypto.DetectFallbackDowngrade([]crypto.KeyProvider{
+		goodProvider("password"), goodProvider("tpm"),
+	})
+	assert.False(t, ok)
+}
+
+// TestDetectFallbackDowngrade_LaterStepDowngradesFromEarlierPeak covers a chain
+// where the weak step isn't directly after the primary: [password, tpm, password]
+// — the strength ceiling set by the tpm step in the middle must still be
+// enforced against the final password fallback, not just against the primary.
+func TestDetectFallbackDowngrade_LaterStepDowngradesFromEarlierPeak(t *testing.T) {
+	d, ok := crypto.DetectFallbackDowngrade([]crypto.KeyProvider{
+		goodProvider("password"), goodProvider("tpm"), goodProvider("password"),
+	})
+	require.True(t, ok)
+	assert.Equal(t, 2, d.Index)
+	assert.Equal(t, crypto.TierHardware, d.FromTier)
+	assert.Equal(t, crypto.TierSoftware, d.ToTier)
+}
+
+// ── MultiKeyProvider runtime downgrade hook ──────────────────────────────────
+
+func TestMultiKeyProvider_KEK_FiresDowngradeHookOnRealFallback(t *testing.T) {
+	m, err := crypto.NewMultiKeyProvider([]crypto.KeyProvider{
+		badProvider("tpm"), goodProvider("password"),
+	})
+	require.NoError(t, err)
+
+	var got *crypto.FallbackDowngrade
+	m.SetDowngradeHook(func(d crypto.FallbackDowngrade) {
+		got = &d
+	})
+
+	_, err = m.KEK()
+	require.NoError(t, err)
+	require.NotNil(t, got, "downgrade hook must fire when the provider that actually succeeds is weaker than an earlier provider in the chain")
+	assert.Equal(t, "password", got.Provider)
+	assert.Equal(t, crypto.TierHardware, got.FromTier)
+	assert.Equal(t, crypto.TierSoftware, got.ToTier)
+}
+
+func TestMultiKeyProvider_KEK_NoDowngradeHookWhenPrimarySucceeds(t *testing.T) {
+	m, err := crypto.NewMultiKeyProvider([]crypto.KeyProvider{
+		goodProvider("tpm"), goodProvider("password"),
+	})
+	require.NoError(t, err)
+
+	called := false
+	m.SetDowngradeHook(func(d crypto.FallbackDowngrade) { called = true })
+
+	_, err = m.KEK()
+	require.NoError(t, err)
+	assert.False(t, called, "the hook must not fire when the primary itself succeeds — no fallback happened")
+}
+
+func TestMultiKeyProvider_KEK_NoDowngradeHookOnSameTierFallback(t *testing.T) {
+	m, err := crypto.NewMultiKeyProvider([]crypto.KeyProvider{
+		badProvider("aws-kms"), goodProvider("gcp-kms"),
+	})
+	require.NoError(t, err)
+
+	called := false
+	m.SetDowngradeHook(func(d crypto.FallbackDowngrade) { called = true })
+
+	_, err = m.KEK()
+	require.NoError(t, err)
+	assert.False(t, called, "a same-tier fallback (e.g. KMS in a different region) must not be treated as a downgrade")
+}

--- a/internal/crypto/provider_tier.go
+++ b/internal/crypto/provider_tier.go
@@ -1,0 +1,119 @@
+package crypto
+
+// ProviderTier ranks how resistant a key-provider TYPE is to a full compromise of
+// the process/host it runs on — used to detect a MultiKeyProvider fallback chain
+// that would silently trade a stronger KEK source for a weaker one. Higher value =
+// stronger. This is an ORDERING for fallback-safety purposes, not an absolute
+// security score: a "distributed" provider (Shamir) is harder to compromise than a
+// single software secret because no ONE piece of key material suffices on its own,
+// but it still doesn't isolate key material inside dedicated hardware the way
+// TPM/HSM/cloud-KMS providers do.
+type ProviderTier int
+
+const (
+	// TierUnknown is returned for a provider name/type this package has no
+	// classification for. It sorts BELOW every known tier (weakest), not above, so
+	// an unrecognized provider is conservatively treated as capable of being a
+	// downgrade target — fail closed instead of silently exempting an unclassified
+	// provider from the fallback-strength check.
+	TierUnknown ProviderTier = iota
+	// TierSoftware covers providers whose key material is a flat secret sitting in
+	// local software state — a passphrase, a file, an env var, or whatever an
+	// arbitrary exec resolver prints to stdout — extractable by anyone who can read
+	// the process's environment, filesystem, or memory.
+	TierSoftware
+	// TierDistributed covers Shamir: the KEK is split across K-of-N shares, so
+	// compromising any single share below the threshold reveals nothing about it.
+	// Meaningfully harder to compromise than one flat software secret, but the
+	// reconstructed KEK still passes through this process's memory like a software
+	// provider's once the shares are combined.
+	TierDistributed
+	// TierHardware covers providers whose key material is sealed to a dedicated
+	// hardware boundary (TPM 2.0) or wrapped by a cloud KMS key that never leaves
+	// the provider's HSM (aws-kms/gcp-kms/azure-kms) — the strongest class of
+	// provider this package supports.
+	TierHardware
+)
+
+// String renders the tier for operator-facing error/log messages.
+func (t ProviderTier) String() string {
+	switch t {
+	case TierHardware:
+		return "hardware-backed"
+	case TierDistributed:
+		return "distributed"
+	case TierSoftware:
+		return "software-derivable"
+	default:
+		return "unknown"
+	}
+}
+
+// providerTiers classifies every built-in provider TYPE by its Name()/config
+// "type" string — the two are identical for every provider this package ships
+// (see each provider's Name() method: NewKMSKeyProvider is constructed with
+// "aws-kms"/"gcp-kms"/"azure-kms", TPMKeyProvider.Name() == "tpm",
+// PasswordKeyProvider.Name() == "password", etc.), so this one table serves both
+// the config-validation path (keyed by the config "type" string) and the
+// KEK()-time runtime path (keyed by the constructed provider's Name()).
+var providerTiers = map[string]ProviderTier{
+	"password":  TierSoftware,
+	"file":      TierSoftware,
+	"env":       TierSoftware,
+	"exec":      TierSoftware,
+	"shamir":    TierDistributed,
+	"tpm":       TierHardware,
+	"aws-kms":   TierHardware,
+	"gcp-kms":   TierHardware,
+	"azure-kms": TierHardware,
+}
+
+// ProviderTierOf returns the strength tier for a provider type/name. Unrecognized
+// names return TierUnknown (see its doc comment for why that is the weakest tier,
+// not a neutral/exempt one).
+func ProviderTierOf(name string) ProviderTier {
+	if t, ok := providerTiers[name]; ok {
+		return t
+	}
+	return TierUnknown
+}
+
+// FallbackDowngrade describes the first point in a provider chain (primary +
+// fallbacks, in configured try-order) where the tier drops below the strongest
+// tier seen so far in the chain.
+type FallbackDowngrade struct {
+	// Index is the position of the weaker provider in the FULL chain passed to
+	// DetectFallbackDowngrade (0 = primary, matching providers[Index]).
+	Index int
+	// Provider is providers[Index].Name().
+	Provider string
+	// FromTier is the strongest tier seen among providers[0:Index].
+	FromTier ProviderTier
+	// ToTier is ProviderTierOf(providers[Index].Name()).
+	ToTier ProviderTier
+}
+
+// DetectFallbackDowngrade scans a provider chain (as passed to
+// NewMultiKeyProvider: providers[0] is the primary, providers[1:] are fallbacks in
+// try-order) and reports the FIRST provider whose tier is weaker than the
+// strongest tier seen among every provider before it in the chain. Returns
+// ok=false if the chain never weakens — this includes empty/single-provider
+// chains, and chains that only stay flat or get stronger (e.g. a KMS primary with
+// a KMS-in-a-different-region fallback, or a password primary with a
+// stronger-tier fallback added on top).
+func DetectFallbackDowngrade(providers []KeyProvider) (downgrade FallbackDowngrade, ok bool) {
+	if len(providers) < 2 {
+		return FallbackDowngrade{}, false
+	}
+	maxTier := ProviderTierOf(providers[0].Name())
+	for i := 1; i < len(providers); i++ {
+		t := ProviderTierOf(providers[i].Name())
+		if t < maxTier {
+			return FallbackDowngrade{Index: i, Provider: providers[i].Name(), FromTier: maxTier, ToTier: t}, true
+		}
+		if t > maxTier {
+			maxTier = t
+		}
+	}
+	return FallbackDowngrade{}, false
+}

--- a/internal/encryption/key_provider_downgrade.go
+++ b/internal/encryption/key_provider_downgrade.go
@@ -1,0 +1,78 @@
+// key_provider_downgrade.go — records a key-provider fallback chain actually
+// downgrading KEK-sourcing strength at KEK() time as a queryable audit event,
+// not just a log line. See config.KeyProviderConfig.AllowWeakerFallback (the
+// config-time, fail-closed gate) and crypto.MultiKeyProvider.SetDowngradeHook
+// (the runtime hook this file wires into).
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/crypto"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// EventKeyProviderFallbackDowngrade is the audit event type recorded when a
+// configured key-provider fallback chain actually falls back, at runtime, to a
+// provider whose strength tier is weaker than an earlier (higher-tier) provider
+// in the chain — e.g. a TPM/KMS-backed primary failing over to a
+// password-derived fallback. Distinct from the config-time startup refusal
+// (NewKeyProviderFromConfig / AllowWeakerFallback): that fires whenever the
+// config PERMITS a downgrade; this fires only when the downgrade actually
+// happened for this process's own KEK derivation.
+const EventKeyProviderFallbackDowngrade = "encryption.key_provider_fallback_downgrade" // #nosec G101 -- audit event type, not a credential
+
+// AuditSink is a minimal audit-write hook, matching storage.Storage's
+// LogAuditEvent method signature exactly so a caller can pass that method value
+// directly (e.g. svc.SetAuditSink(store.LogAuditEvent)) without this package
+// importing the full storage.Storage interface (which would pull encryption into
+// a dependency cycle with the storage layer it is itself used by).
+type AuditSink func(ctx context.Context, event *models.AuditEvent) error
+
+// SetAuditSink wires the security-event sink the Service uses to record runtime
+// events that don't otherwise have a models.AuditEvent home — currently just a
+// key-provider fallback chain actually downgrading KEK strength at KEK()-derivation
+// time. Optional and safe to leave unset: such events are still recorded via the
+// loud "SECURITY:" log line crypto.MultiKeyProvider.KEK always emits either way;
+// wiring a sink (typically store.LogAuditEvent, once storage is available) turns
+// that into a real, queryable trail an operator can alert on instead of a log
+// line that's easy to lose in noise. Must be called before Initialize for a
+// downgrade during THIS process's own KEK derivation to be captured — call it
+// right after NewService, before Initialize.
+func (s *Service) SetAuditSink(sink AuditSink) {
+	s.auditSinkMu.Lock()
+	defer s.auditSinkMu.Unlock()
+	s.auditSink = sink
+}
+
+// auditKeyProviderDowngrade is wired as the crypto.MultiKeyProvider downgrade hook
+// in buildKeyProvider. It fires synchronously from inside KEK() — which itself
+// runs from inside KeyManager.Initialize, called while Service.Initialize still
+// holds s.mu — so it must use its own mutex (auditSinkMu), never s.mu, to avoid a
+// self-deadlock. Best-effort: a sink write failure is logged but never propagated,
+// since the KEK derivation it's reporting on has already succeeded by the time
+// this runs and must not be undone by an audit-logging failure.
+func (s *Service) auditKeyProviderDowngrade(d crypto.FallbackDowngrade) {
+	s.auditSinkMu.RLock()
+	sink := s.auditSink
+	s.auditSinkMu.RUnlock()
+	if sink == nil {
+		return
+	}
+	failed := false // the event itself reports a security-negative condition, not a success
+	event := &models.AuditEvent{
+		EventType: EventKeyProviderFallbackDowngrade,
+		Description: fmt.Sprintf(
+			"key provider fallback fired at runtime: KEK now sourced from %q (%s) after an earlier, %s provider in the configured chain failed",
+			d.Provider, d.ToTier, d.FromTier),
+		Success:   &failed,
+		ActorType: "system",
+		EventTime: time.Now(),
+	}
+	if err := sink(context.Background(), event); err != nil {
+		log.Printf("SECURITY: key provider fallback downgrade: failed to write audit event: %v", err)
+	}
+}

--- a/internal/encryption/multi_provider_config_test.go
+++ b/internal/encryption/multi_provider_config_test.go
@@ -1,11 +1,13 @@
 package encryption_test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -108,4 +110,158 @@ func TestNewKeyProviderFromConfig_AzureKMSContextError(t *testing.T) {
 	_, err := encryption.NewKeyProviderFromConfig(cfg, dir, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "azure-kms")
+}
+
+// ── Weak-fallback gate (allow_weaker_fallback) ───────────────────────────────
+//
+// The "tpm" primary below never touches a real TPM device: with WrappedKeyPath
+// left empty, TPMKeyProvider.KEK() fails immediately and deterministically
+// ("wrapped_key_path is required") before any device access is attempted — see
+// crypto.TPMKeyProvider.KEK. That's exactly what's needed here: the config-shape
+// downgrade check (keyed by Type/Name(), both "tpm") doesn't care whether the
+// provider can actually reach hardware, and the runtime fallback test below
+// needs the primary to reliably fail without depending on test-host hardware.
+
+// TestNewKeyProviderFromConfig_WeakFallback_RejectedWithoutOptIn is the negative
+// case: a TPM (hardware-tier) primary with a password (software-tier) fallback,
+// without allow_weaker_fallback, must be refused at config/startup time — the
+// whole point of the fail-closed gate.
+func TestNewKeyProviderFromConfig_WeakFallback_RejectedWithoutOptIn(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "salt",
+		KeyProvider: config.KeyProviderConfig{
+			Type: "tpm",
+			Fallbacks: []config.KeyProviderConfig{
+				{Type: "password"},
+			},
+		},
+	}
+	_, err := encryption.NewKeyProviderFromConfig(cfg, dir, "test-passphrase")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allow_weaker_fallback")
+	assert.Contains(t, err.Error(), "password")
+}
+
+// TestNewKeyProviderFromConfig_WeakFallback_AcceptedWithOptIn is the positive
+// case: the SAME downgrading chain, with AllowWeakerFallback set, must be
+// accepted and build a working MultiKeyProvider that actually falls through to
+// the (now permitted) weaker password provider at KEK() time.
+func TestNewKeyProviderFromConfig_WeakFallback_AcceptedWithOptIn(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "salt",
+		KeyProvider: config.KeyProviderConfig{
+			Type: "tpm",
+			Fallbacks: []config.KeyProviderConfig{
+				{Type: "password"},
+			},
+			AllowWeakerFallback: true,
+		},
+	}
+	p, err := encryption.NewKeyProviderFromConfig(cfg, dir, "test-passphrase")
+	require.NoError(t, err)
+	assert.Contains(t, p.Name(), "multi(")
+	key, err := p.KEK()
+	require.NoError(t, err, "tpm primary must fail closed (no wrapped_key_path) and fall through to the accepted password fallback")
+	assert.Len(t, key, 32)
+}
+
+// TestNewKeyProviderFromConfig_WeakFallback_RuntimeAuditEvent asserts the
+// runtime-firing signal (item 3 of the fix): when the fallback in an
+// opted-in-downgrading chain actually fires at KEK() time, it must be recorded
+// as more than a log line. buildKeyProvider wires Service.auditKeyProviderDowngrade
+// as the crypto.MultiKeyProvider downgrade hook; this test exercises that wiring
+// end-to-end through Service.Initialize with a fake audit sink standing in for
+// storage.Storage.LogAuditEvent.
+func TestNewKeyProviderFromConfig_WeakFallback_RuntimeAuditEvent(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "salt",
+		KeyProvider: config.KeyProviderConfig{
+			Type: "tpm",
+			Fallbacks: []config.KeyProviderConfig{
+				{Type: "password"},
+			},
+			AllowWeakerFallback: true,
+		},
+	}
+	svc := encryption.NewService(cfg, dir)
+
+	var got *models.AuditEvent
+	svc.SetAuditSink(func(ctx context.Context, event *models.AuditEvent) error {
+		got = event
+		return nil
+	})
+
+	require.NoError(t, svc.Initialize("test-passphrase"))
+	require.NotNil(t, got, "a security-relevant audit event must be recorded when the fallback actually fires at KEK() time, not just a log line")
+	assert.Equal(t, encryption.EventKeyProviderFallbackDowngrade, got.EventType)
+	assert.Equal(t, "system", got.ActorType)
+	require.NotNil(t, got.Success)
+	assert.False(t, *got.Success, "a silent strength downgrade is a security-negative event, not a routine success")
+	assert.Contains(t, got.Description, "password")
+}
+
+// TestNewKeyProviderFromConfig_SameTierFallback_NoRuntimeAuditEvent is the
+// control for the runtime signal: a same-tier fallback firing must NOT be
+// reported as a downgrade event.
+func TestNewKeyProviderFromConfig_SameTierFallback_NoRuntimeAuditEvent(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "salt",
+		KeyProvider: config.KeyProviderConfig{
+			Type:     "file",
+			FilePath: filepath.Join(dir, "nonexistent-primary.key"),
+			Fallbacks: []config.KeyProviderConfig{
+				{Type: "env", EnvVar: "_KEYORIX_TEST_KEK_ABSENT_SAME_TIER_2"},
+			},
+		},
+	}
+	svc := encryption.NewService(cfg, dir)
+
+	called := false
+	svc.SetAuditSink(func(ctx context.Context, event *models.AuditEvent) error {
+		called = true
+		return nil
+	})
+
+	// Both file and env fail here (nonexistent path / unset env var), so
+	// Initialize returns an error — the point is only that no downgrade event
+	// fires along the way, since file→env is a same-tier chain.
+	_ = svc.Initialize("test-passphrase")
+	assert.False(t, called, "a same-tier fallback must never be reported as a downgrade, even when both providers ultimately fail")
+}
+
+// TestNewKeyProviderFromConfig_SameTierFallback_NoOptInRequired is the
+// non-downgrading control case: a same-tier fallback chain (aws-kms primary,
+// gcp-kms fallback — both TierHardware) must keep working with NO opt-in, so the
+// gate never breaks the legitimate multi-provider use case.
+func TestNewKeyProviderFromConfig_SameTierFallback_NoOptInRequired(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "salt",
+		KeyProvider: config.KeyProviderConfig{
+			Type:     "file",
+			FilePath: filepath.Join(dir, "nonexistent-primary.key"),
+			Fallbacks: []config.KeyProviderConfig{
+				{Type: "env", EnvVar: "_KEYORIX_TEST_KEK_ABSENT_SAME_TIER"},
+			},
+			// no AllowWeakerFallback — file and env are both TierSoftware, so this
+			// must be accepted without it.
+		},
+	}
+	p, err := encryption.NewKeyProviderFromConfig(cfg, dir, "test-passphrase")
+	require.NoError(t, err)
+	assert.Contains(t, p.Name(), "multi(")
 }

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -28,6 +28,13 @@ type Service struct {
 	// serverLock is held for as long as this Service is the live DEK holder (set
 	// by AcquireExclusiveKeyLock, released by Shutdown). See exclusive_lock.go.
 	serverLock *os.File
+	// auditSink optionally records security-relevant runtime events (e.g. a
+	// key-provider fallback chain actually firing a downgrade, see
+	// key_provider_downgrade.go) as audit events. Guarded by its own mutex, not mu:
+	// it is read from deep inside Initialize (via the MultiKeyProvider downgrade
+	// hook) while mu is already held for writing, and mu is not reentrant.
+	auditSink   AuditSink
+	auditSinkMu sync.RWMutex
 }
 
 // NewService creates a new encryption Service.
@@ -76,8 +83,18 @@ func (s *Service) Initialize(passphrase string) error {
 }
 
 // buildKeyProvider selects the KEK source for this service from its own config.
+// If the result is a fallback chain (crypto.MultiKeyProvider), wires this
+// Service's audit sink so a downgrade that actually FIRES at KEK() time — not
+// just one the config permits — is recorded as more than a log line.
 func (s *Service) buildKeyProvider(passphrase string) (crypto.KeyProvider, error) {
-	return NewKeyProviderFromConfig(s.config, s.keyManager.baseDir, passphrase)
+	provider, err := NewKeyProviderFromConfig(s.config, s.keyManager.baseDir, passphrase)
+	if err != nil {
+		return nil, err
+	}
+	if mp, ok := provider.(*crypto.MultiKeyProvider); ok {
+		mp.SetDowngradeHook(s.auditKeyProviderDowngrade)
+	}
+	return provider, nil
 }
 
 // NewKeyProviderFromConfig builds the KEK source described by an EncryptionConfig
@@ -105,6 +122,18 @@ func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase 
 			return nil, fmt.Errorf("fallback provider [%d] (%s): %w", i, cfg.KeyProvider.Fallbacks[i].Type, err)
 		}
 		providers = append(providers, fb)
+	}
+	// Fail closed on a fallback chain that can silently downgrade KEK-sourcing
+	// strength (e.g. a TPM/KMS-backed primary falling back to a software-derived
+	// key on any transient failure) unless the operator has explicitly opted in.
+	// This is a config-SHAPE check — it fires whenever the chain CAN downgrade,
+	// regardless of whether a fallback ever actually happens at runtime; see
+	// MultiKeyProvider.KEK / SetDowngradeHook for the separate runtime signal that
+	// fires only when a fallback to a weaker provider actually occurs.
+	if d, downgrades := crypto.DetectFallbackDowngrade(providers); downgrades && !cfg.KeyProvider.AllowWeakerFallback {
+		return nil, fmt.Errorf(
+			"key_provider fallback [%d] (%q, %s) is weaker than an earlier provider in the configured chain (%s) — a fallback chain that can silently downgrade encryption strength requires explicit key_provider.allow_weaker_fallback: true; refusing to start without it",
+			d.Index-1, d.Provider, d.ToTier, d.FromTier)
 	}
 	return crypto.NewMultiKeyProvider(providers)
 }

--- a/internal/evidencesink/objectstore.go
+++ b/internal/evidencesink/objectstore.go
@@ -17,6 +17,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -80,6 +83,76 @@ func objectLockMode(mode string) (s3types.ObjectLockMode, error) {
 	}
 }
 
+// validateObjectStoreEndpoint checks that a custom S3-compatible endpoint URL is
+// well-formed and uses an http(s) scheme, before it is handed to the AWS SDK as
+// BaseEndpoint. Unlike webhook.go's validateEndpoint, this deliberately does NOT
+// block private/link-local destinations: a self-hosted S3-compatible store (MinIO,
+// a local gateway, an in-cluster service, ...) legitimately lives on an internal
+// address — that's the whole point of self-hosting — so the blanket SSRF IP-range
+// guard webhook.go applies to its own (public-collector-shaped) endpoint would
+// break the primary use case here. What IS worth rejecting regardless of target:
+// a malformed URL, or a scheme other than http/https (e.g. file://) that has no
+// business being handed to an S3 client's BaseEndpoint. An empty raw (use the
+// default AWS S3 endpoint) is always fine and returns a nil URL with no error.
+func validateObjectStoreEndpoint(raw string) (*url.URL, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("evidencesink: invalid object-store endpoint %q: %w", raw, err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return nil, fmt.Errorf("evidencesink: object-store endpoint %q must use http or https", raw)
+	}
+	if u.Hostname() == "" {
+		return nil, fmt.Errorf("evidencesink: object-store endpoint %q has no host", raw)
+	}
+	return u, nil
+}
+
+// rawDialContext performs the actual network dial once a target address has been
+// chosen. A package-level var (like lookupIPAddr below it) so tests can observe
+// the address a pinned dial actually connects to without opening a real socket.
+var rawDialContext = (&net.Dialer{}).DialContext
+
+// pinnedDialContext resolves host ONCE — here, at NewObjectStore construction
+// time — and returns a DialContext that connects to that literal resolved IP for
+// EVERY future connection, never re-resolving. This closes the residual DNS-
+// rebinding gap the finding describes: ObjectStoreConfig.Endpoint is a long-lived,
+// operator-set config value reused for many uploads over the ObjectStore's whole
+// lifetime (unlike webhook.go's per-delivery dialer, which re-validates on every
+// dial because it also has a private/link-local block to keep enforcing). Here
+// there is no such block to repeat — the endpoint may legitimately be private —
+// so the only protection worth applying is pinning: if the hostname is LATER
+// repointed via DNS (the domain lapses and is re-registered, an internal DNS
+// record is repointed, ...), this long-lived client keeps talking to the address
+// that was actually resolved at setup time, instead of silently starting to PUT
+// the evidence pack — and its SigV4 Authorization header — to a new, unvetted
+// host. A literal IP endpoint has nothing to resolve or pin.
+func pinnedDialContext(host string) (func(ctx context.Context, network, addr string) (net.Conn, error), error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return rawDialContext, nil
+	}
+	addrs, err := lookupIPAddr(host)
+	if err != nil {
+		return nil, fmt.Errorf("evidencesink: resolve object-store endpoint host %q: %w", host, err)
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("evidencesink: object-store endpoint host %q did not resolve to any address", host)
+	}
+	pinned := addrs[0].IP
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		_, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("evidencesink: invalid dial address %q: %w", addr, err)
+		}
+		return rawDialContext(ctx, network, net.JoinHostPort(pinned.String(), port))
+	}, nil
+}
+
 // NewObjectStore builds the S3-compatible sink. The bucket is required; credentials
 // resolve via the default AWS credential chain.
 func NewObjectStore(ctx context.Context, cfg ObjectStoreConfig) (*ObjectStore, error) {
@@ -93,6 +166,20 @@ func NewObjectStore(ctx context.Context, cfg ObjectStoreConfig) (*ObjectStore, e
 	if lockMode != "" && cfg.LockRetainDays <= 0 {
 		return nil, fmt.Errorf("evidencesink: object_lock_retain_days must be > 0 when object_lock_mode is set")
 	}
+	epURL, err := validateObjectStoreEndpoint(cfg.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	var endpointHTTPClient *http.Client
+	if epURL != nil {
+		dialCtx, derr := pinnedDialContext(epURL.Hostname())
+		if derr != nil {
+			return nil, derr
+		}
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.DialContext = dialCtx
+		endpointHTTPClient = &http.Client{Transport: tr}
+	}
 	var loadOpts []func(*awsconfig.LoadOptions) error
 	if cfg.Region != "" {
 		loadOpts = append(loadOpts, awsconfig.WithRegion(cfg.Region))
@@ -104,6 +191,9 @@ func NewObjectStore(ctx context.Context, cfg ObjectStoreConfig) (*ObjectStore, e
 	client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
 		if cfg.Endpoint != "" {
 			o.BaseEndpoint = aws.String(cfg.Endpoint)
+		}
+		if endpointHTTPClient != nil {
+			o.HTTPClient = endpointHTTPClient
 		}
 		o.UsePathStyle = cfg.UsePathStyle
 	})

--- a/internal/evidencesink/objectstore_test.go
+++ b/internal/evidencesink/objectstore_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"testing"
 	"time"
 
@@ -152,4 +153,129 @@ func TestNormalizePrefix(t *testing.T) {
 	assert.Equal(t, "a/", normalizePrefix("a"))
 	assert.Equal(t, "a/b/", normalizePrefix("a/b"))
 	assert.Equal(t, "a/b/", normalizePrefix("a/b/"))
+}
+
+// TestNewObjectStore_RejectsInvalidEndpointScheme verifies a custom object-store
+// endpoint with a non-http(s) scheme (or a malformed URL) is rejected at
+// construction, rather than being handed to the AWS SDK unchecked. Before this
+// fix, ObjectStoreConfig.Endpoint had NO validation at all — unlike webhook.go's
+// sibling Endpoint field.
+func TestNewObjectStore_RejectsInvalidEndpointScheme(t *testing.T) {
+	_, err := NewObjectStore(context.Background(), ObjectStoreConfig{Bucket: "b", Endpoint: "ftp://example.com"})
+	require.ErrorContains(t, err, "must use http or https")
+
+	_, err = NewObjectStore(context.Background(), ObjectStoreConfig{Bucket: "b", Endpoint: "file:///etc/passwd"})
+	require.ErrorContains(t, err, "must use http or https")
+}
+
+// TestNewObjectStore_RejectsMalformedEndpoint verifies an unparseable endpoint URL
+// is rejected with a clear error instead of surfacing later as an opaque SDK
+// failure.
+func TestNewObjectStore_RejectsMalformedEndpoint(t *testing.T) {
+	_, err := NewObjectStore(context.Background(), ObjectStoreConfig{Bucket: "b", Endpoint: "http://[::1"})
+	require.ErrorContains(t, err, "invalid object-store endpoint")
+}
+
+// TestNewObjectStore_RejectsEndpointWithNoHost verifies a scheme-only endpoint
+// (no host to connect to) is rejected rather than silently passed through.
+func TestNewObjectStore_RejectsEndpointWithNoHost(t *testing.T) {
+	_, err := NewObjectStore(context.Background(), ObjectStoreConfig{Bucket: "b", Endpoint: "https:///path"})
+	require.ErrorContains(t, err, "has no host")
+}
+
+// TestNewObjectStore_AcceptsSelfHostedPrivateEndpoint verifies the primary,
+// legitimate use case — a self-hosted S3-compatible store (MinIO, a local
+// gateway, ...) living on a private/internal address — is still accepted.
+// Unlike webhook.go's blanket SSRF IP-range guard, the object-store endpoint
+// validation must NOT block this: that's the whole point of self-hosting, and
+// the finding itself calls out that a blanket private-IP block would break
+// this primary use case. The endpoint is a literal IP so no DNS resolution is
+// needed, keeping this test hermetic.
+func TestNewObjectStore_AcceptsSelfHostedPrivateEndpoint(t *testing.T) {
+	o, err := NewObjectStore(context.Background(), ObjectStoreConfig{
+		Bucket:       "evidence",
+		Endpoint:     "http://10.0.0.50:9000",
+		UsePathStyle: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, o)
+}
+
+// TestNewObjectStore_EndpointResolutionFailurePropagates verifies a hostname
+// endpoint that fails to resolve at construction time fails NewObjectStore
+// (fail-closed), rather than silently deferring the failure to the first
+// upload — and confirms construction actually resolves the configured host as
+// part of setting up the pinned dialer.
+func TestNewObjectStore_EndpointResolutionFailurePropagates(t *testing.T) {
+	orig := lookupIPAddr
+	defer func() { lookupIPAddr = orig }()
+	lookupIPAddr = func(host string) ([]net.IPAddr, error) {
+		return nil, errors.New("no such host")
+	}
+
+	_, err := NewObjectStore(context.Background(), ObjectStoreConfig{Bucket: "b", Endpoint: "http://minio.internal:9000"})
+	require.ErrorContains(t, err, "resolve object-store endpoint")
+}
+
+// TestPinnedDialContext_ResolvesOnceAndPinsIP is the direct regression test for
+// the DNS-rebinding mitigation: pinnedDialContext must resolve its host exactly
+// ONCE and then dial that same literal IP for every subsequent connection, even
+// if the hostname's DNS answer changes afterward (a DNS-rebinding attacker
+// repointing the operator-configured endpoint after it was set up). This is what
+// closes the finding's residual risk — the evidence pack's PUT (carrying the
+// SigV4 Authorization header) keeps going to the address actually resolved at
+// setup time, not wherever the hostname currently resolves to.
+func TestPinnedDialContext_ResolvesOnceAndPinsIP(t *testing.T) {
+	origLookup := lookupIPAddr
+	origDial := rawDialContext
+	defer func() { lookupIPAddr = origLookup; rawDialContext = origDial }()
+
+	lookups := 0
+	lookupIPAddr = func(host string) ([]net.IPAddr, error) {
+		lookups++
+		if lookups == 1 {
+			return []net.IPAddr{{IP: net.ParseIP("203.0.113.10")}}, nil
+		}
+		// A later call (there should never be one) simulates a rebound
+		// answer — a different IP the pinned dialer must never observe.
+		return []net.IPAddr{{IP: net.ParseIP("198.51.100.99")}}, nil
+	}
+
+	var dialedAddr string
+	rawDialContext = func(_ context.Context, _ string, addr string) (net.Conn, error) {
+		dialedAddr = addr
+		return nil, errors.New("stub: no real dial performed")
+	}
+
+	dial, err := pinnedDialContext("minio.internal")
+	require.NoError(t, err)
+	assert.Equal(t, 1, lookups, "resolves exactly once, at pinning time")
+
+	_, _ = dial(context.Background(), "tcp", "minio.internal:9000")
+	assert.Equal(t, "203.0.113.10:9000", dialedAddr, "dials the pinned first-resolution IP")
+	assert.Equal(t, 1, lookups, "does not re-resolve on dial")
+
+	// A second dial (as happens across the ObjectStore's many uploads over
+	// its lifetime) must still use the originally pinned IP, never a fresh
+	// (possibly rebound) DNS answer.
+	dialedAddr = ""
+	_, _ = dial(context.Background(), "tcp", "minio.internal:9000")
+	assert.Equal(t, "203.0.113.10:9000", dialedAddr, "still pinned to the original IP on a later dial")
+	assert.Equal(t, 1, lookups, "still exactly one resolution total")
+}
+
+// TestPinnedDialContext_LiteralIPSkipsResolution verifies an endpoint that is
+// already a literal IP (no hostname to rebind) dials straight through without
+// consulting the resolver at all.
+func TestPinnedDialContext_LiteralIPSkipsResolution(t *testing.T) {
+	origLookup := lookupIPAddr
+	defer func() { lookupIPAddr = origLookup }()
+	lookupIPAddr = func(host string) ([]net.IPAddr, error) {
+		t.Fatalf("lookupIPAddr must not be called for a literal-IP endpoint, got host %q", host)
+		return nil, nil
+	}
+
+	dial, err := pinnedDialContext("10.0.0.50")
+	require.NoError(t, err)
+	require.NotNil(t, dial)
 }

--- a/internal/notary/notary_fuzz_test.go
+++ b/internal/notary/notary_fuzz_test.go
@@ -58,7 +58,10 @@ func FuzzRFC3161Anchor(f *testing.F) {
 			_, _ = w.Write(body)
 		}))
 		defer srv.Close()
-		r := NewRFC3161(srv.URL, defaultTimeout)
+		r, err := NewRFC3161(srv.URL, defaultTimeout)
+		if err != nil {
+			t.Fatalf("unexpected NewRFC3161 error for loopback test server URL: %v", err)
+		}
 		// Must never panic.
 		_, _ = r.Anchor(context.Background(), []byte("fuzz anchor message"))
 	})

--- a/internal/notary/notary_s17_test.go
+++ b/internal/notary/notary_s17_test.go
@@ -17,7 +17,8 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestNewRFC3161_ZeroTimeout_UsesDefault(t *testing.T) {
-	r := NewRFC3161("https://example.tsa/rfc3161", 0)
+	r, err := NewRFC3161("https://example.tsa/rfc3161", 0)
+	require.NoError(t, err)
 	assert.Equal(t, defaultTimeout, r.client.Timeout)
 }
 
@@ -46,17 +47,20 @@ func TestVerifyReceipt_MalformedToken_NoPanic(t *testing.T) {
 }
 
 func TestNewRFC3161_NegativeTimeout_UsesDefault(t *testing.T) {
-	r := NewRFC3161("https://example.tsa/rfc3161", -1*time.Second)
+	r, err := NewRFC3161("https://example.tsa/rfc3161", -1*time.Second)
+	require.NoError(t, err)
 	assert.Equal(t, defaultTimeout, r.client.Timeout)
 }
 
 func TestNewRFC3161_PositiveTimeout_Respected(t *testing.T) {
-	r := NewRFC3161("https://example.tsa/rfc3161", 5*time.Second)
+	r, err := NewRFC3161("https://example.tsa/rfc3161", 5*time.Second)
+	require.NoError(t, err)
 	assert.Equal(t, 5*time.Second, r.client.Timeout)
 }
 
 func TestRFC3161_Provider(t *testing.T) {
-	r := NewRFC3161("https://freetsa.org/tsr", 5*time.Second)
+	r, err := NewRFC3161("https://freetsa.org/tsr", 5*time.Second)
+	require.NoError(t, err)
 	assert.Equal(t, "rfc3161:https://freetsa.org/tsr", r.Provider())
 }
 
@@ -64,22 +68,24 @@ func TestRFC3161_Provider(t *testing.T) {
 // Anchor — error paths that don't require a live HTTP server
 // ---------------------------------------------------------------------------
 
-// TestRFC3161_Anchor_BadURL exercises the http.NewRequestWithContext error branch:
-// a URL with an invalid control character causes request creation to fail.
+// TestRFC3161_Anchor_BadURL confirms a URL with an invalid control character is
+// rejected. This used to only surface via http.NewRequestWithContext failing at
+// Anchor() time; NewRFC3161 now parses (and https/loopback-validates) the URL at
+// construction, so the same malformed input is now caught earlier, at startup —
+// url.Parse itself rejects the embedded null byte.
 func TestRFC3161_Anchor_BadURL(t *testing.T) {
-	// A URL with a null byte in it causes http.NewRequestWithContext to fail
-	// (invalid control character in URL).
-	r := NewRFC3161("http://host/\x00bad", 5*time.Second)
-	_, err := r.Anchor(context.Background(), []byte("hello"))
+	_, err := NewRFC3161("https://host/\x00bad", 5*time.Second)
 	require.Error(t, err)
 }
 
 // TestRFC3161_Anchor_UnreachableHost exercises the http.Do error path: a URL
-// pointing at a closed local port causes the TCP dial to fail quickly.
+// pointing at a closed local port causes the TCP dial to fail quickly. Plain
+// http to loopback is the documented local-testing exception (validateTSAURL).
 func TestRFC3161_Anchor_UnreachableHost(t *testing.T) {
 	// Port 1 on localhost — connection refused in < 1 ms on any OS.
-	r := NewRFC3161("http://127.0.0.1:1/tsr", 2*time.Second)
-	_, err := r.Anchor(context.Background(), []byte("hello"))
+	r, err := NewRFC3161("http://127.0.0.1:1/tsr", 2*time.Second)
+	require.NoError(t, err)
+	_, err = r.Anchor(context.Background(), []byte("hello"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "post to")
 }
@@ -105,9 +111,9 @@ func TestRFC3161_Anchor_MalformedTSAResponseNoPanic(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(body)
 		}))
-		client := NewRFC3161(srv.URL, 5*time.Second)
+		client, err := NewRFC3161(srv.URL, 5*time.Second)
+		require.NoError(t, err)
 
-		var err error
 		require.NotPanics(t, func() {
 			_, err = client.Anchor(context.Background(), []byte("anchor message"))
 		})
@@ -132,4 +138,50 @@ func TestVerifyReceipt_EmptyToken_FailsClosed(t *testing.T) {
 	_, err := VerifyReceipt(nil, []byte("msg"), nil)
 	require.Error(t, err)
 	// nil roots error fires before empty-token check, so we only need Error here.
+}
+
+// ---------------------------------------------------------------------------
+// validateTSAURL / NewRFC3161 — https-only, loopback exception (Wave 6 #baseline/notary-findings.json#1)
+// ---------------------------------------------------------------------------
+
+// TestNewRFC3161_RejectsPlaintextHTTP_NonLoopback confirms a plaintext http://
+// TSA URL to a non-loopback host is rejected at construction, not silently
+// accepted. A network attacker on that path could otherwise see every
+// checkpoint hash being anchored and swap in a rogue TSA's response.
+func TestNewRFC3161_RejectsPlaintextHTTP_NonLoopback(t *testing.T) {
+	_, err := NewRFC3161("http://tsa.example.com/tsr", 5*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+}
+
+// TestNewRFC3161_AcceptsHTTPS confirms a well-formed https:// TSA URL is still
+// accepted (the common, expected case).
+func TestNewRFC3161_AcceptsHTTPS(t *testing.T) {
+	_, err := NewRFC3161("https://tsa.example.com/tsr", 5*time.Second)
+	require.NoError(t, err)
+}
+
+// TestNewRFC3161_AcceptsPlaintextHTTP_Loopback confirms the local-testing
+// exception this codebase uses elsewhere for operator-configured outbound URLs
+// (internal/storage/remote's validateBaseURL, server/main.go's
+// requireSecureOrLoopback): plain http to localhost/a loopback IP is still
+// accepted, since that can only ever be a local dev/test TSA, not a real
+// network attacker's vantage point.
+func TestNewRFC3161_AcceptsPlaintextHTTP_Loopback(t *testing.T) {
+	for _, u := range []string{
+		"http://127.0.0.1:8080/tsr",
+		"http://localhost:8080/tsr",
+		"http://[::1]:8080/tsr",
+	} {
+		_, err := NewRFC3161(u, 5*time.Second)
+		require.NoError(t, err, u)
+	}
+}
+
+// TestNewRFC3161_RejectsMalformedURL confirms a URL with no host is rejected
+// (unchanged pre-existing behavior, re-pinned after the https-only rewrite of
+// validateTSAURL).
+func TestNewRFC3161_RejectsMalformedURL(t *testing.T) {
+	_, err := NewRFC3161("not-a-url", 5*time.Second)
+	require.Error(t, err)
 }

--- a/internal/notary/notary_test.go
+++ b/internal/notary/notary_test.go
@@ -83,7 +83,9 @@ func TestRFC3161_AnchorAndVerifyRoundTrip(t *testing.T) {
 	roots.AddCert(cert)
 
 	msg := []byte("v1\x00128\x0099\x00deadbeef\x00v1")
-	rec, err := NewRFC3161(srv.URL, 5*time.Second).Anchor(context.Background(), msg)
+	tsa, err := NewRFC3161(srv.URL, 5*time.Second)
+	require.NoError(t, err)
+	rec, err := tsa.Anchor(context.Background(), msg)
 	require.NoError(t, err)
 	require.NotEmpty(t, rec.Token)
 	assert.WithinDuration(t, fixedTime, rec.Time, time.Second)
@@ -128,7 +130,9 @@ func TestRFC3161_Anchor_HTTPError(t *testing.T) {
 		http.Error(w, "nope", http.StatusServiceUnavailable)
 	}))
 	t.Cleanup(srv.Close)
-	_, err := NewRFC3161(srv.URL, 5*time.Second).Anchor(context.Background(), []byte("m"))
+	tsa, err := NewRFC3161(srv.URL, 5*time.Second)
+	require.NoError(t, err)
+	_, err = tsa.Anchor(context.Background(), []byte("m"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HTTP 503")
 }
@@ -138,6 +142,8 @@ func TestRFC3161_Anchor_GarbageResponse(t *testing.T) {
 		_, _ = w.Write([]byte("not-a-timestamp-response"))
 	}))
 	t.Cleanup(srv.Close)
-	_, err := NewRFC3161(srv.URL, 5*time.Second).Anchor(context.Background(), []byte("m"))
+	tsa, err := NewRFC3161(srv.URL, 5*time.Second)
+	require.NoError(t, err)
+	_, err = tsa.Anchor(context.Background(), []byte("m"))
 	require.Error(t, err)
 }

--- a/internal/notary/rfc3161.go
+++ b/internal/notary/rfc3161.go
@@ -6,6 +6,7 @@ import (
 	"crypto"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -30,12 +31,18 @@ type RFC3161 struct {
 }
 
 // NewRFC3161 builds a TSA notary for the given query URL. A non-positive timeout
-// falls back to defaultTimeout.
-func NewRFC3161(url string, timeout time.Duration) *RFC3161 {
+// falls back to defaultTimeout. Returns an error if url is not an https URL (or
+// http to a loopback host, for local testing — see validateTSAURL) so a
+// misconfigured plaintext TSA is caught at startup, not on the first anchor
+// attempt.
+func NewRFC3161(url string, timeout time.Duration) (*RFC3161, error) {
+	if err := validateTSAURL(url); err != nil {
+		return nil, err
+	}
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
-	return &RFC3161{url: url, client: &http.Client{Timeout: timeout, CheckRedirect: refuseRedirect}}
+	return &RFC3161{url: url, client: &http.Client{Timeout: timeout, CheckRedirect: refuseRedirect}}, nil
 }
 
 // refuseRedirect stops the TSA client from following any redirect: without this,
@@ -49,22 +56,41 @@ func refuseRedirect(req *http.Request, _ []*http.Request) error {
 func (r *RFC3161) Provider() string { return "rfc3161:" + r.url }
 
 // validateTSAURL checks that the configured TSA URL is a well-formed absolute
-// http(s) URL. Deliberately does NOT reject private/loopback hosts: this is
-// operator-configured deployment config (see the RFC3161 doc comment above) that
-// may legitimately point at an internal/self-hosted TSA — this only rejects a
-// malformed or non-HTTP(S) destination reaching the outbound client.
+// URL using https. Plaintext http is accepted ONLY to a loopback host
+// (localhost/127.0.0.1/::1), for local development/testing — the same
+// exception this codebase uses for other operator-configured outbound URLs
+// (internal/storage/remote/config.go's validateBaseURL, server/main.go's
+// requireSecureOrLoopback). A non-loopback http:// TSA URL is rejected: the
+// TSA response itself is a signed token, but the request leg (the checkpoint
+// hash being timestamped, plus the response in transit) still needs transport
+// confidentiality/integrity — a network attacker on a plaintext path can see
+// every checkpoint being anchored and swap in a rogue TSA's response, and
+// nothing else in this codebase distinguishes "recorded" from "meaningfully
+// anchored" for the operator relying on this feature.
 func validateTSAURL(raw string) error {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("rfc3161: invalid url %q: %w", raw, err)
 	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("rfc3161: url %q must use http or https", raw)
-	}
 	if u.Host == "" {
 		return fmt.Errorf("rfc3161: url %q is missing a host", raw)
 	}
+	if u.Scheme != "https" && !(u.Scheme == "http" && isLoopbackHost(u.Hostname())) {
+		return fmt.Errorf("rfc3161: url %q must use https (http is allowed only for a loopback host, for local testing)", raw)
+	}
 	return nil
+}
+
+// isLoopbackHost reports whether host is localhost or a loopback IP — mirrors
+// the same helper this codebase uses elsewhere for outbound-URL TLS checks.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 func (r *RFC3161) Anchor(ctx context.Context, message []byte) (_ *Receipt, err error) {

--- a/internal/rotation/mongodb.go
+++ b/internal/rotation/mongodb.go
@@ -77,11 +77,19 @@ func (e *MongoExecutor) Rotate(ctx context.Context, ref, newValue string) error 
 	}
 	c, err := e.conn(ctx)
 	if err != nil {
-		return err
+		// conn() wraps mongo.Connect, whose connection-string parsing was checked
+		// and does not echo the raw URI on the malformed-DSN cases exercised, but
+		// is redacted anyway for defense in depth — matching the same treatment
+		// applied to redis.go's confirmed DSN-echo leak and #132's original fix.
+		return redactConnError("mongodb", ref, err)
 	}
 	defer c.Close(ctx)
 	if err := c.UpdateUserPassword(ctx, ref, newValue); err != nil {
-		return fmt.Errorf("mongodb: rotate user %q: %w", ref, err)
+		// Redact before wrapping — see the comment on the conn() error above; kept
+		// consistent here even though UpdateUserPassword's args are typed BSON
+		// values (not string-concatenated), matching mysql.go's own
+		// defense-in-depth precedent.
+		return redactConnError("mongodb", ref, err)
 	}
 	return nil
 }

--- a/internal/rotation/mongodb_test.go
+++ b/internal/rotation/mongodb_test.go
@@ -68,4 +68,34 @@ func TestMongo_RotateErrors(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "UserNotFound")
 	})
+	// #132 sibling gap: postgres.go/mysql.go redact a driver error that echoes a live
+	// credential before wrapping it; that redaction was never applied to mongodb.go,
+	// reopening the same leak class for a backend whose admin credential lives in the
+	// DSN/URI itself rather than in a SQL statement.
+	t.Run("backend error echoing a URI-shaped credential is redacted", func(t *testing.T) {
+		fake := &fakeMongo{err: errors.New(`dial failed: mongodb://admin:S3cr3t-Live-Value!@db:27017: connection refused`)}
+		err := mongoWith(fake, "app_").Rotate(context.Background(), "app_svc", "v")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "S3cr3t-Live-Value!", "the live credential must never appear in the returned error")
+		assert.Contains(t, err.Error(), "app_svc", "the ref is still useful diagnostic context")
+		assert.Contains(t, err.Error(), "***@", "the redacted userinfo is replaced with a placeholder, not silently dropped")
+	})
+}
+
+// TestMongo_ConnErrorRedactsURICredentialIfEchoed exercises mongodb.go's conn()-error
+// path via a fake newConn that simulates a URI-shaped connect failure. MongoDB's
+// connstring parser was checked empirically (options.Client().ApplyURI + Validate against
+// several malformed-DSN shapes) and does not echo the raw URI on any case exercised, but
+// conn()'s error is still redacted for defense in depth — this confirms that redaction is
+// actually wired up on the connect path too, not only the mutate path, so a future
+// connstring/driver change can't silently reopen this.
+func TestMongo_ConnErrorRedactsURICredentialIfEchoed(t *testing.T) {
+	e := NewMongoExecutor("mongo", "mongodb://admin:pw@db:27017", []string{"app_"})
+	e.newConn = func(context.Context, string) (mongoConn, error) {
+		return nil, errors.New(`dial failed: mongodb://admin:S3cr3t-Live-Value!@db:27017: connection refused`)
+	}
+	err := e.Rotate(context.Background(), "app_svc", "v")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "S3cr3t-Live-Value!", "the live credential must never appear in the returned error")
+	assert.Contains(t, err.Error(), "app_svc", "the ref is still useful diagnostic context")
 }

--- a/internal/rotation/redis.go
+++ b/internal/rotation/redis.go
@@ -68,11 +68,19 @@ func (e *RedisExecutor) Rotate(ctx context.Context, ref, newValue string) error 
 	}
 	c, err := e.conn(ctx)
 	if err != nil {
-		return err
+		// conn() can fail with a redis.ParseURL error that echoes the admin DSN —
+		// credentials and all — verbatim (net/url does not redact on a parse
+		// failure). Redact before wrapping so the live admin password never
+		// egresses via the rotation-failure SIEM audit / notification broadcast
+		// (#132, extended to this backend's DSN-echo leak shape).
+		return redactConnError("redis", ref, err)
 	}
 	defer func() { _ = c.Close() }()
 	if err := c.SetUserPassword(ctx, ref, newValue); err != nil {
-		return fmt.Errorf("redis: rotate user %q: %w", ref, err)
+		// Redact before wrapping — see the comment on the conn() error above; kept
+		// consistent here even though SetUserPassword's args are discrete (not
+		// string-concatenated), matching mysql.go's own defense-in-depth precedent.
+		return redactConnError("redis", ref, err)
 	}
 	return nil
 }

--- a/internal/rotation/redis_test.go
+++ b/internal/rotation/redis_test.go
@@ -63,4 +63,31 @@ func TestRedis_RotateErrors(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "NOPERM")
 	})
+	// #132 sibling gap: postgres.go/mysql.go redact a driver error that echoes a live
+	// credential before wrapping it; that redaction was never applied to redis.go,
+	// reopening the same leak class for a backend whose admin credential lives in the
+	// DSN/URI itself rather than in a SQL statement.
+	t.Run("backend error echoing a URI-shaped credential is redacted", func(t *testing.T) {
+		fake := &fakeRedis{err: errors.New(`dial failed: redis://default:S3cr3t-Live-Value!@db:6379: connection refused`)}
+		err := redisWith(fake, "svc-").Rotate(context.Background(), "svc-app", "v")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "S3cr3t-Live-Value!", "the live credential must never appear in the returned error")
+		assert.Contains(t, err.Error(), "svc-app", "the ref is still useful diagnostic context")
+		assert.Contains(t, err.Error(), "***@", "the redacted userinfo is replaced with a placeholder, not silently dropped")
+	})
+}
+
+// TestRedis_ConnErrorRedactsDSNCredential exercises the REAL redis.ParseURL path (no
+// newConn override): go-redis parses the admin DSN with the stdlib net/url package, and
+// net/url's *url.Error stringifies as `parse %q: %s` with the ORIGINAL raw input on a
+// parse failure — credentials and all (net/url only redacts userinfo when a caller
+// explicitly calls URL.Redacted(), which ParseURL never does; confirmed empirically
+// against github.com/redis/go-redis/v9). A malformed admin DSN — as mundane as a typo'd
+// port — must not leak the live admin password into the returned error.
+func TestRedis_ConnErrorRedactsDSNCredential(t *testing.T) {
+	e := NewRedisExecutor("redis", "redis://admin:S3cr3t-Live-Value!@127.0.0.1:notaport/0", []string{"svc-"})
+	err := e.Rotate(context.Background(), "svc-app", "newpw")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "S3cr3t-Live-Value!", "the admin DSN credential must never appear in the returned error")
+	assert.Contains(t, err.Error(), "svc-app", "the ref is still useful diagnostic context")
 }

--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -143,3 +143,30 @@ func redactSQLError(backend, ref string, err error) error {
 	redacted := sqlStringLiteral.ReplaceAllString(err.Error(), "'***'")
 	return fmt.Errorf("%s: rotate %q: %s", backend, ref, redacted)
 }
+
+// connURICredentialPattern matches the userinfo segment of a URI (scheme://user:pass@ or
+// scheme://user@) — the shape the admin credential takes in redis.go's and mongodb.go's
+// dsn field (redis://user:pass@host, mongodb://user:pass@host).
+var connURICredentialPattern = regexp.MustCompile(`://[^/@\s]*@`)
+
+// redactConnError wraps err with a value-free message: the Redis and MongoDB rotation
+// backends (redis.go, mongodb.go) carry their admin credential IN the DSN/URI itself,
+// rather than in a SQL statement — a different leak shape than PostgreSQL/MySQL's
+// (redactSQLError above), so a literal-scrubbing SQL redaction doesn't transfer; this is
+// a URI-shaped equivalent following the same defensive intent.
+//
+// Confirmed empirically (see internal/rotation package tests / #132 follow-up): go-redis's
+// ParseURL parses the DSN with the stdlib net/url package, and on a malformed DSN,
+// net/url's *url.Error stringifies as `parse %q: %s` with the ORIGINAL raw input —
+// credentials and all. net/url only redacts userinfo when a caller explicitly calls
+// URL.Redacted(); a parse failure never does that. Left unwrapped, a config error as
+// mundane as a typo'd port would put the live admin password into the rotation-failure
+// SIEM audit Description and the Slack/webhook broadcast — the same failure mode #132
+// closed for postgres.go/mysql.go (there via a statement echo; here via a DSN echo).
+// MongoDB's connstring parser was checked too and does not echo the raw URI on the
+// malformed-DSN cases exercised, but the same redaction is applied to it for defense in
+// depth and so a future connstring/driver change can't silently reopen this.
+func redactConnError(backend, ref string, err error) error {
+	redacted := connURICredentialPattern.ReplaceAllString(err.Error(), "://***@")
+	return fmt.Errorf("%s: rotate %q: %s", backend, ref, redacted)
+}

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 )
 
 var FilePermsCmd = &cobra.Command{
@@ -30,6 +32,18 @@ type FilePermSpec struct {
 // read/write to a location outside it (a purely lexical filepath.Clean check would miss
 // that). The target file itself may not exist yet (writes), so its longest existing
 // ancestor is resolved and the unresolved tail re-attached.
+//
+// This is a cheap pre-check only, used to fail fast with a clear "access denied" error
+// on an obviously-escaping path (e.g. "../etc/passwd"). It is NOT sufficient on its own
+// as a security boundary: it can only resolve symlinks up to the longest EXISTING
+// ancestor at the moment it runs, so a not-yet-existing intermediate path component
+// (e.g. baseDir/not-yet-created-dir/file) is passed through unresolved, and an attacker
+// racing between this check and the later open could plant that component as a symlink
+// pointing outside baseDir. Every caller that actually opens the file MUST use
+// secureOpenBeneath (below) to perform the open, which closes that gap by walking the
+// path component-by-component with O_NOFOLLOW relative to already-open parent file
+// descriptors — see its doc comment for why that eliminates the TOCTOU window that this
+// function's path-string check alone cannot.
 func isPathInsideBase(baseDir, targetPath string) (bool, error) {
 	absBase, err := filepath.Abs(baseDir)
 	if err != nil {
@@ -81,11 +95,25 @@ func SafeReadFile(baseDir, filePath string) ([]byte, error) {
 		return nil, fmt.Errorf("access denied: file %q is outside of %q", cleanPath, baseDir)
 	}
 
-	return os.ReadFile(cleanPath)
+	// The actual open happens via secureOpenBeneath, not os.ReadFile(cleanPath): the
+	// isPathInsideBase check above only resolves symlinks up to the longest existing
+	// ancestor, so it cannot see a symlink an attacker plants at a not-yet-existing (or
+	// racily-replaced) intermediate component between this check and the open below.
+	// secureOpenBeneath closes that gap by walking every component with O_NOFOLLOW.
+	f, err := secureOpenBeneath(baseDir, filePath, unix.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return io.ReadAll(f)
 }
 
 // resolveInside joins and cleans baseDir/path and verifies the result stays
 // inside baseDir, returning the validated absolute-ish clean path.
+//
+// The returned path is for error messages and logging only — callers that open the
+// file MUST do so via secureOpenBeneath, not by re-opening this returned string, for
+// the same TOCTOU reason documented on isPathInsideBase.
 func resolveInside(baseDir, path string) (string, error) {
 	cleanPath := filepath.Clean(filepath.Join(baseDir, path))
 	ok, err := isPathInsideBase(baseDir, cleanPath)
@@ -98,6 +126,95 @@ func resolveInside(baseDir, path string) (string, error) {
 	return cleanPath, nil
 }
 
+// safeRelComponents cleans relPath and splits it into path components, rejecting
+// anything absolute, empty, or containing a ".." component that could escape baseDir.
+// This is a lexical check only — it never touches the filesystem. The actual
+// containment guarantee against symlinks (including ones racily planted at an
+// intermediate component) comes from secureOpenBeneath's per-component O_NOFOLLOW
+// walk below, not from this function.
+func safeRelComponents(relPath string) ([]string, error) {
+	if filepath.IsAbs(relPath) {
+		return nil, fmt.Errorf("access denied: path %q must be relative", relPath)
+	}
+	clean := filepath.Clean(relPath)
+	if clean == "." || clean == "" {
+		return nil, fmt.Errorf("access denied: empty path")
+	}
+	parts := strings.Split(clean, string(os.PathSeparator))
+	for _, p := range parts {
+		if p == ".." || p == "" {
+			return nil, fmt.Errorf("access denied: path %q escapes the base directory", relPath)
+		}
+	}
+	return parts, nil
+}
+
+// secureOpenBeneath opens (and, per flags, creates/truncates) the file at
+// baseDir/relPath, refusing to follow a symlink at ANY path component — not just the
+// final one.
+//
+// It walks relPath component-by-component using openat(2) (via golang.org/x/sys/unix)
+// relative to the file descriptor of the directory opened for the PREVIOUS component,
+// passing O_NOFOLLOW|O_DIRECTORY for every intermediate directory component and
+// O_NOFOLLOW for the final (leaf) component. This closes the TOCTOU gap that a plain
+// "validate path string, then os.OpenFile(path, ...O_NOFOLLOW)" leaves open:
+//
+//   - isPathInsideBase/resolveInside can only resolve symlinks up to the longest
+//     EXISTING ancestor at the moment they run; a not-yet-existing intermediate
+//     directory component is passed through unresolved.
+//   - A plain O_NOFOLLOW on the final os.OpenFile call only protects the FINAL path
+//     component — it does nothing to stop an attacker who, in the window between the
+//     validation and that final open, plants a symlink at an INTERMEDIATE component
+//     (one the containment check never resolved because it didn't exist yet).
+//
+// Once a component has been opened here, every subsequent step operates relative to
+// that already-open file descriptor (openat), never by re-resolving the path string —
+// so a symlink swapped in afterward at any already-traversed component cannot redirect
+// anything: the fd is bound to the inode that was actually opened, not to a path. A
+// symlink at a component not yet traversed is refused outright (ELOOP from O_NOFOLLOW)
+// instead of being followed. This mirrors the O_NOFOLLOW-on-open pattern already used
+// elsewhere in this file (SecureWriteFile, SecureWriteFileSync, FixFilePerms,
+// SecureDeleteFile) and extends it to cover every path component, not just the last.
+//
+// It does not create missing intermediate directories (matching the pre-existing
+// contract of SecureWriteFile/SecureWriteFileSync — callers create parent directories
+// themselves); a missing intermediate component is simply an open error.
+func secureOpenBeneath(baseDir, relPath string, flags int, perm os.FileMode) (*os.File, error) {
+	parts, err := safeRelComponents(relPath)
+	if err != nil {
+		return nil, err
+	}
+
+	dirFd, err := unix.Open(baseDir, unix.O_DIRECTORY|unix.O_RDONLY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open base directory %q: %w", baseDir, err)
+	}
+
+	for _, component := range parts[:len(parts)-1] {
+		childFd, oerr := unix.Openat(dirFd, component, unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_RDONLY, 0)
+		_ = unix.Close(dirFd)
+		if oerr != nil {
+			if errors.Is(oerr, unix.ELOOP) {
+				return nil, fmt.Errorf("access denied: path component %q of %q is a symlink", component, relPath)
+			}
+			return nil, fmt.Errorf("open path component %q of %q: %w", component, relPath, oerr)
+		}
+		dirFd = childFd
+	}
+
+	leaf := parts[len(parts)-1]
+	fd, oerr := unix.Openat(dirFd, leaf, flags|unix.O_NOFOLLOW, uint32(perm))
+	_ = unix.Close(dirFd)
+	if oerr != nil {
+		if errors.Is(oerr, unix.ELOOP) {
+			return nil, fmt.Errorf("access denied: %q is a symlink", filepath.Join(baseDir, relPath))
+		}
+		return nil, oerr
+	}
+
+	return os.NewFile(uintptr(fd), filepath.Join(baseDir, relPath)), nil
+}
+
 // SecureWriteFile writes data to filepath.Join(baseDir, path), validating
 // that the resolved path remains inside baseDir. The file mode is enforced
 // even if the file pre-existed with a looser mode (O_CREATE|O_TRUNC alone
@@ -106,15 +223,17 @@ func resolveInside(baseDir, path string) (string, error) {
 // SecureWriteFileSync, minus the fsync). Callers writing durability-critical
 // key material should prefer SecureWriteFileSync instead.
 func SecureWriteFile(baseDir, path string, data []byte, perm os.FileMode) error {
-	cleanPath, err := resolveInside(baseDir, path)
-	if err != nil {
+	// resolveInside is a cheap pre-check that fails fast on an obviously-escaping path
+	// (e.g. "../x") with a clear "access denied" error; the actual open — including the
+	// symlink-safety guarantee — is performed by secureOpenBeneath below. See both
+	// functions' doc comments for why the pre-check alone is not sufficient.
+	if _, err := resolveInside(baseDir, path); err != nil {
 		return err
 	}
-	// O_NOFOLLOW refuses to write THROUGH a final-component symlink. The containment
-	// check resolves EXISTING symlinks, but a DANGLING final symlink (its target not yet
-	// existing) slips past it — os.WriteFile would then follow it and create a file
-	// outside baseDir. With O_NOFOLLOW the open fails (ELOOP) instead of following it.
-	f, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, perm) // #nosec G304 -- cleanPath validated inside baseDir by resolveInside
+	// secureOpenBeneath refuses to traverse OR write THROUGH a symlink at any path
+	// component, not just the final one (see its doc comment for the TOCTOU this
+	// closes that a bare O_NOFOLLOW on the final open would miss).
+	f, err := secureOpenBeneath(baseDir, path, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC, perm) // #nosec G304 -- path validated inside baseDir by resolveInside + secureOpenBeneath's per-component O_NOFOLLOW walk
 	if err != nil {
 		return err
 	}
@@ -138,11 +257,13 @@ func SecureWriteFile(baseDir, path string, data []byte, perm os.FileMode) error 
 // ciphertext. Pair it with SyncDir after any rename to make the rename durable
 // too. The file mode is enforced even if the file pre-existed with a looser mode.
 func SecureWriteFileSync(baseDir, path string, data []byte, perm os.FileMode) error {
-	cleanPath, err := resolveInside(baseDir, path)
-	if err != nil {
+	// See SecureWriteFile above: resolveInside is a fast lexical pre-check only; the
+	// actual symlink-safe open (including intermediate path components, not just the
+	// final one) is performed by secureOpenBeneath.
+	if _, err := resolveInside(baseDir, path); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, perm) // #nosec G304 -- cleanPath validated inside baseDir by resolveInside; O_NOFOLLOW refuses a final-component symlink
+	f, err := secureOpenBeneath(baseDir, path, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC, perm) // #nosec G304 -- path validated inside baseDir by resolveInside + secureOpenBeneath's per-component O_NOFOLLOW walk
 	if err != nil {
 		return err
 	}

--- a/internal/securefiles/securefiles_intermediate_symlink_toctou_test.go
+++ b/internal/securefiles/securefiles_intermediate_symlink_toctou_test.go
@@ -1,0 +1,116 @@
+package securefiles
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSecureWriteFileSync_TOCTOUIntermediateComponentSymlinkNeverFollowed is the
+// regression test for a TOCTOU race distinct from TestFixFilePerms_TOCTOUSymlinkSwapNeverFollowed
+// above: isPathInsideBase/resolveInside can only resolve symlinks up to the longest
+// EXISTING ancestor at check time, so a NOT-YET-EXISTING intermediate path component
+// (here "tenant" in "tenant/secret.bin") is passed through the containment check
+// unresolved. A bare O_NOFOLLOW on the final os.OpenFile call only protects the FINAL
+// path component ("secret.bin") — it does nothing to stop an attacker who, in the
+// window between the containment check and that final open, plants the INTERMEDIATE
+// component ("tenant") as a symlink pointing outside baseDir: O_NOFOLLOW never sees it,
+// because it isn't the component actually being opened with O_CREATE.
+//
+// This test hammers that exact window: one goroutine repeatedly removes "tenant" (so
+// the containment check sees it as absent, its precondition) and replants it as a
+// symlink pointing at a directory OUTSIDE base (the attacker's payload), while another
+// goroutine repeatedly calls SecureWriteFileSync(base, "tenant/secret.bin", ...).
+// Throughout, no file may ever be created inside the outside directory — proving the
+// write path never traverses the symlinked intermediate component, regardless of when
+// it gets swapped in relative to the containment check.
+//
+// Against the pre-fix implementation (a single os.OpenFile(cleanPath,
+// O_WRONLY|O_CREATE|O_TRUNC|O_NOFOLLOW, perm) call after resolveInside), this
+// reproduces the escape: when the writer's OpenFile call lands while "tenant" is
+// symlinked, O_NOFOLLOW only guards "secret.bin" and the open follows "tenant" straight
+// into the outside directory, creating secret.bin there. Against the fix
+// (secureOpenBeneath's per-component O_NOFOLLOW walk via openat), every attempt to
+// traverse "tenant" while it is a symlink is refused outright (ELOOP), so the outside
+// directory must remain empty for the whole test.
+func TestSecureWriteFileSync_TOCTOUIntermediateComponentSymlinkNeverFollowed(t *testing.T) {
+	base := t.TempDir()
+	outside := t.TempDir() // attacker's target: NOT under base
+	tenantPath := filepath.Join(base, "tenant")
+	relPath := filepath.Join("tenant", "secret.bin")
+
+	const iterations = 4000
+	var stop int32
+
+	// require/assert's fatal helpers are documented as unsafe from a non-test goroutine;
+	// this goroutine only performs best-effort filesystem toggling, so errors are simply
+	// ignored (a failed Remove/Symlink just means that iteration doesn't hit the race
+	// window, which does not invalidate the test).
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer atomic.StoreInt32(&stop, 1)
+		for i := 0; i < iterations; i++ {
+			// State A: "tenant" does not exist — the precondition the containment
+			// check's "longest existing ancestor" logic requires to pass through the
+			// not-yet-existing tail unresolved.
+			_ = os.Remove(tenantPath)
+			// State B: "tenant" is a symlink pointing OUTSIDE base — the attacker's
+			// payload, planted as fast as possible after state A so the writer's
+			// check-then-open window has maximum chance of straddling the swap.
+			_ = os.Symlink(outside, tenantPath)
+		}
+		_ = os.Remove(tenantPath)
+	}()
+
+	for atomic.LoadInt32(&stop) == 0 {
+		// Either outcome is acceptable here — ENOENT (tenant absent), access-denied
+		// (tenant existed as a symlink at check time, caught by the pre-check), or a
+		// refused-symlink error from the open walk. The only unacceptable outcome is
+		// silently succeeding while having written outside base, which the final
+		// assertion below checks for directly.
+		_ = SecureWriteFileSync(base, relPath, []byte("tenant-secret-bytes"), 0600)
+	}
+	wg.Wait()
+
+	_, statErr := os.Stat(filepath.Join(outside, "secret.bin"))
+	assert.True(t, os.IsNotExist(statErr), "a write through a racily-symlinked INTERMEDIATE path component must never escape baseDir, even though the component did not exist when the containment check ran")
+}
+
+// TestSecureWriteFile_TOCTOUIntermediateComponentSymlinkNeverFollowed is the same
+// race as above but against SecureWriteFile (the non-fsync variant), which shares the
+// same resolveInside-then-open code shape and so must share the same protection.
+func TestSecureWriteFile_TOCTOUIntermediateComponentSymlinkNeverFollowed(t *testing.T) {
+	base := t.TempDir()
+	outside := t.TempDir()
+	tenantPath := filepath.Join(base, "tenant")
+	relPath := filepath.Join("tenant", "secret.bin")
+
+	const iterations = 4000
+	var stop int32
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer atomic.StoreInt32(&stop, 1)
+		for i := 0; i < iterations; i++ {
+			_ = os.Remove(tenantPath)
+			_ = os.Symlink(outside, tenantPath)
+		}
+		_ = os.Remove(tenantPath)
+	}()
+
+	for atomic.LoadInt32(&stop) == 0 {
+		_ = SecureWriteFile(base, relPath, []byte("tenant-secret-bytes"), 0600)
+	}
+	wg.Wait()
+
+	_, statErr := os.Stat(filepath.Join(outside, "secret.bin"))
+	assert.True(t, os.IsNotExist(statErr), "a write through a racily-symlinked INTERMEDIATE path component must never escape baseDir, even though the component did not exist when the containment check ran")
+}

--- a/internal/securefiles/securefiles_secureopenbeneath_test.go
+++ b/internal/securefiles/securefiles_secureopenbeneath_test.go
@@ -1,0 +1,32 @@
+package securefiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSecureOpenBeneath_RefusesIntermediateSymlink_Direct is a deterministic (non-race)
+// companion to the TOCTOU race tests in securefiles_intermediate_symlink_toctou_test.go:
+// it plants the intermediate-component symlink BEFORE calling secureOpenBeneath at all
+// (no timing dependency), pinning the baseline guarantee that the per-component walk
+// refuses to traverse a symlinked directory component outright, independent of any race
+// window. This exercises secureOpenBeneath directly, so it only compiles against the
+// fixed implementation (the pre-fix codebase has no such function) — the race tests are
+// the ones that demonstrate the actual pre-fix vulnerability via the public API.
+func TestSecureOpenBeneath_RefusesIntermediateSymlink_Direct(t *testing.T) {
+	base := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, os.Symlink(outside, filepath.Join(base, "tenant")))
+
+	f, err := secureOpenBeneath(base, filepath.Join("tenant", "secret.bin"), 0, 0)
+	require.Error(t, err, "an intermediate path component that is a symlink must be refused")
+	if f != nil {
+		_ = f.Close()
+	}
+	_, statErr := os.Stat(filepath.Join(outside, "secret.bin"))
+	assert.True(t, os.IsNotExist(statErr))
+}

--- a/migrations/009_fix_auditor_audit_admin_overgrant.down.sql
+++ b/migrations/009_fix_auditor_audit_admin_overgrant.down.sql
@@ -1,0 +1,14 @@
+-- Revert 009_fix_auditor_audit_admin_overgrant.up.sql: restore the
+-- 'audit.admin' grant on the 'auditor' role.
+--
+-- WARNING: this recreates the original, over-broad grant that
+-- findings-unreviewed/migrations.json#1 flags (medium severity) -- the
+-- 'auditor' role, documented as read-only, regaining "Full administrative
+-- access to audit system". This down-migration exists only for symmetry
+-- with the rest of this directory's reversible migrations (see
+-- migrations/README.md); do not apply it to a production database without
+-- understanding that it reintroduces the finding.
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r, permissions p
+WHERE r.name = 'auditor' AND p.name = 'audit.admin';

--- a/migrations/009_fix_auditor_audit_admin_overgrant.up.sql
+++ b/migrations/009_fix_auditor_audit_admin_overgrant.up.sql
@@ -1,0 +1,28 @@
+-- Corrective migration: revoke the over-broad 'audit.admin' grant from the
+-- legacy 'auditor' role.
+--
+-- 003_rbac_seed_data.up.sql defines 'auditor' as "Can view audit logs and
+-- system information" (read-only intent) but then granted it BOTH
+-- 'audit.read' and 'audit.admin' -- where 'audit.admin' is separately
+-- documented in that same seed data as "Full administrative access to audit
+-- system". That is inconsistent with the live application's canonical
+-- auditor definitions (internal/core/auth_bootstrap.go's system_auditor /
+-- project_auditor roles), which grant only 'audit.read', never an
+-- admin-tier audit permission.
+--
+-- Per migrations/README.md, the authoritative schema mechanism is GORM
+-- AutoMigrate, which is strictly additive on existing databases -- it never
+-- removes or downgrades a previously granted role_permissions row. Any
+-- database originally bootstrapped from migrations 001-003 therefore keeps
+-- this over-grant forever unless it is explicitly revoked, which is what
+-- this migration does. Editing 003 in place would only affect fresh installs
+-- and would rewrite already-applied migration history; this migration
+-- instead corrects the grant going forward for already-seeded databases,
+-- and is idempotent (a re-run after the grant is already gone is a no-op).
+--
+-- Only the 'auditor' role is targeted: 'super_admin' is intentionally
+-- granted every permission, and 'admin' was never granted 'audit.admin' by
+-- 003 in the first place (it only ever received 'audit.read').
+DELETE FROM role_permissions
+WHERE role_id = (SELECT id FROM roles WHERE name = 'auditor')
+  AND permission_id = (SELECT id FROM permissions WHERE name = 'audit.admin');

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -531,3 +531,130 @@ func TestScopeUserGroupRolesDownMigration_PreservesEnvironmentScoping(t *testing
 		t.Fatalf("group_roles_backup.environment_id = %d, want 7", envID)
 	}
 }
+
+// auditorPermissions returns every permission name granted to the 'auditor'
+// role via role_permissions.
+func auditorPermissions(t *testing.T, db *sql.DB) []string {
+	t.Helper()
+
+	rows, err := db.Query(`
+		SELECT p.name FROM permissions p
+		JOIN role_permissions rp ON rp.permission_id = p.id
+		JOIN roles r ON r.id = rp.role_id
+		WHERE r.name = 'auditor'
+		ORDER BY p.name
+	`)
+	if err != nil {
+		t.Fatalf("query auditor role_permissions: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var perms []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan permission name: %v", err)
+		}
+		perms = append(perms, name)
+	}
+	return perms
+}
+
+// TestAuditorSeedDoesNotGrantAuditAdmin pins findings-unreviewed/migrations.json#1:
+// 003_rbac_seed_data.up.sql defines 'auditor' as a read-only role ("Can view
+// audit logs and system information") but originally granted it both
+// 'audit.read' and 'audit.admin' ("Full administrative access to audit
+// system"). This is a non-regression check on 003 itself: applying only
+// 001-003 (the historical bootstrap set) must show the over-grant existed,
+// so the corrective migration below has something real to fix.
+func TestAuditorSeedGrantsAuditAdminBefore009(t *testing.T) {
+	db := openTestDB(t)
+	execSQLFile(t, db, "002_rbac_enhancements.up.sql")
+	execSQLFile(t, db, "003_rbac_seed_data.up.sql")
+
+	perms := auditorPermissions(t, db)
+	found := false
+	for _, p := range perms {
+		if p == "audit.admin" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("auditor permissions = %v, want 'audit.admin' present pre-009 (this pins the documented bug, not the fix)", perms)
+	}
+}
+
+// TestFixAuditorAuditAdminOvergrantMigration pins the fix for
+// findings-unreviewed/migrations.json#1: after applying the corrective
+// 009_fix_auditor_audit_admin_overgrant migration on top of 001-003 (the
+// legacy bootstrap set this directory exists to serve, per
+// migrations/README.md), the 'auditor' role must hold 'audit.read' but must
+// NOT hold 'audit.admin' -- matching the role's own read-only description
+// and the live app's canonical system_auditor/project_auditor definitions
+// (internal/core/auth_bootstrap.go), which never grant audit.admin. It also
+// confirms the migration doesn't collaterally touch any other role's
+// grants -- namely 'admin', which never held audit.admin in the first place.
+func TestFixAuditorAuditAdminOvergrantMigration(t *testing.T) {
+	db := openTestDB(t)
+	execSQLFile(t, db, "002_rbac_enhancements.up.sql")
+	execSQLFile(t, db, "003_rbac_seed_data.up.sql")
+	execSQLFile(t, db, "009_fix_auditor_audit_admin_overgrant.up.sql")
+
+	perms := auditorPermissions(t, db)
+	want := []string{"audit.read", "namespaces.read", "roles.read", "system.read", "users.read"}
+	if len(perms) != len(want) {
+		t.Fatalf("auditor permissions after 009 = %v, want %v", perms, want)
+	}
+	for i, p := range perms {
+		if p != want[i] {
+			t.Fatalf("auditor permissions after 009 = %v, want %v", perms, want)
+		}
+	}
+	for _, p := range perms {
+		if p == "audit.admin" {
+			t.Fatal("auditor role still holds audit.admin after 009_fix_auditor_audit_admin_overgrant.up.sql")
+		}
+	}
+
+	// Non-regression: 'admin' never held audit.admin, and 009 must not
+	// change that (or grant it accidentally via a role-name typo/join bug).
+	var adminHasAuditAdmin int
+	err := db.QueryRow(`
+		SELECT COUNT(*) FROM role_permissions rp
+		JOIN roles r ON r.id = rp.role_id
+		JOIN permissions p ON p.id = rp.permission_id
+		WHERE r.name = 'admin' AND p.name = 'audit.admin'
+	`).Scan(&adminHasAuditAdmin)
+	if err != nil {
+		t.Fatalf("query admin role_permissions: %v", err)
+	}
+	if adminHasAuditAdmin != 0 {
+		t.Fatal("'admin' role unexpectedly holds audit.admin after 009_fix_auditor_audit_admin_overgrant.up.sql")
+	}
+}
+
+// TestFixAuditorAuditAdminOvergrantDownMigration pins that the down-migration
+// correctly reverts the correction: reapplying it restores the (legacy,
+// over-broad) audit.admin grant on 'auditor'. This is deliberate symmetry
+// with the rest of this directory's reversible migrations, not an
+// endorsement of running the down-migration in production.
+func TestFixAuditorAuditAdminOvergrantDownMigration(t *testing.T) {
+	db := openTestDB(t)
+	execSQLFile(t, db, "002_rbac_enhancements.up.sql")
+	execSQLFile(t, db, "003_rbac_seed_data.up.sql")
+	execSQLFile(t, db, "009_fix_auditor_audit_admin_overgrant.up.sql")
+	execSQLFile(t, db, "009_fix_auditor_audit_admin_overgrant.down.sql")
+
+	perms := auditorPermissions(t, db)
+	found := false
+	for _, p := range perms {
+		if p == "audit.admin" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("auditor permissions after up+down = %v, want 'audit.admin' restored by the down-migration", perms)
+	}
+}

--- a/server/checkpoint_notary_startup_test.go
+++ b/server/checkpoint_notary_startup_test.go
@@ -1,0 +1,56 @@
+// checkpoint_notary_startup_test.go — startup TLS-scheme validation for
+// audit.checkpoint_notary (Wave 6 #baseline/notary-findings.json#1): a plaintext
+// http:// TSA URL (non-loopback) must fail closed at startup — initializeCoreService
+// must refuse to build a server that would silently anchor checkpoints over an
+// unencrypted, tamperable channel. Plain http to a loopback host (local dev/test)
+// remains accepted, mirroring this codebase's convention elsewhere
+// (internal/storage/remote's validateBaseURL, server/main.go's requireSecureOrLoopback).
+//
+// The companion behavior — enabling the notary WITHOUT a trust root
+// (ca_cert_path) must NOT fail startup, but must leave CheckpointAnchorVerifiable()
+// false — is covered by TestInitializeCoreService_CheckpointNotary_WithURL_NoCA and
+// TestInitializeCoreService_CheckpointNotary_ValidCA in server_s4_test.go.
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+)
+
+// TestInitializeCoreService_CheckpointNotary_RejectsPlaintextHTTPURL confirms a
+// plaintext http:// TSA URL to a non-loopback host fails startup outright.
+func TestInitializeCoreService_CheckpointNotary_RejectsPlaintextHTTPURL(t *testing.T) {
+	initI18n(t)
+	cfg := newMinimalCfg(t)
+	cfg.Audit.CheckpointNotary = config.CheckpointNotaryConfig{
+		Enabled: true,
+		URL:     "http://tsa.example.com/tsr",
+	}
+
+	_, _, err := initializeCoreService(cfg)
+	if err == nil {
+		t.Fatal("expected initializeCoreService to fail closed on a plaintext http TSA URL, got nil error")
+	}
+	if !strings.Contains(err.Error(), "https") {
+		t.Errorf("expected error to explain the https requirement, got: %v", err)
+	}
+}
+
+// TestInitializeCoreService_CheckpointNotary_AcceptsLoopbackHTTPURL confirms the
+// documented local-testing exception still works at startup: plain http to a
+// loopback host is accepted.
+func TestInitializeCoreService_CheckpointNotary_AcceptsLoopbackHTTPURL(t *testing.T) {
+	initI18n(t)
+	cfg := newMinimalCfg(t)
+	cfg.Audit.CheckpointNotary = config.CheckpointNotaryConfig{
+		Enabled: true,
+		URL:     "http://127.0.0.1:9999/tsr",
+	}
+
+	_, _, err := initializeCoreService(cfg)
+	if err != nil {
+		t.Fatalf("initializeCoreService with a loopback http TSA URL: %v", err)
+	}
+}

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -397,6 +397,12 @@ func (h *AuditHandler) VerifyAuditChain(w http.ResponseWriter, r *http.Request) 
 		if v.AnchoredAt != nil {
 			resp["anchored_at"] = v.AnchoredAt.UTC()
 		}
+		// anchor_trust_root_configured is false when no TSA trust root (ca_cert_path) is
+		// configured — the token above was RECORDED (a real RFC 3161 receipt was
+		// obtained) but this server has never checked it against any root of trust. A
+		// caller must not treat a recorded-but-unverifiable anchor as proof-equivalent
+		// to one this server actually verified without checking this first.
+		resp["anchor_trust_root_configured"] = v.AnchorTrustRootConfigured
 	}
 	sendSuccess(w, resp, "")
 }
@@ -451,6 +457,10 @@ func (h *AuditHandler) WriteAuditCheckpoint(w http.ResponseWriter, r *http.Reque
 		resp["anchored_at"] = cp.AnchoredAt.UTC()
 		resp["anchor_provider"] = cp.AnchorProvider
 		resp["anchor_token"] = base64.StdEncoding.EncodeToString(cp.AnchorToken)
+		// See VerifyAuditChain's anchor_trust_root_configured for what this means: a
+		// token was recorded either way, but without a trust root this server cannot
+		// (and never will, until one is configured) verify it locally.
+		resp["anchor_trust_root_configured"] = h.coreService.CheckpointAnchorVerifiable()
 	}
 	sendSuccess(w, resp, "audit checkpoint written")
 }

--- a/server/http/handlers/audit_checkpoint_anchor_test.go
+++ b/server/http/handlers/audit_checkpoint_anchor_test.go
@@ -57,13 +57,18 @@ func TestAuditHandler_CheckpointAndVerify_SurfaceRawAnchorToken(t *testing.T) {
 
 	var writeResp struct {
 		Data struct {
-			AnchorToken    string `json:"anchor_token"`
-			AnchorProvider string `json:"anchor_provider"`
+			AnchorToken               string `json:"anchor_token"`
+			AnchorProvider            string `json:"anchor_provider"`
+			AnchorTrustRootConfigured bool   `json:"anchor_trust_root_configured"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(wRec.Body.Bytes(), &writeResp))
 	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("opaque-tsa-token")), writeResp.Data.AnchorToken)
 	require.Equal(t, "fake", writeResp.Data.AnchorProvider)
+	// No trust root was configured (SetCheckpointAnchorRoots never called) — the
+	// response must say so explicitly, not just carry a raw token that LOOKS like
+	// verified proof (#baseline/notary-findings.json#1).
+	require.False(t, writeResp.Data.AnchorTrustRootConfigured)
 
 	// The verify endpoint — the surface an operator actually polls — must ALSO
 	// surface it (checkpoints are normally written by the background scheduler, so
@@ -75,11 +80,13 @@ func TestAuditHandler_CheckpointAndVerify_SurfaceRawAnchorToken(t *testing.T) {
 
 	var verifyResp struct {
 		Data struct {
-			AnchorToken    string `json:"anchor_token"`
-			AnchorProvider string `json:"anchor_provider"`
+			AnchorToken               string `json:"anchor_token"`
+			AnchorProvider            string `json:"anchor_provider"`
+			AnchorTrustRootConfigured bool   `json:"anchor_trust_root_configured"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(vRec.Body.Bytes(), &verifyResp))
 	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("opaque-tsa-token")), verifyResp.Data.AnchorToken)
 	require.Equal(t, "fake", verifyResp.Data.AnchorProvider)
+	require.False(t, verifyResp.Data.AnchorTrustRootConfigured)
 }

--- a/server/main.go
+++ b/server/main.go
@@ -227,8 +227,13 @@ const (
 // and returns an initialized encryption.Service. If encryption is disabled in
 // config, it returns nil without error. For the default "password" provider it
 // requires KEYORIX_MASTER_PASSWORD; for the "file"/"env" providers the KEK comes
-// from key material elsewhere, so no passphrase is needed.
-func initializeEncryption(cfg *config.Config) (*encryption.Service, error) {
+// from key material elsewhere, so no passphrase is needed. auditSink, if non-nil,
+// is wired before Initialize so that a key_provider.fallbacks chain actually
+// downgrading KEK strength on THIS boot (not just one the config permits) is
+// recorded as a queryable audit event rather than only a log line — pass
+// store.LogAuditEvent once storage is available; nil is fine (tests, or contexts
+// without a live audit trail) and falls back to logging only.
+func initializeEncryption(cfg *config.Config, auditSink encryption.AuditSink) (*encryption.Service, error) {
 	if !cfg.Storage.Encryption.Enabled {
 		return nil, nil
 	}
@@ -246,6 +251,9 @@ func initializeEncryption(cfg *config.Config) (*encryption.Service, error) {
 		baseDir = "."
 	}
 	svc := encryption.NewService(&cfg.Storage.Encryption, baseDir)
+	if auditSink != nil {
+		svc.SetAuditSink(auditSink)
+	}
 	svc.CleanPendingDEK() // remove leftover .pending file from any interrupted prior rotation
 	if err := svc.Initialize(passphrase); err != nil {
 		return nil, fmt.Errorf("failed to initialize encryption (KEK derivation): %w", err)
@@ -289,7 +297,7 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		return nil, nil, fmt.Errorf("failed to initialize storage: %w", err)
 	}
 
-	encSvc, err := initializeEncryption(cfg)
+	encSvc, err := initializeEncryption(cfg, store.LogAuditEvent)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize encryption: %w", err)
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -370,12 +370,31 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		if cn.URL == "" {
 			log.Printf("Audit checkpoint notary enabled but no url set; skipping external anchoring")
 		} else {
-			coreService.SetCheckpointNotary(notary.NewRFC3161(cn.URL, cn.GetTimeout()))
+			// NewRFC3161 validates the URL is https (or http to a loopback host, for
+			// local testing) — fail closed at startup rather than silently accepting a
+			// plaintext TSA URL that would leak every anchored checkpoint hash (and any
+			// rogue-response substitution) to a network attacker on the path.
+			tsa, err := notary.NewRFC3161(cn.URL, cn.GetTimeout())
+			if err != nil {
+				return nil, nil, fmt.Errorf("audit.checkpoint_notary: %w", err)
+			}
+			coreService.SetCheckpointNotary(tsa)
 			// Load the TSA trust anchor used to VERIFY stored anchors. Without it,
-			// anchoring still records tokens but verification fails closed (an
-			// untrusted issuer must not be trusted).
+			// anchoring still records each checkpoint's raw RFC 3161 receipt — that
+			// token remains valid, portable proof an independent party holding the
+			// TSA's root cert can check out-of-box (#182) — but THIS server cannot
+			// re-verify it locally, and must not present a merely-recorded anchor as
+			// though it were one this server actually checked against a root of trust.
+			// Deliberately not fail-closed here (unlike the URL-scheme check above):
+			// anchoring-without-local-verification is a legitimate, intentional
+			// configuration (see CheckpointNotaryConfig.CACertPath's doc comment) —
+			// the trust root can be wired in later, or verification can be done
+			// entirely off-box. Instead, the unverifiable state is surfaced explicitly
+			// on every checkpoint-verification read (KeyorixCore.CheckpointAnchorVerifiable,
+			// AuditChainVerification.AnchorTrustRootConfigured) so a caller/auditor can
+			// always tell a recorded-but-unverifiable anchor apart from a verified one.
 			if cn.CACertPath == "" {
-				log.Printf("Audit checkpoint external anchoring enabled (rfc3161, url=%s) — WARNING: no ca_cert_path set, stored anchors cannot be verified", cn.URL)
+				log.Printf("Audit checkpoint external anchoring enabled (rfc3161, url=%s) — WARNING: no ca_cert_path set, stored anchors are recorded but CANNOT be locally verified (checkpoint reads will report them as unverified)", cn.URL)
 			} else if roots, err := loadCertPool(cn.CACertPath); err != nil {
 				log.Printf("Audit checkpoint notary: failed to load ca_cert_path %q (%v) — anchors cannot be verified", cn.CACertPath, err)
 			} else {

--- a/server/server_s22_test.go
+++ b/server/server_s22_test.go
@@ -122,7 +122,7 @@ func TestInitializeEncryption_S22_FileProvider_NoPasswordRequired(t *testing.T) 
 			},
 		},
 	}
-	_, err := initializeEncryption(cfg)
+	_, err := initializeEncryption(cfg, nil)
 	// Must get an error — but NOT "KEYORIX_MASTER_PASSWORD is not set".
 	// Any error from reading/deriving is acceptable; the passphrase guard must be silent.
 	if err == nil {
@@ -152,7 +152,7 @@ func TestInitializeEncryption_S22_EnvProvider_NoPasswordRequired(t *testing.T) {
 			},
 		},
 	}
-	_, err := initializeEncryption(cfg)
+	_, err := initializeEncryption(cfg, nil)
 	// Expect an error from the missing/empty env key, NOT from passphrase guard.
 	if err == nil {
 		t.Fatal("expected an error (empty env var key), got nil")

--- a/server/server_s4_test.go
+++ b/server/server_s4_test.go
@@ -702,7 +702,7 @@ func TestInitializeEncryption_Disabled(t *testing.T) {
 			Encryption: config.EncryptionConfig{Enabled: false},
 		},
 	}
-	svc, err := initializeEncryption(cfg)
+	svc, err := initializeEncryption(cfg, nil)
 	if err != nil {
 		t.Errorf("initializeEncryption (disabled): %v", err)
 	}
@@ -722,7 +722,7 @@ func TestInitializeEncryption_PasswordProvider_NoPassword(t *testing.T) {
 			},
 		},
 	}
-	_, err := initializeEncryption(cfg)
+	_, err := initializeEncryption(cfg, nil)
 	if err == nil {
 		t.Fatal("expected error for password provider with no KEYORIX_MASTER_PASSWORD")
 	}
@@ -742,7 +742,7 @@ func TestInitializeEncryption_ExplicitPasswordProvider_NoPassword(t *testing.T) 
 			},
 		},
 	}
-	_, err := initializeEncryption(cfg)
+	_, err := initializeEncryption(cfg, nil)
 	if err == nil {
 		t.Fatal("expected error for explicit password provider with no KEYORIX_MASTER_PASSWORD")
 	}

--- a/server/server_s4_test.go
+++ b/server/server_s4_test.go
@@ -286,16 +286,26 @@ func TestInitializeCoreService_CheckpointNotary_NoURL(t *testing.T) {
 
 // ── initializeCoreService — audit checkpoint notary (url + no ca_cert) ───────
 
+// Enabling the notary without a trust root must NOT fail startup — this is a
+// legitimate, intentional configuration (see config.CheckpointNotaryConfig.
+// CACertPath's doc comment: anchoring still records tokens for later/off-box
+// verification even without a locally-configured trust root). But the resulting
+// core must report the anchor as not locally verifiable
+// (#baseline/notary-findings.json#1), so a caller/auditor reviewing checkpoint
+// records can tell a recorded-but-unverifiable anchor apart from a verified one.
 func TestInitializeCoreService_CheckpointNotary_WithURL_NoCA(t *testing.T) {
 	initI18n(t)
 	cfg := newMinimalCfg(t)
 	cfg.Audit.CheckpointNotary.Enabled = true
-	cfg.Audit.CheckpointNotary.URL = "http://tsa.example.com/ts"
+	cfg.Audit.CheckpointNotary.URL = "https://tsa.example.com/ts"
 	cfg.Audit.CheckpointNotary.CACertPath = ""
 
-	_, _, err := initializeCoreService(cfg)
+	svc, _, err := initializeCoreService(cfg)
 	if err != nil {
 		t.Fatalf("initializeCoreService with notary URL but no CA: %v", err)
+	}
+	if svc.CheckpointAnchorVerifiable() {
+		t.Error("expected CheckpointAnchorVerifiable() to be false with no ca_cert_path configured")
 	}
 }
 
@@ -305,7 +315,7 @@ func TestInitializeCoreService_CheckpointNotary_BadCACert(t *testing.T) {
 	initI18n(t)
 	cfg := newMinimalCfg(t)
 	cfg.Audit.CheckpointNotary.Enabled = true
-	cfg.Audit.CheckpointNotary.URL = "http://tsa.example.com/ts"
+	cfg.Audit.CheckpointNotary.URL = "https://tsa.example.com/ts"
 	cfg.Audit.CheckpointNotary.CACertPath = "/nonexistent/ca.pem"
 
 	// A bad CA path only logs a warning; it must NOT fail startup.
@@ -1748,9 +1758,16 @@ func TestInitializeCoreService_CheckpointNotary_ValidCA(t *testing.T) {
 		},
 	}
 
-	_, _, err := initializeCoreService(cfg)
+	svc, _, err := initializeCoreService(cfg)
 	if err != nil {
 		t.Fatalf("initializeCoreService with valid CA cert: %v", err)
+	}
+	// A configured, loaded trust root must make the anchor locally verifiable
+	// (#baseline/notary-findings.json#1) — contrast with
+	// TestInitializeCoreService_CheckpointNotary_WithURL_NoCA, which pins the
+	// false case.
+	if !svc.CheckpointAnchorVerifiable() {
+		t.Error("expected CheckpointAnchorVerifiable() to be true once a valid ca_cert_path is configured")
 	}
 }
 


### PR DESCRIPTION
## Summary

Eighth batch of the Wave 6 medium-severity remediation (adversarial security review, 2026-08-07/08). Eight independent fixes, each cherry-picked from its own worktree-isolated branch and re-verified together as a combined build.

- **Evidence-sink object-store SSRF/DNS-rebinding**: the S3-compatible object-store endpoint had no scheme/URL validation and re-resolved its hostname on every connection. Added `validateObjectStoreEndpoint` (rejects malformed URLs / non-http(s) schemes; deliberately not a blanket private-IP ban since self-hosted MinIO/R2/B2 on a private address is the primary legitimate use) and `pinnedDialContext`, which resolves the endpoint hostname once at construction and pins every later connection to that literal IP.
- **Anomaly-detector audit-log spam**: `SetBusinessHours` re-audited its own config on every call, even when nothing changed, letting the audit log be spammed into unreadability. Now audits only on an actual policy change, tracked via a canonical-timezone-aware last-audited cache.
- **Legacy `auditor` role over-grant**: the legacy, manually-bootstrapped `auditor` role (seeded only via `migrations/001-003.sql`, never by the live GORM AutoMigrate path) held both `audit.read` and `audit.admin` despite being documented read-only. Adds a new `009` migration that revokes `audit.admin` going forward, following this directory's own no-edit-applied-migrations discipline, with regression tests pinning the pre-fix over-grant, the corrected grant set, and the down-migration round-trip.
- **RFC3161 notary TLS/trust-root gaps**: the configured TSA URL had no scheme restriction (accepted plaintext `http://`, letting a network attacker see checkpoint hashes and swap in a rogue TSA response) and enabling notary anchoring without `ca_cert_path` silently surfaced anchors as if verified. TSA URLs now require `https` (loopback exception for local testing) with a fail-closed startup check; `AnchorTrustRootConfigured` now explicitly flags an anchor as unverifiable through both the HTTP API and CLI when no trust root is configured, since anchoring-without-local-verification is a documented, intentional configuration (the token remains independently verifiable off-box).
- **Redis/Mongo credential-leak sibling gap**: postgres/mysql redact credential-shaped driver errors after a prior incident (#132); redis/mongo never got the same treatment. Confirmed empirically that `go-redis`'s `ParseURL` echoes the raw DSN (credentials included) via stdlib `net/url`'s un-redacted `*url.Error` stringification on a malformed DSN. Added the equivalent redaction to both backends.
- **Securefiles intermediate-symlink TOCTOU**: `isPathInsideBase`/`resolveInside` only resolve symlinks up to the longest *existing* ancestor at check time, leaving a race window at any not-yet-existing intermediate path component that the final `O_NOFOLLOW` open doesn't cover. Closed via `secureOpenBeneath`, an `openat(2)`-style per-component `O_NOFOLLOW` walk, with a concurrent regression test that hammers the exact race window (verified `-race` clean).
- **Key-provider silent weak-fallback downgrade**: `MultiKeyProvider.KEK()` fell through configured key-provider fallbacks strictly in order with no strength awareness, so a transient TPM/KMS failure could silently drop effective KEK strength to whatever a local password/file/env provider offers. Adds a strength-tier concept (software < distributed(shamir) < hardware(tpm/*-kms)), a fail-closed `allow_weaker_fallback` config gate at startup, and a real audit event (`encryption.key_provider_fallback_downgrade`) on an actual runtime downgrade.
- **PAT-expired notification spam**: any presentation of an already-expired personal access token re-fired a fresh in-app/email/webhook notification with no dedup, letting anyone who ever captured the raw token spam its owner indefinitely. Fixed by reusing this package's existing unread-notification-presence dedup convention (keyed by token ID, matching the existing `#G22` name-collision rationale).

## Verification

Each fix independently re-verified from a fresh worktree before integration (build/vet/gofmt/gosec/relevant suites, several with `-race` or empirical pre-fix-failure proof via scoped `git stash`), then all 8 cherry-picked (`-x`) onto one branch off current `main` — three auto-merges (`internal/core/storage/interface.go`, `server/main.go`, `server/server_s4_test.go`), no conflicts.

Combined verification on the integrated branch:
- `go build ./...`, `go vet ./...`, `gofmt -l` — all clean
- `gosec -severity medium -exclude-generated` — 0 issues (798 files, main tree) + 0 issues (operator module, `GOWORK=off`)
- Full `go test ./...` — only the established pre-existing `server/http` `RealServer`/`CSV_Headers`/`SetupToken` failures (unrelated to this batch, confirmed identical against unmodified `main` throughout this campaign)
- Operator module builds clean under `GOWORK=off`

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] Full `go test ./...` — no new failures vs. baseline
- [x] Operator module (`GOWORK=off`) builds and gosec-clean
- [ ] CI: lint, gitleaks, build-and-test