### PR TITLE
fix(security): close Wave 6 low/info batch 2 (storage layer hardening)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1605,6 +1605,31 @@ type ClassificationConfig struct {
 	// RestrictedMFAStepUpWindowMinutes is how long (in minutes) a completed MFA
 	// verification remains valid for restricted-secret reads. 0 = default (15 min).
 	RestrictedMFAStepUpWindowMinutes int `yaml:"restricted_mfa_stepup_window_minutes"`
+	// MFAStepUpGrantRetentionDays bounds how long an MFAStepUpGrant row is kept
+	// past its own expiry (store-mfa-002) before the periodic maintenance sweep
+	// hard-deletes it — every successful VerifyMFAStepUp inserts a new row, kept
+	// briefly for audit purposes rather than deleted the instant it expires (see
+	// internal/storage/store/local_mfa_stepup_grant.go), so without a bound the
+	// table grows forever. This is independent of RestrictedMFAStepUpWindowMinutes
+	// (how long a grant is ACTIVE) — it governs how long the row survives AFTER
+	// it stops being active. 0 = default (30 days, matching
+	// SoftDeleteConfig.GetRetentionDays's default). The sweep runs unconditionally
+	// (like the login-attempt prune it mirrors) — this is bookkeeping cleanup, not
+	// an opt-in compliance-retention feature, and a grant's CREATION is
+	// independently, permanently audited (mfa.stepup_verified, never purged per
+	// ADR-029), so pruning the row itself never destroys the sole evidentiary
+	// record.
+	MFAStepUpGrantRetentionDays int `yaml:"mfa_stepup_grant_retention_days"`
+}
+
+// GetMFAStepUpGrantRetentionDays returns the MFAStepUpGrant retention window in
+// days, defaulting to 30 when unset or non-positive (matches
+// SoftDeleteConfig.GetRetentionDays's default).
+func (c ClassificationConfig) GetMFAStepUpGrantRetentionDays() int {
+	if c.MFAStepUpGrantRetentionDays <= 0 {
+		return 30
+	}
+	return c.MFAStepUpGrantRetentionDays
 }
 
 // WebAuthnConfig configures the WebAuthn relying party (ADR-036). RPID is the

--- a/internal/core/mfa_stepup.go
+++ b/internal/core/mfa_stepup.go
@@ -7,6 +7,8 @@ package core
 import (
 	"context"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -77,4 +79,50 @@ func (c *KeyorixCore) HasActiveMFAStepUp(ctx context.Context, userID uint) (bool
 		return false, err
 	}
 	return grant != nil, nil
+}
+
+// DefaultMFAStepUpGrantRetention is the fallback MFAStepUpGrant retention
+// window (config.ClassificationConfig.MFAStepUpGrantRetentionDays, 0 = this
+// default) used when PruneMFAStepUpGrants is called with a non-positive
+// retention.
+const DefaultMFAStepUpGrantRetention = 30 * 24 * time.Hour
+
+// PruneMFAStepUpGrants removes MFAStepUpGrant rows that expired more than
+// `retention` ago (retention <= 0 falls back to
+// DefaultMFAStepUpGrantRetention). `before`, when non-zero and EARLIER than
+// the retention-derived cutoff, narrows the deletion window further —
+// mirroring PruneLoginAttempts's clamp (CORE-RATE-003): the effective cutoff
+// can never be LATER than now-retention, so a caller (including
+// server/http/handlers/mfa_stepup_proxy.go's PruneMFAStepUpGrantsProxy, the
+// only other caller, decoding a request body from a RemoteStorage spoke node)
+// can only narrow the window, never widen it into an unbounded wipe. Returns
+// the number of rows removed.
+//
+// Unlike PruneLoginAttempts, this does NOT emit an audit event. LoginAttempt
+// rows are themselves the sole record that a login/rate-limit event ever
+// happened, so PruneLoginAttempts audits every deletion (mirroring
+// PurgeExpiredSoftDeletes/PurgeExpiredComplianceRecords). An MFAStepUpGrant
+// row is different: its CREATION is already permanently, independently
+// audited (VerifyMFAStepUp emits mfa.stepup_verified, and audit events are
+// append-only / never purged — ADR-029), so the grant row itself is a
+// short-lived operational copy, not the sole evidentiary record. Losing N of
+// these to routine maintenance is unremarkable; a log line is proportionate
+// to the lower stakes.
+func (c *KeyorixCore) PruneMFAStepUpGrants(ctx context.Context, retention time.Duration, before time.Time) (int64, error) {
+	if retention <= 0 {
+		retention = DefaultMFAStepUpGrantRetention
+	}
+	cutoff := c.now().Add(-retention)
+	if !before.IsZero() && before.Before(cutoff) {
+		cutoff = before
+	}
+
+	n, err := c.storage.PruneMFAStepUpGrants(ctx, cutoff)
+	if err != nil {
+		return n, err
+	}
+	if n > 0 {
+		log.Printf("MFA step-up grant prune removed %d row(s) expired before %s", n, cutoff.UTC().Format(time.RFC3339))
+	}
+	return n, nil
 }

--- a/internal/core/mfa_stepup_grant_prune_test.go
+++ b/internal/core/mfa_stepup_grant_prune_test.go
@@ -1,0 +1,130 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// store-mfa-002: CreateMFAStepUpGrant inserts a brand-new row on every
+// successful VerifyMFAStepUp, and (before this fix) nothing ever pruned them —
+// DeleteMFAStepUpGrantsFor existed but was only reachable via the
+// RemoteStorage HTTP proxy, never called from a local maintenance path. These
+// tests cover the new PruneMFAStepUpGrants sweep, mirroring rate_limit_test.go's
+// TestPruneLoginAttempts_* coverage for the analogous LoginAttempt prune.
+
+// TestPruneMFAStepUpGrants_RemovesOldRowsKeepsRecent exercises the real
+// SQLite path (LocalStorage): a grant expired well past the retention window
+// is removed; a grant that is still within the retention window (even though
+// already expired — it's the retention window, not the active-grant window,
+// that matters here) survives.
+func TestPruneMFAStepUpGrants_RemovesOldRowsKeepsRecent(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	ctx := context.Background()
+
+	retention := 30 * 24 * time.Hour
+
+	// Expired 40 days ago — older than the 30-day retention window, must be pruned.
+	oldGrant := &models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(-40 * 24 * time.Hour)}
+	require.NoError(t, db.Create(oldGrant).Error)
+
+	// Expired 5 days ago — within the 30-day retention window, must survive.
+	recentGrant := &models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(-5 * 24 * time.Hour)}
+	require.NoError(t, db.Create(recentGrant).Error)
+
+	removed, err := c.PruneMFAStepUpGrants(ctx, retention, time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), removed, "only the row past the retention window is removed")
+
+	var remaining []models.MFAStepUpGrant
+	require.NoError(t, db.Find(&remaining).Error)
+	require.Len(t, remaining, 1, "the within-window row must survive")
+	assert.Equal(t, recentGrant.ID, remaining[0].ID)
+}
+
+// TestPruneMFAStepUpGrants_ZeroRetentionUsesDefault confirms retention<=0
+// falls back to DefaultMFAStepUpGrantRetention (30 days) rather than pruning
+// everything (e.g. a zero time.Duration must not mean "prune anything expired
+// at all", which would defeat the "kept for audit purposes" design).
+func TestPruneMFAStepUpGrants_ZeroRetentionUsesDefault(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	ctx := context.Background()
+
+	// Expired 1 day ago — well within even the shortest sane retention window.
+	grant := &models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(-24 * time.Hour)}
+	require.NoError(t, db.Create(grant).Error)
+
+	removed, err := c.PruneMFAStepUpGrants(ctx, 0, time.Time{})
+	require.NoError(t, err)
+	assert.Zero(t, removed, "a recently-expired row must survive the default 30-day retention")
+
+	var count int64
+	require.NoError(t, db.Model(&models.MFAStepUpGrant{}).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+// TestPruneMFAStepUpGrants_ClampsFutureBeforeToRetention is the
+// store-mfa-002/CORE-RATE-003-shaped regression: a caller-supplied `before`
+// LATER than now-retention (e.g. an attacker-influenced request body via the
+// RemoteStorage proxy) must never widen the deletion window — the storage
+// call underneath must always receive the clamped cutoff.
+func TestPruneMFAStepUpGrants_ClampsFutureBeforeToRetention(t *testing.T) {
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	retention := 30 * 24 * time.Hour
+	maxCutoff := now.Add(-retention)
+	attackerBefore := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockStore := new(MockStorage)
+	mockStore.On("PruneMFAStepUpGrants", mock.Anything, maxCutoff).Return(int64(3), nil)
+
+	c := &KeyorixCore{storage: mockStore, now: func() time.Time { return now }, passwordPolicy: DefaultPasswordPolicy()}
+	removed, err := c.PruneMFAStepUpGrants(context.Background(), retention, attackerBefore)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), removed)
+	mockStore.AssertExpectations(t)
+}
+
+// TestPruneMFAStepUpGrants_NarrowerBeforeIsHonored confirms a caller CAN
+// still narrow the deletion window below the retention-derived cutoff — only
+// widening past it is blocked.
+func TestPruneMFAStepUpGrants_NarrowerBeforeIsHonored(t *testing.T) {
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	retention := 30 * 24 * time.Hour
+	narrowerBefore := now.Add(-60 * 24 * time.Hour)
+
+	mockStore := new(MockStorage)
+	mockStore.On("PruneMFAStepUpGrants", mock.Anything, narrowerBefore).Return(int64(1), nil)
+
+	c := &KeyorixCore{storage: mockStore, now: func() time.Time { return now }, passwordPolicy: DefaultPasswordPolicy()}
+	removed, err := c.PruneMFAStepUpGrants(context.Background(), retention, narrowerBefore)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), removed)
+	mockStore.AssertExpectations(t)
+}
+
+// TestPruneMFAStepUpGrants_NoAuditEventEmitted pins the deliberate design
+// decision (see PruneMFAStepUpGrants's doc comment): unlike PruneLoginAttempts,
+// a successful prune here does NOT write an audit event, because a grant
+// row's CREATION is already permanently audited (mfa.stepup_verified) — the
+// row itself is a redundant operational copy, not the sole evidentiary
+// record. This guards against a future change reflexively bolting on an
+// audit event without revisiting that reasoning.
+func TestPruneMFAStepUpGrants_NoAuditEventEmitted(t *testing.T) {
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	mockStore := new(MockStorage)
+	mockStore.On("PruneMFAStepUpGrants", mock.Anything, mock.Anything).Return(int64(5), nil)
+	// Deliberately no .On("LogAuditEvent", ...) expectation — AssertNotCalled below
+	// enforces that it's never invoked.
+
+	c := &KeyorixCore{storage: mockStore, now: func() time.Time { return now }, passwordPolicy: DefaultPasswordPolicy()}
+	removed, err := c.PruneMFAStepUpGrants(context.Background(), 0, time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), removed)
+	mockStore.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -63,6 +63,11 @@ func (m *MockStorage) PruneLoginAttempts(ctx context.Context, before time.Time) 
 	return a.Get(0).(int64), a.Error(1)
 }
 
