### PR TITLE
fix(security): close Wave 6 medium-severity batch 6 (final medium batch, 6 findings)

### DIFF
--- a/cmd/validate-translations/main.go
+++ b/cmd/validate-translations/main.go
@@ -107,9 +107,8 @@ func validateTranslations(localesDir string) (*ValidationSummary, error) { // NO
 
 	for _, filename := range translationFiles {
 		lang := strings.TrimSuffix(filename, ".json")
-		filePath := filepath.Join(cleanDir, filename)
 
-		translationFile, err := loadTranslationFile(filePath)
+		translationFile, err := loadTranslationFile(cleanDir, filename)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load %s: %w", filename, err)
 		}
@@ -158,10 +157,10 @@ func validateTranslations(localesDir string) (*ValidationSummary, error) { // NO
 	return summary, nil
 }
 
-func loadTranslationFile(filePath string) (TranslationFile, error) {
-	// Use secure file reading with base directory validation
-	baseDir := "internal/i18n/locales"
-	data, err := securefiles.SafeReadFile(baseDir, filePath)
+func loadTranslationFile(baseDir, filename string) (TranslationFile, error) {
+	// Use secure file reading with base directory validation, scoped to the
+	// directory actually being scanned so custom locales-directory args work.
+	data, err := securefiles.SafeReadFile(baseDir, filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file securely: %w", err)
 	}
@@ -255,7 +254,7 @@ func printValidationSummary(summary *ValidationSummary) { // NOSONAR -- go:S3776
 			var missingKey []string
 
 			for _, result := range summary.Results {
-				translations, _ := loadTranslationFile(result.FilePath)
+				translations, _ := loadTranslationFile(filepath.Dir(result.FilePath), filepath.Base(result.FilePath))
 				if _, exists := translations[messageID]; exists {
 					hasKey = append(hasKey, result.Language)
 				} else {

--- a/cmd/validate-translations/main_s23_test.go
+++ b/cmd/validate-translations/main_s23_test.go
@@ -44,35 +44,19 @@ func writeJSONFile(t *testing.T, dir, name string, v any) string {
 	return path
 }
 
-// setupTranslationsTest sets up a temp environment for validateTranslations tests.
-//
-// Because loadTranslationFile hardcodes baseDir="internal/i18n/locales" and
-// SecureReadFile joins that with the filePath argument, the only way to avoid a
-// double-nested path is to:
-//   - call validateTranslations("."), so filePath becomes bare "en.json"
-//   - provide the JSON files both at the CWD root (for scanning) and under
-//     internal/i18n/locales/ (for the secure read that loadTranslationFile uses)
-//
-// This function creates both directories, switches CWD to root, and returns root
-// so callers can write JSON files to both locations via writeToScan and writeToRead.
+// setupTranslationsTest creates a temp locales directory for validateTranslations
+// tests. loadTranslationFile scopes its secure read to whatever localesDir is
+// passed to validateTranslations, so a single directory suffices: write JSON
+// files into it and pass it straight to validateTranslations.
 //
 // Usage:
 //
-//	root, scan, secure := setupTranslationsTest(t)
-//	writeJSONFile(t, scan,   "en.json", tf)   // scanned by validateTranslations(".")
-//	writeJSONFile(t, secure, "en.json", tf)   // read by loadTranslationFile("en.json")
-//	summary, err := validateTranslations(".")
-func setupTranslationsTest(t *testing.T) (root, scanDir, secureDir string) {
+//	dir := setupTranslationsTest(t)
+//	writeJSONFile(t, dir, "en.json", tf)
+//	summary, err := validateTranslations(dir)
+func setupTranslationsTest(t *testing.T) (dir string) {
 	t.Helper()
-	root = t.TempDir()
-	// secureDir is where loadTranslationFile actually reads from.
-	secureDir = filepath.Join(root, "internal", "i18n", "locales")
-	require.NoError(t, os.MkdirAll(secureDir, 0700))
-	// scanDir is the directory passed to validateTranslations; using "." means
-	// filePath in loadTranslationFile will be the bare filename only.
-	scanDir = root
-	t.Chdir(root)
-	return root, scanDir, secureDir
+	return t.TempDir()
 }
 
 // ---------------------------------------------------------------------------
@@ -409,6 +393,50 @@ func TestPrintValidationSummary_S23_StatsCoverage(t *testing.T) {
 // validateTranslations — error branches
 // ---------------------------------------------------------------------------
 
+// TestValidateTranslations_S23_RealLocalesDirDefaultInvocation is a regression
+// test for a bug where loadTranslationFile joined its hardcoded baseDir onto a
+// path that validateTranslations had already joined onto localesDir, doubling
+// it (e.g. internal/i18n/locales/internal/i18n/locales/de.json) and making
+// every invocation fail with "no such file or directory" — including the
+// tool's documented default invocation with no arguments. This test exercises
+// that exact shape: a relative "internal/i18n/locales" argument run from the
+// repo root, against the real locale files, rather than a synthetic temp dir.
+func TestValidateTranslations_S23_RealLocalesDirDefaultInvocation(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	t.Chdir(repoRoot)
+
+	summary, err := validateTranslations("internal/i18n/locales")
+	require.NoError(t, err, "validateTranslations must succeed against the real locales directory using the documented default relative path")
+
+	assert.NotZero(t, summary.TotalLanguages)
+	assert.Equal(t, summary.TotalLanguages, len(summary.Results))
+
+	var enResult *ValidationResult
+	for i := range summary.Results {
+		if summary.Results[i].Language == "en" {
+			enResult = &summary.Results[i]
+		}
+	}
+	require.NotNil(t, enResult, "expected an en.json result among the real locale files")
+	assert.NotZero(t, enResult.MessageCount)
+}
+
+// TestLoadTranslationFile_S23_ScopedToPassedBaseDir is a regression test for
+// the same doubled-path bug at the loadTranslationFile call site directly:
+// loadTranslationFile must read filename relative to whatever baseDir it is
+// given, not a hardcoded "internal/i18n/locales" that ignores the baseDir
+// argument entirely.
+func TestLoadTranslationFile_S23_ScopedToPassedBaseDir(t *testing.T) {
+	dir := t.TempDir()
+	tf := TranslationFile{"hello": {One: "Hello", Other: "Hellos"}}
+	writeJSONFile(t, dir, "en.json", tf)
+
+	got, err := loadTranslationFile(dir, "en.json")
+	require.NoError(t, err)
+	assert.Equal(t, tf, got)
+}
+
 func TestValidateTranslations_S23_DirNotFound(t *testing.T) {
 	_, err := validateTranslations("/nonexistent/path/to/locales")
 	require.Error(t, err)
@@ -426,30 +454,25 @@ func TestValidateTranslations_S23_NoJSONFiles(t *testing.T) {
 }
 
 func TestValidateTranslations_S23_InvalidJSON(t *testing.T) {
-	// We need loadTranslationFile to actually reach the file.
-	// Use "." as localesDir and place JSON in both root and internal/i18n/locales/.
-	_, scanDir, _ := setupTranslationsTest(t)
+	dir := setupTranslationsTest(t)
 
-	// Write invalid JSON only to the scan dir; loadTranslationFile will fail
-	// before even reading the secure copy.
-	require.NoError(t, os.WriteFile(filepath.Join(scanDir, "bad.json"), []byte("not-json{{{"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.json"), []byte("not-json{{{"), 0600))
 
-	_, err := validateTranslations(".")
+	_, err := validateTranslations(dir)
 	require.Error(t, err)
 	assert.NotEmpty(t, err.Error())
 }
 
 func TestValidateTranslations_S23_SingleValidLanguage(t *testing.T) {
-	_, scanDir, secureDir := setupTranslationsTest(t)
+	dir := setupTranslationsTest(t)
 
 	tf := TranslationFile{
 		"hello": {Description: "greeting", One: "Hello", Other: "Hellos"},
 		"bye":   {Description: "farewell", One: "Bye", Other: "Goodbyes"},
 	}
-	writeJSONFile(t, scanDir, "en.json", tf)
-	writeJSONFile(t, secureDir, "en.json", tf)
+	writeJSONFile(t, dir, "en.json", tf)
 
-	summary, err := validateTranslations(".")
+	summary, err := validateTranslations(dir)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, summary.TotalLanguages)
@@ -460,17 +483,15 @@ func TestValidateTranslations_S23_SingleValidLanguage(t *testing.T) {
 }
 
 func TestValidateTranslations_S23_MultipleLanguagesAllValid(t *testing.T) {
-	_, scanDir, secureDir := setupTranslationsTest(t)
+	dir := setupTranslationsTest(t)
 
 	enTF := TranslationFile{"greet": {One: "Hi", Other: "His"}}
 	esTF := TranslationFile{"greet": {One: "Hola", Other: "Holas"}}
 
-	writeJSONFile(t, scanDir, "en.json", enTF)
-	writeJSONFile(t, scanDir, "es.json", esTF)
-	writeJSONFile(t, secureDir, "en.json", enTF)
-	writeJSONFile(t, secureDir, "es.json", esTF)
+	writeJSONFile(t, dir, "en.json", enTF)
+	writeJSONFile(t, dir, "es.json", esTF)
 
-	summary, err := validateTranslations(".")
+	summary, err := validateTranslations(dir)
 	require.NoError(t, err)
 
 	assert.Equal(t, 2, summary.TotalLanguages)
@@ -480,7 +501,7 @@ func TestValidateTranslations_S23_MultipleLanguagesAllValid(t *testing.T) {
 }
 
 func TestValidateTranslations_S23_MissingKeyInOneLanguage(t *testing.T) {
-	_, scanDir, secureDir := setupTranslationsTest(t)
+	dir := setupTranslationsTest(t)
 
 	enTF := TranslationFile{
 		"a": {One: "A", Other: "As"},
@@ -490,12 +511,10 @@ func TestValidateTranslations_S23_MissingKeyInOneLanguage(t *testing.T) {
 		"a": {One: "Ae", Other: "Aes"},
 		// "b" intentionally missing
 	}
-	writeJSONFile(t, scanDir, "en.json", enTF)
-	writeJSONFile(t, scanDir, "es.json", esTF)
-	writeJSONFile(t, secureDir, "en.json", enTF)
-	writeJSONFile(t, secureDir, "es.json", esTF)
+	writeJSONFile(t, dir, "en.json", enTF)
+	writeJSONFile(t, dir, "es.json", esTF)
 
-	summary, err := validateTranslations(".")
+	summary, err := validateTranslations(dir)
 	require.NoError(t, err)
 
 	assert.Equal(t, 2, summary.TotalLanguages)
@@ -514,13 +533,12 @@ func TestValidateTranslations_S23_MissingKeyInOneLanguage(t *testing.T) {
 }
 
 func TestValidateTranslations_S23_EmptyMessageInLanguage(t *testing.T) {
-	_, scanDir, secureDir := setupTranslationsTest(t)
+	dir := setupTranslationsTest(t)
 
 	tf := TranslationFile{"welcome": {One: "", Other: ""}}
-	writeJSONFile(t, scanDir, "en.json", tf)
-	writeJSONFile(t, secureDir, "en.json", tf)
+	writeJSONFile(t, dir, "en.json", tf)
 
-	summary, err := validateTranslations(".")
+	summary, err := validateTranslations(dir)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, summary.InvalidLanguages)
@@ -529,32 +547,30 @@ func TestValidateTranslations_S23_EmptyMessageInLanguage(t *testing.T) {
 }
 
 func TestValidateTranslations_S23_NonJSONFilesIgnored(t *testing.T) {
-	_, scanDir, secureDir := setupTranslationsTest(t)
+	dir := setupTranslationsTest(t)
 
 	tf := TranslationFile{"hi": {One: "Hi", Other: "His"}}
-	writeJSONFile(t, scanDir, "en.json", tf)
-	writeJSONFile(t, secureDir, "en.json", tf)
+	writeJSONFile(t, dir, "en.json", tf)
 	// These should be ignored by the JSON file filter.
-	require.NoError(t, os.WriteFile(filepath.Join(scanDir, "README.md"), []byte("docs"), 0600))
-	require.NoError(t, os.WriteFile(filepath.Join(scanDir, ".DS_Store"), []byte("mac"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("docs"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".DS_Store"), []byte("mac"), 0600))
 
-	summary, err := validateTranslations(".")
+	summary, err := validateTranslations(dir)
 	require.NoError(t, err)
 	assert.Equal(t, 1, summary.TotalLanguages)
 }
 
 func TestValidateTranslations_S23_SummaryMessageIDsSorted(t *testing.T) {
-	_, scanDir, secureDir := setupTranslationsTest(t)
+	dir := setupTranslationsTest(t)
 
 	tf := TranslationFile{
 		"zebra": {One: "Zebra", Other: "Zebras"},
 		"apple": {One: "Apple", Other: "Apples"},
 		"mango": {One: "Mango", Other: "Mangos"},
 	}
-	writeJSONFile(t, scanDir, "en.json", tf)
-	writeJSONFile(t, secureDir, "en.json", tf)
+	writeJSONFile(t, dir, "en.json", tf)
 
-	summary, err := validateTranslations(".")
+	summary, err := validateTranslations(dir)
 	require.NoError(t, err)
 
 	sorted := make([]string, len(summary.AllMessageIDs))
@@ -598,7 +614,7 @@ func TestPrintValidationSummary_S23_InconsistentKeyStatLine(t *testing.T) {
 // printValidationSummary emits "Present in:" / "Missing in:" lines for an
 // inconsistent key when loadTranslationFile can actually read the files.
 func TestPrintValidationSummary_S23_InconsistentKeyDetail(t *testing.T) {
-	_, scanDir, secureDir := setupTranslationsTest(t)
+	dir := setupTranslationsTest(t)
 
 	enTF := TranslationFile{
 		"hello": {One: "Hello", Other: "Hellos"},
@@ -608,12 +624,10 @@ func TestPrintValidationSummary_S23_InconsistentKeyDetail(t *testing.T) {
 		"hello": {One: "Hola", Other: "Holas"},
 		// "bye" absent → inconsistent
 	}
-	writeJSONFile(t, scanDir, "en.json", enTF)
-	writeJSONFile(t, scanDir, "es.json", esTF)
-	writeJSONFile(t, secureDir, "en.json", enTF)
-	writeJSONFile(t, secureDir, "es.json", esTF)
+	writeJSONFile(t, dir, "en.json", enTF)
+	writeJSONFile(t, dir, "es.json", esTF)
 
-	summary, err := validateTranslations(".")
+	summary, err := validateTranslations(dir)
 	require.NoError(t, err)
 	require.NotEmpty(t, summary.InconsistentKeys)
 

--- a/configs/dev.yaml
+++ b/configs/dev.yaml
@@ -21,5 +21,5 @@ storage:
     name: keyorix
     user: keyorix
     ssl_mode: disable
-encryption:
-  enabled: true
+  encryption:
+    enabled: true

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -461,6 +461,21 @@ func checkAllComponentsSeen(pinned map[string]Component, seen map[string]bool) e
 // the last successfully-imported bundle — the authoritative input to the no-downgrade gate.
 const installedVersionMarker = ".keyorix-installed-version"
 
+// PersistedInstalledVersion returns the version recorded by a previous successful `import`
+// at destDir (see readInstalledVersion): ok is true and version is set when a marker from a
+// prior import anchors the no-downgrade / anti-skip gate for this destination; ok is false
+// when destDir is empty/nonexistent (a genuine first import, with nothing yet to anchor
+// against). A present-but-unreadable marker, or an otherwise non-empty destDir with no
+// marker, is returned as an error (fail closed — see readInstalledVersion).
+//
+// CLI callers use this to decide whether an operator-supplied --installed-version flag can
+// safely be treated as optional for a given import (a marker already anchors the gate) or
+// must be required (no anchor exists yet, so an omitted flag would silently disable
+// downgrade protection for that import — cli-project-001).
+func PersistedInstalledVersion(destDir string) (version string, ok bool, err error) {
+	return readInstalledVersion(destDir)
+}
+
 // readInstalledVersion returns the persisted installed version at destDir. ok is false
 // when no marker exists (a first install); a present-but-unreadable marker is an error
 // (fail closed — don't silently treat a tampered/locked marker as "first install").

--- a/internal/cli/bundle/bundle.go
+++ b/internal/cli/bundle/bundle.go
@@ -40,8 +40,10 @@ var (
 	buildMinFrom    string
 	buildReleased   string
 	verifyInstalled string
+	verifyForce     bool
 	importDest      string
 	importInstalled string
+	importForce     bool
 	importLicense   string
 )
 
@@ -125,6 +127,9 @@ var verifyCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("verification failed (fail-closed): %w", err)
 		}
+		if err := requireVerifyInstalledVersion(); err != nil {
+			return err
+		}
 		if err := m.CheckUpgrade(verifyInstalled); err != nil {
 			return err
 		}
@@ -165,6 +170,10 @@ var importCmd = &cobra.Command{
 		// deployment). Gating strips nothing from community source builds, which can't
 		// import anyway (no embedded update key).
 		if err := requireAirgapUpdates(reg); err != nil {
+			return err
+		}
+
+		if err := requireImportInstalledVersion(); err != nil {
 			return err
 		}
 
@@ -235,6 +244,72 @@ func configuredDeploymentID() string {
 	return cfg.License.DeploymentID
 }
 
+// requireVerifyInstalledVersion enforces that `bundle verify` gets an operator-supplied
+// --installed-version before the no-downgrade / anti-skip (min-upgrade-from) check runs.
+// `verify` is fully offline and stateless — unlike `import`, there is no staging directory
+// to persist a marker in, so the flag is the ONLY input the check has (cli-project-001: it
+// was previously optional with an empty default, which made ibundle.Manifest.CheckUpgrade
+// silently no-op — a substituted, older-but-validly-signed bundle would then verify clean
+// with no indication it's a downgrade). Skipping the check is still possible, but only as an
+// explicit, auditable --force, never as the silent default.
+func requireVerifyInstalledVersion() error {
+	verifyInstalled = strings.TrimSpace(verifyInstalled)
+	if verifyInstalled != "" {
+		return nil
+	}
+	if !verifyForce {
+		return fmt.Errorf("--installed-version is required to check the no-downgrade / anti-skip " +
+			"(min-upgrade-from) guarantees for this deployment: pass --installed-version " +
+			"<currently-running-version> (recommended — a substituted, older-but-validly-signed bundle " +
+			"would otherwise verify cleanly with no warning that it's a downgrade). Re-run with --force to " +
+			"verify only the signature and component digests, with no downgrade check")
+	}
+	fmt.Fprintln(os.Stderr, "WARNING: --installed-version was not supplied — proceeding with --force means "+
+		"the no-downgrade and anti-skip (min-upgrade-from) checks are SKIPPED for this verification.")
+	return nil
+}
+
+// requireImportInstalledVersion enforces that `bundle import` has *something* to anchor the
+// no-downgrade / anti-skip (min-upgrade-from) check against before it opens or extracts the
+// bundle. Unlike verify, import already has a fail-closed auto-discovery mechanism (#111):
+// ibundle.Extract persists a version marker at --dest on every successful import and treats
+// it as authoritative over this flag on the next one, so a routine re-import needs no flag at
+// all. That mechanism only protects a destination that has already been imported into at
+// least once, though — cli-project-001 is the gap on a FIRST import into a fresh/empty
+// --dest, where --installed-version was merely optional with an empty default. An empty
+// default there means ibundle.Manifest.CheckUpgrade silently no-ops, so the routine `keyorix
+// bundle import --dest /stage <bundle>` invocation from the command's own help text staged a
+// substituted, older-but-validly-signed bundle with zero downgrade protection. This makes
+// that gap an explicit, auditable operator choice (--force) instead of a silent default.
+func requireImportInstalledVersion() error {
+	importInstalled = strings.TrimSpace(importInstalled)
+	if importInstalled != "" {
+		return nil
+	}
+	_, hasMarker, err := ibundle.PersistedInstalledVersion(importDest)
+	if err != nil {
+		return fmt.Errorf("import failed (fail-closed, nothing staged on a verify failure): %w", err)
+	}
+	if hasMarker {
+		// A prior import already anchors the gate at this destination; ibundle.Extract will
+		// read and enforce against that marker regardless of this (empty) flag value.
+		return nil
+	}
+	if !importForce {
+		return fmt.Errorf("--installed-version is required: no prior import was recorded at %q, so there is "+
+			"nothing to anchor the no-downgrade / anti-skip (min-upgrade-from) check against. Pass "+
+			"--installed-version <currently-running-version> (recommended — an attacker, a compromised "+
+			"internal mirror, or a compromised artifact-staging host could otherwise substitute an older, "+
+			"still validly-signed bundle and silently downgrade this deployment). If this really is a first "+
+			"install with nothing yet to protect, re-run with --force to proceed without a downgrade check",
+			importDest)
+	}
+	fmt.Fprintf(os.Stderr, "WARNING: --installed-version was not supplied and no prior import was found at %s "+
+		"— proceeding with --force means the no-downgrade and anti-skip (min-upgrade-from) checks are SKIPPED "+
+		"for this import.\n", importDest)
+	return nil
+}
+
 func init() {
 	buildCmd.Flags().StringVar(&buildSrc, "src", "", "directory of release artifacts to bundle (required)")
 	buildCmd.Flags().StringVar(&buildOut, "out", "", "output bundle file (required)")
@@ -249,10 +324,16 @@ func init() {
 	_ = buildCmd.MarkFlagRequired("key-id")
 	_ = buildCmd.MarkFlagRequired("sign-key")
 
-	verifyCmd.Flags().StringVar(&verifyInstalled, "installed-version", "", "currently-installed version, to enforce no-downgrade / min-upgrade-from")
+	verifyCmd.Flags().StringVar(&verifyInstalled, "installed-version", "",
+		"currently-installed version, to enforce no-downgrade / min-upgrade-from (required unless --force)")
+	verifyCmd.Flags().BoolVar(&verifyForce, "force", false,
+		"proceed without --installed-version (dangerous — skips the no-downgrade / anti-skip check, verifies signature and digests only)")
 
 	importCmd.Flags().StringVar(&importDest, "dest", "", "directory to stage verified artifacts into (required)")
-	importCmd.Flags().StringVar(&importInstalled, "installed-version", "", "currently-installed version, to enforce no-downgrade / min-upgrade-from")
+	importCmd.Flags().StringVar(&importInstalled, "installed-version", "",
+		"currently-installed version, to enforce no-downgrade / min-upgrade-from (required on a first import into --dest, unless --force)")
+	importCmd.Flags().BoolVar(&importForce, "force", false,
+		"proceed without --installed-version on a first import into --dest (dangerous — skips the no-downgrade / anti-skip check)")
 	importCmd.Flags().StringVar(&importLicense, "license", "", "path to the installed license token (bundle import is a commercial feature)")
 	_ = importCmd.MarkFlagRequired("dest")
 

--- a/internal/cli/bundle/bundle_downgrade_guard_test.go
+++ b/internal/cli/bundle/bundle_downgrade_guard_test.go
@@ -1,0 +1,296 @@
+package bundle
+
+// Regression tests for cli-project-001 (HIGH, supply-chain): `bundle import` and `bundle
+// verify` both derive the no-downgrade / anti-skip (min-upgrade-from) check from an
+// operator-supplied --installed-version flag that used to be OPTIONAL with an empty-string
+// default. ibundle.Manifest.CheckUpgrade silently no-ops on an empty installed version, so
+// the routine, help-text-documented invocation `keyorix bundle import --dest /stage <bundle>`
+// (no --installed-version) performed ZERO downgrade protection: a validly-signed but stale
+// bundle — substituted by a compromised mirror or staging host — would import cleanly,
+// silently downgrading an air-gapped deployment past a release with a mandatory security
+// fix or a MinUpgradeFrom-gated migration.
+//
+// These tests assert the fix: both commands now refuse to skip the check silently. Omitting
+// --installed-version is refused with a clear, actionable error unless the operator either
+// (a) has a prior import already anchoring the check via the persisted destDir marker
+// (import only — see resolveIdempotentInstall in internal/bundle), or (b) passes the
+// explicit --force override, in which case a loud warning is printed and the operator's
+// choice to skip the check is auditable rather than silent.
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	ibundle "github.com/keyorixhq/keyorix/internal/bundle"
+	"github.com/keyorixhq/keyorix/internal/trust"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetImportVars saves and restores every importCmd package-level var this test file
+// touches.
+func resetImportVars(t *testing.T) {
+	t.Helper()
+	origD, origL, origI, origF := importDest, importLicense, importInstalled, importForce
+	t.Cleanup(func() {
+		importDest = origD
+		importLicense = origL
+		importInstalled = origI
+		importForce = origF
+	})
+}
+
+// buildAndSignBundle builds and signs a bundle with an EXISTING signing key (unlike
+// buildSignedBundle in bundle_s3_test.go, which always mints a fresh key), so a test can
+// build multiple bundle versions signed by the same trusted key.
+func buildAndSignBundle(t *testing.T, files map[string]string, version, keyID string, priv ed25519.PrivateKey) string {
+	t.Helper()
+	srcDir := srcDirWithFiles(t, files)
+	m, err := ibundle.BuildManifest(srcDir, version, keyID, "", time.Unix(1_700_000_000, 0))
+	require.NoError(t, err)
+	sig, err := ibundle.Sign(m, priv)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, ibundle.WriteBundle(&buf, srcDir, m, sig))
+	bundlePath := filepath.Join(t.TempDir(), "bundle-"+version+".tar.gz")
+	require.NoError(t, os.WriteFile(bundlePath, buf.Bytes(), 0o644))
+	return bundlePath
+}
+
+// TestImportCmd_RequiresInstalledVersion_OnFirstImport is the core regression test: a
+// fresh, never-imported-into --dest with no --installed-version and no --force must be
+// refused BEFORE the bundle is even opened — nothing gets staged.
+func TestImportCmd_RequiresInstalledVersion_OnFirstImport(t *testing.T) {
+	resetDefaultRegistryFn(t)
+	resetImportVars(t)
+
+	const keyID = "test-key-guard-2026"
+	bundlePath, updPub, _ := buildSignedBundle(t, map[string]string{
+		"bin/keyorix": "binary-content",
+	}, "v0.99.0", keyID)
+	tokenPath, licPub := makeLicenseToken(t)
+
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeUpdate, keyID, updPub))
+	require.NoError(t, reg.Add(trust.PurposeLicense, "license-s3-2026", licPub))
+	defaultRegistryFn = func() (*trust.KeyRegistry, error) { return reg, nil }
+	t.Setenv("KEYORIX_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.yaml"))
+
+	destDir := t.TempDir()
+	importDest = destDir
+	importLicense = tokenPath
+	importInstalled = ""
+	importForce = false
+
+	err := importCmd.RunE(importCmd, []string{bundlePath})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--installed-version is required")
+
+	entries, rerr := os.ReadDir(destDir)
+	require.NoError(t, rerr)
+	assert.Empty(t, entries, "refusing the gate must stage nothing")
+}
+
+// TestImportCmd_ForceBypassesMissingInstalledVersion verifies the explicit --force
+// override lets a genuine first import proceed without --installed-version.
+func TestImportCmd_ForceBypassesMissingInstalledVersion(t *testing.T) {
+	resetDefaultRegistryFn(t)
+	resetImportVars(t)
+
+	const keyID = "test-key-guard-force"
+	bundlePath, updPub, _ := buildSignedBundle(t, map[string]string{
+		"bin/keyorix": "binary-content",
+	}, "v0.99.0", keyID)
+	tokenPath, licPub := makeLicenseToken(t)
+
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeUpdate, keyID, updPub))
+	require.NoError(t, reg.Add(trust.PurposeLicense, "license-s3-2026", licPub))
+	defaultRegistryFn = func() (*trust.KeyRegistry, error) { return reg, nil }
+	t.Setenv("KEYORIX_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.yaml"))
+
+	destDir := t.TempDir()
+	importDest = destDir
+	importLicense = tokenPath
+	importInstalled = ""
+	importForce = true
+
+	err := importCmd.RunE(importCmd, []string{bundlePath})
+	require.NoError(t, err)
+
+	entries, rerr := os.ReadDir(destDir)
+	require.NoError(t, rerr)
+	assert.NotEmpty(t, entries, "--force must actually stage the bundle")
+}
+
+// TestImportCmd_PriorMarkerSatisfiesRequirement_NoForceNeeded verifies the existing
+// auto-discovery mechanism (#111's persisted destDir marker) still lets a routine
+// re-import into an ALREADY-imported-into --dest proceed without --installed-version or
+// --force — only a genuine first import (no marker yet) requires an affirmative choice.
+func TestImportCmd_PriorMarkerSatisfiesRequirement_NoForceNeeded(t *testing.T) {
+	resetDefaultRegistryFn(t)
+	resetImportVars(t)
+
+	const keyID = "test-key-guard-marker"
+	_, pub, priv := ed25519KeyPEM(t)
+	tokenPath, licPub := makeLicenseToken(t)
+
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeUpdate, keyID, pub))
+	require.NoError(t, reg.Add(trust.PurposeLicense, "license-s3-2026", licPub))
+	defaultRegistryFn = func() (*trust.KeyRegistry, error) { return reg, nil }
+	t.Setenv("KEYORIX_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.yaml"))
+
+	destDir := t.TempDir()
+	importDest = destDir
+	importLicense = tokenPath
+
+	// First import (explicit --installed-version) establishes the persisted marker at
+	// v0.90.0.
+	firstPath := buildAndSignBundle(t, map[string]string{"bin/keyorix": "v1"}, "v0.90.0", keyID, priv)
+	importInstalled = "v0.10.0"
+	importForce = false
+	require.NoError(t, importCmd.RunE(importCmd, []string{firstPath}))
+
+	// Second import of a newer bundle with NO --installed-version and NO --force must
+	// succeed: the marker written by the first import anchors the gate automatically.
+	secondPath := buildAndSignBundle(t, map[string]string{"bin/keyorix": "v2"}, "v0.95.0", keyID, priv)
+	importInstalled = ""
+	importForce = false
+	err := importCmd.RunE(importCmd, []string{secondPath})
+	require.NoError(t, err, "a prior import's persisted marker should satisfy the gate without --force")
+}
+
+// TestImportCmd_DowngradeStillBlockedWhenInstalledVersionSupplied verifies the actual
+// no-downgrade protection this whole gate exists to guarantee still fires once
+// --installed-version IS supplied: an older, validly-signed bundle must still be
+// rejected, and nothing staged.
+func TestImportCmd_DowngradeStillBlockedWhenInstalledVersionSupplied(t *testing.T) {
+	resetDefaultRegistryFn(t)
+	resetImportVars(t)
+
+	const keyID = "test-key-guard-downgrade"
+	_, pub, priv := ed25519KeyPEM(t)
+	tokenPath, licPub := makeLicenseToken(t)
+
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeUpdate, keyID, pub))
+	require.NoError(t, reg.Add(trust.PurposeLicense, "license-s3-2026", licPub))
+	defaultRegistryFn = func() (*trust.KeyRegistry, error) { return reg, nil }
+	t.Setenv("KEYORIX_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.yaml"))
+
+	oldBundle := buildAndSignBundle(t, map[string]string{"bin/keyorix": "old"}, "v0.50.0", keyID, priv)
+
+	destDir := t.TempDir()
+	importDest = destDir
+	importLicense = tokenPath
+	importInstalled = "v0.99.0" // currently running something much newer than the bundle
+	importForce = false
+
+	err := importCmd.RunE(importCmd, []string{oldBundle})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "import failed")
+
+	entries, rerr := os.ReadDir(destDir)
+	require.NoError(t, rerr)
+	assert.Empty(t, entries, "a rejected downgrade must stage nothing")
+}
+
+// TestImportCmd_AmbiguousDestWithoutMarker_FailsClosed verifies the new gate correctly
+// surfaces the existing #111 fail-closed behavior: a --dest that already holds staged
+// content but no marker (e.g. a prior import failed partway through, or the marker was
+// deleted) is refused, not silently treated as a first install.
+func TestImportCmd_AmbiguousDestWithoutMarker_FailsClosed(t *testing.T) {
+	resetDefaultRegistryFn(t)
+	resetImportVars(t)
+
+	const keyID = "test-key-guard-ambiguous"
+	bundlePath, pub, _ := buildSignedBundle(t, map[string]string{"bin/keyorix": "bytes"}, "v0.99.0", keyID)
+	tokenPath, licPub := makeLicenseToken(t)
+
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeUpdate, keyID, pub))
+	require.NoError(t, reg.Add(trust.PurposeLicense, "license-s3-2026", licPub))
+	defaultRegistryFn = func() (*trust.KeyRegistry, error) { return reg, nil }
+	t.Setenv("KEYORIX_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.yaml"))
+
+	destDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "leftover-file"), []byte("x"), 0o644))
+
+	importDest = destDir
+	importLicense = tokenPath
+	importInstalled = ""
+	importForce = false
+
+	err := importCmd.RunE(importCmd, []string{bundlePath})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already contains staged content but no installed-version marker")
+}
+
+// TestVerifyCmd_RequiresInstalledVersion verifies that offline `bundle verify` — which has
+// no destDir/marker to fall back on — refuses to skip the downgrade check silently.
+func TestVerifyCmd_RequiresInstalledVersion(t *testing.T) {
+	resetDefaultRegistryFn(t)
+	origV, origF := verifyInstalled, verifyForce
+	defer func() { verifyInstalled = origV; verifyForce = origF }()
+
+	const keyID = "test-key-guard-verify"
+	bundlePath, pub, _ := buildSignedBundle(t, map[string]string{"bin/keyorix": "bytes"}, "v0.99.0", keyID)
+
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeUpdate, keyID, pub))
+	defaultRegistryFn = func() (*trust.KeyRegistry, error) { return reg, nil }
+
+	verifyInstalled = ""
+	verifyForce = false
+
+	err := verifyCmd.RunE(verifyCmd, []string{bundlePath})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--installed-version is required")
+}
+
+// TestVerifyCmd_ForceBypassesMissingInstalledVersion verifies --force lets an operator
+// explicitly verify signature/digests only, with no downgrade check.
+func TestVerifyCmd_ForceBypassesMissingInstalledVersion(t *testing.T) {
+	resetDefaultRegistryFn(t)
+	origV, origF := verifyInstalled, verifyForce
+	defer func() { verifyInstalled = origV; verifyForce = origF }()
+
+	const keyID = "test-key-guard-verify-force"
+	bundlePath, pub, _ := buildSignedBundle(t, map[string]string{"bin/keyorix": "bytes"}, "v0.99.0", keyID)
+
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeUpdate, keyID, pub))
+	defaultRegistryFn = func() (*trust.KeyRegistry, error) { return reg, nil }
+
+	verifyInstalled = ""
+	verifyForce = true
+
+	err := verifyCmd.RunE(verifyCmd, []string{bundlePath})
+	require.NoError(t, err)
+}
+
+// TestVerifyCmd_DowngradeStillBlockedWhenInstalledVersionSupplied verifies verify's actual
+// downgrade detection still fires once --installed-version IS supplied.
+func TestVerifyCmd_DowngradeStillBlockedWhenInstalledVersionSupplied(t *testing.T) {
+	resetDefaultRegistryFn(t)
+	origV, origF := verifyInstalled, verifyForce
+	defer func() { verifyInstalled = origV; verifyForce = origF }()
+
+	const keyID = "test-key-guard-verify-downgrade"
+	bundlePath, pub, _ := buildSignedBundle(t, map[string]string{"bin/keyorix": "bytes"}, "v0.50.0", keyID)
+
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeUpdate, keyID, pub))
+	defaultRegistryFn = func() (*trust.KeyRegistry, error) { return reg, nil }
+
+	verifyInstalled = "v0.99.0" // newer than the bundle — a downgrade
+	verifyForce = false
+
+	err := verifyCmd.RunE(verifyCmd, []string{bundlePath})
+	require.Error(t, err)
+}

