### PR TITLE
fix(security): close Wave 6 low/info batch 6 (secret/identity core lifecycle)

### DIFF
--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -1,6 +1,8 @@
 // Package compliance provides `keyorix compliance` — the deployment's controls-
 // posture report for auditors (ISO 27001 / SOC 2 / NIS2 / DORA). Talks to
-// GET /api/v1/compliance/posture (gated by system.read).
+// GET /api/v1/compliance/posture (gated by audit.read, not the system_viewer
+// baseline system.read — same disclosure-family calibration as the other
+// /compliance/* endpoints; see server/http/router.go).
 package compliance
 
 import (

--- a/internal/core/certificate.go
+++ b/internal/core/certificate.go
@@ -99,7 +99,7 @@ func (c *KeyorixCore) InspectCertificate(ctx context.Context, actorID, secretID 
 		DaysUntilExpiry:    int(cert.NotAfter.Sub(now).Hours() / 24),
 		IsExpired:          now.After(cert.NotAfter),
 		IsCA:               cert.IsCA,
-		SelfSigned:         cert.Subject.String() == cert.Issuer.String(),
+		SelfSigned:         isSelfSigned(cert),
 		DNSNames:           cert.DNSNames,
 		SignatureAlgorithm: cert.SignatureAlgorithm.String(),
 		PublicKeyAlgorithm: cert.PublicKeyAlgorithm.String(),
@@ -136,6 +136,38 @@ func (c *KeyorixCore) refreshCertNotAfterCache(ctx context.Context, secret *mode
 	} else {
 		_ = c.storage.SetSecretCertNotAfter(ctx, secret.ID, nil)
 	}
+}
+
+// isSelfSigned reports whether cert's signature cryptographically validates against
+// cert's OWN public key — the actual definition of self-signed: the certificate was
+// signed by the private key corresponding to its own subject public key.
+//
+// #CORE-CERT-003: this replaces a prior `cert.Subject.String() == cert.Issuer.String()`
+// comparison, which only compared the RENDERED RDN strings. That heuristic was
+// spoofable in both directions: a certificate manually constructed with reordered or
+// otherwise mismatched RDN attribute encoding could evade the check despite being
+// genuinely self-signed, and — the more consequential direction, since this field feeds
+// an operator-facing PKI-hygiene signal per ADR-054/056 — a CA-issued certificate whose
+// Issuer happens to render identically to its Subject (matching CN/org by coincidence,
+// or a crafted cert) would be misreported as self-signed even though a different key
+// signed it, producing a false sense of assurance.
+//
+// cert.CheckSignatureFrom(cert) is deliberately NOT used here: it additionally enforces
+// RFC 5280 CA constraints (BasicConstraints/KeyUsage) on the "parent" argument, which is
+// cert itself in a self-check. Those constraints reject the common case of a self-signed
+// LEAF certificate (IsCA: false — most self-signed TLS/service certs never set the CA
+// bit), which would make a genuinely self-signed leaf spuriously report as NOT
+// self-signed. cert.CheckSignature verifies the raw TBS-certificate signature against
+// cert's own public key directly, with no CA/BasicConstraints/KeyUsage involved — the
+// right primitive for "did this certificate sign itself."
+//
+// An error (e.g. an unsupported/weak signature algorithm the stdlib refuses to verify)
+// means self-signed status cannot be cryptographically confirmed. We fail closed to
+// false (not self-signed) rather than assume it is: the whole point of this field is an
+// accurate hygiene signal, and an unverified claim of "self-signed" would itself be a
+// false assurance.
+func isSelfSigned(cert *x509.Certificate) bool {
+	return cert.CheckSignature(cert.SignatureAlgorithm, cert.RawTBSCertificate, cert.Signature) == nil
 }
 
 // maxCertBlocks bounds how many CERTIFICATE blocks we parse from a single value, so a

--- a/internal/core/certificate_test.go
+++ b/internal/core/certificate_test.go
@@ -172,6 +172,65 @@ func TestInspectCertificate(t *testing.T) {
 	assert.Equal(t, "4242", info.SerialNumber)
 }
 
+// TestInspectCertificateCAIssuedWithMatchingSubjectIssuerString guards #CORE-CERT-003:
+// SelfSigned used to be `cert.Subject.String() == cert.Issuer.String()`, a naive RDN
+// string comparison. Here the CA and the leaf are given the IDENTICAL pkix.Name, so
+// their rendered Subject/Issuer strings are byte-for-byte equal — exactly what the old
+// check looked at — but the leaf is signed with the CA's private key, not its own: it is
+// genuinely CA-issued, not self-signed. The cryptographic check (signature verified
+// against the leaf's OWN public key) must correctly report SelfSigned:false, where the
+// old string comparison would have wrongly reported true.
+func TestInspectCertificateCAIssuedWithMatchingSubjectIssuerString(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	c, db := newCertCore(t, now)
+
+	sharedName := pkix.Name{CommonName: "shared-name.example.com"}
+
+	caPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               sharedName,
+		NotBefore:             now.Add(-365 * 24 * time.Hour),
+		NotAfter:              now.Add(365 * 24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caPriv.PublicKey, caPriv)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	leafPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      sharedName, // identical to the CA's Subject → rendered strings match
+		NotBefore:    now.Add(-30 * 24 * time.Hour),
+		NotAfter:     now.Add(60 * 24 * time.Hour),
+	}
+	// Signed by the CA's key (caPriv), NOT the leaf's own key — genuinely CA-issued.
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafPriv.PublicKey, caPriv)
+	require.NoError(t, err)
+
+	// Sanity check the test setup actually exercises the regression: the old naive
+	// check's inputs really must be equal, or this test proves nothing.
+	parsedLeaf, err := x509.ParseCertificate(leafDER)
+	require.NoError(t, err)
+	require.Equal(t, parsedLeaf.Issuer.String(), parsedLeaf.Subject.String(),
+		"test setup: Subject/Issuer strings must render identically")
+
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
+	mkCertSecret(t, db, 1, "ca-issued-matching-strings", "active", leafPEM)
+
+	info, err := c.InspectCertificate(ctx, 9, 1)
+	require.NoError(t, err)
+	assert.False(t, info.SelfSigned,
+		"signature does not verify against the leaf's own key — must not be reported self-signed despite matching Subject/Issuer strings")
+}
+
 func TestInspectCertificateExpired(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)

--- a/internal/core/control_framework.go
+++ b/internal/core/control_framework.go
@@ -3,7 +3,15 @@
 // maps each control Keyorix enforces to its clause references across the regimes an
 // auditor cares about, and evaluates a live status (pass / gap / not-configured)
 // from the posture. It turns the scattered A.5.x tiles into one auditor-ready
-// framework map. Read-only; gated by system.read.
+// framework map. Read-only; gated by audit.read at every real entry point (HTTP
+// GET /api/v1/compliance/controls and /compliance/controls.csv, and the gRPC
+// ComplianceGRPCService.GetComplianceControls). Do not gate this — or any new
+// caller — on system.read: that permission is granted to every user via the
+// baseline system_viewer role, so it is equivalent to no gate at all for this
+// disclosure-sensitive control matrix. Gating on system.read was a real,
+// fixed vulnerability (CP-001/CP-008); see the regression test
+// TestComplianceService_SystemViewerDenied in
+// server/grpc/services/compliance_service_test.go.
 package core
 
 import (

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -30,6 +30,18 @@ const defaultDynamicTTL = 1 * time.Hour
 // SetDynamicMaxLeaseTTL, e.g. in tests that construct KeyorixCore directly).
 const defaultMaxLeaseTTL = 90 * 24 * time.Hour
 
+// maxDynamicTTLSeconds bounds a raw seconds value (ttl_seconds override) before it's
+// multiplied into a time.Duration (mirrors MaxInactiveDays' overflow guard in
+// inactivity_suspend.go). time.Duration is an int64 count of nanoseconds, so
+// time.Duration(seconds) * time.Second overflows for seconds beyond roughly 2^63/1e9
+// (~9.22e9s); a caller-supplied ttl_seconds above that wraps around to an arbitrary —
+// possibly NEGATIVE — Duration that neither the per-config MaxTTLSeconds nor the
+// install-wide ceiling clamp below can catch (both are plain ">" comparisons against a
+// positive max, so a negative wrapped value sails through both). 100 years in seconds
+// is comfortably below the overflow threshold while still far beyond any legitimate
+// lease TTL, matching the generous-headroom style of MaxInactiveDays.
+const maxDynamicTTLSeconds = 100 * 365 * 24 * 3600
+
 // isPrivateIP reports whether ip is disallowed as an admin-DSN target — the
 // canonical private/loopback/link-local/IMDS/CGNAT check, shared (via
 // netutil.IsPrivateOrLinkLocal) with every other backend-infrastructure dial
@@ -148,6 +160,21 @@ func validateAdminDSNHost(adminDSN string) error {
 		}
 		return nil
 	}