+func (m *MockStorage) PruneMFAStepUpGrants(ctx context.Context, before time.Time) (int64, error) {
+	a := m.Called(ctx, before)
+	return a.Get(0).(int64), a.Error(1)
+}
+
 // Permission Management
 
 func (m *MockStorage) CreatePermission(_ context.Context, permission *models.Permission) (*models.Permission, error) {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1346,6 +1346,15 @@ type Storage interface {
 	// DeleteMFAStepUpGrantsFor removes all step-up grants for userID (used on
 	// session revocation or security-incident response).
 	DeleteMFAStepUpGrantsFor(ctx context.Context, userID uint) error
+	// PruneMFAStepUpGrants removes MFAStepUpGrant rows whose ExpiresAt predates
+	// `before`, returning how many were removed (store-mfa-002: each successful
+	// VerifyMFAStepUp creates a new grant row, kept briefly past its own expiry
+	// for audit purposes — see internal/storage/store/local_mfa_stepup_grant.go
+	// — but with no bound this grows without limit). The sole intended caller is
+	// internal/core.KeyorixCore.PruneMFAStepUpGrants, which computes and clamps
+	// the cutoff; callers should not invoke this directly with an
+	// externally-influenced `before`.
+	PruneMFAStepUpGrants(ctx context.Context, before time.Time) (int64, error)
 
 	// WebAuthn / passkeys (ADR-036).
 	CreateWebAuthnCredential(ctx context.Context, c *models.WebAuthnCredential) error

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -43,28 +43,51 @@ var migrationMu sync.Mutex
 // is sufficient there; only Postgres needs the additional cross-process lock.
 const postgresMigrationLockKey = 872341
 
-// withMigrationLock runs fn while holding migrationMu (always) and, when db is a
-// Postgres connection, an additional Postgres session-level advisory lock (closing
-// the cross-replica race #266 describes, not just the in-process one). The
-// advisory lock is released in the same session it was acquired in, so this must
-// run on a single connection for the duration — acquired/released via db.Exec on
-// the same *gorm.DB, which GORM services from one checked-out *sql.Conn per call
-// only within an explicit transaction; to guarantee same-connection acquire/
-// release without depending on that, this wraps fn in db.Transaction.
-func withMigrationLock(db *gorm.DB, isPostgres bool, fn func(*gorm.DB) error) error {
+// withMigrationLock runs fn while holding migrationMu (always) and an additional
+// cross-process lock appropriate to the backend:
+//   - Postgres: a session-level advisory lock (closing the cross-replica race
+//     #266 describes, not just the in-process one). The advisory lock is
+//     released in the same session it was acquired in, so this must run on a
+//     single connection for the duration — acquired/released via db.Exec on the
+//     same *gorm.DB, which GORM services from one checked-out *sql.Conn per call
+//     only within an explicit transaction; to guarantee same-connection acquire/
+//     release without depending on that, this wraps fn in db.Transaction.
+//   - Local SQLite (dbPath != ""): a non-blocking flock(2) sidecar lock on
+//     <dbPath>.migration.lock (#STORAGE-FACTORY-003). migrationMu alone only
+//     serializes goroutines within THIS process; SQLite has no advisory-lock
+//     primitive of its own, so this closes the same cross-process gap the
+//     Postgres branch closes via pg_advisory_lock — a second Keyorix OS process
+//     (another misconfigured replica, or a `keyorix encryption ...` CLI
+//     invocation) pointed at the same local SQLite file fails loud at the start
+//     of migrateDatabase instead of racing this process's DDL statements.
+//     Acquired AFTER migrationMu so only one goroutine in this process ever
+//     attempts it at a time — flock is scoped to the open file description, not
+//     the process, so two concurrent in-process goroutines contending for it
+//     directly (without migrationMu already serializing them) would spuriously
+//     fail one against the other rather than against a genuinely separate OS
+//     process.
+func withMigrationLock(db *gorm.DB, isPostgres bool, dbPath string, fn func(*gorm.DB) error) error {
 	migrationMu.Lock()
 	defer migrationMu.Unlock()
 
-	if !isPostgres {
-		return fn(db)
+	if isPostgres {
+		return db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Exec("SELECT pg_advisory_lock(?)", postgresMigrationLockKey).Error; err != nil {
+				return fmt.Errorf("acquire migration advisory lock: %w", err)
+			}
+			defer tx.Exec("SELECT pg_advisory_unlock(?)", postgresMigrationLockKey)
+			return fn(tx)
+		})
 	}
-	return db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Exec("SELECT pg_advisory_lock(?)", postgresMigrationLockKey).Error; err != nil {
-			return fmt.Errorf("acquire migration advisory lock: %w", err)
+
+	if dbPath != "" {
+		osLock, err := acquireSQLiteMigrationLock(dbPath)
+		if err != nil {
+			return err
 		}
-		defer tx.Exec("SELECT pg_advisory_unlock(?)", postgresMigrationLockKey)
-		return fn(tx)
-	})
+		defer osLock.release()
+	}
+	return fn(db)
 }
 
 // defaultMaxOpenConns bounds the DB connection pool when the operator hasn't set
@@ -192,7 +215,7 @@ func (f *DefaultStorageFactory) createLocalStorage(cfg *config.Config) (storage.
 		return nil, err
 	}
 
-	if err := withMigrationLock(db, false, f.migrateDatabase); err != nil {
+	if err := withMigrationLock(db, false, dbPath, f.migrateDatabase); err != nil {
 		return nil, fmt.Errorf("failed to migrate database: %w", err)
 	}
 
@@ -215,7 +238,7 @@ func (f *DefaultStorageFactory) createPostgresStorage(cfg *config.Config) (stora
 		return nil, err
 	}
 
-	if err := withMigrationLock(db, true, f.migrateDatabase); err != nil {
+	if err := withMigrationLock(db, true, "", f.migrateDatabase); err != nil {
 		return nil, fmt.Errorf("failed to migrate database: %w", err)
 	}
 
@@ -374,8 +397,21 @@ func warnIfDuplicatesExist(db *gorm.DB, table, keyExpr, whereClause, remediation
 // rolePKIsComplete reports whether the given role-assignment table already has the
 // full composite PK: (user_id/group_id, role_id, project_id, environment_id).
 // Detection is dialect-specific:
-//   - SQLite: parse the CREATE TABLE statement from sqlite_master and check whether
-//     the PRIMARY KEY clause mentions "project_id" and "environment_id".
+//   - SQLite: query pragma_table_info(<table>) (the actual parsed schema SQLite
+//     itself resolved, exposed as a table-valued function — the same mechanism
+//     this codebase's Migrator.HasColumn already uses) and check the `pk` column
+//     — nonzero for every column that is actually a member of the table's
+//     primary key — for project_id and environment_id. This was previously a
+//     substring match against everything from the first "primary key" occurrence
+//     in the raw CREATE TABLE text to the end of the statement (#STORAGE-FACTORY-002):
+//     correct only by coincidence of where ALTER TABLE ADD COLUMN happens to place
+//     new columns relative to a trailing table-level PRIMARY KEY constraint, and
+//     it would false-positive (silently skipping the PK rebuild, leaving the
+//     narrower old PK in place) on any DDL where "project_id"/"environment_id"
+//     appear after "primary key" for an unrelated reason — e.g. in a trailing
+//     CHECK or FOREIGN KEY constraint that mentions those columns without them
+//     being PK members. Querying the parsed schema directly makes this immune to
+//     DDL text layout entirely.
 //   - Postgres: query information_schema.key_column_usage for the table's PK and
 //     check that both columns appear among the PK members.
 func rolePKIsComplete(db *gorm.DB, table string) bool {
@@ -396,16 +432,14 @@ func rolePKIsComplete(db *gorm.DB, table string) bool {
 			table, table).Scan(&count)
 		return count >= 2
 	}
-	// SQLite: read the CREATE TABLE SQL and look for project_id in the PK clause.
-	var createSQL string
-	db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&createSQL)
-	lower := strings.ToLower(createSQL)
-	pkStart := strings.Index(lower, "primary key")
-	if pkStart == -1 {
-		return false
-	}
-	pkClause := lower[pkStart:]
-	return strings.Contains(pkClause, "project_id") && strings.Contains(pkClause, "environment_id")
+	// SQLite: ask SQLite's own parsed schema which columns are PK members,
+	// rather than text-matching the raw CREATE TABLE statement.
+	var count int64
+	db.Raw(
+		"SELECT COUNT(*) FROM pragma_table_info(?) WHERE pk > 0 AND name IN ('project_id', 'environment_id')",
+		table,
+	).Scan(&count)
+	return count >= 2
 }
 
 // rebuildRolePKIfNeeded detects whether user_roles / group_roles still carry the
@@ -1866,8 +1900,24 @@ func ensureLegalHoldActiveIndex(db *gorm.DB) error {
 // same type for the same user/project (one per distinct secret/event), so a
 // blanket index across the whole table would silently drop those. Idempotent; works
 // on both SQLite and Postgres (both support partial indexes and IF NOT EXISTS).
+//
+// Like every other ensure*Index helper in this file, this gates the CREATE UNIQUE
+// INDEX on a pre-flight warnIfDuplicatesExist scan (#490, #STORAGE-FACTORY-004):
+// an upgraded install that already accumulated colliding unread reminder rows
+// before this index existed (e.g. via the very TOCTOU this index closes) would
+// otherwise hit an opaque driver-level constraint-violation error deep inside
+// migrateDatabase instead of a clear, actionable one. This was previously the one
+// exception among this file's ensure*Index helpers that skipped the check.
 func ensureReminderNotificationDedupIndex(db *gorm.DB) error {
-	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_notifications_unread_reminder " +
+	const idxName = "uniq_notifications_unread_reminder"
+	if !indexExists(db, idxName) {
+		if err := warnIfDuplicatesExist(db, "notifications", "user_id, type, project_id",
+			"is_read = false AND type IN ('rotation.reminder', 'secret.expiry_reminder')",
+			"mark one of the conflicting unread reminder notifications as read via the application's notifications API before upgrading"); err != nil {
+			return err
+		}
+	}
+	if err := db.Exec(sqlCreateUniqueIdx + idxName + " " +
 		"ON notifications (user_id, type, project_id) " +
 		"WHERE is_read = false AND type IN ('rotation.reminder', 'secret.expiry_reminder')").Error; err != nil {
 		return fmt.Errorf("failed to create partial notifications reminder-dedup index: %w", err)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1499,6 +1499,17 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 		&models.AnomalyConfigRecord{},
 		&models.StatsSnapshot{},
 		&models.DeploymentStatsSnapshot{},
+		// MFAStepUpGrant (store-mfa-002): was never migrated anywhere — a fresh
+		// install's CreateMFAStepUpGrant/GetActiveMFAStepUpGrant/
+		// PruneMFAStepUpGrants calls (VerifyMFAStepUp, the classification gate,
+		// and the mfa_stepup_grant_prune maintenance sweep) would all fail with
+		// "no such table" / "relation does not exist" against a real database.
+		// A plain new, simple table with no legacy columns to conditionally
+		// backfill, so it belongs in this generic bulk list rather than one of
+		// the guarded/existence-checked blocks above (those exist for models
+		// that need to distinguish "already existed" from "freshly created" to
+		// decide whether to add a follow-up column).
+		&models.MFAStepUpGrant{},
 	} {
 		if err := db.AutoMigrate(m); err != nil {
 			return fmt.Errorf("failed to migrate %T: %w", m, err)

--- a/internal/storage/factory_pre_existing_duplicate_index_test.go
+++ b/internal/storage/factory_pre_existing_duplicate_index_test.go
@@ -148,6 +148,86 @@ func TestProjectMembershipIndex_FailsLoudOnPreExistingDuplicates(t *testing.T) {
 	assert.Equal(t, int64(1), revokedCount, "the revoked row (outside the partial predicate) must be untouched")
 }
 
+// TestReminderNotificationDedupIndex_FailsLoudOnPreExistingDuplicates pins
+// #STORAGE-FACTORY-004: ensureReminderNotificationDedupIndex was the one
+// ensure*Index helper in this file that skipped the warnIfDuplicatesExist
+// pre-flight check every sibling helper performs (e.g.
+// ensureDynamicSecretConfigNameIndex above), going straight to a bare
+// `CREATE UNIQUE INDEX IF NOT EXISTS`. An upgraded install that already
+// accumulated colliding unread reminder rows for the same (user, type,
+// project) — precisely the #488 TOCTOU this index exists to close — would hit
+// an opaque driver-level "UNIQUE constraint failed" error instead of the same
+// clear, actionable error every sibling helper produces. This asserts the
+// fixed helper now fails loud with that actionable message, and touches
+// neither conflicting row nor the unrelated ones.
+func TestReminderNotificationDedupIndex_FailsLoudOnPreExistingDuplicates(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "reminder-dedup-dup.db")
+	db, err := gormOpenForTest(t, dbPath)
+	require.NoError(t, err)
+
+	// Create the table WITHOUT the unique index — mirrors a pre-fix database.
+	require.NoError(t, db.AutoMigrate(&models.Notification{}))
+
+	projectID := uint(9)
+	dup1 := &models.Notification{UserID: 1, ProjectID: &projectID, Type: "rotation.reminder", IsRead: false, Title: "rotate me"}
+	require.NoError(t, db.Create(dup1).Error)
+	dup2 := &models.Notification{UserID: 1, ProjectID: &projectID, Type: "rotation.reminder", IsRead: false, Title: "rotate me too"}
+	require.NoError(t, db.Create(dup2).Error)
+	// A read row sharing the same key is outside the partial index's predicate
+	// and must be left alone.
+	read := &models.Notification{UserID: 1, ProjectID: &projectID, Type: "rotation.reminder", IsRead: true, Title: "already read"}
+	require.NoError(t, db.Create(read).Error)
+	// A different notification type legitimately creates more than one unread
+	// row for the same user/project and must not be flagged.
+	other := &models.Notification{UserID: 1, ProjectID: &projectID, Type: "secret.shared", IsRead: false, Title: "shared with you"}
+	require.NoError(t, db.Create(other).Error)
+
+	var countBefore int64
+	require.NoError(t, db.Model(&models.Notification{}).Count(&countBefore).Error)
+	require.Equal(t, int64(4), countBefore)
+
+	err = ensureReminderNotificationDedupIndex(db)
+	require.Error(t, err, "pre-existing duplicate unread reminder rows must block the migration with an actionable error, not fail with an opaque constraint violation")
+	// Must be the actionable warnIfDuplicatesExist message, not the raw
+	// driver-level "UNIQUE constraint failed" error a bare CREATE UNIQUE INDEX
+	// would otherwise surface (which also happens to mention "notifications" —
+	// e.g. "UNIQUE constraint failed: notifications.user_id, ..." — so a check
+	// for that alone would not actually distinguish the two).
+	assert.Contains(t, err.Error(), "pre-existing group(s) of rows already share a value")
+	assert.Contains(t, err.Error(), "notifications API")
+
+	var countAfter int64
+	require.NoError(t, db.Model(&models.Notification{}).Count(&countAfter).Error)
+	assert.Equal(t, int64(4), countAfter, "no row may be deleted by a failed migration check")
+
+	var survivingDup2 models.Notification
+	require.NoError(t, db.First(&survivingDup2, dup2.ID).Error, "dup2 must not have been deleted")
+}
+
+// TestReminderNotificationDedupIndex_NoDuplicates_CreatesIndex confirms the
+// happy path still works: with no pre-existing duplicates, the helper creates
+// the partial unique index and a subsequent conflicting insert is rejected.
+func TestReminderNotificationDedupIndex_NoDuplicates_CreatesIndex(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "reminder-dedup-ok.db")
+	db, err := gormOpenForTest(t, dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Notification{}))
+
+	projectID := uint(3)
+	require.NoError(t, db.Create(&models.Notification{UserID: 1, ProjectID: &projectID, Type: "rotation.reminder", IsRead: false}).Error)
+
+	require.NoError(t, ensureReminderNotificationDedupIndex(db))
+	assert.True(t, indexExists(db, "uniq_notifications_unread_reminder"))
+
+	// A second unread reminder for the same (user, type, project) now violates
+	// the index.
+	err = db.Create(&models.Notification{UserID: 1, ProjectID: &projectID, Type: "rotation.reminder", IsRead: false}).Error
+	require.Error(t, err, "the partial unique index must reject a second unread reminder for the same key")
+
+	// Re-running the helper is idempotent.
+	require.NoError(t, ensureReminderNotificationDedupIndex(db))
+}
+
 // gormOpenForTest opens a fresh SQLite connection at dbPath using the same
 // DSN/config the production factory uses, for tests that need to drive the
 // migration helpers directly against a hand-seeded database.

--- a/internal/storage/factory_rbac_pk_rebuild_test.go
+++ b/internal/storage/factory_rbac_pk_rebuild_test.go
@@ -62,6 +62,34 @@ func TestRolePKIsComplete_SQLite_NewFourColumnPK(t *testing.T) {
 		"four-column composite PK must be detected as complete")
 }
 
+// TestRolePKIsComplete_SQLite_ColumnsMentionedOutsidePKClause pins
+// #STORAGE-FACTORY-002: the old detection heuristic did `strings.Contains` for
+// "project_id"/"environment_id" against EVERY BYTE of the CREATE TABLE
+// statement from the first "primary key" occurrence onward, not just the
+// parenthesized PK column list — so it would false-positive (report the PK
+// complete when it is not) on any DDL where those column names appear later in
+// the statement for an unrelated reason, such as a trailing CHECK or FOREIGN
+// KEY constraint that references them without them being PK members. This
+// table's actual primary key is only (user_id, role_id); project_id and
+// environment_id are ordinary columns referenced by a trailing CHECK
+// constraint placed after "PRIMARY KEY (user_id, role_id)" in the DDL text.
+func TestRolePKIsComplete_SQLite_ColumnsMentionedOutsidePKClause(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "pk-detect-false-positive.db"))
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id        INTEGER NOT NULL,
+		role_id        INTEGER NOT NULL,
+		project_id     INTEGER NOT NULL DEFAULT 0,
+		environment_id INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY (user_id, role_id),
+		CHECK (project_id >= 0 AND environment_id >= 0)
+	)`).Error)
+
+	assert.False(t, rolePKIsComplete(db, "user_roles"),
+		"project_id/environment_id mentioned only in a trailing CHECK constraint (not the PK clause) must not be reported as PK members")
+}
+
 // TestRebuildRolePKSQLite_OldTwoColumnPK_UserRoles exercises the full
 // upgrade path for user_roles when the table has only a (user_id, role_id) PK.
 // After the rebuild, the table must:

--- a/internal/storage/factory_sqlite_migration_lock.go
+++ b/internal/storage/factory_sqlite_migration_lock.go
@@ -1,0 +1,101 @@
+// factory_sqlite_migration_lock.go — cross-process exclusive lock guarding a
+// local SQLite database's connect-and-migrate critical section
+// (#STORAGE-FACTORY-003).
+//
+// migrationMu (see factory.go) only serializes createLocalStorage/migrateDatabase
+// across goroutines WITHIN A SINGLE OS PROCESS; its own doc comment rests on the
+// assumption that "SQLite deployments are single-process-per-file by
+// construction" — but that assumption was never actually enforced anywhere.
+// Nothing previously stopped two separate Keyorix OS processes pointed at the
+// same local SQLite file (a misconfigured multi-replica deployment, or a
+// `keyorix encryption ...` CLI invocation run concurrently with a live server
+// process) from racing gorm.Open's WAL-mode switch and migrateDatabase's DDL
+// statements against each other, unlike the Postgres path which already gets an
+// additional cross-process protection via withMigrationLock's session-level
+// advisory lock.
+package storage
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// sqliteMigrationLockSuffix is appended to the configured SQLite database path
+// to build the sidecar lock file acquireSQLiteMigrationLock takes an flock(2) on.
+const sqliteMigrationLockSuffix = ".migration.lock"
+
+// sqliteMigrationLock holds an acquired exclusive flock(2) on a local SQLite
+// database's migration lock sidecar file.
+type sqliteMigrationLock struct {
+	f *os.File
+}
+
+// release unlocks the flock and closes the underlying file descriptor. Safe to
+// call on a nil receiver or a lock whose file is nil (defensive; every actual
+// caller only calls this after a successful acquireSQLiteMigrationLock).
+func (l *sqliteMigrationLock) release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	_ = l.f.Close()
+}
+
+// acquireSQLiteMigrationLock takes a NON-BLOCKING exclusive flock(2) on
+// <dbPath>.migration.lock, mirroring keymanager_filelock.go's DEK lock (flock is
+// owned by the open file descriptor and released automatically by the kernel on
+// process exit/crash/kill -9 — no stale-lock/PID-liveness bookkeeping to get
+// wrong) and local_bootstrap_lock.go's cross-process critical-section pattern.
+//
+// Unlike keymanager_filelock.go's lock (which falls back to a blocking wait),
+// this is non-blocking ONLY: a second process racing to connect/migrate the same
+// local SQLite file must fail loud and fast at boot with an actionable error,
+// not hang indefinitely waiting on a lock that may never be released (e.g. a
+// wedged sibling process would otherwise stall this process's boot forever) —
+// matching this file's fail-loud-over-silently-degrading design convention
+// (warnIfDuplicatesExist, the invalid storage.type branch in CreateStorage,
+// etc.) rather than the blocking-with-a-log-line convention used for the DEK
+// lock, since a lock held here is expected to be brief (a single boot's connect
+// + migrate) rather than an operator-triggered rotate/migrate-provider run.
+//
+// dbPath is the raw storage.database.path value, which — per sqliteDSN's own
+// doc comment — may already carry DSN query parameters (an operator-supplied
+// "?_pragma=..." suffix) or denote a private/shared in-memory database
+// ("file:name?mode=memory[&cache=shared]" or ":memory:", both used throughout
+// this package's own test suite). Neither case names a real on-disk file this
+// lock can meaningfully protect:
+//   - a query-string suffix is not part of the actual filesystem path, so it is
+//     stripped before building the lock filename (otherwise the lock file's own
+//     name would embed literal "?"/"&" characters from the DSN);
+//   - an in-memory database is confined to the process (and, for a shared
+//     cache, the process's connection pool) that opened it by construction —
+//     there is no second OS process that could ever share it, so no lock is
+//     needed at all and none is taken (acquireSQLiteMigrationLock returns a
+//     nil lock and a nil error; release() on a nil lock is a no-op).
+func acquireSQLiteMigrationLock(dbPath string) (*sqliteMigrationLock, error) {
+	base := dbPath
+	if idx := strings.IndexByte(base, '?'); idx != -1 {
+		base = base[:idx]
+	}
+	if base == "" || base == ":memory:" || strings.Contains(dbPath, "mode=memory") {
+		return nil, nil
+	}
+
+	lockPath := base + sqliteMigrationLockSuffix
+	// #nosec G304 -- lockPath is derived from the operator-configured SQLite
+	// database path (storage.database.path), not attacker input.
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open SQLite migration lock file %s: %w", lockPath, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf(
+			"another process already holds the migration lock on %s — only one Keyorix process (server or CLI) may connect to/migrate a local SQLite database at a time; stop the other process before starting this one",
+			lockPath,
+		)
+	}
+	return &sqliteMigrationLock{f: f}, nil
+}

--- a/internal/storage/factory_sqlite_migration_lock_test.go
+++ b/internal/storage/factory_sqlite_migration_lock_test.go
@@ -1,0 +1,109 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAcquireSQLiteMigrationLock_SecondAttemptFails pins #STORAGE-FACTORY-003:
+// migrationMu (a sync.Mutex) only serializes migrateDatabase within a single OS
+// process; nothing previously stopped two separate OS processes pointed at the
+// same local SQLite file from racing DDL statements. This simulates a second
+// OS process by acquiring the lock a second time via a second, independent
+// open of the same lock file (an flock is scoped to the open file description,
+// not the process, so two separate os.OpenFile calls model two separate
+// processes for this purpose) while the first holder still has it, and asserts
+// the second attempt fails fast (non-blocking) with an actionable error rather
+// than hanging or silently succeeding.
+func TestAcquireSQLiteMigrationLock_SecondAttemptFails(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "concurrent-lock.db")
+
+	first, err := acquireSQLiteMigrationLock(dbPath)
+	require.NoError(t, err, "first acquisition must succeed")
+	defer first.release()
+
+	second, err := acquireSQLiteMigrationLock(dbPath)
+	require.Error(t, err, "a second, concurrent acquisition attempt must fail while the first holder still holds the lock")
+	assert.Nil(t, second)
+	assert.Contains(t, err.Error(), "already holds the migration lock")
+
+	// After the first holder releases, a subsequent acquisition must succeed —
+	// this is not a permanently stuck lock, just held for the duration of one
+	// process's connect-and-migrate critical section.
+	first.release()
+	third, err := acquireSQLiteMigrationLock(dbPath)
+	require.NoError(t, err, "acquisition must succeed again once the prior holder releases")
+	defer third.release()
+}
+
+// TestAcquireSQLiteMigrationLock_InMemoryDSN_SkipsLocking verifies that a
+// storage.database.path denoting an in-memory database — "file:name?mode=memory
+// [&cache=shared]" or ":memory:", both used throughout this package's own test
+// suite via sqliteDSN — does not attempt to create an on-disk lock file at all.
+// An in-memory database is confined to the process that opened it by
+// construction, so no cross-process lock is meaningful; naively appending
+// ".migration.lock" to the raw DSN string would otherwise create a garbage file
+// on disk whose name embeds literal "?"/"&"/":" characters from the DSN.
+func TestAcquireSQLiteMigrationLock_InMemoryDSN_SkipsLocking(t *testing.T) {
+	for _, dbPath := range []string{
+		"file:sometest?mode=memory&cache=shared",
+		"file:sometest?mode=memory",
+		":memory:",
+	} {
+		lock, err := acquireSQLiteMigrationLock(dbPath)
+		require.NoError(t, err, "in-memory DSN %q must not error", dbPath)
+		assert.Nil(t, lock, "in-memory DSN %q must not acquire a real lock", dbPath)
+		lock.release() // must be a safe no-op on a nil lock
+	}
+}
+
+// TestAcquireSQLiteMigrationLock_QueryStringStripped verifies that a real
+// on-disk path carrying an operator-supplied DSN query-string suffix (per
+// sqliteDSN's own doc comment: "the operator already supplied their own DSN
+// query parameters") builds its lock filename from the path portion only, not
+// the full DSN string — and that a plain path and its "?"-suffixed DSN form
+// correctly contend for the SAME lock (they name the same underlying file).
+func TestAcquireSQLiteMigrationLock_QueryStringStripped(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "operator-dsn.db")
+
+	first, err := acquireSQLiteMigrationLock(base + "?_pragma=foo(1)")
+	require.NoError(t, err)
+	defer first.release()
+
+	// The plain path (no query string) names the same file and must contend
+	// for the same lock.
+	_, err = acquireSQLiteMigrationLock(base)
+	require.Error(t, err, "the DSN-suffixed and plain forms of the same path must contend for the same lock")
+	assert.Contains(t, err.Error(), "already holds the migration lock")
+}
+
+// TestCreateStorage_SQLite_FailsWhenMigrationLockHeldByAnotherProcess exercises
+// the real production entry point: a second CreateStorage call against the same
+// local SQLite file, while a lock simulating another OS process already holding
+// the migration lock is in place, must fail loud at boot with an actionable
+// error instead of racing the first process's migration or hanging.
+func TestCreateStorage_SQLite_FailsWhenMigrationLockHeldByAnotherProcess(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	dbPath := filepath.Join(t.TempDir(), "boot-lock-held.db")
+
+	// Simulate another OS process already mid-migration by holding the lock
+	// directly, out of band from CreateStorage.
+	heldByOther, err := acquireSQLiteMigrationLock(dbPath)
+	require.NoError(t, err)
+	defer heldByOther.release()
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Database.Path = dbPath
+
+	_, err = NewStorageFactory().CreateStorage(cfg)
+	require.Error(t, err, "CreateStorage must fail loud, not hang or race, when another process already holds the migration lock")
+	assert.Contains(t, err.Error(), "already holds the migration lock")
+}

--- a/internal/storage/sqlitedialect/migrator.go
+++ b/internal/storage/sqlitedialect/migrator.go
@@ -78,6 +78,9 @@ func (m Migrator) HasColumn(value interface{}, name string) bool {
 func (m Migrator) AlterColumn(value interface{}, name string) error {
 	return m.RunWithoutForeignKey(func() error {
 		return m.recreateTable(value, nil, func(ddl *ddl, stmt *gorm.Statement) (*ddl, []interface{}, error) {
+			if stmt.Schema == nil {
+				return nil, nil, fmt.Errorf("failed to alter field with name %v: model with schema is required", name)
+			}
 			if field := stmt.Schema.LookUpField(name); field != nil {
 				var sqlArgs []interface{}
 				for i, f := range ddl.fields {

--- a/internal/storage/sqlitedialect/migrator.go
+++ b/internal/storage/sqlitedialect/migrator.go
@@ -160,6 +160,9 @@ func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {
 func (m Migrator) DropColumn(value interface{}, name string) error {
 	return m.RunWithoutForeignKey(func() error {
 		return m.recreateTable(value, nil, func(ddl *ddl, stmt *gorm.Statement) (*ddl, []interface{}, error) {
+			if stmt.Schema == nil {
+				return nil, nil, fmt.Errorf("failed to drop field with name %v: model with schema is required", name)
+			}
 			if field := stmt.Schema.LookUpField(name); field != nil {
 				name = field.DBName
 			}

--- a/internal/storage/sqlitedialect/migrator_test.go
+++ b/internal/storage/sqlitedialect/migrator_test.go
@@ -170,6 +170,27 @@ func TestMigrator_AlterColumn(t *testing.T) {
 	require.NoError(t, db.Create(&migratorTestModel{Name: "still-works", Score: 1}).Error)
 }
 
+// TestMigrator_AlterColumn_NilSchemaReturnsErrorNotPanic guards against a
+// nil-pointer panic in AlterColumn. Upstream gorm.io/driver/sqlite checks
+// stmt.Schema != nil before calling stmt.Schema.LookUpField; this fork's
+// AlterColumn was missing that guard. Every AutoMigrate call site in
+// internal/storage/factory.go passes a concrete struct pointer, so stmt.Schema
+// is always resolved in practice today — but AlterColumn is also reachable
+// directly via db.Migrator().AlterColumn(...), and passing a bare table-name
+// string (a value GORM can't resolve a schema for) must return a normal
+// error instead of crashing the process handling migrations.
+func TestMigrator_AlterColumn_NilSchemaReturnsErrorNotPanic(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	assert.NotPanics(t, func() {
+		err := m.AlterColumn("migrator_test_models", "Name")
+		require.Error(t, err, "AlterColumn with a schema-less value must return an error, not panic")
+		assert.Contains(t, err.Error(), "schema")
+	})
+}
+
 func TestMigrator_ColumnTypesAndTablesAndCurrentDatabase(t *testing.T) {
 	db := openTestDB(t)
 	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))

--- a/internal/storage/sqlitedialect/migrator_test.go
+++ b/internal/storage/sqlitedialect/migrator_test.go
@@ -191,6 +191,18 @@ func TestMigrator_AlterColumn_NilSchemaReturnsErrorNotPanic(t *testing.T) {
 	})
 }
 
+func TestMigrator_DropColumn_NilSchemaReturnsErrorNotPanic(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	assert.NotPanics(t, func() {
+		err := m.DropColumn("migrator_test_models", "Name")
+		require.Error(t, err, "DropColumn with a schema-less value must return an error, not panic")
+		assert.Contains(t, err.Error(), "schema")
+	})
+}
+
 func TestMigrator_ColumnTypesAndTablesAndCurrentDatabase(t *testing.T) {
 	db := openTestDB(t)
 	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))

--- a/internal/storage/storage_s22_test.go
+++ b/internal/storage/storage_s22_test.go
@@ -829,11 +829,12 @@ func TestMigrateDatabase_S22_DynConfig_ElseBranch(t *testing.T) {
 // TestWithMigrationLock_S22_SQLiteCallsFn exercises withMigrationLock with the
 // actual *gorm.DB parameter the function signature expects, on the non-Postgres path.
 func TestWithMigrationLock_S22_SQLiteCallsFn(t *testing.T) {
-	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "miglock2.db"))
+	dbPath := filepath.Join(t.TempDir(), "miglock2.db")
+	db, err := gormOpenForTest(t, dbPath)
 	require.NoError(t, err)
 
 	called := false
-	require.NoError(t, withMigrationLock(db, false, func(_ *gorm.DB) error {
+	require.NoError(t, withMigrationLock(db, false, dbPath, func(_ *gorm.DB) error {
 		called = true
 		return nil
 	}))
@@ -843,11 +844,12 @@ func TestWithMigrationLock_S22_SQLiteCallsFn(t *testing.T) {
 // TestWithMigrationLock_S22_PropagatesError verifies that an error returned by
 // the provided function is propagated out of withMigrationLock.
 func TestWithMigrationLock_S22_PropagatesError(t *testing.T) {
-	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "miglock-err.db"))
+	dbPath := filepath.Join(t.TempDir(), "miglock-err.db")
+	db, err := gormOpenForTest(t, dbPath)
 	require.NoError(t, err)
 
 	sentinel := fmt.Errorf("sentinel error from fn")
-	err = withMigrationLock(db, false, func(_ *gorm.DB) error {
+	err = withMigrationLock(db, false, dbPath, func(_ *gorm.DB) error {
 		return sentinel
 	})
 	require.ErrorIs(t, err, sentinel)

--- a/internal/storage/storage_s23_test.go
+++ b/internal/storage/storage_s23_test.go
@@ -247,11 +247,12 @@ func TestApplyPoolSettings_S23_AllThreeBranches(t *testing.T) {
 // TestWithMigrationLock_S23_FnReceivesDB verifies that the *gorm.DB passed to
 // withMigrationLock is forwarded to the callback on the non-Postgres path.
 func TestWithMigrationLock_S23_FnReceivesDB(t *testing.T) {
-	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "miglock-recv.db"))
+	dbPath := filepath.Join(t.TempDir(), "miglock-recv.db")
+	db, err := gormOpenForTest(t, dbPath)
 	require.NoError(t, err)
 
 	var received *gorm.DB
-	require.NoError(t, withMigrationLock(db, false, func(tx *gorm.DB) error {
+	require.NoError(t, withMigrationLock(db, false, dbPath, func(tx *gorm.DB) error {
 		received = tx
 		return nil
 	}))

--- a/internal/storage/storage_s24_test.go
+++ b/internal/storage/storage_s24_test.go
@@ -29,11 +29,12 @@ import (
 // TestWithMigrationLock_S24_FnErrorPropagates verifies that when isPostgres=false
 // and fn returns an error, withMigrationLock propagates that error to the caller.
 func TestWithMigrationLock_S24_FnErrorPropagates(t *testing.T) {
-	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "miglock-err.db"))
+	dbPath := filepath.Join(t.TempDir(), "miglock-err.db")
+	db, err := gormOpenForTest(t, dbPath)
 	require.NoError(t, err)
 
 	sentinel := errors.New("migration failed sentinel")
-	got := withMigrationLock(db, false, func(_ *gorm.DB) error {
+	got := withMigrationLock(db, false, dbPath, func(_ *gorm.DB) error {
 		return sentinel
 	})
 	require.ErrorIs(t, got, sentinel,
@@ -43,11 +44,12 @@ func TestWithMigrationLock_S24_FnErrorPropagates(t *testing.T) {
 // TestWithMigrationLock_S24_FnHappyPath verifies that when isPostgres=false and
 // fn succeeds, withMigrationLock returns nil.
 func TestWithMigrationLock_S24_FnHappyPath(t *testing.T) {
-	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "miglock-ok.db"))
+	dbPath := filepath.Join(t.TempDir(), "miglock-ok.db")
+	db, err := gormOpenForTest(t, dbPath)
 	require.NoError(t, err)
 
 	called := false
-	got := withMigrationLock(db, false, func(tx *gorm.DB) error {
+	got := withMigrationLock(db, false, dbPath, func(tx *gorm.DB) error {
 		called = true
 		assert.NotNil(t, tx)
 		return nil
@@ -60,14 +62,15 @@ func TestWithMigrationLock_S24_FnHappyPath(t *testing.T) {
 // withMigrationLock concurrently to exercise the migrationMu serialization path
 // without a real postgres server.
 func TestWithMigrationLock_S24_ConcurrentNonPostgres(t *testing.T) {
-	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "miglock-conc.db"))
+	dbPath := filepath.Join(t.TempDir(), "miglock-conc.db")
+	db, err := gormOpenForTest(t, dbPath)
 	require.NoError(t, err)
 
 	const goroutines = 4
 	errs := make(chan error, goroutines)
 	for i := 0; i < goroutines; i++ {
 		go func() {
-			errs <- withMigrationLock(db, false, func(_ *gorm.DB) error { return nil })
+			errs <- withMigrationLock(db, false, dbPath, func(_ *gorm.DB) error { return nil })
 		}()
 	}
 	for i := 0; i < goroutines; i++ {

--- a/internal/storage/storage_s27_test.go
+++ b/internal/storage/storage_s27_test.go
@@ -79,7 +79,7 @@ func TestWithMigrationLock_S27_PostgresPathErrorOnSQLite(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "mig-pg-path.db"))
 	require.NoError(t, err)
 
-	err = withMigrationLock(db, true, func(_ *gorm.DB) error { return nil })
+	err = withMigrationLock(db, true, "", func(_ *gorm.DB) error { return nil })
 	require.Error(t, err, "pg_advisory_lock does not exist on SQLite: must error")
 	assert.Contains(t, err.Error(), "acquire migration advisory lock")
 }
@@ -91,7 +91,7 @@ func TestWithMigrationLock_S27_PostgresPathFnNeverCalled(t *testing.T) {
 	require.NoError(t, err)
 
 	called := false
-	_ = withMigrationLock(db, true, func(_ *gorm.DB) error {
+	_ = withMigrationLock(db, true, "", func(_ *gorm.DB) error {
 		called = true
 		return nil
 	})

--- a/internal/storage/store/local_mfa_stepup_grant.go
+++ b/internal/storage/store/local_mfa_stepup_grant.go
@@ -1,6 +1,9 @@
 // local_mfa_stepup_grant.go — MFAStepUpGrant persistence for LocalStorage.
 // Each VerifyMFAStepUp call creates a new grant row; queries return the most
-// recent non-expired one. Expired rows are kept for audit purposes.
+// recent non-expired one. Expired rows are kept for audit purposes, bounded by
+// the PruneMFAStepUpGrants maintenance sweep (store-mfa-002) rather than kept
+// indefinitely — see internal/core.KeyorixCore.PruneMFAStepUpGrants and its
+// scheduler wiring in server/main.go (mfa_stepup_grant_prune).
 package store
 
 import (
@@ -35,4 +38,12 @@ func (ls *LocalStorage) DeleteMFAStepUpGrantsFor(ctx context.Context, userID uin
 	return ls.db.WithContext(ctx).
 		Where("user_id = ?", userID).
 		Delete(&models.MFAStepUpGrant{}).Error
+}
+
+// PruneMFAStepUpGrants deletes grants whose ExpiresAt predates `before` and
+// returns how many were removed (store-mfa-002 maintenance sweep — see
+// internal/core.KeyorixCore.PruneMFAStepUpGrants, the sole intended caller).
+func (ls *LocalStorage) PruneMFAStepUpGrants(ctx context.Context, before time.Time) (int64, error) {
+	res := ls.db.WithContext(ctx).Where("expires_at < ?", before).Delete(&models.MFAStepUpGrant{})
+	return res.RowsAffected, res.Error
 }

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -77,7 +77,15 @@ func (ls *LocalStorage) PurgeDeletedUsersBefore(ctx context.Context, before time
 		}
 		// ShareRecord carries its own DeletedAt (soft-delete) — Unscoped so this is a
 		// true hard delete, not another soft-deleted orphan nothing else purges.
-		if e := tx.Unscoped().Where("recipient_id IN (?) AND is_group = ?", stillEligible(), false).Delete(&models.ShareRecord{}).Error; e != nil {
+		// #store-purge-2: matches BOTH sides — recipient_id (shares the purged user
+		// RECEIVED) and owner_id (shares the purged user GRANTED to someone else).
+		// Only checking recipient_id left a share a purged user created for a
+		// still-active recipient fully live and functional indefinitely: the
+		// recipient's access grant survives (RecipientID still resolves to a real
+		// user) with no owner left to attribute, audit, or ever explicitly revoke
+		// it, and no account-lifecycle or access-review tooling keyed off active
+		// users would ever surface it for re-certification.
+		if e := tx.Unscoped().Where("(recipient_id IN (?) OR owner_id IN (?)) AND is_group = ?", stillEligible(), stillEligible(), false).Delete(&models.ShareRecord{}).Error; e != nil {
 			return e
 		}
 		if e := tx.Where(sqlWhereUserIDIn, stillEligible()).Delete(&models.PersonalAccessToken{}).Error; e != nil {

--- a/internal/storage/store/local_purge_test.go
+++ b/internal/storage/store/local_purge_test.go
@@ -118,6 +118,41 @@ func TestPurgeDeletedUsersBefore_CascadesSecretACL(t *testing.T) {
 	assert.Equal(t, int64(1), count, "a live user's SecretACL grant must survive")
 }
 
+// TestPurgeDeletedUsersBefore_CascadesShareRecordOwnerSide pins #store-purge-2:
+// the ShareRecord cleanup only matched recipient_id (shares the purged user
+// RECEIVED), never owner_id (shares the purged user GRANTED to someone else).
+// A share the purged user created for a still-active recipient survived the
+// purge as a dangling row with no owner left to attribute, audit, or revoke
+// it, while the recipient's access grant stayed fully live. A share owned AND
+// received by unrelated live users must still survive untouched.
+func TestPurgeDeletedUsersBefore_CascadesShareRecordOwnerSide(t *testing.T) {
+	ls := newPurgeTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	old := now.AddDate(0, 0, -40)
+	cutoff := now.AddDate(0, 0, -30)
+
+	require.NoError(t, ls.db.Create(&models.User{ID: 1, Username: "ghost-owner", Email: "g@x"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 2, Username: "recipient", Email: "r@x"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 3, Username: "live-owner", Email: "lo@x"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{ID: 4, Username: "live-recipient", Email: "lr@x"}).Error)
+	// Purged user 1 is the OWNER (not recipient) of a share granted to still-active user 2.
+	require.NoError(t, ls.db.Create(&models.ShareRecord{SecretID: 1, OwnerID: 1, RecipientID: 2, IsGroup: false}).Error)
+	// Control: a share entirely among live users must survive.
+	require.NoError(t, ls.db.Create(&models.ShareRecord{SecretID: 2, OwnerID: 3, RecipientID: 4, IsGroup: false}).Error)
+	require.NoError(t, ls.db.Unscoped().Model(&models.User{}).Where("id = ?", 1).Update("deleted_at", old).Error)
+
+	n, err := ls.PurgeDeletedUsersBefore(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	var count int64
+	require.NoError(t, ls.db.Unscoped().Model(&models.ShareRecord{}).Where("owner_id = ? AND is_group = ?", 1, false).Count(&count).Error)
+	assert.Zero(t, count, "a share the purged user GRANTED must be purged with them, not left dangling")
+	require.NoError(t, ls.db.Unscoped().Model(&models.ShareRecord{}).Where("secret_id = ?", 2).Count(&count).Error)
+	assert.Equal(t, int64(1), count, "a share entirely among live users must survive")
+}
+
 func TestPurgeDeletedProjectsAndEnvironments(t *testing.T) {
 	ls := newPurgeTestStore(t)
 	ctx := context.Background()

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -259,9 +259,16 @@ func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*
 	// Expired (time-bound) shares no longer authorize, so they must not surface in
 	// the "shared with me" listing either — filter them the same way the auth queries do.
 	now := time.Now()
+	// store-secret-acl-002: JOIN users ... deleted_at IS NULL mirrors the group query's
+	// user-liveness guard below (and CheckSharePermission's identical direct-share
+	// guard) — a soft-deleted recipient's direct ShareRecord row stays live for
+	// audit/restore, so without this guard a deleted user's own "shared with me"
+	// listing would keep surfacing secrets whose access CheckSharePermission already
+	// denies for that same account.
 	directQuery := fmt.Sprintf(`
 		SELECT s.* FROM secret_nodes s
 		JOIN share_records sr ON s.id = sr.secret_id