--- a/internal/cli/bundle/bundle_extra_test.go
+++ b/internal/cli/bundle/bundle_extra_test.go
@@ -60,7 +60,7 @@ func TestBuildCmd_HasExpectedFlags(t *testing.T) {
 }
 
 func TestImportCmd_HasExpectedFlags(t *testing.T) {
-	for _, name := range []string{"dest", "installed-version", "license"} {
+	for _, name := range []string{"dest", "installed-version", "license", "force"} {
 		assert.NotNil(t, importCmd.Flags().Lookup(name), "import should have --%s", name)
 	}
 }

--- a/internal/cli/bundle/bundle_s25_test.go
+++ b/internal/cli/bundle/bundle_s25_test.go
@@ -75,7 +75,7 @@ func TestVerifyCmd_Success_MultipleComponents(t *testing.T) {
 	resetDefaultRegistryFn(t)
 	origV := verifyInstalled
 	defer func() { verifyInstalled = origV }()
-	verifyInstalled = ""
+	verifyInstalled = "v0.50.0"
 
 	const keyID = "test-key-s25-multi"
 	bundlePath, pub, _ := buildSignedBundle(t, map[string]string{
@@ -99,8 +99,9 @@ func TestBundleCmd_Metadata(t *testing.T) {
 }
 
 // TestVerifyCmd_HasInstalledVersionFlag verifies the verify subcommand registers
-// --installed-version (registered in init()).
+// --installed-version and --force (registered in init()).
 func TestVerifyCmd_HasInstalledVersionFlag(t *testing.T) {
 	f := verifyCmd.Flags().Lookup("installed-version")
 	assert.NotNil(t, f, "verify should have --installed-version flag")
+	assert.NotNil(t, verifyCmd.Flags().Lookup("force"), "verify should have --force flag")
 }

--- a/internal/cli/bundle/bundle_s3_test.go
+++ b/internal/cli/bundle/bundle_s3_test.go
@@ -275,7 +275,7 @@ func TestVerifyCmd_Success(t *testing.T) {
 	resetDefaultRegistryFn(t)
 	origV := verifyInstalled
 	defer func() { verifyInstalled = origV }()
-	verifyInstalled = ""
+	verifyInstalled = "v0.50.0"
 
 	const keyID = "test-key-s3-2026"
 	bundlePath, pub, _ := buildSignedBundle(t, map[string]string{
@@ -380,18 +380,20 @@ func TestImportCmd_Success_FullPath(t *testing.T) {
 	destDir := t.TempDir()
 	importDest = destDir
 	importLicense = tokenPath
-	importInstalled = ""
+	importInstalled = "v0.50.0" // below the bundle's v0.99.0 — a genuine upgrade
 
 	err := importCmd.RunE(importCmd, []string{bundlePath})
 	require.NoError(t, err)
 }
 
 // TestImportCmd_ExtractFails exercises the ibundle.Extract error path: the
-// license gate passes but the bundle itself is corrupted, so Extract fails.
+// license gate and the installed-version gate both pass (via --force, since a
+// corrupted bundle has no discoverable version), but the bundle itself is
+// corrupted, so Extract fails.
 func TestImportCmd_ExtractFails(t *testing.T) {
 	resetDefaultRegistryFn(t)
-	origD, origL, origI := importDest, importLicense, importInstalled
-	defer func() { importDest = origD; importLicense = origL; importInstalled = origI }()
+	origD, origL, origI, origF := importDest, importLicense, importInstalled, importForce
+	defer func() { importDest = origD; importLicense = origL; importInstalled = origI; importForce = origF }()
 
 	tokenPath, licPub := makeLicenseToken(t)
 
@@ -412,6 +414,7 @@ func TestImportCmd_ExtractFails(t *testing.T) {
 	importDest = t.TempDir()
 	importLicense = tokenPath
 	importInstalled = ""
+	importForce = true
 
 	err := importCmd.RunE(importCmd, []string{bundlePath})
 	require.Error(t, err)
@@ -419,11 +422,13 @@ func TestImportCmd_ExtractFails(t *testing.T) {
 }
 
 // TestImportCmd_MissingBundleFile_AfterLicenseGate exercises the os.Open error
-// path in importCmd.RunE after requireAirgapUpdates passes.
+// path in importCmd.RunE after requireAirgapUpdates and the installed-version
+// gate (bypassed via --force, since a first import into a fresh --dest has
+// nothing to auto-discover a version from) both pass.
 func TestImportCmd_MissingBundleFile_AfterLicenseGate(t *testing.T) {
 	resetDefaultRegistryFn(t)
-	origD, origL, origI := importDest, importLicense, importInstalled
-	defer func() { importDest = origD; importLicense = origL; importInstalled = origI }()
+	origD, origL, origI, origF := importDest, importLicense, importInstalled, importForce
+	defer func() { importDest = origD; importLicense = origL; importInstalled = origI; importForce = origF }()
 
 	tokenPath, licPub := makeLicenseToken(t)
 
@@ -439,6 +444,7 @@ func TestImportCmd_MissingBundleFile_AfterLicenseGate(t *testing.T) {
 	importDest = t.TempDir()
 	importLicense = tokenPath
 	importInstalled = ""
+	importForce = true
 
 	err := importCmd.RunE(importCmd, []string{"/nonexistent/bundle.tar.gz"})
 	require.Error(t, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -1719,8 +1722,22 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("failed to read config file %q: %w", path, err)
 	}
 
+	// KnownFields(true) makes an unrecognized key (e.g. a correctly-spelled field
+	// nested under the wrong parent, or a typo) fail loudly at startup instead of
+	// being silently dropped by yaml.Unmarshal. Without this, an operator can set
+	// e.g. a top-level `encryption:` block (instead of the real `storage.encryption`)
+	// and believe it took effect when it was actually discarded — see configs/dev.yaml
+	// history for a real instance of exactly this bug.
+	//
+	// An empty, whitespace-only, or comments-only file is not an error — yaml.Decoder
+	// returns io.EOF for a document with no content, whereas the package-level
+	// yaml.Unmarshal silently leaves the target at its zero value. Preserve that
+	// historical "no content = all defaults" behavior explicitly rather than
+	// surfacing io.EOF as a confusing "failed to unmarshal config" error.
 	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil && !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 

--- a/internal/config/config_strict_test.go
+++ b/internal/config/config_strict_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// configs/dev.yaml used to declare its `encryption:` block at the top level instead
+// of nesting it under `storage:` (the Config struct has no top-level `encryption`
+// field at all — only StorageConfig.Encryption). Because Load() used a plain,
+// non-strict yaml.Unmarshal, the misplaced block was silently discarded: a developer
+// running `make run` believed local Postgres storage was encrypted when
+// storage.encryption.enabled actually stayed at its Go zero value (false), and every
+// secret value was written to the dev database in plaintext. This test locks in both
+// halves of the fix: the misplaced key is now correctly nested, and Load() itself
+// would refuse to silently swallow a similar mistake in the future.
+func TestLoadDevYAML_EncryptionEnabled(t *testing.T) {
+	repoRoot, err := filepath.Abs("../..")
+	require.NoError(t, err)
+	p := filepath.Join(repoRoot, "configs", "dev.yaml")
+	if _, statErr := os.Stat(p); statErr != nil {
+		t.Skipf("configs/dev.yaml not found at %s: %v", p, statErr)
+	}
+
+	cfg, err := Load(p)
+	require.NoError(t, err, "configs/dev.yaml must load cleanly")
+	assert.True(t, cfg.Storage.Encryption.Enabled,
+		"storage.encryption.enabled must be true — configs/dev.yaml intends to encrypt the local dev Postgres database")
+}
+
+// Regression guard for the class of bug behind configs/dev.yaml's misplaced
+// top-level `encryption:` block: Load() must now use a strict/KnownFields YAML
+// decoder, so any unrecognized key — whether a genuine typo or a correctly-spelled
+// field nested under the wrong parent — fails loudly at startup instead of being
+// silently dropped.
+func TestLoadRejectsUnknownTopLevelKey(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "keyorix.yaml")
+	// Mirrors the exact real-world mistake: `encryption:` belongs under `storage:`,
+	// not at the document root.
+	require.NoError(t, os.WriteFile(p, []byte(
+		"storage:\n  type: postgres\nencryption:\n  enabled: true\n",
+	), 0o600))
+
+	_, err := Load(p)
+	require.Error(t, err, "an unrecognized top-level key must fail Load(), not be silently dropped")
+	assert.Contains(t, err.Error(), "encryption")
+}
+
+// Companion to TestLoadRejectsUnknownTopLevelKey: an unrecognized key nested inside a
+// known block (not just at the document root) must be rejected too.
+func TestLoadRejectsUnknownNestedKey(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(
+		"storage:\n  type: postgres\n  encryption:\n    enabled: true\n    made_up_field: true\n",
+	), 0o600))
+
+	_, err := Load(p)
+	require.Error(t, err, "an unrecognized nested key must fail Load(), not be silently dropped")
+	assert.Contains(t, err.Error(), "made_up_field")
+}
+
+// Strict-mode hardening must not regress the historical behavior for a config file
+// that is empty, whitespace-only, or comments-only: Load() should still succeed and
+// return the all-defaults zero-value Config, matching the old yaml.Unmarshal
+// behavior (which silently no-ops on an empty document) rather than surfacing the
+// yaml.Decoder's io.EOF as a load error.
+func TestLoadEmptyFileIsNotAnError(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := map[string]string{
+		"empty":        "",
+		"whitespace":   "   \n\n   \n",
+		"comment-only": "# nothing but a comment\n",
+	}
+	for name, content := range cases {
+		content := content
+		t.Run(name, func(t *testing.T) {
+			p := filepath.Join(dir, name+".yaml")
+			require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+
+			cfg, err := Load(p)
+			require.NoError(t, err)
+			assert.False(t, cfg.Storage.Encryption.Enabled, "zero-value default")
+		})
+	}
+}
+
+// A well-formed config with only known fields (across nested blocks) must still
+// load cleanly under the strict decoder — a hardening change that's too aggressive
+// is as dangerous as one that's too permissive.
+func TestLoadAcceptsWellFormedConfig(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(
+		"environment: development\n"+
+			"server:\n  http:\n    enabled: true\n    port: \"8080\"\n"+
+			"storage:\n  type: postgres\n  database:\n    host: localhost\n    port: \"5432\"\n"+
+			"  encryption:\n    enabled: true\n",
+	), 0o600))
+
+	cfg, err := Load(p)
+	require.NoError(t, err)
+	assert.Equal(t, "development", cfg.Environment)
+	assert.True(t, cfg.Storage.Encryption.Enabled)
+}

--- a/internal/core/migrate_user_to_machine.go
+++ b/internal/core/migrate_user_to_machine.go
@@ -42,7 +42,17 @@ func (c *KeyorixCore) MigrateUserToMachine(ctx context.Context, username string,
 	if name == "" {
 		name = user.Username
 	}
-	desc := fmt.Sprintf("Migrated from user %q (id %d, %s)", user.Username, user.ID, user.Email)
+	// The machine identity's Description is readable by any project member
+	// holding users.read (project-scoped) via ListMachineIdentities/
+	// ListStaleMachineIdentities — a far lower bar than the users.write
+	// (global) + roles.assign (project) required to perform this migration.
+	// The source user need not be, and often isn't, a member of projectID, so
+	// embedding their email here would leak it to anyone in projectID who has
+	// no other way to look that user up. Keep the Description limited to the
+	// username (already visible in the resulting identity's Name in the
+	// common case) and put the full detail, including the email, in the audit
+	// event below, which is gated behind audit.read.
+	desc := fmt.Sprintf("Migrated from user %q (id %d)", user.Username, user.ID)
 
 	m, err := c.CreateMachineIdentity(ctx, projectID, name, identityType, desc, "", actorID)
 	if err != nil {
@@ -58,9 +68,13 @@ func (c *KeyorixCore) MigrateUserToMachine(ctx context.Context, username string,
 		}
 	}
 
+	// Full detail, including the source user's email, goes in the audit event
+	// rather than the machine identity's Description: the audit log is gated
+	// behind audit.read, whereas Description is readable by any project
+	// member with project-scoped users.read (see the comment above).
 	aid, pid := actorID, projectID
 	c.writeAuditEventFull(ctx, "machine_identity.migrated_from_user", &aid, nil, &pid, "",
-		fmt.Sprintf("user %q (id %d) migrated to machine identity %q (id %d) in project %d", user.Username, user.ID, m.Name, m.ID, projectID))
+		fmt.Sprintf("user %q (id %d, %s) migrated to machine identity %q (id %d) in project %d", user.Username, user.ID, user.Email, m.Name, m.ID, projectID))
 
 	return m, nil
 }

--- a/internal/core/migrate_user_to_machine_test.go
+++ b/internal/core/migrate_user_to_machine_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -52,6 +53,49 @@ func TestMigrateUserToMachine(t *testing.T) {
 		assert.True(t, seen["account.suspended"], "suspend event")
 		assert.True(t, seen["machine_identity.migrated_from_user"], "migration event")
 		store.AssertExpectations(t)
+	})
+
+	t.Run("machine identity Description omits the source user's email; the audit event carries it", func(t *testing.T) {
+		// CMI-2: the created machine identity's Description is readable by any
+		// project member with project-scoped users.read (ListMachineIdentities/
+		// ListStaleMachineIdentities over both HTTP and gRPC), a far lower bar
+		// than the users.write (global) + roles.assign (project) required to
+		// perform this migration. The source user need not be a member of the
+		// target project, so the email must not leak into Description — the
+		// full detail belongs in the audit event instead, which is gated
+		// behind audit.read.
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+
+		store.On("GetUserByUsername", ctx, "jane.doe").
+			Return(&models.User{ID: 4821, Username: "jane.doe", Email: "jane.doe@customer.example", AccountState: "active"}, nil)
+
+		var createdDesc string
+		store.On("CreateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			createdDesc = m.Description
+			return m.ProjectID == 3
+		})).Return(&models.MachineIdentity{ID: 20, ProjectID: 3, Name: "jane.doe", IdentityType: MachineTypeService, State: MachineActive, Description: createdDesc}, nil)
+
+		var auditDescs []string
+		store.On("LogAuditEvent", ctx, mock.MatchedBy(func(e *models.AuditEvent) bool {
+			auditDescs = append(auditDescs, e.Description)
+			return true
+		})).Return(nil)
+
+		_, err := c.MigrateUserToMachine(ctx, "jane.doe", 3, "", "", 9, false)
+		require.NoError(t, err)
+
+		assert.NotContains(t, createdDesc, "jane.doe@customer.example", "machine identity Description must not leak the source user's email")
+		assert.Contains(t, createdDesc, "jane.doe", "Description may still reference the source username")
+
+		foundEmailInAudit := false
+		for _, d := range auditDescs {
+			if strings.Contains(d, "jane.doe@customer.example") {
+				foundEmailInAudit = true
+			}
+		}
+		assert.True(t, foundEmailInAudit, "the migration audit event (gated behind audit.read) should still record the full detail, including email")
 	})
 
 	t.Run("keep-user leaves the source account untouched", func(t *testing.T) {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -58,8 +58,9 @@ func (m *MockStorage) RecordLoginAttempt(_ context.Context, _ string, _ time.Tim
 func (m *MockStorage) CountRecentLoginAttempts(_ context.Context, _ string, _ time.Time) (int64, error) {
 	return 0, nil
 }
-func (m *MockStorage) PruneLoginAttempts(_ context.Context, _ time.Time) (int64, error) {
-	return 0, nil
+func (m *MockStorage) PruneLoginAttempts(ctx context.Context, before time.Time) (int64, error) {
+	a := m.Called(ctx, before)
+	return a.Get(0).(int64), a.Error(1)
 }
 
 // Permission Management

--- a/internal/core/rate_limit.go
+++ b/internal/core/rate_limit.go
@@ -25,6 +25,7 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"net"
 	"time"
@@ -118,10 +119,50 @@ func (c *KeyorixCore) RecordFailedLogin(ctx context.Context, ip string) {
 	_ = c.storage.RecordLoginAttempt(ctx, CanonicalIP(ip), c.now())
 }
 
-// PruneLoginAttempts removes attempts older than the window; called by the
-// maintenance sweep. Returns the number removed.
-func (c *KeyorixCore) PruneLoginAttempts(ctx context.Context) (int64, error) {
-	return c.storage.PruneLoginAttempts(ctx, c.now().Add(-LoginWindow))
+// PruneLoginAttempts removes login/password-reset rate-limit rows older than
+// `before`. `before` is clamped so the effective cutoff can never be LATER
+// than `now - LoginWindow` — the maintenance sweep's own invariant (server/
+// main.go always calls this with a zero `before`, which resolves to exactly
+// that cutoff) — so a caller can only narrow the deletion window, never widen
+// it into an unbounded wipe. This is the sole enforcement point for the
+// bound: server/http/handlers/login_attempts_proxy.go's PruneLoginAttemptsProxy
+// (the only other caller, decoding an attacker-influenced `before` from an
+// HTTP request body) routes through this method rather than calling
+// c.storage.PruneLoginAttempts directly, specifically so it cannot bypass the
+// clamp (CORE-RATE-003: an unbounded `before` let any principal holding
+// system.write wipe the entire login_attempts table on demand — every IP's
+// failed-attempt count and the only record a brute-force campaign was ever
+// attempted from any address — with no trace).
+//
+// actorID is the acting principal's user ID (0 for the scheduler / a
+// non-user principal — e.g. a node/machine credential — matching
+// writeRBACAudit's "0 = no authenticated principal" convention; the
+// context's ActorType tag, set by the caller, still distinguishes
+// system/machine/user attribution on the emitted event). Returns the number
+// of rows removed. When anything is actually removed, emits a
+// `data.login_attempts_pruned` audit event recording the actor, row count,
+// and effective cutoff — mirroring PurgeExpiredSoftDeletes/
+// PurgeExpiredComplianceRecords, which this primitive previously had no
+// equivalent of at all.
+func (c *KeyorixCore) PruneLoginAttempts(ctx context.Context, before time.Time, actorID uint) (int64, error) {
+	cutoff := c.now().Add(-LoginWindow)
+	if !before.IsZero() && before.Before(cutoff) {
+		cutoff = before
+	}
+
+	n, err := c.storage.PruneLoginAttempts(ctx, cutoff)
+	if err != nil {
+		return n, err
+	}
+	if n > 0 {
+		var actor *uint
+		if actorID != 0 {
+			actor = &actorID
+		}
+		c.writeAuditEvent(ctx, "data.login_attempts_pruned", actor, nil,
+			fmt.Sprintf("login-attempts prune removed %d row(s) older than %s", n, cutoff.UTC().Format(time.RFC3339)))
+	}
+	return n, nil
 }
 
 // passwordResetRateLimitPrefix namespaces password-reset attempts within the

--- a/internal/core/rate_limit_test.go
+++ b/internal/core/rate_limit_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
@@ -167,13 +168,106 @@ func TestRateLimit_PruneRemovesAgedRows(t *testing.T) {
 	}
 	// Move past the window and prune — aged rows are removed.
 	setNow(base.Add(LoginWindow + time.Minute))
-	removed, err := c.PruneLoginAttempts(ctx)
+	removed, err := c.PruneLoginAttempts(ctx, time.Time{}, 0)
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), removed)
 
 	n, err := c.storage.CountRecentLoginAttempts(ctx, "1.2.3.4", time.Time{})
 	require.NoError(t, err)
 	assert.Zero(t, n, "table is empty after pruning aged rows")
+}
+
+// TestPruneLoginAttempts_ClampsFutureBeforeToWindow is the CORE-RATE-003
+// regression test at the core layer: a caller-supplied `before` LATER than
+// now-LoginWindow (an attacker-controlled request body's far-future
+// timestamp, e.g. "2099-01-01T00:00:00Z") must never widen the deletion
+// window — the storage call underneath must always receive the clamped
+// cutoff, not the caller's value.
+func TestPruneLoginAttempts_ClampsFutureBeforeToWindow(t *testing.T) {
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	maxCutoff := now.Add(-LoginWindow)
+	attackerBefore := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockStore := new(MockStorage)
+	// Expectation is set on the CLAMPED cutoff, not the attacker's `before` —
+	// if the fix regresses to passing `before` straight through, this
+	// expectation is never satisfied and testify panics on the unexpected call.
+	mockStore.On("PruneLoginAttempts", mock.Anything, maxCutoff).Return(int64(3), nil)
+	mockStore.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	c := &KeyorixCore{storage: mockStore, now: func() time.Time { return now }, passwordPolicy: DefaultPasswordPolicy()}
+	removed, err := c.PruneLoginAttempts(context.Background(), attackerBefore, 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), removed)
+	mockStore.AssertExpectations(t)
+}
+
+// TestPruneLoginAttempts_NarrowerBeforeIsHonored confirms a caller CAN still
+// narrow the deletion window below the default now-LoginWindow cutoff (a
+// stricter, not wider, request) — only widening past the window is blocked.
+func TestPruneLoginAttempts_NarrowerBeforeIsHonored(t *testing.T) {
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	narrowerBefore := now.Add(-2 * LoginWindow)
+
+	mockStore := new(MockStorage)
+	mockStore.On("PruneLoginAttempts", mock.Anything, narrowerBefore).Return(int64(1), nil)
+	mockStore.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	c := &KeyorixCore{storage: mockStore, now: func() time.Time { return now }, passwordPolicy: DefaultPasswordPolicy()}
+	removed, err := c.PruneLoginAttempts(context.Background(), narrowerBefore, 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), removed)
+	mockStore.AssertExpectations(t)
+}
+
+// TestPruneLoginAttempts_AuditsActorRowCountAndCutoff proves the previously
+// entirely-missing audit trail (CORE-RATE-003): a successful prune that
+// actually removes rows emits a data.login_attempts_pruned event recording
+// the acting principal, the row count, and the effective cutoff — mirroring
+// PurgeExpiredSoftDeletes/PurgeExpiredComplianceRecords.
+func TestPruneLoginAttempts_AuditsActorRowCountAndCutoff(t *testing.T) {
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	maxCutoff := now.Add(-LoginWindow)
+
+	mockStore := new(MockStorage)
+	mockStore.On("PruneLoginAttempts", mock.Anything, maxCutoff).Return(int64(7), nil)
+
+	var audited *models.AuditEvent
+	mockStore.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		if e.EventType == "data.login_attempts_pruned" {
+			audited = e
+			return true
+		}
+		return false
+	})).Return(nil)
+
+	c := &KeyorixCore{storage: mockStore, now: func() time.Time { return now }, passwordPolicy: DefaultPasswordPolicy()}
+	actorID := uint(42)
+	removed, err := c.PruneLoginAttempts(context.Background(), time.Time{}, actorID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), removed)
+
+	require.NotNil(t, audited, "a data.login_attempts_pruned audit event must be written when rows are removed")
+	require.NotNil(t, audited.UserID, "the acting principal is recorded")
+	assert.Equal(t, actorID, *audited.UserID)
+	assert.Contains(t, audited.Description, "7", "row count is recorded")
+	assert.Contains(t, audited.Description, maxCutoff.UTC().Format(time.RFC3339), "effective cutoff is recorded")
+}
+
+// TestPruneLoginAttempts_NoAuditWhenNothingRemoved mirrors
+// PurgeExpiredSoftDeletes/PurgeExpiredComplianceRecords: a prune that removes
+// zero rows writes no audit event at all (avoids flooding the audit trail
+// every maintenance-sweep tick when there's nothing to report).
+func TestPruneLoginAttempts_NoAuditWhenNothingRemoved(t *testing.T) {
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	mockStore := new(MockStorage)
+	mockStore.On("PruneLoginAttempts", mock.Anything, mock.Anything).Return(int64(0), nil)
+
+	c := &KeyorixCore{storage: mockStore, now: func() time.Time { return now }, passwordPolicy: DefaultPasswordPolicy()}
+	removed, err := c.PruneLoginAttempts(context.Background(), time.Time{}, 5)
+	require.NoError(t, err)
+	assert.Zero(t, removed)
+	mockStore.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 }
 
 // fakeUpstreamLoginAttempts is a minimal, in-memory stand-in for the real
