### PR TITLE
fix(security): close Wave 6 low/info batch 5 (CLI hygiene + 2 bonus bundles)

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -137,13 +137,28 @@ func cleanComponentPath(p string) (string, error) {
 		return "", fmt.Errorf("bundle: absolute component path %q", p)
 	}
 	clean := path.Clean(filepath.ToSlash(p))
-	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+	if isUnsafeCleanComponentPath(clean) {
 		return "", fmt.Errorf("bundle: component path escapes the bundle: %q", p)
 	}
 	if clean == manifestName || clean == sigName {
 		return "", fmt.Errorf("bundle: component path %q collides with a reserved name", p)
 	}
 	return clean, nil
+}
+
+// isUnsafeCleanComponentPath re-checks an already-cleaned, forward-slash path for
+// escape/absolute shapes. It is split out from cleanComponentPath so the check can be
+// exercised directly with an already-cleaned value (see bundle_extra_test.go): the
+// pre-clean checks above operate on the raw input string, but filepath.ToSlash is
+// OS-specific — on a platform whose separator differs from "/" (e.g. Windows), a raw
+// path using that separator (a UNC path like `\\server\share\evil`) is not caught by
+// the raw-string checks, yet can become absolute-looking (leading "/") once ToSlash +
+// path.Clean run. That conversion never happens on Unix (ToSlash is a no-op there), so
+// this branch is effectively Windows-only today — re-validating the cleaned value here
+// closes the gap regardless of which platform produced it, and regardless of whether a
+// future caller re-validates the joined path the way safeJoin does.
+func isUnsafeCleanComponentPath(clean string) bool {
+	return clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || strings.HasPrefix(clean, "/")
 }
 
 // BuildManifest walks srcDir and pins every regular file (by relative path) with its

--- a/internal/bundle/bundle_extra_test.go
+++ b/internal/bundle/bundle_extra_test.go
@@ -94,6 +94,46 @@ func TestCleanComponentPath(t *testing.T) {
 	}
 }
 
+// TestIsUnsafeCleanComponentPath_PostCleanAbsoluteRejected proves the
+// defense-in-depth check added to cleanComponentPath: the RESULT of
+// path.Clean(filepath.ToSlash(p)) must itself be re-checked for absoluteness,
+// not just the raw input string.
+//
+// On this platform (and on Linux), filepath.ToSlash is a no-op — the OS path
+// separator already is "/" — so there is no raw input string p that satisfies
+// !path.IsAbs(p) && !strings.HasPrefix(p, "/") yet still cleans to a value
+// starting with "/"; empirically, path.Clean never turns a relative path into
+// a rooted one. The gap is real only on a platform whose separator differs
+// from "/" (e.g. Windows): a raw UNC-style component name such as
+// `\\server\share\evil` does not start with "/", so it sails past the
+// pre-clean checks in cleanComponentPath, but filepath.ToSlash converts the
+// backslashes to forward slashes there, and path.Clean("//server/share/evil")
+// collapses the doubled slash to a single leading "/" — exactly the shape
+// this test exercises directly against isUnsafeCleanComponentPath, the
+// extracted post-clean check, so the regression is caught on every platform
+// this test runs on rather than only on Windows.
+func TestIsUnsafeCleanComponentPath_PostCleanAbsoluteRejected(t *testing.T) {
+	cases := []struct {
+		name   string
+		clean  string
+		unsafe bool
+	}{
+		{"post-clean absolute (simulated Windows UNC bypass)", "/server/share/evil", true},
+		{"post-clean absolute root", "/", true},
+		{"post-clean absolute simple", "/etc/passwd", true},
+		{"dot", ".", true},
+		{"dot-dot", "..", true},
+		{"dot-dot prefix", "../escape", true},
+		{"ordinary relative path", "valid/path.txt", false},
+		{"ordinary single segment", "single.txt", false},
+	}
+	for _, c := range cases {
+		if got := isUnsafeCleanComponentPath(c.clean); got != c.unsafe {
+			t.Errorf("isUnsafeCleanComponentPath(%q) = %v, want %v", c.clean, got, c.unsafe)
+		}
+	}
+}
+
 // TestParseVersion_EdgeCases covers non-standard version strings.
 func TestParseVersion_EdgeCases(t *testing.T) {
 	// Negative component.

--- a/internal/cli/accessreview/campaign.go
+++ b/internal/cli/accessreview/campaign.go
@@ -113,7 +113,11 @@ var campaignOpenCmd = &cobra.Command{
 			return err
 		}
 		printCampaignDegradedWarning(out.Campaign)
-		fmt.Printf("Opened campaign %d (%q) for project %d — %s.\n", out.Campaign.ID, out.Campaign.Name, cProject, progressStr(out.Progress))
+		// #G69: Campaign.Name is operator-chosen display text that the server
+		// echoes back verbatim in every subsequent list/show/close response
+		// — %q alone escapes Go string-literal syntax, not terminal control
+		// bytes, so it's sanitized the same as every other free-text field.
+		fmt.Printf("Opened campaign %d (%q) for project %d — %s.\n", out.Campaign.ID, common.SanitizeForTerminal(out.Campaign.Name), cProject, progressStr(out.Progress))
 		fmt.Printf("Review items: keyorix access-review campaign show --project-id %d --campaign-id %d\n", cProject, out.Campaign.ID)
 		return nil
 	},
@@ -156,7 +160,7 @@ var campaignListCmd = &cobra.Command{
 				state += "*"
 				anyDegraded = true
 			}