+	// net.ParseIP does not accept RFC 4007 zone-ID syntax (e.g. "fe80::1%eth0"), so a
+	// zone-qualified link-local IPv6 literal isn't recognised as a literal IP above and
+	// would otherwise fall straight through to net.LookupHost — which errors on a
+	// zone-qualified address (it isn't a valid DNS query), landing in the "unresolvable,
+	// skip validation" branch below and silently bypassing the blocklist for exactly the
+	// fe80::/10 addresses it names. Strip the zone and retry as a literal IP first.
+	if zoneHost, _, hasZone := strings.Cut(host, "%"); hasZone {
+		if ip := net.ParseIP(zoneHost); ip != nil {
+			if isPrivateIP(ip) {
+				return fmt.Errorf("admin_dsn host %q is a private or link-local address; "+
+					"set dynamic_secrets.allow_private_network_targets: true to allow private-network backends", host)
+			}
+			return nil
+		}
+	}
 	addrs, err := net.LookupHost(host)
 	if err != nil {
 		return nil // unresolvable at register time — actual connection fails at issue time
@@ -258,6 +285,17 @@ func validateCreateDynamicSecretConfigRequest(req *CreateDynamicSecretConfigRequ
 	}
 	if req.MaxTTLSeconds > 0 && req.DefaultTTLSeconds > req.MaxTTLSeconds {
 		return fmt.Errorf("default_ttl_seconds (%d) cannot exceed max_ttl_seconds (%d)", req.DefaultTTLSeconds, req.MaxTTLSeconds)
+	}
+	// Sibling of dynamicTTL's override bound: DefaultTTLSeconds/MaxTTLSeconds are also
+	// multiplied by time.Second (in dynamicTTL's clamp and RenewLease's per-lease hardCap
+	// computation) with no upper bound otherwise, so an oversized value set here at
+	// config-create time would overflow int64 nanoseconds just the same as an oversized
+	// caller-supplied ttl_seconds override does. Reject both at the door.
+	if req.DefaultTTLSeconds > maxDynamicTTLSeconds {
+		return fmt.Errorf("default_ttl_seconds (%d) exceeds the maximum of %d seconds", req.DefaultTTLSeconds, maxDynamicTTLSeconds)
+	}
+	if req.MaxTTLSeconds > maxDynamicTTLSeconds {
+		return fmt.Errorf("max_ttl_seconds (%d) exceeds the maximum of %d seconds", req.MaxTTLSeconds, maxDynamicTTLSeconds)
 	}
 	if !IsValidClassification(req.Classification) {
 		return fmt.Errorf("classification must be one of public, internal, confidential, restricted (or empty)")
@@ -492,7 +530,10 @@ func (c *KeyorixCore) IssueLease(ctx context.Context, configID uint, ttlSeconds 
 	if err != nil {
 		return nil, err
 	}
-	ttl := c.dynamicTTL(cfg, ttlSeconds)
+	ttl, err := c.dynamicTTL(cfg, ttlSeconds)
+	if err != nil {
+		return nil, err
+	}
 
 	// Logged BEFORE the mint (not after) so the breadcrumb survives a crash during or
 	// immediately after engine.Issue — see the crash-orphan note on IssueLease's doc
@@ -768,10 +809,21 @@ func (c *KeyorixCore) requireLiveProjectAndEnvironment(ctx context.Context, proj
 // left with MaxTTLSeconds=0 combined with a caller-supplied override would otherwise
 // mint a credential valid for however long the caller asked, with nothing to stop a
 // 100-year lease).
-func (c *KeyorixCore) dynamicTTL(cfg *models.DynamicSecretConfig, override int) time.Duration {
+//
+// override is caller-supplied (HTTP JSON body / gRPC field ttl_seconds) with no upper
+// bound applied before it reaches here, so it's checked against maxDynamicTTLSeconds
+// BEFORE the multiplication below: time.Duration(override) * time.Second overflows
+// int64 nanoseconds for large enough override, wrapping to an arbitrary — possibly
+// NEGATIVE — Duration that the MaxTTLSeconds/install-ceiling clamps further down
+// cannot catch (both are plain "ttl > max" comparisons, which a negative ttl never
+// satisfies), producing an ExpiresAt in the past instead of a rejected request.
+func (c *KeyorixCore) dynamicTTL(cfg *models.DynamicSecretConfig, override int) (time.Duration, error) {
 	ttl := defaultDynamicTTL
 	switch {
 	case override > 0:
+		if override > maxDynamicTTLSeconds {
+			return 0, fmt.Errorf("ttl_seconds (%d) exceeds the maximum of %d seconds", override, maxDynamicTTLSeconds)
+		}
 		ttl = time.Duration(override) * time.Second
 	case cfg.DefaultTTLSeconds > 0:
 		ttl = time.Duration(cfg.DefaultTTLSeconds) * time.Second
@@ -788,7 +840,7 @@ func (c *KeyorixCore) dynamicTTL(cfg *models.DynamicSecretConfig, override int) 
 	if ttl > installMax {
 		ttl = installMax
 	}
-	return ttl
+	return ttl, nil
 }
 
 // RenewLease extends an active lease's expiry by ttlSeconds (or the config
@@ -833,7 +885,11 @@ func (c *KeyorixCore) RenewLease(ctx context.Context, leaseID string, ttlSeconds
 	if eng, eerr := c.dynamicEngine(cfg.BackendType); eerr == nil && eng.IsEphemeralBackend() {
 		return time.Time{}, fmt.Errorf("the %s backend mints self-expiring credentials that cannot be renewed; issue a new lease instead", cfg.BackendType)
 	}
-	newExpiry := c.now().Add(c.dynamicTTL(cfg, ttlSeconds))
+	renewTTL, err := c.dynamicTTL(cfg, ttlSeconds)
+	if err != nil {
+		return time.Time{}, err
+	}
+	newExpiry := c.now().Add(renewTTL)
 	// Never let renewal push total lifetime past the config's max-TTL ceiling.
 	if cfg.MaxTTLSeconds > 0 {
 		if hardCap := lease.IssuedAt.Add(time.Duration(cfg.MaxTTLSeconds) * time.Second); newExpiry.After(hardCap) {

--- a/internal/core/dynamic_secrets_ssrf_test.go
+++ b/internal/core/dynamic_secrets_ssrf_test.go
@@ -94,6 +94,28 @@ func TestValidateAdminDSNHost_PrivateLiteralIPRejected(t *testing.T) {
 	}
 }
 
+// net.ParseIP doesn't accept RFC 4007 zone-ID syntax ("fe80::1%eth0"), so a
+// zone-qualified link-local literal must still be recognised (by stripping the zone
+// and retrying ParseIP) rather than falling through to net.LookupHost — which errors
+// on a zone-qualified address and would otherwise land in the "unresolvable, skip"
+// branch, silently bypassing the fe80::/10 blocklist entry.
+func TestValidateAdminDSNHost_ZoneQualifiedLinkLocalRejected(t *testing.T) {
+	cases := []struct {
+		desc string
+		dsn  string
+	}{
+		{"key-value zone-qualified link-local", "host=fe80::1%eth0 port=5432 user=admin dbname=app"},
+		{"mysql tcp zone-qualified link-local", "admin:pass@tcp(fe80::1%eth0:3306)/app"},
+	}
+	for _, tc := range cases {
+		err := validateAdminDSNHost(tc.dsn)
+		assert.Error(t, err, "should reject zone-qualified link-local (%s): %s", tc.desc, tc.dsn)
+		if err != nil {
+			assert.Contains(t, err.Error(), "private or link-local")
+		}
+	}
+}
+
 func TestValidateAdminDSNHost_PublicIPAllowed(t *testing.T) {
 	dsn := "postgres://admin:pass@203.0.113.5:5432/app" // TEST-NET, globally routable
 	require.NoError(t, validateAdminDSNHost(dsn))

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -535,6 +535,65 @@ func TestDynamicSecrets_MaxTTLClampsIssue(t *testing.T) {
 	assert.Equal(t, fixed.Add(30*time.Minute), issued.ExpiresAt, "issue TTL must be clamped to max_ttl_seconds")
 }
 
+// A caller-supplied ttl_seconds large enough to overflow int64 nanoseconds when
+// multiplied by time.Second must be rejected outright, not silently wrapped into an
+// arbitrary (possibly negative) Duration that would mint a credential with an
+// ExpiresAt in the past. 20_000_000_000 seconds (~634 years) comfortably exceeds the
+// ~9.22e9s int64-nanosecond overflow threshold.
+func TestDynamicSecrets_IssueRejectsOverflowingTTLSeconds(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "overflow-guard", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		ActorID: testAdminActorID,
+	})
+	require.NoError(t, err)
+
+	_, err = c.IssueLease(ctx, cfg.ID, 20_000_000_000, 7)
+	require.Error(t, err, "an overflowing ttl_seconds must be rejected, not silently wrapped into a negative Duration")
+	assert.Contains(t, err.Error(), "exceeds the maximum")
+}
+
+// The same overflow guard applies to RenewLease's ttlSeconds parameter.
+func TestDynamicSecrets_RenewRejectsOverflowingTTLSeconds(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "renew-overflow-guard", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		DefaultTTLSeconds: 600, ActorID: testAdminActorID,
+	})
+	require.NoError(t, err)
+	issued, err := c.IssueLease(ctx, cfg.ID, 0, 7)
+	require.NoError(t, err)
+
+	_, err = c.RenewLease(ctx, issued.LeaseID, 20_000_000_000, 7)
+	require.Error(t, err, "an overflowing renewal ttl_seconds must be rejected, not silently wrapped into a negative Duration")
+	assert.Contains(t, err.Error(), "exceeds the maximum")
+}
+
+// Setting an oversized default_ttl_seconds/max_ttl_seconds at config-create time must
+// also be rejected — both are multiplied by time.Second the same way a caller-supplied
+// override is (in dynamicTTL's clamp and RenewLease's per-lease hardCap), so they carry
+// the identical int64-nanosecond overflow risk.
+func TestDynamicSecrets_CreateRejectsOverflowingConfigTTLFields(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+
+	_, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "bad-default", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		DefaultTTLSeconds: 20_000_000_000, ActorID: testAdminActorID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds the maximum")
+
+	_, err = c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "bad-max", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		MaxTTLSeconds: 20_000_000_000, ActorID: testAdminActorID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds the maximum")
+}
+
 // #97: an install-wide ceiling must clamp a lease's TTL even when the config's own
 // MaxTTLSeconds is left unset (unbounded) — otherwise a caller-supplied override
 // (or, on a misconfigured install, the config default) could mint an arbitrarily

--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -17,6 +17,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -212,7 +213,22 @@ func (c *KeyorixCore) TransitionMachineIdentity(ctx context.Context, projectID, 
 	// the eviction into the core so gRPC callers (which have no HTTP middleware
 	// reference) get the same guarantee automatically (#r124).
 	if to == MachineSuspended || to == MachineRevoked {
-		if hashes, herr := c.MachineTokenHashes(ctx, id); herr == nil {
+		hashes, herr := c.MachineTokenHashes(ctx, id)
+		if herr != nil {
+			// CMI-3: one immediate retry before giving up — a missed eviction here
+			// is not just defence-in-depth for gRPC-originated transitions (unlike
+			// the HTTP handler, server/grpc/services/machine_identity_service.go's
+			// TransitionMachineIdentity has no independent fallback eviction), so
+			// it's worth absorbing a single transient storage blip.
+			hashes, herr = c.MachineTokenHashes(ctx, id)
+		}
+		if herr != nil {
+			// Give up rather than block the already-committed state transition on
+			// storage retries, but a silently-missed eviction here leaves revoked/
+			// suspended credentials live in the shared auth cache for up to
+			// validTokenTTL (30s) — that must be visible to operators, not swallowed.
+			log.Printf("SECURITY: machine identity %d: failed to evict credentials from the auth cache after transition to %q: %v — tokens may remain valid for up to validTokenTTL", id, to, herr)
+		} else {
 			c.invalidateTokenCache(hashes...)
 		}
 	}

--- a/internal/core/machine_identities_test.go
+++ b/internal/core/machine_identities_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -221,6 +222,65 @@ func TestTransitionMachineIdentity(t *testing.T) {
 		_, err := c.TransitionMachineIdentity(ctx, 1, 21, MachineRevoked, 9)
 		require.NoError(t, err)
 		assert.Contains(t, evicted, "hash-cred-def", "revoke must evict the machine token from cache")
+		ms.AssertExpectations(t)
+	})
+
+	// CMI-3: TransitionMachineIdentity is the ONLY eviction path for gRPC-originated
+	// suspend/revoke (server/grpc/services/machine_identity_service.go has no
+	// independent fallback re-fetch/evict the way the HTTP handler does). A storage
+	// error fetching the token hashes must not vanish silently — it must be
+	// retried once and, if still failing, logged loudly so operators can see that
+	// tokens may remain live in the auth cache past the transition.
+	t.Run("suspend logs loudly and does not evict when hash lookup keeps failing", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := newMachineCore(ms)
+		ctx := context.Background()
+		ms.On("LockMachineIdentityForUpdate", ctx, uint(30)).Return(&models.MachineIdentity{ID: 30, ProjectID: 1, State: MachineActive}, nil)
+		ms.On("TransitionMachineIdentityState", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.State == MachineSuspended
+		}), MachineActive).Return(true, nil)
+		ms.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+		ms.On("ListMachineIdentityCredentials", ctx, uint(30)).Return(nil, errors.New("db unavailable"))
+
+		var evicted []string
+		c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+		var err error
+		logged := captureLog(t, func() {
+			_, err = c.TransitionMachineIdentity(ctx, 1, 30, MachineSuspended, 9)
+		})
+		require.NoError(t, err, "a cache-eviction failure must not fail the already-committed transition")
+		assert.Empty(t, evicted, "nothing to evict when the hash lookup failed")
+		assert.Contains(t, logged, "SECURITY", "the failure must be logged loudly, not swallowed")
+		assert.Contains(t, logged, "30", "the log must identify the affected machine identity")
+		// One initial attempt plus one retry — not swallowed on the first transient error.
+		ms.AssertNumberOfCalls(t, "ListMachineIdentityCredentials", 2)
+	})
+
+	t.Run("suspend recovers via the single retry after a transient hash-lookup error", func(t *testing.T) {
+		ms := new(MockStorage)
+		c := newMachineCore(ms)
+		ctx := context.Background()
+		ms.On("LockMachineIdentityForUpdate", ctx, uint(31)).Return(&models.MachineIdentity{ID: 31, ProjectID: 1, State: MachineActive}, nil)
+		ms.On("TransitionMachineIdentityState", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.State == MachineSuspended
+		}), MachineActive).Return(true, nil)
+		ms.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+		ms.On("ListMachineIdentityCredentials", ctx, uint(31)).Return(nil, errors.New("db unavailable")).Once()
+		ms.On("ListMachineIdentityCredentials", ctx, uint(31)).Return([]*models.MachineIdentityCredential{
+			{ID: 3, TokenHash: "hash-cred-ghi"},
+		}, nil).Once()
+
+		var evicted []string
+		c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+		var err error
+		logged := captureLog(t, func() {
+			_, err = c.TransitionMachineIdentity(ctx, 1, 31, MachineSuspended, 9)
+		})
+		require.NoError(t, err)
+		assert.Contains(t, evicted, "hash-cred-ghi", "the retry must still evict once it succeeds")
+		assert.Empty(t, logged, "a transient error that the retry recovers from should not be logged")
 		ms.AssertExpectations(t)
 	})
 

--- a/internal/core/rotation_calendar.go
+++ b/internal/core/rotation_calendar.go
@@ -32,12 +32,23 @@ type RotationCalendarEntry struct {
 // NextRotationAt is computed as LastRotatedAt + IntervalDays, falling back to
 // CreatedAt + IntervalDays for secrets that have never been rotated.
 // from must not be after to.
-func (c *KeyorixCore) GetRotationCalendar(ctx context.Context, from, to time.Time) ([]RotationCalendarEntry, error) {
+//
+// projectID/environmentID are an optional scoping filter, mirroring
+// GetRotationStatus/EvaluateRotationPolicies: nil/nil returns the deployment-wide
+// calendar (every project, every tenant) as before; a non-nil projectID confines
+// the result to that project's policies (via ListRotationPolicies) and — via
+// policyAppliesToEnv + scopedPolicySecrets — a non-nil environmentID further
+// confines it to that environment, so a caller authorized only at project (or
+// environment) scope can request just their own slice instead of the full
+// deployment-wide detail. The HTTP route requires global secrets.read when no
+// filter is supplied and project/environment-scoped secrets.read when one is,
+// via RequireScopedPermission(ScopeFromQuery).
+func (c *KeyorixCore) GetRotationCalendar(ctx context.Context, from, to time.Time, projectID, environmentID *uint) ([]RotationCalendarEntry, error) {
 	if from.After(to) {
 		return nil, fmt.Errorf("from must not be after to")
 	}
 
-	policies, err := c.storage.ListRotationPolicies(ctx, nil, nil)
+	policies, err := c.storage.ListRotationPolicies(ctx, projectID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("rotation calendar: list policies: %w", err)
 	}
@@ -46,10 +57,10 @@ func (c *KeyorixCore) GetRotationCalendar(ctx context.Context, from, to time.Tim
 	var entries []RotationCalendarEntry
 
 	for _, policy := range policies {
-		if !policy.IsActive {
+		if !policy.IsActive || !policyAppliesToEnv(policy, environmentID) {
 			continue
 		}
-		secrets, err := c.scopedPolicySecrets(ctx, policy, nil)
+		secrets, err := c.scopedPolicySecrets(ctx, policy, environmentID)
 		if err != nil {
 			return nil, fmt.Errorf("rotation calendar: policy %d secrets: %w", policy.ID, err)
 		}

--- a/internal/core/rotation_calendar_test.go
+++ b/internal/core/rotation_calendar_test.go
@@ -42,7 +42,7 @@ func TestGetRotationCalendar_InvalidRange(t *testing.T) {
 	ms := new(MockStorage)
 	c := calCore(ms)
 
-	_, err := c.GetRotationCalendar(context.Background(), calTo, calFrom)
+	_, err := c.GetRotationCalendar(context.Background(), calTo, calFrom, nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "from must not be after to")
 }
@@ -54,7 +54,7 @@ func TestGetRotationCalendar_StorageError(t *testing.T) {
 		Return(nil, errors.New("db down"))
 
 	c := calCore(ms)
-	_, err := c.GetRotationCalendar(context.Background(), calFrom, calTo)
+	_, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "db down")
 }
@@ -66,7 +66,7 @@ func TestGetRotationCalendar_InactivePolicy(t *testing.T) {
 		Return([]*models.RotationPolicy{calPolicy(1, false, 30)}, nil)
 
 	c := calCore(ms)
-	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo)
+	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, nil, nil)
 	require.NoError(t, err)
 	require.Empty(t, entries)
 }
@@ -80,7 +80,7 @@ func TestGetRotationCalendar_SecretListError(t *testing.T) {
 		Return(nil, int64(0), errors.New("secrets unavailable"))
 
 	c := calCore(ms)
-	_, err := c.GetRotationCalendar(context.Background(), calFrom, calTo)
+	_, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "secrets unavailable")
 }
@@ -101,7 +101,7 @@ func TestGetRotationCalendar_SecretInWindowUsesLastRotatedAt(t *testing.T) {
 		Return(secrets, int64(1), nil)
 
 	c := calCore(ms)
-	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo)
+	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 
@@ -131,7 +131,7 @@ func TestGetRotationCalendar_FallsBackToCreatedAt(t *testing.T) {
 		Return(secrets, int64(1), nil)
 
 	c := calCore(ms)
-	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo)
+	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 
@@ -155,7 +155,7 @@ func TestGetRotationCalendar_BeforeWindowFiltered(t *testing.T) {
 		Return(secrets, int64(1), nil)
 
 	c := calCore(ms)
-	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo)
+	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, nil, nil)
 	require.NoError(t, err)
 	require.Empty(t, entries)
 }
@@ -175,7 +175,7 @@ func TestGetRotationCalendar_AfterWindowFiltered(t *testing.T) {
 		Return(secrets, int64(1), nil)
 
 	c := calCore(ms)
-	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo)
+	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, nil, nil)
 	require.NoError(t, err)
 	require.Empty(t, entries)
 }
