### PR TITLE
fix(ci): suppress false-positive weak-hashing alert on audit chain (G799)

### DIFF
--- a/internal/storage/store/local_audit_chain.go
+++ b/internal/storage/store/local_audit_chain.go
@@ -75,12 +75,27 @@ const auditChainVerifyBatch = 1000
 // encoding, in ascending id order, before the upgrade takes live traffic) is
 // left to the integrating release process; this change intentionally does not
 // attempt that migration itself, per this change's own review discussion.
+//
+// #G799 (go/weak-sensitive-data-hashing, false positive): the query's dataflow
+// correctly traces AccountState's AccountPasswordResetRequired constant into
+// this function's Description field write, then flags SHA256 as "insecure for
+// password hashing" -- but that constant is an account-status ENUM VALUE
+// ("this account currently requires a password reset"), not a credential; no
+// real password/secret value ever reaches this function. SHA256 is also the
+// deliberately correct choice here regardless: this hash is a tamper-evidence
+// chain link (integrity, not credential storage/verification), where a fast,
+// deterministic, collision-resistant hash is exactly what's wanted -- a slow
+// password KDF (bcrypt/argon2/scrypt) on every audit-log write would be a
+// severe, pointless performance regression with no security benefit, since
+// the threat model here is "detect tampering," not "resist offline brute-
+// forcing a stored hash." See the `write` closure below.
 func computeAuditEntryHash(e *models.AuditEvent, prevHash string) string {
 	h := sha256.New()
 	var lenBuf [8]byte
 	write := func(s string) {
 		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(s)))
 		h.Write(lenBuf[:])
+		// codeql[go/weak-sensitive-data-hashing]
 		h.Write([]byte(s))
 	}
 	uptr := func(p *uint) string {


### PR DESCRIPTION
## Summary
CodeQL's `go/weak-sensitive-data-hashing` query (alert #799, **High**) traced `AccountState`'s `AccountPasswordResetRequired` constant into `computeAuditEntryHash`'s `Description` field write and flagged the tamper-evidence chain's SHA256 as "insecure for password hashing."

**False positive**: that constant is an account-status ENUM VALUE ("this account currently requires a password reset"), not a credential — no real password/secret value ever reaches this function. SHA256 is also the deliberately correct algorithm choice here regardless of the source: this hash is an integrity/tamper-evidence chain link (ADR-029), not credential storage or verification, so a fast, deterministic, collision-resistant hash is exactly right — a slow password KDF (bcrypt/argon2/scrypt) on every audit-log write would be a severe, pointless performance regression with no security benefit against this function's actual threat model (detect tampering, not resist offline brute-forcing a stored hash).

## Fix
Added a correctly-placed `// codeql[go/weak-sensitive-data-hashing]` suppression comment (single dedicated line directly above the sink, per the placement rule `CodeQL's AlertSuppression.qll` enforces — see #1443) plus a full justification in the function's doc comment. No behavior change; existing tests (`TestComputeAuditEntryHash_*`, `TestLogAuditEvent_*`, `TestVerifyAuditChain_*`) already cover the actual hash function and all still pass.

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt -l` clean
- [x] Existing audit-chain test suite passes unchanged (comment-only diff)
- [x] Verified locally: rebuilt a CodeQL database from this exact fix and ran the real `go/weak-sensitive-data-hashing` query alongside `codeql/go-queries`'s own `AlertSuppression.ql` in the same `codeql database analyze` invocation — the finding is now correctly tagged `suppressions: [{"kind": "inSource"}]` in the resulting SARIF
- [ ] GitHub does not auto-close alerts from SARIF suppressions (any tool) — the alert will need a manual dismiss once this merges and CodeQL re-scans `main`