-			fmt.Printf("%-5d %-8s %-28s %s\n", c.Campaign.ID, state, truncate(c.Campaign.Name, 28), progressStr(c.Progress))
+			fmt.Printf("%-5d %-8s %-28s %s\n", c.Campaign.ID, state, truncate(common.SanitizeForTerminal(c.Campaign.Name), 28), progressStr(c.Progress))
 		}
 		if anyDegraded {
 			fmt.Println("\n(* = degraded snapshot; run `campaign show` on it for details)")
@@ -185,7 +189,7 @@ var campaignShowCmd = &cobra.Command{
 		if err := c.Get(context.Background(), campaignBase(cProject)+"/"+strconv.Itoa(cCampaign), &out); err != nil {
 			return err
 		}
-		fmt.Printf("Campaign %d (%q) — %s — %s\n\n", out.Campaign.ID, out.Campaign.Name, out.Campaign.State, progressStr(out.Progress))
+		fmt.Printf("Campaign %d (%q) — %s — %s\n\n", out.Campaign.ID, common.SanitizeForTerminal(out.Campaign.Name), out.Campaign.State, progressStr(out.Progress))
 		printCampaignDegradedWarning(out.Campaign)
 		if len(out.Items) == 0 {
 			fmt.Println("No items.")
@@ -193,13 +197,17 @@ var campaignShowCmd = &cobra.Command{
 		}
 		fmt.Printf("%-6s %-10s %-13s %-22s %-7s %-11s %s\n", "ITEM", "DECISION", "SOURCE", "PRINCIPAL", "ACCESS", "LAST-USED", "DETAIL")
 		for _, it := range out.Items {
-			principal := it.PrincipalName
+			// #G69: principal name/email/role name/secret name are all
+			// attacker-controlled free text — a reviewed principal must not be
+			// able to hide or spoof their own recertification row via a
+			// terminal escape sequence embedded in any of them.
+			principal := common.SanitizeForTerminal(it.PrincipalName)
 			if it.PrincipalType == "user" && it.Email != "" {
-				principal = fmt.Sprintf("%s <%s>", it.PrincipalName, it.Email)
+				principal = fmt.Sprintf("%s <%s>", principal, common.SanitizeForTerminal(it.Email))
 			}
-			detail := "secret=" + it.SecretName
+			detail := "secret=" + common.SanitizeForTerminal(it.SecretName)
 			if it.Source == "role" {
-				detail = "role=" + it.RoleName
+				detail = "role=" + common.SanitizeForTerminal(it.RoleName)
 			}
 			fmt.Printf("%-6d %-10s %-13s %-22s %-7s %-11s %s\n", it.ID, it.Decision, it.Source, truncate(principal, 22), it.AccessLevel, lastUsedLabel(it.PrincipalType, it.LastUsedAt), detail)
 		}

--- a/internal/cli/accessreview/campaign_terminal_injection_test.go
+++ b/internal/cli/accessreview/campaign_terminal_injection_test.go
@@ -1,0 +1,45 @@
+// campaign_terminal_injection_test.go — #G69: the campaign show table printed
+// attacker-controlled principal name/email/secret name/role name (and the
+// campaign's own operator-chosen name, echoed back by the server) straight
+// through fmt.Printf with no sanitization, letting the reviewed principal
+// hide or spoof their own recertification row.
+package accessreview
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCampaignShow_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := struct {
+			Campaign campaignView `json:"campaign"`
+			Items    []itemView   `json:"items"`
+			Progress progressView `json:"progress"`
+		}{
+			Campaign: campaignView{ID: 1, Name: malicious, State: "open"},
+			Items: []itemView{{
+				ID: 1, PrincipalType: "user", PrincipalName: malicious, Email: malicious,
+				Source: "owner", SecretName: malicious, AccessLevel: "read", Decision: "pending",
+			}},
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": body})
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	origProject, origCampaign := cProject, cCampaign
+	t.Cleanup(func() { cProject, cCampaign = origProject, origCampaign })
+	cProject, cCampaign = 1, 1
+
+	out, err := captureStdout(t, func() error { return campaignShowCmd.RunE(campaignShowCmd, nil) })
+	require.NoError(t, err)
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/anomalies/config.go
+++ b/internal/cli/anomalies/config.go
@@ -111,6 +111,33 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 }
 
 func runConfigSetRemote(rc *common.RemoteClient, cmd *cobra.Command) error {
+	// NOTE on the GET-then-PUT race (unsynchronized read-modify-write):
+	//
+	// This is a full-replace update: we GET the current config, patch only the
+	// flags the caller passed on the CLI, and PUT the whole object back. If two
+	// "anomaly config set" invocations (or any other future writer of this
+	// endpoint) run concurrently, the later PUT can silently clobber the
+	// earlier one's change based on its own stale GET — a classic lost-update
+	// race. There is currently no server-side primitive to close this window:
+	// AnomalyConfigRecord has no version/ETag column, UpdateAnomalyConfig
+	// (internal/core/anomaly_config.go) unconditionally stamps UpdatedAt with
+	// time.Now() on every call, and LocalStorage.SaveAnomalyConfig
+	// (internal/storage/store/local_anomaly_config.go) does an unconditional
+	// GORM Save — there is no compare-and-swap to build a conditional PUT on.
+	//
+	// Adding real optimistic concurrency (a version field + migration +
+	// conditional UPDATE ... WHERE version = ? threaded through the storage
+	// interface, both storage backends, the core layer, and the HTTP handler)
+	// is out of scope for this CLI-hygiene pass, and this isn't a security
+	// boundary — anomaly-config is an infrequently-touched operator knob, not
+	// a control an attacker can leverage by winning the race. If concurrent
+	// operators updating this config becomes a real operational problem,
+	// revisit with a proper version/ETag column on AnomalyConfigRecord.
+	//
+	// The window itself is already minimal: everything between the GET and
+	// the PUT below is pure in-memory flag application and JSON marshaling —
+	// no I/O, no unrelated work — so there is nothing further to trim here.
+	//
 	// Fetch the current config so we can do a partial update (only changed flags).
 	var resp anomalyConfigResponse
 	if err := rc.Get(context.Background(), anomalyConfigPath, &resp); err != nil {

--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -455,13 +455,15 @@ func printAuditLogTable(logs []logEntry, total int64) {
 		if e.Impersonation && e.ImpersonatedBy != "" {
 			actor = e.ImpersonatedBy + "→" + e.Actor
 		}
-		// #G69: actor and description are attacker-controlled free text (a
-		// username, or a description built from user-supplied metadata) — a
-		// reviewing operator must not have their terminal spoofed/hidden by
-		// the very row they're trying to audit.
+		// #G69: actor, event type, and description are all attacker-
+		// controlled or attacker-influenced free text (a username, an event
+		// type derived from a client-supplied action string, or a
+		// description built from user-supplied metadata) — a reviewing
+		// operator must not have their terminal spoofed/hidden by the very
+		// row they're trying to audit.
 		fmt.Printf("%-6d %-20s %-16s %-9s %-22s %s\n",
 			e.ID, shortTime(e.Timestamp), truncate(common.SanitizeForTerminal(actor), 16), e.ActorType,
-			truncate(e.EventType, 22), common.SanitizeForTerminal(e.Description))
+			truncate(common.SanitizeForTerminal(e.EventType), 22), common.SanitizeForTerminal(e.Description))
 	}
 	fmt.Printf("\nShowing %d of %d total event(s).\n", len(logs), total)
 }
@@ -605,11 +607,12 @@ func buildAuditSearchQuery() (url.Values, error) {
 func printAuditSearchTable(events []searchEvent, total int64) {
 	fmt.Printf("%-6s %-20s %-9s %-22s %-15s %s\n", "ID", "TIME", "KIND", "EVENT", "IP", "DESCRIPTION")
 	for _, e := range events {
-		// #G69: description is attacker-controlled free text — see
+		// #G69: event type, IP address, and description are all attacker-
+		// controlled or attacker-influenced free text — see
 		// printAuditLogTable's identical guard above.
 		fmt.Printf("%-6d %-20s %-9s %-22s %-15s %s\n",
 			e.ID, shortTime(e.EventTime), truncate(e.ActorType, 9),
-			truncate(e.EventType, 22), truncate(e.IPAddress, 15), common.SanitizeForTerminal(e.Description))
+			truncate(common.SanitizeForTerminal(e.EventType), 22), truncate(common.SanitizeForTerminal(e.IPAddress), 15), common.SanitizeForTerminal(e.Description))
 	}
 	fmt.Printf("\nShowing %d of %d total event(s).\n", len(events), total)
 }

--- a/internal/cli/audit/terminal_injection_test.go
+++ b/internal/cli/audit/terminal_injection_test.go
@@ -33,7 +33,7 @@ func captureStdout(t *testing.T, fn func()) string {
 func TestPrintAuditLogTable_NeutralizesEscapeSequences(t *testing.T) {
 	malicious := "\x1b[1A\x1b[2K  + spoofed clean row\n"
 	logs := []logEntry{{
-		ID: 1, EventType: "secret.read", Actor: malicious, ActorType: "user",
+		ID: 1, EventType: malicious, Actor: malicious, ActorType: "user",
 		Description: malicious, Timestamp: "2026-08-13T00:00:00Z",
 	}}
 	out := captureStdout(t, func() { printAuditLogTable(logs, 1) })
@@ -43,7 +43,7 @@ func TestPrintAuditLogTable_NeutralizesEscapeSequences(t *testing.T) {
 func TestPrintAuditSearchTable_NeutralizesEscapeSequences(t *testing.T) {
 	malicious := "\x1b[1A\x1b[2K  + spoofed clean row\n"
 	events := []searchEvent{{
-		ID: 1, EventType: "secret.read", Description: malicious,
+		ID: 1, EventType: malicious, Description: malicious, IPAddress: malicious,
 		EventTime: "2026-08-13T00:00:00Z", ActorType: "user",
 	}}
 	out := captureStdout(t, func() { printAuditSearchTable(events, 1) })

--- a/internal/cli/compliance/digest.go
+++ b/internal/cli/compliance/digest.go
@@ -3,6 +3,7 @@ package compliance
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/spf13/cobra"
@@ -49,11 +50,28 @@ immediate broadcast to the configured notification channels with --send.`,
 		if err := c.Get(context.Background(), "/api/v1/compliance/digest", &d); err != nil {
 			return err
 		}
-		fmt.Println(d.Title)
+		// #G69: title/body are server-rendered today, but this is auditor-
+		// facing evidence output and any future free text folded into the
+		// digest (event descriptions, control names, etc.) must not be able
+		// to embed terminal escape sequences that overwrite or hide prior
+		// output. Body sanitizes line-by-line rather than as a single blob so
+		// its intentional multi-line formatting survives.
+		fmt.Println(common.SanitizeForTerminal(d.Title))
 		fmt.Println()
-		fmt.Print(d.Body)
+		fmt.Print(sanitizeDigestBody(d.Body))
 		return nil
 	},
+}
+
+// sanitizeDigestBody applies common.SanitizeForTerminal per line so the
+// digest body's intentional newlines (formatting, not attacker-controlled)
+// survive while any CR/ANSI/other control bytes within a line are stripped.
+func sanitizeDigestBody(body string) string {
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		lines[i] = common.SanitizeForTerminal(line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func init() {

--- a/internal/cli/compliance/digest_terminal_injection_test.go
+++ b/internal/cli/compliance/digest_terminal_injection_test.go
@@ -1,0 +1,50 @@
+// digest_terminal_injection_test.go — #G69: the compliance digest printed its
+// title/body straight through fmt.Println/fmt.Print with no sanitization; this
+// is auditor-facing evidence output and any free text folded into it must not
+// be able to embed terminal escape sequences that overwrite or hide prior
+// output. Body sanitization is line-by-line so its intentional multi-line
+// formatting survives (only CR/ANSI/other control bytes within a line strip).
+package compliance
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDigest_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean title"
+	maliciousBody := "line one\n\x1b[1A\x1b[2K  + spoofed clean line\nline three"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]string{
+			"title": malicious, "body": maliciousBody,
+		}})
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	origSend := digestSend
+	t.Cleanup(func() { digestSend = origSend })
+	digestSend = false
+
+	out := captureStdout(t, func() { require.NoError(t, digestCmd.RunE(digestCmd, nil)) })
+	assert.NotContains(t, out, "\x1b")
+	// The body's legitimate newlines must survive sanitization.
+	assert.Contains(t, out, "line one")
+	assert.Contains(t, out, "line three")
+}
+
+func TestSanitizeDigestBody_PreservesNewlines(t *testing.T) {
+	in := "a\r\x1b[2Kb\nc\td"
+	out := sanitizeDigestBody(in)
+	// Only the raw CR/ESC control bytes are stripped (matching
+	// common.SanitizeForTerminal's own documented behavior) — the printable
+	// CSI text that followed ESC is left as inert text, and the line's own
+	// newline boundary survives.
+	assert.Equal(t, "a[2Kb\nc d", out)
+}

--- a/internal/cli/connect/connect.go
+++ b/internal/cli/connect/connect.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	cliconfig "github.com/keyorixhq/keyorix/internal/cli/config"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -296,7 +297,15 @@ func loginWithCredentials(endpoint, username, password string, timeout time.Dura
 	respBody, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("server returned %d: %s", resp.StatusCode, string(respBody))
+		// The response body is server-controlled (a malicious or compromised
+		// KEYORIX_SERVER endpoint) and reaches this operator's terminal verbatim
+		// via the wrapping "login failed: %w" in runConnect — the same threat
+		// model as #G69 (see common.SanitizeForTerminal). Sanitize control/ANSI
+		// bytes and cap the length so a hostile response can't inject terminal
+		// escape sequences or flood the terminal, while still surfacing enough
+		// of the server's message (e.g. "invalid credentials") to be useful.
+		excerpt := truncate(common.SanitizeForTerminal(string(respBody)), 300)
+		return "", fmt.Errorf("server returned %d: %s", resp.StatusCode, excerpt)
 	}
 
 	var result struct {
@@ -312,6 +321,15 @@ func loginWithCredentials(endpoint, username, password string, timeout time.Dura
 	}
 
 	return result.Data.Token, nil
+}
+
+// truncate shortens s to at most n runes, appending "…" when cut.
+func truncate(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n-1]) + "…"
 }
 
 func testServerConnection(endpoint, apiKey string, timeout time.Duration) error {

--- a/internal/cli/connect/connect_extra_test.go
+++ b/internal/cli/connect/connect_extra_test.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -93,6 +94,56 @@ func TestLoginWithCredentials_BadStatus(t *testing.T) {
 
 	_, err := loginWithCredentials(srv.URL, "alice", "wrong", 5*time.Second)
 	require.Error(t, err)
+}
+
+// TestLoginWithCredentials_SanitizesResponseBodyOnFailure is the regression test
+// for the threat model in #G69/common.SanitizeForTerminal: a malicious or
+// compromised KEYORIX_SERVER endpoint could embed ANSI/control-sequence
+// terminal-injection payloads in its login-failure response body. That body
+// reaches the operator's terminal verbatim via loginWithCredentials's returned
+// error (wrapped by runConnect's "login failed: %w" and printed by cobra), so
+// it must be stripped of control/escape bytes before it ever gets there.
+func TestLoginWithCredentials_SanitizesResponseBodyOnFailure(t *testing.T) {
+	// A representative hostile payload: ANSI color escape, BEL, CR, LF mixed in
+	// with a plausible human-readable error message.
+	payload := "invalid credentials\x1b[31;1m\x07\r\nnested \x1b[2Jscreen-clear attempt"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	_, err := loginWithCredentials(srv.URL, "alice", "wrong", 5*time.Second)
+	require.Error(t, err)
+
+	msg := err.Error()
+	// No raw control/escape bytes must reach the returned error (and therefore
+	// the terminal): ESC, BEL, CR, LF are all stripped.
+	assert.NotContains(t, msg, "\x1b")
+	assert.NotContains(t, msg, "\x07")
+	assert.NotContains(t, msg, "\r")
+	assert.NotContains(t, msg, "\n")
+	// The human-readable portions of the server's message are still surfaced —
+	// this isn't a blanket "hide everything" fix, just a sanitize-before-echo one.
+	assert.Contains(t, msg, "invalid credentials")
+	assert.Contains(t, msg, "screen-clear attempt")
+}
+
+// TestLoginWithCredentials_TruncatesLongResponseBodyOnFailure guards against a
+// hostile or misbehaving server flooding the operator's terminal with an
+// oversized error response.
+func TestLoginWithCredentials_TruncatesLongResponseBodyOnFailure(t *testing.T) {
+	long := strings.Repeat("x", 5000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(long))
+	}))
+	defer srv.Close()
+
+	_, err := loginWithCredentials(srv.URL, "alice", "wrong", 5*time.Second)
+	require.Error(t, err)
+	assert.Less(t, len(err.Error()), 400, "error message should be bounded, not carry the full 5000-byte body")
+	assert.Contains(t, err.Error(), "…", "truncated excerpt should be marked with an ellipsis")
 }
 
 func TestTestServerConnection(t *testing.T) {

--- a/internal/cli/encryption/auth_encrypt_validate_s23_test.go
+++ b/internal/cli/encryption/auth_encrypt_validate_s23_test.go
@@ -31,25 +31,6 @@ import (
 
 // ── validate helpers: verbose=true with ONLY encrypted rows (no unmigrated) ──
 
-// TestValidateAPITokens_S23_VerboseNoUnmigrated calls validateAPITokens with
-// verbose=true when ALL tokens are encrypted (zero unmigrated).
-func TestValidateAPITokens_S23_VerboseNoUnmigrated(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	// Insert a single fully-encrypted API token with token set to NULL
-	// to satisfy the unique constraint on the token column.
-	enc, meta, err := ae.EncryptAPIToken("s23-api-tok-only", uint(0))
-	require.NoError(t, err)
-	require.NoError(t, db.Exec(
-		`INSERT INTO api_tokens (client_id, token, encrypted_token, token_metadata, revoked) VALUES (?, NULL, ?, ?, false)`,
-		uint(20), enc, meta,
-	).Error)
-
-	n, err := validateAPITokens(db, ae, true /* verbose */)
-	require.NoError(t, err)
-	assert.Zero(t, n, "zero unmigrated rows expected")
-}
-
 // TestValidatePasswordResetTokens_S23_VerboseNoUnmigrated calls
 // validatePasswordResetTokens with verbose=true when ALL reset tokens are
 // encrypted (zero unmigrated).
@@ -85,28 +66,6 @@ func brokenAuthEnc(t *testing.T, db *gorm.DB) *encryption.AuthEncryption {
 	}
 	// Return an uninitialized AuthEncryption so Encrypt* calls will fail.
 	return encryption.NewAuthEncryption(cfg, dir, db)
-}
-
-// TestMigrateAPITokens_S23_EncryptError drives the "failed to encrypt API token"
-// error path inside migrateAPITokens by providing a broken authEnc.
-func TestMigrateAPITokens_S23_EncryptError(t *testing.T) {
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "apitoks_err.db")
-	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
-	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.APIToken{}))
-	t.Cleanup(func() {
-		if sqlDB, err := db.DB(); err == nil {
-			_ = sqlDB.Close()
-		}
-	})
-
-	require.NoError(t, db.Create(&models.APIToken{ClientID: 1, Token: "plain-api-s23"}).Error)
-
-	ae := brokenAuthEnc(t, db)
-	err = migrateAPITokens(db, ae, false /* dryRun */)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to encrypt API token")
 }
 
 // TestMigratePasswordResetTokens_S23_EncryptError drives the "failed to
@@ -217,10 +176,12 @@ func TestRunValidateAuthEncryption_S23_UnmigratedRows(t *testing.T) {
 	ae := encryption.NewAuthEncryption(encCfg, dir, db)
 	require.NoError(t, ae.Initialize("validate-s23-unmigrated"))
 
-	// Insert unmigrated (plaintext-only) rows.
-	require.NoError(t, db.Create(&models.APIClient{
-		Name: "plain-s23", ClientID: "plain-client-s23",
-		ClientSecret: "plaintext-secret-s23", IsActive: true,
+	// Insert an unmigrated (plaintext-only) row. password_resets is the only
+	// table runValidateAuthEncryption still inspects for unmigrated rows —
+	// api_clients/api_tokens columns hold a SHA-256 hash, never plaintext, so
+	// they're deliberately excluded (see auth_encryption_validate.go).
+	require.NoError(t, db.Create(&models.PasswordReset{
+		UserID: 1, Token: "plaintext-reset-s23",
 	}).Error)
 
 	if sqlDB, err := db.DB(); err == nil {
@@ -329,21 +290,6 @@ func TestRunMigrateAuthData_S23_DryRunConfigPath(t *testing.T) {
 }
 
 // ── validate helpers: decrypt-error paths ────────────────────────────────────
-
-// TestValidateAPITokens_S23_DecryptError drives the "failed to decrypt API
-// token" branch in validateAPITokens.
-func TestValidateAPITokens_S23_DecryptError(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	require.NoError(t, db.Exec(
-		`INSERT INTO api_tokens (client_id, token, encrypted_token, token_metadata, revoked) VALUES (?, NULL, ?, ?, false)`,
-		uint(55), `{"data":"bm90cmVhbA==","metadata":{}}`, `{}`,
-	).Error)
-
-	_, err := validateAPITokens(db, ae, false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to decrypt API token")
-}
 
 // TestValidatePasswordResetTokens_S23_DecryptError drives the "failed to decrypt
 // password reset token" branch in validatePasswordResetTokens.

--- a/internal/cli/encryption/auth_encryption_cli_test.go
+++ b/internal/cli/encryption/auth_encryption_cli_test.go
@@ -92,36 +92,18 @@ func setupMigrateValidateTest(t *testing.T) (*encryption.AuthEncryption, *gorm.D
 func TestMigrateAuthData_ClearsPlaintextColumns(t *testing.T) {
 	authEnc, db := setupMigrateValidateTest(t)
 
-	client := &models.APIClient{Name: "c", ClientID: "client-1", ClientSecret: "plain-client-secret", IsActive: true}
-	require.NoError(t, db.Create(client).Error)
-
-	// Sessions are intentionally NOT part of this migration/table set — see
-	// runMigrateAuthData's comment in auth_encryption_migrate.go: session_token
-	// stores a SHA-256 hash, never plaintext, so there is nothing for
-	// migrateSessions (removed) to have migrated in the first place.
-
-	token := &models.APIToken{ClientID: 1, Token: "plain-api-token"}
-	require.NoError(t, db.Create(token).Error)
+	// Sessions, API clients, and API tokens are intentionally NOT part of this
+	// migration/table set — see runMigrateAuthData's comment in
+	// auth_encryption_migrate.go: session_token/client_secret/token all store a
+	// SHA-256 hash, never plaintext, so there is nothing for
+	// migrateSessions/migrateAPIClients/migrateAPITokens (all removed) to have
+	// migrated in the first place. password_resets.token is the one column here
+	// that IS a genuine legacy plaintext column.
 
 	reset := &models.PasswordReset{UserID: 1, Token: "plain-reset-token"}
 	require.NoError(t, db.Create(reset).Error)
 
-	require.NoError(t, migrateAPIClients(db, authEnc, false))
-	require.NoError(t, migrateAPITokens(db, authEnc, false))
 	require.NoError(t, migratePasswordResetTokens(db, authEnc, false))
-
-	var gotClient models.APIClient
-	require.NoError(t, db.First(&gotClient, client.ID).Error)
-	require.Empty(t, gotClient.ClientSecret, "plaintext client_secret must be cleared after migration")
-	require.NotEmpty(t, gotClient.EncryptedClientSecret)
-	plain, err := authEnc.DecryptClientSecret(gotClient.EncryptedClientSecret, []byte(gotClient.ClientSecretMetadata))
-	require.NoError(t, err)
-	require.Equal(t, "plain-client-secret", plain)
-
-	var gotToken models.APIToken
-	require.NoError(t, db.First(&gotToken, token.ID).Error)
-	require.Empty(t, gotToken.Token, "plaintext token must be cleared after migration")
-	require.NotEmpty(t, gotToken.EncryptedToken)
 
 	var gotReset models.PasswordReset
 	require.NoError(t, db.First(&gotReset, reset.ID).Error)
@@ -132,30 +114,30 @@ func TestMigrateAuthData_ClearsPlaintextColumns(t *testing.T) {
 	// "plaintext present, no encrypted value" query) — and, critically, must not
 	// fail on a unique-constraint collision now that multiple rows share a
 	// cleared (NULL) plaintext column.
-	require.NoError(t, migrateAPIClients(db, authEnc, false))
-	require.NoError(t, migrateAPITokens(db, authEnc, false))
 	require.NoError(t, migratePasswordResetTokens(db, authEnc, false))
 }
 
 // TestMigrateAuthData_ClearsPlaintext_MultipleRowsNoUniqueCollision guards the
 // NULL-not-empty-string choice: token columns carry a unique index, so
 // clearing two rows to "" would collide on the second UPDATE. (Originally
-// written against sessions; sessions were removed from this migration path
-// since session_token is a hash, never plaintext — api_tokens exercises the
-// identical unique-index-collision hazard.)
+// written against sessions, then api_tokens; both were removed from this
+// migration path since their plaintext-holding columns are actually
+// hash-only — password_resets exercises the identical unique-index-collision
+// hazard and is the one remaining table with a genuine legacy plaintext
+// column.)
 func TestMigrateAuthData_ClearsPlaintext_MultipleRowsNoUniqueCollision(t *testing.T) {
 	authEnc, db := setupMigrateValidateTest(t)
 
-	t1 := &models.APIToken{ClientID: 1, Token: "api-token-one"}
-	t2 := &models.APIToken{ClientID: 2, Token: "api-token-two"}
-	require.NoError(t, db.Create(t1).Error)
-	require.NoError(t, db.Create(t2).Error)
+	r1 := &models.PasswordReset{UserID: 1, Token: "reset-token-one"}
+	r2 := &models.PasswordReset{UserID: 2, Token: "reset-token-two"}
+	require.NoError(t, db.Create(r1).Error)
+	require.NoError(t, db.Create(r2).Error)
 
-	require.NoError(t, migrateAPITokens(db, authEnc, false))
+	require.NoError(t, migratePasswordResetTokens(db, authEnc, false))
 
-	var got1, got2 models.APIToken
-	require.NoError(t, db.First(&got1, t1.ID).Error)
-	require.NoError(t, db.First(&got2, t2.ID).Error)
+	var got1, got2 models.PasswordReset
+	require.NoError(t, db.First(&got1, r1.ID).Error)
+	require.NoError(t, db.First(&got2, r2.ID).Error)
 	require.Empty(t, got1.Token)
 	require.Empty(t, got2.Token)
 	require.NotEmpty(t, got1.EncryptedToken)
@@ -169,16 +151,16 @@ func TestValidateAuthEncryption_FlagsUnmigratedRows(t *testing.T) {
 	authEnc, db := setupMigrateValidateTest(t)
 
 	// Unmigrated row: plaintext present, no Encrypted* value at all.
-	unmigrated := &models.APIClient{Name: "u", ClientID: "unmigrated", ClientSecret: "still-plaintext", IsActive: true}
+	unmigrated := &models.PasswordReset{UserID: 1, Token: "still-plaintext"}
 	require.NoError(t, db.Create(unmigrated).Error)
 
 	// Properly migrated row: should validate clean and not be counted.
-	enc, meta, err := authEnc.EncryptClientSecret("already-encrypted")
+	enc, meta, err := authEnc.EncryptPasswordResetToken("already-encrypted", 2)
 	require.NoError(t, err)
-	migrated := &models.APIClient{Name: "m", ClientID: "migrated", EncryptedClientSecret: enc, ClientSecretMetadata: models.JSON(meta), IsActive: true}
+	migrated := &models.PasswordReset{UserID: 2, EncryptedToken: enc, TokenMetadata: models.JSON(meta)}
 	require.NoError(t, db.Create(migrated).Error)
 
-	n, err := validateAPIClients(db, authEnc, false)
+	n, err := validatePasswordResetTokens(db, authEnc, false)
 	require.NoError(t, err)
 	require.Equal(t, 1, n, "exactly one unmigrated row (plaintext, no Encrypted* value) must be flagged")
 }
@@ -188,12 +170,12 @@ func TestValidateAuthEncryption_FlagsUnmigratedRows(t *testing.T) {
 func TestValidateAuthEncryption_CleanWhenFullyMigrated(t *testing.T) {
 	authEnc, db := setupMigrateValidateTest(t)
 
-	enc, meta, err := authEnc.EncryptClientSecret("fully-migrated-secret")
+	enc, meta, err := authEnc.EncryptPasswordResetToken("fully-migrated-secret", 1)
 	require.NoError(t, err)
-	client := &models.APIClient{Name: "m", ClientID: "clean", EncryptedClientSecret: enc, ClientSecretMetadata: models.JSON(meta), IsActive: true}
-	require.NoError(t, db.Create(client).Error)
+	reset := &models.PasswordReset{UserID: 1, EncryptedToken: enc, TokenMetadata: models.JSON(meta)}
+	require.NoError(t, db.Create(reset).Error)
 
-	n, err := validateAPIClients(db, authEnc, false)
+	n, err := validatePasswordResetTokens(db, authEnc, false)
 	require.NoError(t, err)
 	require.Zero(t, n)
 }
@@ -237,14 +219,10 @@ func TestMigrateAuthData_DoesNotCorruptLiveSessionLookup(t *testing.T) {
 	require.NotEqual(t, plaintextToken, stored.SessionToken, "session_token must be a hash, not the plaintext token")
 	require.NotEmpty(t, stored.SessionToken)
 
-	// Seed one row in each table that the migration DOES act on, so this test
+	// Seed a row in the one table the migration DOES act on, so this test
 	// exercises a full, non-trivial migration pass rather than a no-op.
-	require.NoError(t, db.Create(&models.APIClient{Name: "c", ClientID: "regress-client", ClientSecret: "plain-secret", IsActive: true}).Error)
-	require.NoError(t, db.Create(&models.APIToken{ClientID: 1, Token: "plain-api-token-regress"}).Error)
 	require.NoError(t, db.Create(&models.PasswordReset{UserID: 7, Token: "plain-reset-regress"}).Error)
 
-	require.NoError(t, migrateAPIClients(db, authEnc, false))
-	require.NoError(t, migrateAPITokens(db, authEnc, false))
 	require.NoError(t, migratePasswordResetTokens(db, authEnc, false))
 
 	// The regression check: the session must still be findable by its original
@@ -253,10 +231,74 @@ func TestMigrateAuthData_DoesNotCorruptLiveSessionLookup(t *testing.T) {
 	got, err := ls.GetSession(ctx, plaintextToken)
 	require.NoError(t, err, "session must still be findable by its token after migration — session_token must not have been nulled")
 	require.Equal(t, created.ID, got.ID)
+}
 
-	// And validate must not flag the (correctly untouched, hash-only) session
-	// as needing migration either.
-	unmigratedAPIClients, err := validateAPIClients(db, authEnc, false)
+// TestMigrateAuthData_DoesNotCorruptAPIClientOrTokenHash is the HIGH-severity
+// regression test for the cli-encryption-001 defect: api_clients.client_secret
+// and api_tokens.token hold a SHA-256 hash of the credential, never plaintext
+// (see models.APIClient.ClientSecret / models.APIToken.Token) — identical in
+// nature to sessions.session_token, which TestMigrateAuthData_
+// DoesNotCorruptLiveSessionLookup above already guards.
+//
+// migrateAPIClients/migrateAPITokens used to match on "client_secret != ”" /
+// "token != ”" (true for every row, since the column always holds a hash),
+// "encrypt" the hash value as if it were a real secret, and null out the
+// original column in the same UPDATE — permanently destroying the row's only
+// stored credential-verification data on any database carrying rows from
+// before the issuance/auth routes for these credential types were removed
+// (#131). Both functions have been removed entirely (mirroring the earlier
+// sessions fix), so this test seeds rows shaped like real legacy data —
+// api_clients/api_tokens have no live construction path today (see git
+// history), so a direct DB insert is the closest available stand-in for a
+// pre-existing production row — runs the full available migration surface,
+// and asserts neither column was touched.
+func TestMigrateAuthData_DoesNotCorruptAPIClientOrTokenHash(t *testing.T) {
+	authEnc, db := setupMigrateValidateTest(t)
+
+	const clientSecretHash = "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3" // stand-in SHA-256-shaped hash
+	const tokenHash = "3e23e8160039594a33894f6564e1b1348bbd7a00"        // stand-in SHA-256-shaped hash
+
+	client := &models.APIClient{Name: "c", ClientID: "regress-client-hash", ClientSecret: clientSecretHash, IsActive: true}
+	require.NoError(t, db.Create(client).Error)
+	token := &models.APIToken{ClientID: 1, Token: tokenHash}
+	require.NoError(t, db.Create(token).Error)
+
+	// Seed a row in the one table the migration DOES act on, so this exercises
+	// a full, non-trivial migration pass rather than a no-op.
+	require.NoError(t, db.Create(&models.PasswordReset{UserID: 9, Token: "plain-reset-regress-2"}).Error)
+
+	require.NoError(t, migratePasswordResetTokens(db, authEnc, false))
+
+	// The regression check: client_secret/token must be byte-identical to what
+	// was seeded — migrate must never have touched either column.
+	var gotClient models.APIClient
+	require.NoError(t, db.First(&gotClient, client.ID).Error)
+	require.Equal(t, clientSecretHash, gotClient.ClientSecret, "client_secret hash must survive a migration pass untouched")
+	require.Empty(t, gotClient.EncryptedClientSecret, "encrypted_client_secret must never be populated — there is nothing to migrate")
+
+	var gotToken models.APIToken
+	require.NoError(t, db.First(&gotToken, token.ID).Error)
+	require.Equal(t, tokenHash, gotToken.Token, "token hash must survive a migration pass untouched")
+	require.Empty(t, gotToken.EncryptedToken, "encrypted_token must never be populated — there is nothing to migrate")
+}
+
+// TestValidateAuthEncryption_DoesNotFlagAPIClientOrTokenHash is the validate-
+// side counterpart of TestMigrateAuthData_DoesNotCorruptAPIClientOrTokenHash:
+// a hash-only api_clients/api_tokens row must never be reported as needing
+// migration (the cli-encryption-002 defect) — validateAPIClients/
+// validateAPITokens have been removed entirely, so runValidateAuthEncryption's
+// unmigrated count must come back zero even with such rows present.
+func TestValidateAuthEncryption_DoesNotFlagAPIClientOrTokenHash(t *testing.T) {
+	authEnc, db := setupMigrateValidateTest(t)
+
+	require.NoError(t, db.Create(&models.APIClient{Name: "c", ClientID: "validate-hash-client", ClientSecret: "hash-looking-value", IsActive: true}).Error)
+	require.NoError(t, db.Create(&models.APIToken{ClientID: 1, Token: "hash-looking-token"}).Error)
+
+	// The only remaining validate helper (password resets) must still report
+	// clean on an otherwise-empty table, and — critically — nothing here must
+	// surface the seeded API client/token rows as unmigrated, since there is no
+	// longer any code path that even looks at those two tables.
+	n, err := validatePasswordResetTokens(db, authEnc, false)
 	require.NoError(t, err)
-	require.Zero(t, unmigratedAPIClients, "the migrated client should no longer be flagged")
+	require.Zero(t, n, "no table this validate command still inspects should report unmigrated rows")
 }

--- a/internal/cli/encryption/auth_encryption_migrate.go
+++ b/internal/cli/encryption/auth_encryption_migrate.go
@@ -51,12 +51,9 @@ func migrateAuthDataWithConfig(cfg *config.Config, dryRun bool) error {
 		fmt.Println("🔄 Migrating authentication data to encrypted storage...")
 	}
 
-	if err := migrateAPIClients(db, authEnc, dryRun); err != nil {
-		return fmt.Errorf("failed to migrate API clients: %w", err)
-	}
-	// Sessions are deliberately NOT run through this migration. Unlike
-	// api_clients/api_tokens/password_resets, sessions.session_token has NEVER
-	// stored a plaintext value: store.CreateSession/RotateSession (see
+	// Sessions are deliberately NOT run through this migration. Unlike (at the
+	// time) api_clients/api_tokens/password_resets, sessions.session_token has
+	// NEVER stored a plaintext value: store.CreateSession/RotateSession (see
 	// internal/storage/store/local_auth.go) hash the token with SHA-256 before
 	// writing it, and GetSession/GetSessionAny look sessions up by recomputing
 	// that hash and matching it against this same column. There is no plaintext
@@ -72,9 +69,29 @@ func migrateAuthDataWithConfig(cfg *config.Config, dryRun bool) error {
 	// mass-invalidated every logged-in user's session while the CLI reported
 	// success. See git history for the removed migrateSessions/validateSessions
 	// (the latter had the identical false premise) if this ever needs revisiting.
-	if err := migrateAPITokens(db, authEnc, dryRun); err != nil {
-		return fmt.Errorf("failed to migrate API tokens: %w", err)
-	}
+	//
+	// API clients and API tokens are ALSO not run through this migration, for
+	// the identical reason — this was missed when the sessions fix above landed.
+	// Per models.APIClient.ClientSecret and models.APIToken.Token (see
+	// internal/storage/models/models.go), both columns hold a SHA-256 HASH of
+	// the credential, never plaintext — the credential is shown once at
+	// creation and never persisted in recoverable form. (The issuance/auth
+	// routes for these credential types were themselves removed in an earlier
+	// finding; see git history around #131 — but that's incidental: the columns
+	// were never plaintext even while those routes existed.)
+	//
+	// migrateAPIClients/migrateAPITokens used to match on "client_secret != ''"
+	// / "token != ''" — true for every row, since the column always holds a
+	// hash — "encrypted" that hash value as if it were a real secret, and then
+	// set the column to NULL in the same UPDATE. For any pre-existing row (e.g.
+	// carried forward from an older database predating #131's route removal),
+	// that NULL permanently destroyed the only stored credential-verification
+	// data for the row, with the CLI reporting success. There was never a
+	// plaintext state for this migration to move out of either column — the
+	// same false premise validateSessions had, and the same one
+	// validateAPIClients/validateAPITokens (see auth_encryption_validate.go)
+	// shared. See git history for the removed migrateAPIClients/migrateAPITokens
+	// if this ever needs revisiting.
 	if err := migratePasswordResetTokens(db, authEnc, dryRun); err != nil {
 		return fmt.Errorf("failed to migrate password reset tokens: %w", err)
 	}
@@ -83,69 +100,6 @@ func migrateAuthDataWithConfig(cfg *config.Config, dryRun bool) error {
 		fmt.Println("✅ Dry run completed. Use without --dry-run to perform actual migration")
 	} else {
 		fmt.Println("✅ Authentication data migration completed successfully")
-	}
-	return nil
-}
-
-func migrateAPIClients(db *gorm.DB, authEnc *encryption.AuthEncryption, dryRun bool) error {
-	var clients []models.APIClient
-	if err := db.Where("client_secret != '' AND encrypted_client_secret IS NULL").Find(&clients).Error; err != nil {
-		return err
-	}
-	fmt.Printf("🔑 Found %d API clients to migrate\n", len(clients))
-	if dryRun {
-		return nil
-	}
-	for _, client := range clients {
-		enc, meta, err := authEnc.EncryptClientSecret(client.ClientSecret)
-		if err != nil {
-			return fmt.Errorf("failed to encrypt client secret for client %s: %w", client.ClientID, err)
-		}
-		// Clear the plaintext column in the same update that writes the encrypted
-		// value — leaving it populated after a "successful" migration defeats the
-		// point: the #278 compromise surface (a readable plaintext column) would
-		// still be sitting right next to its encrypted replacement. NULL, not "",
-		// since a second migrated row with "" would collide with any unique index
-		// on the column; NULL is exempt from uniqueness checks on every backend
-		// this CLI targets (sqlite/postgres).
-		if err := db.Model(&client).Updates(map[string]interface{}{
-			"encrypted_client_secret": enc,
-			"client_secret_metadata":  meta,
-			"client_secret":           nil,
-		}).Error; err != nil {
-			return fmt.Errorf("failed to update client %s: %w", client.ClientID, err)
-		}
-	}
-	return nil
-}
-
-func migrateAPITokens(db *gorm.DB, authEnc *encryption.AuthEncryption, dryRun bool) error {
-	var tokens []models.APIToken
-	if err := db.Where("token != '' AND encrypted_token IS NULL").Find(&tokens).Error; err != nil {
-		return err
-	}
-	fmt.Printf("🎟️  Found %d API tokens to migrate\n", len(tokens))
-	if dryRun {
-		return nil
-	}
-	for _, token := range tokens {
-		var migrateTokenUserID uint
-		if token.UserID != nil {
-			migrateTokenUserID = *token.UserID
-		}
-		enc, meta, err := authEnc.EncryptAPIToken(token.Token, migrateTokenUserID)
-		if err != nil {
-			return fmt.Errorf("failed to encrypt API token %d: %w", token.ID, err)
-		}
-		// See migrateAPIClients for why the plaintext column is cleared (set to
-		// NULL, not "") in the same update as the encrypted write.
-		if err := db.Model(&token).Updates(map[string]interface{}{
-			"encrypted_token": enc,
-			"token_metadata":  meta,
-			"token":           nil,
-		}).Error; err != nil {
-			return fmt.Errorf("failed to update API token %d: %w", token.ID, err)
-		}
 	}
 	return nil
 }
@@ -164,8 +118,16 @@ func migratePasswordResetTokens(db *gorm.DB, authEnc *encryption.AuthEncryption,
 		if err != nil {
 			return fmt.Errorf("failed to encrypt password reset token %d: %w", reset.ID, err)
 		}
-		// See migrateAPIClients for why the plaintext column is cleared (set to
-		// NULL, not "") in the same update as the encrypted write.
+		// The plaintext column is cleared (set to NULL, not "") in the same update
+		// as the encrypted write: leaving it populated after a "successful"
+		// migration defeats the point (a readable plaintext column sitting right
+		// next to its encrypted replacement), and NULL — not "" — avoids colliding
+		// with the unique index on this column when a second row is migrated (NULL
+		// is exempt from uniqueness checks on every backend this CLI targets).
+		// Unlike this column, password_resets.token is a genuine legacy plaintext
+		// column (see models.PasswordReset), not a hash — see the comment above
+		// this function's call site for why api_clients/api_tokens/sessions are
+		// deliberately excluded from this migration.
 		if err := db.Model(&reset).Updates(map[string]interface{}{
 			"encrypted_token": enc,
 			"token_metadata":  meta,

--- a/internal/cli/encryption/auth_encryption_validate.go
+++ b/internal/cli/encryption/auth_encryption_validate.go
@@ -50,12 +50,6 @@ func validateAuthEncryptionWithConfig(cfg *config.Config, verbose bool) error {
 
 	var unmigrated int
 
-	n, err := validateAPIClients(db, authEnc, verbose)
-	if err != nil {
-		return fmt.Errorf("API client validation failed: %w", err)
-	}
-	unmigrated += n
-
 	// Sessions are deliberately not validated here — see the comment in
 	// auth_encryption_migrate.go's runMigrateAuthData for why: session_token
 	// stores a SHA-256 hash, never plaintext, so there is no "unmigrated
@@ -63,14 +57,23 @@ func validateAuthEncryptionWithConfig(cfg *config.Config, verbose bool) error {
 	// queried "session_token != ''" (true for every live session) and reported
 	// every one of them as needing migration — a permanent false positive that
 	// would fail this command on any deployment with active sessions.
+	//
+	// API clients and API tokens are ALSO deliberately not validated here, for
+	// the identical reason — this was missed when the sessions fix above landed.
+	// Per models.APIClient.ClientSecret and models.APIToken.Token (see
+	// internal/storage/models/models.go), both columns hold a SHA-256 HASH of
+	// the credential, never plaintext. A prior validateAPIClients/
+	// validateAPITokens queried "client_secret != ''"/"token != ''" (true for
+	// every row, since the column always holds a hash) and reported every one
+	// as needing migration — the same permanent false positive validateSessions
+	// had, funneling operators toward running the destructive
+	// 'auth-encryption migrate' command (see auth_encryption_migrate.go's
+	// removed migrateAPIClients/migrateAPITokens for why that's destructive:
+	// it nulls the row's only stored credential-verification data). See git
+	// history for the removed validateAPIClients/validateAPITokens if this ever
+	// needs revisiting.
 
-	n, err = validateAPITokens(db, authEnc, verbose)
-	if err != nil {
-		return fmt.Errorf("API token validation failed: %w", err)
-	}
-	unmigrated += n
-
-	n, err = validatePasswordResetTokens(db, authEnc, verbose)
+	n, err := validatePasswordResetTokens(db, authEnc, verbose)
 	if err != nil {
 		return fmt.Errorf("password reset token validation failed: %w", err)
 	}
@@ -90,69 +93,6 @@ func validateAuthEncryptionWithConfig(cfg *config.Config, verbose bool) error {
 
 	fmt.Println("✅ All authentication encryption validation checks passed")
 	return nil
-}
-
-// validateAPIClients decrypts every already-encrypted API client row (proving
-// the current keys work), then separately reports and counts rows that still
-// hold a plaintext client_secret with no Encrypted* counterpart — those are
-// invisible to the decrypt check above since it only ever queries
-// "encrypted_client_secret IS NOT NULL".
-func validateAPIClients(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose bool) (int, error) {
-	var clients []models.APIClient
-	if err := db.Where("encrypted_client_secret IS NOT NULL").Find(&clients).Error; err != nil {
-		return 0, err
-	}
-	if verbose {
-		fmt.Printf("🔑 Validating %d encrypted API clients...\n", len(clients))
-	}
-	for _, client := range clients {
-		if _, err := authEnc.DecryptClientSecret(client.EncryptedClientSecret, []byte(client.ClientSecretMetadata)); err != nil {
-			return 0, fmt.Errorf("failed to decrypt client secret for client %s: %w", client.ClientID, err)
-		}
-		if verbose {
-			fmt.Printf("  ✅ Client %s: OK\n", client.ClientID)
-		}
-	}
-
-	var unmigrated []models.APIClient
-	if err := db.Where("client_secret != '' AND client_secret IS NOT NULL AND encrypted_client_secret IS NULL").Find(&unmigrated).Error; err != nil {
-		return 0, err
-	}
-	for _, client := range unmigrated {
-		fmt.Printf("  ⚠️  Client %s: plaintext client_secret with no encrypted counterpart — needs migration\n", client.ClientID)
-	}
-	return len(unmigrated), nil
-}
-
-func validateAPITokens(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose bool) (int, error) {
-	var tokens []models.APIToken
-	if err := db.Where("encrypted_token IS NOT NULL").Find(&tokens).Error; err != nil {
-		return 0, err
-	}
-	if verbose {
-		fmt.Printf("🎟️  Validating %d encrypted API tokens...\n", len(tokens))
-	}
-	for _, token := range tokens {
-		var validateTokenUserID uint
-		if token.UserID != nil {
-			validateTokenUserID = *token.UserID
-		}
-		if _, err := authEnc.DecryptAPIToken(token.EncryptedToken, []byte(token.TokenMetadata), validateTokenUserID); err != nil {
-			return 0, fmt.Errorf("failed to decrypt API token %d: %w", token.ID, err)
-		}
-		if verbose {
-			fmt.Printf("  ✅ API Token %d: OK\n", token.ID)
-		}
-	}
-
-	var unmigrated []models.APIToken
-	if err := db.Where("token != '' AND token IS NOT NULL AND encrypted_token IS NULL").Find(&unmigrated).Error; err != nil {
-		return 0, err
-	}
-	for _, token := range unmigrated {
-		fmt.Printf("  ⚠️  API Token %d: plaintext token with no encrypted counterpart — needs migration\n", token.ID)
-	}
-	return len(unmigrated), nil
 }
 
 func validatePasswordResetTokens(db *gorm.DB, authEnc *encryption.AuthEncryption, verbose bool) (int, error) {

--- a/internal/cli/encryption/encryption_s22_test.go
+++ b/internal/cli/encryption/encryption_s22_test.go
@@ -189,45 +189,38 @@ locale:
 func TestRunMigrateAuthData_S22_DryRunWithRows(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
 
-	// Insert rows for the three migrated tables so the "Found N … to migrate"
-	// lines fire. Sessions are intentionally excluded — session_token is a
-	// hash, never plaintext, so migrateSessions was removed (see
-	// auth_encryption_migrate.go).
-	require.NoError(t, db.Create(&models.APIClient{Name: "x", ClientID: "c1", ClientSecret: "plain", IsActive: true}).Error)
-	require.NoError(t, db.Create(&models.APIToken{ClientID: 1, Token: "api"}).Error)
+	// Insert a row for the one remaining migrated table so the "Found N … to
+	// migrate" line fires. Sessions, API clients, and API tokens are
+	// intentionally excluded — their plaintext-looking columns actually hold a
+	// SHA-256 hash, never plaintext, so migrateSessions/migrateAPIClients/
+	// migrateAPITokens were all removed (see auth_encryption_migrate.go).
 	require.NoError(t, db.Create(&models.PasswordReset{UserID: 1, Token: "rst"}).Error)
 
-	require.NoError(t, migrateAPIClients(db, ae, true))
-	require.NoError(t, migrateAPITokens(db, ae, true))
 	require.NoError(t, migratePasswordResetTokens(db, ae, true))
 
-	// Rows must be untouched (dry-run must not write encrypted values).
-	var client models.APIClient
-	require.NoError(t, db.First(&client).Error)
-	assert.Equal(t, "plain", client.ClientSecret)
-	assert.Empty(t, client.EncryptedClientSecret)
+	// Row must be untouched (dry-run must not write encrypted values).
+	var reset models.PasswordReset
+	require.NoError(t, db.First(&reset).Error)
+	assert.Equal(t, "rst", reset.Token)
+	assert.Empty(t, reset.EncryptedToken)
 }
 
 // TestRunMigrateAuthData_S22_NonDryRunWithAllTables exercises the non-dry-run
-// path of all four migrate helpers when each table has at least one row.
-// This is distinct from TestMigrateAuthData_ClearsPlaintextColumns which only
-// checks the post-state — here we drive through the encrypt+update path for
-// all four tables in one pass and verify the final encrypted state.
+// path of the remaining migrate helper. This is distinct from
+// TestMigrateAuthData_ClearsPlaintextColumns which only checks the
+// post-state — here we drive through the encrypt+update path and verify the
+// final encrypted state.
 func TestRunMigrateAuthData_S22_NonDryRunWithAllTables(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
 
-	require.NoError(t, db.Create(&models.APIClient{Name: "a", ClientID: "cli-s22", ClientSecret: "secret-s22", IsActive: true}).Error)
-	require.NoError(t, db.Create(&models.APIToken{ClientID: 1, Token: "tok-s22"}).Error)
 	require.NoError(t, db.Create(&models.PasswordReset{UserID: 10, Token: "reset-s22"}).Error)
 
-	require.NoError(t, migrateAPIClients(db, ae, false))
-	require.NoError(t, migrateAPITokens(db, ae, false))
 	require.NoError(t, migratePasswordResetTokens(db, ae, false))
 
-	var c models.APIClient
-	require.NoError(t, db.Where("client_id = ?", "cli-s22").First(&c).Error)
-	assert.Empty(t, c.ClientSecret)
-	assert.NotEmpty(t, c.EncryptedClientSecret)
+	var r models.PasswordReset
+	require.NoError(t, db.Where("user_id = ?", 10).First(&r).Error)
+	assert.Empty(t, r.Token)
+	assert.NotEmpty(t, r.EncryptedToken)
 }
 
 // ── runValidateAuthEncryption: unmigrated>0 error return ─────────────────
@@ -239,22 +232,13 @@ func TestRunMigrateAuthData_S22_NonDryRunWithAllTables(t *testing.T) {
 func TestRunValidateAuthEncryption_S22_UnmigratedReturnsError(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
 
-	// Insert one unmigrated row in each of the three validated tables. Sessions
-	// are intentionally excluded — validateSessions was removed since
-	// session_token is a hash, never plaintext (see auth_encryption_validate.go).
-	require.NoError(t, db.Create(&models.APIClient{Name: "u1", ClientID: "um1", ClientSecret: "pt1", IsActive: true}).Error)
-	require.NoError(t, db.Create(&models.APIToken{ClientID: 2, Token: "ptapi"}).Error)
+	// Insert one unmigrated row in the one remaining validated table. Sessions,
+	// API clients, and API tokens are intentionally excluded — validateSessions/
+	// validateAPIClients/validateAPITokens were all removed since their columns
+	// hold a hash, never plaintext (see auth_encryption_validate.go).
 	require.NoError(t, db.Create(&models.PasswordReset{UserID: 99, Token: "ptreset"}).Error)
 
-	n, err := validateAPIClients(db, ae, false)
-	require.NoError(t, err)
-	assert.Equal(t, 1, n)
-
-	n, err = validateAPITokens(db, ae, false)
-	require.NoError(t, err)
-	assert.Equal(t, 1, n)
-
-	n, err = validatePasswordResetTokens(db, ae, false)
+	n, err := validatePasswordResetTokens(db, ae, false)
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
 }
@@ -291,52 +275,11 @@ locale:
 // decryptable) blob while leaving the plaintext column empty. When the
 // validate helper tries to decrypt it, the DecryptXxx call must fail, driving
 // the decrypt-error branch.
-func tamperAPIClientRow(t *testing.T, db *gorm.DB) models.APIClient {
-	t.Helper()
-	c := models.APIClient{
-		Name:                  "tamper",
-		ClientID:              "tamper-client",
-		EncryptedClientSecret: []byte("not-valid-ciphertext"),
-		IsActive:              true,
-	}
-	require.NoError(t, db.Create(&c).Error)
-	return c
-}
-
-func tamperAPITokenRow(t *testing.T, db *gorm.DB) models.APIToken {
-	t.Helper()
-	tok := models.APIToken{ClientID: 7, EncryptedToken: []byte("not-valid-ciphertext")}
-	require.NoError(t, db.Create(&tok).Error)
-	return tok
-}
-
 func tamperPasswordResetRow(t *testing.T, db *gorm.DB) models.PasswordReset {
 	t.Helper()
 	r := models.PasswordReset{UserID: 77, EncryptedToken: []byte("not-valid-ciphertext")}
 	require.NoError(t, db.Create(&r).Error)
 	return r
-}
-
-// TestValidateAPIClients_S22_DecryptError drives the DecryptClientSecret
-// error branch in validateAPIClients: an invalid ciphertext in the encrypted
-// column causes the helper to return a non-nil error.
-func TestValidateAPIClients_S22_DecryptError(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-	tamperAPIClientRow(t, db)
-
-	_, err := validateAPIClients(db, ae, false)
-	require.Error(t, err, "decrypt error must propagate")
-	assert.Contains(t, err.Error(), "tamper-client")
-}
-
-// TestValidateAPITokens_S22_DecryptError drives the DecryptAPIToken error
-// branch in validateAPITokens.
-func TestValidateAPITokens_S22_DecryptError(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-	tamperAPITokenRow(t, db)
-
-	_, err := validateAPITokens(db, ae, false)
-	require.Error(t, err, "decrypt error must propagate")
 }
 
 // TestValidatePasswordResetTokens_S22_DecryptError drives the
@@ -347,17 +290,6 @@ func TestValidatePasswordResetTokens_S22_DecryptError(t *testing.T) {
 
 	_, err := validatePasswordResetTokens(db, ae, false)
 	require.Error(t, err, "decrypt error must propagate")
-}
-
-// TestValidateAPIClients_S22_VerboseDecryptError exercises the verbose path
-// for validateAPIClients when an encrypted row is present and decryption fails,
-// confirming the error is returned even in verbose mode.
-func TestValidateAPIClients_S22_VerboseDecryptError(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-	tamperAPIClientRow(t, db)
-
-	_, err := validateAPIClients(db, ae, true)
-	require.Error(t, err)
 }
 
 // ── findMigrateBackups: directory-entry IsDir skip ────────────────────────
@@ -489,35 +421,39 @@ func TestMigrateProviderCleanupWithConfig_S22_ConfirmedDeletesBackup(t *testing.
 	assert.True(t, os.IsNotExist(statErr), "backup file must be deleted after confirmed cleanup")
 }
 
-// ── migrateAPIClients dry-run isolation ──────────────────────────────────
+// ── migratePasswordResetTokens dry-run isolation ──────────────────────────
 
-// TestMigrateAPIClients_S22_DryRunIsolated verifies the dryRun=true early-
-// return in migrateAPIClients in isolation (separate from the combined table
-// test in auth_encryption_cli_test.go).
-func TestMigrateAPIClients_S22_DryRunIsolated(t *testing.T) {
+// TestMigratePasswordResetTokens_S22_DryRunIsolated verifies the dryRun=true
+// early-return in migratePasswordResetTokens in isolation (separate from the
+// combined table test in auth_encryption_cli_test.go). (Originally written
+// against migrateAPIClients; api_clients was removed from this migration path
+// since client_secret is a hash, never plaintext — password_resets is the one
+// remaining table with a genuine legacy plaintext column.)
+func TestMigratePasswordResetTokens_S22_DryRunIsolated(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
-	require.NoError(t, db.Create(&models.APIClient{
-		Name:         "dry-s22",
-		ClientID:     "dry-client-s22",
-		ClientSecret: "dry-plain-s22",
-		IsActive:     true,
+	require.NoError(t, db.Create(&models.PasswordReset{
+		UserID: 22,
+		Token:  "dry-plain-s22",
 	}).Error)
 
-	require.NoError(t, migrateAPIClients(db, ae, true))
+	require.NoError(t, migratePasswordResetTokens(db, ae, true))
 
-	var got models.APIClient
-	require.NoError(t, db.Where("client_id = ?", "dry-client-s22").First(&got).Error)
-	assert.Equal(t, "dry-plain-s22", got.ClientSecret, "dry-run must not modify the row")
-	assert.Empty(t, got.EncryptedClientSecret)
+	var got models.PasswordReset
+	require.NoError(t, db.Where("user_id = ?", 22).First(&got).Error)
+	assert.Equal(t, "dry-plain-s22", got.Token, "dry-run must not modify the row")
+	assert.Empty(t, got.EncryptedToken)
 }
 
-// ── validateAPIClients: empty encrypted set, non-verbose ─────────────────
+// ── validatePasswordResetTokens: empty encrypted set, non-verbose ────────
 
-// TestValidateAPIClients_S22_EmptyEncryptedNonVerbose verifies validateAPIClients
-// with no encrypted rows and no unmigrated rows (the quiet, no-output path).
-func TestValidateAPIClients_S22_EmptyEncryptedNonVerbose(t *testing.T) {
+// TestValidatePasswordResetTokens_S22_EmptyEncryptedNonVerbose verifies
+// validatePasswordResetTokens with no encrypted rows and no unmigrated rows
+// (the quiet, no-output path). (Originally written against validateAPIClients;
+// api_clients was removed from this validate path since client_secret is a
+// hash, never plaintext.)
+func TestValidatePasswordResetTokens_S22_EmptyEncryptedNonVerbose(t *testing.T) {
 	ae, db := getSharedS3Fixture(t)
-	n, err := validateAPIClients(db, ae, false)
+	n, err := validatePasswordResetTokens(db, ae, false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, n)
 }

--- a/internal/cli/encryption/encryption_s23_test.go
+++ b/internal/cli/encryption/encryption_s23_test.go
@@ -13,7 +13,6 @@ package encryption
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -238,46 +237,15 @@ func TestMigrateProviderCleanupWithConfig_S23_DryRunWithBackup(t *testing.T) {
 }
 
 // ── runValidateAuthEncryption: per-table error wrapping ─────────────────────
-
-// TestRunValidateAuthEncryption_S23_APIClientValidationError drives the
-// "API client validation failed" error-wrapping branch in
-// runValidateAuthEncryption by inserting a row with invalid ciphertext into a
-// full local DB so the validate shim reaches validateAPIClients and fails there.
-func TestRunValidateAuthEncryption_S23_APIClientValidationError(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	// Insert a row with invalid ciphertext: validateAPIClients will try to
-	// DecryptClientSecret and fail, returning an error.
-	require.NoError(t, db.Create(&models.APIClient{
-		Name:                  "bad-client",
-		ClientID:              "bad-crypt-s23",
-		EncryptedClientSecret: []byte("not-valid-ciphertext"),
-		IsActive:              true,
-	}).Error)
-
-	// Call the helpers directly in the same order as runValidateAuthEncryption to
-	// confirm the error wrapping message surfaces.
-	_, err := validateAPIClients(db, ae, false)
-	require.Error(t, err)
-	assert.True(t,
-		strings.Contains(err.Error(), "bad-crypt-s23") || strings.Contains(err.Error(), "decrypt"),
-		"error should reference the client or decryption failure: %v", err)
-}
-
-// TestRunValidateAuthEncryption_S23_APITokenValidationError drives the
-// "API token validation failed" error-wrapping branch.
-func TestRunValidateAuthEncryption_S23_APITokenValidationError(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	require.NoError(t, db.Create(&models.APIToken{
-		ClientID:       9,
-		EncryptedToken: []byte("garbage-ciphertext-s23"),
-	}).Error)
-
-	_, err := validateAPITokens(db, ae, false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "token")
-}
+//
+// TestRunValidateAuthEncryption_S23_APIClientValidationError and
+// TestRunValidateAuthEncryption_S23_APITokenValidationError, which used to
+// live here, drove validateAPIClients/validateAPITokens's decrypt-error
+// branches. Both helpers have been removed entirely — api_clients.client_secret
+// and api_tokens.token hold a SHA-256 hash, never plaintext, so
+// runValidateAuthEncryption no longer inspects either table (see
+// auth_encryption_validate.go). password_resets below is the one remaining
+// table this per-table error-wrapping coverage applies to.
 
 // TestRunValidateAuthEncryption_S23_ResetTokenValidationError drives the
 // "password reset token validation failed" error-wrapping branch.

--- a/internal/cli/encryption/encryption_s24_test.go
+++ b/internal/cli/encryption/encryption_s24_test.go
@@ -7,9 +7,10 @@
 //     upgradeAADWithConfig password OK → storage.OpenGormDB fails
 //     validateWithConfig enabled → ValidateKeyFiles error path
 //   - shamir_split.go:       ssOutDir != "" → commitment.hex symlink → write error
-//   - auth_encryption_migrate.go: migrateAPIClients encrypt error (broken authEnc)
-//   - auth_encryption_validate.go: verbose=true paths for tokens/resets
-//     with unmigrated rows
+//   - auth_encryption_validate.go: verbose=true paths for password reset tokens
+//     with unmigrated rows (validateAPIClients/validateAPITokens were removed
+//     entirely — see auth_encryption_validate.go — so their former coverage
+//     here was removed too)
 //   - migrate_provider.go:   copyFile src read OK but dst dir fsync fails (non-existent dir)
 //     migrateProviderWithConfig → oldSvc.Initialize fails
 package encryption
@@ -216,31 +217,6 @@ func TestShamirSplit_S24_CommitmentSymlinkRejected(t *testing.T) {
 // encrypted-row path together with unmigrated rows so the full function body
 // executes in one call.
 
-// TestValidateAPITokens_S24_VerboseWithUnmigrated calls validateAPITokens with
-// verbose=true when the DB contains both an encrypted token and a plaintext-only
-// (unmigrated) token.
-func TestValidateAPITokens_S24_VerboseWithUnmigrated(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	encTok, encMeta, err := ae.EncryptAPIToken("s24-api-token", uint(0))
-	require.NoError(t, err)
-	require.NoError(t, db.Create(&models.APIToken{
-		ClientID:       10,
-		Token:          "",
-		EncryptedToken: encTok,
-		TokenMetadata:  encMeta,
-	}).Error)
-
-	require.NoError(t, db.Create(&models.APIToken{
-		ClientID: 11,
-		Token:    "plaintext-unmigrated-s24",
-	}).Error)
-
-	n, err := validateAPITokens(db, ae, true /* verbose */)
-	require.NoError(t, err)
-	assert.Equal(t, 1, n, "one unmigrated API token must be flagged")
-}
-
 // TestValidatePasswordResetTokens_S24_VerboseWithUnmigrated calls
 // validatePasswordResetTokens with verbose=true when the DB contains both an
 // encrypted reset token and a plaintext-only (unmigrated) reset token.
@@ -264,34 +240,6 @@ func TestValidatePasswordResetTokens_S24_VerboseWithUnmigrated(t *testing.T) {
 	n, err := validatePasswordResetTokens(db, ae, true /* verbose */)
 	require.NoError(t, err)
 	assert.Equal(t, 1, n, "one unmigrated reset token must be flagged")
-}
-
-// TestValidateAPIClients_S24_VerboseWithUnmigrated calls validateAPIClients
-// with verbose=true when the DB contains both an encrypted client and a
-// plaintext-only (unmigrated) client.
-func TestValidateAPIClients_S24_VerboseWithUnmigrated(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	encSec, encMeta, err := ae.EncryptClientSecret("s24-client-secret")
-	require.NoError(t, err)
-	require.NoError(t, db.Create(&models.APIClient{
-		Name:                  "enc-s24",
-		ClientID:              "enc-client-s24",
-		IsActive:              true,
-		EncryptedClientSecret: encSec,
-		ClientSecretMetadata:  models.JSON(encMeta),
-	}).Error)
-
-	require.NoError(t, db.Create(&models.APIClient{
-		Name:         "plain-s24",
-		ClientID:     "plain-client-s24",
-		ClientSecret: "plaintext-unmigrated-s24",
-		IsActive:     true,
-	}).Error)
-
-	n, err := validateAPIClients(db, ae, true /* verbose */)
-	require.NoError(t, err)
-	assert.Equal(t, 1, n, "one unmigrated API client must be flagged")
 }
 
 // ── migrateProviderWithConfig: oldSvc.Initialize fails ──────────────────────

--- a/internal/cli/encryption/encryption_s27_test.go
+++ b/internal/cli/encryption/encryption_s27_test.go
@@ -8,9 +8,9 @@
 //     runRotateAuthEncryption: success path after Rotate (best-effort via real config)
 //
 //   - auth_encryption_migrate.go:
-//     migrateAPIClients:          "failed to update client" DB error branch
-//     migrateAPITokens:           "failed to update API token" DB error branch
 //     migratePasswordResetTokens: "failed to update password reset token" DB error branch
+//     (migrateAPIClients/migrateAPITokens were removed entirely — see
+//     auth_encryption_migrate.go — so their former coverage here was removed too)
 //
 //   - encryption.go:
 //     runInit/runStatus/runValidate/runFixPerms/runRotate/runUpgradeAAD:
@@ -291,63 +291,15 @@ func TestFixPermsWithConfig_S27_ServiceInitFails(t *testing.T) {
 	}
 }
 
-// ── migrateAPIClients: "failed to update client" DB error branch ─────────────
+// ── migratePasswordResetTokens: "failed to update password reset token" DB error branch ─────
 //
-// Strategy: insert plaintext rows, then install a BEFORE UPDATE trigger that
+// Strategy: insert a plaintext row, then install a BEFORE UPDATE trigger that
 // raises an error (SQLite RAISE(ABORT, ...)) so the SELECT succeeds and
 // returns in-memory rows, but the subsequent UPDATE call fails with
-// "triggered abort".
-
-// TestMigrateAPIClients_S27_UpdateFails exercises the
-// "failed to update client %s" error branch inside migrateAPIClients by
-// installing a SQLite trigger that aborts every UPDATE on api_clients.
-func TestMigrateAPIClients_S27_UpdateFails(t *testing.T) {
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "migrate_update_err.db")
-	ae, db := setupMigrateValidateTestAt(t, dir, dbPath)
-
-	// Insert a plaintext client so the migration query finds it.
-	require.NoError(t, db.Create(&models.APIClient{
-		Name:         "s27-update-fail",
-		ClientID:     "s27-client-update",
-		ClientSecret: "plaintext-s27",
-		IsActive:     true,
-	}).Error)
-
-	// Install a trigger that aborts every UPDATE on api_clients.
-	require.NoError(t, db.Exec(
-		`CREATE TRIGGER abort_api_clients_update BEFORE UPDATE ON api_clients BEGIN
-			SELECT RAISE(ABORT, 'trigger: update aborted for test');
-		END`,
-	).Error)
-
-	err := migrateAPIClients(db, ae, false /* dryRun */)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to update client")
-}
-
-// TestMigrateAPITokens_S27_UpdateFails exercises the
-// "failed to update API token %d" error branch inside migrateAPITokens.
-func TestMigrateAPITokens_S27_UpdateFails(t *testing.T) {
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "migrate_api_update_err.db")
-	ae, db := setupMigrateValidateTestAt(t, dir, dbPath)
-
-	require.NoError(t, db.Create(&models.APIToken{
-		ClientID: 1,
-		Token:    "s27-api-plain",
-	}).Error)
-
-	require.NoError(t, db.Exec(
-		`CREATE TRIGGER abort_api_tokens_update BEFORE UPDATE ON api_tokens BEGIN
-			SELECT RAISE(ABORT, 'trigger: update aborted for test');
-		END`,
-	).Error)
-
-	err := migrateAPITokens(db, ae, false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to update API token")
-}
+// "triggered abort". (This section originally also covered
+// migrateAPIClients/migrateAPITokens; both were removed entirely since
+// client_secret/token hold a SHA-256 hash, never plaintext — see
+// auth_encryption_migrate.go.)
 
 // TestMigratePasswordResetTokens_S27_UpdateFails exercises the
 // "failed to update password reset token %d" error branch.

--- a/internal/cli/encryption/encryption_s3_test.go
+++ b/internal/cli/encryption/encryption_s3_test.go
@@ -72,47 +72,11 @@ func getSharedS3Fixture(t *testing.T) (*encryption.AuthEncryption, *gorm.DB) {
 	return s3Fixture.authEnc, s3Fixture.db
 }
 
-// ── validateAPITokens ─────────────────────────────────────────────────────────
-
-func TestValidateAPITokens_EmptyDB(t *testing.T) {
-	ae, db := getSharedS3Fixture(t)
-	n, err := validateAPITokens(db, ae, false)
-	require.NoError(t, err)
-	assert.Equal(t, 0, n)
-}
-
-func TestValidateAPITokens_VerboseEmptyDB(t *testing.T) {
-	ae, db := getSharedS3Fixture(t)
-	n, err := validateAPITokens(db, ae, true)
-	require.NoError(t, err)
-	assert.Equal(t, 0, n)
-}
-
-func TestValidateAPITokens_UnmigratedRow(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	tok := &models.APIToken{ClientID: 1, Token: "plaintext-api-token"}
-	require.NoError(t, db.Create(tok).Error)
-
-	n, err := validateAPITokens(db, ae, false)
-	require.NoError(t, err)
-	assert.Equal(t, 1, n)
-}
-
-func TestValidateAPITokens_EncryptedRow_Verbose(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	enc, meta, err := ae.EncryptAPIToken("api-token-value", uint(0))
-	require.NoError(t, err)
-	tok := &models.APIToken{ClientID: 1, EncryptedToken: enc, TokenMetadata: meta}
-	require.NoError(t, db.Create(tok).Error)
-
-	n, err := validateAPITokens(db, ae, true)
-	require.NoError(t, err)
-	assert.Equal(t, 0, n)
-}
-
 // ── validatePasswordResetTokens ───────────────────────────────────────────────
+//
+// (validateAPITokens coverage, which used to live here, was removed —
+// api_tokens.token holds a SHA-256 hash, never plaintext, so validateAPITokens
+// was removed entirely. See auth_encryption_validate.go.)
 
 func TestValidatePasswordResetTokens_EmptyDB(t *testing.T) {
 	ae, db := getSharedS3Fixture(t)
@@ -152,26 +116,9 @@ func TestValidatePasswordResetTokens_EncryptedRow_Verbose(t *testing.T) {
 	assert.Equal(t, 0, n)
 }
 
-// ── validateAPIClients: verbose path ─────────────────────────────────────────
-
-func TestValidateAPIClients_Verbose(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-
-	enc, meta, err := ae.EncryptClientSecret("secret-value")
-	require.NoError(t, err)
-	client := &models.APIClient{
-		Name:                  "test",
-		ClientID:              "verbose-client",
-		EncryptedClientSecret: enc,
-		ClientSecretMetadata:  models.JSON(meta),
-		IsActive:              true,
-	}
-	require.NoError(t, db.Create(client).Error)
-
-	n, err := validateAPIClients(db, ae, true)
-	require.NoError(t, err)
-	assert.Equal(t, 0, n)
-}
+// (validateAPIClients coverage, which used to live here, was removed —
+// api_clients.client_secret holds a SHA-256 hash, never plaintext, so
+// validateAPIClients was removed entirely. See auth_encryption_validate.go.)
 
 // ── showAuthEncryptionStats: encryptionEnabled=false path ─────────────────────
 
@@ -188,13 +135,11 @@ func TestShowAuthEncryptionStats_EncryptionEnabled(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// ── migrateAPITokens dry-run=false ────────────────────────────────────────────
-
-func TestMigrateAPITokens_NonDryRun_Empty(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-	err := migrateAPITokens(db, ae, false)
-	require.NoError(t, err)
-}
+// ── migratePasswordResetTokens dry-run=false ──────────────────────────────────
+//
+// (migrateAPITokens coverage, which used to live here, was removed —
+// api_tokens.token holds a SHA-256 hash, never plaintext, so migrateAPITokens
+// was removed entirely. See auth_encryption_migrate.go.)
 
 func TestMigratePasswordResetTokens_NonDryRun_Empty(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)
@@ -202,18 +147,7 @@ func TestMigratePasswordResetTokens_NonDryRun_Empty(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// dry-run=true paths for tokens/resets (covers the "return nil" early branch)
-
-func TestMigrateAPITokens_DryRun(t *testing.T) {
-	ae, db := setupMigrateValidateTest(t)
-	tok := &models.APIToken{ClientID: 1, Token: "api-tok"}
-	require.NoError(t, db.Create(tok).Error)
-	err := migrateAPITokens(db, ae, true)
-	require.NoError(t, err)
-	var got models.APIToken
-	require.NoError(t, db.First(&got, tok.ID).Error)
-	assert.Equal(t, "api-tok", got.Token)
-}
+// dry-run=true path for resets (covers the "return nil" early branch)
 
 func TestMigratePasswordResetTokens_DryRun(t *testing.T) {
 	ae, db := setupMigrateValidateTest(t)

--- a/internal/cli/encryption/shamir_split.go
+++ b/internal/cli/encryption/shamir_split.go
@@ -12,6 +12,7 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/keyorixhq/keyorix/internal/crypto"
@@ -75,6 +76,25 @@ unrecoverable. Store shares separately and back them up.`,
 		fmt.Printf("Generated a new 32-byte KEK split into %d shares (threshold %d).\n", ssShares, ssThreshold)
 		fmt.Println("The KEK itself is not stored — keep at least the threshold many shares safe.")
 		fmt.Println()
+		if ssOutDir == "" {
+			// #cli-encryption-005: each printed share, on its own, is genuine key
+			// material below the configured threshold (only the KEK itself is never
+			// printed). Unlike the KEK, a run without --out-dir puts these shares
+			// straight into whatever is watching this terminal — scrollback, a
+			// tmux/screen logger, a session recorder, a CI log, or a shoulder-surfer
+			// during a live demo. Enough of them reaching the same log/recording lets
+			// the reader reconstruct the KEK without ever touching a custodian's share
+			// file. Warn loudly on stderr (not stdout) immediately before printing any
+			// share, so the warning survives even if stdout alone is piped/redirected
+			// away from the terminal.
+			fmt.Fprintln(os.Stderr, "⚠️  WARNING: printing Shamir shares to stdout.")
+			fmt.Fprintln(os.Stderr, "   Each share below is genuine key material — enough of them (threshold")
+			fmt.Fprintln(os.Stderr, "   many) reconstruct the KEK. Anything capturing this terminal (scrollback,")
+			fmt.Fprintln(os.Stderr, "   tmux/screen logging, session recorders, CI logs) can leak that key.")
+			fmt.Fprintln(os.Stderr, "   Prefer --out-dir <dir> unless this is a live, unrecorded,")
+			fmt.Fprintln(os.Stderr, "   single-viewer terminal.")
+			fmt.Fprintln(os.Stderr)
+		}
 		for i, s := range shares {
 			enc := hex.EncodeToString(s)
 			if ssOutDir == "" {

--- a/internal/cli/encryption/shamir_split_test.go
+++ b/internal/cli/encryption/shamir_split_test.go
@@ -1,7 +1,9 @@
 package encryption
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,4 +40,58 @@ func TestShamirSplit_WritesSharesWithSecurePermissions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, os.FileMode(0o600), fi.Mode().Perm(), "%s must be 0600", path)
 	}
+}
+
+// captureStderr redirects os.Stderr for the duration of fn and returns everything
+// written to it, so tests can assert on the operator-facing warning independently
+// of the (separately captured) stdout share output.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	fn()
+	require.NoError(t, w.Close())
+	os.Stderr = old
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	return buf.String()
+}
+
+// cli-encryption-005: printing Shamir shares to stdout (the default, no --out-dir)
+// must be preceded by a loud warning on stderr — each share is genuine key material
+// below the configured threshold, and stdout alone may end up in scrollback, a
+// tmux/screen log, a session recorder, or a CI log. The warning goes to stderr (not
+// stdout) specifically so it survives even when the operator pipes/redirects stdout
+// away from the terminal.
+func TestShamirSplit_WarnsOnStderrWhenPrintingSharesToStdout(t *testing.T) {
+	ssShares, ssThreshold, ssOutDir = 5, 3, ""
+
+	var stdout string
+	stderr := captureStderr(t, func() {
+		stdout = captureStdout(t, func() {
+			require.NoError(t, shamirSplitCmd.RunE(shamirSplitCmd, nil))
+		})
+	})
+
+	assert.Contains(t, stderr, "WARNING", "must warn loudly before printing shares to stdout")
+	assert.Contains(t, stderr, "stdout")
+	assert.Contains(t, stderr, "--out-dir", "warning must recommend the safer alternative")
+	assert.Contains(t, stdout, "share 1:", "shares must still print to stdout (unchanged default behavior)")
+	assert.NotContains(t, stdout, "WARNING", "the warning itself must not land on stdout")
+}
+
+// The warning is specific to the stdout path — writing shares to --out-dir doesn't
+// put key material on the terminal, so no stderr warning should fire.
+func TestShamirSplit_NoStderrWarningWhenWritingToOutDir(t *testing.T) {
+	dir := t.TempDir()
+	ssShares, ssThreshold, ssOutDir = 5, 3, dir
+
+	stderr := captureStderr(t, func() {
+		require.NoError(t, shamirSplitCmd.RunE(shamirSplitCmd, nil))
+	})
+
+	assert.Empty(t, stderr, "no stdout-specific warning should print when shares are written to --out-dir")
 }

--- a/internal/cli/hygiene/hygiene.go
+++ b/internal/cli/hygiene/hygiene.go
@@ -79,8 +79,11 @@ func printRollup(r *rollup) {
 	fmt.Printf("\nProjects with debt (%d):\n", len(r.Projects))
 	fmt.Printf("%-6s %-22s %-9s %-7s %-9s %-9s %s\n", "ID", "NAME", "ORPHANED", "UNUSED", "EXPIRING", "STALE-MI", "ROT-OVERDUE")
 	for _, p := range r.Projects {
+		// #G69: ProjectName is attacker-controlled free text — a crafted
+		// project name must not be able to embed terminal escape sequences
+		// that overwrite or hide rows in this deployment-wide rollup.
 		fmt.Printf("%-6d %-22s %-9d %-7d %-9d %-9d %d\n",
-			p.ProjectID, p.ProjectName, p.OrphanedSecrets, p.UnusedSecrets,
+			p.ProjectID, common.SanitizeForTerminal(p.ProjectName), p.OrphanedSecrets, p.UnusedSecrets,
 			p.ExpiringSecrets, p.StaleMachineIdentities, p.RotationOverdue)
 	}
 }

--- a/internal/cli/hygiene/terminal_injection_test.go
+++ b/internal/cli/hygiene/terminal_injection_test.go
@@ -1,0 +1,20 @@
+// terminal_injection_test.go — #G69: printRollup printed the attacker-
+// controlled ProjectName straight through fmt.Printf with no sanitization,
+// letting a crafted project name embed terminal escape sequences that
+// overwrite, hide, or spoof rows in this deployment-wide rollup.
+package hygiene
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintRollup_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row"
+	r := &rollup{
+		Projects: []projectBreakdown{{ProjectID: 1, ProjectName: malicious}},
+	}
+	out := captureStdout(t, func() { printRollup(r) })
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/risk/risk.go
+++ b/internal/cli/risk/risk.go
@@ -66,12 +66,13 @@ var listCmd = &cobra.Command{
 			if e.Approved {
 				approval = "approved"
 			}
-			// #G69: Title/Category/Justification are attacker-controlled free
-			// text — Reference alone being %q-quoted (which does escape
-			// control characters) left the other three as an inconsistent,
-			// unsanitized terminal-escape-injection path.
+			// #G69: Title/Category/Justification/Reference are all
+			// attacker-controlled free text. Reference was previously only
+			// %q-quoted — that escapes Go string-literal syntax, which is a
+			// different and weaker guarantee than stripping ANSI/control
+			// bytes, so it's sanitized the same as the other three here too.
 			fmt.Printf("[%s, %s] #%d %s (category=%s, ref=%q)\n", e.Status, approval, e.ID,
-				common.SanitizeForTerminal(e.Title), common.SanitizeForTerminal(e.Category), e.Reference)
+				common.SanitizeForTerminal(e.Title), common.SanitizeForTerminal(e.Category), common.SanitizeForTerminal(e.Reference))
 			fmt.Printf("        expires %s — %s\n", e.ExpiresAt, common.SanitizeForTerminal(e.Justification))
 		}
 		return nil

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -41,6 +41,11 @@ replaced with underscores before becoming an env var key:
   db-password  →  DB_PASSWORD
   api.endpoint →  API_ENDPOINT
 
+If two different secret names collide onto the same env var key after this
+conversion (e.g. "my-secret" and "my_secret" both becoming MY_SECRET), the
+command aborts with an error instead of silently letting one overwrite the
+other — rename one of the secrets to resolve the collision.
+
 Authentication:
   • Session tokens written by 'keyorix auth login' are used automatically
     when the CLI is in client mode.
@@ -161,6 +166,7 @@ func fetchSecretsEmbedded(ctx context.Context, project, env string) (map[string]
 	// silently missing environment variables.
 	const pageSize = 500
 	result := make(map[string]string)
+	envKeySources := make(map[string]string)
 	for page := 1; ; page++ {
 		secrets, _, err := svc.ListSecrets(ctx, &coreStorage.SecretFilter{
 			ProjectID:     &projectID,
@@ -177,7 +183,9 @@ func fetchSecretsEmbedded(ctx context.Context, project, env string) (map[string]
 				fmt.Fprintf(os.Stderr, "warning: skipping secret %q (id=%d): %v\n", s.Name, s.ID, err)
 				continue
 			}
-			result[toEnvKey(s.Name)] = string(val)
+			if err := setEnvKey(result, envKeySources, s.Name, string(val)); err != nil {
+				return nil, err
+			}
 		}
 		if len(secrets) < pageSize {
 			break
@@ -254,6 +262,7 @@ func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env strin
 	// process, silently truncating or failing the launch instead of a clear error.
 	const maxRunInjectedSecrets = 2000
 	result := make(map[string]string)
+	envKeySources := make(map[string]string)
 	for page := 1; ; page++ {
 		listPath := fmt.Sprintf(
 			"/api/v1/secrets?project_id=%d&environment_id=%d&page_size=%d&page=%d",
@@ -280,7 +289,9 @@ func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env strin
 				fmt.Fprintf(os.Stderr, "warning: skipping secret %q (id=%d): %v\n", s.Name, s.ID, err)
 				continue
 			}
-			result[toEnvKey(s.Name)] = secretBody.Value
+			if err := setEnvKey(result, envKeySources, s.Name, secretBody.Value); err != nil {
+				return nil, err
+			}
 		}
 		if len(secretsBody.Secrets) < pageSize {
 			break
@@ -303,6 +314,26 @@ func toEnvKey(name string) string {
 		}
 	}
 	return b.String()
+}
+
+// setEnvKey records secret name's value under its toEnvKey-derived key in result,
+// tracking which secret name produced each key in envKeySources so a collision can
+// be detected. Two DIFFERENT secret names can sanitize to the SAME env var key
+// (e.g. "my-secret" and "my_secret" both become MY_SECRET) — without this check the
+// second secret processed would silently overwrite the first in result, and the
+// operator would have no indication that one of their two secrets never actually
+// reached the child process's environment (which could read the WRONG secret's
+// value under an expected variable name). Matches this codebase's fail-closed-on-
+// ambiguity convention (see the dangerousEnvVarNames / maxRunInjectedSecrets guards
+// above): abort the whole run rather than silently picking a winner.
+func setEnvKey(result map[string]string, envKeySources map[string]string, name, value string) error {
+	key := toEnvKey(name)
+	if existing, ok := envKeySources[key]; ok && existing != name {
+		return fmt.Errorf("secrets %q and %q both sanitize to the same environment variable %q — 'keyorix run' refuses to continue since one of them would silently be dropped from the child process's environment; rename one of the secrets to avoid the collision", existing, name, key)
+	}
+	envKeySources[key] = name
+	result[key] = value
+	return nil
 }
 
 // dangerousEnvVarNames names environment variables that affect dynamic-linker,

--- a/internal/cli/run/run_fetch_test.go
+++ b/internal/cli/run/run_fetch_test.go
@@ -58,6 +58,40 @@ func TestFetchSecretsRemote(t *testing.T) {
 	assert.Equal(t, map[string]string{"DB_PASSWORD": "s3cr3t"}, got)
 }
 
+// TestFetchSecretsRemote_CollisionAborts is the regression test for the toEnvKey
+// collision finding: two DIFFERENT secret names ("my-secret" and "my_secret") both
+// sanitize to the same env var key (MY_SECRET) via toEnvKey. Before this fix the
+// second one processed would silently overwrite the first in the returned map with
+// no indication anything was dropped. Assert fetchSecretsRemote now returns an
+// error naming both colliding secrets instead of silently picking a winner.
+func TestFetchSecretsRemote_CollisionAborts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		case "/api/v1/projects/1/environments":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"environments":[{"id":2,"name":"dev"}]}}`))
+		case "/api/v1/secrets":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[{"id":9,"name":"my-secret"},{"id":10,"name":"my_secret"}]}}`))
+		case "/api/v1/secrets/9":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"value":"first"}}`))
+		case "/api/v1/secrets/10":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"value":"second"}}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	got, err := fetchSecretsRemote(context.Background(), srv.URL, "tok", "web", "dev")
+	require.Error(t, err, "colliding secret names must abort the fetch, not silently overwrite one")
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "my-secret")
+	assert.Contains(t, err.Error(), "my_secret")
+	assert.Contains(t, err.Error(), "MY_SECRET")
+}
+
 func TestFetchSecretsRemote_ProjectNotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[]}}`))