+		JOIN users u ON u.id = sr.recipient_id AND u.deleted_at IS NULL
 		WHERE sr.recipient_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL AND s.deleted_at IS NULL
 		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
 		LIMIT %d
@@ -325,22 +332,47 @@ func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, user
 	// secretOwnedBy helper (permissions.go) already carries this guard for its own
 	// callers, but this storage-layer check reimplemented the comparison independently
 	// — closing it here too rather than relying solely on callers validating userID != 0.
+	//
+	// store-secret-acl-002: a soft-deleted (deprovisioned) owner's account row stays
+	// live for audit/restore, and DeleteUser's session/token-cache invalidation runs on
+	// a separate code path whose propagation isn't instantaneous across instances — so
+	// the OwnerID==userID branch must independently verify the owner account is still
+	// active, exactly as the group-share branch below already verifies group-member
+	// liveness. Without this, a deleted owner's STRONGEST access path (owner-level
+	// "write") would outlive its WEAKEST (group share), which is already denied.
 	if secret.OwnerID != 0 && secret.OwnerID == userID {
-		return "write", nil
+		var ownerActive int64
+		if err := ls.db.Model(&models.User{}).
+			Where("id = ? AND deleted_at IS NULL", secret.OwnerID).
+			Count(&ownerActive).Error; err != nil {
+			return "", fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
+		}
+		if ownerActive > 0 {
+			return "write", nil
+		}
+		// Owner account soft-deleted: fall through to the direct/group share checks
+		// below instead of returning here — fail-closed, not fail-open.
 	}
 
 	// Skip expired (time-bound) shares — an expired share grants no permission.
 	now := time.Now()