@@ -196,7 +196,7 @@ func TestGetRotationCalendar_OverdueSecret(t *testing.T) {
 		Return(secrets, int64(1), nil)
 
 	c := calCore(ms)
-	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo)
+	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 
@@ -224,7 +224,7 @@ func TestGetRotationCalendar_SortedByNextRotation(t *testing.T) {
 		Return(secrets, int64(3), nil)
 
 	c := calCore(ms)
-	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo)
+	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, entries, 3)
 
@@ -241,7 +241,7 @@ func TestGetRotationCalendar_NoPolicies(t *testing.T) {
 		Return([]*models.RotationPolicy{}, nil)
 
 	c := calCore(ms)
-	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo)
+	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, nil, nil)
 	require.NoError(t, err)
 	require.Empty(t, entries)
 }
@@ -280,10 +280,80 @@ func TestGetRotationCalendar_MultiplePolicies(t *testing.T) {
 	})).Return(p2Secrets, int64(1), nil)
 
 	c := calCore(ms)
-	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo)
+	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, entries, 2)
 	// sorted: p2-key next=07-29, p1-key next=08-09
 	require.Equal(t, uint(31), entries[0].SecretID)
 	require.Equal(t, uint(30), entries[1].SecretID)
+}
+
+// core-rotation-2026-08-08-003: GetRotationCalendar previously had no way to scope
+// down from the full deployment-wide aggregate, so any caller who cleared the
+// (broad, global-scope) secrets.read bar saw every project's secret names/rotation
+// detail. A non-nil projectID now confines the calendar to that project: it's
+// passed straight through to ListRotationPolicies (the storage layer's own project
+// filter), so a policy belonging to a different project is never even fetched —
+// mirroring GetRotationStatus/EvaluateRotationPolicies' existing scoping. Since the
+// mock only has an expectation for ListRotationPolicies(&projectA, nil), a
+// regression back to the unscoped ListRotationPolicies(nil, nil) call would panic
+// here on an unmatched call rather than silently leaking project B's data.
+func TestGetRotationCalendar_ScopedToProject(t *testing.T) {
+	ms := new(MockStorage)
+	projectA := uint(1)
+	polA := calPolicy(20, true, 30)
+	polA.ProjectID = &projectA
+
+	rA := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC) // next=2026-08-09
+	secretsA := []*models.SecretNode{
+		{ID: 40, Name: "project-a-key", ProjectID: projectA, EnvironmentID: 2, LastRotatedAt: &rA},
+	}
+
+	ms.On("ListRotationPolicies", mock.Anything, &projectA, (*uint)(nil)).
+		Return([]*models.RotationPolicy{polA}, nil)
+	ms.On("ListSecrets", mock.Anything, mock.MatchedBy(func(f *storage.SecretFilter) bool {
+		return f.ProjectID != nil && *f.ProjectID == projectA
+	})).Return(secretsA, int64(1), nil)
+
+	c := calCore(ms)
+	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, &projectA, nil)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, uint(40), entries[0].SecretID)
+	require.Equal(t, "project-a-key", entries[0].SecretName)
+	require.Equal(t, projectA, entries[0].ProjectID)
+	ms.AssertExpectations(t)
+}
+
+// When the caller further restricts to a specific environment, a project-scoped
+// policy's secret enumeration is confined to that environment, and any
+// environment-scoped policy targeting a DIFFERENT environment is skipped
+// entirely (never even reaches scopedPolicySecrets) — mirrors
+// TestGetRotationStatus_ConfinedToEnvironment via the same
+// policyAppliesToEnv + scopedPolicySecrets(reqEnvID) machinery.
+func TestGetRotationCalendar_ScopedToEnvironment(t *testing.T) {
+	ms := new(MockStorage)
+	projectID := uint(1)
+	envID := uint(2)
+	otherEnv := uint(9)
+
+	projPolicy := calPolicy(21, true, 30)
+	projPolicy.ProjectID = &projectID
+	otherEnvPolicy := &models.RotationPolicy{ID: 22, Name: "env9", Scope: "environment", EnvironmentID: &otherEnv, IntervalDays: 30, IsActive: true}
+
+	r := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC) // next=2026-08-09
+	ms.On("ListRotationPolicies", mock.Anything, &projectID, (*uint)(nil)).
+		Return([]*models.RotationPolicy{projPolicy, otherEnvPolicy}, nil)
+	ms.On("ListSecrets", mock.Anything, mock.MatchedBy(func(f *storage.SecretFilter) bool {
+		return f.EnvironmentID != nil && *f.EnvironmentID == envID
+	})).Return([]*models.SecretNode{
+		{ID: 41, Name: "env2-key", ProjectID: projectID, EnvironmentID: envID, LastRotatedAt: &r},
+	}, int64(1), nil)
+
+	c := calCore(ms)
+	entries, err := c.GetRotationCalendar(context.Background(), calFrom, calTo, &projectID, &envID)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the project policy's env-2 secret; the env-9 policy is skipped")
+	require.Equal(t, uint(41), entries[0].SecretID)
+	ms.AssertExpectations(t)
 }