@@ -325,7 +419,7 @@ func TestRateLimit_RemoteStorageGenuinelyThrottles(t *testing.T) {
 	// and actually removes the now-aged rows upstream (both the login-attempt rows
 	// for 203.0.113.5 and the password-reset-prefixed rows for 198.51.100.9 — every
 	// row recorded at `base`, now past both windows).
-	removed, err := c.PruneLoginAttempts(ctx)
+	removed, err := c.PruneLoginAttempts(ctx, time.Time{}, 0)
 	require.NoError(t, err, "PruneLoginAttempts now succeeds against a real remote-storage upstream")
 	assert.Equal(t, int64(LoginMaxAttempts+PasswordResetMaxAttempts), removed, "every aged login/password-reset attempt row was pruned upstream")
 }

--- a/server/http/handlers/login_attempts_proxy.go
+++ b/server/http/handlers/login_attempts_proxy.go
@@ -14,7 +14,13 @@
 // /auth/login path already uses (ADR-040) — no rate-limiting POLICY decision (the
 // threshold, the window) is made here; that stays entirely in the CALLING server's
 // own internal/core.KeyorixCore, exactly as it does against a local backend. This
-// file only persists/counts/prunes the raw (key, timestamp) rows.
+// file only persists/counts/prunes the raw (key, timestamp) rows. The one exception
+// is PruneLoginAttemptsProxy (CORE-RATE-003): it deliberately does NOT call
+// storage.Storage.PruneLoginAttempts directly, because the request body's `before`
+// is attacker-influenced and an unbounded passthrough let any system.write
+// principal wipe the entire table on demand. It routes through
+// core.KeyorixCore.PruneLoginAttempts instead, which clamps the cutoff and audits
+// the deletion — see that handler's own doc comment.
 //
 // Response envelope: these three handlers deliberately do NOT use the package's
 // generic sendSuccess/sendError helpers. Those write {"data":...}/{"error":"...",