+	// store-secret-acl-002: JOIN users ... deleted_at IS NULL mirrors the group-share
+	// query's user-liveness guard below — a soft-deleted recipient's direct
+	// ShareRecord row stays live for audit/restore, so without this guard a deleted
+	// user's direct share would keep granting access even though the equivalent
+	// group-share path already denies it for a deleted group member.
 	var directShare models.ShareRecord
-	haveDirect := false
-	err := ls.db.Where(
-		"secret_id = ? AND recipient_id = ? AND is_group = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
-		secretID, userID, false, now,
-	).First(&directShare).Error
-	if err == nil {
-		haveDirect = true
-	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
-		return "", fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
+	directQuery := `
+		SELECT sr.* FROM share_records sr
+		JOIN users u ON u.id = sr.recipient_id AND u.deleted_at IS NULL
+		WHERE sr.secret_id = ? AND sr.recipient_id = ? AND sr.is_group = ? AND sr.deleted_at IS NULL
+		  AND (sr.expires_at IS NULL OR sr.expires_at > ?)
+		LIMIT 1
+	`
+	dres := ls.db.Raw(directQuery, secretID, userID, false, now).Scan(&directShare)
+	haveDirect := dres.Error == nil && directShare.ID != 0
+	if dres.Error != nil && !errors.Is(dres.Error, gorm.ErrRecordNotFound) {
+		return "", fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), dres.Error)
 	}
 
 	// #G01: ug.project_id = 0 OR ug.project_id = ? (secret.ProjectID) — a

