### PR TITLE
fix(security): close Wave 6 low/info batch 3 (gRPC + handlers authz gaps)

### DIFF
--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -458,7 +458,7 @@ func (c *KeyorixCore) requireMachinePrivilegeCeiling(ctx context.Context, actorI
 		return fmt.Errorf("failed to verify actor authority: %w", err)
 	}
 	if !isAdmin {
-		return fmt.Errorf("issuing a token for a machine identity that holds administrative roles requires administrative authority")
+		return fmt.Errorf("%w: issuing a token for a machine identity that holds administrative roles requires administrative authority", ErrMachinePrivilegeCeilingDenied)
 	}
 	return nil
 }

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -93,4 +93,16 @@ var (
 	// err.Error() (which the dynamic %s/%d detail appended to each of these
 	// errors would make spoofable by anything that can influence that detail).
 	ErrAuditCheckpointRefused = errors.New("refusing to checkpoint")
+
+	// ErrMachinePrivilegeCeilingDenied is returned by requireMachinePrivilegeCeiling
+	// (MACH-001) when a non-admin actor tries to issue a token for a machine identity
+	// that holds admin-tier roles — the token would inherit those roles, so issuing
+	// one is equivalent to granting the actor administrative authority. Callers use
+	// errors.Is against this sentinel (server/grpc/services.mapMachineError) instead
+	// of substring-matching err.Error(), so this deliberate, terminal authorization
+	// denial is classified as codes.PermissionDenied rather than falling through to
+	// codes.Internal and being mistaken by clients/monitoring for a transient failure.
+	// Deliberately worded without "permission"/"denied"/etc so it can't accidentally
+	// satisfy mapMachineError's substring switch and mask a reliance on errors.Is.
+	ErrMachinePrivilegeCeilingDenied = errors.New("machine identity privilege ceiling exceeded")
 )

--- a/internal/core/impersonation.go
+++ b/internal/core/impersonation.go
@@ -137,18 +137,22 @@ func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID 
 // EndImpersonation terminates the impersonation session identified by token,
 // logging an impersonation.end event with the session duration and the number
 // of actions taken while impersonating. The token must belong to an
-// impersonation session. Restoring the admin's own session is a caller (HTTP
-// handler) concern — see admin_impersonation.go's End, which stashes the
-// admin's token in a second cookie at Start and reads it back here, rather than
-// this core layer trying to recall a plaintext token it never retains (session
-// tokens are stored only as a hash, see local_auth.go's hashSessionToken).
-func (c *KeyorixCore) EndImpersonation(ctx context.Context, token string) error {
+// impersonation session. Returns the admin ID that was impersonating (i.e.
+// the ended session's ImpersonatedBy) so the caller can bind any "restore my
+// own session" step to that SAME admin, rather than trusting whatever session
+// token happens to be sitting in a client-supplied cookie (see
+// admin_impersonation.go's End). Restoring the admin's own session is
+// otherwise a caller (HTTP handler) concern — End stashes the admin's token in
+// a second cookie at Start and reads it back here, rather than this core
+// layer trying to recall a plaintext token it never retains (session tokens
+// are stored only as a hash, see local_auth.go's hashSessionToken).
+func (c *KeyorixCore) EndImpersonation(ctx context.Context, token string) (uint, error) {
 	session, err := c.storage.GetSession(ctx, token)
 	if err != nil {
-		return fmt.Errorf("session not found")
+		return 0, fmt.Errorf("session not found")
 	}
 	if session.ImpersonatedBy == nil {
-		return fmt.Errorf("not an impersonation session")
+		return 0, fmt.Errorf("not an impersonation session")
 	}
 	adminID := *session.ImpersonatedBy
 	targetID := session.UserID
@@ -172,14 +176,14 @@ func (c *KeyorixCore) EndImpersonation(ctx context.Context, token string) error 
 	// mid-operation, reserving the explicit failed-audit-event helper for
 	// pre-mutation authorization denials instead.
 	if err := c.storage.DeleteSession(ctx, session.ID); err != nil {
-		return fmt.Errorf("failed to end impersonation session: %w", err)
+		return 0, fmt.Errorf("failed to end impersonation session: %w", err)
 	}
 
 	diff := fmt.Sprintf(`{"duration_seconds":%d,"action_count":%d}`, int64(duration.Seconds()), actions)
 	desc := fmt.Sprintf("impersonation ended after %s (%d action(s))", duration.Round(time.Second), actions)
 	c.writeImpersonationEvent(ctx, EventImpersonationEnd, adminID, targetID, session.IPAddress, desc, diff)
 
-	return nil
+	return adminID, nil
 }
 
 // ReauthorizeImpersonation re-verifies an ACTIVE impersonation session's admin

--- a/internal/core/impersonation_test.go
+++ b/internal/core/impersonation_test.go
@@ -362,8 +362,12 @@ func TestEndImpersonation_LogsDurationAndActionCount(t *testing.T) {
 	})).Return(nil)
 	store.On("DeleteSession", ctx, uint(99)).Return(nil)
 
-	if err := c.EndImpersonation(ctx, "tok"); err != nil {
+	gotAdminID, err := c.EndImpersonation(ctx, "tok")
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAdminID != admin {
+		t.Fatalf("expected returned adminID %d, got %d", admin, gotAdminID)
 	}
 	store.AssertExpectations(t)
 }