@@ -30,6 +36,8 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
 // remoteAPIResponse mirrors internal/storage/remote.APIResponse's wire shape.
@@ -117,6 +125,20 @@ func (h *AuthHandler) CountLoginAttemptsProxy(w http.ResponseWriter, r *http.Req
 }
 
 // PruneLoginAttemptsProxy handles POST /api/v1/system/login-attempts/prune.
+//
+// CORE-RATE-003: this used to call h.coreService.Storage().PruneLoginAttempts
+// directly — an unbounded passthrough onto the raw storage primitive with the
+// only validation being "before is non-zero". Any principal holding
+// system.write (the group's baseline permission) could pass an arbitrary
+// future `before` (e.g. year 2099) and wipe the ENTIRE login_attempts table
+// on demand: every IP's failed-login counter reset to zero and the only
+// record a brute-force campaign was ever attempted from any address erased,
+// with no audit trail marking that the wipe occurred. It now routes through
+// core.KeyorixCore.PruneLoginAttempts instead, which clamps the effective
+// cutoff to never exceed `now - LoginWindow` (the maintenance sweep's own
+// invariant — a caller here can only narrow the window, never widen it) and
+// emits a `data.login_attempts_pruned` audit event (actor + row count +
+// cutoff) whenever anything is actually removed.
 func (h *AuthHandler) PruneLoginAttemptsProxy(w http.ResponseWriter, r *http.Request) {
 	var body loginAttemptPruneBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -127,7 +149,11 @@ func (h *AuthHandler) PruneLoginAttemptsProxy(w http.ResponseWriter, r *http.Req
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "before is required")
 		return
 	}