--- a/internal/storage/store/local_sharing_test.go
+++ b/internal/storage/store/local_sharing_test.go
@@ -465,6 +465,77 @@ func TestCheckSharePermission_ProjectScopedMembershipDoesNotCrossProjects(t *tes
 	}
 }
 
+// store-secret-acl-002: CheckSharePermission's owner-equality branch used to grant
+// owner-level "write" purely on secret.OwnerID == userID, with no check that the
+// owner account itself was still live — unlike the group-share branch, which already
+// JOINs users ... deleted_at IS NULL and denies a soft-deleted group member. A
+// deprovisioned owner's account row stays live for audit/restore (SCIM/DeleteUser
+// soft-delete), and DeleteUser's session/cache invalidation runs on a separate code
+// path whose propagation isn't instantaneous across instances, so this branch must
+// independently verify owner liveness — the same guard the group branch already has.
+func TestCheckSharePermission_SoftDeletedOwnerDeniesAccess(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner", Email: "o@x.io"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 300, Name: "s4", ProjectID: 1, EnvironmentID: 1, OwnerID: 1, Status: "active", Type: "password",
+	}).Error)
+
+	// While the owner is live, owner-equality grants "write".
+	perm, err := ls.CheckSharePermission(ctx, 300, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "write", perm, "a live owner must still get owner-level access")
+
+	// Soft-delete the owner's account (mirrors DeleteUser's user-row soft delete).
+	require.NoError(t, db.Delete(&models.User{}, 1).Error)
+
+	perm, err = ls.CheckSharePermission(ctx, 300, 1)
+	require.Error(t, err, "a soft-deleted owner must not retain owner-level access via OwnerID equality")
+	assert.Empty(t, perm)
+}
+
+// store-secret-acl-002: CheckSharePermission's direct-share query used to have no
+// user-liveness guard at all, unlike the group-share query's JOIN users ...
+// deleted_at IS NULL. A soft-deleted direct recipient's ShareRecord row stays live
+// for audit/restore, so without this guard a deleted user's direct share kept
+// granting access even though the equivalent group-share path already denied it for
+// a deleted group member (see TestGroupShare_SoftDeletedMemberExcluded). Also checks
+// ListSharedSecrets's identical direct-query gap, fixed for the same consistency
+// reason.
+func TestCheckSharePermission_SoftDeletedDirectRecipientDeniesAccess(t *testing.T) {
+	db := sharingConcurrentDB(t)
+	ls := NewLocalStorage(db)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner3", Email: "o3@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "grantee3", Email: "g3@x.io"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{
+		ID: 301, Name: "s5", ProjectID: 1, EnvironmentID: 1, OwnerID: 1, Status: "active", Type: "password",
+	}).Error)
+	_, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: 301, RecipientID: 2, IsGroup: false, OwnerID: 1, Permission: "write",
+	})
+	require.NoError(t, err)
+
+	// While the recipient is live, the direct share grants access.
+	perm, err := ls.CheckSharePermission(ctx, 301, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "write", perm, "a live direct recipient must still get the shared permission")
+	secrets, err := ls.ListSharedSecrets(ctx, 2)
+	require.NoError(t, err)
+	assert.Len(t, secrets, 1, "a live direct recipient must see the secret in their shared list")
+
+	// Soft-delete the recipient's account.
+	require.NoError(t, db.Delete(&models.User{}, 2).Error)
+
+	perm, err = ls.CheckSharePermission(ctx, 301, 2)
+	require.Error(t, err, "a soft-deleted direct recipient must not retain access via their ShareRecord")
+	assert.Empty(t, perm)
+	secrets, err = ls.ListSharedSecrets(ctx, 2)
+	require.NoError(t, err)
+	assert.Empty(t, secrets, "a soft-deleted direct recipient must not see the secret in their shared list")
+}
+
 // CWE-284 / sibling of #370: DeleteSecret must also delete SecretACL rows in the
 // same transaction so that ACL-based access cannot silently reactivate when the
 // secret is later restored from the recycle bin (the same class of bug fixed for