@@ -151,4 +185,74 @@ func TestFetchSecretsEmbedded(t *testing.T) {
 	_, err = fetchSecretsEmbedded(ctx, "ghost", "dev")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestFetchSecretsEmbedded_CollisionAborts mirrors TestFetchSecretsRemote_
+// CollisionAborts for the embedded (local core service) path: two distinct secret
+// names that sanitize to the same toEnvKey output must abort fetchSecretsEmbedded
+// with a clear error rather than silently dropping one of them from the child
+// process's environment.
+func TestFetchSecretsEmbedded_CollisionAborts(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "s2.db")}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	ctx := context.Background()
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	project, err := svc.CreateProjectWithEnvs(ctx, "web", "", []string{"dev"})
+	require.NoError(t, err)
+	envs, err := svc.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+	_, err = svc.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "my-secret", Value: []byte("first"), ProjectID: project.ID,
+		EnvironmentID: envs[0].ID, Type: "password", CreatedBy: "test",
+	})
+	require.NoError(t, err)
+	_, err = svc.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "my_secret", Value: []byte("second"), ProjectID: project.ID,
+		EnvironmentID: envs[0].ID, Type: "password", CreatedBy: "test",
+	})
+	require.NoError(t, err)
+
+	got, err := fetchSecretsEmbedded(ctx, "web", "dev")
+	require.Error(t, err, "colliding secret names must abort the fetch, not silently overwrite one")
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "my-secret")
+	assert.Contains(t, err.Error(), "my_secret")
+	assert.Contains(t, err.Error(), "MY_SECRET")
+}
+
+// TestSetEnvKey_CollisionDetection unit-tests the shared collision-detection helper
+// directly: the same secret name is idempotent (re-processing it, e.g. across a
+// pagination boundary, must not itself trip the collision check), while two
+// DIFFERENT names sanitizing to the same key must error.
+func TestSetEnvKey_CollisionDetection(t *testing.T) {
+	result := make(map[string]string)
+	sources := make(map[string]string)
+
+	require.NoError(t, setEnvKey(result, sources, "my-secret", "first"))
+	assert.Equal(t, "first", result["MY_SECRET"])
+
+	// Same name again (e.g. seen twice) must not be treated as a collision.
+	require.NoError(t, setEnvKey(result, sources, "my-secret", "first-updated"))
+	assert.Equal(t, "first-updated", result["MY_SECRET"])
+
+	err := setEnvKey(result, sources, "my_secret", "second")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "my-secret")
+	assert.Contains(t, err.Error(), "my_secret")
+	assert.Contains(t, err.Error(), "MY_SECRET")
+	// The original value must be left untouched — the second secret is rejected,
+	// not silently applied before erroring.
+	assert.Equal(t, "first-updated", result["MY_SECRET"])
 }

