### PR TITLE
fix(security): close Wave 6 low/info batch 4 (server robustness/input-bounding)

### DIFF
--- a/internal/core/oidc_jwks.go
+++ b/internal/core/oidc_jwks.go
@@ -8,6 +8,7 @@ package core
 
 import (
 	"context"
+	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
@@ -361,13 +362,17 @@ func parseJWK(k jwk) (interface{}, error) { // NOSONAR -- cognitive complexity 1
 		return &rsa.PublicKey{N: n, E: int(e.Int64())}, nil
 	case "EC":
 		var curve elliptic.Curve
+		var ecdhCurve ecdh.Curve
 		switch k.Crv {
 		case "P-256":
 			curve = elliptic.P256()
+			ecdhCurve = ecdh.P256()
 		case "P-384":
 			curve = elliptic.P384()
+			ecdhCurve = ecdh.P384()
 		case "P-521":
 			curve = elliptic.P521()
+			ecdhCurve = ecdh.P521()
 		default:
 			return nil, fmt.Errorf("unsupported EC curve %q", k.Crv)
 		}
@@ -390,7 +395,15 @@ func parseJWK(k jwk) (interface{}, error) { // NOSONAR -- cognitive complexity 1
 		if x.BitLen() > fieldBits || y.BitLen() > fieldBits {
 			return nil, fmt.Errorf("ec coordinate size exceeds curve %q field size (%d bits)", k.Crv, fieldBits)
 		}
-		if !curve.IsOnCurve(x, y) {
+		// elliptic.Curve.IsOnCurve is deprecated (low-level, unsafe API) in favor
+		// of crypto/ecdh, which performs the on-curve check as part of decoding
+		// an uncompressed point via NewPublicKey — same guarantee, supported API.
+		byteLen := (fieldBits + 7) / 8
+		point := make([]byte, 1+2*byteLen)
+		point[0] = 0x04
+		x.FillBytes(point[1 : 1+byteLen])
+		y.FillBytes(point[1+byteLen : 1+2*byteLen])
+		if _, err := ecdhCurve.NewPublicKey(point); err != nil {
 			return nil, fmt.Errorf("ec point is not on curve %q", k.Crv)
 		}
 		return &ecdsa.PublicKey{Curve: curve, X: x, Y: y}, nil

--- a/internal/core/oidc_jwks.go
+++ b/internal/core/oidc_jwks.go
@@ -69,6 +69,20 @@ const (
 	minRSABits = 2048
 )
 
+// maxRSAPublicExponent bounds the RSA public exponent accepted from a JWKS.
+// Verification cost (modular exponentiation) grows with the bit length of the
+// exponent, same as it does with the modulus — parseJWK previously only
+// checked that e was a positive int64 (i.e. anything up to ~63 bits), so a
+// compromised/MITM'd issuer could pair an in-bounds [minRSABits,maxRSABits]
+// modulus with a needlessly huge exponent and make every verification against
+// that cached key several times more expensive than a normal e=65537 key —
+// the same sustained-DoS shape maxRSABits guards against, just via the other
+// operand. 2^32 comfortably exceeds every exponent used in real-world
+// deployments (3, 17, and 65537 are effectively universal; even unusual
+// configurations don't approach this) while remaining far below the ~63-bit
+// ceiling the int64 conversion otherwise allows.
+const maxRSAPublicExponent = 1 << 32
+
 // jwksStaleGrace bounds how far PAST the TTL a cached key set may still be served
 // as a fallback when a JWKS refetch fails transiently. Without a bound, a key the
 // issuer rotated out — e.g. because its private key was compromised — would keep
@@ -341,6 +355,9 @@ func parseJWK(k jwk) (interface{}, error) { // NOSONAR -- cognitive complexity 1
 		if !e.IsInt64() || e.Int64() <= 0 {
 			return nil, fmt.Errorf("rsa e out of range")
 		}
+		if e.Int64() > maxRSAPublicExponent {
+			return nil, fmt.Errorf("rsa exponent %d exceeds allowed maximum %d", e.Int64(), int64(maxRSAPublicExponent))
+		}
 		return &rsa.PublicKey{N: n, E: int(e.Int64())}, nil
 	case "EC":
 		var curve elliptic.Curve
@@ -361,6 +378,20 @@ func parseJWK(k jwk) (interface{}, error) { // NOSONAR -- cognitive complexity 1
 		y, err := b64uBigInt(k.Y)
 		if err != nil {
 			return nil, err
+		}
+		// Explicit, independent bound-check on the raw coordinates, mirroring the
+		// RSA modulus/exponent checks above: this file's own defense-in-depth
+		// guarantee shouldn't rely solely on the underlying crypto/ecdsa (or
+		// nistec) verification path rejecting an oversized or off-curve point —
+		// that's an implementation detail of the Go toolchain in use, not a
+		// contract parseJWK controls. maxJWKSBytes bounds the whole JWKS response
+		// but not an individual coordinate within it.
+		fieldBits := curve.Params().BitSize
+		if x.BitLen() > fieldBits || y.BitLen() > fieldBits {
+			return nil, fmt.Errorf("ec coordinate size exceeds curve %q field size (%d bits)", k.Crv, fieldBits)
+		}
+		if !curve.IsOnCurve(x, y) {
+			return nil, fmt.Errorf("ec point is not on curve %q", k.Crv)
 		}
 		return &ecdsa.PublicKey{Curve: curve, X: x, Y: y}, nil
 	default:

--- a/internal/core/oidc_jwks_test.go
+++ b/internal/core/oidc_jwks_test.go
@@ -478,7 +478,7 @@ func TestParseJWK_RejectsOffCurveECPoint(t *testing.T) {
 	require.NoError(t, err)
 	ecKey, isEC := parsed.(*ecdsa.PublicKey)
 	require.True(t, isEC)
-	assert.Equal(t, 0, priv.X.Cmp(ecKey.X))
+	assert.True(t, priv.PublicKey.Equal(ecKey))
 }
 
 // TestParseJWK_RejectsOversizedECCoordinate pins CORE-OIDC-05: a coordinate

--- a/internal/core/oidc_jwks_test.go
+++ b/internal/core/oidc_jwks_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
@@ -383,4 +385,123 @@ func TestHTTPJWKSResolver_RejectsOversizedRSAKey(t *testing.T) {
 
 	_, err = r.Key(context.Background(), "https://iss", "huge")
 	require.ErrorContains(t, err, "no usable signing keys")
+}
+
+// TestParseJWK_RejectsOversizedRSAExponent pins CORE-OIDC-05: an RSA modulus
+// within [minRSABits,maxRSABits] paired with a needlessly huge public exponent
+// (up to the ~63-bit int64 ceiling the old code allowed) makes every cached
+// verification against that key several times more expensive than a normal
+// e=65537 key — the same sustained-DoS shape maxRSABits guards against, via
+// the other operand of the modexp.
+func TestParseJWK_RejectsOversizedRSAExponent(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	// e is a large-but-valid int64 (well above maxRSAPublicExponent, far below
+	// the int64 ceiling the old code capped at).
+	hugeE := new(big.Int).Lsh(big.NewInt(1), 62)
+	k := jwk{
+		Kty: "RSA",
+		Kid: "huge-exponent",
+		N:   base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(hugeE.Bytes()),
+	}
+	got, err := parseJWK(k)
+	require.Error(t, err, "an oversized RSA exponent must be rejected")
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "exceeds allowed maximum")
+
+	// A real, common exponent on the same modulus still parses fine.
+	ok := jwk{Kty: "RSA", Kid: "ok",
+		N: base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+		E: base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes())}
+	parsed, err := parseJWK(ok)
+	require.NoError(t, err)
+	require.IsType(t, &rsa.PublicKey{}, parsed)
+}
+
+// TestHTTPJWKSResolver_RejectsOversizedRSAExponentInJWKS confirms the exponent
+// guard is wired through the full fetch path, mirroring
+// TestHTTPJWKSResolver_RejectsOversizedRSAKeyInJWKS for the modulus check.
+func TestHTTPJWKSResolver_RejectsOversizedRSAExponentInJWKS(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	hugeE := new(big.Int).Lsh(big.NewInt(1), 62)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"keys": []map[string]string{{
+				"kty": "RSA", "kid": "huge-exponent", "use": "sig",
+				"n": base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+				"e": base64.RawURLEncoding.EncodeToString(hugeE.Bytes()),
+			}},
+		})
+	}))
+	defer srv.Close()
+	r, err := NewHTTPJWKSResolver(map[string]string{"https://iss": srv.URL})
+	require.NoError(t, err)
+
+	_, err = r.Key(context.Background(), "https://iss", "huge-exponent")
+	require.ErrorContains(t, err, "no usable signing keys")
+}
+
+// TestParseJWK_RejectsOffCurveECPoint pins CORE-OIDC-05's EC half: parseJWK
+// must independently verify a decoded (X,Y) actually lies on the claimed
+// curve, rather than handing an unchecked point straight to ecdsa.PublicKey
+// and relying solely on whatever validation the underlying crypto/ecdsa
+// verification path happens to do internally.
+func TestParseJWK_RejectsOffCurveECPoint(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	// Perturb Y so (X,Y) no longer satisfies the P-256 curve equation, while
+	// keeping both coordinates comfortably within the field size.
+	offY := new(big.Int).Add(priv.Y, big.NewInt(2))
+
+	k := jwk{
+		Kty: "EC",
+		Kid: "off-curve",
+		Crv: "P-256",
+		X:   base64.RawURLEncoding.EncodeToString(priv.X.Bytes()),
+		Y:   base64.RawURLEncoding.EncodeToString(offY.Bytes()),
+	}
+	got, err := parseJWK(k)
+	require.Error(t, err, "an off-curve EC point must be rejected")
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "not on curve")
+
+	// The genuine, on-curve point still parses fine.
+	ok := jwk{Kty: "EC", Kid: "ok", Crv: "P-256",
+		X: base64.RawURLEncoding.EncodeToString(priv.X.Bytes()),
+		Y: base64.RawURLEncoding.EncodeToString(priv.Y.Bytes())}
+	parsed, err := parseJWK(ok)
+	require.NoError(t, err)
+	ecKey, isEC := parsed.(*ecdsa.PublicKey)
+	require.True(t, isEC)
+	assert.Equal(t, 0, priv.X.Cmp(ecKey.X))
+}
+
+// TestParseJWK_RejectsOversizedECCoordinate pins CORE-OIDC-05: a coordinate
+// whose bit length exceeds the claimed curve's field size must be rejected by
+// parseJWK's own check, independent of (in addition to) whatever bound the
+// underlying crypto/ecdsa/nistec implementation happens to enforce.
+func TestParseJWK_RejectsOversizedECCoordinate(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	// P-256's field size is 256 bits; build an X well beyond that.
+	oversizedX := new(big.Int).Lsh(big.NewInt(1), 512)
+	oversizedX.Or(oversizedX, priv.X)
+
+	k := jwk{
+		Kty: "EC",
+		Kid: "oversized-coord",
+		Crv: "P-256",
+		X:   base64.RawURLEncoding.EncodeToString(oversizedX.Bytes()),
+		Y:   base64.RawURLEncoding.EncodeToString(priv.Y.Bytes()),
+	}
+	got, err := parseJWK(k)
+	require.Error(t, err, "an oversized EC coordinate must be rejected")
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "exceeds curve")
 }