--- a/server/http/handlers/handlers_s10_test.go
+++ b/server/http/handlers/handlers_s10_test.go
@@ -222,13 +222,23 @@ func TestGetSecret_IncludeValue_UserPath_S10(t *testing.T) {
 }
 
 // ── GetSecretValueByRef: success path (isolated DB) ──────────────────────────
+//
+// GetSecretValueByRef no longer resolves the "ref" query param itself — that
+// now happens exactly once, in middleware.RequireScopedSecretRefPermission,
+// which pins the resolved secret on the request context before dispatch (see
+// core-secret-ref-4). These tests simulate that hand-off directly, exactly as
+// the middleware would, via customMiddleware.WithResolvedSecretRef.
 
 func TestGetSecretValueByRef_Success_MachineIdentity_S10(t *testing.T) {
 	h, projName, envName, _ := seedS10Secret(t, "s10-proj-ref", "s10-ref-secret")
 
 	ref := fmt.Sprintf("%s/%s/%s", projName, envName, "s10-ref-secret")
+	secret, err := h.coreService.ResolveSecretRef(context.Background(), ref)
+	require.NoError(t, err)
+
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/secrets/by-ref?ref="+ref, nil)
 	r = withMachineCtxS10(r)
+	r = r.WithContext(customMiddleware.WithResolvedSecretRef(r.Context(), secret))
 	w := httptest.NewRecorder()
 
 	h.GetSecretValueByRef(w, r)
@@ -244,8 +254,12 @@ func TestGetSecretValueByRef_UserPath_S10(t *testing.T) {
 	h, projName, envName, _ := seedS10Secret(t, "s10-proj-userref", "s10-userref-secret")
 
 	ref := fmt.Sprintf("%s/%s/%s", projName, envName, "s10-userref-secret")
+	secret, err := h.coreService.ResolveSecretRef(context.Background(), ref)
+	require.NoError(t, err)
+
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/secrets/by-ref?ref="+ref, nil)
 	r = withUserCtx(r)
+	r = r.WithContext(customMiddleware.WithResolvedSecretRef(r.Context(), secret))
 	w := httptest.NewRecorder()
 
 	h.GetSecretValueByRef(w, r)

--- a/server/http/handlers/handlers_s13_project_test.go
+++ b/server/http/handlers/handlers_s13_project_test.go
@@ -27,6 +27,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -237,6 +240,43 @@ func TestInviteMember_MissingFields_S13(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.InviteMember(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestInviteMember_IDPResolved_ClientCannotBypassVerification_S13 — PM-008
+// regression: InviteMember's HTTP body no longer has an idp_resolved field, so
+// a legacy client that still sends `"idp_resolved":true` must have it silently
+// ignored (unknown JSON field), not smuggled through to core.InviteMember. In
+// ValidationModeIDP that field controls whether a new membership starts at
+// `provisioned` (skipping invited/identity_verified) — only the real
+// SSO/JIT-provisioning path may assert that, never a client-supplied bool on
+// this general-purpose, roles.assign-gated endpoint. Assert the resulting
+// membership lands at `invited`, exactly as an untrusted invite should.
+func TestInviteMember_IDPResolved_ClientCannotBypassVerification_S13(t *testing.T) {
+	t.Parallel()
+	cs, db := freshCoreS12WithAdmin(t)
+	cs.SetMembershipValidationMode(core.ValidationModeIDP)
+	h := NewCatalogHandler(cs)
+
+	role := &models.Role{Name: "pm008-viewer-s13", Description: "viewer"}
+	require.NoError(t, db.Create(role).Error)
+	targetUser := &models.User{Username: "pm008target_s13", Email: "pm008target_s13@example.com", AccountState: "active"}
+	require.NoError(t, db.Create(targetUser).Error)
+
+	proj, err := cs.CreateProject(context.Background(), "pm008-idp-trust-s13", "")
+	require.NoError(t, err)
+
+	body := fmt.Sprintf(`{"user_id":%d,"role":"pm008-viewer-s13","idp_resolved":true}`, targetUser.ID)
+	r := withChiParam(withUserCtx(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))),
+		"id", fmt.Sprintf("%d", proj.ID))
+	w := httptest.NewRecorder()
+	h.InviteMember(w, r)
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	memberships, err := cs.ListProjectMemberships(context.Background(), proj.ID)
+	require.NoError(t, err)
+	require.Len(t, memberships, 1)
+	assert.Equal(t, core.MembershipInvited, memberships[0].State,
+		"a client-supplied idp_resolved must not bypass invited/identity_verified in idp mode")
 }
 
 // TestTransitionMembership_BadProjectID_S13 — non-numeric project ID → 400.

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -9189,12 +9189,21 @@ func TestSecretHandler_GetSecretValueByRef_Unauthorized(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
+// TestSecretHandler_GetSecretValueByRef_MissingRef covers the handler's
+// defensive branch: ref resolution now happens exactly once, in
+// middleware.RequireScopedSecretRefPermission, which pins the resolved secret
+// on the request context before dispatch (see core-secret-ref-4 /
+// server/middleware/auth_s24_test.go for the 400/404 coverage of the
+// middleware's own resolution — including a missing "ref" param, which
+// ParseSecretRef treats as invalid format). A direct handler call that
+// bypasses the middleware, as this test does, never gets that context value,
+// so the handler must 500 rather than fall back to resolving the ref itself.
 func TestSecretHandler_GetSecretValueByRef_MissingRef(t *testing.T) {
 	h := newSecretHandlerS4(t)
 	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/", nil))
 	w := httptest.NewRecorder()
 	h.GetSecretValueByRef(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestSecretHandler_GetSecretValueByRef_NotFound(t *testing.T) {
@@ -9202,8 +9211,8 @@ func TestSecretHandler_GetSecretValueByRef_NotFound(t *testing.T) {
 	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/?ref=projects/1/environments/1/secrets/nope", nil))
 	w := httptest.NewRecorder()
 	h.GetSecretValueByRef(w, req)
-	// secret not found → error
-	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
+	// no resolved secret pinned on context (middleware bypassed) → 500
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 // ── sso.go: CompleteSSO ───────────────────────────────────────────────────────

--- a/server/http/handlers/handlers_s5_test.go
+++ b/server/http/handlers/handlers_s5_test.go
@@ -1406,13 +1406,20 @@ func TestSecretHandler_GetSecretValueByRef_UnauthorizedS5(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
-func TestSecretHandler_GetSecretValueByRef_NotFoundS5(t *testing.T) {
+// TestSecretHandler_GetSecretValueByRef_NoResolvedSecretInContextS5 covers the
+// handler's defensive branch: ref resolution now happens exactly once, in
+// middleware.RequireScopedSecretRefPermission, which pins the resolved secret
+// on the request context before dispatch. A direct handler call that bypasses
+// the middleware never gets that context value, so the handler must 500
+// rather than fall back to re-resolving the ref itself (see
+// core-secret-ref-4 / server/middleware/auth_s24_test.go for the 400/404
+// coverage of the middleware's own resolution).
+func TestSecretHandler_GetSecretValueByRef_NoResolvedSecretInContextS5(t *testing.T) {
 	h := newSecretHandlerS4(t)
 	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/?ref=prod/myapp/db_password", nil))
 	w := httptest.NewRecorder()
 	h.GetSecretValueByRef(w, req)
-	// ref not found → not 401
-	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 // ── access_request_proxy.go — additional paths not yet in s4 ─────────────────
@@ -4984,22 +4991,16 @@ func TestSecretHandler_GetSecretValueByRef_Unauthorized_S5(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
-func TestSecretHandler_GetSecretValueByRef_InvalidRef_S5(t *testing.T) {
+// TestSecretHandler_GetSecretValueByRef_NoResolvedSecretInContext_S5 is a
+// second instance of the defensive-branch coverage above (this file has
+// accreted a few near-duplicate GetSecretValueByRef tests across sprints);
+// kept distinct since it exercises a different malformed-ref string.
+func TestSecretHandler_GetSecretValueByRef_NoResolvedSecretInContext_S5(t *testing.T) {
 	h := newSecretHandlerS4(t)
 	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/?ref=invalid-ref-no-slashes", nil))
 	w := httptest.NewRecorder()
 	h.GetSecretValueByRef(w, req)
-	// Invalid ref format → 400
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-}
-
-func TestSecretHandler_GetSecretValueByRef_NotFound_S5(t *testing.T) {
-	h := newSecretHandlerS4(t)
-	req := withUserCtx(httptest.NewRequest(http.MethodGet, "/?ref=proj-x/env-x/secret-x", nil))
-	w := httptest.NewRecorder()
-	h.GetSecretValueByRef(w, req)
-	// Not found → 404 or error
-	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestSecretHandler_RestoreSecret_Unauthorized_S5(t *testing.T) {

--- a/server/http/handlers/handlers_s7_test.go
+++ b/server/http/handlers/handlers_s7_test.go
@@ -544,32 +544,22 @@ func TestGetSecretValueByRef_Unauthorized_S7(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
-// TestGetSecretValueByRef_InvalidRef_S7 tests an invalid ref format.
-func TestGetSecretValueByRef_InvalidRef_S7(t *testing.T) {
-	h := newSecretHandlerS7(t)
-	req := withUserCtxS7(httptest.NewRequest(http.MethodGet, "/?ref=invalid", nil))
-	w := httptest.NewRecorder()
-	h.GetSecretValueByRef(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-}
-
-// TestGetSecretValueByRef_EmptyRef_S7 tests missing ref param.
-func TestGetSecretValueByRef_EmptyRef_S7(t *testing.T) {
-	h := newSecretHandlerS7(t)
-	req := withUserCtxS7(httptest.NewRequest(http.MethodGet, "/?ref=", nil))
-	w := httptest.NewRecorder()
-	h.GetSecretValueByRef(w, req)
-	// Empty ref is treated as invalid format → 400
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-}
-
-// TestGetSecretValueByRef_NotFound_S7 tests a well-formed ref with no match.
-func TestGetSecretValueByRef_NotFound_S7(t *testing.T) {
+// TestGetSecretValueByRef_NoResolvedSecretInContext_S7 covers the handler's
+// defensive branch. Ref resolution now happens exactly once, in
+// middleware.RequireScopedSecretRefPermission (see auth_s24_test.go in
+// server/middleware for the 400 invalid-format / 404 not-found coverage that
+// used to live here as three separate tests), which pins the resolved secret
+// on the request context before dispatch. A direct handler call that bypasses
+// the middleware — as every test in this file does — never gets that context
+// value, so the handler must 500 rather than fall back to re-resolving the
+// ref itself; that fallback is exactly the second resolution that made
+// ResolveSecretRef callable twice per request (core-secret-ref-4).
+func TestGetSecretValueByRef_NoResolvedSecretInContext_S7(t *testing.T) {
 	h := newSecretHandlerS7(t)
 	req := withUserCtxS7(httptest.NewRequest(http.MethodGet, "/?ref=noproj/noenv/nosecret", nil))
 	w := httptest.NewRecorder()
 	h.GetSecretValueByRef(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 // ── machine_identities.go: CreateMachineIdentity ───────────────────────────

--- a/server/http/handlers/project_memberships.go
+++ b/server/http/handlers/project_memberships.go
@@ -68,10 +68,25 @@ func (h *CatalogHandler) InviteMember(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
+	// PM-008: this general-purpose, roles.assign-gated endpoint deliberately does
+	// NOT accept idp_resolved from the request body. In ValidationModeIDP,
+	// InviteMember starts a membership straight at `provisioned` (skipping
+	// invited/identity_verified) when idpResolved is true — that's supposed to
+	// be a guarantee that the identity was actually vouched for by the
+	// configured IdP. Any project_admin holding roles.assign can call this
+	// endpoint, so a client-supplied bool here would let them assert IdP
+	// resolution for anyone, defeating the mode's purpose while leaving an
+	// audit trail indistinguishable from a genuinely IdP-resolved invite. The
+	// only trustworthy signal is the actual SSO/JIT-provisioning code path
+	// (internal/core/sso.go) that validates the IdP's signed assertion itself —
+	// that path, if and when it starts project onboarding, should call
+	// core.InviteMember directly with a real server-derived idpResolved,
+	// bypassing this HTTP endpoint entirely. A legacy client that still sends
+	// "idp_resolved" in the JSON body is unaffected: the field decodes into
+	// nothing and is silently ignored, same as any other unknown field.
 	var body struct {
-		UserID      uint   `json:"user_id"`
-		Role        string `json:"role"`
-		IDPResolved bool   `json:"idp_resolved"`
+		UserID uint   `json:"user_id"`
+		Role   string `json:"role"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		sendError(w, "InvalidJSON", "Invalid request body", http.StatusBadRequest, nil)
@@ -81,7 +96,8 @@ func (h *CatalogHandler) InviteMember(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "ValidationError", "user_id and role are required", http.StatusBadRequest, nil)
 		return
 	}
-	m, err := h.coreService.InviteMember(r.Context(), uint(id), body.UserID, body.Role, actor.UserID, body.IDPResolved)
+	const idpResolvedNotAcceptedFromClient = false
+	m, err := h.coreService.InviteMember(r.Context(), uint(id), body.UserID, body.Role, actor.UserID, idpResolvedNotAcceptedFromClient)
 	if err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()

--- a/server/http/handlers/rotation_calendar_handler.go
+++ b/server/http/handlers/rotation_calendar_handler.go
@@ -3,7 +3,9 @@
 // Returns all policy-covered secrets with a computed NextRotationAt that falls
 // within a caller-supplied [from, to] window. Both params are required and
 // accepted as RFC 3339 timestamps or plain YYYY-MM-DD dates (interpreted as
-// midnight UTC).
+// midnight UTC). Optional project_id/environment_id query params narrow the
+// result to that scope; the route itself gates the required permission scope
+// accordingly (see router.go's use of RequireScopedPermission + ScopeFromQuery).
 package handlers
 
 import (
@@ -24,7 +26,7 @@ func NewRotationCalendarHandler(svc *core.KeyorixCore) *RotationCalendarHandler 
 	return &RotationCalendarHandler{coreService: svc}
 }
 
-// Get handles GET /api/v1/rotation-calendar?from=&to=
+// Get handles GET /api/v1/rotation-calendar?from=&to=&project_id=&environment_id=
 func (h *RotationCalendarHandler) Get(w http.ResponseWriter, r *http.Request) {
 	fromStr := r.URL.Query().Get("from")
 	toStr := r.URL.Query().Get("to")
@@ -47,7 +49,20 @@ func (h *RotationCalendarHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entries, err := h.coreService.GetRotationCalendar(r.Context(), from, to)
+	// Optional scoping filter (see router.go: the route requires global secrets.read
+	// when neither is supplied, and project/environment-scoped secrets.read otherwise).
+	projectID, perr := parseOptionalUintQuery(r, "project_id")
+	if perr != nil {
+		sendError(w, "InvalidParameter", errInvalidProjectIDField, http.StatusBadRequest, nil)
+		return
+	}
+	environmentID, perr := parseOptionalUintQuery(r, "environment_id")
+	if perr != nil {
+		sendError(w, "InvalidParameter", errInvalidEnvIDField, http.StatusBadRequest, nil)
+		return
+	}
+
+	entries, err := h.coreService.GetRotationCalendar(r.Context(), from, to, projectID, environmentID)
 	if err != nil {
 		log.Printf("Error fetching rotation calendar [%s, %s]: %v", from.Format(time.DateOnly), to.Format(time.DateOnly), err)
 		sendError(w, "InternalError", "Failed to fetch rotation calendar", http.StatusInternalServerError, nil)

--- a/server/http/handlers/rotation_calendar_handler_test.go
+++ b/server/http/handlers/rotation_calendar_handler_test.go
@@ -186,6 +186,67 @@ func TestRotationCalendarHandler_WithEntries(t *testing.T) {
 	assert.NotEmpty(t, entry["next_rotation_at"])
 }
 
+// core-rotation-2026-08-08-003: an optional project_id query param confines the
+// calendar to that project — a caller scoped to project A's secrets.read (see
+// router.go's RequireScopedPermission(permSecretsRead, ScopeFromQuery) gate on
+// this route) gets project A's rotation detail without needing the broader
+// global grant, and never sees project B's secret in the response.
+func TestRotationCalendarHandler_ScopedToProject(t *testing.T) {
+	svc, db := freshCalendarDB(t)
+
+	projA := &models.Project{Name: "project-a"}
+	require.NoError(t, db.Create(projA).Error)
+	envA := &models.Environment{Name: "prod", ProjectID: projA.ID}
+	require.NoError(t, db.Create(envA).Error)
+	polA := &models.RotationPolicy{Name: "30-day-a", Scope: "project", ProjectID: &projA.ID, IntervalDays: 30, IsActive: true}
+	require.NoError(t, db.Create(polA).Error)
+
+	projB := &models.Project{Name: "project-b"}
+	require.NoError(t, db.Create(projB).Error)
+	envB := &models.Environment{Name: "prod", ProjectID: projB.ID}
+	require.NoError(t, db.Create(envB).Error)
+	polB := &models.RotationPolicy{Name: "30-day-b", Scope: "project", ProjectID: &projB.ID, IntervalDays: 30, IsActive: true}
+	require.NoError(t, db.Create(polB).Error)
+
+	lastRotated := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	secretA := &models.SecretNode{Name: "a-key", ProjectID: projA.ID, EnvironmentID: envA.ID, LastRotatedAt: &lastRotated}
+	require.NoError(t, db.Create(secretA).Error)
+	secretB := &models.SecretNode{Name: "b-key", ProjectID: projB.ID, EnvironmentID: envB.ID, LastRotatedAt: &lastRotated}
+	require.NoError(t, db.Create(secretB).Error)
+
+	r := chi.NewRouter()
+	h := NewRotationCalendarHandler(svc)
+	r.Get("/rotation-calendar", h.Get)
+
+	url := fmt.Sprintf("/rotation-calendar?from=2026-07-01&to=2026-08-31&project_id=%d", projA.ID)
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	data := body["data"].([]interface{})
+	require.Len(t, data, 1, "only project A's secret, never project B's")
+	entry := data[0].(map[string]interface{})
+	assert.Equal(t, "a-key", entry["secret_name"])
+	assert.Equal(t, float64(projA.ID), entry["project_id"])
+}
+
+// An invalid project_id query param is rejected as a 400, not silently ignored.
+func TestRotationCalendarHandler_InvalidProjectID(t *testing.T) {
+	svc, _ := freshCalendarDB(t)
+
+	r := chi.NewRouter()
+	h := NewRotationCalendarHandler(svc)
+	r.Get("/rotation-calendar", h.Get)
+
+	req := httptest.NewRequest(http.MethodGet, "/rotation-calendar?from=2026-07-01&to=2026-08-31&project_id=not-a-number", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
 // RFC 3339 timestamps are also accepted as from/to values.
 func TestRotationCalendarHandler_RFC3339Format(t *testing.T) {
 	svc, _ := freshCalendarDB(t)

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -339,7 +339,14 @@ func (h *SecretHandler) GetSecretByName(w http.ResponseWriter, r *http.Request) 
 // reads a secret's value resolved by a human-readable reference instead of a numeric
 // ID, for integrations (e.g. the External Secrets Operator) that template a key string.
 // It reuses the exact by-id read path: the route's scoped-permission gate
-// (ScopeFromRefQuery) authorizes the caller against the resolved secret's scope, and the
+// (middleware.RequireScopedSecretRefPermission) resolves the ref, authorizes the caller
+// against the resolved secret's scope, and pins the resolution on the request context —
+// this handler reuses THAT SAME resolution (middleware.GetResolvedSecretRefFromContext)
+// rather than resolving the ref again by name. core.ResolveSecretRef has no
+// snapshot/version guarantee (a soft-deleted project's name is free for reuse), so two
+// independent resolutions of one ref string could legitimately return secrets from two
+// different projects if a delete-and-recreate landed between them; resolving once in the
+// middleware and threading the result here closes that TOCTOU window structurally. The
 // value is read through the same max-reads / suspension / audit machinery as GetSecret.
 func (h *SecretHandler) GetSecretValueByRef(w http.ResponseWriter, r *http.Request) {
 	userCtx, ok := mustGetUser(w, r)
@@ -347,23 +354,20 @@ func (h *SecretHandler) GetSecretValueByRef(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	secret, err := h.coreService.ResolveSecretRef(r.Context(), r.URL.Query().Get("ref"))
-	if err != nil {
-		switch {
-		case errors.Is(err, core.ErrSecretRefInvalid):
-			h.sendError(w, "InvalidParameter", "ref must be \"project/environment/name\"", http.StatusBadRequest, nil)
-		case errors.Is(err, core.ErrSecretRefNotFound):
-			h.sendError(w, "NotFound", errSecretNotFound, http.StatusNotFound, nil)
-		default:
-			h.sendError(w, "InternalError", "Failed to resolve secret", http.StatusInternalServerError, nil)
-		}
+	secret := middleware.GetResolvedSecretRefFromContext(r.Context())
+	if secret == nil {
+		// Defensive only: every route serving this handler goes through
+		// RequireScopedSecretRefPermission, which always sets this on success.
+		h.sendError(w, "InternalError", "Failed to resolve secret", http.StatusInternalServerError, nil)
 		return
 	}
 
 	// Machine principals are already authorized at the secret's scope by the route gate
-	// (ScopeFromRefQuery); the per-user owner/sharing check applies to users only.
+	// (RequireScopedSecretRefPermission); the per-user owner/sharing check applies to
+	// users only.
 	isMachine := userCtx.MachineIdentityID != nil
 	var value []byte
+	var err error
 	if isMachine {
 		value, err = h.coreService.GetSecretValue(r.Context(), secret.ID)
 	} else {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -626,7 +626,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/name-conformance", secretHandler.DeploymentSecretNameConformance)
 			// By-reference value read (ESO etc.): resolve project/environment/name → the
 			// secret's value. Scoped to the resolved secret; static path, before /{id}.
-			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, customMiddleware.ScopeFromRefQuery)).Get("/value", secretHandler.GetSecretValueByRef)
+			// RequireScopedSecretRefPermission resolves the ref exactly once and pins
+			// the result on the request context so GetSecretValueByRef reuses it
+			// instead of re-resolving by name (closes a TOCTOU window — see its doc).
+			r.With(customMiddleware.RequireScopedSecretRefPermission(permSecretsRead)).Get("/value", secretHandler.GetSecretValueByRef)
 			// By-name metadata lookup, scoped by project_id/environment_id query params
 			// (same gate/convention as ListSecrets above) — the server-side counterpart
 			// RemoteStorage.GetSecretByName (#497) needs; a caller with only a secret's

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -741,8 +741,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedPermission(permSecretsDelete, folderScope)).Delete("/{id}", folderHandler.DeleteFolder)
 		})
 
-		// Rotation calendar — deployment-wide view of upcoming / overdue rotations.
-		r.With(customMiddleware.RequirePermission(permSecretsRead)).Get("/rotation-calendar", rotationCalendarHandler.Get)
+		// Rotation calendar. Deployment-wide by default (requires global secrets.read),
+		// but — like the rotation-policies List/Evaluate/Status routes below — accepts
+		// an optional ?project_id=/&environment_id= scope filter via ScopeFromQuery, in
+		// which case only a project (or environment) scoped secrets.read grant is
+		// required and the response is confined to that scope. This lets a caller who
+		// isn't authorized deployment-wide get their own project's calendar instead of
+		// needing the broader global grant just to see one project's rotation schedule.
+		r.With(customMiddleware.RequireScopedPermission(permSecretsRead, customMiddleware.ScopeFromQuery)).Get("/rotation-calendar", rotationCalendarHandler.Get)
 
 		// Rotation policies endpoints. List/evaluate take an optional scope
 		// filter; per-policy routes resolve scope from the policy; create

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -145,6 +145,11 @@ type contextKey string
 const (
 	userContextKey        contextKey = "user"
 	coreServiceContextKey contextKey = "coreService"
+	// resolvedSecretRefContextKey carries the *models.SecretNode resolved by
+	// RequireScopedSecretRefPermission through to the handler, so a by-ref
+	// value read reuses that ONE resolution instead of resolving the ref by
+	// name a second time. See WithResolvedSecretRef / GetResolvedSecretRefFromContext.
+	resolvedSecretRefContextKey contextKey = "resolvedSecretRef"
 
 	// TTL for valid token cache entries (session is trusted for this window).
 	validTokenTTL = 30 * time.Second
@@ -540,6 +545,70 @@ func handleScopedSecretPermissionRequest(next http.Handler, w http.ResponseWrite
 	finishScopedPermissionRequest(next, w, r, cs, scope, allowed, err)
 }
 
+// RequireScopedSecretRefPermission is RequireScopedPermission specialized for
+// the by-reference value read (GET .../secrets/value?ref=project/environment/name).
+//
+// core.ResolveSecretRef carries no snapshot/version guarantee: project name
+// uniqueness is enforced only while a project is not soft-deleted, so a
+// soft-deleted project's name is free for a brand-new project to reuse. If
+// this middleware resolved the ref to compute the authorization scope and the
+// handler independently resolved the SAME ref string again by name, a
+// delete-and-recreate landing between the two calls could legitimately
+// resolve them to secrets in two DIFFERENT projects — authorizing against one
+// project's scope and then reading a secret from another. This middleware
+// closes that window structurally: it resolves the ref EXACTLY ONCE, and pins
+// the resolved *models.SecretNode on the request context
+// (GetResolvedSecretRefFromContext) so the handler consumes that same
+// resolution rather than calling ResolveSecretRef again.
+func RequireScopedSecretRefPermission(permission string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handleScopedSecretRefPermissionRequest(next, w, r, permission)
+		})
+	}
+}
+
+func handleScopedSecretRefPermissionRequest(next http.Handler, w http.ResponseWriter, r *http.Request, permission string) {
+	userCtx, cs, ok := requireUserAndCore(w, r)
+	if !ok {
+		return
+	}
+	secret, err := cs.ResolveSecretRef(r.Context(), r.URL.Query().Get("ref"))
+	if err != nil {
+		resolveErr := errTargetNotFound
+		if errors.Is(err, core.ErrSecretRefInvalid) {
+			resolveErr = errInvalidTarget
+		}
+		handleScopeResolutionError(w, r, cs, userCtx, permission, resolveErr)
+		return
+	}
+	scope := core.Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
+	allowed, err := cs.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), permission, scope)
+	// Pin the resolution on the request context BEFORE dispatch, regardless of
+	// the authorize outcome (finishScopedPermissionRequest still gates on
+	// allowed/err below) — this is the ONLY resolution of this ref for the
+	// entire request; the handler must reuse it rather than resolve again.
+	r = r.WithContext(WithResolvedSecretRef(r.Context(), secret))
+	finishScopedPermissionRequest(next, w, r, cs, scope, allowed, err)
+}
+
+// WithResolvedSecretRef stores a secret resolved by ref on ctx, for
+// RequireScopedSecretRefPermission to hand off to its downstream handler (and
+// for tests to simulate that hand-off without going through the middleware).
+func WithResolvedSecretRef(ctx context.Context, secret *models.SecretNode) context.Context {
+	return context.WithValue(ctx, resolvedSecretRefContextKey, secret)
+}
+
+// GetResolvedSecretRefFromContext retrieves the secret resolved by
+// RequireScopedSecretRefPermission from the request context. Returns nil if no
+// ref resolution ran (e.g. the route isn't wired through that middleware).
+func GetResolvedSecretRefFromContext(ctx context.Context) *models.SecretNode {
+	if secret, ok := ctx.Value(resolvedSecretRefContextKey).(*models.SecretNode); ok {
+		return secret
+	}
+	return nil
+}
+
 // requireUserAndCore fetches the authenticated user and core service from the
 // request context, writing the appropriate error response and returning
 // ok=false if either is missing. Shared by RequireScopedPermission and
@@ -737,22 +806,6 @@ func ScopeFromSecretParam(param string) ScopeResolver {
 		}
 		return core.Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}, nil
 	}
-}
-
-// ScopeFromRefQuery resolves scope from a "?ref=project/environment/name" query param,
-// for the by-reference value read. It locates the referenced secret (no value read, no
-// read-count side effect) and returns its project/environment scope, so the standard
-// scoped-permission gate authorizes the caller against the secret's real scope — a
-// caller scoped to another project is denied exactly as for the by-id route.
-func ScopeFromRefQuery(r *http.Request, cs *core.KeyorixCore) (core.Scope, error) {
-	secret, err := cs.ResolveSecretRef(r.Context(), r.URL.Query().Get("ref"))
-	if err != nil {
-		if errors.Is(err, core.ErrSecretRefInvalid) {
-			return core.Scope{}, errInvalidTarget
-		}
-		return core.Scope{}, errTargetNotFound
-	}
-	return core.Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}, nil
 }
 
 // ScopeFromDeletedSecretParam resolves the scope of a secret that may be

--- a/server/middleware/auth_s24_test.go
+++ b/server/middleware/auth_s24_test.go
@@ -6,30 +6,20 @@ package middleware
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/gorm"
 
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
-
-// authS24DBSeq makes each in-memory DB unique within the process, so that
-// repeated invocations of the same test (go test -count=N) don't attach to a
-// live leftover DB from a prior iteration.
-var authS24DBSeq atomic.Int64
 
 // ── validateToken branches ────────────────────────────────────────────────────
 
@@ -190,47 +180,159 @@ func TestPruneLocked_TimeBasedSweep(t *testing.T) {
 	assert.False(t, stillThere, "pruneLocked time-based sweep must remove expired entries")
 }
 
-// ── ScopeFromRefQuery — ErrSecretRefInvalid branch ───────────────────────────
+// ── RequireScopedSecretRefPermission — ErrSecretRefInvalid / not-found branches ──
+//
+// RequireScopedSecretRefPermission (and handleScopedSecretRefPermissionRequest)
+// replaced the old standalone ScopeFromRefQuery resolver: it now resolves a
+// "?ref=project/environment/name" query param EXACTLY ONCE per request and pins
+// the result on the request context (GetResolvedSecretRefFromContext) instead of
+// letting the handler resolve the same ref again by name — see the doc comment
+// on RequireScopedSecretRefPermission in auth.go for the TOCTOU this closes.
 
-// TestScopeFromRefQuery_InvalidRefFormat verifies that a malformed ref string
-// (not "project/environment/name") returns errInvalidTarget (400 BadRequest),
-// not errTargetNotFound (404).
-func TestScopeFromRefQuery_InvalidRefFormat(t *testing.T) {
-	require.NoError(t, i18n.InitializeForTesting())
-	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:scopeRefInvalid_%d?mode=memory&cache=shared", authS24DBSeq.Add(1))), &gorm.Config{})
-	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(
-		&models.Project{}, &models.Environment{}, &models.SecretNode{},
-	))
+// TestRequireScopedSecretRefPermission_InvalidRefFormat verifies that a
+// malformed ref string (not "project/environment/name") 400s, not 404s.
+func TestRequireScopedSecretRefPermission_InvalidRefFormat(t *testing.T) {
+	db := newScopedTestDB(t)
+	seedAdmin(t, db, 1)
 	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	userCtx := &UserContext{UserID: 1, ActorType: core.ActorTypeUser}
 
 	// A ref with only one segment is invalid (needs "proj/env/name").
-	req := httptest.NewRequest(http.MethodGet, "/?ref=onlyone", nil)
-	_, err = ScopeFromRefQuery(req, cs)
-	assert.ErrorIs(t, err, errInvalidTarget,
-		"a malformed ref must return errInvalidTarget, not errTargetNotFound")
+	req := makeRequest(t, http.MethodGet, "/secrets/value?ref=onlyone", nil, userCtx, cs)
+	rec := httptest.NewRecorder()
+	nextCalled := false
+	handleScopedSecretRefPermissionRequest(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}), rec, req, "secrets.read")
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code,
+		"a malformed ref must 400, not 404")
+	assert.False(t, nextCalled, "next must not run on a resolution failure")
 }
 
-// TestScopeFromRefQuery_NotFound verifies that a well-formed ref that points to
-// a non-existent secret returns errTargetNotFound.
-func TestScopeFromRefQuery_NotFound(t *testing.T) {
-	require.NoError(t, i18n.InitializeForTesting())
-	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:scopeRefNotFound_%d?mode=memory&cache=shared", authS24DBSeq.Add(1))), &gorm.Config{})
-	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(
-		&models.Project{}, &models.Environment{}, &models.SecretNode{},
-	))
+// TestRequireScopedSecretRefPermission_NotFound verifies that a well-formed ref
+// pointing to a non-existent secret 404s (this admin test user holds the
+// permission globally, so handleScopeResolutionError takes the "reveal" branch).
+func TestRequireScopedSecretRefPermission_NotFound(t *testing.T) {
+	db := newScopedTestDB(t)
+	seedAdmin(t, db, 1)
 	// Seed minimal project + environment so the ref can be parsed but the secret
 	// lookup fails (no matching name).
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "myproject"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "prod"}).Error)
-
 	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	userCtx := &UserContext{UserID: 1, ActorType: core.ActorTypeUser}
 
-	req := httptest.NewRequest(http.MethodGet, "/?ref=myproject/prod/missing-secret", nil)
-	_, err = ScopeFromRefQuery(req, cs)
-	assert.ErrorIs(t, err, errTargetNotFound,
-		"a valid-format ref for a missing secret must return errTargetNotFound")
+	req := makeRequest(t, http.MethodGet, "/secrets/value?ref=myproject/prod/missing-secret", nil, userCtx, cs)
+	rec := httptest.NewRecorder()
+	nextCalled := false
+	handleScopedSecretRefPermissionRequest(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}), rec, req, "secrets.read")
+
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"a valid-format ref for a missing secret must 404")
+	assert.False(t, nextCalled, "next must not run on a resolution failure")
+}
+
+// TestRequireScopedSecretRefPermission_PinsResolvedSecretOnContext proves the
+// context hand-off itself: on a successful authorization, the exact
+// *models.SecretNode resolved by the middleware is retrievable from the next
+// handler's request context via GetResolvedSecretRefFromContext.
+func TestRequireScopedSecretRefPermission_PinsResolvedSecretOnContext(t *testing.T) {
+	db := newScopedTestDB(t)
+	seedAdmin(t, db, 1)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "prod"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, ProjectID: 1, EnvironmentID: 1, Name: "db"}).Error)
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	userCtx := &UserContext{UserID: 1, ActorType: core.ActorTypeUser}
+
+	req := makeRequest(t, http.MethodGet, "/secrets/value?ref=proj/prod/db", nil, userCtx, cs)
+	rec := httptest.NewRecorder()
+	var pinned *models.SecretNode
+	handleScopedSecretRefPermissionRequest(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pinned = GetResolvedSecretRefFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}), rec, req, "secrets.read")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, pinned, "the handler must see the resolved secret on its request context")
+	assert.Equal(t, uint(1), pinned.ID)
+	assert.Equal(t, uint(1), pinned.ProjectID)
+	assert.Equal(t, uint(1), pinned.EnvironmentID)
+}
+
+// TestRequireScopedSecretRefPermission_SingleResolutionSurvivesRename is the
+// TOCTOU regression test for core-secret-ref-4: it reproduces the exact race
+// the old two-resolution flow was vulnerable to — a project soft-delete plus a
+// same-named recreate landing between the authorization-scope resolution and
+// the value-read resolution — and proves the fix makes the two "reads" of the
+// resolved secret (the context pin, checked both immediately and again after
+// the race) agree, because there is structurally only ONE resolution call for
+// the whole request. It also independently confirms the race is real: an
+// UNRELATED, fresh call to ResolveSecretRef with the identical ref string
+// AFTER the rename lands on the NEW project — exactly the divergence the old
+// GetSecretValueByRef code path would have handed back to the caller as "the"
+// secret to read, despite authorization having been decided against the OLD
+// project.
+func TestRequireScopedSecretRefPermission_SingleResolutionSurvivesRename(t *testing.T) {
+	db := newScopedTestDB(t)
+	seedAdmin(t, db, 1)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "race-proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "prod"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, ProjectID: 1, EnvironmentID: 1, Name: "db"}).Error)
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	userCtx := &UserContext{UserID: 1, ActorType: core.ActorTypeUser}
+	ref := "race-proj/prod/db"
+
+	req := makeRequest(t, http.MethodGet, "/secrets/value?ref="+ref, nil, userCtx, cs)
+	rec := httptest.NewRecorder()
+	var pinnedBeforeRace, pinnedAfterRace *models.SecretNode
+	var staleReResolution *models.SecretNode
+
+	handleScopedSecretRefPermissionRequest(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// This is the ONE resolution the request ever performs — captured
+		// before simulating anything, exactly as the real handler would read
+		// it via middleware.GetResolvedSecretRefFromContext.
+		pinnedBeforeRace = GetResolvedSecretRefFromContext(r.Context())
+
+		// Simulate the race: soft-delete the original project and create a
+		// brand-new project with the SAME name (name uniqueness is only
+		// enforced while deleted_at IS NULL, so this is legal), with its own
+		// environment/secret rows also named "prod"/"db".
+		require.NoError(t, db.Delete(&models.Project{}, 1).Error)
+		require.NoError(t, db.Create(&models.Project{ID: 2, Name: "race-proj"}).Error)
+		require.NoError(t, db.Create(&models.Environment{ID: 2, ProjectID: 2, Name: "prod"}).Error)
+		require.NoError(t, db.Create(&models.SecretNode{ID: 2, ProjectID: 2, EnvironmentID: 2, Name: "db"}).Error)
+
+		// Prove the race is real: an independent resolution of the identical
+		// ref string, performed now, lands on the NEW project — this is what
+		// the pre-fix GetSecretValueByRef's second ResolveSecretRef call would
+		// have returned instead of the secret actually authorized against.
+		var err error
+		staleReResolution, err = cs.ResolveSecretRef(r.Context(), ref)
+		require.NoError(t, err)
+
+		// The fixed handler never makes that second call — it reads the SAME
+		// context value again, which must still be the pre-race resolution.
+		pinnedAfterRace = GetResolvedSecretRefFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}), rec, req, "secrets.read")
+
+	require.NotNil(t, pinnedBeforeRace)
+	require.NotNil(t, staleReResolution)
+	require.NotNil(t, pinnedAfterRace)
+
+	assert.Equal(t, uint(1), pinnedBeforeRace.ProjectID, "authorization was decided against project 1")
+	assert.Equal(t, uint(2), staleReResolution.ProjectID,
+		"a second by-name resolution after the race diverges onto project 2 — confirming the race is real")
+	assert.Same(t, pinnedBeforeRace, pinnedAfterRace,
+		"the context-pinned resolution must be the exact same value throughout the request, unaffected by the race")
+	assert.Equal(t, uint(1), pinnedAfterRace.ProjectID,
+		"the handler must still act on project 1's secret — the one authorization was actually decided against")
 }
 
 // ── hostOnly — bare IP (no port) branch ─────────────────────────────────────

--- a/server/middleware/middleware_s2_test.go
+++ b/server/middleware/middleware_s2_test.go
@@ -249,14 +249,20 @@ func TestGetCoreServiceFromContext_WithNilValue(t *testing.T) {
 	}
 }
 
-// --- ScopeFromRefQuery ---
+// --- GetResolvedSecretRefFromContext ---
 
-// TestScopeFromRefQuery_MissingRef returns errTargetNotFound for an empty ref.
-func TestScopeFromRefQuery_MissingRef(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/?ref=", nil)
-	_, err := ScopeFromRefQuery(req, nil)
-	if err == nil {
-		t.Error("expected error for missing ref, got nil")
+// TestGetResolvedSecretRefFromContext_WithNilValue confirms nil is returned
+// when the key exists with a non-*models.SecretNode value — mirroring
+// GetCoreServiceFromContext_WithNilValue above. Ref-resolution behavior
+// (invalid format / not found) is covered end to end at the middleware level
+// by TestRequireScopedSecretRefPermission_* in auth_s24_test.go, now that
+// RequireScopedSecretRefPermission resolves the ref exactly once instead of
+// exposing a standalone ScopeFromRefQuery resolver.
+func TestGetResolvedSecretRefFromContext_WithNilValue(t *testing.T) {
+	ctx := context.WithValue(context.Background(), resolvedSecretRefContextKey, "wrong type")
+	got := GetResolvedSecretRefFromContext(ctx)
+	if got != nil {
+		t.Errorf("expected nil for wrong type, got %v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes 8 low-severity singletons from Wave 6's core secret/identity lifecycle batch.

- `CORE-CERT-003` — `certificate.go`'s `SelfSigned` field used a naive `Subject.String() == Issuer.String()` heuristic; a CA-issued cert whose Issuer happens to render identically to its Subject was misreported as self-signed. Now verified cryptographically via `cert.CheckSignature` against the cert's own public key (deliberately not `CheckSignatureFrom`, which enforces CA `BasicConstraints` a self-signed leaf won't have).
- `CORE-COMPLIANCE-DIGEST-3` — stale doc comments in `control_framework.go` and `internal/cli/compliance/compliance.go` claimed the compliance control matrix is gated by `system.read`; it's actually `audit.read` since CP-001/CP-008 (verified against the real router/gRPC gating and the regression test that pins that history). Comment-only fix.
- `CORE-DYNSEC-003` + `CORE-DYNSEC-005` — `validateAdminDSNHost` missed zone-qualified link-local IPv6 hosts (`fe80::1%eth0`), an SSRF-blocklist bypass; and `dynamicTTL` had no upper bound before an `int64` multiplication, letting an oversized `ttl_seconds` overflow into a negative Duration. Both fixed in `dynamic_secrets.go`, plus a sibling overflow guard added to config-field validation.
- `CMI-3` — `TransitionMachineIdentity`'s token-cache eviction silently swallowed a storage error with no logging or retry, and is the *sole* eviction path for gRPC-originated suspend/revoke. Now retries once and logs loudly on repeated failure.
- `PM-008` — the HTTP `InviteMember` endpoint let a client self-assert `idp_resolved: true`, bypassing the `idp` validation mode's intended IdP-verification requirement. Traced every caller of `core.InviteMember`; the HTTP handler was the only untrusted path, so the fix is scoped there — the client-supplied field is now ignored.
- `core-rotation-2026-08-08-003` — `GetRotationCalendar` had no project/environment scoping and always returned full deployment-wide per-secret detail to any global `secrets.read` holder. Added optional scoping, mirroring the existing `GetRotationStatus`/`EvaluateRotationPolicies` pattern exactly.
- `core-secret-ref-4` — the by-ref secret read resolved `ResolveSecretRef` twice per request (once for authorization scope, once for the value fetch), with no snapshot guarantee — a project soft-delete+recreate race between the two calls could authorize against one project and read from another. Fixed structurally: resolves once, pins the result on the request context, and the handler reuses it instead of re-resolving.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `gofmt -l` — clean across all changed files
- `gosec -severity medium -exclude-generated ./...` — 0 issues (795 files, 157k lines)
- Full `go test ./...` — only the established pre-existing failures (`TestPermissionBaseline_CSV_Headers`, the `TestRemoteStorage*_RealServer` family in `server/http`), no new failures
- Each of the 7 underlying fixes independently verified (build/vet/gofmt/gosec/package suite) before being cherry-picked onto this combined branch; combined verification re-run above catches any cross-fix interaction (one auto-merge in `server/http/router.go` between the rotation-calendar and secret-ref fixes, confirmed clean)