--- a/internal/cli/share/list.go
+++ b/internal/cli/share/list.go
@@ -38,6 +38,22 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 	service := core.NewKeyorixCore(st)
 
+	// cli-connect-007 (info, deliberate — not a bug): ListSecretShares is the
+	// non-authorization-checked variant (see its doc comment and
+	// ListSecretSharesWithPermissionCheck, both in
+	// internal/core/sharing_query.go) — unlike HTTP/gRPC, which gate the caller
+	// to the secret's owner, this local CLI path does not. That's intentional:
+	// embedded/local mode has no authenticated-user concept (share/remote.go:7-9),
+	// so there is no caller identity to check against, and this command can
+	// enumerate the share list for any --secret-id. The residual risk is if
+	// embedded mode is ever pointed at a genuinely shared/multi-tenant backend
+	// (the scenario common.go's InitializeCoreService warning already
+	// contemplates for the cli-connect-004/#G67 ResolveActorID fix) — then this
+	// becomes an unrestricted enumeration surface. If that deployment shape ever
+	// becomes real, route this through common.ResolveActorID() and
+	// ListSecretSharesWithPermissionCheck instead, consistent with how
+	// group_shares.go's ListGroupShares call was hardened in #G10.
+	//
 	// Call service
 	ctx := context.Background()
 	shares, err := service.ListSecretShares(ctx, listSecretID)