--- a/internal/storage/store/remote_mfa_stepup_grant.go
+++ b/internal/storage/store/remote_mfa_stepup_grant.go
@@ -111,3 +111,31 @@ func (rs *RemoteStorage) DeleteMFAStepUpGrantsFor(ctx context.Context, userID ui
 	}
 	return nil
 }
+
+// mfaStepUpGrantPruneWire is the request body for PruneMFAStepUpGrants.
+type mfaStepUpGrantPruneWire struct {
+	Before time.Time `json:"before"`
+}
+
+// PruneMFAStepUpGrants removes expired MFA step-up grant rows via
+// POST /api/v1/system/mfa/stepup-grants/prune (store-mfa-002 maintenance
+// sweep). The upstream handler re-derives/clamps the effective cutoff itself
+// (mirroring PruneLoginAttemptsProxy's CORE-RATE-003 defense) rather than
+// trusting `before` verbatim, so this passthrough is safe even though `before`
+// crosses the wire.
+func (rs *RemoteStorage) PruneMFAStepUpGrants(ctx context.Context, before time.Time) (int64, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/mfa/stepup-grants/prune", mfaStepUpGrantPruneWire{Before: before})
+	if err != nil {
+		return 0, fmt.Errorf("failed to prune MFA step-up grants: %w", err)
+	}
+	if !resp.Success {
+		return 0, fmt.Errorf("prune MFA step-up grants failed: %s", resp.Error.Error())
+	}
+	var result struct {
+		Deleted int64 `json:"deleted"`
+	}
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return 0, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Deleted, nil
+}

--- a/migrations/010_fix_share_status_soft_delete_sync.down.sql
+++ b/migrations/010_fix_share_status_soft_delete_sync.down.sql
@@ -1,0 +1,14 @@
+-- Revert 010_fix_share_status_soft_delete_sync.up.sql: drop the corrective
+-- soft-delete trigger, restoring the original (stale) behaviour where
+-- secret_nodes.is_shared only recomputes on a raw SQL DELETE from
+-- share_records, not on the GORM soft delete the application actually
+-- issues.
+--
+-- WARNING: this reintroduces the gap that migrations-003 (this migration's
+-- own up-migration) fixes -- is_shared will again fail to flip back to
+-- FALSE when every share on a secret is revoked via the application's real
+-- DeleteShareRecord/DeleteExpiredShareRecords paths. This down-migration
+-- exists only for symmetry with the rest of this directory's reversible
+-- migrations (see migrations/README.md); do not apply it to a production
+-- database without understanding that it reintroduces the finding.
+DROP TRIGGER IF EXISTS update_secret_shared_status_soft_delete;

--- a/migrations/010_fix_share_status_soft_delete_sync.up.sql
+++ b/migrations/010_fix_share_status_soft_delete_sync.up.sql
@@ -1,0 +1,39 @@
+-- Corrective migration: keep secret_nodes.is_shared synchronized with real
+-- share revocations performed through a soft delete, not just a raw SQL
+-- DELETE.
+--
+-- 005_secret_sharing.up.sql's update_secret_shared_status_delete trigger
+-- fires AFTER DELETE ON share_records and recomputes secret_nodes.is_shared.
+-- But share_records has its own deleted_at soft-delete column, and the
+-- application's actual revoke/expiry paths (internal/storage/store/
+-- local_sharing.go's DeleteShareRecord and DeleteExpiredShareRecords) both
+-- perform a GORM soft delete -- an UPDATE setting deleted_at -- never a raw
+-- SQL DELETE, by that file's own doc comments. So the AFTER DELETE trigger
+-- never fires under normal application usage: once a secret is shared
+-- (is_shared flips to TRUE via the sibling AFTER INSERT trigger, which DOES
+-- fire on GORM Create) and every share on it is later revoked, is_shared
+-- never flips back to FALSE.
+--
+-- Per migrations/README.md, GORM AutoMigrate is the live, authoritative
+-- schema mechanism, and it never creates or manages SQL triggers -- it only
+-- adds missing tables/columns/indexes. A fresh/AutoMigrate-only install
+-- never runs these legacy *.sql files at all, so it never has either
+-- trigger (or this bug) in the first place. This migration only matters for
+-- a database originally bootstrapped from migrations 001-005 (before
+-- AutoMigrate existed): AutoMigrate being additive-only means it can never
+-- retire that database's stale 005 trigger, so the gap persists forever on
+-- such a database unless corrected here -- the same reasoning
+-- 009_fix_auditor_audit_admin_overgrant applied to the legacy 001-003 seed
+-- data.
+--
+-- Fix: add a trigger that also fires on the soft-delete UPDATE path and
+-- recomputes is_shared the same way the existing AFTER DELETE trigger does.
+-- That AFTER DELETE trigger is left in place -- harmless, and still correct
+-- if a hard DELETE is ever issued directly against share_records.
+CREATE TRIGGER update_secret_shared_status_soft_delete
+AFTER UPDATE OF deleted_at ON share_records
+BEGIN
+    UPDATE secret_nodes SET is_shared = (
+        SELECT EXISTS(SELECT 1 FROM share_records WHERE secret_id = NEW.secret_id AND deleted_at IS NULL)
+    ) WHERE id = NEW.secret_id;
+END;

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -658,3 +658,152 @@ func TestFixAuditorAuditAdminOvergrantDownMigration(t *testing.T) {
 		t.Fatalf("auditor permissions after up+down = %v, want 'audit.admin' restored by the down-migration", perms)
 	}
 }