-	n, err := h.coreService.Storage().PruneLoginAttempts(r.Context(), body.Before)
+	var actorID uint
+	if userCtx := middleware.GetUserFromContext(r.Context()); userCtx != nil {
+		actorID = userCtx.UserID
+	}
+	n, err := h.coreService.PruneLoginAttempts(r.Context(), body.Before, actorID)
 	if err != nil {
 		log.Printf("login-attempts proxy: prune failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))

--- a/server/http/handlers/login_attempts_prune_audit_test.go
+++ b/server/http/handlers/login_attempts_prune_audit_test.go
@@ -1,0 +1,111 @@
+// login_attempts_prune_audit_test.go — CORE-RATE-003 regression test.
+//
+// PruneLoginAttemptsProxy (POST /api/v1/system/login-attempts/prune) used to
+// pass an attacker-controlled `before` from the request body straight to
+// storage.Storage.PruneLoginAttempts with no ceiling and no audit trail: any
+// principal holding system.write could supply a far-future `before` (e.g.
+// "2099-01-01T00:00:00Z") and wipe the ENTIRE login_attempts table on demand
+// — every IP's failed-login counter reset to zero, and the only record a
+// brute-force campaign was ever attempted from any address erased, silently.
+//
+// This test proves the fix at the effective enforcement point (the proxy
+// handler, now routed through core.KeyorixCore.PruneLoginAttempts): a
+// far-future `before` cannot remove a row still inside the active
+// rate-limit window, and an actual deletion leaves a
+// data.login_attempts_pruned audit event behind.
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// freshCoreForLoginPruneAudit opens a dedicated in-memory SQLite DB (with
+// LoginAttempt + AuditEvent migrated, since this test asserts on both) and
+// returns a ready KeyorixCore plus the raw *gorm.DB for direct audit-row
+// verification.
+func freshCoreForLoginPruneAudit(t *testing.T) (*core.KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.LoginAttempt{}, &models.AuditEvent{}))
+	return core.NewKeyorixCore(store.NewLocalStorage(db)), db
+}
+
+func TestPruneLoginAttemptsProxy_ClampsFutureBeforeAndAudits(t *testing.T) {
+	cs, db := freshCoreForLoginPruneAudit(t)
+	h := NewAuthHandler(cs, false)
+	ctx := context.Background()
+
+	// A login attempt recorded "now" — still well inside core.LoginWindow (15
+	// minutes) — must survive ANY prune request, no matter what `before` the
+	// caller supplies: it is live rate-limit state, not aged-out evidence.
+	require.NoError(t, cs.Storage().RecordLoginAttempt(ctx, "203.0.113.9", time.Now()))
+	// An attempt genuinely past the window (16 minutes ago) is legitimately
+	// eligible for removal.
+	require.NoError(t, cs.Storage().RecordLoginAttempt(ctx, "198.51.100.4", time.Now().Add(-16*time.Minute)))
+
+	// The exploit payload: an unbounded, attacker-supplied far-future cutoff —
+	// e.g. the finding's own "2099-01-01T00:00:00Z" example — that would wipe
+	// the whole table under the pre-fix passthrough.
+	attackerBefore := time.Now().Add(100 * 365 * 24 * time.Hour)
+	body := proxyJSON(map[string]interface{}{"before": attackerBefore})
+	req := httptest.NewRequest(http.MethodPost, "/system/login-attempts/prune", body)
+	w := httptest.NewRecorder()
+	h.PruneLoginAttemptsProxy(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := decodeRemoteResp(t, w)
+	require.True(t, resp.Success)
+
+	// The still-fresh row for 203.0.113.9 must have survived: the clamp to
+	// now-LoginWindow, not the attacker's far-future `before`, governed the
+	// deletion.
+	n, err := cs.Storage().CountRecentLoginAttempts(ctx, "203.0.113.9", time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "a login attempt inside the active rate-limit window must survive an unbounded prune request")
+
+	// The genuinely aged row was still pruned — the fix narrows the blast
+	// radius, it doesn't disable maintenance pruning altogether.
+	n, err = cs.Storage().CountRecentLoginAttempts(ctx, "198.51.100.4", time.Time{})
+	require.NoError(t, err)
+	assert.Zero(t, n, "a login attempt genuinely past the rate-limit window is still pruned")
+
+	// Exactly one data.login_attempts_pruned audit event was written for the
+	// actual deletion — the primitive that previously left NO trace at all of
+	// an on-demand wipe of brute-force evidence.
+	var events []models.AuditEvent
+	require.NoError(t, db.Find(&events, "event_type = ?", "data.login_attempts_pruned").Error)
+	require.Len(t, events, 1, "exactly one audit event for the prune")
+	assert.Contains(t, events[0].Description, "1", "the audit description records the row count")
+}
+
+func TestPruneLoginAttemptsProxy_NoAuditWhenNothingToPrune(t *testing.T) {
+	cs, db := freshCoreForLoginPruneAudit(t)
+	h := NewAuthHandler(cs, false)
+
+	// No rows recorded at all: the prune legitimately removes nothing.
+	body := proxyJSON(map[string]interface{}{"before": time.Now()})
+	req := httptest.NewRequest(http.MethodPost, "/system/login-attempts/prune", body)
+	w := httptest.NewRecorder()
+	h.PruneLoginAttemptsProxy(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var events []models.AuditEvent
+	require.NoError(t, db.Find(&events, "event_type = ?", "data.login_attempts_pruned").Error)
+	assert.Empty(t, events, "no audit event when nothing was actually removed")
+}

--- a/server/main.go
+++ b/server/main.go
@@ -1372,7 +1372,13 @@ func startSchedulers(ctx context.Context, cfg *config.Config, coreService *core.
 	// 15 minutes, so a 15-minute cadence keeps the table at roughly one window of rows.
 	runScheduler(ctx, "login_attempt_prune", 15*time.Minute, func() middleware.SchedulerOutcome {
 		return lockedRun(ctx, coreService.Storage(), schedLockLoginPrune, "Login-attempt prune", func() error {
-			_, perr := coreService.PruneLoginAttempts(ctx)
+			// Zero `before` and a zero actorID: PruneLoginAttempts resolves the
+			// cutoff itself (now - LoginWindow) and attributes the event to no
+			// human/machine principal. System-actored via WithActorType so the
+			// resulting data.login_attempts_pruned audit event (when anything is
+			// removed) reads as "system", not the default "user".
+			sysCtx := core.WithActorType(ctx, core.ActorTypeSystem)
+			_, perr := coreService.PruneLoginAttempts(sysCtx, time.Time{}, 0)
 			return perr
 		})
 	})

--- a/web/src/components/layout/ImpersonationBanner.tsx
+++ b/web/src/components/layout/ImpersonationBanner.tsx
@@ -44,7 +44,7 @@ export const ImpersonationBanner: React.FC = () => {
     return (
         <div
             role="alert"
-            className="flex items-center justify-center gap-4 px-4 py-2 text-sm font-medium text-white"
+            className="sticky top-0 z-50 flex items-center justify-center gap-4 px-4 py-2 text-sm font-medium text-white"
             style={{ backgroundColor: 'var(--warning, #b45309)' }}
         >
             <span>

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -37,11 +37,18 @@ const Layout: React.FC<LayoutProps> = ({ children, breadcrumbs, showFooter = tru
 
             {/* Main content area */}
             <div className="lg:pl-64 flex flex-col min-h-screen">
-                {/* Impersonation warning bar (visible only while impersonating) */}
-                <ImpersonationBanner />
+                {/* Impersonation banner + header stick together at the top of the
+                    viewport (not just the banner) so the header never scrolls up
+                    underneath the sticky banner and clips against it — see
+                    ImpersonationBanner's own `sticky` for why the banner must never
+                    scroll out of view during an impersonated session. */}
+                <div className="sticky top-0 z-50 flex flex-col">
+                    {/* Impersonation warning bar (visible only while impersonating) */}
+                    <ImpersonationBanner />
 
-                {/* Header */}
-                <Header onMenuClick={() => setSidebarOpen(true)} />
+                    {/* Header */}
+                    <Header onMenuClick={() => setSidebarOpen(true)} />
+                </div>
 
                 {/* Main content */}
                 <main className="flex-1">

--- a/web/src/components/layout/__tests__/ImpersonationBanner.test.tsx
+++ b/web/src/components/layout/__tests__/ImpersonationBanner.test.tsx
@@ -58,6 +58,18 @@ describe('ImpersonationBanner', () => {
         expect(screen.getByText(/signed in as Admin One/)).toBeInTheDocument();
     });
 
+    it('stays pinned to the viewport top so it cannot scroll out of view on tall pages', () => {
+        authState.user = { displayName: 'Target User' };
+        authState.impersonatedBy = { adminId: 1, adminUsername: 'admin1' };
+        render(<ImpersonationBanner />);
+
+        // Regression guard for web-layout-extras#0: the banner is the admin's only
+        // visual cue that actions are taken as the impersonated user, not
+        // themselves. Without `sticky top-0`, it scrolls away with the page on
+        // any content taller than the viewport (long secrets/RBAC/audit lists).
+        expect(screen.getByRole('alert')).toHaveClass('sticky', 'top-0');
+    });
+
     it('falls back to the username when the impersonated user has no display name', () => {
         authState.user = { username: 'target' };
         authState.impersonatedBy = { adminId: 1, adminUsername: 'admin1' };

--- a/web/src/components/layout/__tests__/Layout.test.tsx
+++ b/web/src/components/layout/__tests__/Layout.test.tsx
@@ -65,6 +65,22 @@ describe('Layout', () => {
         expect(screen.getByTestId('page-content')).toBeInTheDocument();
     });
 
+    it('keeps the impersonation banner and header stuck to the viewport top as a unit', () => {
+        render(
+            <Layout>
+                <div>content</div>
+            </Layout>
+        );
+
+        // Regression guard for web-layout-extras#0: the banner (and the header
+        // below it) must stay pinned while scrolling a tall page, not just be
+        // laid out in normal flow above a scrolling body.
+        const banner = screen.getByTestId('impersonation-banner-stub');
+        const stickyWrapper = banner.parentElement;
+        expect(stickyWrapper).toHaveClass('sticky', 'top-0');
+        expect(stickyWrapper).toContainElement(screen.getByText('open-sidebar-trigger'));
+    });
+
     it('does not render a breadcrumb when no breadcrumbs prop is passed', () => {
         render(
             <Layout>


### PR DESCRIPTION
## Summary

Sixth and final batch of the Wave 6 medium-severity remediation (adversarial security review, 2026-08-07/08). Six fixes, each cherry-picked from its own worktree-isolated branch and re-verified together as a combined build.

Note: one of the six planned items (`cli-project.json#2`, `project env delete`'s ignored `--project` flag) turned out to already be fixed as a side effect of an earlier batch's environment-tenant-scoping work (verified via direct grep before dispatch). It was swapped for the next real, still-open item in that same finding file — which is actually **high** severity (supply-chain), not medium, and appears to have been missed from the earlier critical/high wave.

- **Bundle downgrade-protection silently skippable** (high, supply-chain): `bundle import`/`bundle verify`'s anti-downgrade check (including the `MinUpgradeFrom` anti-skip floor) is a no-op whenever `--installed-version` is omitted, which it is by default — the flag is optional, empty-string default, never mentioned in the command's own help examples. A validly-signed but stale bundle (e.g. from a compromised mirror or staging host) would import cleanly and silently downgrade an air-gapped deployment past a release with a mandatory security fix. Both commands now refuse to skip the check silently: `import` already had a partial marker-based mitigation for routine re-imports (unaffected), but a genuine first import into a fresh `--dest`, or any `verify` call, now requires either `--installed-version` or an explicit, loudly-warned `--force`.
- **`PruneLoginAttempts` unaudited, unbounded bulk deletion**: the login-attempts-prune HTTP proxy passed an attacker-controlled `before` cutoff straight to storage with no ceiling and no audit trail — any `system.write` holder could wipe the entire brute-force-evidence table on demand with zero trace. The core primitive now clamps the effective cutoff to never exceed `now - LoginWindow` and emits a `data.login_attempts_pruned` audit event (actor, row count, cutoff) whenever it removes rows, mirroring the existing purge/retention audit pattern. Both the HTTP proxy and the scheduler now route through this single enforcement point.
- **`MigrateUserToMachine` PII disclosure**: the migrated user's email and internal ID were embedded verbatim in the new machine identity's `Description`, readable by any project member holding only project-scoped `users.read` — well below the global `users.write` + `roles.assign` required to perform the migration itself, and the source user need not even belong to the target project. The email is now dropped from `Description`; the full detail (including the email) moves into the existing `machine_identity.migrated_from_user` audit event, already gated behind the stronger `audit.read` permission.
- **Impersonation banner not sticky**: the banner's own doc comment calls it "a fixed warning bar," but it scrolled out of view on any page taller than the viewport — the one visual cue that actions are being taken as the impersonated user, gone exactly when a long secrets/RBAC/audit list is being scrolled. Now sticky-pinned to the viewport top, with the Header wrapped alongside it so it doesn't scroll up underneath and clip.
- **Translation validator never worked**: `cmd/validate-translations` has never successfully completed a run against real locale files since its original commit — a double base-directory join made every invocation fail with a path-not-found error, silently disabling the CI-quality-gate it exists to provide. Fixed the double-join; the tool now runs to completion and correctly surfaces the real, pre-existing translation-coverage gaps it was built to catch.
- **`dev.yaml` misconfigured, encryption silently off**: the dev config's `encryption: enabled: true` block was declared at the YAML document root instead of nested under `storage:`, matching no field in `Config` — `yaml.Unmarshal`'s default unknown-key tolerance silently dropped it, so local dev secrets were stored in plaintext despite the file appearing to enable encryption. Moved the block to the correct location, and hardened `config.Load()` to decode with a strict `KnownFields(true)` YAML decoder so this entire class of bug (a correctly-spelled but misplaced key) now fails loudly at startup instead of being silently discarded, for any config file, not just this one. Verified every YAML file that flows through `config.Load` still parses cleanly under strict mode.

## Verification

Each fix independently re-verified from a fresh worktree before integration (build/vet/gofmt/gosec/relevant suites, several with pre-fix-failure proof via scoped `git stash`), then all 6 cherry-picked (`-x`) onto one branch off current `main` — one auto-merge (`server/main.go`), no conflicts.

Combined verification on the integrated branch:
- `go build ./...`, `go vet ./...`, `gofmt -l` — all clean
- `gosec -severity medium -exclude-generated` — 0 issues (799 files, main tree) + 0 issues (operator module, `GOWORK=off`)
- Full `go test ./...` — only the established pre-existing `server/http` `RealServer`/`CSV_Headers`/`SetupToken` failures (unrelated to this batch, confirmed identical against unmodified `main` throughout this campaign)
- Full frontend suite (`pnpm test --run`) — 3026/3026 tests pass; `pnpm type-check`, `pnpm lint`, `pnpm format:check` all clean
- Operator module builds clean under `GOWORK=off`

This closes out the Wave 6 medium-severity triage (50 items across 6 batches, PRs #1449-#1454 + this one). Remaining: 65 untriaged low/info Wave 6 singletons, and three recorded follow-ups from earlier batches (tracked in `keyorix-private/adversarial-review/REMEDIATION-STATUS.md`).

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] Full `go test ./...` — no new failures vs. baseline
- [x] Operator module (`GOWORK=off`) builds and gosec-clean
- [x] Frontend: `pnpm test --run` (3026/3026), `pnpm type-check`, `pnpm lint`, `pnpm format:check`
- [ ] CI: lint, gitleaks, build-and-test