--- a/internal/cli/share/shared_secrets.go
+++ b/internal/cli/share/shared_secrets.go
@@ -41,6 +41,20 @@ func runSharedSecrets(cmd *cobra.Command, args []string) error {
 	}
 	service := core.NewKeyorixCore(st)
 
+	// cli-connect-007 (info, deliberate — not a bug): same as the remote branch
+	// above, --user-id is not checked against the invoking operator here either
+	// — ListSharedSecrets (internal/core/sharing_query.go) takes a bare userID
+	// with no caller/actor parameter at all. Intentional: embedded/local mode
+	// has no authenticated-user concept (share/remote.go:7-9), so an embedded
+	// admin can query any user's shared secrets. The residual risk is if
+	// embedded mode is ever pointed at a genuinely shared/multi-tenant backend
+	// (the scenario common.go's InitializeCoreService warning already
+	// contemplates for the cli-connect-004/#G67 ResolveActorID fix) — then this
+	// becomes an unrestricted enumeration surface. If that deployment shape ever
+	// becomes real, route this through common.ResolveActorID() and an
+	// actor-aware, permission-checked core variant, consistent with how
+	// group_shares.go's ListGroupShares call was hardened in #G10.
+	//
 	// Call service
 	ctx := context.Background()
 	secrets, err := service.ListSharedSecrets(ctx, sharedSecretsUserID)