+
+// seedSharedSecretForStatusSyncTest seeds one owner, one recipient, and one
+// secret shared between them (share_records row id=1, secret_nodes row
+// id=1). 005_secret_sharing.up.sql's AFTER INSERT trigger fires on the
+// share_records insert below and sets secret_nodes.is_shared to TRUE, so
+// callers start from a known "currently shared" state.
+func seedSharedSecretForStatusSyncTest(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	if _, err := db.Exec(
+		`INSERT INTO users (username, email, password_hash) VALUES ('owner1', 'owner1@example.com', 'x')`,
+	); err != nil {
+		t.Fatalf("seed users (owner): %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO users (username, email, password_hash) VALUES ('recipient1', 'recipient1@example.com', 'x')`,
+	); err != nil {
+		t.Fatalf("seed users (recipient): %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO namespaces (name) VALUES ('ns1')`); err != nil {
+		t.Fatalf("seed namespaces: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO zones (name) VALUES ('zone1')`); err != nil {
+		t.Fatalf("seed zones: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO environments (name) VALUES ('env1')`); err != nil {
+		t.Fatalf("seed environments: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO secret_nodes (namespace_id, zone_id, environment_id, name, is_secret, type, created_by, owner_id)
+		 VALUES (1, 1, 1, 's1', 1, 'secret', 'owner1', 1)`,
+	); err != nil {
+		t.Fatalf("seed secret_nodes: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO share_records (secret_id, owner_id, recipient_id, is_group, permission, created_at, updated_at)
+		 VALUES (1, 1, 2, 0, 'read', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+	); err != nil {
+		t.Fatalf("seed share_records: %v", err)
+	}
+}
+
+// softDeleteShareRecord mirrors what internal/storage/store/local_sharing.go's
+// DeleteShareRecord and DeleteExpiredShareRecords actually issue via GORM
+// against a ShareRecord (whose DeletedAt field is a gorm.DeletedAt soft-delete
+// column): an UPDATE setting deleted_at, never a raw SQL DELETE.
+func softDeleteShareRecord(t *testing.T, db *sql.DB, id int) {
+	t.Helper()
+
+	if _, err := db.Exec(`UPDATE share_records SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?`, id); err != nil {
+		t.Fatalf("soft-delete share_records id=%d: %v", id, err)
+	}
+}
+
+func assertSecretIsShared(t *testing.T, db *sql.DB, secretID int, want bool) {
+	t.Helper()
+
+	var isShared bool
+	if err := db.QueryRow(`SELECT is_shared FROM secret_nodes WHERE id = ?`, secretID).Scan(&isShared); err != nil {
+		t.Fatalf("query secret_nodes.is_shared for id=%d: %v", secretID, err)
+	}
+	if isShared != want {
+		t.Fatalf("secret_nodes.is_shared for id=%d = %v, want %v", secretID, isShared, want)
+	}
+}
+
+// TestShareStatusStaleAfterSoftDeleteBefore010 pins migrations-003: applying
+// only 005 (the historical bootstrap set this migration's fix targets, per
+// migrations/README.md), revoking the only share on a secret through the
+// application's real GORM soft-delete path leaves secret_nodes.is_shared
+// incorrectly TRUE, because 005's update_secret_shared_status_delete trigger
+// only fires on a raw SQL DELETE, which the application never issues. This is
+// a non-regression check on 005 itself: it must show the bug exists before
+// 010 is applied, so the corrective migration below has something real to
+// fix.
+func TestShareStatusStaleAfterSoftDeleteBefore010(t *testing.T) {
+	db := openTestDB(t)
+	execSQLFile(t, db, "005_secret_sharing.up.sql")
+
+	seedSharedSecretForStatusSyncTest(t, db)
+	assertSecretIsShared(t, db, 1, true)
+
+	softDeleteShareRecord(t, db, 1)
+
+	// This pins the documented bug pre-010: the AFTER DELETE trigger never
+	// fires for a soft delete, so is_shared incorrectly stays TRUE even
+	// though the secret's only share was just revoked.
+	assertSecretIsShared(t, db, 1, true)
+}
+
+// TestFixShareStatusSoftDeleteSyncMigration pins the fix for migrations-003:
+// after applying the corrective 010_fix_share_status_soft_delete_sync
+// migration on top of 005, revoking a secret's only share through the
+// application's real GORM soft-delete path correctly flips
+// secret_nodes.is_shared back to FALSE.
+func TestFixShareStatusSoftDeleteSyncMigration(t *testing.T) {
+	db := openTestDB(t)
+	execSQLFile(t, db, "005_secret_sharing.up.sql")
+	execSQLFile(t, db, "010_fix_share_status_soft_delete_sync.up.sql")
+
+	seedSharedSecretForStatusSyncTest(t, db)
+	assertSecretIsShared(t, db, 1, true)
+
+	softDeleteShareRecord(t, db, 1)
+
+	// Regression fix: is_shared must flip back to FALSE once the only share
+	// on the secret has been soft-deleted.
+	assertSecretIsShared(t, db, 1, false)
+
+	// Non-regression: a secret that still has an active share must remain
+	// marked as shared after some OTHER share on it is revoked.
+	if _, err := db.Exec(
+		`INSERT INTO share_records (secret_id, owner_id, recipient_id, is_group, permission, created_at, updated_at)
+		 VALUES (1, 1, 2, 0, 'read', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+	); err != nil {
+		t.Fatalf("seed second share_records row: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO share_records (secret_id, owner_id, recipient_id, is_group, permission, created_at, updated_at)
+		 VALUES (1, 1, 2, 0, 'read', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+	); err != nil {
+		t.Fatalf("seed third share_records row: %v", err)
+	}
+	assertSecretIsShared(t, db, 1, true)
+	softDeleteShareRecord(t, db, 2)
+	assertSecretIsShared(t, db, 1, true)
+}
+
+// TestFixShareStatusSoftDeleteSyncDownMigration pins that the down-migration
+// correctly reverts the correction: reapplying it restores the original
+// (stale) behaviour where a soft-deleted share no longer flips is_shared back
+// to FALSE. This is deliberate symmetry with the rest of this directory's
+// reversible migrations, not an endorsement of running the down-migration in
+// production.
+func TestFixShareStatusSoftDeleteSyncDownMigration(t *testing.T) {
+	db := openTestDB(t)
+	execSQLFile(t, db, "005_secret_sharing.up.sql")
+	execSQLFile(t, db, "010_fix_share_status_soft_delete_sync.up.sql")
+	execSQLFile(t, db, "010_fix_share_status_soft_delete_sync.down.sql")
+
+	seedSharedSecretForStatusSyncTest(t, db)
+	assertSecretIsShared(t, db, 1, true)
+
+	softDeleteShareRecord(t, db, 1)
+
+	// After up+down, the corrective trigger is gone again -- the original
+	// stale is_shared bug is restored.
+	assertSecretIsShared(t, db, 1, true)
+}

--- a/server/http/handlers/mfa_stepup_proxy.go
+++ b/server/http/handlers/mfa_stepup_proxy.go
@@ -1,6 +1,7 @@
 // mfa_stepup_proxy.go — server-side endpoints backing RemoteStorage's
 // MFAStepUpGrant storage primitives:
-// CreateMFAStepUpGrant / GetActiveMFAStepUpGrant / DeleteMFAStepUpGrantsFor.
+// CreateMFAStepUpGrant / GetActiveMFAStepUpGrant / DeleteMFAStepUpGrantsFor /
+// PruneMFAStepUpGrants.
 //
 // A downstream Keyorix server booted with storage.type: remote (ADR-049)
 // proxies these calls to this server's real storage backend so that the MFA
@@ -111,4 +112,41 @@ func (h *AuthHandler) DeleteMFAStepUpGrantsForProxy(w http.ResponseWriter, r *ht
 		return
 	}
 	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}
+
+// mfaStepUpGrantPruneBody is the wire body for POST /api/v1/system/mfa/stepup-grants/prune.
+type mfaStepUpGrantPruneBody struct {
+	Before time.Time `json:"before"`
+}
+
+// PruneMFAStepUpGrantsProxy handles POST /api/v1/system/mfa/stepup-grants/prune
+// (store-mfa-002). Mirrors login_attempts_proxy.go's PruneLoginAttemptsProxy
+// (CORE-RATE-003): deliberately does NOT call
+// h.coreService.Storage().PruneMFAStepUpGrants directly with the request
+// body's `before` — that value is attacker/caller-influenced (any
+// system.write / node-credential principal), and an unbounded passthrough
+// would let a caller wipe the entire mfa_stepup_grants table on demand. It
+// routes through core.KeyorixCore.PruneMFAStepUpGrants instead, which clamps
+// the effective cutoff to the configured/default retention window so a
+// caller can only narrow the deletion window, never widen it.
+func (h *AuthHandler) PruneMFAStepUpGrantsProxy(w http.ResponseWriter, r *http.Request) {
+	var body mfaStepUpGrantPruneBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
+		return
+	}
+	if body.Before.IsZero() {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "before is required")
+		return
+	}
+	// retention=0: this upstream server uses its own configured/default
+	// retention window (see core.KeyorixCore.PruneMFAStepUpGrants), not one
+	// dictated by the downstream caller.
+	n, err := h.coreService.PruneMFAStepUpGrants(r.Context(), 0, body.Before)
+	if err != nil {
+		log.Printf("mfa stepup proxy: prune failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]int64{"deleted": n})
 }

--- a/server/http/handlers/project_mfa_aggregate_test.go
+++ b/server/http/handlers/project_mfa_aggregate_test.go
@@ -68,6 +68,7 @@ func newHTTPMFAAggregateTestRig(t *testing.T) *httpMFAAggregateTestRig {
 	}).Error)
 
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "auditor", Email: "auditor@example.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "recipient", Email: "recipient@example.com"}).Error)
 	require.NoError(t, db.Create(&models.ShareRecord{SecretID: 1, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}).Error)
 	require.NoError(t, db.Create(&models.ShareRecord{SecretID: 2, OwnerID: 1, RecipientID: 2, IsGroup: false, Permission: "read"}).Error)
 

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1892,10 +1892,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// MFAStepUpGrant proxy — lets a RemoteStorage spoke node persist and
 			// query step-up grants against this server's real storage backend, so
 			// the classification gate works correctly under storage.type: remote.
-			// Static sub-path ("stepup-grants/active") is registered before the
-			// {userId} wildcard to avoid route shadowing.
+			// Static sub-paths ("stepup-grants/active", "stepup-grants/prune") are
+			// registered before the {userId} wildcard to avoid route shadowing.
+			// stepup-grants/prune (store-mfa-002) backs the periodic maintenance
+			// sweep (mfa_stepup_grant_prune scheduler, server/main.go) that bounds
+			// retention of expired grant rows.
 			r.Post("/mfa/stepup-grants", authHandler.CreateMFAStepUpGrantProxy)
 			r.Post("/mfa/stepup-grants/active", authHandler.GetActiveMFAStepUpGrantProxy)
+			r.Post("/mfa/stepup-grants/prune", authHandler.PruneMFAStepUpGrantsProxy)
 			r.Delete("/mfa/stepup-grants/{userId}", authHandler.DeleteMFAStepUpGrantsForProxy)
 
 			// Project/environment catalog CRUD storage-primitive proxy (finding #528).

--- a/server/main.go
+++ b/server/main.go
@@ -205,22 +205,23 @@ func main() { // NOSONAR -- cognitive complexity 22, suppress go:S3776
 // namespaced to each background job, so on PostgreSQL only one replica runs a
 // given scheduler per tick. Distinct from the audit-chain key (0x4B455941_55444954).
 const (
-	schedLockAnomaly      int64 = 0x4B455953_414E4F4D // "KEYSANOM"
-	schedLockPurge        int64 = 0x4B455953_50555247 // "KEYSPURG"
-	schedLockDynamicSweep int64 = 0x4B455953_44594E53 // "KEYSDYNS"
-	schedLockLoginPrune   int64 = 0x4B455953_4C474E50 // "KEYSLGNP"
-	schedLockRotationRmdr int64 = 0x4B455953_524F5452 // "KEYSROTR"
-	schedLockExpiryRmdr   int64 = 0x4B455953_45585052 // "KEYSEXPR"
-	schedLockCertExpiry   int64 = 0x4B455953_43455254 // "KEYSCERT"
-	schedLockAutoRotate   int64 = 0x4B455953_4155544F // "KEYSAUTO"
-	schedLockAuditCkpt    int64 = 0x4B455953_41434B50 // "KEYSACKP"
-	schedLockJITExpiry    int64 = 0x4B455953_4A495445 // "KEYSJITE"
-	schedLockRetention    int64 = 0x4B455953_52455445 // "KEYSRETE"
-	schedLockEvidence     int64 = 0x4B455953_45564944 // "KEYSEVID"
-	schedLockRecertify    int64 = 0x4B455953_52454354 // "KEYSRECT"
-	schedLockDigest       int64 = 0x4B455953_44494753 // "KEYSDIGS"
-	schedLockLicenseExp   int64 = 0x4B455953_4C494345 // "KEYSLICE"
-	schedLockReadQuota    int64 = 0x4B455953_52445154 // "KEYSRDQT"
+	schedLockAnomaly       int64 = 0x4B455953_414E4F4D // "KEYSANOM"
+	schedLockPurge         int64 = 0x4B455953_50555247 // "KEYSPURG"
+	schedLockDynamicSweep  int64 = 0x4B455953_44594E53 // "KEYSDYNS"
+	schedLockLoginPrune    int64 = 0x4B455953_4C474E50 // "KEYSLGNP"
+	schedLockRotationRmdr  int64 = 0x4B455953_524F5452 // "KEYSROTR"
+	schedLockExpiryRmdr    int64 = 0x4B455953_45585052 // "KEYSEXPR"
+	schedLockCertExpiry    int64 = 0x4B455953_43455254 // "KEYSCERT"
+	schedLockAutoRotate    int64 = 0x4B455953_4155544F // "KEYSAUTO"
+	schedLockAuditCkpt     int64 = 0x4B455953_41434B50 // "KEYSACKP"
+	schedLockJITExpiry     int64 = 0x4B455953_4A495445 // "KEYSJITE"
+	schedLockRetention     int64 = 0x4B455953_52455445 // "KEYSRETE"
+	schedLockEvidence      int64 = 0x4B455953_45564944 // "KEYSEVID"
+	schedLockRecertify     int64 = 0x4B455953_52454354 // "KEYSRECT"
+	schedLockDigest        int64 = 0x4B455953_44494753 // "KEYSDIGS"
+	schedLockLicenseExp    int64 = 0x4B455953_4C494345 // "KEYSLICE"
+	schedLockReadQuota     int64 = 0x4B455953_52445154 // "KEYSRDQT"
+	schedLockMFAGrantPrune int64 = 0x4B455953_4D464147 // "KEYSMFAG"
 )
 
 // initializeEncryption sources the KEK per the configured key provider (ADR-038)
@@ -1379,6 +1380,31 @@ func startSchedulers(ctx context.Context, cfg *config.Config, coreService *core.
 			// removed) reads as "system", not the default "user".
 			sysCtx := core.WithActorType(ctx, core.ActorTypeSystem)
 			_, perr := coreService.PruneLoginAttempts(sysCtx, time.Time{}, 0)
+			return perr
+		})
+	})
+
+	// Prune expired MFA step-up grant rows every 6 hours (store-mfa-002). Each
+	// successful VerifyMFAStepUp creates a new MFAStepUpGrant row, kept briefly
+	// past its own expiry for audit purposes (internal/storage/store/
+	// local_mfa_stepup_grant.go) — with no sweep, every legitimate
+	// re-verification left a permanent row (DeleteMFAStepUpGrantsFor exists but
+	// is only reachable via the RemoteStorage proxy, never called from a local
+	// maintenance path). Like login_attempt_prune above, this ALWAYS runs — not
+	// legal-hold-gated: a grant row's CREATION is already permanently,
+	// independently audited (mfa.stepup_verified, never purged — ADR-029), so
+	// pruning the row itself never destroys evidence, only a redundant
+	// operational copy, and letting a long-running legal hold block this would
+	// just grow the table unbounded for no compliance benefit. Retention
+	// defaults to 30 days (config classification.mfa_stepup_grant_retention_days,
+	// mirroring SoftDeleteConfig's default) — much looser than the 15-minute
+	// cadence/window ratio login_attempt_prune uses, since grant rows are
+	// created far less often (once per MFA step-up verification, not once per
+	// rate-limit check).
+	mfaGrantRetention := time.Duration(cfg.Classification.GetMFAStepUpGrantRetentionDays()) * 24 * time.Hour
+	runScheduler(ctx, "mfa_stepup_grant_prune", 6*time.Hour, func() middleware.SchedulerOutcome {
+		return lockedRun(ctx, coreService.Storage(), schedLockMFAGrantPrune, "MFA step-up grant prune", func() error {
+			_, perr := coreService.PruneMFAStepUpGrants(ctx, mfaGrantRetention, time.Time{})
 			return perr
 		})
 	})

--- a/server/mfa_stepup_grant_prune_scheduler_test.go
+++ b/server/mfa_stepup_grant_prune_scheduler_test.go
@@ -1,0 +1,87 @@
+// mfa_stepup_grant_prune_scheduler_test.go — store-mfa-002: confirms
+// startSchedulers actually wires up and calls PruneMFAStepUpGrants, not just
+// that PruneMFAStepUpGrants itself works (covered at the core layer in
+// internal/core/mfa_stepup_grant_prune_test.go). Follows the same direct-call
+// convention server_s27_test.go's TestStartSchedulers_S27_AnomalyOffHoursNumeric
+// established for exercising a startSchedulers branch without a full HTTP
+// listener.
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// TestStartSchedulers_MFAStepUpGrantPrune_RemovesExpiredRow seeds a grant row
+// expired well past the default 30-day retention window and one that is not
+// expired at all, starts the real scheduler set, waits for the immediate
+// first tick, then confirms: the long-expired row is gone (a follow-up manual
+// prune call finds nothing left to remove) and the unexpired row survives.
+func TestStartSchedulers_MFAStepUpGrantPrune_RemovesExpiredRow(t *testing.T) {
+	initI18n(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cfg := &config.Config{
+		Storage: config.StorageConfig{
+			Type:     "local",
+			Database: config.DatabaseConfig{Path: "mfa_grant_prune_scheduler.db"},
+		},
+	}
+	coreService := mustInitCoreService(t, cfg)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	if err := coreService.Storage().CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
+		UserID:    1,
+		ExpiresAt: now.Add(-400 * 24 * time.Hour), // long expired, past any sane retention
+	}); err != nil {
+		t.Fatalf("seed long-expired grant: %v", err)
+	}
+	if err := coreService.Storage().CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
+		UserID:    2,
+		ExpiresAt: now.Add(time.Hour), // not expired at all
+	}); err != nil {
+		t.Fatalf("seed unexpired grant: %v", err)
+	}
+
+	schedCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startSchedulers(schedCtx, cfg, coreService)
+
+	// startSchedulers only wires up the scheduler goroutines and returns
+	// immediately; give the mfa_stepup_grant_prune scheduler's first
+	// (immediate) tick a moment to run.
+	deadline := time.Now().Add(2 * time.Second)
+	var oldGone bool
+	for time.Now().Before(deadline) {
+		// A wide manual prune (cutoff = now) removes anything still present
+		// that expired before now. If the scheduler already removed the old
+		// row, this returns 0.
+		n, err := coreService.Storage().PruneMFAStepUpGrants(ctx, now)
+		if err != nil {
+			t.Fatalf("manual verification prune: %v", err)
+		}
+		if n == 0 {
+			oldGone = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !oldGone {
+		t.Fatal("mfa_stepup_grant_prune scheduler did not remove the long-expired grant row within the deadline")
+	}
+
+	// The unexpired grant must never have been touched.
+	active, err := coreService.HasActiveMFAStepUp(ctx, 2)
+	if err != nil {
+		t.Fatalf("HasActiveMFAStepUp: %v", err)
+	}
+	if !active {
+		t.Fatal("the unexpired grant must survive the prune sweep")
+	}
+}


### PR DESCRIPTION
## Summary

Second batch of the Wave 6 low/info-severity remediation (adversarial security review, 2026-08-07/08).

- **`rolePKIsComplete`'s fragile SQLite DDL text-match** (`internal/storage/factory.go`): the RBAC Phase-2 composite-primary-key rebuild check matched `project_id`/`environment_id` against everything after the first `"primary key"` substring in the raw `CREATE TABLE` text — a false positive (columns mentioned outside the actual PK clause, e.g. in a trailing CHECK/FK constraint) would silently skip the rebuild and degrade project/environment-scoped RBAC to a single global grant per (user, role). Replaced with a `pragma_table_info`-based query against the actually-parsed schema.
- **No cross-process lock on local SQLite migrations** (`internal/storage/factory.go`): the existing `migrationMu` only serializes within one OS process; nothing stopped two Keyorix processes (a misconfigured multi-replica deployment, or a CLI tool run concurrently with a live server) from racing DDL against the same SQLite file. Added a non-blocking `flock(2)` sidecar lock, mirroring the existing DEK-lock/bootstrap-lock pattern, failing loud and fast rather than hanging or corrupting the database.
- **`ensureReminderNotificationDedupIndex` skipped the pre-flight duplicate check** every sibling `ensure*Index` helper performs, so a pre-existing duplicate surfaced an opaque driver error instead of the file's usual actionable message — now consistent with its siblings.
- **`sqlitedialect.Migrator.AlterColumn`/`DropColumn` missing nil-Schema guards** (`internal/storage/sqlitedialect/migrator.go`, a fork of `gorm.io/driver/sqlite`): both called `stmt.Schema.LookUpField` without checking for nil first, unlike upstream and unlike their own already-guarded siblings — not reachable via any current `AutoMigrate` call site, but would turn a future direct `db.Migrator().AlterColumn(...)`/`DropColumn(...)` call with an unresolvable value into a process-crashing panic instead of a normal error.
- **`PurgeDeletedUsersBefore` only purged `ShareRecord` rows a deleted user received, not ones they granted** (`internal/storage/store/local_purge.go`): a share a since-purged user created for a still-active recipient survived indefinitely with no owner left to attribute, audit, or revoke it. Extended the existing delete to cover both sides, re-checked against the same live-eligibility subquery already used elsewhere in this function.
- **`CheckSharePermission`'s owner and direct-share paths had no deleted-user guard** (`internal/storage/store/local_sharing.go`), unlike its group-share path, which already required the recipient's `users` row to be live — a deleted account's strongest access paths (ownership, direct share) could outlive its weakest (group share) during cache-invalidation propagation windows. Added the same guard to both paths, plus `ListSharedSecrets`' equivalent direct-query path for consistency.
- **`share_records`'s `AFTER DELETE` trigger never fires under normal application usage** (`migrations/005_secret_sharing.up.sql`): the app's real revoke paths perform a GORM soft delete, never a raw SQL `DELETE`, so `secret_nodes.is_shared` never flips back to `FALSE` once every share is revoked. Confirmed this only affects databases bootstrapped from the legacy 001-005 migrations (a fresh/AutoMigrate-only install never has this trigger or the bug at all — GORM never manages SQL triggers), added migration `010` with a companion trigger firing on the soft-delete path too, following the same discipline as the earlier `009` corrective migration in this directory.
- **`MFAStepUpGrant` rows accumulated indefinitely with no pruning path**: every successful MFA re-verification left a permanent row with nothing to bound retention (unlike `LoginAttempt`, which has an explicit maintenance sweep). Added `PruneMFAStepUpGrants` (core + both storage backends + proxy route), wired into a new scheduler job, with a configurable 30-day-default retention window. **Also fixes a real, independently-discovered production bug found while testing this fix**: `models.MFAStepUpGrant` was never included in `internal/storage/factory.go`'s `AutoMigrate` list at all — the `mfa_step_up_grants` table was never created against a real (non-test-harness) database, so `VerifyMFAStepUp`, the classification MFA gate, and this new prune sweep would all fail with "no such table" in production. Added it to the existing bulk migration list.

## Cross-fix regression caught and fixed

Running the full combined test suite surfaced one real regression: the sharing-liveness-guard fix's new recipient-liveness JOIN in `ListSharedSecrets` correctly started requiring a live `users` row for the recipient — which exposed that an unrelated existing test (`TestListSharedSecrets_DeniesGlobalScopeMFABypass`, `server/http/handlers/project_mfa_aggregate_test.go`) never created a `models.User` row for its recipient ID, unlike its own documented gRPC sibling test, which does. Fixed the fixture to match (confirmed the gRPC sibling's convention is correct); the underlying MFA-gate behavior itself was never broken, only this one test's setup.

## Verification

Each fix independently re-verified from a fresh worktree before integration (build/vet/gofmt/gosec/relevant suites, several with pre-fix-failure proof via scoped `git stash`, one with a full `-race` pass given its concurrency-lock changes), then cherry-picked (`-x`) onto one branch off current `main` — one clean auto-merge (`internal/storage/factory.go`, migration-lock changes composing with the new `AutoMigrate` entry), no conflicts.

Combined verification on the integrated branch:
- `go build ./...`, `go vet ./...`, `gofmt -l` — all clean
- `gosec -severity medium -exclude-generated` — 0 issues (800 files)
- Full `go test ./...` — only the established pre-existing `server/http` `RealServer`/`CSV_Headers`/`SetupToken` failures (unrelated to this batch, confirmed identical against unmodified `main` throughout this campaign)

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] Full `go test ./...` — no new failures vs. baseline (after fixing the one cross-fix test-fixture gap found)
- [ ] CI: lint, gitleaks, build-and-test