--- a/internal/core/project_suspend_test.go
+++ b/internal/core/project_suspend_test.go
@@ -21,7 +21,11 @@ func TestSuspendResumeProjectSecrets(t *testing.T) {
 	require.NoError(t, err)
 	sqlDB, _ := db.DB()
 	sqlDB.SetMaxOpenConns(1)
-	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}))
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{},
+		&models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
+		&models.GroupRole{}, &models.SecretACL{},
+	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
 
@@ -35,19 +39,23 @@ func TestSuspendResumeProjectSecrets(t *testing.T) {
 	e2, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
 	require.NoError(t, err)
 
+	// Actor 1 is a live project member (and owner of its own secrets) in p1 — the
+	// standard "full authority" caller for the happy-path assertions below.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: p1.ID}).Error)
+
 	// Project p1: three secrets (one already suspended). Project p2: one (must be untouched).
-	mk := func(name string, projectID, envID uint, status string) uint {
+	mk := func(name string, projectID, envID, ownerID uint, status string) uint {
 		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{
-			Name: name, ProjectID: projectID, EnvironmentID: envID, Type: "password", OwnerID: 1, IsSecret: true,
+			Name: name, ProjectID: projectID, EnvironmentID: envID, Type: "password", OwnerID: ownerID, IsSecret: true,
 			Status: status, CreatedAt: time.Now(), UpdatedAt: time.Now(),
 		})
 		require.NoError(t, err)
 		return s.ID
 	}
-	mk("a", p1.ID, e1.ID, SecretStatusActive)
-	mk("b", p1.ID, e1.ID, SecretStatusActive)
-	mk("c", p1.ID, e1.ID, SecretStatusSuspended) // already suspended
-	otherID := mk("z", p2.ID, e2.ID, SecretStatusActive)
+	mk("a", p1.ID, e1.ID, 1, SecretStatusActive)
+	mk("b", p1.ID, e1.ID, 1, SecretStatusActive)
+	mk("c", p1.ID, e1.ID, 1, SecretStatusSuspended) // already suspended
+	otherID := mk("z", p2.ID, e2.ID, 1, SecretStatusActive)
 
 	t.Run("suspend-all suspends only the active secrets in the project", func(t *testing.T) {
 		n, err := c.SuspendProjectSecrets(ctx, p1.ID, 1, "breach")
@@ -75,5 +83,99 @@ func TestSuspendResumeProjectSecrets(t *testing.T) {
 		require.Error(t, err)
 		_, err = c.ResumeProjectSecrets(ctx, 1, 0)
 		require.Error(t, err)
+	})
+}
+
+// TestSuspendResumeProjectSecrets_PerSecretAuthzReCheck is the handlers-secrets-
+// expiring-F6 regression test: SuspendProjectSecrets/ResumeProjectSecrets must
+// re-check EnforceSecretWritePermission for each candidate secret — exactly like
+// ExtendExpiringSecrets does — instead of trusting the project-wide route gate
+// alone. It builds a mixed-authority caller directly against real permission
+// resolution (no mocking of CheckSecretPermission itself): actor 1 has write
+// authority over "shared" via a direct share, but no ownership, share, ACL, or
+// project role gives it any authority over "unshared" in the same project. A
+// caller who could not PUT-update "unshared" individually must not be able to
+// suspend/resume it via the bulk project-wide op either.
+func TestSuspendResumeProjectSecrets_PerSecretAuthzReCheck(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{},
+		&models.SecretAccessLog{}, &models.ShareRecord{}, &models.Group{}, &models.UserGroup{}, &models.UserRole{},
+		&models.GroupRole{}, &models.SecretACL{}, &models.User{},
+	))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	ctx := context.Background()
+
+	p, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
+	require.NoError(t, err)
+	e, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p.ID})
+	require.NoError(t, err)
+
+	const actorID = uint(1)
+	const otherOwnerID = uint(99)
+
+	// CreateShareRecord verifies the recipient user row exists.
+	require.NoError(t, db.Create(&models.User{ID: actorID, Username: "actor", Email: "actor@example.com"}).Error)
+
+	// Both secrets are owned by someone else and actor 1 holds no project role at
+	// all (so it never passes via ownership or the RBAC fallback) — the ONLY
+	// thing that distinguishes them is a direct write share on "shared".
+	mk := func(name string) uint {
+		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{
+			Name: name, ProjectID: p.ID, EnvironmentID: e.ID, Type: "password", OwnerID: otherOwnerID, IsSecret: true,
+			Status: SecretStatusActive, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		})
+		require.NoError(t, err)
+		return s.ID
+	}
+	sharedID := mk("shared")
+	unsharedID := mk("unshared")
+
+	_, err = c.storage.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: sharedID, OwnerID: otherOwnerID, RecipientID: actorID, IsGroup: false, Permission: "write", CreatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Sanity check: actor 1 really can write "shared" but not "unshared" via the
+	// single-secret path (this is exactly the authority the bulk op must mirror).
+	_, err = c.EnforceSecretWritePermission(ctx, sharedID, actorID)
+	require.NoError(t, err, "precondition: actor has write authority on the shared secret")
+	_, err = c.EnforceSecretWritePermission(ctx, unsharedID, actorID)
+	require.Error(t, err, "precondition: actor has no write authority on the unshared secret")
+
+	t.Run("suspend-all only suspends the secret the caller has write authority over", func(t *testing.T) {
+		n, err := c.SuspendProjectSecrets(ctx, p.ID, actorID, "breach")
+		require.NoError(t, err)
+		assert.Equal(t, 1, n, "only the shared secret is suspended")
+
+		shared, err := c.storage.GetSecret(ctx, sharedID)
+		require.NoError(t, err)
+		assert.Equal(t, SecretStatusSuspended, shared.Status)
+
+		unshared, err := c.storage.GetSecret(ctx, unsharedID)
+		require.NoError(t, err)
+		assert.Equal(t, SecretStatusActive, unshared.Status, "denied secret must be left untouched, not silently suspended")
+	})
+
+	t.Run("resume-all only resumes the secret the caller has write authority over", func(t *testing.T) {
+		// Suspend both directly (bypassing the bulk op) so both start suspended.
+		_, err := c.SuspendSecret(ctx, unsharedID, otherOwnerID, "setup")
+		require.NoError(t, err)
+
+		n, err := c.ResumeProjectSecrets(ctx, p.ID, actorID)
+		require.NoError(t, err)
+		assert.Equal(t, 1, n, "only the shared secret is resumed")
+
+		shared, err := c.storage.GetSecret(ctx, sharedID)
+		require.NoError(t, err)
+		assert.Equal(t, SecretStatusActive, shared.Status)
+
+		unshared, err := c.storage.GetSecret(ctx, unsharedID)
+		require.NoError(t, err)
+		assert.Equal(t, SecretStatusSuspended, unshared.Status, "denied secret must be left untouched, not silently resumed")
 	})
 }

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -337,7 +337,7 @@ func (c *KeyorixCore) scimUpdateUserTx(ctx context.Context, tx storage.Storage, 
 	// PATCH that never touches lifecycle state.
 	origState := user.AccountState
 	wasActive := user.IsActive
-	if displayName != nil {
+	if displayName != nil && *displayName != "" {
 		user.DisplayName = *displayName
 	}
 	if email != nil && *email != "" {

--- a/internal/core/secret_suspend.go
+++ b/internal/core/secret_suspend.go
@@ -63,9 +63,10 @@ const projectSuspendPageSize = 500
 
 // SuspendProjectSecrets freezes value reads of every active secret in a project (a
 // breach-response "freeze the project" action) and returns how many it suspended.
-// Already-suspended secrets are left untouched; a per-secret failure is skipped so one
-// bad secret doesn't abort the freeze. The caller must have enforced scoped
-// secrets.write on the project.
+// Already-suspended secrets are left untouched; a per-secret failure (including a
+// per-secret authorization denial — see the EnforceSecretWritePermission re-check
+// below) is skipped so one bad secret doesn't abort the freeze. The caller must have
+// enforced scoped secrets.write on the project.
 func (c *KeyorixCore) SuspendProjectSecrets(ctx context.Context, projectID, actorID uint, reason string) (int, error) {
 	if projectID == 0 || actorID == 0 {
 		return 0, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID and actor ID are required")
@@ -77,6 +78,14 @@ func (c *KeyorixCore) SuspendProjectSecrets(ctx context.Context, projectID, acto
 	n := 0
 	for _, s := range secrets {
 		if s.Status == SecretStatusSuspended {
+			continue
+		}
+		// Re-check per-secret write authorization (owner/share). The project-wide
+		// secrets.write route gate is not sufficient on its own — the single-secret PUT
+		// path enforces this too, so a caller who can't update a secret individually must
+		// not be able to via the bulk op (mirrors ExtendExpiringSecrets). Skip (don't
+		// abort) on denial.
+		if _, err := c.EnforceSecretWritePermission(ctx, s.ID, actorID); err != nil {
 			continue
 		}
 		if _, err := c.SuspendSecret(ctx, s.ID, actorID, reason); err == nil {
@@ -99,6 +108,11 @@ func (c *KeyorixCore) ResumeProjectSecrets(ctx context.Context, projectID, actor
 	n := 0
 	for _, s := range secrets {
 		if s.Status != SecretStatusSuspended {
+			continue
+		}
+		// Re-check per-secret write authorization — see the matching check in
+		// SuspendProjectSecrets above.
+		if _, err := c.EnforceSecretWritePermission(ctx, s.ID, actorID); err != nil {
 			continue
 		}
 		if _, err := c.ResumeSecret(ctx, s.ID, actorID); err == nil {

--- a/internal/core/secret_value_crypto.go
+++ b/internal/core/secret_value_crypto.go
@@ -14,8 +14,10 @@
 //
 // Fail-closed is the governing rule for a security product: an encryption failure on
 // write is surfaced, never silently downgraded to a plaintext write; and a row whose
-// own metadata marks it encrypted is never returned as if it were plaintext when no
-// key is available to decrypt it.
+// own metadata marks it encrypted — or whose metadata is malformed/ambiguous rather
+// than the confirmed-empty plaintext marker — is never returned as if it were
+// plaintext when no key is available (or no algorithm can be determined) to decrypt
+// it.
 package core
 
 import (
@@ -53,14 +55,27 @@ func (c *KeyorixCore) encryptVersionValue(secret *models.SecretNode, value []byt
 //   - Encrypted row (metadata carries an algorithm): it MUST be decrypted with a wired
 //     encryptor. If none is available, this errors rather than handing back ciphertext
 //     as though it were plaintext.
-//   - Plaintext row (empty "{}" metadata — written while encryption was disabled):
-//     returned as-is.
+//   - Plaintext row (empty "{}"/nil metadata — written while encryption was
+//     disabled): returned as-is.
+//   - Ambiguous row (metadata fails to parse, or parses but has no usable
+//     "algorithm"): this can only happen via data corruption — every current writer
+//     sets EncryptedValue and EncryptionMetadata together — but if it does, we cannot
+//     tell whether EncryptedValue is real ciphertext or plaintext, so this errors
+//     rather than guessing.
 //
 // The AAD is reconstructed from the row's identity exactly as encryptVersionValue
 // bound it, so a transplanted ciphertext fails authentication.
 func (c *KeyorixCore) decryptVersionValue(secret *models.SecretNode, version *models.SecretVersion) ([]byte, error) {
-	if !versionIsEncrypted(version.EncryptionMetadata) {
+	switch versionMetadataStatus(version.EncryptionMetadata) {
+	case metadataPlaintext:
 		return version.EncryptedValue, nil
+	case metadataAmbiguous:
+		// The metadata is neither the confirmed-plaintext empty marker nor a
+		// well-formed encrypted envelope. We cannot tell whether EncryptedValue
+		// holds real ciphertext or plaintext, so we refuse to guess — handing back
+		// the raw bytes here would risk leaking ciphertext (or corrupting a
+		// genuine plaintext value) as if it were the secret's real value.
+		return nil, fmt.Errorf("secret version %d has malformed encryption metadata; refusing to guess whether it is plaintext", version.ID)
 	}
 	if c.secretValueEncryptor == nil {
 		return nil, fmt.Errorf("secret version %d is encrypted at rest but no encryption key is available to decrypt it — refusing to return raw ciphertext (check storage.encryption / KEYORIX_MASTER_PASSWORD)", version.ID)
@@ -73,20 +88,55 @@ func (c *KeyorixCore) decryptVersionValue(secret *models.SecretNode, version *mo
 	return plaintext, nil
 }
 
-// versionIsEncrypted reports whether a stored version's EncryptionMetadata marks it as
-// encrypted at rest. Encrypted rows carry a non-empty AES-256-GCM envelope metadata
-// (Algorithm set); plaintext rows carry empty "{}" metadata. Malformed/empty metadata
-// is treated as plaintext — the fail-closed direction, since a genuinely encrypted
-// blob will then fail to parse as plaintext downstream rather than leak.
-func versionIsEncrypted(meta models.JSON) bool {
+// metadataStatus classifies a stored version's EncryptionMetadata for routing in
+// decryptVersionValue. There are three distinct states, and they must NOT be
+// collapsed into a single bool: only metadataPlaintext is safe to read verbatim.
+type metadataStatus int
+
+const (
+	// metadataPlaintext: the confirmed plaintext marker — metadata is nil/empty
+	// (exactly "{}" or len==0). Written by the current code path only when
+	// encryption is disabled. Safe to return EncryptedValue as-is.
+	metadataPlaintext metadataStatus = iota
+	// metadataEncrypted: well-formed JSON with a non-empty "algorithm" field.
+	// Must be decrypted with a wired encryptor; decryptVersionValue errors if
+	// none is available rather than returning ciphertext.
+	metadataEncrypted
+	// metadataAmbiguous: metadata that is neither of the above — JSON that fails
+	// to parse at all, or well-formed JSON whose "algorithm" field is empty or
+	// absent. This can only arise from data corruption (the two columns are
+	// always written together today), but if it does, EncryptedValue's true
+	// nature is unknown and must NOT be treated as plaintext.
+	metadataAmbiguous
+)
+
+// versionMetadataStatus classifies a stored version's EncryptionMetadata into one of
+// the three metadataStatus states described above. Only a genuinely empty object
+// (nil/len==0 bytes, or a well-formed "{}" with no fields at all) is treated as
+// confirmed plaintext. Anything that fails to parse as JSON, or parses but carries a
+// non-empty object without a usable "algorithm" field, is ambiguous and must fail
+// closed in decryptVersionValue rather than being silently treated as plaintext.
+func versionMetadataStatus(meta models.JSON) metadataStatus {
 	if len(meta) == 0 {
-		return false
+		return metadataPlaintext
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(meta, &fields); err != nil {
+		// Not a valid JSON object at all (garbage bytes, truncated JSON, etc).
+		return metadataAmbiguous
+	}
+	if len(fields) == 0 {
+		// Exactly "{}" (or equivalent empty object) — the intended plaintext marker.
+		return metadataPlaintext
 	}
 	var m struct {
 		Algorithm string `json:"algorithm"`
 	}
 	if err := json.Unmarshal(meta, &m); err != nil {
-		return false
+		return metadataAmbiguous
 	}
-	return m.Algorithm != ""
+	if m.Algorithm == "" {
+		return metadataAmbiguous
+	}
+	return metadataEncrypted
 }

--- a/internal/core/secret_value_crypto_test.go
+++ b/internal/core/secret_value_crypto_test.go
@@ -63,7 +63,7 @@ func TestSecretValue_EncryptedRoundTrip(t *testing.T) {
 	version, err := c.storage.GetLatestSecretVersion(ctx, secret.ID)
 	require.NoError(t, err)
 	assert.False(t, bytes.Equal(version.EncryptedValue, []byte(plaintext)), "must be ciphertext at rest")
-	assert.True(t, versionIsEncrypted(version.EncryptionMetadata), "metadata must mark the row encrypted")
+	assert.Equal(t, metadataEncrypted, versionMetadataStatus(version.EncryptionMetadata), "metadata must mark the row encrypted")
 
 	got, err := c.GetSecretValue(ctx, secret.ID)
 	require.NoError(t, err)
@@ -129,4 +129,72 @@ func TestSecretValue_PlaintextRowStillReadable(t *testing.T) {
 	got, err := c.decryptVersionValue(secret, plaintextRow)
 	require.NoError(t, err)
 	assert.Equal(t, "legacy-plaintext", string(got))
+}
+
+// TestSecretValue_MalformedMetadataFailsClosed proves that EncryptionMetadata which
+// fails to parse as JSON at all (garbage/truncated bytes — e.g. from a corrupted
+// column or inconsistent backup restore) is treated as ambiguous, not plaintext:
+// decryptVersionValue must error rather than silently returning EncryptedValue as if
+// it were the secret's real value.
+func TestSecretValue_MalformedMetadataFailsClosed(t *testing.T) {
+	c, projectID, _ := newEncryptedCore(t)
+
+	secret := &models.SecretNode{ID: 43, ProjectID: projectID}
+	corruptedRow := &models.SecretVersion{
+		SecretNodeID:       secret.ID,
+		VersionNumber:      1,
+		EncryptedValue:     []byte("possibly-real-ciphertext-bytes"),
+		EncryptionMetadata: models.JSON(`{not valid json`),
+	}
+
+	assert.Equal(t, metadataAmbiguous, versionMetadataStatus(corruptedRow.EncryptionMetadata))
+
+	got, err := c.decryptVersionValue(secret, corruptedRow)
+	require.Error(t, err, "unparseable metadata must fail closed, not be treated as plaintext")
+	assert.Nil(t, got)
+	assert.NotEqual(t, "possibly-real-ciphertext-bytes", string(got))
+}
+
+// TestSecretValue_MissingAlgorithmFailsClosed proves that well-formed JSON metadata
+// which is NOT the confirmed-empty "{}" plaintext marker, but also carries no (or an
+// empty) "algorithm" field, is treated as ambiguous rather than plaintext.
+// decryptVersionValue must error instead of silently returning EncryptedValue.
+func TestSecretValue_MissingAlgorithmFailsClosed(t *testing.T) {
+	c, projectID, _ := newEncryptedCore(t)
+
+	testCases := []struct {
+		name string
+		meta models.JSON
+	}{
+		{"empty algorithm field", models.JSON(`{"algorithm":""}`)},
+		{"other fields, no algorithm", models.JSON(`{"nonce":"abc123"}`)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			secret := &models.SecretNode{ID: 44, ProjectID: projectID}
+			row := &models.SecretVersion{
+				SecretNodeID:       secret.ID,
+				VersionNumber:      1,
+				EncryptedValue:     []byte("possibly-real-ciphertext-bytes"),
+				EncryptionMetadata: tc.meta,
+			}
+
+			assert.Equal(t, metadataAmbiguous, versionMetadataStatus(row.EncryptionMetadata))
+
+			got, err := c.decryptVersionValue(secret, row)
+			require.Error(t, err, "metadata with no usable algorithm must fail closed")
+			assert.Nil(t, got)
+		})
+	}
+}
+
+// TestSecretValue_EmptyObjectMetadataIsPlaintext is the non-regression check for the
+// intended plaintext marker: an exact "{}" object (the shape the current write path
+// always produces when encryption is disabled) must still be classified as confirmed
+// plaintext and returned verbatim.
+func TestSecretValue_EmptyObjectMetadataIsPlaintext(t *testing.T) {
+	assert.Equal(t, metadataPlaintext, versionMetadataStatus(models.JSON("{}")))
+	assert.Equal(t, metadataPlaintext, versionMetadataStatus(nil))
+	assert.Equal(t, metadataPlaintext, versionMetadataStatus(models.JSON("")))
 }

--- a/server/http/handlers/scim_test.go
+++ b/server/http/handlers/scim_test.go
@@ -186,6 +186,53 @@ func TestSCIM_ReplaceUserAllowsGenuinelyManagedAccount(t *testing.T) {
 	assert.Equal(t, "Bob Updated", u.DisplayName)
 }
 
+// TestSCIM_ReplaceUser_OmittedDisplayNamePreservesExisting is the scim-07 regression:
+// ReplaceUser always passed a non-nil *string to UpdateSCIMUser even when the PUT body
+// omitted both displayName and name.formatted (p.displayName() then returns ""), and
+// scimUpdateUserTx applied it unconditionally — unlike the email field two lines below
+// it, which explicitly skips an empty value. Any PUT lacking displayName (e.g. a
+// minimal/misconfigured IdP payload) silently blanked the stored value on every sync.
+// The fix mirrors the email guard: an empty displayName must leave the existing value
+// untouched.
+func TestSCIM_ReplaceUser_OmittedDisplayNamePreservesExisting(t *testing.T) {
+	h, db := setupSCIMTest(t)
+	require.NoError(t, db.Create(&models.User{
+		ID: 1, Username: "bob", Email: "bob@corp.com", DisplayName: "Bob Existing",
+		IsActive: true, AccountState: core.AccountActive, ExternalID: "okta|bob",
+	}).Error)
+
+	// No displayName and no name.formatted in the payload.
+	body := `{"userName":"bob@corp.com","emails":[{"value":"bob@corp.com","primary":true}]}`
+	w := httptest.NewRecorder()
+	h.ReplaceUser(w, withID(httptest.NewRequest(http.MethodPut, "/scim/v2/Users/1", bytes.NewReader([]byte(body))), "1"))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var u models.User
+	require.NoError(t, db.First(&u, 1).Error)
+	assert.Equal(t, "Bob Existing", u.DisplayName, "a PUT that omits displayName must not blank the existing value")
+}
+
+// TestSCIM_ReplaceUser_SuppliedDisplayNameStillUpdates is the positive control for the
+// scim-07 fix: a PUT that DOES supply a displayName must still update it, confirming the
+// empty-value guard didn't turn into a blanket refusal to ever update the field (mirrors
+// TestSCIM_ReplaceUserAllowsGenuinelyManagedAccount above).
+func TestSCIM_ReplaceUser_SuppliedDisplayNameStillUpdates(t *testing.T) {
+	h, db := setupSCIMTest(t)
+	require.NoError(t, db.Create(&models.User{
+		ID: 1, Username: "bob", Email: "bob@corp.com", DisplayName: "Bob Existing",
+		IsActive: true, AccountState: core.AccountActive, ExternalID: "okta|bob",
+	}).Error)
+
+	body := `{"userName":"bob@corp.com","displayName":"Bob New","emails":[{"value":"bob@corp.com","primary":true}]}`
+	w := httptest.NewRecorder()
+	h.ReplaceUser(w, withID(httptest.NewRequest(http.MethodPut, "/scim/v2/Users/1", bytes.NewReader([]byte(body))), "1"))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var u models.User
+	require.NoError(t, db.First(&u, 1).Error)
+	assert.Equal(t, "Bob New", u.DisplayName, "a PUT that supplies displayName must still update it")
+}
+
 // TestSCIM_ListFilterDoesNotLeakNativeAccount pins the "List adoption" half of
 // #120: a userName-filter query (the IdP's reconciliation lookup) must not surface a
 // NATIVE account by email match — doing so would leak its numeric SCIM resource id

--- a/server/main.go
+++ b/server/main.go
@@ -1726,8 +1726,52 @@ func startGRPCServer(ctx context.Context, cfg *config.Config, coreService *core.
 
 	// Graceful shutdown
 	log.Println("Shutting down gRPC server...")
-	grpcServer.GracefulStop()
+	stopGRPCServerWithTimeout(grpcServer, grpcShutdownTimeout)
 	return nil
+}
+
+// grpcShutdownTimeout bounds how long startGRPCServer waits for
+// grpcServer.GracefulStop() to drain in-flight RPCs before falling back to
+// the forceful grpcServer.Stop(). Matches the HTTP listener's shutdownCtx
+// timeout (see startHTTPServer) so neither transport can block shutdown past
+// 10s on its own — main()'s outer 30s select/time.After backstop only forces
+// process exit; it never calls grpcServer.Stop() or otherwise interrupts a
+// goroutine still blocked inside GracefulStop(), so without this the abandoned
+// goroutine (and any in-flight RPC/cleanup inside it) would just be leaked
+// rather than drained deterministically.
+const grpcShutdownTimeout = 10 * time.Second
+
+// grpcGracefulStopper is the subset of *grpc.Server's shutdown surface that
+// stopGRPCServerWithTimeout needs. Extracted as an interface (rather than
+// depending on *grpc.Server directly) so a test can exercise the
+// timeout/fallback branch with a fake whose GracefulStop() blocks
+// indefinitely, without standing up a real gRPC listener or an actual
+// long-lived RPC.
+type grpcGracefulStopper interface {
+	GracefulStop()
+	Stop()
+}
+
+// stopGRPCServerWithTimeout runs gs.GracefulStop() in a goroutine and waits
+// up to timeout for it to finish draining in-flight RPCs. A client that opens
+// a long-lived or slow streaming RPC (e.g. StreamAuditLogs) and never closes
+// it would otherwise block GracefulStop() forever; if timeout fires first,
+// this calls gs.Stop() to forcibly cancel every outstanding RPC immediately
+// instead of leaving that goroutine — and whatever RPC/cleanup it's still
+// waiting on — abandoned mid-flight when main() eventually gives up.
+func stopGRPCServerWithTimeout(gs grpcGracefulStopper, timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		gs.GracefulStop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		log.Println("gRPC graceful shutdown timeout exceeded, forcing stop")
+		gs.Stop()
+	}
 }
 
 func createTLSConfig(cfg *config.Config) (*tls.Config, error) {

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -281,6 +281,28 @@ func handleAuthRequest(next http.Handler, w http.ResponseWriter, r *http.Request
 	validatedAt := time.Now()
 	userCtx, err := validateToken(r.Context(), validator, token)
 	if err != nil {
+		// #G-transient: a TRANSIENT infrastructure failure (DB timeout, connection
+		// error, context deadline exceeded during the underlying lookup) says
+		// nothing about whether this token/credential is actually valid — it must
+		// not be treated the same as a genuinely bad token. validateToken's
+		// underlying validators (ValidateSessionToken/ValidatePATToken/
+		// ValidateMachineToken/ValidateOIDCToken) collapse every storage error into
+		// an opaque message before it reaches here (deliberately — the detailed
+		// reason must never leak to an unauthenticated caller), so the request's
+		// OWN context is the only reliable transient-vs-permanent signal available
+		// at this layer: if it was canceled or hit its deadline while validation
+		// was in flight, that — not credential invalidity — is almost certainly
+		// why validation failed. See isTransientValidationError.
+		if isTransientValidationError(r.Context(), err) {
+			// Do NOT negative-cache: a stale "invalid" entry would keep rejecting
+			// this same token for up to invalidTokenTTL even after the backend
+			// recovers. Do NOT count against the per-IP brute-force budget either:
+			// many legitimate callers sharing one NAT/egress IP retrying during a
+			// shared blip would otherwise trip tokenAuthFailureBurst and start
+			// getting 429'd once the backend is already healthy again.
+			serviceUnavailableResponse(w, "authentication temporarily unavailable, please retry")
+			return
+		}
 		// Cache the negative result so subsequent retries skip the DB.
 		cacheSet(key, tokenCacheEntry{userCtx: nil, expiresAt: time.Now().Add(invalidTokenTTL)})
 		// Rate-limit by source IP: after tokenAuthFailureBurst failures the IP is
@@ -318,6 +340,26 @@ func handleAuthRequest(next http.Handler, w http.ResponseWriter, r *http.Request
 		coreService.TouchMachineTokenLastUsed(r.Context(), userCtx.machineCredID)
 	}
 	next.ServeHTTP(w, r.WithContext(buildRequestContext(r.Context(), userCtx, coreService)))
+}
+
+// isTransientValidationError reports whether a validateToken failure reflects a
+// transient infrastructure problem (the caller's context was canceled or hit its
+// deadline while validation was in flight) rather than the credential itself
+// being invalid. ctx is checked directly — not just err — because the storage
+// layer's own errors are deliberately opaque by the time they reach this
+// package (ValidateSessionToken/ValidatePATToken/ValidateMachineToken collapse
+// every lookup failure, including a DB timeout or connection error, into a
+// generic message so the specific reason never leaks to an unauthenticated
+// caller). A context that was canceled or ran out of time during that lookup is
+// therefore the one reliable signal available here that the failure was ours
+// (or the client's, disconnecting mid-request), not the token's. errors.Is is
+// still checked against err too, in case a future/alternate validator
+// implementation does propagate a wrapped context error.
+func isTransientValidationError(ctx context.Context, err error) bool {
+	if ctx.Err() != nil {
+		return true
+	}
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }
 
 // serveAuthCacheHit handles the fast-path cache hit. #146 originally re-fetched
@@ -1137,6 +1179,20 @@ func tooManyRequestsResponse(w http.ResponseWriter, message string) {
 	w.WriteHeader(http.StatusTooManyRequests)
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"error": "RateLimited", "message": message, "code": http.StatusTooManyRequests,
+	})
+}
+
+// serviceUnavailableResponse sends a 503 Service Unavailable response for a
+// transient failure (e.g. a storage-layer hiccup during token validation, see
+// isTransientValidationError) that the caller should simply retry, as opposed
+// to a 401 which tells the caller its credential itself is bad. Retry-After is
+// short — this is meant for a brief infrastructure blip, not a sustained outage.
+func serviceUnavailableResponse(w http.ResponseWriter, message string) {
+	w.Header().Set(hdrContentType, mimeJSON)
+	w.Header().Set("Retry-After", "2")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": "ServiceUnavailable", "message": message, "code": http.StatusServiceUnavailable,
 	})
 }
 

--- a/server/middleware/auth_transient_error_test.go
+++ b/server/middleware/auth_transient_error_test.go
@@ -1,0 +1,154 @@
+package middleware
+
+// auth_transient_error_test.go — regression coverage for the auth middleware's
+// transient-vs-permanent error handling (Wave 6 low/info finding,
+// findings-server/middleware-auth.json index 2).
+//
+// Before this fix, handleAuthRequest's slow path treated ANY error from
+// validateToken identically — a genuinely bad token and a transient
+// infrastructure failure (DB timeout, connection error, context deadline
+// exceeded during the underlying storage lookup) both got negative-cached for
+// invalidTokenTTL and counted against the per-source-IP brute-force budget
+// (recordTokenAuthFailure / tokenAuthFailureBurst, PAT-003). That meant a brief
+// storage blip could: (1) keep rejecting a legitimate token from the negative
+// cache for up to invalidTokenTTL after the backend recovered, and (2) push a
+// shared NAT/corporate-egress IP over the failure-burst threshold from
+// concurrent legitimate retries, starting to 429 unrelated healthy traffic.
+//
+// isTransientValidationError (auth.go) now distinguishes the two by checking
+// whether the request's own context was canceled or hit its deadline during
+// validation — the storage layer's errors are deliberately opaque by the time
+// they reach this package, so the context is the one reliable signal available
+// here. These tests simulate that with an already-canceled request context,
+// standing in for a DB timeout/connection error aborting the in-flight lookup.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleAuthRequest_TransientError_SkipsNegativeCacheAndRateLimit is the
+// negative-behavior-change case: a transient failure (simulated via an
+// already-canceled request context, standing in for a context-deadline-exceeded
+// DB error) must NOT negative-cache the token and must NOT consume any of the
+// per-IP brute-force budget, and must surface as a retryable 503 rather than a
+// 401.
+func TestHandleAuthRequest_TransientError_SkipsNegativeCacheAndRateLimit(t *testing.T) {
+	// A source IP unused by any other test in this package, so this test's
+	// budget assertions can't be polluted by (or pollute) the shared,
+	// package-global recordTokenAuthFailure limiter.
+	const remoteAddr = "203.0.113.10:5555"
+	const ip = "203.0.113.10"
+
+	handler := newTestAuthMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token := "not-a-recognized-token-transient"
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.RemoteAddr = remoteAddr
+
+	// Simulate the request's context already having been canceled/timed out by
+	// the time validateToken returns — standing in for a DB timeout or
+	// connection error aborting the underlying storage lookup mid-flight.
+	ctx, cancel := context.WithCancel(req.Context())
+	cancel()
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code,
+		"a transient infrastructure failure must surface as a retryable 503, not a 401")
+
+	// Must NOT be negative-cached: a retry after the backend recovers should
+	// re-attempt validation rather than being auto-rejected from a stale
+	// "invalid" cache entry for up to invalidTokenTTL.
+	key := tokenKey(token)
+	_, found := cacheGet(key)
+	assert.False(t, found, "a transient error must not populate the negative token cache")
+
+	// Must NOT have consumed the per-IP brute-force budget: every one of
+	// tokenAuthFailureBurst allowances should still be available for this IP,
+	// proving the request above did not call recordTokenAuthFailure.
+	for i := 0; i < tokenAuthFailureBurst; i++ {
+		assert.True(t, recordTokenAuthFailure(ip),
+			"budget slot %d should still be available — a transient error must not consume the per-IP failure budget", i)
+	}
+}
+
+// TestHandleAuthRequest_InvalidCredential_StillNegativeCachesAndRateLimits is
+// the unchanged-behavior case: a genuinely invalid credential (normal,
+// non-canceled context) must still negative-cache and still count against the
+// per-IP brute-force budget exactly as before, so this fix does not weaken the
+// PAT-003 brute-force protection the negative-caching/rate-limiting exists for.
+func TestHandleAuthRequest_InvalidCredential_StillNegativeCachesAndRateLimits(t *testing.T) {
+	const remoteAddr = "203.0.113.20:5555"
+	const ip = "203.0.113.20"
+
+	handler := newTestAuthMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token := "not-a-recognized-token-permanent"
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.RemoteAddr = remoteAddr
+	// Deliberately NOT canceled/deadline-bound — an ordinary, live request
+	// context, so isTransientValidationError must return false here.
+	require.Nil(t, req.Context().Err())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code, "an invalid credential must still be rejected with 401")
+
+	// Must be negative-cached, exactly as before this fix.
+	key := tokenKey(token)
+	entry, found := cacheGet(key)
+	require.True(t, found, "an invalid credential must still populate the negative token cache")
+	assert.Nil(t, entry.userCtx, "the negative cache entry must carry a nil userCtx")
+
+	// Must have consumed exactly one unit of the per-IP brute-force budget: only
+	// tokenAuthFailureBurst-1 further allowances should remain for this IP.
+	for i := 0; i < tokenAuthFailureBurst-1; i++ {
+		assert.True(t, recordTokenAuthFailure(ip),
+			"remaining budget slot %d should still be available", i)
+	}
+	assert.False(t, recordTokenAuthFailure(ip),
+		"the budget should now be exhausted — the request above must have consumed one unit")
+}
+
+// TestIsTransientValidationError unit-tests the classifier directly, covering
+// its documented signals: a canceled/deadline-exceeded context, a wrapped
+// context sentinel in err, and the ordinary "neither" case.
+func TestIsTransientValidationError(t *testing.T) {
+	plainErr := context.DeadlineExceeded // reused below only as a distinct error value where noted
+
+	t.Run("canceled context is transient", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		assert.True(t, isTransientValidationError(ctx, errors.New("session not found")))
+	})
+
+	t.Run("deadline-exceeded context is transient", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 0)
+		defer cancel()
+		assert.True(t, isTransientValidationError(ctx, errors.New("session not found")))
+	})
+
+	t.Run("err wrapping context.DeadlineExceeded is transient even with a live context", func(t *testing.T) {
+		assert.True(t, isTransientValidationError(context.Background(), plainErr))
+	})
+
+	t.Run("an ordinary invalid-credential error with a live context is not transient", func(t *testing.T) {
+		assert.False(t, isTransientValidationError(context.Background(), errors.New("session not found")))
+	})
+}

--- a/server/middleware/client_ip.go
+++ b/server/middleware/client_ip.go
@@ -46,7 +46,15 @@ func clientIPFromRequest(r *http.Request, trusted []*net.IPNet) string {
 	// a trusted proxy — the client as seen by the trusted edge. Stopping at the first
 	// untrusted hop from the right means a spoofed leftmost (client-prepended) entry is
 	// ignored, so the client cannot claim an arbitrary source IP.
-	if xff := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); xff != "" {
+	//
+	// r.Header.Get returns only the FIRST occurrence of a header name; net/http does not
+	// fold duplicate header lines for arbitrary headers the way RFC 7230 §3.2.2 requires
+	// recipients to. Most proxies comma-fold X-Forwarded-For into a single header line, but
+	// one that instead appends its own hop via Header.Add (a second, separate line) would
+	// have its trusted hop silently dropped by Get, leaving only the attacker-controlled
+	// line. Use Header.Values and join every occurrence with "," first, so the walk below
+	// always sees the full chain regardless of how the proxy emitted it.
+	if xff := strings.TrimSpace(strings.Join(r.Header.Values("X-Forwarded-For"), ",")); xff != "" {
 		parts := strings.Split(xff, ",")
 		for i := len(parts) - 1; i >= 0; i-- {
 			hop := strings.TrimSpace(parts[i])
@@ -63,8 +71,19 @@ func clientIPFromRequest(r *http.Request, trusted []*net.IPNet) string {
 	// no chain, so its anti-spoof guarantee depends entirely on the trusted proxy
 	// OVERWRITING it (not passing a client-supplied value through). Preferring the XFF
 	// walk above avoids trusting a possibly-passed-through X-Real-IP whenever XFF exists.
-	if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" && net.ParseIP(xri) != nil {
-		return xri
+	//
+	// X-Real-IP is a single-address header, not a comma-separated list, so unlike XFF we
+	// can't join multiple occurrences and parse the result as one IP. But it's subject to
+	// the same Header.Get first-occurrence pitfall: a trusted proxy that appends its own
+	// X-Real-IP via Header.Add (rather than overwriting a client-supplied one) leaves its
+	// trusted value as the LAST header line, with the client's own value first. Walk the
+	// occurrences from the last back to the first and take the first one that parses as a
+	// valid IP, so the proxy-appended hop wins over anything the client sent.
+	xriValues := r.Header.Values("X-Real-IP")
+	for i := len(xriValues) - 1; i >= 0; i-- {
+		if xri := strings.TrimSpace(xriValues[i]); xri != "" && net.ParseIP(xri) != nil {
+			return xri
+		}
 	}
 	return ""
 }

--- a/server/middleware/client_ip_test.go
+++ b/server/middleware/client_ip_test.go
@@ -96,3 +96,54 @@ func TestClientIP_BareIPTrustedProxy(t *testing.T) {
 		t.Errorf("RemoteAddr = %q; want the X-Real-IP from the trusted proxy", got)
 	}
 }
+
+// serveAndCaptureRemoteAddrMultiHeader is like serveAndCaptureRemoteAddr but calls
+// r.Header.Add twice for the given header name, producing two SEPARATE header lines
+// (as net/http stores them) rather than one comma-joined value. This is the exact wire
+// shape a proxy produces when it appends its own hop via Header.Add instead of folding it
+// into the client-supplied value first — the case r.Header.Get mishandles by returning
+// only the first line.
+func serveAndCaptureRemoteAddrMultiHeader(trusted []string, remoteAddr, headerName, firstLine, secondLine string) string {
+	var seen string
+	h := ClientIP(trusted)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = r.RemoteAddr
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = remoteAddr
+	req.Header.Add(headerName, firstLine)
+	req.Header.Add(headerName, secondLine)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	return seen
+}
+
+func TestClientIP_XForwardedForFoldsMultipleHeaderLines(t *testing.T) {
+	// The client's spoofed X-Forwarded-For value arrives as the FIRST header line
+	// ("6.6.6.6" — a claim about its own IP), and the trusted proxy appends the real
+	// client IP it observed as a SEPARATE second header line (Header.Add, not
+	// comma-folded into the first). r.Header.Get would see only the first line and the
+	// right-to-left walk over it would return the attacker's spoofed "6.6.6.6" — a
+	// successful spoof. The fix must join both lines before walking, so the walk instead
+	// sees "6.6.6.6,203.0.113.9" and correctly returns the trusted proxy's own observation.
+	got := serveAndCaptureRemoteAddrMultiHeader(
+		[]string{"10.0.0.0/8"}, "10.1.2.3:443", "X-Forwarded-For",
+		"6.6.6.6",     // attacker-supplied first line, spoofing its own address
+		"203.0.113.9", // trusted proxy's own appended hop (the real client IP), second header line
+	)
+	if got != "203.0.113.9" {
+		t.Errorf("RemoteAddr = %q; want the real client IP derived from the full joined XFF header, not the attacker's spoofed first line", got)
+	}
+}
+
+func TestClientIP_XRealIPFoldsMultipleHeaderLines(t *testing.T) {
+	// Same scenario for X-Real-IP: the client sends its own X-Real-IP line, and the
+	// trusted proxy appends its own value as a second, separate header line rather than
+	// overwriting the first. r.Header.Get would return only the client's spoofed value.
+	got := serveAndCaptureRemoteAddrMultiHeader(
+		[]string{"10.0.0.0/8"}, "10.1.2.3:443", "X-Real-IP",
+		"6.6.6.6",      // attacker-supplied first line
+		"198.51.100.7", // trusted proxy's own appended hop, as a second header line
+	)
+	if got != "198.51.100.7" {
+		t.Errorf("RemoteAddr = %q; want the trusted proxy's appended X-Real-IP, not the attacker's first line", got)
+	}
+}

--- a/server/server_s28_test.go
+++ b/server/server_s28_test.go
@@ -1,0 +1,110 @@
+// server_s28_test.go — Wave 6 low-severity regression: bounded gRPC shutdown.
+//
+// startGRPCServer used to call grpcServer.GracefulStop() directly, which
+// blocks until every in-flight RPC completes with no timeout of its own. A
+// client holding open a long-lived/slow streaming RPC (e.g. StreamAuditLogs)
+// and never closing it would block that call forever; main()'s outer 30s
+// select/time.After is only a whole-process backstop — it logs "Shutdown
+// timeout exceeded, forcing exit" and returns, but never interrupts the
+// goroutine still stuck inside GracefulStop(), so the in-flight RPC and any
+// pending cleanup in that goroutine were abandoned rather than drained
+// deterministically the way startHTTPServer's shutdownCtx-bounded
+// server.Shutdown(shutdownCtx) already is.
+//
+// stopGRPCServerWithTimeout (server/main.go) now mirrors that HTTP pattern:
+// GracefulStop() runs in a goroutine bounded by a timeout, falling back to
+// the forceful Stop() (which cancels every outstanding RPC immediately) if
+// the timeout fires first. This is exercised here via a fake
+// grpcGracefulStopper rather than a real gRPC listener + blocked RPC, since a
+// deliberately-slow GracefulStop() call is what needs to be simulated, not
+// gRPC wire behavior itself.
+package main
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeGracefulStopper simulates *grpc.Server's shutdown surface for
+// TestStopGRPCServerWithTimeout_S28: GracefulStop() blocks for gracefulDelay
+// unless Stop() is called first, mirroring how a real *grpc.Server's
+// Stop() call unblocks a GracefulStop() already in progress by forcibly
+// cancelling the RPCs it was waiting to drain.
+type fakeGracefulStopper struct {
+	gracefulDelay time.Duration
+	stopCh        chan struct{}
+	stopCalled    atomic.Bool
+	gracefulDone  atomic.Bool
+}
+
+func newFakeGracefulStopper(gracefulDelay time.Duration) *fakeGracefulStopper {
+	return &fakeGracefulStopper{gracefulDelay: gracefulDelay, stopCh: make(chan struct{})}
+}
+
+func (f *fakeGracefulStopper) GracefulStop() {
+	select {
+	case <-time.After(f.gracefulDelay):
+	case <-f.stopCh:
+	}
+	f.gracefulDone.Store(true)
+}
+
+func (f *fakeGracefulStopper) Stop() {
+	f.stopCalled.Store(true)
+	close(f.stopCh)
+}
+
+// TestStopGRPCServerWithTimeout_S28_CompletesWithinTimeout verifies that when
+// GracefulStop() finishes well inside the timeout (the common case — no
+// stuck RPCs), stopGRPCServerWithTimeout returns promptly WITHOUT falling
+// back to the forceful Stop(). Pins that the fallback isn't triggered
+// unconditionally.
+func TestStopGRPCServerWithTimeout_S28_CompletesWithinTimeout(t *testing.T) {
+	fake := newFakeGracefulStopper(5 * time.Millisecond)
+
+	start := time.Now()
+	stopGRPCServerWithTimeout(fake, 2*time.Second)
+	elapsed := time.Since(start)
+
+	if fake.stopCalled.Load() {
+		t.Fatal("Stop() (forceful fallback) must not be called when GracefulStop() completes before the timeout")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("stopGRPCServerWithTimeout took %v to return after a fast GracefulStop(); expected it to return promptly", elapsed)
+	}
+}
+
+// TestStopGRPCServerWithTimeout_S28_FallsBackOnTimeout is the regression for
+// the finding: it simulates a client holding a long-lived/slow streaming RPC
+// open (GracefulStop() blocked indefinitely, standing in for e.g. an open
+// StreamAuditLogs stream that never closes) via a gracefulDelay far longer
+// than the configured timeout. Before the fix, the equivalent direct
+// grpcServer.GracefulStop() call had no bound of its own and would hang for
+// the full delay (in production: forever, until main()'s 30s whole-process
+// backstop gives up and returns without ever unblocking this goroutine).
+//
+// With the fix, stopGRPCServerWithTimeout must return within roughly the
+// configured timeout (not the full gracefulDelay) and must have called the
+// forceful Stop() fallback, proving the bounded-shutdown/fallback logic
+// actually fires rather than only existing in the happy path.
+func TestStopGRPCServerWithTimeout_S28_FallsBackOnTimeout(t *testing.T) {
+	const timeout = 30 * time.Millisecond
+	// Far longer than timeout so — absent the fix — this test would hang for
+	// the full duration instead of returning at ~timeout.
+	fake := newFakeGracefulStopper(10 * time.Second)
+
+	start := time.Now()
+	stopGRPCServerWithTimeout(fake, timeout)
+	elapsed := time.Since(start)
+
+	if !fake.stopCalled.Load() {
+		t.Fatal("Stop() (forceful fallback) must be called when GracefulStop() does not complete before the timeout")
+	}
+	// Generous upper bound for scheduling jitter under test load — the point
+	// is proving this returns in roughly `timeout`, several orders of
+	// magnitude before the 10s gracefulDelay would have elapsed on its own.
+	if elapsed > 2*time.Second {
+		t.Fatalf("stopGRPCServerWithTimeout took %v to return with a %v timeout and a blocked GracefulStop(); it must not wait for the full graceful delay", elapsed, timeout)
+	}
+}

--- a/server/validation/validator.go
+++ b/server/validation/validator.go
@@ -321,6 +321,12 @@ func (v *Validator) validateMax(field reflect.Value, param string) error {
 	return nil
 }
 
+// emailRegex matches the email format accepted by validateEmail. Compiled
+// once at package init (like identifierRegex below) instead of per-call,
+// since Validate is invoked by many concurrent goroutines against a single
+// shared *Validator on every request that carries an `email` field.
+var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+
 // validateEmail validates email format
 func (v *Validator) validateEmail(field reflect.Value) error {
 	resolved, ok := derefForRule(field)
@@ -337,13 +343,16 @@ func (v *Validator) validateEmail(field reflect.Value) error {
 		return nil
 	}
 
-	emailRegex := regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
 	if !emailRegex.MatchString(email) {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), i18n.T("LabelEmail", nil))
 	}
 
 	return nil
 }
+
+// urlRegex matches the URL format accepted by validateURL. Compiled once at
+// package init instead of per-call (see emailRegex).
+var urlRegex = regexp.MustCompile(`^https?://[^\s/$.?#].[^\s]*$`)
 
 // validateURL validates URL format
 func (v *Validator) validateURL(field reflect.Value) error {
@@ -361,13 +370,16 @@ func (v *Validator) validateURL(field reflect.Value) error {
 		return nil
 	}
 
-	urlRegex := regexp.MustCompile(`^https?://[^\s/$.?#].[^\s]*$`)
 	if !urlRegex.MatchString(url) {
 		return fmt.Errorf("%s: must be a valid URL", i18n.T("ErrorValidation", nil))
 	}
 
 	return nil
 }
+
+// alphaRegex matches the alphabetic-only charset accepted by validateAlpha.
+// Compiled once at package init instead of per-call (see emailRegex).
+var alphaRegex = regexp.MustCompile(`^[a-zA-Z]+$`)
 
 // validateAlpha validates alphabetic characters only
 func (v *Validator) validateAlpha(field reflect.Value) error {
@@ -385,13 +397,17 @@ func (v *Validator) validateAlpha(field reflect.Value) error {
 		return nil
 	}
 
-	alphaRegex := regexp.MustCompile(`^[a-zA-Z]+$`)
 	if !alphaRegex.MatchString(str) {
 		return fmt.Errorf("%s: must contain only alphabetic characters", i18n.T("ErrorValidation", nil))
 	}
 
 	return nil
 }
+
+// alphaNumRegex matches the alphanumeric-only charset accepted by
+// validateAlphaNum. Compiled once at package init instead of per-call (see
+// emailRegex).
+var alphaNumRegex = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 
 // validateAlphaNum validates alphanumeric characters only
 func (v *Validator) validateAlphaNum(field reflect.Value) error {
@@ -409,13 +425,16 @@ func (v *Validator) validateAlphaNum(field reflect.Value) error {
 		return nil
 	}
 
-	alphaNumRegex := regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 	if !alphaNumRegex.MatchString(str) {
 		return fmt.Errorf("%s: must contain only alphanumeric characters", i18n.T("ErrorValidation", nil))
 	}
 
 	return nil
 }
+
+// numericRegex matches the numeric-only charset accepted by validateNumeric.
+// Compiled once at package init instead of per-call (see emailRegex).
+var numericRegex = regexp.MustCompile(`^[0-9]+$`)
 
 // validateNumeric validates numeric characters only
 func (v *Validator) validateNumeric(field reflect.Value) error {
@@ -433,7 +452,6 @@ func (v *Validator) validateNumeric(field reflect.Value) error {
 		return nil
 	}
 
-	numericRegex := regexp.MustCompile(`^[0-9]+$`)
 	if !numericRegex.MatchString(str) {
 		return fmt.Errorf("%s: must contain only numeric characters", i18n.T("ErrorValidation", nil))
 	}

--- a/server/validation/validator_wave6_regex_hoisting_test.go
+++ b/server/validation/validator_wave6_regex_hoisting_test.go
@@ -1,0 +1,134 @@
+// validator_wave6_regex_hoisting_test.go — Wave 6 low/info batch: regression
+// coverage for findings-server/validation.json#4 (resource-exhaustion).
+// validateEmail, validateURL, validateAlpha, validateAlphaNum, and
+// validateNumeric each used to call regexp.MustCompile INLINE on every
+// invocation instead of reusing a package-level compiled *regexp.Regexp, the
+// way identifierRegex already did. Since Validate is invoked by many
+// concurrent goroutines against a single shared *Validator on every request
+// (see the Validator doc comment), that repeated compilation multiplied
+// attacker-controlled request-rate into server CPU cost. The fix hoists all
+// five regexes to package-level vars; these tests confirm (a) the package
+// vars are the SAME *regexp.Regexp instance across calls (proving the
+// compile-once behavior actually took effect, not just that patterns
+// didn't change) and (b) accept/reject behavior for each rule is unchanged.
+package validation
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidate_Wave6_RegexVarsAreReusedNotRecompiled verifies that the
+// package-level regex vars backing email/url/alpha/alphanum/numeric are
+// stable *regexp.Regexp pointers across repeated Validate calls, i.e. they
+// are compiled once at package init rather than re-compiled per call.
+func TestValidate_Wave6_RegexVarsAreReusedNotRecompiled(t *testing.T) {
+	type payload struct {
+		Email    string `json:"email" validate:"omitempty,email"`
+		URL      string `json:"url" validate:"omitempty,url"`
+		Alpha    string `json:"alpha" validate:"omitempty,alpha"`
+		AlphaNum string `json:"alphanum" validate:"omitempty,alphanum"`
+		Numeric  string `json:"numeric" validate:"omitempty,numeric"`
+	}
+	v := NewValidator()
+
+	before := []*regexp.Regexp{emailRegex, urlRegex, alphaRegex, alphaNumRegex, numericRegex}
+
+	require.NoError(t, v.Validate(payload{
+		Email:    "a@b.co",
+		URL:      "https://example.com",
+		Alpha:    "abc",
+		AlphaNum: "abc123",
+		Numeric:  "123",
+	}))
+	require.NoError(t, v.Validate(payload{
+		Email:    "c@d.co",
+		URL:      "http://example.org/x",
+		Alpha:    "xyz",
+		AlphaNum: "xyz789",
+		Numeric:  "789",
+	}))
+
+	after := []*regexp.Regexp{emailRegex, urlRegex, alphaRegex, alphaNumRegex, numericRegex}
+
+	for i := range before {
+		require.Same(t, before[i], after[i], "regex var must be the same compiled instance across calls, not recompiled per call")
+	}
+}
+
+// TestValidate_Wave6_RegexHoistingPreservesEmailBehavior verifies validateEmail's
+// accept/reject behavior is unchanged after hoisting emailRegex to a package var.
+func TestValidate_Wave6_RegexHoistingPreservesEmailBehavior(t *testing.T) {
+	type payload struct {
+		Email string `json:"email" validate:"omitempty,email"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{Email: ""}))
+	require.NoError(t, v.Validate(payload{Email: "user@example.com"}))
+	require.NoError(t, v.Validate(payload{Email: "user.name+tag@sub.example.co"}))
+	require.Error(t, v.Validate(payload{Email: "not-an-email"}))
+	require.Error(t, v.Validate(payload{Email: "missing-domain@"}))
+	require.Error(t, v.Validate(payload{Email: "@missing-local.com"}))
+}
+
+// TestValidate_Wave6_RegexHoistingPreservesURLBehavior verifies validateURL's
+// accept/reject behavior is unchanged after hoisting urlRegex to a package var.
+func TestValidate_Wave6_RegexHoistingPreservesURLBehavior(t *testing.T) {
+	type payload struct {
+		URL string `json:"url" validate:"omitempty,url"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{URL: ""}))
+	require.NoError(t, v.Validate(payload{URL: "https://example.com/x"}))
+	require.NoError(t, v.Validate(payload{URL: "http://example.com"}))
+	require.Error(t, v.Validate(payload{URL: "ftp://example.com"}))
+	require.Error(t, v.Validate(payload{URL: "not a url"}))
+}
+
+// TestValidate_Wave6_RegexHoistingPreservesAlphaBehavior verifies validateAlpha's
+// accept/reject behavior is unchanged after hoisting alphaRegex to a package var.
+func TestValidate_Wave6_RegexHoistingPreservesAlphaBehavior(t *testing.T) {
+	type payload struct {
+		Alpha string `json:"alpha" validate:"omitempty,alpha"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{Alpha: ""}))
+	require.NoError(t, v.Validate(payload{Alpha: "abcXYZ"}))
+	require.Error(t, v.Validate(payload{Alpha: "abc123"}))
+	require.Error(t, v.Validate(payload{Alpha: "abc-def"}))
+}
+
+// TestValidate_Wave6_RegexHoistingPreservesAlphaNumBehavior verifies
+// validateAlphaNum's accept/reject behavior is unchanged after hoisting
+// alphaNumRegex to a package var.
+func TestValidate_Wave6_RegexHoistingPreservesAlphaNumBehavior(t *testing.T) {
+	type payload struct {
+		AlphaNum string `json:"alphanum" validate:"omitempty,alphanum"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{AlphaNum: ""}))
+	require.NoError(t, v.Validate(payload{AlphaNum: "abc123XYZ"}))
+	require.Error(t, v.Validate(payload{AlphaNum: "abc-123"}))
+	require.Error(t, v.Validate(payload{AlphaNum: "abc 123"}))
+}
+
+// TestValidate_Wave6_RegexHoistingPreservesNumericBehavior verifies
+// validateNumeric's accept/reject behavior is unchanged after hoisting
+// numericRegex to a package var.
+func TestValidate_Wave6_RegexHoistingPreservesNumericBehavior(t *testing.T) {
+	type payload struct {
+		Numeric string `json:"numeric" validate:"omitempty,numeric"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{Numeric: ""}))
+	require.NoError(t, v.Validate(payload{Numeric: "1234567890"}))
+	require.Error(t, v.Validate(payload{Numeric: "12a"}))
+	require.Error(t, v.Validate(payload{Numeric: "12.3"}))
+}


### PR DESCRIPTION
## Summary

Fourth batch of the Wave 6 low/info-severity remediation (adversarial security review, 2026-08-07/08). All 8 findings re-verified against current `main` before dispatch.

- **`SuspendProjectSecrets`/`ResumeProjectSecrets` missing the per-secret write-authz re-check** their sibling `ExtendExpiringSecrets` already has: both bulk operations trusted the single project-scope `secrets.write` route gate alone, unlike `ExtendExpiringSecrets`, which re-checks `EnforceSecretWritePermission` per candidate secret specifically so a caller who can't update a secret individually can't do so via a bulk op either. Not currently exploitable under today's RBAC model (a role that satisfies the route gate also satisfies the per-secret check), but a real defense-in-depth gap against any future per-secret restriction. Now enforces symmetrically with its sibling — denied secrets are skipped, not silently acted on.
- **SCIM `ReplaceUser` silently blanked `displayName`** when a PUT omitted it, unlike the `email` field two lines below it, which already skips empty values. A minimal or misconfigured IdP sync payload could silently destroy a user's display name with no error surfaced to anyone. Added the same empty-value guard.
- **`grpcServer.GracefulStop()` had no bounded timeout**, unlike the HTTP listener's explicit 10-second shutdown budget — a client holding open a long-lived streaming RPC (e.g. `StreamAuditLogs`) could block shutdown indefinitely, with only a 30-second whole-process backstop that abandons the in-flight RPC rather than draining it deterministically. Added a bounded-timeout wrapper mirroring the HTTP path, falling back to a forceful `Stop()` on timeout.
- **Auth middleware negative-cached and rate-limit-penalized transient infrastructure errors** (DB timeout, context deadline exceeded) identically to genuine bad-credential errors — a brief storage blip got treated as an attacker-supplied bad token for the next 10 seconds per token, and could trip the shared per-IP brute-force counter for every legitimate client sharing that IP (e.g. behind a corporate NAT), producing a deployment-wide 429 storm once the backend was already healthy again. Now distinguishes a canceled/deadline-exceeded request context as transient and returns a retryable 503 instead, skipping both the negative-cache write and the rate-limit penalty.
- **`X-Forwarded-For`/`X-Real-IP` read via `Header.Get`** (first-occurrence-only) instead of `Header.Values` — silently mishandles a trusted proxy that appends its hop as a separate header line rather than comma-folding it into the client-supplied value, which would let the anti-spoofing right-to-left XFF walk operate on attacker-controlled content only. Now folds all occurrences before parsing, per RFC 7230 §3.2.2.
- **5 inline `regexp.MustCompile` calls in the validator** running on every request (email/URL/alpha/alphanumeric/numeric validation) instead of hoisted to package-level vars, unlike `identifierRegex`, which already does this correctly — pure refactor, no behavior change, closes an unnecessary per-request CPU amplification.
- **`parseJWK`'s RSA exponent and EC coordinates had no bound** comparable to the existing RSA-modulus bound — a compromised/MITM'd issuer could pair an in-bounds modulus with a needlessly huge exponent to inflate the modexp cost of every cached signature verification, a smaller-scale instance of the same sustained-DoS class the modulus bound exists to prevent. Added an explicit exponent ceiling and an independent on-curve + coordinate-bit-length check for EC keys.
- **`versionIsEncrypted` treated malformed/unparseable encryption metadata identically to confirmed-plaintext `{}` metadata** — on a DB-corruption edge case (inconsistent backup restore, manual DBA fix-up, a future migration that updates columns separately), this would silently return raw ciphertext bytes as if they were the secret's plaintext value, with no error, contradicting the file's own documented fail-closed design. Now distinguishes confirmed-plaintext from ambiguous/malformed metadata and fails closed on the latter.

## Follow-ups surfaced during triage (not yet actioned, both medium severity, out of scope for this low/info-only wave)

- `server/middleware/auth.go`: role revocation (`RemoveUserRole`/`SetUserRoles`) never calls `InvalidateTokenCache`, unlike every other credential-lifecycle event in the same package (password change, suspend/deactivate/delete, PAT revoke, machine-identity suspend/revoke all explicitly evict the cache) — a just-revoked role keeps authorizing requests for up to the 30s positive-cache TTL.
- `server/middleware/rate_limit.go`: `ipFailureLimiter.allow()` runs a full O(n) map-scan sweep on every call (unlike the sibling `principalRateLimiter`, which amortizes the same sweep to every 1000 calls) — a guard-of-guards failure where the auth-flood-survival layer becomes the bottleneck under that exact attack. Related: IP-keyed rate limiters collapse to one shared bucket for every client behind a proxy/LB when `trusted_proxies` is unset (the shipped `production.yaml` doesn't set it).

## Verification

Each fix independently re-verified from a fresh worktree before integration (build/vet/gofmt/gosec/relevant suites, several with pre-fix-failure proof via scoped diff/patch — not `git stash`, which repeatedly collided with concurrent sessions sharing this repo's `refs/stash` during this batch's dispatch), then cherry-picked (`-x`) onto one branch off current `main` — zero conflicts across all 8.

Combined verification on the integrated branch:
- `go build ./...`, `go vet ./...`, `gofmt -l` — all clean
- `gosec -severity medium -exclude-generated` — 0 issues (800 files)
- Full `go test ./...` — only the established pre-existing `internal/core` (`TestGetSecretValue(ByVersion)?_DeniedOutsideAccessSchedule`) and `server/http` (`RealServer`/`CSV_Headers`/`SetupToken`) failures, both confirmed identical against unmodified `main` throughout this campaign

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated ./...` — 0 issues
- [x] Full `go test ./...` — no new failures vs. baseline
- [ ] CI: lint, gitleaks, build-and-test