--- a/internal/cli/usage/terminal_injection_test.go
+++ b/internal/cli/usage/terminal_injection_test.go
@@ -1,0 +1,46 @@
+// terminal_injection_test.go — #G69: printReport printed the attacker-
+// controlled ProjectName straight through fmt.Fprintf with no sanitization,
+// letting a crafted project name embed terminal escape sequences that
+// overwrite, hide, or spoof rows in this usage report.
+package usage
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fnErr := fn()
+
+	require.NoError(t, w.Close())
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	return buf.String(), fnErr
+}
+
+func TestPrintReport_NeutralizesEscapeSequences(t *testing.T) {
+	malicious := "\x1b[1A\x1b[2K  + spoofed clean row"
+	report := &storage.UsageReport{
+		WindowDays:  30,
+		GeneratedAt: time.Now(),
+		Projects:    []storage.ProjectUsageStat{{ProjectID: 1, ProjectName: malicious}},
+	}
+	out, err := captureStdout(t, func() error { return printReport(report) })
+	require.NoError(t, err)
+	assert.NotContains(t, out, "\x1b")
+}

--- a/internal/cli/usage/usage.go
+++ b/internal/cli/usage/usage.go
@@ -107,7 +107,10 @@ func printReport(report *storage.UsageReport) error {
 		return err
 	}
 	for _, p := range report.Projects {
-		name := p.ProjectName
+		// #G69: ProjectName is attacker-controlled free text — an operator
+		// or self-chosen display name must not be able to embed terminal
+		// escape sequences that overwrite or hide rows in this report.
+		name := common.SanitizeForTerminal(p.ProjectName)
 		if name == "" {
 			name = fmt.Sprintf("(project %d)", p.ProjectID)
 		}

--- a/scripts/demo-keyorix.sh
+++ b/scripts/demo-keyorix.sh
@@ -60,15 +60,23 @@ if [[ -n "$KEYORIX_TOKEN" ]]; then
     DEMO_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/keyorix-demo.XXXXXX")
     RESPONSE_FILE="$DEMO_TMP_DIR/keyorix-demo-user.json"
     HEADER_FILE="$DEMO_TMP_DIR/auth.header"
+    BODY_FILE="$DEMO_TMP_DIR/keyorix-demo-user-body.json"
+    # Generate the demo user's password at runtime rather than hardcoding one:
+    # a fixed literal here is easy to copy-paste into a real deployment by
+    # someone following this script as a tutorial. Printed below so the
+    # operator can still log in as this user.
+    DEMO_USER_PASSWORD=$(head -c 24 /dev/urandom | base64)
     (umask 077 && printf 'Authorization: Bearer %s\n' "$KEYORIX_TOKEN" > "$HEADER_FILE")
+    (umask 077 && printf '{"username":"demo","email":"demo@keyorix.com","password":"%s","display_name":"Demo User"}' "$DEMO_USER_PASSWORD" > "$BODY_FILE")
     HTTP_CODE=$(curl -s -o "$RESPONSE_FILE" -w "%{http_code}" \
         -X POST "$SERVER/api/v1/users" \
         -H @"$HEADER_FILE" \
         -H "Content-Type: application/json" \
-        -d '{"username":"demo","email":"demo@keyorix.com","password":"Demo#Pass!2026","display_name":"Demo User"}')
-    rm -f "$HEADER_FILE"
+        --data @"$BODY_FILE")
+    rm -f "$HEADER_FILE" "$BODY_FILE"
     if [[ "$HTTP_CODE" = "200" ]] || [[ "$HTTP_CODE" = "201" ]]; then
         demo_success "Created demo user demo@keyorix.com (viewer role)"