@@ -374,7 +378,7 @@ func TestEndImpersonation_RejectsNonImpersonationSession(t *testing.T) {
 	ctx := context.Background()
 	store.On("GetSession", ctx, "tok").Return(&models.Session{ID: 1, UserID: 2}, nil)
 
-	if err := c.EndImpersonation(ctx, "tok"); err == nil {
+	if _, err := c.EndImpersonation(ctx, "tok"); err == nil {
 		t.Fatal("expected an error for a non-impersonation session")
 	}
 }
@@ -398,7 +402,7 @@ func TestEndImpersonation_DeleteSessionFails_NoMisleadingAuditEvent(t *testing.T
 	store.On("CountImpersonatedActions", uint(2), uint(1), started).Return(int64(1), nil)
 	store.On("DeleteSession", ctx, uint(99)).Return(fmt.Errorf("db unavailable"))
 
-	err := c.EndImpersonation(ctx, "tok")
+	_, err := c.EndImpersonation(ctx, "tok")
 	if err == nil {
 		t.Fatal("expected an error when the session delete fails")
 	}

--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -39,7 +39,8 @@ const auditStreamBatch = 100
 // principal may hold open — an unbounded caller could otherwise open arbitrarily many
 // streams, each subscribed to the audit broker, amplifying the fan-out cost of every
 // audit write across the whole install (auditBroker.signal iterates every subscriber
-// under one lock).
+// under one lock). Enforced per-process via streamCounts below; see that field's
+// doc comment for the documented multi-replica residual.
 const auditStreamMaxPerPrincipal = 3
 
 // AuditGRPCService implements pb.AuditServiceServer.
@@ -47,8 +48,32 @@ type AuditGRPCService struct {
 	pb.UnimplementedAuditServiceServer
 	core *core.KeyorixCore
 
+	// streamCounts's residual (findings-server/grpc-audit-service.json#4, scoped
+	// down, documented rather than built): this cap is enforced per PROCESS, not
+	// per principal cluster-wide. A horizontally-scaled deployment running N gRPC
+	// replicas behind a load balancer gives one principal up to
+	// auditStreamMaxPerPrincipal*N total concurrent streams (up to 3 per replica,
+	// each replica's AuditGRPCService holding its own independent map) instead of
+	// the documented 3 — proportionally increasing auditBroker.signal's per-event
+	// fan-out cost, but NOT bypassing authorization: every stream still requires a
+	// live, actively-reauthorized audit.read credential (see
+	// reauthorizeAuditStream), so this is a soft cost/proportionality bound, not an
+	// access-control gap. Closing it for real means either (a) a lock held for the
+	// stream's entire (potentially very long) lifetime, which would serialize
+	// stream open/close across the WHOLE cluster rather than just the enrolling
+	// principal, or (b) a new crash-safe heartbeat/lease table (migration +
+	// storage-layer methods + orphan-expiry handling + cross-replica test
+	// harness) layered onto this already heavily-hardened, security-sensitive
+	// stream path (see the #G05/#G18/#108/MT-007 history above) — both
+	// disproportionate to a low-severity, multi-replica-only cost concern with a
+	// low per-replica bound (3) already in place. If this needs closing later,
+	// reuse the Postgres-advisory-lock + process-mutex, SQLite-is-single-process
+	// pattern already established for exactly this split in
+	// internal/storage/store/local_bootstrap_lock.go and
+	// local_audit_checkpoint_lock.go, keyed per-principal rather than globally so
+	// concurrent unrelated principals don't contend.
 	streamCountsMu sync.Mutex
-	streamCounts   map[string]int // "kind:id" -> concurrently open StreamAuditLogs calls
+	streamCounts   map[string]int // "kind:id" -> concurrently open StreamAuditLogs calls, PROCESS-LOCAL (see residual above)
 }
 
 // Compile-time assertion that the service satisfies the generated interface.

--- a/server/grpc/services/break_glass_service.go
+++ b/server/grpc/services/break_glass_service.go
@@ -51,6 +51,9 @@ func (s *BreakGlassGRPCService) ListBreakGlassActivations(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
+	if req.GetProjectId() == 0 {
+		return nil, status.Error(codes.InvalidArgument, "project_id is required")
+	}
 	if err := authorizeScoped(ctx, s.core, actor, "roles.read", core.Scope{ProjectID: uint(req.GetProjectId())}); err != nil {
 		return nil, err
 	}
@@ -70,6 +73,9 @@ func (s *BreakGlassGRPCService) RevokeBreakGlass(ctx context.Context, req *pb.Re
 	actor, err := requireUser(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if req.GetProjectId() == 0 {
+		return nil, status.Error(codes.InvalidArgument, "project_id is required")
 	}
 	if err := authorizeScoped(ctx, s.core, actor, "roles.assign", core.Scope{ProjectID: uint(req.GetProjectId())}); err != nil {
 		return nil, err

--- a/server/grpc/services/break_glass_service_test.go
+++ b/server/grpc/services/break_glass_service_test.go
@@ -70,3 +70,44 @@ func TestBreakGlass_Unauthenticated(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 }
+
+// TestBreakGlass_ZeroProjectIDRejectedBeforeAuthz guards against the gap where
+// ListBreakGlassActivations/RevokeBreakGlass called authorizeScoped(ctx, ...,
+// core.Scope{ProjectID: uint(req.GetProjectId())}, ...) without first rejecting
+// project_id == 0, unlike every machine-identity RPC. core.Scope{} (ProjectID 0)
+// is the GLOBAL scope, so a project_id: 0 request was authorized against
+// roles.read/roles.assign at GLOBAL scope instead of being rejected up front.
+//
+// This is proven by giving the actor a roles.read/roles.assign grant ONLY at
+// project 1 (via the "admin" role, which bypasses per-permission checks but
+// ONLY within the scope it is assigned — see adminRoleNames in
+// internal/core/authz.go) and NO global grant at all. Before the fix, calling
+// with ProjectId: 0 would route into authorizeScoped(Scope{ProjectID: 0}) — the
+// actor holds no global grant, so that call fails PermissionDenied only AFTER
+// evaluating the (wrong) global-scope authorization check. After the fix, the
+// RPC rejects with InvalidArgument before authorizeScoped/the core layer are
+// ever reached, matching the machine-identity RPCs' project_id != 0 guard.
+func TestBreakGlass_ZeroProjectIDRejectedBeforeAuthz(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+	require.NoError(t, h.DB.AutoMigrate(&models.BreakGlassActivation{}, &models.AuditEvent{}))
+
+	const scopedUserID = uint(2)
+	proj := uint(1)
+	// role 2 = "admin": grants roles.read/roles.assign and admin bypass, but
+	// ONLY within project 1's scope — this user holds NO global-scope grant.
+	h.AssignUserRole(t, scopedUserID, 2, &proj)
+
+	ctx := authCtx(scopedUserID, "project-scoped-admin", "roles.read", "roles.assign")
+	svc := NewBreakGlassService(h.CoreService)
+
+	_, err := svc.ListBreakGlassActivations(ctx, &pb.ListBreakGlassActivationsRequest{ProjectId: 0})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err),
+		"project_id: 0 must be rejected before the (wrong) global-scope authorization check runs")
+
+	_, err = svc.RevokeBreakGlass(ctx, &pb.RevokeBreakGlassRequest{ProjectId: 0, ActivationId: 1})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err),
+		"project_id: 0 must be rejected before the (wrong) global-scope authorization check runs")
+}

--- a/server/grpc/services/machine_identity_service.go
+++ b/server/grpc/services/machine_identity_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -29,6 +30,16 @@ func NewMachineIdentityService(coreService *core.KeyorixCore) *MachineIdentityGR
 }
 
 func mapMachineError(err error) error {
+	// MACH-001: a privilege-ceiling denial (requireMachinePrivilegeCeiling) is a
+	// deliberate, terminal authorization refusal, not an internal error. Check the
+	// typed sentinel via errors.Is BEFORE the substring switch below — the message
+	// text is prose ("requires administrative authority") that doesn't match any of
+	// the switch's fixed substrings and would otherwise fall through to the default
+	// codes.Internal bucket, which clients/monitoring commonly treat as transient
+	// and retryable, unlike codes.PermissionDenied.
+	if errors.Is(err, core.ErrMachinePrivilegeCeilingDenied) {
+		return status.Error(codes.PermissionDenied, "access denied")
+	}
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "not found"):

--- a/server/grpc/services/machine_identity_service_test.go
+++ b/server/grpc/services/machine_identity_service_test.go
@@ -24,6 +24,15 @@ import (
 // grants users.read + roles.assign (the perms the machine RPCs require), and
 // returns the MachineIdentityService over a real core.
 func newMachineTestRig(t *testing.T) *MachineIdentityGRPCService {
+	svc, _ := newMachineTestRigWithDB(t)
+	return svc
+}
+
+// newMachineTestRigWithDB is newMachineTestRig plus the underlying db, for
+// tests (like the MACH-001 regression below) that need to seed additional
+// fixtures — e.g. granting a machine identity an admin-tier role directly,
+// which core.AssignMachineRole itself would refuse from a non-admin actor.
+func newMachineTestRigWithDB(t *testing.T) (*MachineIdentityGRPCService, *gorm.DB) {
 	t.Helper()
 	require.NoError(t, i18n.Initialize(&config.Config{
 		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
@@ -52,7 +61,7 @@ func newMachineTestRig(t *testing.T) *MachineIdentityGRPCService {
 	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 2}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error) // global grant
 	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
-	return NewMachineIdentityService(coreService)
+	return NewMachineIdentityService(coreService), db
 }
 
 func TestMachineIdentityService_Lifecycle(t *testing.T) {
@@ -131,4 +140,41 @@ func TestMachineIdentityService_AuthzAndValidation(t *testing.T) {
 	_, err = svc.TransitionMachineIdentity(admin, &pb.TransitionMachineIdentityRequest{ProjectId: 1, MachineId: 1, Action: "explode"})
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestMachineIdentityService_IssueMachineToken_PrivilegeCeilingDeniedIsPermissionDenied
+// guards MACH-001's gRPC classification: a non-global-admin actor with
+// roles.assign (so they pass the RPC's own authz gate) who tries to issue a
+// token for a machine identity holding an admin-tier role must be rejected
+// with codes.PermissionDenied — the caller (user 1) has roles.assign via the
+// "machine-admin" role seeded by newMachineTestRig, but that role name is not
+// in adminRoleNames, so IsGlobalAdmin(1) is false and
+// requireMachinePrivilegeCeiling (MACH-001) refuses. Before mapMachineError
+// learned to check core.ErrMachinePrivilegeCeilingDenied via errors.Is, this
+// denial's message ("...requires administrative authority") matched none of
+// mapMachineError's substrings and fell through to codes.Internal instead.
+func TestMachineIdentityService_IssueMachineToken_PrivilegeCeilingDeniedIsPermissionDenied(t *testing.T) {
+	svc, db := newMachineTestRigWithDB(t)
+	ctx := authCtx(1, "admin")
+
+	m, err := svc.CreateMachineIdentity(ctx, &pb.CreateMachineIdentityRequest{
+		ProjectId: 1, Name: "admin-bot", IdentityType: "ci",
+	})
+	require.NoError(t, err)
+
+	// Grant the machine identity an admin-tier role (a name recognized by
+	// adminRoleNames — see internal/core/authz.go), so a token issued for it
+	// would inherit admin authority. User 1's own "machine-admin" role (seeded
+	// by newMachineTestRig) is NOT in adminRoleNames, so IsGlobalAdmin(1) is
+	// false and requireMachinePrivilegeCeiling (MACH-001) must refuse.
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.MachineIdentityRole{
+		MachineIdentityID: uint(m.GetId()), RoleID: 2,
+	}).Error)
+
+	_, err = svc.IssueMachineToken(ctx, &pb.IssueMachineTokenRequest{
+		ProjectId: 1, MachineId: m.GetId(), Name: "escalate",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }

--- a/server/grpc/services/project_service.go
+++ b/server/grpc/services/project_service.go
@@ -92,6 +92,15 @@ func (s *ProjectGRPCService) GetProjectRotationOrder(ctx context.Context, req *p
 	if err := authorizeScoped(ctx, s.core, user, permSecretsRead, core.Scope{ProjectID: uint(req.GetId())}); err != nil {
 		return nil, err
 	}
+	// authorizeScoped only checks the caller's role binding, not whether the project
+	// itself is still live: UserRole/GroupRole rows scoped to a project are deliberately
+	// left in place across a soft-delete (to support RestoreProject), so a caller who
+	// held a scoped grant before the project was deleted would otherwise keep passing
+	// this check indefinitely. Confirm the project is live before proceeding, mirroring
+	// the CreateProjectEnvironment precedent (catalog.go).
+	if _, err := s.core.GetProject(ctx, uint(req.GetId())); err != nil {
+		return nil, mapProjectError(err)
+	}
 	order, err := s.core.GetProjectRotationOrder(ctx, uint(req.GetId()))
 	if err != nil {
 		return nil, mapProjectError(err)
@@ -111,6 +120,11 @@ func (s *ProjectGRPCService) GetProjectRotationPlan(ctx context.Context, req *pb
 	}
 	if err := authorizeScoped(ctx, s.core, user, permSecretsRead, core.Scope{ProjectID: uint(req.GetId())}); err != nil {
 		return nil, err
+	}
+	// See GetProjectRotationOrder above: a scoped role binding survives project
+	// soft-delete, so confirm the project is still live before proceeding.
+	if _, err := s.core.GetProject(ctx, uint(req.GetId())); err != nil {
+		return nil, mapProjectError(err)
 	}
 	plan, err := s.core.GenerateRotationPlan(ctx, uint(req.GetId()))
 	if err != nil {
@@ -219,6 +233,11 @@ func (s *ProjectGRPCService) ListEnvironments(ctx context.Context, req *pb.ListE
 	}
 	if err := authorizeScoped(ctx, s.core, user, permSecretsRead, core.Scope{ProjectID: uint(req.GetProjectId())}); err != nil {
 		return nil, err
+	}
+	// See GetProjectRotationOrder above: a scoped role binding survives project
+	// soft-delete, so confirm the project is still live before proceeding.
+	if _, err := s.core.GetProject(ctx, uint(req.GetProjectId())); err != nil {
+		return nil, mapProjectError(err)
 	}
 	envs, err := s.core.ListEnvironmentsByProject(ctx, uint(req.GetProjectId()))
 	if err != nil {

--- a/server/grpc/services/project_service_test.go
+++ b/server/grpc/services/project_service_test.go
@@ -110,6 +110,48 @@ func TestProjectService_Unauthorized(t *testing.T) {
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }
 
+// TestProjectService_ListRotateOnSoftDeletedProject_GlobalGrantStillEmpty verifies
+// the liveness check added to ListEnvironments / GetProjectRotationOrder /
+// GetProjectRotationPlan. A caller who holds a GLOBAL (project_id=0) secrets.read
+// grant passes authorizeScoped for ANY project regardless of that project's liveness
+// — the deleted_at exclusion GetUserRoleIDsAt applies only to a grant whose OWN
+// project_id matches the target scope, not to a project_id=0 grant, which is
+// unconditional by design. Before this fix, ListEnvironmentsByProject /
+// ListSecretDependenciesForProject / GenerateRotationPlan query raw project_id with
+// no liveness check of their own, so such a caller got a quiet EMPTY success instead
+// of NotFound for a soft-deleted project — the exact "structural gap" this fix closes
+// (GetProject/UpdateProject already get NotFound for free via storage.GetProject).
+func TestProjectService_ListRotateOnSoftDeletedProject_GlobalGrantStillEmpty(t *testing.T) {
+	svc, db := newProjectTestRigWithDB(t)
+
+	// Project 2: a second, later-deleted project. User 1 (the rig's seeded global
+	// writer, ProjectID:0) never held a project-2-scoped grant — only the global one.
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "doomed"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, ProjectID: 2, Name: "staging"}).Error)
+
+	globalCtx := authCtx(1, "owner")
+
+	// Sanity: before deletion, the global grant reads project 2 fine.
+	envs, err := svc.ListEnvironments(globalCtx, &pb.ListEnvironmentsRequest{ProjectId: 2})
+	require.NoError(t, err)
+	require.Len(t, envs.GetEnvironments(), 1)
+
+	// Soft-delete project 2 (its environment is cascaded into the same soft-delete).
+	require.NoError(t, svc.core.DeleteProject(context.Background(), 2, true))
+
+	_, err = svc.ListEnvironments(globalCtx, &pb.ListEnvironmentsRequest{ProjectId: 2})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+
+	_, err = svc.GetProjectRotationOrder(globalCtx, &pb.GetProjectRequest{Id: 2})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+
+	_, err = svc.GetProjectRotationPlan(globalCtx, &pb.GetProjectRequest{Id: 2})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
 func TestProjectService_InvalidArgument(t *testing.T) {
 	svc := newProjectTestRig(t)
 	ctx := authCtx(1, "owner")

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -120,6 +120,16 @@ func (s *RoleGRPCService) UpdateRole(ctx context.Context, req *pb.UpdateRoleRequ
 	if err != nil {
 		return nil, mapRoleError(err)
 	}
+	// A built-in role must not be mutable over gRPC either — mirrors the CreateRole/
+	// DeleteRole guards above/below. UpdateRole unconditionally strips a role's entire
+	// current permission set before re-adding the caller-supplied one (see below), so
+	// without this check a roles.write holder could shrink e.g. admin/system_admin down
+	// to whatever subset they hold themselves, silently locking out every administrator
+	// who relies on that built-in role. The HTTP handler applies the identical guard
+	// (handlers/rbac.go); without it here the guard is bypassable by switching transport.
+	if core.IsBuiltinRole(role.Name) {
+		return nil, status.Errorf(codes.FailedPrecondition, "cannot update built-in role: %s", role.Name)
+	}
 
 	if req.Description != nil {
 		role.Description = req.GetDescription()

--- a/server/grpc/services/role_service_test.go
+++ b/server/grpc/services/role_service_test.go
@@ -159,6 +159,28 @@ func TestRoleService_UpdateRole(t *testing.T) {
 	assert.Equal(t, "new description", updated.GetDescription())
 }
 
+// TestRoleService_UpdateRole_BuiltinRefused proves the gRPC path refuses to
+// update a product built-in role, matching the HTTP handler. Without the guard a
+// roles.write holder could shrink super_admin/admin's permission set over gRPC
+// (UpdateRole strips the entire current set before re-adding the caller-supplied
+// one) and lock out every administrator who relies on that role. A non-built-in
+// role must remain updatable, matching TestRoleService_UpdateRole above.
+func TestRoleService_UpdateRole_BuiltinRefused(t *testing.T) {
+	svc, _ := newRoleService(t)
+	// super_admin is seeded with ID 1 by the RBAC test helper.
+	_, err := svc.UpdateRole(roleAdminCtx(), &pb.UpdateRoleRequest{
+		Id: 1, Description: strPtr("hijacked description"),
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+	// And it is unchanged afterwards.
+	got, gerr := svc.GetRole(roleAdminCtx(), &pb.GetRoleRequest{Id: 1})
+	require.NoError(t, gerr)
+	assert.Equal(t, "super_admin", got.GetName())
+	assert.NotEqual(t, "hijacked description", got.GetDescription())
+}
+
 func TestRoleService_DeleteRole(t *testing.T) {
 	svc, h := newRoleService(t)
 	created, err := svc.CreateRole(roleAdminCtx(), &pb.CreateRoleRequest{

--- a/server/grpc/services/services_s2_test.go
+++ b/server/grpc/services/services_s2_test.go
@@ -2,8 +2,10 @@ package services
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -138,6 +140,21 @@ func TestMapMachineError_Default_Internal(t *testing.T) {
 	st, _ := status.FromError(err)
 	if st.Code() != codes.Internal {
 		t.Errorf("expected Internal, got %v", st.Code())
+	}
+}
+
+// TestMapMachineError_PrivilegeCeilingDenied guards against the MACH-001
+// misclassification: requireMachinePrivilegeCeiling's message ("...requires
+// administrative authority") contains none of the switch's fixed substrings
+// ("permission", "denied", "required", etc — note "requires" != "required"),
+// so before the errors.Is(core.ErrMachinePrivilegeCeilingDenied) check was added
+// it fell through to the default codes.Internal bucket instead of
+// codes.PermissionDenied, even though the request was correctly denied.
+func TestMapMachineError_PrivilegeCeilingDenied(t *testing.T) {
+	err := mapMachineError(fmt.Errorf("%w: issuing a token for a machine identity that holds administrative roles requires administrative authority", core.ErrMachinePrivilegeCeilingDenied))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
 	}
 }
 

--- a/server/http/handlers/admin_impersonation.go
+++ b/server/http/handlers/admin_impersonation.go
@@ -124,7 +124,8 @@ func (h *ImpersonationHandler) End(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "BadRequest", "Missing authorization token", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.EndImpersonation(r.Context(), token); err != nil {
+	adminID, err := h.coreService.EndImpersonation(r.Context(), token)
+	if err != nil {
 		if strings.Contains(err.Error(), "not an impersonation") {
 			sendError(w, "BadRequest", "Not an impersonation session", http.StatusBadRequest, nil)
 		} else {
@@ -145,7 +146,20 @@ func (h *ImpersonationHandler) End(w http.ResponseWriter, r *http.Request) {
 		// expired, or the admin's account may have been suspended, while they
 		// were impersonating. This is the same check every other request goes
 		// through, not a new trust boundary.
-		if _, _, verr := h.coreService.ValidateSessionToken(r.Context(), adminCookie.Value); verr == nil {
+		//
+		// Beyond validity, the resolved session must belong to the SAME admin
+		// who was just impersonating (adminID, from the ended session's own
+		// ImpersonatedBy — resolved server-side, not client-supplied). Without
+		// this binding, ANY currently-valid session token sitting in the
+		// AdminSessionCookieName cookie — a stale cookie left over from a
+		// PREVIOUS, different admin's impersonation on a shared browser
+		// profile, or one substituted by a client capable of setting an
+		// arbitrary Cookie header for this origin — would be silently promoted
+		// to the caller's active session. The cookie is HttpOnly, so this isn't
+		// exploitable from in-browser JS, but nothing else here enforces that
+		// the restored session actually belongs to the admin who started this
+		// impersonation.
+		if adminUser, _, verr := h.coreService.ValidateSessionToken(r.Context(), adminCookie.Value); verr == nil && adminUser != nil && adminUser.ID == adminID {
 			middleware.SetSessionCookie(w, adminCookie.Value, nil, h.tlsEnabled)
 			if csrfToken, cerr2 := middleware.GenerateCSRFToken(); cerr2 == nil {
 				middleware.SetCSRFCookie(w, csrfToken, h.tlsEnabled)

--- a/server/http/handlers/delete_user_self_action_test.go
+++ b/server/http/handlers/delete_user_self_action_test.go
@@ -1,0 +1,114 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// setupDeleteUserTest builds a fully bootstrapped core (real BootstrapSystem over
+// the full RBAC schema) with TWO global admins: user 1, the bootstrap admin
+// (matching withUserCtx's hardcoded UserID: 1), and a second, independently
+// admin-role-assigned user.
+//
+// Unlike setupUserHandlerTest (revoke_sessions_self_action_test.go), DeleteUser
+// routes through core's guardLastAdminDeactivation, which calls IsGlobalAdmin and
+// needs the full RBAC schema to resolve rather than erroring on missing tables.
+// Seeding a SECOND admin is the point of this setup: it means core's "last install
+// administrator" guard would NOT block user 1 from deleting themselves (another
+// admin survives them), so if the self-action delete is still rejected, it can
+// only be the handler-level guard doing it — exactly the gap this test pins.
+func setupDeleteUserTest(t *testing.T) (handler *UserHandler, secondAdminID uint) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SystemMetadata{},
+		&models.MachineIdentity{}, &models.MachineIdentityRole{},
+		&models.PersonalAccessToken{}, &models.Session{}, &models.ShareRecord{},
+		&models.AuditEvent{},
+		&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.ProjectMembership{},
+		&models.SecretNode{}, &models.SecretVersion{}, &models.DynamicSecretConfig{}, &models.SoDPolicy{},
+		&models.StatsSnapshot{}, &models.DeploymentStatsSnapshot{},
+		&models.MFAStepupToken{}, &models.MFAStepUpGrant{},
+		&models.SecretACL{}, &models.PasswordHistory{},
+		&models.SecretAccessSchedule{},
+	))
+
+	ctx := context.Background()
+	st := store.NewLocalStorage(db)
+	c := core.NewKeyorixCore(st)
+	c.SetBootstrapToken("test-bootstrap-token")
+	result, err := c.BootstrapSystem(ctx, &core.BootstrapRequest{
+		Username: "admin", Email: "admin@example.com", Password: "BootstrapPass123!", DisplayName: "Admin",
+		Token: "test-bootstrap-token",
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint(1), result.User.ID, "withUserCtx hardcodes UserID 1 as the acting admin")
+
+	secondAdmin, err := st.CreateUser(ctx, &models.User{
+		Username: "second-admin", Email: "second-admin@example.com", IsActive: true,
+	})
+	require.NoError(t, err)
+	adminRole, err := st.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, secondAdmin.ID, adminRole.ID, core.Scope{}))
+
+	handler, err = NewUserHandler(c)
+	require.NoError(t, err)
+	return handler, secondAdmin.ID
+}
+
+// DeleteUser previously had no guard against an admin targeting their own ID —
+// unlike accountStateAction (Suspend/Reactivate/RequirePasswordReset) and
+// RevokeSessions, which explicitly block self-action. Core's own backstop
+// (guardLastAdminDeactivation, "refusing to deactivate the last install
+// administrator") only fires when the target is the SOLE admin, so it does
+// nothing to stop a self-delete while other admins still exist — exactly the
+// setup here (a second admin is seeded). Only the handler-level guard added
+// below can catch this case.
+func TestDeleteUser_BlocksSelfAction(t *testing.T) {
+	handler, _ := setupDeleteUserTest(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/users/1", nil)
+	req = withUserCtx(req) // admin, UserID: 1
+	req = withChiParam(req, "id", "1")
+
+	w := httptest.NewRecorder()
+	handler.DeleteUser(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "an admin must not be able to delete their own account")
+}
+
+func TestDeleteUser_AllowsTargetingOtherUsers(t *testing.T) {
+	handler, secondAdminID := setupDeleteUserTest(t)
+	idStr := strconv.FormatUint(uint64(secondAdminID), 10)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/users/"+idStr, nil)
+	req = withUserCtx(req) // admin, UserID: 1
+	req = withChiParam(req, "id", idStr)
+
+	w := httptest.NewRecorder()
+	handler.DeleteUser(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code, "deleting another user must still work")
+}

--- a/server/http/handlers/handlers_s11_test.go
+++ b/server/http/handlers/handlers_s11_test.go
@@ -432,6 +432,82 @@ func TestImpersonationEnd_HappyPath_NoAdminCookie_S11(t *testing.T) {
 	assert.False(t, data["admin_session_restored"].(bool), "admin session should NOT have been restored")
 }
 
+// TestImpersonationEnd_MismatchedAdminCookie_NotRestored_S11 is the
+// admin-billing-2 regression: End() must bind the restore check to the
+// impersonation session's OWN ImpersonatedBy admin, not just "any currently
+// valid session token sitting in the AdminSessionCookieName cookie". This
+// starts a real impersonation (admin → target), then calls End with the
+// impersonation token but with a DIFFERENT, unrelated (and still perfectly
+// valid) user's session token in the admin cookie — e.g. a stale cookie left
+// over from a previous admin's impersonation on a shared browser profile, or
+// one substituted by a client capable of sending an arbitrary Cookie header
+// for this origin. Before the fix, ValidateSessionToken succeeding was the
+// ONLY check, so the unrelated session would be silently promoted to the
+// caller's active session (admin_session_restored=true, kx_session swapped to
+// the other user's token). After the fix, the mismatched cookie must be
+// rejected: admin_session_restored=false and the session cookie cleared, not
+// swapped to the wrong session.
+func TestImpersonationEnd_MismatchedAdminCookie_NotRestored_S11(t *testing.T) {
+	t.Parallel()
+	cs := freshCoreS11(t)
+	h := NewImpersonationHandler(cs, false)
+
+	bootstrapS11(t, cs, "impendmis")
+	ctx := context.Background()
+	admin, err := cs.GetUserByUsername(ctx, "s11impendmis")
+	require.NoError(t, err)
+
+	// Create the impersonation target.
+	target, err := cs.CreateUser(ctx, &core.CreateUserRequest{
+		Username:    "s11impendmis-target",
+		Email:       "s11impendmis-target@example.com",
+		DisplayName: "Target",
+		Password:    "Kx#Vr9$Mn2!Zp4@Qw",
+	})
+	require.NoError(t, err)
+
+	// Create a wholly unrelated third user with their OWN live session — this
+	// stands in for the "different, unrelated but still-valid session token"
+	// from the finding. It is never the admin who started this impersonation.
+	_, err = cs.CreateUser(ctx, &core.CreateUserRequest{
+		Username:    "s11impendmis-other",
+		Email:       "s11impendmis-other@example.com",
+		DisplayName: "Other",
+		Password:    "Kx#Vr9$Mn2!Zp4@Qw",
+	})
+	require.NoError(t, err)
+	otherSession, _, err := cs.Login(ctx, &core.LoginRequest{
+		Username: "s11impendmis-other",
+		Password: "Kx#Vr9$Mn2!Zp4@Qw",
+	})
+	require.NoError(t, err)
+
+	impSession, _, err := cs.StartImpersonation(ctx, admin.ID, target.ID, "127.0.0.1")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+impSession.SessionToken)
+	// The admin cookie holds someone else's valid session, not the impersonating
+	// admin's own stashed token.
+	req.AddCookie(&http.Cookie{Name: middleware.AdminSessionCookieName, Value: otherSession.SessionToken})
+	w := httptest.NewRecorder()
+	h.End(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp2 map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp2))
+	data2, _ := resp2["data"].(map[string]any)
+	assert.False(t, data2["admin_session_restored"].(bool), "a different admin's session must not be restored")
+
+	// The session cookie must be CLEARED, not swapped to the other user's
+	// token — assert no Set-Cookie for kx_session carries otherSession's value.
+	for _, c := range w.Result().Cookies() {
+		if c.Name == middleware.SessionCookieName {
+			assert.NotEqual(t, otherSession.SessionToken, c.Value, "session cookie must not be swapped to the unrelated session's token")
+		}
+	}
+}
+
 // ── catalog.go: ListProjects / ListEnvironments ───────────────────────────────
 
 // TestListProjects_IncludeDeleted_S11 — ?include_deleted=true → 200.

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -317,6 +317,18 @@ func (h *RBACHandler) UpdateRole(w http.ResponseWriter, r *http.Request) { // NO
 		}
 		return
 	}
+	// A built-in role must not be mutable through the API — mirrors the CreateRole/
+	// DeleteRole guards below/above. replaceRolePermissions unconditionally strips a
+	// role's entire current permission set before re-adding the caller-supplied one, so
+	// without this check a roles.write holder could shrink e.g. admin/system_admin down
+	// to whatever subset they hold themselves, silently locking out every administrator
+	// who relies on that built-in role. The gRPC RoleGRPCService.UpdateRole applies the
+	// identical guard (server/grpc/services/role_service.go); without it here the guard
+	// is bypassable by switching transport.
+	if core.IsBuiltinRole(role.Name) {
+		sendError(w, "Forbidden", "Cannot update built-in role: "+role.Name, http.StatusForbidden, nil)
+		return
+	}
 
 	// #169: resolve + authorize every requested permission BEFORE touching the
 	// role's existing permission set — otherwise a request naming even one

--- a/server/http/handlers/rbac_real_test.go
+++ b/server/http/handlers/rbac_real_test.go
@@ -287,6 +287,53 @@ func TestRBACReal_DeleteRole_Builtin_Forbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+// TestRBACReal_UpdateRole_Builtin_Forbidden proves UpdateRole refuses to touch a
+// product built-in role. Without this guard replaceRolePermissions unconditionally
+// strips a role's entire current permission set before re-adding the caller-supplied
+// one, so a roles.write holder could shrink e.g. admin's grants down to whatever
+// subset they hold themselves, silently locking out every administrator who relies
+// on that built-in role. Mirrors DeleteRole's identical guard above.
+func TestRBACReal_UpdateRole_Builtin_Forbidden(t *testing.T) {
+	handler, _, db := setupRBACTestWithDB(t)
+	role := mustCreateRole(t, db, "admin")
+
+	body := `{"description":"hijacked description"}`
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/roles/%d", role.ID), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUserCtx(withChiParam(req, "id", fmt.Sprintf("%d", role.ID)))
+	w := httptest.NewRecorder()
+
+	handler.UpdateRole(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	// Unchanged in storage — the request must never reach Storage().UpdateRole.
+	var reloaded models.Role
+	require.NoError(t, db.First(&reloaded, role.ID).Error)
+	assert.Equal(t, "admin role", reloaded.Description)
+}
+
+// TestRBACReal_UpdateRole_NonBuiltin_Succeeds proves the new built-in guard does not
+// over-block: an ordinary, non-reserved role must remain updatable exactly as before.
+func TestRBACReal_UpdateRole_NonBuiltin_Succeeds(t *testing.T) {
+	handler, _, db := setupRBACTestWithDB(t)
+	role := mustCreateRole(t, db, "custom-role")
+
+	body := `{"description":"updated description"}`
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/roles/%d", role.ID), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUserCtx(withChiParam(req, "id", fmt.Sprintf("%d", role.ID)))
+	w := httptest.NewRecorder()
+
+	handler.UpdateRole(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var reloaded models.Role
+	require.NoError(t, db.First(&reloaded, role.ID).Error)
+	assert.Equal(t, "updated description", reloaded.Description)
+}
+
 func TestRBACReal_GetRole_NotFound(t *testing.T) {
 	handler, _, _ := setupRBACTestWithDB(t)
 

--- a/server/http/handlers/secret_acl_handler.go
+++ b/server/http/handlers/secret_acl_handler.go
@@ -150,11 +150,22 @@ func (h *SecretHandler) RevokeSecretACL(w http.ResponseWriter, r *http.Request) 
 }
 
 // aclErrorStatus maps a core ACL error to an HTTP status.
+//
+// The "Validation error" case matches core.KeyorixCore's i18n.T("ErrorValidation", nil)
+// prefix (see internal/i18n/locales/en.json), which every input-validation error in
+// internal/core/secret_acl.go is built from (fmt.Errorf("%s: ...", i18n.T("ErrorValidation", nil), ...)).
+// Some of those messages already happen to contain "invalid", "required", or
+// "permission" and matched the case below before this one existed, but others
+// (e.g. GrantSecretACL's "user %d is not a member of this secret's project" check)
+// don't contain any of those substrings and fell through to the 500 default —
+// misreporting a client-correctable 400-class request as an internal server error.
+// Matching the shared "Validation error" prefix directly covers the whole class
+// instead of enumerating every message body.
 func aclErrorStatus(msg string) int {
 	switch {
 	case strings.Contains(msg, "not found"):
 		return http.StatusNotFound
-	case strings.Contains(msg, "invalid"), strings.Contains(msg, "required"), strings.Contains(msg, "permission"):
+	case strings.Contains(msg, "Validation error"), strings.Contains(msg, "invalid"), strings.Contains(msg, "required"), strings.Contains(msg, "permission"):
 		return http.StatusBadRequest
 	case strings.Contains(msg, "not authorized"):
 		return http.StatusForbidden

--- a/server/http/handlers/secret_acl_handler_test.go
+++ b/server/http/handlers/secret_acl_handler_test.go
@@ -358,6 +358,39 @@ func TestGrantSecretACL_InvalidPermission(t *testing.T) {
 	assert.NotEqual(t, http.StatusOK, w.Code)
 }
 
+// TestGrantSecretACL_NonMemberUser verifies that granting an ACL to a user who
+// isn't a member of the secret's project is reported as a 4xx client error, not
+// a 500. core.GrantSecretACL's project-membership check returns
+// "Validation error: user %d is not a member of this secret's project" — a
+// message that doesn't contain "invalid", "required", or "permission", so
+// before aclErrorStatus grew a "Validation error" case, this client-correctable
+// request was misreported as an Internal Server Error (handlers-secret-acl-handler-001).
+func TestGrantSecretACL_NonMemberUser(t *testing.T) {
+	t.Parallel()
+	cs, db := freshCoreACL(t)
+	sid := mkACLHandlerSecret(t, db, "grant-nonmember")
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	// User 555 exists but was never added as a member of project 1 (unlike
+	// freshCoreACL's seeded grant-target users 77/88/99/123).
+	require.NoError(t, db.Create(&models.User{
+		ID:       555,
+		Username: "testgrant_555_nonmember",
+		Email:    "grant555@example.com",
+	}).Error)
+
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 555, "permissions": []string{"secrets.read"}})
+	req := withUserCtxACL(withChiParam(
+		httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/secrets/%d/acl", sid), bytes.NewReader(body)),
+		"id", fmt.Sprintf("%d", sid),
+	))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.GrantSecretACL(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "non-member grant target should be a 4xx client error, not a 500")
+	assert.Contains(t, w.Body.String(), "not a member")
+}
+
 // TestRevokeSecretACL_HappyPath is a standalone targeted test for the revoke success branch.
 func TestRevokeSecretACL_HappyPath(t *testing.T) {
 	t.Parallel()
@@ -549,6 +582,15 @@ func TestAclErrorStatus_BadRequest(t *testing.T) {
 func TestAclErrorStatus_InternalServerError(t *testing.T) {
 	code := aclErrorStatus("database connection failed")
 	assert.Equal(t, http.StatusInternalServerError, code)
+}
+
+// TestAclErrorStatus_ValidationErrorPrefix verifies that the exact error string
+// core.GrantSecretACL's project-membership check produces — which contains
+// neither "invalid", "required", nor "permission" — maps to 400, not the 500
+// default (handlers-secret-acl-handler-001).
+func TestAclErrorStatus_ValidationErrorPrefix(t *testing.T) {
+	code := aclErrorStatus("Validation error: user 42 is not a member of this secret's project")
+	assert.Equal(t, http.StatusBadRequest, code)
 }
 
 // TestGrantRevokeACL_RoundTrip verifies the full grant → list → revoke → list cycle.

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -786,6 +786,14 @@ func (h *UserHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "InvalidParameter", errInvalidUserID, http.StatusBadRequest, nil)
 		return
 	}
+	// A global admin must not delete their own account and lock themselves out
+	// of admin access. Mirrors accountStateAction's / RevokeSessions' self-action
+	// guard; core's "last install administrator" check does not fire here since
+	// other admins may still exist.
+	if uint(id) == userCtx.UserID {
+		sendError(w, "BadRequest", "Cannot delete your own account", http.StatusBadRequest, nil)
+		return
+	}
 	if err := h.coreService.DeleteUser(r.Context(), userCtx.UserID, uint(id)); err != nil {
 		log.Printf("Error deleting user: %v", err)
 		switch {


### PR DESCRIPTION
## Summary

Third batch of the Wave 6 low/info-severity remediation (adversarial security review, 2026-08-07/08). All 8 findings re-verified against current `main` before dispatch — one (`grpc-audit-service.json#3`, `WriteAuditCheckpoint`'s error-classification substring match) turned out already fixed via an earlier `errors.Is`-based sentinel refactor, and was swapped for the file's other remaining low-severity gap (`#4`, the stream-cap's process-local counter).

- **`UpdateRole` missing built-in-role guard** (both `server/grpc/services/role_service.go` and `server/http/handlers/rbac.go`): unlike their sibling `CreateRole`/`DeleteRole`, `UpdateRole` had no `IsBuiltinRole` check in either transport — any `roles.write` holder could shrink a built-in role's (e.g. `admin`, `system_admin`) entire permission set down to a subset of their own, silently locking out administrators who rely on it. Fixed in both transports (fixing only one would leave the other wide open).
- **Admin impersonation `End()` restored any valid session as the returning admin** (`server/http/handlers/admin_impersonation.go`): the only check was "is this session token currently valid" — no verification that it belonged to the specific admin who started the just-ended impersonation session. A stale admin-session cookie from a *different* admin's earlier impersonation on a shared browser profile would be silently promoted to active. `EndImpersonation` now returns the admin ID it resolved before deleting the session; `End()` only restores when the validated cookie's user ID matches.
- **`DeleteUser` missing the self-action guard** every sibling admin-action handler in `users_crud.go` already has (`SuspendUser`/`ReactivateUser`/`RequirePasswordReset`/`RevokeSessions` all block targeting your own account) — the core-layer "last admin" backstop doesn't fire when other admins exist, so nothing stopped an admin from deleting their own account mid-session while other admins were still present.
- **`aclErrorStatus` misclassified a whole class of validation errors as HTTP 500** (`server/http/handlers/secret_acl_handler.go`): every validation-class error from `internal/core/secret_acl.go` shares an i18n `"Validation error"` prefix, but the switch only matched `"invalid"`/`"required"`/`"permission"` substrings — the project-membership check's message ("is not a member of this secret's project") matched none of them and fell through to 500, polluting error-rate monitoring on a routine, client-correctable 400-class request.
- **`mapMachineError` misclassified the MACH-001 privilege-ceiling denial as `codes.Internal`** instead of `codes.PermissionDenied` (a message-wording mismatch — "requires", not "required" — in the substring switch). The operation was still correctly denied, just misreported to clients/monitoring as transient rather than terminal. Fixed with a typed sentinel (`core.ErrMachinePrivilegeCeilingDenied`) checked via `errors.Is`, matching this campaign's established preference over brittle substring matching.
- **Break-glass RPCs missing the early `project_id == 0` rejection** every machine-identity RPC already has: `ListBreakGlassActivations`/`RevokeBreakGlass` authorized directly against `core.Scope{ProjectID: 0}` (the *global* scope) when given a zero project ID, relying entirely on a second, independent core-layer check to catch it — not currently exploitable (the core layer does catch it today), but removed as a first-line invariant.
- **Three gRPC project RPCs missing a project-liveness check** `GetProject`/`UpdateProject` get "for free" via their own soft-delete-filtered lookup: `ListEnvironments`, `GetProjectRotationOrder`, `GetProjectRotationPlan` authorized purely via scoped role bindings with no check that the project itself still exists. Investigation refined the finding: the project-scoped-grant path this finding originally described is already closed by an earlier fix (project-scoped grants now require `deleted_at IS NULL` at the RBAC-resolution layer); the real remaining gap is a **global-grant holder** querying a soft-deleted project ID, which sailed through with a quiet empty success instead of `NotFound`. Fixed with the same `core.GetProject`-based liveness check `CreateProjectEnvironment` already uses for its write path. (Flagged, not fixed: the identical structural gap in `server/http/handlers/secret_dependencies.go`, tracked as a follow-up below.)
- **Audit-stream per-principal concurrency cap is process-local**, not cross-replica (`server/grpc/services/audit_service.go`) — in a multi-replica deployment, one principal can open `3×N` total concurrent streams instead of the documented 3. Deliberately scoped down and documented as an accepted residual risk rather than building new cross-process lease infrastructure: the gap is a cost/proportionality bound (every stream still requires a live, actively-reauthorized `audit.read` credential — no authorization bypass), and a real fix means either holding a lock for a stream's entire lifetime (serializing stream open/close cluster-wide) or a new crash-safe heartbeat/lease table layered onto an already heavily-hardened path. Matches the established notary CRL/OCSP scope-down precedent.

## Follow-up to track (out of scope for this PR)

`server/http/handlers/secret_dependencies.go` has the identical project-liveness gap the `project_service.go` fix above closes for the gRPC surface — not touched here, flagged for a future fix.

## Verification

Each fix independently re-verified from a fresh worktree before integration (build/vet/gofmt/gosec/relevant suites, most with pre-fix-failure proof via scoped `git stash`), then cherry-picked (`-x`) onto one branch off current `main` — zero conflicts across all 8.

Combined verification on the integrated branch:
- `go build ./...`, `go vet ./...`, `gofmt -l` — all clean
- `gosec -severity medium -exclude-generated` — 0 issues (800 files)
- Full `go test ./...` — only the established pre-existing `internal/core` (`TestGetSecretValue(ByVersion)?_DeniedOutsideAccessSchedule`, confirmed identical against unmodified `main`) and `server/http` (`RealServer`/`CSV_Headers`/`SetupToken`) failures — both unrelated to this batch

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] Full `go test ./...` — no new failures vs. baseline
- [ ] CI: lint, gitleaks, build-and-test