### PR TITLE
fix(security): close Wave 6 low/info batch 1 (crypto/KMS/notary hardening)

### DIFF
--- a/internal/crypto/awskms/awskms.go
+++ b/internal/crypto/awskms/awskms.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
@@ -19,23 +20,45 @@ import (
 type awsKMSAPI interface {
 	Encrypt(ctx context.Context, in *kms.EncryptInput, optFns ...func(*kms.Options)) (*kms.EncryptOutput, error)
 	Decrypt(ctx context.Context, in *kms.DecryptInput, optFns ...func(*kms.Options)) (*kms.DecryptOutput, error)
+	DescribeKey(ctx context.Context, in *kms.DescribeKeyInput, optFns ...func(*kms.Options)) (*kms.DescribeKeyOutput, error)
 }
+
+// FallbackHook, when non-nil, is invoked after a Decrypt succeeds ONLY via the
+// no-context fallback retry (allowFallback, see New's doc comment) — i.e. every
+// time this client actually used the weaker, unbound decrypt path. Lets a caller
+// (internal/encryption.Service) turn that event into a durable audit record
+// instead of only the log.Printf line this file always emits. Best-effort: called
+// synchronously from Decrypt, so it must not block or panic.
+type FallbackHook func(ctx context.Context, keyID string)
 
 type client struct {
 	kms           awsKMSAPI
 	keyID         string
 	encCtx        map[string]string // AWS EncryptionContext bound to the wrapped KEK (may be empty)
 	allowFallback bool              // #123: opt-in, see KMSAllowContextFallback's doc comment
+	fallbackHook  FallbackHook      // optional; see FallbackHook's doc comment
 }
 
 // New builds an AWS-KMS-backed crypto.KMSClient for the given key (ID, ARN, or
 // alias). It loads the default AWS config; the caller's environment supplies the
-// region and credentials. encContext, when non-empty, is bound to the wrapped KEK so
-// a different install sharing the same CMK cannot unwrap it — UNLESS allowFallback is
-// also set, in which case a context-bound Decrypt failure retries once without any
-// context (see config.KeyProviderConfig.KMSAllowContextFallback for the full
-// rationale; default false = the binding is strictly enforced).
-func New(ctx context.Context, keyID string, encContext map[string]string, allowFallback bool) (keyorixcrypto.KMSClient, error) {
+// region and credentials. keyID is resolved ONCE, here, to its canonical key ARN
+// via kms:DescribeKey (which accepts an ID, ARN, or alias and always returns the
+// immutable ARN) and that ARN — never the original alias — is what every
+// subsequent Encrypt/Decrypt pins as KeyId. This matters because an alias is a
+// mutable pointer: whoever holds alias-management IAM privilege can repoint
+// "alias/foo" to a different CMK at any time with zero visibility from this
+// codebase, which would otherwise silently undermine the confused-deputy KeyId
+// pinning this client relies on (see TestAWSKMS_CrossInstallDenied). Resolution
+// failure is fatal — New fails closed rather than falling back to pinning the
+// possibly-mutable alias verbatim.
+//
+// encContext, when non-empty, is bound to the wrapped KEK so a different install
+// sharing the same CMK cannot unwrap it — UNLESS allowFallback is also set, in
+// which case a context-bound Decrypt failure retries once without any context
+// (see config.KeyProviderConfig.KMSAllowContextFallback for the full rationale;
+// default false = the binding is strictly enforced). fallbackHook, if non-nil, is
+// called on every successful use of that fallback path — see FallbackHook.
+func New(ctx context.Context, keyID string, encContext map[string]string, allowFallback bool, fallbackHook FallbackHook) (keyorixcrypto.KMSClient, error) {
 	if keyID == "" {
 		return nil, fmt.Errorf("aws-kms: kms_key_id is required")
 	}
@@ -43,7 +66,40 @@ func New(ctx context.Context, keyID string, encContext map[string]string, allowF
 	if err != nil {
 		return nil, fmt.Errorf("aws-kms: load AWS config: %w", err)
 	}
-	return &client{kms: kms.NewFromConfig(cfg), keyID: keyID, encCtx: encContext, allowFallback: allowFallback}, nil
+	return newClient(ctx, kms.NewFromConfig(cfg), keyID, encContext, allowFallback, fallbackHook)
+}
+
+// newClient is the testable core New() delegates to, taking the awsKMSAPI as a
+// parameter so tests can inject a fake and exercise the DescribeKey-based ARN
+// resolution (and everything downstream of it) without a real AWS call.
+func newClient(ctx context.Context, api awsKMSAPI, keyID string, encContext map[string]string, allowFallback bool, fallbackHook FallbackHook) (keyorixcrypto.KMSClient, error) {
+	arn, err := resolveKeyARN(ctx, api, keyID)
+	if err != nil {
+		return nil, err
+	}
+	return &client{
+		kms:           api,
+		keyID:         arn,
+		encCtx:        maps.Clone(encContext), // defensive copy: caller's map must not be a live handle into this client's binding
+		allowFallback: allowFallback,
+		fallbackHook:  fallbackHook,
+	}, nil
+}
+
+// resolveKeyARN resolves an ID/ARN/alias to its canonical, immutable key ARN via
+// kms:DescribeKey. DescribeKey accepts any of the three forms and always returns
+// the same ARN for a given CMK regardless of which alias currently points at it,
+// so this is safe to call unconditionally rather than special-casing
+// already-ARN/ID input.
+func resolveKeyARN(ctx context.Context, api awsKMSAPI, keyID string) (string, error) {
+	out, err := api.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: &keyID})
+	if err != nil {
+		return "", fmt.Errorf("aws-kms: resolve key ARN for %q: %w", keyID, err)
+	}
+	if out.KeyMetadata == nil || out.KeyMetadata.Arn == nil || *out.KeyMetadata.Arn == "" {
+		return "", fmt.Errorf("aws-kms: DescribeKey for %q returned no key ARN", keyID)
+	}
+	return *out.KeyMetadata.Arn, nil
 }
 
 func (c *client) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
@@ -80,6 +136,9 @@ func (c *client) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error)
 		out, err = c.kms.Decrypt(ctx, &kms.DecryptInput{CiphertextBlob: ciphertext, KeyId: &c.keyID})
 		if err == nil {
 			log.Printf("aws-kms: decrypted a wrapped KEK WITHOUT its configured encryption context (kms_allow_context_fallback is on) — this blob is not bound to this install; re-wrap it under the context via 'keyorix encryption migrate-provider --to-kms-encryption-context=...' and disable kms_allow_context_fallback")
+			if c.fallbackHook != nil {
+				c.fallbackHook(ctx, c.keyID)
+			}
 		}
 	}
 	if err != nil {

--- a/internal/crypto/awskms/awskms_extra_test.go
+++ b/internal/crypto/awskms/awskms_extra_test.go
@@ -20,6 +20,10 @@ func (fakeKMSEncryptError) Decrypt(_ context.Context, _ *kms.DecryptInput, _ ...
 	return nil, errors.New("KMSAccessDeniedException: not authorized")
 }
 
+func (fakeKMSEncryptError) DescribeKey(_ context.Context, _ *kms.DescribeKeyInput, _ ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
+	return nil, errors.New("KMSAccessDeniedException: not authorized")
+}
+
 // TestAWSKMS_EncryptError verifies Encrypt propagates KMS errors.
 func TestAWSKMS_EncryptError(t *testing.T) {
 	c := &client{kms: fakeKMSEncryptError{}, keyID: "test-key"}
@@ -44,6 +48,10 @@ func (fakeKMSInternalError) Encrypt(_ context.Context, _ *kms.EncryptInput, _ ..
 }
 
 func (fakeKMSInternalError) Decrypt(_ context.Context, _ *kms.DecryptInput, _ ...func(*kms.Options)) (*kms.DecryptOutput, error) {
+	return nil, errors.New("AccessDeniedException: user arn:aws:iam::" + fakeKMSMarker + " is not authorized")
+}
+
+func (fakeKMSInternalError) DescribeKey(_ context.Context, _ *kms.DescribeKeyInput, _ ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
 	return nil, errors.New("AccessDeniedException: user arn:aws:iam::" + fakeKMSMarker + " is not authorized")
 }
 
@@ -123,7 +131,7 @@ func TestAWSKMS_DecryptError(t *testing.T) {
 // (New itself cannot be tested without real AWS credentials, but the empty-key
 // guard fires before any network call.)
 func TestAWSKMS_New_EmptyKeyID(t *testing.T) {
-	_, err := New(context.Background(), "", nil, false)
+	_, err := New(context.Background(), "", nil, false, nil)
 	if err == nil {
 		t.Fatal("expected an error for an empty key ID")
 	}

--- a/internal/crypto/awskms/awskms_s25_test.go
+++ b/internal/crypto/awskms/awskms_s25_test.go
@@ -8,44 +8,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestAWSKMS_New_SucceedsWithValidKeyID verifies that New succeeds (reaching the
-// return statement) when a keyID is provided and the AWS SDK environment is
-// operational — as it normally is in a CI environment where LoadDefaultConfig
-// returns no error even without real credentials.
-func TestAWSKMS_New_SucceedsWithValidKeyID(t *testing.T) {
-	// Unset AWS_PROFILE so we don't accidentally use a profile that doesn't
-	// exist on the CI machine; LoadDefaultConfig succeeds with no profile set.
+// TestAWSKMS_New_DescribeKeyResolutionRequired_FailsClosedWithoutCredentials
+// verifies that New (unlike before this fix) does NOT just wire the raw keyID
+// straight through: it now resolves it to a canonical ARN via kms:DescribeKey,
+// and since this test environment has no real AWS credentials, that resolution
+// must fail — and New must propagate the failure rather than silently falling
+// back to pinning the caller-supplied (possibly-mutable-alias) keyID. This is the
+// fail-closed half of the awskms-001 fix: a caller that can't resolve simply
+// cannot construct a client at all, so a stale/never-resolved alias binding can't
+// happen. AWS_EC2_METADATA_DISABLED skips the (slow, always-failing off-EC2) IMDS
+// credential lookup so this fails fast rather than after an IMDS timeout.
+func TestAWSKMS_New_DescribeKeyResolutionRequired_FailsClosedWithoutCredentials(t *testing.T) {
 	t.Setenv("AWS_PROFILE", "")
 	t.Setenv("AWS_CONFIG_FILE", "")
 	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 
-	c, err := New(context.Background(), "alias/test-key", nil, false)
-	// LoadDefaultConfig succeeds without real credentials (it only builds a config
-	// object; it doesn't dial AWS). The returned KMSClient must be non-nil.
-	require.NoError(t, err)
-	assert.NotNil(t, c)
+	_, err := New(context.Background(), "alias/test-key", nil, false, nil)
+	require.Error(t, err, "New must fail closed when it cannot resolve keyID to a canonical ARN")
+	assert.Contains(t, err.Error(), "aws-kms")
 }
 
-// TestAWSKMS_New_WithEncContextAndFallback verifies that New wires the
-// encContext and allowFallback fields correctly. We exercise both by creating a
-// client with those parameters and confirming round-trip + fallback behaviour
-// on the constructed client (without calling real AWS — just confirming the
-// fields make it through).
+// TestAWSKMS_New_WithEncContextAndFallback verifies that New (via its testable
+// newClient core, injecting a fake so no real AWS call is made) resolves the
+// alias to its canonical ARN and wires encContext/allowFallback correctly.
 func TestAWSKMS_New_WithEncContextAndFallback(t *testing.T) {
-	t.Setenv("AWS_PROFILE", "")
-	t.Setenv("AWS_CONFIG_FILE", "")
-	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
-
 	ctx := context.Background()
-	c, err := New(ctx, "alias/test-key", map[string]string{"env": "ci"}, true)
+	fake := &fakeKMSWithDescribe{resolvedARN: "arn:aws:kms:us-east-1:123456789012:key/canonical-test-key"}
+	c, err := newClient(ctx, fake, "alias/test-key", map[string]string{"env": "ci"}, true, nil)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 
-	// We can't make real KMS calls, but we can verify the client is a *client
-	// with the correct fields set by casting back through the internal type.
+	// newClient must return a *client with the RESOLVED ARN pinned — not the
+	// alias originally passed in — plus the other fields wired through unchanged.
 	impl, ok := c.(*client)
-	require.True(t, ok, "New must return a *client")
-	assert.Equal(t, "alias/test-key", impl.keyID)
+	require.True(t, ok, "newClient must return a *client")
+	assert.Equal(t, "arn:aws:kms:us-east-1:123456789012:key/canonical-test-key", impl.keyID)
 	assert.Equal(t, map[string]string{"env": "ci"}, impl.encCtx)
 	assert.True(t, impl.allowFallback)
 }
@@ -62,9 +63,10 @@ func TestAWSKMS_New_LoadConfigError(t *testing.T) {
 	t.Setenv("AWS_CONFIG_FILE", "/nonexistent/awskms-test-config.ini")
 	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/nonexistent/awskms-test-creds")
 
-	_, err := New(context.Background(), "alias/test-key", nil, false)
+	_, err := New(context.Background(), "alias/test-key", nil, false, nil)
 	// The SDK must fail to load the named profile from the nonexistent file,
-	// and New must propagate that error (not silently swallow it).
+	// and New must propagate that error (not silently swallow it) — this happens
+	// before any DescribeKey call is attempted.
 	require.Error(t, err, "New must propagate LoadDefaultConfig errors")
 	assert.Contains(t, err.Error(), "aws-kms")
 }

--- a/internal/crypto/awskms/awskms_test.go
+++ b/internal/crypto/awskms/awskms_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
 )
 
 // fakeKMS models AWS KMS EncryptionContext semantics: a blob decrypts only with the
@@ -34,6 +35,47 @@ func (fakeKMS) Decrypt(_ context.Context, in *kms.DecryptInput, _ ...func(*kms.O
 		return nil, errors.New("InvalidCiphertextException: encryption context mismatch")
 	}
 	return &kms.DecryptOutput{Plaintext: b.Plaintext}, nil
+}
+
+// DescribeKey treats whatever KeyId it's asked about as already canonical, echoing
+// it back as the "resolved" ARN — fine for fakeKMS's usual role (tests build a
+// *client directly via newTestClient, bypassing resolution entirely). Tests that
+// specifically exercise alias-to-ARN resolution use fakeKMSWithDescribe instead,
+// which resolves to a DIFFERENT value than the input so the two are distinguishable.
+func (fakeKMS) DescribeKey(_ context.Context, in *kms.DescribeKeyInput, _ ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
+	arn := *in.KeyId
+	return &kms.DescribeKeyOutput{KeyMetadata: &types.KeyMetadata{KeyId: in.KeyId, Arn: &arn}}, nil
+}
+
+// fakeKMSWithDescribe extends fakeKMS with a DescribeKey that resolves ANY input
+// KeyId to a fixed canonical ARN distinct from the input — modeling a real alias
+// resolution — and records the KeyId used on the most recent Encrypt/Decrypt call
+// so tests can assert calls pin the resolved ARN, not the original alias/ID passed
+// to New.
+type fakeKMSWithDescribe struct {
+	fakeKMS
+	resolvedARN      string
+	describeErr      error
+	lastEncryptKeyID string
+	lastDecryptKeyID string
+}
+
+func (f *fakeKMSWithDescribe) DescribeKey(_ context.Context, _ *kms.DescribeKeyInput, _ ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
+	if f.describeErr != nil {
+		return nil, f.describeErr
+	}
+	arn := f.resolvedARN
+	return &kms.DescribeKeyOutput{KeyMetadata: &types.KeyMetadata{Arn: &arn}}, nil
+}
+
+func (f *fakeKMSWithDescribe) Encrypt(ctx context.Context, in *kms.EncryptInput, optFns ...func(*kms.Options)) (*kms.EncryptOutput, error) {
+	f.lastEncryptKeyID = *in.KeyId
+	return f.fakeKMS.Encrypt(ctx, in, optFns...)
+}
+
+func (f *fakeKMSWithDescribe) Decrypt(ctx context.Context, in *kms.DecryptInput, optFns ...func(*kms.Options)) (*kms.DecryptOutput, error) {
+	f.lastDecryptKeyID = *in.KeyId
+	return f.fakeKMS.Decrypt(ctx, in, optFns...)
 }
 
 func contextEqual(a, b map[string]string) bool {

--- a/internal/crypto/awskms/awskms_wave6_test.go
+++ b/internal/crypto/awskms/awskms_wave6_test.go
@@ -1,0 +1,199 @@
+package awskms
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- awskms-001: alias resolved to its canonical ARN once at New()-time, and
+// that resolved ARN — not the possibly-mutable alias — is what every subsequent
+// call pins. ---
+
+// TestAWSKMS_New_PinsResolvedARN_NotAlias verifies that after New() resolves an
+// alias via DescribeKey, every subsequent Encrypt/Decrypt call sends the RESOLVED
+// ARN as KeyId, never the original alias string.
+func TestAWSKMS_New_PinsResolvedARN_NotAlias(t *testing.T) {
+	const arn = "arn:aws:kms:us-east-1:123456789012:key/canonical-id"
+	fake := &fakeKMSWithDescribe{resolvedARN: arn}
+	c, err := newClient(context.Background(), fake, "alias/prod-kek", nil, false, nil)
+	require.NoError(t, err)
+
+	impl, ok := c.(*client)
+	require.True(t, ok)
+	assert.Equal(t, arn, impl.keyID, "New must pin the DescribeKey-resolved ARN, not the input alias")
+
+	ct, err := c.Encrypt(context.Background(), []byte("kek-material"))
+	require.NoError(t, err)
+	assert.Equal(t, arn, fake.lastEncryptKeyID, "Encrypt must send the resolved ARN as KeyId")
+
+	_, err = c.Decrypt(context.Background(), ct)
+	require.NoError(t, err)
+	assert.Equal(t, arn, fake.lastDecryptKeyID, "Decrypt must send the resolved ARN as KeyId")
+}
+
+// TestAWSKMS_AliasRepointAfterNew_DoesNotAffectPinnedARN is the core
+// confused-deputy regression test for awskms-001: it simulates an alias being
+// repointed to a different CMK AFTER the client was constructed (e.g. by whoever
+// holds alias-management IAM privilege) and asserts the already-constructed
+// client keeps pinning the ORIGINAL resolved ARN — proving resolution happens
+// once, at New()-time, not on every call. Before this fix, the client stored the
+// alias string itself and would have silently started trusting the repointed key.
+func TestAWSKMS_AliasRepointAfterNew_DoesNotAffectPinnedARN(t *testing.T) {
+	const originalARN = "arn:aws:kms:us-east-1:123456789012:key/original-cmk"
+	fake := &fakeKMSWithDescribe{resolvedARN: originalARN}
+	c, err := newClient(context.Background(), fake, "alias/prod-kek", nil, false, nil)
+	require.NoError(t, err)
+
+	// Simulate the alias being repointed to a different CMK after construction.
+	fake.resolvedARN = "arn:aws:kms:us-east-1:123456789012:key/attacker-repointed-cmk"
+
+	_, err = c.Encrypt(context.Background(), []byte("kek-material"))
+	require.NoError(t, err)
+	assert.Equal(t, originalARN, fake.lastEncryptKeyID,
+		"an already-constructed client must keep pinning the ARN resolved at New()-time, not re-resolve the alias on every call")
+}
+
+// TestAWSKMS_New_DescribeKeyFailure_FailsClosed verifies New propagates a
+// DescribeKey error rather than falling back to pinning the unresolved keyID.
+func TestAWSKMS_New_DescribeKeyFailure_FailsClosed(t *testing.T) {
+	fake := &fakeKMSWithDescribe{describeErr: assert.AnError}
+	_, err := newClient(context.Background(), fake, "alias/prod-kek", nil, false, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aws-kms")
+}
+
+// TestAWSKMS_New_DescribeKeyEmptyARN_FailsClosed verifies New treats a
+// DescribeKey response with no ARN as a resolution failure rather than silently
+// proceeding with an empty/zero-value KeyId.
+func TestAWSKMS_New_DescribeKeyEmptyARN_FailsClosed(t *testing.T) {
+	fake := &fakeKMSWithDescribe{resolvedARN: ""}
+	_, err := newClient(context.Background(), fake, "alias/prod-kek", nil, false, nil)
+	require.Error(t, err)
+}
+
+// --- awskms-002: a KMSAllowContextFallback decrypt firing must be reported via
+// the FallbackHook, and ONLY when the fallback path is actually used. ---
+
+// TestAWSKMS_Decrypt_FallbackFiresHook verifies the fallback hook is called,
+// with the pinned keyID, exactly when a Decrypt succeeds only via the no-context
+// retry path.
+func TestAWSKMS_Decrypt_FallbackFiresHook(t *testing.T) {
+	legacy := newTestClient(nil, false)
+	ct, err := legacy.Encrypt(context.Background(), []byte("legacy-kek"))
+	require.NoError(t, err)
+
+	var firedKeyID string
+	fireCount := 0
+	hook := func(_ context.Context, keyID string) {
+		fireCount++
+		firedKeyID = keyID
+	}
+	bound := &client{kms: fakeKMS{}, keyID: "test-key", encCtx: map[string]string{"install": "inst-X"}, allowFallback: true, fallbackHook: hook}
+
+	pt, err := bound.Decrypt(context.Background(), ct)
+	require.NoError(t, err)
+	assert.Equal(t, "legacy-kek", string(pt))
+	assert.Equal(t, 1, fireCount, "fallback hook must fire exactly once for a successful fallback decrypt")
+	assert.Equal(t, "test-key", firedKeyID)
+}
+
+// TestAWSKMS_Decrypt_NoFallbackNeeded_HookNotCalled verifies the fallback hook
+// does NOT fire on an ordinary direct decrypt (context matches, no retry needed).
+func TestAWSKMS_Decrypt_NoFallbackNeeded_HookNotCalled(t *testing.T) {
+	called := false
+	hook := func(_ context.Context, _ string) { called = true }
+	c := &client{kms: fakeKMS{}, keyID: "test-key", encCtx: map[string]string{"k": "v"}, allowFallback: true, fallbackHook: hook}
+
+	ct, err := c.Encrypt(context.Background(), []byte("data"))
+	require.NoError(t, err)
+	_, err = c.Decrypt(context.Background(), ct)
+	require.NoError(t, err)
+	assert.False(t, called, "fallback hook must not fire when the direct (context-bound) decrypt already succeeded")
+}
+
+// TestAWSKMS_Decrypt_FallbackDisabled_HookNotCalled verifies the fallback hook
+// never fires when allowFallback is off, even though a hook is wired.
+func TestAWSKMS_Decrypt_FallbackDisabled_HookNotCalled(t *testing.T) {
+	planted := newTestClient(nil, false)
+	ct, err := planted.Encrypt(context.Background(), []byte("malicious-kek"))
+	require.NoError(t, err)
+
+	called := false
+	hook := func(_ context.Context, _ string) { called = true }
+	bound := &client{kms: fakeKMS{}, keyID: "test-key", encCtx: map[string]string{"install": "inst-1"}, allowFallback: false, fallbackHook: hook}
+
+	_, err = bound.Decrypt(context.Background(), ct)
+	require.Error(t, err, "fallback disabled: the no-context blob must still be rejected")
+	assert.False(t, called, "fallback hook must not fire when the fallback path itself never runs")
+}
+
+// --- awskms-003: New() must defensively copy encContext, so a caller mutating
+// its own map after construction cannot change an already-built client's binding. ---
+
+// TestAWSKMS_New_DefensiveCopyOfEncContext verifies that mutating the caller's
+// original map after New() returns does not affect the constructed client.
+func TestAWSKMS_New_DefensiveCopyOfEncContext(t *testing.T) {
+	original := map[string]string{"install": "inst-1"}
+	fake := &fakeKMSWithDescribe{resolvedARN: "arn:aws:kms:us-east-1:123456789012:key/x"}
+	c, err := newClient(context.Background(), fake, "alias/x", original, false, nil)
+	require.NoError(t, err)
+
+	// Mutate the caller's original map after construction — this must NOT leak
+	// into the already-built client's EncryptionContext binding.
+	original["install"] = "mutated-after-new"
+	original["extra"] = "should-not-appear"
+
+	impl, ok := c.(*client)
+	require.True(t, ok)
+	assert.Equal(t, map[string]string{"install": "inst-1"}, impl.encCtx,
+		"New must copy encContext; mutating the caller's original map after New must not affect the client's binding")
+}
+
+// TestAWSKMS_New_DefensiveCopyOfEncContext_EndToEnd is the round-trip version of
+// the same property: a blob encrypted after the caller mutates its original map
+// must still decrypt against a freshly built client bound to the ORIGINAL
+// (pre-mutation) context, proving the encrypting client used its own frozen copy.
+func TestAWSKMS_New_DefensiveCopyOfEncContext_EndToEnd(t *testing.T) {
+	original := map[string]string{"install": "inst-1"}
+	fake := &fakeKMSWithDescribe{resolvedARN: "arn:aws:kms:us-east-1:123456789012:key/x"}
+	c, err := newClient(context.Background(), fake, "alias/x", original, false, nil)
+	require.NoError(t, err)
+
+	original["install"] = "mutated-after-new"
+
+	ct, err := c.Encrypt(context.Background(), []byte("data"))
+	require.NoError(t, err)
+
+	// A separately-built client bound to the ORIGINAL, unmutated context must be
+	// able to decrypt it.
+	unaffected, err := newClient(context.Background(), fake, "alias/x", map[string]string{"install": "inst-1"}, false, nil)
+	require.NoError(t, err)
+	pt, err := unaffected.Decrypt(context.Background(), ct)
+	require.NoError(t, err)
+	assert.Equal(t, "data", string(pt))
+}
+
+// TestAWSKMS_New_DefensiveCopyOfEncContext_NilInput sanity-checks that a nil
+// encContext still results in a nil/empty encCtx (maps.Clone(nil) is nil), not a
+// panic or a spuriously non-nil empty map.
+func TestAWSKMS_New_DefensiveCopyOfEncContext_NilInput(t *testing.T) {
+	fake := &fakeKMSWithDescribe{resolvedARN: "arn:aws:kms:us-east-1:123456789012:key/x"}
+	c, err := newClient(context.Background(), fake, "alias/x", nil, false, nil)
+	require.NoError(t, err)
+	impl, ok := c.(*client)
+	require.True(t, ok)
+	assert.True(t, len(impl.encCtx) == 0)
+}
+
+// sanity check that maps.Clone is actually what's used (guards against a
+// find/replace regression silently reverting to a bare assignment).
+func TestAWSKMS_MapsCloneSanity(t *testing.T) {
+	m := map[string]string{"a": "1"}
+	clone := maps.Clone(m)
+	m["a"] = "2"
+	assert.Equal(t, "1", clone["a"])
+}

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/crypto/pbkdf2"
@@ -19,10 +21,41 @@ const (
 	aesCipherSuite = "AES-256-GCM"
 )
 
+// nonceBudgetWarnThreshold is a conservative, coarse checkpoint on the number of
+// Encrypt/EncryptWithAAD calls made under a single DEK, logged as a one-time loud
+// warning to nudge an operator toward a routine `keyorix encryption rotate` well
+// before nonce-collision risk becomes material. Standard random 96-bit AES-GCM
+// nonces only become a real birthday-bound collision risk near 2^32 encryptions
+// under one key; this threshold (2^28, ~268M) sits far below that boundary, giving
+// a wide safety margin. This is purely an observability nudge — not a hard limit,
+// and encryption is never refused past this point.
+const nonceBudgetWarnThreshold uint64 = 1 << 28
+
 // EncryptionService handles all encryption/decryption operations
 type EncryptionService struct {
 	dek []byte // Data Encryption Key
 	gcm cipher.AEAD
+
+	// encryptCount is a coarse, non-durable (reset on process restart) tally of
+	// Encrypt/EncryptWithAAD calls made under this DEK. It exists only to drive
+	// the one-time nonceBudgetWarnThreshold warning below — not a security
+	// control, and rotation is never enforced or blocked on it.
+	encryptCount atomic.Uint64
+	// nonceBudgetWarned latches once the nonce-budget warning has fired, so
+	// sustained write volume past the threshold logs it exactly once rather
+	// than on every subsequent call.
+	nonceBudgetWarned atomic.Bool
+}
+
+// checkNonceBudget increments the per-DEK encryption counter and, the first time it
+// crosses nonceBudgetWarnThreshold, logs a loud one-time warning nudging the operator
+// toward a routine DEK rotation (`keyorix encryption rotate --confirm`). See
+// nonceBudgetWarnThreshold for why this threshold, not 2^32, is used.
+func (es *EncryptionService) checkNonceBudget() {
+	count := es.encryptCount.Add(1)
+	if count >= nonceBudgetWarnThreshold && es.nonceBudgetWarned.CompareAndSwap(false, true) {
+		log.Printf("[WARN] SECURITY: this DEK has performed %d encryptions, approaching the AES-GCM 96-bit random-nonce birthday bound — run `keyorix encryption rotate --confirm` to rotate to a fresh DEK", count)
+	}
 }
 
 // EncryptionMetadata contains metadata about encrypted data
@@ -100,6 +133,8 @@ func GenerateRandomKey(size int) ([]byte, error) {
 
 // Encrypt encrypts data using AES-GCM with the KEK
 func (es *EncryptionService) Encrypt(plaintext []byte, keyVersion string) (*EncryptedData, error) {
+	es.checkNonceBudget()
+
 	nonce := make([]byte, es.gcm.NonceSize())
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, fmt.Errorf("failed to generate nonce: %w", err)
@@ -206,6 +241,8 @@ func DynamicSecretLeaseAAD(leaseID string, configID uint) []byte {
 // The AAD is mixed into the GCM authentication tag — it is not stored in the
 // ciphertext but must be supplied identically on decryption.
 func (es *EncryptionService) EncryptWithAAD(plaintext []byte, keyVersion string, aad []byte) (*EncryptedData, error) {
+	es.checkNonceBudget()
+
 	nonce := make([]byte, es.gcm.NonceSize())
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, fmt.Errorf("failed to generate nonce: %w", err)

--- a/internal/encryption/kms_context_fallback_audit.go
+++ b/internal/encryption/kms_context_fallback_audit.go
@@ -1,0 +1,56 @@
+// kms_context_fallback_audit.go — records a KMS-provider (currently aws-kms)
+// KMSAllowContextFallback decrypt actually firing as a queryable audit event, not
+// just a log line. See config.KeyProviderConfig.KMSAllowContextFallback (the
+// opt-in, transient migration aid this reports on) and awskms.FallbackHook (the
+// runtime hook this file wires into). Modeled directly on
+// key_provider_downgrade.go's AuditSink wiring for the sibling
+// key_provider_fallback_downgrade event.
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// EventKMSContextFallbackUsed is the audit event type recorded whenever a KMS key
+// provider configured with kms_allow_context_fallback actually decrypts a blob via
+// the no-context fallback path — i.e. an install accepted a KEK wrapping that is
+// NOT bound to its own encryption context. This flag is meant as a transient
+// migration aid; nothing else enforces that, so each use is recorded durably here
+// rather than relying solely on the per-decrypt log.Printf line, which an operator
+// who enables the flag and forgets to disable it could easily lose in log noise.
+const EventKMSContextFallbackUsed = "encryption.kms_context_fallback_used" // #nosec G101 -- audit event type, not a credential
+
+// auditKMSContextFallback is wired as the awskms.FallbackHook (via
+// NewKeyProviderFromConfig's kmsFallbackHook parameter) when building a live
+// aws-kms key provider in buildKeyProvider. It fires synchronously from inside
+// Decrypt, so it must use its own mutex (auditSinkMu), never s.mu, exactly like
+// auditKeyProviderDowngrade — the KEK-manager call chain that reaches here may
+// already hold s.mu. Best-effort: a sink write failure is logged but never
+// propagated, since the decrypt it's reporting on has already succeeded by the
+// time this runs and must not be undone by an audit-logging failure.
+func (s *Service) auditKMSContextFallback(ctx context.Context, keyID string) {
+	s.auditSinkMu.RLock()
+	sink := s.auditSink
+	s.auditSinkMu.RUnlock()
+	if sink == nil {
+		return
+	}
+	failed := false // the event itself reports a security-negative condition, not a success
+	event := &models.AuditEvent{
+		EventType: EventKMSContextFallbackUsed,
+		Description: fmt.Sprintf(
+			"KMS decrypt for key %q succeeded only via the no-context fallback (kms_allow_context_fallback) — this blob is not bound to this install's encryption context; re-wrap it via 'keyorix encryption migrate-provider --to-kms-encryption-context=...' and disable kms_allow_context_fallback",
+			keyID),
+		Success:   &failed,
+		ActorType: "system",
+		EventTime: time.Now(),
+	}
+	if err := sink(ctx, event); err != nil {
+		log.Printf("SECURITY: kms context fallback: failed to write audit event: %v", err)
+	}
+}

--- a/internal/encryption/kms_context_fallback_audit_test.go
+++ b/internal/encryption/kms_context_fallback_audit_test.go
@@ -1,0 +1,81 @@
+package encryption
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func testKMSFallbackAuditConfig() *config.EncryptionConfig {
+	return &config.EncryptionConfig{
+		Enabled:     true,
+		DEKPath:     "dek.key",
+		SaltPath:    "salt",
+		KeyProvider: config.KeyProviderConfig{Type: "password"},
+	}
+}
+
+// TestService_AuditKMSContextFallback_RecordsEvent is the whitebox unit test for
+// auditKMSContextFallback (awskms-002): wired as the awskms.FallbackHook from
+// buildKeyProvider, it must turn a fallback firing into a durable, queryable audit
+// event — not just the log.Printf line awskms.Decrypt always emits — matching this
+// codebase's established pattern for auditKeyProviderDowngrade (see
+// key_provider_downgrade.go and its TestNewKeyProviderFromConfig_WeakFallback_
+// RuntimeAuditEvent). A real end-to-end test through Service.Initialize (like that
+// downgrade test does with tpm/password) isn't possible here without live AWS
+// credentials, since aws-kms's New() now makes a real kms:DescribeKey call — so
+// this exercises the hook function directly, matching the actual unit boundary.
+func TestService_AuditKMSContextFallback_RecordsEvent(t *testing.T) {
+	svc := NewService(testKMSFallbackAuditConfig(), t.TempDir())
+
+	var got *models.AuditEvent
+	svc.SetAuditSink(func(_ context.Context, event *models.AuditEvent) error {
+		got = event
+		return nil
+	})
+
+	svc.auditKMSContextFallback(context.Background(), "arn:aws:kms:us-east-1:123456789012:key/canonical-id")
+
+	if got == nil {
+		t.Fatal("a KMS context-fallback event must be recorded as an audit event, not just a log line")
+	}
+	if got.EventType != EventKMSContextFallbackUsed {
+		t.Fatalf("EventType = %q, want %q", got.EventType, EventKMSContextFallbackUsed)
+	}
+	if got.ActorType != "system" {
+		t.Fatalf("ActorType = %q, want %q", got.ActorType, "system")
+	}
+	if got.Success == nil || *got.Success {
+		t.Fatal("a KMS context-fallback event reports a security-negative condition and must have Success = false")
+	}
+	if !strings.Contains(got.Description, "arn:aws:kms:us-east-1:123456789012:key/canonical-id") {
+		t.Fatalf("Description must name the affected key, got %q", got.Description)
+	}
+	if !strings.Contains(got.Description, "kms_allow_context_fallback") {
+		t.Fatalf("Description must reference kms_allow_context_fallback so an operator knows what to disable, got %q", got.Description)
+	}
+}
+
+// TestService_AuditKMSContextFallback_NilSinkIsNoOp verifies the hook is safe to
+// call before SetAuditSink is ever wired (matches auditKeyProviderDowngrade's
+// nil-sink behavior): it must not panic, and obviously records nothing.
+func TestService_AuditKMSContextFallback_NilSinkIsNoOp(t *testing.T) {
+	svc := NewService(testKMSFallbackAuditConfig(), t.TempDir())
+	svc.auditKMSContextFallback(context.Background(), "some-key-id") // must not panic
+}
+
+// TestService_AuditKMSContextFallback_SinkErrorIsBestEffort verifies a sink write
+// failure is swallowed (logged, not propagated) — the caller of Decrypt already
+// has its plaintext by the time this hook runs and must not be affected by an
+// audit-logging failure.
+func TestService_AuditKMSContextFallback_SinkErrorIsBestEffort(t *testing.T) {
+	svc := NewService(testKMSFallbackAuditConfig(), t.TempDir())
+	svc.SetAuditSink(func(_ context.Context, _ *models.AuditEvent) error {
+		return errors.New("simulated sink write failure")
+	})
+	svc.auditKMSContextFallback(context.Background(), "some-key-id") // must not panic
+}

--- a/internal/encryption/nonce_budget_test.go
+++ b/internal/encryption/nonce_budget_test.go
@@ -1,0 +1,127 @@
+package encryption
+
+// nonce_budget_test.go — regression test for the DEK nonce-budget observability
+// nudge (Wave 6 info-severity finding): Encrypt/EncryptWithAAD draw a fresh random
+// 96-bit nonce per call with no per-DEK invocation counter or warning anywhere in
+// the package, so a long-lived, never-automatically-rotated DEK under sustained
+// write volume has no signal steering an operator toward `keyorix encryption
+// rotate` before nonce-collision risk (real, but only near 2^32 encryptions under
+// one key) becomes material. This test drives EncryptionService.encryptCount
+// directly to just below nonceBudgetWarnThreshold — rather than actually calling
+// Encrypt ~268 million times — and asserts the warning fires exactly once, only
+// after the threshold is crossed.
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+// captureLogOutput redirects the standard logger to a buffer for the duration of
+// the test and restores the previous output/flags on cleanup.
+func captureLogOutput(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	origOutput := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(origOutput)
+		log.SetFlags(origFlags)
+	})
+	return &buf
+}
+
+func TestNonceBudgetWarning_NoWarningBelowThreshold(t *testing.T) {
+	kek, err := GenerateRandomKey(32)
+	if err != nil {
+		t.Fatalf("Failed to generate KEK: %v", err)
+	}
+	service, err := NewEncryptionService(kek)
+	if err != nil {
+		t.Fatalf("Failed to create encryption service: %v", err)
+	}
+
+	logBuf := captureLogOutput(t)
+
+	// Seed the counter to just below the threshold without actually performing
+	// hundreds of millions of encryptions.
+	service.encryptCount.Store(nonceBudgetWarnThreshold - 2)
+
+	if _, err := service.Encrypt([]byte("below threshold"), testKeyVersion); err != nil {
+		t.Fatalf("Encrypt failed: %v", err)
+	}
+
+	if logBuf.Len() != 0 {
+		t.Fatalf("expected no warning below nonceBudgetWarnThreshold, got: %q", logBuf.String())
+	}
+}
+
+func TestNonceBudgetWarning_FiresExactlyOnceAtThreshold(t *testing.T) {
+	kek, err := GenerateRandomKey(32)
+	if err != nil {
+		t.Fatalf("Failed to generate KEK: %v", err)
+	}
+	service, err := NewEncryptionService(kek)
+	if err != nil {
+		t.Fatalf("Failed to create encryption service: %v", err)
+	}
+
+	logBuf := captureLogOutput(t)
+
+	// One call short of the threshold — this call's increment lands exactly on it.
+	service.encryptCount.Store(nonceBudgetWarnThreshold - 1)
+
+	if _, err := service.Encrypt([]byte("at threshold"), testKeyVersion); err != nil {
+		t.Fatalf("Encrypt failed: %v", err)
+	}
+
+	warning := logBuf.String()
+	if !strings.Contains(warning, "encryption rotate") {
+		t.Fatalf("expected a nonce-budget warning pointing at `keyorix encryption rotate`, got: %q", warning)
+	}
+	if strings.Count(warning, "encryption rotate") != 1 {
+		t.Fatalf("expected exactly one warning line, got: %q", warning)
+	}
+
+	// Further calls past the threshold (via either Encrypt or EncryptWithAAD) must
+	// NOT log a duplicate warning.
+	logBuf.Reset()
+	if _, err := service.Encrypt([]byte("past threshold #1"), testKeyVersion); err != nil {
+		t.Fatalf("Encrypt failed: %v", err)
+	}
+	if _, err := service.EncryptWithAAD([]byte("past threshold #2"), testKeyVersion, []byte("aad")); err != nil {
+		t.Fatalf("EncryptWithAAD failed: %v", err)
+	}
+	if logBuf.Len() != 0 {
+		t.Fatalf("expected no duplicate nonce-budget warning after it already fired, got: %q", logBuf.String())
+	}
+}
+
+// TestNonceBudgetWarning_EncryptWithAADAlsoCounts confirms EncryptWithAAD
+// increments the same shared counter as Encrypt (they share one DEK's nonce
+// budget), and can itself be the call that crosses the threshold.
+func TestNonceBudgetWarning_EncryptWithAADAlsoCounts(t *testing.T) {
+	kek, err := GenerateRandomKey(32)
+	if err != nil {
+		t.Fatalf("Failed to generate KEK: %v", err)
+	}
+	service, err := NewEncryptionService(kek)
+	if err != nil {
+		t.Fatalf("Failed to create encryption service: %v", err)
+	}
+
+	logBuf := captureLogOutput(t)
+
+	service.encryptCount.Store(nonceBudgetWarnThreshold - 1)
+
+	if _, err := service.EncryptWithAAD([]byte("at threshold via AAD path"), testKeyVersion, []byte("aad")); err != nil {
+		t.Fatalf("EncryptWithAAD failed: %v", err)
+	}
+
+	if !strings.Contains(logBuf.String(), "encryption rotate") {
+		t.Fatalf("expected EncryptWithAAD to trigger the nonce-budget warning at threshold, got: %q", logBuf.String())
+	}
+}

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -87,7 +87,7 @@ func (s *Service) Initialize(passphrase string) error {
 // Service's audit sink so a downgrade that actually FIRES at KEK() time — not
 // just one the config permits — is recorded as more than a log line.
 func (s *Service) buildKeyProvider(passphrase string) (crypto.KeyProvider, error) {
-	provider, err := NewKeyProviderFromConfig(s.config, s.keyManager.baseDir, passphrase)
+	provider, err := newKeyProviderFromConfig(s.config, s.keyManager.baseDir, passphrase, s.auditKMSContextFallback)
 	if err != nil {
 		return nil, err
 	}
@@ -106,9 +106,24 @@ func (s *Service) buildKeyProvider(passphrase string) (crypto.KeyProvider, error
 // configured, wraps all providers in a MultiKeyProvider that tries them in order.
 // baseDir resolves provider-relative paths (salt / wrapped_key_path). Exported so
 // the KEK-provider migration tool can build a *target* provider from a different
-// config than the running service's.
+// config than the running service's — the returned provider gets no
+// kms-context-fallback audit wiring (see newKeyProviderFromConfig), which is
+// correct here since a migration-target provider is never used to serve a live
+// decrypt.
 func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase string) (crypto.KeyProvider, error) {
-	primary, err := buildSingleProvider(&cfg.KeyProvider, baseDir, passphrase, cfg.SaltPath)
+	return newKeyProviderFromConfig(cfg, baseDir, passphrase, nil)
+}
+
+// newKeyProviderFromConfig is NewKeyProviderFromConfig's implementation, with an
+// added kmsFallbackHook wired only from Service.buildKeyProvider (the live-serving
+// path) so a KMSAllowContextFallback decrypt actually firing gets recorded as more
+// than a log line — see awskms.FallbackHook and Service.auditKMSContextFallback.
+// Kept unexported rather than added as a new exported parameter so the many
+// existing NewKeyProviderFromConfig call sites (tests, the migration CLI) that
+// have no audit sink to wire don't need updating for an audit path that doesn't
+// apply to them.
+func newKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase string, kmsFallbackHook awskms.FallbackHook) (crypto.KeyProvider, error) {
+	primary, err := buildSingleProvider(&cfg.KeyProvider, baseDir, passphrase, cfg.SaltPath, kmsFallbackHook)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +132,7 @@ func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase 
 	}
 	providers := []crypto.KeyProvider{primary}
 	for i := range cfg.KeyProvider.Fallbacks {
-		fb, err := buildSingleProvider(&cfg.KeyProvider.Fallbacks[i], baseDir, passphrase, cfg.SaltPath)
+		fb, err := buildSingleProvider(&cfg.KeyProvider.Fallbacks[i], baseDir, passphrase, cfg.SaltPath, kmsFallbackHook)
 		if err != nil {
 			return nil, fmt.Errorf("fallback provider [%d] (%s): %w", i, cfg.KeyProvider.Fallbacks[i].Type, err)
 		}
@@ -140,7 +155,8 @@ func NewKeyProviderFromConfig(cfg *config.EncryptionConfig, baseDir, passphrase 
 
 // buildSingleProvider constructs a single KeyProvider from one KeyProviderConfig.
 // saltPath is the encryption config's salt file path (used by the password provider).
-func buildSingleProvider(kp *config.KeyProviderConfig, baseDir, passphrase, saltPath string) (crypto.KeyProvider, error) {
+// kmsFallbackHook is wired into an aws-kms provider only (see NewKeyProviderFromConfig).
+func buildSingleProvider(kp *config.KeyProviderConfig, baseDir, passphrase, saltPath string, kmsFallbackHook awskms.FallbackHook) (crypto.KeyProvider, error) {
 	switch kp.Type {
 	case "", "password":
 		return crypto.NewPasswordKeyProvider(passphrase, baseDir, saltPath), nil
@@ -155,7 +171,7 @@ func buildSingleProvider(kp *config.KeyProviderConfig, baseDir, passphrase, salt
 	case "tpm":
 		return crypto.NewTPMKeyProvider(kp.TPMDevice, baseDir, kp.WrappedKeyPath), nil
 	case "aws-kms":
-		kmsClient, err := awskms.New(context.Background(), kp.KMSKeyID, kp.KMSEncryptionContext, kp.KMSAllowContextFallback)
+		kmsClient, err := awskms.New(context.Background(), kp.KMSKeyID, kp.KMSEncryptionContext, kp.KMSAllowContextFallback, kmsFallbackHook)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/notary/notary.go
+++ b/internal/notary/notary.go
@@ -15,6 +15,7 @@ package notary
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
 	"fmt"
@@ -43,8 +44,9 @@ type Notary interface {
 // VerifyReceipt re-checks an RFC 3161 receipt token against the original message.
 // It (1) verifies the token's signature chains to one of the configured TSA roots
 // with the time-stamping extended key usage — so a self-signed or otherwise
-// untrusted issuer is rejected; (2) confirms the token's hashed message equals
-// SHA-256(message), binding the receipt to exactly this message; and (3) returns
+// untrusted issuer is rejected; (2) confirms the token declares a SHA-256
+// message-imprint algorithm and that its hashed message equals SHA-256(message),
+// binding the receipt to exactly this message and this algorithm; and (3) returns
 // the authority's asserted time.
 //
 // roots is REQUIRED: without a trust anchor a token's issuer cannot be trusted, so
@@ -70,6 +72,19 @@ func VerifyReceipt(roots *x509.CertPool, message, token []byte) (_ time.Time, er
 	if err != nil {
 		return time.Time{}, fmt.Errorf("notary: invalid timestamp token: %w", err)
 	}
+	// The token declares its own message-imprint hash algorithm (digitorus/timestamp
+	// resolves the ASN.1 OID into ts.HashAlgorithm and already rejects unrecognized
+	// OIDs at Parse time). We only ever compute a SHA-256 digest of message below, so
+	// confirm the token actually claims SHA-256 (OID 2.16.840.1.101.3.4.2.1) before
+	// comparing bytes — otherwise a token declaring a different algorithm (e.g.
+	// SHA-1) but happening to carry a HashedMessage of the same length as a SHA-256
+	// digest would pass a raw byte comparison even though it was never validated
+	// against that algorithm. digitorus/timestamp does not itself check that
+	// HashedMessage's length matches the declared algorithm's output size, so this
+	// check is the only thing tying the comparison to the algorithm the token claims.
+	if ts.HashAlgorithm != crypto.SHA256 {
+		return time.Time{}, fmt.Errorf("notary: receipt uses unsupported message-imprint hash algorithm %v (want SHA-256)", ts.HashAlgorithm)
+	}
 	want := sha256.Sum256(message)
 	if !bytes.Equal(ts.HashedMessage, want[:]) {
 		return time.Time{}, fmt.Errorf("notary: receipt does not bind this message (timestamped digest differs)")
@@ -86,6 +101,20 @@ func VerifyReceipt(roots *x509.CertPool, message, token []byte) (_ time.Time, er
 	for _, c := range p7.Certificates {
 		intermediates.AddCert(c)
 	}
+	// #notary-findings-2's residual (scoped down, documented rather than built): this
+	// chain check does NOT perform CRL/OCSP revocation checking of the TSA cert
+	// chain — neither Go's x509.Verify nor digitorus/pkcs7's VerifyWithOpts (which is
+	// a thin wrapper around it, confirmed by reading both vendored sources) expose
+	// any revocation hook to wire into, so there is no small change available here;
+	// a real one means shipping an OCSP client or a CRL fetch+cache path, plus a
+	// fail-open-vs-fail-closed policy for a network call sitting inside a signature-
+	// verification path — all of that is disproportionate to this being a low-
+	// severity, defense-in-depth gap on a niche feature (checkpoint anchoring) with a
+	// narrow window (only matters if the configured TSA's signing key is later
+	// compromised AND the malicious token also carries a ts.Time predating the real
+	// revocation date, since verification is deliberately pinned to the token's own
+	// claimed time — see below). If this needs closing later, prefer OCSP stapling
+	// or a periodically-refreshed CRL cache over a synchronous fetch per verify call.
 	if err := p7.VerifyWithOpts(x509.VerifyOptions{
 		Roots:         roots,
 		Intermediates: intermediates,

--- a/internal/notary/notary_s17_test.go
+++ b/internal/notary/notary_s17_test.go
@@ -2,12 +2,20 @@ package notary
 
 import (
 	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/digitorus/timestamp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -184,4 +192,86 @@ func TestNewRFC3161_AcceptsPlaintextHTTP_Loopback(t *testing.T) {
 func TestNewRFC3161_RejectsMalformedURL(t *testing.T) {
 	_, err := NewRFC3161("not-a-url", 5*time.Second)
 	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// VerifyReceipt — message-imprint hash algorithm must be SHA-256
+// (Wave 6, notary-findings.json#2)
+// ---------------------------------------------------------------------------
+
+// craftTokenWithHashAlgorithm builds a validly-signed RFC 3161 TimeStampToken,
+// self-issued by a fresh timestamping cert, whose message-imprint declares
+// hashAlg as its hash algorithm but carries hashedMessage as the raw imprint
+// bytes verbatim — regardless of whether hashedMessage is actually
+// hashAlg(message). This mirrors what a misconfigured or hostile TSA could
+// produce: digitorus/timestamp does not itself check that HashedMessage's
+// length/content matches the declared algorithm.
+func craftTokenWithHashAlgorithm(t *testing.T, fixedTime time.Time, hashAlg crypto.Hash, hashedMessage []byte) ([]byte, *x509.Certificate) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test TSA"},
+		NotBefore:             fixedTime.Add(-365 * 24 * time.Hour),
+		NotAfter:              fixedTime.Add(3650 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	ts := &timestamp.Timestamp{
+		HashAlgorithm:     hashAlg,
+		HashedMessage:     hashedMessage,
+		Time:              fixedTime,
+		Policy:            asn1.ObjectIdentifier{1, 2, 3, 4, 1},
+		SerialNumber:      big.NewInt(42),
+		AddTSACertificate: true,
+	}
+	resp, err := ts.CreateResponseWithOpts(cert, key, crypto.SHA256)
+	require.NoError(t, err)
+	parsed, err := timestamp.ParseResponse(resp)
+	require.NoError(t, err)
+	return parsed.RawToken, cert
+}
+
+// TestVerifyReceipt_RejectsNonSHA256HashAlgorithm crafts a token that declares
+// SHA-384 as its message-imprint hash algorithm but carries a HashedMessage
+// equal to sha256.Sum256(message) — the scenario the pre-fix code accepted, since it
+// compared raw bytes against a SHA-256 digest regardless of what algorithm the
+// token claimed to have used. VerifyReceipt must reject the mismatch instead of
+// silently trusting the byte comparison.
+func TestVerifyReceipt_RejectsNonSHA256HashAlgorithm(t *testing.T) {
+	fixedTime := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	msg := []byte("checkpoint bytes being anchored")
+	want := sha256.Sum256(msg)
+
+	token, cert := craftTokenWithHashAlgorithm(t, fixedTime, crypto.SHA384, want[:])
+	roots := x509.NewCertPool()
+	roots.AddCert(cert)
+
+	_, err := VerifyReceipt(roots, msg, token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hash algorithm")
+}
+
+// TestVerifyReceipt_AcceptsSHA256HashAlgorithm is the positive-path sibling:
+// a token that correctly declares SHA-256 and carries the matching digest must
+// still verify — the new check must not reject the legitimate case.
+func TestVerifyReceipt_AcceptsSHA256HashAlgorithm(t *testing.T) {
+	fixedTime := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	msg := []byte("checkpoint bytes being anchored")
+	want := sha256.Sum256(msg)
+
+	token, cert := craftTokenWithHashAlgorithm(t, fixedTime, crypto.SHA256, want[:])
+	roots := x509.NewCertPool()
+	roots.AddCert(cert)
+
+	at, err := VerifyReceipt(roots, msg, token)
+	require.NoError(t, err)
+	assert.WithinDuration(t, fixedTime, at, time.Second)
 }


### PR DESCRIPTION
## Summary

First batch of the Wave 6 low/info-severity remediation (adversarial security review, 2026-08-07/08). This is the final phase of Wave 6: 65 low/info singletons remained after the critical/high and medium-severity triage passes closed (see `keyorix-private/adversarial-review/REMEDIATION-STATUS.md`); each was independently re-verified against current code before dispatch (found 1 stale — `operator-keyorix.json#2`, already fixed).

This batch covers 3 of the 4 originally-dispatched fixes; a 4th (GCP KMS AAD-encoding hardening) was deliberately held back — see "Held back" below.

- **AWS KMS provider hardening** (3 findings, `internal/crypto/awskms/awskms.go`): `kms_key_id` accepted a mutable AWS alias and pinned it verbatim into every `Encrypt`/`Decrypt` call, so whoever holds alias-management IAM privilege could silently repoint the alias to a different CMK, undermining the confused-deputy `KeyId`-pinning guard. `New()` now resolves the configured key to its canonical, immutable ARN via `kms:DescribeKey` once at construction and pins that ARN forever after (fails closed if resolution fails — **note: this adds a new required IAM permission, `kms:DescribeKey`, alongside the existing KMS permissions this feature already needs**). Also: `kms_allow_context_fallback` usage (an opt-in migration aid) was only logged via `log.Printf`, easy to lose in noise if an operator forgets to disable it — now emits a durable `encryption.kms_context_fallback_used` audit event, matching this campaign's established pattern. Also: the caller-supplied encryption-context map was stored by reference rather than defensively copied — now `maps.Clone`'d.
- **DEK nonce-budget observability** (`internal/encryption/encryption.go`): no per-DEK invocation counter existed anywhere, so nothing would nudge an operator toward rotating a long-lived, never-automatically-rotated DEK before the random-nonce birthday bound becomes a real (if extremely distant) concern. Added a coarse, non-durable atomic counter with a one-time warning at a conservative threshold (2^28, well below the actual risk zone) pointing the operator at `keyorix encryption rotate --confirm`. Purely observational — no enforcement, no persistence.
- **Notary receipt verification completeness** (`internal/notary/notary.go`): `VerifyReceipt` compared a TSA token's `HashedMessage` against a raw SHA-256 digest without ever checking the token's declared hash-algorithm OID — a token claiming a different algorithm but carrying a 32-byte imprint equal to the real SHA-256 digest would still pass. Now rejects any token that doesn't declare SHA-256. (Two sibling findings in this same package — a panic-on-malformed-response bug and a TLS/trust-root gap — were already fixed in Wave 6 batch 5, PR #1454.) A third gap (no CRL/OCSP revocation checking of the TSA cert chain) was investigated and deliberately scoped down: neither Go's `x509.Verify` nor the vendored `digitorus/pkcs7` library expose a revocation-check hook, so closing it fully means building an OCSP/CRL client from scratch — disproportionate to a low-severity, narrow-exploit-window (requires TSA private-key compromise **and** a backdated timestamp) gap on a niche feature. Documented as a residual risk in a code comment, matching this codebase's existing pattern for scoped-down defense-in-depth gaps.

## Held back: GCP KMS AAD-encoding hardening

A 4th finding (`crypto-gcpkms-01`: `encContextAAD`'s unescaped `"key=value\n"` join is not injective — adversarial `=`/`\n` content in a key or value lets two structurally different context maps serialize to identical AAD, undermining the cross-install isolation guarantee) was fixed but is **not included in this PR**. The fix changes the AAD wire format for any install using `kms_encryption_context`, requiring existing wrapped KEKs to be re-wrapped via the already-existing `kms_allow_context_fallback` + `migrate-provider` migration path after upgrade. Per explicit decision, this is being held separately rather than bundled into a routine low-severity batch, even though the migration tooling already exists. Two co-located, non-breaking findings in the same file (CRC32C integrity checks on Encrypt/Decrypt, and routing the AAD-fallback event to the audit trail) are bundled with it on branch `fix-wave6-gcpkms-hardening` and will be revisited separately.

## Verification

Each fix independently re-verified from a fresh worktree before integration (build/vet/gofmt/gosec/relevant suites, each with pre-fix-failure proof via scoped `git stash`), then cherry-picked (`-x`) onto one branch off current `main` — no conflicts.

Combined verification on the integrated branch:
- `go build ./...`, `go vet ./...`, `gofmt -l` — all clean
- `gosec -severity medium -exclude-generated` — 0 issues (32 files across `internal/crypto`, `internal/encryption`, `internal/notary`)
- Full `go test ./...` — only the established pre-existing `server/http` `RealServer`/`CSV_Headers`/`SetupToken` failures (unrelated to this batch, confirmed identical against unmodified `main` throughout this campaign)

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] Full `go test ./...` — no new failures vs. baseline
- [ ] CI: lint, gitleaks, build-and-test