+        demo_info "Demo user password: $DEMO_USER_PASSWORD (save it — needed to log in as this user)"
     elif [[ "$HTTP_CODE" = "409" ]]; then
         demo_info "Demo user demo@keyorix.com already exists — skipping"
     else

--- a/scripts/mutation-testing/notify-summary.sh
+++ b/scripts/mutation-testing/notify-summary.sh
@@ -34,20 +34,31 @@ cleanup_ntfy_curl_cfg() {
 }
 trap cleanup_ntfy_curl_cfg EXIT
 
-efficacy="$(python3 -c "import json; print(json.load(open('$SUMMARY_JSON')).get('test_efficacy_pct'))")"
-total="$(python3 -c "import json; print(json.load(open('$SUMMARY_JSON')).get('total_mutants'))")"
-lived_count="$(python3 -c "import json; print(len(json.load(open('$SUMMARY_JSON')).get('lived', [])))")"
-not_covered="$(python3 -c "import json; print(json.load(open('$SUMMARY_JSON')).get('counts', {}).get('NOT COVERED', 0))")"
+efficacy="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("test_efficacy_pct"))' "$SUMMARY_JSON")"
+total="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("total_mutants"))' "$SUMMARY_JSON")"
+lived_count="$(python3 -c 'import json, sys; print(len(json.load(open(sys.argv[1])).get("lived", [])))' "$SUMMARY_JSON")"
+not_covered="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("counts", {}).get("NOT COVERED", 0))' "$SUMMARY_JSON")"
 
 regressed=false
 regression_body=""
 if [[ -n "$PREV_SUMMARY_JSON" && -f "$PREV_SUMMARY_JSON" ]]; then
-  prev_efficacy="$(python3 -c "import json; e = json.load(open('$PREV_SUMMARY_JSON')).get('test_efficacy_pct'); print(e if e is not None else -1)")"
-  if python3 -c "
+  prev_efficacy="$(python3 -c 'import json, sys; e = json.load(open(sys.argv[1])).get("test_efficacy_pct"); print(e if e is not None else -1)' "$PREV_SUMMARY_JSON")"
+  # Values are passed as argv rather than interpolated into the Python
+  # source string, so a value containing a quote/backslash can't break out
+  # of a string literal and get read as Python code.
+  if python3 -c '
 import sys
-eff, prev, thresh = $efficacy, $prev_efficacy, $MUTATION_EFFICACY_DROP_THRESHOLD
-sys.exit(0 if (prev >= 0 and eff is not None and prev - eff >= thresh) else 1)
-"; then
+
+
+def parse_num(s):
+    return None if s == "None" else float(s)
+
+
+eff = parse_num(sys.argv[1])
+prev = parse_num(sys.argv[2])
+thresh = parse_num(sys.argv[3])
+sys.exit(0 if (prev is not None and prev >= 0 and eff is not None and prev - eff >= thresh) else 1)
+' "$efficacy" "$prev_efficacy" "$MUTATION_EFFICACY_DROP_THRESHOLD"; then
     regressed=true
     regression_body="$(python3 - "$SUMMARY_JSON" "$PREV_SUMMARY_JSON" <<'PYEOF'
 import json, sys


### PR DESCRIPTION
## Summary

Closes 8 planned low/info-severity singletons from Wave 6's CLI-hygiene batch, plus 2 bonus bundles discovered during triage (never covered by the original critical/high wave, confirmed genuinely open).

**Planned 8:**
- `cli-encryption-005` — Shamir-split shares printed to stdout with no warning; adds a loud stderr warning before printing (default behavior unchanged, non-breaking).
- `cli-connect-007` — embedded-mode share enumeration; confirmed documentation-only per the finding's own text (the one file that could be actor-scoped, `group_shares.go`, was already fixed by an earlier round).
- `bundle-findings.json#1` — `cleanComponentPath`'s raw-string absolute-path check wasn't re-applied to the post-`Clean` value (Unix-unreachable today, live on a hypothetical Windows build); added the missing check.
- `cli-audit.json#4` — anomaly-config `set`'s unsynchronized GET-then-PUT race; no conditional-update primitive exists anywhere in the storage stack, so this is a documented-limitation fix rather than new distributed-locking infrastructure.
- `cli-connect.json#5` — `loginWithCredentials` echoed the raw HTTP response body on login failure; now sanitized + truncated before reaching the terminal.
- `cli-billing.json#2` — `toEnvKey` let two distinct secret names silently collide onto the same env var in `keyorix run`; now aborts with both colliding names named, matching this codebase's fail-closed-on-ambiguity convention.
- `scripts.json#0` — hardcoded demo password in `demo-keyorix.sh`; now generated at runtime and printed to the operator.
- `scripts.json#1` — `python3 -c` string interpolation in `notify-summary.sh`; converted to `sys.argv`-based argument passing.

**Bonus bundle 1 — `cli-encryption-001` (high, destructive data loss):** `migrateAPIClients`/`migrateAPITokens` treated a SHA-256 hash column as plaintext, "encrypted" it, then nulled the original — permanently destroying the only copy of the hash. Identical bug pattern an earlier commit already fixed for the `sessions` table but never applied to this sibling. Removed both destructive functions (and their `validate` counterparts) per that same precedent. The two other findings in this cluster (DEK lock coverage, backup-restore file-mode) turned out to already be fixed by prior commits — confirmed, not duplicated.

**Bonus bundle 2 — terminal-escape-injection sweep (6 files):** the primary sanitization pass for this threat class had already landed in PR #1411, but missed several sibling call sites sharing the same root cause: `accessreview/campaign.go`, `compliance/digest.go`, `usage/usage.go`, `hygiene/hygiene.go`, plus two still-unsanitized fields in `audit/audit.go` and the inconsistent guard-on-one-field-only bug in `risk/risk.go`. All now route through the shared `common.SanitizeForTerminal`.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `gofmt -l` — clean across all changed files
- `gosec -severity medium -exclude-generated ./...` — 0 issues (795 files, 156k lines)
- Full `go test ./...` — only the established pre-existing failures (`TestPermissionBaseline_CSV_Headers`, the `TestRemoteStorage*_RealServer` family in `server/http`), no new failures
- Each of the 10 underlying fixes independently verified (build/vet/gofmt/gosec/package suite) before being cherry-picked onto this combined branch; combined verification re-run above catches any cross-fix interaction